### PR TITLE
Prompt for microphone access before enabling dictation

### DIFF
--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -32,6 +32,7 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   const modelStates = useAppStore((s) => s.modelStates)
   const refreshModelStates = useAppStore((s) => s.refreshModelStates)
   const [catalog, setCatalog] = useState<SpeechModelManifest[]>([])
+  const [permissionPending, setPermissionPending] = useState(false)
 
   useEffect(() => {
     refreshModelStates()
@@ -57,6 +58,37 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
     })
   }
 
+  const toggleVoiceDictation = async (): Promise<void> => {
+    if (voiceSettings.enabled) {
+      updateVoiceSettings({ enabled: false })
+      return
+    }
+
+    setPermissionPending(true)
+    try {
+      // Why: enabling dictation is the point where users expect the macOS
+      // microphone prompt, not after their first attempted recording fails.
+      const result = await window.api.developerPermissions.request({ id: 'microphone' })
+      if (result.status === 'granted' || result.status === 'unsupported') {
+        updateVoiceSettings({ enabled: true })
+      }
+
+      if (result.status === 'granted') {
+        toast.success('Microphone permission granted')
+      } else if (result.openedSystemSettings) {
+        toast.message(
+          'Opened macOS Privacy & Security. Enable dictation again after granting access.'
+        )
+      } else if (result.status !== 'unsupported') {
+        toast.message('Microphone permission is required before enabling voice dictation.')
+      }
+    } catch {
+      toast.error('Could not request microphone permission. Voice dictation was not enabled.')
+    } finally {
+      setPermissionPending(false)
+    }
+  }
+
   const getModelState = (id: string): SpeechModelState | undefined =>
     modelStates.find((s) => s.id === id)
 
@@ -79,10 +111,12 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
           role="switch"
           aria-checked={voiceSettings.enabled}
           aria-label="Enable Voice Dictation"
-          onClick={() => updateVoiceSettings({ enabled: !voiceSettings.enabled })}
+          aria-busy={permissionPending}
+          disabled={permissionPending}
+          onClick={() => void toggleVoiceDictation()}
           className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
             voiceSettings.enabled ? 'bg-foreground' : 'bg-muted-foreground/30'
-          }`}
+          } ${permissionPending ? 'cursor-wait opacity-70' : ''}`}
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${


### PR DESCRIPTION
## Summary
- request microphone permission when the user enables Voice Dictation
- keep the toggle pending while the permission request is in flight
- only persist dictation as enabled once microphone access is granted, while preserving non-macOS unsupported-permission behavior

## Review
- Codex subagent review initially found a blocker: denied macOS permission could still leave dictation enabled
- Fixed that blocker and reran Codex subagent review; no actionable issues found

## Verification
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/settings/VoicePane.tsx
- git diff --check

Note: typecheck emitted the existing local engine warning because this shell is using Node v25.9.0 while package.json wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
