### PR TITLE
Remove GitHub API budget compact indicators

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -57,7 +57,6 @@ import TeamMultiCombobox from '@/components/ui/team-multi-combobox'
 import RepoDotLabel from '@/components/repo/RepoDotLabel'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import IssueSourceSelector, { issueSourceChipClass } from '@/components/github/IssueSourceSelector'
-import GitHubRateLimitPill from '@/components/github/GitHubRateLimitPill'
 import { reconcileLinearTeamSelection } from '@/components/task-page-linear-team-selection'
 import { stripRepoQualifiers } from '../../../shared/task-query'
 import GitHubItemDialog from '@/components/GitHubItemDialog'
@@ -2161,13 +2160,6 @@ export default function TaskPage(): React.JSX.Element {
                       </div>
 
                       <div className="flex shrink-0 items-center gap-2">
-                        {/* Why: GitHub API budget pill is anchored next to the
-                            Refresh button so the "maybe I shouldn't click
-                            refresh again" decision is one glance away. Only
-                            rendered in the GitHub section because Linear has
-                            its own SDK-based quota and doesn't consume gh
-                            budget. */}
-                        <GitHubRateLimitPill />
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button

--- a/src/renderer/src/components/github/GitHubRateLimitPill.tsx
+++ b/src/renderer/src/components/github/GitHubRateLimitPill.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import { GitHubRateLimitCompact } from './github-rate-limit-display'
-
-export default function GitHubRateLimitPill(): React.JSX.Element | null {
-  return <GitHubRateLimitCompact label="GitHub API budget" tooltipSide="bottom" />
-}

--- a/src/renderer/src/components/github/github-rate-limit-display.tsx
+++ b/src/renderer/src/components/github/github-rate-limit-display.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Gauge, RefreshCw } from 'lucide-react'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -43,33 +42,6 @@ export function toneForGitHubBucket(remaining: number, limit: number): 'ok' | 'w
     return 'warn'
   }
   return 'ok'
-}
-
-function worstGitHubRateLimitTone(snapshot: GitHubRateLimitSnapshot): 'ok' | 'warn' | 'crit' {
-  const tones = BUCKETS.map((b) =>
-    toneForGitHubBucket(snapshot[b.key].remaining, snapshot[b.key].limit)
-  )
-  if (tones.includes('crit')) {
-    return 'crit'
-  }
-  if (tones.includes('warn')) {
-    return 'warn'
-  }
-  return 'ok'
-}
-
-function tightestGitHubBucket(snapshot: GitHubRateLimitSnapshot): BucketMeta {
-  let worst = BUCKETS[0]
-  let worstPct = 1
-  for (const b of BUCKETS) {
-    const { remaining, limit } = snapshot[b.key]
-    const pct = limit > 0 ? remaining / limit : 1
-    if (pct < worstPct) {
-      worstPct = pct
-      worst = b
-    }
-  }
-  return worst
 }
 
 export function useGitHubRateLimitSnapshot(options?: { autoRefresh?: boolean }): {
@@ -169,64 +141,6 @@ function GitHubRateLimitRows({
         )
       })}
     </div>
-  )
-}
-
-export function GitHubRateLimitCompact({
-  className,
-  hideHealthy = true,
-  label = 'GitHub API budget',
-  tooltipSide = 'top'
-}: {
-  className?: string
-  hideHealthy?: boolean
-  label?: string
-  tooltipSide?: 'top' | 'right' | 'bottom' | 'left'
-}): React.JSX.Element | null {
-  const { snapshot, hasError, refresh } = useGitHubRateLimitSnapshot()
-  if (!snapshot || hasError) {
-    return null
-  }
-
-  const tone = worstGitHubRateLimitTone(snapshot)
-  if (hideHealthy && tone === 'ok') {
-    return null
-  }
-  const tight = tightestGitHubBucket(snapshot)
-  const tightBucket = snapshot[tight.key]
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onClick={() => void refresh(true)}
-          aria-label={label}
-          className={cn(
-            'inline-flex h-6 min-w-0 items-center gap-1 rounded-md border px-1.5 text-[10px] font-medium transition',
-            tone === 'ok' && 'border-border bg-secondary text-secondary-foreground hover:bg-accent',
-            tone === 'crit' &&
-              'border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300 hover:bg-red-500/20',
-            tone === 'warn' &&
-              'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300 hover:bg-amber-500/20',
-            className
-          )}
-        >
-          <Gauge className="size-3 shrink-0" />
-          <span className="truncate">
-            {tightBucket.remaining} {tight.label.toLowerCase()} left · resets in{' '}
-            {formatGitHubRateLimitReset(tightBucket.resetAt)}
-          </span>
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side={tooltipSide} sideOffset={6} className="text-xs">
-        <div className="font-medium">{label}</div>
-        <div className="mt-1">
-          <GitHubRateLimitRows snapshot={snapshot} />
-        </div>
-        <div className="mt-1 text-muted-foreground">Click to refresh</div>
-      </TooltipContent>
-    </Tooltip>
   )
 }
 

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -22,7 +22,6 @@ import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
 import PortsPanel from './PortsPanel'
-import { GitHubRateLimitCompact } from '@/components/github/github-rate-limit-display'
 
 const MIN_WIDTH = 220
 // Why: long file names (e.g. construction drawing sheets, multi-part document
@@ -214,8 +213,6 @@ function RightSidebarInner(): React.JSX.Element {
   const effectiveTab = visibleItems.some((item) => item.id === rightSidebarTab)
     ? rightSidebarTab
     : visibleItems[0].id
-  const showGitHubBudgetInPanel =
-    !isFolder && (effectiveTab === 'source-control' || effectiveTab === 'checks')
 
   const activityBarSideWidth = activityBarPosition === 'side' ? ACTIVITY_BAR_SIDE_WIDTH : 0
   const maxWidth = useWindowAwareMaxWidth()
@@ -335,13 +332,6 @@ function RightSidebarInner(): React.JSX.Element {
             </TooltipProvider>
           </div>
         )}
-
-        {showGitHubBudgetInPanel ? (
-          <GitHubRateLimitCompact
-            className="mx-2 my-1.5 max-w-[calc(100%-1rem)] self-start"
-            label="GitHub API budget for this panel"
-          />
-        ) : null}
 
         {panelContent}
 

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -39,7 +39,6 @@ import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { PetStatusSegment } from './PetStatusSegment'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { FloatingTerminalIconContextMenu } from '@/components/floating-terminal/FloatingTerminalIconContextMenu'
-import { GitHubRateLimitCompact } from '@/components/github/github-rate-limit-display'
 
 type StatusBarProps = {
   floatingTerminalOpen: boolean
@@ -858,7 +857,6 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
       }}
     >
       <div className="flex items-center gap-3">
-        <GitHubRateLimitCompact label="GitHub API budget" />
         {showClaude && <ClaudeSwitcherMenu claude={claude} compact={compact} iconOnly={iconOnly} />}
         {showCodex && <CodexSwitcherMenu codex={codex} compact={compact} iconOnly={iconOnly} />}
         {showGemini && (


### PR DESCRIPTION
## Summary
- remove the compact GitHub API budget pill from task refresh controls, right sidebar panels, and status bar
- delete the now-unused compact rate-limit display component and wrapper

## Verification
- review agent reported no issues
- pnpm typecheck passed in review pass
- pre-commit oxlint and oxfmt passed