### PR TITLE
Show cross-Space unread total on All Projects pill

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1515,6 +1515,11 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     if (state.activeRepoId !== worktree.repoId) {
       state.setActiveRepo(worktree.repoId)
     }
+    // Why: keep the active Space consistent with the row the user is
+    // previewing, so returning to terminal view lands in the right Space
+    // rather than leaving the sidebar in its prior Space.
+    const targetSpaceId = state.repoSpaceAssignments[worktree.repoId] ?? null
+    state.setActiveSpace(targetSpaceId)
     if (state.activeWorktreeId !== worktree.id) {
       state.setActiveWorktree(worktree.id)
     }
@@ -1563,7 +1568,23 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       return
     }
     markThreadRead(thread)
-    activateAndRevealWorktree(thread.worktree.id)
+    const activated = activateAndRevealWorktree(thread.worktree.id)
+    if (!activated) {
+      return
+    }
+    // Why: re-read state — activateAndRevealWorktree may have created an
+    // initial terminal via ensureWorktreeHasInitialTerminal, so the pre-call
+    // tabsByWorktree snapshot could be stale.
+    const after = useAppStore.getState()
+    const liveTabs = after.tabsByWorktree[thread.worktree.id] ?? []
+    if (!liveTabs.some((t) => t.id === thread.tab.id)) {
+      return
+    }
+    const parsed = parsePaneKey(thread.paneKey)
+    activateTabAndFocusPane(
+      thread.tab.id,
+      parsed && parsed.tabId === thread.tab.id ? parsed.leafId : null
+    )
   }
 
   const hasUnreadThreads = allThreads.some((thread) => thread.unread)

--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -4,41 +4,27 @@ import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
+import { countUnreadAgentEvents } from '@/lib/agent-status-unread'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 
-// Why: keep the unread accumulator local; "Mark all read" moved to the
-// thread-list overflow menu in ActivityPrototypePage so it lives next to
+// Why: per-pane unread accumulation lives in agent-status-unread.ts so the
+// per-Space pill badges share the same definition. "Mark all read" moved to
+// the thread-list overflow menu in ActivityPrototypePage so it lives next to
 // the cards it acts on.
 
 function useActivityUnreadCount(): number {
   return useAppStore((s) => {
     let count = 0
-    const isUnreadState = (state: AgentStatusState): boolean =>
-      state === 'done' || state === 'blocked' || state === 'waiting'
-    // Why: Activity feed surfaces every historical done/blocked/waiting event from
-    // stateHistory plus the live state, so the badge must mirror the same walk —
-    // counting only on entry.state under-counts panes that started a new turn.
-    const accumulate = (entry: AgentStatusEntry, ackAt: number): void => {
-      for (const history of entry.stateHistory) {
-        if (isUnreadState(history.state) && ackAt < history.startedAt) {
-          count += 1
-        }
-      }
-      if (isUnreadState(entry.state) && ackAt < entry.stateStartedAt) {
-        count += 1
-      }
-    }
     for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
-      accumulate(entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+      count += countUnreadAgentEvents(entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
     }
     for (const [paneKey, retained] of Object.entries(s.retainedAgentsByPaneKey)) {
-      accumulate(retained.entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+      count += countUnreadAgentEvents(retained.entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
     }
     for (const unsupported of Object.values(s.migrationUnsupportedByPtyId)) {
       const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
       if (entry) {
-        accumulate(entry, s.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
+        count += countUnreadAgentEvents(entry, s.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
       }
     }
     return count

--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -4,35 +4,15 @@ import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { countUnreadAgentEvents } from '@/lib/agent-status-unread'
-import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
+import { useAllAgentsUnreadCount } from '@/components/sidebar/use-space-notification-counts'
 
-// Why: per-pane unread accumulation lives in agent-status-unread.ts so the
-// per-Space pill badges share the same definition. "Mark all read" moved to
-// the thread-list overflow menu in ActivityPrototypePage so it lives next to
-// the cards it acts on.
-
-function useActivityUnreadCount(): number {
-  return useAppStore((s) => {
-    let count = 0
-    for (const [paneKey, entry] of Object.entries(s.agentStatusByPaneKey)) {
-      count += countUnreadAgentEvents(entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
-    }
-    for (const [paneKey, retained] of Object.entries(s.retainedAgentsByPaneKey)) {
-      count += countUnreadAgentEvents(retained.entry, s.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
-    }
-    for (const unsupported of Object.values(s.migrationUnsupportedByPtyId)) {
-      const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
-      if (entry) {
-        count += countUnreadAgentEvents(entry, s.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
-      }
-    }
-    return count
-  })
-}
+// Why: the cross-Space total lives in use-space-notification-counts.ts so this
+// titlebar badge and the "All Projects" pill in the sidebar share one
+// definition. "Mark all read" moved to the thread-list overflow menu in
+// ActivityPrototypePage so it lives next to the cards it acts on.
 
 export function ActivityTitlebarControls(): React.JSX.Element {
-  const unreadCount = useActivityUnreadCount()
+  const unreadCount = useAllAgentsUnreadCount()
   const closeActivityPage = useAppStore((s) => s.closeActivityPage)
 
   return (

--- a/src/renderer/src/components/sidebar/RepoAddToSpaceButton.tsx
+++ b/src/renderer/src/components/sidebar/RepoAddToSpaceButton.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { Plus } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import RepoSpacePickerItems from './RepoSpacePickerItems'
+
+type Props = {
+  repoId: string
+}
+
+// Why: only rendered for repos with no space assignment in the All Projects
+// view. Shares geometry with the assigned-space pill (same slot, same height)
+// so adjacent repo rows align; the dashed border distinguishes "empty slot you
+// can fill" from "already assigned to X".
+export default function RepoAddToSpaceButton({ repoId }: Props): React.JSX.Element {
+  return (
+    <DropdownMenu modal={false}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Badge
+              variant="outline"
+              role="button"
+              tabIndex={0}
+              aria-label="Add to space"
+              className="h-[16px] shrink-0 cursor-pointer gap-0.5 rounded border-dashed border-foreground/25 bg-transparent px-1.5 text-[10px] font-medium leading-none text-foreground/60 transition-colors hover:border-foreground/40 hover:bg-foreground/[0.06] hover:text-foreground"
+              onClick={(e) => {
+                // Why: the parent repo-header row's onClick toggles group
+                // collapse — stopPropagation keeps the click scoped to the
+                // dropdown trigger.
+                e.stopPropagation()
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.stopPropagation()
+                }
+              }}
+            >
+              <Plus className="size-2.5" strokeWidth={2.5} />
+              Add
+            </Badge>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={8}>
+          Add to space
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        className="w-44"
+        align="start"
+        sideOffset={4}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <RepoSpacePickerItems repoId={repoId} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/renderer/src/components/sidebar/RepoGroupHeaderDraggable.tsx
+++ b/src/renderer/src/components/sidebar/RepoGroupHeaderDraggable.tsx
@@ -1,38 +1,25 @@
-import React, { useCallback, useRef, useState } from 'react'
-import { useDraggable } from '@dnd-kit/core'
+import React, { useCallback, useState } from 'react'
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import RepoMoveToSpaceMenu from './RepoMoveToSpaceMenu'
+import { writeRepoDragData } from './repo-drag-types'
 
 type Props = {
   repoId: string
   children: React.ReactNode
 }
 
-// Wraps a repo group header so it can be dragged onto a Space tab AND
-// right-clicked for "Move to Space ▸ …". The pointer-down listener from
-// dnd-kit is applied at this wrapper level; the existing folder-icon
-// reorder drag stops propagation to keep its own threshold authoritative.
+// Why: uses native HTML5 drag (not dnd-kit) so this gesture shares the same
+// event system as the worktree-card kanban drag — both then route through
+// SpaceTab's HTML5 drop handlers. dnd-kit's useDraggable here was unreachable
+// in practice because the inner folder-icon stops pointer propagation for its
+// own reorder controller.
 export default function RepoGroupHeaderDraggable({ repoId, children }: Props): React.JSX.Element {
-  const { attributes, listeners, setNodeRef } = useDraggable({
-    id: `repo-${repoId}`,
-    data: { kind: 'repo', repoId }
-  })
-
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
-  const scopeRef = useRef<HTMLDivElement>(null)
-
-  const setRefs = useCallback(
-    (node: HTMLDivElement | null) => {
-      setNodeRef(node)
-      scopeRef.current = node
-    },
-    [setNodeRef]
-  )
 
   const onContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
@@ -41,13 +28,19 @@ export default function RepoGroupHeaderDraggable({ repoId, children }: Props): R
     setMenuOpen(true)
   }, [])
 
+  const onDragStart = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      writeRepoDragData(event.dataTransfer, repoId)
+    },
+    [repoId]
+  )
+
   return (
     <div
-      ref={setRefs}
       className="relative"
+      draggable
+      onDragStart={onDragStart}
       onContextMenu={onContextMenu}
-      {...listeners}
-      {...attributes}
     >
       {children}
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>

--- a/src/renderer/src/components/sidebar/RepoGroupHeaderDraggable.tsx
+++ b/src/renderer/src/components/sidebar/RepoGroupHeaderDraggable.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useRef, useState } from 'react'
+import { useDraggable } from '@dnd-kit/core'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import RepoMoveToSpaceMenu from './RepoMoveToSpaceMenu'
+
+type Props = {
+  repoId: string
+  children: React.ReactNode
+}
+
+// Wraps a repo group header so it can be dragged onto a Space tab AND
+// right-clicked for "Move to Space ▸ …". The pointer-down listener from
+// dnd-kit is applied at this wrapper level; the existing folder-icon
+// reorder drag stops propagation to keep its own threshold authoritative.
+export default function RepoGroupHeaderDraggable({ repoId, children }: Props): React.JSX.Element {
+  const { attributes, listeners, setNodeRef } = useDraggable({
+    id: `repo-${repoId}`,
+    data: { kind: 'repo', repoId }
+  })
+
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
+  const scopeRef = useRef<HTMLDivElement>(null)
+
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      setNodeRef(node)
+      scopeRef.current = node
+    },
+    [setNodeRef]
+  )
+
+  const onContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const bounds = event.currentTarget.getBoundingClientRect()
+    setMenuPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
+    setMenuOpen(true)
+  }, [])
+
+  return (
+    <div
+      ref={setRefs}
+      className="relative"
+      onContextMenu={onContextMenu}
+      {...listeners}
+      {...attributes}
+    >
+      {children}
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-hidden
+            tabIndex={-1}
+            className="pointer-events-none absolute size-px opacity-0"
+            style={{ left: menuPoint.x, top: menuPoint.y }}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-52" sideOffset={0} align="start">
+          <RepoMoveToSpaceMenu repoId={repoId} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/RepoMoveToSpaceMenu.tsx
+++ b/src/renderer/src/components/sidebar/RepoMoveToSpaceMenu.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback } from 'react'
-import { Check, FolderInput } from 'lucide-react'
+import React from 'react'
+import { FolderInput } from 'lucide-react'
 import {
   DropdownMenuSub,
   DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuItem,
-  DropdownMenuSeparator
+  DropdownMenuSubTrigger
 } from '@/components/ui/dropdown-menu'
-import { useAppStore } from '@/store'
+import RepoSpacePickerItems from './RepoSpacePickerItems'
 
 type Props = {
   repoId: string
@@ -21,20 +19,6 @@ export default function RepoMoveToSpaceMenu({
   repoId,
   label = 'Move to Space'
 }: Props): React.JSX.Element {
-  const spaces = useAppStore((s) => s.spaces)
-  const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
-  const moveRepoToSpace = useAppStore((s) => s.moveRepoToSpace)
-
-  const currentSpaceId = repoSpaceAssignments[repoId] ?? null
-  const sortedSpaces = React.useMemo(() => [...spaces].sort((a, b) => a.order - b.order), [spaces])
-
-  const handleMove = useCallback(
-    (spaceId: string | null) => {
-      moveRepoToSpace(repoId, spaceId)
-    },
-    [moveRepoToSpace, repoId]
-  )
-
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger>
@@ -42,21 +26,7 @@ export default function RepoMoveToSpaceMenu({
         {label}
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-44">
-        <DropdownMenuItem onSelect={() => handleMove(null)}>
-          <span className="inline-flex size-3.5 items-center justify-center">
-            {currentSpaceId === null ? <Check className="size-3" /> : null}
-          </span>
-          All Projects
-        </DropdownMenuItem>
-        {sortedSpaces.length > 0 ? <DropdownMenuSeparator /> : null}
-        {sortedSpaces.map((space) => (
-          <DropdownMenuItem key={space.id} onSelect={() => handleMove(space.id)}>
-            <span className="inline-flex size-3.5 items-center justify-center">
-              {currentSpaceId === space.id ? <Check className="size-3" /> : null}
-            </span>
-            <span className="truncate">{space.name}</span>
-          </DropdownMenuItem>
-        ))}
+        <RepoSpacePickerItems repoId={repoId} />
       </DropdownMenuSubContent>
     </DropdownMenuSub>
   )

--- a/src/renderer/src/components/sidebar/RepoMoveToSpaceMenu.tsx
+++ b/src/renderer/src/components/sidebar/RepoMoveToSpaceMenu.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback } from 'react'
+import { Check, FolderInput } from 'lucide-react'
+import {
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@/components/ui/dropdown-menu'
+import { useAppStore } from '@/store'
+
+type Props = {
+  repoId: string
+  // Why: this submenu is reused for both the repo group header (single-repo
+  // context) and the worktree card (per-worktree context). The label clarifies
+  // intent for the latter where the action target isn't obvious.
+  label?: string
+}
+
+export default function RepoMoveToSpaceMenu({
+  repoId,
+  label = 'Move to Space'
+}: Props): React.JSX.Element {
+  const spaces = useAppStore((s) => s.spaces)
+  const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
+  const moveRepoToSpace = useAppStore((s) => s.moveRepoToSpace)
+
+  const currentSpaceId = repoSpaceAssignments[repoId] ?? null
+  const sortedSpaces = React.useMemo(() => [...spaces].sort((a, b) => a.order - b.order), [spaces])
+
+  const handleMove = useCallback(
+    (spaceId: string | null) => {
+      moveRepoToSpace(repoId, spaceId)
+    },
+    [moveRepoToSpace, repoId]
+  )
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        <FolderInput className="size-3.5" />
+        {label}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-44">
+        <DropdownMenuItem onSelect={() => handleMove(null)}>
+          <span className="inline-flex size-3.5 items-center justify-center">
+            {currentSpaceId === null ? <Check className="size-3" /> : null}
+          </span>
+          All Projects
+        </DropdownMenuItem>
+        {sortedSpaces.length > 0 ? <DropdownMenuSeparator /> : null}
+        {sortedSpaces.map((space) => (
+          <DropdownMenuItem key={space.id} onSelect={() => handleMove(space.id)}>
+            <span className="inline-flex size-3.5 items-center justify-center">
+              {currentSpaceId === space.id ? <Check className="size-3" /> : null}
+            </span>
+            <span className="truncate">{space.name}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}

--- a/src/renderer/src/components/sidebar/RepoSpacePickerItems.tsx
+++ b/src/renderer/src/components/sidebar/RepoSpacePickerItems.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback } from 'react'
+import { Check } from 'lucide-react'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
+import { useAppStore } from '@/store'
+
+type Props = {
+  repoId: string
+}
+
+// Why: shared between the right-click "Move to Space" submenu and the
+// click-to-open "Add to Space" picker so both surfaces always offer the same
+// destinations and selection markers from a single source of truth.
+export default function RepoSpacePickerItems({ repoId }: Props): React.JSX.Element {
+  const spaces = useAppStore((s) => s.spaces)
+  const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
+  const moveRepoToSpace = useAppStore((s) => s.moveRepoToSpace)
+
+  const currentSpaceId = repoSpaceAssignments[repoId] ?? null
+  const sortedSpaces = React.useMemo(() => [...spaces].sort((a, b) => a.order - b.order), [spaces])
+
+  const handleMove = useCallback(
+    (spaceId: string | null) => {
+      moveRepoToSpace(repoId, spaceId)
+    },
+    [moveRepoToSpace, repoId]
+  )
+
+  return (
+    <>
+      <DropdownMenuItem onSelect={() => handleMove(null)}>
+        <span className="inline-flex size-3.5 items-center justify-center">
+          {currentSpaceId === null ? <Check className="size-3" /> : null}
+        </span>
+        All Projects
+      </DropdownMenuItem>
+      {sortedSpaces.length > 0 ? <DropdownMenuSeparator /> : null}
+      {sortedSpaces.map((space) => (
+        <DropdownMenuItem key={space.id} onSelect={() => handleMove(space.id)}>
+          <span className="inline-flex size-3.5 items-center justify-center">
+            {currentSpaceId === space.id ? <Check className="size-3" /> : null}
+          </span>
+          <span className="truncate">{space.name}</span>
+        </DropdownMenuItem>
+      ))}
+    </>
+  )
+}

--- a/src/renderer/src/components/sidebar/SpaceTab.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTab.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react'
-import { useDroppable } from '@dnd-kit/core'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import {
@@ -11,8 +10,8 @@ import {
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 import type { Space } from '../../../../shared/types'
-
-export type SpaceTabDropData = { kind: 'space'; spaceId: string | null }
+import { hasRepoDragData } from './repo-drag-types'
+import { hasWorkspaceDragData } from './workspace-status'
 
 type SpaceTabProps = {
   // null means the permanent "All Projects" tab.
@@ -43,16 +42,6 @@ export default function SpaceTab({
   onRenameCancel
 }: SpaceTabProps): React.JSX.Element {
   const isAllProjects = space === null
-  // Why: All Projects is rendered outside the SortableContext and never
-  // reorders, so it only needs a droppable target. User Spaces wrap both so
-  // they can be reordered AND accept dropped repos.
-  const droppableId = isAllProjects ? 'space-drop-all' : `space-drop-${space.id}`
-  const dropData: SpaceTabDropData = { kind: 'space', spaceId: space?.id ?? null }
-
-  const { setNodeRef: setDroppableRef, isOver } = useDroppable({
-    id: droppableId,
-    data: dropData
-  })
 
   const sortable = useSortable({
     id: space?.id ?? '__all_projects__',
@@ -60,6 +49,16 @@ export default function SpaceTab({
     disabled: isAllProjects
   })
 
+  const [isDragOver, setIsDragOver] = useState(false)
+  // Why: the actual drop is committed by useSpaceTabDocumentDrop in capture
+  // phase (preload's drop listener stopPropagation()s the bubble path).
+  // dragend on the source still propagates normally, so it's a reliable
+  // signal to clear the highlight after the drop completes or is cancelled.
+  useEffect(() => {
+    const onDragEnd = (): void => setIsDragOver(false)
+    document.addEventListener('dragend', onDragEnd, true)
+    return () => document.removeEventListener('dragend', onDragEnd, true)
+  }, [])
   const renameInputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
     if (!isRenaming) {
@@ -74,13 +73,42 @@ export default function SpaceTab({
 
   const setRefs = useCallback(
     (node: HTMLElement | null) => {
-      setDroppableRef(node)
       if (!isAllProjects) {
         sortable.setNodeRef(node)
       }
     },
-    [setDroppableRef, sortable, isAllProjects]
+    [sortable, isAllProjects]
   )
+
+  const acceptsDrag = useCallback((dataTransfer: DataTransfer) => {
+    return hasRepoDragData(dataTransfer) || hasWorkspaceDragData(dataTransfer)
+  }, [])
+
+  const onDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      if (!acceptsDrag(event.dataTransfer)) {
+        return
+      }
+      // Why: preventDefault here tells the browser "this is a valid drop
+      // target" — without it the cursor stays as the red "no drop" symbol
+      // and onDrop never fires.
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'move'
+      if (!isDragOver) {
+        setIsDragOver(true)
+      }
+    },
+    [acceptsDrag, isDragOver]
+  )
+
+  const onDragLeave = useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    // Why: dragleave fires when crossing into a child element too. Only clear
+    // the highlight when the pointer truly leaves the tab.
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return
+    }
+    setIsDragOver(false)
+  }, [])
 
   const style: React.CSSProperties = isAllProjects
     ? {}
@@ -98,6 +126,7 @@ export default function SpaceTab({
       style={style}
       data-active={isActive ? 'true' : 'false'}
       data-space-id={space?.id ?? 'all'}
+      data-space-drop-target={space?.id ?? 'all'}
       onClick={() => {
         if (isRenaming) {
           return
@@ -110,6 +139,8 @@ export default function SpaceTab({
         }
         onRequestRename()
       }}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
       {...(isAllProjects ? {} : sortable.attributes)}
       {...(isAllProjects || isRenaming ? {} : sortable.listeners)}
       className={cn(
@@ -117,7 +148,7 @@ export default function SpaceTab({
         isActive
           ? 'bg-sidebar-accent text-sidebar-accent-foreground'
           : 'text-muted-foreground hover:text-foreground',
-        isOver && 'ring-1 ring-sidebar-ring/60'
+        isDragOver && 'ring-1 ring-sidebar-ring/60'
       )}
     >
       {isRenaming ? (

--- a/src/renderer/src/components/sidebar/SpaceTab.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTab.tsx
@@ -25,9 +25,10 @@ type SpaceTabProps = {
   onRenameChange?: (value: string) => void
   onRenameCommit?: () => void
   onRenameCancel?: () => void
-  /** Unread agent-event count for this Space. Rendered as a trailing chip
-   *  when > 0; never rendered on the "All Projects" pill because that count
-   *  would re-summarize every other Space's badge (double-counting). */
+  /** Unread agent-event count to render as a trailing chip when > 0. For a
+   *  Space, this is the per-Space total; for the "All Projects" pill, this
+   *  is the grand total across every repo (assigned + unassigned), matching
+   *  the Activity titlebar count. */
   notificationCount?: number
 }
 
@@ -185,7 +186,7 @@ export default function SpaceTab({
       ) : (
         <>
           <span className="truncate max-w-[140px]">{label}</span>
-          {!isAllProjects && notificationCount > 0 ? (
+          {notificationCount > 0 ? (
             <span
               aria-label={`${notificationCount} unread`}
               className={cn(

--- a/src/renderer/src/components/sidebar/SpaceTab.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTab.tsx
@@ -25,6 +25,14 @@ type SpaceTabProps = {
   onRenameChange?: (value: string) => void
   onRenameCommit?: () => void
   onRenameCancel?: () => void
+  /** Unread agent-event count for this Space. Rendered as a trailing chip
+   *  when > 0; never rendered on the "All Projects" pill because that count
+   *  would re-summarize every other Space's badge (double-counting). */
+  notificationCount?: number
+}
+
+function formatNotificationCount(count: number): string {
+  return count >= 100 ? '99+' : String(count)
 }
 
 const ALL_PROJECTS_LABEL = 'All Projects'
@@ -39,7 +47,8 @@ export default function SpaceTab({
   renameValue,
   onRenameChange,
   onRenameCommit,
-  onRenameCancel
+  onRenameCancel,
+  notificationCount = 0
 }: SpaceTabProps): React.JSX.Element {
   const isAllProjects = space === null
 
@@ -174,7 +183,25 @@ export default function SpaceTab({
           aria-label={`Rename Space ${space?.name ?? ''}`}
         />
       ) : (
-        <span className="truncate max-w-[140px]">{label}</span>
+        <>
+          <span className="truncate max-w-[140px]">{label}</span>
+          {!isAllProjects && notificationCount > 0 ? (
+            <span
+              aria-label={`${notificationCount} unread`}
+              className={cn(
+                'ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                // Why: re-tint on the active pill so the chip stays legible
+                // against bg-sidebar-accent — `foreground/10` would all but
+                // vanish there.
+                isActive
+                  ? 'bg-background/25 text-foreground'
+                  : 'bg-foreground/10 text-foreground/80'
+              )}
+            >
+              {formatNotificationCount(notificationCount)}
+            </span>
+          ) : null}
+        </>
       )}
     </div>
   )

--- a/src/renderer/src/components/sidebar/SpaceTab.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTab.tsx
@@ -1,0 +1,177 @@
+import React, { useCallback, useEffect, useRef } from 'react'
+import { useDroppable } from '@dnd-kit/core'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import type { Space } from '../../../../shared/types'
+
+export type SpaceTabDropData = { kind: 'space'; spaceId: string | null }
+
+type SpaceTabProps = {
+  // null means the permanent "All Projects" tab.
+  space: Space | null
+  isActive: boolean
+  onActivate: () => void
+  onRequestRename?: () => void
+  onRequestDelete?: () => void
+  isRenaming?: boolean
+  renameValue?: string
+  onRenameChange?: (value: string) => void
+  onRenameCommit?: () => void
+  onRenameCancel?: () => void
+}
+
+const ALL_PROJECTS_LABEL = 'All Projects'
+
+export default function SpaceTab({
+  space,
+  isActive,
+  onActivate,
+  onRequestRename,
+  onRequestDelete,
+  isRenaming,
+  renameValue,
+  onRenameChange,
+  onRenameCommit,
+  onRenameCancel
+}: SpaceTabProps): React.JSX.Element {
+  const isAllProjects = space === null
+  // Why: All Projects is rendered outside the SortableContext and never
+  // reorders, so it only needs a droppable target. User Spaces wrap both so
+  // they can be reordered AND accept dropped repos.
+  const droppableId = isAllProjects ? 'space-drop-all' : `space-drop-${space.id}`
+  const dropData: SpaceTabDropData = { kind: 'space', spaceId: space?.id ?? null }
+
+  const { setNodeRef: setDroppableRef, isOver } = useDroppable({
+    id: droppableId,
+    data: dropData
+  })
+
+  const sortable = useSortable({
+    id: space?.id ?? '__all_projects__',
+    data: { kind: 'tab' as const, spaceId: space?.id ?? null },
+    disabled: isAllProjects
+  })
+
+  const renameInputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (!isRenaming) {
+      return
+    }
+    const frame = requestAnimationFrame(() => {
+      renameInputRef.current?.focus()
+      renameInputRef.current?.select()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [isRenaming])
+
+  const setRefs = useCallback(
+    (node: HTMLElement | null) => {
+      setDroppableRef(node)
+      if (!isAllProjects) {
+        sortable.setNodeRef(node)
+      }
+    },
+    [setDroppableRef, sortable, isAllProjects]
+  )
+
+  const style: React.CSSProperties = isAllProjects
+    ? {}
+    : {
+        transform: CSS.Transform.toString(sortable.transform),
+        transition: sortable.transition,
+        opacity: sortable.isDragging ? 0.5 : 1
+      }
+
+  const label = isAllProjects ? ALL_PROJECTS_LABEL : space.name
+
+  const tab = (
+    <div
+      ref={setRefs}
+      style={style}
+      data-active={isActive ? 'true' : 'false'}
+      data-space-id={space?.id ?? 'all'}
+      onClick={() => {
+        if (isRenaming) {
+          return
+        }
+        onActivate()
+      }}
+      onDoubleClick={() => {
+        if (isAllProjects || !onRequestRename) {
+          return
+        }
+        onRequestRename()
+      }}
+      {...(isAllProjects ? {} : sortable.attributes)}
+      {...(isAllProjects || isRenaming ? {} : sortable.listeners)}
+      className={cn(
+        'group inline-flex h-7 shrink-0 cursor-pointer select-none items-center rounded-md px-2.5 text-[11px] font-medium transition-colors',
+        isActive
+          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+          : 'text-muted-foreground hover:text-foreground',
+        isOver && 'ring-1 ring-sidebar-ring/60'
+      )}
+    >
+      {isRenaming ? (
+        <Input
+          ref={renameInputRef}
+          value={renameValue ?? ''}
+          onChange={(e) => onRenameChange?.(e.target.value)}
+          onBlur={() => onRenameCommit?.()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              onRenameCommit?.()
+            } else if (e.key === 'Escape') {
+              e.preventDefault()
+              onRenameCancel?.()
+            }
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+          className="h-5 w-[96px] min-w-[96px] max-w-[96px] px-1 py-0 text-[11px]"
+          spellCheck={false}
+          aria-label={`Rename Space ${space?.name ?? ''}`}
+        />
+      ) : (
+        <span className="truncate max-w-[140px]">{label}</span>
+      )}
+    </div>
+  )
+
+  if (isAllProjects) {
+    return tab
+  }
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{tab}</ContextMenuTrigger>
+      <ContextMenuContent className="w-40">
+        <ContextMenuItem
+          onSelect={() => {
+            onRequestRename?.()
+          }}
+        >
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem
+          variant="destructive"
+          onSelect={() => {
+            onRequestDelete?.()
+          }}
+        >
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/renderer/src/components/sidebar/SpaceTabs.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTabs.tsx
@@ -5,7 +5,10 @@ import { useAppStore } from '@/store'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Input } from '@/components/ui/input'
 import SpaceTab from './SpaceTab'
-import { useSpaceNotificationCounts } from './use-space-notification-counts'
+import {
+  useAllAgentsUnreadCount,
+  useSpaceNotificationCounts
+} from './use-space-notification-counts'
 import { useSpaceTabDocumentDrop } from './use-space-tab-drop'
 
 type RenameState = { spaceId: string; value: string }
@@ -24,6 +27,7 @@ export default function SpaceTabs(): React.JSX.Element {
   const renameSpace = useAppStore((s) => s.renameSpace)
   const deleteSpace = useAppStore((s) => s.deleteSpace)
   const notificationCounts = useSpaceNotificationCounts()
+  const allAgentsCount = useAllAgentsUnreadCount()
 
   useSpaceTabDocumentDrop()
 
@@ -172,6 +176,7 @@ export default function SpaceTabs(): React.JSX.Element {
             space={null}
             isActive={activeSpaceId === null}
             onActivate={() => setActiveSpace(null)}
+            notificationCount={allAgentsCount}
           />
           <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
             {sortedSpaces.map((space) => (

--- a/src/renderer/src/components/sidebar/SpaceTabs.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTabs.tsx
@@ -114,7 +114,15 @@ export default function SpaceTabs(): React.JSX.Element {
   }, [])
 
   return (
-    <div ref={outerRef} className="relative mt-2 px-2" role="tablist" aria-label="Project Spaces">
+    // Why: clicks anywhere in the Space tabs strip must not dismiss the
+    // open Workspace board — switching spaces keeps the board open.
+    <div
+      ref={outerRef}
+      className="relative mt-2 px-2"
+      role="tablist"
+      aria-label="Project Spaces"
+      data-workspace-board-preserve-open=""
+    >
       <div
         ref={scrollRef}
         className="flex items-center gap-1 overflow-x-auto scrollbar-none"

--- a/src/renderer/src/components/sidebar/SpaceTabs.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTabs.tsx
@@ -1,0 +1,189 @@
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
+import { Plus } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Input } from '@/components/ui/input'
+import SpaceTab from './SpaceTab'
+
+type RenameState = { spaceId: string; value: string }
+
+// Why: when the scroll content overflows, fade both edges so labels disappear
+// gracefully instead of getting clipped mid-character. The left fade starts
+// 12px in so the All Projects tab stays fully opaque at the leftmost edge.
+const MASK_BOTH =
+  'linear-gradient(to right, transparent 0px, black 12px, black calc(100% - 12px), transparent 100%)'
+
+export default function SpaceTabs(): React.JSX.Element {
+  const spaces = useAppStore((s) => s.spaces)
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
+  const setActiveSpace = useAppStore((s) => s.setActiveSpace)
+  const addSpace = useAppStore((s) => s.addSpace)
+  const renameSpace = useAppStore((s) => s.renameSpace)
+  const deleteSpace = useAppStore((s) => s.deleteSpace)
+
+  const [rename, setRename] = useState<RenameState | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [createValue, setCreateValue] = useState('')
+  const createInputRef = useRef<HTMLInputElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const outerRef = useRef<HTMLDivElement>(null)
+
+  const sortedSpaces = React.useMemo(() => [...spaces].sort((a, b) => a.order - b.order), [spaces])
+  const sortableIds = React.useMemo(() => sortedSpaces.map((s) => s.id), [sortedSpaces])
+
+  useEffect(() => {
+    if (!creating) {
+      return
+    }
+    const frame = requestAnimationFrame(() => {
+      createInputRef.current?.focus()
+      createInputRef.current?.select()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [creating])
+
+  // Why: only show the mask fades when content actually overflows; otherwise
+  // the leftmost/rightmost tab would render visibly faded for no reason.
+  const updateOverflow = useCallback(() => {
+    const el = scrollRef.current
+    const outer = outerRef.current
+    if (!el || !outer) {
+      return
+    }
+    const overflowing = el.scrollWidth > el.clientWidth + 1
+    if (overflowing) {
+      outer.dataset.overflow = 'true'
+      outer.style.maskImage = MASK_BOTH
+      outer.style.webkitMaskImage = MASK_BOTH
+    } else {
+      delete outer.dataset.overflow
+      outer.style.maskImage = ''
+      outer.style.webkitMaskImage = ''
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    updateOverflow()
+  }, [updateOverflow, sortedSpaces.length])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const ro = new ResizeObserver(() => updateOverflow())
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [updateOverflow])
+
+  const handleCreateCommit = useCallback(() => {
+    const trimmed = createValue.trim()
+    if (trimmed.length === 0) {
+      setCreating(false)
+      setCreateValue('')
+      return
+    }
+    const created = addSpace(trimmed)
+    if (created) {
+      setActiveSpace(created.id)
+    }
+    setCreating(false)
+    setCreateValue('')
+  }, [addSpace, createValue, setActiveSpace])
+
+  const handleCreateCancel = useCallback(() => {
+    setCreating(false)
+    setCreateValue('')
+  }, [])
+
+  const handleRequestRename = useCallback((spaceId: string, currentName: string) => {
+    setRename({ spaceId, value: currentName })
+  }, [])
+
+  const handleRenameCommit = useCallback(() => {
+    if (!rename) {
+      return
+    }
+    renameSpace(rename.spaceId, rename.value)
+    setRename(null)
+  }, [rename, renameSpace])
+
+  const handleRenameCancel = useCallback(() => {
+    setRename(null)
+  }, [])
+
+  return (
+    <div ref={outerRef} className="relative mt-2 px-2" role="tablist" aria-label="Project Spaces">
+      <div
+        ref={scrollRef}
+        className="flex items-center gap-1 overflow-x-auto scrollbar-none"
+        style={{ scrollbarWidth: 'none' }}
+      >
+        <SpaceTab
+          space={null}
+          isActive={activeSpaceId === null}
+          onActivate={() => setActiveSpace(null)}
+        />
+        <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
+          {sortedSpaces.map((space) => (
+            <SpaceTab
+              key={space.id}
+              space={space}
+              isActive={activeSpaceId === space.id}
+              onActivate={() => setActiveSpace(space.id)}
+              onRequestRename={() => handleRequestRename(space.id, space.name)}
+              onRequestDelete={() => deleteSpace(space.id)}
+              isRenaming={rename?.spaceId === space.id}
+              renameValue={rename?.spaceId === space.id ? rename.value : undefined}
+              onRenameChange={(v) =>
+                setRename((prev) =>
+                  prev && prev.spaceId === space.id ? { ...prev, value: v } : prev
+                )
+              }
+              onRenameCommit={handleRenameCommit}
+              onRenameCancel={handleRenameCancel}
+            />
+          ))}
+        </SortableContext>
+        {creating ? (
+          <Input
+            ref={createInputRef}
+            value={createValue}
+            placeholder="Space name"
+            onChange={(e) => setCreateValue(e.target.value)}
+            onBlur={handleCreateCommit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleCreateCommit()
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                handleCreateCancel()
+              }
+            }}
+            className="h-7 w-[120px] min-w-[120px] max-w-[120px] px-2 text-[11px]"
+            spellCheck={false}
+            aria-label="New Space name"
+          />
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setCreating(true)}
+                aria-label="New Space"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/60 hover:text-foreground"
+              >
+                <Plus className="size-3.5" strokeWidth={2.25} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              New Space
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/SpaceTabs.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTabs.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { SortableContext, horizontalListSortingStrategy } from '@dnd-kit/sortable'
-import { Plus } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Input } from '@/components/ui/input'
@@ -28,6 +28,10 @@ export default function SpaceTabs(): React.JSX.Element {
   const [rename, setRename] = useState<RenameState | null>(null)
   const [creating, setCreating] = useState(false)
   const [createValue, setCreateValue] = useState('')
+  // Why: chevrons only render when there's actual headroom to scroll in that
+  // direction, so the affordance disappears at the edges instead of misleading.
+  const [canScrollLeft, setCanScrollLeft] = useState(false)
+  const [canScrollRight, setCanScrollRight] = useState(false)
   const createInputRef = useRef<HTMLInputElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const outerRef = useRef<HTMLDivElement>(null)
@@ -64,6 +68,8 @@ export default function SpaceTabs(): React.JSX.Element {
       outer.style.maskImage = ''
       outer.style.webkitMaskImage = ''
     }
+    setCanScrollLeft(overflowing && el.scrollLeft > 0)
+    setCanScrollRight(overflowing && el.scrollLeft < el.scrollWidth - el.clientWidth - 1)
   }, [])
 
   useLayoutEffect(() => {
@@ -72,13 +78,47 @@ export default function SpaceTabs(): React.JSX.Element {
 
   useEffect(() => {
     const el = scrollRef.current
-    if (!el || typeof ResizeObserver === 'undefined') {
+    if (!el) {
       return
     }
-    const ro = new ResizeObserver(() => updateOverflow())
-    ro.observe(el)
-    return () => ro.disconnect()
+    const onScroll = (): void => updateOverflow()
+    el.addEventListener('scroll', onScroll, { passive: true })
+    let ro: ResizeObserver | undefined
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(() => updateOverflow())
+      ro.observe(el)
+    }
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      ro?.disconnect()
+    }
   }, [updateOverflow])
+
+  // Why: vertical wheel deltas should pan the strip horizontally, matching the
+  // same affordance the main TabBar uses — otherwise mouse-wheel users have no
+  // way to traverse the bar without clicking the chevrons.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) {
+      return
+    }
+    const onWheel = (e: WheelEvent): void => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        e.preventDefault()
+        el.scrollLeft += e.deltaY
+      }
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [])
+
+  const scrollByDirection = useCallback((dir: 1 | -1) => {
+    const el = scrollRef.current
+    if (!el) {
+      return
+    }
+    el.scrollBy({ left: dir * Math.floor(el.clientWidth * 0.6), behavior: 'smooth' })
+  }, [])
 
   const handleCreateCommit = useCallback(() => {
     const trimmed = createValue.trim()
@@ -119,82 +159,98 @@ export default function SpaceTabs(): React.JSX.Element {
   return (
     // Why: clicks anywhere in the Space tabs strip must not dismiss the
     // open Workspace board — switching spaces keeps the board open.
-    <div
-      ref={outerRef}
-      className="relative mt-2 px-2"
-      role="tablist"
-      aria-label="Project Spaces"
-      data-workspace-board-preserve-open=""
-    >
-      <div
-        ref={scrollRef}
-        className="flex items-center gap-1 overflow-x-auto scrollbar-none"
-        style={{ scrollbarWidth: 'none' }}
-      >
-        <SpaceTab
-          space={null}
-          isActive={activeSpaceId === null}
-          onActivate={() => setActiveSpace(null)}
-        />
-        <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
-          {sortedSpaces.map((space) => (
-            <SpaceTab
-              key={space.id}
-              space={space}
-              isActive={activeSpaceId === space.id}
-              onActivate={() => setActiveSpace(space.id)}
-              onRequestRename={() => handleRequestRename(space.id, space.name)}
-              onRequestDelete={() => deleteSpace(space.id)}
-              isRenaming={rename?.spaceId === space.id}
-              renameValue={rename?.spaceId === space.id ? rename.value : undefined}
-              onRenameChange={(v) =>
-                setRename((prev) =>
-                  prev && prev.spaceId === space.id ? { ...prev, value: v } : prev
-                )
-              }
-              onRenameCommit={handleRenameCommit}
-              onRenameCancel={handleRenameCancel}
-            />
-          ))}
-        </SortableContext>
-        {creating ? (
-          <Input
-            ref={createInputRef}
-            value={createValue}
-            placeholder="Space name"
-            onChange={(e) => setCreateValue(e.target.value)}
-            onBlur={handleCreateCommit}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                handleCreateCommit()
-              } else if (e.key === 'Escape') {
-                e.preventDefault()
-                handleCreateCancel()
-              }
-            }}
-            className="h-7 w-[120px] min-w-[120px] max-w-[120px] px-2 text-[11px]"
-            spellCheck={false}
-            aria-label="New Space name"
+    <div className="relative mt-2" data-workspace-board-preserve-open="">
+      <div ref={outerRef} className="px-2" role="tablist" aria-label="Project Spaces">
+        <div
+          ref={scrollRef}
+          className="flex items-center gap-1 overflow-x-auto scrollbar-none"
+          style={{ scrollbarWidth: 'none' }}
+        >
+          <SpaceTab
+            space={null}
+            isActive={activeSpaceId === null}
+            onActivate={() => setActiveSpace(null)}
           />
-        ) : (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={() => setCreating(true)}
-                aria-label="New Space"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/60 hover:text-foreground"
-              >
-                <Plus className="size-3.5" strokeWidth={2.25} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6}>
-              New Space
-            </TooltipContent>
-          </Tooltip>
-        )}
+          <SortableContext items={sortableIds} strategy={horizontalListSortingStrategy}>
+            {sortedSpaces.map((space) => (
+              <SpaceTab
+                key={space.id}
+                space={space}
+                isActive={activeSpaceId === space.id}
+                onActivate={() => setActiveSpace(space.id)}
+                onRequestRename={() => handleRequestRename(space.id, space.name)}
+                onRequestDelete={() => deleteSpace(space.id)}
+                isRenaming={rename?.spaceId === space.id}
+                renameValue={rename?.spaceId === space.id ? rename.value : undefined}
+                onRenameChange={(v) =>
+                  setRename((prev) =>
+                    prev && prev.spaceId === space.id ? { ...prev, value: v } : prev
+                  )
+                }
+                onRenameCommit={handleRenameCommit}
+                onRenameCancel={handleRenameCancel}
+              />
+            ))}
+          </SortableContext>
+          {creating ? (
+            <Input
+              ref={createInputRef}
+              value={createValue}
+              placeholder="Space name"
+              onChange={(e) => setCreateValue(e.target.value)}
+              onBlur={handleCreateCommit}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleCreateCommit()
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  handleCreateCancel()
+                }
+              }}
+              className="h-7 w-[120px] min-w-[120px] max-w-[120px] px-2 text-[11px]"
+              spellCheck={false}
+              aria-label="New Space name"
+            />
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setCreating(true)}
+                  aria-label="New Space"
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/60 hover:text-foreground"
+                >
+                  <Plus className="size-3.5" strokeWidth={2.25} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                New Space
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       </div>
+      {canScrollLeft && (
+        <button
+          type="button"
+          aria-label="Scroll spaces left"
+          onClick={() => scrollByDirection(-1)}
+          className="absolute left-0.5 top-1/2 z-20 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md bg-sidebar/80 text-muted-foreground shadow-sm backdrop-blur-sm hover:bg-sidebar hover:text-foreground"
+        >
+          <ChevronLeft className="size-3.5" strokeWidth={2.25} />
+        </button>
+      )}
+      {canScrollRight && (
+        <button
+          type="button"
+          aria-label="Scroll spaces right"
+          onClick={() => scrollByDirection(1)}
+          className="absolute right-0.5 top-1/2 z-20 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md bg-sidebar/80 text-muted-foreground shadow-sm backdrop-blur-sm hover:bg-sidebar hover:text-foreground"
+        >
+          <ChevronRight className="size-3.5" strokeWidth={2.25} />
+        </button>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/SpaceTabs.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTabs.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '@/store'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Input } from '@/components/ui/input'
 import SpaceTab from './SpaceTab'
+import { useSpaceTabDocumentDrop } from './use-space-tab-drop'
 
 type RenameState = { spaceId: string; value: string }
 
@@ -21,6 +22,8 @@ export default function SpaceTabs(): React.JSX.Element {
   const addSpace = useAppStore((s) => s.addSpace)
   const renameSpace = useAppStore((s) => s.renameSpace)
   const deleteSpace = useAppStore((s) => s.deleteSpace)
+
+  useSpaceTabDocumentDrop()
 
   const [rename, setRename] = useState<RenameState | null>(null)
   const [creating, setCreating] = useState(false)

--- a/src/renderer/src/components/sidebar/SpaceTabs.tsx
+++ b/src/renderer/src/components/sidebar/SpaceTabs.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '@/store'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Input } from '@/components/ui/input'
 import SpaceTab from './SpaceTab'
+import { useSpaceNotificationCounts } from './use-space-notification-counts'
 import { useSpaceTabDocumentDrop } from './use-space-tab-drop'
 
 type RenameState = { spaceId: string; value: string }
@@ -22,6 +23,7 @@ export default function SpaceTabs(): React.JSX.Element {
   const addSpace = useAppStore((s) => s.addSpace)
   const renameSpace = useAppStore((s) => s.renameSpace)
   const deleteSpace = useAppStore((s) => s.deleteSpace)
+  const notificationCounts = useSpaceNotificationCounts()
 
   useSpaceTabDocumentDrop()
 
@@ -189,6 +191,7 @@ export default function SpaceTabs(): React.JSX.Element {
                 }
                 onRenameCommit={handleRenameCommit}
                 onRenameCancel={handleRenameCancel}
+                notificationCount={notificationCounts[space.id] ?? 0}
               />
             ))}
           </SortableContext>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -24,6 +24,7 @@ import { SshDisconnectedDialog } from './SshDisconnectedDialog'
 import WorktreeCardAgents from './WorktreeCardAgents'
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getRepoTintBackground } from '@/lib/repo-tint'
 import { getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
@@ -342,309 +343,321 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showUnreadEmphasis = cardProps.includes('unread') && worktree.isUnread
 
   const cardBody = (
+    // Why: tint wrapper paints a subtle repo.badgeColor wash behind the row
+    // so each project owns a swim lane. State overlays (active darkening,
+    // hover, multi-select) live on the inner div and composite on top of the
+    // tint without specificity fights.
     <div
-      className={cn(
-        'group relative flex items-start gap-1.5 px-1.5 py-1.5 cursor-pointer transition-all duration-200 outline-none select-none ml-1',
-        isMultiSelected ? 'rounded-sm' : 'rounded-lg',
-        isActive
-          ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
-          : isMultiSelected
-            ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
-            : 'border border-transparent hover:bg-sidebar-accent/40',
-        isActive && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
-        !nativeDragEnabled && !isDeleting && '!cursor-grab',
-        isDeleting && 'opacity-50 grayscale cursor-not-allowed',
-        isSshDisconnected && !isDeleting && 'opacity-60'
-      )}
-      onClick={handleClick}
-      onDoubleClick={handleDoubleClick}
-      draggable={nativeDragEnabled && !isDeleting}
-      onDragStart={nativeDragEnabled ? handleDragStart : undefined}
-      aria-busy={isDeleting}
+      className={cn('ml-1', isMultiSelected ? 'rounded-sm' : 'rounded-lg')}
+      style={repo ? { backgroundColor: getRepoTintBackground(repo.badgeColor) } : undefined}
     >
-      {isDeleting && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/50 backdrop-blur-[1px]">
-          <div className="inline-flex items-center gap-1.5 rounded-full bg-background px-3 py-1 text-[11px] font-medium text-foreground shadow-sm border border-border/50">
-            <LoaderCircle className="size-3.5 animate-spin text-muted-foreground" />
-            Deleting…
+      <div
+        className={cn(
+          'group relative flex items-start gap-1.5 px-1.5 py-1.5 cursor-pointer transition-all duration-200 outline-none select-none',
+          isMultiSelected ? 'rounded-sm' : 'rounded-lg',
+          isActive
+            ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
+            : isMultiSelected
+              ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
+              : 'border border-transparent hover:bg-sidebar-accent/40',
+          isActive && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
+          !nativeDragEnabled && !isDeleting && '!cursor-grab',
+          isDeleting && 'opacity-50 grayscale cursor-not-allowed',
+          isSshDisconnected && !isDeleting && 'opacity-60'
+        )}
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        draggable={nativeDragEnabled && !isDeleting}
+        onDragStart={nativeDragEnabled ? handleDragStart : undefined}
+        aria-busy={isDeleting}
+      >
+        {isDeleting && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/50 backdrop-blur-[1px]">
+            <div className="inline-flex items-center gap-1.5 rounded-full bg-background px-3 py-1 text-[11px] font-medium text-foreground shadow-sm border border-border/50">
+              <LoaderCircle className="size-3.5 animate-spin text-muted-foreground" />
+              Deleting…
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Status indicator on the left */}
-      {(cardProps.includes('status') || cardProps.includes('unread')) && (
-        <div className="flex flex-col items-center justify-start pt-[2px] gap-2 shrink-0">
-          {cardProps.includes('status') && (
-            <>
-              <StatusIndicator status={status} aria-hidden="true" />
-              <span className="sr-only">{getWorktreeStatusLabel(status)}</span>
-            </>
-          )}
+        {/* Status indicator on the left */}
+        {(cardProps.includes('status') || cardProps.includes('unread')) && (
+          <div className="flex flex-col items-center justify-start pt-[2px] gap-2 shrink-0">
+            {cardProps.includes('status') && (
+              <>
+                <StatusIndicator status={status} aria-hidden="true" />
+                <span className="sr-only">{getWorktreeStatusLabel(status)}</span>
+              </>
+            )}
 
-          {cardProps.includes('unread') && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleToggleUnreadQuick}
-                  className={cn(
-                    'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
-                    'hover:bg-accent/80 active:scale-95',
-                    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
-                  )}
-                  aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
-                >
-                  {worktree.isUnread ? (
-                    <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
-                  ) : (
-                    <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={8}>
-                <span>{unreadTooltip}</span>
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </div>
-      )}
-
-      {/* Content area */}
-      <div className="flex-1 min-w-0 flex flex-col gap-1.5">
-        {/* Header row: Title and Checks */}
-        <div className="flex items-center justify-between min-w-0 gap-2">
-          <div className="flex items-center gap-1.5 min-w-0">
-            {repo?.connectionId && (
+            {cardProps.includes('unread') && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="shrink-0 inline-flex items-center">
-                    {isSshDisconnected ? (
-                      <ServerOff className="size-3 text-red-400" />
-                    ) : (
-                      <Server className="size-3 text-muted-foreground" />
+                  <button
+                    type="button"
+                    onClick={handleToggleUnreadQuick}
+                    className={cn(
+                      'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
+                      'hover:bg-accent/80 active:scale-95',
+                      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
                     )}
-                  </span>
+                    aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
+                  >
+                    {worktree.isUnread ? (
+                      <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
+                    ) : (
+                      <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
+                    )}
+                  </button>
                 </TooltipTrigger>
                 <TooltipContent side="right" sideOffset={8}>
-                  {isSshDisconnected ? 'SSH disconnected' : 'Remote repository via SSH'}
+                  <span>{unreadTooltip}</span>
                 </TooltipContent>
               </Tooltip>
             )}
+          </div>
+        )}
 
-            {/* Why: weight alone carries the unread signal; color stays
+        {/* Content area */}
+        <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+          {/* Header row: Title and Checks */}
+          <div className="flex items-center justify-between min-w-0 gap-2">
+            <div className="flex items-center gap-1.5 min-w-0">
+              {repo?.connectionId && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="shrink-0 inline-flex items-center">
+                      {isSshDisconnected ? (
+                        <ServerOff className="size-3 text-red-400" />
+                      ) : (
+                        <Server className="size-3 text-muted-foreground" />
+                      )}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    {isSshDisconnected ? 'SSH disconnected' : 'Remote repository via SSH'}
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {/* Why: weight alone carries the unread signal; color stays
                  at text-foreground in both states so the title keeps
                  hierarchy against the muted branch row below (muting the
                  title as well flattened the card — same reasoning as the
                  repo chip comment below). */}
-            <div
-              className={cn(
-                'text-[12px] truncate leading-tight text-foreground',
-                showUnreadEmphasis ? 'font-semibold' : 'font-normal'
-              )}
-            >
-              {/* Why: the card root is a non-interactive <div>, so aria-label
+              <div
+                className={cn(
+                  'text-[12px] truncate leading-tight text-foreground',
+                  showUnreadEmphasis ? 'font-semibold' : 'font-normal'
+                )}
+              >
+                {/* Why: the card root is a non-interactive <div>, so aria-label
                    on it is announced inconsistently across screen readers.
                    A visible-text prefix inside the accessible name is reliable. */}
-              {showUnreadEmphasis && <span className="sr-only">Unread: </span>}
-              {worktree.displayName}
-            </div>
+                {showUnreadEmphasis && <span className="sr-only">Unread: </span>}
+                {worktree.displayName}
+              </div>
 
-            {/* Why: the primary worktree (the original clone directory) cannot be
+              {/* Why: the primary worktree (the original clone directory) cannot be
                  deleted via `git worktree remove`. Placing this badge next to the
                  name makes it immediately visible and avoids confusion with the
                  branch name "main" shown below. */}
-            {worktree.isMainWorktree && !isFolder && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
-                  >
-                    primary
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  Primary worktree (original clone directory)
-                </TooltipContent>
-              </Tooltip>
+              {worktree.isMainWorktree && !isFolder && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
+                    >
+                      primary
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    Primary worktree (original clone directory)
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {worktree.isSparse && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-amber-700 dark:text-amber-300 border-amber-500/30 bg-amber-500/5"
+                    >
+                      sparse
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8} className="max-w-72">
+                    <div className="space-y-1">
+                      <div>Partial checkout. Files outside these paths are not on disk.</div>
+                      {worktree.sparseDirectories && worktree.sparseDirectories.length > 0 ? (
+                        <div className="font-mono text-[11px] opacity-80">
+                          {formatSparseDirectoryPreview(worktree.sparseDirectories)}
+                        </div>
+                      ) : null}
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+
+            <div className="flex items-center gap-1 shrink-0">
+              {/* CI Checks & PR state on the right */}
+              {showCI && hostedReview && hostedReview.status !== 'neutral' && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex items-center opacity-80 hover:opacity-100 transition-opacity">
+                      {hostedReview.status === 'success' && (
+                        <CircleCheck className="size-3.5 text-emerald-500" />
+                      )}
+                      {hostedReview.status === 'failure' && (
+                        <CircleX className="size-3.5 text-rose-500" />
+                      )}
+                      {hostedReview.status === 'pending' && (
+                        <LoaderCircle className="size-3.5 text-amber-500 animate-spin" />
+                      )}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    <span>CI checks {checksLabel(hostedReview.status).toLowerCase()}</span>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+
+          {/* Subtitle row: Repo badge + Branch */}
+          <div className="flex items-center gap-1.5 min-w-0">
+            {repo && !hideRepoBadge && (
+              <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
+                <div
+                  className="size-1.5 rounded-full"
+                  style={{ backgroundColor: repo.badgeColor }}
+                />
+                <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
+                  {repo.displayName}
+                </span>
+              </div>
             )}
 
-            {worktree.isSparse && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-amber-700 dark:text-amber-300 border-amber-500/30 bg-amber-500/5"
-                  >
-                    sparse
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8} className="max-w-72">
-                  <div className="space-y-1">
-                    <div>Partial checkout. Files outside these paths are not on disk.</div>
-                    {worktree.sparseDirectories && worktree.sparseDirectories.length > 0 ? (
-                      <div className="font-mono text-[11px] opacity-80">
-                        {formatSparseDirectoryPreview(worktree.sparseDirectories)}
-                      </div>
-                    ) : null}
-                  </div>
-                </TooltipContent>
-              </Tooltip>
+            {isFolder ? (
+              <Badge
+                variant="secondary"
+                className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 text-muted-foreground bg-accent border border-border dark:bg-accent/80 dark:border-border/50 leading-none"
+              >
+                {repo ? getRepoKindLabel(repo) : 'Folder'}
+              </Badge>
+            ) : (
+              <span className="text-[11px] text-muted-foreground truncate leading-none">
+                {branch}
+              </span>
+            )}
+
+            {/* Why: the conflict operation (merge/rebase/cherry-pick) is the
+               only signal that the worktree is in an incomplete operation state.
+               Showing it on the card lets the user spot worktrees that need
+               attention without switching to them first. */}
+            {conflictOperation && conflictOperation !== 'unknown' && (
+              <Badge
+                variant="outline"
+                className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 text-amber-600 border-amber-500/30 bg-amber-500/5 dark:text-amber-400 dark:border-amber-400/30 dark:bg-amber-400/5 leading-none"
+              >
+                <GitMerge className="size-2.5" />
+                {CONFLICT_OPERATION_LABELS[conflictOperation]}
+              </Badge>
+            )}
+
+            <CacheTimer worktreeId={worktree.id} />
+
+            {parentLabel && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  'h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 leading-none',
+                  lineageState === 'missing'
+                    ? 'text-muted-foreground border-border bg-muted/40'
+                    : 'text-muted-foreground border-border bg-accent/50'
+                )}
+              >
+                <Workflow className="size-2.5" />
+                <span className="max-w-[7rem] truncate">
+                  {lineageState === 'missing' ? 'Missing parent' : `from ${parentLabel}`}
+                </span>
+              </Badge>
             )}
           </div>
 
-          <div className="flex items-center gap-1 shrink-0">
-            {/* CI Checks & PR state on the right */}
-            {showCI && hostedReview && hostedReview.status !== 'neutral' && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="inline-flex items-center opacity-80 hover:opacity-100 transition-opacity">
-                    {hostedReview.status === 'success' && (
-                      <CircleCheck className="size-3.5 text-emerald-500" />
-                    )}
-                    {hostedReview.status === 'failure' && (
-                      <CircleX className="size-3.5 text-rose-500" />
-                    )}
-                    {hostedReview.status === 'pending' && (
-                      <LoaderCircle className="size-3.5 text-amber-500 animate-spin" />
-                    )}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  <span>CI checks {checksLabel(hostedReview.status).toLowerCase()}</span>
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </div>
-        </div>
+          {/* Meta section: Issue / hosted review / Comment
+             Layout coupling: spacing here is used to derive size estimates in
+             WorktreeList's estimateSize. Update that function if changing spacing. */}
+          {((cardProps.includes('issue') && issueDisplay) ||
+            (cardProps.includes('pr') && prDisplay) ||
+            (cardProps.includes('comment') && worktree.comment)) && (
+            <div className="flex flex-col gap-[3px] mt-0.5">
+              {cardProps.includes('issue') && issueDisplay && (
+                <IssueSection issue={issueDisplay} onClick={handleEditIssue} />
+              )}
+              {cardProps.includes('pr') && prDisplay && (
+                <ReviewSection review={prDisplay} onEdit={handleEditPr} onRemove={handleRemovePr} />
+              )}
+              {cardProps.includes('comment') && worktree.comment && (
+                <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />
+              )}
+            </div>
+          )}
 
-        {/* Subtitle row: Repo badge + Branch */}
-        <div className="flex items-center gap-1.5 min-w-0">
-          {repo && !hideRepoBadge && (
-            <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
-              <div className="size-1.5 rounded-full" style={{ backgroundColor: repo.badgeColor }} />
-              <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
-                {repo.displayName}
+          {remoteBranchConflict && (
+            <div className="mt-0.5 flex items-start gap-1.5 rounded border border-amber-500/25 bg-amber-500/5 px-1.5 py-1 text-[10.5px] leading-snug text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="mt-[1px] size-3 shrink-0" />
+              <span className="min-w-0 flex-1">
+                {remoteBranchConflict.remote}/{remoteBranchConflict.branchName} already exists.
               </span>
             </div>
           )}
 
-          {isFolder ? (
-            <Badge
-              variant="secondary"
-              className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 text-muted-foreground bg-accent border border-border dark:bg-accent/80 dark:border-border/50 leading-none"
-            >
-              {repo ? getRepoKindLabel(repo) : 'Folder'}
-            </Badge>
-          ) : (
-            <span className="text-[11px] text-muted-foreground truncate leading-none">
-              {branch}
-            </span>
-          )}
-
-          {/* Why: the conflict operation (merge/rebase/cherry-pick) is the
-               only signal that the worktree is in an incomplete operation state.
-               Showing it on the card lets the user spot worktrees that need
-               attention without switching to them first. */}
-          {conflictOperation && conflictOperation !== 'unknown' && (
-            <Badge
-              variant="outline"
-              className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 text-amber-600 border-amber-500/30 bg-amber-500/5 dark:text-amber-400 dark:border-amber-400/30 dark:bg-amber-400/5 leading-none"
-            >
-              <GitMerge className="size-2.5" />
-              {CONFLICT_OPERATION_LABELS[conflictOperation]}
-            </Badge>
-          )}
-
-          <CacheTimer worktreeId={worktree.id} />
-
-          {parentLabel && (
-            <Badge
-              variant="outline"
-              className={cn(
-                'h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 leading-none',
-                lineageState === 'missing'
-                  ? 'text-muted-foreground border-border bg-muted/40'
-                  : 'text-muted-foreground border-border bg-accent/50'
-              )}
-            >
-              <Workflow className="size-2.5" />
-              <span className="max-w-[7rem] truncate">
-                {lineageState === 'missing' ? 'Missing parent' : `from ${parentLabel}`}
-              </span>
-            </Badge>
-          )}
-        </div>
-
-        {/* Meta section: Issue / hosted review / Comment
-             Layout coupling: spacing here is used to derive size estimates in
-             WorktreeList's estimateSize. Update that function if changing spacing. */}
-        {((cardProps.includes('issue') && issueDisplay) ||
-          (cardProps.includes('pr') && prDisplay) ||
-          (cardProps.includes('comment') && worktree.comment)) && (
-          <div className="flex flex-col gap-[3px] mt-0.5">
-            {cardProps.includes('issue') && issueDisplay && (
-              <IssueSection issue={issueDisplay} onClick={handleEditIssue} />
-            )}
-            {cardProps.includes('pr') && prDisplay && (
-              <ReviewSection review={prDisplay} onEdit={handleEditPr} onRemove={handleRemovePr} />
-            )}
-            {cardProps.includes('comment') && worktree.comment && (
-              <CommentSection comment={worktree.comment} onDoubleClick={handleEditComment} />
-            )}
-          </div>
-        )}
-
-        {remoteBranchConflict && (
-          <div className="mt-0.5 flex items-start gap-1.5 rounded border border-amber-500/25 bg-amber-500/5 px-1.5 py-1 text-[10.5px] leading-snug text-amber-700 dark:text-amber-300">
-            <AlertTriangle className="mt-[1px] size-3 shrink-0" />
-            <span className="min-w-0 flex-1">
-              {remoteBranchConflict.remote}/{remoteBranchConflict.branchName} already exists.
-            </span>
-          </div>
-        )}
-
-        {/* Why: inline agent list. Gated on the 'inline-agents' card
+          {/* Why: inline agent list. Gated on the 'inline-agents' card
              property so users can hide it. Layout coupling: this block
              grows the card height dynamically — WorktreeList uses
              measureElement on each row, so the virtualizer re-measures
              naturally when agents appear/disappear. */}
-        {cardProps.includes('inline-agents') && <WorktreeCardAgents worktreeId={worktree.id} />}
+          {cardProps.includes('inline-agents') && <WorktreeCardAgents worktreeId={worktree.id} />}
 
-        {showLineageChildChip && (
-          <div
-            className="relative mt-1 flex min-w-0 justify-start"
-            style={{ color: 'color-mix(in srgb, var(--muted-foreground) 42%, var(--sidebar))' }}
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  className="relative z-10 h-[18px] max-w-[8rem] gap-1 rounded-md border border-sidebar-border bg-sidebar px-1.5 text-[10px] font-medium leading-none text-muted-foreground shadow-none hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring"
-                  aria-label={`${lineageCollapsed ? 'Show' : 'Hide'} ${childWorkspaceLabel}`}
-                  aria-expanded={!lineageCollapsed}
-                  onClick={onLineageToggle}
-                >
-                  <Workflow className="size-2.5" />
-                  <span className="truncate">{childWorkspaceShortLabel}</span>
-                  <ChevronDown
-                    className={cn(
-                      'size-2.5 transition-transform',
-                      lineageCollapsed && '-rotate-90'
-                    )}
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={8}>
-                {lineageCollapsed ? 'Show child workspaces' : 'Hide child workspaces'}
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
+          {showLineageChildChip && (
+            <div
+              className="relative mt-1 flex min-w-0 justify-start"
+              style={{ color: 'color-mix(in srgb, var(--muted-foreground) 42%, var(--sidebar))' }}
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    className="relative z-10 h-[18px] max-w-[8rem] gap-1 rounded-md border border-sidebar-border bg-sidebar px-1.5 text-[10px] font-medium leading-none text-muted-foreground shadow-none hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+                    aria-label={`${lineageCollapsed ? 'Show' : 'Hide'} ${childWorkspaceLabel}`}
+                    aria-expanded={!lineageCollapsed}
+                    onClick={onLineageToggle}
+                  >
+                    <Workflow className="size-2.5" />
+                    <span className="truncate">{childWorkspaceShortLabel}</span>
+                    <ChevronDown
+                      className={cn(
+                        'size-2.5 transition-transform',
+                        lineageCollapsed && '-rotate-90'
+                      )}
+                    />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {lineageCollapsed ? 'Show child workspaces' : 'Hide child workspaces'}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
 
-        {lineageChildren && <div className="-ml-4 mt-1.5 space-y-1">{lineageChildren}</div>}
+          {lineageChildren && <div className="-ml-4 mt-1.5 space-y-1">{lineageChildren}</div>}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -465,12 +465,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
               {worktree.isMainWorktree && !isFolder && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Badge
-                      variant="outline"
-                      className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
-                    >
+                    <span className="shrink-0 text-[9px] font-medium uppercase tracking-wide leading-none text-muted-foreground/55">
                       primary
-                    </Badge>
+                    </span>
                   </TooltipTrigger>
                   <TooltipContent side="right" sideOffset={8}>
                     Primary worktree (original clone directory)

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -38,6 +38,7 @@ import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedSc
 import { getLineageRenderInfo } from './worktree-list-groups'
 import { getWorkspaceStatus, getWorkspaceStatusVisualMeta } from './workspace-status'
 import { WorktreeOpenInSubMenu } from './WorktreeOpenInMenu'
+import RepoMoveToSpaceMenu from './RepoMoveToSpaceMenu'
 
 type Props = {
   worktree: Worktree
@@ -482,6 +483,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+          {!isMultiContext && (
+            <RepoMoveToSpaceMenu repoId={worktree.repoId} label="Move Project to Space" />
+          )}
           {!isMultiContext && (
             <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
               <Pencil className="size-3.5" />

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/store/selectors'
 import WorktreeCard from './WorktreeCard'
 import WorktreeCardAgents from './WorktreeCardAgents'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -453,6 +454,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const prCacheLen = useAppStore((s) => Object.keys(s.prCache).length)
   const issueCacheLen = useAppStore((s) => Object.keys(s.issueCache).length)
+  const spaces = useAppStore((s) => s.spaces)
+  const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
+  const setActiveSpace = useAppStore((s) => s.setActiveSpace)
   const renderRowKeySignature = useMemo(
     () => renderRows.map(getRenderRowKey).join('\n'),
     [renderRows]
@@ -752,6 +756,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           if (row.type === 'header') {
             const isRepoHeader = groupBy === 'repo' && row.repo !== undefined
             const repoIdForHeader = isRepoHeader ? row.repo!.id : undefined
+            const assignedSpace =
+              isRepoHeader && row.repo
+                ? (spaces.find((sp) => sp.id === repoSpaceAssignments[row.repo!.id]) ?? null)
+                : null
             const isDraggingThis =
               canReorderRepoHeaders &&
               repoDrag.state.draggingRepoId !== null &&
@@ -834,9 +842,43 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     <div className="truncate text-[13px] font-semibold leading-none">
                       {row.label}
                     </div>
-                    <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
-                      {row.count}
-                    </div>
+                    {isRepoHeader ? (
+                      assignedSpace ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge
+                              variant="outline"
+                              role="button"
+                              tabIndex={0}
+                              className="h-[16px] shrink-0 cursor-pointer rounded border-foreground/20 bg-foreground/[0.06] px-1.5 text-[10px] font-medium leading-none text-foreground/70 transition-colors hover:bg-foreground/[0.12] hover:text-foreground"
+                              onClick={(e) => {
+                                // Why: the parent row's onClick toggles
+                                // group collapse — without stopPropagation
+                                // the pill click would also fire that.
+                                e.stopPropagation()
+                                setActiveSpace(assignedSpace.id)
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault()
+                                  e.stopPropagation()
+                                  setActiveSpace(assignedSpace.id)
+                                }
+                              }}
+                            >
+                              {assignedSpace.name}
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent side="right" sideOffset={8}>
+                            Switch to {assignedSpace.name} space
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : null
+                    ) : (
+                      <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
+                        {row.count}
+                      </div>
+                    )}
                   </div>
                 </div>
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -63,6 +63,7 @@ import {
   type VirtualizedScrollAnchor
 } from '@/hooks/useVirtualizedScrollAnchor'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { LINEAGE_REPO_TINT_PERCENT, getRepoTintBackground } from '@/lib/repo-tint'
 import { useRepoHeaderDrag } from './repo-header-drag'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import {
@@ -770,120 +771,134 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 className="absolute left-0 right-0"
                 style={{ transform: getVirtualRowTransform(vItem.start) }}
               >
+                {/* Why: tint wrapper paints a subtle repo.badgeColor wash
+                    behind the header. mt-2 lives on the wrapper so the gap
+                    stays outside the tinted band. Only repo-group headers
+                    get a tint; pinned/status headers stay neutral. */}
                 <div
-                  role="button"
-                  tabIndex={0}
-                  data-repo-header-id={repoIdForHeader}
-                  data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
-                  data-workspace-status={headerWorkspaceStatus ?? undefined}
-                  data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
                   className={cn(
-                    'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1 text-left transition-all',
-                    'cursor-pointer',
-                    isDraggingThis &&
-                      'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
-                    headerWorkspaceStatus &&
-                      dragOverStatus === headerWorkspaceStatus &&
-                      'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
-                    isPinnedHeader &&
-                      pinDragOver &&
-                      'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
+                    'rounded-md',
                     // First header sits directly under SidebarHeader, which already
                     // supplies its own spacing — only offset secondary group headers.
-                    vItem.index !== firstHeaderIndex && 'mt-2',
-                    row.repo && 'overflow-hidden'
+                    vItem.index !== firstHeaderIndex && 'mt-2'
                   )}
-                  onDragOver={
-                    isPinnedHeader
-                      ? handleWorkspacePinDragOver
-                      : headerWorkspaceStatus
-                        ? (event) => handleWorkspaceStatusDragOver(event, headerWorkspaceStatus)
-                        : undefined
-                  }
-                  onDragLeave={
-                    isPinnedHeader
-                      ? handleWorkspacePinDragLeave
-                      : headerWorkspaceStatus
-                        ? handleWorkspaceStatusDragLeave
-                        : undefined
-                  }
-                  onDrop={
-                    headerWorkspaceStatus
-                      ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
+                  style={
+                    isRepoHeader && row.repo
+                      ? { backgroundColor: getRepoTintBackground(row.repo.badgeColor) }
                       : undefined
                   }
-                  onClick={() => toggleGroupWithScrollAnchor(row.key)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      toggleGroupWithScrollAnchor(row.key)
-                    }
-                  }}
                 >
-                  {row.icon ? (
-                    <div
-                      onPointerDown={
-                        canReorderRepoHeaders && isRepoHeader && repoIdForHeader
-                          ? (e) => repoDrag.onHandlePointerDown(e, repoIdForHeader)
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    data-repo-header-id={repoIdForHeader}
+                    data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
+                    data-workspace-status={headerWorkspaceStatus ?? undefined}
+                    data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
+                    className={cn(
+                      'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1 text-left transition-all rounded-md',
+                      'cursor-pointer',
+                      isDraggingThis && 'bg-accent/80 ring-1 ring-ring/40 shadow-md scale-[1.01]',
+                      headerWorkspaceStatus &&
+                        dragOverStatus === headerWorkspaceStatus &&
+                        'bg-sidebar-accent ring-1 ring-sidebar-ring/40',
+                      isPinnedHeader &&
+                        pinDragOver &&
+                        'bg-sidebar-accent ring-1 ring-sidebar-ring/40',
+                      row.repo && 'overflow-hidden'
+                    )}
+                    onDragOver={
+                      isPinnedHeader
+                        ? handleWorkspacePinDragOver
+                        : headerWorkspaceStatus
+                          ? (event) => handleWorkspaceStatusDragOver(event, headerWorkspaceStatus)
                           : undefined
+                    }
+                    onDragLeave={
+                      isPinnedHeader
+                        ? handleWorkspacePinDragLeave
+                        : headerWorkspaceStatus
+                          ? handleWorkspaceStatusDragLeave
+                          : undefined
+                    }
+                    onDrop={
+                      headerWorkspaceStatus
+                        ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
+                        : undefined
+                    }
+                    onClick={() => toggleGroupWithScrollAnchor(row.key)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        toggleGroupWithScrollAnchor(row.key)
                       }
-                      className={cn(
-                        'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                        row.repo ? 'text-muted-foreground' : row.tone
-                      )}
-                    >
-                      <row.icon className={row.repo ? 'size-3.5' : 'size-3'} />
-                    </div>
-                  ) : null}
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      <div className="truncate text-[13px] font-semibold leading-none">
-                        {row.label}
+                    }}
+                  >
+                    {row.icon ? (
+                      <div
+                        onPointerDown={
+                          canReorderRepoHeaders && isRepoHeader && repoIdForHeader
+                            ? (e) => repoDrag.onHandlePointerDown(e, repoIdForHeader)
+                            : undefined
+                        }
+                        className={cn(
+                          'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
+                          row.repo ? 'text-muted-foreground' : row.tone
+                        )}
+                      >
+                        <row.icon className={row.repo ? 'size-3.5' : 'size-3'} />
                       </div>
-                      <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
-                        {row.count}
+                    ) : null}
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <div className="truncate text-[13px] font-semibold leading-none">
+                          {row.label}
+                        </div>
+                        <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
+                          {row.count}
+                        </div>
                       </div>
                     </div>
-                  </div>
 
-                  <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
-                    <ChevronDown
-                      className={cn(
-                        'size-3.5 cursor-pointer transition-transform [&_path]:cursor-pointer',
-                        collapsedGroups.has(row.key) && '-rotate-90'
-                      )}
-                    />
-                  </div>
+                    <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
+                      <ChevronDown
+                        className={cn(
+                          'size-3.5 cursor-pointer transition-transform [&_path]:cursor-pointer',
+                          collapsedGroups.has(row.key) && '-rotate-90'
+                        )}
+                      />
+                    </div>
 
-                  {row.repo && groupBy === 'repo' ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
-                          aria-label={`Create worktree for ${row.label}`}
-                          onClick={(event) => {
-                            event.preventDefault()
-                            event.stopPropagation()
-                            if (row.repo && isGitRepoKind(row.repo)) {
-                              handleCreateForRepo(row.repo.id)
-                            }
-                          }}
-                          disabled={row.repo ? !isGitRepoKind(row.repo) : false}
-                        >
-                          <Plus className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={6}>
-                        {row.repo && !isGitRepoKind(row.repo)
-                          ? `${row.label} is opened as a folder`
-                          : `Create worktree for ${row.label}`}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
+                    {row.repo && groupBy === 'repo' ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
+                            aria-label={`Create worktree for ${row.label}`}
+                            onClick={(event) => {
+                              event.preventDefault()
+                              event.stopPropagation()
+                              if (row.repo && isGitRepoKind(row.repo)) {
+                                handleCreateForRepo(row.repo.id)
+                              }
+                            }}
+                            disabled={row.repo ? !isGitRepoKind(row.repo) : false}
+                          >
+                            <Plus className="size-3" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" sideOffset={6}>
+                          {row.repo && !isGitRepoKind(row.repo)
+                            ? `${row.label} is opened as a folder`
+                            : `Create worktree for ${row.label}`}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : null}
+                  </div>
                 </div>
               </div>
             )
@@ -904,113 +919,130 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 key={child.worktree.id}
                 style={{ paddingLeft: `${Math.max(0, child.depth - 1) * LINEAGE_INDENT}px` }}
               >
-                <WorktreeContextMenu
-                  worktree={child.worktree}
-                  selectedWorktrees={selectedWorktrees}
-                  onContextMenuSelect={(event) => onContextMenuSelect(event, child.worktree)}
+                {/* Why: lineage children get a slightly lighter tint than
+                    parent cards because indented rows feel visually heavier
+                    when matched to the parent percentage. */}
+                <div
+                  className="rounded-md"
+                  style={
+                    child.repo
+                      ? {
+                          backgroundColor: getRepoTintBackground(
+                            child.repo.badgeColor,
+                            LINEAGE_REPO_TINT_PERCENT
+                          )
+                        }
+                      : undefined
+                  }
                 >
-                  <div
-                    id={getWorktreeOptionId(child.worktree.id)}
-                    role="option"
-                    aria-selected={selectedWorktreeIds.has(child.worktree.id)}
-                    aria-current={isActive ? 'page' : undefined}
-                    className={cn(
-                      'flex cursor-pointer items-start gap-1.5 rounded-md border border-transparent px-2 py-1.5 transition-colors',
-                      isActive
-                        ? 'border-black/[0.015] bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:border-border/40 dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
-                        : 'hover:bg-sidebar-accent/40'
-                    )}
-                    onClick={handleClick}
-                    onDoubleClick={(event) => event.stopPropagation()}
+                  <WorktreeContextMenu
+                    worktree={child.worktree}
+                    selectedWorktrees={selectedWorktrees}
+                    onContextMenuSelect={(event) => onContextMenuSelect(event, child.worktree)}
                   >
-                    <span className="mt-[2px] flex w-4 shrink-0 justify-center pt-[2px]">
-                      <span className="size-2 rounded-full bg-emerald-500" />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-[12px] leading-tight text-foreground">
-                        {child.worktree.displayName}
-                      </div>
-                      <div className="mt-1 flex min-w-0 items-center gap-1.5">
-                        {child.repo && groupBy !== 'repo' ? (
-                          <span className="flex h-[16px] shrink-0 items-center gap-1.5 rounded-[4px] border border-border bg-accent px-1.5 text-[10px] font-semibold leading-none text-foreground dark:bg-accent/50 dark:border-border/60">
-                            <span
-                              className="size-1.5 rounded-full"
-                              style={{ backgroundColor: child.repo.badgeColor }}
-                            />
-                            <span className="max-w-[6rem] truncate lowercase">
-                              {child.repo.displayName}
-                            </span>
-                          </span>
-                        ) : null}
-                        <span className="truncate text-[10.5px] leading-none text-muted-foreground">
-                          {branchDisplayName(child.worktree.branch)}
-                        </span>
-                      </div>
-                      {child.worktree.linkedIssue || child.worktree.comment ? (
-                        <div className="mt-1.5 truncate text-[10.5px] leading-tight text-muted-foreground">
-                          {child.worktree.linkedIssue ? (
-                            <span className="font-medium text-foreground/80">
-                              #{child.worktree.linkedIssue}
+                    <div
+                      id={getWorktreeOptionId(child.worktree.id)}
+                      role="option"
+                      aria-selected={selectedWorktreeIds.has(child.worktree.id)}
+                      aria-current={isActive ? 'page' : undefined}
+                      className={cn(
+                        'flex cursor-pointer items-start gap-1.5 rounded-md border border-transparent px-2 py-1.5 transition-colors',
+                        isActive
+                          ? 'border-black/[0.015] bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:border-border/40 dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
+                          : 'hover:bg-sidebar-accent/40'
+                      )}
+                      onClick={handleClick}
+                      onDoubleClick={(event) => event.stopPropagation()}
+                    >
+                      <span className="mt-[2px] flex w-4 shrink-0 justify-center pt-[2px]">
+                        <span className="size-2 rounded-full bg-emerald-500" />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[12px] leading-tight text-foreground">
+                          {child.worktree.displayName}
+                        </div>
+                        <div className="mt-1 flex min-w-0 items-center gap-1.5">
+                          {child.repo && groupBy !== 'repo' ? (
+                            <span className="flex h-[16px] shrink-0 items-center gap-1.5 rounded-[4px] border border-border bg-accent px-1.5 text-[10px] font-semibold leading-none text-foreground dark:bg-accent/50 dark:border-border/60">
+                              <span
+                                className="size-1.5 rounded-full"
+                                style={{ backgroundColor: child.repo.badgeColor }}
+                              />
+                              <span className="max-w-[6rem] truncate lowercase">
+                                {child.repo.displayName}
+                              </span>
                             </span>
                           ) : null}
-                          {child.worktree.linkedIssue && child.worktree.comment ? '  ' : null}
-                          {child.worktree.comment}
+                          <span className="truncate text-[10.5px] leading-none text-muted-foreground">
+                            {branchDisplayName(child.worktree.branch)}
+                          </span>
                         </div>
-                      ) : null}
-                      {child.lineageChildCount > 0 && child.lineageGroupKey ? (
-                        <div className="mt-1.5 flex min-w-0 justify-start">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="xs"
-                                className="h-[18px] max-w-[8rem] gap-1 rounded-md border border-sidebar-border bg-sidebar px-1.5 text-[10px] font-medium leading-none text-muted-foreground shadow-none hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring"
-                                aria-label={`${child.lineageCollapsed ? 'Show' : 'Hide'} ${
-                                  child.lineageChildCount
-                                } child ${
-                                  child.lineageChildCount === 1 ? 'workspace' : 'workspaces'
-                                }`}
-                                aria-expanded={!child.lineageCollapsed}
-                                onClick={(event) => {
-                                  event.preventDefault()
-                                  event.stopPropagation()
-                                  toggleGroup(child.lineageGroupKey!)
-                                }}
-                              >
-                                <Workflow className="size-2.5" />
-                                <span className="truncate">
-                                  {child.lineageChildCount}{' '}
-                                  {child.lineageChildCount === 1 ? 'child' : 'children'}
-                                </span>
-                                <ChevronDown
-                                  className={cn(
-                                    'size-2.5 transition-transform',
-                                    child.lineageCollapsed && '-rotate-90'
-                                  )}
-                                />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="right" sideOffset={8}>
-                              {child.lineageCollapsed
-                                ? 'Show child workspaces'
-                                : 'Hide child workspaces'}
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
-                      ) : null}
-                      {showInlineAgentCards ? (
-                        // Why: nested lineage children use this compact
-                        // renderer instead of WorktreeCard, so their inline
-                        // agent rows must be mounted here explicitly.
-                        <WorktreeCardAgents
-                          worktreeId={child.worktree.id}
-                          className="mt-1 divide-y-0"
-                        />
-                      ) : null}
+                        {child.worktree.linkedIssue || child.worktree.comment ? (
+                          <div className="mt-1.5 truncate text-[10.5px] leading-tight text-muted-foreground">
+                            {child.worktree.linkedIssue ? (
+                              <span className="font-medium text-foreground/80">
+                                #{child.worktree.linkedIssue}
+                              </span>
+                            ) : null}
+                            {child.worktree.linkedIssue && child.worktree.comment ? '  ' : null}
+                            {child.worktree.comment}
+                          </div>
+                        ) : null}
+                        {child.lineageChildCount > 0 && child.lineageGroupKey ? (
+                          <div className="mt-1.5 flex min-w-0 justify-start">
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="xs"
+                                  className="h-[18px] max-w-[8rem] gap-1 rounded-md border border-sidebar-border bg-sidebar px-1.5 text-[10px] font-medium leading-none text-muted-foreground shadow-none hover:bg-sidebar-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+                                  aria-label={`${child.lineageCollapsed ? 'Show' : 'Hide'} ${
+                                    child.lineageChildCount
+                                  } child ${
+                                    child.lineageChildCount === 1 ? 'workspace' : 'workspaces'
+                                  }`}
+                                  aria-expanded={!child.lineageCollapsed}
+                                  onClick={(event) => {
+                                    event.preventDefault()
+                                    event.stopPropagation()
+                                    toggleGroup(child.lineageGroupKey!)
+                                  }}
+                                >
+                                  <Workflow className="size-2.5" />
+                                  <span className="truncate">
+                                    {child.lineageChildCount}{' '}
+                                    {child.lineageChildCount === 1 ? 'child' : 'children'}
+                                  </span>
+                                  <ChevronDown
+                                    className={cn(
+                                      'size-2.5 transition-transform',
+                                      child.lineageCollapsed && '-rotate-90'
+                                    )}
+                                  />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent side="right" sideOffset={8}>
+                                {child.lineageCollapsed
+                                  ? 'Show child workspaces'
+                                  : 'Hide child workspaces'}
+                              </TooltipContent>
+                            </Tooltip>
+                          </div>
+                        ) : null}
+                        {showInlineAgentCards ? (
+                          // Why: nested lineage children use this compact
+                          // renderer instead of WorktreeCard, so their inline
+                          // agent rows must be mounted here explicitly.
+                          <WorktreeCardAgents
+                            worktreeId={child.worktree.id}
+                            className="mt-1 divide-y-0"
+                          />
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-                </WorktreeContextMenu>
+                  </WorktreeContextMenu>
+                </div>
               </div>
             )
           }

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/store/selectors'
 import WorktreeCard from './WorktreeCard'
 import WorktreeCardAgents from './WorktreeCardAgents'
+import RepoAddToSpaceButton from './RepoAddToSpaceButton'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -457,6 +458,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const spaces = useAppStore((s) => s.spaces)
   const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
   const setActiveSpace = useAppStore((s) => s.setActiveSpace)
+  // Why: badge/add-button logic below renders only in the All Projects view
+  // (activeSpaceId === null). Inside a specific space, the assignment is
+  // already implied by the active tab so showing it on every row is redundant.
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
   const renderRowKeySignature = useMemo(
     () => renderRows.map(getRenderRowKey).join('\n'),
     [renderRows]
@@ -843,36 +848,40 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       {row.label}
                     </div>
                     {isRepoHeader ? (
-                      assignedSpace ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Badge
-                              variant="outline"
-                              role="button"
-                              tabIndex={0}
-                              className="h-[16px] shrink-0 cursor-pointer rounded border-foreground/20 bg-foreground/[0.06] px-1.5 text-[10px] font-medium leading-none text-foreground/70 transition-colors hover:bg-foreground/[0.12] hover:text-foreground"
-                              onClick={(e) => {
-                                // Why: the parent row's onClick toggles
-                                // group collapse — without stopPropagation
-                                // the pill click would also fire that.
-                                e.stopPropagation()
-                                setActiveSpace(assignedSpace.id)
-                              }}
-                              onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                  e.preventDefault()
+                      activeSpaceId === null ? (
+                        assignedSpace ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Badge
+                                variant="outline"
+                                role="button"
+                                tabIndex={0}
+                                className="h-[16px] shrink-0 cursor-pointer rounded border-foreground/20 bg-foreground/[0.06] px-1.5 text-[10px] font-medium leading-none text-foreground/70 transition-colors hover:bg-foreground/[0.12] hover:text-foreground"
+                                onClick={(e) => {
+                                  // Why: the parent row's onClick toggles
+                                  // group collapse — without stopPropagation
+                                  // the pill click would also fire that.
                                   e.stopPropagation()
                                   setActiveSpace(assignedSpace.id)
-                                }
-                              }}
-                            >
-                              {assignedSpace.name}
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" sideOffset={8}>
-                            Switch to {assignedSpace.name} space
-                          </TooltipContent>
-                        </Tooltip>
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    setActiveSpace(assignedSpace.id)
+                                  }
+                                }}
+                              >
+                                {assignedSpace.name}
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" sideOffset={8}>
+                              Switch to {assignedSpace.name} space
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <RepoAddToSpaceButton repoId={row.repo!.id} />
+                        )
                       ) : null
                     ) : (
                       <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -64,6 +64,7 @@ import {
 } from '@/hooks/useVirtualizedScrollAnchor'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoHeaderDrag } from './repo-header-drag'
+import RepoGroupHeaderDraggable from './RepoGroupHeaderDraggable'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import {
   areWorktreeSelectionsEqual,
@@ -759,6 +760,130 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses)
                 : null
             const isPinnedHeader = row.key === PINNED_GROUP_KEY
+            const headerInner = (
+              <div
+                role="button"
+                tabIndex={0}
+                data-repo-header-id={repoIdForHeader}
+                data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
+                data-workspace-status={headerWorkspaceStatus ?? undefined}
+                data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
+                className={cn(
+                  'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1 text-left transition-all',
+                  'cursor-pointer',
+                  isDraggingThis &&
+                    'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
+                  headerWorkspaceStatus &&
+                    dragOverStatus === headerWorkspaceStatus &&
+                    'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
+                  isPinnedHeader &&
+                    pinDragOver &&
+                    'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
+                  // First header sits directly under SidebarHeader, which already
+                  // supplies its own spacing — only offset secondary group headers.
+                  vItem.index !== firstHeaderIndex && 'mt-2',
+                  row.repo && 'overflow-hidden'
+                )}
+                onDragOver={
+                  isPinnedHeader
+                    ? handleWorkspacePinDragOver
+                    : headerWorkspaceStatus
+                      ? (event) => handleWorkspaceStatusDragOver(event, headerWorkspaceStatus)
+                      : undefined
+                }
+                onDragLeave={
+                  isPinnedHeader
+                    ? handleWorkspacePinDragLeave
+                    : headerWorkspaceStatus
+                      ? handleWorkspaceStatusDragLeave
+                      : undefined
+                }
+                onDrop={
+                  headerWorkspaceStatus
+                    ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
+                    : undefined
+                }
+                onClick={() => toggleGroupWithScrollAnchor(row.key)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    toggleGroupWithScrollAnchor(row.key)
+                  }
+                }}
+              >
+                {row.icon ? (
+                  <div
+                    onPointerDown={
+                      canReorderRepoHeaders && isRepoHeader && repoIdForHeader
+                        ? (e) => {
+                            // Why: keep the repo-reorder controller authoritative
+                            // for the folder icon. Without stopPropagation, the
+                            // outer dnd-kit useDraggable would also arm and a
+                            // single press could end up tracked by both systems.
+                            e.stopPropagation()
+                            repoDrag.onHandlePointerDown(e, repoIdForHeader)
+                          }
+                        : undefined
+                    }
+                    className={cn(
+                      'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
+                      row.repo ? 'text-muted-foreground' : row.tone
+                    )}
+                  >
+                    <row.icon className={row.repo ? 'size-3.5' : 'size-3'} />
+                  </div>
+                ) : null}
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <div className="truncate text-[13px] font-semibold leading-none">
+                      {row.label}
+                    </div>
+                    <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
+                      {row.count}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
+                  <ChevronDown
+                    className={cn(
+                      'size-3.5 cursor-pointer transition-transform [&_path]:cursor-pointer',
+                      collapsedGroups.has(row.key) && '-rotate-90'
+                    )}
+                  />
+                </div>
+
+                {row.repo && groupBy === 'repo' ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
+                        aria-label={`Create worktree for ${row.label}`}
+                        onClick={(event) => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          if (row.repo && isGitRepoKind(row.repo)) {
+                            handleCreateForRepo(row.repo.id)
+                          }
+                        }}
+                        disabled={row.repo ? !isGitRepoKind(row.repo) : false}
+                      >
+                        <Plus className="size-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" sideOffset={6}>
+                      {row.repo && !isGitRepoKind(row.repo)
+                        ? `${row.label} is opened as a folder`
+                        : `Create worktree for ${row.label}`}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
+              </div>
+            )
             return (
               <div
                 key={vItem.key}
@@ -770,121 +895,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 className="absolute left-0 right-0"
                 style={{ transform: getVirtualRowTransform(vItem.start) }}
               >
-                <div
-                  role="button"
-                  tabIndex={0}
-                  data-repo-header-id={repoIdForHeader}
-                  data-workspace-status-drop-target={headerWorkspaceStatus ? '' : undefined}
-                  data-workspace-status={headerWorkspaceStatus ?? undefined}
-                  data-workspace-pin-drop-target={isPinnedHeader ? '' : undefined}
-                  className={cn(
-                    'group flex h-7 w-full items-center gap-1.5 pl-3 pr-1 text-left transition-all',
-                    'cursor-pointer',
-                    isDraggingThis &&
-                      'bg-accent/80 ring-1 ring-ring/40 shadow-md rounded-md scale-[1.01]',
-                    headerWorkspaceStatus &&
-                      dragOverStatus === headerWorkspaceStatus &&
-                      'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
-                    isPinnedHeader &&
-                      pinDragOver &&
-                      'rounded-md bg-sidebar-accent ring-1 ring-sidebar-ring/40',
-                    // First header sits directly under SidebarHeader, which already
-                    // supplies its own spacing — only offset secondary group headers.
-                    vItem.index !== firstHeaderIndex && 'mt-2',
-                    row.repo && 'overflow-hidden'
-                  )}
-                  onDragOver={
-                    isPinnedHeader
-                      ? handleWorkspacePinDragOver
-                      : headerWorkspaceStatus
-                        ? (event) => handleWorkspaceStatusDragOver(event, headerWorkspaceStatus)
-                        : undefined
-                  }
-                  onDragLeave={
-                    isPinnedHeader
-                      ? handleWorkspacePinDragLeave
-                      : headerWorkspaceStatus
-                        ? handleWorkspaceStatusDragLeave
-                        : undefined
-                  }
-                  onDrop={
-                    headerWorkspaceStatus
-                      ? (event) => handleWorkspaceStatusDrop(event, headerWorkspaceStatus)
-                      : undefined
-                  }
-                  onClick={() => toggleGroupWithScrollAnchor(row.key)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      toggleGroupWithScrollAnchor(row.key)
-                    }
-                  }}
-                >
-                  {row.icon ? (
-                    <div
-                      onPointerDown={
-                        canReorderRepoHeaders && isRepoHeader && repoIdForHeader
-                          ? (e) => repoDrag.onHandlePointerDown(e, repoIdForHeader)
-                          : undefined
-                      }
-                      className={cn(
-                        'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                        row.repo ? 'text-muted-foreground' : row.tone
-                      )}
-                    >
-                      <row.icon className={row.repo ? 'size-3.5' : 'size-3'} />
-                    </div>
-                  ) : null}
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      <div className="truncate text-[13px] font-semibold leading-none">
-                        {row.label}
-                      </div>
-                      <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
-                        {row.count}
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
-                    <ChevronDown
-                      className={cn(
-                        'size-3.5 cursor-pointer transition-transform [&_path]:cursor-pointer',
-                        collapsedGroups.has(row.key) && '-rotate-90'
-                      )}
-                    />
-                  </div>
-
-                  {row.repo && groupBy === 'repo' ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
-                          aria-label={`Create worktree for ${row.label}`}
-                          onClick={(event) => {
-                            event.preventDefault()
-                            event.stopPropagation()
-                            if (row.repo && isGitRepoKind(row.repo)) {
-                              handleCreateForRepo(row.repo.id)
-                            }
-                          }}
-                          disabled={row.repo ? !isGitRepoKind(row.repo) : false}
-                        >
-                          <Plus className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={6}>
-                        {row.repo && !isGitRepoKind(row.repo)
-                          ? `${row.label} is opened as a folder`
-                          : `Create worktree for ${row.label}`}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                </div>
+                {isRepoHeader && repoIdForHeader ? (
+                  <RepoGroupHeaderDraggable repoId={repoIdForHeader}>
+                    {headerInner}
+                  </RepoGroupHeaderDraggable>
+                ) : (
+                  headerInner
+                )}
               </div>
             )
           }
@@ -1160,6 +1177,8 @@ const WorktreeList = React.memo(function WorktreeList({
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
+  const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
   const openModal = useAppStore((s) => s.openModal)
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const updateWorktreesMeta = useAppStore((s) => s.updateWorktreesMeta)
@@ -1432,7 +1451,9 @@ const WorktreeList = React.memo(function WorktreeList({
       browserTabsByWorktree,
       activeWorktreeId,
       hideDefaultBranchWorkspace,
-      repoMap
+      repoMap,
+      activeSpaceId,
+      repoSpaceAssignments
     })
     return ids.map((id) => worktreeMap.get(id)).filter((w): w is Worktree => w != null)
   }, [
@@ -1446,7 +1467,9 @@ const WorktreeList = React.memo(function WorktreeList({
     browserTabsByWorktree,
     sortedIds,
     worktreeMap,
-    worktreesByRepo
+    worktreesByRepo,
+    activeSpaceId,
+    repoSpaceAssignments
   ])
 
   const worktrees = visibleWorktrees

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
+import { DndContext, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core'
 import { useAppStore } from '@/store'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import SidebarHeader from './SidebarHeader'
 import SidebarNav from './SidebarNav'
+import SpaceTabs from './SpaceTabs'
 import WorktreeList from './WorktreeList'
 import SidebarToolbar from './SidebarToolbar'
 import WorktreeMetaDialog from './WorktreeMetaDialog'
@@ -30,6 +32,55 @@ function Sidebar({
   const setSidebarWidth = useAppStore((s) => s.setSidebarWidth)
   const repos = useAppStore((s) => s.repos)
   const fetchAllWorktrees = useAppStore((s) => s.fetchAllWorktrees)
+  const spaces = useAppStore((s) => s.spaces)
+  const moveRepoToSpace = useAppStore((s) => s.moveRepoToSpace)
+  const reorderSpaces = useAppStore((s) => s.reorderSpaces)
+
+  // Why: 4px matches the tab-reorder + repo-reorder thresholds elsewhere in the
+  // sidebar so click-to-switch on a tab still fires without engaging dnd-kit on
+  // tiny accidental movements.
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 4 }
+  })
+  const sensors = useSensors(pointerSensor)
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over) {
+        return
+      }
+      const activeKind = active.data.current?.kind
+      const overKind = over.data.current?.kind
+
+      // Repo dragged onto a Space tab → (re)assign or unassign.
+      if (activeKind === 'repo' && overKind === 'space') {
+        const repoId = active.data.current?.repoId as string | undefined
+        const spaceId = (over.data.current?.spaceId ?? null) as string | null
+        if (repoId) {
+          moveRepoToSpace(repoId, spaceId)
+        }
+        return
+      }
+
+      // Space tab reorder — active.id and over.id are Space ids inside the
+      // SortableContext. Build the new order by swapping active into over's
+      // index in the current sorted-by-order list.
+      if (activeKind === 'tab' && overKind === 'tab' && active.id !== over.id) {
+        const sortedIds = [...spaces].sort((a, b) => a.order - b.order).map((s) => s.id)
+        const fromIndex = sortedIds.indexOf(String(active.id))
+        const toIndex = sortedIds.indexOf(String(over.id))
+        if (fromIndex < 0 || toIndex < 0) {
+          return
+        }
+        const next = sortedIds.slice()
+        next.splice(fromIndex, 1)
+        next.splice(toIndex, 0, String(active.id))
+        reorderSpaces(next)
+      }
+    },
+    [moveRepoToSpace, reorderSpaces, spaces]
+  )
 
   const setLiveSidebarWidth = React.useCallback((width: number) => {
     document.documentElement.style.setProperty('--workspace-sidebar-live-width', `${width}px`)
@@ -65,12 +116,16 @@ function Sidebar({
       >
         {/* Fixed controls */}
         <SidebarNav />
-        <SidebarHeader />
 
-        <WorktreeList
-          scrollOffsetRef={worktreeScrollOffsetRef}
-          scrollAnchorRef={worktreeScrollAnchorRef}
-        />
+        <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+          <SpaceTabs />
+          <SidebarHeader />
+
+          <WorktreeList
+            scrollOffsetRef={worktreeScrollOffsetRef}
+            scrollAnchorRef={worktreeScrollAnchorRef}
+          />
+        </DndContext>
 
         {/* Fixed bottom toolbar */}
         <SidebarToolbar />

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -33,7 +33,6 @@ function Sidebar({
   const repos = useAppStore((s) => s.repos)
   const fetchAllWorktrees = useAppStore((s) => s.fetchAllWorktrees)
   const spaces = useAppStore((s) => s.spaces)
-  const moveRepoToSpace = useAppStore((s) => s.moveRepoToSpace)
   const reorderSpaces = useAppStore((s) => s.reorderSpaces)
 
   // Why: 4px matches the tab-reorder + repo-reorder thresholds elsewhere in the
@@ -53,19 +52,10 @@ function Sidebar({
       const activeKind = active.data.current?.kind
       const overKind = over.data.current?.kind
 
-      // Repo dragged onto a Space tab → (re)assign or unassign.
-      if (activeKind === 'repo' && overKind === 'space') {
-        const repoId = active.data.current?.repoId as string | undefined
-        const spaceId = (over.data.current?.spaceId ?? null) as string | null
-        if (repoId) {
-          moveRepoToSpace(repoId, spaceId)
-        }
-        return
-      }
-
       // Space tab reorder — active.id and over.id are Space ids inside the
       // SortableContext. Build the new order by swapping active into over's
-      // index in the current sorted-by-order list.
+      // index in the current sorted-by-order list. Repo→Space drops do not
+      // come through here — those use native HTML5 drag handled in SpaceTab.
       if (activeKind === 'tab' && overKind === 'tab' && active.id !== over.id) {
         const sortedIds = [...spaces].sort((a, b) => a.order - b.order).map((s) => s.id)
         const fromIndex = sortedIds.indexOf(String(active.id))
@@ -79,7 +69,7 @@ function Sidebar({
         reorderSpaces(next)
       }
     },
-    [moveRepoToSpace, reorderSpaces, spaces]
+    [reorderSpaces, spaces]
   )
 
   const setLiveSidebarWidth = React.useCallback((width: number) => {

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -123,7 +123,7 @@ function Sidebar({
         {/* Resize handle */}
         <div
           data-sidebar-resize-handle=""
-          className="absolute top-0 right-0 h-full w-5 cursor-col-resize transition-colors z-10 before:absolute before:inset-y-0 before:right-0 before:w-1 before:transition-colors hover:before:bg-ring/20 active:before:bg-ring/30"
+          className="absolute top-0 right-0 h-full w-2 cursor-col-resize transition-colors z-10 before:absolute before:inset-y-0 before:right-0 before:w-1 before:transition-colors hover:before:bg-ring/20 active:before:bg-ring/30"
           onMouseDown={onResizeStart}
         />
       </div>

--- a/src/renderer/src/components/sidebar/repo-drag-types.ts
+++ b/src/renderer/src/components/sidebar/repo-drag-types.ts
@@ -1,0 +1,24 @@
+// Why: project headers and Space tabs use native HTML5 drag-and-drop (not
+// dnd-kit) so the gesture lives in the same event system as the existing
+// worktree-card kanban drag. This module owns the repo-id payload used when a
+// project header is dragged onto a Space tab.
+
+export const ORCA_REPO_DRAG_TYPE = 'application/x-orca-repo-id'
+
+export function writeRepoDragData(dataTransfer: DataTransfer, repoId: string): void {
+  dataTransfer.effectAllowed = 'move'
+  dataTransfer.setData(ORCA_REPO_DRAG_TYPE, repoId)
+  // Why: a text/plain fallback keeps the drag intelligible to other surfaces
+  // (Electron's outer chrome, debug tooling) that don't recognize the custom
+  // MIME type but can still show a useful label.
+  dataTransfer.setData('text/plain', repoId)
+}
+
+export function readRepoDragId(dataTransfer: DataTransfer): string | null {
+  const typed = dataTransfer.getData(ORCA_REPO_DRAG_TYPE)
+  return typed.length > 0 ? typed : null
+}
+
+export function hasRepoDragData(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.types).includes(ORCA_REPO_DRAG_TYPE)
+}

--- a/src/renderer/src/components/sidebar/space-notification-test-fixtures.ts
+++ b/src/renderer/src/components/sidebar/space-notification-test-fixtures.ts
@@ -1,0 +1,96 @@
+import type {
+  AgentStatusEntry,
+  MigrationUnsupportedPtyEntry
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab, Worktree } from '../../../../shared/types'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { AppState } from '@/store'
+
+export const LEAF_A = '11111111-1111-4111-8111-111111111111'
+export const LEAF_B = '22222222-2222-4222-8222-222222222222'
+export const LEAF_C = '33333333-3333-4333-8333-333333333333'
+export const LEAF_D = '44444444-4444-4444-8444-444444444444'
+
+export type StoreInputs = {
+  tabsByWorktree?: Record<string, TerminalTab[]>
+  worktreesByRepo?: Record<string, Worktree[]>
+  repoSpaceAssignments?: Record<string, string>
+  agentStatusByPaneKey?: Record<string, AgentStatusEntry>
+  retainedAgentsByPaneKey?: Record<string, RetainedAgentEntry>
+  migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>
+  acknowledgedAgentsByPaneKey?: Record<string, number>
+}
+
+export function makeState(inputs: StoreInputs = {}): AppState {
+  return {
+    tabsByWorktree: {},
+    worktreesByRepo: {},
+    repoSpaceAssignments: {},
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    migrationUnsupportedByPtyId: {},
+    acknowledgedAgentsByPaneKey: {},
+    ...inputs
+  } as unknown as AppState
+}
+
+export function makeTab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    ptyId: 'pty-1',
+    worktreeId,
+    title: 'bash',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+export function makeWorktree(id: string, repoId: string): Worktree {
+  return {
+    id,
+    repoId,
+    path: `/tmp/${id}`,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+export function makeEntry(args: {
+  paneKey: string
+  state: AgentStatusEntry['state']
+  stateStartedAt?: number
+  history?: AgentStatusEntry['stateHistory']
+}): AgentStatusEntry {
+  return {
+    paneKey: args.paneKey,
+    state: args.state,
+    prompt: '',
+    updatedAt: args.stateStartedAt ?? 1_000,
+    stateStartedAt: args.stateStartedAt ?? 1_000,
+    stateHistory: args.history ?? []
+  }
+}
+
+export function makeRetained(entry: AgentStatusEntry, worktreeId: string): RetainedAgentEntry {
+  return {
+    entry,
+    worktreeId,
+    tab: makeTab('retained-tab', worktreeId),
+    agentType: 'unknown',
+    startedAt: entry.stateStartedAt
+  }
+}

--- a/src/renderer/src/components/sidebar/use-space-notification-counts.test.ts
+++ b/src/renderer/src/components/sidebar/use-space-notification-counts.test.ts
@@ -1,102 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import type {
-  AgentStatusEntry,
-  MigrationUnsupportedPtyEntry
-} from '../../../../shared/agent-status-types'
-import type { TerminalTab, Worktree } from '../../../../shared/types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
-import type { RetainedAgentEntry } from '@/store/slices/agent-status'
-import type { AppState } from '@/store'
-import { selectSpaceNotificationCounts } from './use-space-notification-counts'
-
-const LEAF_A = '11111111-1111-4111-8111-111111111111'
-const LEAF_B = '22222222-2222-4222-8222-222222222222'
-const LEAF_C = '33333333-3333-4333-8333-333333333333'
-const LEAF_D = '44444444-4444-4444-8444-444444444444'
-
-type StoreInputs = {
-  tabsByWorktree?: Record<string, TerminalTab[]>
-  worktreesByRepo?: Record<string, Worktree[]>
-  repoSpaceAssignments?: Record<string, string>
-  agentStatusByPaneKey?: Record<string, AgentStatusEntry>
-  retainedAgentsByPaneKey?: Record<string, RetainedAgentEntry>
-  migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>
-  acknowledgedAgentsByPaneKey?: Record<string, number>
-}
-
-function makeState(inputs: StoreInputs = {}): AppState {
-  return {
-    tabsByWorktree: {},
-    worktreesByRepo: {},
-    repoSpaceAssignments: {},
-    agentStatusByPaneKey: {},
-    retainedAgentsByPaneKey: {},
-    migrationUnsupportedByPtyId: {},
-    acknowledgedAgentsByPaneKey: {},
-    ...inputs
-  } as unknown as AppState
-}
-
-function makeTab(id: string, worktreeId: string): TerminalTab {
-  return {
-    id,
-    ptyId: 'pty-1',
-    worktreeId,
-    title: 'bash',
-    customTitle: null,
-    color: null,
-    sortOrder: 0,
-    createdAt: 0
-  }
-}
-
-function makeWorktree(id: string, repoId: string): Worktree {
-  return {
-    id,
-    repoId,
-    path: `/tmp/${id}`,
-    head: '',
-    branch: '',
-    isBare: false,
-    isMainWorktree: false,
-    displayName: id,
-    comment: '',
-    linkedIssue: null,
-    linkedPR: null,
-    linkedLinearIssue: null,
-    isArchived: false,
-    isUnread: false,
-    isPinned: false,
-    sortOrder: 0,
-    lastActivityAt: 0
-  }
-}
-
-function makeEntry(args: {
-  paneKey: string
-  state: AgentStatusEntry['state']
-  stateStartedAt?: number
-  history?: AgentStatusEntry['stateHistory']
-}): AgentStatusEntry {
-  return {
-    paneKey: args.paneKey,
-    state: args.state,
-    prompt: '',
-    updatedAt: args.stateStartedAt ?? 1_000,
-    stateStartedAt: args.stateStartedAt ?? 1_000,
-    stateHistory: args.history ?? []
-  }
-}
-
-function makeRetained(entry: AgentStatusEntry, worktreeId: string): RetainedAgentEntry {
-  return {
-    entry,
-    worktreeId,
-    tab: makeTab('retained-tab', worktreeId),
-    agentType: 'unknown',
-    startedAt: entry.stateStartedAt
-  }
-}
+import {
+  LEAF_A,
+  LEAF_B,
+  LEAF_C,
+  LEAF_D,
+  makeEntry,
+  makeRetained,
+  makeState,
+  makeTab,
+  makeWorktree
+} from './space-notification-test-fixtures'
+import {
+  selectAllAgentsUnreadCount,
+  selectSpaceNotificationCounts
+} from './use-space-notification-counts'
 
 describe('selectSpaceNotificationCounts', () => {
   it('returns {} for an empty store', () => {
@@ -235,5 +153,127 @@ describe('selectSpaceNotificationCounts', () => {
     })
 
     expect(selectSpaceNotificationCounts(state)).toEqual({ 'space-legacy': 1 })
+  })
+})
+
+describe('selectAllAgentsUnreadCount', () => {
+  it('returns 0 for an empty store', () => {
+    expect(selectAllAgentsUnreadCount(makeState())).toBe(0)
+  })
+
+  it('sums unread across assigned and unassigned repos', () => {
+    const paneOrca = makePaneKey('tab-orca-1', LEAF_A)
+    const paneBusiness = makePaneKey('tab-business-1', LEAF_B)
+    const paneUnassigned = makePaneKey('tab-unassigned-1', LEAF_C)
+
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-orca': [makeTab('tab-orca-1', 'wt-orca')],
+        'wt-business': [makeTab('tab-business-1', 'wt-business')],
+        'wt-unassigned': [makeTab('tab-unassigned-1', 'wt-unassigned')]
+      },
+      worktreesByRepo: {
+        'repo-orca': [makeWorktree('wt-orca', 'repo-orca')],
+        'repo-business': [makeWorktree('wt-business', 'repo-business')],
+        'repo-unassigned': [makeWorktree('wt-unassigned', 'repo-unassigned')]
+      },
+      repoSpaceAssignments: {
+        'repo-orca': 'space-orca',
+        'repo-business': 'space-business'
+      },
+      agentStatusByPaneKey: {
+        [paneOrca]: makeEntry({
+          paneKey: paneOrca,
+          state: 'blocked',
+          stateStartedAt: 2_000,
+          history: [{ state: 'done', prompt: '', startedAt: 1_500 }]
+        }),
+        [paneBusiness]: makeEntry({
+          paneKey: paneBusiness,
+          state: 'done',
+          stateStartedAt: 2_000
+        }),
+        [paneUnassigned]: makeEntry({
+          paneKey: paneUnassigned,
+          state: 'waiting',
+          stateStartedAt: 5_000,
+          history: [
+            { state: 'done', prompt: '', startedAt: 1_000 },
+            { state: 'blocked', prompt: '', startedAt: 2_000 },
+            { state: 'waiting', prompt: '', startedAt: 3_000 },
+            { state: 'done', prompt: '', startedAt: 4_000 }
+          ]
+        })
+      }
+    })
+
+    // 2 (orca) + 1 (business) + 5 (unassigned) = 8
+    expect(selectAllAgentsUnreadCount(state)).toBe(8)
+
+    // The load-bearing invariant: All Projects = Σ(per-Space) + unassigned.
+    const perSpace = selectSpaceNotificationCounts(state)
+    const spaceSum = Object.values(perSpace).reduce((a, b) => a + b, 0)
+    expect(selectAllAgentsUnreadCount(state)).toBe(spaceSum + 5)
+  })
+
+  it('respects acknowledgement timestamps', () => {
+    const paneAck = makePaneKey('tab-ack', LEAF_A)
+    const paneFresh = makePaneKey('tab-fresh', LEAF_B)
+
+    const state = makeState({
+      agentStatusByPaneKey: {
+        [paneAck]: makeEntry({ paneKey: paneAck, state: 'done', stateStartedAt: 1_000 }),
+        [paneFresh]: makeEntry({ paneKey: paneFresh, state: 'done', stateStartedAt: 2_000 })
+      },
+      acknowledgedAgentsByPaneKey: {
+        [paneAck]: 5_000,
+        [paneFresh]: 1_500
+      }
+    })
+
+    expect(selectAllAgentsUnreadCount(state)).toBe(1)
+  })
+
+  it('counts retained agents regardless of Space assignment', () => {
+    const retainedAssigned = makePaneKey('tab-assigned-vanished', LEAF_A)
+    const retainedUnassigned = makePaneKey('tab-unassigned-vanished', LEAF_B)
+
+    const state = makeState({
+      worktreesByRepo: {
+        'repo-orca': [makeWorktree('wt-orca', 'repo-orca')]
+      },
+      repoSpaceAssignments: { 'repo-orca': 'space-orca' },
+      retainedAgentsByPaneKey: {
+        [retainedAssigned]: makeRetained(
+          makeEntry({ paneKey: retainedAssigned, state: 'done', stateStartedAt: 1_000 }),
+          'wt-orca'
+        ),
+        [retainedUnassigned]: makeRetained(
+          makeEntry({ paneKey: retainedUnassigned, state: 'done', stateStartedAt: 2_000 }),
+          'wt-floating'
+        )
+      }
+    })
+
+    expect(selectAllAgentsUnreadCount(state)).toBe(2)
+  })
+
+  it('includes migration-unsupported entries', () => {
+    const migrationPane = makePaneKey('tab-legacy', LEAF_D)
+
+    const state = makeState({
+      migrationUnsupportedByPtyId: {
+        'pty-legacy-1': {
+          ptyId: 'pty-legacy-1',
+          paneKey: migrationPane,
+          worktreeId: 'wt-legacy',
+          reason: 'legacy-numeric-pane-key',
+          source: 'local',
+          updatedAt: 1_000
+        }
+      }
+    })
+
+    expect(selectAllAgentsUnreadCount(state)).toBe(1)
   })
 })

--- a/src/renderer/src/components/sidebar/use-space-notification-counts.test.ts
+++ b/src/renderer/src/components/sidebar/use-space-notification-counts.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  AgentStatusEntry,
+  MigrationUnsupportedPtyEntry
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab, Worktree } from '../../../../shared/types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { AppState } from '@/store'
+import { selectSpaceNotificationCounts } from './use-space-notification-counts'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+const LEAF_C = '33333333-3333-4333-8333-333333333333'
+const LEAF_D = '44444444-4444-4444-8444-444444444444'
+
+type StoreInputs = {
+  tabsByWorktree?: Record<string, TerminalTab[]>
+  worktreesByRepo?: Record<string, Worktree[]>
+  repoSpaceAssignments?: Record<string, string>
+  agentStatusByPaneKey?: Record<string, AgentStatusEntry>
+  retainedAgentsByPaneKey?: Record<string, RetainedAgentEntry>
+  migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>
+  acknowledgedAgentsByPaneKey?: Record<string, number>
+}
+
+function makeState(inputs: StoreInputs = {}): AppState {
+  return {
+    tabsByWorktree: {},
+    worktreesByRepo: {},
+    repoSpaceAssignments: {},
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    migrationUnsupportedByPtyId: {},
+    acknowledgedAgentsByPaneKey: {},
+    ...inputs
+  } as unknown as AppState
+}
+
+function makeTab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    ptyId: 'pty-1',
+    worktreeId,
+    title: 'bash',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeWorktree(id: string, repoId: string): Worktree {
+  return {
+    id,
+    repoId,
+    path: `/tmp/${id}`,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+function makeEntry(args: {
+  paneKey: string
+  state: AgentStatusEntry['state']
+  stateStartedAt?: number
+  history?: AgentStatusEntry['stateHistory']
+}): AgentStatusEntry {
+  return {
+    paneKey: args.paneKey,
+    state: args.state,
+    prompt: '',
+    updatedAt: args.stateStartedAt ?? 1_000,
+    stateStartedAt: args.stateStartedAt ?? 1_000,
+    stateHistory: args.history ?? []
+  }
+}
+
+function makeRetained(entry: AgentStatusEntry, worktreeId: string): RetainedAgentEntry {
+  return {
+    entry,
+    worktreeId,
+    tab: makeTab('retained-tab', worktreeId),
+    agentType: 'unknown',
+    startedAt: entry.stateStartedAt
+  }
+}
+
+describe('selectSpaceNotificationCounts', () => {
+  it('returns {} for an empty store', () => {
+    expect(selectSpaceNotificationCounts(makeState())).toEqual({})
+  })
+
+  it('counts unread events per space, skipping unassigned repos', () => {
+    const paneOrcaA = makePaneKey('tab-orca-1', LEAF_A)
+    const paneBusiness = makePaneKey('tab-business-1', LEAF_B)
+    const paneUnassigned = makePaneKey('tab-unassigned-1', LEAF_C)
+
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-orca': [makeTab('tab-orca-1', 'wt-orca')],
+        'wt-business': [makeTab('tab-business-1', 'wt-business')],
+        'wt-unassigned': [makeTab('tab-unassigned-1', 'wt-unassigned')]
+      },
+      worktreesByRepo: {
+        'repo-orca': [makeWorktree('wt-orca', 'repo-orca')],
+        'repo-business': [makeWorktree('wt-business', 'repo-business')],
+        'repo-unassigned': [makeWorktree('wt-unassigned', 'repo-unassigned')]
+      },
+      repoSpaceAssignments: {
+        'repo-orca': 'space-orca',
+        'repo-business': 'space-business'
+      },
+      agentStatusByPaneKey: {
+        // 2 unread for orca: one historical `done`, one live `blocked`.
+        [paneOrcaA]: makeEntry({
+          paneKey: paneOrcaA,
+          state: 'blocked',
+          stateStartedAt: 2_000,
+          history: [{ state: 'done', prompt: '', startedAt: 1_500 }]
+        }),
+        // 1 unread for business.
+        [paneBusiness]: makeEntry({
+          paneKey: paneBusiness,
+          state: 'done',
+          stateStartedAt: 2_000
+        }),
+        // 5 unread for an unassigned repo — must not be counted under any space.
+        [paneUnassigned]: makeEntry({
+          paneKey: paneUnassigned,
+          state: 'waiting',
+          stateStartedAt: 5_000,
+          history: [
+            { state: 'done', prompt: '', startedAt: 1_000 },
+            { state: 'blocked', prompt: '', startedAt: 2_000 },
+            { state: 'waiting', prompt: '', startedAt: 3_000 },
+            { state: 'done', prompt: '', startedAt: 4_000 }
+          ]
+        })
+      }
+    })
+
+    expect(selectSpaceNotificationCounts(state)).toEqual({
+      'space-orca': 2,
+      'space-business': 1
+    })
+  })
+
+  it('respects acknowledgement timestamps', () => {
+    const paneAck = makePaneKey('tab-ack', LEAF_A)
+    const paneFresh = makePaneKey('tab-fresh', LEAF_B)
+
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-ack': [makeTab('tab-ack', 'wt-ack')],
+        'wt-fresh': [makeTab('tab-fresh', 'wt-fresh')]
+      },
+      worktreesByRepo: {
+        'repo-ack': [makeWorktree('wt-ack', 'repo-ack')],
+        'repo-fresh': [makeWorktree('wt-fresh', 'repo-fresh')]
+      },
+      repoSpaceAssignments: {
+        'repo-ack': 'space-x',
+        'repo-fresh': 'space-x'
+      },
+      agentStatusByPaneKey: {
+        [paneAck]: makeEntry({ paneKey: paneAck, state: 'done', stateStartedAt: 1_000 }),
+        [paneFresh]: makeEntry({ paneKey: paneFresh, state: 'done', stateStartedAt: 2_000 })
+      },
+      acknowledgedAgentsByPaneKey: {
+        // Acknowledged after the event → not counted.
+        [paneAck]: 5_000,
+        // Acknowledged before the event → still unread.
+        [paneFresh]: 1_500
+      }
+    })
+
+    expect(selectSpaceNotificationCounts(state)).toEqual({ 'space-x': 1 })
+  })
+
+  it('counts retained agents via their stored worktreeId (no pane-key reverse lookup)', () => {
+    const retainedPane = makePaneKey('tab-vanished', LEAF_A)
+
+    const state = makeState({
+      // Tab is gone from tabsByWorktree — the entry only resolves via retained.worktreeId.
+      tabsByWorktree: {},
+      worktreesByRepo: {
+        'repo-orca': [makeWorktree('wt-orca', 'repo-orca')]
+      },
+      repoSpaceAssignments: { 'repo-orca': 'space-orca' },
+      retainedAgentsByPaneKey: {
+        [retainedPane]: makeRetained(
+          makeEntry({ paneKey: retainedPane, state: 'done', stateStartedAt: 1_000 }),
+          'wt-orca'
+        )
+      }
+    })
+
+    expect(selectSpaceNotificationCounts(state)).toEqual({ 'space-orca': 1 })
+  })
+
+  it('includes migration-unsupported entries', () => {
+    const migrationPane = makePaneKey('tab-legacy', LEAF_D)
+
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-legacy': [makeTab('tab-legacy', 'wt-legacy')]
+      },
+      worktreesByRepo: {
+        'repo-legacy': [makeWorktree('wt-legacy', 'repo-legacy')]
+      },
+      repoSpaceAssignments: { 'repo-legacy': 'space-legacy' },
+      migrationUnsupportedByPtyId: {
+        'pty-legacy-1': {
+          ptyId: 'pty-legacy-1',
+          paneKey: migrationPane,
+          worktreeId: 'wt-legacy',
+          reason: 'legacy-numeric-pane-key',
+          source: 'local',
+          updatedAt: 1_000
+        }
+      }
+    })
+
+    expect(selectSpaceNotificationCounts(state)).toEqual({ 'space-legacy': 1 })
+  })
+})

--- a/src/renderer/src/components/sidebar/use-space-notification-counts.ts
+++ b/src/renderer/src/components/sidebar/use-space-notification-counts.ts
@@ -9,13 +9,12 @@ import type { AppState } from '@/store'
  * Per-Space unread agent-event count, keyed by spaceId.
  *
  * Worktrees whose repo has no Space assignment are intentionally excluded —
- * they only appear under "All Projects", which never shows a badge to avoid
- * re-summarizing counts the user can already see on individual rows.
+ * those events are surfaced by `selectAllAgentsUnreadCount` instead, which
+ * powers the "All Projects" pill and the Activity titlebar badge.
  *
- * Why this matches `useActivityUnreadCount`: when every repo is assigned to
- * a space, the per-space totals sum exactly to the `Agents N` badge in the
- * titlebar. Both readers go through `countUnreadAgentEvents`, so the two
- * surfaces cannot drift.
+ * Why nothing drifts: every reader in this file routes through
+ * `countUnreadAgentEvents`, so the per-Space pills, the All Projects pill,
+ * and the titlebar share one definition of "unread".
  */
 export function selectSpaceNotificationCounts(state: AppState): Record<string, number> {
   const counts: Record<string, number> = {}
@@ -58,10 +57,7 @@ export function selectSpaceNotificationCounts(state: AppState): Record<string, n
   }
 
   for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
-    const events = countUnreadAgentEvents(
-      entry,
-      state.acknowledgedAgentsByPaneKey[paneKey] ?? 0
-    )
+    const events = countUnreadAgentEvents(entry, state.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
     if (events === 0) {
       continue
     }
@@ -111,4 +107,31 @@ export function selectSpaceNotificationCounts(state: AppState): Record<string, n
 
 export function useSpaceNotificationCounts(): Record<string, number> {
   return useAppStore(useShallow(selectSpaceNotificationCounts))
+}
+
+/**
+ * Total unread agent events across every repo — assigned, unassigned, retained,
+ * and migration-unsupported alike. Drives both the "All Projects" pill badge
+ * and the Activity titlebar count, so the two cannot diverge.
+ */
+export function selectAllAgentsUnreadCount(state: AppState): number {
+  let count = 0
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    count += countUnreadAgentEvents(entry, state.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+  }
+  for (const [paneKey, retained] of Object.entries(state.retainedAgentsByPaneKey)) {
+    count += countUnreadAgentEvents(retained.entry, state.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+  }
+  for (const unsupported of Object.values(state.migrationUnsupportedByPtyId)) {
+    const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
+    if (!entry) {
+      continue
+    }
+    count += countUnreadAgentEvents(entry, state.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
+  }
+  return count
+}
+
+export function useAllAgentsUnreadCount(): number {
+  return useAppStore(selectAllAgentsUnreadCount)
 }

--- a/src/renderer/src/components/sidebar/use-space-notification-counts.ts
+++ b/src/renderer/src/components/sidebar/use-space-notification-counts.ts
@@ -1,0 +1,114 @@
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import { countUnreadAgentEvents } from '@/lib/agent-status-unread'
+import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { AppState } from '@/store'
+
+/**
+ * Per-Space unread agent-event count, keyed by spaceId.
+ *
+ * Worktrees whose repo has no Space assignment are intentionally excluded —
+ * they only appear under "All Projects", which never shows a badge to avoid
+ * re-summarizing counts the user can already see on individual rows.
+ *
+ * Why this matches `useActivityUnreadCount`: when every repo is assigned to
+ * a space, the per-space totals sum exactly to the `Agents N` badge in the
+ * titlebar. Both readers go through `countUnreadAgentEvents`, so the two
+ * surfaces cannot drift.
+ */
+export function selectSpaceNotificationCounts(state: AppState): Record<string, number> {
+  const counts: Record<string, number> = {}
+
+  // Why: build the reverse `tabId → worktreeId` map once per evaluation so
+  // each live-agent pane lookup is O(1) instead of scanning every worktree's
+  // tab list for every entry.
+  const tabIdToWorktreeId = new Map<string, string>()
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    for (const tab of tabs) {
+      tabIdToWorktreeId.set(tab.id, worktreeId)
+    }
+  }
+
+  // Why: worktreeId encodes its repoId via the worktree-id format, but we
+  // already iterate `worktreesByRepo` to flatten — caching the
+  // `worktreeId → repoId` mapping keeps the per-entry lookup O(1) and avoids
+  // re-parsing the encoded id (which several stale-snapshot ids in tests do
+  // not follow).
+  const worktreeIdToRepoId = new Map<string, string>()
+  for (const [repoId, worktrees] of Object.entries(state.worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      worktreeIdToRepoId.set(worktree.id, repoId)
+    }
+  }
+
+  const addToSpace = (worktreeId: string | undefined, events: number): void => {
+    if (!worktreeId || events === 0) {
+      return
+    }
+    const repoId = worktreeIdToRepoId.get(worktreeId)
+    if (!repoId) {
+      return
+    }
+    const spaceId = state.repoSpaceAssignments[repoId]
+    if (!spaceId) {
+      return
+    }
+    counts[spaceId] = (counts[spaceId] ?? 0) + events
+  }
+
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    const events = countUnreadAgentEvents(
+      entry,
+      state.acknowledgedAgentsByPaneKey[paneKey] ?? 0
+    )
+    if (events === 0) {
+      continue
+    }
+    const parsed = parsePaneKey(paneKey)
+    if (!parsed) {
+      continue
+    }
+    addToSpace(tabIdToWorktreeId.get(parsed.tabId), events)
+  }
+
+  for (const [paneKey, retained] of Object.entries(state.retainedAgentsByPaneKey)) {
+    const events = countUnreadAgentEvents(
+      retained.entry,
+      state.acknowledgedAgentsByPaneKey[paneKey] ?? 0
+    )
+    addToSpace(retained.worktreeId, events)
+  }
+
+  for (const unsupported of Object.values(state.migrationUnsupportedByPtyId)) {
+    const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
+    if (!entry) {
+      continue
+    }
+    const events = countUnreadAgentEvents(
+      entry,
+      state.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0
+    )
+    if (events === 0) {
+      continue
+    }
+    // Why: migration-unsupported entries can carry an explicit worktreeId
+    // (when the registry knew it at the time the legacy pane was seen).
+    // Fall back to the paneKey reverse lookup so a worktreeId-less entry
+    // still counts when its tab is still in tabsByWorktree.
+    let worktreeId = unsupported.worktreeId
+    if (!worktreeId) {
+      const parsed = parsePaneKey(entry.paneKey)
+      if (parsed) {
+        worktreeId = tabIdToWorktreeId.get(parsed.tabId)
+      }
+    }
+    addToSpace(worktreeId, events)
+  }
+
+  return counts
+}
+
+export function useSpaceNotificationCounts(): Record<string, number> {
+  return useAppStore(useShallow(selectSpaceNotificationCounts))
+}

--- a/src/renderer/src/components/sidebar/use-space-tab-drop.ts
+++ b/src/renderer/src/components/sidebar/use-space-tab-drop.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+import { getWorktreeMapFromState } from '@/store/selectors'
+import { hasRepoDragData, readRepoDragId } from './repo-drag-types'
+import { hasWorkspaceDragData, readWorkspaceDragData } from './workspace-status'
+
+const SPACE_TAB_DROP_TARGET_SELECTOR = '[data-space-drop-target]'
+const ALL_PROJECTS_MARKER = 'all'
+
+// Why: Electron's preload bridge (src/preload/index.ts) installs a document
+// capture-phase `drop` listener that stopPropagation()s every drop whose
+// dataTransfer is not a native OS file drop, which silently kills React's
+// synthetic onDrop on SpaceTab. Routing via a document capture listener
+// mirrors useWorkspaceStatusDocumentDrop and lands the drop before preload
+// can cancel it.
+export function useSpaceTabDocumentDrop(enabled = true): void {
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const handleDrop = (event: DragEvent): void => {
+      const dataTransfer = event.dataTransfer
+      if (!dataTransfer) {
+        return
+      }
+      if (!hasRepoDragData(dataTransfer) && !hasWorkspaceDragData(dataTransfer)) {
+        return
+      }
+      const target = event.target
+      if (!(target instanceof Element)) {
+        return
+      }
+      const dropTarget = target.closest<HTMLElement>(SPACE_TAB_DROP_TARGET_SELECTOR)
+      if (!dropTarget) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      const rawTarget = dropTarget.dataset.spaceDropTarget ?? ''
+      const targetSpaceId = rawTarget === ALL_PROJECTS_MARKER ? null : rawTarget
+      const store = useAppStore.getState()
+
+      const directRepoId = readRepoDragId(dataTransfer)
+      if (directRepoId) {
+        store.moveRepoToSpace(directRepoId, targetSpaceId)
+        return
+      }
+      const worktreeId = readWorkspaceDragData(dataTransfer)
+      if (!worktreeId) {
+        return
+      }
+      const worktree = getWorktreeMapFromState(store).get(worktreeId)
+      if (worktree) {
+        store.moveRepoToSpace(worktree.repoId, targetSpaceId)
+      }
+    }
+
+    document.addEventListener('drop', handleDrop, true)
+    return () => {
+      document.removeEventListener('drop', handleDrop, true)
+    }
+  }, [enabled])
+}

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -18,6 +18,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const activeSpaceId = useAppStore((s) => s.activeSpaceId)
+  const repoSpaceAssignments = useAppStore((s) => s.repoSpaceAssignments)
   const tabsByWorktree = useAppStore((s) => (showActiveOnly ? s.tabsByWorktree : null))
   const ptyIdsByTabId = useAppStore((s) => (showActiveOnly ? s.ptyIdsByTabId : null))
   const browserTabsByWorktree = useAppStore((s) =>
@@ -37,7 +39,9 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         browserTabsByWorktree,
         activeWorktreeId,
         hideDefaultBranchWorkspace,
-        repoMap
+        repoMap,
+        activeSpaceId,
+        repoSpaceAssignments
       })
     )
   }, [
@@ -50,6 +54,8 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     repoMap,
     showActiveOnly,
     tabsByWorktree,
-    worktreesByRepo
+    worktreesByRepo,
+    activeSpaceId,
+    repoSpaceAssignments
   ])
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -64,6 +64,8 @@ function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions
     activeWorktreeId: null,
     hideDefaultBranchWorkspace: false,
     repoMap,
+    activeSpaceId: null,
+    repoSpaceAssignments: {},
     ...overrides
   }
 }
@@ -197,6 +199,38 @@ describe('computeVisibleWorktreeIds', () => {
     )
 
     expect(result).toEqual([feature.id])
+  })
+
+  it('filters worktrees by activeSpaceId via repoSpaceAssignments', () => {
+    const wt1 = makeWorktree('wt1', 'repo1')
+    const wt2 = makeWorktree('wt2', 'repo2')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [wt1], repo2: [wt2] },
+      [wt1.id, wt2.id],
+      visibleOptions({
+        activeSpaceId: 'space-a',
+        repoSpaceAssignments: { repo1: 'space-a' }
+      })
+    )
+
+    expect(result).toEqual([wt1.id])
+  })
+
+  it('returns all worktrees when activeSpaceId is null (All Projects)', () => {
+    const wt1 = makeWorktree('wt1', 'repo1')
+    const wt2 = makeWorktree('wt2', 'repo2')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [wt1], repo2: [wt2] },
+      [wt1.id, wt2.id],
+      visibleOptions({
+        activeSpaceId: null,
+        repoSpaceAssignments: { repo1: 'space-a' }
+      })
+    )
+
+    expect(result).toEqual([wt1.id, wt2.id])
   })
 
   it('composes with filterRepoIds: hides mains only within the selected repos', () => {

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -18,6 +18,9 @@ export function isDefaultBranchWorkspace(worktree: Worktree): boolean {
 }
 
 /** Inputs describing every sidebar filter that can leave the list empty. */
+// Why: Space membership is intentionally excluded — Spaces are navigation
+// (the user picked a tab), not a clearable filter. Clear Filters must not
+// rip the user out of their active Space.
 export type SidebarFilterState = {
   showActiveOnly: boolean
   filterRepoIds: readonly string[]
@@ -89,6 +92,11 @@ export function computeVisibleWorktreeIds(
     // forgetting to pass it.
     hideDefaultBranchWorkspace: boolean
     repoMap: Map<string, Repo>
+    // Why required: same reasoning as hideDefaultBranchWorkspace — the Space
+    // filter is part of the active sidebar view contract. A caller that
+    // forgot to pass it would silently widen the list across all Spaces.
+    activeSpaceId: string | null
+    repoSpaceAssignments: Record<string, string>
   }
 ): string[] {
   let all: Worktree[] = getAllWorktreesFromState({ worktreesByRepo })
@@ -104,6 +112,10 @@ export function computeVisibleWorktreeIds(
   if (opts.filterRepoIds.length > 0) {
     const selectedRepoIds = new Set(opts.filterRepoIds)
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
+  }
+
+  if (opts.activeSpaceId !== null) {
+    all = all.filter((w) => opts.repoSpaceAssignments[w.repoId] === opts.activeSpaceId)
   }
 
   // Filter active only
@@ -207,6 +219,8 @@ export function getVisibleWorktreeIds(): string[] {
     browserTabsByWorktree: state.browserTabsByWorktree,
     activeWorktreeId: state.activeWorktreeId,
     hideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
-    repoMap
+    repoMap,
+    activeSpaceId: state.activeSpaceId,
+    repoSpaceAssignments: state.repoSpaceAssignments
   })
 }

--- a/src/renderer/src/lib/agent-status-unread.ts
+++ b/src/renderer/src/lib/agent-status-unread.ts
@@ -1,0 +1,24 @@
+import type { AgentStatusEntry, AgentStatusState } from '../../../shared/agent-status-types'
+
+// Why: single source of truth for "what counts as unread" — the Activity
+// titlebar badge and per-space pill badges both consume this so the totals
+// can never drift. An entry's unread events include every historical
+// done/blocked/waiting transition still ahead of the user's ack, plus the
+// current state when it qualifies.
+
+function isUnreadState(state: AgentStatusState): boolean {
+  return state === 'done' || state === 'blocked' || state === 'waiting'
+}
+
+export function countUnreadAgentEvents(entry: AgentStatusEntry, ackAt: number): number {
+  let count = 0
+  for (const history of entry.stateHistory) {
+    if (isUnreadState(history.state) && ackAt < history.startedAt) {
+      count += 1
+    }
+  }
+  if (isUnreadState(entry.state) && ackAt < entry.stateStartedAt) {
+    count += 1
+  }
+  return count
+}

--- a/src/renderer/src/lib/repo-tint.ts
+++ b/src/renderer/src/lib/repo-tint.ts
@@ -1,0 +1,12 @@
+// Why: mix against --sidebar (a defined token) instead of transparent so the
+// result is a solid color; downstream state overlays (active darkening, hover)
+// then composite predictably on top in both light and dark mode.
+export const REPO_TINT_PERCENT = 4
+export const LINEAGE_REPO_TINT_PERCENT = 3
+
+export function getRepoTintBackground(
+  badgeColor: string,
+  percent: number = REPO_TINT_PERCENT
+): string {
+  return `color-mix(in srgb, ${badgeColor} ${percent}%, var(--sidebar))`
+}

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -133,6 +133,13 @@ export function activateAndRevealWorktree(
     state.setActiveRepo(wt.repoId)
   }
 
+  // 1b. Switch to the Space that contains this repo. Without this, the
+  // sidebar's visible-worktrees filter hides any worktree whose repo isn't
+  // in the active Space, so step 6's revealWorktreeInSidebar silently
+  // no-ops. setActiveSpace already early-returns on no-op.
+  const targetSpaceId = state.repoSpaceAssignments[wt.repoId] ?? null
+  state.setActiveSpace(targetSpaceId)
+
   // 2. Switch any non-terminal view back to terminal
   if (state.activeView !== 'terminal') {
     state.setActiveView('terminal')

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -123,6 +123,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         toast.success(isGitRepoKind(repo) ? 'Project added' : 'Folder added', {
           description: repo.displayName
         })
+        // Why: when the user is browsing a non-All Space and adds a project,
+        // they expect the new project to belong to *that* Space. Otherwise it
+        // would appear to vanish (visible only under All Projects).
+        const { activeSpaceId, moveRepoToSpace } = get()
+        if (activeSpaceId !== null) {
+          moveRepoToSpace(repo.id, activeSpaceId)
+        }
       }
       return repo
     } catch (err) {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -7,6 +7,7 @@ import type {
   CustomPet,
   PersistedTrustedOrcaHooks,
   PersistedUIState,
+  Space,
   StatusBarItem,
   TaskProvider,
   TaskResumeState,
@@ -197,6 +198,66 @@ function sanitizeWorkspaceCleanupDismissals(
   return out
 }
 
+function sanitizePersistedSpaces(value: unknown): Space[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const out: Space[] = []
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') {
+      continue
+    }
+    const input = raw as Record<string, unknown>
+    if (typeof input.id !== 'string' || input.id.length === 0) {
+      continue
+    }
+    if (typeof input.name !== 'string') {
+      continue
+    }
+    if (typeof input.order !== 'number' || !Number.isFinite(input.order)) {
+      continue
+    }
+    if (typeof input.createdAt !== 'number' || !Number.isFinite(input.createdAt)) {
+      continue
+    }
+    const space: Space = {
+      id: input.id,
+      name: input.name,
+      order: input.order,
+      createdAt: input.createdAt
+    }
+    if (typeof input.color === 'string') {
+      space.color = input.color
+    }
+    out.push(space)
+  }
+  return out
+}
+
+function sanitizeRepoSpaceAssignments(
+  value: unknown,
+  validRepoIds: Set<string>,
+  validSpaceIds: Set<string>
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  const out: Record<string, string> = {}
+  for (const [repoId, spaceId] of Object.entries(value as Record<string, unknown>)) {
+    if (repoId === '__proto__' || repoId === 'constructor' || repoId === 'prototype') {
+      continue
+    }
+    if (typeof spaceId !== 'string') {
+      continue
+    }
+    if (!validRepoIds.has(repoId) || !validSpaceIds.has(spaceId)) {
+      continue
+    }
+    out[repoId] = spaceId
+  }
+  return out
+}
+
 function sanitizeTaskResumeState(value: unknown): TaskResumeState | undefined {
   if (!value || typeof value !== 'object') {
     return undefined
@@ -364,6 +425,18 @@ export type UISlice = {
   setHideDefaultBranchWorkspace: (v: boolean) => void
   filterRepoIds: string[]
   setFilterRepoIds: (ids: string[]) => void
+  /** User-created Spaces (named sidebar tabs that group projects). */
+  spaces: Space[]
+  /** Currently active Space. null === All Projects. */
+  activeSpaceId: string | null
+  /** repoId → spaceId membership map. Missing key means unassigned. */
+  repoSpaceAssignments: Record<string, string>
+  addSpace: (name: string) => Space | null
+  renameSpace: (id: string, name: string) => void
+  deleteSpace: (id: string) => void
+  setActiveSpace: (id: string | null) => void
+  moveRepoToSpace: (repoId: string, spaceId: string | null) => void
+  reorderSpaces: (orderedIds: string[]) => void
   collapsedGroups: Set<string>
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]
@@ -738,6 +811,130 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   filterRepoIds: [],
   setFilterRepoIds: (ids) => set({ filterRepoIds: ids }),
 
+  spaces: [],
+  activeSpaceId: null,
+  repoSpaceAssignments: {},
+  addSpace: (name) => {
+    const trimmed = name.trim()
+    if (trimmed.length === 0) {
+      return null
+    }
+    const space: Space = {
+      id: crypto.randomUUID(),
+      name: trimmed,
+      order: 0,
+      createdAt: Date.now()
+    }
+    let created: Space | null = null
+    set((s) => {
+      // Append to the end and rewrite order so it stays a contiguous 0-based
+      // sequence even after intermediate deletes.
+      const nextSpaces = [...s.spaces, space].map((sp, i) => ({ ...sp, order: i }))
+      created = nextSpaces.find((sp) => sp.id === space.id) ?? space
+      window.api.ui.set({ spaces: nextSpaces }).catch(console.error)
+      return { spaces: nextSpaces }
+    })
+    return created
+  },
+  renameSpace: (id, name) => {
+    const trimmed = name.trim()
+    if (trimmed.length === 0) {
+      return
+    }
+    set((s) => {
+      let changed = false
+      const nextSpaces = s.spaces.map((sp) => {
+        if (sp.id !== id || sp.name === trimmed) {
+          return sp
+        }
+        changed = true
+        return { ...sp, name: trimmed }
+      })
+      if (!changed) {
+        return s
+      }
+      window.api.ui.set({ spaces: nextSpaces }).catch(console.error)
+      return { spaces: nextSpaces }
+    })
+  },
+  deleteSpace: (id) =>
+    set((s) => {
+      if (!s.spaces.some((sp) => sp.id === id)) {
+        return s
+      }
+      const nextSpaces = s.spaces.filter((sp) => sp.id !== id).map((sp, i) => ({ ...sp, order: i }))
+      const nextAssignments: Record<string, string> = {}
+      for (const [repoId, spaceId] of Object.entries(s.repoSpaceAssignments)) {
+        if (spaceId !== id) {
+          nextAssignments[repoId] = spaceId
+        }
+      }
+      const nextActive = s.activeSpaceId === id ? null : s.activeSpaceId
+      window.api.ui
+        .set({
+          spaces: nextSpaces,
+          repoSpaceAssignments: nextAssignments,
+          activeSpaceId: nextActive
+        })
+        .catch(console.error)
+      return {
+        spaces: nextSpaces,
+        repoSpaceAssignments: nextAssignments,
+        activeSpaceId: nextActive
+      }
+    }),
+  setActiveSpace: (id) =>
+    set((s) => {
+      if (id !== null && !s.spaces.some((sp) => sp.id === id)) {
+        return s
+      }
+      if (s.activeSpaceId === id) {
+        return s
+      }
+      window.api.ui.set({ activeSpaceId: id }).catch(console.error)
+      return { activeSpaceId: id }
+    }),
+  moveRepoToSpace: (repoId, spaceId) =>
+    set((s) => {
+      if (spaceId !== null && !s.spaces.some((sp) => sp.id === spaceId)) {
+        return s
+      }
+      const current = s.repoSpaceAssignments[repoId] ?? null
+      if (current === spaceId) {
+        return s
+      }
+      const next = { ...s.repoSpaceAssignments }
+      if (spaceId === null) {
+        delete next[repoId]
+      } else {
+        next[repoId] = spaceId
+      }
+      window.api.ui.set({ repoSpaceAssignments: next }).catch(console.error)
+      return { repoSpaceAssignments: next }
+    }),
+  reorderSpaces: (orderedIds) =>
+    set((s) => {
+      if (orderedIds.length === 0) {
+        return s
+      }
+      const byId = new Map(s.spaces.map((sp) => [sp.id, sp]))
+      const nextSpaces: Space[] = []
+      for (let i = 0; i < orderedIds.length; i++) {
+        const sp = byId.get(orderedIds[i])
+        if (sp) {
+          nextSpaces.push({ ...sp, order: i })
+          byId.delete(orderedIds[i])
+        }
+      }
+      // Append any Spaces not present in orderedIds so a stale call cannot
+      // drop entries silently.
+      for (const sp of byId.values()) {
+        nextSpaces.push({ ...sp, order: nextSpaces.length })
+      }
+      window.api.ui.set({ spaces: nextSpaces }).catch(console.error)
+      return { spaces: nextSpaces }
+    }),
+
   collapsedGroups: new Set<string>(),
   toggleCollapsedGroup: (key) =>
     set((s) => {
@@ -884,6 +1081,17 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   hydratePersistedUI: (ui) =>
     set((s) => {
       const validRepoIds = new Set(s.repos.map((repo) => repo.id))
+      const persistedSpaces = sanitizePersistedSpaces(ui.spaces)
+      const validSpaceIds = new Set(persistedSpaces.map((sp) => sp.id))
+      const repoSpaceAssignments = sanitizeRepoSpaceAssignments(
+        ui.repoSpaceAssignments,
+        validRepoIds,
+        validSpaceIds
+      )
+      const activeSpaceId =
+        typeof ui.activeSpaceId === 'string' && validSpaceIds.has(ui.activeSpaceId)
+          ? ui.activeSpaceId
+          : null
       // Why: persisted UI from pre-rename builds used sidekick* keys. Read
       // those only as fallbacks so new pet* writes win immediately after upgrade.
       const customPets = Array.isArray(ui.customPets)
@@ -926,6 +1134,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         showActiveOnly: ui.showActiveOnly,
         hideDefaultBranchWorkspace: ui.hideDefaultBranchWorkspace ?? false,
         filterRepoIds: (ui.filterRepoIds ?? []).filter((repoId) => validRepoIds.has(repoId)),
+        spaces: persistedSpaces,
+        activeSpaceId,
+        repoSpaceAssignments,
         collapsedGroups: new Set(ui.collapsedGroups ?? []),
         uiZoomLevel: ui.uiZoomLevel ?? 0,
         editorFontZoomLevel: ui.editorFontZoomLevel ?? 0,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -77,6 +77,24 @@ export type Repo = {
   symlinkPaths?: string[]
 }
 
+/**
+ * A user-created named tab that groups projects in the sidebar. A project
+ * (Repo) can live in at most one Space. The permanent "All Projects" view is
+ * represented by activeSpaceId === null, not by a Space row.
+ *
+ * Why this isn't a field on `Repo`: Repo is written by main-process git code,
+ * the AddRepo flow, and SSH bridges. The Space → repo membership map lives in
+ * UISlice alongside sibling filter state and persists through the same
+ * `window.api.ui.set()` channel — mirrors the trustedOrcaHooks pattern.
+ */
+export type Space = {
+  id: string
+  name: string
+  order: number
+  color?: string
+  createdAt: number
+}
+
 export type SetupRunPolicy = 'ask' | 'run-by-default' | 'skip-by-default'
 export type SetupDecision = 'inherit' | 'run' | 'skip'
 
@@ -1717,6 +1735,15 @@ export type PersistedUIState = {
    *  sidebar filters reached through the same dropdown. */
   hideDefaultBranchWorkspace: boolean
   filterRepoIds: string[]
+  /** User-created Spaces (named sidebar tabs that group projects). Absent on
+   *  fresh installs and pre-Spaces persisted state — treated as []. */
+  spaces?: Space[]
+  /** Currently selected Space id. null === All Projects (no filter). */
+  activeSpaceId?: string | null
+  /** repoId → spaceId membership map. Missing key means the repo is
+   *  unassigned (visible only in All Projects). Kept here rather than on
+   *  Repo so non-UI repo writers don't have to think about it. */
+  repoSpaceAssignments?: Record<string, string>
   collapsedGroups: string[]
   uiZoomLevel: number
   editorFontZoomLevel: number


### PR DESCRIPTION
The Activity titlebar already showed a grand-total unread count across every repo, but the "All Projects" sidebar pill rendered no badge to avoid double-counting the per-Space chips that #6 introduced. The two surfaces disagreed visually even though both mean "everything across every Space".

This branch wires them up to the same selector so they can't drift.

## Changes

- Add `selectAllAgentsUnreadCount` / `useAllAgentsUnreadCount` to `use-space-notification-counts.ts`. Counts every `agentStatusByPaneKey`, every retained agent, and every migration-unsupported entry — assigned or not.
- Remove the `!isAllProjects` special-case from `SpaceTab.tsx` and pass the new count through from `SpaceTabs.tsx`.
- Drop the duplicate `useActivityUnreadCount` hook from `ActivityTitlebarControls.tsx` in favor of the shared one.
- Move the test helpers (`makeState`, `makeEntry`, `makeWorktree`, …) into `space-notification-test-fixtures.ts` so both the existing per-Space tests and the new selector tests reuse them.

## Test plan

- [x] Added 4 new tests in `use-space-notification-counts.test.ts` covering: empty store, sum across assigned + unassigned (with the invariant `All Projects = Σ(per-Space) + unassigned`), acknowledgement timestamps, retained agents, and migration-unsupported entries.
- [ ] Manual sanity check that the All Projects pill badge matches the Activity titlebar count in a live session.
