### PR TITLE
Add configurable Open In applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ docs/**
 !docs/reference/
 !docs/reference/**
 !docs/STYLEGUIDE.md
+!docs/configurable-open-in-menu.md
 
 # Stably CLI (only docs/ are tracked)
 .stably/*

--- a/docs/configurable-open-in-menu.md
+++ b/docs/configurable-open-in-menu.md
@@ -1,0 +1,126 @@
+# Configurable Open In Menu
+
+## Current behavior (code-checked)
+
+- `WorktreeOpenInMenu` renders exactly two entries: `VS Code` and platform file manager (`Finder`/`File Explorer`/`File Manager`).
+- `openWorktreePath()` blocks local launches for remote/server context via `isLocalPathOpenBlocked(...)` before IPC.
+- Renderer calls `window.api.shell.openInExternalEditor(path)` with one argument only.
+- Preload/API types expose `openInExternalEditor(path: string)` only.
+- Main IPC `shell:openInExternalEditor` always launches hardcoded `code` (via `resolveCliCommand('code')`), validates absolute+exists path, and returns `{ ok: false, reason: 'not-absolute' | 'not-found' | 'launch-failed' }` on failure.
+- Settings persistence currently shallow-merges most fields. Only `notifications` and `telemetry` are deep-merged in main; renderer deep-merges `notifications`, `telemetry`, and `voice` locally.
+- `settings:set` returns the merged settings object, but the renderer currently ignores that return value and applies its own optimistic merge.
+
+## Goal
+
+Add configurable extra editor launchers (Cursor, Zed, custom) to the worktree sidebar `Open in` submenu while preserving:
+
+- VS Code as fixed default entry.
+- existing local-path blocking for remote/SSH/server contexts.
+- existing path validation and failure-to-toast behavior.
+
+## Non-goals
+
+- No remote editor launching.
+- No command existence checks during settings editing.
+- No shell template expansion, env interpolation, per-launcher cwd overrides, or argv parsing.
+- No removal/configuration of the built-in VS Code row.
+
+## Data model
+
+Add to `GlobalSettings`:
+
+- `openInApplications?: OpenInApplication[]`
+- `type OpenInApplication = { id: string; label: string; command: string }`
+
+Default in `getDefaultSettings()`:
+
+- `openInApplications: []`
+
+Why optional in type but present in defaults: keeps backward compatibility with older persisted files while giving runtime code a stable default after merge.
+
+## Normalization contract
+
+Implement one shared normalizer in `src/shared/` and use it in both renderer update path and main persistence update path. It must run in main before persistence.
+
+Rules:
+
+- trim `label`/`command`.
+- drop rows with empty `label` or empty `command`.
+- drop rows with duplicate `id` (keep first).
+- if `id` is missing/blank, generate one (e.g. `crypto.randomUUID()` in renderer before save).
+- cap length (e.g. 8).
+
+Do not dedupe by `command`: users may intentionally keep separate labels for the same command with different wrappers/scripts later.
+
+Main remains source of truth. Renderer normalization is UX only; main normalization must always run.
+
+Also normalize on load (not only on `settings:set`) so externally edited/stale persisted rows are repaired on startup.
+
+## IPC and launch behavior
+
+Change signature across shared preload surface and main handler:
+
+- `openInExternalEditor(path: string, command?: string)`
+
+Main launch behavior:
+
+- if `command` is missing/blank after trim, fall back to `code`.
+- otherwise resolve and launch that command token (same resolution path currently used for `code` via `resolveCliCommand`).
+- keep existing `validateLocalPathTarget(...)` path checks.
+- keep `getSpawnArgsForWindows(command, [path])` path for Windows.
+- keep detached spawn semantics and `launch-failed` mapping.
+
+Constraint to document in UI copy: command is not shell-parsed. `cursor --new-window` is treated as a binary name and will fail. Users must provide an executable command (or wrapper script) only.
+
+Important: this is not “free”. Every call site and type layer (`preload/index.ts`, `preload/api-types.ts`, renderer callers, `shell.test.ts`) must be updated together.
+
+## Menu behavior
+
+`WorktreeOpenInMenu` order:
+
+1. `VS Code` (fixed)
+2. configured `openInApplications`
+3. file manager
+
+Each configured row invokes `openInExternalEditor(worktreePath, app.command)`.
+
+Remote/local guard stays exactly where it is now (`openWorktreePath`) so all rows (including file manager) remain blocked consistently in remote contexts.
+
+## Settings UI
+
+Add General section: `Open In Menu`.
+
+- static note: VS Code is always included.
+- presets: add Cursor (`cursor`) and Zed (`zed`).
+- editable rows for label/command.
+- remove row.
+- add custom row.
+
+Search indexing: add entries in `general-search.ts` so settings search can discover this section.
+
+## Consistency and concurrency
+
+- Multi-window: renderer has a `settings:changed` listener, but main currently emits that event only for View > Appearance toggles. `settings:set` does not broadcast generic updates. So edits to `openInApplications` in one window are not guaranteed to appear live in another until reload/fetch.
+- Renderer optimistic merge is temporary UI state only. Main write result is authoritative and may normalize away invalid rows. Use the `settings:set` return value to rebase local state immediately after each write.
+- Concurrent edits are last-write-wins at the field level (`openInApplications` array replaced wholesale). There is no compare-and-swap/version guard.
+- External file mutation of `orca-data.json` is only observed on app restart; no live file watch exists.
+
+## Edge cases
+
+- Empty/whitespace command or label -> dropped by normalizer.
+- Missing `openInApplications` in persisted settings -> treated as `[]` via defaults merge.
+- Duplicate IDs (including hand-edited config) -> first survives, later rows dropped.
+- Command strings with spaces/flags (e.g. `cursor --foo`) -> fail at spawn unless provided via wrapper executable.
+- Launcher not in PATH or non-executable -> `launch-failed` and existing toast.
+- Path exists but is a file (not directory) still passes current validation and will be passed to launcher/file manager; this is existing behavior.
+- Relative/non-existent worktree path -> existing `not-absolute`/`not-found` error flow.
+- Remote/server worktree -> blocked before IPC regardless of configured launchers.
+
+## Tests required
+
+- `shell.test.ts`: optional command path, blank command fallback to `code`, Windows spawn arg path, failure mapping.
+- `WorktreeOpenInMenu.test.tsx`: configured rows render in order, command forwarded, remote guard still blocks all targets.
+- settings normalization tests (shared normalizer + persistence update path): trim, drop invalid rows, cap, duplicate-id behavior.
+- settings normalization tests: missing/blank id handling and generated-id stability on edit.
+- `settings:set`/renderer integration test: renderer applies authoritative returned settings, not only optimistic local merge.
+- General settings search entries include new section keywords.

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -94,13 +94,13 @@ describe('registerShellHandlers', () => {
     statMock.mockResolvedValue({ isDirectory: () => true })
   })
 
-  function getHandler(channel: string): (event: unknown, args?: unknown) => Promise<unknown> {
+  function getHandler(channel: string): (event: unknown, ...args: unknown[]) => Promise<unknown> {
     registerShellHandlers()
     const call = handleMock.mock.calls.find((c: unknown[]) => c[0] === channel)
     if (!call) {
       throw new Error(`${channel} handler not registered`)
     }
-    return call[1] as (event: unknown, args?: unknown) => Promise<unknown>
+    return call[1] as (event: unknown, ...args: unknown[]) => Promise<unknown>
   }
 
   it('picks audio files with a constrained native dialog filter', async () => {
@@ -238,6 +238,25 @@ describe('registerShellHandlers', () => {
         windowsHide: true
       })
       expect(openPathMock).not.toHaveBeenCalled()
+    })
+
+    it('uses a provided launcher command', async () => {
+      const workspacePath = resolve('workspace')
+      const handler = getHandler('shell:openInExternalEditor')
+
+      await expect(handler({}, workspacePath, 'cursor')).resolves.toEqual({ ok: true })
+      expect(resolveCliCommandMock).toHaveBeenCalledWith('cursor')
+      expect(getSpawnArgsForWindowsMock).toHaveBeenCalledWith('editor-cli', [
+        normalize(workspacePath)
+      ])
+    })
+
+    it('falls back to VS Code when command is blank', async () => {
+      const workspacePath = resolve('workspace')
+      const handler = getHandler('shell:openInExternalEditor')
+
+      await expect(handler({}, workspacePath, '   ')).resolves.toEqual({ ok: true })
+      expect(resolveCliCommandMock).toHaveBeenCalledWith(EXTERNAL_EDITOR_CLI_COMMAND)
     })
 
     it('uses platform-safe launcher command arguments', async () => {

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -46,8 +46,13 @@ async function openInFileManager(pathValue: string): Promise<ShellOpenLocalPathR
   }
 }
 
-async function launchExternalEditor(pathValue: string): Promise<void> {
-  const editorCommand = resolveCliCommand(EXTERNAL_EDITOR_CLI_COMMAND)
+function resolveExternalEditorCommand(command?: string): string {
+  const trimmed = command?.trim()
+  return resolveCliCommand(trimmed || EXTERNAL_EDITOR_CLI_COMMAND)
+}
+
+async function launchExternalEditor(pathValue: string, command?: string): Promise<void> {
+  const editorCommand = resolveExternalEditorCommand(command)
   const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(editorCommand, [pathValue])
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
@@ -75,13 +80,16 @@ async function launchExternalEditor(pathValue: string): Promise<void> {
   })
 }
 
-async function openInExternalEditor(pathValue: string): Promise<ShellOpenLocalPathResult> {
+async function openInExternalEditor(
+  pathValue: string,
+  command?: string
+): Promise<ShellOpenLocalPathResult> {
   const target = await validateLocalPathTarget(pathValue)
   if (!target.ok) {
     return target
   }
   try {
-    await launchExternalEditor(target.path)
+    await launchExternalEditor(target.path, command)
     return { ok: true }
   } catch {
     return { ok: false, reason: 'launch-failed' }
@@ -100,7 +108,8 @@ export function registerShellHandlers(): void {
 
   ipcMain.handle(
     'shell:openInExternalEditor',
-    (_event, path: string): Promise<ShellOpenLocalPathResult> => openInExternalEditor(path)
+    (_event, path: string, command?: string): Promise<ShellOpenLocalPathResult> =>
+      openInExternalEditor(path, command)
   )
 
   ipcMain.handle('shell:openUrl', (_event, rawUrl: string) => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -195,6 +195,7 @@ describe('Store', () => {
     expect(settings.rightSidebarOpenByDefault).toBe(true)
     expect(settings.showTasksButton).toBe(true)
     expect(settings.visibleTaskProviders).toEqual(['github', 'gitlab', 'linear'])
+    expect(settings.openInApplications).toEqual([])
     expect(settings.experimentalActivity).toBe(true)
     expect(settings.floatingTerminalEnabled).toBe(true)
     expect(settings.floatingTerminalDefaultedForAllUsers).toBe(true)
@@ -487,6 +488,31 @@ describe('Store', () => {
     expect(store.getSettings().visibleTaskProviders).toEqual(['gitlab'])
   })
 
+  it('normalizes persisted open-in applications on load', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        openInApplications: [
+          { id: 'cursor', label: ' Cursor ', command: ' cursor ' },
+          { id: 'cursor', label: 'Dup', command: 'dup' },
+          { id: '', label: 'Zed', command: 'zed' },
+          { id: 'bad', label: ' ', command: 'bad' }
+        ]
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().openInApplications).toEqual([
+      { id: 'cursor', label: 'Cursor', command: 'cursor' },
+      { id: 'open-in-3', label: 'Zed', command: 'zed' }
+    ])
+  })
+
   it('migrates the legacy floating terminal disabled default to enabled', async () => {
     writeDataFile({
       schemaVersion: 1,
@@ -768,6 +794,20 @@ describe('Store', () => {
     expect(updated.terminalFontWeight).toBe(600)
     // Other fields preserved
     expect(updated.branchPrefix).toBe('git-username')
+  })
+
+  it('updateSettings normalizes open-in applications', async () => {
+    const store = await createStore()
+    const updated = store.updateSettings({
+      openInApplications: [
+        { id: 'cursor', label: ' Cursor ', command: ' cursor ' },
+        { id: 'cursor', label: 'Dup', command: 'dup' },
+        { id: 'bad', label: '', command: 'bad' }
+      ]
+    })
+    expect(updated.openInApplications).toEqual([
+      { id: 'cursor', label: 'Cursor', command: 'cursor' }
+    ])
   })
 
   it('updateSettings toggles editorAutoSave', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -75,6 +75,7 @@ import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session
 import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
 import { normalizeVisibleTaskProviders } from '../shared/task-providers'
+import { normalizeOpenInApplications } from '../shared/open-in-applications'
 import {
   DEFAULT_WORKSPACE_STATUS_ID,
   clampWorkspaceBoardOpacity,
@@ -1201,6 +1202,7 @@ export class Store {
             visibleTaskProviders: normalizeVisibleTaskProviders(
               parsed.settings?.visibleTaskProviders
             ),
+            openInApplications: normalizeOpenInApplications(parsed.settings?.openInApplications),
             notifications: {
               ...getDefaultNotificationSettings(),
               ...parsed.settings?.notifications
@@ -2012,6 +2014,9 @@ export class Store {
       sanitizedUpdates.visibleTaskProviders = normalizeVisibleTaskProviders(
         updates.visibleTaskProviders
       )
+    }
+    if ('openInApplications' in updates) {
+      sanitizedUpdates.openInApplications = normalizeOpenInApplications(updates.openInApplications)
     }
     // Why: `telemetry` is deep-merged for the same reason `notifications` is —
     // partial updates from the Privacy pane / consent flow (e.g., flipping

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1153,7 +1153,7 @@ export type PreloadApi = {
   shell: {
     openPath: (path: string) => Promise<void>
     openInFileManager: (path: string) => Promise<ShellOpenLocalPathResult>
-    openInExternalEditor: (path: string) => Promise<ShellOpenLocalPathResult>
+    openInExternalEditor: (path: string, command?: string) => Promise<ShellOpenLocalPathResult>
     openUrl: (url: string) => Promise<void>
     openFilePath: (path: string) => Promise<void>
     openFileUri: (uri: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1282,8 +1282,8 @@ const api = {
     openInFileManager: (path: string): Promise<ShellOpenLocalPathResult> =>
       ipcRenderer.invoke('shell:openInFileManager', path),
 
-    openInExternalEditor: (path: string): Promise<ShellOpenLocalPathResult> =>
-      ipcRenderer.invoke('shell:openInExternalEditor', path),
+    openInExternalEditor: (path: string, command?: string): Promise<ShellOpenLocalPathResult> =>
+      ipcRenderer.invoke('shell:openInExternalEditor', path, command),
 
     openUrl: (url: string): Promise<void> => ipcRenderer.invoke('shell:openUrl', url),
 

--- a/src/renderer/src/components/settings/GeneralPane.test.ts
+++ b/src/renderer/src/components/settings/GeneralPane.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { shouldCommitOpenInApplicationsDraft } from './GeneralPane'
+
+describe('GeneralPane open-in application drafts', () => {
+  it('does not commit rows until both label and command are present', () => {
+    expect(
+      shouldCommitOpenInApplicationsDraft([{ id: 'draft', label: 'Cursor', command: '' }])
+    ).toBe(false)
+    expect(
+      shouldCommitOpenInApplicationsDraft([{ id: 'draft', label: '', command: 'cursor' }])
+    ).toBe(false)
+    expect(
+      shouldCommitOpenInApplicationsDraft([{ id: 'draft', label: '   ', command: 'cursor' }])
+    ).toBe(false)
+    expect(
+      shouldCommitOpenInApplicationsDraft([{ id: 'draft', label: 'Cursor', command: '   ' }])
+    ).toBe(false)
+  })
+
+  it('allows commit when every draft row has a label and command', () => {
+    expect(shouldCommitOpenInApplicationsDraft([])).toBe(true)
+    expect(
+      shouldCommitOpenInApplicationsDraft([{ id: 'cursor', label: 'Cursor', command: 'cursor' }])
+    ).toBe(true)
+    expect(
+      shouldCommitOpenInApplicationsDraft([
+        { id: 'cursor', label: 'Cursor', command: 'cursor' },
+        { id: 'zed', label: 'Zed', command: 'zed' }
+      ])
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -49,6 +49,12 @@ function createPresetOpenInApplication(label: string, command: string): OpenInAp
   }
 }
 
+export function shouldCommitOpenInApplicationsDraft(applications: OpenInApplication[]): boolean {
+  return applications.every((application) => {
+    return application.label.trim() !== '' && application.command.trim() !== ''
+  })
+}
+
 export { GENERAL_PANE_SEARCH_ENTRIES }
 
 type GeneralPaneProps = {
@@ -149,7 +155,15 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   }, [settings.openInApplications])
 
   const commitOpenInApplications = (applications: OpenInApplication[]): void => {
+    if (!shouldCommitOpenInApplicationsDraft(applications)) {
+      return
+    }
     updateSettings({ openInApplications: applications })
+  }
+
+  const applyOpenInApplicationsDraft = (applications: OpenInApplication[]): void => {
+    setOpenInApplicationsDraft(applications)
+    commitOpenInApplications(applications)
   }
 
   const handleBrowseWorkspace = async () => {
@@ -353,12 +367,10 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
               variant="outline"
               size="sm"
               onClick={() =>
-                updateSettings({
-                  openInApplications: [
-                    ...openInApplicationsDraft,
-                    createPresetOpenInApplication('Cursor', 'cursor')
-                  ]
-                })
+                applyOpenInApplicationsDraft([
+                  ...openInApplicationsDraft,
+                  createPresetOpenInApplication('Cursor', 'cursor')
+                ])
               }
             >
               Add Cursor
@@ -367,12 +379,10 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
               variant="outline"
               size="sm"
               onClick={() =>
-                updateSettings({
-                  openInApplications: [
-                    ...openInApplicationsDraft,
-                    createPresetOpenInApplication('Zed', 'zed')
-                  ]
-                })
+                applyOpenInApplicationsDraft([
+                  ...openInApplicationsDraft,
+                  createPresetOpenInApplication('Zed', 'zed')
+                ])
               }
             >
               Add Zed
@@ -417,7 +427,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                   onClick={() => {
                     const next = openInApplicationsDraft.filter((entry) => entry.id !== app.id)
                     setOpenInApplicationsDraft(next)
-                    updateSettings({ openInApplications: next })
+                    commitOpenInApplications(next)
                   }}
                 >
                   Remove

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -2,7 +2,7 @@
    splitting individual settings into separate files would scatter related controls without a
    meaningful abstraction boundary. */
 import { useEffect, useRef, useState } from 'react'
-import type { GlobalSettings } from '../../../../shared/types'
+import type { GlobalSettings, OpenInApplication } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -16,6 +16,7 @@ import {
   MAX_EDITOR_AUTO_SAVE_DELAY_MS,
   MIN_EDITOR_AUTO_SAVE_DELAY_MS
 } from '../../../../shared/constants'
+import { OPEN_IN_APPLICATIONS_MAX } from '../../../../shared/open-in-applications'
 import { clampNumber } from '@/lib/terminal-theme'
 import {
   GENERAL_CACHE_TIMER_SEARCH_ENTRIES,
@@ -29,6 +30,24 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
+
+function createOpenInApplication(): OpenInApplication {
+  return {
+    id:
+      globalThis.crypto?.randomUUID?.() ??
+      `open-in-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
+    label: '',
+    command: ''
+  }
+}
+
+function createPresetOpenInApplication(label: string, command: string): OpenInApplication {
+  return {
+    ...createOpenInApplication(),
+    label,
+    command
+  }
+}
 
 export { GENERAL_PANE_SEARCH_ENTRIES }
 
@@ -67,6 +86,9 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   const [appVersion, setAppVersion] = useState<string | null>(null)
   const [autoSaveDelayDraft, setAutoSaveDelayDraft] = useState(
     String(settings.editorAutoSaveDelayMs)
+  )
+  const [openInApplicationsDraft, setOpenInApplicationsDraft] = useState<OpenInApplication[]>(
+    settings.openInApplications ?? []
   )
   // Why: the star state is derived from gh, not from settings, so it does not
   // live in the global settings store. 'hidden' covers the gh-unavailable and
@@ -121,6 +143,14 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   useEffect(() => {
     setAutoSaveDelayDraft(String(settings.editorAutoSaveDelayMs))
   }, [settings.editorAutoSaveDelayMs])
+
+  useEffect(() => {
+    setOpenInApplicationsDraft(settings.openInApplications ?? [])
+  }, [settings.openInApplications])
+
+  const commitOpenInApplications = (applications: OpenInApplication[]): void => {
+    updateSettings({ openInApplications: applications })
+  }
 
   const handleBrowseWorkspace = async () => {
     const path = await window.api.repos.pickFolder()
@@ -300,6 +330,112 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             </button>
           </SearchableSetting>
         </div>
+
+        <SearchableSetting
+          title="Open In Menu"
+          description="Add custom launchers to the worktree Open in menu."
+          keywords={['open in', 'editor', 'launcher', 'cursor', 'zed', 'command', 'vscode']}
+          className="space-y-3"
+        >
+          <div className="space-y-1">
+            <Label>Open In Menu</Label>
+            <p className="text-xs text-muted-foreground">
+              VS Code is always included first. Add executables to show extra entries in each
+              worktree&apos;s Open in menu.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Commands are not shell-parsed. Use only an executable command name. For flags, use a
+              wrapper script.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                updateSettings({
+                  openInApplications: [
+                    ...openInApplicationsDraft,
+                    createPresetOpenInApplication('Cursor', 'cursor')
+                  ]
+                })
+              }
+            >
+              Add Cursor
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                updateSettings({
+                  openInApplications: [
+                    ...openInApplicationsDraft,
+                    createPresetOpenInApplication('Zed', 'zed')
+                  ]
+                })
+              }
+            >
+              Add Zed
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {openInApplicationsDraft.map((app, index) => (
+              <div key={app.id} className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                <Input
+                  value={app.label}
+                  placeholder="Label"
+                  onChange={(event) => {
+                    const next = [...openInApplicationsDraft]
+                    next[index] = { ...app, label: event.target.value }
+                    setOpenInApplicationsDraft(next)
+                  }}
+                  onBlur={() => commitOpenInApplications(openInApplicationsDraft)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      commitOpenInApplications(openInApplicationsDraft)
+                    }
+                  }}
+                />
+                <Input
+                  value={app.command}
+                  placeholder="Executable command"
+                  onChange={(event) => {
+                    const next = [...openInApplicationsDraft]
+                    next[index] = { ...app, command: event.target.value }
+                    setOpenInApplicationsDraft(next)
+                  }}
+                  onBlur={() => commitOpenInApplications(openInApplicationsDraft)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      commitOpenInApplications(openInApplicationsDraft)
+                    }
+                  }}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    const next = openInApplicationsDraft.filter((entry) => entry.id !== app.id)
+                    setOpenInApplicationsDraft(next)
+                    updateSettings({ openInApplications: next })
+                  }}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              setOpenInApplicationsDraft([...openInApplicationsDraft, createOpenInApplication()])
+            }
+            disabled={openInApplicationsDraft.length >= OPEN_IN_APPLICATIONS_MAX}
+          >
+            Add Custom Launcher
+          </Button>
+        </SearchableSetting>
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, GENERAL_EDITOR_SEARCH_ENTRIES) ? (

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -20,6 +20,11 @@ export const GENERAL_WORKSPACE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     title: 'Skip Delete Automation Confirmation',
     description: 'Delete automations without a confirmation dialog.',
     keywords: ['delete', 'automation', 'confirm', 'dialog', 'skip', 'prompt']
+  },
+  {
+    title: 'Open In Menu',
+    description: 'Add custom launchers to the worktree Open in menu.',
+    keywords: ['open in', 'editor', 'launcher', 'cursor', 'zed', 'command', 'vscode']
   }
 ]
 

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DropdownMenuSubContent, DropdownMenuSubTrigger } from '@/components/ui/dropdown-menu'
 import {
+  getWorktreeOpenInEntries,
   getLocalFileManagerLabel,
   openWorktreePath,
   WorktreeOpenInSubMenu
@@ -15,7 +16,10 @@ type ReactElementLike = {
 const { mockState, openInExternalEditorMock, openInFileManagerMock, toastErrorMock } = vi.hoisted(
   () => ({
     mockState: {
-      settings: { activeRuntimeEnvironmentId: null as string | null }
+      settings: {
+        activeRuntimeEnvironmentId: null as string | null,
+        openInApplications: [] as { id: string; label: string; command: string }[]
+      }
     },
     openInExternalEditorMock: vi.fn(),
     openInFileManagerMock: vi.fn(),
@@ -70,7 +74,7 @@ function findByType(node: unknown, type: unknown): ReactElementLike {
 
 describe('WorktreeOpenInMenu', () => {
   beforeEach(() => {
-    mockState.settings = { activeRuntimeEnvironmentId: null }
+    mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [] }
     toastErrorMock.mockReset()
     openInFileManagerMock.mockReset()
     openInExternalEditorMock.mockReset()
@@ -119,7 +123,7 @@ describe('WorktreeOpenInMenu', () => {
   })
 
   it('uses the blocked-path toast without calling main IPC', async () => {
-    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1' }
+    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
 
     await openWorktreePath({
       target: 'file-manager',
@@ -143,9 +147,47 @@ describe('WorktreeOpenInMenu', () => {
       connectionId: null
     })
 
-    expect(openInExternalEditorMock).toHaveBeenCalledWith('/tmp/workspace')
+    expect(openInExternalEditorMock).toHaveBeenCalledWith('/tmp/workspace', undefined)
     expect(toastErrorMock).toHaveBeenCalledWith('Could not open workspace folder.', {
       description: 'Check the editor command or file manager configuration on this machine.'
     })
+  })
+
+  it('builds menu entries with VS Code first and file manager last', () => {
+    expect(
+      getWorktreeOpenInEntries(
+        [
+          { id: 'cursor', label: 'Cursor', command: 'cursor' },
+          { id: 'zed', label: 'Zed', command: 'zed' }
+        ],
+        'File Manager'
+      ).map((entry) => entry.label)
+    ).toEqual(['VS Code', 'Cursor', 'Zed', 'File Manager'])
+  })
+
+  it('forwards the configured command when opening a configured launcher', async () => {
+    await openWorktreePath({
+      target: 'external-editor',
+      worktreePath: '/tmp/workspace',
+      connectionId: null,
+      command: 'cursor'
+    })
+    expect(openInExternalEditorMock).toHaveBeenCalledWith('/tmp/workspace', 'cursor')
+  })
+
+  it('blocks configured launchers in remote context before calling main IPC', async () => {
+    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
+
+    await openWorktreePath({
+      target: 'external-editor',
+      worktreePath: '/tmp/workspace',
+      connectionId: null,
+      command: 'cursor'
+    })
+
+    expect(openInExternalEditorMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Opening remote paths in the local OS is not available.'
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
@@ -10,11 +10,19 @@ import {
 import { useAppStore } from '@/store'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import type { ShellOpenLocalPathFailureReason } from '../../../../shared/shell-open-types'
+import type { OpenInApplication } from '../../../../shared/types'
 
 type WorktreeOpenInMenuItemsProps = {
   worktreePath: string
   connectionId?: string | null
   disabled?: boolean
+}
+
+type OpenInMenuEntry = {
+  id: string
+  label: string
+  target: 'external-editor' | 'file-manager'
+  command?: string
 }
 
 export function getLocalFileManagerLabel(userAgent?: string): string {
@@ -27,6 +35,22 @@ export function getLocalFileManagerLabel(userAgent?: string): string {
     return 'File Explorer'
   }
   return 'File Manager'
+}
+
+export function getWorktreeOpenInEntries(
+  openInApplications: OpenInApplication[],
+  fileManagerLabel: string
+): OpenInMenuEntry[] {
+  return [
+    { id: 'vscode', label: 'VS Code', target: 'external-editor' },
+    ...openInApplications.map((application) => ({
+      id: application.id,
+      label: application.label,
+      target: 'external-editor' as const,
+      command: application.command
+    })),
+    { id: 'file-manager', label: fileManagerLabel, target: 'file-manager' }
+  ]
 }
 
 function showOpenFailureToast(reason: ShellOpenLocalPathFailureReason): void {
@@ -53,6 +77,7 @@ export async function openWorktreePath(args: {
   target: 'file-manager' | 'external-editor'
   worktreePath: string
   connectionId?: string | null
+  command?: string
 }): Promise<void> {
   if (
     isLocalPathOpenBlocked(useAppStore.getState().settings, {
@@ -66,7 +91,7 @@ export async function openWorktreePath(args: {
   const result =
     args.target === 'file-manager'
       ? await window.api.shell.openInFileManager(args.worktreePath)
-      : await window.api.shell.openInExternalEditor(args.worktreePath)
+      : await window.api.shell.openInExternalEditor(args.worktreePath, args.command)
   if (!result.ok) {
     showOpenFailureToast(result.reason)
   }
@@ -75,10 +100,13 @@ export async function openWorktreePath(args: {
 function useOpenInWorktreePath({
   worktreePath,
   connectionId
-}: WorktreeOpenInMenuItemsProps): (target: 'file-manager' | 'external-editor') => Promise<void> {
+}: WorktreeOpenInMenuItemsProps): (
+  target: 'file-manager' | 'external-editor',
+  command?: string
+) => Promise<void> {
   return useCallback(
-    async (target) => {
-      await openWorktreePath({ target, worktreePath, connectionId })
+    async (target, command) => {
+      await openWorktreePath({ target, worktreePath, connectionId, command })
     },
     [connectionId, worktreePath]
   )
@@ -90,30 +118,29 @@ export function WorktreeOpenInMenuItems({
   disabled
 }: WorktreeOpenInMenuItemsProps): React.JSX.Element {
   const openInWorktreePath = useOpenInWorktreePath({ worktreePath, connectionId })
+  const openInApplications = useAppStore((s) => s.settings?.openInApplications ?? [])
   const fileManagerLabel = getLocalFileManagerLabel()
+  const entries = getWorktreeOpenInEntries(openInApplications, fileManagerLabel)
 
   return (
     <>
-      <DropdownMenuItem
-        onClick={stopMenuPropagation}
-        onSelect={() => {
-          void openInWorktreePath('external-editor')
-        }}
-        disabled={disabled}
-      >
-        <ExternalLink className="size-3.5" />
-        VS Code
-      </DropdownMenuItem>
-      <DropdownMenuItem
-        onClick={stopMenuPropagation}
-        onSelect={() => {
-          void openInWorktreePath('file-manager')
-        }}
-        disabled={disabled}
-      >
-        <FolderOpen className="size-3.5" />
-        {fileManagerLabel}
-      </DropdownMenuItem>
+      {entries.map((entry) => (
+        <DropdownMenuItem
+          key={entry.id}
+          onClick={stopMenuPropagation}
+          onSelect={() => {
+            void openInWorktreePath(entry.target, entry.command)
+          }}
+          disabled={disabled}
+        >
+          {entry.target === 'file-manager' ? (
+            <FolderOpen className="size-3.5" />
+          ) : (
+            <ExternalLink className="size-3.5" />
+          )}
+          {entry.label}
+        </DropdownMenuItem>
+      ))}
     </>
   )
 }

--- a/src/renderer/src/store/slices/settings.test.ts
+++ b/src/renderer/src/store/slices/settings.test.ts
@@ -83,6 +83,28 @@ beforeEach(() => {
 })
 
 describe('createSettingsSlice runtime switching', () => {
+  it('rebases local state to the authoritative settings:set response', async () => {
+    settingsSet.mockResolvedValueOnce({
+      openInApplications: [{ id: 'cursor', label: 'Cursor', command: 'cursor' }],
+      notifications: {}
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: {
+        openInApplications: [],
+        notifications: {}
+      } as unknown as AppState['settings']
+    })
+
+    await store.getState().updateSettings({
+      openInApplications: [{ id: '  ', label: ' Cursor ', command: ' cursor ' }] as never
+    })
+
+    expect(store.getState().settings?.openInApplications).toEqual([
+      { id: 'cursor', label: 'Cursor', command: 'cursor' }
+    ])
+  })
+
   it('clears stale runtime-owned state before loading the selected environment', async () => {
     const store = createTestStore()
     store.setState({

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -9,6 +9,7 @@ import {
 } from '@/runtime/runtime-terminal-stream'
 import { normalizeTerminalQuickCommands } from '../../../../shared/terminal-quick-commands'
 import { normalizeVisibleTaskProviders } from '../../../../shared/task-providers'
+import { normalizeOpenInApplications } from '../../../../shared/open-in-applications'
 
 export type SettingsSlice = {
   settings: GlobalSettings | null
@@ -22,6 +23,13 @@ export type SettingsSlice = {
 function normalizeRuntimeEnvironmentId(value: string | null | undefined): string | null {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
+}
+
+function createOpenInApplicationId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `open-in-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  )
 }
 
 function runtimeScopedStateReset(): Partial<AppState> {
@@ -238,42 +246,16 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
           updates.visibleTaskProviders
         )
       }
-      await window.api.settings.set(sanitizedUpdates)
-      set((s) => {
-        if (!s.settings) {
-          return { settings: null }
-        }
-        // Deep-merge telemetry so partial writes do not clobber sibling
-        // fields like `installId`, `existedBeforeTelemetryRelease`, or
-        // `optedIn` in local renderer state until the next fetchSettings.
-        // Mirrors the main-side merge in src/main/persistence.ts:551-573.
-        // `telemetry` is optional on GlobalSettings, so guard against the case
-        // where both current and incoming telemetry are undefined — otherwise
-        // the spread would produce an empty object and we'd materialize a
-        // telemetry key that shouldn't exist.
-        const mergedTelemetry =
-          sanitizedUpdates.telemetry !== undefined
-            ? { ...s.settings.telemetry, ...sanitizedUpdates.telemetry }
-            : s.settings.telemetry
-        // Why: voice is optional and partially writable (e.g. only `selectedModelId`
-        // changes), so deep-merge sibling fields like `mode` and `holdShortcut`
-        // and avoid materializing a `voice` key when neither current nor incoming
-        // settings define one.
-        const mergedVoice =
-          updates.voice !== undefined ? { ...s.settings.voice, ...updates.voice } : s.settings.voice
-        return {
-          settings: {
-            ...s.settings,
-            ...sanitizedUpdates,
-            notifications: {
-              ...s.settings.notifications,
-              ...sanitizedUpdates.notifications
-            },
-            ...(mergedTelemetry !== undefined ? { telemetry: mergedTelemetry } : {}),
-            ...(mergedVoice !== undefined ? { voice: mergedVoice } : {})
+      if ('openInApplications' in updates) {
+        sanitizedUpdates.openInApplications = normalizeOpenInApplications(
+          updates.openInApplications,
+          {
+            createId: createOpenInApplicationId
           }
-        }
-      })
+        )
+      }
+      const nextSettings = await window.api.settings.set(sanitizedUpdates)
+      set((s) => ({ settings: (nextSettings as GlobalSettings | undefined) ?? s.settings }))
     } catch (err) {
       console.error('Failed to update settings:', err)
     }
@@ -296,10 +278,14 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
       // clearing browser maps so the old server does not retain orphan pages.
       await closeRemoteTerminalsBeforeRuntimeSwitch(get(), previousId)
       await closeRemoteBrowserPagesBeforeRuntimeSwitch(get())
-      await window.api.settings.set({ activeRuntimeEnvironmentId: nextId })
+      const nextSettings = await window.api.settings.set({
+        activeRuntimeEnvironmentId: nextId
+      })
       set((s) => ({
         ...runtimeScopedStateReset(),
-        settings: s.settings ? { ...s.settings, activeRuntimeEnvironmentId: nextId } : null
+        settings:
+          (nextSettings as GlobalSettings | undefined) ??
+          (s.settings ? { ...s.settings, activeRuntimeEnvironmentId: nextId } : null)
       }))
       // Why: server-owned state is cleared before refetch so old worktree,
       // terminal, browser, and issue IDs cannot be used against the new server

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -217,6 +217,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackBytes: 10_000_000,
     openLinksInApp: true,
+    openInApplications: [],
     rightSidebarOpenByDefault: true,
     showGitIgnoredFiles: true,
     showTitlebarAppName: true,

--- a/src/shared/open-in-applications.test.ts
+++ b/src/shared/open-in-applications.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeOpenInApplications } from './open-in-applications'
+
+describe('normalizeOpenInApplications', () => {
+  it('trims fields, drops invalid rows, keeps first duplicate id, and caps list', () => {
+    const rows = normalizeOpenInApplications([
+      { id: 'a', label: ' Cursor ', command: ' cursor ' },
+      { id: 'a', label: 'Dup', command: 'dup' },
+      { id: 'b', label: '   ', command: 'zed' },
+      { id: 'c', label: 'Zed', command: '   ' },
+      { id: 'd', label: 'D', command: 'd' },
+      { id: 'e', label: 'E', command: 'e' },
+      { id: 'f', label: 'F', command: 'f' },
+      { id: 'g', label: 'G', command: 'g' },
+      { id: 'h', label: 'H', command: 'h' },
+      { id: 'i', label: 'I', command: 'i' },
+      { id: 'j', label: 'J', command: 'j' }
+    ])
+
+    expect(rows).toEqual([
+      { id: 'a', label: 'Cursor', command: 'cursor' },
+      { id: 'd', label: 'D', command: 'd' },
+      { id: 'e', label: 'E', command: 'e' },
+      { id: 'f', label: 'F', command: 'f' },
+      { id: 'g', label: 'G', command: 'g' },
+      { id: 'h', label: 'H', command: 'h' },
+      { id: 'i', label: 'I', command: 'i' },
+      { id: 'j', label: 'J', command: 'j' }
+    ])
+  })
+
+  it('generates ids for missing or blank ids', () => {
+    let counter = 0
+    const rows = normalizeOpenInApplications(
+      [
+        { label: 'Cursor', command: 'cursor' },
+        { id: '   ', label: 'Zed', command: 'zed' }
+      ],
+      { createId: () => `gen-${++counter}` }
+    )
+
+    expect(rows).toEqual([
+      { id: 'gen-1', label: 'Cursor', command: 'cursor' },
+      { id: 'gen-2', label: 'Zed', command: 'zed' }
+    ])
+  })
+})

--- a/src/shared/open-in-applications.ts
+++ b/src/shared/open-in-applications.ts
@@ -1,0 +1,58 @@
+import type { OpenInApplication } from './types'
+
+export const OPEN_IN_APPLICATIONS_MAX = 8
+
+type NormalizeOpenInApplicationsOptions = {
+  createId?: () => string
+}
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function makeFallbackId(index: number): string {
+  return `open-in-${index + 1}`
+}
+
+export function normalizeOpenInApplications(
+  value: unknown,
+  options: NormalizeOpenInApplicationsOptions = {}
+): OpenInApplication[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const normalized: OpenInApplication[] = []
+  const seenIds = new Set<string>()
+
+  for (const [index, row] of value.entries()) {
+    if (normalized.length >= OPEN_IN_APPLICATIONS_MAX) {
+      break
+    }
+    if (!row || typeof row !== 'object') {
+      continue
+    }
+
+    const label = normalizeToken((row as { label?: unknown }).label)
+    const command = normalizeToken((row as { command?: unknown }).command)
+    if (!label || !command) {
+      continue
+    }
+
+    let id = normalizeToken((row as { id?: unknown }).id)
+    if (!id) {
+      id = normalizeToken(options.createId?.())
+      if (!id) {
+        id = makeFallbackId(index)
+      }
+    }
+
+    if (seenIds.has(id)) {
+      continue
+    }
+    seenIds.add(id)
+    normalized.push({ id, label, command })
+  }
+
+  return normalized
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1253,6 +1253,12 @@ export type TerminalQuickCommand = {
   appendEnter: boolean
 }
 
+export type OpenInApplication = {
+  id: string
+  label: string
+  command: string
+}
+
 export type FloatingTerminalCwdRequest = {
   path?: string
 }
@@ -1348,6 +1354,8 @@ export type GlobalSettings = {
    *  The setting stays opt-in so existing workflows continue to use the system browser
    *  until the user explicitly wants worktree-scoped in-app browsing. */
   openLinksInApp: boolean
+  /** Extra launcher rows for the worktree "Open in" submenu. VS Code is always shown first. */
+  openInApplications?: OpenInApplication[]
   rightSidebarOpenByDefault: boolean
   showGitIgnoredFiles?: boolean
   /** Whether to show the Orca app name in the titlebar. */


### PR DESCRIPTION
## Summary
- add configurable **Open In** applications for worktree context menus, including shared application presets and command templates
- persist Open In configuration in main-process settings and wire it through preload/renderer APIs
- add Settings > General controls to manage enabled applications and order, then reflect configuration in the sidebar Open In submenu
- keep remote safety behavior: configured launchers are blocked in unsupported remote environments

## Design Doc
- `docs/configurable-open-in-menu.md`

## Validation (Electron)
Validation passed in the running Electron build:
- default menu shows VS Code + file manager only
- Settings > General can enable Cursor/Zed presets and rows display commands
- configured submenu order shows VS Code, Cursor, Zed, file manager
- Cursor launcher shim invoked with selected worktree path
- Zed launcher shim invoked with selected worktree path
- remote guard blocks configured launcher and writes no marker
- Copy Path still writes the selected worktree path to clipboard

Notes:
- local validation screenshots are available in `validation-screenshots/` and intentionally uncommitted for reviewer reference
- scenario-6 produced expected `Unknown environment env-e2e`; separate `temp-repo` no-remotes warning is unrelated
