### PR TITLE
Fix workspace board portal layering

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx
@@ -49,7 +49,7 @@ export default function WorkspaceStatusAppearancePopover({
         align="end"
         side="left"
         sideOffset={8}
-        className="w-72 p-2"
+        className="z-[80] w-72 p-2"
         data-workspace-status-appearance-popover=""
         onOpenAutoFocus={(event) => event.preventDefault()}
       >

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
@@ -1,11 +1,27 @@
 import { useEffect } from 'react'
 import type React from 'react'
 
-const WORKSPACE_BOARD_KEEP_OPEN_SELECTOR =
-  '[data-workspace-board-trigger], [data-workspace-board-preserve-open]'
+const WORKSPACE_BOARD_KEEP_OPEN_SELECTOR = [
+  '[data-workspace-board-trigger]',
+  '[data-workspace-board-preserve-open]',
+  '[data-workspace-status-appearance-popover]',
+  '[data-radix-popper-content-wrapper]',
+  '[data-slot="dropdown-menu-content"]',
+  '[data-slot="context-menu-content"]',
+  '[data-slot="popover-content"]',
+  '[data-slot="dialog-content"]',
+  '[data-slot="dialog-overlay"]',
+  '[role="dialog"][data-state="open"]',
+  '[role="alertdialog"][data-state="open"]',
+  '[role="menu"][data-state="open"]'
+].join(', ')
 
 export function isWorkspaceBoardKeepOpenTarget(target: EventTarget | null): boolean {
-  return target instanceof Element && Boolean(target.closest(WORKSPACE_BOARD_KEEP_OPEN_SELECTOR))
+  const element =
+    target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+  // Why: board-owned menus and confirmation dialogs portal to document.body,
+  // so DOM containment alone would treat their clicks/focus as board exits.
+  return Boolean(element?.closest(WORKSPACE_BOARD_KEEP_OPEN_SELECTOR))
 }
 
 export function useWorkspaceKanbanOutsideDismiss(params: {


### PR DESCRIPTION
## Summary
- render the status appearance popover above the board settings dropdown
- keep the workspace board open for board-owned portal layers, including worktree delete confirmations

## Verification
- pnpm lint src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
- pnpm run typecheck:web
- git diff --check
- Electron visual verification for status appearance layering and delete confirmation board persistence