### PR TITLE
Fix editor copy when Browser split is open

### DIFF
--- a/src/renderer/src/components/browser-pane/browser-keyboard.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-keyboard.test.ts
@@ -18,6 +18,14 @@ describe('isEditableKeyboardTarget', () => {
     expect(isEditableKeyboardTarget(child)).toBe(true)
   })
 
+  it('returns true for Monaco editor descendants', () => {
+    const child = {
+      isContentEditable: false,
+      closest: (selector: string) => (selector.includes('.monaco-editor') ? {} : null)
+    }
+    expect(isEditableKeyboardTarget(child)).toBe(true)
+  })
+
   it('returns false for non-editable elements', () => {
     const div = {
       isContentEditable: false,

--- a/src/renderer/src/components/browser-pane/browser-keyboard.ts
+++ b/src/renderer/src/components/browser-pane/browser-keyboard.ts
@@ -12,12 +12,21 @@ export function isEditableKeyboardTarget(target: EventTarget | EditableTargetLik
     return false
   }
 
-  // Why: grab-mode single-key shortcuts should never fire while the user is
-  // typing into the browser chrome itself (address bar/search fields) or any
-  // other editable control. Treat nested elements inside those controls as
-  // editable too so composition wrappers or icons inside the input don't cause
-  // C/S to be swallowed unexpectedly.
-  const editableHost = element.closest?.('input, textarea, [contenteditable="true"]')
+  // Why: Browser panes stay mounted beside editor splits, so their global
+  // shortcut listeners must treat editor surfaces as editable too.
+  const editableHost = element.closest?.(
+    [
+      'input',
+      'textarea',
+      'select',
+      '[contenteditable=""]',
+      '[contenteditable="true"]',
+      '.monaco-editor',
+      '.diff-editor',
+      '.rich-markdown-editor',
+      '.rich-markdown-editor-shell'
+    ].join(', ')
+  )
   if (editableHost) {
     return true
   }


### PR DESCRIPTION
## Summary
- Treat Monaco, diff, and rich markdown editor surfaces as editable targets for BrowserPane shortcut guards
- Prevent active Browser panes from claiming Cmd/Ctrl+C when copy originates in the editor split
- Add coverage for Monaco descendants in `isEditableKeyboardTarget`

Fixes #1841

## Verification
- Reproduced in Electron before the fix: editor + browser split, focused Monaco, selected `package.json`, pressed Cmd+C; clipboard stayed at sentinel instead of editor content.
- Verified in Electron after the fix with the same flow; clipboard contained selected `package.json` content while Browser stayed open.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-keyboard.test.ts`
- `pnpm exec oxlint src/renderer/src/components/browser-pane/browser-keyboard.ts src/renderer/src/components/browser-pane/browser-keyboard.test.ts`
- `pnpm run typecheck:web`
- Subagent review: no findings.

Made with [Orca](https://github.com/stablyai/orca) 🐋
