### PR TITLE
Fix floating terminal toggle overlap

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -275,6 +275,9 @@ function App(): React.JSX.Element {
     (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
   )
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
+  const showFloatingTerminalButton =
+    floatingTerminalEnabled &&
+    (floatingTerminalTriggerLocation === 'floating-button' || !statusBarVisible)
   // Why: the floating terminal is a transient overlay; hotkey minimize should
   // return keyboard focus to the surface the user was working in before it.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
@@ -1457,6 +1460,15 @@ function App(): React.JSX.Element {
                     {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
                   </Suspense>
                 </div>
+                {showFloatingTerminalButton ? (
+                  <FloatingTerminalToggleButton
+                    // Why: anchor the floating trigger to the center surface so it
+                    // cannot cover the worktree sidebar or right sidebar.
+                    className="absolute bottom-8 right-3"
+                    open={floatingTerminalOpen}
+                    onToggle={() => setFloatingTerminalOpenWithFocus((open) => !open)}
+                  />
+                ) : null}
               </div>
             </div>
           </div>
@@ -1468,18 +1480,10 @@ function App(): React.JSX.Element {
           {showRightSidebarControls ? <RightSidebar /> : null}
         </div>
         {floatingTerminalEnabled ? (
-          <>
-            <FloatingTerminalPanel
-              open={floatingTerminalOpen}
-              onOpenChange={setFloatingTerminalOpenWithFocus}
-            />
-            {floatingTerminalTriggerLocation === 'floating-button' || !statusBarVisible ? (
-              <FloatingTerminalToggleButton
-                open={floatingTerminalOpen}
-                onToggle={() => setFloatingTerminalOpenWithFocus((open) => !open)}
-              />
-            ) : null}
-          </>
+          <FloatingTerminalPanel
+            open={floatingTerminalOpen}
+            onOpenChange={setFloatingTerminalOpenWithFocus}
+          />
         ) : null}
         <StatusBar floatingTerminalOpen={floatingTerminalOpen} />
         {/* Why: root overlays can render Radix <Tooltip>s; keep them inside

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
@@ -1,21 +1,24 @@
 import { TerminalSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 import { FloatingTerminalIconContextMenu } from './FloatingTerminalIconContextMenu'
 
 export function FloatingTerminalToggleButton({
   open,
-  onToggle
+  onToggle,
+  className
 }: {
   open: boolean
   onToggle: () => void
+  className?: string
 }): React.JSX.Element {
   const shortcutLabel =
     typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac') ? '⌘⌥T' : 'Ctrl+Alt+T'
   return (
     <FloatingTerminalIconContextMenu
       currentLocation="floating-button"
-      className="fixed bottom-8 right-3 z-40"
+      className={cn('fixed bottom-8 right-3 z-40', className)}
     >
       <Tooltip>
         <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- anchor the floating terminal toggle inside the center work surface instead of the full app viewport
- keep the floating terminal panel mounted at the app root while allowing the toggle wrapper to override positioning

## Verification
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/App.tsx src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
- Electron/CDP geometry check confirmed the toggle clears both sidebar boundaries

Made with [Orca](https://github.com/stablyai/orca) 🐋
