### PR TITLE
Update README hero media

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@
   <a href="#install"><strong>Download 🐋</strong></a>
 </p>
 
-<p align="center">
-  <img src="docs/assets/file-drag.gif" alt="Orca Screenshot" width="800" />
-</p>
+![Orca worktree IDE demo showing Claude Code, Codex, and OpenCode running in parallel across isolated git worktrees](docs/assets/file-drag.gif)
 
 ## Supported Agents
 


### PR DESCRIPTION
## Summary
- Replace the README hero block with the marketing hero animation using plain Markdown
- Keep the hero immediately visible on GitHub instead of relying on an inline video tag, which GitHub strips from README rendering

## Validation
- Verified with GitHub Markdown rendering via `gh api markdown`

<img width="980" height="719" alt="image" src="https://github.com/user-attachments/assets/ffe7d516-0369-4b28-b3d7-503f86dfe39a" />
