### PR TITLE
Coalesce stale conflict polling

### DIFF
--- a/src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts
+++ b/src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createCoalescedPollRunner } from './coalesced-poll-runner'
+
+function deferred(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve: () => void = () => {}
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('createCoalescedPollRunner', () => {
+  it('keeps one task in flight and runs one trailing task after skipped triggers', async () => {
+    const calls: ReturnType<typeof deferred>[] = []
+    const task = vi.fn(() => {
+      const call = deferred()
+      calls.push(call)
+      return call.promise
+    })
+    const runner = createCoalescedPollRunner(task)
+
+    runner.run()
+    runner.run()
+    runner.run()
+    await flushMicrotasks()
+
+    expect(task).toHaveBeenCalledTimes(1)
+    calls[0]?.resolve()
+    await flushMicrotasks()
+
+    expect(task).toHaveBeenCalledTimes(2)
+    calls[1]?.resolve()
+    await flushMicrotasks()
+    expect(task).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops queued trailing work after disposal', async () => {
+    const call = deferred()
+    const task = vi.fn(() => call.promise)
+    const runner = createCoalescedPollRunner(task)
+
+    runner.run()
+    runner.run()
+    runner.dispose()
+    call.resolve()
+    await flushMicrotasks()
+
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/coalesced-poll-runner.ts
+++ b/src/renderer/src/components/right-sidebar/coalesced-poll-runner.ts
@@ -1,0 +1,43 @@
+export type CoalescedPollRunner = {
+  run: () => void
+  dispose: () => void
+}
+
+export function createCoalescedPollRunner(task: () => Promise<void>): CoalescedPollRunner {
+  let disposed = false
+  let inFlight = false
+  let rerun = false
+
+  const run = (): void => {
+    if (disposed) {
+      return
+    }
+    if (inFlight) {
+      rerun = true
+      return
+    }
+    inFlight = true
+    void task()
+      .catch(() => {
+        // Poll callers handle their own expected transient errors. A rejected
+        // task must still release the in-flight latch and optional trailing run.
+      })
+      .finally(() => {
+        inFlight = false
+        if (rerun && !disposed) {
+          rerun = false
+          run()
+          return
+        }
+        rerun = false
+      })
+  }
+
+  return {
+    run,
+    dispose: () => {
+      disposed = true
+      rerun = false
+    }
+  }
+}

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -6,6 +6,7 @@ import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeGitConflictOperation } from '@/runtime/runtime-git-client'
 import { refreshGitStatusForWorktree } from './git-status-refresh'
+import { createCoalescedPollRunner } from './coalesced-poll-runner'
 
 const POLL_INTERVAL_MS = 3000
 
@@ -164,15 +165,20 @@ export function useGitStatusPolling(): void {
       }
     }
 
-    void pollStale()
+    // Why: remote conflict probes can exceed the 3s interval. Keep one poll in
+    // flight and coalesce skipped ticks into one trailing pass so stale badges
+    // catch up without stacking SSH/RPC work.
+    const pollRunner = createCoalescedPollRunner(pollStale)
+    pollRunner.run()
     const intervalId = setInterval(() => {
       if (document.hasFocus()) {
-        void pollStale()
+        pollRunner.run()
       }
     }, POLL_INTERVAL_MS)
-    const onFocus = (): void => void pollStale()
+    const onFocus = (): void => pollRunner.run()
     window.addEventListener('focus', onFocus)
     return () => {
+      pollRunner.dispose()
       clearInterval(intervalId)
       window.removeEventListener('focus', onFocus)
     }


### PR DESCRIPTION
## Summary
- Coalesce non-active stale conflict-operation polls so a slow SSH/runtime probe cannot stack overlapping polling loops every 3 seconds.
- Add a small coalesced poll runner that keeps one async poll in flight and runs at most one trailing pass for skipped ticks.
- Dispose the runner on effect cleanup so queued trailing work does not survive the polling lifecycle.

## Repro / Evidence
- Repro: trigger the same poll runner multiple times while the first async poll promise is unresolved. The regression test proves only one poll starts immediately and exactly one trailing poll runs after the first settles.
- Cleanup proof: a second test queues a trailing poll, disposes the runner, then resolves the in-flight task; no trailing poll runs.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/coalesced-poll-runner.test.ts`
- `pnpm run typecheck:web`
- `pnpm lint`
- `git diff --check`

## Note
- Full `pnpm test` is blocked in this worktree by the existing native `better-sqlite3` rebuild mismatch (`NODE_MODULE_VERSION 145`; current Node needs `137`).