### PR TITLE
Restore weekly usage label

### DIFF
--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -74,7 +74,7 @@ function mapRpcWindow(
   return {
     usedPercent: Math.min(100, Math.max(0, raw.usedPercent)),
     // Why: Codex currently reports remaining minutes in `windowDurationMins`.
-    // Orca's UI needs the fixed bucket duration so labels stay "5h" / "7d".
+    // Orca's UI needs the fixed bucket duration so labels stay "5h" / "wk".
     windowMinutes: expectedWindowMinutes,
     resetsAt,
     resetDescription

--- a/src/renderer/src/lib/window-label-formatter.test.ts
+++ b/src/renderer/src/lib/window-label-formatter.test.ts
@@ -10,8 +10,8 @@ describe('formatWindowLabel', () => {
     expect(formatWindowLabel(60)).toBe('1h')
   })
 
-  it('returns "7d" for 10080 minutes (7 days)', () => {
-    expect(formatWindowLabel(10080)).toBe('7d')
+  it('returns "wk" for 10080 minutes (7 days)', () => {
+    expect(formatWindowLabel(10080)).toBe('wk')
   })
 
   it('returns "1d" for 1440 minutes (1 day)', () => {

--- a/src/renderer/src/lib/window-label-formatter.ts
+++ b/src/renderer/src/lib/window-label-formatter.ts
@@ -1,12 +1,12 @@
 /**
  * Returns a short human-readable label for a usage window duration.
  *
- * Why: the status bar uses duration labels, so the weekly bucket is shown as
- * "7d" instead of a calendar-period label like "wk".
+ * Why: 10080 minutes (7 days) is hard-coded as "wk" for backward
+ * compatibility with the original StatusBar implementation.
  */
 export function formatWindowLabel(windowMinutes: number): string {
   if (windowMinutes === 10080) {
-    return '7d'
+    return 'wk'
   }
   if (windowMinutes === 300) {
     return '5h'


### PR DESCRIPTION
## Summary
- restore the weekly usage window label from `7d` back to `wk`
- update the Codex rate-limit mapper comment to match the restored compact label
- keep the existing Codex RPC normalization behavior intact

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/window-label-formatter.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/rate-limits/codex-fetcher.test.ts
- pnpm exec oxlint src/main/rate-limits/codex-fetcher.ts src/renderer/src/lib/window-label-formatter.ts src/renderer/src/lib/window-label-formatter.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web

Made with [Orca](https://github.com/stablyai/orca) 🐋
