### PR TITLE
Fix worktree sidebar scroll and sleep persistence

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -78,10 +78,19 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 // Prevents jarring position shifts when background events (AI starting work,
 // terminal title changes) trigger score recalculations.
 const SORT_SETTLE_MS = 3_000
+const USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 500
 const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
   // Why: TanStack Virtual owns scroll correction. Native browser anchoring can
   // fight virtual row measurement/remounts and produce visible jumps.
   overflowAnchor: 'none'
+}
+
+export function shouldAdjustWorktreeSidebarMeasuredRowScroll(args: {
+  isScrolling: boolean
+  now: number
+  suppressUntil: number
+}): boolean {
+  return !args.isScrolling && args.now >= args.suppressUntil
 }
 
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -275,6 +284,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   scrollAnchorRef
 }: VirtualizedWorktreeViewportProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
+  const suppressMeasurementAdjustmentUntilRef = useRef(0)
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
   const canReorderRepoHeaders = groupBy === 'repo' && repoGroupOrdering === 'manual'
@@ -344,6 +354,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     },
     [isCurrentVirtualRowElement]
   )
+  const markDirectScrollInput = useCallback(() => {
+    suppressMeasurementAdjustmentUntilRef.current =
+      window.performance.now() + USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS
+  }, [])
+  const shouldSkipScrollAnchorRestore = useCallback(
+    () => window.performance.now() < suppressMeasurementAdjustmentUntilRef.current,
+    []
+  )
 
   const virtualizer = useVirtualizer({
     count: renderRows.length,
@@ -352,6 +370,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     measureElement: measureCurrentVirtualRowElement,
     overscan: 10,
     gap: 6,
+    isScrollingResetDelay: USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS,
     // Why: the sidebar rows are rich cards. Flushing their React render inside
     // TanStack's native scroll listener can make wheel input wait on card work;
     // overscan gives the async render enough runway to stay visually filled.
@@ -364,6 +383,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     initialOffset: () => scrollOffsetRef.current,
     getItemKey: getVirtualItemKey
   })
+  // Why: rich worktree cards remeasure while the user wheels through them.
+  // TanStack's default correction writes scrollTop in that path, which feels
+  // like rubber-banding. Structural mutations still use our explicit anchor
+  // restore after direct scroll input has settled.
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (_item, _delta, instance) =>
+    shouldAdjustWorktreeSidebarMeasuredRowScroll({
+      isScrolling: instance.isScrolling,
+      now: window.performance.now(),
+      suppressUntil: suppressMeasurementAdjustmentUntilRef.current
+    })
 
   React.useEffect(() => {
     if (!pendingRevealWorktreeId) {
@@ -498,6 +527,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     rows: renderRows,
     scrollElementRef: scrollRef,
     scrollOffsetRef,
+    shouldSkipRestore: shouldSkipScrollAnchorRestore,
     totalSize,
     virtualizer
   })
@@ -724,6 +754,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       aria-multiselectable="true"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
+      onTouchMove={markDirectScrollInput}
+      onWheel={markDirectScrollInput}
       className="worktree-sidebar-scrollbar flex-1 overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
       style={WORKTREE_SIDEBAR_SCROLL_STYLE}
     >

--- a/src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAdjustWorktreeSidebarMeasuredRowScroll } from './WorktreeList'
+
+describe('shouldAdjustWorktreeSidebarMeasuredRowScroll', () => {
+  it('suppresses measured-row scroll correction while TanStack is scrolling', () => {
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        isScrolling: true,
+        now: 1_000,
+        suppressUntil: 0
+      })
+    ).toBe(false)
+  })
+
+  it('suppresses measured-row scroll correction during direct scroll input grace period', () => {
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        isScrolling: false,
+        now: 1_000,
+        suppressUntil: 1_250
+      })
+    ).toBe(false)
+  })
+
+  it('allows measured-row scroll correction after direct scrolling settles', () => {
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        isScrolling: false,
+        now: 1_500,
+        suppressUntil: 1_250
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -21,6 +21,7 @@ type UseVirtualizedScrollAnchorOptions<
   rows: readonly TRow[]
   scrollElementRef: RefObject<TScrollElement | null>
   scrollOffsetRef: MutableRefObject<number>
+  shouldSkipRestore?: () => boolean
   totalSize: number
   virtualizer: Virtualizer<TScrollElement, TItemElement>
 }
@@ -45,6 +46,7 @@ export function useVirtualizedScrollAnchor<
   rows,
   scrollElementRef,
   scrollOffsetRef,
+  shouldSkipRestore,
   totalSize,
   virtualizer
 }: UseVirtualizedScrollAnchorOptions<TRow, TScrollElement, TItemElement>): void {
@@ -221,6 +223,9 @@ export function useVirtualizedScrollAnchor<
       // the anchor in that window writes scrollTop and fights the user's wheel.
       return
     }
+    if (shouldSkipRestore?.()) {
+      return
+    }
 
     const resolvedKey = rowIndexByKey.has(anchor.key)
       ? anchor.key
@@ -298,6 +303,7 @@ export function useVirtualizedScrollAnchor<
     rowIndexByKey,
     scrollElementRef,
     scrollOffsetRef,
+    shouldSkipRestore,
     totalSize,
     virtualizer,
     virtualizer.isScrolling

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -112,6 +112,26 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
+  it('writes when live PTY bindings change without terminal tab changes', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionState) => void>()
+    const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
+
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    useAppStore.setState({
+      ptyIdsByTabId: {
+        ...useAppStore.getState().ptyIdsByTabId,
+        'tab-1': []
+      }
+    })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
   it('updates its baseline without scheduling when shouldSchedulePersist returns false', () => {
     const persist = vi.fn<(payload: WorkspaceSessionState) => void>()
     let shouldSchedule = false

--- a/src/renderer/src/lib/workspace-session-browser-history.test.ts
+++ b/src/renderer/src/lib/workspace-session-browser-history.test.ts
@@ -9,6 +9,7 @@ function createSnapshot(browserUrlHistory: BrowserHistoryEntry[]): WorkspaceSess
     activeWorktreeId: null,
     activeTabId: null,
     tabsByWorktree: {},
+    ptyIdsByTabId: {},
     terminalLayoutsByTabId: {},
     activeTabIdByWorktree: {},
     openFiles: [],

--- a/src/renderer/src/lib/workspace-session-liveness.test.ts
+++ b/src/renderer/src/lib/workspace-session-liveness.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { buildWorkspaceSessionPayload, type WorkspaceSessionSnapshot } from './workspace-session'
+
+function createSnapshot(
+  overrides: Partial<WorkspaceSessionSnapshot> = {}
+): WorkspaceSessionSnapshot {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: 'wt-1',
+    activeTabId: 'tab-1',
+    tabsByWorktree: {},
+    ptyIdsByTabId: {},
+    terminalLayoutsByTabId: {},
+    activeTabIdByWorktree: {},
+    openFiles: [],
+    activeFileIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    browserTabsByWorktree: {},
+    browserPagesByWorkspace: {},
+    activeBrowserTabIdByWorktree: {},
+    browserUrlHistory: [],
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    activeGroupIdByWorktree: {},
+    sshConnectionStates: new Map(),
+    repos: [],
+    worktreesByRepo: {},
+    lastKnownRelayPtyIdByTabId: {},
+    lastVisitedAtByWorktreeId: {},
+    ...overrides
+  }
+}
+
+describe('workspace session live PTY persistence', () => {
+  it('does not treat slept terminal wake hints as active on restart', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-1': [
+            {
+              id: 'tab-1',
+              title: 'shell',
+              ptyId: 'preserved-wake-hint',
+              worktreeId: 'wt-1'
+            } as never
+          ]
+        },
+        ptyIdsByTabId: { 'tab-1': [] }
+      })
+    )
+
+    expect(payload.activeWorktreeIdsOnShutdown).toEqual([])
+  })
+
+  it('does not persist remote session ids for slept SSH tabs', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        tabsByWorktree: {
+          'wt-ssh': [
+            {
+              id: 'tab-ssh',
+              title: 'remote',
+              ptyId: 'relay-sess-42',
+              worktreeId: 'wt-ssh'
+            } as never
+          ]
+        },
+        ptyIdsByTabId: { 'tab-ssh': [] },
+        lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'relay-sess-42' },
+        repos: [
+          {
+            id: 'repo-ssh',
+            path: '/repo-ssh',
+            displayName: 'SSH',
+            badgeColor: '#fff',
+            addedAt: 1,
+            connectionId: 'conn-1'
+          }
+        ],
+        worktreesByRepo: {
+          'repo-ssh': [{ id: 'wt-ssh', repoId: 'repo-ssh' } as never]
+        }
+      })
+    )
+
+    expect(payload.activeWorktreeIdsOnShutdown).toEqual([])
+    expect(payload.remoteSessionIdsByTabId).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
+++ b/src/renderer/src/lib/workspace-session-relevant-fields.test.ts
@@ -9,6 +9,7 @@ describe('SESSION_RELEVANT_FIELDS', () => {
     activeWorktreeId: true,
     activeTabId: true,
     tabsByWorktree: true,
+    ptyIdsByTabId: true,
     terminalLayoutsByTabId: true,
     activeTabIdByWorktree: true,
     openFiles: true,

--- a/src/renderer/src/lib/workspace-session.test.ts
+++ b/src/renderer/src/lib/workspace-session.test.ts
@@ -12,6 +12,10 @@ function createSnapshot(overrides: Partial<AppState> = {}): AppState {
       'wt-1': [{ id: 'tab-1', title: 'shell', ptyId: 'pty-1', worktreeId: 'wt-1' }],
       'wt-2': [{ id: 'tab-2', title: 'editor', ptyId: null, worktreeId: 'wt-2' }]
     },
+    ptyIdsByTabId: {
+      'tab-1': ['pty-1'],
+      'tab-2': []
+    },
     terminalLayoutsByTabId: {
       'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
     },
@@ -125,6 +129,9 @@ describe('buildWorkspaceSessionPayload', () => {
         },
         activeTabIdByWorktree: {
           [FLOATING_TERMINAL_WORKTREE_ID]: 'floating-tab-1'
+        },
+        ptyIdsByTabId: {
+          'floating-tab-1': ['floating-pty-1']
         }
       })
     )
@@ -169,6 +176,9 @@ describe('buildWorkspaceSessionPayload', () => {
             } as never
           ]
         },
+        ptyIdsByTabId: {
+          'tab-local': ['pty-1']
+        },
         terminalLayoutsByTabId: {
           'tab-local': {
             root: null,
@@ -206,6 +216,9 @@ describe('buildWorkspaceSessionPayload', () => {
             } as never
           ]
         },
+        ptyIdsByTabId: {
+          'tab-ssh': ['relay-pty-1']
+        },
         terminalLayoutsByTabId: {
           'tab-ssh': {
             root: null,
@@ -224,12 +237,16 @@ describe('buildWorkspaceSessionPayload', () => {
     })
   })
 
-  it('uses lastKnownRelayPtyIdByTabId fallback for SSH worktrees with null ptyIds', () => {
+  it('uses lastKnownRelayPtyIdByTabId fallback for disconnected SSH worktrees', () => {
     const payload = buildWorkspaceSessionPayload(
       createSnapshot({
         tabsByWorktree: {
           'wt-1': [{ id: 'tab-1', title: 'shell', ptyId: 'pty-1', worktreeId: 'wt-1' } as never],
           'wt-ssh': [{ id: 'tab-ssh', title: 'remote', ptyId: null, worktreeId: 'wt-ssh' } as never]
+        },
+        ptyIdsByTabId: {
+          'tab-1': ['pty-1'],
+          'tab-ssh': []
         },
         lastKnownRelayPtyIdByTabId: { 'tab-ssh': 'relay-sess-42' },
         repos: [createRepo('repo-ssh', 'conn-1')],

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -33,6 +33,7 @@ export type WorkspaceSessionSnapshot = Pick<
   | 'activeWorktreeId'
   | 'activeTabId'
   | 'tabsByWorktree'
+  | 'ptyIdsByTabId'
   | 'terminalLayoutsByTabId'
   | 'activeTabIdByWorktree'
   | 'openFiles'
@@ -64,6 +65,7 @@ export const SESSION_RELEVANT_FIELDS = [
   'activeWorktreeId',
   'activeTabId',
   'tabsByWorktree',
+  'ptyIdsByTabId',
   'terminalLayoutsByTabId',
   'activeTabIdByWorktree',
   'openFiles',
@@ -197,14 +199,23 @@ export function buildWorkspaceSessionPayload(
   const layoutByWorktree = snapshot.layoutByWorktree
   const activeGroupIdByWorktree = snapshot.activeGroupIdByWorktree
 
-  // Why: lastKnownRelayPtyIdByTabId preserves session IDs across relay
-  // disconnect/reconnect cycles. tab.ptyId is cleared on disconnect, but
-  // the relay keeps the PTY alive — using the lastKnown fallback ensures
-  // the session save captures the ID even when the mux is temporarily down.
+  // Why: ptyIdsByTabId is the live-PTY map. tab.ptyId is only a wake hint that
+  // sleep intentionally preserves, so using it as liveness would revive slept
+  // worktrees as active after restart.
+  const ptyIdsByTabId = snapshot.ptyIdsByTabId
+  const hasLivePty = (tabId: string): boolean => (ptyIdsByTabId[tabId]?.length ?? 0) > 0
+
+  // Why: lastKnownRelayPtyIdByTabId preserves remote session IDs across relay
+  // disconnect/reconnect cycles, where clearTabPtyId(null) clears tab.ptyId
+  // but keeps the relay PTY alive. Sleep is different: it preserves tab.ptyId
+  // as a wake hint after clearing ptyIdsByTabId, so that shape must not count
+  // as active on restart.
   const lastKnown = snapshot.lastKnownRelayPtyIdByTabId
+  const hasReconnectableSession = (tab: { id: string; ptyId: string | null }): boolean =>
+    hasLivePty(tab.id) || (!tab.ptyId && Boolean(lastKnown[tab.id]))
 
   const activeWorktreeIdsOnShutdown = Object.entries(tabsByWorktree)
-    .filter(([, tabs]) => tabs.some((tab) => tab.ptyId || lastKnown[tab.id]))
+    .filter(([, tabs]) => tabs.some(hasReconnectableSession))
     .map(([worktreeId]) => worktreeId)
 
   // Why: sshConnectionStates is a Map<string, SshConnectionState>, not a plain
@@ -235,6 +246,9 @@ export function buildWorkspaceSessionPayload(
       continue
     }
     for (const tab of tabs) {
+      if (!hasReconnectableSession(tab)) {
+        continue
+      }
       const sessionId = tab.ptyId || lastKnown[tab.id]
       if (sessionId) {
         remoteSessionIdsByTabId[tab.id] = sessionId


### PR DESCRIPTION
## Summary
- suppress worktree sidebar virtualizer scroll corrections during direct wheel/touch scrolling so measured row updates do not rubber-band the list
- make workspace-session shutdown liveness use `ptyIdsByTabId` instead of preserved `tab.ptyId` wake hints, while keeping the disconnected SSH relay fallback
- add regression coverage for scroll adjustment, slept local/SSH worktrees, and session writes when live PTY bindings change

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts src/renderer/src/lib/workspace-session.test.ts src/renderer/src/lib/workspace-session-liveness.test.ts src/renderer/src/lib/workspace-session-relevant-fields.test.ts src/renderer/src/lib/workspace-session-browser-history.test.ts src/renderer/src/lib/session-write-subscriber.test.ts`
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/hooks/useVirtualizedScrollAnchor.ts src/renderer/src/lib/workspace-session.ts src/renderer/src/lib/workspace-session.test.ts src/renderer/src/lib/workspace-session-liveness.test.ts src/renderer/src/lib/workspace-session-relevant-fields.test.ts src/renderer/src/lib/workspace-session-browser-history.test.ts src/renderer/src/lib/session-write-subscriber.test.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts`
- `pnpm run typecheck:tsc:web`
- Electron/CDP real wheel repro: before fix, 58 backward scroll jumps; after fix, 0 reversals over 80 wheel events
- Full isolated-profile sleep/restart repro:
  - copied dev `orca-data.json` into a temporary `ORCA_DEV_USER_DATA_PATH`
  - slept an active local worktree through live renderer/store calls
  - verified preserved tab `ptyId`s but empty live `ptyIdsByTabId`
  - verified cloned `orca-data.json` no longer included that worktree in `workspaceSession.activeWorktreeIdsOnShutdown`
  - restarted the isolated app against the same cloned profile
  - verified the slept worktree was not in `pendingReconnectWorktreeIds`, had no live PTYs, did not pass the Active filter, and had no mounted row under Active-only filtering

Made with [Orca](https://github.com/stablyai/orca) 🐋
