### PR TITLE
fix: combine buf0-bot validated bug fixes

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1896,7 +1896,20 @@ export default function SessionScreen() {
         if (!terminalGestureInputInFlightRef.current.has(handle)) {
           void flushTerminalGestureInput(handle)
         } else {
-          terminalGestureInputQueuesRef.current.delete(handle)
+          // Why: an RPC is in-flight and the new batch would overflow the
+          // pending-sequences cap. Appending preserves the already-queued
+          // bytes (which would otherwise be dropped) — the in-flight flush's
+          // finally block will pick up the merged queue. The cap is a soft
+          // guideline; brief overflow during in-flight is preferable to
+          // silently dropping user input.
+          current.bytes += bytes
+          current.sequenceCount += sequenceCount
+          current.lastUpdatedMs = now
+          current.timer = setTimeout(() => {
+            current.timer = null
+            void flushTerminalGestureInput(handle)
+          }, TERMINAL_GESTURE_INPUT_FLUSH_DELAY_MS)
+          return
         }
       }
 

--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -153,6 +153,68 @@ describe('AutomationService', () => {
     })
   })
 
+  it('does not recollect usage for an already-finalized run', async () => {
+    vi.setSystemTime(new Date('2026-05-13T10:00:00'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Costed check',
+      prompt: 'Check spend',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+    const run = store.createAutomationRun(automation, Date.now(), 'manual')
+    store.updateAutomationRun({
+      runId: run.id,
+      status: 'dispatched',
+      workspaceId: 'wt1',
+      terminalSessionId: 'tab-1',
+      error: null
+    })
+    const usage = {
+      status: 'known' as const,
+      provider: 'claude' as const,
+      model: 'claude-sonnet-4-6',
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 25,
+      cacheWriteTokens: 10,
+      reasoningOutputTokens: null,
+      totalTokens: 185,
+      estimatedCostUsd: 0.001,
+      estimatedCostSource: 'api_equivalent' as const,
+      providerSessionId: 'provider-session-1',
+      attribution: 'provider_session_time_window' as const,
+      collectedAt: Date.now(),
+      unavailableReason: null,
+      unavailableMessage: null
+    }
+    const getAutomationRunUsage = vi.fn().mockResolvedValue(usage)
+    const service = new AutomationService(store, {
+      tickMs: 60_000,
+      claudeUsage: { getAutomationRunUsage } as never
+    })
+    const result = {
+      runId: run.id,
+      status: 'completed' as const,
+      workspaceId: 'wt1',
+      terminalSessionId: 'tab-1',
+      error: null
+    }
+
+    const first = await service.markDispatchResult(result)
+    const second = await service.markDispatchResult(result)
+
+    expect(first.usage).toEqual(usage)
+    expect(second.usage).toEqual(usage)
+    expect(getAutomationRunUsage).toHaveBeenCalledTimes(1)
+  })
+
   it('records unsupported usage cleanly for completed agents without local usage stores', async () => {
     vi.setSystemTime(new Date('2026-05-13T10:00:00'))
     const store = await createStore()

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -78,6 +78,13 @@ export class AutomationService {
     if (!isFinalRunStatus(run.status)) {
       return run
     }
+    // Why: the renderer's mark-completed effect can re-fire for the same run
+    // before refresh() flips its status snapshot off 'dispatched'. Re-running
+    // collectRunUsage advances the attribution window and can rewrite an
+    // already-collected 'known' usage to 'unavailable'/'ambiguous_session'.
+    if (run.usage) {
+      return run
+    }
     const usage = await this.collectRunUsage(run)
     return this.store.updateAutomationRun({
       runId: run.id,

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -307,7 +307,16 @@ export class ClaudeUsageStore {
       if (parsed.schemaVersion !== SCHEMA_VERSION) {
         // Why: scanner semantics affect persisted totals, so old Claude caches
         // must be rebuilt after parser/source changes instead of reused briefly.
-        return getDefaultState()
+        // Preserve scanState.enabled so existing users keep tracking on across
+        // schema bumps; the next refresh will repopulate the analytics.
+        const defaults = getDefaultState()
+        return {
+          ...defaults,
+          scanState: {
+            ...defaults.scanState,
+            enabled: parsed.scanState?.enabled ?? defaults.scanState.enabled
+          }
+        }
       }
       return {
         ...getDefaultState(),

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -720,16 +720,34 @@ export class CodexRuntimeHomeService {
   }
 
   private readSystemDefaultSnapshot(snapshotPath: string): CodexSystemDefaultSnapshot | null {
+    let rawContents: string
     try {
-      const parsed = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as unknown
+      rawContents = readFileSync(snapshotPath, 'utf-8')
+    } catch {
+      return null
+    }
+    try {
+      const parsed = JSON.parse(rawContents) as unknown
       if (
         parsed &&
         typeof parsed === 'object' &&
         !Array.isArray(parsed) &&
         'authJson' in parsed &&
-        (typeof parsed.authJson === 'string' || parsed.authJson === null)
+        (typeof (parsed as { authJson: unknown }).authJson === 'string' ||
+          (parsed as { authJson: unknown }).authJson === null)
       ) {
         return parsed as CodexSystemDefaultSnapshot
+      }
+      // Why: pre-PR snapshots wrote raw auth.json contents verbatim. Treat any
+      // valid JSON object without an authJson wrapper as the legacy format so
+      // upgraders do not lose their system-default auth on first deselect.
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed) &&
+        !('authJson' in parsed)
+      ) {
+        return { authJson: rawContents }
       }
     } catch {
       return null

--- a/src/main/codex-usage/store.test.ts
+++ b/src/main/codex-usage/store.test.ts
@@ -654,7 +654,7 @@ describe('CodexUsageStore', () => {
       sessions: [],
       dailyAggregates: [],
       scanState: {
-        enabled: false,
+        enabled: true,
         lastScanStartedAt: null,
         lastScanCompletedAt: null,
         lastScanError: null

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -113,7 +113,16 @@ export function normalizePersistedState(state: CodexUsagePersistedState): CodexU
     // Reusing an older cache would silently serve wrong model/session rows
     // until the next forced rescan, so schema changes must invalidate stale
     // persisted analytics instead of best-effort patching partial data.
-    return getDefaultState()
+    // Preserve scanState.enabled so existing users keep tracking on across
+    // schema bumps; the next refresh will repopulate the analytics.
+    const defaults = getDefaultState()
+    return {
+      ...defaults,
+      scanState: {
+        ...defaults.scanState,
+        enabled: state.scanState?.enabled ?? defaults.scanState.enabled
+      }
+    }
   }
   return {
     ...state,

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -164,6 +164,8 @@ describePosix('daemon shell-ready launch config', () => {
     getShellReadyLaunchConfig('/bin/zsh')
 
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    expect(zshenv).toContain('local _orca_user_zdotdir="${_orca_spawn_orig_zdotdir:-$HOME}"')
+    expect(zshenv).toContain('[[ -f "$_orca_user_zdotdir/.zshenv" ]]')
     expect(zshenv).toContain('*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;')
   })
 

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -126,11 +126,39 @@ function ensureShellReadyWrappers(): void {
   const bashDir = join(root, 'bash')
 
   const zshEnv = `# Orca daemon zsh shell-ready wrapper
-export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "\${ORCA_ORIG_ZDOTDIR%/}" in
+_orca_spawn_orig_zdotdir="\${ORCA_ORIG_ZDOTDIR:-}"
+# Why: clearing ZDOTDIR lets user .zshenv use the canonical XDG idiom
+# \`export ZDOTDIR="\${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"\` to compute its
+# preferred dir; pre-setting it (even to HOME) defeats that default.
+unset ZDOTDIR
+# Why: function isolates user .zshenv \`return\` so it doesn't abort our wrapper.
+# Trade-off: top-level \`setopt LOCAL_OPTIONS\`/\`LOCAL_TRAPS\`, \`TRAPEXIT\`, and
+# bare \`local\`/\`typeset\` in user .zshenv become function-scoped; use \`typeset -g\`
+# or \`export\` to escape.
+__orca_source_user_zshenv() {
+  # Why: honor an externally-set ZDOTDIR (login manager, /etc/zshenv, parent
+  # shell) so users whose real .zshenv lives at $ZDOTDIR (not $HOME) still
+  # get PATH/aliases/exports loaded. Falls back to $HOME when no spawn-env
+  # ZDOTDIR was inherited.
+  local _orca_user_zdotdir="\${_orca_spawn_orig_zdotdir:-$HOME}"
+  [[ -f "$_orca_user_zdotdir/.zshenv" ]] && source "$_orca_user_zdotdir/.zshenv"
+}
+__orca_source_user_zshenv
+unfunction __orca_source_user_zshenv
+# Why: prefer the ZDOTDIR user .zshenv resolved (XDG case); else preserve
+# the spawn-env value (an inherited resolution from a parent Orca PTY);
+# else HOME.
+export ORCA_ORIG_ZDOTDIR="\${ZDOTDIR:-\${_orca_spawn_orig_zdotdir:-$HOME}}"
+unset _orca_spawn_orig_zdotdir
+# Why: strip trailing slashes (matches Node-side normalizer) before the
+# self-loop check, so a wrapper-shaped ZDOTDIR with one or more trailing
+# slashes still gets normalized away from .zprofile/.zshrc/.zlogin.
+while [[ "\${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
+  ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR%/}"
+done
+case "\${ORCA_ORIG_ZDOTDIR}" in
   */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
 esac
-[[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `
   const zshProfile = `# Orca daemon zsh shell-ready wrapper

--- a/src/main/ipc/filesystem-watcher.test.ts
+++ b/src/main/ipc/filesystem-watcher.test.ts
@@ -195,6 +195,92 @@ describe('registerFilesystemWatcherHandlers', () => {
     expect(unwatchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('dedupes concurrent pending SSH worktree watcher installs', async () => {
+    const sendOne = vi.fn()
+    const sendTwo = vi.fn()
+    const senderOne = { isDestroyed: () => false, send: sendOne, once: vi.fn(), id: 1 }
+    const senderTwo = { isDestroyed: () => false, send: sendTwo, once: vi.fn(), id: 2 }
+    const unwatchMock = vi.fn()
+    let resolveWatch: (unwatch: () => void) => void = () => {}
+    const watchPromise = new Promise<() => void>((resolve) => {
+      resolveWatch = resolve
+    })
+    const watchMock = vi.fn().mockReturnValue(watchPromise)
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    const firstWatch = handlers['fs:watchWorktree'](
+      { sender: senderOne },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    ) as Promise<unknown>
+    const secondWatch = handlers['fs:watchWorktree'](
+      { sender: senderTwo },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    ) as Promise<unknown>
+
+    await Promise.resolve()
+    expect(watchMock).toHaveBeenCalledTimes(1)
+
+    resolveWatch(unwatchMock)
+    await Promise.all([firstWatch, secondWatch])
+
+    const onEvents = watchMock.mock.calls[0][1]
+    onEvents([{ path: '/home/me/repo/file.txt', type: 'update' }])
+    expect(sendOne).toHaveBeenCalledTimes(1)
+    expect(sendTwo).toHaveBeenCalledTimes(1)
+
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 1 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 2 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    expect(unwatchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a pending SSH watcher install alive when only one pending sender unwatches', async () => {
+    const sendOne = vi.fn()
+    const sendTwo = vi.fn()
+    const senderOne = { isDestroyed: () => false, send: sendOne, once: vi.fn(), id: 1 }
+    const senderTwo = { isDestroyed: () => false, send: sendTwo, once: vi.fn(), id: 2 }
+    const unwatchMock = vi.fn()
+    let resolveWatch: (unwatch: () => void) => void = () => {}
+    const watchPromise = new Promise<() => void>((resolve) => {
+      resolveWatch = resolve
+    })
+    const watchMock = vi.fn().mockReturnValue(watchPromise)
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    const firstWatch = handlers['fs:watchWorktree'](
+      { sender: senderOne },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    ) as Promise<unknown>
+    const secondWatch = handlers['fs:watchWorktree'](
+      { sender: senderTwo },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    ) as Promise<unknown>
+
+    await Promise.resolve()
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 2 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    resolveWatch(unwatchMock)
+    await Promise.all([firstWatch, secondWatch])
+
+    const onEvents = watchMock.mock.calls[0][1]
+    onEvents([{ path: '/home/me/repo/file.txt', type: 'update' }])
+    expect(sendOne).toHaveBeenCalledTimes(1)
+    expect(sendTwo).not.toHaveBeenCalled()
+
+    handlers['fs:unwatchWorktree'](
+      { sender: { id: 1 } },
+      { worktreePath: '/home/me/repo', connectionId: 'conn-1' }
+    )
+    expect(unwatchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('registers one destroyed listener for many SSH worktree watches', async () => {
     const destroyedCallbacks: (() => void)[] = []
     const sender = {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -440,6 +440,11 @@ type RemoteWatcherState = {
   listeners: Map<number, WebContents>
 }
 
+type RemoteWatcherInstallToken = {
+  cancelled: boolean
+  listeners: Map<number, WebContents>
+}
+
 // Key: `${connectionId}:${worktreePath}`, Value: shared remote watch state.
 const remoteWatchers = new Map<string, RemoteWatcherState>()
 const loggedUnavailableRemoteWatchers = new Set<string>()
@@ -448,7 +453,12 @@ const pendingRemoteWatcherRetries = new Map<string, ReturnType<typeof setTimeout
 // arrives while a watch is still resolving can mark the install cancelled.
 // Without this, the awaited unwatch handle would be installed after the
 // renderer thinks the watch is gone, leaking a native watcher.
-const inFlightRemoteInstalls = new Map<string, { cancelled: boolean }>()
+const inFlightRemoteInstalls = new Map<string, RemoteWatcherInstallToken>()
+// Why: dedupe concurrent installRemoteWatcher calls for the same key so
+// overlapping fs:watchWorktree IPCs share one native watcher and one listener
+// map, instead of each call independently invoking provider.watch() and
+// overwriting the per-key state on resolution.
+const pendingRemoteInstallPromises = new Map<string, Promise<RemoteWatcherInstallResult>>()
 const REMOTE_WATCH_RETRY_MS = 1_000
 const REMOTE_WATCH_RETRY_TIMEOUT_MS = 60_000
 
@@ -498,8 +508,50 @@ async function installRemoteWatcher(
     addRemoteWatchListener(key, sender)
     return 'installed'
   }
-  const cancelToken = { cancelled: false }
+  // Why: a second concurrent fs:watchWorktree for the same key must share the
+  // first call's provider.watch() instead of starting its own. Without this,
+  // both calls would create distinct native watchers and the second's resolve
+  // would overwrite the per-key state, dropping the first's unwatch handle
+  // and erasing its sender from the listener map.
+  const pendingInstall = pendingRemoteInstallPromises.get(key)
+  if (pendingInstall) {
+    const inFlight = inFlightRemoteInstalls.get(key)
+    if (inFlight && !sender.isDestroyed()) {
+      inFlight.listeners.set(sender.id, sender)
+    }
+    const result = await pendingInstall
+    if (
+      result === 'installed' &&
+      remoteWatchers.has(key) &&
+      !sender.isDestroyed() &&
+      (!inFlight || inFlight.listeners.has(sender.id))
+    ) {
+      addRemoteWatchListener(key, sender)
+    }
+    return result
+  }
+  const cancelToken: RemoteWatcherInstallToken = {
+    cancelled: false,
+    listeners: sender.isDestroyed() ? new Map() : new Map([[sender.id, sender]])
+  }
   inFlightRemoteInstalls.set(key, cancelToken)
+  const installPromise = doInstallRemoteWatcher(provider, key, worktreePath, cancelToken)
+  pendingRemoteInstallPromises.set(key, installPromise)
+  try {
+    return await installPromise
+  } finally {
+    if (pendingRemoteInstallPromises.get(key) === installPromise) {
+      pendingRemoteInstallPromises.delete(key)
+    }
+  }
+}
+
+async function doInstallRemoteWatcher(
+  provider: NonNullable<ReturnType<typeof getSshFilesystemProvider>>,
+  key: string,
+  worktreePath: string,
+  cancelToken: RemoteWatcherInstallToken
+): Promise<RemoteWatcherInstallResult> {
   let unwatch: () => void
   try {
     unwatch = await provider.watch(worktreePath, (events) => {
@@ -522,7 +574,10 @@ async function installRemoteWatcher(
       inFlightRemoteInstalls.delete(key)
     }
   }
-  if (cancelToken.cancelled || sender.isDestroyed()) {
+  const liveListeners = new Map(
+    Array.from(cancelToken.listeners.entries()).filter(([, listener]) => !listener.isDestroyed())
+  )
+  if (cancelToken.cancelled || liveListeners.size === 0) {
     try {
       unwatch()
     } catch (err) {
@@ -530,8 +585,10 @@ async function installRemoteWatcher(
     }
     return 'cancelled'
   }
-  remoteWatchers.set(key, { unwatch, listeners: new Map() })
-  addRemoteWatchListener(key, sender)
+  remoteWatchers.set(key, { unwatch, listeners: liveListeners })
+  for (const listener of liveListeners.values()) {
+    registerSenderCleanup(listener)
+  }
   loggedUnavailableRemoteWatchers.delete(key)
   return 'installed'
 }
@@ -630,7 +687,8 @@ export function registerFilesystemWatcherHandlers(): void {
         // of leaving the renderer with a watcher it asked to stop.
         const inFlight = inFlightRemoteInstalls.get(key)
         if (inFlight) {
-          inFlight.cancelled = true
+          inFlight.listeners.delete(_event.sender.id)
+          inFlight.cancelled = inFlight.listeners.size === 0
         }
         loggedUnavailableRemoteWatchers.delete(key)
         releaseRemoteWatchListener(key, _event?.sender?.id ?? 0)

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -8,6 +8,7 @@ import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-pa
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
+import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { getActiveMultiplexer } from './ssh'
 
 const execFileAsync = promisify(execFile)
@@ -169,6 +170,16 @@ async function isGlabAuthenticated(): Promise<boolean> {
 export async function runPreflightCheck(force = false): Promise<PreflightStatus> {
   if (cached && !force) {
     return cached
+  }
+
+  if (force) {
+    // Why: the GitLab known-hosts cache (gl-utils) is populated lazily on the
+    // first GitLab request and never invalidated within a session. A user who
+    // runs `glab auth login` for a self-hosted host after Orca starts would
+    // otherwise see "No GitLab project found" until app relaunch. The Re-check
+    // path in IntegrationsPane forces preflight, so piggyback on that signal
+    // to refresh the host list too.
+    _resetKnownHostsCache()
   }
 
   const [gitInstalled, ghInstalled, glabInstalled] = await Promise.all([

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1301,6 +1301,7 @@ describe('registerPtyHandlers', () => {
         try {
           expect(controller.kill('remote-pty')).toBe(true)
           await Promise.resolve()
+          await Promise.resolve()
         } finally {
           warnSpy.mockRestore()
           deletePtyOwnership('remote-pty')
@@ -1311,7 +1312,7 @@ describe('registerPtyHandlers', () => {
           'remote-pty',
           'terminated'
         )
-        expect(runtime.onPtyExit).not.toHaveBeenCalled()
+        expect(runtime.onPtyExit).toHaveBeenCalledWith('remote-pty', -1)
       })
 
       it('strips ORCA_PANE_KEY/TAB_ID/WORKTREE_ID from SSH spawn env when remote agent hooks are disabled', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -956,6 +956,11 @@ export function registerPtyHandlers(
           console.warn(
             `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
           )
+          // Why: callers of controller.kill must observe a kill→exit pair so
+          // runtime tail buffers close and agents stop treating the pane as
+          // live. Preserve provider/lease state so a retry can still target
+          // the remote PTY if it survived the transient failure.
+          runtime?.onPtyExit(ptyId, -1)
         })
       return true
     },

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -242,6 +242,8 @@ describePosix('local PTY shell-ready launch config', () => {
     getShellReadyLaunchConfig('/bin/zsh')
 
     const zshenv = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'), 'utf8')
+    expect(zshenv).toContain('local _orca_user_zdotdir="${_orca_spawn_orig_zdotdir:-$HOME}"')
+    expect(zshenv).toContain('[[ -f "$_orca_user_zdotdir/.zshenv" ]]')
     expect(zshenv).toContain('*/shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;')
   })
 

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -217,11 +217,39 @@ function ensureShellReadyWrappers(): void {
   const bashDir = `${root}/bash`
 
   const zshEnv = `# Orca zsh shell-ready wrapper
-export ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}"
-case "\${ORCA_ORIG_ZDOTDIR%/}" in
+_orca_spawn_orig_zdotdir="\${ORCA_ORIG_ZDOTDIR:-}"
+# Why: clearing ZDOTDIR lets user .zshenv use the canonical XDG idiom
+# \`export ZDOTDIR="\${ZDOTDIR:-$XDG_CONFIG_HOME/zsh}"\` to compute its
+# preferred dir; pre-setting it (even to HOME) defeats that default.
+unset ZDOTDIR
+# Why: function isolates user .zshenv \`return\` so it doesn't abort our wrapper.
+# Trade-off: top-level \`setopt LOCAL_OPTIONS\`/\`LOCAL_TRAPS\`, \`TRAPEXIT\`, and
+# bare \`local\`/\`typeset\` in user .zshenv become function-scoped; use \`typeset -g\`
+# or \`export\` to escape.
+__orca_source_user_zshenv() {
+  # Why: honor an externally-set ZDOTDIR (login manager, /etc/zshenv, parent
+  # shell) so users whose real .zshenv lives at $ZDOTDIR (not $HOME) still
+  # get PATH/aliases/exports loaded. Falls back to $HOME when no spawn-env
+  # ZDOTDIR was inherited.
+  local _orca_user_zdotdir="\${_orca_spawn_orig_zdotdir:-$HOME}"
+  [[ -f "$_orca_user_zdotdir/.zshenv" ]] && source "$_orca_user_zdotdir/.zshenv"
+}
+__orca_source_user_zshenv
+unfunction __orca_source_user_zshenv
+# Why: prefer the ZDOTDIR user .zshenv resolved (XDG case); else preserve
+# the spawn-env value (an inherited resolution from a parent Orca PTY);
+# else HOME.
+export ORCA_ORIG_ZDOTDIR="\${ZDOTDIR:-\${_orca_spawn_orig_zdotdir:-$HOME}}"
+unset _orca_spawn_orig_zdotdir
+# Why: strip trailing slashes (matches Node-side normalizer) before the
+# self-loop check, so a wrapper-shaped ZDOTDIR with one or more trailing
+# slashes still gets normalized away from .zprofile/.zshrc/.zlogin.
+while [[ "\${ORCA_ORIG_ZDOTDIR}" == */ ]]; do
+  ORCA_ORIG_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR%/}"
+done
+case "\${ORCA_ORIG_ZDOTDIR}" in
   */shell-ready/zsh) export ORCA_ORIG_ZDOTDIR="$HOME" ;;
 esac
-[[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `
   const zshProfile = `# Orca zsh shell-ready wrapper

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6129,10 +6129,11 @@ export class OrcaRuntimeService {
       leafId?: string
     } = {}
   ): Promise<RuntimeTerminalCreate> {
-    if (opts.focus !== true && opts.rendererBacked !== true) {
-      if (!worktreeSelector) {
-        throw new Error('MISSING_WORKTREE')
-      }
+    // Why: pre-diff createTerminal fell back to the renderer's active worktree
+    // when no selector was provided. The new background-spawn branch hard-
+    // requires a resolvable selector, so route the no-selector case through
+    // the renderer IPC path to preserve that behavior.
+    if (opts.focus !== true && opts.rendererBacked !== true && worktreeSelector) {
       if (!this.ptyController?.spawn) {
         throw new Error('runtime_unavailable')
       }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -273,6 +273,7 @@ function App(): React.JSX.Element {
   const floatingTerminalTriggerLocation = useAppStore(
     (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
   )
+  const statusBarVisible = useAppStore((s) => s.statusBarVisible)
   // Why: the floating terminal is a transient overlay; hotkey minimize should
   // return keyboard focus to the surface the user was working in before it.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
@@ -1452,7 +1453,7 @@ function App(): React.JSX.Element {
               open={floatingTerminalOpen}
               onOpenChange={setFloatingTerminalOpenWithFocus}
             />
-            {floatingTerminalTriggerLocation === 'floating-button' ? (
+            {floatingTerminalTriggerLocation === 'floating-button' || !statusBarVisible ? (
               <FloatingTerminalToggleButton
                 open={floatingTerminalOpen}
                 onToggle={() => setFloatingTerminalOpenWithFocus((open) => !open)}

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1115,6 +1115,9 @@ export default function TaskPage(): React.JSX.Element {
   // Why: team IDs belong to one Linear workspace. Switching workspaces while a
   // saved subset exists must not leave the task list filtered by stale team IDs.
   useEffect(() => {
+    if (availableTeams.length === 0) {
+      return
+    }
     setLinearTeamSelection(reconcileLinearTeamSelection(availableTeams, defaultLinearTeamSelection))
   }, [availableTeams, defaultLinearTeamSelection])
 
@@ -1706,7 +1709,13 @@ export default function TaskPage(): React.JSX.Element {
 
   useEffect(() => {
     // Why: when a modal is open, let it own Esc dismissal.
-    if (dialogWorkItem || newIssueOpen || newLinearIssueOpen || activeModal !== 'none') {
+    if (
+      dialogWorkItem ||
+      selectedLinearIssue ||
+      newIssueOpen ||
+      newLinearIssueOpen ||
+      activeModal !== 'none'
+    ) {
       return
     }
 
@@ -1740,7 +1749,14 @@ export default function TaskPage(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [activeModal, closeTaskPage, dialogWorkItem, newIssueOpen, newLinearIssueOpen])
+  }, [
+    activeModal,
+    closeTaskPage,
+    dialogWorkItem,
+    newIssueOpen,
+    newLinearIssueOpen,
+    selectedLinearIssue
+  ])
 
   // Why: check Linear connection status on mount so the UI can show the
   // correct connected/disconnected state without requiring a settings visit.

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -183,6 +183,54 @@ function makeThreads(result: ReturnType<typeof buildActivityEvents>) {
 }
 
 describe('buildActivityEvents', () => {
+  it('keeps every pane visible before applying the global activity cap', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree()
+    const tabs: TerminalTab[] = []
+    const entries: Record<string, AgentStatusEntry> = {}
+
+    for (let paneIndex = 0; paneIndex < 18; paneIndex += 1) {
+      const tabId = `tab-${paneIndex}`
+      const paneKey = makePaneKey(
+        tabId,
+        `00000000-0000-4000-8000-${String(paneIndex + 1).padStart(12, '0')}`
+      )
+      tabs.push(makeTabWithIds(tabId, worktree.id, `Agent ${paneIndex}`))
+      // Why: later pane indexes are older, so the pre-fix global 80-event cap
+      // would drop the final panes entirely when every pane had five events.
+      const newestTimestamp = 100_000 - paneIndex * 1_000
+      entries[paneKey] = {
+        state: 'done',
+        prompt: `Prompt ${paneIndex} current`,
+        updatedAt: newestTimestamp,
+        stateStartedAt: newestTimestamp,
+        paneKey,
+        terminalTitle: `Agent ${paneIndex}`,
+        stateHistory: [1, 2, 3, 4].map((offset) => ({
+          state: 'done',
+          prompt: `Prompt ${paneIndex} history ${offset}`,
+          startedAt: newestTimestamp - offset
+        })),
+        agentType: 'claude'
+      }
+    }
+
+    const { events, liveAgentByPaneKey } = buildActivityEvents({
+      agentStatusByPaneKey: entries,
+      retainedAgentsByPaneKey: {},
+      tabsByWorktree: { [worktree.id]: tabs },
+      worktreeMap: new Map([[worktree.id, worktree]]),
+      repoMap: new Map([[repo.id, repo]]),
+      acknowledgedAgentsByPaneKey: {},
+      now: 100_000
+    })
+    const threads = buildAgentPaneThreads({ events, liveAgentByPaneKey })
+
+    expect(events).toHaveLength(80)
+    expect(threads).toHaveLength(18)
+    expect(new Set(threads.map((thread) => thread.paneKey)).size).toBe(18)
+  })
+
   it('keeps a prior done event after the same pane starts working again', () => {
     const result = makeActivityResult({
       entries: {

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -721,20 +721,41 @@ export function buildActivityEvents(args: {
 
   const sorted = events.sort((a, b) => b.timestamp - a.timestamp)
   const perPaneCount = new Map<string, number>()
+  const includedEventIds = new Set<string>()
   const capped: ActivityEvent[] = []
+  // Why: reserve each pane's most-recent event before applying the global 80
+  // cap so a pane never disappears from the left list when many panes are
+  // active. The validator's scenario (>16 panes × ≥5 events) could push a
+  // pane's events past the 80-event window, hiding the pane entirely.
   for (const event of sorted) {
+    const paneKey = event.entry.paneKey
+    if (perPaneCount.has(paneKey)) {
+      continue
+    }
+    if (capped.length >= 80) {
+      break
+    }
+    perPaneCount.set(paneKey, 1)
+    includedEventIds.add(event.id)
+    capped.push(event)
+  }
+  for (const event of sorted) {
+    if (includedEventIds.has(event.id)) {
+      continue
+    }
+    if (capped.length >= 80) {
+      break
+    }
     const paneKey = event.entry.paneKey
     const count = perPaneCount.get(paneKey) ?? 0
     if (count >= EVENTS_PER_PANE_CAP) {
       continue
     }
     perPaneCount.set(paneKey, count + 1)
+    includedEventIds.add(event.id)
     capped.push(event)
-    if (capped.length >= 80) {
-      break
-    }
   }
-  return { events: capped, liveAgentByPaneKey }
+  return { events: capped.sort((a, b) => b.timestamp - a.timestamp), liveAgentByPaneKey }
 }
 
 export function buildAgentPaneThreads(args: {

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -117,6 +117,7 @@ export default function AutomationsPage(): React.JSX.Element {
   const [dontAskDeleteAgain, setDontAskDeleteAgain] = useState(false)
   const editRequestRef = useRef(0)
   const deleteConfirmButtonRef = useRef<HTMLButtonElement>(null)
+  const completionInFlightRef = useRef<Set<string>>(new Set())
   const [draft, setDraft] = useState<AutomationDraft>({
     name: '',
     prompt: '',
@@ -219,8 +220,12 @@ export default function AutomationsPage(): React.JSX.Element {
   }, [refresh])
 
   useEffect(() => {
+    const inFlight = completionInFlightRef.current
     const completedRuns = runs.filter((run) => {
       if (run.status !== 'dispatched' || !run.terminalSessionId) {
+        return false
+      }
+      if (inFlight.has(run.id)) {
         return false
       }
       const paneKeyPrefix = `${run.terminalSessionId}:`
@@ -238,6 +243,9 @@ export default function AutomationsPage(): React.JSX.Element {
     if (completedRuns.length === 0) {
       return
     }
+    for (const run of completedRuns) {
+      inFlight.add(run.id)
+    }
     void Promise.all(
       completedRuns.map((run) =>
         window.api.automations.markDispatchResult({
@@ -248,7 +256,16 @@ export default function AutomationsPage(): React.JSX.Element {
           error: null
         })
       )
-    ).then(() => refresh())
+    )
+      .then(() => refresh())
+      .catch((error) => {
+        console.error('[automations] failed to mark completed dispatch result:', error)
+      })
+      .finally(() => {
+        for (const run of completedRuns) {
+          inFlight.delete(run.id)
+        }
+      })
   }, [agentStatusByPaneKey, retainedAgentsByPaneKey, refresh, runs])
 
   useEffect(() => {

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -738,16 +738,11 @@ export default function ChecksPanel(): React.JSX.Element {
     if (activeReviewClassification.readyToMerge) {
       badges.push('Ready to merge')
     }
-    if (activeReviewClassification.requested) {
-      badges.push('Review requested')
-    }
-    if (activeReviewClassification.state === 'mine') {
-      badges.push('My PR')
-    } else if (activeReviewClassification.state === 'agent') {
-      badges.push('AI PR')
-    } else {
-      badges.push('Teammate PR')
-    }
+    // Why: viewer/author/requestedReviewer signals are not wired into the
+    // ChecksPanel call site yet, so `state` and `requested` would mis-classify
+    // every PR (collapsing to 'teammate'). Suppress those badges until the
+    // inputs are available; needs-response / ready-to-merge work from PR
+    // metadata alone and remain accurate.
     return badges
   }, [activeReviewClassification])
 

--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -86,17 +86,21 @@ export function CreatePullRequestDialog({
       setError(null)
       return
     }
-    const initializationKey = `${repoId}:${branch}:${eligibility ? 'ready' : 'pending'}`
+    if (!eligibility) {
+      return
+    }
+    const initializationKey = `${repoId}:${branch}`
     if (initializedFromEligibilityRef.current === initializationKey) {
       return
     }
     // Why: eligibility refreshes while the dialog is open; only seed fields
-    // once per branch so late refreshes do not overwrite user edits.
+    // once per branch so late refreshes (including populated→null transitions
+    // when a background eligibility fetch errors out) do not overwrite user edits.
     initializedFromEligibilityRef.current = initializationKey
-    const initialBase = eligibility?.defaultBaseRef ?? ''
+    const initialBase = eligibility.defaultBaseRef ?? ''
     setBase(stripBaseRef(initialBase))
-    setTitle(eligibility?.title ?? '')
-    setBody(eligibility?.body ?? '')
+    setTitle(eligibility.title ?? '')
+    setBody(eligibility.body ?? '')
     setDraft(false)
     setBaseQuery('')
     setBaseResults([])

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -92,6 +92,19 @@ const SidebarHeader = React.memo(function SidebarHeader() {
       if (workspaceBoardMenuOpen) {
         return
       }
+      // Why: Escape must dismiss any nested overlay (Radix dropdown, popover,
+      // tooltip, dialog, context menu) ahead of collapsing this non-modal
+      // companion panel. Radix portals open popper content into a wrapper
+      // element, and dialogs/menus expose `data-state="open"` on their
+      // content node, so the presence of either signals the user's intent
+      // is to dismiss that overlay rather than the workspace board.
+      if (
+        document.querySelector(
+          '[data-radix-popper-content-wrapper], [role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"], [role="menu"][data-state="open"], [role="listbox"][data-state="open"]'
+        )
+      ) {
+        return
+      }
       event.preventDefault()
       setWorkspaceBoardOpen(false)
     }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -818,13 +818,16 @@ describe('useIpcEvents updater integration', () => {
     storeState.ptyIdsByTabId = { 'tab-existing': ['pty-bg'] }
     createTab.mockClear()
     setActiveTab.mockClear()
+    setTabCustomTitle.mockClear()
     createTerminalListenerRef.current({
       worktreeId: 'wt-2',
-      ptyId: 'pty-bg'
+      ptyId: 'pty-bg',
+      title: 'Runtime title'
     })
 
     expect(createTab).not.toHaveBeenCalled()
     expect(setActiveTab).toHaveBeenCalledWith('tab-existing')
+    expect(setTabCustomTitle).not.toHaveBeenCalled()
 
     createTerminalListenerRef.current({
       requestId: 'req-reveal',

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -578,21 +578,25 @@ export function useIpcEvents(): void {
               // logic; see docs/cmd-j-empty-query-ordering.md.
               store.markWorktreeVisited(worktreeId)
             }
-            const tab = ptyId
-              ? ((store.tabsByWorktree[worktreeId] ?? []).find(
+            const existingTab = ptyId
+              ? (store.tabsByWorktree[worktreeId] ?? []).find(
                   (candidate) =>
                     candidate.ptyId === ptyId ||
                     (store.ptyIdsByTabId[candidate.id] ?? []).includes(ptyId)
-                ) ??
-                store.createTab(worktreeId, undefined, undefined, {
-                  initialPtyId: ptyId,
-                  activate: shouldActivate,
-                  // Why: tabId hint comes from CLI-spawned PTYs whose env
-                  // already has the pane key baked in. Adopting the tab under
-                  // the same id keeps hook-event attribution working.
-                  ...(tabId !== undefined ? { id: tabId } : {})
-                }))
-              : store.createTab(worktreeId)
+                )
+              : undefined
+            const tab =
+              existingTab ??
+              (ptyId
+                ? store.createTab(worktreeId, undefined, undefined, {
+                    initialPtyId: ptyId,
+                    activate: shouldActivate,
+                    // Why: tabId hint comes from CLI-spawned PTYs whose env
+                    // already has the pane key baked in. Adopting the tab under
+                    // the same id keeps hook-event attribution working.
+                    ...(tabId !== undefined ? { id: tabId } : {})
+                  })
+                : store.createTab(worktreeId))
             // Why: when an existing tab already owns this ptyId, we reuse it instead of
             // minting a new one — but the PTY env already carries a paneKey from main.
             // If the existing tab id doesn't match the hint, hook attribution degrades
@@ -607,7 +611,11 @@ export function useIpcEvents(): void {
               store.setActiveTab(tab.id)
               store.revealWorktreeInSidebar(worktreeId)
             }
-            if (title) {
+            // Why: only stamp the runtime-supplied title on freshly created tabs.
+            // Existing tabs may have a user customTitle (set via UI rename) that
+            // the runtime's stored title would otherwise silently overwrite on
+            // every focus.
+            if (title && !existingTab) {
               store.setTabCustomTitle(tab.id, title)
             }
             if (leafId && ptyId) {


### PR DESCRIPTION
Combines the open buf0-bot validated bug-fix PRs after rebasing onto current main, resolving stale conflicts, tightening unsafe patches, and adding missing regression coverage.

Supersedes buf0-bot PRs:
#1698 #1718 #1729 #1756 #1792 #1855 #1889 #1890 #2040 #2041 #2042 #2043 #2044 #2045 #2046 #2047 #2048

Corrections made while combining:
- Tightened Codex legacy auth snapshot handling so malformed wrapped snapshots are not treated as raw legacy auth.
- Made the automations completion in-flight guard clear on failures.
- Fixed SSH watcher pending install dedupe so one pending sender unwatch does not cancel other pending listeners.
- Added regression coverage for the combined/rebased fixes.

Verified locally:
- pnpm exec oxlint
- pnpm run typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/pty.test.ts src/main/codex-usage/store.test.ts src/main/automations/service.test.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/components/activity/ActivityPrototypePage.test.ts src/renderer/src/components/task-page-linear-team-selection.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts
- pnpm test
