### PR TITLE
Improve workspace board drag scrolling

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -119,7 +119,7 @@ const SidebarHeader = React.memo(function SidebarHeader() {
     <>
       <div className="mt-2 flex h-8 items-center justify-between px-2 gap-2">
         <div className="flex min-w-0 items-center gap-1">
-          <span className="px-2 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80 select-none">
+          <span className="pl-2 pr-0.5 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80 select-none">
             Workspaces
           </span>
           <Tooltip>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -4,8 +4,8 @@ import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import WorkspaceKanbanAreaSelectionOverlay from './WorkspaceKanbanAreaSelectionOverlay'
 import WorkspaceKanbanDrawerHeader from './WorkspaceKanbanDrawerHeader'
+import WorkspaceKanbanLaneGrid from './WorkspaceKanbanLaneGrid'
 import WorkspaceKanbanPinDropTarget from './WorkspaceKanbanPinDropTarget'
-import WorkspaceKanbanStatusLane from './WorkspaceKanbanStatusLane'
 import {
   getWorkspaceStatus,
   hasWorkspaceDragData,
@@ -16,6 +16,7 @@ import { useWorkspaceKanbanAreaSelection } from './use-workspace-kanban-area-sel
 import { useWorkspaceKanbanColumnResize } from './use-workspace-kanban-column-resize'
 import { useWorkspaceKanbanCreateWorktree } from './use-workspace-kanban-create-worktree'
 import { useWorkspaceKanbanSelection } from './use-workspace-kanban-selection'
+import { useWorkspaceKanbanShiftWheelScroll } from './use-workspace-kanban-shift-wheel-scroll'
 import {
   isWorkspaceBoardKeepOpenTarget,
   useWorkspaceKanbanOutsideDismiss
@@ -54,6 +55,7 @@ export default function WorkspaceKanbanDrawer({
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const boardRef = useRef<HTMLDivElement>(null)
+  const laneScrollerRef = useRef<HTMLDivElement>(null)
   const areaSelectionOverlayRef = useRef<HTMLDivElement>(null)
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
@@ -308,6 +310,7 @@ export default function WorkspaceKanbanDrawer({
     }
   )
 
+  useWorkspaceKanbanShiftWheelScroll(boardRef, laneScrollerRef, open)
   useWorkspaceKanbanOutsideDismiss({ open, boardRef, preserveOpenForMenu, onOpenChange })
 
   const opacityPercent = Math.round(workspaceBoardOpacity * 100)
@@ -330,7 +333,7 @@ export default function WorkspaceKanbanDrawer({
             left: drawerLeftCss,
             top: 36,
             height: 'calc(100% - 36px)',
-            width: `min(calc(100vw - ${drawerLeftCss}), 1180px)`,
+            width: `min(calc(100vw - ${drawerLeftCss}), 1320px)`,
             opacity: workspaceBoardOpacity
           } as React.CSSProperties
         }
@@ -390,43 +393,32 @@ export default function WorkspaceKanbanDrawer({
             onDragOver={handlePinDragOver}
             onDragLeave={handlePinDragLeave}
           />
-          <div className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-sleek">
-            <div
-              className="grid h-full min-h-0 min-w-full grid-rows-[minmax(0,1fr)] gap-3"
-              style={{
-                gridTemplateColumns: `repeat(${workspaceStatuses.length}, minmax(${columnWidth}px, ${columnWidth}px))`
-              }}
-            >
-              {workspaceStatuses.map((status) => {
-                const items = worktreesByStatus.get(status.id) ?? []
-
-                return (
-                  <WorkspaceKanbanStatusLane
-                    key={status.id}
-                    status={status}
-                    items={items}
-                    repoMap={repoMap}
-                    activeWorktreeId={activeWorktreeId}
-                    compact={workspaceBoardCompact}
-                    columnWidth={columnWidth}
-                    isResizingColumn={isResizingColumn}
-                    isDragTarget={dragOverStatus === status.id}
-                    canCreateWorktree={canCreateWorktree}
-                    selectedWorktreeIds={selectedWorktreeIds}
-                    selectedWorktrees={selectedWorktrees}
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    onDrop={handleDrop}
-                    onActivate={handleWorktreeActivate}
-                    onSelectionGesture={updateSelectionForGesture}
-                    onContextMenuSelect={selectForContextMenu}
-                    onCreateWorktree={createWorktreeForStatus}
-                    onColumnResizeStart={onColumnResizeStart}
-                    onColumnResizeKeyDown={onColumnResizeKeyDown}
-                  />
-                )
-              })}
-            </div>
+          <div
+            ref={laneScrollerRef}
+            className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-sleek"
+          >
+            <WorkspaceKanbanLaneGrid
+              statuses={workspaceStatuses}
+              worktreesByStatus={worktreesByStatus}
+              repoMap={repoMap}
+              activeWorktreeId={activeWorktreeId}
+              compact={workspaceBoardCompact}
+              columnWidth={columnWidth}
+              isResizingColumn={isResizingColumn}
+              dragOverStatus={dragOverStatus}
+              canCreateWorktree={canCreateWorktree}
+              selectedWorktreeIds={selectedWorktreeIds}
+              selectedWorktrees={selectedWorktrees}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onActivate={handleWorktreeActivate}
+              onSelectionGesture={updateSelectionForGesture}
+              onContextMenuSelect={selectForContextMenu}
+              onCreateWorktree={createWorktreeForStatus}
+              onColumnResizeStart={onColumnResizeStart}
+              onColumnResizeKeyDown={onColumnResizeKeyDown}
+            />
           </div>
         </div>
       </SheetContent>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import type {
+  Repo,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition,
+  Worktree
+} from '../../../../shared/types'
+import WorkspaceKanbanStatusLane from './WorkspaceKanbanStatusLane'
+
+type WorkspaceKanbanLaneGridProps = {
+  statuses: readonly WorkspaceStatusDefinition[]
+  worktreesByStatus: ReadonlyMap<WorkspaceStatus, readonly Worktree[]>
+  repoMap: Map<string, Repo>
+  activeWorktreeId: string | null
+  compact: boolean
+  columnWidth: number
+  isResizingColumn: boolean
+  dragOverStatus: WorkspaceStatus | null
+  canCreateWorktree: boolean
+  selectedWorktreeIds: ReadonlySet<string>
+  selectedWorktrees: readonly Worktree[]
+  onDragOver: (event: React.DragEvent, statusId: string) => void
+  onDragLeave: (event: React.DragEvent) => void
+  onDrop: (event: React.DragEvent, statusId: string) => void
+  onActivate: () => void
+  onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktreeId: string) => boolean
+  onContextMenuSelect: (
+    event: React.MouseEvent<HTMLElement>,
+    worktree: Worktree
+  ) => readonly Worktree[]
+  onCreateWorktree: (statusId: string) => void
+  onColumnResizeStart: (event: React.PointerEvent<HTMLElement>) => void
+  onColumnResizeKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void
+}
+
+export default function WorkspaceKanbanLaneGrid({
+  statuses,
+  worktreesByStatus,
+  repoMap,
+  activeWorktreeId,
+  compact,
+  columnWidth,
+  isResizingColumn,
+  dragOverStatus,
+  canCreateWorktree,
+  selectedWorktreeIds,
+  selectedWorktrees,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onActivate,
+  onSelectionGesture,
+  onContextMenuSelect,
+  onCreateWorktree,
+  onColumnResizeStart,
+  onColumnResizeKeyDown
+}: WorkspaceKanbanLaneGridProps): React.JSX.Element {
+  return (
+    <div
+      className="grid h-full min-h-0 min-w-full grid-rows-[minmax(0,1fr)] gap-3"
+      style={{
+        gridTemplateColumns: `repeat(${statuses.length}, minmax(${columnWidth}px, ${columnWidth}px))`
+      }}
+    >
+      {statuses.map((status) => (
+        <WorkspaceKanbanStatusLane
+          key={status.id}
+          status={status}
+          items={worktreesByStatus.get(status.id) ?? []}
+          repoMap={repoMap}
+          activeWorktreeId={activeWorktreeId}
+          compact={compact}
+          columnWidth={columnWidth}
+          isResizingColumn={isResizingColumn}
+          isDragTarget={dragOverStatus === status.id}
+          canCreateWorktree={canCreateWorktree}
+          selectedWorktreeIds={selectedWorktreeIds}
+          selectedWorktrees={selectedWorktrees}
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+          onActivate={onActivate}
+          onSelectionGesture={onSelectionGesture}
+          onContextMenuSelect={onContextMenuSelect}
+          onCreateWorktree={onCreateWorktree}
+          onColumnResizeStart={onColumnResizeStart}
+          onColumnResizeKeyDown={onColumnResizeKeyDown}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceStatusAppearancePopover.tsx
@@ -54,21 +54,20 @@ export default function WorkspaceStatusAppearancePopover({
         onOpenAutoFocus={(event) => event.preventDefault()}
       >
         <div className="px-1 py-1 text-[11px] font-semibold text-muted-foreground">Color</div>
-        <div className="grid grid-cols-4 gap-1">
+        <div className="grid grid-cols-8 gap-1">
           {WORKSPACE_STATUS_COLOR_OPTIONS.map((color) => (
             <Tooltip key={color.id}>
               <TooltipTrigger asChild>
                 <button
                   type="button"
                   className={cn(
-                    'flex h-8 items-center gap-1.5 rounded-md border border-transparent px-2 text-[11px] text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
+                    'flex size-8 items-center justify-center rounded-md border border-transparent outline-none transition-colors hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
                     status.color === color.id && 'border-ring bg-accent'
                   )}
                   onClick={() => onChangeColor(status.id, color.id)}
                   aria-label={`Set ${status.label} color to ${color.label}`}
                 >
-                  <span className={cn('size-3 rounded-full', color.swatch)} />
-                  <span className="min-w-0 truncate">{color.label}</span>
+                  <span className={cn('size-3.5 rounded-full', color.swatch)} />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" sideOffset={4}>

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-shift-wheel-scroll.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-shift-wheel-scroll.ts
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+import type React from 'react'
+import { hasWorkspaceDragData } from './workspace-status'
+
+function getWheelPixels(event: WheelEvent): number {
+  const unit = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : window.innerHeight
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
+    return event.deltaY || event.deltaX
+  }
+  return (event.deltaY || event.deltaX) * unit
+}
+
+function isEventInsideElement(event: WheelEvent, element: HTMLElement): boolean {
+  const target = event.target
+  if (target instanceof Node && element.contains(target)) {
+    return true
+  }
+  const rect = element.getBoundingClientRect()
+  return (
+    event.clientX >= rect.left &&
+    event.clientX <= rect.right &&
+    event.clientY >= rect.top &&
+    event.clientY <= rect.bottom
+  )
+}
+
+export function useWorkspaceKanbanShiftWheelScroll(
+  boardRef: React.RefObject<HTMLElement | null>,
+  scrollerRef: React.RefObject<HTMLElement | null>,
+  enabled: boolean
+): void {
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    let isWorkspaceDragActive = false
+
+    const stopTrackingDrag = (): void => {
+      isWorkspaceDragActive = false
+    }
+
+    const handleDragStart = (event: DragEvent): void => {
+      isWorkspaceDragActive = event.dataTransfer ? hasWorkspaceDragData(event.dataTransfer) : false
+    }
+
+    const handleWheel = (event: WheelEvent): void => {
+      const board = boardRef.current
+      const scroller = scrollerRef.current
+      if (
+        !event.shiftKey ||
+        !isWorkspaceDragActive ||
+        !board ||
+        !scroller ||
+        !isEventInsideElement(event, board)
+      ) {
+        return
+      }
+
+      const delta = getWheelPixels(event)
+      if (delta === 0) {
+        return
+      }
+      event.preventDefault()
+      scroller.scrollLeft += delta
+    }
+
+    document.addEventListener('dragstart', handleDragStart)
+    document.addEventListener('drop', stopTrackingDrag, true)
+    document.addEventListener('dragend', stopTrackingDrag, true)
+    window.addEventListener('blur', stopTrackingDrag)
+    document.addEventListener('wheel', handleWheel, { passive: false })
+    return () => {
+      document.removeEventListener('dragstart', handleDragStart)
+      document.removeEventListener('drop', stopTrackingDrag, true)
+      document.removeEventListener('dragend', stopTrackingDrag, true)
+      window.removeEventListener('blur', stopTrackingDrag)
+      document.removeEventListener('wheel', handleWheel)
+    }
+  }, [boardRef, enabled, scrollerRef])
+}


### PR DESCRIPTION
Summary:\n- Allow Shift+wheel to horizontally scroll the workspace board while dragging workspace cards.\n- Increase the workspace board drawer max width from 1180px to 1320px.\n- Extract the lane grid render into a focused component.\n\nTests:\n- pnpm lint src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx src/renderer/src/components/sidebar/use-workspace-kanban-shift-wheel-scroll.ts\n- pnpm test -- src/renderer/src/components/sidebar/workspace-status.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts\n- pnpm typecheck\n- git diff --check