### PR TITLE
Drain runtime watcher unsubscribes on shutdown

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,7 @@ import { resolveConsent } from './telemetry/consent'
 import { triggerStartupNotificationRegistration } from './ipc/notifications'
 import { OrcaRuntimeService } from './runtime/orca-runtime'
 import { OrcaRuntimeRpcServer } from './runtime/runtime-rpc'
+import { awaitRuntimeFileWatcherUnsubscribes } from './runtime/orca-runtime-files'
 import { clearRuntimeMetadataIfOwned } from './runtime/runtime-metadata'
 import { registerAppMenu, rebuildAppMenu } from './menu/register-app-menu'
 import { checkForUpdatesFromMenu, isQuittingForUpdate } from './updater'
@@ -1060,6 +1061,7 @@ app.on('will-quit', (e) => {
     const rpcStopAndClear = runtimeRpc
       ? runtimeRpc
           .stop()
+          .then(() => awaitRuntimeFileWatcherUnsubscribes())
           .then(() => {
             if (ownedRuntimeId) {
               clearRuntimeMetadataIfOwned(app.getPath('userData'), ownedPid, ownedRuntimeId)

--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -32,11 +32,10 @@ import { subscribe as subscribeParcelWatcher } from '@parcel/watcher'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
 
-describe('local filesystem watcher shutdown', () => {
+describe('local filesystem watcher unsubscribe cleanup', () => {
   const handlers: HandlerMap = {}
 
-  beforeEach(() => {
-    vi.useRealTimers()
+  beforeEach(async () => {
     handleMock.mockReset()
     vi.mocked(stat).mockReset()
     vi.mocked(subscribeParcelWatcher).mockReset()
@@ -47,9 +46,10 @@ describe('local filesystem watcher shutdown', () => {
       handlers[channel] = handler
     })
     registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
   })
 
-  it('awaits unsubscribe already started by sender cleanup during shutdown', async () => {
+  it('awaits an unsubscribe already started by sender cleanup during shutdown', async () => {
     vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
     let resolveUnsubscribe: () => void = () => {}
     const unsubscribeMock = vi.fn(
@@ -73,6 +73,39 @@ describe('local filesystem watcher shutdown', () => {
 
     await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
     destroyedCallbacks[0]()
+
+    let shutdownResolved = false
+    const shutdownPromise = closeAllWatchers().then(() => {
+      shutdownResolved = true
+    })
+    await Promise.resolve()
+
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+    expect(shutdownResolved).toBe(false)
+
+    resolveUnsubscribe()
+    await shutdownPromise
+    expect(shutdownResolved).toBe(true)
+  })
+
+  it('awaits an unsubscribe already started by watcher error cleanup during shutdown', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
+    let watcherCallback: (err: Error | null, events: []) => void = () => {}
+    let resolveUnsubscribe: () => void = () => {}
+    const unsubscribeMock = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUnsubscribe = resolve
+        })
+    )
+    vi.mocked(subscribeParcelWatcher).mockImplementation(async (_root, callback) => {
+      watcherCallback = callback as typeof watcherCallback
+      return { unsubscribe: unsubscribeMock } as never
+    })
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    watcherCallback(new Error('root disappeared'), [])
 
     let shutdownResolved = false
     const shutdownPromise = closeAllWatchers().then(() => {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -278,9 +278,7 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
           // is deleted or inaccessible at startup).  Guard against null so
           // the cleanup path doesn't crash the main process.
           if (root.subscription) {
-            void root.subscription.unsubscribe().catch(() => {
-              // Already errored — ignore cleanup failures
-            })
+            void trackLocalUnsubscribe(rootKey, root)
           }
           errorCleanedUp = true
           watchedRoots.delete(rootKey)
@@ -298,7 +296,7 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
     // orphaned.  Unsubscribe it immediately to avoid leaking a native
     // file-watcher handle that no code path would ever clean up.
     if (errorCleanedUp) {
-      void root.subscription.unsubscribe().catch(() => {})
+      void trackLocalUnsubscribe(rootKey, root)
       throw new Error(`Watcher for ${rootKey} errored during subscribe`)
     }
   } catch (err) {

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -3,11 +3,14 @@ import type * as Fs from 'fs'
 import type * as FsPromises from 'fs/promises'
 import type * as FilesystemAuth from '../ipc/filesystem-auth'
 
-const { resolveAuthorizedPathMock, statMock, watchMock } = vi.hoisted(() => ({
-  resolveAuthorizedPathMock: vi.fn(),
-  statMock: vi.fn(),
-  watchMock: vi.fn()
-}))
+const { resolveAuthorizedPathMock, statMock, subscribeParcelWatcherMock, watchMock } = vi.hoisted(
+  () => ({
+    resolveAuthorizedPathMock: vi.fn(),
+    statMock: vi.fn(),
+    subscribeParcelWatcherMock: vi.fn(),
+    watchMock: vi.fn()
+  })
+)
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof Fs>('fs')
@@ -25,6 +28,10 @@ vi.mock('fs/promises', async () => {
   }
 })
 
+vi.mock('@parcel/watcher', () => ({
+  subscribe: subscribeParcelWatcherMock
+}))
+
 vi.mock('../ipc/filesystem-auth', async () => {
   const actual = await vi.importActual<typeof FilesystemAuth>('../ipc/filesystem-auth')
   return {
@@ -37,7 +44,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   getSshFilesystemProvider: vi.fn()
 }))
 
-import { RuntimeFileCommands } from './orca-runtime-files'
+import { awaitRuntimeFileWatcherUnsubscribes, RuntimeFileCommands } from './orca-runtime-files'
 
 describe('RuntimeFileCommands', () => {
   const originalPlatform = process.platform
@@ -46,6 +53,7 @@ describe('RuntimeFileCommands', () => {
     vi.useFakeTimers()
     resolveAuthorizedPathMock.mockReset()
     statMock.mockReset()
+    subscribeParcelWatcherMock.mockReset()
     watchMock.mockReset()
     Object.defineProperty(process, 'platform', {
       configurable: true,
@@ -53,7 +61,8 @@ describe('RuntimeFileCommands', () => {
     })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await awaitRuntimeFileWatcherUnsubscribes()
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: originalPlatform
@@ -108,5 +117,47 @@ describe('RuntimeFileCommands', () => {
 
     unsubscribe()
     expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks native Parcel watcher unsubscribe work so shutdown can await it', async () => {
+    const store = { getRepo: vi.fn(() => undefined) }
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    statMock.mockResolvedValue({ isDirectory: () => true })
+    let resolveUnsubscribe: () => void = () => {}
+    const unsubscribeMock = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUnsubscribe = resolve
+        })
+    )
+    subscribeParcelWatcherMock.mockResolvedValue({ unsubscribe: unsubscribeMock })
+
+    const commands = new RuntimeFileCommands({
+      getRuntimeId: () => 'runtime-1',
+      requireStore: () => store,
+      resolveWorktreeSelector: vi.fn(async () => ({
+        id: 'wt-1',
+        repoId: 'repo-1',
+        path: '/repo'
+      })),
+      resolveRuntimeGitTarget: vi.fn(),
+      openFile: vi.fn()
+    } as never)
+
+    const unsubscribe = await commands.watchFileExplorer('id:wt-1', vi.fn())
+    unsubscribe()
+
+    let drained = false
+    const drainPromise = awaitRuntimeFileWatcherUnsubscribes().then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1)
+    expect(drained).toBe(false)
+
+    resolveUnsubscribe()
+    await drainPromise
+    expect(drained).toBe(true)
   })
 })

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -56,6 +56,9 @@ const MOBILE_FILE_LIST_LIMIT = 5000
 const MOBILE_FILE_READ_MAX_BYTES = 512 * 1024
 const RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES = 10 * 1024 * 1024
 const WINDOWS_RUNTIME_FILE_WATCH_DEBOUNCE_MS = 150
+// Why: runtime files.watch subscriptions are cleaned up through synchronous RPC
+// callbacks. Track native Parcel unsubscribe work so app shutdown can drain it.
+const pendingRuntimeFileWatcherUnsubscribes = new Set<Promise<void>>()
 const MOBILE_BINARY_EXTENSIONS = new Set([
   '.avif',
   '.bmp',
@@ -82,6 +85,25 @@ const RUNTIME_PREVIEWABLE_BINARY_MIME_TYPES: Record<string, string> = {
   '.bmp': 'image/bmp',
   '.ico': 'image/x-icon',
   '.pdf': 'application/pdf'
+}
+
+function trackRuntimeFileWatcherUnsubscribe(
+  rootPath: string,
+  unsubscribe: () => Promise<void>
+): void {
+  const promise = Promise.resolve()
+    .then(unsubscribe)
+    .catch((err: unknown) => {
+      console.error('[runtime-files.watch] unsubscribe error', { rootPath, err })
+    })
+    .finally(() => {
+      pendingRuntimeFileWatcherUnsubscribes.delete(promise)
+    })
+  pendingRuntimeFileWatcherUnsubscribes.add(promise)
+}
+
+export async function awaitRuntimeFileWatcherUnsubscribes(): Promise<void> {
+  await Promise.allSettled(Array.from(pendingRuntimeFileWatcherUnsubscribes))
 }
 
 export type ResolvedRuntimeFileWorktree = Worktree & { git: GitWorktreeInfo }
@@ -269,9 +291,7 @@ export class RuntimeFileCommands {
       }
     )
     return () => {
-      void subscription.unsubscribe().catch((err: unknown) => {
-        console.error('[runtime-files.watch] unsubscribe error', { rootPath, err })
-      })
+      trackRuntimeFileWatcherUnsubscribe(rootPath, () => subscription.unsubscribe())
     }
   }
 


### PR DESCRIPTION
## Summary
- Track local filesystem watcher unsubscribe promises for error cleanup paths as well as sender cleanup
- Track runtime file watcher Parcel unsubscribe promises and drain them during app shutdown after the RPC server stops
- Add regression coverage for both watcher error cleanup and runtime file watcher unsubscribe draining

## Verification
- Commit hook: oxlint and oxfmt on staged files
- Skipped explicit test runs per instruction