### PR TITLE
Revert "Fix Linux terminal WebGL glyph corruption"

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -477,7 +477,7 @@ export function TerminalPane({
 
         <SearchableSetting
           title="GPU Acceleration"
-          description="Controls whether the terminal uses xterm.js WebGL rendering. Auto uses DOM on Linux to avoid driver glyph corruption, and otherwise tries WebGL with DOM fallback."
+          description="Controls whether the terminal uses xterm.js WebGL rendering. Auto mirrors VS Code: try GPU and fall back to DOM if WebGL fails."
           keywords={[
             'terminal',
             'gpu',
@@ -513,7 +513,7 @@ export function TerminalPane({
               ? 'WebGL is disabled; xterm uses the DOM renderer for maximum compatibility.'
               : settings.terminalGpuAcceleration === 'on'
                 ? 'WebGL is always attempted for terminal panes.'
-                : 'Auto uses the DOM renderer on Linux to avoid GPU glyph corruption, and otherwise tries WebGL with DOM fallback.'}
+                : 'Auto tries WebGL for performance and falls back to the DOM renderer if WebGL fails, matching VS Code.'}
           </p>
         </SearchableSetting>
       </section>

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -45,7 +45,7 @@ export const TERMINAL_RENDERING_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'GPU Acceleration',
     description:
-      'Controls whether the terminal uses xterm.js WebGL rendering. Auto uses DOM on Linux to avoid driver glyph corruption, and otherwise tries WebGL with DOM fallback.',
+      'Controls whether the terminal uses xterm.js WebGL rendering. Auto mirrors VS Code: try GPU and fall back to DOM if WebGL fails.',
     keywords: [
       'terminal',
       'gpu',

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -96,10 +96,6 @@ describe('attachWebgl', () => {
     webglMock.dispose.mockClear()
     vi.mocked(WebglAddon).mockClear()
     resetTerminalWebglSuggestion()
-    vi.stubGlobal('navigator', {
-      platform: 'MacIntel',
-      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
-    })
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(16)
       return 1
@@ -156,32 +152,6 @@ describe('attachWebgl', () => {
 
     expect(pane.webglAddon).toBeNull()
     expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
-  })
-
-  it('uses DOM rendering for auto GPU acceleration on Linux', () => {
-    vi.stubGlobal('navigator', {
-      platform: 'Linux x86_64',
-      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
-    })
-    const pane = createPane()
-
-    attachWebgl(pane)
-
-    expect(pane.webglAddon).toBeNull()
-    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
-  })
-
-  it('still allows forced WebGL on Linux', () => {
-    vi.stubGlobal('navigator', {
-      platform: 'Linux x86_64',
-      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
-    })
-    const pane = createPane()
-    pane.terminalGpuAcceleration = 'on'
-
-    attachWebgl(pane)
-
-    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
   })
 
   it('uses DOM for later auto panes after WebGL attach fails until the suggestion resets', () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts
@@ -72,18 +72,4 @@ describe('applyTerminalGpuAcceleration', () => {
     expect(pane.webglAddon).toBeNull()
     expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
   })
-
-  it('returns Linux panes to DOM when switching from forced WebGL back to auto', () => {
-    vi.stubGlobal('navigator', {
-      platform: 'Linux x86_64',
-      userAgent: 'Mozilla/5.0 (X11; Linux x86_64)'
-    })
-    const pane = createPane()
-    const options: PaneManagerOptions = { terminalGpuAcceleration: 'on' }
-
-    applyTerminalGpuAcceleration([pane], options, 'auto')
-
-    expect(pane.webglAddon).toBeNull()
-    expect(pane.fitAddon.fit).toHaveBeenCalledTimes(1)
-  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -1,10 +1,5 @@
 import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
-import {
-  attachWebgl,
-  disposeWebgl,
-  resetTerminalWebglSuggestion,
-  shouldUseTerminalWebgl
-} from './pane-webgl-renderer'
+import { attachWebgl, disposeWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
 import { safeFit } from './pane-tree-ops'
 
 export function applyTerminalGpuAcceleration(
@@ -20,7 +15,7 @@ export function applyTerminalGpuAcceleration(
   }
   for (const pane of panes) {
     pane.terminalGpuAcceleration = nextMode
-    if (!shouldUseTerminalWebgl(pane)) {
+    if (nextMode === 'off' || (nextMode === 'auto' && pane.hasComplexScriptOutput)) {
       disposeWebgl(pane, { refreshDimensions: true })
       continue
     }
@@ -28,7 +23,8 @@ export function applyTerminalGpuAcceleration(
       pane.gpuRenderingEnabled &&
       !pane.webglAddon &&
       !pane.webglAttachmentDeferred &&
-      !pane.webglDisabledAfterContextLoss
+      !pane.webglDisabledAfterContextLoss &&
+      (nextMode === 'on' || !pane.hasComplexScriptOutput)
     ) {
       attachWebgl(pane)
       safeFit(pane)

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -10,21 +10,9 @@ export function resetTerminalWebglSuggestion(): void {
   suggestedRendererType = undefined
 }
 
-function isLinuxRenderer(): boolean {
-  if (typeof navigator === 'undefined') {
-    return false
-  }
-  return navigator.platform.includes('Linux') || navigator.userAgent.includes('Linux')
-}
-
-export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
+function shouldUseWebgl(pane: ManagedPaneInternal): boolean {
   if (pane.terminalGpuAcceleration === 'on') {
     return true
-  }
-  if (isLinuxRenderer()) {
-    // Why: multiple Linux/Wayland GPU stacks corrupt xterm's WebGL glyph atlas
-    // without raising context loss; tab switching only masks it by rebuilding WebGL.
-    return false
   }
   return (
     pane.terminalGpuAcceleration === 'auto' &&
@@ -83,7 +71,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
   if (
     !ENABLE_WEBGL_RENDERER ||
     !pane.gpuRenderingEnabled ||
-    !shouldUseTerminalWebgl(pane) ||
+    !shouldUseWebgl(pane) ||
     pane.webglAttachmentDeferred ||
     pane.webglDisabledAfterContextLoss
   ) {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -170,8 +170,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
     terminalLineHeight: 1,
-    // Why: keep the setting on "auto" so explicit user choices stay available,
-    // but renderer policy maps Linux auto to DOM to avoid GPU glyph corruption.
+    // Why: VS Code defaults terminal GPU acceleration to "auto": prefer
+    // xterm WebGL for performance, but allow renderer failure to choose DOM.
     terminalGpuAcceleration: 'auto',
     // Why 'auto': when the user has picked a known ligature font we want the
     // feature enabled by default, but we never force it if they pick a font

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1291,7 +1291,7 @@ export type GlobalSettings = {
   terminalFontWeight: number
   terminalLineHeight: number
   /** Mirrors VS Code's terminal.integrated.gpuAcceleration shape.
-   *  - 'auto': use DOM on Linux; otherwise try xterm WebGL and fall back to DOM if the renderer fails.
+   *  - 'auto': try xterm WebGL and fall back to DOM if the renderer fails.
    *  - 'on': always try xterm WebGL.
    *  - 'off': keep terminal rendering on xterm's DOM renderer. */
   terminalGpuAcceleration: 'auto' | 'on' | 'off'


### PR DESCRIPTION
Reverts stablyai/orca#1988
Revert since this is a Claude Code bug

Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.