### PR TITLE
Fix sidebar wheel scroll anchoring jitter

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -352,6 +352,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     measureElement: measureCurrentVirtualRowElement,
     overscan: 10,
     gap: 6,
+    // Why: the sidebar rows are rich cards. Flushing their React render inside
+    // TanStack's native scroll listener can make wheel input wait on card work;
+    // overscan gives the async render enough runway to stay visually filled.
+    useFlushSync: false,
     // Why: tells the virtualizer to start its internal scrollOffset at the
     // ref value rather than 0, so the first getVirtualItems() call after
     // remount picks the correct window of rows. The sibling useLayoutEffect

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -7,6 +7,7 @@ export type VirtualizedScrollAnchor = {
   offset: number
 } | null
 export const VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT = 'orca-record-virtualized-scroll-anchor'
+const RECORD_ANCHOR_SCROLL_IDLE_DELAY_MS = 150
 
 type UseVirtualizedScrollAnchorOptions<
   TRow,
@@ -95,17 +96,8 @@ export function useVirtualizedScrollAnchor<
     [getItemElementKey, itemElementSelector, rowIndexByKey]
   )
 
-  const recordScrollAnchor = useCallback(
+  const recordVirtualScrollAnchor = useCallback(
     (scrollTop: number) => {
-      const scrollElement = scrollElementRef.current
-      if (scrollElement) {
-        const domAnchor = findDomAnchor(scrollElement)
-        if (domAnchor) {
-          anchorRef.current = domAnchor
-          return
-        }
-      }
-
       const virtualItems = virtualizer.getVirtualItems()
       const firstVisible = virtualItems.find((item) => item.end > scrollTop)
       const row = firstVisible ? rows[firstVisible.index] : undefined
@@ -123,7 +115,23 @@ export function useVirtualizedScrollAnchor<
         offset: Math.max(0, scrollTop - firstVisible.start)
       }
     },
-    [anchorRef, findDomAnchor, getRowKey, rows, scrollElementRef, virtualizer]
+    [anchorRef, getRowKey, rows, virtualizer]
+  )
+
+  const recordScrollAnchor = useCallback(
+    (scrollTop: number) => {
+      const scrollElement = scrollElementRef.current
+      if (scrollElement) {
+        const domAnchor = findDomAnchor(scrollElement)
+        if (domAnchor) {
+          anchorRef.current = domAnchor
+          return
+        }
+      }
+
+      recordVirtualScrollAnchor(scrollTop)
+    },
+    [anchorRef, findDomAnchor, recordVirtualScrollAnchor, scrollElementRef]
   )
 
   useLayoutEffect(() => {
@@ -138,6 +146,35 @@ export function useVirtualizedScrollAnchor<
       el.scrollTop = targetOffset
     }
 
+    let frameId: number | null = null
+    let idleTimerId: number | null = null
+    const cancelScheduledRecord = (): void => {
+      if (idleTimerId !== null) {
+        window.clearTimeout(idleTimerId)
+        idleTimerId = null
+      }
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId)
+        frameId = null
+      }
+    }
+    const scheduleRecordAnchor = (): void => {
+      cancelScheduledRecord()
+      idleTimerId = window.setTimeout(() => {
+        idleTimerId = null
+        // Why: recording the row anchor reads layout. Wait until wheel scrolling
+        // is idle, then do the read on the next frame instead of the input path.
+        frameId = window.requestAnimationFrame(() => {
+          frameId = null
+          recordScrollAnchor(el.scrollTop)
+        })
+      }, RECORD_ANCHOR_SCROLL_IDLE_DELAY_MS)
+    }
+    const recordCurrentAnchor = (): void => {
+      cancelScheduledRecord()
+      scrollOffsetRef.current = el.scrollTop
+      recordScrollAnchor(el.scrollTop)
+    }
     const onScroll = (): void => {
       if (restoring) {
         // Why: during a fresh virtualizer mount, total height may still be
@@ -145,42 +182,43 @@ export function useVirtualizedScrollAnchor<
         // user's real position until the intended offset is reachable.
         if (el.scrollTop === targetOffset) {
           restoring = false
-          scrollOffsetRef.current = el.scrollTop
-          recordScrollAnchor(el.scrollTop)
+          recordCurrentAnchor()
           return
         }
         if (el.scrollHeight - el.clientHeight >= targetOffset) {
           el.scrollTop = targetOffset
           if (el.scrollTop === targetOffset) {
             restoring = false
-            scrollOffsetRef.current = el.scrollTop
-            recordScrollAnchor(el.scrollTop)
+            recordCurrentAnchor()
           }
         }
         return
       }
       scrollOffsetRef.current = el.scrollTop
-      recordScrollAnchor(el.scrollTop)
-    }
-    const recordCurrentAnchor = (): void => {
-      scrollOffsetRef.current = el.scrollTop
-      recordScrollAnchor(el.scrollTop)
+      recordVirtualScrollAnchor(el.scrollTop)
+      scheduleRecordAnchor()
     }
 
     el.addEventListener('scroll', onScroll, { passive: true })
     el.addEventListener(VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT, recordCurrentAnchor)
     return () => {
+      cancelScheduledRecord()
       scrollOffsetRef.current = el.scrollTop
       recordScrollAnchor(el.scrollTop)
       el.removeEventListener(VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT, recordCurrentAnchor)
       el.removeEventListener('scroll', onScroll)
     }
-  }, [recordScrollAnchor, scrollElementRef, scrollOffsetRef])
+  }, [recordScrollAnchor, recordVirtualScrollAnchor, scrollElementRef, scrollOffsetRef])
 
   useLayoutEffect(() => {
     const anchor = anchorRef.current
     const el = scrollElementRef.current
     if (!anchor || !el) {
+      return
+    }
+    if (virtualizer.isScrolling) {
+      // Why: remeasurement during wheel scrolling can change totalSize. Restoring
+      // the anchor in that window writes scrollTop and fights the user's wheel.
       return
     }
 
@@ -261,6 +299,7 @@ export function useVirtualizedScrollAnchor<
     scrollElementRef,
     scrollOffsetRef,
     totalSize,
-    virtualizer
+    virtualizer,
+    virtualizer.isScrolling
   ])
 }


### PR DESCRIPTION
## Summary
- keep sidebar scroll anchors current cheaply during wheel scroll using virtual rows, then refresh the precise DOM anchor only after scroll idle
- skip anchor restoration while TanStack Virtual reports active scrolling so remeasurement cannot fight wheel input
- disable TanStack React Virtual flushSync for the rich worktree sidebar so React card rendering is not forced inside the native scroll listener

## Diagnosis
- Before the fix, the Electron probe captured a mid-wheel `scrollTop` write from `useVirtualizedScrollAnchor` (`value=2285`) while the user was wheel scrolling, which produced the visible correction/jitter.
- Chrome `long-animation-frame` attribution also pointed at TanStack React Virtual's native `DIV.onscroll` listener doing synchronous React work via the default flushSync path.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts`
- Electron CDP wheel probe after fix: 12 wheel steps from the lower sidebar produced monotonic deltas, `writes: []`, and the final scrollTop stayed stable after scroll idle.
- Electron CDP long-animation-frame probe after disabling flushSync: remaining dev-build long frame moved out of TanStack's native scroll listener and into React's scheduled `MessagePort` work.
- Electron disposable bottom workspace regression: created `zz-codex-sidebar-verify-*`, slept it while active, then deleted only that disposable workspace; sleep/delete both kept the sidebar at the bottom with `maxOverlap: 0` and no jump to top.
- Electron bottom-section collapse/expand regression: collapsed and expanded a bottom repo section with `maxOverlap: 0` and no jump to top.
