### PR TITLE
Surface commit details in history graph

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -112,6 +112,18 @@ function getInitialCombinedDiffSideBySide(diffDefaultView: string | undefined): 
   return combinedDiffSideBySidePreference ?? diffDefaultView === 'side-by-side'
 }
 
+function commitMessageBody(message: string | undefined, subject: string | undefined): string {
+  const normalized = (message ?? '').replace(/\r\n/g, '\n').trim()
+  if (!normalized) {
+    return ''
+  }
+  const [firstLine = '', ...bodyLines] = normalized.split('\n')
+  if (subject && firstLine.trim() === subject.trim()) {
+    return bodyLines.join('\n').trim()
+  }
+  return normalized
+}
+
 export default function CombinedDiffViewer({
   file,
   viewStateKey
@@ -840,39 +852,76 @@ export default function CombinedDiffViewer({
     }
   }, [clearDiffComments, diffCommentCount, file.worktreeId, isClearingNotes])
 
+  const commitBody = commitMessageBody(commitCompare?.message, commitCompare?.subject)
+  const commitHeader =
+    isCommitMode && commitCompare ? (
+      <div className="border-b border-border bg-background px-4 py-3">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            {commitCompare.subject && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className="truncate text-sm font-semibold text-foreground"
+                    title={commitCompare.subject}
+                  >
+                    {commitCompare.subject}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6} className="max-w-96">
+                  {commitCompare.subject}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {commitBody && (
+              <div className="mt-1 max-h-24 overflow-auto whitespace-pre-wrap text-xs leading-5 text-muted-foreground scrollbar-sleek">
+                {commitBody}
+              </div>
+            )}
+          </div>
+          <span className="shrink-0 font-mono text-[11px] leading-5 text-muted-foreground">
+            {commitCompare.compareRef}
+          </span>
+        </div>
+      </div>
+    ) : null
+
   if (sections.length === 0 && (file.skippedConflicts?.length ?? 0) > 0) {
     return (
-      <div className="flex h-full items-center justify-center px-6 text-center">
-        <div className="max-w-md space-y-3">
-          <div className="text-sm font-medium text-foreground">
-            Conflicted files are reviewed separately
-          </div>
-          <div className="text-xs text-muted-foreground">
-            This diff view excludes unresolved conflicts because the normal two-way diff pipeline is
-            not conflict-safe.
-          </div>
-          <div className="text-xs text-muted-foreground">
-            {file.skippedConflicts!.map((entry) => entry.path).join(', ')}
-          </div>
-          <div className="flex justify-center">
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={() =>
-                openConflictReview(
-                  file.worktreeId,
-                  file.filePath,
-                  file.skippedConflicts!.map((entry) => ({
-                    path: entry.path,
-                    conflictKind: entry.conflictKind
-                  })),
-                  'combined-diff-exclusion'
-                )
-              }
-            >
-              Review conflicts
-            </Button>
+      <div className="flex h-full min-h-0 flex-col">
+        {commitHeader}
+        <div className="flex flex-1 items-center justify-center px-6 text-center">
+          <div className="max-w-md space-y-3">
+            <div className="text-sm font-medium text-foreground">
+              Conflicted files are reviewed separately
+            </div>
+            <div className="text-xs text-muted-foreground">
+              This diff view excludes unresolved conflicts because the normal two-way diff pipeline
+              is not conflict-safe.
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {file.skippedConflicts!.map((entry) => entry.path).join(', ')}
+            </div>
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  openConflictReview(
+                    file.worktreeId,
+                    file.filePath,
+                    file.skippedConflicts!.map((entry) => ({
+                      path: entry.path,
+                      conflictKind: entry.conflictKind
+                    })),
+                    'combined-diff-exclusion'
+                  )
+                }
+              >
+                Review conflicts
+              </Button>
+            </div>
           </div>
         </div>
       </div>
@@ -881,8 +930,11 @@ export default function CombinedDiffViewer({
 
   if (sections.length === 0) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        No changes to display
+      <div className="flex h-full min-h-0 flex-col">
+        {commitHeader}
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          No changes to display
+        </div>
       </div>
     )
   }
@@ -1012,6 +1064,7 @@ export default function CombinedDiffViewer({
           </div>
         </div>
 
+        {commitHeader}
         <div ref={scrollContainerRef} className="flex-1 overflow-auto scrollbar-editor">
           {skippedConflictNotice}
           <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>

--- a/src/renderer/src/components/right-sidebar/GitHistoryGraphSvg.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryGraphSvg.tsx
@@ -6,9 +6,10 @@ import {
   type GitHistoryItemViewModel
 } from '../../../../shared/git-history-graph'
 
-const SWIMLANE_HEIGHT = 22
+const SWIMLANE_HEIGHT = 34
 const SWIMLANE_WIDTH = 11
 const SWIMLANE_CURVE_RADIUS = 5
+const SWIMLANE_NODE_Y = SWIMLANE_HEIGHT / 2
 const CIRCLE_RADIUS = 3.5
 const CIRCLE_STROKE_WIDTH = 1.5
 
@@ -66,7 +67,7 @@ export function GitHistoryGraphSvg({
             color={color}
             d={[
               `M ${SWIMLANE_WIDTH * (index + 1)} 0`,
-              `A ${SWIMLANE_WIDTH} ${SWIMLANE_WIDTH} 0 0 1 ${SWIMLANE_WIDTH * index} ${SWIMLANE_WIDTH}`,
+              `A ${SWIMLANE_WIDTH} ${SWIMLANE_WIDTH} 0 0 1 ${SWIMLANE_WIDTH * index} ${SWIMLANE_NODE_Y}`,
               `H ${SWIMLANE_WIDTH * (circleIndex + 1)}`
             ].join(' ')}
           />
@@ -153,7 +154,7 @@ export function GitHistoryGraphSvg({
   }
 
   const cx = SWIMLANE_WIDTH * (circleIndex + 1)
-  const cy = SWIMLANE_WIDTH
+  const cy = SWIMLANE_NODE_Y
   const width = SWIMLANE_WIDTH * (Math.max(inputSwimlanes.length, outputSwimlanes.length, 1) + 1)
   const isBoundaryNode =
     viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { ChevronDown, RefreshCw } from 'lucide-react'
+import { ChevronDown, CircleHelp, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -30,17 +30,26 @@ function GitHistoryRefBadge({
 }: {
   itemRef: NonNullable<GitHistoryResult['currentRef']>
 }): React.JSX.Element {
+  const refLabel = itemRef.category ? `${itemRef.name} (${itemRef.category})` : itemRef.name
+
   return (
-    <span
-      className="max-w-[8rem] truncate rounded-full border px-1.5 py-0.5 text-[10px] leading-none"
-      style={{
-        borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
-        color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
-      }}
-      title={itemRef.name}
-    >
-      {itemRef.name}
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="max-w-[8rem] truncate rounded-full border bg-sidebar px-1.5 py-0.5 text-[10px] leading-none"
+          style={{
+            borderColor: itemRef.color ? graphColor(itemRef.color) : 'var(--border)',
+            color: itemRef.color ? graphColor(itemRef.color) : 'var(--muted-foreground)'
+          }}
+          title={itemRef.name}
+        >
+          {itemRef.name}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+        {refLabel}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -56,16 +65,20 @@ function GitHistoryRow({
   const isBoundaryNode =
     viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
   const canOpenCommit = !isBoundaryNode && Boolean(onOpenCommit)
+  const refs = item.references ?? []
+  const visibleRefs = refs.slice(0, 2)
+  const hiddenRefs = refs.slice(2)
+  const rowTooltip = item.message || item.subject
 
   return (
     <button
       type="button"
       className={cn(
-        'flex h-[22px] w-full min-w-0 items-center gap-1.5 px-3 text-left text-xs leading-none transition-colors disabled:cursor-default disabled:opacity-100',
+        'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-stretch gap-1.5 px-3 py-1 text-left text-xs transition-colors disabled:cursor-default disabled:opacity-100',
         canOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
         isBoundaryNode && 'text-muted-foreground'
       )}
-      title={item.message || item.subject}
+      title={rowTooltip}
       data-testid="git-history-row"
       disabled={!canOpenCommit}
       onClick={() => {
@@ -75,22 +88,52 @@ function GitHistoryRow({
       }}
     >
       <GitHistoryGraphSvg viewModel={viewModel} />
-      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-        <span className="min-w-0 flex-1 truncate text-foreground">{item.subject}</span>
-        {item.references?.map((ref) => (
-          <GitHistoryRefBadge key={ref.id} itemRef={ref} />
-        ))}
-        {item.author && (
-          <span className="max-w-[5.5rem] shrink truncate text-[11px] text-muted-foreground">
-            {item.author}
-          </span>
-        )}
-        {timestamp && (
-          <span className="shrink-0 text-[11px] text-muted-foreground">{timestamp}</span>
+      <div className="flex min-w-0 flex-col justify-center overflow-hidden">
+        <div className="flex min-w-0 items-baseline gap-1.5">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="min-w-0 flex-1 truncate text-foreground" title={rowTooltip}>
+                {item.subject}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+              {rowTooltip}
+            </TooltipContent>
+          </Tooltip>
+          {item.author && (
+            <span className="max-w-[5.5rem] shrink truncate text-[11px] text-muted-foreground">
+              {item.author}
+            </span>
+          )}
+          {timestamp && (
+            <span className="shrink-0 text-[11px] text-muted-foreground">{timestamp}</span>
+          )}
+        </div>
+        {refs.length > 0 && (
+          <div className="mt-0.5 flex h-3.5 min-w-0 items-center gap-1 overflow-hidden">
+            {visibleRefs.map((ref) => (
+              <GitHistoryRefBadge key={ref.id} itemRef={ref} />
+            ))}
+            {hiddenRefs.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="shrink-0 text-[10px] leading-none text-muted-foreground"
+                    title={hiddenRefs.map((ref) => ref.name).join(', ')}
+                  >
+                    +{hiddenRefs.length}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+                  {hiddenRefs.map((ref) => ref.name).join(', ')}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
         )}
       </div>
       {item.displayId && !isBoundaryNode && (
-        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+        <span className="mt-0.5 shrink-0 font-mono text-[10px] leading-none text-muted-foreground">
           {item.displayId}
         </span>
       )}
@@ -151,6 +194,26 @@ export function GitHistoryPanel({
             <span className="text-[11px] font-medium tabular-nums">{count}</span>
             {result?.hasMore && <span className="text-[11px] font-medium">+</span>}
           </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="h-auto w-auto p-0.5 text-muted-foreground hover:text-foreground"
+                aria-label="What are graph refs?"
+                onClick={(event) => {
+                  event.stopPropagation()
+                }}
+              >
+                <CircleHelp className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6} className="max-w-72">
+              Refs are branch or tag names pointing at that exact commit. They only appear where Git
+              has a named ref for the commit.
+            </TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1987,7 +1987,8 @@ function SourceControlInner(): React.JSX.Element {
           worktreePath,
           result.summary,
           result.entries,
-          item.subject
+          item.subject,
+          item.message
         )
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to load commit diff')

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -61,6 +61,7 @@ export type CommitCompareSnapshot = Pick<
 > & {
   compareVersion: string
   subject?: string
+  message?: string
 }
 
 type BranchCompareLike = Pick<
@@ -71,7 +72,10 @@ type BranchCompareLike = Pick<
 type CommitCompareLike = Pick<
   GitCommitCompareSummary,
   'commitOid' | 'parentOid' | 'compareRef' | 'baseRef'
->
+> & {
+  subject?: string
+  message?: string
+}
 
 type CombinedDiffAlternate = {
   source: 'combined-uncommitted' | 'combined-branch'
@@ -342,7 +346,8 @@ export type EditorSlice = {
     worktreePath: string,
     compare: GitCommitCompareSummary,
     entries: GitBranchChangeEntry[],
-    subject?: string
+    subject?: string,
+    message?: string
   ) => void
 
   // Cursor line tracking per file
@@ -1939,8 +1944,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     )
   },
 
-  openCommitAllDiffs: (worktreeId, worktreePath, compare, entries, subject) => {
-    const commitCompare = toCommitCompareSnapshot(compare, subject)
+  openCommitAllDiffs: (worktreeId, worktreePath, compare, entries, subject, message) => {
+    const commitCompare = toCommitCompareSnapshot(compare, subject, message)
     const id = `${worktreeId}::all-diffs::commit::${commitCompare.commitOid}`
     const label = subject
       ? `Commit ${commitCompare.compareRef}: ${subject}`
@@ -2741,7 +2746,8 @@ function toBranchCompareSnapshot(compare: BranchCompareLike): BranchCompareSnaps
 
 function toCommitCompareSnapshot(
   compare: CommitCompareLike,
-  subject?: string
+  subject?: string,
+  message?: string
 ): CommitCompareSnapshot {
   return {
     commitOid: compare.commitOid,
@@ -2751,7 +2757,10 @@ function toCommitCompareSnapshot(
     compareVersion: `${compare.parentOid ?? 'empty-tree'}:${compare.commitOid}`,
     subject:
       subject ??
-      ('subject' in compare && typeof compare.subject === 'string' ? compare.subject : undefined)
+      ('subject' in compare && typeof compare.subject === 'string' ? compare.subject : undefined),
+    message:
+      message ??
+      ('message' in compare && typeof compare.message === 'string' ? compare.message : undefined)
   }
 }
 


### PR DESCRIPTION
## Summary

Shows richer commit context from the Git graph and commit diff flow:
- Adds commit subjects and message bodies to commit diff headers.
- Makes graph rows taller so commit subjects, authors, dates, refs, and hashes have room to scan.
- Collapses extra refs behind a count tooltip and adds a short refs help tooltip.

## Screenshots

Not captured in this run.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

No automated test changes: this is a focused presentation/state plumbing change covered by TypeScript and reviewed against the changed UI data flow.

## AI Review Report

Ran a review agent against `git diff $(git merge-base origin/main HEAD)` for correctness, security, type safety, error handling, performance, dead code, and unused imports. It reported no issues. The review also considered cross-platform compatibility for macOS, Linux, and Windows; this PR does not touch shortcuts, labels, filesystem paths, shell behavior, or Electron platform-specific APIs.

## Security Audit

No new command execution, auth, secrets, dependency, path handling, or IPC surface was introduced. The new rendering path displays commit metadata already returned by the existing Git history/compare flow, and React escapes text content by default.

## Notes

UI-only risk: very long commit messages are constrained with a max-height scroll area in the diff header, and extra refs are hidden behind a tooltip count to avoid row overflow.