### PR TITLE
Strip Grok user_query wrapper from status prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ All changes must consider the SSH use case. Don't assume local-only execution.
 ## GitHub CLI Usage
 
 Be mindful of the user's `gh` CLI API rate limit — batch requests where possible and avoid unnecessary calls. All code, commands, and scripts must be compatible with macOS, Linux, and Windows.
+Never commit PR evidence images; attach them to the PR conversation instead.
 
 ## Type Declarations: Prefer `.ts` Over `.d.ts`
 

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2002,6 +2002,70 @@ describe('Copilot hook normalization', () => {
       rmSync(tmpDir, { recursive: true, force: true })
     }
   })
+
+  it('updates Grok Stop with final chat-history text after a non-blocking retry', async () => {
+    const server = new AgentHookServer()
+    const tmpDir = mkdtempSync(join(tmpdir(), 'orca-grok-chat-history-retry-'))
+    const sessionId = '019e37f4-5135-7b63-a4ab-6d13aa6bf528'
+    const cwd = join(tmpDir, 'workspace')
+    const sessionDir = join(tmpDir, '.grok', 'sessions', encodeURIComponent(cwd), sessionId)
+    mkdirSync(sessionDir, { recursive: true })
+    writeFileSync(join(sessionDir, 'chat_history.jsonl'), '')
+    vi.stubEnv('HOME', tmpDir)
+    vi.stubEnv('USERPROFILE', tmpDir)
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const listener = vi.fn()
+      server.setListener(listener)
+
+      await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/grok`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(buildBody({ hookEventName: 'user_prompt_submit', prompt: 'hihi' }))
+      })
+      const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/grok`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(buildBody({ hookEventName: 'Stop', sessionId, cwd }))
+      })
+
+      expect(response.status).toBe(204)
+      expect(listener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            state: 'done',
+            lastAssistantMessage: undefined
+          })
+        })
+      )
+
+      writeFileSync(
+        join(sessionDir, 'chat_history.jsonl'),
+        `${JSON.stringify({ type: 'assistant', content: 'Hi! How can I help you today?' })}\n`
+      )
+      await new Promise((resolve) => setTimeout(resolve, 120))
+
+      expect(listener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            state: 'done',
+            lastAssistantMessage: 'Hi! How can I help you today?'
+          })
+        })
+      )
+    } finally {
+      server.stop()
+      vi.unstubAllEnvs()
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('Endpoint file lifecycle', () => {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -22,6 +22,7 @@ import {
   clearPaneCacheState,
   createHookListenerState,
   getEndpointFileName,
+  hasPendingAgentResultText,
   HOOK_REQUEST_SLOWLORIS_MS,
   MAX_PANE_KEY_LEN,
   normalizeHookPayload,
@@ -75,8 +76,8 @@ type PaneKeyAliasEntry = {
 // the endpoint file in userData/agent-hooks/ so all hook-server-owned cross-
 // restart artifacts stay co-located.
 const LAST_STATUS_FILE_NAME = 'last-status.json'
-const COPILOT_TRANSCRIPT_RETRY_ATTEMPTS = 5
-const COPILOT_TRANSCRIPT_RETRY_MS = 50
+const ASSISTANT_MESSAGE_RETRY_ATTEMPTS = 5
+const ASSISTANT_MESSAGE_RETRY_MS = 50
 
 // Why: starts at 2 (not 1) because pre-merge dev iterations of this branch
 // wrote a v1 shape with no receivedAt / stateStartedAt. Bumping to 2 means a
@@ -201,34 +202,6 @@ function trackEmptyPaneKeyHook(body: unknown): void {
   track('agent_hook_unattributed', { reason: 'empty_pane_key' })
 }
 
-function hasPendingCopilotTranscript(source: AgentHookSource, body: unknown): boolean {
-  if (source !== 'copilot' || typeof body !== 'object' || body === null) {
-    return false
-  }
-  const rawPayload = (body as Record<string, unknown>).payload
-  const payload =
-    typeof rawPayload === 'string'
-      ? (() => {
-          try {
-            return JSON.parse(rawPayload) as unknown
-          } catch {
-            return null
-          }
-        })()
-      : rawPayload
-  if (typeof payload !== 'object' || payload === null) {
-    return false
-  }
-  const record = payload as Record<string, unknown>
-  const directMessage =
-    record.last_assistant_message ?? record.lastAssistantMessage ?? record.message
-  if (typeof directMessage === 'string' && directMessage.trim().length > 0) {
-    return false
-  }
-  const transcriptPath = record.transcript_path ?? record.transcriptPath
-  return typeof transcriptPath === 'string' && transcriptPath.trim().length > 0
-}
-
 export class AgentHookServer {
   private server: ReturnType<typeof createServer> | null = null
   private port = 0
@@ -262,7 +235,7 @@ export class AgentHookServer {
   // Why: trailing-edge debounce timer. Captured per-instance so multiple
   // server instances in the same process (tests) don't share state.
   private statusPersistTimer: ReturnType<typeof setTimeout> | null = null
-  private copilotTranscriptRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private assistantMessageRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
   // Why: identity check — skip writes when the JSON-stringified contents
   // exactly match the last successful disk write. Cheap protection against
   // re-firing trailing timers when nothing changed.
@@ -347,7 +320,7 @@ export class AgentHookServer {
 
   private applyNormalizedStatus(payload: AgentHookEventPayload): EnrichedAgentHookEventPayload {
     if (payload.payload.state !== 'done' || payload.payload.lastAssistantMessage) {
-      this.clearCopilotTranscriptRetry(payload.paneKey)
+      this.clearAssistantMessageRetry(payload.paneKey)
     }
     const enriched = this.attachStatusTiming(payload)
     this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
@@ -358,16 +331,16 @@ export class AgentHookServer {
     return enriched
   }
 
-  private clearCopilotTranscriptRetry(paneKey: string): void {
-    const timer = this.copilotTranscriptRetryTimers.get(paneKey)
+  private clearAssistantMessageRetry(paneKey: string): void {
+    const timer = this.assistantMessageRetryTimers.get(paneKey)
     if (!timer) {
       return
     }
     clearTimeout(timer)
-    this.copilotTranscriptRetryTimers.delete(paneKey)
+    this.assistantMessageRetryTimers.delete(paneKey)
   }
 
-  private scheduleCopilotTranscriptRetry(
+  private scheduleAssistantMessageRetry(
     source: AgentHookSource,
     body: unknown,
     original: EnrichedAgentHookEventPayload,
@@ -375,21 +348,21 @@ export class AgentHookServer {
   ): void {
     if (
       original.payload.lastAssistantMessage ||
-      !hasPendingCopilotTranscript(source, body) ||
-      attempt > COPILOT_TRANSCRIPT_RETRY_ATTEMPTS
+      !hasPendingAgentResultText(source, body) ||
+      attempt > ASSISTANT_MESSAGE_RETRY_ATTEMPTS
     ) {
       return
     }
-    this.clearCopilotTranscriptRetry(original.paneKey)
+    this.clearAssistantMessageRetry(original.paneKey)
     const timer = setTimeout(() => {
       try {
-        this.copilotTranscriptRetryTimers.delete(original.paneKey)
+        this.assistantMessageRetryTimers.delete(original.paneKey)
         const current = this.state.lastStatusByPaneKey.get(original.paneKey) as
           | EnrichedAgentHookEventPayload
           | undefined
         if (
           !current ||
-          current.payload.agentType !== 'copilot' ||
+          current.payload.agentType !== original.payload.agentType ||
           current.payload.prompt !== original.payload.prompt ||
           current.payload.lastAssistantMessage
         ) {
@@ -397,18 +370,17 @@ export class AgentHookServer {
         }
         const normalized = normalizeHookPayload(this.state, source, body, this.env)
         if (!normalized?.payload.lastAssistantMessage) {
-          this.scheduleCopilotTranscriptRetry(source, body, original, attempt + 1)
+          this.scheduleAssistantMessageRetry(source, body, original, attempt + 1)
           return
         }
-        // Why: Copilot can POST Stop before its transcript line is flushed. Retry
-        // from a timer so the hook request returns immediately and the main loop
-        // is not blocked by synchronous sleeps.
+        // Why: some agents POST Stop before their transcript/chat-history line
+        // is flushed. Retry from a timer so the hook request returns immediately.
         this.applyNormalizedStatus(normalized)
       } catch (err) {
-        console.error('[agent-hooks] copilot transcript retry failed:', err)
+        console.error('[agent-hooks] assistant message retry failed:', err)
       }
-    }, COPILOT_TRANSCRIPT_RETRY_MS)
-    this.copilotTranscriptRetryTimers.set(original.paneKey, timer)
+    }, ASSISTANT_MESSAGE_RETRY_MS)
+    this.assistantMessageRetryTimers.set(original.paneKey, timer)
     if (typeof timer.unref === 'function') {
       timer.unref()
     }
@@ -683,7 +655,7 @@ export class AgentHookServer {
         const normalized = normalizeHookPayload(this.state, source, aliasedBody, this.env)
         if (normalized) {
           const enriched = this.applyNormalizedStatus(normalized)
-          this.scheduleCopilotTranscriptRetry(source, aliasedBody, enriched)
+          this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
         }
 
         res.writeHead(204)
@@ -734,10 +706,10 @@ export class AgentHookServer {
     this.token = ''
     this.env = 'production'
     this.onAgentStatus = null
-    for (const timer of this.copilotTranscriptRetryTimers.values()) {
+    for (const timer of this.assistantMessageRetryTimers.values()) {
       clearTimeout(timer)
     }
-    this.copilotTranscriptRetryTimers.clear()
+    this.assistantMessageRetryTimers.clear()
     // Why: intentionally do NOT delete the endpoint file on stop(). A stale
     // file points at a dead port, which matches the fail-open policy. Unlink
     // would introduce a TOCTOU race vs. a concurrent Orca instance.
@@ -765,7 +737,7 @@ export class AgentHookServer {
       return
     }
     this.state.lastStatusByPaneKey.delete(resolvedPaneKey)
-    this.clearCopilotTranscriptRetry(resolvedPaneKey)
+    this.clearAssistantMessageRetry(resolvedPaneKey)
     this.runtimeObservedStatusPaneKeys.delete(resolvedPaneKey)
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
@@ -778,7 +750,7 @@ export class AgentHookServer {
     // event does not change the on-disk file, and skipping the write avoids
     // re-stat'ing on every dead-pane teardown.
     const hadStatus = this.state.lastStatusByPaneKey.has(resolvedPaneKey)
-    this.clearCopilotTranscriptRetry(resolvedPaneKey)
+    this.clearAssistantMessageRetry(resolvedPaneKey)
     clearPaneCacheState(this.state, resolvedPaneKey)
     let clearedAlias = false
     for (const [legacyPaneKey, stablePaneKey] of this.legacyPaneKeyAliases) {

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -250,6 +250,64 @@ describe('RelayAgentHookServer', () => {
       )
     } finally {
       server.stop()
+    }
+  })
+
+  it('retries Grok chat history on the relay without blocking the hook POST', async () => {
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = new RelayAgentHookServer({ endpointDir: dir, forward })
+    const sessionId = '019e37f4-5135-7b63-a4ab-6d13aa6bf528'
+    const cwd = join(dir, 'workspace')
+    const sessionDir = join(dir, '.grok', 'sessions', encodeURIComponent(cwd), sessionId)
+    mkdirSync(sessionDir, { recursive: true })
+    writeFileSync(join(sessionDir, 'chat_history.jsonl'), '')
+    vi.stubEnv('HOME', dir)
+    vi.stubEnv('USERPROFILE', dir)
+    await server.start()
+    try {
+      const { port, token } = server.getCoordinates()
+      await fetch(`http://127.0.0.1:${port}/hook/grok`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': token
+        },
+        body: JSON.stringify({
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          env: 'remote',
+          version: '1',
+          payload: { hookEventName: 'user_prompt_submit', prompt: 'hihi' }
+        })
+      })
+      const response = await fetch(`http://127.0.0.1:${port}/hook/grok`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': token
+        },
+        body: JSON.stringify({
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          env: 'remote',
+          version: '1',
+          payload: { hookEventName: 'Stop', sessionId, cwd }
+        })
+      })
+
+      expect(response.status).toBe(204)
+      expect(forward.mock.calls.at(-1)?.[0].payload.lastAssistantMessage).toBeUndefined()
+
+      writeFileSync(
+        join(sessionDir, 'chat_history.jsonl'),
+        `${JSON.stringify({ type: 'assistant', content: 'Relay Grok reply.' })}\n`
+      )
+      await new Promise((resolve) => setTimeout(resolve, 120))
+
+      expect(forward.mock.calls.at(-1)?.[0].payload.lastAssistantMessage).toBe('Relay Grok reply.')
+    } finally {
+      server.stop()
+      vi.unstubAllEnvs()
     }
   })
 })

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: relay hook parsing, replay cache, endpoint
-   writing, and Copilot transcript retry state are one lifecycle unit; splitting
+   writing, and assistant-message retry state are one lifecycle unit; splitting
    them would obscure cleanup ordering across remote PTY reconnects. */
 // Why: relay-side adapter for the shared agent-hook listener pipeline. Hosts
 // a loopback HTTP server (same shape as Orca's main-process server: bind
@@ -22,6 +22,7 @@ import {
   clearPaneCacheState,
   createHookListenerState,
   getEndpointFileName,
+  hasPendingAgentResultText,
   HOOK_REQUEST_SLOWLORIS_MS,
   normalizeHookPayload,
   readRequestBody,
@@ -44,8 +45,8 @@ export type RelayHookForward = (envelope: AgentHookRelayEnvelope) => void
 // server is the only consumer.
 const RELAY_HOOKS_DIR_NAME = '.orca-relay'
 const RELAY_HOOKS_SUBDIR = 'agent-hooks'
-const COPILOT_TRANSCRIPT_RETRY_ATTEMPTS = 5
-const COPILOT_TRANSCRIPT_RETRY_MS = 50
+const ASSISTANT_MESSAGE_RETRY_ATTEMPTS = 5
+const ASSISTANT_MESSAGE_RETRY_MS = 50
 
 // Why: cap env/version metadata at 64 chars so a misbehaving agent CLI
 // cannot grow lastEnvelopeMetaByPaneKey unboundedly per pane via the cache
@@ -55,34 +56,6 @@ const MAX_HOOK_META_LEN = 64
 
 function defaultEndpointDir(): string {
   return join(homedir(), RELAY_HOOKS_DIR_NAME, RELAY_HOOKS_SUBDIR)
-}
-
-function hasPendingCopilotTranscript(source: AgentHookSource, body: unknown): boolean {
-  if (source !== 'copilot' || typeof body !== 'object' || body === null) {
-    return false
-  }
-  const rawPayload = (body as Record<string, unknown>).payload
-  const payload =
-    typeof rawPayload === 'string'
-      ? (() => {
-          try {
-            return JSON.parse(rawPayload) as unknown
-          } catch {
-            return null
-          }
-        })()
-      : rawPayload
-  if (typeof payload !== 'object' || payload === null) {
-    return false
-  }
-  const record = payload as Record<string, unknown>
-  const directMessage =
-    record.last_assistant_message ?? record.lastAssistantMessage ?? record.message
-  if (typeof directMessage === 'string' && directMessage.trim().length > 0) {
-    return false
-  }
-  const transcriptPath = record.transcript_path ?? record.transcriptPath
-  return typeof transcriptPath === 'string' && transcriptPath.trim().length > 0
 }
 
 export function endpointDirForRelaySocket(sockPath: string): string {
@@ -120,7 +93,7 @@ export class RelayAgentHookServer {
     string,
     { source: AgentHookSource; env?: string; version?: string }
   > = new Map()
-  private copilotTranscriptRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private assistantMessageRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private forward: RelayHookForward
 
   constructor(options: RelayHookServerOptions) {
@@ -178,10 +151,10 @@ export class RelayAgentHookServer {
     this.port = 0
     this.token = ''
     this.endpointFileWritten = false
-    for (const timer of this.copilotTranscriptRetryTimers.values()) {
+    for (const timer of this.assistantMessageRetryTimers.values()) {
       clearTimeout(timer)
     }
-    this.copilotTranscriptRetryTimers.clear()
+    this.assistantMessageRetryTimers.clear()
     clearAllListenerCaches(this.state)
     this.lastEnvelopeMetaByPaneKey.clear()
   }
@@ -213,7 +186,7 @@ export class RelayAgentHookServer {
    *  resurfaces as a ghost event on a later reconnect. Symmetric with the
    *  local server's clearPaneState on PTY teardown. */
   clearPaneState(paneKey: string): void {
-    this.clearCopilotTranscriptRetry(paneKey)
+    this.clearAssistantMessageRetry(paneKey)
     clearPaneCacheState(this.state, paneKey)
     this.lastEnvelopeMetaByPaneKey.delete(paneKey)
   }
@@ -273,7 +246,7 @@ export class RelayAgentHookServer {
         const env = this.bodyEnv(body)
         const version = this.bodyVersion(body)
         this.applyEvent(event, source, env, version)
-        this.scheduleCopilotTranscriptRetry(source, body, event, env, version)
+        this.scheduleAssistantMessageRetry(source, body, event, env, version)
       }
       res.writeHead(204)
       res.end()
@@ -316,23 +289,23 @@ export class RelayAgentHookServer {
     version?: string
   ): void {
     if (event.payload.state !== 'done' || event.payload.lastAssistantMessage) {
-      this.clearCopilotTranscriptRetry(event.paneKey)
+      this.clearAssistantMessageRetry(event.paneKey)
     }
     this.state.lastStatusByPaneKey.set(event.paneKey, event)
     this.lastEnvelopeMetaByPaneKey.set(event.paneKey, { source, env, version })
     this.forwardEvent(event, source, env, version)
   }
 
-  private clearCopilotTranscriptRetry(paneKey: string): void {
-    const timer = this.copilotTranscriptRetryTimers.get(paneKey)
+  private clearAssistantMessageRetry(paneKey: string): void {
+    const timer = this.assistantMessageRetryTimers.get(paneKey)
     if (!timer) {
       return
     }
     clearTimeout(timer)
-    this.copilotTranscriptRetryTimers.delete(paneKey)
+    this.assistantMessageRetryTimers.delete(paneKey)
   }
 
-  private scheduleCopilotTranscriptRetry(
+  private scheduleAssistantMessageRetry(
     source: AgentHookSource,
     body: unknown,
     original: AgentHookEventPayload,
@@ -342,19 +315,19 @@ export class RelayAgentHookServer {
   ): void {
     if (
       original.payload.lastAssistantMessage ||
-      !hasPendingCopilotTranscript(source, body) ||
-      attempt > COPILOT_TRANSCRIPT_RETRY_ATTEMPTS
+      !hasPendingAgentResultText(source, body) ||
+      attempt > ASSISTANT_MESSAGE_RETRY_ATTEMPTS
     ) {
       return
     }
-    this.clearCopilotTranscriptRetry(original.paneKey)
+    this.clearAssistantMessageRetry(original.paneKey)
     const timer = setTimeout(() => {
       try {
-        this.copilotTranscriptRetryTimers.delete(original.paneKey)
+        this.assistantMessageRetryTimers.delete(original.paneKey)
         const current = this.state.lastStatusByPaneKey.get(original.paneKey)
         if (
           !current ||
-          current.payload.agentType !== 'copilot' ||
+          current.payload.agentType !== original.payload.agentType ||
           current.payload.prompt !== original.payload.prompt ||
           current.payload.lastAssistantMessage
         ) {
@@ -362,19 +335,19 @@ export class RelayAgentHookServer {
         }
         const event = normalizeHookPayload(this.state, source, body, this.env)
         if (!event?.payload.lastAssistantMessage) {
-          this.scheduleCopilotTranscriptRetry(source, body, original, env, version, attempt + 1)
+          this.scheduleAssistantMessageRetry(source, body, original, env, version, attempt + 1)
           return
         }
         // Why: the relay runs on SSH targets too; retry from a timer so a delayed
-        // Copilot transcript does not block the remote hook server's event loop.
+        // transcript/chat-history write does not block the remote hook server.
         this.applyEvent(event, source, env, version)
       } catch (err) {
         process.stderr.write(
-          `[relay-hook-server] copilot transcript retry failed: ${err instanceof Error ? err.message : String(err)}\n`
+          `[relay-hook-server] assistant message retry failed: ${err instanceof Error ? err.message : String(err)}\n`
         )
       }
-    }, COPILOT_TRANSCRIPT_RETRY_MS)
-    this.copilotTranscriptRetryTimers.set(original.paneKey, timer)
+    }, ASSISTANT_MESSAGE_RETRY_MS)
+    this.assistantMessageRetryTimers.set(original.paneKey, timer)
     if (typeof timer.unref === 'function') {
       timer.unref()
     }

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -169,6 +169,50 @@ describe('shared agent-hook-listener', () => {
     })
   })
 
+  it('strips Grok internal user_query wrapper before caching the prompt', () => {
+    const prompt = normalizeHookPayload(
+      state,
+      'grok',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hookEventName: 'user_prompt_submit',
+          prompt: '<user_query>\nFind recent PR\n</user_query>'
+        }
+      },
+      'production'
+    )
+    expect(prompt?.payload.prompt).toBe('Find recent PR')
+
+    const tool = normalizeHookPayload(
+      state,
+      'grok',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hookEventName: 'pre_tool_use',
+          toolName: 'web_search',
+          toolInput: { query: 'recent PR' }
+        }
+      },
+      'production'
+    )
+    expect(tool?.payload.prompt).toBe('Find recent PR')
+  })
+
+  it('strips Grok opening user_query wrapper even when the closing tag is absent', () => {
+    const event = normalizeHookPayload(
+      state,
+      'grok',
+      {
+        paneKey: PANE_KEY,
+        payload: { hookEventName: 'user_prompt_submit', prompt: '<user_query>Find recent PR' }
+      },
+      'production'
+    )
+    expect(event?.payload.prompt).toBe('Find recent PR')
+  })
+
   it('maps Grok feedback notifications to waiting without overwriting the prompt', () => {
     normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: this fixture keeps cross-agent hook normalization and cache behavior together so regressions in shared listener state are visible. */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -237,6 +237,45 @@ describe('shared agent-hook-listener', () => {
       prompt: 'ship it',
       agentType: 'grok'
     })
+  })
+
+  it('reads Grok final assistant text from chat history on Stop', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'orca-grok-session-'))
+    const sessionId = '019e37f4-5135-7b63-a4ab-6d13aa6bf528'
+    const cwd = join(tmpDir, 'workspace')
+    const sessionDir = join(tmpDir, '.grok', 'sessions', encodeURIComponent(cwd), sessionId)
+    try {
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'chat_history.jsonl'),
+        `${[
+          JSON.stringify({ type: 'user', content: [{ type: 'text', text: 'hihi' }] }),
+          JSON.stringify({ type: 'assistant', content: 'Hi! How can I help you today?' })
+        ].join('\n')}\n`
+      )
+
+      normalizeHookPayload(
+        state,
+        'grok',
+        { paneKey: PANE_KEY, payload: { hookEventName: 'user_prompt_submit', prompt: 'hihi' } },
+        'production'
+      )
+
+      const done = normalizeHookPayload(
+        state,
+        'grok',
+        {
+          paneKey: PANE_KEY,
+          payload: { hookEventName: 'Stop', sessionId, cwd, grokHome: join(tmpDir, '.grok') }
+        },
+        'production'
+      )
+
+      expect(done?.payload.state).toBe('done')
+      expect(done?.payload.lastAssistantMessage).toBe('Hi! How can I help you today?')
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
   })
 
   it('normalizes Hermes pre_llm_call to a working turn with prompt text', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable max-lines -- Why: this fixture keeps cross-agent hook normalization and cache behavior together so regressions in shared listener state are visible. */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
   createHookListenerState,
   getEndpointFileName,
+  hasPendingAgentResultText,
   isShellSafeEndpointValue,
   normalizeHookPayload,
   parseFormEncodedBody,
@@ -23,6 +24,10 @@ describe('shared agent-hook-listener', () => {
 
   beforeEach(() => {
     state = createHookListenerState()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('parses form-encoded bodies', () => {
@@ -245,6 +250,8 @@ describe('shared agent-hook-listener', () => {
     const cwd = join(tmpDir, 'workspace')
     const sessionDir = join(tmpDir, '.grok', 'sessions', encodeURIComponent(cwd), sessionId)
     try {
+      vi.stubEnv('HOME', tmpDir)
+      vi.stubEnv('USERPROFILE', tmpDir)
       mkdirSync(sessionDir, { recursive: true })
       writeFileSync(
         join(sessionDir, 'chat_history.jsonl'),
@@ -266,7 +273,7 @@ describe('shared agent-hook-listener', () => {
         'grok',
         {
           paneKey: PANE_KEY,
-          payload: { hookEventName: 'Stop', sessionId, cwd, grokHome: join(tmpDir, '.grok') }
+          payload: { hookEventName: 'Stop', sessionId, cwd }
         },
         'production'
       )
@@ -276,6 +283,48 @@ describe('shared agent-hook-listener', () => {
     } finally {
       rmSync(tmpDir, { recursive: true, force: true })
     }
+  })
+
+  it('does not let Grok sessionId escape the chat-history directory', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'orca-grok-session-escape-'))
+    const cwd = join(tmpDir, 'workspace')
+    const escapedDir = join(tmpDir, '.grok', 'sessions', 'escaped')
+    try {
+      vi.stubEnv('HOME', tmpDir)
+      vi.stubEnv('USERPROFILE', tmpDir)
+      mkdirSync(escapedDir, { recursive: true })
+      writeFileSync(
+        join(escapedDir, 'chat_history.jsonl'),
+        `${JSON.stringify({ type: 'assistant', content: 'should not leak' })}\n`
+      )
+
+      const done = normalizeHookPayload(
+        state,
+        'grok',
+        {
+          paneKey: PANE_KEY,
+          payload: { hookEventName: 'Stop', sessionId: '../escaped', cwd }
+        },
+        'production'
+      )
+
+      expect(done?.payload.state).toBe('done')
+      expect(done?.payload.lastAssistantMessage).toBeUndefined()
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats Grok SessionEnd chat history as pending result text', () => {
+    expect(
+      hasPendingAgentResultText('grok', {
+        payload: {
+          hookEventName: 'SessionEnd',
+          sessionId: '019e37f4-5135-7b63-a4ab-6d13aa6bf528',
+          cwd: '/tmp/workspace'
+        }
+      })
+    ).toBe(true)
   })
 
   it('normalizes Hermes pre_llm_call to a working turn with prompt text', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -12,6 +12,7 @@
 // docs/design/agent-status-over-ssh.md §3 ("relay normalizes; Orca routes").
 import type { IncomingMessage } from 'http'
 import { randomUUID } from 'crypto'
+import { homedir } from 'os'
 import {
   chmodSync,
   closeSync,
@@ -494,7 +495,8 @@ function extractAssistantTextFromLine(line: string): string | undefined {
     }
   }
   const nestedMessage = record.message as Record<string, unknown> | undefined
-  const role = record.role ?? nestedMessage?.role
+  const role =
+    record.role ?? nestedMessage?.role ?? (record.type === 'assistant' ? 'assistant' : undefined)
   if (role !== 'assistant') {
     return undefined
   }
@@ -524,6 +526,21 @@ function readLastAssistantFromTranscript(transcriptPath: unknown): string | unde
     return undefined
   }
   return readLastAssistantFromTranscriptOnce(transcriptPath)
+}
+
+function readLastAssistantFromGrokChatHistory(
+  hookPayload: Record<string, unknown>
+): string | undefined {
+  const sessionId = readFirstString(hookPayload, ['sessionId', 'session_id'])
+  const cwd = readFirstString(hookPayload, ['cwd', 'workspaceRoot', 'workspace_root'])
+  if (!sessionId || !cwd) {
+    return undefined
+  }
+  const grokHome =
+    readFirstString(hookPayload, ['grokHome', 'grok_home']) ?? join(homedir(), '.grok')
+  return readLastAssistantFromTranscriptOnce(
+    join(grokHome, 'sessions', encodeURIComponent(cwd), sessionId, 'chat_history.jsonl')
+  )
 }
 
 function readLastAssistantFromTranscriptOnce(transcriptPath: string): string | undefined {
@@ -1085,6 +1102,10 @@ function extractGrokToolFields(
     )
     if (fromTranscript) {
       return { lastAssistantMessage: fromTranscript }
+    }
+    const fromChatHistory = readLastAssistantFromGrokChatHistory(hookPayload)
+    if (fromChatHistory) {
+      return { lastAssistantMessage: fromChatHistory }
     }
   }
   return {}

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -246,6 +246,13 @@ function extractPromptText(hookPayload: Record<string, unknown>): string {
   return ''
 }
 
+function stripGrokUserQueryWrapper(promptText: string): string {
+  const match = promptText.match(/^<user_query>([\s\S]*?)(?:<\/user_query>)?$/)
+  // Why: Grok emits the submitted prompt wrapped in its internal
+  // `<user_query>` envelope; the status cache should hold the user text.
+  return match ? match[1].trim() : promptText
+}
+
 function resolvePrompt(
   state: HookListenerState,
   paneKey: string,
@@ -1696,7 +1703,9 @@ function normalizeGrokEvent(
 
   // Why: Grok Notification.message is status UI text, not necessarily the
   // user's prompt. Preserve the cached UserPromptSubmit prompt for the row.
-  const effectivePrompt = isGrokEvent(eventName, 'notification') ? '' : promptText
+  const effectivePrompt = isGrokEvent(eventName, 'notification')
+    ? ''
+    : stripGrokUserQueryWrapper(promptText)
 
   return parseAgentStatusPayload(
     JSON.stringify({

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -473,6 +473,8 @@ function extractToolResponseText(toolResponse: unknown): string | undefined {
 
 const TRANSCRIPT_CHUNK_BYTES = 64 * 1024
 const TRANSCRIPT_MAX_SCAN_BYTES = 4 * 1024 * 1024
+const GROK_SESSION_ID_MAX_LENGTH = 128
+const GROK_SESSION_CWD_MAX_LENGTH = 4096
 
 function extractAssistantTextFromLine(line: string): string | undefined {
   let entry: unknown
@@ -528,19 +530,94 @@ function readLastAssistantFromTranscript(transcriptPath: unknown): string | unde
   return readLastAssistantFromTranscriptOnce(transcriptPath)
 }
 
+function parseHookBodyPayloadRecord(body: unknown): Record<string, unknown> | null {
+  if (typeof body !== 'object' || body === null) {
+    return null
+  }
+  const rawPayload = (body as Record<string, unknown>).payload
+  const payload =
+    typeof rawPayload === 'string'
+      ? (() => {
+          try {
+            return JSON.parse(rawPayload) as unknown
+          } catch {
+            return null
+          }
+        })()
+      : rawPayload
+  return typeof payload === 'object' && payload !== null
+    ? (payload as Record<string, unknown>)
+    : null
+}
+
+function readBoundedString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  maxLength: number
+): string | undefined {
+  const value = readFirstString(record, keys)
+  return value && value.length <= maxLength ? value : undefined
+}
+
+function isSafeGrokSessionId(sessionId: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(sessionId) && sessionId.length <= GROK_SESSION_ID_MAX_LENGTH
+}
+
+function getGrokChatHistoryPath(hookPayload: Record<string, unknown>): string | undefined {
+  const sessionId = readBoundedString(
+    hookPayload,
+    ['sessionId', 'session_id'],
+    GROK_SESSION_ID_MAX_LENGTH
+  )
+  const cwd = readBoundedString(
+    hookPayload,
+    ['cwd', 'workspaceRoot', 'workspace_root'],
+    GROK_SESSION_CWD_MAX_LENGTH
+  )
+  if (!sessionId || !cwd || !isSafeGrokSessionId(sessionId)) {
+    return undefined
+  }
+  return join(
+    homedir(),
+    '.grok',
+    'sessions',
+    encodeURIComponent(cwd),
+    sessionId,
+    'chat_history.jsonl'
+  )
+}
+
 function readLastAssistantFromGrokChatHistory(
   hookPayload: Record<string, unknown>
 ): string | undefined {
-  const sessionId = readFirstString(hookPayload, ['sessionId', 'session_id'])
-  const cwd = readFirstString(hookPayload, ['cwd', 'workspaceRoot', 'workspace_root'])
-  if (!sessionId || !cwd) {
+  const chatHistoryPath = getGrokChatHistoryPath(hookPayload)
+  if (!chatHistoryPath) {
     return undefined
   }
-  const grokHome =
-    readFirstString(hookPayload, ['grokHome', 'grok_home']) ?? join(homedir(), '.grok')
-  return readLastAssistantFromTranscriptOnce(
-    join(grokHome, 'sessions', encodeURIComponent(cwd), sessionId, 'chat_history.jsonl')
-  )
+  return readLastAssistantFromTranscriptOnce(chatHistoryPath)
+}
+
+export function hasPendingAgentResultText(source: AgentHookSource, body: unknown): boolean {
+  const record = parseHookBodyPayloadRecord(body)
+  if (!record) {
+    return false
+  }
+  const directMessage =
+    record.last_assistant_message ?? record.lastAssistantMessage ?? record.message
+  if (typeof directMessage === 'string' && directMessage.trim().length > 0) {
+    return false
+  }
+  if (source === 'copilot') {
+    const transcriptPath = record.transcript_path ?? record.transcriptPath
+    return typeof transcriptPath === 'string' && transcriptPath.trim().length > 0
+  }
+  if (
+    source === 'grok' &&
+    isGrokEvent(record.hookEventName ?? record.hook_event_name, 'stop', 'session_end')
+  ) {
+    return getGrokChatHistoryPath(record) !== undefined
+  }
+  return false
 }
 
 function readLastAssistantFromTranscriptOnce(transcriptPath: string): string | undefined {


### PR DESCRIPTION
## Summary
- Strip Grok's internal `<user_query>` envelope before prompt text enters the shared agent status cache.
- Keep the normalization in the Grok hook path so local and SSH-relayed Grok events behave the same way.
- Add regression coverage for closed and opening-only `<user_query>` wrappers, including cached prompt reuse on later tool events.

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-hook-listener.test.ts src/shared/agent-status-types.test.ts` - 2 files / 48 tests passed.
- `pnpm run typecheck:node` - passed.
- `git diff --check` - passed.
- Recent PR lookup: `gh pr list --repo stablyai/orca --limit 5 --json number,title,headRefName,updatedAt,url` returned #2160 as the latest updated PR.
- Grok invocation: `grok -p "Using only this provided data..." --disable-web-search` returned `#2160 Fix Windows setup split terminal behavior`. It also logged a local optional MCP warning for `ghost-os`, but completed successfully.