### PR TITLE
Make combined diff file tree opt-in by default

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -74,7 +74,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     floatingTerminalCwd: '~',
     floatingTerminalTriggerLocation: 'floating-button',
     diffDefaultView: 'inline',
-    combinedDiffFileTreeVisibleByDefault: true,
+    combinedDiffFileTreeVisibleByDefault: false,
     notifications: {
       enabled: true,
       agentTaskComplete: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -67,7 +67,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     floatingTerminalCwd: '~',
     floatingTerminalTriggerLocation: 'floating-button',
     diffDefaultView: 'inline',
-    combinedDiffFileTreeVisibleByDefault: true,
+    combinedDiffFileTreeVisibleByDefault: false,
     notifications: {
       enabled: true,
       agentTaskComplete: true,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -596,7 +596,7 @@ describe('Store', () => {
     expect(store.getSettings().refreshLocalBaseRefOnWorktreeCreate).toBe(false)
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
     expect(store.getSettings().showTasksButton).toBe(true)
-    expect(store.getSettings().combinedDiffFileTreeVisibleByDefault).toBe(true)
+    expect(store.getSettings().combinedDiffFileTreeVisibleByDefault).toBe(false)
     expect(store.getSettings().visibleTaskProviders).toEqual(['github', 'gitlab', 'linear'])
     expect(store.getSettings().experimentalActivity).toBe(true)
     expect(store.getSettings().notifications.customSoundPath).toBeNull()

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -121,7 +121,9 @@ function getInitialCombinedDiffSideBySide(diffDefaultView: string | undefined): 
 function getInitialCombinedDiffFileTreeCollapsed(
   combinedDiffFileTreeVisibleByDefault: boolean | undefined
 ): boolean {
-  return combinedDiffFileTreeCollapsedPreference ?? combinedDiffFileTreeVisibleByDefault === false
+  // Why: the tree is opt-in for new sessions; only an explicit saved setting
+  // should make it the opening surface while settings are still loading.
+  return combinedDiffFileTreeCollapsedPreference ?? combinedDiffFileTreeVisibleByDefault !== true
 }
 
 function commitMessageBody(message: string | undefined, subject: string | undefined): string {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -222,7 +222,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     floatingTerminalTriggerLocation: 'floating-button',
     notifications: getDefaultNotificationSettings(),
     diffDefaultView: 'inline',
-    combinedDiffFileTreeVisibleByDefault: true,
+    combinedDiffFileTreeVisibleByDefault: false,
     promptCacheTimerEnabled: false,
     promptCacheTtlMs: 300_000,
     codexManagedAccounts: [],


### PR DESCRIPTION
## Summary
- default the combined diff file tree setting to hidden
- keep saved user preference behavior intact while settings load
- update settings tests for the new default

## Tests
- pnpm typecheck