### PR TITLE
Add conflict review file tree

### DIFF
--- a/src/renderer/src/components/editor/ConflictComponents.test.tsx
+++ b/src/renderer/src/components/editor/ConflictComponents.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import type { GitStatusEntry } from '../../../../shared/types'
+import { ConflictReviewPanel } from './ConflictComponents'
+
+function createConflictReviewFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: 'repo::/repo::conflict-review',
+    filePath: '/repo',
+    relativePath: 'Conflict Review',
+    worktreeId: 'repo::/repo',
+    language: 'text',
+    isDirty: false,
+    mode: 'conflict-review',
+    conflictReview: {
+      source: 'live-summary',
+      snapshotTimestamp: Date.UTC(2026, 4, 17, 19, 9, 7),
+      entries: [
+        {
+          path: 'src/renderer/src/store/slices/linear.test.ts',
+          conflictKind: 'both_added'
+        },
+        {
+          path: 'src/renderer/src/store/slices/linear.ts',
+          conflictKind: 'both_modified'
+        }
+      ]
+    },
+    ...overrides
+  }
+}
+
+function createLiveEntry(
+  path: string,
+  status: GitStatusEntry['status'] = 'modified'
+): GitStatusEntry {
+  return {
+    path,
+    status,
+    area: 'unstaged',
+    conflictKind: path.endsWith('.test.ts') ? 'both_added' : 'both_modified',
+    conflictStatus: 'unresolved',
+    conflictStatusSource: 'git'
+  }
+}
+
+describe('ConflictReviewPanel', () => {
+  it('renders unresolved conflicts as a left file tree', () => {
+    const file = createConflictReviewFile()
+    const html = renderToStaticMarkup(
+      <ConflictReviewPanel
+        file={file}
+        liveEntries={[
+          createLiveEntry('src/renderer/src/store/slices/linear.test.ts', 'added'),
+          createLiveEntry('src/renderer/src/store/slices/linear.ts')
+        ]}
+        onOpenEntry={vi.fn()}
+        onDismiss={vi.fn()}
+        onRefreshSnapshot={vi.fn()}
+        onReturnToSourceControl={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('Files')
+    expect(html).toContain('Collapse file tree')
+    expect(html).toContain('src/renderer/src/store/slices')
+    expect(html).toContain('linear.test.ts')
+    expect(html).toContain('linear.ts')
+    expect(html).toContain('Select a conflict from the file tree')
+    expect(html).not.toContain('Choose which version to keep, or combine them')
+  })
+})

--- a/src/renderer/src/components/editor/ConflictComponents.tsx
+++ b/src/renderer/src/components/editor/ConflictComponents.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { CircleCheck, GitMerge, RefreshCw, TriangleAlert, X } from 'lucide-react'
+import { CircleCheck, GitMerge, PanelLeftOpen, RefreshCw, TriangleAlert, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
-import type { OpenFile } from '@/store/slices/editor'
+import type { ConflictReviewEntry, OpenFile } from '@/store/slices/editor'
 import type { GitConflictKind, GitStatusEntry } from '../../../../shared/types'
+import { ConflictReviewFileTree } from './ConflictReviewFileTree'
 
 export const CONFLICT_KIND_LABELS: Record<GitConflictKind, string> = {
   both_modified: 'Both modified',
@@ -24,6 +26,9 @@ export const CONFLICT_HINT_MAP: Record<GitConflictKind, string> = {
   added_by_them: 'Review the added file before keeping it',
   both_deleted: 'Resolve in Git or restore one side before editing'
 }
+
+const EMPTY_CONFLICT_REVIEW_ENTRIES: readonly ConflictReviewEntry[] = []
+let conflictReviewFileTreeCollapsedPreference = false
 
 export function ConflictBanner({
   file,
@@ -114,13 +119,36 @@ export function ConflictReviewPanel({
   onRefreshSnapshot: () => void
   onReturnToSourceControl: () => void
 }): React.JSX.Element {
-  const snapshotEntries = file.conflictReview?.entries ?? []
-  const liveEntriesByPath = new Map(liveEntries.map((entry) => [entry.path, entry]))
-  const unresolvedSnapshotEntries = snapshotEntries.filter(
-    (entry) => liveEntriesByPath.get(entry.path)?.conflictStatus === 'unresolved'
+  const [fileTreeCollapsed, setFileTreeCollapsedState] = React.useState(
+    () => conflictReviewFileTreeCollapsedPreference
   )
+  const snapshotEntries = file.conflictReview?.entries ?? EMPTY_CONFLICT_REVIEW_ENTRIES
+  const liveEntriesByPath = React.useMemo(
+    () => new Map(liveEntries.map((entry) => [entry.path, entry])),
+    [liveEntries]
+  )
+  const treeEntries = React.useMemo(
+    () =>
+      snapshotEntries.map((entry) => ({
+        ...entry,
+        liveEntry: liveEntriesByPath.get(entry.path)
+      })),
+    [liveEntriesByPath, snapshotEntries]
+  )
+  const unresolvedSnapshotEntries = treeEntries.filter(
+    (entry) => entry.liveEntry?.conflictStatus === 'unresolved'
+  )
+  const unresolvedCount = unresolvedSnapshotEntries.length
+  const resolvedCount = Math.max(0, snapshotEntries.length - unresolvedCount)
+  const snapshotTime = new Date(
+    file.conflictReview?.snapshotTimestamp ?? Date.now()
+  ).toLocaleTimeString()
+  const setFileTreeCollapsed = React.useCallback((collapsed: boolean) => {
+    conflictReviewFileTreeCollapsedPreference = collapsed
+    setFileTreeCollapsedState(collapsed)
+  }, [])
 
-  if (snapshotEntries.length > 0 && unresolvedSnapshotEntries.length === 0) {
+  if (snapshotEntries.length > 0 && unresolvedCount === 0) {
     return (
       <div className="flex h-full items-center justify-center px-6 text-center">
         <div className="max-w-md space-y-3">
@@ -144,58 +172,76 @@ export function ConflictReviewPanel({
   }
 
   return (
-    <div className="h-full overflow-auto px-4 py-4">
-      <div className="mb-3">
-        <div className="text-sm font-medium text-foreground">
-          {snapshotEntries.length} unresolved conflict{snapshotEntries.length === 1 ? '' : 's'}
-        </div>
-        <div className="mt-1 text-xs text-muted-foreground">
-          Snapshot captured at{' '}
-          {new Date(file.conflictReview?.snapshotTimestamp ?? Date.now()).toLocaleTimeString()}.
-        </div>
-        <div className="mt-2 flex items-center gap-2">
+    <div className="flex h-full min-h-0 bg-background">
+      <ConflictReviewFileTree
+        entries={treeEntries}
+        collapsed={fileTreeCollapsed}
+        onCollapsedChange={setFileTreeCollapsed}
+        onOpenEntry={onOpenEntry}
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border px-5 py-4">
+          <div className="flex min-w-0 items-start gap-2">
+            {fileTreeCollapsed && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="Show file tree"
+                    onClick={() => setFileTreeCollapsed(false)}
+                  >
+                    <PanelLeftOpen className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  Show file tree
+                </TooltipContent>
+              </Tooltip>
+            )}
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-foreground">
+                {unresolvedCount} unresolved conflict{unresolvedCount === 1 ? '' : 's'}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                Snapshot captured at {snapshotTime}.
+              </div>
+            </div>
+          </div>
           <Button type="button" size="sm" variant="outline" onClick={onRefreshSnapshot}>
             <RefreshCw className="size-3.5" />
             Refresh
           </Button>
         </div>
-      </div>
-      <div className="space-y-2">
-        {snapshotEntries.map((snapshotEntry) => {
-          const liveEntry = liveEntriesByPath.get(snapshotEntry.path)
-          const isStillUnresolved = liveEntry?.conflictStatus === 'unresolved'
-          return (
-            <button
-              key={snapshotEntry.path}
-              type="button"
-              className="flex w-full items-start justify-between rounded-md border border-border/60 px-3 py-2 text-left hover:bg-accent/30"
-              onClick={() => {
-                if (liveEntry) {
-                  onOpenEntry(liveEntry)
-                }
-              }}
-              disabled={!liveEntry}
-            >
-              <div className="min-w-0">
-                <div className="truncate text-sm text-foreground">{snapshotEntry.path}</div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  {CONFLICT_KIND_LABELS[snapshotEntry.conflictKind]} ·{' '}
-                  {CONFLICT_HINT_MAP[snapshotEntry.conflictKind]}
-                </div>
+        <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center">
+          <div className="max-w-md space-y-3">
+            <div className="mx-auto flex size-10 items-center justify-center rounded-md border border-border bg-card text-muted-foreground">
+              <GitMerge className="size-4" />
+            </div>
+            <div className="text-sm font-medium text-foreground">
+              Select a conflict from the file tree
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Open each unresolved file, edit the conflict markers, then refresh this snapshot.
+            </div>
+            {resolvedCount > 0 && (
+              <div className="text-xs text-muted-foreground">
+                {resolvedCount} conflict{resolvedCount === 1 ? '' : 's'} no longer live in Git.
               </div>
-              <span
-                className={cn(
-                  'ml-3 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold',
-                  isStillUnresolved
-                    ? 'bg-destructive/12 text-destructive'
-                    : 'bg-muted text-muted-foreground'
-                )}
-              >
-                {isStillUnresolved ? 'Unresolved' : liveEntry ? 'Resolved' : 'Gone'}
-              </span>
-            </button>
-          )
-        })}
+            )}
+            <div className="flex items-center justify-center gap-2">
+              <Button type="button" size="sm" variant="outline" onClick={onReturnToSourceControl}>
+                <GitMerge className="size-3.5" />
+                Source Control
+              </Button>
+              <Button type="button" size="sm" variant="ghost" onClick={onDismiss}>
+                <X className="size-3.5" />
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/editor/ConflictReviewFileTree.tsx
+++ b/src/renderer/src/components/editor/ConflictReviewFileTree.tsx
@@ -1,0 +1,182 @@
+import React from 'react'
+import { ChevronDown, Folder, FolderOpen, PanelLeftClose } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { getFileTypeIcon } from '@/lib/file-type-icons'
+import { cn } from '@/lib/utils'
+import {
+  buildSourceControlTree,
+  compactSourceControlTree,
+  flattenSourceControlTree,
+  type SourceControlTreeNode
+} from '@/components/right-sidebar/source-control-tree'
+import type { ConflictReviewEntry } from '@/store/slices/editor'
+import type { GitStatusEntry } from '../../../../shared/types'
+
+type ConflictReviewTreeEntry = ConflictReviewEntry & {
+  liveEntry?: GitStatusEntry
+}
+
+type ConflictReviewTreeNode = SourceControlTreeNode<ConflictReviewTreeEntry, 'conflict-review'>
+
+const CONFLICT_REVIEW_TREE_INDENT_PX = 12
+const CONFLICT_REVIEW_DIRECTORY_PADDING_PX = 8
+const CONFLICT_REVIEW_FILE_PADDING_PX = 20
+
+function buildConflictReviewRows(
+  entries: readonly ConflictReviewTreeEntry[],
+  collapsedDirectoryKeys: ReadonlySet<string>
+): ConflictReviewTreeNode[] {
+  const roots = compactSourceControlTree(
+    buildSourceControlTree('conflict-review', [...entries])
+  ) as ConflictReviewTreeNode[]
+  return flattenSourceControlTree(roots, collapsedDirectoryKeys) as ConflictReviewTreeNode[]
+}
+
+export function ConflictReviewFileTree({
+  entries,
+  collapsed,
+  onCollapsedChange,
+  onOpenEntry
+}: {
+  entries: readonly ConflictReviewTreeEntry[]
+  collapsed: boolean
+  onCollapsedChange: (collapsed: boolean) => void
+  onOpenEntry: (entry: GitStatusEntry) => void
+}): React.JSX.Element | null {
+  const [collapsedDirectoryKeys, setCollapsedDirectoryKeys] = React.useState<Set<string>>(
+    () => new Set()
+  )
+  const rows = React.useMemo(
+    () => buildConflictReviewRows(entries, collapsedDirectoryKeys),
+    [collapsedDirectoryKeys, entries]
+  )
+  const toggleDirectory = React.useCallback((key: string) => {
+    setCollapsedDirectoryKeys((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  if (collapsed) {
+    return null
+  }
+
+  return (
+    <aside className="flex w-72 shrink-0 flex-col border-r border-border bg-background">
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+          Files
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="text-[11px] text-muted-foreground tabular-nums">{entries.length}</div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Collapse file tree"
+            onClick={() => onCollapsedChange(true)}
+          >
+            <PanelLeftClose className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto py-1 scrollbar-sleek">
+        {rows.length === 0 ? (
+          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
+            No conflicts in this snapshot.
+          </div>
+        ) : (
+          rows.map((node) => (
+            <ConflictReviewFileTreeRow
+              key={node.key}
+              node={node}
+              isCollapsed={collapsedDirectoryKeys.has(node.key)}
+              onToggleDirectory={toggleDirectory}
+              onOpenEntry={onOpenEntry}
+            />
+          ))
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function ConflictReviewFileTreeRow({
+  node,
+  isCollapsed,
+  onToggleDirectory,
+  onOpenEntry
+}: {
+  node: ConflictReviewTreeNode
+  isCollapsed: boolean
+  onToggleDirectory: (key: string) => void
+  onOpenEntry: (entry: GitStatusEntry) => void
+}): React.JSX.Element {
+  if (node.type === 'directory') {
+    return (
+      <button
+        type="button"
+        className="group flex w-full items-center gap-1 py-1 pr-3 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
+        style={{
+          paddingLeft: `${node.depth * CONFLICT_REVIEW_TREE_INDENT_PX + CONFLICT_REVIEW_DIRECTORY_PADDING_PX}px`
+        }}
+        onClick={() => onToggleDirectory(node.key)}
+        aria-expanded={!isCollapsed}
+      >
+        <ChevronDown
+          className={cn('size-3 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
+        />
+        {isCollapsed ? (
+          <Folder className="size-3 shrink-0" />
+        ) : (
+          <FolderOpen className="size-3 shrink-0" />
+        )}
+        <span className="min-w-0 flex-1 truncate">{node.name}</span>
+        <span className="w-4 shrink-0 text-center text-[10px] font-bold tabular-nums text-muted-foreground/80">
+          {node.fileCount}
+        </span>
+      </button>
+    )
+  }
+
+  const FileIcon = getFileTypeIcon(node.entry.path)
+  const liveEntry = node.entry.liveEntry
+  const isStillUnresolved = liveEntry?.conflictStatus === 'unresolved'
+
+  return (
+    <button
+      type="button"
+      className="group flex w-full min-w-0 cursor-pointer items-center gap-1 py-1 pr-3 text-left text-xs transition-colors hover:bg-accent/40 disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent"
+      style={{
+        paddingLeft: `${node.depth * CONFLICT_REVIEW_TREE_INDENT_PX + CONFLICT_REVIEW_FILE_PADDING_PX}px`
+      }}
+      disabled={!liveEntry}
+      title={node.entry.path}
+      onClick={() => {
+        if (liveEntry) {
+          onOpenEntry(liveEntry)
+        }
+      }}
+    >
+      <FileIcon className={cn('size-3.5 shrink-0', isStillUnresolved && 'text-destructive')} />
+      <span className="min-w-0 flex-1 truncate">
+        <span className="text-foreground">{node.name}</span>
+      </span>
+      <span
+        className={cn(
+          'ml-1 shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold',
+          isStillUnresolved
+            ? 'bg-destructive/12 text-destructive'
+            : 'bg-muted text-muted-foreground'
+        )}
+      >
+        {isStillUnresolved ? 'Unresolved' : liveEntry ? 'Resolved' : 'Gone'}
+      </span>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a left-side file tree to the conflict review panel so unresolved snapshot entries are grouped by path and easier to navigate. The panel keeps the existing empty/resolved states and now shows a compact selection prompt next to the tree.

## Screenshots

Not captured; this is a conflict-state UI that requires an active unresolved Git conflict snapshot.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Also ran:
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/ConflictComponents.test.tsx`

## AI Review Report

Ran a single-agent review of the branch diff against `origin/main`, including the untracked new tree and test files before commit. The review checked correctness, logical bugs, type safety, error handling, performance, dead code, and cross-platform compatibility for macOS, Linux, and Windows. It found no Critical, High, Medium, or Low issues.

Cross-platform review notes: this PR only changes React renderer UI for conflict review navigation; it does not add keyboard shortcuts, shortcut labels, shell behavior, platform-specific paths, IPC, or Electron main/preload behavior. Path display and grouping reuse the existing normalized source-control tree utilities.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency, and IPC risks. The change renders Git conflict entry paths already provided by app state, adds no command execution, no auth or secret handling, no dependency changes, and no IPC surface. No follow-up security work identified.

## Notes

Local validation passed with `pnpm typecheck` and the targeted conflict component Vitest coverage. Full lint, full test, and build were left to CI.