### PR TITLE
Add automation run history view

### DIFF
--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -36,7 +36,7 @@ for (const platform of PLATFORMS) {
     outfile: join(outDir, 'relay.js'),
     // Native addons cannot be bundled — they must exist on the remote host.
     // The relay gracefully degrades when they are absent.
-    external: ['node-pty', '@parcel/watcher'],
+    external: ['node-pty', '@parcel/watcher', 'better-sqlite3'],
     sourcemap: false,
     minify: true,
     define: {

--- a/src/main/automations/external-job-mappers.ts
+++ b/src/main/automations/external-job-mappers.ts
@@ -1,4 +1,9 @@
-import type { ExternalAutomationJob } from '../../shared/automations-types'
+import type {
+  ExternalAutomationJob,
+  ExternalAutomationProvider,
+  ExternalAutomationRun,
+  ExternalAutomationRunStatus
+} from '../../shared/automations-types'
 
 type ExternalJobRecord = Record<string, unknown>
 
@@ -43,6 +48,52 @@ function isoFromMs(value: unknown): string | null {
   return Number.isNaN(date.getTime()) ? null : date.toISOString()
 }
 
+function asExternalRunStatus(value: unknown): ExternalAutomationRunStatus {
+  return value === 'completed' || value === 'failed' || value === 'unknown' ? value : 'unknown'
+}
+
+function mapExternalRuns({
+  managerId,
+  provider,
+  jobId,
+  rawRuns
+}: {
+  managerId: string
+  provider: ExternalAutomationProvider
+  jobId: string
+  rawRuns: unknown
+}): ExternalAutomationRun[] {
+  if (!Array.isArray(rawRuns)) {
+    return []
+  }
+  return rawRuns
+    .filter(isRecord)
+    .map((run, index) => {
+      const runAt = asString(run.run_at) ?? asString(run.runAt)
+      const id = asString(run.id) ?? `${jobId}:${runAt ?? index}`
+      return {
+        id,
+        managerId,
+        provider,
+        jobId: asString(run.job_id) ?? asString(run.jobId) ?? jobId,
+        runAt,
+        status: asExternalRunStatus(run.status),
+        outputPreview: asString(run.output_preview) ?? asString(run.outputPreview),
+        outputContent: asString(run.output_content) ?? asString(run.outputContent),
+        error: asString(run.error),
+        outputPath: asString(run.output_path) ?? asString(run.outputPath)
+      }
+    })
+    .sort((a, b) => {
+      const aTime = a.runAt ? Date.parse(a.runAt) : Number.NaN
+      const bTime = b.runAt ? Date.parse(b.runAt) : Number.NaN
+      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+        return bTime - aTime
+      }
+      return b.id.localeCompare(a.id)
+    })
+}
+
 function hermesScheduleDisplay(job: ExternalJobRecord): string {
   const direct = asString(job.schedule_display)
   if (direct) {
@@ -59,6 +110,19 @@ function hermesScheduleDisplay(job: ExternalJobRecord): string {
     )
   }
   return asString(schedule) ?? '?'
+}
+
+function hermesRawSchedule(job: ExternalJobRecord): string | null {
+  const schedule = job.schedule
+  if (isRecord(schedule)) {
+    return (
+      asString(schedule.expr) ??
+      asString(schedule.value) ??
+      asString(schedule.display) ??
+      asString(schedule.run_at)
+    )
+  }
+  return asString(schedule) ?? asString(job.schedule_display)
 }
 
 function hermesPromptPreview(job: ExternalJobRecord): string {
@@ -94,6 +158,14 @@ function openClawScheduleDisplay(job: ExternalJobRecord): string {
   return kind ?? '?'
 }
 
+function openClawRawSchedule(job: ExternalJobRecord): string | null {
+  const schedule = job.schedule
+  if (!isRecord(schedule)) {
+    return asString(schedule)
+  }
+  return asString(schedule.expr) ?? asString(schedule.cron) ?? null
+}
+
 function openClawPromptPreview(job: ExternalJobRecord): string {
   const payload = job.payload
   if (!isRecord(payload)) {
@@ -117,14 +189,23 @@ export function mapHermesJobs(managerId: string, rawJobs: unknown): ExternalAuto
       provider: 'hermes',
       name: (asString(job.name) ?? preview) || id,
       schedule: hermesScheduleDisplay(job),
+      rawSchedule: hermesRawSchedule(job),
       enabled,
       state: asString(job.state) ?? (enabled ? 'scheduled' : 'paused'),
+      prompt: asString(job.prompt),
       promptPreview: preview,
       nextRunAt: asString(job.next_run_at),
       lastRunAt: asString(job.last_run_at),
       lastStatus: asString(job.last_status),
       lastError: asString(job.last_error) ?? asString(job.last_delivery_error),
-      workdir: asString(job.workdir)
+      workdir: asString(job.workdir),
+      runCount: asNumber(job.run_count) ?? (Array.isArray(job.runs) ? job.runs.length : 0),
+      runs: mapExternalRuns({
+        managerId,
+        provider: 'hermes',
+        jobId: id,
+        rawRuns: job.runs
+      })
     }
   })
 }
@@ -147,18 +228,27 @@ export function mapOpenClawJobs(managerId: string, rawJobs: unknown): ExternalAu
       provider: 'openclaw',
       name: (asString(job.name) ?? preview) || id,
       schedule: openClawScheduleDisplay(job),
+      rawSchedule: openClawRawSchedule(job),
       enabled,
       state: !enabled
         ? 'disabled'
         : asNumber(state.runningAtMs)
           ? 'running'
           : (lastStatus ?? 'idle'),
+      prompt: openClawPromptPreview(job) || null,
       promptPreview: preview,
       nextRunAt: isoFromMs(state.nextRunAtMs),
       lastRunAt: isoFromMs(state.lastRunAtMs),
       lastStatus,
       lastError: asString(state.lastError) ?? asString(state.lastDeliveryError),
-      workdir: null
+      workdir: null,
+      runCount: asNumber(job.run_count) ?? (Array.isArray(job.runs) ? job.runs.length : 0),
+      runs: mapExternalRuns({
+        managerId,
+        provider: 'openclaw',
+        jobId: id,
+        rawRuns: job.runs
+      })
     }
   })
 }

--- a/src/main/automations/external-manager.test.ts
+++ b/src/main/automations/external-manager.test.ts
@@ -1,6 +1,13 @@
+/* eslint-disable max-lines -- Why: external automation mapping and lifecycle IPC share fixtures. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { runExternalAutomationAction } from './external-manager'
+import {
+  createExternalAutomation,
+  listExternalAutomationRuns,
+  runExternalAutomationAction,
+  updateExternalAutomation
+} from './external-manager'
 import { mapHermesJobs, mapOpenClawJobs } from './external-job-mappers'
+import { getActiveMultiplexer } from '../ipc/ssh'
 
 const execFileMock = vi.hoisted(() =>
   vi.fn((...args: unknown[]) => {
@@ -20,6 +27,7 @@ vi.mock('../ipc/ssh', () => ({
 
 beforeEach(() => {
   execFileMock.mockClear()
+  vi.mocked(getActiveMultiplexer).mockReset()
 })
 
 describe('mapHermesJobs', () => {
@@ -46,14 +54,72 @@ describe('mapHermesJobs', () => {
         provider: 'hermes',
         name: 'Nightly audit',
         schedule: '0 9 * * 1-5',
+        rawSchedule: '0 9 * * 1-5',
         enabled: true,
         state: 'scheduled',
+        prompt: 'Audit the repo for risky dependency changes',
         promptPreview: 'Audit the repo for risky dependency changes',
         nextRunAt: '2026-05-16T09:00:00Z',
         lastRunAt: '2026-05-15T09:00:00Z',
         lastStatus: 'ok',
         lastError: null,
-        workdir: '/repo'
+        workdir: '/repo',
+        runCount: 0,
+        runs: []
+      }
+    ])
+  })
+
+  it('normalizes Hermes output files into run history', () => {
+    const jobs = mapHermesJobs('hermes:local', [
+      {
+        id: 'job-1',
+        name: 'Nightly audit',
+        schedule_display: '0 9 * * 1-5',
+        runs: [
+          {
+            id: 'job-1:2026-05-15_09-00-00.md',
+            job_id: 'job-1',
+            run_at: '2026-05-15T09:00:00',
+            status: 'completed',
+            output_preview: 'No risky dependency changes.',
+            output_path: '/home/me/.hermes/cron/output/job-1/2026-05-15_09-00-00.md'
+          },
+          {
+            id: 'job-1:2026-05-14_09-00-00.md',
+            job_id: 'job-1',
+            run_at: '2026-05-14T09:00:00',
+            status: 'failed',
+            error: 'RuntimeError: missing key'
+          }
+        ]
+      }
+    ])
+
+    expect(jobs[0].runs).toEqual([
+      {
+        id: 'job-1:2026-05-15_09-00-00.md',
+        managerId: 'hermes:local',
+        provider: 'hermes',
+        jobId: 'job-1',
+        runAt: '2026-05-15T09:00:00',
+        status: 'completed',
+        outputPreview: 'No risky dependency changes.',
+        outputContent: null,
+        error: null,
+        outputPath: '/home/me/.hermes/cron/output/job-1/2026-05-15_09-00-00.md'
+      },
+      {
+        id: 'job-1:2026-05-14_09-00-00.md',
+        managerId: 'hermes:local',
+        provider: 'hermes',
+        jobId: 'job-1',
+        runAt: '2026-05-14T09:00:00',
+        status: 'failed',
+        outputPreview: null,
+        outputContent: null,
+        error: 'RuntimeError: missing key',
+        outputPath: null
       }
     ])
   })
@@ -78,8 +144,74 @@ describe('mapHermesJobs', () => {
       enabled: false,
       state: 'paused',
       promptPreview: 'Script: disk-check.sh',
+      prompt: null,
+      rawSchedule: 'every 30m',
       lastError: 'home channel missing'
     })
+  })
+})
+
+describe('createExternalAutomation', () => {
+  it('creates local Hermes cron jobs through the CLI', async () => {
+    await createExternalAutomation({
+      managerId: 'hermes:local',
+      provider: 'hermes',
+      target: { type: 'local' },
+      name: 'Nightly audit',
+      prompt: 'Audit the repo',
+      schedule: '0 9 * * 1-5',
+      workdir: '/repo'
+    })
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'hermes',
+      [
+        'cron',
+        'create',
+        '0 9 * * 1-5',
+        'Audit the repo',
+        '--name',
+        'Nightly audit',
+        '--deliver',
+        'local',
+        '--workdir',
+        '/repo'
+      ],
+      { encoding: 'utf-8' },
+      expect.any(Function)
+    )
+  })
+
+  it('updates local Hermes cron jobs through the CLI', async () => {
+    await updateExternalAutomation({
+      managerId: 'hermes:local',
+      provider: 'hermes',
+      target: { type: 'local' },
+      jobId: 'job-1',
+      name: 'Nightly audit',
+      prompt: 'Audit the repo',
+      schedule: '0 10 * * 1-5',
+      workdir: '/repo'
+    })
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'hermes',
+      [
+        'cron',
+        'edit',
+        'job-1',
+        '--schedule',
+        '0 10 * * 1-5',
+        '--prompt',
+        'Audit the repo',
+        '--name',
+        'Nightly audit',
+        '--workdir',
+        '/repo'
+      ],
+      { encoding: 'utf-8' },
+      expect.any(Function)
+    )
   })
 })
 
@@ -133,6 +265,63 @@ describe('runExternalAutomationAction', () => {
   })
 })
 
+describe('listExternalAutomationRuns', () => {
+  it('requests paginated Hermes runs from the remote relay', async () => {
+    const request = vi.fn().mockResolvedValue({
+      total: 42,
+      runs: [
+        {
+          id: 'job-1:2026-05-15_09-00-00.md',
+          job_id: 'job-1',
+          run_at: '2026-05-15T09:00:00',
+          status: 'completed',
+          output_preview: 'No risky dependency changes.'
+        }
+      ]
+    })
+    vi.mocked(getActiveMultiplexer).mockReturnValue({
+      isDisposed: () => false,
+      request
+    } as unknown as ReturnType<typeof getActiveMultiplexer>)
+
+    await expect(
+      listExternalAutomationRuns({
+        managerId: 'hermes:ssh:ssh-1',
+        provider: 'hermes',
+        target: { type: 'ssh', connectionId: 'ssh-1' },
+        jobId: 'job-1',
+        page: 2,
+        pageSize: 10
+      })
+    ).resolves.toMatchObject({
+      managerId: 'hermes:ssh:ssh-1',
+      provider: 'hermes',
+      jobId: 'job-1',
+      page: 2,
+      pageSize: 10,
+      total: 42,
+      runs: [
+        {
+          id: 'job-1:2026-05-15_09-00-00.md',
+          managerId: 'hermes:ssh:ssh-1',
+          provider: 'hermes',
+          jobId: 'job-1',
+          runAt: '2026-05-15T09:00:00',
+          status: 'completed',
+          outputPreview: 'No risky dependency changes.'
+        }
+      ]
+    })
+
+    expect(request).toHaveBeenCalledWith('externalAutomations.runs', {
+      provider: 'hermes',
+      jobId: 'job-1',
+      page: 2,
+      pageSize: 10
+    })
+  })
+})
+
 describe('mapOpenClawJobs', () => {
   it('normalizes OpenClaw cron jobs into external automation rows', () => {
     const jobs = mapOpenClawJobs('openclaw:local', {
@@ -159,8 +348,10 @@ describe('mapOpenClawJobs', () => {
       provider: 'openclaw',
       name: 'Morning report',
       schedule: 'cron 0 9 * * * @ America/Phoenix',
+      rawSchedule: '0 9 * * *',
       enabled: true,
       state: 'ok',
+      prompt: 'Summarize overnight alerts',
       promptPreview: 'Summarize overnight alerts',
       nextRunAt: '2026-05-16T16:00:00.000Z',
       lastRunAt: '2026-05-15T16:00:00.000Z',

--- a/src/main/automations/external-manager.ts
+++ b/src/main/automations/external-manager.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- Why: external automation discovery, pagination,
+ * and lifecycle routing share provider/target validation and remote relay fallbacks. */
 import { execFile } from 'child_process'
 import { existsSync } from 'fs'
 import { readFile } from 'fs/promises'
@@ -7,16 +9,23 @@ import { promisify } from 'util'
 import type {
   ExternalAutomationAction,
   ExternalAutomationActionInput,
+  ExternalAutomationCreateInput,
   ExternalAutomationManager,
-  ExternalAutomationProvider
+  ExternalAutomationProvider,
+  ExternalAutomationRunsInput,
+  ExternalAutomationRunsPage,
+  ExternalAutomationUpdateInput
 } from '../../shared/automations-types'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { Store } from '../persistence'
 import { getActiveMultiplexer } from '../ipc/ssh'
 import { mapHermesJobs, mapOpenClawJobs } from './external-job-mappers'
+import { readHermesCronOutputRunsPage } from './hermes-cron-output'
 
 const execFileAsync = promisify(execFile)
-const HERMES_JOBS_FILE = join(homedir(), '.hermes', 'cron', 'jobs.json')
+const HERMES_HOME = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
+const HERMES_CRON_DIR = join(HERMES_HOME, 'cron')
+const HERMES_JOBS_FILE = join(HERMES_CRON_DIR, 'jobs.json')
 const OPENCLAW_JOBS_FILE = join(homedir(), '.openclaw', 'cron', 'jobs.json')
 const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
 
@@ -40,7 +49,28 @@ async function readLocalHermesJobs(): Promise<unknown[]> {
   }
   const content = await readFile(HERMES_JOBS_FILE, 'utf-8')
   const parsed = JSON.parse(content) as unknown
-  return Array.isArray(parsed) ? parsed : []
+  const jobs = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.jobs)
+      ? parsed.jobs
+      : []
+  return Promise.all(
+    jobs.map(async (job) => {
+      if (!isRecord(job)) {
+        return job
+      }
+      const jobId = typeof job.id === 'string' ? job.id : null
+      if (!jobId) {
+        return job
+      }
+      const runsPage = await readHermesCronOutputRunsPage(jobId, { page: 1, pageSize: 0 })
+      return {
+        ...job,
+        run_count: runsPage.total,
+        runs: []
+      }
+    })
+  )
 }
 
 async function readLocalOpenClawJobs(): Promise<unknown[]> {
@@ -69,6 +99,7 @@ async function listLocalHermesManager(): Promise<ExternalAutomationManager | nul
     id: managerId,
     provider: 'hermes',
     label: 'Hermes on this computer',
+    targetLabel: 'this computer',
     target: { type: 'local' },
     status: readError ? 'unavailable' : 'available',
     error:
@@ -96,6 +127,7 @@ async function listLocalOpenClawManager(): Promise<ExternalAutomationManager | n
     id: managerId,
     provider: 'openclaw',
     label: 'OpenClaw on this computer',
+    targetLabel: 'this computer',
     target: { type: 'local' },
     status: readError ? 'unavailable' : 'available',
     error:
@@ -134,6 +166,7 @@ async function listRemoteManager(
       id: managerProviderId,
       provider,
       label: `${providerLabel} on ${target.label}`,
+      targetLabel: target.label,
       target: { type: 'ssh', connectionId: target.id },
       status: 'unavailable',
       error: 'SSH target is not connected.',
@@ -155,6 +188,7 @@ async function listRemoteManager(
       id: managerProviderId,
       provider,
       label: `${providerLabel} on ${target.label}`,
+      targetLabel: target.label,
       target: { type: 'ssh', connectionId: target.id },
       status: readError ? 'unavailable' : 'available',
       error:
@@ -170,6 +204,7 @@ async function listRemoteManager(
       id: managerProviderId,
       provider,
       label: `${providerLabel} on ${target.label}`,
+      targetLabel: target.label,
       target: { type: 'ssh', connectionId: target.id },
       status: 'unavailable',
       error: remoteRelayErrorMessage(error),
@@ -198,6 +233,64 @@ export async function listExternalAutomationManagers(
   ]
 }
 
+export async function listExternalAutomationRuns(
+  input: ExternalAutomationRunsInput
+): Promise<ExternalAutomationRunsPage> {
+  if (!EXTERNAL_JOB_ID_PATTERN.test(input.jobId)) {
+    throw new Error('Invalid external automation job ID.')
+  }
+  const page = Number.isFinite(input.page) ? Math.max(1, Math.floor(input.page)) : 1
+  const pageSize = Number.isFinite(input.pageSize)
+    ? Math.min(100, Math.max(1, Math.floor(input.pageSize)))
+    : 25
+  if (input.provider !== 'hermes') {
+    return {
+      managerId: input.managerId,
+      provider: input.provider,
+      target: input.target,
+      jobId: input.jobId,
+      page,
+      pageSize,
+      total: 0,
+      runs: []
+    }
+  }
+  if (input.target.type === 'local') {
+    const result = await readHermesCronOutputRunsPage(input.jobId, { page, pageSize })
+    return {
+      managerId: input.managerId,
+      provider: input.provider,
+      target: input.target,
+      jobId: input.jobId,
+      page,
+      pageSize,
+      total: result.total,
+      runs: mapHermesJobs(input.managerId, [{ id: input.jobId, runs: result.runs }])[0]?.runs ?? []
+    }
+  }
+  const mux = getActiveMultiplexer(input.target.connectionId)
+  if (!mux || mux.isDisposed()) {
+    throw new Error(`SSH target "${input.target.connectionId}" is not connected.`)
+  }
+  const result = (await mux.request('externalAutomations.runs', {
+    provider: input.provider,
+    jobId: input.jobId,
+    page,
+    pageSize
+  })) as { total?: number; runs?: unknown[] }
+  return {
+    managerId: input.managerId,
+    provider: input.provider,
+    target: input.target,
+    jobId: input.jobId,
+    page,
+    pageSize,
+    total: typeof result.total === 'number' && Number.isFinite(result.total) ? result.total : 0,
+    runs:
+      mapHermesJobs(input.managerId, [{ id: input.jobId, runs: result.runs ?? [] }])[0]?.runs ?? []
+  }
+}
+
 function hermesCommandForAction(action: ExternalAutomationAction): string {
   switch (action) {
     case 'pause':
@@ -222,6 +315,123 @@ function openClawCommandForAction(action: ExternalAutomationAction): string {
     case 'delete':
       return 'rm'
   }
+}
+
+function normalizeHermesCronMutationInput(input: ExternalAutomationCreateInput): {
+  name: string
+  prompt: string
+  schedule: string
+  workdir: string | null
+} {
+  if (input.provider !== 'hermes') {
+    throw new Error('Only Hermes cron creation and editing are supported.')
+  }
+  const name = input.name.trim()
+  const prompt = input.prompt.trim()
+  const schedule = input.schedule.trim()
+  const workdir = input.workdir?.trim() || null
+  if (!prompt) {
+    throw new Error('Hermes cron requires a prompt.')
+  }
+  if (!schedule) {
+    throw new Error('Hermes cron requires a schedule.')
+  }
+  return {
+    name: name || prompt.slice(0, 50).trim() || 'Hermes cron',
+    prompt,
+    schedule,
+    workdir
+  }
+}
+
+function hermesCronCreateArgs(input: {
+  name: string
+  prompt: string
+  schedule: string
+  workdir: string | null
+}): string[] {
+  const args = [
+    'cron',
+    'create',
+    input.schedule,
+    input.prompt,
+    '--name',
+    input.name,
+    '--deliver',
+    'local'
+  ]
+  if (input.workdir) {
+    args.push('--workdir', input.workdir)
+  }
+  return args
+}
+
+function hermesCronEditArgs(
+  jobId: string,
+  input: {
+    name: string
+    prompt: string
+    schedule: string
+    workdir: string | null
+  }
+): string[] {
+  const args = [
+    'cron',
+    'edit',
+    jobId,
+    '--schedule',
+    input.schedule,
+    '--prompt',
+    input.prompt,
+    '--name',
+    input.name
+  ]
+  if (input.workdir) {
+    args.push('--workdir', input.workdir)
+  }
+  return args
+}
+
+export async function createExternalAutomation(
+  input: ExternalAutomationCreateInput
+): Promise<void> {
+  const normalized = normalizeHermesCronMutationInput(input)
+  if (input.target.type === 'local') {
+    await execFileAsync('hermes', hermesCronCreateArgs(normalized), { encoding: 'utf-8' })
+    return
+  }
+  const mux = getActiveMultiplexer(input.target.connectionId)
+  if (!mux || mux.isDisposed()) {
+    throw new Error(`SSH target "${input.target.connectionId}" is not connected.`)
+  }
+  await mux.request('externalAutomations.create', {
+    provider: input.provider,
+    ...normalized
+  })
+}
+
+export async function updateExternalAutomation(
+  input: ExternalAutomationUpdateInput
+): Promise<void> {
+  if (!EXTERNAL_JOB_ID_PATTERN.test(input.jobId)) {
+    throw new Error('Invalid external automation job ID.')
+  }
+  const normalized = normalizeHermesCronMutationInput(input)
+  if (input.target.type === 'local') {
+    await execFileAsync('hermes', hermesCronEditArgs(input.jobId, normalized), {
+      encoding: 'utf-8'
+    })
+    return
+  }
+  const mux = getActiveMultiplexer(input.target.connectionId)
+  if (!mux || mux.isDisposed()) {
+    throw new Error(`SSH target "${input.target.connectionId}" is not connected.`)
+  }
+  await mux.request('externalAutomations.update', {
+    provider: input.provider,
+    jobId: input.jobId,
+    ...normalized
+  })
 }
 
 export async function runExternalAutomationAction(

--- a/src/main/automations/hermes-cron-output.test.ts
+++ b/src/main/automations/hermes-cron-output.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let hermesHome: string | null = null
+let extraTempDirs: string[] = []
+const previousHermesHome = process.env.HERMES_HOME
+const fakeDbRows = vi.hoisted(() => ({
+  sessions: [] as Record<string, unknown>[],
+  messages: [] as Record<string, unknown>[]
+}))
+const fakePrepareSqls = vi.hoisted(() => [] as string[])
+const fakeDatabase = vi.hoisted(() =>
+  vi.fn(function FakeDatabase() {
+    return {
+      prepare: vi.fn((sql: string) => {
+        fakePrepareSqls.push(sql)
+        return {
+          get: vi.fn((param: string) =>
+            sql.includes('FROM sessions')
+              ? fakeDbRows.sessions.find((session) => session.id === param)
+              : undefined
+          ),
+          all: vi.fn((param: string) =>
+            sql.includes('FROM sessions')
+              ? fakeDbRows.sessions
+              : fakeDbRows.messages.filter((message) => message.session_id === param)
+          )
+        }
+      }),
+      close: vi.fn()
+    }
+  })
+)
+
+vi.mock('better-sqlite3', () => ({
+  default: fakeDatabase
+}))
+
+async function loadReader() {
+  vi.resetModules()
+  return import('./hermes-cron-output')
+}
+
+async function createHermesHome(): Promise<string> {
+  hermesHome = await mkdtemp(join(tmpdir(), 'orca-hermes-output-'))
+  process.env.HERMES_HOME = hermesHome
+  return hermesHome
+}
+
+beforeEach(() => {
+  fakeDbRows.sessions = []
+  fakeDbRows.messages = []
+  fakePrepareSqls.length = 0
+  fakeDatabase.mockClear()
+})
+
+afterEach(async () => {
+  if (previousHermesHome === undefined) {
+    delete process.env.HERMES_HOME
+  } else {
+    process.env.HERMES_HOME = previousHermesHome
+  }
+  if (hermesHome) {
+    await rm(hermesHome, { recursive: true, force: true })
+    hermesHome = null
+  }
+  await Promise.all(extraTempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  extraTempDirs = []
+  vi.resetModules()
+})
+
+describe('readHermesCronOutputRunsPage', () => {
+  it('attaches the state.db transcript to the matching Hermes output file run', async () => {
+    const home = await createHermesHome()
+    const outputDir = join(home, 'cron', 'output', 'job-1')
+    const scriptLogPath = join(home, 'Automations', 'x-automation', 'logs', 'x-monitor.log')
+    await mkdir(outputDir, { recursive: true })
+    await mkdir(dirname(scriptLogPath), { recursive: true })
+    await writeFile(scriptLogPath, 'raw script log line\nsecond raw script log line\n', 'utf-8')
+    await writeFile(
+      join(outputDir, '2026-05-15_09-02-00.md'),
+      `# Cron Job: Monitor automation
+
+**Job ID:** job-1
+
+## Response
+
+Success — ./run-x-monitor.sh completed with exit code 0.
+Latest log path: ${scriptLogPath}
+Run summary: monitor automation completed successfully.
+`,
+      'utf-8'
+    )
+
+    await writeFile(join(home, 'state.db'), '', 'utf-8')
+    fakeDbRows.sessions = [
+      {
+        id: 'cron_job-1_20260515_090000',
+        title: 'Monitor automation',
+        started_at: Date.UTC(2026, 4, 15, 9, 0, 0) / 1000,
+        ended_at: Date.UTC(2026, 4, 15, 9, 1, 58) / 1000,
+        model: 'gpt-5',
+        message_count: 2,
+        input_tokens: 100,
+        output_tokens: 50
+      }
+    ]
+    fakeDbRows.messages = [
+      {
+        session_id: 'cron_job-1_20260515_090000',
+        role: 'tool',
+        content: 'full command output line',
+        tool_name: 'terminal',
+        timestamp: Date.UTC(2026, 4, 15, 9, 1, 0) / 1000
+      }
+    ]
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 25 })
+
+    expect(page.total).toBe(1)
+    expect(page.runs[0]).toMatchObject({
+      id: 'job-1:2026-05-15_09-02-00.md',
+      status: 'completed',
+      output_path: join(outputDir, '2026-05-15_09-02-00.md')
+    })
+    expect((page.runs[0] as { output_content?: string }).output_content).toContain(
+      'monitor automation completed successfully.'
+    )
+    expect((page.runs[0] as { output_content?: string }).output_content).toContain(
+      '## Latest log file'
+    )
+    expect((page.runs[0] as { output_content?: string }).output_content).toContain(
+      'raw script log line'
+    )
+    expect((page.runs[0] as { output_content?: string }).output_content).toContain(
+      '## Full session log'
+    )
+    expect((page.runs[0] as { output_content?: string }).output_content).toContain(
+      'full command output line'
+    )
+  })
+
+  it('does not hydrate referenced logs outside Hermes home', async () => {
+    const home = await createHermesHome()
+    const outputDir = join(home, 'cron', 'output', 'job-1')
+    const outsideDir = await mkdtemp(join(tmpdir(), 'orca-hermes-outside-'))
+    extraTempDirs.push(outsideDir)
+    const outsideLogPath = join(outsideDir, 'secret.log')
+    await mkdir(outputDir, { recursive: true })
+    await writeFile(outsideLogPath, 'do not expose this\n', 'utf-8')
+    await writeFile(
+      join(outputDir, '2026-05-15_09-02-00.md'),
+      `# Cron Job: Monitor automation
+
+## Response
+
+Latest log path: ${outsideLogPath}
+Run summary: monitor automation completed successfully.
+`,
+      'utf-8'
+    )
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 25 })
+
+    expect((page.runs[0] as { output_content?: string }).output_content).not.toContain(
+      '## Latest log file'
+    )
+    expect((page.runs[0] as { output_content?: string }).output_content).not.toContain(
+      'do not expose this'
+    )
+  })
+
+  it('uses a count-only path when page size is zero', async () => {
+    const home = await createHermesHome()
+    const outputDir = join(home, 'cron', 'output', 'job-1')
+    await mkdir(outputDir, { recursive: true })
+    await writeFile(
+      join(outputDir, '2026-05-15_09-02-00.md'),
+      'this content should not be read for count-only listing',
+      'utf-8'
+    )
+    await writeFile(join(home, 'state.db'), '', 'utf-8')
+    fakeDbRows.sessions = [
+      {
+        id: 'cron_job-1_20260515_090000',
+        started_at: Date.UTC(2026, 4, 15, 9, 0, 0) / 1000
+      }
+    ]
+    fakeDbRows.messages = [
+      {
+        session_id: 'cron_job-1_20260515_090000',
+        role: 'tool',
+        content: 'full command output line'
+      }
+    ]
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 0 })
+
+    expect(page).toEqual({ total: 1, runs: [] })
+    expect(fakePrepareSqls.some((sql) => sql.includes('FROM messages'))).toBe(false)
+  })
+})

--- a/src/main/automations/hermes-cron-output.ts
+++ b/src/main/automations/hermes-cron-output.ts
@@ -1,0 +1,604 @@
+/* eslint-disable max-lines -- Why: Hermes run history has to reconcile
+ * markdown output files with SQLite session transcripts from separate stores. */
+import { existsSync } from 'fs'
+import { open, readdir, readFile, realpath, stat } from 'fs/promises'
+import { homedir } from 'os'
+import { isAbsolute, join, relative, resolve } from 'path'
+import Database from 'better-sqlite3'
+
+const HERMES_HOME = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
+const HERMES_OUTPUT_DIR = join(HERMES_HOME, 'cron', 'output')
+const HERMES_STATE_DB = join(HERMES_HOME, 'state.db')
+const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+const HERMES_OUTPUT_FILE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})\.md$/
+const HERMES_RUN_KEY_PATTERN = /^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$/
+const MAX_SESSION_OUTPUT_GAP_MS = 24 * 60 * 60 * 1000
+const MAX_REFERENCED_LOG_BYTES = 5 * 1024 * 1024
+const FULL_SESSION_LOG_HEADING = '## Full session log'
+const REFERENCED_LOG_HEADING = '## Latest log file'
+const LATEST_LOG_PATH_PATTERN =
+  /\bLatest log path:\s*(?<path>(?:[A-Za-z]:[\\/]|\/)[^\r\n]*?)(?=\s+Run summary:|\r?\n|$)/i
+
+export type HermesCronOutputRunsPage = {
+  total: number
+  runs: unknown[]
+}
+
+type HermesOutputRunRef = {
+  kind: 'output'
+  id: string
+  job_id: string
+  run_at: string | null
+  run_key: string | null
+  output_path: string
+}
+
+type HermesSessionRunRef = {
+  kind: 'session'
+  id: string
+  job_id: string
+  run_at: string | null
+  run_key: string | null
+}
+
+type HermesMergedRunRef = {
+  id: string
+  job_id: string
+  run_at: string | null
+  run_key: string | null
+  output: HermesOutputRunRef | null
+  session: HermesSessionRunRef | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function runAtFromHermesOutputFile(filename: string): string | null {
+  const match = HERMES_OUTPUT_FILE_PATTERN.exec(filename)
+  if (!match) {
+    return null
+  }
+  const [, year, month, day, hour, minute, second] = match
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}`
+}
+
+function runKeyFromHermesOutputFile(filename: string): string | null {
+  const match = HERMES_OUTPUT_FILE_PATTERN.exec(filename)
+  if (!match) {
+    return null
+  }
+  const [, year, month, day, hour, minute, second] = match
+  return `${year}${month}${day}_${hour}${minute}${second}`
+}
+
+function runAtFromUnixSeconds(value: unknown): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+  const date = new Date(value * 1000)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function sortableTimeFromRunKey(runKey: string | null): number {
+  if (!runKey) {
+    return Number.NaN
+  }
+  const match = HERMES_RUN_KEY_PATTERN.exec(runKey)
+  if (!match) {
+    return Number.NaN
+  }
+  const [, year, month, day, hour, minute, second] = match
+  return Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  )
+}
+
+function escapeSqlLike(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')
+}
+
+function cleanRunPreview(value: string): string | null {
+  const normalized = value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/[#*_`>()]/g, ' ')
+    .replaceAll('[', ' ')
+    .replaceAll(']', ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!normalized) {
+    return null
+  }
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized
+}
+
+function parseHermesOutput(content: string): {
+  status: 'completed' | 'failed' | 'unknown'
+  outputPreview: string | null
+  outputContent: string
+  error: string | null
+} {
+  const failed = /^#\s+Cron Job:.*\(FAILED\)/m.test(content) || /^##\s+Error\b/m.test(content)
+  const errorMatch = /##\s+Error\s+```([\s\S]*?)```/m.exec(content)
+  const responseMatch = /##\s+Response\s+([\s\S]*)$/m.exec(content)
+  const error = errorMatch ? cleanRunPreview(errorMatch[1]) : null
+  return {
+    status: failed ? 'failed' : responseMatch ? 'completed' : 'unknown',
+    outputPreview: cleanRunPreview(responseMatch?.[1] ?? errorMatch?.[1] ?? content),
+    outputContent: content,
+    error
+  }
+}
+
+function extractLatestLogPath(content: string): string | null {
+  const rawPath = LATEST_LOG_PATH_PATTERN.exec(content)?.groups?.path?.trim()
+  if (!rawPath) {
+    return null
+  }
+  return rawPath.replace(/^`|`$/g, '').trim()
+}
+
+async function readReferencedLogFile(content: string): Promise<{
+  path: string
+  content: string
+  truncated: boolean
+} | null> {
+  const logPath = extractLatestLogPath(content)
+  if (!logPath || !isAbsolute(logPath)) {
+    return null
+  }
+  try {
+    const homeRealPath = await realpath(HERMES_HOME)
+    const logRealPath = await realpath(logPath)
+    const relativeToHermesHome = relative(resolve(homeRealPath), resolve(logRealPath))
+    // Why: the output body can contain agent-authored text, so only hydrate
+    // referenced files that resolve inside Hermes' own data directory.
+    if (relativeToHermesHome.startsWith('..') || isAbsolute(relativeToHermesHome)) {
+      return null
+    }
+    const logStat = await stat(logPath)
+    if (!logStat.isFile()) {
+      return null
+    }
+    if (logStat.size <= MAX_REFERENCED_LOG_BYTES) {
+      return {
+        path: logPath,
+        content: await readFile(logPath, 'utf-8'),
+        truncated: false
+      }
+    }
+    const file = await open(logPath, 'r')
+    try {
+      const buffer = Buffer.alloc(MAX_REFERENCED_LOG_BYTES)
+      await file.read(buffer, 0, MAX_REFERENCED_LOG_BYTES, logStat.size - MAX_REFERENCED_LOG_BYTES)
+      return {
+        path: logPath,
+        content: buffer.toString('utf-8'),
+        truncated: true
+      }
+    } finally {
+      await file.close()
+    }
+  } catch {
+    return null
+  }
+}
+
+async function appendReferencedLogFile(content: string): Promise<string> {
+  if (content.includes(REFERENCED_LOG_HEADING)) {
+    return content
+  }
+  const logFile = await readReferencedLogFile(content)
+  if (!logFile) {
+    return content
+  }
+  const note = logFile.truncated
+    ? `Showing the last ${MAX_REFERENCED_LOG_BYTES} bytes because the log file is larger.`
+    : null
+  return [
+    content,
+    '---',
+    REFERENCED_LOG_HEADING,
+    '',
+    `Path: ${logFile.path}`,
+    note,
+    '```text',
+    logFile.content.trimEnd(),
+    '```'
+  ]
+    .filter((part) => part !== null)
+    .join('\n\n')
+}
+
+function formatSessionMessages(messages: Record<string, unknown>[]): string | null {
+  if (messages.length === 0) {
+    return null
+  }
+  return messages
+    .map((message) => {
+      const role = typeof message.role === 'string' ? message.role : 'message'
+      const content = typeof message.content === 'string' ? message.content.trim() : ''
+      const toolName = typeof message.tool_name === 'string' ? message.tool_name.trim() : ''
+      const reasoning =
+        typeof message.reasoning_content === 'string'
+          ? message.reasoning_content.trim()
+          : typeof message.reasoning === 'string'
+            ? message.reasoning.trim()
+            : ''
+      const parts = [
+        `## ${role}${toolName ? ` / ${toolName}` : ''}`,
+        reasoning ? `### Reasoning\n\n${reasoning}` : null,
+        content || '(empty)'
+      ].filter(Boolean)
+      return parts.join('\n\n')
+    })
+    .join('\n\n---\n\n')
+}
+
+function getRunKey(run: unknown): string | null {
+  return isRecord(run) ? asString(run.run_key) : null
+}
+
+function getRunOutputContent(run: unknown): string | null {
+  return isRecord(run) ? asString(run.output_content) : null
+}
+
+function mergeOutputAndSessionContent(
+  outputContent: string | null,
+  sessionContent: string | null
+): string | null {
+  if (!sessionContent) {
+    return outputContent
+  }
+  if (!outputContent) {
+    return `${FULL_SESSION_LOG_HEADING}\n\n${sessionContent}`
+  }
+  if (outputContent.includes(FULL_SESSION_LOG_HEADING)) {
+    return outputContent
+  }
+  return `${outputContent}\n\n---\n\n${FULL_SESSION_LOG_HEADING}\n\n${sessionContent}`
+}
+
+function findMatchingSessionRunIndex(
+  outputRun: unknown,
+  sessionRuns: unknown[],
+  usedSessionRunIndexes: Set<number>
+): number | null {
+  const outputRunKey = getRunKey(outputRun)
+  const exactMatchIndex = sessionRuns.findIndex(
+    (sessionRun, index) =>
+      !usedSessionRunIndexes.has(index) && getRunKey(sessionRun) === outputRunKey
+  )
+  if (exactMatchIndex >= 0) {
+    return exactMatchIndex
+  }
+
+  const outputTime = sortableTimeFromRunKey(outputRunKey)
+  if (!Number.isFinite(outputTime)) {
+    return null
+  }
+
+  let bestIndex: number | null = null
+  let bestGap = Number.POSITIVE_INFINITY
+  for (let index = 0; index < sessionRuns.length; index += 1) {
+    if (usedSessionRunIndexes.has(index)) {
+      continue
+    }
+    const sessionTime = sortableTimeFromRunKey(getRunKey(sessionRuns[index]))
+    if (!Number.isFinite(sessionTime)) {
+      continue
+    }
+    const gap = outputTime - sessionTime
+    if (gap < 0 || gap > MAX_SESSION_OUTPUT_GAP_MS || gap >= bestGap) {
+      continue
+    }
+    bestIndex = index
+    bestGap = gap
+  }
+  return bestIndex
+}
+
+function mergeHermesOutputAndSessionRuns(outputRuns: unknown[], sessionRuns: unknown[]): unknown[] {
+  const usedSessionRunIndexes = new Set<number>()
+  const mergedOutputRuns = outputRuns.map((outputRun) => {
+    if (!isRecord(outputRun)) {
+      return outputRun
+    }
+    const sessionRunIndex = findMatchingSessionRunIndex(
+      outputRun,
+      sessionRuns,
+      usedSessionRunIndexes
+    )
+    if (sessionRunIndex === null) {
+      return outputRun
+    }
+    const sessionRun = sessionRuns[sessionRunIndex]
+    if (!isRecord(sessionRun)) {
+      return outputRun
+    }
+    usedSessionRunIndexes.add(sessionRunIndex)
+    // Hermes writes the markdown output at completion, while state.db keeps
+    // the actual turn-by-turn transcript under the cron session start time.
+    return {
+      ...outputRun,
+      output_preview: asString(outputRun.output_preview) ?? asString(sessionRun.output_preview),
+      output_content: mergeOutputAndSessionContent(
+        getRunOutputContent(outputRun),
+        getRunOutputContent(sessionRun)
+      )
+    }
+  })
+  return [
+    ...mergedOutputRuns,
+    ...sessionRuns.filter((_, index) => !usedSessionRunIndexes.has(index))
+  ]
+}
+
+function mergeHermesOutputAndSessionRunRefs(
+  outputRefs: HermesOutputRunRef[],
+  sessionRefs: HermesSessionRunRef[]
+): HermesMergedRunRef[] {
+  const usedSessionRunIndexes = new Set<number>()
+  const mergedOutputRefs = outputRefs.map((outputRef) => {
+    const sessionRunIndex = findMatchingSessionRunIndex(
+      outputRef,
+      sessionRefs,
+      usedSessionRunIndexes
+    )
+    const sessionRef = sessionRunIndex === null ? null : sessionRefs[sessionRunIndex]
+    if (sessionRunIndex !== null) {
+      usedSessionRunIndexes.add(sessionRunIndex)
+    }
+    return {
+      id: outputRef.id,
+      job_id: outputRef.job_id,
+      run_at: outputRef.run_at,
+      run_key: outputRef.run_key,
+      output: outputRef,
+      session: sessionRef
+    }
+  })
+  return [
+    ...mergedOutputRefs,
+    ...sessionRefs
+      .filter((_, index) => !usedSessionRunIndexes.has(index))
+      .map((sessionRef) => ({
+        id: sessionRef.id,
+        job_id: sessionRef.job_id,
+        run_at: sessionRef.run_at,
+        run_key: sessionRef.run_key,
+        output: null,
+        session: sessionRef
+      }))
+  ]
+}
+
+export async function readHermesCronOutputRuns(jobId: string): Promise<unknown[]> {
+  return (await readHermesCronOutputRunsPage(jobId, { page: 1, pageSize: Number.MAX_SAFE_INTEGER }))
+    .runs
+}
+
+async function readHermesCronOutputRunRefs(jobId: string): Promise<HermesMergedRunRef[]> {
+  const outputRuns = await readHermesOutputFileRunRefs(jobId)
+  return mergeHermesOutputAndSessionRunRefs(outputRuns, readHermesSessionDbRunRefs(jobId)).sort(
+    (a, b) => {
+      const aTime = getRawRunTime(a)
+      const bTime = getRawRunTime(b)
+      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+        return bTime - aTime
+      }
+      return getRawRunId(b).localeCompare(getRawRunId(a))
+    }
+  )
+}
+
+async function readHermesCronOutputRunCount(jobId: string): Promise<number> {
+  return (await readHermesCronOutputRunRefs(jobId)).length
+}
+
+async function hydrateHermesRunRef(jobId: string, ref: HermesMergedRunRef): Promise<unknown> {
+  const outputRun = ref.output ? await readHermesOutputFileRun(ref.output) : null
+  const sessionRun = ref.session ? readHermesSessionDbRunById(jobId, ref.session.id) : null
+  return (
+    mergeHermesOutputAndSessionRuns(
+      outputRun ? [outputRun] : [],
+      sessionRun ? [sessionRun] : []
+    )[0] ??
+    outputRun ??
+    sessionRun ??
+    ref
+  )
+}
+
+export async function readHermesCronOutputRunsPage(
+  jobId: string,
+  {
+    page,
+    pageSize
+  }: {
+    page: number
+    pageSize: number
+  }
+): Promise<HermesCronOutputRunsPage> {
+  if (!EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
+    return { total: 0, runs: [] }
+  }
+  const safePage = Math.max(1, Math.floor(page))
+  const safePageSize = Math.max(0, Math.floor(pageSize))
+  if (safePageSize === 0) {
+    // Why: manager listing only needs a badge count; hydrating markdown logs
+    // and full session transcripts can make opening Automations very slow.
+    return { total: await readHermesCronOutputRunCount(jobId), runs: [] }
+  }
+  const runRefs = await readHermesCronOutputRunRefs(jobId)
+  const start = (safePage - 1) * safePageSize
+  const pageRefs = runRefs.slice(start, start + safePageSize)
+  return {
+    total: runRefs.length,
+    runs: await Promise.all(pageRefs.map((ref) => hydrateHermesRunRef(jobId, ref)))
+  }
+}
+
+function getRawRunId(run: unknown): string {
+  if (typeof run === 'object' && run !== null && 'id' in run) {
+    return String((run as { id: unknown }).id)
+  }
+  return ''
+}
+
+function getRawRunTime(run: unknown): number {
+  if (typeof run !== 'object' || run === null || !('run_at' in run)) {
+    return Number.NaN
+  }
+  const runAt = (run as { run_at: unknown }).run_at
+  return typeof runAt === 'string' ? Date.parse(runAt) : Number.NaN
+}
+
+async function readHermesOutputFileRunRefs(jobId: string): Promise<HermesOutputRunRef[]> {
+  const outputDir = join(HERMES_OUTPUT_DIR, jobId)
+  if (!existsSync(outputDir)) {
+    return []
+  }
+  const entries = await readdir(outputDir, { withFileTypes: true })
+  return entries
+    .filter((entry) => entry.isFile() && HERMES_OUTPUT_FILE_PATTERN.test(entry.name))
+    .map((entry) => ({
+      kind: 'output' as const,
+      id: `${jobId}:${entry.name}`,
+      job_id: jobId,
+      run_at: runAtFromHermesOutputFile(entry.name),
+      run_key: runKeyFromHermesOutputFile(entry.name),
+      output_path: join(outputDir, entry.name)
+    }))
+}
+
+async function readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown> {
+  try {
+    const content = await readFile(ref.output_path, 'utf-8')
+    const parsed = parseHermesOutput(content)
+    const outputContent = await appendReferencedLogFile(parsed.outputContent)
+    return {
+      id: ref.id,
+      job_id: ref.job_id,
+      run_at: ref.run_at,
+      run_key: ref.run_key,
+      status: parsed.status,
+      output_preview: parsed.outputPreview,
+      output_content: outputContent,
+      error: parsed.error,
+      output_path: ref.output_path
+    }
+  } catch (error) {
+    return {
+      id: ref.id,
+      job_id: ref.job_id,
+      run_at: ref.run_at,
+      run_key: ref.run_key,
+      status: 'unknown',
+      output_preview: null,
+      output_content: null,
+      error: error instanceof Error ? error.message : String(error),
+      output_path: ref.output_path
+    }
+  }
+}
+
+function readHermesSessionDbRunRefs(jobId: string): HermesSessionRunRef[] {
+  if (!existsSync(HERMES_STATE_DB)) {
+    return []
+  }
+  try {
+    const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
+    try {
+      const pattern = `cron\\_${escapeSqlLike(jobId)}\\_%`
+      const rows = db
+        .prepare(
+          `SELECT id, started_at
+             FROM sessions
+            WHERE id LIKE ? ESCAPE '\\'
+            ORDER BY started_at DESC`
+        )
+        .all(pattern) as Record<string, unknown>[]
+      return rows.map((row) => {
+        const runId = typeof row.id === 'string' ? row.id : `${jobId}:${String(row.started_at)}`
+        return {
+          kind: 'session',
+          id: runId,
+          job_id: jobId,
+          run_at: runAtFromUnixSeconds(row.started_at),
+          run_key: runId.split(`${jobId}_`).at(-1) ?? null
+        }
+      })
+    } finally {
+      db.close()
+    }
+  } catch {
+    return []
+  }
+}
+
+function readHermesSessionDbRunById(jobId: string, runId: string): unknown | null {
+  if (!existsSync(HERMES_STATE_DB)) {
+    return null
+  }
+  try {
+    const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
+    try {
+      const row = db
+        .prepare(
+          `SELECT id, title, started_at, ended_at, end_reason, model, message_count,
+                  input_tokens, output_tokens, estimated_cost_usd
+             FROM sessions
+            WHERE id = ?`
+        )
+        .get(runId) as Record<string, unknown> | undefined
+      if (!row) {
+        return null
+      }
+      const messages = db
+        .prepare(
+          `SELECT role, content, tool_name, reasoning, reasoning_content
+               FROM messages
+              WHERE session_id = ?
+              ORDER BY timestamp, id`
+        )
+        .all(runId) as Record<string, unknown>[]
+      const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : null
+      const model = typeof row.model === 'string' && row.model.trim() ? row.model.trim() : null
+      const messageCount = typeof row.message_count === 'number' ? row.message_count : null
+      const tokenCount =
+        (typeof row.input_tokens === 'number' ? row.input_tokens : 0) +
+        (typeof row.output_tokens === 'number' ? row.output_tokens : 0)
+      const summaryParts = [
+        title,
+        model ? `Model: ${model}` : null,
+        messageCount !== null ? `${messageCount} messages` : null,
+        tokenCount > 0 ? `${tokenCount} tokens` : null
+      ].filter(Boolean)
+      return {
+        id: runId,
+        job_id: jobId,
+        run_at: runAtFromUnixSeconds(row.started_at),
+        run_key: runId.split(`${jobId}_`).at(-1) ?? null,
+        status: typeof row.ended_at === 'number' ? 'completed' : 'unknown',
+        output_preview: summaryParts.join(' · ') || null,
+        output_content: formatSessionMessages(messages),
+        error: null,
+        output_path: HERMES_STATE_DB
+      }
+    } finally {
+      db.close()
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/main/ipc/automations.ts
+++ b/src/main/ipc/automations.ts
@@ -5,14 +5,21 @@ import type {
   Automation,
   AutomationCreateInput,
   AutomationDispatchResult,
+  ExternalAutomationCreateInput,
   ExternalAutomationActionInput,
   ExternalAutomationManager,
+  ExternalAutomationRunsInput,
+  ExternalAutomationRunsPage,
+  ExternalAutomationUpdateInput,
   AutomationRun,
   AutomationUpdateInput
 } from '../../shared/automations-types'
 import {
+  createExternalAutomation,
   listExternalAutomationManagers,
-  runExternalAutomationAction
+  listExternalAutomationRuns,
+  runExternalAutomationAction,
+  updateExternalAutomation
 } from '../automations/external-manager'
 
 export function registerAutomationHandlers(store: Store, service: AutomationService): void {
@@ -24,6 +31,18 @@ export function registerAutomationHandlers(store: Store, service: AutomationServ
   )
   ipcMain.handle('automations:listExternalManagers', (): Promise<ExternalAutomationManager[]> => {
     return listExternalAutomationManagers(store)
+  })
+  ipcMain.handle(
+    'automations:listExternalRuns',
+    (_event, input: ExternalAutomationRunsInput): Promise<ExternalAutomationRunsPage> => {
+      return listExternalAutomationRuns(input)
+    }
+  )
+  ipcMain.handle('automations:createExternal', (_event, input: ExternalAutomationCreateInput) => {
+    return createExternalAutomation(input)
+  })
+  ipcMain.handle('automations:updateExternal', (_event, input: ExternalAutomationUpdateInput) => {
+    return updateExternalAutomation(input)
   })
   ipcMain.handle(
     'automations:runExternalAction',
@@ -51,6 +70,11 @@ export function registerAutomationHandlers(store: Store, service: AutomationServ
     'automations:markDispatchResult',
     (_event, result: AutomationDispatchResult): Promise<AutomationRun> =>
       service.markDispatchResult(result)
+  )
+  ipcMain.handle(
+    'automations:snapshotWorkspaceName',
+    (_event, args: { workspaceId: string; displayName: string }): number =>
+      store.snapshotAutomationRunWorkspaceDisplayName(args.workspaceId, args.displayName)
   )
   ipcMain.handle('automations:rendererReady', (): void => {
     service.setRendererReady()

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -430,6 +430,98 @@ describe('Store', () => {
     expect(second.title).toBe('Nightly run 2')
   })
 
+  it('snapshots automation run workspace names for deleted-workspace history', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    store.setWorktreeMeta('wt1', { displayName: 'Nightly workspace' })
+    const automation = store.createAutomation({
+      name: 'Nightly',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+
+    const run = store.createAutomationRun(automation, new Date('2026-05-13T09:00:00Z').getTime())
+    store.removeWorktreeMeta('wt1')
+
+    expect(run.workspaceDisplayName).toBe('Nightly workspace')
+    expect(store.listAutomationRuns(automation.id)[0].workspaceDisplayName).toBe(
+      'Nightly workspace'
+    )
+  })
+
+  it('backfills automation run workspace names before workspace deletion', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Nightly',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+    store.createAutomationRun(automation, new Date('2026-05-13T09:00:00Z').getTime())
+
+    const updatedCount = store.snapshotAutomationRunWorkspaceDisplayName('wt1', 'Deleted workspace')
+
+    expect(updatedCount).toBe(1)
+    expect(store.listAutomationRuns(automation.id)[0].workspaceDisplayName).toBe(
+      'Deleted workspace'
+    )
+  })
+
+  it('persists automation run output snapshots across later status updates', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Nightly',
+      prompt: 'Run checks',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-13T00:00:00Z').getTime()
+    })
+    const run = store.createAutomationRun(automation, new Date('2026-05-13T09:00:00Z').getTime())
+
+    store.updateAutomationRun({
+      runId: run.id,
+      status: 'completed',
+      workspaceId: 'wt1',
+      outputSnapshot: {
+        format: 'plain_text',
+        content: 'Run finished',
+        capturedAt: 1,
+        truncated: false
+      },
+      error: null
+    })
+    store.updateAutomationRun({
+      runId: run.id,
+      status: 'completed',
+      workspaceId: 'wt1',
+      terminalSessionId: 'tab-1',
+      usage: null,
+      error: null
+    })
+
+    expect(store.listAutomationRuns(automation.id)[0].outputSnapshot).toMatchObject({
+      content: 'Run finished',
+      truncated: false
+    })
+  })
+
   // ── 3. Corrupt JSON → falls back to defaults ────────────────────────
 
   it('falls back to defaults when data file contains invalid JSON', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -20,6 +20,7 @@ import type {
   Automation,
   AutomationCreateInput,
   AutomationDispatchResult,
+  AutomationRunOutputSnapshot,
   AutomationRun,
   AutomationRunTrigger,
   AutomationUpdateInput
@@ -72,7 +73,7 @@ import {
 import { agentHookServer } from './agent-hooks/server'
 import { pruneLocalTerminalScrollbackBuffers } from '../shared/workspace-session-terminal-buffers'
 import { pruneWorkspaceSessionBrowserHistory } from '../shared/workspace-session-browser-history'
-import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
+import { getRepoIdFromWorktreeId, getWorktreePathBasenameFromId } from '../shared/worktree-id'
 import { normalizeTerminalQuickCommands } from '../shared/terminal-quick-commands'
 import { normalizeVisibleTaskProviders } from '../shared/task-providers'
 import {
@@ -172,6 +173,32 @@ function normalizeSortBy(sortBy: unknown): 'name' | 'smart' | 'recent' | 'repo' 
     return sortBy
   }
   return getDefaultUIState().sortBy
+}
+
+function normalizeAutomationRunWorkspaceDisplayName(value: string | null): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function normalizeAutomationRunOutputSnapshot(
+  value: AutomationRunOutputSnapshot | null | undefined
+): AutomationRunOutputSnapshot | null {
+  if (!value || value.format !== 'plain_text') {
+    return null
+  }
+  const content = typeof value.content === 'string' ? value.content : ''
+  if (!content.trim()) {
+    return null
+  }
+  return {
+    format: 'plain_text',
+    content,
+    capturedAt:
+      typeof value.capturedAt === 'number' && Number.isFinite(value.capturedAt)
+        ? value.capturedAt
+        : Date.now(),
+    truncated: value.truncated === true
+  }
 }
 
 // Why: old persisted targets predate configHost. Default to label-based lookup
@@ -1891,9 +1918,11 @@ export class Store {
       status: 'pending',
       trigger,
       workspaceId: automation.workspaceId,
+      workspaceDisplayName: this.getAutomationRunWorkspaceDisplayName(automation.workspaceId),
       sessionKind: 'terminal',
       chatSessionId: null,
       terminalSessionId: null,
+      outputSnapshot: null,
       usage: null,
       error: null,
       startedAt: null,
@@ -1912,11 +1941,22 @@ export class Store {
     }
     const now = Date.now()
     const current = this.state.automationRuns[index]
+    const workspaceId = result.workspaceId ?? current.workspaceId
+    const workspaceDisplayName = Object.hasOwn(result, 'workspaceDisplayName')
+      ? normalizeAutomationRunWorkspaceDisplayName(result.workspaceDisplayName ?? null)
+      : null
     const updated: AutomationRun = {
       ...current,
       status: result.status,
-      workspaceId: result.workspaceId ?? current.workspaceId,
+      workspaceId,
+      workspaceDisplayName:
+        workspaceDisplayName ??
+        normalizeAutomationRunWorkspaceDisplayName(current.workspaceDisplayName ?? null) ??
+        this.getAutomationRunWorkspaceDisplayName(workspaceId),
       terminalSessionId: result.terminalSessionId ?? current.terminalSessionId,
+      outputSnapshot: Object.hasOwn(result, 'outputSnapshot')
+        ? normalizeAutomationRunOutputSnapshot(result.outputSnapshot)
+        : normalizeAutomationRunOutputSnapshot(current.outputSnapshot),
       usage: Object.hasOwn(result, 'usage') ? (result.usage ?? null) : (current.usage ?? null),
       error: result.error ?? null,
       startedAt: current.startedAt ?? now,
@@ -1930,6 +1970,37 @@ export class Store {
     }
     this.flush()
     return updated
+  }
+
+  snapshotAutomationRunWorkspaceDisplayName(workspaceId: string, displayName: string): number {
+    const normalizedDisplayName = normalizeAutomationRunWorkspaceDisplayName(displayName)
+    if (!normalizedDisplayName) {
+      return 0
+    }
+    let updatedCount = 0
+    this.state.automationRuns = (this.state.automationRuns ?? []).map((run) => {
+      if (run.workspaceId !== workspaceId || run.workspaceDisplayName === normalizedDisplayName) {
+        return run
+      }
+      updatedCount += 1
+      return { ...run, workspaceDisplayName: normalizedDisplayName }
+    })
+    if (updatedCount > 0) {
+      this.flush()
+    }
+    return updatedCount
+  }
+
+  private getAutomationRunWorkspaceDisplayName(
+    workspaceId: string | null | undefined
+  ): string | null {
+    if (!workspaceId) {
+      return null
+    }
+    return normalizeAutomationRunWorkspaceDisplayName(
+      this.state.worktreeMeta[workspaceId]?.displayName ??
+        getWorktreePathBasenameFromId(workspaceId)
+    )
   }
 
   advanceAutomationNextRun(id: string, now = Date.now()): Automation {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -237,8 +237,12 @@ import type {
   AutomationCreateInput,
   AutomationDispatchRequest,
   AutomationDispatchResult,
+  ExternalAutomationCreateInput,
   ExternalAutomationActionInput,
   ExternalAutomationManager,
+  ExternalAutomationRunsInput,
+  ExternalAutomationRunsPage,
+  ExternalAutomationUpdateInput,
   AutomationRun,
   AutomationUpdateInput
 } from '../shared/automations-types'
@@ -1693,12 +1697,16 @@ export type PreloadApi = {
     list: () => Promise<Automation[]>
     listRuns: (args?: { automationId?: string }) => Promise<AutomationRun[]>
     listExternalManagers: () => Promise<ExternalAutomationManager[]>
+    listExternalRuns: (input: ExternalAutomationRunsInput) => Promise<ExternalAutomationRunsPage>
+    createExternal: (input: ExternalAutomationCreateInput) => Promise<void>
+    updateExternal: (input: ExternalAutomationUpdateInput) => Promise<void>
     runExternalAction: (input: ExternalAutomationActionInput) => Promise<void>
     create: (input: AutomationCreateInput) => Promise<Automation>
     update: (args: { id: string; updates: AutomationUpdateInput }) => Promise<Automation>
     delete: (args: { id: string }) => Promise<void>
     runNow: (args: { id: string }) => Promise<AutomationRun>
     markDispatchResult: (result: AutomationDispatchResult) => Promise<AutomationRun>
+    snapshotWorkspaceName: (args: { workspaceId: string; displayName: string }) => Promise<number>
     rendererReady: () => Promise<void>
     onDispatchRequested: (callback: (request: AutomationDispatchRequest) => void) => () => void
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -101,8 +101,12 @@ import type {
   AutomationCreateInput,
   AutomationDispatchRequest,
   AutomationDispatchResult,
+  ExternalAutomationCreateInput,
   ExternalAutomationActionInput,
   ExternalAutomationManager,
+  ExternalAutomationRunsInput,
+  ExternalAutomationRunsPage,
+  ExternalAutomationUpdateInput,
   AutomationRun,
   AutomationUpdateInput
 } from '../shared/automations-types'
@@ -2723,6 +2727,12 @@ const api = {
       ipcRenderer.invoke('automations:listRuns', args),
     listExternalManagers: (): Promise<ExternalAutomationManager[]> =>
       ipcRenderer.invoke('automations:listExternalManagers'),
+    listExternalRuns: (input: ExternalAutomationRunsInput): Promise<ExternalAutomationRunsPage> =>
+      ipcRenderer.invoke('automations:listExternalRuns', input),
+    createExternal: (input: ExternalAutomationCreateInput): Promise<void> =>
+      ipcRenderer.invoke('automations:createExternal', input),
+    updateExternal: (input: ExternalAutomationUpdateInput): Promise<void> =>
+      ipcRenderer.invoke('automations:updateExternal', input),
     runExternalAction: (input: ExternalAutomationActionInput): Promise<void> =>
       ipcRenderer.invoke('automations:runExternalAction', input),
     create: (input: AutomationCreateInput): Promise<Automation> =>
@@ -2734,6 +2744,8 @@ const api = {
       ipcRenderer.invoke('automations:runNow', args),
     markDispatchResult: (result: AutomationDispatchResult): Promise<AutomationRun> =>
       ipcRenderer.invoke('automations:markDispatchResult', result),
+    snapshotWorkspaceName: (args: { workspaceId: string; displayName: string }): Promise<number> =>
+      ipcRenderer.invoke('automations:snapshotWorkspaceName', args),
     rendererReady: (): Promise<void> => ipcRenderer.invoke('automations:rendererReady'),
     onDispatchRequested: (callback: (request: AutomationDispatchRequest) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, request: AutomationDispatchRequest) =>

--- a/src/relay/external-automations-handler.test.ts
+++ b/src/relay/external-automations-handler.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExternalAutomationsHandler } from './external-automations-handler'
+import type { RelayDispatcher } from './dispatcher'
+
+const execFileMock = vi.hoisted(() =>
+  vi.fn((...args: unknown[]) => {
+    const callback = args.at(-1)
+    if (typeof callback === 'function') {
+      const execCallback = callback as (error: Error | null, stdout: string, stderr: string) => void
+      execCallback(null, '', '')
+    }
+  })
+)
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+
+type CapturedHandler = (params?: Record<string, unknown>) => Promise<unknown>
+
+function createHandlerHarness(): {
+  handler: ExternalAutomationsHandler
+  requestHandlers: Map<string, CapturedHandler>
+} {
+  const requestHandlers = new Map<string, CapturedHandler>()
+  const dispatcher = {
+    onRequest(method: string, handler: CapturedHandler): void {
+      requestHandlers.set(method, handler)
+    }
+  }
+  const handler = new ExternalAutomationsHandler(dispatcher as unknown as RelayDispatcher)
+  return { handler, requestHandlers }
+}
+
+beforeEach(() => {
+  execFileMock.mockClear()
+})
+
+describe('ExternalAutomationsHandler', () => {
+  it('runs external lifecycle actions without shell wrapping', async () => {
+    const { requestHandlers } = createHandlerHarness()
+
+    await requestHandlers.get('externalAutomations.act')?.({
+      provider: 'hermes',
+      action: 'run',
+      jobId: 'job-1'
+    })
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'hermes',
+      ['cron', 'run', 'job-1'],
+      { encoding: 'utf-8', timeout: 30_000 },
+      expect.any(Function)
+    )
+  })
+
+  it('paginates remote Hermes run history after ref lookup', async () => {
+    const { handler, requestHandlers } = createHandlerHarness()
+    const handlerInternals = handler as unknown as {
+      readHermesRunRefs: (jobId: string) => Promise<{ id: string; run_at: string }[]>
+      hydrateHermesRunRef: (
+        jobId: string,
+        ref: { id: string; run_at: string }
+      ) => Promise<{ id: string; run_at: string }>
+    }
+    handlerInternals.readHermesRunRefs = vi.fn().mockResolvedValue([
+      {
+        id: 'cron_job-1_20260516_090000',
+        run_at: '2026-05-16T09:00:00'
+      },
+      {
+        id: 'job-1:2026-05-15_09-00-00.md',
+        run_at: '2026-05-15T09:00:00'
+      },
+      {
+        id: 'job-1:2026-05-14_09-00-00.md',
+        run_at: '2026-05-14T09:00:00'
+      }
+    ])
+    handlerInternals.hydrateHermesRunRef = vi.fn(async (_jobId, ref) => ref)
+
+    const result = (await requestHandlers.get('externalAutomations.runs')?.({
+      provider: 'hermes',
+      jobId: 'job-1',
+      page: 1,
+      pageSize: 2
+    })) as { total: number; runs: { id: string }[] }
+
+    expect(result.total).toBe(3)
+    expect(result.runs.map((run) => run.id)).toEqual([
+      'cron_job-1_20260516_090000',
+      'job-1:2026-05-15_09-00-00.md'
+    ])
+  })
+
+  it('uses a count-only path for remote Hermes manager listing run counts', async () => {
+    const { handler, requestHandlers } = createHandlerHarness()
+    const handlerInternals = handler as unknown as {
+      readHermesRunCount: (jobId: string) => Promise<number>
+    }
+    handlerInternals.readHermesRunCount = vi.fn().mockResolvedValue(42)
+
+    const result = (await requestHandlers.get('externalAutomations.runs')?.({
+      provider: 'hermes',
+      jobId: 'job-1',
+      page: 1,
+      pageSize: 0
+    })) as { total: number; runs: unknown[] }
+
+    expect(result).toEqual({ total: 42, runs: [] })
+  })
+})

--- a/src/relay/external-automations-handler.ts
+++ b/src/relay/external-automations-handler.ts
@@ -1,28 +1,74 @@
+/* eslint-disable max-lines -- Why: relay external automation listing, paginated
+ * run history, and actions must stay co-located behind one relay request handler. */
 import { execFile } from 'child_process'
 import { existsSync } from 'fs'
-import { readFile } from 'fs/promises'
+import { open, readdir, readFile, realpath, stat } from 'fs/promises'
+import { createRequire } from 'module'
 import { homedir } from 'os'
-import { join } from 'path'
+import { isAbsolute, join, relative, resolve } from 'path'
 import { promisify } from 'util'
+import type Database from 'better-sqlite3'
 import type { RelayDispatcher } from './dispatcher'
 
 const execFileAsync = promisify(execFile)
-const HERMES_JOBS_FILE = join(homedir(), '.hermes', 'cron', 'jobs.json')
+const requireOptional = createRequire(__filename)
+const HERMES_HOME = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
+const HERMES_CRON_DIR = join(HERMES_HOME, 'cron')
+const HERMES_JOBS_FILE = join(HERMES_CRON_DIR, 'jobs.json')
+const HERMES_OUTPUT_DIR = join(HERMES_CRON_DIR, 'output')
+const HERMES_STATE_DB = join(HERMES_HOME, 'state.db')
 const OPENCLAW_JOBS_FILE = join(homedir(), '.openclaw', 'cron', 'jobs.json')
 const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
+const HERMES_OUTPUT_FILE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})_(\d{2})-(\d{2})-(\d{2})\.md$/
+const HERMES_RUN_KEY_PATTERN = /^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$/
+const MAX_SESSION_OUTPUT_GAP_MS = 24 * 60 * 60 * 1000
+const MAX_REFERENCED_LOG_BYTES = 5 * 1024 * 1024
+const FULL_SESSION_LOG_HEADING = '## Full session log'
+const REFERENCED_LOG_HEADING = '## Latest log file'
+const LATEST_LOG_PATH_PATTERN =
+  /\bLatest log path:\s*(?<path>(?:[A-Za-z]:[\\/]|\/)[^\r\n]*?)(?=\s+Run summary:|\r?\n|$)/i
+type DatabaseConstructor = typeof Database
+let databaseConstructor: DatabaseConstructor | null | undefined
 
 type ExternalProvider = 'hermes' | 'openclaw'
 type HermesAction = 'pause' | 'resume' | 'run' | 'delete'
+type HermesOutputRunRef = {
+  kind: 'output'
+  id: string
+  job_id: string
+  run_at: string | null
+  run_key: string | null
+  output_path: string
+}
+type HermesSessionRunRef = {
+  kind: 'session'
+  id: string
+  job_id: string
+  run_at: string | null
+  run_key: string | null
+}
+type HermesMergedRunRef = {
+  id: string
+  job_id: string
+  run_at: string | null
+  run_key: string | null
+  output: HermesOutputRunRef | null
+  session: HermesSessionRunRef | null
+}
 
 export class ExternalAutomationsHandler {
   constructor(private readonly dispatcher: RelayDispatcher) {
     this.dispatcher.onRequest('externalAutomations.list', (params) => this.listJobs(params))
+    this.dispatcher.onRequest('externalAutomations.runs', (params) => this.listRuns(params))
+    this.dispatcher.onRequest('externalAutomations.create', (params) => this.createJob(params))
+    this.dispatcher.onRequest('externalAutomations.update', (params) => this.updateJob(params))
     this.dispatcher.onRequest('externalAutomations.act', (params) => this.runAction(params))
   }
 
   private async isCommandAvailable(command: string): Promise<boolean> {
+    const finder = process.platform === 'win32' ? 'where' : 'which'
     try {
-      await execFileAsync('/bin/sh', ['-lc', `which ${command}`], {
+      await execFileAsync(finder, [command], {
         encoding: 'utf-8',
         timeout: 5000
       })
@@ -39,15 +85,629 @@ export class ExternalAutomationsHandler {
     }
     const content = await readFile(jobsFile, 'utf-8')
     const parsed = JSON.parse(content) as unknown
-    if (Array.isArray(parsed)) {
-      return parsed
+    const jobs = Array.isArray(parsed)
+      ? parsed
+      : typeof parsed === 'object' &&
+          parsed !== null &&
+          !Array.isArray(parsed) &&
+          Array.isArray((parsed as { jobs?: unknown }).jobs)
+        ? (parsed as { jobs: unknown[] }).jobs
+        : []
+    if (provider !== 'hermes') {
+      return jobs
     }
-    return typeof parsed === 'object' &&
-      parsed !== null &&
-      !Array.isArray(parsed) &&
-      Array.isArray((parsed as { jobs?: unknown }).jobs)
-      ? (parsed as { jobs: unknown[] }).jobs
-      : []
+    return Promise.all(
+      jobs.map(async (job) => {
+        if (!this.isRecord(job) || typeof job.id !== 'string') {
+          return job
+        }
+        const runsPage = await this.listRuns({
+          provider: 'hermes',
+          jobId: job.id,
+          page: 1,
+          pageSize: 0
+        })
+        return {
+          ...job,
+          run_count: runsPage.total,
+          runs: runsPage.runs
+        }
+      })
+    )
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+  }
+
+  private runAtFromHermesOutputFile(filename: string): string | null {
+    const match = HERMES_OUTPUT_FILE_PATTERN.exec(filename)
+    if (!match) {
+      return null
+    }
+    const [, year, month, day, hour, minute, second] = match
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}`
+  }
+
+  private runKeyFromHermesOutputFile(filename: string): string | null {
+    const match = HERMES_OUTPUT_FILE_PATTERN.exec(filename)
+    if (!match) {
+      return null
+    }
+    const [, year, month, day, hour, minute, second] = match
+    return `${year}${month}${day}_${hour}${minute}${second}`
+  }
+
+  private runAtFromUnixSeconds(value: unknown): string | null {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return null
+    }
+    const date = new Date(value * 1000)
+    return Number.isNaN(date.getTime()) ? null : date.toISOString()
+  }
+
+  private sortableTimeFromRunKey(runKey: string | null): number {
+    if (!runKey) {
+      return Number.NaN
+    }
+    const match = HERMES_RUN_KEY_PATTERN.exec(runKey)
+    if (!match) {
+      return Number.NaN
+    }
+    const [, year, month, day, hour, minute, second] = match
+    return Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second)
+    )
+  }
+
+  private escapeSqlLike(value: string): string {
+    return value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')
+  }
+
+  private cleanRunPreview(value: string): string | null {
+    const normalized = value
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/[#*_`>()]/g, ' ')
+      .replaceAll('[', ' ')
+      .replaceAll(']', ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (!normalized) {
+      return null
+    }
+    return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized
+  }
+
+  private parseHermesOutput(content: string): {
+    status: 'completed' | 'failed' | 'unknown'
+    outputPreview: string | null
+    outputContent: string
+    error: string | null
+  } {
+    const failed = /^#\s+Cron Job:.*\(FAILED\)/m.test(content) || /^##\s+Error\b/m.test(content)
+    const errorMatch = /##\s+Error\s+```([\s\S]*?)```/m.exec(content)
+    const responseMatch = /##\s+Response\s+([\s\S]*)$/m.exec(content)
+    const error = errorMatch ? this.cleanRunPreview(errorMatch[1]) : null
+    return {
+      status: failed ? 'failed' : responseMatch ? 'completed' : 'unknown',
+      outputPreview: this.cleanRunPreview(responseMatch?.[1] ?? errorMatch?.[1] ?? content),
+      outputContent: content,
+      error
+    }
+  }
+
+  private extractLatestLogPath(content: string): string | null {
+    const rawPath = LATEST_LOG_PATH_PATTERN.exec(content)?.groups?.path?.trim()
+    if (!rawPath) {
+      return null
+    }
+    return rawPath.replace(/^`|`$/g, '').trim()
+  }
+
+  private async readReferencedLogFile(content: string): Promise<{
+    path: string
+    content: string
+    truncated: boolean
+  } | null> {
+    const logPath = this.extractLatestLogPath(content)
+    if (!logPath || !isAbsolute(logPath)) {
+      return null
+    }
+    try {
+      const homeRealPath = await realpath(HERMES_HOME)
+      const logRealPath = await realpath(logPath)
+      const relativeToHermesHome = relative(resolve(homeRealPath), resolve(logRealPath))
+      // Why: the output body can contain agent-authored text, so only hydrate
+      // referenced files that resolve inside Hermes' own data directory.
+      if (relativeToHermesHome.startsWith('..') || isAbsolute(relativeToHermesHome)) {
+        return null
+      }
+      const logStat = await stat(logPath)
+      if (!logStat.isFile()) {
+        return null
+      }
+      if (logStat.size <= MAX_REFERENCED_LOG_BYTES) {
+        return {
+          path: logPath,
+          content: await readFile(logPath, 'utf-8'),
+          truncated: false
+        }
+      }
+      const file = await open(logPath, 'r')
+      try {
+        const buffer = Buffer.alloc(MAX_REFERENCED_LOG_BYTES)
+        await file.read(
+          buffer,
+          0,
+          MAX_REFERENCED_LOG_BYTES,
+          logStat.size - MAX_REFERENCED_LOG_BYTES
+        )
+        return {
+          path: logPath,
+          content: buffer.toString('utf-8'),
+          truncated: true
+        }
+      } finally {
+        await file.close()
+      }
+    } catch {
+      return null
+    }
+  }
+
+  private async appendReferencedLogFile(content: string): Promise<string> {
+    if (content.includes(REFERENCED_LOG_HEADING)) {
+      return content
+    }
+    const logFile = await this.readReferencedLogFile(content)
+    if (!logFile) {
+      return content
+    }
+    const note = logFile.truncated
+      ? `Showing the last ${MAX_REFERENCED_LOG_BYTES} bytes because the log file is larger.`
+      : null
+    return [
+      content,
+      '---',
+      REFERENCED_LOG_HEADING,
+      '',
+      `Path: ${logFile.path}`,
+      note,
+      '```text',
+      logFile.content.trimEnd(),
+      '```'
+    ]
+      .filter((part) => part !== null)
+      .join('\n\n')
+  }
+
+  private formatSessionMessages(messages: Record<string, unknown>[]): string | null {
+    if (messages.length === 0) {
+      return null
+    }
+    return messages
+      .map((message) => {
+        const role = typeof message.role === 'string' ? message.role : 'message'
+        const content = typeof message.content === 'string' ? message.content.trim() : ''
+        const toolName = typeof message.tool_name === 'string' ? message.tool_name.trim() : ''
+        const reasoning =
+          typeof message.reasoning_content === 'string'
+            ? message.reasoning_content.trim()
+            : typeof message.reasoning === 'string'
+              ? message.reasoning.trim()
+              : ''
+        const parts = [
+          `## ${role}${toolName ? ` / ${toolName}` : ''}`,
+          reasoning ? `### Reasoning\n\n${reasoning}` : null,
+          content || '(empty)'
+        ].filter(Boolean)
+        return parts.join('\n\n')
+      })
+      .join('\n\n---\n\n')
+  }
+
+  private getRunKey(run: unknown): string | null {
+    return this.isRecord(run) && typeof run.run_key === 'string' && run.run_key.trim()
+      ? run.run_key
+      : null
+  }
+
+  private getRunOutputContent(run: unknown): string | null {
+    return this.isRecord(run) && typeof run.output_content === 'string' && run.output_content.trim()
+      ? run.output_content
+      : null
+  }
+
+  private getRunOutputPreview(run: unknown): string | null {
+    return this.isRecord(run) && typeof run.output_preview === 'string' && run.output_preview.trim()
+      ? run.output_preview
+      : null
+  }
+
+  private mergeOutputAndSessionContent(
+    outputContent: string | null,
+    sessionContent: string | null
+  ): string | null {
+    if (!sessionContent) {
+      return outputContent
+    }
+    if (!outputContent) {
+      return `${FULL_SESSION_LOG_HEADING}\n\n${sessionContent}`
+    }
+    if (outputContent.includes(FULL_SESSION_LOG_HEADING)) {
+      return outputContent
+    }
+    return `${outputContent}\n\n---\n\n${FULL_SESSION_LOG_HEADING}\n\n${sessionContent}`
+  }
+
+  private findMatchingSessionRunIndex(
+    outputRun: unknown,
+    sessionRuns: unknown[],
+    usedSessionRunIndexes: Set<number>
+  ): number | null {
+    const outputRunKey = this.getRunKey(outputRun)
+    const exactMatchIndex = sessionRuns.findIndex(
+      (sessionRun, index) =>
+        !usedSessionRunIndexes.has(index) && this.getRunKey(sessionRun) === outputRunKey
+    )
+    if (exactMatchIndex >= 0) {
+      return exactMatchIndex
+    }
+
+    const outputTime = this.sortableTimeFromRunKey(outputRunKey)
+    if (!Number.isFinite(outputTime)) {
+      return null
+    }
+
+    let bestIndex: number | null = null
+    let bestGap = Number.POSITIVE_INFINITY
+    for (let index = 0; index < sessionRuns.length; index += 1) {
+      if (usedSessionRunIndexes.has(index)) {
+        continue
+      }
+      const sessionTime = this.sortableTimeFromRunKey(this.getRunKey(sessionRuns[index]))
+      if (!Number.isFinite(sessionTime)) {
+        continue
+      }
+      const gap = outputTime - sessionTime
+      if (gap < 0 || gap > MAX_SESSION_OUTPUT_GAP_MS || gap >= bestGap) {
+        continue
+      }
+      bestIndex = index
+      bestGap = gap
+    }
+    return bestIndex
+  }
+
+  private mergeHermesOutputAndSessionRuns(
+    outputRuns: unknown[],
+    sessionRuns: unknown[]
+  ): unknown[] {
+    const usedSessionRunIndexes = new Set<number>()
+    const mergedOutputRuns = outputRuns.map((outputRun) => {
+      if (!this.isRecord(outputRun)) {
+        return outputRun
+      }
+      const sessionRunIndex = this.findMatchingSessionRunIndex(
+        outputRun,
+        sessionRuns,
+        usedSessionRunIndexes
+      )
+      if (sessionRunIndex === null) {
+        return outputRun
+      }
+      const sessionRun = sessionRuns[sessionRunIndex]
+      if (!this.isRecord(sessionRun)) {
+        return outputRun
+      }
+      usedSessionRunIndexes.add(sessionRunIndex)
+      // Hermes writes the markdown output at completion, while state.db keeps
+      // the actual turn-by-turn transcript under the cron session start time.
+      return {
+        ...outputRun,
+        output_preview: this.getRunOutputPreview(outputRun) ?? this.getRunOutputPreview(sessionRun),
+        output_content: this.mergeOutputAndSessionContent(
+          this.getRunOutputContent(outputRun),
+          this.getRunOutputContent(sessionRun)
+        )
+      }
+    })
+    return [
+      ...mergedOutputRuns,
+      ...sessionRuns.filter((_, index) => !usedSessionRunIndexes.has(index))
+    ]
+  }
+
+  private mergeHermesOutputAndSessionRunRefs(
+    outputRefs: HermesOutputRunRef[],
+    sessionRefs: HermesSessionRunRef[]
+  ): HermesMergedRunRef[] {
+    const usedSessionRunIndexes = new Set<number>()
+    const mergedOutputRefs = outputRefs.map((outputRef) => {
+      const sessionRunIndex = this.findMatchingSessionRunIndex(
+        outputRef,
+        sessionRefs,
+        usedSessionRunIndexes
+      )
+      const sessionRef = sessionRunIndex === null ? null : sessionRefs[sessionRunIndex]
+      if (sessionRunIndex !== null) {
+        usedSessionRunIndexes.add(sessionRunIndex)
+      }
+      return {
+        id: outputRef.id,
+        job_id: outputRef.job_id,
+        run_at: outputRef.run_at,
+        run_key: outputRef.run_key,
+        output: outputRef,
+        session: sessionRef
+      }
+    })
+    return [
+      ...mergedOutputRefs,
+      ...sessionRefs
+        .filter((_, index) => !usedSessionRunIndexes.has(index))
+        .map((sessionRef) => ({
+          id: sessionRef.id,
+          job_id: sessionRef.job_id,
+          run_at: sessionRef.run_at,
+          run_key: sessionRef.run_key,
+          output: null,
+          session: sessionRef
+        }))
+    ]
+  }
+
+  private getDatabaseConstructor(): DatabaseConstructor | null {
+    if (databaseConstructor !== undefined) {
+      return databaseConstructor
+    }
+    try {
+      const loaded = requireOptional('better-sqlite3') as
+        | DatabaseConstructor
+        | { default?: DatabaseConstructor }
+      databaseConstructor = typeof loaded === 'function' ? loaded : (loaded.default ?? null)
+    } catch {
+      databaseConstructor = null
+    }
+    return databaseConstructor
+  }
+
+  private async readHermesRunRefs(jobId: string): Promise<HermesMergedRunRef[]> {
+    const outputRuns = await this.readHermesOutputFileRunRefs(jobId)
+    return this.mergeHermesOutputAndSessionRunRefs(
+      outputRuns,
+      this.readHermesSessionDbRunRefs(jobId)
+    ).sort((a, b) => {
+      const aTime = this.getRawRunTime(a)
+      const bTime = this.getRawRunTime(b)
+      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+        return bTime - aTime
+      }
+      return this.getRawRunId(b).localeCompare(this.getRawRunId(a))
+    })
+  }
+
+  private async hydrateHermesRunRef(jobId: string, ref: HermesMergedRunRef): Promise<unknown> {
+    const outputRun = ref.output ? await this.readHermesOutputFileRun(ref.output) : null
+    const sessionRun = ref.session ? this.readHermesSessionDbRunById(jobId, ref.session.id) : null
+    return (
+      this.mergeHermesOutputAndSessionRuns(
+        outputRun ? [outputRun] : [],
+        sessionRun ? [sessionRun] : []
+      )[0] ??
+      outputRun ??
+      sessionRun ??
+      ref
+    )
+  }
+
+  private async readHermesRunCount(jobId: string): Promise<number> {
+    if (!EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
+      return 0
+    }
+    return (await this.readHermesRunRefs(jobId)).length
+  }
+
+  private async listRuns(params: Record<string, unknown> = {}): Promise<{
+    total: number
+    runs: unknown[]
+  }> {
+    const provider = params.provider === 'openclaw' ? 'openclaw' : 'hermes'
+    const jobId = params.jobId
+    const page =
+      typeof params.page === 'number' && Number.isFinite(params.page)
+        ? Math.max(1, Math.floor(params.page))
+        : 1
+    const pageSize =
+      typeof params.pageSize === 'number' && Number.isFinite(params.pageSize)
+        ? Math.min(100, Math.max(0, Math.floor(params.pageSize)))
+        : 25
+    if (provider !== 'hermes') {
+      return { total: 0, runs: [] }
+    }
+    if (typeof jobId !== 'string' || !EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
+      throw new Error('Invalid external automation job ID.')
+    }
+    if (pageSize === 0) {
+      // Why: manager listing only needs a badge count; hydrating markdown logs
+      // and full session transcripts can make opening Automations very slow.
+      return { total: await this.readHermesRunCount(jobId), runs: [] }
+    }
+    const runRefs = await this.readHermesRunRefs(jobId)
+    const start = (page - 1) * pageSize
+    return {
+      total: runRefs.length,
+      runs: await Promise.all(
+        runRefs.slice(start, start + pageSize).map((ref) => this.hydrateHermesRunRef(jobId, ref))
+      )
+    }
+  }
+
+  private getRawRunId(run: unknown): string {
+    if (this.isRecord(run) && 'id' in run) {
+      return String(run.id)
+    }
+    return ''
+  }
+
+  private getRawRunTime(run: unknown): number {
+    if (!this.isRecord(run) || !('run_at' in run)) {
+      return Number.NaN
+    }
+    return typeof run.run_at === 'string' ? Date.parse(run.run_at) : Number.NaN
+  }
+
+  private async readHermesOutputFileRunRefs(jobId: string): Promise<HermesOutputRunRef[]> {
+    const outputDir = join(HERMES_OUTPUT_DIR, jobId)
+    if (!existsSync(outputDir)) {
+      return []
+    }
+    const entries = await readdir(outputDir, { withFileTypes: true })
+    return entries
+      .filter((entry) => entry.isFile() && HERMES_OUTPUT_FILE_PATTERN.test(entry.name))
+      .map((entry) => ({
+        kind: 'output' as const,
+        id: `${jobId}:${entry.name}`,
+        job_id: jobId,
+        run_at: this.runAtFromHermesOutputFile(entry.name),
+        run_key: this.runKeyFromHermesOutputFile(entry.name),
+        output_path: join(outputDir, entry.name)
+      }))
+  }
+
+  private async readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown> {
+    try {
+      const content = await readFile(ref.output_path, 'utf-8')
+      const parsed = this.parseHermesOutput(content)
+      const outputContent = await this.appendReferencedLogFile(parsed.outputContent)
+      return {
+        id: ref.id,
+        job_id: ref.job_id,
+        run_at: ref.run_at,
+        run_key: ref.run_key,
+        status: parsed.status,
+        output_preview: parsed.outputPreview,
+        output_content: outputContent,
+        error: parsed.error,
+        output_path: ref.output_path
+      }
+    } catch (error) {
+      return {
+        id: ref.id,
+        job_id: ref.job_id,
+        run_at: ref.run_at,
+        run_key: ref.run_key,
+        status: 'unknown',
+        output_preview: null,
+        output_content: null,
+        error: error instanceof Error ? error.message : String(error),
+        output_path: ref.output_path
+      }
+    }
+  }
+
+  private readHermesSessionDbRunRefs(jobId: string): HermesSessionRunRef[] {
+    if (!existsSync(HERMES_STATE_DB)) {
+      return []
+    }
+    const Database = this.getDatabaseConstructor()
+    if (!Database) {
+      return []
+    }
+    try {
+      const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
+      try {
+        const pattern = `cron\\_${this.escapeSqlLike(jobId)}\\_%`
+        const rows = db
+          .prepare(
+            `SELECT id, started_at
+               FROM sessions
+              WHERE id LIKE ? ESCAPE '\\'
+              ORDER BY started_at DESC`
+          )
+          .all(pattern) as Record<string, unknown>[]
+        return rows.map((row) => {
+          const runId = typeof row.id === 'string' ? row.id : `${jobId}:${String(row.started_at)}`
+          return {
+            kind: 'session',
+            id: runId,
+            job_id: jobId,
+            run_at: this.runAtFromUnixSeconds(row.started_at),
+            run_key: runId.split(`${jobId}_`).at(-1) ?? null
+          }
+        })
+      } finally {
+        db.close()
+      }
+    } catch {
+      return []
+    }
+  }
+
+  private readHermesSessionDbRunById(jobId: string, runId: string): unknown | null {
+    if (!existsSync(HERMES_STATE_DB)) {
+      return null
+    }
+    const Database = this.getDatabaseConstructor()
+    if (!Database) {
+      return null
+    }
+    try {
+      const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
+      try {
+        const row = db
+          .prepare(
+            `SELECT id, title, started_at, ended_at, end_reason, model, message_count,
+                    input_tokens, output_tokens, estimated_cost_usd
+               FROM sessions
+              WHERE id = ?`
+          )
+          .get(runId) as Record<string, unknown> | undefined
+        if (!row) {
+          return null
+        }
+        const messages = db
+          .prepare(
+            `SELECT role, content, tool_name, reasoning, reasoning_content
+                 FROM messages
+                WHERE session_id = ?
+                ORDER BY timestamp, id`
+          )
+          .all(runId) as Record<string, unknown>[]
+        const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : null
+        const model = typeof row.model === 'string' && row.model.trim() ? row.model.trim() : null
+        const messageCount = typeof row.message_count === 'number' ? row.message_count : null
+        const tokenCount =
+          (typeof row.input_tokens === 'number' ? row.input_tokens : 0) +
+          (typeof row.output_tokens === 'number' ? row.output_tokens : 0)
+        const summaryParts = [
+          title,
+          model ? `Model: ${model}` : null,
+          messageCount !== null ? `${messageCount} messages` : null,
+          tokenCount > 0 ? `${tokenCount} tokens` : null
+        ].filter(Boolean)
+        return {
+          id: runId,
+          job_id: jobId,
+          run_at: this.runAtFromUnixSeconds(row.started_at),
+          run_key: runId.split(`${jobId}_`).at(-1) ?? null,
+          status: typeof row.ended_at === 'number' ? 'completed' : 'unknown',
+          output_preview: summaryParts.join(' · ') || null,
+          output_content: this.formatSessionMessages(messages),
+          error: null,
+          output_path: HERMES_STATE_DB
+        }
+      } finally {
+        db.close()
+      }
+    } catch {
+      return null
+    }
   }
 
   private async listJobs(params?: Record<string, unknown>): Promise<{
@@ -97,6 +757,84 @@ export class ExternalAutomationsHandler {
     }
   }
 
+  private normalizeHermesJobMutation(params: Record<string, unknown>): {
+    name: string
+    prompt: string
+    schedule: string
+    workdir: string
+  } {
+    const provider = params.provider === 'openclaw' ? 'openclaw' : 'hermes'
+    if (provider !== 'hermes') {
+      throw new Error('Only Hermes cron creation and editing are supported.')
+    }
+    const name = typeof params.name === 'string' ? params.name.trim() : ''
+    const prompt = typeof params.prompt === 'string' ? params.prompt.trim() : ''
+    const schedule = typeof params.schedule === 'string' ? params.schedule.trim() : ''
+    const workdir = typeof params.workdir === 'string' ? params.workdir.trim() : ''
+    if (!prompt) {
+      throw new Error('Hermes cron requires a prompt.')
+    }
+    if (!schedule) {
+      throw new Error('Hermes cron requires a schedule.')
+    }
+    return {
+      name: name || prompt.slice(0, 50).trim(),
+      prompt,
+      schedule,
+      workdir
+    }
+  }
+
+  private async runHermesCronCommand(args: string[]): Promise<void> {
+    await execFileAsync('hermes', args, {
+      encoding: 'utf-8',
+      timeout: 30_000
+    })
+  }
+
+  private async createJob(params: Record<string, unknown> = {}): Promise<{ ok: true }> {
+    const input = this.normalizeHermesJobMutation(params)
+    const args = [
+      'cron',
+      'create',
+      input.schedule,
+      input.prompt,
+      '--name',
+      input.name,
+      '--deliver',
+      'local'
+    ]
+    if (input.workdir) {
+      args.push('--workdir', input.workdir)
+    }
+    await this.runHermesCronCommand(args)
+    return { ok: true }
+  }
+
+  private async updateJob(params: Record<string, unknown> = {}): Promise<{ ok: true }> {
+    const input = this.normalizeHermesJobMutation(params)
+    const jobId = params.jobId
+    if (typeof jobId !== 'string' || !EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
+      throw new Error('Invalid external automation job ID.')
+    }
+    const args = [
+      'cron',
+      'edit',
+      jobId,
+      '--schedule',
+      input.schedule,
+      '--prompt',
+      input.prompt,
+      '--name',
+      input.name
+    ]
+    if (input.workdir) {
+      args.push('--workdir', input.workdir)
+    }
+    await this.runHermesCronCommand(args)
+    return { ok: true }
+  }
+
   private async runAction(params: Record<string, unknown> = {}): Promise<{ ok: true }> {
     const provider = params.provider === 'openclaw' ? 'openclaw' : 'hermes'
     const action = params.action
@@ -109,7 +847,7 @@ export class ExternalAutomationsHandler {
     }
     const command =
       provider === 'hermes' ? this.hermesCommand(action) : this.openClawCommand(action)
-    await execFileAsync('/bin/sh', ['-lc', `${provider} cron ${command} ${jobId}`], {
+    await execFileAsync(provider, ['cron', command, jobId], {
       encoding: 'utf-8',
       timeout: 30_000
     })

--- a/src/renderer/src/components/automations/AutomationDetail.tsx
+++ b/src/renderer/src/components/automations/AutomationDetail.tsx
@@ -5,18 +5,11 @@ import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
 import type { Automation, AutomationRun } from '../../../../shared/automations-types'
-import type { Worktree } from '../../../../shared/types'
 import { formatAutomationSchedule } from '../../../../shared/automation-schedules'
-import {
-  formatAutomationDateTime,
-  formatAutomationDateTimeWithRelative,
-  getAutomationRunStatusLabel,
-  getAutomationRunStatusVariant
-} from './automation-page-parts'
+import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
 import {
   formatAutomationCost,
   formatAutomationTokens,
-  getAutomationUsageStatusLabel,
   summarizeAutomationRunUsage
 } from './automation-usage-model'
 
@@ -26,10 +19,8 @@ type AutomationDetailProps = {
   projectName: string
   workspaceName: string
   projectDefaultBaseRef: string | null
-  worktreeMap: Map<string, Worktree>
   now: number
   onRunNow: (automation: Automation) => void
-  onOpenRunWorkspace: (run: AutomationRun) => void
   onEdit: (automation: Automation) => void
   onToggle: (automation: Automation) => void
   onDelete: (automation: Automation) => void
@@ -93,10 +84,8 @@ export function AutomationDetail({
   projectName,
   workspaceName,
   projectDefaultBaseRef,
-  worktreeMap,
   now,
   onRunNow,
-  onOpenRunWorkspace,
   onEdit,
   onToggle,
   onDelete
@@ -211,96 +200,6 @@ export function AutomationDetail({
               {automation.prompt}
             </p>
           </div>
-        </div>
-      </div>
-
-      <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
-        <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
-          <div className="text-sm font-medium">Run history</div>
-          <div className="text-xs text-muted-foreground">{runs.length} runs</div>
-        </div>
-        <div className="grid grid-cols-[minmax(9rem,1fr)_minmax(11rem,1.2fr)_minmax(5rem,.55fr)_minmax(5rem,.55fr)_minmax(6rem,auto)] gap-3 border-b border-border/50 px-3 py-1.5 text-[11px] font-medium uppercase text-muted-foreground">
-          <div>Run</div>
-          <div>Workspace</div>
-          <div>Spend</div>
-          <div>Tokens</div>
-          <div>Status</div>
-        </div>
-        <div className="divide-y divide-border/50">
-          {runs.map((run) => {
-            const runWorktree = run.workspaceId ? (worktreeMap.get(run.workspaceId) ?? null) : null
-            const workspaceLabel = run.workspaceId
-              ? (runWorktree?.displayName ?? 'Missing workspace')
-              : 'Not launched'
-            const rowClassName =
-              'grid grid-cols-[minmax(9rem,1fr)_minmax(11rem,1.2fr)_minmax(5rem,.55fr)_minmax(5rem,.55fr)_minmax(6rem,auto)] items-center gap-3 px-3 py-2 text-left text-sm outline-none transition-colors'
-            const usageLabel = getAutomationUsageStatusLabel(run.usage)
-            const rowContent = (
-              <>
-                <div className="min-w-0">
-                  <div>{formatAutomationDateTime(run.scheduledFor)}</div>
-                  {run.error || run.usage?.status === 'unavailable' ? (
-                    <div className="mt-1 truncate text-xs text-muted-foreground">
-                      {run.error ?? run.usage?.unavailableMessage}
-                    </div>
-                  ) : null}
-                </div>
-                <div
-                  className={
-                    runWorktree
-                      ? 'min-w-0 truncate text-foreground'
-                      : 'min-w-0 truncate text-muted-foreground'
-                  }
-                >
-                  {workspaceLabel}
-                </div>
-                <div
-                  className={
-                    run.usage?.status === 'known'
-                      ? 'text-sm tabular-nums'
-                      : 'text-sm text-muted-foreground'
-                  }
-                  title={usageLabel}
-                >
-                  {formatAutomationCost(run.usage?.estimatedCostUsd)}
-                </div>
-                <div
-                  className={
-                    run.usage?.status === 'known'
-                      ? 'text-sm tabular-nums'
-                      : 'text-sm text-muted-foreground'
-                  }
-                  title={usageLabel}
-                >
-                  {run.usage?.status === 'known'
-                    ? formatAutomationTokens(run.usage.totalTokens)
-                    : 'n/a'}
-                </div>
-                <div className="flex justify-start">
-                  <Badge variant={getAutomationRunStatusVariant(run.status)}>
-                    {getAutomationRunStatusLabel(run.status)}
-                  </Badge>
-                </div>
-              </>
-            )
-            return runWorktree ? (
-              <button
-                key={run.id}
-                type="button"
-                className={`${rowClassName} w-full cursor-pointer hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:ring-[3px] focus-visible:ring-ring/50`}
-                onClick={() => onOpenRunWorkspace(run)}
-              >
-                {rowContent}
-              </button>
-            ) : (
-              <div key={run.id} className={rowClassName}>
-                {rowContent}
-              </div>
-            )
-          })}
-          {runs.length === 0 ? (
-            <div className="px-3 py-6 text-center text-sm text-muted-foreground">No runs yet.</div>
-          ) : null}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -29,6 +29,8 @@ import { WorkspaceCombobox } from './WorkspaceCombobox'
 
 const PICKER_TRIGGER_CLASS =
   'border-input bg-input/30 shadow-xs hover:bg-accent/60 dark:bg-input/30 dark:hover:bg-input/50'
+const MODE_TOGGLE_ITEM_CLASS =
+  'w-full border-input bg-input/30 shadow-xs hover:bg-accent/60 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:hover:bg-primary/90 dark:bg-input/30 dark:data-[state=on]:bg-primary dark:data-[state=on]:text-primary-foreground dark:data-[state=on]:hover:bg-primary/90'
 
 export type AutomationDraft = {
   name: string
@@ -46,17 +48,21 @@ export type AutomationDraft = {
   scheduleWarning: string | null
 }
 
+export type AutomationCreateTarget = 'orca' | 'hermes'
+
 type AutomationEditorDialogProps = {
   open: boolean
   isEditing: boolean
   isSaving: boolean
   canSave: boolean
+  createTarget: AutomationCreateTarget
   repos: Repo[]
   repoMap: Map<string, Repo>
   worktrees: Worktree[]
   settings: GlobalSettings | null
   draft: AutomationDraft
   onProjectChange: (projectId: string) => void
+  onCreateTargetChange: (target: AutomationCreateTarget) => void
   onOpenChange: (open: boolean) => void
   onDraftChange: (updater: (current: AutomationDraft) => AutomationDraft) => void
   onApplyTemplate: (template: AutomationTemplate) => void
@@ -90,66 +96,97 @@ export function AutomationEditorDialog({
   isEditing,
   isSaving,
   canSave,
+  createTarget,
   repos,
   repoMap,
   worktrees,
   settings,
   draft,
   onProjectChange,
+  onCreateTargetChange,
   onOpenChange,
   onDraftChange,
   onApplyTemplate,
   onSave
 }: AutomationEditorDialogProps): React.JSX.Element {
   const [templateOpen, setTemplateOpen] = React.useState(false)
+  const isHermesCreate = !isEditing && createTarget === 'hermes'
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex max-h-[90vh] flex-col gap-0 p-0 sm:max-w-[920px]"
+        className="flex max-h-[90vh] flex-col gap-0 p-0 dark:border-border dark:bg-card dark:text-card-foreground sm:max-w-[920px]"
         onOpenAutoFocus={(event) => {
           event.preventDefault()
         }}
       >
-        <DialogHeader className="border-b border-border/50 px-5 py-4">
+        <DialogHeader className="border-b border-border/50 px-5 py-4 pr-12">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0 flex-1 space-y-2">
               <DialogTitle className="text-sm font-medium">
-                {isEditing ? 'Edit automation' : 'Create automation'}
+                {isEditing
+                  ? 'Edit automation'
+                  : isHermesCreate
+                    ? 'Create Hermes cron'
+                    : 'Create automation'}
               </DialogTitle>
               <Input
                 value={draft.name}
                 placeholder="Weekday repo audit"
                 aria-label="Automation name"
-                className="h-10 border-0 bg-transparent px-0 text-lg font-semibold shadow-none focus-visible:ring-0"
+                className="h-10 max-w-md border-input bg-input/30 px-3 text-lg font-semibold text-foreground shadow-xs placeholder:text-muted-foreground dark:bg-input/30"
                 onChange={(event) =>
                   onDraftChange((current) => ({ ...current, name: event.target.value }))
                 }
               />
             </div>
             {!isEditing ? (
-              <Popover open={templateOpen} onOpenChange={setTemplateOpen}>
-                <PopoverTrigger asChild>
-                  <Button type="button" variant="outline" size="sm">
-                    <Sparkles className="size-4" />
-                    Use template
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-96 p-3">
-                  <div className="grid gap-2">
-                    {AUTOMATION_TEMPLATES.map((template) => (
-                      <AutomationTemplateCard
-                        key={template.id}
-                        template={template}
-                        onSelect={() => {
-                          onApplyTemplate(template)
-                          setTemplateOpen(false)
-                        }}
-                      />
-                    ))}
-                  </div>
-                </PopoverContent>
-              </Popover>
+              <div className="flex shrink-0 items-center gap-2">
+                <ToggleGroup
+                  type="single"
+                  value={createTarget}
+                  onValueChange={(value) =>
+                    value && onCreateTargetChange(value as AutomationCreateTarget)
+                  }
+                  variant="outline"
+                  size="sm"
+                  className="grid grid-cols-2"
+                >
+                  <ToggleGroupItem value="orca" className={MODE_TOGGLE_ITEM_CLASS}>
+                    Orca
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="hermes" className={MODE_TOGGLE_ITEM_CLASS}>
+                    Hermes
+                  </ToggleGroupItem>
+                </ToggleGroup>
+                <Popover open={templateOpen} onOpenChange={setTemplateOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className={PICKER_TRIGGER_CLASS}
+                    >
+                      <Sparkles className="size-4" />
+                      Use template
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-96 p-3">
+                    <div className="grid gap-2">
+                      {AUTOMATION_TEMPLATES.map((template) => (
+                        <AutomationTemplateCard
+                          key={template.id}
+                          template={template}
+                          onSelect={() => {
+                            onApplyTemplate(template)
+                            setTemplateOpen(false)
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </div>
             ) : null}
           </div>
         </DialogHeader>
@@ -173,7 +210,13 @@ export function AutomationEditorDialog({
         </div>
 
         <div className="border-t border-border/50 px-5 py-4">
-          <div className="grid gap-3 lg:grid-cols-[minmax(9rem,1.1fr)_minmax(14rem,1.4fr)_minmax(12rem,1.2fr)_minmax(8rem,0.8fr)_minmax(9rem,1fr)]">
+          <div
+            className={
+              isHermesCreate
+                ? 'grid gap-3 lg:grid-cols-[minmax(9rem,1.1fr)_minmax(14rem,1.4fr)_minmax(12rem,1.2fr)]'
+                : 'grid gap-3 lg:grid-cols-[minmax(9rem,1.1fr)_minmax(14rem,1.4fr)_minmax(12rem,1.2fr)_minmax(8rem,0.8fr)_minmax(9rem,1fr)]'
+            }
+          >
             <Field label="Project">
               <RepoCombobox
                 repos={repos}
@@ -184,35 +227,39 @@ export function AutomationEditorDialog({
                 showStandaloneAddButton={false}
               />
             </Field>
-            <Field label={draft.workspaceMode === 'new_per_run' ? 'Start branch' : 'Workspace'}>
-              <ToggleGroup
-                type="single"
-                value={draft.workspaceMode}
-                onValueChange={(workspaceMode) =>
-                  workspaceMode &&
-                  onDraftChange((current) => ({
-                    ...current,
-                    workspaceMode: workspaceMode as AutomationWorkspaceMode
-                  }))
-                }
-                variant="outline"
-                size="sm"
-                className="mb-2 grid w-full grid-cols-2"
-              >
-                <ToggleGroupItem
-                  value="existing"
-                  className="w-full border-input bg-input/30 shadow-xs data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground dark:bg-input/30"
+            <Field
+              label={
+                isHermesCreate
+                  ? 'Workspace'
+                  : draft.workspaceMode === 'new_per_run'
+                    ? 'Start branch'
+                    : 'Workspace'
+              }
+            >
+              {isHermesCreate ? null : (
+                <ToggleGroup
+                  type="single"
+                  value={draft.workspaceMode}
+                  onValueChange={(workspaceMode) =>
+                    workspaceMode &&
+                    onDraftChange((current) => ({
+                      ...current,
+                      workspaceMode: workspaceMode as AutomationWorkspaceMode
+                    }))
+                  }
+                  variant="outline"
+                  size="sm"
+                  className="mb-2 grid w-full grid-cols-2"
                 >
-                  Workspace
-                </ToggleGroupItem>
-                <ToggleGroupItem
-                  value="new_per_run"
-                  className="w-full border-input bg-input/30 shadow-xs data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground dark:bg-input/30"
-                >
-                  New run
-                </ToggleGroupItem>
-              </ToggleGroup>
-              {draft.workspaceMode === 'existing' ? (
+                  <ToggleGroupItem value="existing" className={MODE_TOGGLE_ITEM_CLASS}>
+                    worktree
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="new_per_run" className={MODE_TOGGLE_ITEM_CLASS}>
+                    New run
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              )}
+              {draft.workspaceMode === 'existing' || isHermesCreate ? (
                 <WorkspaceCombobox
                   worktrees={worktrees}
                   value={draft.workspaceId}
@@ -234,17 +281,19 @@ export function AutomationEditorDialog({
                 />
               )}
             </Field>
-            <Field label="Agent">
-              <AgentCombobox
-                agents={AGENT_CATALOG}
-                value={draft.agentId}
-                onValueChange={(agentId) =>
-                  agentId && onDraftChange((current) => ({ ...current, agentId }))
-                }
-                defaultAgent={settings?.defaultTuiAgent ?? null}
-                triggerClassName={`h-9 w-full min-w-0 ${PICKER_TRIGGER_CLASS}`}
-              />
-            </Field>
+            {isHermesCreate ? null : (
+              <Field label="Agent">
+                <AgentCombobox
+                  agents={AGENT_CATALOG}
+                  value={draft.agentId}
+                  onValueChange={(agentId) =>
+                    agentId && onDraftChange((current) => ({ ...current, agentId }))
+                  }
+                  defaultAgent={settings?.defaultTuiAgent ?? null}
+                  triggerClassName={`h-9 w-full min-w-0 ${PICKER_TRIGGER_CLASS}`}
+                />
+              </Field>
+            )}
             <Field label="Schedule">
               <AutomationSchedulePicker
                 draft={draft}
@@ -252,49 +301,51 @@ export function AutomationEditorDialog({
                 onDraftChange={onDraftChange}
               />
             </Field>
-            <Field
-              label={
-                <span className="inline-flex items-center gap-1">
-                  Grace
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        aria-label="Missed-run grace help"
-                        className="rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                      >
-                        <Info className="size-3.5" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" sideOffset={6} className="max-w-72">
-                      If Orca or the execution host was unavailable at the scheduled time, Orca runs
-                      one missed occurrence when it becomes available within this window. Older
-                      missed runs are skipped.
-                    </TooltipContent>
-                  </Tooltip>
-                </span>
-              }
-            >
-              <Select
-                value={draft.missedRunGraceMinutes}
-                onValueChange={(missedRunGraceMinutes) =>
-                  onDraftChange((current) => ({ ...current, missedRunGraceMinutes }))
+            {isHermesCreate ? null : (
+              <Field
+                label={
+                  <span className="inline-flex items-center gap-1">
+                    Grace
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          aria-label="Missed-run grace help"
+                          className="rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                        >
+                          <Info className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" sideOffset={6} className="max-w-72">
+                        If Orca or the execution host was unavailable at the scheduled time, Orca
+                        runs one missed occurrence when it becomes available within this window.
+                        Older missed runs are skipped.
+                      </TooltipContent>
+                    </Tooltip>
+                  </span>
                 }
               >
-                <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
-                  <SelectItem value="0">No grace</SelectItem>
-                  <SelectItem value="30">30 minutes</SelectItem>
-                  <SelectItem value="60">1 hour</SelectItem>
-                  <SelectItem value="180">3 hours</SelectItem>
-                  <SelectItem value="720">12 hours</SelectItem>
-                  <SelectItem value="1440">24 hours</SelectItem>
-                  <SelectItem value="2880">48 hours</SelectItem>
-                </SelectContent>
-              </Select>
-            </Field>
+                <Select
+                  value={draft.missedRunGraceMinutes}
+                  onValueChange={(missedRunGraceMinutes) =>
+                    onDraftChange((current) => ({ ...current, missedRunGraceMinutes }))
+                  }
+                >
+                  <SelectTrigger className={`w-full ${PICKER_TRIGGER_CLASS}`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" side="bottom" align="start" sideOffset={4}>
+                    <SelectItem value="0">No grace</SelectItem>
+                    <SelectItem value="30">30 minutes</SelectItem>
+                    <SelectItem value="60">1 hour</SelectItem>
+                    <SelectItem value="180">3 hours</SelectItem>
+                    <SelectItem value="720">12 hours</SelectItem>
+                    <SelectItem value="1440">24 hours</SelectItem>
+                    <SelectItem value="2880">48 hours</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
           </div>
           <div className="mt-4 flex justify-end gap-2">
             <Button variant="outline" onClick={() => onOpenChange(false)}>
@@ -306,8 +357,8 @@ export function AutomationEditorDialog({
               disabled={isSaving || repos.length === 0 || !canSave}
               className="border-foreground/25 bg-foreground/[0.04] text-foreground hover:bg-foreground/[0.08]"
             >
-              {isEditing ? null : <Plus className="size-4" />}
-              {isEditing ? 'Save Changes' : 'Save Automation'}
+              {isEditing || isHermesCreate || isSaving ? null : <Plus className="size-4" />}
+              {isEditing ? 'Save Changes' : isSaving || isHermesCreate ? 'Save' : 'Create'}
             </Button>
           </div>
         </div>

--- a/src/renderer/src/components/automations/AutomationRunHistory.tsx
+++ b/src/renderer/src/components/automations/AutomationRunHistory.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import type { AutomationRun } from '../../../../shared/automations-types'
+import type { Worktree } from '../../../../shared/types'
+import {
+  formatAutomationDateTime,
+  getAutomationRunStatusLabel,
+  getAutomationRunStatusVariant
+} from './automation-page-parts'
+import {
+  formatAutomationCost,
+  formatAutomationTokens,
+  getAutomationUsageStatusLabel
+} from './automation-usage-model'
+import { getAutomationRunWorkspaceDisplay } from './automation-run-workspace-display'
+
+type AutomationRunHistoryProps = {
+  runs: AutomationRun[]
+  automationId: string
+  worktreeMap: Map<string, Worktree>
+  onOpenRun: (run: AutomationRun) => void
+}
+
+export function AutomationRunHistory({
+  runs,
+  automationId,
+  worktreeMap,
+  onOpenRun
+}: AutomationRunHistoryProps): React.JSX.Element {
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+  const runCountLabel = useMemo(() => {
+    const completed = runs.filter((run) => run.status === 'completed').length
+    return `${runs.length} ${runs.length === 1 ? 'run' : 'runs'} · ${completed} completed`
+  }, [runs])
+
+  useEffect(() => {
+    setSelectedRunId((current) =>
+      current && runs.some((run) => run.id === current) ? current : (runs[0]?.id ?? null)
+    )
+  }, [automationId, runs])
+
+  const selectedRun = runs.find((run) => run.id === selectedRunId) ?? runs[0] ?? null
+
+  return (
+    <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
+      <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
+        <div className="text-sm font-medium">Run history</div>
+        <div className="text-xs text-muted-foreground">{runCountLabel}</div>
+      </div>
+      <div className="min-h-[18rem] min-w-0">
+        <div className="grid grid-cols-[minmax(9rem,1fr)_minmax(10rem,1.1fr)_minmax(5rem,.55fr)_minmax(5rem,.55fr)_minmax(6rem,auto)] gap-3 border-b border-border/50 px-3 py-1.5 text-[11px] font-medium uppercase text-muted-foreground">
+          <div>Run</div>
+          <div>Workspace</div>
+          <div>Spend</div>
+          <div>Tokens</div>
+          <div>Status</div>
+        </div>
+        <div className="divide-y divide-border/50">
+          {runs.map((run) => {
+            const runWorktree = run.workspaceId ? (worktreeMap.get(run.workspaceId) ?? null) : null
+            const workspaceLabel = getAutomationRunWorkspaceDisplay({
+              run,
+              worktree: runWorktree
+            })
+            const usageLabel = getAutomationUsageStatusLabel(run.usage)
+            return (
+              <button
+                key={run.id}
+                type="button"
+                data-current={selectedRun?.id === run.id}
+                className={cn(
+                  'grid w-full grid-cols-[minmax(9rem,1fr)_minmax(10rem,1.1fr)_minmax(5rem,.55fr)_minmax(5rem,.55fr)_minmax(6rem,auto)] items-center gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                  selectedRun?.id === run.id && 'bg-accent text-accent-foreground'
+                )}
+                onClick={() => {
+                  setSelectedRunId(run.id)
+                  onOpenRun(run)
+                }}
+              >
+                <div className="min-w-0">
+                  <div>{formatAutomationDateTime(run.scheduledFor)}</div>
+                  <div className="mt-1 truncate text-xs text-muted-foreground">
+                    {workspaceLabel.detailLabel}
+                  </div>
+                </div>
+                <div
+                  className={
+                    workspaceLabel.muted
+                      ? 'min-w-0 truncate text-muted-foreground'
+                      : 'min-w-0 truncate text-foreground'
+                  }
+                  title={workspaceLabel.title}
+                >
+                  {workspaceLabel.rowLabel}
+                </div>
+                <div
+                  className={
+                    run.usage?.status === 'known'
+                      ? 'text-sm tabular-nums'
+                      : 'text-sm text-muted-foreground'
+                  }
+                  title={usageLabel}
+                >
+                  {formatAutomationCost(run.usage?.estimatedCostUsd)}
+                </div>
+                <div
+                  className={
+                    run.usage?.status === 'known'
+                      ? 'text-sm tabular-nums'
+                      : 'text-sm text-muted-foreground'
+                  }
+                  title={usageLabel}
+                >
+                  {run.usage?.status === 'known'
+                    ? formatAutomationTokens(run.usage.totalTokens)
+                    : 'n/a'}
+                </div>
+                <div className="flex justify-start">
+                  <Badge variant={getAutomationRunStatusVariant(run.status)}>
+                    {getAutomationRunStatusLabel(run.status)}
+                  </Badge>
+                </div>
+              </button>
+            )
+          })}
+          {runs.length === 0 ? (
+            <div className="px-3 py-6 text-center text-sm text-muted-foreground">No runs yet.</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationRunPageFrame.tsx
+++ b/src/renderer/src/components/automations/AutomationRunPageFrame.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+type AutomationRunPageFrameProps = {
+  title: string
+  breadcrumbs: string[]
+  statusLabel: string
+  statusVariant: React.ComponentProps<typeof Badge>['variant']
+  detail?: string | null
+  actions?: React.ReactNode
+  children: React.ReactNode
+  onBack: () => void
+}
+
+export function AutomationRunPageFrame({
+  title,
+  breadcrumbs,
+  statusLabel,
+  statusVariant,
+  detail,
+  actions,
+  children,
+  onBack
+}: AutomationRunPageFrameProps): React.JSX.Element {
+  return (
+    <div className="flex min-h-full flex-col rounded-md border border-border/50 bg-background shadow-sm">
+      <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div className="flex min-w-0 flex-1 items-start gap-2">
+          <div className="shrink-0">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Back to runs"
+              onClick={onBack}
+            >
+              <ArrowLeft className="size-3.5" />
+            </Button>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-foreground" aria-current="page">
+              {title}
+            </div>
+            {breadcrumbs.length > 0 ? (
+              <ol
+                aria-label="Run context"
+                className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground"
+              >
+                {breadcrumbs.map((breadcrumb, index) => (
+                  <React.Fragment key={`${breadcrumb}:${index}`}>
+                    {index > 0 ? (
+                      <li aria-hidden="true" className="shrink-0 opacity-50">
+                        ·
+                      </li>
+                    ) : null}
+                    <li className="max-w-[28ch] truncate">{breadcrumb}</li>
+                  </React.Fragment>
+                ))}
+              </ol>
+            ) : null}
+            {detail ? (
+              <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground/80">
+                {detail}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Badge variant={statusVariant}>{statusLabel}</Badge>
+          {actions}
+        </div>
+      </div>
+      <div className="scrollbar-sleek min-h-0 flex-1 overflow-auto p-4">{children}</div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -5,14 +5,17 @@ import {
   CalendarClock,
   Check,
   Clock,
+  Eye,
   Pause,
   Pencil,
   Play,
   Plus,
   RefreshCw,
-  Trash2
+  Trash2,
+  X
 } from 'lucide-react'
 import { toast } from 'sonner'
+import type { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   ContextMenu,
@@ -29,6 +32,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -41,30 +45,68 @@ import type {
   ExternalAutomationAction,
   ExternalAutomationJob,
   ExternalAutomationManager,
+  ExternalAutomationRun,
   AutomationRun,
   AutomationUpdateInput
 } from '../../../../shared/automations-types'
+import type { SshConnectionStatus } from '../../../../shared/ssh-types'
 import type { Worktree } from '../../../../shared/types'
+import { getWorktreePathBasenameFromId } from '../../../../shared/worktree-id'
 import {
   buildAutomationRrule,
   formatAutomationSchedule,
   isValidAutomationSchedule,
   tryParseAutomationRrule
 } from '../../../../shared/automation-schedules'
-import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
+import {
+  formatAutomationDateTimeWithRelative,
+  getAutomationRunStatusLabel,
+  getAutomationRunStatusVariant
+} from './automation-page-parts'
 import {
   formatAutomationCost,
   formatAutomationTokens,
   summarizeAutomationRunUsage
 } from './automation-usage-model'
+import { getAutomationRunViewState } from './automation-run-view-state'
+import { getAutomationRunWorkspaceDisplay } from './automation-run-workspace-display'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import { AutomationDetail } from './AutomationDetail'
-import { AutomationEditorDialog, type AutomationDraft } from './AutomationEditorDialog'
+import { HermesCronOutputView } from './HermesCronOutputView'
+import {
+  AutomationEditorDialog,
+  type AutomationCreateTarget,
+  type AutomationDraft
+} from './AutomationEditorDialog'
+import { AutomationRunPageFrame } from './AutomationRunPageFrame'
+import { AutomationRunHistory } from './AutomationRunHistory'
 import { AUTOMATION_TEMPLATES, type AutomationTemplate } from './automation-templates'
 import { ExternalAutomationManagers } from './ExternalAutomationManagers'
+import type { FetchExternalAutomationRuns } from './ExternalAutomationRunTable'
 
 const AGENTS = AGENT_CATALOG.map((agent) => agent.id)
 const DEFAULT_TIME = '09:00'
 const AUTOMATIONS_CHANGED_EVENT = 'orca:automations-changed'
+type AutomationPaneTab = 'overview' | 'runs'
+
+type ExternalAutomationListEntry =
+  | {
+      kind: 'job'
+      key: string
+      manager: ExternalAutomationManager
+      job: ExternalAutomationJob
+    }
+  | {
+      kind: 'source'
+      key: string
+      manager: ExternalAutomationManager
+    }
+
+type SelectedExternalRunPage = {
+  manager: ExternalAutomationManager
+  job: ExternalAutomationJob
+  run: ExternalAutomationRun
+}
 
 function getDefaultWorktree(worktrees: readonly Worktree[]): Worktree | null {
   return worktrees.find((worktree) => worktree.isMainWorktree) ?? worktrees[0] ?? null
@@ -74,21 +116,124 @@ function formatTimeInput(hour: number, minute: number): string {
   return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
 }
 
+function parseDraftTime(time: string): { hour: number; minute: number } {
+  const [rawHour, rawMinute] = time.split(':').map((part) => Number(part))
+  return {
+    hour: Number.isFinite(rawHour) ? rawHour : 9,
+    minute: Number.isFinite(rawMinute) ? rawMinute : 0
+  }
+}
+
+function buildHermesCronSchedule(draft: AutomationDraft): string {
+  if (draft.preset === 'custom') {
+    return draft.customSchedule.trim()
+  }
+  const { hour, minute } = parseDraftTime(draft.time)
+  if (draft.preset === 'hourly') {
+    return `${minute} * * * *`
+  }
+  if (draft.preset === 'daily') {
+    return `${minute} ${hour} * * *`
+  }
+  if (draft.preset === 'weekdays') {
+    return `${minute} ${hour} * * 1-5`
+  }
+  return `${minute} ${hour} * * ${Number(draft.dayOfWeek)}`
+}
+
 function getAgentLabel(agentId: string): string {
   return AGENT_CATALOG.find((agent) => agent.id === agentId)?.label ?? agentId
+}
+
+function getExternalAutomationKey(
+  manager: ExternalAutomationManager,
+  job: ExternalAutomationJob
+): string {
+  return `${manager.id}:${job.id}`
+}
+
+function getExternalAutomationSourceKey(manager: ExternalAutomationManager): string {
+  return `${manager.id}:source`
+}
+
+function formatExternalDate(value: string | null, now: number): string {
+  if (!value) {
+    return 'Never'
+  }
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) {
+    return value
+  }
+  return formatAutomationDateTimeWithRelative(parsed, now)
+}
+
+function getExternalProviderLabel(manager: ExternalAutomationManager): string {
+  return manager.provider === 'hermes' ? 'Hermes' : 'OpenClaw'
+}
+
+function getExternalTargetKindLabel(manager: ExternalAutomationManager): string {
+  return manager.target.type === 'ssh' ? 'Remote SSH' : 'Local'
+}
+
+function isSshConnectionBusy(status: SshConnectionStatus | undefined): boolean {
+  return status === 'connecting' || status === 'deploying-relay' || status === 'reconnecting'
+}
+
+function getExternalRunStatusLabel(run: ExternalAutomationRun): string {
+  switch (run.status) {
+    case 'completed':
+      return 'Completed'
+    case 'failed':
+      return 'Failed'
+    case 'unknown':
+      return 'Unknown'
+  }
+}
+
+function getExternalRunStatusVariant(
+  run: ExternalAutomationRun
+): React.ComponentProps<typeof Badge>['variant'] {
+  switch (run.status) {
+    case 'completed':
+      return 'secondary'
+    case 'failed':
+      return 'destructive'
+    case 'unknown':
+      return 'outline'
+  }
+}
+
+function getExternalRunContent(run: ExternalAutomationRun): string {
+  return run.outputContent ?? run.error ?? run.outputPreview ?? 'No output content available.'
+}
+
+function getAutomationRunContent(run: AutomationRun): string {
+  const savedOutput = run.outputSnapshot?.content.trim()
+  if (savedOutput) {
+    return run.outputSnapshot?.content ?? savedOutput
+  }
+  return run.error ?? run.usage?.unavailableMessage ?? 'No output content available.'
+}
+
+function isMissingExternalRunsApiError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /listExternalRuns|automations:listExternalRuns|No handler registered/i.test(message)
 }
 
 export default function AutomationsPage(): React.JSX.Element {
   const repos = useAppStore((s) => s.repos)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const unifiedTabsByWorktree = useAppStore((s) => s.unifiedTabsByWorktree)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const fetchAllWorktrees = useAppStore((s) => s.fetchAllWorktrees)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const closeAutomationsPage = useAppStore((s) => s.closeAutomationsPage)
   const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
   const retainedAgentsByPaneKey = useAppStore((s) => s.retainedAgentsByPaneKey)
+  const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const settings = useAppStore((s) => s.settings)
   const selectedId = useAppStore((s) => s.selectedAutomationId)
   const setSelectedId = useAppStore((s) => s.setSelectedAutomationId)
@@ -101,22 +246,42 @@ export default function AutomationsPage(): React.JSX.Element {
 
   const [automations, setAutomations] = useState<Automation[]>([])
   const [runs, setRuns] = useState<AutomationRun[]>([])
+  const [selectedAutomationRuns, setSelectedAutomationRuns] = useState<{
+    automationId: string | null
+    runs: AutomationRun[]
+  }>({ automationId: null, runs: [] })
   const [externalManagers, setExternalManagers] = useState<ExternalAutomationManager[]>([])
   const [externalActionKey, setExternalActionKey] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
+  const [createTarget, setCreateTarget] = useState<AutomationCreateTarget>('orca')
   const [editingAutomationId, setEditingAutomationId] = useState<string | null>(null)
   const [relativeNow, setRelativeNow] = useState(Date.now())
+  const [activePaneTab, setActivePaneTab] = useState<AutomationPaneTab>('overview')
+  const [selectedAutomationRunPageId, setSelectedAutomationRunPageId] = useState<string | null>(
+    null
+  )
+  const [selectedExternalKey, setSelectedExternalKey] = useState<string | null>(null)
+  const [selectedExternalRunPage, setSelectedExternalRunPage] =
+    useState<SelectedExternalRunPage | null>(null)
+  const [connectingExternalSourceKey, setConnectingExternalSourceKey] = useState<string | null>(
+    null
+  )
   const [draftAtOpen, setDraftAtOpen] = useState<AutomationDraft | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Automation | null>(null)
   const [externalDeleteTarget, setExternalDeleteTarget] = useState<{
     manager: ExternalAutomationManager
     job: ExternalAutomationJob
   } | null>(null)
+  const [editingExternalTarget, setEditingExternalTarget] = useState<{
+    manager: ExternalAutomationManager
+    job: ExternalAutomationJob
+  } | null>(null)
   const [dontAskDeleteAgain, setDontAskDeleteAgain] = useState(false)
   const editRequestRef = useRef(0)
   const deleteConfirmButtonRef = useRef<HTMLButtonElement>(null)
+  const workspaceNameCacheRef = useRef<Map<string, string>>(new Map())
   const [draft, setDraft] = useState<AutomationDraft>({
     name: '',
     prompt: '',
@@ -133,13 +298,123 @@ export default function AutomationsPage(): React.JSX.Element {
     scheduleWarning: null
   })
 
+  const externalAutomationEntries = useMemo<ExternalAutomationListEntry[]>(
+    () =>
+      externalManagers.flatMap((manager): ExternalAutomationListEntry[] => {
+        if (manager.jobs.length === 0) {
+          if (
+            manager.provider === 'hermes' &&
+            (manager.status === 'unavailable' || manager.error)
+          ) {
+            return [
+              {
+                kind: 'source' as const,
+                key: getExternalAutomationSourceKey(manager),
+                manager
+              }
+            ]
+          }
+          return []
+        }
+        return manager.jobs.map((job) => ({
+          kind: 'job' as const,
+          key: getExternalAutomationKey(manager, job),
+          manager,
+          job
+        }))
+      }),
+    [externalManagers]
+  )
+  const selectedExternal =
+    externalAutomationEntries.find((entry) => entry.key === selectedExternalKey) ??
+    (automations.length === 0 ? (externalAutomationEntries[0] ?? null) : null)
   const selected =
-    automations.find((automation) => automation.id === selectedId) ?? automations[0] ?? null
-  const selectedRuns = runs.filter((run) => run.automationId === selected?.id)
+    selectedExternal === null
+      ? (automations.find((automation) => automation.id === selectedId) ?? automations[0] ?? null)
+      : null
+  const runsWithWorkspaceNames = useMemo(
+    () =>
+      runs.map((run) => {
+        if (!run.workspaceId || run.workspaceDisplayName?.trim()) {
+          return run
+        }
+        const displayName =
+          worktreeMap.get(run.workspaceId)?.displayName ??
+          workspaceNameCacheRef.current.get(run.workspaceId) ??
+          getWorktreePathBasenameFromId(run.workspaceId)
+        const trimmedDisplayName = displayName?.trim()
+        return trimmedDisplayName ? { ...run, workspaceDisplayName: trimmedDisplayName } : run
+      }),
+    [runs, worktreeMap]
+  )
+  const selectedAutomationRunsWithWorkspaceNames = useMemo(
+    () =>
+      selectedAutomationRuns.runs.map((run) => {
+        if (!run.workspaceId || run.workspaceDisplayName?.trim()) {
+          return run
+        }
+        const displayName =
+          worktreeMap.get(run.workspaceId)?.displayName ??
+          workspaceNameCacheRef.current.get(run.workspaceId) ??
+          getWorktreePathBasenameFromId(run.workspaceId)
+        const trimmedDisplayName = displayName?.trim()
+        return trimmedDisplayName ? { ...run, workspaceDisplayName: trimmedDisplayName } : run
+      }),
+    [selectedAutomationRuns.runs, worktreeMap]
+  )
+  // Why: keep the detail tab scoped even while the selected-run fetch catches up.
+  const selectedRunsSource =
+    selected && selectedAutomationRuns.automationId === selected.id
+      ? selectedAutomationRunsWithWorkspaceNames
+      : runsWithWorkspaceNames
+  const selectedRuns = selected
+    ? selectedRunsSource.filter((run) => run.automationId === selected.id)
+    : []
+  const selectedAutomationRunPage = selectedAutomationRunPageId
+    ? (selectedRuns.find((run) => run.id === selectedAutomationRunPageId) ?? null)
+    : null
   const worktrees = useMemo(
     () => worktreesByRepo[draft.projectId] ?? [],
     [draft.projectId, worktreesByRepo]
   )
+
+  useEffect(() => {
+    for (const [workspaceId, worktree] of worktreeMap) {
+      const displayName = worktree.displayName.trim()
+      if (displayName) {
+        workspaceNameCacheRef.current.set(workspaceId, displayName)
+      }
+    }
+  }, [worktreeMap])
+  const activeTerminalTabIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const tabs of Object.values(unifiedTabsByWorktree)) {
+      for (const tab of tabs) {
+        if (tab.contentType === 'terminal') {
+          ids.add(tab.entityId)
+        }
+      }
+    }
+    return ids
+  }, [unifiedTabsByWorktree])
+  const selectedAutomationRunPageWorktree = selectedAutomationRunPage?.workspaceId
+    ? (worktreeMap.get(selectedAutomationRunPage.workspaceId) ?? null)
+    : null
+  const selectedAutomationRunPageWorkspaceDisplay = selectedAutomationRunPage
+    ? getAutomationRunWorkspaceDisplay({
+        run: selectedAutomationRunPage,
+        worktree: selectedAutomationRunPageWorktree
+      })
+    : null
+  const selectedAutomationRunPageViewState = selectedAutomationRunPage
+    ? getAutomationRunViewState({
+        run: selectedAutomationRunPage,
+        workspaceExists: Boolean(selectedAutomationRunPageWorktree),
+        terminalTabExists: selectedAutomationRunPage.terminalSessionId
+          ? activeTerminalTabIds.has(selectedAutomationRunPage.terminalSessionId)
+          : false
+      })
+    : null
   const selectedRepo = selected ? (repoMap.get(selected.projectId) ?? null) : null
   const selectedWorktree =
     selected && selected.workspaceId ? (worktreeMap.get(selected.workspaceId) ?? null) : null
@@ -147,6 +422,32 @@ export default function AutomationsPage(): React.JSX.Element {
     editingAutomationId === null ||
     !draftAtOpen ||
     JSON.stringify(draft) !== JSON.stringify(draftAtOpen)
+  const selectedExternalSshSource =
+    selectedExternal?.kind === 'source' && selectedExternal.manager.target.type === 'ssh'
+      ? {
+          manager: selectedExternal.manager,
+          connectionId: selectedExternal.manager.target.connectionId,
+          sourceKey: getExternalAutomationSourceKey(selectedExternal.manager)
+        }
+      : null
+  const isSelectedExternalSshConnecting =
+    selectedExternalSshSource !== null &&
+    (connectingExternalSourceKey === selectedExternalSshSource.sourceKey ||
+      isSshConnectionBusy(sshConnectionStates.get(selectedExternalSshSource.connectionId)?.status))
+
+  useEffect(() => {
+    if ((!selected || selectedExternal) && activePaneTab === 'runs') {
+      setActivePaneTab('overview')
+    }
+  }, [activePaneTab, selected, selectedExternal])
+
+  useEffect(() => {
+    setSelectedExternalRunPage(null)
+  }, [selectedExternalKey])
+
+  useEffect(() => {
+    setSelectedAutomationRunPageId(null)
+  }, [selected?.id])
 
   const getDefaultTarget = useCallback(() => {
     const activeWorktree = activeWorktreeId ? worktreeMap.get(activeWorktreeId) : null
@@ -171,13 +472,23 @@ export default function AutomationsPage(): React.JSX.Element {
         window.api.automations.listRuns(),
         window.api.automations.listExternalManagers()
       ])
-      setAutomations(nextAutomations)
-      setRuns(nextRuns)
-      setExternalManagers(nextExternalManagers)
       const currentSelectedId = useAppStore.getState().selectedAutomationId
       const hasCurrentSelection = nextAutomations.some(
         (automation) => automation.id === currentSelectedId
       )
+      const nextSelectedId = hasCurrentSelection
+        ? currentSelectedId
+        : (nextAutomations[0]?.id ?? null)
+      const nextSelectedRuns = nextSelectedId
+        ? await window.api.automations.listRuns({ automationId: nextSelectedId })
+        : []
+      setAutomations(nextAutomations)
+      setRuns(nextRuns)
+      setSelectedAutomationRuns({
+        automationId: nextSelectedId,
+        runs: nextSelectedRuns
+      })
+      setExternalManagers(nextExternalManagers)
       if (!hasCurrentSelection) {
         setSelectedId(nextAutomations[0]?.id ?? null)
       }
@@ -195,6 +506,23 @@ export default function AutomationsPage(): React.JSX.Element {
     const timer = window.setInterval(() => setRelativeNow(Date.now()), 60 * 1000)
     return () => window.clearInterval(timer)
   }, [])
+
+  useEffect(() => {
+    const automationId = selected?.id ?? null
+    if (!automationId) {
+      setSelectedAutomationRuns({ automationId: null, runs: [] })
+      return
+    }
+    let cancelled = false
+    void window.api.automations.listRuns({ automationId }).then((nextRuns) => {
+      if (!cancelled) {
+        setSelectedAutomationRuns({ automationId, runs: nextRuns })
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [selected?.id, runs])
 
   useEffect(() => {
     const onAutomationsChanged = (): void => {
@@ -291,10 +619,23 @@ export default function AutomationsPage(): React.JSX.Element {
     }))
   }, [])
 
+  const handleCreateTargetChange = useCallback((target: AutomationCreateTarget): void => {
+    setCreateTarget(target)
+    if (target === 'hermes') {
+      setDraft((current) => ({
+        ...current,
+        agentId: 'hermes',
+        workspaceMode: 'existing'
+      }))
+    }
+  }, [])
+
   const openCreateDialog = (template?: AutomationTemplate): void => {
     editRequestRef.current += 1
     const target = getDefaultTarget()
     setEditingAutomationId(null)
+    setEditingExternalTarget(null)
+    setCreateTarget('orca')
     const baseDraft: AutomationDraft = {
       name: '',
       prompt: '',
@@ -330,6 +671,8 @@ export default function AutomationsPage(): React.JSX.Element {
 
   const openEditDialog = async (automation: Automation): Promise<void> => {
     const requestId = (editRequestRef.current += 1)
+    setEditingExternalTarget(null)
+    setCreateTarget('orca')
     let latest = automation
     try {
       latest =
@@ -367,6 +710,52 @@ export default function AutomationsPage(): React.JSX.Element {
     setCreateOpen(true)
   }
 
+  const openEditExternalDialog = (
+    manager: ExternalAutomationManager,
+    job: ExternalAutomationJob
+  ): void => {
+    editRequestRef.current += 1
+    const rawSchedule = job.rawSchedule ?? job.schedule
+    const hasCustomSchedule = isValidAutomationSchedule(rawSchedule)
+    const targetWorktree =
+      Object.values(worktreesByRepo)
+        .flat()
+        .find((worktree) => {
+          const repo = repoMap.get(worktree.repoId)
+          const repoTargetMatches =
+            manager.target.type === 'local'
+              ? !repo?.connectionId
+              : repo?.connectionId === manager.target.connectionId
+          return repoTargetMatches && job.workdir !== null && worktree.path === job.workdir
+        }) ?? null
+    const fallbackTarget = getDefaultTarget()
+    const projectId = targetWorktree?.repoId ?? fallbackTarget.projectId
+    const workspaceId = targetWorktree?.id ?? fallbackTarget.workspaceId
+    const nextDraft: AutomationDraft = {
+      name: job.name,
+      prompt: job.prompt ?? job.promptPreview,
+      agentId: 'hermes',
+      projectId,
+      workspaceMode: 'existing',
+      workspaceId,
+      baseBranch: '',
+      preset: hasCustomSchedule ? 'custom' : 'weekdays',
+      time: DEFAULT_TIME,
+      dayOfWeek: '1',
+      customSchedule: hasCustomSchedule ? rawSchedule : '',
+      missedRunGraceMinutes: '720',
+      scheduleWarning: hasCustomSchedule
+        ? null
+        : 'This Hermes cron has an unsupported saved schedule. Pick a supported schedule before saving changes.'
+    }
+    setEditingAutomationId(null)
+    setEditingExternalTarget({ manager, job })
+    setCreateTarget('hermes')
+    setDraft(nextDraft)
+    setDraftAtOpen(nextDraft)
+    setCreateOpen(true)
+  }
+
   const handleProjectChange = useCallback(
     (projectId: string): void => {
       const currentWorktrees = worktreesByRepo[projectId] ?? []
@@ -397,10 +786,12 @@ export default function AutomationsPage(): React.JSX.Element {
   )
 
   const saveAutomation = async (): Promise<void> => {
-    const [hour, minute] = draft.time.split(':').map((part) => Number(part))
+    const { hour, minute } = parseDraftTime(draft.time)
+    const isHermesSave =
+      editingAutomationId === null && (createTarget === 'hermes' || editingExternalTarget !== null)
     if (
       !draft.projectId ||
-      (draft.workspaceMode === 'existing' && !draft.workspaceId) ||
+      ((draft.workspaceMode === 'existing' || isHermesSave) && !draft.workspaceId) ||
       !draft.prompt.trim()
     ) {
       toast.error('Choose a run location and enter a prompt before saving.')
@@ -423,6 +814,54 @@ export default function AutomationsPage(): React.JSX.Element {
         toast.error('Choose an available workspace before saving.')
         return
       }
+      if (isHermesSave) {
+        const repo = repoMap.get(draft.projectId)
+        const selectedWorktree = worktreeMap.get(draft.workspaceId) ?? null
+        if (!repo || !selectedWorktree) {
+          toast.error('Choose an available workspace before saving.')
+          return
+        }
+        const target =
+          editingExternalTarget?.manager.target ??
+          (repo.connectionId
+            ? { type: 'ssh' as const, connectionId: repo.connectionId }
+            : { type: 'local' as const })
+        const repoTargetMatches =
+          target.type === 'local' ? !repo.connectionId : repo.connectionId === target.connectionId
+        if (!repoTargetMatches) {
+          toast.error('Choose a workspace on the same host as this Hermes cron.')
+          return
+        }
+        const schedule = buildHermesCronSchedule(draft)
+        const managerId =
+          editingExternalTarget?.manager.id ??
+          (target.type === 'ssh' ? `hermes:ssh:${target.connectionId}` : 'hermes:local')
+        const input = {
+          managerId,
+          provider: 'hermes' as const,
+          target,
+          name: draft.name,
+          prompt: draft.prompt,
+          schedule,
+          workdir: selectedWorktree.path
+        }
+        await (editingExternalTarget
+          ? window.api.automations.updateExternal({
+              ...input,
+              jobId: editingExternalTarget.job.id
+            })
+          : window.api.automations.createExternal(input))
+        await refresh()
+        setCreateOpen(false)
+        setEditingExternalTarget(null)
+        setSelectedExternalKey(
+          editingExternalTarget
+            ? getExternalAutomationKey(editingExternalTarget.manager, editingExternalTarget.job)
+            : null
+        )
+        toast.success(editingExternalTarget ? 'Hermes cron updated.' : 'Hermes cron created.')
+        return
+      }
       const now = Date.now()
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
       const rrule =
@@ -430,8 +869,8 @@ export default function AutomationsPage(): React.JSX.Element {
           ? draft.customSchedule.trim()
           : buildAutomationRrule({
               preset: draft.preset,
-              hour: Number.isFinite(hour) ? hour : 9,
-              minute: Number.isFinite(minute) ? minute : 0,
+              hour,
+              minute,
               dayOfWeek: Number(draft.dayOfWeek)
             })
       const rawMissedRunGraceMinutes = Number(draft.missedRunGraceMinutes)
@@ -596,6 +1035,53 @@ export default function AutomationsPage(): React.JSX.Element {
     }
   }
 
+  const fetchExternalAutomationRuns = useCallback<FetchExternalAutomationRuns>(
+    async ({ manager, job, page, pageSize }) => {
+      const fallbackRunsPage = {
+        runs: job.runs.slice(page * pageSize, page * pageSize + pageSize),
+        totalCount: job.runCount
+      }
+      const listExternalRuns = (
+        window.api.automations as Partial<Pick<typeof window.api.automations, 'listExternalRuns'>>
+      ).listExternalRuns
+      if (typeof listExternalRuns !== 'function') {
+        return fallbackRunsPage
+      }
+      try {
+        const result = await listExternalRuns({
+          managerId: manager.id,
+          provider: manager.provider,
+          target: manager.target,
+          jobId: job.id,
+          page: page + 1,
+          pageSize
+        })
+        return {
+          runs: result.runs,
+          totalCount: result.total
+        }
+      } catch (error) {
+        if (isMissingExternalRunsApiError(error)) {
+          return fallbackRunsPage
+        }
+        throw error
+      }
+    },
+    []
+  )
+
+  const openExternalRunPage = (
+    manager: ExternalAutomationManager,
+    job: ExternalAutomationJob,
+    run: ExternalAutomationRun
+  ): void => {
+    setSelectedExternalRunPage({ manager, job, run })
+  }
+
+  const openAutomationRunPage = (run: AutomationRun): void => {
+    setSelectedAutomationRunPageId(run.id)
+  }
+
   const requestExternalAction = (
     manager: ExternalAutomationManager,
     job: ExternalAutomationJob,
@@ -617,26 +1103,137 @@ export default function AutomationsPage(): React.JSX.Element {
     await runExternalAction(target.manager, target.job, 'delete')
   }
 
+  const connectExternalAutomationSource = async (
+    manager: ExternalAutomationManager
+  ): Promise<void> => {
+    if (manager.target.type !== 'ssh') {
+      return
+    }
+    const sourceKey = getExternalAutomationSourceKey(manager)
+    setConnectingExternalSourceKey(sourceKey)
+    try {
+      const state = await window.api.ssh.connect({ targetId: manager.target.connectionId })
+      if (!state || state.status !== 'connected') {
+        toast.error(state?.error ?? 'SSH connections are unavailable in this client.')
+        return
+      }
+      await refresh()
+      toast.success('SSH connected.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'SSH connection failed.')
+    } finally {
+      setConnectingExternalSourceKey(null)
+    }
+  }
+
   const openRunWorkspace = (run: AutomationRun): void => {
-    if (!run.workspaceId || !activateAndRevealWorktree(run.workspaceId)) {
+    const runWorktree = run.workspaceId ? (worktreeMap.get(run.workspaceId) ?? null) : null
+    const store = useAppStore.getState()
+    const runViewState = getAutomationRunViewState({
+      run,
+      workspaceExists: Boolean(runWorktree),
+      terminalTabExists: run.terminalSessionId
+        ? Boolean(store.getTab(run.terminalSessionId))
+        : false
+    })
+    if (!run.workspaceId || !runWorktree || !runViewState.canOpen) {
+      toast.error(runViewState.statusLabel)
+      return
+    }
+    const terminalTabExistsBeforeActivation = run.terminalSessionId
+      ? Boolean(store.getTab(run.terminalSessionId))
+      : false
+    if (run.terminalSessionId) {
+      if (terminalTabExistsBeforeActivation && activateAndRevealWorktree(run.workspaceId)) {
+        store.setActiveTab(run.terminalSessionId)
+        store.setActiveTabType('terminal')
+        return
+      }
+    }
+    if (!activateAndRevealWorktree(run.workspaceId)) {
       toast.error('Workspace is not available.')
       return
     }
-    if (run.terminalSessionId) {
-      const store = useAppStore.getState()
-      if (store.getTab(run.terminalSessionId)) {
-        store.setActiveTab(run.terminalSessionId)
-        store.setActiveTabType('terminal')
-      }
-    }
+    // Why: activation can create a fresh terminal for an empty workspace; tell
+    // users when that is not the original automation run session.
+    toast.message(runViewState.statusLabel)
   }
+
+  useEffect(() => {
+    if (createOpen || deleteTarget || externalDeleteTarget) {
+      return
+    }
+
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key !== 'Escape' || event.defaultPrevented) {
+        return
+      }
+
+      const target = event.target
+      if (!(target instanceof HTMLElement)) {
+        return
+      }
+
+      // Why: match Tasks page behavior: Esc first exits field focus, then exits
+      // the page once focus is back on page chrome.
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.isContentEditable
+      ) {
+        event.preventDefault()
+        target.blur()
+        return
+      }
+
+      event.preventDefault()
+      closeAutomationsPage()
+    }
+
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+  }, [closeAutomationsPage, createOpen, deleteTarget, externalDeleteTarget])
 
   return (
     <main className="relative flex h-full min-h-0 flex-col bg-background text-foreground">
       <header className="flex shrink-0 items-center justify-between px-5 pb-3 pt-1.5 md:px-8">
         <div className="flex items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 rounded-full"
+                onClick={closeAutomationsPage}
+                aria-label="Close automations"
+              >
+                <X className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              Close · Esc
+            </TooltipContent>
+          </Tooltip>
+          <div className="mx-1 h-5 w-px bg-border/50" aria-hidden />
           <CalendarClock className="size-4 text-muted-foreground" />
           <h1 className="text-sm font-semibold">Automations</h1>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Add automation"
+                onClick={() => openCreateDialog()}
+                className="border border-border/50 bg-transparent hover:bg-muted/50"
+              >
+                <Plus className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              Add automation
+            </TooltipContent>
+          </Tooltip>
         </div>
         <div className="flex items-center gap-2">
           <Tooltip>
@@ -656,22 +1253,6 @@ export default function AutomationsPage(): React.JSX.Element {
               Refresh automations
             </TooltipContent>
           </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Add automation"
-                onClick={() => openCreateDialog()}
-                className="border border-border/50 bg-transparent hover:bg-muted/50"
-              >
-                <Plus className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6}>
-              Add automation
-            </TooltipContent>
-          </Tooltip>
         </div>
       </header>
 
@@ -680,12 +1261,14 @@ export default function AutomationsPage(): React.JSX.Element {
         isEditing={editingAutomationId !== null}
         isSaving={isSaving}
         canSave={canSaveDraft}
+        createTarget={createTarget}
         repos={repos}
         repoMap={repoMap}
         worktrees={worktrees}
         settings={settings}
         draft={draft}
         onProjectChange={handleProjectChange}
+        onCreateTargetChange={handleCreateTargetChange}
         onOpenChange={setCreateOpen}
         onDraftChange={setDraft}
         onApplyTemplate={applyTemplateToDraft}
@@ -789,7 +1372,11 @@ export default function AutomationsPage(): React.JSX.Element {
               <span className="break-all font-medium text-foreground">
                 {externalDeleteTarget?.job.name}
               </span>{' '}
-              from {externalDeleteTarget?.manager.label}.
+              from{' '}
+              {externalDeleteTarget
+                ? getExternalProviderLabel(externalDeleteTarget.manager)
+                : 'external source'}{' '}
+              on {externalDeleteTarget?.manager.targetLabel}.
             </DialogDescription>
           </DialogHeader>
           {externalDeleteTarget ? (
@@ -818,8 +1405,8 @@ export default function AutomationsPage(): React.JSX.Element {
 
       <div className="grid min-h-0 flex-1 grid-cols-[minmax(280px,360px)_1fr] overflow-hidden border-t border-border/50">
         <section className="flex min-h-0 flex-col border-r border-border/50 bg-muted/20">
-          <div className="min-h-0 flex-1 overflow-auto p-2">
-            {automations.length > 0 ? (
+          <div className="scrollbar-sleek min-h-0 flex-1 overflow-auto p-2">
+            {automations.length + externalAutomationEntries.length > 0 ? (
               <div className="grid grid-cols-[1fr_auto] gap-2 px-2 pb-2 text-[11px] font-medium uppercase text-muted-foreground">
                 <span>Automation</span>
                 <span>Next</span>
@@ -853,10 +1440,13 @@ export default function AutomationsPage(): React.JSX.Element {
                   <ContextMenuTrigger asChild>
                     <button
                       type="button"
-                      onClick={() => setSelectedId(automation.id)}
+                      onClick={() => {
+                        setSelectedExternalKey(null)
+                        setSelectedId(automation.id)
+                      }}
                       className={cn(
                         'mb-1 grid w-full grid-cols-[minmax(0,1fr)_auto] gap-3 rounded-md border px-3 py-2 text-left text-sm transition-colors',
-                        selected?.id === automation.id
+                        selectedExternal === null && selected?.id === automation.id
                           ? 'border-foreground/30 bg-muted/70 text-foreground shadow-sm'
                           : 'border-transparent hover:bg-muted/50'
                       )}
@@ -930,7 +1520,152 @@ export default function AutomationsPage(): React.JSX.Element {
                 </ContextMenu>
               )
             })}
-            {automations.length === 0 ? (
+            {externalAutomationEntries.map((entry) => {
+              const providerLabel = getExternalProviderLabel(entry.manager)
+              const targetKindLabel = getExternalTargetKindLabel(entry.manager)
+              if (entry.kind === 'source') {
+                const sourceStatus =
+                  entry.manager.target.type === 'ssh' ? 'Connect to load jobs' : 'Unavailable'
+                const sourceSummary =
+                  entry.manager.error ??
+                  `${providerLabel} source unavailable until ${targetKindLabel.toLowerCase()} connects.`
+                return (
+                  <button
+                    key={entry.key}
+                    type="button"
+                    onClick={() => {
+                      setSelectedExternalKey(entry.key)
+                      setActivePaneTab('overview')
+                    }}
+                    className={cn(
+                      'mb-1 grid w-full grid-cols-[minmax(0,1fr)_auto] gap-3 rounded-md border px-3 py-2 text-left text-sm transition-colors',
+                      selectedExternal?.key === entry.key
+                        ? 'border-foreground/30 bg-muted/70 text-foreground shadow-sm'
+                        : 'border-transparent hover:bg-muted/50'
+                    )}
+                  >
+                    <span className="min-w-0">
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="size-2 rounded-full bg-muted-foreground/40" />
+                        <span className="truncate font-medium">{entry.manager.targetLabel}</span>
+                      </span>
+                      <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                        <span>{providerLabel} source</span>
+                        <span className="shrink-0">/</span>
+                        <span className="truncate">{targetKindLabel}</span>
+                      </span>
+                      <span className="mt-1 block truncate text-xs text-muted-foreground">
+                        {sourceSummary}
+                      </span>
+                    </span>
+                    <span className="flex max-w-28 flex-col items-end gap-1 text-right text-xs text-muted-foreground">
+                      <Clock className="size-3.5" />
+                      <span className="line-clamp-2">{sourceStatus}</span>
+                    </span>
+                  </button>
+                )
+              }
+              const nextRunLabel = entry.job.enabled
+                ? formatExternalDate(entry.job.nextRunAt, relativeNow)
+                : 'Paused'
+              const actionDisabled = !entry.manager.canManage || externalActionKey !== null
+              return (
+                <ContextMenu key={entry.key}>
+                  <ContextMenuTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSelectedExternalKey(entry.key)
+                        setActivePaneTab('overview')
+                      }}
+                      className={cn(
+                        'mb-1 grid w-full grid-cols-[minmax(0,1fr)_auto] gap-3 rounded-md border px-3 py-2 text-left text-sm transition-colors',
+                        selectedExternal?.key === entry.key
+                          ? 'border-foreground/30 bg-muted/70 text-foreground shadow-sm'
+                          : 'border-transparent hover:bg-muted/50'
+                      )}
+                    >
+                      <span className="min-w-0">
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span
+                            className={cn(
+                              'size-2 rounded-full',
+                              entry.job.enabled ? 'bg-foreground' : 'bg-muted-foreground/40'
+                            )}
+                          />
+                          <span className="truncate font-medium">{entry.job.name}</span>
+                        </span>
+                        <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+                          <span>{providerLabel}</span>
+                          <span className="shrink-0">/</span>
+                          <span className="truncate">{entry.manager.targetLabel}</span>
+                        </span>
+                        <span className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                          <span className="truncate">{entry.job.schedule}</span>
+                          <span className="shrink-0">·</span>
+                          <span className="truncate">
+                            {entry.manager.provider === 'hermes'
+                              ? `${entry.job.runCount} ${entry.job.runCount === 1 ? 'run' : 'runs'}`
+                              : entry.manager.canManage
+                                ? 'Manageable'
+                                : 'Read-only'}
+                          </span>
+                        </span>
+                      </span>
+                      <span className="flex max-w-28 flex-col items-end gap-1 text-right text-xs text-muted-foreground">
+                        <Clock className="size-3.5" />
+                        <span className="line-clamp-2">{nextRunLabel}</span>
+                      </span>
+                    </button>
+                  </ContextMenuTrigger>
+                  <ContextMenuContent className="w-48">
+                    <ContextMenuItem
+                      disabled={actionDisabled}
+                      onSelect={() => requestExternalAction(entry.manager, entry.job, 'run')}
+                    >
+                      <Play className="size-3.5" />
+                      Run Now
+                    </ContextMenuItem>
+                    {entry.manager.provider === 'hermes' ? (
+                      <ContextMenuItem
+                        disabled={!entry.manager.canManage || externalActionKey !== null}
+                        onSelect={() => openEditExternalDialog(entry.manager, entry.job)}
+                      >
+                        <Pencil className="size-3.5" />
+                        Edit
+                      </ContextMenuItem>
+                    ) : null}
+                    <ContextMenuItem
+                      disabled={actionDisabled}
+                      onSelect={() =>
+                        requestExternalAction(
+                          entry.manager,
+                          entry.job,
+                          entry.job.enabled ? 'pause' : 'resume'
+                        )
+                      }
+                    >
+                      {entry.job.enabled ? (
+                        <Pause className="size-3.5" />
+                      ) : (
+                        <Play className="size-3.5" />
+                      )}
+                      {entry.job.enabled ? 'Pause' : 'Resume'}
+                    </ContextMenuItem>
+                    <ContextMenuSeparator />
+                    <ContextMenuItem
+                      variant="destructive"
+                      disabled={actionDisabled}
+                      onSelect={() => requestExternalAction(entry.manager, entry.job, 'delete')}
+                    >
+                      <Trash2 className="size-3.5" />
+                      Delete
+                    </ContextMenuItem>
+                  </ContextMenuContent>
+                </ContextMenu>
+              )
+            })}
+            {automations.length === 0 && externalAutomationEntries.length === 0 ? (
               <div className="grid gap-2 p-2">
                 <div className="px-1 pb-1 text-sm font-medium">Start from a template</div>
                 {AUTOMATION_TEMPLATES.map((template) => (
@@ -963,31 +1698,169 @@ export default function AutomationsPage(): React.JSX.Element {
           </div>
         </section>
 
-        <section className="min-h-0 overflow-auto p-5">
-          <AutomationDetail
-            automation={selected}
-            runs={selectedRuns}
-            projectName={selectedRepo?.displayName ?? 'Unknown project'}
-            projectDefaultBaseRef={selectedRepo?.worktreeBaseRef ?? null}
-            workspaceName={
-              selected?.workspaceMode === 'new_per_run'
-                ? 'New workspace each run'
-                : (selectedWorktree?.displayName ?? 'Missing workspace')
-            }
-            worktreeMap={worktreeMap}
-            now={relativeNow}
-            onRunNow={(automation) => void runNow(automation)}
-            onOpenRunWorkspace={openRunWorkspace}
-            onEdit={(automation) => void openEditDialog(automation)}
-            onToggle={(automation) => void toggleAutomation(automation)}
-            onDelete={requestDeleteAutomation}
-          />
-          <ExternalAutomationManagers
-            managers={externalManagers}
-            now={relativeNow}
-            runningActionKey={externalActionKey}
-            onAction={requestExternalAction}
-          />
+        <section className="flex min-h-0 flex-col overflow-hidden">
+          {selectedExternal ? (
+            <div className="scrollbar-sleek min-h-0 overflow-auto p-5">
+              {selectedExternalRunPage ? (
+                <AutomationRunPageFrame
+                  title={selectedExternalRunPage.job.name}
+                  breadcrumbs={[
+                    formatExternalDate(selectedExternalRunPage.run.runAt, relativeNow),
+                    getExternalProviderLabel(selectedExternalRunPage.manager),
+                    selectedExternalRunPage.manager.targetLabel
+                  ]}
+                  detail={selectedExternalRunPage.run.outputPath}
+                  statusLabel={getExternalRunStatusLabel(selectedExternalRunPage.run)}
+                  statusVariant={getExternalRunStatusVariant(selectedExternalRunPage.run)}
+                  onBack={() => setSelectedExternalRunPage(null)}
+                >
+                  <HermesCronOutputView
+                    content={getExternalRunContent(selectedExternalRunPage.run)}
+                  />
+                </AutomationRunPageFrame>
+              ) : selectedExternal.kind === 'job' ? (
+                <ExternalAutomationManagers
+                  managers={[
+                    {
+                      ...selectedExternal.manager,
+                      jobs: [selectedExternal.job]
+                    }
+                  ]}
+                  now={relativeNow}
+                  runningActionKey={externalActionKey}
+                  onAction={requestExternalAction}
+                  onFetchRuns={fetchExternalAutomationRuns}
+                  onOpenRun={openExternalRunPage}
+                  onEdit={openEditExternalDialog}
+                />
+              ) : (
+                <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
+                  <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">
+                        {selectedExternal.manager.targetLabel}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {getExternalProviderLabel(selectedExternal.manager)} source unavailable
+                        {selectedExternal.manager.error
+                          ? ` - ${selectedExternal.manager.error}`
+                          : null}
+                      </div>
+                    </div>
+                    {selectedExternalSshSource ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={isSelectedExternalSshConnecting}
+                        onClick={() =>
+                          void connectExternalAutomationSource(selectedExternalSshSource.manager)
+                        }
+                      >
+                        {isSelectedExternalSshConnecting ? (
+                          <RefreshCw className="size-3.5 animate-spin" />
+                        ) : null}
+                        {isSelectedExternalSshConnecting ? 'Connecting...' : 'Connect SSH'}
+                      </Button>
+                    ) : null}
+                  </div>
+                  <div className="px-3 py-6 text-sm text-muted-foreground">
+                    Connect this source to check for Hermes cron jobs in the remote profile.
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <Tabs
+              value={activePaneTab}
+              onValueChange={(value) => setActivePaneTab(value as AutomationPaneTab)}
+              className="min-h-0 flex-1 gap-0"
+            >
+              <div className="flex shrink-0 items-center justify-between border-b border-border/50 px-5 py-2">
+                <TabsList variant="line" className="h-8">
+                  <TabsTrigger value="overview">Overview</TabsTrigger>
+                  <TabsTrigger value="runs" disabled={!selected}>
+                    Runs
+                    <span className="text-xs text-muted-foreground">{selectedRuns.length}</span>
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+
+              <TabsContent value="overview" className="scrollbar-sleek min-h-0 overflow-auto p-5">
+                <AutomationDetail
+                  automation={selected}
+                  runs={selectedRuns}
+                  projectName={selectedRepo?.displayName ?? 'Unknown project'}
+                  projectDefaultBaseRef={selectedRepo?.worktreeBaseRef ?? null}
+                  workspaceName={
+                    selected?.workspaceMode === 'new_per_run'
+                      ? 'New workspace each run'
+                      : (selectedWorktree?.displayName ?? 'Missing workspace')
+                  }
+                  now={relativeNow}
+                  onRunNow={(automation) => void runNow(automation)}
+                  onEdit={(automation) => void openEditDialog(automation)}
+                  onToggle={(automation) => void toggleAutomation(automation)}
+                  onDelete={requestDeleteAutomation}
+                />
+              </TabsContent>
+
+              <TabsContent value="runs" className="scrollbar-sleek min-h-0 overflow-auto p-5">
+                {selectedAutomationRunPage ? (
+                  <AutomationRunPageFrame
+                    title={selected?.name ?? selectedAutomationRunPage.title}
+                    breadcrumbs={[
+                      formatAutomationDateTimeWithRelative(
+                        selectedAutomationRunPage.scheduledFor,
+                        relativeNow
+                      ),
+                      'Orca',
+                      selectedAutomationRunPageWorkspaceDisplay?.detailLabel ?? 'No workspace'
+                    ]}
+                    detail={
+                      selectedAutomationRunPage.outputSnapshot?.truncated
+                        ? 'Latest saved output'
+                        : null
+                    }
+                    statusLabel={getAutomationRunStatusLabel(selectedAutomationRunPage.status)}
+                    statusVariant={getAutomationRunStatusVariant(selectedAutomationRunPage.status)}
+                    actions={
+                      selectedAutomationRunPageViewState ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={!selectedAutomationRunPageViewState.canOpen}
+                          onClick={() => openRunWorkspace(selectedAutomationRunPage)}
+                        >
+                          <Eye className="size-3.5" />
+                          {selectedAutomationRunPageViewState.actionLabel}
+                        </Button>
+                      ) : null
+                    }
+                    onBack={() => setSelectedAutomationRunPageId(null)}
+                  >
+                    <CommentMarkdown
+                      variant="document"
+                      content={getAutomationRunContent(selectedAutomationRunPage)}
+                      className="text-sm leading-relaxed text-foreground"
+                    />
+                  </AutomationRunPageFrame>
+                ) : selected ? (
+                  <AutomationRunHistory
+                    runs={selectedRuns}
+                    automationId={selected.id}
+                    worktreeMap={worktreeMap}
+                    onOpenRun={openAutomationRunPage}
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                    Select an automation to view runs.
+                  </div>
+                )}
+              </TabsContent>
+            </Tabs>
+          )}
         </section>
       </div>
     </main>

--- a/src/renderer/src/components/automations/CreateFromPicker.tsx
+++ b/src/renderer/src/components/automations/CreateFromPicker.tsx
@@ -151,7 +151,10 @@ export function CreateFromPicker({
             aria-expanded={open}
             className={cn('h-9 w-full justify-between px-3 text-sm font-normal', triggerClassName)}
           >
-            <span className="truncate">{selectedLabel}</span>
+            <span className="flex min-w-0 items-center gap-1.5">
+              <span className="shrink-0 text-muted-foreground">Branch from</span>
+              <span className="truncate">{selectedLabel}</span>
+            </span>
             <ChevronsUpDown className="size-4 opacity-50" />
           </Button>
         </PopoverTrigger>

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -1,14 +1,19 @@
 import React from 'react'
-import { Pause, Play, RefreshCw, Trash2 } from 'lucide-react'
+import { Pause, Pencil, Play, RefreshCw, Trash2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type {
   ExternalAutomationAction,
   ExternalAutomationJob,
-  ExternalAutomationManager
+  ExternalAutomationManager,
+  ExternalAutomationRun
 } from '../../../../shared/automations-types'
 import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
+import {
+  ExternalAutomationRunTable,
+  type FetchExternalAutomationRuns
+} from './ExternalAutomationRunTable'
 
 type ExternalAutomationManagersProps = {
   managers: ExternalAutomationManager[]
@@ -19,6 +24,13 @@ type ExternalAutomationManagersProps = {
     job: ExternalAutomationJob,
     action: ExternalAutomationAction
   ) => void
+  onFetchRuns?: FetchExternalAutomationRuns
+  onOpenRun?: (
+    manager: ExternalAutomationManager,
+    job: ExternalAutomationJob,
+    run: ExternalAutomationRun
+  ) => void
+  onEdit?: (manager: ExternalAutomationManager, job: ExternalAutomationJob) => void
 }
 
 function formatExternalDate(value: string | null, now: number): string {
@@ -38,6 +50,14 @@ function actionKey(
   action: ExternalAutomationAction
 ): string {
   return `${manager.id}:${job.id}:${action}`
+}
+
+function getProviderLabel(manager: ExternalAutomationManager): string {
+  return manager.provider === 'hermes' ? 'Hermes' : 'OpenClaw'
+}
+
+function getTargetKindLabel(manager: ExternalAutomationManager): string {
+  return manager.target.type === 'ssh' ? 'Remote SSH' : 'Local'
 }
 
 function ExternalActionButton({
@@ -78,16 +98,21 @@ export function ExternalAutomationManagers({
   managers,
   now,
   runningActionKey,
-  onAction
+  onAction,
+  onFetchRuns,
+  onOpenRun,
+  onEdit
 }: ExternalAutomationManagersProps): React.JSX.Element {
+  const automationCount = managers.reduce((sum, manager) => sum + manager.jobs.length, 0)
+
   return (
-    <div className="mt-6 rounded-md border border-border/50 bg-muted/20 shadow-sm">
+    <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
       <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
         <div>
-          <div className="text-sm font-medium">External managers</div>
+          <div className="text-sm font-medium">External automations</div>
         </div>
         <Badge variant="outline">
-          {managers.reduce((sum, manager) => sum + manager.jobs.length, 0)} jobs
+          {automationCount} {automationCount === 1 ? 'automation' : 'automations'}
         </Badge>
       </div>
       <div className="divide-y divide-border/50">
@@ -95,8 +120,9 @@ export function ExternalAutomationManagers({
           <div key={manager.id} className="px-3 py-3">
             <div className="mb-2 flex items-center justify-between gap-3">
               <div className="min-w-0">
-                <div className="truncate text-sm font-medium">{manager.label}</div>
+                <div className="truncate text-sm font-medium">{manager.targetLabel}</div>
                 <div className="text-xs text-muted-foreground">
+                  {getProviderLabel(manager)} / {getTargetKindLabel(manager)} ·{' '}
                   {manager.status === 'available'
                     ? manager.canManage
                       ? 'Manageable'
@@ -121,11 +147,15 @@ export function ExternalAutomationManagers({
                       <Badge variant={job.enabled ? 'secondary' : 'outline'}>
                         {job.enabled ? 'Active' : 'Paused'}
                       </Badge>
-                      <Badge variant="outline">Usage unsupported</Badge>
                     </div>
                     <div className="mt-1 truncate text-xs text-muted-foreground">
                       {job.schedule} · next {formatExternalDate(job.nextRunAt, now)}
                     </div>
+                    {manager.provider === 'hermes' ? (
+                      <div className="mt-1 truncate text-xs text-muted-foreground">
+                        {job.runCount} {job.runCount === 1 ? 'run' : 'runs'} found
+                      </div>
+                    ) : null}
                     {job.promptPreview || job.lastError ? (
                       <div className="mt-1 truncate text-xs text-muted-foreground">
                         {job.lastError ?? job.promptPreview}
@@ -148,6 +178,15 @@ export function ExternalAutomationManagers({
                         <Play className="size-3.5" />
                       )}
                     </ExternalActionButton>
+                    {manager.provider === 'hermes' ? (
+                      <ExternalActionButton
+                        label="Edit external automation"
+                        disabled={!manager.canManage || runningActionKey !== null}
+                        onClick={() => onEdit?.(manager, job)}
+                      >
+                        <Pencil className="size-3.5" />
+                      </ExternalActionButton>
+                    ) : null}
                     <ExternalActionButton
                       label={
                         job.enabled ? 'Pause external automation' : 'Resume external automation'
@@ -177,6 +216,17 @@ export function ExternalAutomationManagers({
                       )}
                     </ExternalActionButton>
                   </div>
+                  {manager.provider === 'hermes' ? (
+                    <div className="col-span-3">
+                      <ExternalAutomationRunTable
+                        manager={manager}
+                        job={job}
+                        now={now}
+                        onFetchRuns={onFetchRuns}
+                        onOpenRun={(run) => onOpenRun?.(manager, job, run)}
+                      />
+                    </div>
+                  ) : null}
                 </div>
               ))}
               {manager.jobs.length === 0 ? (

--- a/src/renderer/src/components/automations/ExternalAutomationRunTable.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationRunTable.tsx
@@ -1,0 +1,285 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { AlertCircle, ChevronLeft, ChevronRight, FileText, Loader2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import type {
+  ExternalAutomationJob,
+  ExternalAutomationManager,
+  ExternalAutomationRun
+} from '../../../../shared/automations-types'
+import { formatAutomationDateTimeWithRelative } from './automation-page-parts'
+
+const PAGE_SIZE = 8
+
+export type ExternalAutomationRunPage = {
+  runs: ExternalAutomationRun[]
+  totalCount?: number
+}
+
+export type FetchExternalAutomationRuns = (input: {
+  manager: ExternalAutomationManager
+  job: ExternalAutomationJob
+  page: number
+  pageSize: number
+}) => Promise<ExternalAutomationRun[] | ExternalAutomationRunPage>
+
+type ExternalAutomationRunTableProps = {
+  manager: ExternalAutomationManager
+  job: ExternalAutomationJob
+  now: number
+  onFetchRuns?: FetchExternalAutomationRuns
+  onOpenRun?: (run: ExternalAutomationRun) => void
+}
+
+function formatExternalDate(value: string | null, now: number): string {
+  if (!value) {
+    return 'Never'
+  }
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) {
+    return value
+  }
+  return formatAutomationDateTimeWithRelative(parsed, now)
+}
+
+function getRunStatusLabel(run: ExternalAutomationRun): string {
+  switch (run.status) {
+    case 'completed':
+      return 'Completed'
+    case 'failed':
+      return 'Failed'
+    case 'unknown':
+      return 'Unknown'
+  }
+}
+
+function getRunStatusVariant(
+  run: ExternalAutomationRun
+): React.ComponentProps<typeof Badge>['variant'] {
+  switch (run.status) {
+    case 'completed':
+      return 'secondary'
+    case 'failed':
+      return 'destructive'
+    case 'unknown':
+      return 'outline'
+  }
+}
+
+function getRunSummary(run: ExternalAutomationRun): string {
+  return run.error ?? run.outputPreview ?? 'No output preview'
+}
+
+function normalizeRunPage(
+  result: ExternalAutomationRun[] | ExternalAutomationRunPage
+): ExternalAutomationRunPage {
+  if (Array.isArray(result)) {
+    return { runs: result }
+  }
+  return result
+}
+
+export function ExternalAutomationRunTable({
+  manager,
+  job,
+  now,
+  onFetchRuns,
+  onOpenRun
+}: ExternalAutomationRunTableProps): React.JSX.Element {
+  const [page, setPage] = useState(0)
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(job.runs[0]?.id ?? null)
+  const [fetchedRuns, setFetchedRuns] = useState<ExternalAutomationRun[] | null>(null)
+  const [fetchedTotalCount, setFetchedTotalCount] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const managerRef = useRef(manager)
+  const jobRef = useRef(job)
+
+  managerRef.current = manager
+  jobRef.current = job
+
+  useEffect(() => {
+    setPage(0)
+    setSelectedRunId(job.runs[0]?.id ?? null)
+    setFetchedRuns(null)
+    setFetchedTotalCount(null)
+    setFetchError(null)
+  }, [job.id, job.runs])
+
+  useEffect(() => {
+    if (!onFetchRuns) {
+      return
+    }
+    let cancelled = false
+    setIsLoading(true)
+    setFetchError(null)
+    void onFetchRuns({
+      manager: managerRef.current,
+      job: jobRef.current,
+      page,
+      pageSize: PAGE_SIZE
+    })
+      .then((result) => {
+        if (cancelled) {
+          return
+        }
+        const nextPage = normalizeRunPage(result)
+        setFetchedRuns(nextPage.runs)
+        setFetchedTotalCount(nextPage.totalCount ?? null)
+        setSelectedRunId((current) => {
+          if (current && nextPage.runs.some((run) => run.id === current)) {
+            return current
+          }
+          return nextPage.runs[0]?.id ?? null
+        })
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setFetchedRuns(null)
+          setFetchedTotalCount(null)
+          setFetchError(error instanceof Error ? error.message : 'Failed to load runs.')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [job.id, manager.id, onFetchRuns, page])
+
+  const fallbackRuns = job.runs
+  const visibleRuns = onFetchRuns
+    ? (fetchedRuns ?? fallbackRuns.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE))
+    : fallbackRuns.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
+  const totalCount = onFetchRuns ? (fetchedTotalCount ?? job.runCount) : job.runCount
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
+  const selectedRun = useMemo(
+    () =>
+      visibleRuns.find((run) => run.id === selectedRunId) ??
+      fallbackRuns.find((run) => run.id === selectedRunId) ??
+      visibleRuns[0] ??
+      null,
+    [fallbackRuns, selectedRunId, visibleRuns]
+  )
+  const hasVisibleRuns = visibleRuns.length > 0
+  const pageStart = totalCount === 0 || !hasVisibleRuns ? 0 : page * PAGE_SIZE + 1
+  const pageEnd = Math.min(totalCount, page * PAGE_SIZE + visibleRuns.length)
+
+  useEffect(() => {
+    if (selectedRunId && visibleRuns.some((run) => run.id === selectedRunId)) {
+      return
+    }
+    setSelectedRunId(visibleRuns[0]?.id ?? null)
+  }, [selectedRunId, visibleRuns])
+
+  return (
+    <div className="mt-2 rounded-md border border-border/50 bg-background/50">
+      <div className="flex items-center justify-between border-b border-border/50 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="text-xs font-medium">Runs</div>
+          {isLoading ? <Loader2 className="size-3.5 animate-spin text-muted-foreground" /> : null}
+          {fetchError ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <AlertCircle className="size-3.5 text-destructive" />
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {fetchError}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {totalCount} {totalCount === 1 ? 'run' : 'runs'}
+        </div>
+      </div>
+
+      {hasVisibleRuns ? (
+        <div>
+          <div className="min-w-0 border-b border-border/50">
+            <div className="grid grid-cols-[minmax(7.5rem,.45fr)_minmax(0,1fr)_auto] gap-3 border-b border-border/50 px-3 py-1.5 text-[11px] font-medium uppercase text-muted-foreground">
+              <span>Run time</span>
+              <span>Preview</span>
+              <span>Status</span>
+            </div>
+            <div className="divide-y divide-border/50">
+              {visibleRuns.map((run) => (
+                <button
+                  key={run.id}
+                  type="button"
+                  data-current={selectedRun?.id === run.id}
+                  onClick={() => {
+                    setSelectedRunId(run.id)
+                    onOpenRun?.(run)
+                  }}
+                  className={cn(
+                    'grid w-full grid-cols-[minmax(7.5rem,.45fr)_minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                    selectedRun?.id === run.id && 'bg-accent text-accent-foreground'
+                  )}
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-xs">
+                      {formatExternalDate(run.runAt, now)}
+                    </span>
+                    {run.outputPath ? (
+                      <span className="mt-0.5 block truncate font-mono text-[11px] text-muted-foreground">
+                        {run.outputPath}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="min-w-0 truncate text-xs text-muted-foreground">
+                    {getRunSummary(run)}
+                  </span>
+                  <Badge variant={getRunStatusVariant(run)}>{getRunStatusLabel(run)}</Badge>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="px-3 py-4 text-sm text-muted-foreground">
+          {isLoading ? 'Loading runs...' : 'No Hermes runs found yet.'}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-border/50 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+          <FileText className="size-3.5" />
+          <span>
+            {pageStart}-{pageEnd} of {totalCount}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Previous run page"
+            disabled={page === 0 || isLoading}
+            onClick={() => setPage((current) => Math.max(0, current - 1))}
+          >
+            <ChevronLeft className="size-3.5" />
+          </Button>
+          <div className="min-w-14 text-center text-xs text-muted-foreground">
+            {page + 1} / {totalPages}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Next run page"
+            disabled={page >= totalPages - 1 || isLoading}
+            onClick={() => setPage((current) => Math.min(totalPages - 1, current + 1))}
+          >
+            <ChevronRight className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/HermesCronOutputView.tsx
+++ b/src/renderer/src/components/automations/HermesCronOutputView.tsx
@@ -1,0 +1,432 @@
+import React, { useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Fingerprint,
+  MessageSquare,
+  Sparkles,
+  Terminal
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import {
+  formatAutomationSchedule,
+  isValidAutomationSchedule
+} from '../../../../shared/automation-schedules'
+
+type ParsedSection = {
+  heading: string
+  level: number
+  body: string
+}
+
+type ParsedHermesOutput = {
+  title: string | null
+  metadata: { label: string; value: string }[]
+  sections: ParsedSection[]
+}
+
+const METADATA_LINE_PATTERN = /^\*\*([^*]+):\*\*\s+(.+?)\s*$/
+const CRON_FIELD_NAMES = ['minute', 'hour', 'day of month', 'month', 'weekday'] as const
+const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+function splitSections(content: string): ParsedSection[] {
+  const lines = content.split(/\r?\n/)
+  const sections: ParsedSection[] = []
+  let current: ParsedSection | null = null
+  for (const line of lines) {
+    const heading = /^(#{2,6})\s+(.+?)\s*$/.exec(line)
+    if (heading) {
+      if (current) {
+        current.body = current.body.trimEnd()
+        sections.push(current)
+      }
+      current = { heading: heading[2], level: heading[1].length, body: '' }
+      continue
+    }
+    if (current) {
+      current.body += `${line}\n`
+    }
+  }
+  if (current) {
+    current.body = current.body.trimEnd()
+    sections.push(current)
+  }
+  return sections
+}
+
+function parseHermesOutput(content: string): ParsedHermesOutput {
+  const lines = content.split(/\r?\n/)
+  let title: string | null = null
+  const metadata: { label: string; value: string }[] = []
+  let bodyStart = 0
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (!title) {
+      const titleMatch = /^#\s+(?:Cron Job:\s*)?(.+?)\s*$/.exec(line)
+      if (titleMatch) {
+        title = titleMatch[1]
+        bodyStart = index + 1
+        continue
+      }
+    }
+    const metaMatch = METADATA_LINE_PATTERN.exec(line)
+    if (metaMatch) {
+      metadata.push({ label: metaMatch[1].trim(), value: metaMatch[2].trim() })
+      bodyStart = index + 1
+      continue
+    }
+    if (line.trim() === '') {
+      if (metadata.length > 0 || title) {
+        bodyStart = index + 1
+        continue
+      }
+      continue
+    }
+    if (title || metadata.length > 0) {
+      break
+    }
+  }
+  const remainder = lines.slice(bodyStart).join('\n')
+  return {
+    title,
+    metadata,
+    sections: splitSections(remainder)
+  }
+}
+
+function isPromptSection(section: ParsedSection): boolean {
+  return /^prompt$/i.test(section.heading.trim())
+}
+
+function isResponseSection(section: ParsedSection): boolean {
+  return /^response$/i.test(section.heading.trim())
+}
+
+function isErrorSection(section: ParsedSection): boolean {
+  return /^error$/i.test(section.heading.trim())
+}
+
+function formatCronTime(hour: number, minute: number): string {
+  const date = new Date()
+  date.setHours(hour, minute, 0, 0)
+  return new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(date)
+}
+
+function parseSingleCronNumber(value: string, min: number, max: number): number | null {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    return null
+  }
+  return parsed
+}
+
+function describeSimpleCron(parts: string[]): string | null {
+  const [minuteField, hourField, dayOfMonthField, monthField, weekdayField] = parts
+  const minute = parseSingleCronNumber(minuteField, 0, 59)
+  const hour = parseSingleCronNumber(hourField, 0, 23)
+  const time = minute !== null && hour !== null ? formatCronTime(hour, minute) : null
+
+  if (time && dayOfMonthField === '*' && monthField === '*' && weekdayField === '*') {
+    return `Runs daily at ${time}.`
+  }
+  if (
+    minute !== null &&
+    hourField === '*' &&
+    dayOfMonthField === '*' &&
+    monthField === '*' &&
+    weekdayField === '*'
+  ) {
+    return `Runs hourly at :${String(minute).padStart(2, '0')}.`
+  }
+  if (
+    time &&
+    dayOfMonthField === '*' &&
+    monthField === '*' &&
+    /^(?:1-5|MON-FRI)$/i.test(weekdayField)
+  ) {
+    return `Runs on weekdays at ${time}.`
+  }
+  const weekday = parseSingleCronNumber(weekdayField, 0, 7)
+  if (time && dayOfMonthField === '*' && monthField === '*' && weekday !== null) {
+    return `Runs every ${WEEKDAY_NAMES[weekday === 7 ? 0 : weekday]} at ${time}.`
+  }
+  const dayOfMonth = parseSingleCronNumber(dayOfMonthField, 1, 31)
+  if (time && dayOfMonth !== null && monthField === '*' && weekdayField === '*') {
+    return `Runs monthly on day ${dayOfMonth} at ${time}.`
+  }
+  return null
+}
+
+function describeCronFields(parts: string[]): string {
+  return parts.map((part, index) => `${CRON_FIELD_NAMES[index]} ${part}`).join(', ')
+}
+
+function getScheduleDescription(value: string): string | null {
+  const trimmed = value.trim()
+  if (!isValidAutomationSchedule(trimmed)) {
+    return null
+  }
+  if (trimmed.includes('=')) {
+    return formatAutomationSchedule(trimmed)
+  }
+  const parts = trimmed.split(/\s+/)
+  if (parts.length !== 5) {
+    return null
+  }
+  return describeSimpleCron(parts) ?? `Cron fields: ${describeCronFields(parts)}.`
+}
+
+function isScheduleMetadataLabel(label: string): boolean {
+  return /^(?:schedule|cron schedule|cron)$/i.test(label.trim())
+}
+
+type MetadataIconStyle = { icon: LucideIcon; iconClass: string; ringClass: string }
+
+function getMetadataIconStyle(label: string): MetadataIconStyle {
+  const normalized = label.toLowerCase()
+  if (/(^|\s)(job\s*id|id)(\s|$)/.test(normalized)) {
+    return {
+      icon: Fingerprint,
+      iconClass: 'text-violet-400',
+      ringClass: 'bg-violet-500/10 ring-1 ring-violet-500/30'
+    }
+  }
+  if (/time|run/.test(normalized)) {
+    return {
+      icon: Clock,
+      iconClass: 'text-sky-400',
+      ringClass: 'bg-sky-500/10 ring-1 ring-sky-500/30'
+    }
+  }
+  if (/schedule|cron/.test(normalized)) {
+    return {
+      icon: CalendarClock,
+      iconClass: 'text-amber-400',
+      ringClass: 'bg-amber-500/10 ring-1 ring-amber-500/30'
+    }
+  }
+  return {
+    icon: Sparkles,
+    iconClass: 'text-muted-foreground',
+    ringClass: 'bg-muted/40 ring-1 ring-border/60'
+  }
+}
+
+type CollapsibleSectionProps = {
+  title: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+  tone?: 'default' | 'muted'
+  icon?: LucideIcon
+  iconClass?: string
+}
+
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+  tone = 'default',
+  icon: Icon,
+  iconClass
+}: CollapsibleSectionProps): React.JSX.Element {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <section
+      className={cn(
+        'overflow-hidden rounded-lg border border-border/50',
+        tone === 'muted' ? 'bg-muted/15' : 'bg-background'
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-foreground transition-colors hover:bg-muted/40"
+      >
+        {open ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+        {Icon ? <Icon className={cn('size-3.5', iconClass ?? 'text-muted-foreground')} /> : null}
+        {title}
+      </button>
+      {open ? <div className="border-t border-border/50 px-4 py-3">{children}</div> : null}
+    </section>
+  )
+}
+
+type SectionCardProps = {
+  title: string
+  accent?: 'response' | 'error' | 'default'
+  children: React.ReactNode
+}
+
+function SectionCard({ title, accent = 'default', children }: SectionCardProps): React.JSX.Element {
+  const Icon = accent === 'error' ? AlertTriangle : CheckCircle2
+  return (
+    <section
+      className={cn(
+        'relative overflow-hidden rounded-lg border shadow-sm',
+        accent === 'error'
+          ? 'border-rose-500/30 bg-gradient-to-br from-rose-500/10 via-background to-background'
+          : accent === 'response'
+            ? 'border-emerald-500/25 bg-gradient-to-br from-emerald-500/5 via-background to-background'
+            : 'border-border/50 bg-background'
+      )}
+    >
+      <header
+        className={cn(
+          'flex items-center gap-2 border-b px-4 py-2.5 text-xs font-semibold uppercase tracking-wide',
+          accent === 'error'
+            ? 'border-rose-500/20 text-rose-700 dark:text-rose-300'
+            : accent === 'response'
+              ? 'border-emerald-500/20 text-emerald-700 dark:text-emerald-300'
+              : 'border-border/50 text-foreground'
+        )}
+      >
+        {accent !== 'default' ? <Icon className="size-3.5" /> : null}
+        {title}
+      </header>
+      <div className="px-4 py-3">{children}</div>
+    </section>
+  )
+}
+
+function MetadataValue({ label, value }: { label: string; value: string }): React.JSX.Element {
+  const scheduleDescription = isScheduleMetadataLabel(label) ? getScheduleDescription(value) : null
+
+  if (!scheduleDescription) {
+    return <dd className="mt-0.5 break-all font-mono text-xs text-foreground">{value}</dd>
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <dd
+          tabIndex={0}
+          className="mt-0.5 break-all rounded-sm font-mono text-xs text-foreground underline decoration-dotted underline-offset-2 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {value}
+        </dd>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4} className="max-w-64 text-left">
+        {scheduleDescription}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function HermesCronOutputView({ content }: { content: string }): React.JSX.Element {
+  const parsed = useMemo(() => parseHermesOutput(content), [content])
+
+  const responseSection = parsed.sections.find(isResponseSection)
+  const errorSection = parsed.sections.find(isErrorSection)
+  const promptSection = parsed.sections.find(isPromptSection)
+  const otherSections = parsed.sections.filter(
+    (section) =>
+      !isResponseSection(section) && !isErrorSection(section) && !isPromptSection(section)
+  )
+
+  const hasStructure =
+    parsed.metadata.length > 0 || [responseSection, errorSection, promptSection].some(Boolean)
+
+  if (!hasStructure) {
+    return (
+      <CommentMarkdown
+        variant="document"
+        content={content}
+        className="text-sm leading-relaxed text-foreground"
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {parsed.metadata.length > 0 ? (
+        <dl className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {parsed.metadata.map((entry) => {
+            const { icon: Icon, iconClass, ringClass } = getMetadataIconStyle(entry.label)
+            return (
+              <div
+                key={entry.label}
+                className="flex items-start gap-3 rounded-lg border border-border/50 bg-muted/15 px-3 py-2.5"
+              >
+                <span
+                  className={cn(
+                    'mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md',
+                    ringClass
+                  )}
+                >
+                  <Icon className={cn('size-3.5', iconClass)} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <dt className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {entry.label}
+                  </dt>
+                  <MetadataValue label={entry.label} value={entry.value} />
+                </div>
+              </div>
+            )
+          })}
+        </dl>
+      ) : null}
+
+      {errorSection ? (
+        <SectionCard title="Error" accent="error">
+          <CommentMarkdown
+            variant="document"
+            content={errorSection.body}
+            className="text-sm leading-relaxed text-foreground"
+          />
+        </SectionCard>
+      ) : null}
+
+      {responseSection ? (
+        <SectionCard title="Response" accent="response">
+          <CommentMarkdown
+            variant="document"
+            content={responseSection.body}
+            className="text-sm leading-relaxed text-foreground"
+          />
+        </SectionCard>
+      ) : null}
+
+      {promptSection ? (
+        <CollapsibleSection
+          title="Prompt"
+          tone="muted"
+          icon={MessageSquare}
+          iconClass="text-indigo-700 dark:text-indigo-400"
+        >
+          <CommentMarkdown
+            variant="document"
+            content={promptSection.body}
+            className="text-sm leading-relaxed text-foreground/90"
+          />
+        </CollapsibleSection>
+      ) : null}
+
+      {otherSections.map((section) => (
+        <CollapsibleSection
+          key={section.heading}
+          title={section.heading}
+          tone="muted"
+          icon={Terminal}
+          iconClass="text-muted-foreground"
+        >
+          <CommentMarkdown
+            variant="document"
+            content={section.body}
+            className="text-sm leading-relaxed text-foreground/90"
+          />
+        </CollapsibleSection>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/automation-page-parts.tsx
+++ b/src/renderer/src/components/automations/automation-page-parts.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 import type { AutomationRun } from '../../../../shared/automations-types'
 
 export function formatAutomationDateTime(value: number | null | undefined): string {
@@ -90,13 +91,15 @@ export function getAutomationRunStatusLabel(status: AutomationRun['status']): st
 
 export function Field({
   label,
-  children
+  children,
+  className
 }: {
   label: React.ReactNode
   children: React.ReactNode
+  className?: string
 }): React.JSX.Element {
   return (
-    <div className="space-y-1.5">
+    <div className={cn('space-y-1.5', className)}>
       <div className="text-xs text-muted-foreground">{label}</div>
       {children}
     </div>

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAutomationRunOutputSnapshotBuffer } from './automation-run-output-snapshot'
+
+describe('automation run output snapshot buffer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-16T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('captures a plain-text snapshot from terminal chunks', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('\u001b[32mDone\u001b[0m\r\n')
+    buffer.append('All checks passed')
+
+    expect(buffer.snapshot()).toEqual({
+      format: 'plain_text',
+      content: 'Done\nAll checks passed',
+      capturedAt: new Date('2026-05-16T12:00:00Z').getTime(),
+      truncated: false
+    })
+  })
+
+  it('returns null for empty terminal noise', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('\u001b[?25h\r')
+
+    expect(buffer.snapshot()).toBeNull()
+  })
+})

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-control-regex -- terminal snapshots normalize ANSI/control output. */
+import type { AutomationRunOutputSnapshot } from '../../../../shared/automations-types'
+
+const MAX_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
+
+const ANSI_PATTERN =
+  /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g
+const CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g
+
+export type AutomationRunOutputSnapshotBuffer = {
+  append: (chunk: string) => void
+  snapshot: () => AutomationRunOutputSnapshot | null
+}
+
+function stripTerminalControls(value: string): string {
+  return value
+    .replace(ANSI_PATTERN, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(CONTROL_PATTERN, '')
+}
+
+export function createAutomationRunOutputSnapshotBuffer(): AutomationRunOutputSnapshotBuffer {
+  const chunks: string[] = []
+  let totalChars = 0
+  let truncated = false
+
+  return {
+    append(chunk) {
+      if (!chunk) {
+        return
+      }
+      chunks.push(chunk)
+      totalChars += chunk.length
+      while (totalChars > MAX_OUTPUT_SNAPSHOT_CHARS && chunks.length > 1) {
+        totalChars -= chunks.shift()!.length
+        truncated = true
+      }
+      if (totalChars > MAX_OUTPUT_SNAPSHOT_CHARS && chunks.length === 1) {
+        chunks[0] = chunks[0].slice(-MAX_OUTPUT_SNAPSHOT_CHARS)
+        totalChars = chunks[0].length
+        truncated = true
+      }
+    },
+    snapshot() {
+      const content = stripTerminalControls(chunks.join('')).trim()
+      if (!content) {
+        return null
+      }
+      return {
+        format: 'plain_text',
+        content,
+        capturedAt: Date.now(),
+        truncated
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/automations/automation-run-view-state.test.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import type { AutomationRun } from '../../../../shared/automations-types'
+import { getAutomationRunViewState } from './automation-run-view-state'
+
+function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: 'run-1',
+    automationId: 'automation-1',
+    title: 'Run 1',
+    scheduledFor: 1,
+    status: 'completed',
+    trigger: 'manual',
+    workspaceId: 'wt-1',
+    sessionKind: 'terminal',
+    chatSessionId: null,
+    terminalSessionId: 'tab-1',
+    outputSnapshot: null,
+    usage: null,
+    error: null,
+    startedAt: 1,
+    dispatchedAt: 1,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+describe('automation run view state', () => {
+  it('opens the exact terminal when the run tab is still available', () => {
+    expect(
+      getAutomationRunViewState({
+        run: makeRun(),
+        workspaceExists: true,
+        terminalTabExists: true
+      })
+    ).toMatchObject({
+      availability: 'terminal',
+      actionLabel: 'View run',
+      statusLabel: 'Run is open',
+      canOpen: true
+    })
+  })
+
+  it('falls back to opening the workspace when terminal history is gone', () => {
+    expect(
+      getAutomationRunViewState({
+        run: makeRun(),
+        workspaceExists: true,
+        terminalTabExists: false
+      })
+    ).toMatchObject({
+      availability: 'workspace',
+      actionLabel: 'Open workspace',
+      statusLabel: 'Opened workspace; original terminal is closed.',
+      canOpen: true
+    })
+  })
+
+  it('keeps skipped or missing-workspace runs as metadata-only history', () => {
+    expect(
+      getAutomationRunViewState({
+        run: makeRun({ workspaceId: null, terminalSessionId: null }),
+        workspaceExists: false,
+        terminalTabExists: false
+      })
+    ).toMatchObject({
+      availability: 'metadata',
+      statusLabel: 'No workspace launched',
+      canOpen: false
+    })
+  })
+
+  it('describes deleted workspaces without the ambiguous unavailable label', () => {
+    expect(
+      getAutomationRunViewState({
+        run: makeRun({ workspaceDisplayName: 'Nightly Checks' }),
+        workspaceExists: false,
+        terminalTabExists: false
+      })
+    ).toMatchObject({
+      availability: 'metadata',
+      statusLabel: 'Nightly Checks no longer available',
+      canOpen: false
+    })
+  })
+
+  it('keeps a deleted-workspace run viewable through its saved snapshot', () => {
+    expect(
+      getAutomationRunViewState({
+        run: makeRun({
+          outputSnapshot: {
+            format: 'plain_text',
+            content: 'Run completed',
+            capturedAt: 1,
+            truncated: false
+          }
+        }),
+        workspaceExists: false,
+        terminalTabExists: false
+      })
+    ).toMatchObject({
+      availability: 'snapshot',
+      actionLabel: 'Snapshot saved',
+      statusLabel: 'Showing saved run snapshot.',
+      canOpen: false
+    })
+  })
+})

--- a/src/renderer/src/components/automations/automation-run-view-state.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.ts
@@ -1,0 +1,60 @@
+import type { AutomationRun } from '../../../../shared/automations-types'
+
+export type AutomationRunViewAvailability = 'terminal' | 'workspace' | 'snapshot' | 'metadata'
+
+export type AutomationRunViewState = {
+  availability: AutomationRunViewAvailability
+  actionLabel: string
+  statusLabel: string
+  canOpen: boolean
+}
+
+export function getAutomationRunViewState({
+  run,
+  workspaceExists,
+  terminalTabExists
+}: {
+  run: AutomationRun
+  workspaceExists: boolean
+  terminalTabExists: boolean
+}): AutomationRunViewState {
+  if (run.workspaceId && workspaceExists && run.terminalSessionId && terminalTabExists) {
+    return {
+      availability: 'terminal',
+      actionLabel: 'View run',
+      statusLabel: 'Run is open',
+      canOpen: true
+    }
+  }
+
+  if (run.workspaceId && workspaceExists) {
+    return {
+      availability: 'workspace',
+      actionLabel: 'Open workspace',
+      statusLabel: run.terminalSessionId
+        ? 'Opened workspace; original terminal is closed.'
+        : 'Opened workspace.',
+      canOpen: true
+    }
+  }
+
+  if (run.outputSnapshot?.content.trim()) {
+    return {
+      availability: 'snapshot',
+      actionLabel: 'Snapshot saved',
+      statusLabel: 'Showing saved run snapshot.',
+      canOpen: false
+    }
+  }
+
+  return {
+    availability: 'metadata',
+    actionLabel: 'View run',
+    statusLabel: run.workspaceId
+      ? run.workspaceDisplayName?.trim()
+        ? `${run.workspaceDisplayName.trim()} no longer available`
+        : 'Workspace no longer available'
+      : 'No workspace launched',
+    canOpen: false
+  }
+}

--- a/src/renderer/src/components/automations/automation-run-workspace-display.ts
+++ b/src/renderer/src/components/automations/automation-run-workspace-display.ts
@@ -1,0 +1,50 @@
+import type { AutomationRun } from '../../../../shared/automations-types'
+import type { Worktree } from '../../../../shared/types'
+
+export type AutomationRunWorkspaceDisplay = {
+  rowLabel: string
+  detailLabel: string
+  muted: boolean
+  title?: string
+}
+
+export function getAutomationRunWorkspaceDisplay({
+  run,
+  worktree
+}: {
+  run: AutomationRun
+  worktree: Worktree | null
+}): AutomationRunWorkspaceDisplay {
+  if (!run.workspaceId) {
+    return {
+      rowLabel: 'Not launched',
+      detailLabel: 'Not launched',
+      muted: true
+    }
+  }
+  if (worktree) {
+    return {
+      rowLabel: worktree.displayName,
+      detailLabel: worktree.displayName,
+      muted: false,
+      title: worktree.displayName
+    }
+  }
+
+  const previousName = run.workspaceDisplayName?.trim()
+  if (previousName) {
+    const deletedLabel = `${previousName} (no longer available)`
+    return {
+      rowLabel: previousName,
+      detailLabel: deletedLabel,
+      muted: true,
+      title: deletedLabel
+    }
+  }
+
+  return {
+    rowLabel: 'Workspace no longer available',
+    detailLabel: 'Workspace no longer available',
+    muted: true
+  }
+}

--- a/src/renderer/src/components/automations/automation-usage-model.test.ts
+++ b/src/renderer/src/components/automations/automation-usage-model.test.ts
@@ -18,6 +18,7 @@ function makeRun(overrides: Partial<AutomationRun>): AutomationRun {
     sessionKind: 'terminal',
     chatSessionId: null,
     terminalSessionId: 'tab-1',
+    outputSnapshot: null,
     usage: null,
     error: null,
     startedAt: 1,

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -59,7 +59,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border/50 bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'relative z-[70] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border/50 bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -3,6 +3,7 @@ import { launchAgentBackgroundSession } from '@/lib/launch-agent-background-sess
 import { useAppStore } from '@/store'
 import type { AutomationDispatchResult } from '../../../shared/automations-types'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import { createAutomationRunOutputSnapshotBuffer } from '@/components/automations/automation-run-output-snapshot'
 
 const AUTOMATIONS_CHANGED_EVENT = 'orca:automations-changed'
 
@@ -31,13 +32,19 @@ export function useAutomationDispatchEvents(): void {
         activeTabType: state.activeTabType
       }
       const repo = state.repos.find((entry) => entry.id === automation.projectId)
+      const automationWorktree = automation.workspaceId
+        ? state.allWorktrees().find((entry) => entry.id === automation.workspaceId)
+        : null
       let dispatchWorkspaceId = automation.workspaceId
+      let dispatchWorkspaceDisplayName =
+        automationWorktree?.displayName ?? run.workspaceDisplayName ?? null
 
       if (!repo) {
         await markDispatchResult({
           runId: run.id,
           status: 'skipped_unavailable',
           workspaceId: run.workspaceId,
+          workspaceDisplayName: run.workspaceDisplayName ?? null,
           error: 'The target project is no longer available.'
         })
         return
@@ -52,6 +59,7 @@ export function useAutomationDispatchEvents(): void {
             runId: run.id,
             status: 'skipped_needs_interactive_auth',
             workspaceId: dispatchWorkspaceId,
+            workspaceDisplayName: dispatchWorkspaceDisplayName,
             error: 'SSH reconnect requires interactive credentials.'
           })
           return
@@ -68,6 +76,7 @@ export function useAutomationDispatchEvents(): void {
               runId: run.id,
               status: 'skipped_unavailable',
               workspaceId: dispatchWorkspaceId,
+              workspaceDisplayName: dispatchWorkspaceDisplayName,
               error: error instanceof Error ? error.message : String(error)
             })
             return
@@ -96,10 +105,7 @@ export function useAutomationDispatchEvents(): void {
                   )
               ).worktree
             : automation.workspaceId
-              ? useAppStore
-                  .getState()
-                  .allWorktrees()
-                  .find((entry) => entry.id === automation.workspaceId)
+              ? automationWorktree
               : null
 
         if (!worktree) {
@@ -107,12 +113,15 @@ export function useAutomationDispatchEvents(): void {
             runId: run.id,
             status: 'skipped_unavailable',
             workspaceId: automation.workspaceId,
+            workspaceDisplayName: dispatchWorkspaceDisplayName,
             error: 'The target workspace is no longer available.'
           })
           return
         }
         dispatchWorkspaceId = worktree.id
+        dispatchWorkspaceDisplayName = worktree.displayName
 
+        const outputSnapshotBuffer = createAutomationRunOutputSnapshotBuffer()
         let dispatchMarked = false
         let pendingExitCode: number | null = null
         let pendingDone = false
@@ -128,6 +137,8 @@ export function useAutomationDispatchEvents(): void {
             runId: run.id,
             status: 'completed',
             workspaceId: worktree.id,
+            workspaceDisplayName: worktree.displayName,
+            outputSnapshot: outputSnapshotBuffer.snapshot(),
             error: null
           })
         }
@@ -137,6 +148,8 @@ export function useAutomationDispatchEvents(): void {
             runId: run.id,
             status: code === 0 ? 'completed' : 'dispatch_failed',
             workspaceId: worktree.id,
+            workspaceDisplayName: worktree.displayName,
+            outputSnapshot: outputSnapshotBuffer.snapshot(),
             error: code === 0 ? null : `Automation process exited with code ${code}.`
           })
         }
@@ -172,6 +185,9 @@ export function useAutomationDispatchEvents(): void {
           prompt: automation.prompt,
           launchSource: 'unknown',
           title: run.title,
+          onData: (chunk) => {
+            outputSnapshotBuffer.append(chunk)
+          },
           onAgentStatus: (payload) => {
             if (payload.state !== 'done') {
               return
@@ -198,6 +214,7 @@ export function useAutomationDispatchEvents(): void {
             runId: run.id,
             status: 'dispatched',
             workspaceId: worktree.id,
+            workspaceDisplayName: worktree.displayName,
             terminalSessionId: result.tabId,
             error: null
           })
@@ -230,6 +247,7 @@ export function useAutomationDispatchEvents(): void {
           runId: run.id,
           status: 'dispatch_failed',
           workspaceId: dispatchWorkspaceId,
+          workspaceDisplayName: dispatchWorkspaceDisplayName,
           error: error instanceof Error ? error.message : String(error)
         })
       }

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -30,6 +30,7 @@ export type LaunchAgentBackgroundSessionArgs = {
   prompt?: string
   launchSource?: LaunchSource
   title?: string
+  onData?: (chunk: string) => void
   onExit?: (ptyId: string, code: number) => void
   onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
 }
@@ -43,7 +44,7 @@ export type LaunchAgentBackgroundSessionResult = {
 export async function launchAgentBackgroundSession(
   args: LaunchAgentBackgroundSessionArgs
 ): Promise<LaunchAgentBackgroundSessionResult | null> {
-  const { agent, worktreeId, prompt, launchSource, title, onExit, onAgentStatus } = args
+  const { agent, worktreeId, prompt, launchSource, title, onData, onExit, onAgentStatus } = args
   const store = useAppStore.getState()
   const worktree = store.allWorktrees().find((entry) => entry.id === worktreeId)
   const repo = worktree ? store.repos.find((entry) => entry.id === worktree.repoId) : null
@@ -157,6 +158,7 @@ export async function launchAgentBackgroundSession(
   }
   const processAgentStatus = createAgentStatusOscProcessor()
   const handleData = (data: string): void => {
+    onData?.(data)
     const processed = processAgentStatus(data)
     for (const payload of processed.payloads) {
       useAppStore.getState().setAgentStatus(paneKey, payload, undefined)

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -546,6 +546,22 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       await get().shutdownWorktreeBrowsers(worktreeId)
       await get().shutdownWorktreeTerminals(worktreeId)
       const target = getActiveRuntimeTarget(get().settings)
+      const worktreeDisplayName = get()
+        .allWorktrees()
+        .find((entry) => entry.id === worktreeId)
+        ?.displayName?.trim()
+      if (worktreeDisplayName) {
+        try {
+          await window.api.automations?.snapshotWorkspaceName?.({
+            workspaceId: worktreeId,
+            displayName: worktreeDisplayName
+          })
+        } catch (error) {
+          // Why: preserving automation history labels is best-effort; a stale
+          // preload/test harness must not block worktree removal cleanup.
+          console.warn('Failed to snapshot automation workspace name:', error)
+        }
+      }
       await (target.kind === 'local'
         ? window.api.worktrees.remove({ worktreeId, force, skipArchive })
         : callRuntimeRpc(

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -47,6 +47,13 @@ export type AutomationRunUsage = {
   unavailableMessage: string | null
 }
 
+export type AutomationRunOutputSnapshot = {
+  format: 'plain_text'
+  content: string
+  capturedAt: number
+  truncated: boolean
+}
+
 export type Automation = {
   id: string
   name: string
@@ -79,9 +86,13 @@ export type AutomationRun = {
   status: AutomationRunStatus
   trigger: AutomationRunTrigger
   workspaceId: string | null
+  /** Why: run history must remain understandable after the backing workspace
+   *  is deleted and its live metadata is gone. */
+  workspaceDisplayName?: string | null
   sessionKind: 'terminal'
   chatSessionId: string | null
   terminalSessionId: string | null
+  outputSnapshot: AutomationRunOutputSnapshot | null
   usage: AutomationRunUsage | null
   error: string | null
   startedAt: number | null
@@ -131,7 +142,9 @@ export type AutomationDispatchResult = {
   runId: string
   status: AutomationRunStatus
   workspaceId?: string | null
+  workspaceDisplayName?: string | null
   terminalSessionId?: string | null
+  outputSnapshot?: AutomationRunOutputSnapshot | null
   usage?: AutomationRunUsage | null
   error?: string | null
 }
@@ -139,6 +152,7 @@ export type AutomationDispatchResult = {
 export type ExternalAutomationProvider = 'hermes' | 'openclaw'
 export type ExternalAutomationManagerStatus = 'available' | 'unavailable'
 export type ExternalAutomationAction = 'pause' | 'resume' | 'run' | 'delete'
+export type ExternalAutomationRunStatus = 'completed' | 'failed' | 'unknown'
 
 export type ExternalAutomationTarget =
   | {
@@ -155,20 +169,72 @@ export type ExternalAutomationJob = {
   provider: ExternalAutomationProvider
   name: string
   schedule: string
+  rawSchedule: string | null
   enabled: boolean
   state: string
+  prompt: string | null
   promptPreview: string
   nextRunAt: string | null
   lastRunAt: string | null
   lastStatus: string | null
   lastError: string | null
   workdir: string | null
+  runCount: number
+  runs: ExternalAutomationRun[]
+}
+
+export type ExternalAutomationRun = {
+  id: string
+  managerId: string
+  provider: ExternalAutomationProvider
+  jobId: string
+  runAt: string | null
+  status: ExternalAutomationRunStatus
+  outputPreview: string | null
+  outputContent: string | null
+  error: string | null
+  outputPath: string | null
+}
+
+export type ExternalAutomationRunsPage = {
+  managerId: string
+  provider: ExternalAutomationProvider
+  target: ExternalAutomationTarget
+  jobId: string
+  page: number
+  pageSize: number
+  total: number
+  runs: ExternalAutomationRun[]
+}
+
+export type ExternalAutomationRunsInput = {
+  managerId: string
+  provider: ExternalAutomationProvider
+  target: ExternalAutomationTarget
+  jobId: string
+  page: number
+  pageSize: number
+}
+
+export type ExternalAutomationCreateInput = {
+  managerId: string
+  provider: ExternalAutomationProvider
+  target: ExternalAutomationTarget
+  name: string
+  prompt: string
+  schedule: string
+  workdir: string | null
+}
+
+export type ExternalAutomationUpdateInput = ExternalAutomationCreateInput & {
+  jobId: string
 }
 
 export type ExternalAutomationManager = {
   id: string
   provider: ExternalAutomationProvider
   label: string
+  targetLabel: string
   target: ExternalAutomationTarget
   status: ExternalAutomationManagerStatus
   error: string | null

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { WORKTREE_ID_SEPARATOR, getRepoIdFromWorktreeId, splitWorktreeId } from './worktree-id'
+import {
+  WORKTREE_ID_SEPARATOR,
+  getRepoIdFromWorktreeId,
+  getWorktreePathBasenameFromId,
+  splitWorktreeId
+} from './worktree-id'
 
 describe('WORKTREE_ID_SEPARATOR', () => {
   it('is the literal "::" separator', () => {
@@ -67,5 +72,24 @@ describe('splitWorktreeId', () => {
 
   it('splits on the first separator when the path itself contains "::"', () => {
     expect(splitWorktreeId('repo::a::b')).toEqual({ repoId: 'repo', worktreePath: 'a::b' })
+  })
+})
+
+describe('getWorktreePathBasenameFromId', () => {
+  it('returns the path basename for POSIX worktree ids', () => {
+    expect(getWorktreePathBasenameFromId('repo-123::/abs/path/nightly-checks')).toBe(
+      'nightly-checks'
+    )
+  })
+
+  it('returns the path basename for Windows worktree ids', () => {
+    expect(getWorktreePathBasenameFromId('repo-123::C:\\workspaces\\nightly-checks')).toBe(
+      'nightly-checks'
+    )
+  })
+
+  it('returns null when no worktree path is available', () => {
+    expect(getWorktreePathBasenameFromId('repo-123')).toBeNull()
+    expect(getWorktreePathBasenameFromId('repo-123::')).toBeNull()
   })
 })

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -22,3 +22,13 @@ export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {
     worktreePath: worktreeId.slice(separatorIdx + WORKTREE_ID_SEPARATOR.length)
   }
 }
+
+export function getWorktreePathBasenameFromId(worktreeId: string): string | null {
+  const parsed = splitWorktreeId(worktreeId)
+  const normalizedPath = parsed?.worktreePath.trim().replace(/[\\/]+$/g, '') ?? ''
+  if (!normalizedPath) {
+    return null
+  }
+  const basename = normalizedPath.split(/[\\/]/).filter(Boolean).at(-1)?.trim()
+  return basename || null
+}


### PR DESCRIPTION
## Summary
- add Hermes/OpenClaw automation run history, creation, and edit plumbing across local and SSH relay managers
- add Automations run detail/history UI with saved output snapshots and deleted-workspace labels
- add Hermes cron output/session transcript readers with paginated/count-only loading

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/automations/hermes-cron-output.test.ts src/relay/external-automations-handler.test.ts
- pnpm typecheck
- pnpm run build:relay