### PR TITLE
Remove child workspace nesting toggle

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -338,7 +338,6 @@ function App(): React.JSX.Element {
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const groupBy = useAppStore((s) => s.groupBy)
-  const showWorkspaceLineage = useAppStore((s) => s.showWorkspaceLineage)
   const sortBy = useAppStore((s) => s.sortBy)
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
@@ -810,7 +809,6 @@ function App(): React.JSX.Element {
         sidebarWidth,
         rightSidebarWidth,
         groupBy,
-        showWorkspaceLineage,
         sortBy,
         showActiveOnly,
         hideDefaultBranchWorkspace,
@@ -830,7 +828,6 @@ function App(): React.JSX.Element {
     sidebarWidth,
     rightSidebarWidth,
     groupBy,
-    showWorkspaceLineage,
     sortBy,
     showActiveOnly,
     hideDefaultBranchWorkspace,

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -66,8 +66,6 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const setSortBy = useAppStore((s) => s.setSortBy)
   const groupBy = useAppStore((s) => s.groupBy)
   const setGroupBy = useAppStore((s) => s.setGroupBy)
-  const showWorkspaceLineage = useAppStore((s) => s.showWorkspaceLineage)
-  const setShowWorkspaceLineage = useAppStore((s) => s.setShowWorkspaceLineage)
 
   const handleWorkspaceBoardOpenChange = useCallback((open: boolean) => {
     setWorkspaceBoardOpen(open)
@@ -194,15 +192,6 @@ const SidebarHeader = React.memo(function SidebarHeader() {
                   ))}
                 </ToggleGroup>
               </div>
-
-              <DropdownMenuSeparator />
-              <DropdownMenuCheckboxItem
-                checked={showWorkspaceLineage}
-                onCheckedChange={(checked) => setShowWorkspaceLineage(Boolean(checked))}
-                onSelect={(e) => e.preventDefault()}
-              >
-                Nest child workspaces
-              </DropdownMenuCheckboxItem>
 
               <DropdownMenuSeparator />
               <DropdownMenuLabel>Sort by</DropdownMenuLabel>

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -644,7 +644,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           </div>
         )}
 
-        {lineageChildren && <div className="-ml-4 mt-1.5 space-y-1">{lineageChildren}</div>}
+        {lineageChildren && <div className="-ml-3 mt-1.5 space-y-1">{lineageChildren}</div>}
       </div>
     </div>
   )

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -109,13 +109,12 @@ function getWorktreeOptionId(worktreeId: string): string {
   return `worktree-list-option-${encodeURIComponent(worktreeId)}`
 }
 
-const LINEAGE_INDENT = 24
+const LINEAGE_INDENT = 18
 
 type VirtualizedWorktreeViewportProps = {
   rows: Row[]
   activeWorktreeId: string | null
   groupBy: WorktreeGroupBy
-  showWorkspaceLineage: boolean
   showInlineAgentCards: boolean
   repoGroupOrdering: RepoGroupOrdering
   toggleGroup: (key: string) => void
@@ -172,11 +171,7 @@ function renderRowContainsWorktree(row: RenderRow, worktreeId: string | null): b
   return row.type === 'item' && row.worktree.id === worktreeId
 }
 
-function buildRenderableRows(rows: Row[], showWorkspaceLineage: boolean): RenderRow[] {
-  if (!showWorkspaceLineage) {
-    return rows
-  }
-
+function buildRenderableRows(rows: Row[]): RenderRow[] {
   const renderRows: RenderRow[] = []
   for (let index = 0; index < rows.length; index++) {
     const row = rows[index]
@@ -245,7 +240,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   rows,
   activeWorktreeId,
   groupBy,
-  showWorkspaceLineage,
   showInlineAgentCards,
   repoGroupOrdering,
   toggleGroup,
@@ -286,10 +280,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     onCommit: reorderRepos,
     getScrollContainer: () => scrollRef.current
   })
-  const renderRows = useMemo(
-    () => buildRenderableRows(rows, showWorkspaceLineage),
-    [rows, showWorkspaceLineage]
-  )
+  const renderRows = useMemo(() => buildRenderableRows(rows), [rows])
   const activeWorktreeRowIndex = useMemo(
     () => renderRows.findIndex((row) => renderRowContainsWorktree(row, activeWorktreeId)),
     [renderRows, activeWorktreeId]
@@ -372,7 +363,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
     {
       const targetWorktree = worktrees.find((w) => w.id === pendingRevealWorktreeId)
-      if (targetWorktree && showWorkspaceLineage && !targetWorktree.isPinned) {
+      if (targetWorktree && !targetWorktree.isPinned) {
         const seen = new Set<string>()
         let current: Worktree | undefined = targetWorktree
         while (current && !seen.has(current.id)) {
@@ -440,7 +431,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     prCache,
     worktreeLineageById,
     worktreeMap,
-    showWorkspaceLineage,
     renderRows,
     virtualizer,
     clearPendingRevealWorktreeId,
@@ -531,7 +521,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         repoGroupOrdering,
         worktreeLineageById,
         worktreeMap,
-        showWorkspaceLineage
+        true
       ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
       if (worktreeRows.length === 0) {
         return
@@ -576,8 +566,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       repoOrder,
       workspaceStatuses,
       worktreeLineageById,
-      worktreeMap,
-      showWorkspaceLineage
+      worktreeMap
     ]
   )
 
@@ -1154,7 +1143,6 @@ const WorktreeList = React.memo(function WorktreeList({
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const groupBy = useAppStore((s) => s.groupBy)
-  const showWorkspaceLineage = useAppStore((s) => s.showWorkspaceLineage)
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sortBy = useAppStore((s) => s.sortBy)
   const showActiveOnly = useAppStore((s) => s.showActiveOnly)
@@ -1480,7 +1468,7 @@ const WorktreeList = React.memo(function WorktreeList({
         repoGroupOrdering,
         worktreeLineageById,
         worktreeMap,
-        showWorkspaceLineage
+        true
       ),
     [
       groupBy,
@@ -1492,8 +1480,7 @@ const WorktreeList = React.memo(function WorktreeList({
       workspaceStatuses,
       repoGroupOrdering,
       worktreeLineageById,
-      worktreeMap,
-      showWorkspaceLineage
+      worktreeMap
     ]
   )
   // Why: header/mode changes can shift entire groups, so remount the
@@ -1505,8 +1492,8 @@ const WorktreeList = React.memo(function WorktreeList({
       .filter((r): r is GroupHeaderRow => r.type === 'header')
       .map((r) => r.key)
       .join(',')
-    return `${groupBy}:${showWorkspaceLineage ? 'lineage' : 'flat'}:${headers}`
-  }, [groupBy, rows, showWorkspaceLineage])
+    return `${groupBy}:lineage:${headers}`
+  }, [groupBy, rows])
 
   // Why: derive the rendered item order from the post-buildRows() row list,
   // not the flat `worktrees` array, because grouping (groupBy: 'repo' or
@@ -1726,7 +1713,6 @@ const WorktreeList = React.memo(function WorktreeList({
       rows={rows}
       activeWorktreeId={selectedSidebarWorktreeId}
       groupBy={groupBy}
-      showWorkspaceLineage={showWorkspaceLineage}
       showInlineAgentCards={cardProps.includes('inline-agents')}
       repoGroupOrdering={repoGroupOrdering}
       toggleGroup={toggleGroup}

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -35,7 +35,6 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     sidebarWidth: 280,
     rightSidebarWidth: 350,
     groupBy: 'repo',
-    showWorkspaceLineage: false,
     sortBy: 'name',
     showActiveOnly: false,
     hideDefaultBranchWorkspace: false,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -354,8 +354,6 @@ export type UISlice = {
   clearOrcaHookTrustForRepo: (repoId: string) => void
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   setGroupBy: (g: UISlice['groupBy']) => void
-  showWorkspaceLineage: boolean
-  setShowWorkspaceLineage: (v: boolean) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo'
   setSortBy: (s: UISlice['sortBy']) => void
   showActiveOnly: boolean
@@ -723,9 +721,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ groupBy: g, collapsedGroups: new Set<string>() })
   },
 
-  showWorkspaceLineage: false,
-  setShowWorkspaceLineage: (v) => set({ showWorkspaceLineage: v }),
-
   sortBy: 'recent',
   setSortBy: (s) => set({ sortBy: s }),
 
@@ -918,7 +913,6 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
           MAX_RIGHT_SIDEBAR_WIDTH
         ),
         groupBy: (ui.groupBy as UISlice['groupBy'] | 'parent') === 'parent' ? 'repo' : ui.groupBy,
-        showWorkspaceLineage: ui.showWorkspaceLineage ?? false,
         sortBy,
         // Why: "Active only" is part of the user's sidebar working set, not a
         // transient render detail. Restoring it on launch keeps the filtered

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -341,7 +341,6 @@ export function getDefaultUIState(): PersistedUIState {
     sidebarWidth: 280,
     rightSidebarWidth: 350,
     groupBy: 'repo',
-    showWorkspaceLineage: false,
     sortBy: 'recent',
     showActiveOnly: false,
     hideDefaultBranchWorkspace: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1706,7 +1706,6 @@ export type PersistedUIState = {
   sidebarWidth: number
   rightSidebarWidth: number
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
-  showWorkspaceLineage?: boolean
   sortBy: 'name' | 'smart' | 'recent' | 'repo'
   showActiveOnly: boolean
   /** Hide the repo's original checked-out branch from workspace navigation


### PR DESCRIPTION
## Summary
- remove the persisted/view-option toggle for nesting child workspaces
- always render child workspace lineage nested in the sidebar
- reduce the per-level nested indentation and align the parent child-count chip with the parent subtitle text

## Validation
- pnpm run typecheck:web
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/lib/startup-ui-hydration.test.ts
- Electron dev validation with triple lineage nesting; screenshot: .playwright-cli/lineage-real-ids-restored.png

Made with [Orca](https://github.com/stablyai/orca) 🐋
