### PR TITLE
Fix notes send launch watchdog handling

### DIFF
--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowLaunchWatchdogTimeout } from './QuickLaunchButton'
+
+describe('shouldShowLaunchWatchdogTimeout', () => {
+  it('lets the paste timeout own ready-but-not-pasteable notes launches', () => {
+    expect(
+      shouldShowLaunchWatchdogTimeout({
+        launchSource: 'notes_send',
+        prompt: 'Fix the race in Source Control.',
+        pasteDraftAfterLaunch: true,
+        hasPty: true
+      })
+    ).toBe(false)
+  })
+
+  it('still reports notes launches where no PTY appeared', () => {
+    expect(
+      shouldShowLaunchWatchdogTimeout({
+        launchSource: 'notes_send',
+        prompt: 'Fix the race in Source Control.',
+        pasteDraftAfterLaunch: true,
+        hasPty: false
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the launch watchdog for notes launches without paste fallback', () => {
+    expect(
+      shouldShowLaunchWatchdogTimeout({
+        launchSource: 'notes_send',
+        prompt: 'Start with this prompt.',
+        pasteDraftAfterLaunch: false,
+        hasPty: true
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the launch watchdog for empty notes prompts and non-notes launch sources', () => {
+    expect(
+      shouldShowLaunchWatchdogTimeout({
+        launchSource: 'notes_send',
+        prompt: '   \n\t',
+        pasteDraftAfterLaunch: true,
+        hasPty: true
+      })
+    ).toBe(true)
+
+    expect(
+      shouldShowLaunchWatchdogTimeout({
+        launchSource: 'tab_bar_quick_launch',
+        prompt: 'Start with this prompt.',
+        pasteDraftAfterLaunch: true,
+        hasPty: true
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -46,6 +46,29 @@ function orderAgents(
   return [defaultAgent, ...inCatalogOrder.filter((id) => id !== defaultAgent)]
 }
 
+export function shouldShowLaunchWatchdogTimeout({
+  launchSource,
+  prompt,
+  pasteDraftAfterLaunch,
+  hasPty
+}: {
+  launchSource?: LaunchSource
+  prompt?: string
+  pasteDraftAfterLaunch: boolean
+  hasPty: boolean
+}): boolean {
+  return !(
+    launchSource === 'notes_send' &&
+    (prompt?.trim().length ?? 0) > 0 &&
+    pasteDraftAfterLaunch &&
+    hasPty
+  )
+}
+
+function getLaunchWatchdogTimeoutMessage(label: string): string {
+  return `Couldn't launch ${label} — the terminal is still open.`
+}
+
 function QuickLaunchAgentMenuItemsInner({
   worktreeId,
   groupId,
@@ -114,7 +137,18 @@ function QuickLaunchAgentMenuItemsInner({
         if (state.activeWorktreeId !== worktreeId) {
           return
         }
-        toast.message(`Couldn't launch ${label} — the terminal is still open.`)
+        const hasPty = (state.ptyIdsByTabId[result.tabId]?.length ?? 0) > 0
+        if (
+          !shouldShowLaunchWatchdogTimeout({
+            launchSource,
+            prompt,
+            pasteDraftAfterLaunch: result.pasteDraftAfterLaunch,
+            hasPty
+          })
+        ) {
+          return
+        }
+        toast.message(getLaunchWatchdogTimeoutMessage(label))
       })
     },
     [worktreeId, groupId, onFocusTerminal, prompt, launchSource]

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -27,6 +27,7 @@ export type LaunchAgentInNewTabArgs = {
 export type LaunchAgentInNewTabResult = {
   tabId: string
   startupPlan: AgentStartupPlan
+  pasteDraftAfterLaunch: boolean
 } | null
 
 /**
@@ -178,5 +179,5 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   order.push(tab.id)
   fresh.setTabBarOrder(worktreeId, order)
 
-  return { tabId: tab.id, startupPlan }
+  return { tabId: tab.id, startupPlan, pasteDraftAfterLaunch: pasteDraftAfterLaunch !== null }
 }


### PR DESCRIPTION
## Summary
- keep the quick-launch watchdog active for notes-send launches so true launch failures still surface
- suppress only the duplicate watchdog timeout when the post-launch draft paste timeout owns the user-facing error
- add unit coverage for notes-send watchdog timeout decisions

## Tests
- pnpm typecheck
- pnpm test -- src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts