### PR TITLE
fix: keep CLI registration current after app updates

### DIFF
--- a/docs/cli-updates-with-app.md
+++ b/docs/cli-updates-with-app.md
@@ -1,0 +1,278 @@
+# CLI Updates With App Updates
+
+## Problem or Goal
+
+Users expect the public `orca` shell command to run the CLI bundled with the Orca app they just updated. That matters because CLI features can ship with the desktop app, such as parent-child workspace flags. If the shell command still resolves to an old app bundle, users see old CLI behavior even though they believe Orca is updated.
+
+Goal: keep `orca` registered once, then make future app updates automatically route through the newly installed app bundle without asking users to reinstall the shell command.
+
+Non-goals:
+
+- Do not ship a separate npm/Homebrew CLI package.
+- Do not make the CLI self-update independently of the app.
+- Do not auto-replace unrelated commands named `orca`.
+
+## Current Behavior
+
+- Packaged builds copy a platform launcher into the app resources: Windows copies `resources/win32/bin/orca.cmd` to `resources/bin/orca.cmd`, macOS copies `resources/darwin/bin/orca` to `Contents/Resources/bin/orca`, and Linux copies `resources/linux/bin/orca` to `resources/bin/orca` ([config/electron-builder.config.cjs:92](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/config/electron-builder.config.cjs:92), [config/electron-builder.config.cjs:148](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/config/electron-builder.config.cjs:148), [config/electron-builder.config.cjs:181](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/config/electron-builder.config.cjs:181)).
+- The CLI runtime is intentionally unpacked from `app.asar` so the launcher can execute it with `ELECTRON_RUN_AS_NODE` ([config/electron-builder.config.cjs:37](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/config/electron-builder.config.cjs:37), [config/electron-builder.config.cjs:54](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/config/electron-builder.config.cjs:54)).
+- The macOS bundled launcher resolves the `.app` path from the launcher location, then runs `Contents/Resources/app.asar.unpacked/out/cli/index.js` through the bundled Electron binary ([resources/darwin/bin/orca:4](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/resources/darwin/bin/orca:4), [resources/darwin/bin/orca:21](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/resources/darwin/bin/orca:21)).
+- The Linux and Windows bundled launchers resolve the executable and CLI relative to their own resources directory ([resources/linux/bin/orca:4](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/resources/linux/bin/orca:4), [resources/linux/bin/orca:17](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/resources/linux/bin/orca:17), [resources/win32/bin/orca.cmd:3](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/resources/win32/bin/orca.cmd:3), [resources/win32/bin/orca.cmd:17](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/resources/win32/bin/orca.cmd:17)).
+- `CliInstaller` currently registers `/usr/local/bin/orca` on macOS, `~/.local/bin/orca` on Linux, and `%LOCALAPPDATA%\\Programs\\Orca\\bin\\orca.cmd` on Windows ([src/main/cli/cli-installer.ts:12](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:12), [src/main/cli/cli-installer.ts:199](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:199)).
+- For packaged apps, `CliInstaller` treats the bundled resources launcher as the expected target ([src/main/cli/cli-installer.ts:222](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:222), [src/main/cli/cli-installer.ts:622](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:622)).
+- POSIX installs create a symlink directly to the bundled launcher; Windows writes a forwarding `.cmd` to the bundled launcher ([src/main/cli/cli-installer.ts:240](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:240), [src/main/cli/cli-installer.ts:278](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:278), [src/main/cli/cli-installer.ts:529](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/cli/cli-installer.ts:529)).
+- The settings UI exposes manual install/remove/status refresh, but there is no startup repair or updater-specific reconciliation of CLI registration ([src/main/ipc/cli.ts:5](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/ipc/cli.ts:5), [src/renderer/src/components/settings/CliSection.tsx:51](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/renderer/src/components/settings/CliSection.tsx:51), [src/renderer/src/components/settings/CliSection.tsx:73](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/renderer/src/components/settings/CliSection.tsx:73)).
+- App updates are handled by `electron-updater`; `quitAndInstall()` schedules replacement/restart, and `setupAutoUpdater()` registers updater handlers, but neither path touches CLI registration ([src/main/updater.ts:607](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/updater.ts:607), [src/main/updater.ts:697](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/updater.ts:697), [src/main/updater.ts:778](/Users/thebr/orca/workspaces/orca/cli-update-from-last-release/src/main/updater.ts:778)).
+
+Important implication: if `/usr/local/bin/orca` points to `/Applications/Orca.app/Contents/Resources/bin/orca` and the updater replaces `/Applications/Orca.app` in place, the CLI should update naturally. The gap is that Orca does not currently prove or repair this invariant after updates, app moves, legacy registrations, or Windows wrapper drift.
+
+## Ref-OSS Findings
+
+Used `ref-oss`, synced repos with `scripts/sync-ref-oss.sh --all`, and inspected `/Users/thebr/projects/orca-ref-oss/vscode`.
+
+Relevant VS Code patterns:
+
+- VS Code's macOS `code` command is a symlink to a launcher inside the app bundle. The launcher resolves the `.app` from its own path and runs the bundled CLI with `ELECTRON_RUN_AS_NODE` ([/Users/thebr/projects/orca-ref-oss/vscode/resources/darwin/bin/code.sh:15](/Users/thebr/projects/orca-ref-oss/vscode/resources/darwin/bin/code.sh:15), [/Users/thebr/projects/orca-ref-oss/vscode/resources/darwin/bin/code.sh:31](/Users/thebr/projects/orca-ref-oss/vscode/resources/darwin/bin/code.sh:31)).
+- VS Code installs `/usr/local/bin/<appName>` to the app's bundled `bin/code` and only replaces it when the existing symlink target differs ([/Users/thebr/projects/orca-ref-oss/vscode/src/vs/platform/native/electron-main/nativeHostMainService.ts:470](/Users/thebr/projects/orca-ref-oss/vscode/src/vs/platform/native/electron-main/nativeHostMainService.ts:470), [/Users/thebr/projects/orca-ref-oss/vscode/src/vs/platform/native/electron-main/nativeHostMainService.ts:550](/Users/thebr/projects/orca-ref-oss/vscode/src/vs/platform/native/electron-main/nativeHostMainService.ts:550)).
+- VS Code exposes explicit command-palette install/uninstall actions rather than silently claiming arbitrary commands ([/Users/thebr/projects/orca-ref-oss/vscode/src/vs/workbench/electron-browser/actions/installActions.ts:19](/Users/thebr/projects/orca-ref-oss/vscode/src/vs/workbench/electron-browser/actions/installActions.ts:19)).
+- VS Code's Linux packages register `/usr/bin/code` as a symlink to the package-owned app launcher, so package updates replace the target in place ([/Users/thebr/projects/orca-ref-oss/vscode/resources/linux/debian/postinst.template:6](/Users/thebr/projects/orca-ref-oss/vscode/resources/linux/debian/postinst.template:6), [/Users/thebr/projects/orca-ref-oss/vscode/resources/linux/rpm/code.spec.template:39](/Users/thebr/projects/orca-ref-oss/vscode/resources/linux/rpm/code.spec.template:39)).
+- VS Code's Windows launcher can include a versioned resources path when the install layout needs it ([/Users/thebr/projects/orca-ref-oss/vscode/resources/win32/versioned/bin/code.cmd:1](/Users/thebr/projects/orca-ref-oss/vscode/resources/win32/versioned/bin/code.cmd:1), [/Users/thebr/projects/orca-ref-oss/vscode/build/gulpfile.vscode.ts:450](/Users/thebr/projects/orca-ref-oss/vscode/build/gulpfile.vscode.ts:450)).
+
+Implementation should reuse the VS Code principle, not necessarily its exact mechanics: the public command should be a stable entrypoint whose first hop is app-owned, and the app should only repair launchers it can prove are Orca-owned.
+
+## Proposed Design
+
+System model:
+
+```text
+User shell
+  |
+  | PATH lookup
+  v
+Public command
+  macOS: /usr/local/bin/orca
+  Linux: ~/.local/bin/orca
+  Windows: %LOCALAPPDATA%\Programs\Orca\bin\orca.cmd
+  |
+  | symlink or managed wrapper, installed once
+  v
+Stable user-data launcher
+  <app.getPath('userData')>/cli/bin/orca(.cmd)
+  |
+  | rewritten by the currently running packaged app
+  v
+Bundled launcher in current app resources
+  process.resourcesPath/bin/orca(.cmd)
+  |
+  | ELECTRON_RUN_AS_NODE
+  v
+Unpacked CLI entrypoint
+  app.asar.unpacked/out/cli/index.js
+```
+
+The load-bearing invariant is that the public command points to the stable user-data launcher, not directly to a versioned or movable app bundle. Startup reconciliation is responsible for keeping that stable launcher pointed at the currently running app.
+
+### 1. Add an App-Managed Stable Launcher
+
+Create a packaged-app stable launcher under user data:
+
+- macOS/Linux: `<app.getPath('userData')>/cli/bin/orca`
+- Windows: `<app.getPath('userData')>\\cli\\bin\\orca.cmd`
+
+On every packaged app startup, rewrite this stable launcher to forward to the current bundled launcher:
+
+- macOS/Linux: `exec "<current process.resourcesPath>/bin/orca" "$@"`
+- Windows: `call "<current process.resourcesPath>\\bin\\orca.cmd" %*`
+
+Write this launcher through a platform-local atomic replace:
+
+- Ensure the parent directory exists first.
+- Write the new content to a temp file in the same directory.
+- Set POSIX executable mode before the rename.
+- Rename over the previous launcher.
+- Skip the rename when existing content already matches, to reduce churn.
+
+Atomic replace matters because the CLI can be invoked from a shell while the app is starting. The user should either run the previous valid launcher or the new valid launcher, never a truncated script.
+
+Keep the bundled resource launchers as the canonical launchers for executing the CLI. The stable launcher is only a durable first hop that can be rewritten without needing `/usr/local/bin` or machine PATH privileges.
+
+Development builds can keep the current generated launcher path, but should share the same atomic-write helper names so install-status tests cover both packaged and dev launchers.
+
+### 2. Change Public Registration to Point at the Stable Launcher
+
+Update `CliInstaller.resolveLauncherPath()` for packaged builds to return the app-managed stable launcher, creating/refreshing it first. Existing `getBundledLauncherPath()` remains as an internal target for the stable launcher.
+
+Install behavior:
+
+- POSIX: `/usr/local/bin/orca` or `~/.local/bin/orca` symlinks to the stable user-data launcher.
+- Windows: the PATH-visible `orca.cmd` forwards to the stable user-data launcher.
+
+This means app updates only need to rewrite the user-data launcher on restart; the public command's PATH-visible hop does not need privileged repair after the first install.
+
+Status inspection should classify the current public command into explicit ownership buckets:
+
+- `installed`: exact symlink/wrapper to the stable launcher.
+- `legacy_bundled`: Orca-owned symlink/wrapper to the bundled launcher from the current direct-registration design.
+- `legacy_bundled_elsewhere`: Orca-shaped symlink/wrapper to a bundled launcher under another app path, usually from an app move or replacement outside the normal updater path.
+- `stale_orca`: Orca-shaped target that is not one the app can confidently rewrite silently.
+- `conflict`: non-Orca file or unknown wrapper.
+- `not_installed`: missing public command.
+
+Only `installed` is fully healthy. `legacy_bundled` and `legacy_bundled_elsewhere` are migratable by startup reconciliation when the public path is user-writable and inspection proves the target matches Orca's generated launcher shape; otherwise Settings should report a repair action instead of implying that the CLI is unusable.
+
+### 3. Startup Reconciliation for Existing Users
+
+Add `CliInstaller.reconcileAfterAppUpdate()` and call it once during main-process startup after app paths are available and before the renderer asks for CLI status. A good location is near other startup-owned user-global setup in `src/main/index.ts` after service initialization, with errors logged but not fatal.
+
+Reconciliation rules:
+
+- Always refresh the stable user-data launcher to the currently running app.
+- If the public command is not installed, do nothing.
+- If the public command already points to the stable launcher, do nothing.
+- If the public command points to the current bundled launcher from an older Orca version of this installer, migrate it to the stable launcher.
+- If the public command points to a recognizable legacy bundled Orca launcher at another app path, migrate it only when the replacement can be done without elevation and the target matches Orca's generated symlink/wrapper shape.
+- If the public command points elsewhere, preserve the existing `stale` or `conflict` status and require explicit user action.
+- Never show an administrator prompt during startup. If `/usr/local/bin` cannot be rewritten automatically, leave status actionable in Settings.
+
+This keeps updates quiet when everything is healthy, while avoiding surprise ownership changes.
+
+The method should return a small result object for tests and logging, for example `refreshed_stable_launcher`, `already_installed`, `migrated_legacy_launcher`, `permission_denied`, `not_installed`, or `conflict_preserved`. The caller logs non-success results but never blocks startup.
+
+### 4. Clarify Status and User-Facing Copy
+
+Keep the existing public `CliInstallStatus.state` values unless implementation needs a new state. Prefer using `detail` to explain:
+
+- `installed`: registered and managed by Orca.
+- `stale`: points to another launcher; use Settings to repair.
+- `conflict`: path exists but is not an Orca symlink/wrapper.
+
+Settings should continue to show the command path and existing target. If reconciliation failed due to permissions, the existing install action should repair it through the current elevated macOS fallback.
+
+User-facing states:
+
+| State | User meaning | Action |
+| --- | --- | --- |
+| Installed | `orca` is managed by Orca and follows app updates after the app launches. | No action. |
+| Legacy direct launcher | `orca` still points at an older Orca-managed launcher shape. It may work for same-path updates, but future app moves require repair. | Auto-migrate if ownership is provable and the public path is writable; otherwise show Register/Repair. |
+| Stale | `orca` points to another Orca-looking location that cannot be safely migrated. | Show Register/Repair. |
+| Conflict | The path is occupied by something Orca cannot prove it owns. | Do not replace automatically; explain the path conflict. |
+| Not installed | No public command exists. | Show Register. |
+
+### 5. Updater Hook Is Optional, Startup Repair Is Required
+
+Do not rely only on `quitAndInstall()` because users can update by replacing the app bundle, Homebrew cask, external package manager, or OS-level installer. Startup reconciliation covers all update sources after the new app launches.
+
+The updater path can optionally log a breadcrumb when an install completes, but the actual CLI repair should be idempotent startup work.
+
+Update data flows:
+
+```text
+Happy path, same app path:
+old /usr/local/bin/orca -> stable launcher -> /Applications/Orca.app/.../bin/orca
+app replaced in place
+stable launcher path still resolves to /Applications/Orca.app/.../bin/orca
+next app launch rewrites the same content if needed
+```
+
+```text
+Moved app path:
+public command -> stable launcher -> old app resources
+user launches Orca from new location
+startup rewrites stable launcher -> new process.resourcesPath/bin/orca
+future shell invocations reach the new app
+```
+
+```text
+Legacy direct registration:
+public command -> current bundled launcher
+startup refreshes stable launcher
+startup migrates public command -> stable launcher when writable
+if not writable, status remains actionable and Settings repair can elevate
+```
+
+```text
+Legacy direct registration after app move:
+public command -> old Orca.app resources
+user launches Orca from new location
+startup refreshes stable launcher -> new process.resourcesPath/bin/orca
+startup migrates public command -> stable launcher when the old target is provably Orca-owned and the public path is writable
+if not writable or not provable, Settings shows repair instead of silently replacing it
+```
+
+```text
+Conflict or unknown wrapper:
+public command -> non-Orca target
+startup refreshes stable launcher only
+public command is preserved and Settings explains the conflict
+```
+
+### 6. Security and Ownership Boundaries
+
+The stable launcher lives in user data, so it is not a trust boundary. It must never grant additional privileges; it only forwards to the current app's bundled launcher as the same user. This is acceptable because a same-user process that can edit user data can already affect that user's PATH, shell startup files, and Windows user environment.
+
+The public command remains the ownership boundary. Startup reconciliation may only rewrite it when inspection proves it is Orca-owned or the path is missing. Unknown files, non-symlink POSIX commands, and wrappers that do not match Orca's generated templates stay untouched.
+
+## Edge Cases
+
+- Same-path app update: `/Applications/Orca.app` is replaced in place; both legacy direct symlinks and new stable launchers should resolve to the new bundle.
+- App moved after registration: the stable launcher is rewritten on next launch from the new location; legacy direct symlinks may need migration if the command still points at the old app.
+- CLI invoked before the updated app is launched once: same-path updates work; moved-app updates may still hit the old path until Orca starts and rewrites the stable launcher.
+- Permission denied for `/usr/local/bin`: do not prompt on startup; keep Settings repair available.
+- PATH collision: do not replace a non-symlink POSIX command or unknown Windows wrapper.
+- Linux package conflict with GNOME Orca: keep the current user-scoped `~/.local/bin/orca` default; do not claim `/usr/bin/orca`.
+- Windows app update layout changes: generated wrappers should forward through the stable user-data launcher so versioned or relocated resources only require rewriting one app-managed file.
+- SSH/remote runtime: local shell-command registration is a local desktop concern. Remote `orca` commands should continue to use their remote installation or pairing/environment configuration; do not assume a local app path exists on SSH targets.
+- App translocation/quarantine on macOS: the stable launcher should be refreshed only from a running packaged app. If the app is translocated, status can still show the concrete target so users can move Orca into `/Applications`.
+- Downgrade or rollback: startup refresh points to the currently running app, so CLI behavior follows the installed app version in either direction.
+- Concurrent startup/status calls: both paths may refresh the stable launcher. Atomic replace and content equality checks make this harmless.
+
+## Test Plan
+
+Unit coverage:
+
+- Add `src/main/cli/cli-installer.test.ts` cases for packaged-mode stable launcher creation on macOS, Linux, and Windows.
+- Verify install points the public command at the stable launcher, not directly at `resources/bin/orca`.
+- Verify rewriting the stable launcher from fake version `1` to fake version `2` changes the downstream bundled launcher path without changing the public symlink/wrapper.
+- Verify stable launcher refresh is atomic by pre-creating an old launcher, forcing a rewrite, and asserting the final content is complete and executable.
+- Verify migration from the current legacy direct symlink target to the stable launcher.
+- Verify migration from a recognizable legacy direct symlink/wrapper under an old app path when the public command path is writable.
+- Verify stale/conflict commands are not auto-replaced.
+- Verify permission failures during startup reconciliation are non-fatal and leave actionable status.
+- Verify Windows wrapper comparison treats the current stable-launcher wrapper as installed and an old direct-bundled wrapper as migratable.
+- Verify generated Windows wrappers preserve arguments with spaces and propagate the bundled launcher's exit code.
+
+Build/package coverage:
+
+- Add or extend a packaging smoke test that asserts each platform artifact contains `resources/bin/orca` or `resources/bin/orca.cmd` plus the unpacked CLI entrypoint.
+- Add a script-level smoke test with a fake app path: register `orca`, replace the fake app's bundled launcher with a new version marker, rerun startup reconciliation, then assert invoking the public command reaches the new marker.
+
+Playwright/Electron coverage:
+
+- Add an Electron/Playwright test for Settings > Orca CLI status using mocked `CliInstaller` paths if the current test harness supports main-process dependency injection.
+- If full updater simulation is too heavy, cover the user-visible repair path: stale legacy target appears in Settings, clicking Register repairs it, refreshing shows installed.
+
+Manual validation:
+
+- macOS release-like packaged build: install shell command, confirm `command -v orca`, update/replace `Orca.app` at the same path, relaunch, confirm `orca --help` or a version marker comes from the new app.
+- macOS moved app: register from one app path, move app, launch moved app, confirm startup reconciliation either repairs without prompting or Settings reports repair action.
+- Windows packaged build: confirm user PATH command survives update and invokes the new app's bundled CLI.
+- Linux AppImage/deb: confirm `~/.local/bin/orca` follows the refreshed launcher and does not touch `/usr/bin/orca`.
+
+## Rollout Order
+
+1. Add stable-launcher helpers and tests while keeping current public install behavior unchanged.
+2. Change packaged install/status resolution to use the stable launcher; keep recognizing legacy direct bundled launchers.
+3. Add startup reconciliation and non-fatal logging.
+4. Update Settings copy only if status wording changes.
+5. Add packaging and Electron coverage.
+6. Ship in one release, then monitor support reports for stale `/usr/local/bin/orca` and Windows PATH wrapper drift.
+
+## Ref-OSS Reuse
+
+Ref-OSS was used. Reuse these implementation patterns:
+
+- VS Code's app-bundle-relative launcher model for the canonical bundled launcher.
+- VS Code's conservative ownership check before replacing the public shell command.
+- VS Code's explicit user repair flow for privileged shell command installation.
+
+Do not reuse VS Code's Linux `/usr/bin` package ownership as-is because Orca intentionally avoids colliding with GNOME Orca.

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -1,4 +1,14 @@
-import { mkdtemp, mkdir, readFile, symlink, writeFile } from 'node:fs/promises'
+/* eslint-disable max-lines -- Why: this suite keeps cross-platform CLI install fixtures beside the status/reconciliation cases they exercise. */
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readlink,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -27,66 +37,105 @@ async function makeFixture(): Promise<{
   return { root, userDataPath, appPath }
 }
 
+async function makePackagedFixture(
+  platform: NodeJS.Platform,
+  appDir = 'Orca.app'
+): Promise<{
+  root: string
+  userDataPath: string
+  resourcesPath: string
+  bundledLauncherPath: string
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-cli-packaged-'))
+  const userDataPath = join(root, 'userData')
+  const resourcesPath =
+    platform === 'darwin' ? join(root, appDir, 'Contents', 'Resources') : join(root, 'resources')
+  const bundledLauncherPath = join(resourcesPath, 'bin', platform === 'win32' ? 'orca.cmd' : 'orca')
+  await mkdir(join(resourcesPath, 'bin'), { recursive: true })
+  await writeFile(bundledLauncherPath, bundledLauncherContent(platform), 'utf8')
+  return { root, userDataPath, resourcesPath, bundledLauncherPath }
+}
+
+function bundledLauncherContent(platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    return [
+      '@echo off',
+      'set ELECTRON_RUN_AS_NODE=1',
+      'set "CLI=%RESOURCES_DIR%\\app.asar.unpacked\\out\\cli\\index.js"'
+    ].join('\n')
+  }
+  return [
+    '#!/usr/bin/env bash',
+    'ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CONTENTS/Resources/app.asar.unpacked/out/cli/index.js" "$@"'
+  ].join('\n')
+}
+
 describe('CliInstaller', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
   // Why: this test creates Unix symlinks and shell scripts that only apply on macOS.
-  it.skipIf(process.platform === 'win32')('creates a dev launcher and installs a macOS symlink in the requested path', async () => {
-    const fixture = await makeFixture()
-    const installPath = join(fixture.root, 'bin', 'orca')
-    const installer = new CliInstaller({
-      platform: 'darwin',
-      isPackaged: false,
-      userDataPath: fixture.userDataPath,
-      execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
-      appPath: fixture.appPath,
-      commandPathOverride: installPath,
-      processPathEnv: join(fixture.root, 'bin')
-    })
+  it.skipIf(process.platform === 'win32')(
+    'creates a dev launcher and installs a macOS symlink in the requested path',
+    async () => {
+      const fixture = await makeFixture()
+      const installPath = join(fixture.root, 'bin', 'orca')
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: false,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        commandPathOverride: installPath,
+        processPathEnv: join(fixture.root, 'bin')
+      })
 
-    const initial = await installer.getStatus()
-    expect(initial.state).toBe('not_installed')
-    expect(initial.launcherPath).toContain(join('userData', 'cli', 'bin', 'orca'))
+      const initial = await installer.getStatus()
+      expect(initial.state).toBe('not_installed')
+      expect(initial.launcherPath).toContain(join('userData', 'cli', 'bin', 'orca'))
 
-    const installed = await installer.install()
-    expect(installed.state).toBe('installed')
-    expect(installed.pathConfigured).toBe(true)
+      const installed = await installer.install()
+      expect(installed.state).toBe('installed')
+      expect(installed.pathConfigured).toBe(true)
 
-    const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
-    expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
-    expect(launcherContent).toContain(join(fixture.appPath, 'out', 'cli', 'index.js'))
+      const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
+      expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
+      expect(launcherContent).toContain(join(fixture.appPath, 'out', 'cli', 'index.js'))
 
-    const removed = await installer.remove()
-    expect(removed.state).toBe('not_installed')
-  })
+      const removed = await installer.remove()
+      expect(removed.state).toBe('not_installed')
+    }
+  )
 
   // Why: this test creates Unix symlinks and shell scripts that only apply on Linux.
-  it.skipIf(process.platform === 'win32')('creates a linux symlink under the requested path and warns when PATH is missing', async () => {
-    const fixture = await makeFixture()
-    const installPath = join(fixture.root, '.local', 'bin', 'orca')
-    const installer = new CliInstaller({
-      platform: 'linux',
-      isPackaged: false,
-      userDataPath: fixture.userDataPath,
-      execPath: '/opt/Orca/orca',
-      appPath: fixture.appPath,
-      commandPathOverride: installPath,
-      processPathEnv: '/usr/bin'
-    })
+  it.skipIf(process.platform === 'win32')(
+    'creates a linux symlink under the requested path and warns when PATH is missing',
+    async () => {
+      const fixture = await makeFixture()
+      const installPath = join(fixture.root, '.local', 'bin', 'orca')
+      const installer = new CliInstaller({
+        platform: 'linux',
+        isPackaged: false,
+        userDataPath: fixture.userDataPath,
+        execPath: '/opt/Orca/orca',
+        appPath: fixture.appPath,
+        commandPathOverride: installPath,
+        processPathEnv: '/usr/bin'
+      })
 
-    const installed = await installer.install()
-    expect(installed.state).toBe('installed')
-    expect(installed.pathConfigured).toBe(false)
-    expect(installed.detail).toContain('.local')
+      const installed = await installer.install()
+      expect(installed.state).toBe('installed')
+      expect(installed.pathConfigured).toBe(false)
+      expect(installed.detail).toContain('.local')
 
-    const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
-    expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
+      const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
+      expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
 
-    const removed = await installer.remove()
-    expect(removed.state).toBe('not_installed')
-  })
+      const removed = await installer.remove()
+      expect(removed.state).toBe('not_installed')
+    }
+  )
 
   it('creates a windows wrapper and updates the user PATH', async () => {
     const fixture = await makeFixture()
@@ -120,24 +169,364 @@ describe('CliInstaller', () => {
   })
 
   // Why: this test creates a Unix symlink to /tmp/not-orca, which only applies on macOS/Linux.
-  it.skipIf(process.platform === 'win32')('reports stale when a different symlink already exists', async () => {
-    const fixture = await makeFixture()
-    const installPath = join(fixture.root, 'bin', 'orca')
-    await mkdir(join(fixture.root, 'bin'), { recursive: true })
-    await symlink('/tmp/not-orca', installPath)
+  it.skipIf(process.platform === 'win32')(
+    'reports stale when a different symlink already exists',
+    async () => {
+      const fixture = await makeFixture()
+      const installPath = join(fixture.root, 'bin', 'orca')
+      await mkdir(join(fixture.root, 'bin'), { recursive: true })
+      await symlink('/tmp/not-orca', installPath)
 
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: false,
+        userDataPath: fixture.userDataPath,
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+        appPath: fixture.appPath,
+        commandPathOverride: installPath
+      })
+
+      await expect(installer.getStatus()).resolves.toMatchObject({
+        state: 'stale',
+        supported: true
+      })
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps packaged macOS installs pointed at the app-bundle launcher',
+    async () => {
+      const fixture = await makePackagedFixture('darwin')
+      const installPath = join(fixture.root, 'bin', 'orca')
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        resourcesPath: fixture.resourcesPath,
+        commandPathOverride: installPath,
+        processPathEnv: join(fixture.root, 'bin')
+      })
+
+      const installed = await installer.install()
+      expect(installed.state).toBe('installed')
+      expect(installed.launcherPath).toBe(fixture.bundledLauncherPath)
+      expect(await readlink(installPath)).toBe(fixture.bundledLauncherPath)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'refreshes the Linux stable launcher without changing the public symlink',
+    async () => {
+      const first = await makePackagedFixture('linux')
+      const installPath = join(first.root, 'bin', 'orca')
+      const firstInstaller = new CliInstaller({
+        platform: 'linux',
+        isPackaged: true,
+        userDataPath: first.userDataPath,
+        resourcesPath: first.resourcesPath,
+        commandPathOverride: installPath,
+        processPathEnv: join(first.root, 'bin')
+      })
+
+      const installed = await firstInstaller.install()
+      const stableLauncherPath = installed.launcherPath as string
+      expect(await readlink(installPath)).toBe(stableLauncherPath)
+      expect((await stat(stableLauncherPath)).mode & 0o111).not.toBe(0)
+
+      const nextResourcesPath = join(first.root, 'next', 'resources')
+      const nextBundledLauncherPath = join(nextResourcesPath, 'bin', 'orca')
+      await mkdir(join(nextResourcesPath, 'bin'), { recursive: true })
+      await writeFile(nextBundledLauncherPath, bundledLauncherContent('linux'), 'utf8')
+
+      const nextInstaller = new CliInstaller({
+        platform: 'linux',
+        isPackaged: true,
+        userDataPath: first.userDataPath,
+        resourcesPath: nextResourcesPath,
+        commandPathOverride: installPath,
+        processPathEnv: join(first.root, 'bin')
+      })
+
+      await expect(nextInstaller.getStatus()).resolves.toMatchObject({ state: 'installed' })
+      expect(await readlink(installPath)).toBe(stableLauncherPath)
+      expect(await readFile(stableLauncherPath, 'utf8')).toContain(nextBundledLauncherPath)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'migrates a legacy macOS direct bundled symlink after an app move',
+    async () => {
+      const oldFixture = await makePackagedFixture('darwin', 'Old.app')
+      const newResourcesPath = join(oldFixture.root, 'New.app', 'Contents', 'Resources')
+      const newBundledLauncherPath = join(newResourcesPath, 'bin', 'orca')
+      await mkdir(join(newResourcesPath, 'bin'), { recursive: true })
+      await writeFile(newBundledLauncherPath, bundledLauncherContent('darwin'), 'utf8')
+      const installPath = join(oldFixture.root, 'bin', 'orca')
+      await mkdir(join(oldFixture.root, 'bin'), { recursive: true })
+      await symlink(oldFixture.bundledLauncherPath, installPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        userDataPath: oldFixture.userDataPath,
+        resourcesPath: newResourcesPath,
+        commandPathOverride: installPath,
+        processPathEnv: join(oldFixture.root, 'bin')
+      })
+
+      await expect(installer.getStatus()).resolves.toMatchObject({
+        state: 'stale',
+        currentTarget: oldFixture.bundledLauncherPath
+      })
+      await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('migrated_legacy_launcher')
+      const repaired = await installer.getStatus()
+      expect(repaired.state).toBe('installed')
+      expect(await readlink(installPath)).toBe(newBundledLauncherPath)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'does not elevate when startup reconciliation cannot rewrite a macOS symlink',
+    async () => {
+      const oldFixture = await makePackagedFixture('darwin', 'Old.app')
+      const newResourcesPath = join(oldFixture.root, 'New.app', 'Contents', 'Resources')
+      const newBundledLauncherPath = join(newResourcesPath, 'bin', 'orca')
+      const commandDir = join(oldFixture.root, 'bin')
+      const installPath = join(commandDir, 'orca')
+      const privilegedRunner = vi.fn()
+      await mkdir(join(newResourcesPath, 'bin'), { recursive: true })
+      await writeFile(newBundledLauncherPath, bundledLauncherContent('darwin'), 'utf8')
+      await mkdir(commandDir, { recursive: true })
+      await symlink(oldFixture.bundledLauncherPath, installPath)
+      await chmod(commandDir, 0o555)
+      try {
+        const installer = new CliInstaller({
+          platform: 'darwin',
+          isPackaged: true,
+          userDataPath: oldFixture.userDataPath,
+          resourcesPath: newResourcesPath,
+          commandPathOverride: installPath,
+          privilegedRunner,
+          processPathEnv: commandDir
+        })
+
+        await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('permission_denied')
+        expect(privilegedRunner).not.toHaveBeenCalled()
+        expect(await readlink(installPath)).toBe(oldFixture.bundledLauncherPath)
+      } finally {
+        await chmod(commandDir, 0o755)
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'migrates a legacy Linux direct bundled symlink to the stable launcher',
+    async () => {
+      const oldFixture = await makePackagedFixture('linux')
+      const newResourcesPath = join(oldFixture.root, 'next', 'resources')
+      const newBundledLauncherPath = join(newResourcesPath, 'bin', 'orca')
+      const installPath = join(oldFixture.root, 'bin', 'orca')
+      await mkdir(join(newResourcesPath, 'bin'), { recursive: true })
+      await writeFile(newBundledLauncherPath, bundledLauncherContent('linux'), 'utf8')
+      await mkdir(join(oldFixture.root, 'bin'), { recursive: true })
+      await symlink(oldFixture.bundledLauncherPath, installPath)
+
+      const installer = new CliInstaller({
+        platform: 'linux',
+        isPackaged: true,
+        userDataPath: oldFixture.userDataPath,
+        resourcesPath: newResourcesPath,
+        commandPathOverride: installPath,
+        processPathEnv: join(oldFixture.root, 'bin')
+      })
+
+      await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('migrated_legacy_launcher')
+      const repaired = await installer.getStatus()
+      expect(repaired.state).toBe('installed')
+      expect(await readlink(installPath)).toBe(repaired.launcherPath)
+      expect(await readFile(repaired.launcherPath as string, 'utf8')).toContain(
+        newBundledLauncherPath
+      )
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves stale symlinks that are not Orca launchers',
+    async () => {
+      const fixture = await makePackagedFixture('darwin')
+      const installPath = join(fixture.root, 'bin', 'orca')
+      await mkdir(join(fixture.root, 'bin'), { recursive: true })
+      await symlink('/tmp/not-orca', installPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        resourcesPath: fixture.resourcesPath,
+        commandPathOverride: installPath
+      })
+
+      await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('stale_preserved')
+      expect(await readlink(installPath)).toBe('/tmp/not-orca')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves missing legacy-shaped symlinks because ownership cannot be verified',
+    async () => {
+      const fixture = await makePackagedFixture('darwin')
+      const installPath = join(fixture.root, 'bin', 'orca')
+      const missingLegacyTarget = join(
+        fixture.root,
+        'Missing.app',
+        'Contents',
+        'Resources',
+        'bin',
+        'orca'
+      )
+      await mkdir(join(fixture.root, 'bin'), { recursive: true })
+      await symlink(missingLegacyTarget, installPath)
+
+      const installer = new CliInstaller({
+        platform: 'darwin',
+        isPackaged: true,
+        userDataPath: fixture.userDataPath,
+        resourcesPath: fixture.resourcesPath,
+        commandPathOverride: installPath
+      })
+
+      await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('stale_preserved')
+      expect(await readlink(installPath)).toBe(missingLegacyTarget)
+    }
+  )
+
+  it('points packaged Windows installs at a stable user-data launcher', async () => {
+    const fixture = await makePackagedFixture('win32')
+    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    let userPath = ''
     const installer = new CliInstaller({
-      platform: 'darwin',
-      isPackaged: false,
+      platform: 'win32',
+      isPackaged: true,
       userDataPath: fixture.userDataPath,
-      execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
-      appPath: fixture.appPath,
-      commandPathOverride: installPath
+      resourcesPath: fixture.resourcesPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => userPath,
+      userPathWriter: async (value) => {
+        userPath = value
+      }
+    })
+
+    const installed = await installer.install()
+    expect(installed.state).toBe('installed')
+    expect(installed.launcherPath).toBe(join(fixture.userDataPath, 'cli', 'bin', 'orca.cmd'))
+
+    const publicWrapper = await readFile(installPath, 'utf8')
+    expect(publicWrapper).toContain(`ORCA_LAUNCHER=${installed.launcherPath}`)
+
+    const stableLauncher = await readFile(installed.launcherPath as string, 'utf8')
+    expect(stableLauncher).toContain(`ORCA_BUNDLED_LAUNCHER=${fixture.bundledLauncherPath}`)
+    expect(stableLauncher).toContain('exit /b %ERRORLEVEL%')
+  })
+
+  it('refreshes the Windows stable launcher without changing the public wrapper', async () => {
+    const first = await makePackagedFixture('win32')
+    const installPath = join(first.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    let userPath = join(first.root, 'Programs', 'Orca', 'bin')
+    const firstInstaller = new CliInstaller({
+      platform: 'win32',
+      isPackaged: true,
+      userDataPath: first.userDataPath,
+      resourcesPath: first.resourcesPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => userPath,
+      userPathWriter: async (value) => {
+        userPath = value
+      }
+    })
+
+    const installed = await firstInstaller.install()
+    const stableLauncherPath = installed.launcherPath as string
+    expect(await readFile(installPath, 'utf8')).toContain(`ORCA_LAUNCHER=${stableLauncherPath}`)
+
+    const nextResourcesPath = join(first.root, 'next', 'resources')
+    const nextBundledLauncherPath = join(nextResourcesPath, 'bin', 'orca.cmd')
+    await mkdir(join(nextResourcesPath, 'bin'), { recursive: true })
+    await writeFile(nextBundledLauncherPath, bundledLauncherContent('win32'), 'utf8')
+    const nextInstaller = new CliInstaller({
+      platform: 'win32',
+      isPackaged: true,
+      userDataPath: first.userDataPath,
+      resourcesPath: nextResourcesPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => userPath,
+      userPathWriter: async (value) => {
+        userPath = value
+      }
+    })
+
+    await expect(nextInstaller.getStatus()).resolves.toMatchObject({ state: 'installed' })
+    expect(await readFile(installPath, 'utf8')).toContain(`ORCA_LAUNCHER=${stableLauncherPath}`)
+    expect(await readFile(stableLauncherPath, 'utf8')).toContain(nextBundledLauncherPath)
+  })
+
+  it('migrates a legacy Windows wrapper during startup reconciliation', async () => {
+    const fixture = await makePackagedFixture('win32')
+    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    await mkdir(join(fixture.root, 'Programs', 'Orca', 'bin'), { recursive: true })
+    await writeFile(
+      installPath,
+      [
+        '@echo off',
+        'setlocal',
+        `set "ORCA_LAUNCHER=${fixture.bundledLauncherPath}"`,
+        '"%ORCA_LAUNCHER%" %*',
+        ''
+      ].join('\n'),
+      'utf8'
+    )
+    const installer = new CliInstaller({
+      platform: 'win32',
+      isPackaged: true,
+      userDataPath: fixture.userDataPath,
+      resourcesPath: fixture.resourcesPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => join(fixture.root, 'Programs', 'Orca', 'bin'),
+      userPathWriter: async () => undefined
     })
 
     await expect(installer.getStatus()).resolves.toMatchObject({
       state: 'stale',
-      supported: true
+      currentTarget: fixture.bundledLauncherPath
     })
+    await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('migrated_legacy_launcher')
+    await expect(installer.getStatus()).resolves.toMatchObject({ state: 'installed' })
+    expect(await readFile(installPath, 'utf8')).toContain(
+      `ORCA_LAUNCHER=${join(fixture.userDataPath, 'cli', 'bin', 'orca.cmd')}`
+    )
+  })
+
+  it('preserves custom Windows wrappers even when they reference an Orca launcher', async () => {
+    const fixture = await makePackagedFixture('win32')
+    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    const customWrapper = [
+      '@echo off',
+      'echo custom preflight',
+      `set "ORCA_LAUNCHER=${fixture.bundledLauncherPath}"`,
+      '"%ORCA_LAUNCHER%" %*'
+    ].join('\n')
+    await mkdir(join(fixture.root, 'Programs', 'Orca', 'bin'), { recursive: true })
+    await writeFile(installPath, customWrapper, 'utf8')
+    const installer = new CliInstaller({
+      platform: 'win32',
+      isPackaged: true,
+      userDataPath: fixture.userDataPath,
+      resourcesPath: fixture.resourcesPath,
+      commandPathOverride: installPath,
+      userPathReader: async () => join(fixture.root, 'Programs', 'Orca', 'bin'),
+      userPathWriter: async () => undefined
+    })
+
+    await expect(installer.reconcileAfterAppUpdate()).resolves.toBe('stale_preserved')
+    expect(await readFile(installPath, 'utf8')).toBe(customWrapper)
   })
 })

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -2,15 +2,36 @@
 import { app } from 'electron'
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { lstat, mkdir, readFile, readlink, symlink, unlink, writeFile } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  readFile,
+  readlink,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile
+} from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import type { CliInstallMethod, CliInstallStatus } from '../../shared/cli-install-types'
 
 const execFileAsync = promisify(execFile)
 const DEFAULT_MAC_COMMAND_PATH = '/usr/local/bin/orca'
 const DEV_LAUNCHER_DIR = ['cli', 'bin']
+
+export type CliReconcileResult =
+  | 'unsupported'
+  | 'refreshed_stable_launcher'
+  | 'already_installed'
+  | 'migrated_legacy_launcher'
+  | 'permission_denied'
+  | 'not_installed'
+  | 'conflict_preserved'
+  | 'stale_preserved'
+  | 'skipped_development'
 
 type CliInstallerOptions = {
   platform?: NodeJS.Platform
@@ -129,7 +150,7 @@ export class CliInstaller {
 
     // eslint-disable-next-line unicorn/prefer-ternary -- Why: the install path performs async side effects and is easier to audit as an explicit branch than as an awaited ternary.
     if (status.installMethod === 'symlink') {
-      await this.installSymlink(status)
+      await this.installSymlink(status, { allowPrivilege: true })
     } else {
       await this.installWindowsWrapper(status.commandPath, status.launcherPath)
     }
@@ -142,6 +163,47 @@ export class CliInstaller {
     }
 
     return this.getStatus()
+  }
+
+  async reconcileAfterAppUpdate(): Promise<CliReconcileResult> {
+    const status = await this.getStatus()
+    if (!this.isPackaged) {
+      return 'skipped_development'
+    }
+    if (!status.supported) {
+      return 'unsupported'
+    }
+    if (status.state === 'installed') {
+      return 'already_installed'
+    }
+    if (status.state === 'not_installed') {
+      return 'not_installed'
+    }
+    if (status.state === 'conflict') {
+      return 'conflict_preserved'
+    }
+    if (
+      status.state !== 'stale' ||
+      !status.commandPath ||
+      !status.launcherPath ||
+      !status.installMethod ||
+      !(await this.isLegacyBundledLauncher(status))
+    ) {
+      return 'stale_preserved'
+    }
+
+    try {
+      await (status.installMethod === 'symlink'
+        ? this.installSymlink(status, { allowPrivilege: false })
+        : this.installWindowsWrapper(status.commandPath, status.launcherPath))
+    } catch (error) {
+      if (isPermissionError(error)) {
+        return 'permission_denied'
+      }
+      throw error
+    }
+
+    return 'migrated_legacy_launcher'
   }
 
   async remove(): Promise<CliInstallStatus> {
@@ -226,7 +288,17 @@ export class CliInstaller {
 
     if (this.isPackaged) {
       const bundledPath = getBundledLauncherPath(this.platform, this.resourcesPath)
-      return bundledPath && existsSync(bundledPath) ? bundledPath : null
+      if (!bundledPath || !existsSync(bundledPath)) {
+        return null
+      }
+      if (this.platform === 'darwin') {
+        return bundledPath
+      }
+      return ensureStableLauncher({
+        platform: this.platform,
+        userDataPath: this.userDataPath,
+        bundledLauncherPath: bundledPath
+      })
     }
 
     return ensureDevLauncher({
@@ -237,7 +309,10 @@ export class CliInstaller {
     })
   }
 
-  private async installSymlink(status: CliInstallStatus): Promise<void> {
+  private async installSymlink(
+    status: CliInstallStatus,
+    options: { allowPrivilege: boolean }
+  ): Promise<void> {
     try {
       if (status.state === 'installed') {
         return
@@ -247,7 +322,7 @@ export class CliInstaller {
       }
       await symlink(status.launcherPath as string, status.commandPath as string)
     } catch (error) {
-      if (this.platform !== 'darwin' || !isPermissionError(error)) {
+      if (this.platform !== 'darwin' || !options.allowPrivilege || !isPermissionError(error)) {
         throw error
       }
 
@@ -348,13 +423,14 @@ export class CliInstaller {
 
       const currentContent = await readFile(commandPath, 'utf8')
       const expectedContent = buildWindowsForwarder(launcherPath)
+      const currentLauncher = readWindowsForwarderLauncherPath(currentContent)
       return this.buildStatus({
         commandPath,
         launcherPath,
         installMethod: 'wrapper',
         supported: true,
         state: currentContent === expectedContent ? 'installed' : 'stale',
-        currentTarget: launcherPath,
+        currentTarget: currentLauncher ?? launcherPath,
         detail:
           currentContent === expectedContent
             ? `Registered at ${commandPath}.`
@@ -461,6 +537,82 @@ export class CliInstaller {
     )
     await this.userPathWriter(nextEntries.join(';'))
   }
+
+  private async isLegacyBundledLauncher(status: CliInstallStatus): Promise<boolean> {
+    if (!status.currentTarget) {
+      return false
+    }
+    if (status.installMethod === 'symlink') {
+      return this.isOrcaBundledLauncher(status.currentTarget)
+    }
+    if (status.installMethod === 'wrapper' && status.commandPath) {
+      try {
+        const content = await readFile(status.commandPath, 'utf8')
+        const forwardedLauncher = readWindowsForwarderLauncherPath(content)
+        return forwardedLauncher &&
+          normalizeLineEndings(content) ===
+            normalizeLineEndings(buildWindowsForwarder(forwardedLauncher))
+          ? this.isOrcaBundledLauncher(forwardedLauncher)
+          : false
+      } catch (error) {
+        if (isMissingError(error)) {
+          return false
+        }
+        throw error
+      }
+    }
+    return false
+  }
+
+  private async isOrcaBundledLauncher(launcherPath: string): Promise<boolean> {
+    if (!isPotentialBundledLauncherPath(this.platform, launcherPath)) {
+      return false
+    }
+    try {
+      return isOrcaBundledLauncherContent(this.platform, await readFile(launcherPath, 'utf8'))
+    } catch (error) {
+      if (isMissingError(error)) {
+        return false
+      }
+      throw error
+    }
+  }
+}
+
+async function ensureStableLauncher(args: {
+  platform: NodeJS.Platform
+  userDataPath: string
+  bundledLauncherPath: string
+}): Promise<string | null> {
+  if (
+    !isAbsoluteForPlatform(args.platform, args.bundledLauncherPath) &&
+    !isAbsolute(args.bundledLauncherPath)
+  ) {
+    return null
+  }
+
+  const launcherPath = getStableLauncherPath(args.platform, args.userDataPath)
+  if (!launcherPath) {
+    return null
+  }
+
+  const content =
+    args.platform === 'win32'
+      ? buildWindowsStableLauncher(args.bundledLauncherPath)
+      : buildUnixStableLauncher(args.bundledLauncherPath)
+  await writeFileAtomicallyIfChanged(
+    launcherPath,
+    content,
+    args.platform === 'win32' ? null : 0o755
+  )
+  return launcherPath
+}
+
+function getStableLauncherPath(platform: NodeJS.Platform, userDataPath: string): string | null {
+  if (!['darwin', 'linux', 'win32'].includes(platform)) {
+    return null
+  }
+  return join(userDataPath, ...DEV_LAUNCHER_DIR, platform === 'win32' ? 'orca.cmd' : 'orca')
 }
 
 async function ensureDevLauncher(args: {
@@ -499,6 +651,23 @@ async function ensureDevLauncher(args: {
   return launcherPath
 }
 
+function buildUnixStableLauncher(bundledLauncherPath: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+ORCA_BUNDLED_LAUNCHER=${quoteShell(bundledLauncherPath)}
+exec "$ORCA_BUNDLED_LAUNCHER" "$@"
+`
+}
+
+function buildWindowsStableLauncher(bundledLauncherPath: string): string {
+  return `@echo off
+setlocal
+set "ORCA_BUNDLED_LAUNCHER=${escapeWindowsBatchValue(bundledLauncherPath)}"
+call "%ORCA_BUNDLED_LAUNCHER%" %*
+exit /b %ERRORLEVEL%
+`
+}
+
 function buildUnixDevLauncher(execPathValue: string, cliEntryPath: string): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
@@ -534,6 +703,37 @@ set "ORCA_LAUNCHER=${escapeWindowsBatchValue(launcherPath)}"
 `
 }
 
+async function writeFileAtomicallyIfChanged(
+  targetPath: string,
+  content: string,
+  mode: number | null
+): Promise<void> {
+  try {
+    if ((await readFile(targetPath, 'utf8')) === content) {
+      return
+    }
+  } catch (error) {
+    if (!isMissingError(error)) {
+      throw error
+    }
+  }
+
+  await mkdir(dirname(targetPath), { recursive: true })
+  const tempPath = join(
+    dirname(targetPath),
+    `.${basename(targetPath)}.${process.pid}.${process.hrtime.bigint()}.tmp`
+  )
+  try {
+    await (mode === null
+      ? writeFile(tempPath, content, 'utf8')
+      : writeFile(tempPath, content, { encoding: 'utf8', mode }))
+    await rename(tempPath, targetPath)
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+}
+
 function splitPathEntries(platform: NodeJS.Platform, value: string | null): string[] {
   if (!value) {
     return []
@@ -555,7 +755,16 @@ function normalizeWindowsPath(value: string): string {
 }
 
 function escapeWindowsBatchValue(value: string): string {
-  return value.replaceAll('"', '""')
+  return value.replaceAll('%', '%%').replaceAll('"', '""')
+}
+
+function readWindowsForwarderLauncherPath(content: string): string | null {
+  const match = /^set "ORCA_LAUNCHER=(.*)"$/im.exec(content)
+  return match?.[1]?.replaceAll('%%', '%').replaceAll('""', '"') ?? null
+}
+
+function normalizeLineEndings(content: string): string {
+  return content.replaceAll('\r\n', '\n')
 }
 
 function isPermissionError(error: unknown): boolean {
@@ -630,4 +839,32 @@ export function getBundledLauncherPath(
     return join(resourcesPath, 'bin', 'orca.cmd')
   }
   return null
+}
+
+function isPotentialBundledLauncherPath(platform: NodeJS.Platform, launcherPath: string): boolean {
+  const normalized =
+    platform === 'win32' ? normalizeWindowsPath(launcherPath) : launcherPath.replaceAll('\\', '/')
+  if (platform === 'darwin') {
+    return normalized.endsWith('.app/Contents/Resources/bin/orca')
+  }
+  if (platform === 'linux') {
+    return normalized.endsWith('/resources/bin/orca')
+  }
+  if (platform === 'win32') {
+    return normalized.endsWith('\\resources\\bin\\orca.cmd')
+  }
+  return false
+}
+
+function isOrcaBundledLauncherContent(platform: NodeJS.Platform, content: string): boolean {
+  if (platform === 'win32') {
+    return (
+      content.includes('ELECTRON_RUN_AS_NODE=1') &&
+      content.includes('app.asar.unpacked\\out\\cli\\index.js')
+    )
+  }
+  return (
+    content.includes('ELECTRON_RUN_AS_NODE=1') &&
+    content.includes('app.asar.unpacked/out/cli/index.js')
+  )
 }

--- a/src/main/ipc/cli.test.ts
+++ b/src/main/ipc/cli.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  handleMock,
+  reconcileAfterAppUpdateMock,
+  getStatusMock,
+  installMock,
+  removeMock,
+  CliInstallerMock
+} = vi.hoisted(() => {
+  const reconcileAfterAppUpdateMock = vi.fn()
+  const getStatusMock = vi.fn()
+  const installMock = vi.fn()
+  const removeMock = vi.fn()
+  const CliInstallerMock = vi.fn(function CliInstaller() {
+    return {
+      reconcileAfterAppUpdate: reconcileAfterAppUpdateMock,
+      getStatus: getStatusMock,
+      install: installMock,
+      remove: removeMock
+    }
+  })
+  return {
+    handleMock: vi.fn(),
+    reconcileAfterAppUpdateMock,
+    getStatusMock,
+    installMock,
+    removeMock,
+    CliInstallerMock
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('../cli/cli-installer', () => ({
+  CliInstaller: CliInstallerMock
+}))
+
+import { CliInstaller } from '../cli/cli-installer'
+import { registerCliHandlers } from './cli'
+
+describe('registerCliHandlers', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    reconcileAfterAppUpdateMock.mockReset()
+    reconcileAfterAppUpdateMock.mockResolvedValue('already_installed')
+    getStatusMock.mockReset()
+    installMock.mockReset()
+    removeMock.mockReset()
+    vi.mocked(CliInstaller).mockClear()
+  })
+
+  it('starts app-update reconciliation and registers CLI IPC handlers', () => {
+    registerCliHandlers()
+
+    expect(reconcileAfterAppUpdateMock).toHaveBeenCalledTimes(1)
+    expect(handleMock).toHaveBeenCalledWith('cli:getInstallStatus', expect.any(Function))
+    expect(handleMock).toHaveBeenCalledWith('cli:install', expect.any(Function))
+    expect(handleMock).toHaveBeenCalledWith('cli:remove', expect.any(Function))
+  })
+
+  it('does not throw when startup reconciliation fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    reconcileAfterAppUpdateMock.mockRejectedValueOnce(new Error('permission denied'))
+
+    expect(() => registerCliHandlers()).not.toThrow()
+    await Promise.resolve()
+
+    expect(warnSpy).toHaveBeenCalledWith('[cli] startup reconciliation failed:', expect.any(Error))
+    warnSpy.mockRestore()
+  })
+})

--- a/src/main/ipc/cli.ts
+++ b/src/main/ipc/cli.ts
@@ -3,6 +3,23 @@ import type { CliInstallStatus } from '../../shared/cli-install-types'
 import { CliInstaller } from '../cli/cli-installer'
 
 export function registerCliHandlers(): void {
+  void new CliInstaller().reconcileAfterAppUpdate().then(
+    (result) => {
+      if (
+        result === 'migrated_legacy_launcher' ||
+        result === 'permission_denied' ||
+        result === 'stale_preserved'
+      ) {
+        console.info(`[cli] startup reconciliation result: ${result}`)
+      }
+    },
+    (error: unknown) => {
+      // Why: CLI reconciliation is a best-effort app-update repair. Startup
+      // must continue even when a PATH-visible launcher is not writable.
+      console.warn('[cli] startup reconciliation failed:', error)
+    }
+  )
+
   ipcMain.handle('cli:getInstallStatus', async (): Promise<CliInstallStatus> => {
     return new CliInstaller().getStatus()
   })


### PR DESCRIPTION
Risk: high
Historic risk metadata backfill based on the existing `risk:high` label.