### PR TITLE
Run E2E tests on a schedule

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,16 @@ on:
         description: Ref to check out (defaults to the calling workflow's ref)
         required: false
         type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref to check out (defaults to the workflow ref)
+        required: false
+        type: string
+  schedule:
+    # Why: GitHub cron uses UTC; these slots map to 10am and 3pm
+    # America/Phoenix for the default-branch E2E run.
+    - cron: '0 17,22 * * *'
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,12 +88,3 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-  e2e:
-    uses: ./.github/workflows/e2e.yml
-    # Why: check out the PR head directly instead of refs/pull/N/merge.
-    # The merge ref doesn't exist when the PR has conflicts or GitHub
-    # hasn't computed the merge commit yet, causing checkout to fail
-    # for reasons unrelated to the code under test.
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary
- remove the reusable E2E workflow from PR checks
- run the E2E workflow on GitHub cron at 10am and 3pm America/Phoenix
- keep manual and reusable workflow entry points available

## Validation
- ruby YAML parse for changed workflow files
- git diff --check