### PR TITLE
Fix sidebar grouping mode persistence

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -223,6 +223,33 @@ describe('Store', () => {
     expect(ui.lastUpdateCheckAt).toBeNull()
   })
 
+  it('preserves legacy none grouping as ungrouped workspaces', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      ui: { groupBy: 'none' }
+    })
+    const store = await createStore()
+    expect(store.getUI().groupBy).toBe('none')
+  })
+
+  it('normalizes interim flat grouping back to none', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      ui: { groupBy: 'flat' }
+    })
+    const store = await createStore()
+    expect(store.getUI().groupBy).toBe('none')
+  })
+
+  it('preserves explicit workspace status grouping', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      ui: { groupBy: 'workspace-status' }
+    })
+    const store = await createStore()
+    expect(store.getUI().groupBy).toBe('workspace-status')
+  })
+
   // ── 2. Load from existing valid file ─────────────────────────────────
 
   it('reads repos from an existing data file', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -160,10 +160,15 @@ function backupPath(dataFile: string, index: number): string {
 }
 
 function normalizeGroupBy(groupBy: unknown): PersistedState['ui']['groupBy'] {
-  if (groupBy === 'flat' || groupBy === 'none' || groupBy === 'repo' || groupBy === 'pr-status') {
+  if (
+    groupBy === 'none' ||
+    groupBy === 'workspace-status' ||
+    groupBy === 'repo' ||
+    groupBy === 'pr-status'
+  ) {
     return groupBy
   }
-  if (groupBy === 'workspace-status') {
+  if (groupBy === 'flat') {
     return 'none'
   }
   return getDefaultUIState().groupBy

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -20,8 +20,8 @@ import SidebarFilter from './SidebarFilter'
 import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
 
 const GROUP_BY_OPTIONS = [
-  { id: 'flat', label: 'None' },
-  { id: 'none', label: 'Status' },
+  { id: 'none', label: 'None' },
+  { id: 'workspace-status', label: 'Status' },
   { id: 'pr-status', label: 'PR' },
   { id: 'repo', label: 'Repo' }
 ] as const

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -637,7 +637,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const hasWorkspaceDropTargets = useMemo(
     () =>
-      groupBy === 'none' ||
+      groupBy === 'workspace-status' ||
       rows.some((row) => row.type === 'header' && row.key === PINNED_GROUP_KEY),
     [groupBy, rows]
   )
@@ -751,7 +751,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               repoDrag.state.draggingRepoId !== null &&
               repoDrag.state.draggingRepoId === repoIdForHeader
             const headerWorkspaceStatus =
-              groupBy === 'none' ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses) : null
+              groupBy === 'workspace-status'
+                ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses)
+                : null
             const isPinnedHeader = row.key === PINNED_GROUP_KEY
             return (
               <div
@@ -1094,7 +1096,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           }
 
           const itemWorkspaceStatus =
-            groupBy === 'none' ? getWorkspaceStatus(row.worktree, workspaceStatuses) : null
+            groupBy === 'workspace-status'
+              ? getWorkspaceStatus(row.worktree, workspaceStatuses)
+              : null
 
           return (
             <div

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   buildRows,
+  getGroupKeyForWorktree,
   getLineageGroupKey,
   getLineageRenderInfo,
   getPRGroupKey,
@@ -53,6 +54,18 @@ describe('getPRGroupKey', () => {
   })
 })
 
+describe('getGroupKeyForWorktree', () => {
+  it('returns no group key for the ungrouped mode', () => {
+    expect(getGroupKeyForWorktree('none', worktree, repoMap, null)).toBeNull()
+  })
+
+  it('returns a workspace-status key only in status grouping mode', () => {
+    expect(getGroupKeyForWorktree('workspace-status', worktree, repoMap, null)).toBe(
+      'workspace-status:in-progress'
+    )
+  })
+})
+
 describe('buildRows with pinned worktrees', () => {
   const pinned = { ...worktree, id: 'wt-pinned', isPinned: true, displayName: 'pinned-feature' }
   const unpinned1 = { ...worktree, id: 'wt-1', displayName: 'alpha' }
@@ -64,8 +77,8 @@ describe('buildRows with pinned worktrees', () => {
     expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: 'wt-pinned' } })
   })
 
-  it('renders a flat list without status headers in groupBy flat', () => {
-    const rows = buildRows('flat', [unpinned1, unpinned2], repoMap, null, new Set())
+  it('renders a flat list without status headers in groupBy none', () => {
+    const rows = buildRows('none', [unpinned1, unpinned2], repoMap, null, new Set())
 
     expect(rows).toMatchObject([
       { type: 'item', worktree: { id: 'wt-1' } },
@@ -74,7 +87,7 @@ describe('buildRows with pinned worktrees', () => {
   })
 
   it('keeps pinned worktrees above the flat list', () => {
-    const rows = buildRows('flat', [unpinned1, pinned, unpinned2], repoMap, null, new Set())
+    const rows = buildRows('none', [unpinned1, pinned, unpinned2], repoMap, null, new Set())
 
     expect(rows).toMatchObject([
       { type: 'header', key: 'pinned', count: 1 },
@@ -84,8 +97,14 @@ describe('buildRows with pinned worktrees', () => {
     ])
   })
 
-  it('emits status headers for unpinned worktrees in groupBy none', () => {
-    const rows = buildRows('none', [unpinned1, pinned, unpinned2], repoMap, null, new Set())
+  it('emits status headers for unpinned worktrees in groupBy workspace-status', () => {
+    const rows = buildRows(
+      'workspace-status',
+      [unpinned1, pinned, unpinned2],
+      repoMap,
+      null,
+      new Set()
+    )
     expect(rows[2]).toMatchObject({
       type: 'header',
       key: 'workspace-status:in-progress',
@@ -108,8 +127,8 @@ describe('buildRows with pinned worktrees', () => {
     }
   })
 
-  it('omits empty pinned sections in groupBy none', () => {
-    const rows = buildRows('none', [unpinned1, unpinned2], repoMap, null, new Set())
+  it('omits empty pinned sections in groupBy workspace-status', () => {
+    const rows = buildRows('workspace-status', [unpinned1, unpinned2], repoMap, null, new Set())
     expect(rows[0]).toMatchObject({
       type: 'header',
       key: 'workspace-status:in-progress',
@@ -121,7 +140,13 @@ describe('buildRows with pinned worktrees', () => {
   })
 
   it('collapses pinned group when in collapsedGroups', () => {
-    const rows = buildRows('none', [pinned, unpinned1], repoMap, null, new Set(['pinned']))
+    const rows = buildRows(
+      'workspace-status',
+      [pinned, unpinned1],
+      repoMap,
+      null,
+      new Set(['pinned'])
+    )
     expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned' })
     expect(rows[1]).toMatchObject({ type: 'header', key: 'workspace-status:in-progress' })
     expect(rows[2]).toMatchObject({ type: 'item', worktree: { id: 'wt-1' } })
@@ -129,7 +154,7 @@ describe('buildRows with pinned worktrees', () => {
 
   it('does not emit empty status sections when all worktrees are pinned', () => {
     const allPinned = { ...unpinned1, isPinned: true }
-    const rows = buildRows('none', [pinned, allPinned], repoMap, null, new Set())
+    const rows = buildRows('workspace-status', [pinned, allPinned], repoMap, null, new Set())
     expect(rows.filter((r) => r.type === 'header')).toHaveLength(1)
     expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned', count: 2 })
   })
@@ -176,9 +201,9 @@ describe('buildRows with pinned worktrees', () => {
     expect(rows[1]).toMatchObject({ type: 'item', worktree: { id: folderWorktree.id } })
   })
 
-  it('emits assigned workspace statuses as sections in groupBy none', () => {
+  it('emits assigned workspace statuses as sections in groupBy workspace-status', () => {
     const review = { ...worktree, id: 'wt-review', workspaceStatus: 'in-review' as const }
-    const rows = buildRows('none', [review], repoMap, null, new Set())
+    const rows = buildRows('workspace-status', [review], repoMap, null, new Set())
 
     expect(
       rows
@@ -196,7 +221,7 @@ describe('buildRows with pinned worktrees', () => {
     const blocked = { ...worktree, id: 'wt-blocked', workspaceStatus: 'blocked' }
     const doing = { ...worktree, id: 'wt-doing', workspaceStatus: 'in-progress' }
     const rows = buildRows(
-      'none',
+      'workspace-status',
       [doing, blocked],
       repoMap,
       null,
@@ -320,8 +345,8 @@ describe('getRepoGroupOrdering', () => {
     ['repo', 'smart', 'visible-worktree-order'],
     ['repo', 'name', 'manual'],
     ['repo', 'repo', 'manual'],
-    ['flat', 'recent', 'manual'],
     ['none', 'recent', 'manual'],
+    ['workspace-status', 'recent', 'manual'],
     ['pr-status', 'recent', 'manual']
   ] as const)('uses %s/%s -> %s', (groupBy, sortBy, expected) => {
     expect(getRepoGroupOrdering(groupBy, sortBy)).toBe(expected)

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -24,9 +24,7 @@ import type { SortBy } from './smart-sort'
 
 export { branchName }
 
-// Why: `none` is the legacy persisted value for Status grouping. The actual
-// ungrouped sidebar mode is `flat`.
-export type WorktreeGroupBy = 'flat' | 'none' | 'repo' | 'pr-status'
+export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status'
 export type RepoGroupOrdering = 'manual' | 'visible-worktree-order'
 
 export function getRepoGroupOrdering(groupBy: WorktreeGroupBy, sortBy: SortBy): RepoGroupOrdering {
@@ -374,7 +372,7 @@ export function buildRows(
   )
   const unpinned = pinnedIds.size > 0 ? worktrees.filter((w) => !pinnedIds.has(w.id)) : worktrees
 
-  if (groupBy === 'flat') {
+  if (groupBy === 'none') {
     appendWorktreeRows(result, unpinned, repoMap, lineageById, worktreeMap, {
       nestLineage,
       showLineageContext: nestLineage,
@@ -392,7 +390,7 @@ export function buildRows(
       repo = repoMap.get(w.repoId)
       key = `repo:${w.repoId}`
       label = repo?.displayName ?? 'Unknown'
-    } else if (groupBy === 'none') {
+    } else if (groupBy === 'workspace-status') {
       const workspaceStatus = getWorkspaceStatus(w, workspaceStatuses)
       key = getWorkspaceStatusGroupKey(workspaceStatus)
       label =
@@ -417,10 +415,9 @@ export function buildRows(
         orderedGroups.push([key, group])
       }
     }
-  } else if (groupBy === 'none') {
-    // Why: the old "All" grouping now organizes workspaces by user status.
-    // Keep the sidebar compact by rendering only sections that contain cards;
-    // the board drawer is the wider all-lanes drag target.
+  } else if (groupBy === 'workspace-status') {
+    // Why: status grouping is opt-in while the board drawer remains the wider
+    // all-lanes drag target; keep the sidebar compact by omitting empty lanes.
     for (const status of workspaceStatuses) {
       const key = getWorkspaceStatusGroupKey(status.id)
       const group = grouped.get(key)
@@ -465,7 +462,7 @@ export function buildRows(
             icon: REPO_GROUP_META.icon,
             repo
           }
-        : groupBy === 'none'
+        : groupBy === 'workspace-status'
           ? (() => {
               const workspaceStatus =
                 getWorkspaceStatusFromGroupKey(key, workspaceStatuses) ??
@@ -515,10 +512,10 @@ export function getGroupKeyForWorktree(
   prCache: Record<string, unknown> | null,
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = cloneDefaultWorkspaceStatuses()
 ): string | null {
-  if (groupBy === 'flat') {
+  if (groupBy === 'none') {
     return null
   }
-  if (groupBy === 'none') {
+  if (groupBy === 'workspace-status') {
     return getWorkspaceStatusGroupKey(getWorkspaceStatus(worktree, workspaceStatuses))
   }
   if (groupBy === 'repo') {

--- a/src/renderer/src/lib/startup-ui-hydration.test.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.test.ts
@@ -52,6 +52,7 @@ describe('startup UI hydration fallback', () => {
 
     expect(hydratePersistedUI).toHaveBeenCalledTimes(1)
     expect(hydratePersistedUI.mock.calls[0][0].sidebarWidth).toBe(280)
+    expect(hydratePersistedUI.mock.calls[0][0].groupBy).toBe('repo')
     expect(hydratePersistedUI.mock.calls[0][0].sortBy).toBe('name')
   })
 

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -34,7 +34,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     lastActiveWorktreeId: null,
     sidebarWidth: 280,
     rightSidebarWidth: 350,
-    groupBy: 'none',
+    groupBy: 'repo',
     showWorkspaceLineage: false,
     sortBy: 'name',
     showActiveOnly: false,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -352,7 +352,7 @@ export type UISlice = {
   ) => void
   markOrcaHookRepoAlwaysTrusted: (repoId: string) => void
   clearOrcaHookTrustForRepo: (repoId: string) => void
-  groupBy: 'flat' | 'none' | 'repo' | 'pr-status'
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   setGroupBy: (g: UISlice['groupBy']) => void
   showWorkspaceLineage: boolean
   setShowWorkspaceLineage: (v: boolean) => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1705,7 +1705,7 @@ export type PersistedUIState = {
   lastActiveWorktreeId: string | null
   sidebarWidth: number
   rightSidebarWidth: number
-  groupBy: 'flat' | 'none' | 'repo' | 'pr-status'
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   showWorkspaceLineage?: boolean
   sortBy: 'name' | 'smart' | 'recent' | 'repo'
   showActiveOnly: boolean


### PR DESCRIPTION
## Summary
- separate the persisted ungrouped sidebar mode from workspace status grouping
- preserve legacy/interim grouping values through main-process normalization
- update sidebar grouping tests and startup fallback expectations

## Verification
- pnpm run typecheck
- pnpm test
- pnpm oxlint src/main/persistence.ts src/main/persistence.test.ts src/renderer/src/components/sidebar/SidebarHeader.tsx src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-list-groups.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/lib/startup-ui-hydration.ts src/renderer/src/lib/startup-ui-hydration.test.ts src/renderer/src/store/slices/ui.ts src/shared/types.ts