### PR TITLE
Simplify dev Dock instance naming

### DIFF
--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -59,28 +59,8 @@ function formatDevInstanceLabel(branch, worktreeName) {
   return branch || worktreeName || null
 }
 
-function createBadgeSuffix(seed) {
-  const n = parseInt(createHash('sha1').update(seed).digest('hex').slice(0, 8), 16)
-  return (n % 1296).toString(36).toUpperCase().padStart(2, '0')
-}
-
-function createDockBadgeLabel(displayValue, identitySeed) {
-  const source = lastBranchSegment(displayValue || identitySeed || '')
-  const words = source.split(/[^a-zA-Z0-9]+/).filter(Boolean)
-  const prefix =
-    words.length > 1
-      ? words
-          .slice(0, 2)
-          .map((word) => word[0])
-          .join('')
-      : (words[0] ?? 'D').slice(0, 2)
-  const normalizedPrefix = (prefix.replace(/[^a-zA-Z0-9]/g, '').toUpperCase() || 'D').slice(0, 2)
-  return `${normalizedPrefix}${createBadgeSuffix(identitySeed || displayValue || source)}`
-}
-
-function createDockTitle(branch, label, badgeLabel) {
-  const title = `Orca Dev${badgeLabel ? ` [${badgeLabel}]` : ''}`
-  return `${title}: ${branch || label || 'dev'}`
+function createDockTitle(branch, label) {
+  return `Orca: ${branch || label || 'dev'}`
 }
 
 function seedDevInstanceIdentityEnv() {
@@ -91,10 +71,7 @@ function seedDevInstanceIdentityEnv() {
   const worktreeName = process.env.ORCA_DEV_WORKTREE_NAME || path.basename(repoRoot)
   const label = process.env.ORCA_DEV_INSTANCE_LABEL || formatDevInstanceLabel(branch, worktreeName)
   const identitySeed = process.env.ORCA_DEV_INSTANCE_KEY || repoRoot
-  const badgeLabel =
-    process.env.ORCA_DEV_DOCK_BADGE_LABEL ||
-    createDockBadgeLabel(worktreeName || branch || label, identitySeed)
-  const dockTitle = process.env.ORCA_DEV_DOCK_TITLE || createDockTitle(branch, label, badgeLabel)
+  const dockTitle = process.env.ORCA_DEV_DOCK_TITLE || createDockTitle(branch, label)
 
   process.env.ORCA_DEV_REPO_ROOT ||= repoRoot
   process.env.ORCA_DEV_INSTANCE_KEY ||= identitySeed
@@ -106,11 +83,8 @@ function seedDevInstanceIdentityEnv() {
   }
   if (label) {
     // Why: parallel `pn dev` runs need a stable origin label for window titles,
-    // Dock badges, and automation sessions without re-running git in Electron.
+    // Dock names, and automation sessions without re-running git in Electron.
     process.env.ORCA_DEV_INSTANCE_LABEL ||= label
-  }
-  if (badgeLabel) {
-    process.env.ORCA_DEV_DOCK_BADGE_LABEL ||= badgeLabel
   }
   process.env.ORCA_DEV_DOCK_TITLE ||= dockTitle
 }
@@ -133,12 +107,12 @@ function sanitizeMacAppBundleName(value) {
   return (
     Array.from(value, (char) => {
       const code = char.charCodeAt(0)
-      return code < 32 || code === 127 || char === ':' || char === '/' || char === '\\' ? '-' : char
+      return code < 32 || code === 127 || char === '/' || char === '\\' ? '-' : char
     })
       .join('')
       .replace(/\s+/g, ' ')
       .trim()
-      .slice(0, 120) || 'Orca Dev'
+      .slice(0, 120) || 'Orca'
   )
 }
 
@@ -158,9 +132,9 @@ function prepareMacDevElectronApp() {
     electronVersion = JSON.parse(readFileSync(electronPackagePath, 'utf8')).version ?? null
   } catch {}
 
-  const title = process.env.ORCA_DEV_DOCK_TITLE || 'Orca Dev'
+  const title = process.env.ORCA_DEV_DOCK_TITLE || 'Orca: dev'
   const identityKey = process.env.ORCA_DEV_INSTANCE_KEY || repoRoot
-  const bundleLayoutVersion = 'dock-title-app-filename-v1'
+  const bundleLayoutVersion = 'dock-title-app-filename-v2'
   const hash = createHash('sha1')
     .update(
       `${sourceAppPath}\0${electronVersion ?? ''}\0${title}\0${identityKey}\0${bundleLayoutVersion}`
@@ -326,10 +300,7 @@ const userPassedPort = forwardedRaw.some(
 // a debug-port line would be noise.
 const isHelpOrVersion = forwardedRaw.some((a) => a === '--help' || a === '-h' || a === '--version')
 if (!isHelpOrVersion && process.env.ORCA_DEV_INSTANCE_LABEL) {
-  const badge = process.env.ORCA_DEV_DOCK_BADGE_LABEL
-    ? ` [${process.env.ORCA_DEV_DOCK_BADGE_LABEL}]`
-    : ''
-  console.error(`[orca-dev] Instance: ${process.env.ORCA_DEV_INSTANCE_LABEL}${badge}`)
+  console.error(`[orca-dev] Instance: ${process.env.ORCA_DEV_INSTANCE_LABEL}`)
 }
 let forwardedExtras = []
 if (!userPassedPort && !isHelpOrVersion) {

--- a/src/main/dock/unread-badge.test.ts
+++ b/src/main/dock/unread-badge.test.ts
@@ -23,25 +23,21 @@ describe('unread Dock badge', () => {
     vi.resetModules()
   })
 
-  it('shows the dev identity badge when unread count is zero', async () => {
+  it('clears the native badge when unread count is zero', async () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
-    const { setIdleDockBadgeLabel, setUnreadDockBadgeCount } = await import('./unread-badge')
-
-    setIdleDockBadgeLabel('DI')
-    expect(setBadgeMock).toHaveBeenLastCalledWith('DI')
+    const { setUnreadDockBadgeCount } = await import('./unread-badge')
 
     setUnreadDockBadgeCount(5)
     expect(setBadgeMock).toHaveBeenLastCalledWith('5')
 
     setUnreadDockBadgeCount(0)
-    expect(setBadgeMock).toHaveBeenLastCalledWith('DI')
+    expect(setBadgeMock).toHaveBeenLastCalledWith('')
   })
 
-  it('caps unread counts while preserving the idle badge', async () => {
+  it('caps unread counts', async () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
-    const { setIdleDockBadgeLabel, setUnreadDockBadgeCount } = await import('./unread-badge')
+    const { setUnreadDockBadgeCount } = await import('./unread-badge')
 
-    setIdleDockBadgeLabel('DI')
     setUnreadDockBadgeCount(104)
     expect(setBadgeMock).toHaveBeenLastCalledWith('99+')
   })

--- a/src/main/dock/unread-badge.ts
+++ b/src/main/dock/unread-badge.ts
@@ -1,6 +1,5 @@
 import { app } from 'electron'
 
-let idleDockBadgeLabel = ''
 let unreadCount = 0
 
 function applyDockBadge(): void {
@@ -8,15 +7,8 @@ function applyDockBadge(): void {
     return
   }
 
-  const label =
-    unreadCount === 0 ? idleDockBadgeLabel : unreadCount > 99 ? '99+' : String(unreadCount)
-
+  const label = unreadCount === 0 ? '' : unreadCount > 99 ? '99+' : String(unreadCount)
   app.dock?.setBadge(label)
-}
-
-export function setIdleDockBadgeLabel(label: string | null | undefined): void {
-  idleDockBadgeLabel = label ?? ''
-  applyDockBadge()
 }
 
 export function setUnreadDockBadgeCount(count: number): void {
@@ -26,7 +18,5 @@ export function setUnreadDockBadgeCount(count: number): void {
 
   unreadCount = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0
 
-  // Why: unread counts own the native badge while active; otherwise dev builds
-  // keep their worktree badge visible so parallel `pn dev` windows stay distinct.
   applyDockBadge()
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -68,7 +68,7 @@ import {
 } from './ipc/pty'
 import { AgentBrowserBridge } from './browser/agent-browser-bridge'
 import { browserManager } from './browser/browser-manager'
-import { setIdleDockBadgeLabel, setUnreadDockBadgeCount } from './dock/unread-badge'
+import { setUnreadDockBadgeCount } from './dock/unread-badge'
 import { registerFeatureWallFirstAgentTour } from './feature-wall/first-agent-tour'
 import { AutomationService } from './automations/service'
 import { AgentAwakeService } from './agent-awake-service'
@@ -723,7 +723,6 @@ app.whenReady().then(async () => {
   if (process.platform === 'darwin' && is.dev) {
     const dockIcon = nativeImage.createFromPath(devIcon)
     app.dock?.setIcon(dockIcon)
-    setIdleDockBadgeLabel(devInstanceIdentity.dockBadgeLabel)
   }
 
   store = new Store()

--- a/src/main/startup/dev-instance-identity.test.ts
+++ b/src/main/startup/dev-instance-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createDevDockBadgeLabel, getDevInstanceIdentity } from './dev-instance-identity'
+import { getDevInstanceIdentity } from './dev-instance-identity'
 
 describe('dev-instance-identity', () => {
   it('keeps packaged identity stable', () => {
@@ -26,8 +26,8 @@ describe('dev-instance-identity', () => {
       devWorktreeName: 'dev-indicator',
       devRepoRoot: '/repo/worktrees/dev-indicator'
     })
-    expect(identity.name).toMatch(/^Orca Dev \[DI[A-Z0-9]{2}\]: nwparker\/dev-indicator$/)
-    expect(identity.dockBadgeLabel).toMatch(/^DI[A-Z0-9]{2}$/)
+    expect(identity.name).toBe('Orca: nwparker/dev-indicator')
+    expect(identity.dockBadgeLabel).toBeNull()
     expect(identity.appUserModelId).toMatch(/^com\.stablyai\.orca\.dev\.[a-f0-9]{10}$/)
   })
 
@@ -39,8 +39,8 @@ describe('dev-instance-identity', () => {
     })
 
     expect(identity.devLabel).toBe('payment-ui @ feature/billing-shell')
-    expect(identity.name).toMatch(/^Orca Dev \[PU[A-Z0-9]{2}\]: feature\/billing-shell$/)
-    expect(identity.dockBadgeLabel).toMatch(/^PU[A-Z0-9]{2}$/)
+    expect(identity.name).toBe('Orca: feature/billing-shell')
+    expect(identity.dockBadgeLabel).toBeNull()
   })
 
   it('allows an explicit label override', () => {
@@ -51,16 +51,7 @@ describe('dev-instance-identity', () => {
     })
 
     expect(identity.devLabel).toBe('manual label')
-    expect(identity.name).toMatch(/^Orca Dev \[DI[A-Z0-9]{2}\]: feature\/other$/)
-    expect(identity.dockBadgeLabel).toMatch(/^DI[A-Z0-9]{2}$/)
-  })
-
-  it('creates compact alphanumeric Dock labels with stable collision suffixes', () => {
-    expect(createDevDockBadgeLabel('dev-indicator', '/repo/a')).toMatch(/^DI[A-Z0-9]{2}$/)
-    expect(createDevDockBadgeLabel('feature/singleword', '/repo/a')).toMatch(/^SI[A-Z0-9]{2}$/)
-    expect(createDevDockBadgeLabel('pr-123', '/repo/a')).toMatch(/^P1[A-Z0-9]{2}$/)
-    expect(createDevDockBadgeLabel('dev-indicator', '/repo/a')).not.toBe(
-      createDevDockBadgeLabel('dev-indicator', '/repo/b')
-    )
+    expect(identity.name).toBe('Orca: feature/other')
+    expect(identity.dockBadgeLabel).toBeNull()
   })
 })

--- a/src/main/startup/dev-instance-identity.ts
+++ b/src/main/startup/dev-instance-identity.ts
@@ -35,32 +35,6 @@ function formatLabel(branch: string | null, worktreeName: string | null): string
   return branch ?? worktreeName
 }
 
-function createBadgeSuffix(seed: string): string {
-  const n = parseInt(createHash('sha1').update(seed).digest('hex').slice(0, 8), 16)
-  return (n % 1296).toString(36).toUpperCase().padStart(2, '0')
-}
-
-export function createDevDockBadgeLabel(
-  value: string | null,
-  identitySeed?: string | null
-): string | null {
-  if (!value) {
-    return null
-  }
-
-  const source = lastPathSegment(value)
-  const words = source.split(/[^a-zA-Z0-9]+/).filter(Boolean)
-  const label =
-    words.length > 1
-      ? words
-          .slice(0, 2)
-          .map((word) => word[0])
-          .join('')
-      : (words[0] ?? source).slice(0, 2)
-  const prefix = (label.replace(/[^a-zA-Z0-9]/g, '').toUpperCase() || 'D').slice(0, 2)
-  return `${prefix}${createBadgeSuffix(identitySeed ?? value)}`
-}
-
 function createDevAppUserModelId(identityKey: string | null): string {
   if (!identityKey) {
     return BASE_APP_USER_MODEL_ID
@@ -92,13 +66,8 @@ export function getDevInstanceIdentity(
     cleanEnvValue(env.ORCA_DEV_WORKTREE_NAME) ??
     cleanEnvValue(path.basename(repoRoot ?? process.cwd()))
   const devLabel = cleanEnvValue(env.ORCA_DEV_INSTANCE_LABEL) ?? formatLabel(branch, worktreeName)
-  const identitySeed = cleanEnvValue(env.ORCA_DEV_INSTANCE_KEY) ?? repoRoot ?? devLabel
-  const dockBadgeLabel =
-    cleanEnvValue(env.ORCA_DEV_DOCK_BADGE_LABEL) ??
-    createDevDockBadgeLabel(worktreeName ?? branch ?? devLabel, identitySeed)
   const dockTitle =
-    cleanEnvValue(env.ORCA_DEV_DOCK_TITLE) ??
-    `${BASE_APP_NAME} Dev${dockBadgeLabel ? ` [${dockBadgeLabel}]` : ''}: ${branch ?? devLabel ?? 'dev'}`
+    cleanEnvValue(env.ORCA_DEV_DOCK_TITLE) ?? `${BASE_APP_NAME}: ${branch ?? devLabel ?? 'dev'}`
 
   return {
     name: dockTitle,
@@ -107,7 +76,7 @@ export function getDevInstanceIdentity(
     devBranch: branch,
     devWorktreeName: worktreeName,
     devRepoRoot: repoRoot,
-    dockBadgeLabel,
+    dockBadgeLabel: null,
     appUserModelId: createDevAppUserModelId(repoRoot ?? devLabel)
   }
 }

--- a/src/main/startup/run-electron-vite-dev.test.ts
+++ b/src/main/startup/run-electron-vite-dev.test.ts
@@ -119,7 +119,9 @@ describe('run-electron-vite-dev', () => {
         ORCA_DEV_WRAPPER_TEST_PID_FILE: pidFile,
         ORCA_DEV_WRAPPER_TEST_ENV_FILE: envFile,
         ORCA_DEV_BRANCH: 'feature/billing-shell',
-        ORCA_DEV_WORKTREE_NAME: 'payment-ui'
+        ORCA_DEV_WORKTREE_NAME: 'payment-ui',
+        ORCA_DEV_DOCK_BADGE_LABEL: undefined,
+        ORCA_DEV_DOCK_TITLE: undefined
       },
       stdio: 'ignore'
     })
@@ -146,7 +148,7 @@ describe('run-electron-vite-dev', () => {
       branch: string
       worktreeName: string
       repoRoot: string
-      badgeLabel: string
+      badgeLabel: string | null
       dockTitle: string
       stableName: string | null
       electronExecPath: string | null
@@ -156,8 +158,8 @@ describe('run-electron-vite-dev', () => {
     expect(envSnapshot.branch).toBe('feature/billing-shell')
     expect(envSnapshot.worktreeName).toBe('payment-ui')
     expect(envSnapshot.repoRoot).toBe(resolve('.'))
-    expect(envSnapshot.badgeLabel).toMatch(/^PU[A-Z0-9]{2}$/)
-    expect(envSnapshot.dockTitle).toMatch(/^Orca Dev \[PU[A-Z0-9]{2}\]: feature\/billing-shell$/)
+    expect(envSnapshot.badgeLabel).toBeNull()
+    expect(envSnapshot.dockTitle).toBe('Orca: feature/billing-shell')
     expect(envSnapshot.stableName).toBeNull()
     expect(envSnapshot.electronExecPath).toBeNull()
 


### PR DESCRIPTION
## Summary
- change macOS dev Dock/app names to `Orca: <branch>`
- stop seeding/applying the dev identity Dock badge fallback
- update focused startup and Dock badge tests

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/dev-instance-identity.test.ts src/main/startup/run-electron-vite-dev.test.ts src/main/dock/unread-badge.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`