### PR TITLE
Fix sidebar virtual row stale measurement

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -392,8 +392,42 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const prCacheLen = useAppStore((s) => Object.keys(s.prCache).length)
   const issueCacheLen = useAppStore((s) => Object.keys(s.issueCache).length)
+  const renderRowKeySignature = useMemo(
+    () => renderRows.map(getRenderRowKey).join('\n'),
+    [renderRows]
+  )
+  const renderRowsRef = useRef(renderRows)
+  renderRowsRef.current = renderRows
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()
+
+  const measureMountedRows = useCallback(() => {
+    const currentRows = renderRowsRef.current
+    virtualizer.elementsCache.forEach((element) => {
+      const idx = parseInt(element.getAttribute('data-index') ?? '', 10)
+      const row = Number.isNaN(idx) ? undefined : currentRows[idx]
+      const expectedKey = row ? getRenderRowKey(row) : null
+      if (
+        !element.isConnected ||
+        expectedKey === null ||
+        element.getAttribute('data-worktree-virtual-row-key') !== expectedKey
+      ) {
+        return
+      }
+      virtualizer.measureElement(element)
+    })
+  }, [virtualizer])
+
+  useLayoutEffect(() => {
+    // Why: after delete/collapse, TanStack may briefly retain the removed row's
+    // cached element. Measuring that disconnected node reports 0px and corrupts
+    // the next row's slot, so measure only elements whose DOM key still matches
+    // the row currently rendered at that index.
+    measureMountedRows()
+    const frameId = window.requestAnimationFrame(measureMountedRows)
+    return () => window.cancelAnimationFrame(frameId)
+  }, [prCacheLen, issueCacheLen, measureMountedRows, renderRowKeySignature])
+
   useVirtualizedScrollAnchor({
     anchorRef: scrollAnchorRef,
     getRowKey: getRenderRowKey,
@@ -403,16 +437,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     totalSize,
     virtualizer
   })
-
-  useLayoutEffect(() => {
-    virtualizer.elementsCache.forEach((element) => {
-      const idx = parseInt(element.getAttribute('data-index') ?? '', 10)
-      if (Number.isNaN(idx) || idx >= renderRows.length) {
-        return
-      }
-      virtualizer.measureElement(element)
-    })
-  }, [prCacheLen, issueCacheLen, virtualizer, renderRows.length])
 
   const navigateWorktree = useCallback(
     (direction: 'up' | 'down') => {


### PR DESCRIPTION
## Summary
- Skip stale/disconnected virtual row elements when manually remeasuring sidebar rows.
- Rerun mounted-row measurement on row key changes so delete/collapse/expand does not poison TanStack Virtual's size cache.

## Verification
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx
- pnpm run typecheck:web
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- Electron CDP: temporarily removed bottom renderer row nwparker/next-16 while nwparker/orca-launchctl-env was active; before rows were visible, after deletion maxAfterOverlap=0, minAfterGap=6.229px, scrollDelta=0.
- Electron CDP: toggled bottom noqa repo section collapse/expand; maxCollapsedOverlap=0 and maxExpandedOverlap=0.

No real worktrees were deleted; the delete verification only mutated renderer state and restored it in finally.