### PR TITLE
Fix automation log terminal control cleanup

### DIFF
--- a/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
@@ -32,4 +32,40 @@ describe('automation run output snapshot buffer', () => {
 
     expect(buffer.snapshot()).toBeNull()
   })
+
+  it('strips ST-terminated OSC title and progress frames from Codex TUI output', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('\u001b]0;\u2834 orca q\u2022Working q\u001b\\')
+    buffer.append('\u001b]9;4;3;Working\u001b\\')
+    buffer.append('\u001b[32m\u2022 Ran agent-slack channel list --all\u001b[0m\r\n')
+    buffer.append('\u2514 { "name": "stably-bugs-and-feedback" }\r\n')
+
+    expect(buffer.snapshot()).toMatchObject({
+      format: 'plain_text',
+      content:
+        '\u2022 Ran agent-slack channel list --all\n\u2514 { "name": "stably-bugs-and-feedback" }',
+      truncated: false
+    })
+  })
+
+  it('strips CSI sequences with intermediate bytes', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('\u001b[2 q\u001b[?25lDone\u001b[?25h')
+
+    expect(buffer.snapshot()).toMatchObject({
+      content: 'Done'
+    })
+  })
+
+  it('strips digit-final ESC cursor save and restore sequences', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('\u001b7Loading\u001b8Done')
+
+    expect(buffer.snapshot()).toMatchObject({
+      content: 'LoadingDone'
+    })
+  })
 })

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.ts
@@ -3,9 +3,14 @@ import type { AutomationRunOutputSnapshot } from '../../../../shared/automations
 
 const MAX_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
 
-const ANSI_PATTERN =
-  /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g
-const CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g
+// Why: Codex/Claude TUIs emit OSC title/progress frames in hidden automation
+// PTYs; saved run output should keep command text, not terminal metadata.
+const OSC_SEQUENCE_PATTERN = /(?:\u001b\]|\u009d)[\s\S]*?(?:\u0007|\u001b\\|\u009c)/g
+const STRING_SEQUENCE_PATTERN =
+  /(?:\u001b[P_^X]|\u0090|\u0098|\u009e|\u009f)[\s\S]*?(?:\u001b\\|\u009c)/g
+const CSI_SEQUENCE_PATTERN = /(?:\u001b\[|\u009b)[0-?]*[ -/]*[@-~]/g
+const ESCAPE_SEQUENCE_PATTERN = /\u001b[ -/]*[0-~]/g
+const CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g
 
 export type AutomationRunOutputSnapshotBuffer = {
   append: (chunk: string) => void
@@ -14,7 +19,10 @@ export type AutomationRunOutputSnapshotBuffer = {
 
 function stripTerminalControls(value: string): string {
   return value
-    .replace(ANSI_PATTERN, '')
+    .replace(OSC_SEQUENCE_PATTERN, '')
+    .replace(STRING_SEQUENCE_PATTERN, '')
+    .replace(CSI_SEQUENCE_PATTERN, '')
+    .replace(ESCAPE_SEQUENCE_PATTERN, '')
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .replace(CONTROL_PATTERN, '')


### PR DESCRIPTION
## Summary
- Strip OSC, string, CSI, and ESC terminal control sequences before saving automation run output snapshots
- Preserve command/output text from Codex/Claude TUI logs while removing title/progress metadata
- Add regression tests for ST-terminated OSC frames, CSI intermediate bytes, and digit-final ESC cursor controls

## Tests
- pnpm vitest run src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test (fails locally in unrelated Hermes CLI visibility test when installed CLI exceeds Vitest 5s timeout; terminal-attribution rerun passed)