### PR TITLE
Add feature tour Help menu hint

### DIFF
--- a/src/renderer/src/components/feature-wall/FeatureTourNudge.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureTourNudge.tsx
@@ -127,8 +127,14 @@ export function FeatureTourNudge(): JSX.Element | null {
             )}
           </button>
 
-          <p className="line-clamp-2 text-xs leading-snug text-muted-foreground">
+          <p
+            className="line-clamp-2 text-xs leading-snug text-muted-foreground"
+            data-feature-tour-nudge-caption
+          >
             {FEATURE_TOUR_NUDGE_TILE.caption}
+          </p>
+          <p className="text-xs leading-snug text-muted-foreground">
+            Reopen this any time from Help &gt; Feature tour.
           </p>
 
           <Button variant="default" size="sm" className="w-full gap-1.5" onClick={handleOpenTour}>

--- a/src/renderer/src/components/feature-wall/FeatureWallModal.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallModal.tsx
@@ -252,7 +252,8 @@ export default function FeatureWallModal(): JSX.Element | null {
         <DialogHeader className="gap-1">
           <DialogTitle>Explore some of Orca&apos;s features</DialogTitle>
           <DialogDescription>
-            Tasks, terminal, agents, browser, SSH, review, and more.
+            <span className="block">Tasks, terminal, agents, browser, SSH, review, and more.</span>
+            <span className="block">Reopen this any time from Help &gt; Feature tour.</span>
           </DialogDescription>
         </DialogHeader>
 

--- a/tests/e2e/feature-wall.spec.ts
+++ b/tests/e2e/feature-wall.spec.ts
@@ -145,9 +145,13 @@ test.describe('Feature tour modal', () => {
         'Browse GitHub and Linear tasks in-app. Start worktrees, review PRs, and approve without switching context.'
       )
     ).toBeVisible()
+    await expect(nudge.getByText('Reopen this any time from Help > Feature tour.')).toBeVisible()
     await expect
       .poll(
-        () => nudge.locator('p').evaluate((node) => node.scrollHeight <= node.clientHeight + 1),
+        () =>
+          nudge
+            .locator('[data-feature-tour-nudge-caption]')
+            .evaluate((node) => node.scrollHeight <= node.clientHeight + 1),
         {
           message: 'feature tour nudge caption should not be clipped'
         }

--- a/tests/e2e/feature-wall.spec.ts
+++ b/tests/e2e/feature-wall.spec.ts
@@ -51,6 +51,7 @@ test.describe('Feature tour modal', () => {
     await expect(
       orcaPage.getByText('Tasks, terminal, agents, browser, SSH, review, and more.')
     ).toBeVisible()
+    await expect(orcaPage.getByText('Reopen this any time from Help > Feature tour.')).toBeVisible()
     await expect(orcaPage.getByRole('listitem')).toHaveCount(12)
     await expect(
       orcaPage.getByRole('listitem', { name: /Remote worktrees over SSH/i })


### PR DESCRIPTION
## Summary
- Add a short line to the feature tour modal explaining it can be reopened from Help > Feature tour.
- Assert the new copy in the feature-wall e2e coverage.

## Validation
- pnpm exec playwright test tests/e2e/feature-wall.spec.ts --config tests/playwright.config.ts --project electron-headless
- Fresh-profile Electron check via config/scripts/dev-fresh-profile.sh with screenshot captured locally at artifacts/feature-tour-fresh-user.png

Made with [Orca](https://github.com/stablyai/orca) 🐋
