### PR TITLE
Fix workspace board drag preview visuals

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -805,6 +805,88 @@
   }
 }
 
+/* Why: board-origin cards use pointer drag so Shift+scroll can keep firing;
+   these replace the native drag cursor and ghost affordance. */
+[data-workspace-board-pointer-draggable='true'] {
+  cursor: grab;
+}
+
+[data-workspace-board-card-pointer-dragging='true'] {
+  outline: 1px solid var(--sidebar-ring);
+  outline-offset: 1px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--sidebar-ring) 36%, transparent);
+}
+
+[data-workspace-board-card-pointer-dragging='true'],
+[data-workspace-board-card-pointer-dragging='true'] *,
+:root[data-workspace-board-pointer-dragging] * {
+  cursor: grabbing !important;
+}
+
+[data-workspace-board-card-drag-preview='true'] {
+  z-index: 2147483647;
+  overflow: visible;
+  border-radius: var(--radius);
+  outline: 1px solid var(--sidebar-ring);
+  outline-offset: 1px;
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--foreground) 16%, transparent);
+  opacity: 0.96;
+  will-change: transform;
+}
+
+[data-workspace-board-card-drag-preview='true'][data-workspace-board-card-drag-stack='true'] {
+  isolation: isolate;
+}
+
+[data-workspace-board-card-drag-card='true'] {
+  width: 100%;
+  height: 100%;
+}
+
+[data-workspace-board-card-drag-preview='true'][data-workspace-board-card-drag-stack='true']::before,
+[data-workspace-board-card-drag-preview='true'][data-workspace-board-card-drag-stack='true']::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in srgb, var(--sidebar-ring) 44%, transparent);
+  background: var(--sidebar);
+}
+
+[data-workspace-board-card-drag-preview='true'][data-workspace-board-card-drag-stack='true']::before {
+  transform: translate(4px, 4px);
+  opacity: 0.72;
+}
+
+[data-workspace-board-card-drag-preview='true'][data-workspace-board-card-drag-stack='true']::after {
+  transform: translate(8px, 8px);
+  opacity: 0.44;
+}
+
+[data-workspace-board-card-drag-preview='true'] * {
+  cursor: grabbing !important;
+}
+
+[data-workspace-board-card-drag-count='true'] {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  z-index: 2;
+  display: flex;
+  min-width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  border: 1px solid var(--sidebar-border);
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+}
+
 .sidebar-header {
   padding: 12px 16px 8px;
   font-size: 11px;

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -67,6 +67,7 @@ function WorkspaceKanbanCard({
       data-workspace-board-card-id={worktree.id}
       data-workspace-board-card-mode="detailed"
       data-workspace-board-card-selected={isSelected ? 'true' : 'false'}
+      data-workspace-board-pointer-draggable={nativeDragEnabled ? undefined : 'true'}
     >
       {worktree.isPinned ? (
         <Badge
@@ -175,11 +176,15 @@ function WorkspaceKanbanCompactCard({
                   : 'border-transparent text-foreground hover:bg-sidebar-accent/60 focus-visible:border-sidebar-ring',
               isActive && isSelected && 'ring-1 ring-sidebar-ring/35',
               'data-[workspace-board-card-area-selected=true]:border-sidebar-ring/50 data-[workspace-board-card-area-selected=true]:bg-sidebar-accent/75 data-[workspace-board-card-area-selected=true]:ring-1 data-[workspace-board-card-area-selected=true]:ring-sidebar-ring/30',
+              !nativeDragEnabled && !isDeleting && '!cursor-grab',
               isDeleting && 'cursor-not-allowed opacity-50 grayscale'
             )}
             data-workspace-board-card-mode="compact"
             data-workspace-board-card-id={worktree.id}
             data-workspace-board-card-selected={isSelected ? 'true' : 'false'}
+            data-workspace-board-pointer-draggable={
+              nativeDragEnabled || isDeleting ? undefined : 'true'
+            }
             aria-label={`Open ${worktree.displayName}`}
             aria-busy={isDeleting}
           >

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -21,6 +21,7 @@ type WorkspaceKanbanCardProps = {
   isSelected: boolean
   selectedWorktrees?: readonly Worktree[]
   compact: boolean
+  nativeDragEnabled?: boolean
   onActivate: () => void
   onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktreeId: string) => boolean
   onContextMenuSelect: (
@@ -36,6 +37,7 @@ function WorkspaceKanbanCard({
   isSelected,
   selectedWorktrees,
   compact,
+  nativeDragEnabled = true,
   onActivate,
   onSelectionGesture,
   onContextMenuSelect
@@ -51,6 +53,7 @@ function WorkspaceKanbanCard({
         onActivate={onActivate}
         onSelectionGesture={onSelectionGesture}
         onContextMenuSelect={onContextMenuSelect}
+        nativeDragEnabled={nativeDragEnabled}
       />
     )
   }
@@ -81,6 +84,7 @@ function WorkspaceKanbanCard({
         isMultiSelected={isSelected}
         selectedWorktrees={contextWorktrees}
         hideCiCheck={worktree.isPinned}
+        nativeDragEnabled={nativeDragEnabled}
         onActivate={onActivate}
         onSelectionGesture={onSelectionGesture}
         onContextMenuSelect={(event) => onContextMenuSelect(event, worktree)}
@@ -97,6 +101,7 @@ function WorkspaceKanbanCompactCard({
   isActive,
   isSelected,
   selectedWorktrees,
+  nativeDragEnabled = true,
   onActivate,
   onSelectionGesture,
   onContextMenuSelect
@@ -158,8 +163,8 @@ function WorkspaceKanbanCompactCard({
         <HoverCardTrigger asChild>
           <button
             type="button"
-            draggable={!isDeleting}
-            onDragStart={handleDragStart}
+            draggable={nativeDragEnabled && !isDeleting}
+            onDragStart={nativeDragEnabled ? handleDragStart : undefined}
             onClick={handleClick}
             className={cn(
               'flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border px-2 text-left text-[12px] outline-none transition-colors',

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: the board drawer owns shared board state, drag/drop, and settings callbacks that need one coordinated surface. */
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { useAllWorktrees, useRepoMap } from '@/store/selectors'
@@ -13,6 +14,7 @@ import {
 } from './workspace-status'
 import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
 import { useWorkspaceKanbanAreaSelection } from './use-workspace-kanban-area-selection'
+import { useWorkspaceKanbanCardPointerDrag } from './use-workspace-kanban-card-pointer-drag'
 import { useWorkspaceKanbanColumnResize } from './use-workspace-kanban-column-resize'
 import { useWorkspaceKanbanCreateWorktree } from './use-workspace-kanban-create-worktree'
 import { useWorkspaceKanbanSelection } from './use-workspace-kanban-selection'
@@ -60,13 +62,11 @@ export default function WorkspaceKanbanDrawer({
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
   const { canCreateWorktree, createWorktreeForStatus } = useWorkspaceKanbanCreateWorktree()
-
   const visibleWorktreeIdSet = useVisibleWorkspaceKanbanWorktreeIds({
     allWorktrees,
     activeWorktreeId,
     repoMap
   })
-
   const worktreesByStatus = useMemo(() => {
     return groupWorkspaceKanbanWorktrees({
       worktrees: allWorktrees,
@@ -78,7 +78,6 @@ export default function WorkspaceKanbanDrawer({
     () => new Map(allWorktrees.map((worktree) => [worktree.id, worktree])),
     [allWorktrees]
   )
-
   const boardWorktrees = useMemo(
     () => workspaceStatuses.flatMap((status) => worktreesByStatus.get(status.id) ?? []),
     [worktreesByStatus, workspaceStatuses]
@@ -101,7 +100,6 @@ export default function WorkspaceKanbanDrawer({
   })
   const { columnWidth, isResizingColumn, onColumnResizeStart, onColumnResizeKeyDown } =
     useWorkspaceKanbanColumnResize(workspaceBoardColumnWidth, setWorkspaceBoardColumnWidth)
-
   const moveWorktreeToStatus = useCallback(
     (worktreeId: string, status: WorkspaceStatus) => {
       const current = worktreeById.get(worktreeId)
@@ -112,7 +110,6 @@ export default function WorkspaceKanbanDrawer({
     },
     [updateWorktreeMeta, workspaceStatuses, worktreeById]
   )
-
   const moveWorktreesToStatus = useCallback(
     (worktreeIds: readonly string[], status: WorkspaceStatus) => {
       const updates = new Map<string, { workspaceStatus: WorkspaceStatus }>()
@@ -129,7 +126,6 @@ export default function WorkspaceKanbanDrawer({
     },
     [updateWorktreesMeta, workspaceStatuses, worktreeById]
   )
-
   const pinWorktree = useCallback(
     (worktreeId: string) => {
       const current = worktreeById.get(worktreeId)
@@ -157,7 +153,16 @@ export default function WorkspaceKanbanDrawer({
     },
     [updateWorktreesMeta, worktreeById]
   )
-
+  const { isPointerDragActiveRef, onCardPointerDownCapture } = useWorkspaceKanbanCardPointerDrag({
+    open,
+    boardRef,
+    selectedWorktreeIds,
+    selectedWorktrees,
+    onMoveWorktreesToStatus: moveWorktreesToStatus,
+    onPinWorktrees: pinWorktrees,
+    onDragTargetChange: setDragOverStatus,
+    onPinDragTargetChange: setPinDragOver
+  })
   const handleDragOver = useCallback((event: React.DragEvent, status: WorkspaceStatus) => {
     if (!hasWorkspaceDragData(event.dataTransfer)) {
       return
@@ -310,7 +315,7 @@ export default function WorkspaceKanbanDrawer({
     }
   )
 
-  useWorkspaceKanbanShiftWheelScroll(boardRef, laneScrollerRef, open)
+  useWorkspaceKanbanShiftWheelScroll(boardRef, laneScrollerRef, open, isPointerDragActiveRef)
   useWorkspaceKanbanOutsideDismiss({ open, boardRef, preserveOpenForMenu, onOpenChange })
 
   const opacityPercent = Math.round(workspaceBoardOpacity * 100)
@@ -385,6 +390,7 @@ export default function WorkspaceKanbanDrawer({
           ref={boardRef}
           className="relative flex min-h-0 flex-1 flex-col overflow-hidden p-3"
           data-workspace-board-selection-surface=""
+          onPointerDownCapture={onCardPointerDownCapture}
           onPointerDown={handleAreaSelectionPointerDown}
         >
           <WorkspaceKanbanAreaSelectionOverlay ref={areaSelectionOverlayRef} />

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
@@ -76,6 +76,7 @@ export default function WorkspaceKanbanLaneGrid({
           canCreateWorktree={canCreateWorktree}
           selectedWorktreeIds={selectedWorktreeIds}
           selectedWorktrees={selectedWorktrees}
+          nativeDragEnabled={false}
           onDragOver={onDragOver}
           onDragLeave={onDragLeave}
           onDrop={onDrop}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx
@@ -21,6 +21,7 @@ type WorkspaceKanbanStatusLaneProps = {
   isResizingColumn: boolean
   isDragTarget: boolean
   canCreateWorktree: boolean
+  nativeDragEnabled?: boolean
   selectedWorktreeIds: ReadonlySet<string>
   selectedWorktrees: readonly Worktree[]
   onDragOver: (event: React.DragEvent, statusId: string) => void
@@ -47,6 +48,7 @@ export default function WorkspaceKanbanStatusLane({
   isResizingColumn,
   isDragTarget,
   canCreateWorktree,
+  nativeDragEnabled = true,
   selectedWorktreeIds,
   selectedWorktrees,
   onDragOver,
@@ -148,6 +150,7 @@ export default function WorkspaceKanbanStatusLane({
                   repo={repoMap.get(worktree.repoId)}
                   isActive={activeWorktreeId === worktree.id}
                   isSelected={isSelected}
+                  nativeDragEnabled={nativeDragEnabled}
                   selectedWorktrees={
                     isSelected && selectedWorktrees.length > 0 ? selectedWorktrees : undefined
                   }

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -56,6 +56,7 @@ type WorktreeCardProps = {
   onActivate?: () => void
   onSelectionGesture?: (event: React.MouseEvent<HTMLElement>, worktreeId: string) => boolean
   onContextMenuSelect?: (event: React.MouseEvent<HTMLElement>) => readonly Worktree[]
+  nativeDragEnabled?: boolean
 }
 
 function formatSparseDirectoryPreview(directories: string[]): string {
@@ -72,6 +73,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   onActivate,
   onSelectionGesture,
   onContextMenuSelect,
+  nativeDragEnabled = true,
   hideRepoBadge,
   hideCiCheck = false,
   parentLabel,
@@ -355,8 +357,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
       )}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
-      draggable={!isDeleting}
-      onDragStart={handleDragStart}
+      draggable={nativeDragEnabled && !isDeleting}
+      onDragStart={nativeDragEnabled ? handleDragStart : undefined}
       aria-busy={isDeleting}
     >
       {isDeleting && (

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -352,6 +352,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
             ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
             : 'border border-transparent hover:bg-sidebar-accent/40',
         isActive && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
+        !nativeDragEnabled && !isDeleting && '!cursor-grab',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
         isSshDisconnected && !isDeleting && 'opacity-60'
       )}

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useRef } from 'react'
 import type React from 'react'
 import type { WorkspaceStatus, Worktree } from '../../../../shared/types'
+import {
+  CARD_SELECTOR,
+  createDragPreview,
+  getDraggedCards,
+  getDropTarget,
+  setDragDocumentStyles,
+  setDraggedCardsDragging,
+  updateDragPreviewPosition
+} from './workspace-kanban-card-pointer-drag-dom'
 
-const CARD_SELECTOR = '[data-workspace-board-card-id]'
-const STATUS_DROP_TARGET = '[data-workspace-status-drop-target]'
-const PIN_DROP_TARGET = '[data-workspace-pin-drop-target]'
 const POINTER_DRAG_THRESHOLD = 5
 
 type DragState = {
@@ -15,6 +21,10 @@ type DragState = {
   currentY: number
   worktreeIds: string[]
   sourceCard: HTMLElement
+  draggedCards: HTMLElement[]
+  preview: HTMLElement | null
+  previewOffsetX: number
+  previewOffsetY: number
   started: boolean
 }
 
@@ -37,6 +47,7 @@ function shouldIgnorePointerDown(target: EventTarget | null, card: HTMLElement):
     [
       'a',
       'input',
+      'button',
       'select',
       'textarea',
       '[contenteditable="true"]',
@@ -45,36 +56,6 @@ function shouldIgnorePointerDown(target: EventTarget | null, card: HTMLElement):
     ].join(',')
   )
   return interactive !== null && interactive !== card
-}
-
-function getDropTarget(
-  board: HTMLElement,
-  x: number,
-  y: number
-): { status: WorkspaceStatus | null; isPinDrop: boolean } {
-  const target = document.elementFromPoint(x, y)
-  if (!(target instanceof Element) || !board.contains(target)) {
-    return { status: null, isPinDrop: false }
-  }
-
-  const pinTarget = target.closest<HTMLElement>(PIN_DROP_TARGET)
-  if (pinTarget && board.contains(pinTarget)) {
-    return { status: null, isPinDrop: true }
-  }
-
-  const statusTarget = target.closest<HTMLElement>(STATUS_DROP_TARGET)
-  return {
-    status:
-      statusTarget && board.contains(statusTarget)
-        ? (statusTarget.dataset.workspaceStatus ?? null)
-        : null,
-    isPinDrop: false
-  }
-}
-
-function setDragDocumentStyles(enabled: boolean): void {
-  document.body.style.cursor = enabled ? 'grabbing' : ''
-  document.body.style.userSelect = enabled ? 'none' : ''
 }
 
 export function useWorkspaceKanbanCardPointerDrag({
@@ -121,7 +102,8 @@ export function useWorkspaceKanbanCardPointerDrag({
         return
       }
       dragRef.current = null
-      state.sourceCard.removeAttribute('data-workspace-board-card-pointer-dragging')
+      setDraggedCardsDragging(state.draggedCards, false)
+      state.preview?.remove()
       setDragDocumentStyles(false)
       clearDragTarget()
 
@@ -152,7 +134,8 @@ export function useWorkspaceKanbanCardPointerDrag({
   const startPointerDrag = useCallback((state: DragState) => {
     state.started = true
     isPointerDragActiveRef.current = true
-    state.sourceCard.setAttribute('data-workspace-board-card-pointer-dragging', 'true')
+    setDraggedCardsDragging(state.draggedCards, true)
+    state.preview = createDragPreview(state)
     setDragDocumentStyles(true)
   }, [])
 
@@ -191,6 +174,7 @@ export function useWorkspaceKanbanCardPointerDrag({
         return
       }
       event.preventDefault()
+      updateDragPreviewPosition(state)
       updatePointerDragTarget(state)
     }
 
@@ -261,6 +245,10 @@ export function useWorkspaceKanbanCardPointerDrag({
         currentY: event.clientY,
         worktreeIds,
         sourceCard: card,
+        draggedCards: getDraggedCards(board, worktreeIds, card),
+        preview: null,
+        previewOffsetX: 0,
+        previewOffsetY: 0,
         started: false
       }
     },

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts
@@ -1,0 +1,271 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type React from 'react'
+import type { WorkspaceStatus, Worktree } from '../../../../shared/types'
+
+const CARD_SELECTOR = '[data-workspace-board-card-id]'
+const STATUS_DROP_TARGET = '[data-workspace-status-drop-target]'
+const PIN_DROP_TARGET = '[data-workspace-pin-drop-target]'
+const POINTER_DRAG_THRESHOLD = 5
+
+type DragState = {
+  pointerId: number
+  startX: number
+  startY: number
+  currentX: number
+  currentY: number
+  worktreeIds: string[]
+  sourceCard: HTMLElement
+  started: boolean
+}
+
+type UseWorkspaceKanbanCardPointerDragParams = {
+  open: boolean
+  boardRef: React.RefObject<HTMLElement | null>
+  selectedWorktreeIds: ReadonlySet<string>
+  selectedWorktrees: readonly Worktree[]
+  onMoveWorktreesToStatus: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
+  onPinWorktrees: (worktreeIds: readonly string[]) => void
+  onDragTargetChange: (status: WorkspaceStatus | null) => void
+  onPinDragTargetChange: (isOver: boolean) => void
+}
+
+function shouldIgnorePointerDown(target: EventTarget | null, card: HTMLElement): boolean {
+  if (!(target instanceof Element)) {
+    return false
+  }
+  const interactive = target.closest(
+    [
+      'a',
+      'input',
+      'select',
+      'textarea',
+      '[contenteditable="true"]',
+      '[data-workspace-board-column-resize-handle]',
+      '[role="menuitem"]'
+    ].join(',')
+  )
+  return interactive !== null && interactive !== card
+}
+
+function getDropTarget(
+  board: HTMLElement,
+  x: number,
+  y: number
+): { status: WorkspaceStatus | null; isPinDrop: boolean } {
+  const target = document.elementFromPoint(x, y)
+  if (!(target instanceof Element) || !board.contains(target)) {
+    return { status: null, isPinDrop: false }
+  }
+
+  const pinTarget = target.closest<HTMLElement>(PIN_DROP_TARGET)
+  if (pinTarget && board.contains(pinTarget)) {
+    return { status: null, isPinDrop: true }
+  }
+
+  const statusTarget = target.closest<HTMLElement>(STATUS_DROP_TARGET)
+  return {
+    status:
+      statusTarget && board.contains(statusTarget)
+        ? (statusTarget.dataset.workspaceStatus ?? null)
+        : null,
+    isPinDrop: false
+  }
+}
+
+function setDragDocumentStyles(enabled: boolean): void {
+  document.body.style.cursor = enabled ? 'grabbing' : ''
+  document.body.style.userSelect = enabled ? 'none' : ''
+}
+
+export function useWorkspaceKanbanCardPointerDrag({
+  open,
+  boardRef,
+  selectedWorktreeIds,
+  selectedWorktrees,
+  onMoveWorktreesToStatus,
+  onPinWorktrees,
+  onDragTargetChange,
+  onPinDragTargetChange
+}: UseWorkspaceKanbanCardPointerDragParams): {
+  isPointerDragActiveRef: React.MutableRefObject<boolean>
+  onCardPointerDownCapture: (event: React.PointerEvent<HTMLElement>) => void
+} {
+  const dragRef = useRef<DragState | null>(null)
+  const isPointerDragActiveRef = useRef(false)
+  const suppressClickUntilRef = useRef(0)
+  const selectedWorktreeIdsRef = useRef(selectedWorktreeIds)
+  const selectedWorktreesRef = useRef(selectedWorktrees)
+  const moveWorktreesRef = useRef(onMoveWorktreesToStatus)
+  const pinWorktreesRef = useRef(onPinWorktrees)
+  const dragTargetChangeRef = useRef(onDragTargetChange)
+  const pinDragTargetChangeRef = useRef(onPinDragTargetChange)
+
+  useEffect(() => {
+    selectedWorktreeIdsRef.current = selectedWorktreeIds
+    selectedWorktreesRef.current = selectedWorktrees
+    moveWorktreesRef.current = onMoveWorktreesToStatus
+    pinWorktreesRef.current = onPinWorktrees
+    dragTargetChangeRef.current = onDragTargetChange
+    pinDragTargetChangeRef.current = onPinDragTargetChange
+  })
+
+  const clearDragTarget = useCallback(() => {
+    dragTargetChangeRef.current(null)
+    pinDragTargetChangeRef.current(false)
+  }, [])
+
+  const stopPointerDrag = useCallback(
+    (commit: boolean) => {
+      const state = dragRef.current
+      if (!state) {
+        return
+      }
+      dragRef.current = null
+      state.sourceCard.removeAttribute('data-workspace-board-card-pointer-dragging')
+      setDragDocumentStyles(false)
+      clearDragTarget()
+
+      if (!state.started) {
+        return
+      }
+
+      isPointerDragActiveRef.current = false
+      suppressClickUntilRef.current = performance.now() + 250
+      if (!commit) {
+        return
+      }
+
+      const board = boardRef.current
+      if (!board) {
+        return
+      }
+      const dropTarget = getDropTarget(board, state.currentX, state.currentY)
+      if (dropTarget.isPinDrop) {
+        pinWorktreesRef.current(state.worktreeIds)
+      } else if (dropTarget.status) {
+        moveWorktreesRef.current(state.worktreeIds, dropTarget.status)
+      }
+    },
+    [boardRef, clearDragTarget]
+  )
+
+  const startPointerDrag = useCallback((state: DragState) => {
+    state.started = true
+    isPointerDragActiveRef.current = true
+    state.sourceCard.setAttribute('data-workspace-board-card-pointer-dragging', 'true')
+    setDragDocumentStyles(true)
+  }, [])
+
+  const updatePointerDragTarget = useCallback(
+    (state: DragState) => {
+      const board = boardRef.current
+      if (!board) {
+        clearDragTarget()
+        return
+      }
+      const dropTarget = getDropTarget(board, state.currentX, state.currentY)
+      pinDragTargetChangeRef.current(dropTarget.isPinDrop)
+      dragTargetChangeRef.current(dropTarget.status)
+    },
+    [boardRef, clearDragTarget]
+  )
+
+  useEffect(() => {
+    if (!open) {
+      stopPointerDrag(false)
+      return
+    }
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      const state = dragRef.current
+      if (!state || event.pointerId !== state.pointerId) {
+        return
+      }
+      state.currentX = event.clientX
+      state.currentY = event.clientY
+      const distance = Math.hypot(event.clientX - state.startX, event.clientY - state.startY)
+      if (!state.started && distance >= POINTER_DRAG_THRESHOLD) {
+        startPointerDrag(state)
+      }
+      if (!state.started) {
+        return
+      }
+      event.preventDefault()
+      updatePointerDragTarget(state)
+    }
+
+    const handlePointerUp = (event: PointerEvent): void => {
+      const state = dragRef.current
+      if (!state || event.pointerId !== state.pointerId) {
+        return
+      }
+      state.currentX = event.clientX
+      state.currentY = event.clientY
+      event.preventDefault()
+      stopPointerDrag(true)
+    }
+
+    const handleClick = (event: MouseEvent): void => {
+      if (performance.now() > suppressClickUntilRef.current) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      event.stopImmediatePropagation()
+    }
+
+    const handleBlur = (): void => stopPointerDrag(false)
+
+    document.addEventListener('pointermove', handlePointerMove, true)
+    document.addEventListener('pointerup', handlePointerUp, true)
+    document.addEventListener('pointercancel', handlePointerUp, true)
+    document.addEventListener('click', handleClick, true)
+    window.addEventListener('blur', handleBlur)
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove, true)
+      document.removeEventListener('pointerup', handlePointerUp, true)
+      document.removeEventListener('pointercancel', handlePointerUp, true)
+      document.removeEventListener('click', handleClick, true)
+      window.removeEventListener('blur', handleBlur)
+      stopPointerDrag(false)
+    }
+  }, [open, startPointerDrag, stopPointerDrag, updatePointerDragTarget])
+
+  const onCardPointerDownCapture = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (!open || event.button !== 0 || event.pointerType === 'touch') {
+        return
+      }
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+      const card = target.closest<HTMLElement>(CARD_SELECTOR)
+      const worktreeId = card?.dataset.workspaceBoardCardId
+      const board = boardRef.current
+      if (!card || !worktreeId || !board?.contains(card) || shouldIgnorePointerDown(target, card)) {
+        return
+      }
+
+      const selectedIds = selectedWorktreeIdsRef.current
+      const selectedWorktrees = selectedWorktreesRef.current
+      const worktreeIds =
+        selectedIds.has(worktreeId) && selectedWorktrees.length > 1
+          ? selectedWorktrees.map((worktree) => worktree.id)
+          : [worktreeId]
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        currentX: event.clientX,
+        currentY: event.clientY,
+        worktreeIds,
+        sourceCard: card,
+        started: false
+      }
+    },
+    [boardRef, open]
+  )
+
+  return { isPointerDragActiveRef, onCardPointerDownCapture }
+}

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-shift-wheel-scroll.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-shift-wheel-scroll.ts
@@ -40,7 +40,8 @@ function pointIsInsideElement(
 export function useWorkspaceKanbanShiftWheelScroll(
   boardRef: React.RefObject<HTMLElement | null>,
   scrollerRef: React.RefObject<HTMLElement | null>,
-  enabled: boolean
+  enabled: boolean,
+  isPointerDragActiveRef?: React.RefObject<boolean>
 ): void {
   useEffect(() => {
     if (!enabled) {
@@ -70,9 +71,10 @@ export function useWorkspaceKanbanShiftWheelScroll(
     const handleWheel = (event: WheelEvent): void => {
       const board = boardRef.current
       const scroller = scrollerRef.current
+      const isPointerDragActive = isPointerDragActiveRef?.current === true
       if (
         !event.shiftKey ||
-        !isWorkspaceDragActive ||
+        (!isWorkspaceDragActive && !isPointerDragActive) ||
         !board ||
         !scroller ||
         (!isEventInsideElement(event, board) && !pointIsInsideElement(lastDragPoint, board))
@@ -106,5 +108,5 @@ export function useWorkspaceKanbanShiftWheelScroll(
       window.removeEventListener('blur', stopTrackingDrag)
       document.removeEventListener('wheel', handleWheel, true)
     }
-  }, [boardRef, enabled, scrollerRef])
+  }, [boardRef, enabled, isPointerDragActiveRef, scrollerRef])
 }

--- a/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts
@@ -1,0 +1,129 @@
+import type { WorkspaceStatus } from '../../../../shared/types'
+
+export const CARD_SELECTOR = '[data-workspace-board-card-id]'
+export const STATUS_DROP_TARGET = '[data-workspace-status-drop-target]'
+export const PIN_DROP_TARGET = '[data-workspace-pin-drop-target]'
+
+const POINTER_CARD_DRAGGING_ATTR = 'data-workspace-board-card-pointer-dragging'
+const POINTER_DRAG_CARD_ATTR = 'data-workspace-board-card-drag-card'
+const POINTER_DRAG_COUNT_ATTR = 'data-workspace-board-card-drag-count'
+const POINTER_DRAGGING_ATTR = 'data-workspace-board-pointer-dragging'
+const POINTER_DRAG_PREVIEW_ATTR = 'data-workspace-board-card-drag-preview'
+const POINTER_DRAG_STACK_ATTR = 'data-workspace-board-card-drag-stack'
+
+type DragPreviewState = {
+  startX: number
+  startY: number
+  currentX: number
+  currentY: number
+  worktreeIds: readonly string[]
+  sourceCard: HTMLElement
+  preview: HTMLElement | null
+  previewOffsetX: number
+  previewOffsetY: number
+}
+
+export function getDropTarget(
+  board: HTMLElement,
+  x: number,
+  y: number
+): { status: WorkspaceStatus | null; isPinDrop: boolean } {
+  const target = document.elementFromPoint(x, y)
+  if (!(target instanceof Element) || !board.contains(target)) {
+    return { status: null, isPinDrop: false }
+  }
+
+  const pinTarget = target.closest<HTMLElement>(PIN_DROP_TARGET)
+  if (pinTarget && board.contains(pinTarget)) {
+    return { status: null, isPinDrop: true }
+  }
+
+  const statusTarget = target.closest<HTMLElement>(STATUS_DROP_TARGET)
+  return {
+    status:
+      statusTarget && board.contains(statusTarget)
+        ? (statusTarget.dataset.workspaceStatus ?? null)
+        : null,
+    isPinDrop: false
+  }
+}
+
+export function setDragDocumentStyles(enabled: boolean): void {
+  document.body.style.cursor = enabled ? 'grabbing' : ''
+  document.body.style.userSelect = enabled ? 'none' : ''
+  document.documentElement.toggleAttribute(POINTER_DRAGGING_ATTR, enabled)
+}
+
+export function getDraggedCards(
+  board: HTMLElement,
+  worktreeIds: readonly string[],
+  fallbackCard: HTMLElement
+): HTMLElement[] {
+  const ids = new Set(worktreeIds)
+  const cards = Array.from(board.querySelectorAll<HTMLElement>(CARD_SELECTOR)).filter((card) =>
+    ids.has(card.dataset.workspaceBoardCardId ?? '')
+  )
+  return cards.length > 0 ? cards : [fallbackCard]
+}
+
+export function setDraggedCardsDragging(cards: readonly HTMLElement[], enabled: boolean): void {
+  for (const card of cards) {
+    if (enabled) {
+      card.setAttribute(POINTER_CARD_DRAGGING_ATTR, 'true')
+    } else {
+      card.removeAttribute(POINTER_CARD_DRAGGING_ATTR)
+    }
+  }
+}
+
+function removeDuplicatePreviewAttributes(preview: HTMLElement): void {
+  preview.removeAttribute('data-workspace-board-card-id')
+  preview.removeAttribute(POINTER_CARD_DRAGGING_ATTR)
+  preview.removeAttribute('id')
+  preview.removeAttribute('aria-describedby')
+  preview.querySelectorAll<HTMLElement>('[data-workspace-board-card-id]').forEach((element) => {
+    element.removeAttribute('data-workspace-board-card-id')
+  })
+  preview.querySelectorAll<HTMLElement>(`[${POINTER_CARD_DRAGGING_ATTR}]`).forEach((element) => {
+    element.removeAttribute(POINTER_CARD_DRAGGING_ATTR)
+  })
+  preview.querySelectorAll<HTMLElement>('[id],[aria-describedby]').forEach((element) => {
+    element.removeAttribute('id')
+    element.removeAttribute('aria-describedby')
+  })
+}
+
+export function updateDragPreviewPosition(state: DragPreviewState): void {
+  const left = state.currentX - state.previewOffsetX
+  const top = state.currentY - state.previewOffsetY
+  state.preview?.style.setProperty('transform', `translate3d(${left}px, ${top}px, 0)`)
+}
+
+export function createDragPreview(state: DragPreviewState): HTMLElement {
+  const rect = state.sourceCard.getBoundingClientRect()
+  const preview = document.createElement('div')
+  const previewCard = state.sourceCard.cloneNode(true) as HTMLElement
+  state.previewOffsetX = Math.min(Math.max(state.startX - rect.left, 0), rect.width)
+  state.previewOffsetY = Math.min(Math.max(state.startY - rect.top, 0), rect.height)
+  preview.setAttribute(POINTER_DRAG_PREVIEW_ATTR, 'true')
+  preview.setAttribute('aria-hidden', 'true')
+  previewCard.setAttribute(POINTER_DRAG_CARD_ATTR, 'true')
+  removeDuplicatePreviewAttributes(previewCard)
+  preview.appendChild(previewCard)
+  if (state.worktreeIds.length > 1) {
+    const countBadge = document.createElement('span')
+    preview.setAttribute(POINTER_DRAG_STACK_ATTR, 'true')
+    countBadge.setAttribute(POINTER_DRAG_COUNT_ATTR, 'true')
+    countBadge.textContent = String(state.worktreeIds.length)
+    preview.appendChild(countBadge)
+  }
+  preview.style.setProperty('position', 'fixed')
+  preview.style.setProperty('left', '0')
+  preview.style.setProperty('top', '0')
+  preview.style.setProperty('width', `${rect.width}px`)
+  preview.style.setProperty('height', `${rect.height}px`)
+  preview.style.setProperty('pointer-events', 'none')
+  updateDragPreviewPosition({ ...state, preview })
+  document.body.appendChild(preview)
+  return preview
+}


### PR DESCRIPTION
## Summary
- keep board-origin pointer dragging while restoring grab/grabbing affordances
- show outlines for every selected workspace during multi-drag
- render multi-drag preview as a stack with an unclipped count badge

## Verification
- pnpm lint src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.ts src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx src/renderer/src/components/sidebar/WorktreeCard.tsx
- pnpm typecheck
- pnpm test -- src/renderer/src/components/sidebar/workspace-status.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- Electron gesture verification: multi-drag showed two outlined cards, visible stack badge, overflow visible, contain none