### PR TITLE
fix: keep awake for mobile sessions

### DIFF
--- a/docs/keep-awake-mobile-hotspot.md
+++ b/docs/keep-awake-mobile-hotspot.md
@@ -1,0 +1,266 @@
+# Keep Awake for Mobile Hotspot Sessions
+
+## Problem or Goal
+
+The existing "Keep computer awake while agents are working" setting only considers agent
+status. When a paired phone is connected to Orca over a mobile hotspot, closing or idling
+the laptop can drop the hotspot/Wi-Fi path and make the mobile companion unusable even
+though the user enabled the awake feature.
+
+Goal: when the user enables the keep-awake feature, Orca should also keep the desktop
+awake while an authenticated Orca Mobile client is actively connected. The implementation
+must be clear about the OS limit: Electron/macOS power assertions can prevent idle sleep,
+but cannot reliably force a laptop to keep networking alive after the physical lid is
+closed.
+
+## Current Behavior
+
+- `src/main/agent-awake-service.ts:12` accepts only Electron
+  `powerSaveBlocker.start('prevent-app-suspension')`.
+- `src/main/agent-awake-service.ts:41` stores a single enabled bit, and
+  `src/main/agent-awake-service.ts:49` stores only agent status snapshots.
+- `src/main/agent-awake-service.ts:61` starts the blocker only when the setting is enabled
+  and at least one fresh, current-runtime agent status is `working`.
+- `src/main/index.ts:731` creates the awake service, `src/main/index.ts:733` initializes
+  it from `keepComputerAwakeWhileAgentsRun`, and `src/main/index.ts:738` wires only
+  `agentHookServer.subscribeStatusChanges(...)` into it.
+- `src/main/ipc/settings.ts:43` updates the service only when
+  `keepComputerAwakeWhileAgentsRun` changes.
+- `src/renderer/src/components/settings/AgentAwakeSetting.tsx:17` and
+  `src/renderer/src/components/settings/AgentAwakeSetting.tsx:25` describe an
+  agent-only behavior and state that the display can still turn off.
+- Mobile clients connect through the runtime WebSocket path:
+  `src/main/runtime/runtime-rpc.ts:414` starts the WebSocket transport,
+  `src/main/runtime/runtime-rpc.ts:443` handles E2EE readiness,
+  `src/main/runtime/runtime-rpc.ts:449` validates the device token and updates
+  `lastSeenAt`, and `src/main/runtime/runtime-rpc.ts:484` handles connection close.
+- `src/main/runtime/rpc/ws-transport.ts:105` already reports close events with
+  `hasOtherConnections`, so the runtime can distinguish one socket closing from the last
+  socket for a paired device.
+- Mobile has reconnection tolerance for laptop wake/network blips:
+  `mobile/src/transport/rpc-client.ts:66` uses a tiered reconnect backoff and
+  `mobile/src/transport/connection-health.ts:3` classifies longer outages as unreachable.
+
+Reference behavior:
+
+- Electron documents `prevent-app-suspension` as keeping the app/system active while
+  allowing the screen to turn off, and `prevent-display-sleep` as a stronger mode that
+  keeps the display active too:
+  https://www.electronjs.org/docs/latest/api/power-save-blocker
+- Apple documents IOPM assertions as best-effort power assertions:
+  https://developer.apple.com/documentation/iokit/iopmlib_h/iopmassertiontypes
+
+## Proposed Design
+
+Keep the existing persisted setting for compatibility, but expand its behavior and copy
+from agent-only to "active Orca work":
+
+Direction decision:
+
+- Use the existing keep-awake setting as the single user control. A second mobile-only
+  toggle would add settings complexity while controlling the same local power assertion.
+- Do not attempt an OS-specific lid-close or hotspot override. Electron power blockers
+  are idle-sleep assertions, not a reliable way to keep a closed laptop associated with a
+  phone hotspot.
+- Do not introduce a relay or overlay-network fallback in this change. That may be a
+  better long-term answer for closed-lid/mobile-hotspot reliability, but it is larger than
+  this power-management fix.
+
+1. Extend the awake service with a second input for authenticated mobile connectivity.
+   - Add `setActiveMobileConnectionCount(count: number)` to `AgentAwakeService`.
+   - Do not rename the class in this PR. The setting key, IPC wiring, tests, and
+     renderer component names are currently agent-oriented; a rename is mechanical churn
+     and can be handled separately if the broader feature name sticks.
+   - Keep the persisted setting key `keepComputerAwakeWhileAgentsRun` for this change to
+     avoid a migration.
+   - Normalize incoming counts with `Number.isFinite`, `Math.trunc`, and
+     `Math.max(0, value)` before storing them. A bad callback must not strand a wake
+     blocker.
+   - Compute `shouldBlock` from the enabled setting plus either a fresh working agent
+     status or at least one active mobile connection.
+   - Keep one blocker ID regardless of how many wake reasons are present. Stop it only
+     after every reason is gone or the setting is disabled.
+   - Continue using `prevent-app-suspension` as the default blocker. It is the right
+     tradeoff for long-running agent/mobile sessions because it keeps the system active
+     without forcing the display to stay on. Do not switch to `prevent-display-sleep`
+     without a separate explicit product decision because that burns battery and still
+     does not reliably solve physical lid closure.
+
+2. Report authenticated mobile-scoped WebSocket connection count from the runtime RPC server.
+   - Add an optional constructor callback to `OrcaRuntimeRpcServer`, for example
+     `onMobileConnectionCountChange?: (count: number) => void`.
+   - Track only WebSockets whose E2EE channel validates to a `DeviceEntry` with
+     `scope === 'mobile'`. Do not count runtime-scoped web/CLI tokens.
+   - Add `private activeMobileWebSockets = new Set<WebSocket>()` and emit
+     `activeMobileWebSockets.size`.
+   - Add small private helpers such as `trackAuthenticatedMobileSocket(ws, device)` and
+     `untrackMobileSocket(ws)`. They should emit only when `Set` membership changes, so
+     duplicate auth/request paths do not produce noisy refreshes.
+   - Add the socket to the set in the E2EE `onReady` path after
+     `deviceRegistry.validateToken(...)` returns the `DeviceEntry`. Do not use
+     `handleWebSocketMessage(...)` as the primary tracking point because the wake reason
+     is authenticated connection presence, not receipt of an RPC frame.
+   - Continue calling `wsTransport.setClientId(ws, ch.deviceToken)` for every validated
+     channel so close cleanup and the pre-auth timer keep their current behavior.
+   - Remove that socket from the set in `wsTransport.onConnectionClose(...)` before
+     deleting the E2EE channel and connection id. Emit the new count whenever membership
+     changes.
+   - In `stop()`, clear the set and emit `0` before awaiting transport shutdown. Close
+     handlers may still run afterward, but the untrack helper must be idempotent and must
+     not re-emit zero repeatedly.
+   - Wire the callback in `src/main/index.ts` to
+     `agentAwakeService.setActiveMobileConnectionCount(count)`.
+
+3. Update settings UX without adding a new toggle.
+   - Update the setting title/description/search metadata to mention agents and mobile,
+     e.g. "Keep computer awake during active sessions" and "Keeps this computer awake
+     while agents are working or a paired phone is connected."
+   - Add a short limitation sentence in the setting description or Mobile pane:
+     "Closing a laptop lid can still force sleep and disconnect this computer from a mobile
+     hotspot."
+   - Preserve the switch role, existing setting storage, and styleguide token usage.
+
+4. Keep SSH behavior unchanged.
+   - The awake blocker applies to the local desktop that is hosting the UI/runtime, even
+     when the active worktree or terminal is backed by SSH.
+   - Do not infer remote activity from SSH connection state; only agent hook status and
+     authenticated mobile client presence should create local awake reasons.
+
+## Architecture and Data Flow
+
+System context:
+
+```text
+[Renderer settings switch]
+          |
+          v
+[settings IPC + Store] ---- enabled ----+
+                                        |
+[Agent hook server] ---- statuses ------+
+                                        v
+                            [AgentAwakeService]
+                                        |
+                                        v
+                          [Electron powerSaveBlocker]
+
+[Mobile WebSocket + E2EE]
+          |
+          v
+[OrcaRuntimeRpcServer activeMobileWebSockets]
+          |
+          +---- count callback ---------+
+```
+
+Data-flow cases:
+
+- Happy path: the user enables the setting, a mobile-scoped WebSocket completes E2EE
+  authentication, `OrcaRuntimeRpcServer` validates the token to a mobile `DeviceEntry`,
+  the socket is added to `activeMobileWebSockets`, the count callback emits `1`, and
+  `AgentAwakeService` starts one `prevent-app-suspension` blocker. On socket close, the
+  runtime removes that exact socket and emits the new count.
+- Nil/missing data: if WebSocket support is disabled, the device registry is unavailable,
+  or no callback is passed in tests, the runtime emits no mobile wake reason and existing
+  agent-only behavior remains unchanged.
+- Empty collection: when `activeMobileWebSockets.size === 0`, mobile contributes no wake
+  reason. The blocker remains active only if a fresh current-runtime agent status is still
+  `working`.
+- Upstream error: failed E2EE auth, token revocation, WebSocket error, transport stop, or
+  app quit must all converge through idempotent cleanup that removes the socket from the
+  active set and emits `0` when the last mobile socket is gone.
+
+User-facing states:
+
+- Setting off: no local power blocker is held for agents or mobile.
+- Setting on, no active agents/mobile: the setting is enabled but no blocker is held.
+- Setting on, active agent or mobile connection: one local blocker is held; no new status
+  badge is needed because the setting controls policy, not a live connection monitor.
+- Laptop lid closed: the UI copy must not imply a guarantee. The limitation sentence is
+  the user-facing recovery path for hotspot/clamshell behavior.
+
+## Edge Cases
+
+- Multiple sockets from one phone: count sockets, or use a `Set<WebSocket>`, so host screen
+  plus accounts/terminal streams keep the blocker until the last socket closes.
+- Duplicate E2EE/auth paths for the same socket: `Set<WebSocket>` tracking must be
+  idempotent and must emit only when the effective count changes.
+- Multiple phones: keep blocking until all authenticated mobile-scoped sockets close.
+- Runtime-scoped browser/CLI clients: do not count them; the feature is for Orca Mobile.
+- Pre-auth or failed-auth WebSockets: do not count them.
+- Device revocation: `terminateClientConnections(...)` should trigger close cleanup and
+  decrement the mobile awake count.
+- WebSocket server stop or app quit: force the count to zero.
+- Agent statuses go stale while mobile remains connected: blocker stays active because
+  mobile is a separate reason.
+- Mobile disconnects while an agent is still working: blocker stays active because agent
+  status is still eligible.
+- Setting disabled while mobile is connected: blocker stops immediately.
+- Physical lid close: document as not reliably preventable by Orca. Users should leave
+  the laptop open, use OS/clamshell-supported hardware setup, or use an overlay network
+  path that does not depend on the laptop keeping a hotspot association alive.
+
+## Test Plan
+
+Unit tests:
+
+- Extend `src/main/agent-awake-service.test.ts`:
+  - starts the blocker when enabled with `activeMobileConnectionCount > 0` and no working
+    agents.
+  - does not start when disabled with a mobile connection.
+  - keeps one blocker when both mobile and agent reasons are present.
+  - stops only after both the last mobile connection drops and no eligible agent statuses
+    remain.
+  - ignores negative, fractional, and `NaN` mobile counts by normalizing to a
+    non-negative integer.
+
+- Extend `src/main/runtime/runtime-rpc.test.ts` or add a focused runtime RPC test:
+  - authenticated mobile-scoped E2EE WebSocket increments the mobile count using the
+    existing `authenticateMobileWs(...)` mocked-phone helper.
+  - closing one of two sockets for the same mobile token emits `1`, not `0`.
+  - closing the last mobile socket emits `0`.
+  - duplicate auth/RPC activity on the same socket does not emit a duplicate increment.
+  - runtime-scoped tokens and failed-auth sockets do not affect the count.
+  - revocation/transport stop clears the count exactly once from the caller's perspective.
+
+Renderer tests:
+
+- Update `src/renderer/src/components/settings/AgentsPane.test.tsx` for the new title,
+  description, and search terms (`mobile`, `hotspot`, `lid`).
+
+Playwright / mocked phone coverage:
+
+- Keep `tests/e2e/settings-agent-awake.spec.ts` focused on persistence, updating locators
+  to the new accessible name.
+- Add mocked-phone coverage at the main/runtime layer rather than requiring a physical
+  device. The repo already has `authenticateMobileWs(...)` in
+  `src/main/runtime/runtime-rpc.test.ts`, which exercises the real WebSocket + E2EE
+  handshake against a local server.
+- Manual mocked-phone validation after implementation:
+  1. Start Orca dev/Electron with mobile enabled.
+  2. Pair the local mocked/mobile WebSocket client.
+  3. Enable the keep-awake setting.
+  4. Confirm the desktop starts one Electron power save blocker while the mocked phone is
+     connected and stops after disconnect.
+  5. Confirm the settings copy warns that closing the lid can still disconnect hotspot
+     sessions.
+
+Not covered in automation:
+
+- Actual laptop lid-close behavior and carrier/mobile-hotspot behavior. That depends on
+  hardware, OS power policy, and hotspot implementation, so it should be documented and
+  manually spot-checked only.
+
+## Rollout Order
+
+1. Add mobile connection-count tracking and tests in `OrcaRuntimeRpcServer`.
+2. Extend the awake service reason model and tests.
+3. Wire runtime mobile count into the service in `src/main/index.ts`.
+4. Update settings copy/search tests and the E2E locator.
+5. Run targeted tests, then `pnpm typecheck` and `pnpm lint`.
+6. Validate with a mocked mobile WebSocket/client path if available; otherwise document
+   that validation used runtime-level mocked mobile connections.
+
+## ref-oss
+
+`ref-oss` was not used. This change is mostly Electron/macOS power-management behavior
+and Orca's own mobile WebSocket lifecycle; official Electron and Apple documentation are
+more directly relevant than editor or terminal OSS patterns.

--- a/src/main/agent-awake-runtime-wiring.test.ts
+++ b/src/main/agent-awake-runtime-wiring.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentAwakeService } from './agent-awake-service'
+import { createAgentAwakeRuntimeWiring } from './agent-awake-runtime-wiring'
+
+describe('agent awake runtime wiring', () => {
+  it('forwards mobile connection counts to the current awake service', () => {
+    const first = { setActiveMobileConnectionCount: vi.fn() } as unknown as AgentAwakeService
+    const second = { setActiveMobileConnectionCount: vi.fn() } as unknown as AgentAwakeService
+    let current: AgentAwakeService | null = first
+    const wiring = createAgentAwakeRuntimeWiring(() => current)
+
+    wiring.onMobileConnectionCountChange(2)
+    current = second
+    wiring.onMobileConnectionCountChange(0)
+    current = null
+    wiring.onMobileConnectionCountChange(1)
+
+    expect(first.setActiveMobileConnectionCount).toHaveBeenCalledWith(2)
+    expect(second.setActiveMobileConnectionCount).toHaveBeenCalledWith(0)
+  })
+
+  it('is included in the production runtime RPC bootstrap options', () => {
+    const source = readFileSync(join(import.meta.dirname, 'index.ts'), 'utf-8')
+
+    expect(source).toContain('...createAgentAwakeRuntimeWiring(() => agentAwakeService)')
+  })
+})

--- a/src/main/agent-awake-runtime-wiring.ts
+++ b/src/main/agent-awake-runtime-wiring.ts
@@ -1,0 +1,15 @@
+import type { AgentAwakeService } from './agent-awake-service'
+
+export type AgentAwakeRuntimeWiring = {
+  onMobileConnectionCountChange: (count: number) => void
+}
+
+export function createAgentAwakeRuntimeWiring(
+  getService: () => AgentAwakeService | null
+): AgentAwakeRuntimeWiring {
+  return {
+    onMobileConnectionCountChange: (count) => {
+      getService()?.setActiveMobileConnectionCount(count)
+    }
+  }
+}

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -71,6 +71,73 @@ describe('AgentAwakeService', () => {
     expect(blocker.start).toHaveBeenCalledWith('prevent-app-suspension')
   })
 
+  it('starts one blocker when enabled with an active mobile connection and no agents', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.setActiveMobileConnectionCount(1)
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+    expect(blocker.start).toHaveBeenCalledWith('prevent-app-suspension')
+  })
+
+  it('does not start for active mobile connections while disabled', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setActiveMobileConnectionCount(1)
+
+    expect(blocker.start).not.toHaveBeenCalled()
+  })
+
+  it('keeps one blocker while both agent and mobile reasons are active', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.setStatuses([workingStatus()])
+    service.setActiveMobileConnectionCount(2)
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops only after mobile and agent wake reasons are both gone', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.setStatuses([workingStatus()])
+    service.setActiveMobileConnectionCount(1)
+    service.setStatuses([])
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    service.setActiveMobileConnectionCount(0)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+  })
+
+  it('normalizes invalid mobile connection counts to a non-negative integer', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.setActiveMobileConnectionCount(-1)
+    service.setActiveMobileConnectionCount(Number.NaN)
+
+    expect(blocker.start).not.toHaveBeenCalled()
+
+    service.setActiveMobileConnectionCount(1.9)
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+
+    service.setActiveMobileConnectionCount(1.1)
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    service.setActiveMobileConnectionCount(0.9)
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+  })
+
   it('starts and stops from settings flips around an already-running status', () => {
     const blocker = createBlocker()
     const service = createService(() => 1_000, blocker)

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -10,7 +10,7 @@ export type AgentAwakeStatus = {
 }
 
 type PowerSaveBlocker = {
-  start: (type: 'prevent-app-suspension') => number
+  start: (type: 'prevent-app-suspension' | 'prevent-display-sleep') => number
   stop: (id: number) => void
   isStarted: (id: number) => boolean
 }
@@ -26,6 +26,7 @@ type AgentAwakeServiceOptions = {
 export class AgentAwakeService {
   private enabled = false
   private statuses: AgentAwakeStatus[] = []
+  private activeMobileConnectionCount = 0
   private blockerId: number | null = null
   private staleTimer: ReturnType<typeof setTimeout> | null = null
   private readonly blocker: PowerSaveBlocker
@@ -51,6 +52,15 @@ export class AgentAwakeService {
     this.refresh('status-change')
   }
 
+  setActiveMobileConnectionCount(count: number): void {
+    const normalized = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0
+    if (this.activeMobileConnectionCount === normalized) {
+      return
+    }
+    this.activeMobileConnectionCount = normalized
+    this.refresh('mobile-connection-change')
+  }
+
   dispose(): void {
     this.clearStaleTimer()
     this.stopBlocker('dispose')
@@ -59,7 +69,8 @@ export class AgentAwakeService {
   private refresh(reason: string): void {
     this.scheduleStaleTimer()
     const runningStatusCount = this.getEligibleRunningStatusCount()
-    const shouldBlock = this.enabled && runningStatusCount > 0
+    const shouldBlock =
+      this.enabled && (runningStatusCount > 0 || this.activeMobileConnectionCount > 0)
     if (shouldBlock) {
       this.startBlocker(reason, runningStatusCount)
     } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,6 +74,7 @@ import { setUnreadDockBadgeCount } from './dock/unread-badge'
 import { registerFeatureWallFirstAgentTour } from './feature-wall/first-agent-tour'
 import { AutomationService } from './automations/service'
 import { AgentAwakeService } from './agent-awake-service'
+import { createAgentAwakeRuntimeWiring } from './agent-awake-runtime-wiring'
 import {
   getCrashBreadcrumbSnapshot,
   recordCrashBreadcrumb
@@ -919,7 +920,8 @@ app.whenReady().then(async () => {
     ...(isE2E ? { wsPort: 0 } : {}),
     ...(devWsPort !== undefined ? { wsPort: devWsPort } : {}),
     ...(serveOptions?.wsPort !== undefined ? { wsPort: serveOptions.wsPort } : {}),
-    webClientRoot: getBundledWebClientRoot()
+    webClientRoot: getBundledWebClientRoot(),
+    ...createAgentAwakeRuntimeWiring(() => agentAwakeService)
   })
   registerMobileHandlers(runtimeRpc)
 

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -145,7 +145,13 @@ function waitForWsClose(ws: WebSocket): Promise<void> {
   })
 }
 
-async function authenticateMobileWs(pairingUrl: string): Promise<WebSocket> {
+type AuthenticatedWsSession = {
+  ws: WebSocket
+  sharedKey: Uint8Array
+  deviceToken: string
+}
+
+async function authenticateWsSession(pairingUrl: string): Promise<AuthenticatedWsSession> {
   const parsed = parsePairingCode(pairingUrl)
   expect(parsed).toBeTruthy()
   const ws = await connectWs(parsed!.endpoint)
@@ -168,7 +174,11 @@ async function authenticateMobileWs(pairingUrl: string): Promise<WebSocket> {
     type: 'e2ee_authenticated'
   })
 
-  return ws
+  return { ws, sharedKey, deviceToken: parsed!.deviceToken }
+}
+
+async function authenticateMobileWs(pairingUrl: string): Promise<WebSocket> {
+  return (await authenticateWsSession(pairingUrl)).ws
 }
 
 class FakeWebSocket extends EventEmitter {
@@ -455,11 +465,13 @@ describe('OrcaRuntimeRpcServer', () => {
   it('terminates active WebSockets for a revoked mobile device', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
     const runtime = new OrcaRuntimeService()
+    const onMobileConnectionCountChange = vi.fn()
     const server = new OrcaRuntimeRpcServer({
       runtime,
       userDataPath,
       enableWebSocket: true,
-      wsPort: 0
+      wsPort: 0,
+      onMobileConnectionCountChange
     })
     const disconnectSpy = vi.spyOn(runtime, 'onClientDisconnected')
 
@@ -477,16 +489,174 @@ describe('OrcaRuntimeRpcServer', () => {
       }
       const first = await authenticateMobileWs(offer.pairingUrl)
       const second = await authenticateMobileWs(offer.pairingUrl)
+      await waitFor(() => onMobileConnectionCountChange.mock.calls.length === 2)
 
       expect(server.revokeMobileDevice(offer.deviceId)).toBe(true)
       await Promise.all([waitForWsClose(first), waitForWsClose(second)])
       await waitFor(() => server['e2eeChannels'].size === 0 && server['wsConnectionIds'].size === 0)
 
       expect(disconnectSpy).toHaveBeenCalledTimes(1)
+      expect(onMobileConnectionCountChange.mock.calls).toEqual([[1], [2], [1], [0]])
     } finally {
       disconnectSpy.mockRestore()
       await server.stop()
     }
+  })
+
+  it('reports active authenticated mobile WebSocket count until the last socket closes', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const onMobileConnectionCountChange = vi.fn()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0,
+      onMobileConnectionCountChange
+    })
+
+    await server.start()
+
+    try {
+      const offer = server.createPairingOffer({
+        address: '127.0.0.1',
+        name: 'mobile-test',
+        scope: 'mobile'
+      })
+      expect(offer.available).toBe(true)
+      if (!offer.available) {
+        throw new Error('WebSocket pairing unavailable')
+      }
+
+      const first = await authenticateWsSession(offer.pairingUrl)
+      await waitFor(() => onMobileConnectionCountChange.mock.calls.length === 1)
+      expect(onMobileConnectionCountChange).toHaveBeenLastCalledWith(1)
+
+      const second = await authenticateWsSession(offer.pairingUrl)
+      await waitFor(() => onMobileConnectionCountChange.mock.calls.length === 2)
+      expect(onMobileConnectionCountChange).toHaveBeenLastCalledWith(2)
+
+      first.ws.send(
+        encrypt(
+          JSON.stringify({
+            id: 'status-after-auth',
+            method: 'status.get',
+            deviceToken: first.deviceToken
+          }),
+          first.sharedKey
+        )
+      )
+      expect(JSON.parse(decrypt(await nextWsMessage(first.ws), first.sharedKey)!)).toMatchObject({
+        id: 'status-after-auth',
+        ok: true
+      })
+      expect(onMobileConnectionCountChange).toHaveBeenCalledTimes(2)
+
+      first.ws.close()
+      await waitForWsClose(first.ws)
+      await waitFor(() => onMobileConnectionCountChange.mock.calls.length === 3)
+      expect(onMobileConnectionCountChange).toHaveBeenLastCalledWith(1)
+
+      second.ws.close()
+      await waitForWsClose(second.ws)
+      await waitFor(() => onMobileConnectionCountChange.mock.calls.length === 4)
+      expect(onMobileConnectionCountChange).toHaveBeenLastCalledWith(0)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not report runtime-scoped or failed-auth WebSockets as mobile connections', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const onMobileConnectionCountChange = vi.fn()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0,
+      onMobileConnectionCountChange
+    })
+
+    await server.start()
+
+    try {
+      const runtimeOffer = server.createPairingOffer({
+        address: '127.0.0.1',
+        name: 'runtime-test'
+      })
+      expect(runtimeOffer.available).toBe(true)
+      if (!runtimeOffer.available) {
+        throw new Error('WebSocket pairing unavailable')
+      }
+      const runtimeWs = await authenticateMobileWs(runtimeOffer.pairingUrl)
+      expect(onMobileConnectionCountChange).not.toHaveBeenCalled()
+
+      const mobileOffer = server.createPairingOffer({
+        address: '127.0.0.1',
+        name: 'mobile-test',
+        scope: 'mobile'
+      })
+      expect(mobileOffer.available).toBe(true)
+      if (!mobileOffer.available) {
+        throw new Error('WebSocket pairing unavailable')
+      }
+      const parsed = parsePairingCode(mobileOffer.pairingUrl)!
+      const failedWs = await connectWs(parsed.endpoint)
+      const failedKeys = generateKeyPair()
+      const failedSharedKey = deriveSharedKey(
+        failedKeys.secretKey,
+        Uint8Array.from(Buffer.from(parsed.publicKeyB64, 'base64'))
+      )
+      failedWs.send(
+        JSON.stringify({
+          type: 'e2ee_hello',
+          publicKeyB64: Buffer.from(failedKeys.publicKey).toString('base64')
+        })
+      )
+      expect(JSON.parse(await nextWsMessage(failedWs))).toEqual({ type: 'e2ee_ready' })
+      failedWs.send(
+        encrypt(JSON.stringify({ type: 'e2ee_auth', deviceToken: 'bad-token' }), failedSharedKey)
+      )
+      await waitForWsClose(failedWs)
+
+      expect(onMobileConnectionCountChange).not.toHaveBeenCalled()
+      runtimeWs.close()
+      await waitForWsClose(runtimeWs)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('clears mobile connection count once when stopping with active mobile sockets', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const onMobileConnectionCountChange = vi.fn()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0,
+      onMobileConnectionCountChange
+    })
+
+    await server.start()
+
+    const offer = server.createPairingOffer({
+      address: '127.0.0.1',
+      name: 'mobile-test',
+      scope: 'mobile'
+    })
+    expect(offer.available).toBe(true)
+    if (!offer.available) {
+      throw new Error('WebSocket pairing unavailable')
+    }
+    await authenticateMobileWs(offer.pairingUrl)
+    await waitFor(() => onMobileConnectionCountChange.mock.calls.length === 1)
+
+    await server.stop()
+
+    expect(onMobileConnectionCountChange.mock.calls).toEqual([[1], [0]])
   })
 
   it('does not revoke runtime-scoped devices through mobile revocation', async () => {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -17,7 +17,7 @@ import type { RpcMessageContext, RpcTransport } from './rpc/transport'
 import { UnixSocketTransport } from './rpc/unix-socket-transport'
 import { WebSocketTransport } from './rpc/ws-transport'
 import type { WebSocket } from 'ws'
-import { DeviceRegistry, type DeviceScope } from './device-registry'
+import { DeviceRegistry, type DeviceEntry, type DeviceScope } from './device-registry'
 import { loadOrCreateE2EEKeypair, type E2EEKeypair } from './e2ee-keypair'
 import { E2EEChannel } from './rpc/e2ee-channel'
 import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../../shared/pairing'
@@ -36,6 +36,7 @@ type OrcaRuntimeRpcServerOptions = {
   enableWebSocket?: boolean
   wsPort?: number
   webClientRoot?: string
+  onMobileConnectionCountChange?: (count: number) => void
   // Why: test-only overrides for the two time-bound constants below.
   // Production callers must not pass these — defaults are set by the design
   // doc (§3.1) and changing them in production would weaken the admission
@@ -187,6 +188,7 @@ export class OrcaRuntimeRpcServer {
   private readonly enableWebSocket: boolean
   private readonly wsPort: number
   private readonly webClientRoot: string | undefined
+  private readonly onMobileConnectionCountChange: ((count: number) => void) | undefined
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
   private readonly longPollCap: number
@@ -203,6 +205,9 @@ export class OrcaRuntimeRpcServer {
   // subscriptions, so the server can reap a closing socket's subscriptions
   // without affecting other live sockets that share the same deviceToken.
   private wsConnectionIds = new Map<WebSocket, string>()
+  // Why: mobile presence is a connection-level wake reason; track exact sockets
+  // so multi-screen phones and duplicate auth paths clean up idempotently.
+  private activeMobileWebSockets = new Set<WebSocket>()
   private readonly binaryStreamHandlers = new Map<
     string,
     Map<number, (frame: TerminalStreamFrame) => void>
@@ -220,6 +225,7 @@ export class OrcaRuntimeRpcServer {
     enableWebSocket = false,
     wsPort = DEFAULT_WS_PORT,
     webClientRoot,
+    onMobileConnectionCountChange,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
     longPollCap = LONG_POLL_CAP
   }: OrcaRuntimeRpcServerOptions) {
@@ -231,6 +237,7 @@ export class OrcaRuntimeRpcServer {
     this.enableWebSocket = enableWebSocket
     this.wsPort = wsPort
     this.webClientRoot = webClientRoot
+    this.onMobileConnectionCountChange = onMobileConnectionCountChange
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.longPollCap = longPollCap
   }
@@ -258,6 +265,29 @@ export class OrcaRuntimeRpcServer {
     }
     this.wsTransport?.terminateClientConnections(device.token)
     return true
+  }
+
+  private trackAuthenticatedMobileSocket(ws: WebSocket, device: DeviceEntry): void {
+    if (device.scope !== 'mobile' || this.activeMobileWebSockets.has(ws)) {
+      return
+    }
+    this.activeMobileWebSockets.add(ws)
+    this.onMobileConnectionCountChange?.(this.activeMobileWebSockets.size)
+  }
+
+  private untrackMobileSocket(ws: WebSocket): void {
+    if (!this.activeMobileWebSockets.delete(ws)) {
+      return
+    }
+    this.onMobileConnectionCountChange?.(this.activeMobileWebSockets.size)
+  }
+
+  private clearMobileSockets(): void {
+    if (this.activeMobileWebSockets.size === 0) {
+      return
+    }
+    this.activeMobileWebSockets.clear()
+    this.onMobileConnectionCountChange?.(0)
   }
 
   getWebSocketEndpoint(): string | null {
@@ -449,6 +479,7 @@ export class OrcaRuntimeRpcServer {
                   const device = this.deviceRegistry?.validateToken(ch.deviceToken)
                   if (device) {
                     this.deviceRegistry?.updateLastSeen(device.deviceId)
+                    this.trackAuthenticatedMobileSocket(ws, device)
                   }
                 }
               },
@@ -482,6 +513,7 @@ export class OrcaRuntimeRpcServer {
         // so destroy the channel for THIS exact ws and skip the per-client
         // teardown when other sockets for the same token are still alive.
         wsTransport.onConnectionClose((clientId, ws, hasOtherConnections) => {
+          this.untrackMobileSocket(ws)
           // Why: sweep streaming subscriptions for THIS ws regardless of
           // hasOtherConnections, so per-ws listeners (notifications,
           // accounts, terminal) don't leak across reconnects. This is
@@ -532,6 +564,7 @@ export class OrcaRuntimeRpcServer {
       // behind a live but undiscoverable control plane.
       this.activeTransports = []
       this.transports = []
+      this.clearMobileSockets()
       await Promise.all(activeTransports.map((t) => t.stop().catch(() => {}))).catch(() => {})
       throw error
     }
@@ -542,6 +575,7 @@ export class OrcaRuntimeRpcServer {
     this.activeTransports = []
     this.transports = []
     this.wsTransport = null
+    this.clearMobileSockets()
     if (transports.length === 0) {
       return
     }

--- a/src/renderer/src/components/settings/AgentAwakeSetting.tsx
+++ b/src/renderer/src/components/settings/AgentAwakeSetting.tsx
@@ -2,6 +2,12 @@ import type { GlobalSettings } from '../../../../shared/types'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 
+export const AGENT_AWAKE_SETTING_TITLE = 'Keep computer awake during active sessions'
+export const AGENT_AWAKE_SETTING_DESCRIPTION =
+  'Keeps this computer awake while agents are working or a paired phone is connected. Closing a laptop lid can still force sleep and disconnect this computer from a mobile hotspot.'
+const AGENT_AWAKE_SETTING_LABEL_ID = 'agent-awake-setting-label'
+const AGENT_AWAKE_SETTING_DESCRIPTION_ID = 'agent-awake-setting-description'
+
 type AgentAwakeSettingProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
@@ -14,20 +20,32 @@ export function AgentAwakeSetting({
   return (
     <section className="space-y-3">
       <SearchableSetting
-        title="Keep computer awake while agents are working"
-        description="Keeps this computer awake while agents are working. The display can still turn off."
-        keywords={['awake', 'sleep', 'power', 'agent', 'running', 'working']}
+        title={AGENT_AWAKE_SETTING_TITLE}
+        description={AGENT_AWAKE_SETTING_DESCRIPTION}
+        keywords={[
+          'awake',
+          'sleep',
+          'power',
+          'agent',
+          'running',
+          'working',
+          'mobile',
+          'phone',
+          'hotspot',
+          'lid'
+        ]}
         className="flex items-start justify-between gap-4 px-1 py-2"
       >
         <div className="min-w-0 shrink space-y-0.5">
-          <Label>Keep computer awake while agents are working</Label>
-          <p className="text-xs text-muted-foreground">
-            Keeps this computer awake while agents are working. The display can still turn off.
+          <Label id={AGENT_AWAKE_SETTING_LABEL_ID}>{AGENT_AWAKE_SETTING_TITLE}</Label>
+          <p id={AGENT_AWAKE_SETTING_DESCRIPTION_ID} className="text-xs text-muted-foreground">
+            {AGENT_AWAKE_SETTING_DESCRIPTION}
           </p>
         </div>
         <button
           role="switch"
-          aria-label="Keep computer awake while agents are working"
+          aria-labelledby={AGENT_AWAKE_SETTING_LABEL_ID}
+          aria-describedby={AGENT_AWAKE_SETTING_DESCRIPTION_ID}
           aria-checked={settings.keepComputerAwakeWhileAgentsRun}
           onClick={() =>
             updateSettings({

--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import type { GlobalSettings } from '../../../../shared/types'
 import { useAppStore } from '../../store'
-import { AgentAwakeSetting } from './AgentAwakeSetting'
+import {
+  AGENT_AWAKE_SETTING_DESCRIPTION,
+  AGENT_AWAKE_SETTING_TITLE,
+  AgentAwakeSetting
+} from './AgentAwakeSetting'
 import { AgentsPane, AGENTS_PANE_SEARCH_ENTRIES } from './AgentsPane'
 import { matchesSettingsSearch } from './settings-search'
 
@@ -63,10 +67,8 @@ describe('AgentsPane', () => {
   it('renders the keep-awake toggle from settings', () => {
     const markup = renderPane(getDefaultSettings('/tmp'))
 
-    expect(markup).toContain('Keep computer awake while agents are working')
-    expect(markup).toContain(
-      'Keeps this computer awake while agents are working. The display can still turn off.'
-    )
+    expect(markup).toContain(AGENT_AWAKE_SETTING_TITLE)
+    expect(markup).toContain(AGENT_AWAKE_SETTING_DESCRIPTION)
     expect(markup).toContain('aria-checked="false"')
   })
 
@@ -81,7 +83,8 @@ describe('AgentsPane', () => {
     })
 
     const keepAwakeSwitch = findSwitch(element)
-    expect(keepAwakeSwitch.props['aria-label']).toBe('Keep computer awake while agents are working')
+    expect(keepAwakeSwitch.props['aria-labelledby']).toBe('agent-awake-setting-label')
+    expect(keepAwakeSwitch.props['aria-describedby']).toBe('agent-awake-setting-description')
     expect(keepAwakeSwitch.props['aria-checked']).toBe(false)
 
     const onClick = keepAwakeSwitch.props.onClick as () => void
@@ -95,5 +98,8 @@ describe('AgentsPane', () => {
   it('includes awake and sleep search metadata for the setting', () => {
     expect(matchesSettingsSearch('awake', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
     expect(matchesSettingsSearch('sleep', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('mobile', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('hotspot', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('lid', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
   })
 })

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -1,4 +1,5 @@
 import type { SettingsSearchEntry } from './settings-search'
+import { AGENT_AWAKE_SETTING_DESCRIPTION, AGENT_AWAKE_SETTING_TITLE } from './AgentAwakeSetting'
 
 export const AGENTS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
@@ -41,9 +42,19 @@ export const AGENTS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ]
   },
   {
-    title: 'Keep computer awake while agents are working',
-    description:
-      'Keeps this computer awake while agents are working. The display can still turn off.',
-    keywords: ['awake', 'sleep', 'power', 'agent', 'running', 'working']
+    title: AGENT_AWAKE_SETTING_TITLE,
+    description: AGENT_AWAKE_SETTING_DESCRIPTION,
+    keywords: [
+      'awake',
+      'sleep',
+      'power',
+      'agent',
+      'running',
+      'working',
+      'mobile',
+      'phone',
+      'hotspot',
+      'lid'
+    ]
   }
 ]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1464,7 +1464,7 @@ export type GlobalSettings = {
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
-  /** When true, Orca prevents local app suspension while hook-reported agents are working. */
+  /** When true, Orca prevents local app suspension during active agent or mobile sessions. */
   keepComputerAwakeWhileAgentsRun: boolean
   /** Why: macOS terminals must choose between letting Option compose layout
    *  characters (@ on German, € on French) or treating Option as Meta/Esc for

--- a/tests/e2e/settings-agent-awake.spec.ts
+++ b/tests/e2e/settings-agent-awake.spec.ts
@@ -25,11 +25,11 @@ test.describe('Agent awake setting', () => {
     await orcaPage.getByPlaceholder('Search settings').fill('awake')
 
     await expect(
-      orcaPage.getByText('Keep computer awake while agents are working').first()
+      orcaPage.getByText('Keep computer awake during active sessions').first()
     ).toBeVisible()
 
     const keepAwakeSwitch = orcaPage.getByRole('switch', {
-      name: 'Keep computer awake while agents are working'
+      name: 'Keep computer awake during active sessions'
     })
 
     await expect(keepAwakeSwitch).toHaveAttribute('aria-checked', 'false')


### PR DESCRIPTION
## Summary
- Extend the existing keep-awake setting so authenticated Orca Mobile WebSocket sessions hold the local Electron power-save blocker, even when no agent status is currently working.
- Track only mobile-scoped, E2EE-authenticated sockets and cleanly drop the wake reason on close, revocation, failed auth exclusion, runtime-scoped clients, and runtime stop.
- Update settings copy/search/accessibility to explain paired-phone support and the hard laptop-lid/mobile-hotspot limitation.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-awake-service.test.ts src/main/agent-awake-runtime-wiring.test.ts src/renderer/src/components/settings/AgentsPane.test.tsx src/main/runtime/runtime-rpc.test.ts --testNamePattern "AgentAwakeService|agent awake runtime wiring|AgentsPane|terminates active WebSockets|active authenticated mobile WebSocket count|runtime-scoped or failed-auth|stopping with active mobile"`
- `npx playwright test tests/e2e/settings-agent-awake.spec.ts --config tests/playwright.config.ts --project electron-headless`
- Manual Electron validation via the electron skill: settings copy, toggle persistence, search terms, accessibility wiring, and nearby Mobile settings checked.

## Notes
- Physical lid-close/mobile-hotspot behavior cannot be guaranteed by Electron automation or by the power-save blocker; the UI now states that closing the lid can still force sleep and disconnect this computer from a mobile hotspot.

Made with [Orca](https://github.com/stablyai/orca)