### PR TITLE
Improve Linear issue page

### DIFF
--- a/src/main/ipc/linear.ts
+++ b/src/main/ipc/linear.ts
@@ -10,6 +10,7 @@ import {
   addIssueComment,
   getIssueComments
 } from '../linear/issues'
+import { listProjects } from '../linear/projects'
 import { listTeams, getTeamStates, getTeamLabels, getTeamMembers } from '../linear/teams'
 import type { LinearListFilter } from '../linear/issues'
 import type { LinearIssueUpdate, LinearWorkspaceSelection } from '../../shared/types'
@@ -90,7 +91,14 @@ export function registerLinearHandlers(): void {
     'linear:createIssue',
     async (
       _event,
-      args: { teamId: string; title: string; description?: string; workspaceId?: string }
+      args: {
+        teamId: string
+        title: string
+        description?: string
+        workspaceId?: string
+        parentIssueId?: string
+        projectId?: string | null
+      }
     ) => {
       if (typeof args?.teamId !== 'string' || !args.teamId.trim()) {
         return { ok: false, error: 'Team ID is required' }
@@ -102,7 +110,11 @@ export function registerLinearHandlers(): void {
         args.teamId.trim(),
         args.title.trim(),
         args.description?.trim() || undefined,
-        normalizeWorkspaceId(args.workspaceId)
+        normalizeWorkspaceId(args.workspaceId),
+        {
+          parentId: typeof args.parentIssueId === 'string' ? args.parentIssueId.trim() : undefined,
+          projectId: typeof args.projectId === 'string' ? args.projectId.trim() : null
+        }
       )
     }
   )
@@ -142,6 +154,13 @@ export function registerLinearHandlers(): void {
       ) {
         return { ok: false, error: 'Label IDs must be an array of strings' }
       }
+      if (
+        u.projectId !== undefined &&
+        u.projectId !== null &&
+        (typeof u.projectId !== 'string' || !u.projectId.trim())
+      ) {
+        return { ok: false, error: 'Invalid project ID' }
+      }
       return updateIssue(args.id.trim(), args.updates, normalizeWorkspaceId(args.workspaceId))
     }
   )
@@ -177,6 +196,17 @@ export function registerLinearHandlers(): void {
     'linear:listTeams',
     async (_event, args?: { workspaceId?: LinearWorkspaceSelection }) => {
       return listTeams(normalizeWorkspaceSelection(args?.workspaceId))
+    }
+  )
+
+  ipcMain.handle(
+    'linear:listProjects',
+    async (
+      _event,
+      args?: { query?: string; limit?: number; workspaceId?: LinearWorkspaceSelection }
+    ) => {
+      const limit = Math.min(Math.max(1, args?.limit ?? 20), 50)
+      return listProjects(args?.query, limit, normalizeWorkspaceSelection(args?.workspaceId))
     }
   )
 

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -19,9 +19,10 @@ import { mapLinearIssue } from './mappers'
 
 async function mapIssueForWorkspace(
   entry: LinearClientForWorkspace,
-  issue: Parameters<typeof mapLinearIssue>[0]
+  issue: Parameters<typeof mapLinearIssue>[0],
+  options?: Parameters<typeof mapLinearIssue>[1]
 ): Promise<LinearIssue> {
-  const mapped = await mapLinearIssue(issue)
+  const mapped = await mapLinearIssue(issue, options)
   return {
     ...mapped,
     workspaceId: entry.workspace.id,
@@ -52,7 +53,10 @@ export async function getIssue(
     await acquire()
     try {
       const issue = await entry.client.issue(id)
-      return await mapIssueForWorkspace(entry, issue)
+      return await mapIssueForWorkspace(entry, issue, {
+        includeChildren: true,
+        includeProject: true
+      })
     } catch (error) {
       if (isAuthError(error)) {
         clearToken(entry.workspace.id)
@@ -84,7 +88,11 @@ export async function searchIssues(
       await acquire()
       try {
         const result = await entry.client.searchIssues(query, { first: limit })
-        return await Promise.all(result.nodes.map((issue) => mapIssueForWorkspace(entry, issue)))
+        return await Promise.all(
+          result.nodes.map((issue) =>
+            mapIssueForWorkspace(entry, issue, { includeChildren: false })
+          )
+        )
       } catch (error) {
         if (isAuthError(error)) {
           clearToken(entry.workspace.id)
@@ -138,7 +146,9 @@ export async function listIssues(
             filter: ACTIVE_STATE_FILTER
           })
           return await Promise.all(
-            connection.nodes.map((issue) => mapIssueForWorkspace(entry, issue))
+            connection.nodes.map((issue) =>
+              mapIssueForWorkspace(entry, issue, { includeChildren: false })
+            )
           )
         }
 
@@ -150,7 +160,9 @@ export async function listIssues(
             filter: ACTIVE_STATE_FILTER
           })
           return await Promise.all(
-            connection.nodes.map((issue) => mapIssueForWorkspace(entry, issue))
+            connection.nodes.map((issue) =>
+              mapIssueForWorkspace(entry, issue, { includeChildren: false })
+            )
           )
         }
 
@@ -162,7 +174,9 @@ export async function listIssues(
             filter: COMPLETED_STATE_FILTER
           })
           return await Promise.all(
-            connection.nodes.map((issue) => mapIssueForWorkspace(entry, issue))
+            connection.nodes.map((issue) =>
+              mapIssueForWorkspace(entry, issue, { includeChildren: false })
+            )
           )
         }
 
@@ -173,7 +187,9 @@ export async function listIssues(
           filter: ACTIVE_STATE_FILTER
         })
         return await Promise.all(
-          connection.nodes.map((issue) => mapIssueForWorkspace(entry, issue))
+          connection.nodes.map((issue) =>
+            mapIssueForWorkspace(entry, issue, { includeChildren: false })
+          )
         )
       } catch (error) {
         if (isAuthError(error)) {
@@ -197,9 +213,11 @@ export async function createIssue(
   teamId: string,
   title: string,
   description?: string,
-  workspaceId?: string | null
+  workspaceId?: string | null,
+  options?: { parentId?: string; projectId?: string | null }
 ): Promise<
-  { ok: true; id: string; identifier: string; url: string } | { ok: false; error: string }
+  | { ok: true; id: string; identifier: string; title: string; url: string }
+  | { ok: false; error: string }
 > {
   const entry = getClients(workspaceId)[0]
   if (!entry) {
@@ -211,7 +229,9 @@ export async function createIssue(
     const result = await entry.client.createIssue({
       teamId,
       title,
-      ...(description ? { description } : {})
+      ...(description ? { description } : {}),
+      ...(options?.parentId ? { parentId: options.parentId } : {}),
+      ...(options?.projectId ? { projectId: options.projectId } : {})
     })
     if (!result.success) {
       return { ok: false, error: 'Linear create failed' }
@@ -220,7 +240,13 @@ export async function createIssue(
     if (!issue) {
       return { ok: false, error: 'Issue was created but could not be retrieved' }
     }
-    return { ok: true, id: issue.id, identifier: issue.identifier, url: issue.url }
+    return {
+      ok: true,
+      id: issue.id,
+      identifier: issue.identifier,
+      title: issue.title,
+      url: issue.url
+    }
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.workspace.id)
@@ -266,6 +292,9 @@ export async function updateIssue(
     }
     if (resolvedLabelIds !== undefined) {
       payload.labelIds = resolvedLabelIds
+    }
+    if (updates.projectId !== undefined) {
+      payload.projectId = updates.projectId
     }
 
     const result = await entry.client.updateIssue(id, payload)

--- a/src/main/linear/mappers.ts
+++ b/src/main/linear/mappers.ts
@@ -1,13 +1,35 @@
 import type { Issue, IssueSearchResult } from '@linear/sdk'
-import type { LinearIssue } from '../../shared/types'
+import type { LinearIssue, LinearIssueChildSummary } from '../../shared/types'
+
+type IssueWithChildren = Issue & {
+  children: Issue['children']
+}
+
+type MapLinearIssueOptions = {
+  includeChildren?: boolean
+  includeProject?: boolean
+}
+
+function mapLinearIssueChild(issue: Issue): LinearIssueChildSummary {
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    url: issue.url
+  }
+}
 
 // Why: the @linear/sdk uses lazy-loading for related entities — state, team,
 // and assignee are fetched on property access and return promises. This mapper
 // awaits them all so callers receive a plain serializable object safe for IPC
 // transfer. Labels use the labels() method on Issue but IssueSearchResult only
 // has labelIds (string UUIDs), so we conditionally resolve label names.
-export async function mapLinearIssue(issue: Issue | IssueSearchResult): Promise<LinearIssue> {
+export async function mapLinearIssue(
+  issue: Issue | IssueSearchResult,
+  options: MapLinearIssueOptions = {}
+): Promise<LinearIssue> {
   const [state, team, assignee] = await Promise.all([issue.state, issue.team, issue.assignee])
+  const project = options.includeProject ? await issue.project : undefined
 
   // Why: IssueSearchResult does not expose the labels() relation method — only
   // the raw labelIds array. For Issue instances we resolve actual label names;
@@ -27,6 +49,16 @@ export async function mapLinearIssue(issue: Issue | IssueSearchResult): Promise<
     labelIds = issue.labelIds as string[]
   }
 
+  let subIssues: LinearIssueChildSummary[] | undefined
+  if (options.includeChildren && 'children' in issue && typeof issue.children === 'function') {
+    try {
+      const childrenConnection = await (issue as IssueWithChildren).children({ first: 25 })
+      subIssues = childrenConnection.nodes.map(mapLinearIssueChild)
+    } catch {
+      // Swallow — child issues are secondary display data and creation still works without them.
+    }
+  }
+
   return {
     id: issue.id,
     identifier: issue.identifier,
@@ -43,6 +75,15 @@ export async function mapLinearIssue(issue: Issue | IssueSearchResult): Promise<
       name: team?.name ?? '',
       key: team?.key ?? ''
     },
+    project: project
+      ? {
+          id: project.id,
+          name: project.name,
+          url: project.url ?? undefined,
+          color: project.color ?? undefined
+        }
+      : undefined,
+    subIssues,
     labels: labelNames,
     labelIds,
     assignee: assignee

--- a/src/main/linear/projects.ts
+++ b/src/main/linear/projects.ts
@@ -1,0 +1,52 @@
+import type { Project, ProjectSearchResult } from '@linear/sdk'
+import type { LinearProjectSummary, LinearWorkspaceSelection } from '../../shared/types'
+import { acquire, clearToken, getClients, isAuthError, release } from './client'
+
+function mapLinearProject(project: Project | ProjectSearchResult): LinearProjectSummary {
+  return {
+    id: project.id,
+    name: project.name,
+    url: project.url ?? undefined,
+    color: project.color ?? undefined
+  }
+}
+
+export async function listProjects(
+  query: string | undefined,
+  limit = 20,
+  workspaceId?: LinearWorkspaceSelection | null
+): Promise<LinearProjectSummary[]> {
+  const trimmed = query?.trim()
+  if (!trimmed) {
+    return []
+  }
+
+  const entries = getClients(workspaceId)
+  if (entries.length === 0) {
+    return []
+  }
+
+  const results = await Promise.all(
+    entries.map(async (entry) => {
+      await acquire()
+      try {
+        const connection = await entry.client.searchProjects(trimmed, { first: limit })
+        return connection.nodes.map(mapLinearProject)
+      } catch (error) {
+        if (isAuthError(error)) {
+          clearToken(entry.workspace.id)
+          if (workspaceId !== 'all') {
+            throw error
+          }
+        } else {
+          console.warn('[linear] listProjects failed:', error)
+        }
+        return []
+      } finally {
+        release()
+      }
+    })
+  )
+
+  return results.flat().slice(0, limit)
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -145,6 +145,7 @@ import {
   updateIssue as updateLinearIssue,
   type LinearListFilter
 } from '../linear/issues'
+import { listProjects as listLinearProjects } from '../linear/projects'
 import {
   getTeamLabels as getLinearTeamLabels,
   getTeamMembers as getLinearTeamMembers,
@@ -8308,9 +8309,14 @@ export class OrcaRuntimeService {
     teamId: string,
     title: string,
     description?: string,
-    workspaceId?: string
+    workspaceId?: string,
+    parentIssueId?: string,
+    projectId?: string | null
   ): ReturnType<typeof createLinearIssue> {
-    return createLinearIssue(teamId, title, description, workspaceId)
+    return createLinearIssue(teamId, title, description, workspaceId, {
+      parentId: parentIssueId,
+      projectId
+    })
   }
 
   linearGetIssue(id: string, workspaceId?: string): ReturnType<typeof getLinearIssue> {
@@ -8342,6 +8348,14 @@ export class OrcaRuntimeService {
 
   linearListTeams(workspaceId?: LinearWorkspaceSelection): ReturnType<typeof listLinearTeams> {
     return listLinearTeams(workspaceId)
+  }
+
+  linearListProjects(
+    query?: string,
+    limit = 20,
+    workspaceId?: LinearWorkspaceSelection
+  ): ReturnType<typeof listLinearProjects> {
+    return listLinearProjects(query, Math.min(Math.max(1, limit), 50), workspaceId)
   }
 
   linearTeamStates(teamId: string, workspaceId?: string): ReturnType<typeof getLinearTeamStates> {

--- a/src/main/runtime/rpc/methods/linear.test.ts
+++ b/src/main/runtime/rpc/methods/linear.test.ts
@@ -71,7 +71,22 @@ describe('linear RPC methods', () => {
       makeRequest('linear.updateIssue', {
         id: 'issue-3',
         workspaceId: 'workspace-1',
-        updates: { stateId: 'state-1', assigneeId: null, priority: 2, labelIds: ['label-1'] }
+        updates: {
+          stateId: 'state-1',
+          assigneeId: null,
+          priority: 2,
+          labelIds: ['label-1'],
+          projectId: 'project-1'
+        }
+      })
+    )
+    await dispatcher.dispatch(
+      makeRequest('linear.createIssue', {
+        parentIssueId: 'issue-3',
+        teamId: 'team-1',
+        title: 'Child task',
+        workspaceId: 'workspace-1',
+        projectId: 'project-1'
       })
     )
     await dispatcher.dispatch(
@@ -92,7 +107,17 @@ describe('linear RPC methods', () => {
       'team-1',
       'Fix bug',
       'Details',
-      'workspace-1'
+      'workspace-1',
+      undefined,
+      undefined
+    )
+    expect(runtime.linearCreateIssue).toHaveBeenCalledWith(
+      'team-1',
+      'Child task',
+      undefined,
+      'workspace-1',
+      'issue-3',
+      'project-1'
     )
     expect(runtime.linearUpdateIssue).toHaveBeenCalledWith(
       'issue-3',
@@ -100,7 +125,8 @@ describe('linear RPC methods', () => {
         stateId: 'state-1',
         assigneeId: null,
         priority: 2,
-        labelIds: ['label-1']
+        labelIds: ['label-1'],
+        projectId: 'project-1'
       },
       'workspace-1'
     )
@@ -116,6 +142,7 @@ describe('linear RPC methods', () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       linearListTeams: vi.fn().mockResolvedValue([{ id: 'team-1' }]),
+      linearListProjects: vi.fn().mockResolvedValue([{ id: 'project-1' }]),
       linearTeamStates: vi.fn().mockResolvedValue([{ id: 'state-1' }]),
       linearTeamLabels: vi.fn().mockResolvedValue([{ id: 'label-1' }]),
       linearTeamMembers: vi.fn().mockResolvedValue([{ id: 'member-1' }])
@@ -123,6 +150,7 @@ describe('linear RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: LINEAR_METHODS })
 
     await dispatcher.dispatch(makeRequest('linear.listTeams', { workspaceId: 'all' }))
+    await dispatcher.dispatch(makeRequest('linear.listProjects', { query: 'roadmap', limit: 5 }))
     await dispatcher.dispatch(
       makeRequest('linear.teamStates', { teamId: 'team-1', workspaceId: 'workspace-1' })
     )
@@ -134,6 +162,7 @@ describe('linear RPC methods', () => {
     )
 
     expect(runtime.linearListTeams).toHaveBeenCalledWith('all')
+    expect(runtime.linearListProjects).toHaveBeenCalledWith('roadmap', 5, undefined)
     expect(runtime.linearTeamStates).toHaveBeenCalledWith('team-1', 'workspace-1')
     expect(runtime.linearTeamLabels).toHaveBeenCalledWith('team-1', 'workspace-1')
     expect(runtime.linearTeamMembers).toHaveBeenCalledWith('team-1', 'workspace-1')

--- a/src/main/runtime/rpc/methods/linear.ts
+++ b/src/main/runtime/rpc/methods/linear.ts
@@ -36,7 +36,9 @@ const CreateIssue = z.object({
   teamId: requiredString('Team ID is required'),
   title: requiredString('Title is required'),
   description: OptionalString,
-  workspaceId: OptionalString
+  workspaceId: OptionalString,
+  parentIssueId: OptionalString,
+  projectId: z.union([z.string(), z.null()]).optional()
 })
 
 const IssueId = z.object({
@@ -49,6 +51,14 @@ const IssueComment = z.object({
   body: requiredString('Comment body is required'),
   workspaceId: OptionalString
 })
+
+const ListProjects = z
+  .object({
+    query: OptionalString,
+    limit: OptionalFiniteNumber,
+    workspaceId: OptionalString
+  })
+  .optional()
 
 const TeamId = z.object({
   teamId: requiredString('Team ID is required'),
@@ -63,7 +73,8 @@ const IssueUpdate = z.object({
     title: OptionalString,
     assigneeId: z.union([z.string(), z.null()]).optional(),
     priority: z.number().int().min(0).max(4).optional(),
-    labelIds: z.array(z.string()).optional()
+    labelIds: z.array(z.string()).optional(),
+    projectId: z.union([z.string(), z.null()]).optional()
   })
 })
 
@@ -113,7 +124,9 @@ export const LINEAR_METHODS: RpcMethod[] = [
         params.teamId.trim(),
         params.title.trim(),
         params.description?.trim() || undefined,
-        params.workspaceId
+        params.workspaceId,
+        params.parentIssueId,
+        params.projectId
       )
   }),
   defineMethod({
@@ -147,6 +160,12 @@ export const LINEAR_METHODS: RpcMethod[] = [
     name: 'linear.listTeams',
     params: WorkspaceSelection,
     handler: async (params, { runtime }) => runtime.linearListTeams(params?.workspaceId)
+  }),
+  defineMethod({
+    name: 'linear.listProjects',
+    params: ListProjects,
+    handler: async (params, { runtime }) =>
+      runtime.linearListProjects(params?.query, params?.limit, params?.workspaceId)
   }),
   defineMethod({
     name: 'linear.teamStates',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -63,6 +63,7 @@ import type {
   LinearWorkflowState,
   LinearLabel,
   LinearMember,
+  LinearProjectSummary,
   LinearTeam,
   MarkdownDocument,
   FloatingTerminalCwdRequest,
@@ -1036,8 +1037,11 @@ export type PreloadApi = {
       title: string
       description?: string
       workspaceId?: string
+      parentIssueId?: string
+      projectId?: string | null
     }) => Promise<
-      { ok: true; id: string; identifier: string; url: string } | { ok: false; error: string }
+      | { ok: true; id: string; identifier: string; title: string; url: string }
+      | { ok: false; error: string }
     >
     getIssue: (args: { id: string; workspaceId?: string }) => Promise<LinearIssue | null>
     updateIssue: (args: {
@@ -1052,6 +1056,11 @@ export type PreloadApi = {
     }) => Promise<{ ok: true; id: string } | { ok: false; error: string }>
     issueComments: (args: { issueId: string; workspaceId?: string }) => Promise<LinearComment[]>
     listTeams: (args?: { workspaceId?: LinearWorkspaceSelection }) => Promise<LinearTeam[]>
+    listProjects: (args?: {
+      query?: string
+      limit?: number
+      workspaceId?: LinearWorkspaceSelection
+    }) => Promise<LinearProjectSummary[]>
     teamStates: (args: { teamId: string; workspaceId?: string }) => Promise<LinearWorkflowState[]>
     teamLabels: (args: { teamId: string; workspaceId?: string }) => Promise<LinearLabel[]>
     teamMembers: (args: { teamId: string; workspaceId?: string }) => Promise<LinearMember[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1025,8 +1025,11 @@ const api = {
       title: string
       description?: string
       workspaceId?: string
+      parentIssueId?: string
+      projectId?: string | null
     }): Promise<
-      { ok: true; id: string; identifier: string; url: string } | { ok: false; error: string }
+      | { ok: true; id: string; identifier: string; title: string; url: string }
+      | { ok: false; error: string }
     > => ipcRenderer.invoke('linear:createIssue', args),
 
     getIssue: (args: { id: string; workspaceId?: string }): Promise<unknown> =>
@@ -1051,6 +1054,12 @@ const api = {
 
     listTeams: (args?: { workspaceId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('linear:listTeams', args),
+
+    listProjects: (args?: {
+      query?: string
+      limit?: number
+      workspaceId?: string
+    }): Promise<unknown[]> => ipcRenderer.invoke('linear:listProjects', args),
 
     teamStates: (args: { teamId: string; workspaceId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('linear:teamStates', args),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -75,6 +75,7 @@ import {
   setRuntimeGraphSyncEnabled
 } from './runtime/sync-runtime-graph'
 import { useGlobalFileDrop } from './hooks/useGlobalFileDrop'
+import { useRadixBodyPointerEventsRecovery } from './hooks/useRadixBodyPointerEventsRecovery'
 import { registerUpdaterBeforeUnloadBypass } from './lib/updater-beforeunload'
 import {
   buildWorkspaceSessionPayload,
@@ -219,6 +220,7 @@ function applyRemoteWorkspacePatchStatus(
 
 function App(): React.JSX.Element {
   useUnreadDockBadge()
+  useRadixBodyPointerEventsRecovery()
   const [floatingTerminalOpen, setFloatingTerminalOpen] = useState(false)
 
   // Why: Zustand actions are referentially stable, but each individual

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -218,11 +218,11 @@
     list-style: none;
   }
 
-  button:not(:disabled) {
+  :where(button:not(:disabled)) {
     cursor: pointer;
   }
 
-  button:disabled {
+  :where(button:disabled) {
     cursor: default;
   }
 }

--- a/src/renderer/src/components/LinearIssueWorkspace.tsx
+++ b/src/renderer/src/components/LinearIssueWorkspace.tsx
@@ -1,16 +1,25 @@
+/* eslint-disable max-lines -- Why: the Linear issue page co-locates the
+   full-page layout with its hydration/comment state so the selected issue
+   surface stays coherent with the existing Linear drawer behavior. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowRight,
+  Check,
+  ChevronDown,
+  ChevronRight,
   Clipboard,
-  ExternalLink,
+  FolderKanban,
   GitBranch,
+  Link,
   LoaderCircle,
+  Plus,
   RefreshCw,
   X
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { VisuallyHidden } from 'radix-ui'
 
+import { LinearIcon } from '@/components/icons/LinearIcon'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import {
   initLinearIssueEditState,
@@ -20,6 +29,7 @@ import {
   type LinearLocalComment
 } from '@/components/LinearItemDrawer'
 import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { createBrowserUuid } from '@/lib/browser-uuid'
@@ -29,8 +39,19 @@ import {
   buildLinearIssuePrompt,
   formatLinearIssueRelativeTime
 } from '@/components/linear-issue-workspace-text'
-import { linearGetIssue, linearIssueComments } from '@/runtime/runtime-linear-client'
-import type { LinearComment, LinearIssue } from '../../../shared/types'
+import {
+  linearCreateSubIssue,
+  linearGetIssue,
+  linearIssueComments,
+  linearListProjects,
+  linearUpdateIssue
+} from '@/runtime/runtime-linear-client'
+import type {
+  LinearComment,
+  LinearIssue,
+  LinearIssueChildSummary,
+  LinearProjectSummary
+} from '../../../shared/types'
 
 type LinearIssueWorkspaceProps = {
   issue: LinearIssue | null
@@ -47,6 +68,277 @@ async function copyTextToClipboard(text: string, label: string): Promise<void> {
   }
 }
 
+function LinearIssueAvatar({
+  avatarUrl,
+  name,
+  className = 'size-6'
+}: {
+  avatarUrl?: string
+  name?: string
+  className?: string
+}): React.JSX.Element {
+  if (avatarUrl) {
+    return <img src={avatarUrl} alt={name ?? ''} className={`${className} shrink-0 rounded-full`} />
+  }
+
+  const initial = name?.trim().charAt(0).toUpperCase() || '?'
+  return (
+    <span
+      className={`${className} flex shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-medium text-muted-foreground`}
+      aria-hidden="true"
+    >
+      {initial}
+    </span>
+  )
+}
+
+function LinearIssueSubIssueButton({ issue }: { issue: LinearIssue }): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const [open, setOpen] = useState(false)
+  const [title, setTitle] = useState('')
+  const [subIssues, setSubIssues] = useState<LinearIssueChildSummary[]>(issue.subIssues ?? [])
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    setSubIssues(issue.subIssues ?? [])
+  }, [issue.id, issue.subIssues])
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = title.trim()
+    if (!trimmed) {
+      return
+    }
+    setSubmitting(true)
+    try {
+      const result = await linearCreateSubIssue(settings, {
+        parentIssueId: issue.id,
+        teamId: issue.team.id,
+        title: trimmed,
+        workspaceId: issue.workspaceId,
+        projectId: issue.project?.id ?? null
+      })
+      if (result.ok) {
+        const child = {
+          id: result.id,
+          identifier: result.identifier,
+          title: result.title || trimmed,
+          url: result.url
+        }
+        setSubIssues((prev) =>
+          prev.some((subIssue) => subIssue.id === child.id) ? prev : [...prev, child]
+        )
+        toast.success(`Created ${result.identifier}`)
+        setTitle('')
+        setOpen(false)
+      } else {
+        toast.error(result.error)
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create sub-issue')
+    } finally {
+      setSubmitting(false)
+    }
+  }, [issue.id, issue.project?.id, issue.team.id, issue.workspaceId, settings, title])
+
+  return (
+    <section className="mt-10 max-w-[820px]">
+      {subIssues.length > 0 ? (
+        <div className="mb-3 space-y-1">
+          {subIssues.map((subIssue) => (
+            <button
+              key={subIssue.id}
+              type="button"
+              onClick={() => window.api.shell.openUrl(subIssue.url)}
+              className="flex min-h-8 w-full min-w-0 items-center gap-2 rounded-md px-1.5 py-1 text-left text-sm text-muted-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <span className="shrink-0 font-mono text-xs">{subIssue.identifier}</span>
+              <span className="min-w-0 flex-1 truncate">{subIssue.title}</span>
+              <ArrowRight className="size-3.5 shrink-0" />
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="flex h-9 items-center gap-2 rounded-md px-1 text-sm font-medium text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <Plus className="size-4" />
+            <span>Add sub-issues</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80 p-3" align="start">
+          <div className="space-y-3">
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault()
+                  void handleCreate()
+                }
+              }}
+              placeholder="Sub-issue title"
+              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                onClick={() => void handleCreate()}
+                disabled={!title.trim() || submitting}
+              >
+                {submitting ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+                Create
+              </Button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </section>
+  )
+}
+
+function LinearIssueSidebarProjectCard({
+  issue,
+  onProjectChanged
+}: {
+  issue: LinearIssue
+  onProjectChanged: (project: LinearProjectSummary) => void
+}): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const patchLinearIssue = useAppStore((s) => s.patchLinearIssue)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [projects, setProjects] = useState<LinearProjectSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [savingProjectId, setSavingProjectId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    let cancelled = false
+    const timeout = window.setTimeout(() => {
+      setLoading(true)
+      void linearListProjects(settings, query, 20, issue.workspaceId)
+        .then((result) => {
+          if (!cancelled) {
+            setProjects(result)
+          }
+        })
+        .catch((error) => {
+          if (!cancelled) {
+            toast.error(error instanceof Error ? error.message : 'Failed to load projects')
+          }
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setLoading(false)
+          }
+        })
+    }, 150)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+    }
+  }, [issue.workspaceId, open, query, settings])
+
+  const handleSelectProject = useCallback(
+    async (project: LinearProjectSummary) => {
+      setSavingProjectId(project.id)
+      try {
+        const result = await linearUpdateIssue(
+          settings,
+          issue.id,
+          { projectId: project.id },
+          issue.workspaceId
+        )
+        if (result.ok) {
+          onProjectChanged(project)
+          patchLinearIssue(issue.id, { project })
+          toast.success('Project updated')
+          setOpen(false)
+        } else {
+          toast.error(result.error)
+        }
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to update project')
+      } finally {
+        setSavingProjectId(null)
+      }
+    },
+    [issue.id, issue.workspaceId, onProjectChanged, patchLinearIssue, settings]
+  )
+
+  return (
+    <section className="rounded-xl border border-border/60 bg-card text-card-foreground shadow-xs">
+      <div className="flex h-10 items-center gap-1 border-b border-border/50 px-4 text-sm font-medium text-muted-foreground">
+        <span>Project</span>
+        <ChevronDown className="size-3.5" />
+      </div>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="m-3 flex min-h-9 w-[calc(100%-1.5rem)] items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <FolderKanban className="size-4 shrink-0" />
+            <span className="min-w-0 flex-1 truncate">
+              {issue.project?.name ?? 'Add to project'}
+            </span>
+            <ChevronDown className="size-3.5 shrink-0" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-72 p-2" align="start">
+          <div className="space-y-2">
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search projects"
+              className="h-8 w-full rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            <div className="max-h-64 overflow-y-auto scrollbar-sleek">
+              {loading ? (
+                <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
+                  <LoaderCircle className="size-3.5 animate-spin" />
+                  Loading projects
+                </div>
+              ) : projects.length > 0 ? (
+                projects.map((project) => (
+                  <button
+                    key={project.id}
+                    type="button"
+                    onClick={() => void handleSelectProject(project)}
+                    disabled={savingProjectId !== null}
+                    className="flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-70"
+                  >
+                    <span
+                      className="size-2 shrink-0 rounded-full bg-muted"
+                      style={project.color ? { backgroundColor: project.color } : undefined}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                    {savingProjectId === project.id ? (
+                      <LoaderCircle className="size-3.5 animate-spin" />
+                    ) : issue.project?.id === project.id ? (
+                      <Check className="size-3.5" />
+                    ) : null}
+                  </button>
+                ))
+              ) : (
+                <div className="px-2 py-3 text-sm text-muted-foreground">
+                  {query.trim() ? 'No projects found.' : 'Search for a project to add.'}
+                </div>
+              )}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </section>
+  )
+}
+
 export default function LinearIssueWorkspace({
   issue,
   onUse,
@@ -60,11 +352,13 @@ export default function LinearIssueWorkspace({
   const [commentsError, setCommentsError] = useState<string | null>(null)
   const [editState, setEditState] = useState<LinearEditState | null>(null)
   const requestIdRef = useRef(0)
+  const hydratedIssueKeyRef = useRef<string | null>(null)
   const hasEditedRef = useRef(false)
   const optimisticCommentsRef = useRef<LinearComment[]>([])
 
   const handleEditStateChange = useCallback((patch: Partial<LinearEditState>) => {
     hasEditedRef.current = true
+    setFullIssue((prev) => (prev ? { ...prev, ...patch } : prev))
     setEditState((prev) => (prev ? { ...prev, ...patch } : prev))
   }, [])
 
@@ -102,6 +396,7 @@ export default function LinearIssueWorkspace({
 
   useEffect(() => {
     if (!issue) {
+      hydratedIssueKeyRef.current = null
       setFullIssue(null)
       setIssueLoading(false)
       setComments([])
@@ -111,6 +406,12 @@ export default function LinearIssueWorkspace({
       optimisticCommentsRef.current = []
       return
     }
+
+    const issueKey = `${settings?.activeRuntimeEnvironmentId ?? 'local'}:${issue.workspaceId ?? 'selected'}:${issue.id}`
+    if (hydratedIssueKeyRef.current === issueKey) {
+      return
+    }
+    hydratedIssueKeyRef.current = issueKey
 
     requestIdRef.current += 1
     const requestId = requestIdRef.current
@@ -131,7 +432,21 @@ export default function LinearIssueWorkspace({
         }
         if (issueResult) {
           const fetched = issueResult as LinearIssue
-          setFullIssue(fetched)
+          setFullIssue((prev) => {
+            if (!hasEditedRef.current || !prev) {
+              return fetched
+            }
+            // Why: late hydration can carry pre-edit field data; keep the
+            // optimistic fields while accepting fresh non-field detail data.
+            return {
+              ...fetched,
+              state: prev.state,
+              priority: prev.priority,
+              assignee: prev.assignee,
+              labelIds: prev.labelIds,
+              labels: prev.labels
+            }
+          })
           if (!hasEditedRef.current) {
             setEditState(initLinearIssueEditState(fetched))
           }
@@ -162,16 +477,15 @@ export default function LinearIssueWorkspace({
     setComments((prev) => [...prev, newComment])
   }, [])
 
+  const handleProjectChanged = useCallback((project: LinearProjectSummary) => {
+    setFullIssue((prev) => (prev ? { ...prev, project } : prev))
+  }, [])
+
   const actionItems = useMemo(() => {
     if (!displayed) {
       return []
     }
     return [
-      {
-        label: 'Open in Linear',
-        icon: ExternalLink,
-        action: () => window.api.shell.openUrl(displayed.url)
-      },
       {
         label: 'Copy URL',
         icon: Clipboard,
@@ -201,7 +515,7 @@ export default function LinearIssueWorkspace({
       <SheetContent
         side="right"
         showCloseButton={false}
-        className="w-[min(92vw,760px)] p-0 sm:max-w-[760px]"
+        className="w-[min(92vw,1180px)] bg-background p-0 sm:max-w-[1180px]"
         onOpenAutoFocus={(event) => {
           event.preventDefault()
         }}
@@ -217,34 +531,73 @@ export default function LinearIssueWorkspace({
 
         {displayed ? (
           <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
-            <div className="flex-none border-b border-border/50 bg-muted/30 px-4 py-3">
-              <div className="flex items-start gap-3">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-                    <span className="font-mono">{displayed.identifier}</span>
-                    {displayed.workspaceName ? <span>{displayed.workspaceName}</span> : null}
-                    <span>{displayed.team.name}</span>
-                    <span>{formatLinearIssueRelativeTime(displayed.updatedAt)}</span>
-                    {issueLoading ? <LoaderCircle className="size-3 animate-spin" /> : null}
-                  </div>
-                  <h2 className="mt-1 text-[20px] font-semibold leading-tight text-foreground">
-                    {displayed.title}
-                  </h2>
-                </div>
-                <Button
-                  onClick={() => onUse(displayed)}
-                  className="hidden shrink-0 gap-2 sm:inline-flex"
-                  size="sm"
-                >
-                  Start workspace
-                  <ArrowRight className="size-4" />
-                </Button>
+            <header className="flex h-[61px] flex-none items-center justify-between gap-4 border-b border-border/60 px-5">
+              <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+                <LinearIcon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="truncate font-medium text-foreground">
+                  {displayed.workspaceName ?? 'Linear'}
+                </span>
+                <ChevronRight className="size-3.5 shrink-0" />
+                <span className="shrink-0">Issues</span>
+                <ChevronRight className="size-3.5 shrink-0" />
+                <span className="shrink-0 font-mono">{displayed.identifier}</span>
+                <span className="min-w-0 truncate font-medium text-foreground">
+                  {displayed.title}
+                </span>
+                {issueLoading ? <LoaderCircle className="size-3.5 shrink-0 animate-spin" /> : null}
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <span className="hidden px-2 text-sm text-muted-foreground md:inline">2 / 17</span>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
                       variant="ghost"
                       size="icon-sm"
-                      className="shrink-0"
+                      onClick={() => void copyTextToClipboard(displayed.url, 'URL')}
+                      aria-label="Copy Linear URL"
+                    >
+                      <Link className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={6}>
+                    Copy URL
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => void copyTextToClipboard(displayed.identifier, 'Identifier')}
+                      aria-label="Copy issue identifier"
+                    >
+                      <Clipboard className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={6}>
+                    Copy identifier
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => onUse(displayed)}
+                      aria-label="Start workspace from issue"
+                    >
+                      <ArrowRight className="size-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={6}>
+                    Start workspace
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
                       onClick={onClose}
                       aria-label="Close Linear issue preview"
                     >
@@ -256,150 +609,161 @@ export default function LinearIssueWorkspace({
                   </TooltipContent>
                 </Tooltip>
               </div>
-            </div>
+            </header>
 
-            {editState ? (
-              <LinearIssueEditSection
-                issue={displayed}
-                editState={editState}
-                onEditStateChange={handleEditStateChange}
-              />
-            ) : null}
+            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+              <div className="mx-auto grid w-full grid-cols-1 gap-10 px-7 py-10 lg:grid-cols-[minmax(0,1fr)_320px] lg:px-10 xl:px-12">
+                <main className="min-w-0">
+                  <h1 className="max-w-[820px] text-[28px] font-semibold leading-tight text-foreground">
+                    {displayed.title}
+                  </h1>
 
-            <div className="grid min-h-0 flex-1 grid-cols-1 xl:grid-cols-[minmax(0,1fr)_220px]">
-              <div className="min-h-0 overflow-y-auto scrollbar-sleek">
-                <section className="border-b border-border/40 px-4 py-4">
-                  <div className="mb-2 flex items-center gap-2">
-                    <span
-                      className="inline-block size-2 rounded-full"
-                      style={{ backgroundColor: displayed.state.color }}
-                    />
-                    <span className="text-xs font-medium text-foreground">
-                      {displayed.state.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      {displayed.assignee?.displayName ?? 'Unassigned'}
-                    </span>
-                  </div>
-                  {displayed.description?.trim() ? (
-                    <CommentMarkdown
-                      content={displayed.description}
-                      className="text-[14px] leading-relaxed"
-                    />
-                  ) : (
-                    <p className="text-sm italic text-muted-foreground">No description provided.</p>
-                  )}
-                </section>
+                  <section className="mt-7 max-w-[820px] text-[15px] leading-7 text-foreground">
+                    {displayed.description?.trim() ? (
+                      <CommentMarkdown
+                        content={displayed.description}
+                        className="text-[15px] leading-7"
+                      />
+                    ) : (
+                      <p className="text-sm italic text-muted-foreground">
+                        No description provided.
+                      </p>
+                    )}
+                  </section>
 
-                <section className="px-4 py-4">
-                  <div className="mb-3 flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2">
-                      <span className="text-[13px] font-medium text-foreground">Comments</span>
-                      {comments.length > 0 ? (
-                        <span className="text-[12px] text-muted-foreground">{comments.length}</span>
-                      ) : null}
+                  <LinearIssueSubIssueButton issue={displayed} />
+
+                  <section className="mt-12 border-t border-border/60 pt-9">
+                    <div className="mb-8 flex items-center justify-between gap-3">
+                      <h2 className="text-xl font-semibold text-foreground">Activity</h2>
+                      <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                        <LinearIssueAvatar
+                          avatarUrl={displayed.assignee?.avatarUrl}
+                          name={displayed.assignee?.displayName}
+                          className="size-6"
+                        />
+                      </div>
                     </div>
+
+                    <div className="mb-7 flex items-center gap-3 text-sm text-muted-foreground">
+                      <LinearIssueAvatar
+                        avatarUrl={displayed.assignee?.avatarUrl}
+                        name={displayed.assignee?.displayName}
+                        className="size-5"
+                      />
+                      <span>
+                        {displayed.assignee?.displayName ?? 'Someone'} updated the issue ·{' '}
+                        {formatLinearIssueRelativeTime(displayed.updatedAt)}
+                      </span>
+                    </div>
+
                     {commentsError ? (
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        onClick={() => void loadComments(displayed, requestIdRef.current)}
-                        disabled={commentsLoading}
-                        className="gap-1"
-                      >
-                        {commentsLoading ? (
-                          <LoaderCircle className="size-3 animate-spin" />
-                        ) : (
-                          <RefreshCw className="size-3" />
-                        )}
-                        Retry
-                      </Button>
-                    ) : null}
-                  </div>
-
-                  {commentsError ? (
-                    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                      {commentsError}
-                    </div>
-                  ) : commentsLoading && comments.length === 0 ? (
-                    <div className="flex items-center justify-center py-8">
-                      <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
-                    </div>
-                  ) : comments.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">No comments yet.</p>
-                  ) : (
-                    <div className="flex flex-col gap-3">
-                      {comments.map((comment) => (
-                        <div
-                          key={comment.id}
-                          className="rounded-md border border-border/50 bg-muted/20"
+                      <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                        <span>{commentsError}</span>
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          onClick={() => void loadComments(displayed, requestIdRef.current)}
+                          disabled={commentsLoading}
+                          className="gap-1"
                         >
-                          <div className="flex min-w-0 items-center gap-2 border-b border-border/40 px-3 py-2">
-                            {comment.user?.avatarUrl ? (
-                              <img
-                                src={comment.user.avatarUrl}
-                                alt={comment.user.displayName}
-                                className="size-5 shrink-0 rounded-full"
-                              />
-                            ) : null}
-                            <span className="truncate text-[13px] font-semibold text-foreground">
-                              {comment.user?.displayName ?? 'Unknown'}
-                            </span>
-                            <span className="shrink-0 text-[12px] text-muted-foreground">
-                              {formatLinearIssueRelativeTime(comment.createdAt)}
-                            </span>
-                          </div>
-                          <div className="px-3 py-2">
-                            <CommentMarkdown
-                              content={comment.body}
-                              className="text-[13px] leading-relaxed"
+                          {commentsLoading ? (
+                            <LoaderCircle className="size-3 animate-spin" />
+                          ) : (
+                            <RefreshCw className="size-3" />
+                          )}
+                          Retry
+                        </Button>
+                      </div>
+                    ) : null}
+
+                    {commentsLoading && comments.length === 0 ? (
+                      <div className="mb-5 flex items-center justify-center py-8">
+                        <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : comments.length > 0 ? (
+                      <div className="mb-6 flex flex-col gap-5">
+                        {comments.map((comment) => (
+                          <article key={comment.id} className="flex gap-3">
+                            <LinearIssueAvatar
+                              avatarUrl={comment.user?.avatarUrl}
+                              name={comment.user?.displayName}
+                              className="size-7"
                             />
-                          </div>
-                        </div>
-                      ))}
+                            <div className="min-w-0 flex-1">
+                              <div className="mb-1 flex min-w-0 items-center gap-2 text-sm">
+                                <span className="truncate font-semibold text-foreground">
+                                  {comment.user?.displayName ?? 'Unknown'}
+                                </span>
+                                <span className="shrink-0 text-muted-foreground">
+                                  {formatLinearIssueRelativeTime(comment.createdAt)}
+                                </span>
+                              </div>
+                              <div className="rounded-lg border border-border/60 bg-card px-4 py-3">
+                                <CommentMarkdown
+                                  content={comment.body}
+                                  className="text-[14px] leading-7"
+                                />
+                              </div>
+                            </div>
+                          </article>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    <LinearIssueCommentFooter
+                      issueId={displayed.id}
+                      workspaceId={displayed.workspaceId}
+                      onCommentAdded={handleCommentAdded}
+                      variant="linear-page"
+                    />
+                  </section>
+                </main>
+
+                <aside className="space-y-3 lg:sticky lg:top-6 lg:self-start">
+                  {editState ? (
+                    <LinearIssueEditSection
+                      issue={displayed}
+                      editState={editState}
+                      onEditStateChange={handleEditStateChange}
+                      layout="properties"
+                    />
+                  ) : null}
+                  <LinearIssueSidebarProjectCard
+                    issue={displayed}
+                    onProjectChanged={handleProjectChanged}
+                  />
+                  <section className="rounded-xl border border-border/60 bg-card text-card-foreground shadow-xs">
+                    <div className="flex h-10 items-center gap-1 border-b border-border/50 px-4 text-sm font-medium text-muted-foreground">
+                      <span>Actions</span>
+                      <ChevronDown className="size-3.5" />
                     </div>
-                  )}
-                </section>
+                    <div className="space-y-1 p-3">
+                      {actionItems.map((item) => {
+                        const Icon = item.icon
+                        return (
+                          <Tooltip key={item.label}>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                onClick={item.action}
+                                className="flex min-h-9 w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                              >
+                                <Icon className="size-4 shrink-0" />
+                                <span className="truncate">{item.label}</span>
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="left" sideOffset={6}>
+                              {item.label}
+                            </TooltipContent>
+                          </Tooltip>
+                        )
+                      })}
+                    </div>
+                  </section>
+                </aside>
               </div>
-
-              <aside className="border-t border-border/50 bg-muted/20 px-3 py-3 xl:border-l xl:border-t-0">
-                <Button
-                  onClick={() => onUse(displayed)}
-                  className="mb-3 w-full justify-center gap-2 sm:hidden"
-                >
-                  Start workspace
-                  <ArrowRight className="size-4" />
-                </Button>
-                <div className="grid gap-1">
-                  {actionItems.map((item) => {
-                    const Icon = item.icon
-                    return (
-                      <Tooltip key={item.label}>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            onClick={item.action}
-                            className="flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
-                          >
-                            <Icon className="size-3.5 shrink-0" />
-                            <span className="truncate">{item.label}</span>
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" sideOffset={6}>
-                          {item.label}
-                        </TooltipContent>
-                      </Tooltip>
-                    )
-                  })}
-                </div>
-              </aside>
             </div>
-
-            <LinearIssueCommentFooter
-              issueId={displayed.id}
-              workspaceId={displayed.workspaceId}
-              onCommentAdded={handleCommentAdded}
-            />
           </div>
         ) : null}
       </SheetContent>

--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -1,6 +1,17 @@
 /* eslint-disable max-lines -- Why: the Linear drawer co-locates read-only preview, edit controls, and comment input so the full issue surface stays in one file. */
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowRight, ExternalLink, LoaderCircle, Send, X } from 'lucide-react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  ChevronDown,
+  Circle,
+  ExternalLink,
+  LoaderCircle,
+  Send,
+  Tag,
+  UserRound,
+  X
+} from 'lucide-react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
@@ -18,6 +29,10 @@ import {
   useTeamMembers,
   useImmediateMutation
 } from '@/hooks/useIssueMetadata'
+import {
+  getLinearStateMarkerStyle,
+  getLinearStatePillStyle
+} from '@/components/linear-state-pill-style'
 import type { LinearIssue, LinearComment } from '../../../shared/types'
 import {
   linearAddIssueComment,
@@ -44,6 +59,29 @@ const PRIORITY_LABELS: Record<number, string> = {
   4: 'Low'
 }
 
+const LINEAR_EDIT_CHIP_CLASS =
+  'inline-flex h-6 min-w-0 max-w-[14rem] cursor-pointer items-center gap-1.5 rounded-full border border-border/70 bg-background/70 px-2.5 text-[11px] font-medium leading-none text-muted-foreground shadow-xs transition-[background-color,border-color,color,box-shadow] hover:border-border hover:bg-accent hover:text-accent-foreground hover:[--linear-state-pill-current-background:var(--linear-state-pill-hover-background)] hover:[--linear-state-pill-current-border:var(--linear-state-pill-hover-border)] hover:[--linear-state-pill-current-foreground:var(--linear-state-pill-hover-foreground)] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-80'
+
+const LINEAR_EDIT_MENU_ITEM_CLASS =
+  'flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent'
+
+const LINEAR_EDIT_MENU_ITEM_WITH_ICON_CLASS =
+  'flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent'
+
+function LinearEditChipAdornment({
+  loading,
+  pending
+}: {
+  loading?: boolean
+  pending?: boolean
+}): React.JSX.Element {
+  if (loading || pending) {
+    return <LoaderCircle className="size-3 shrink-0 animate-spin opacity-70" />
+  }
+
+  return <ChevronDown className="size-3 shrink-0 opacity-55" />
+}
+
 function formatRelativeTime(input: string): string {
   const date = new Date(input)
   if (Number.isNaN(date.getTime())) {
@@ -61,16 +99,6 @@ function formatRelativeTime(input: string): string {
   }
   const diffDays = Math.round(diffHours / 24)
   return formatter.format(diffDays, 'day')
-}
-
-// Why: derive pill border/background/text from the actual Linear state color
-// so the pill always matches the colored dot, regardless of state type.
-function statePillStyle(color: string): React.CSSProperties {
-  return {
-    borderColor: `color-mix(in srgb, ${color} 30%, transparent)`,
-    backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-    color
-  }
 }
 
 type LinearItemDrawerProps = {
@@ -91,12 +119,14 @@ type EditSectionProps = {
   issue: LinearIssue
   editState: LinearEditState
   onEditStateChange: (patch: Partial<LinearEditState>) => void
+  layout?: 'chips' | 'properties'
 }
 
 export function LinearIssueEditSection({
   issue,
   editState,
-  onEditStateChange
+  onEditStateChange,
+  layout = 'chips'
 }: EditSectionProps): React.JSX.Element {
   const [labelPopoverOpen, setLabelPopoverOpen] = useState(false)
   const patchLinearIssue = useAppStore((s) => s.patchLinearIssue)
@@ -246,6 +276,16 @@ export function LinearIssueEditSection({
   const currentStateId = states.data.find(
     (s) => s.name === localState.name && s.type === localState.type
   )?.id
+  const statePending = isPending('state')
+  const priorityPending = isPending('priority')
+  const assigneePending = isPending('assignee')
+  const labelsPending = isPending('labels')
+  const labelSummary =
+    localLabels.length === 0
+      ? '+ Label'
+      : localLabels.length === 1
+        ? localLabels[0]
+        : `${localLabels[0]} +${localLabels.length - 1}`
 
   const checkIcon = (
     <svg className="size-2.5" viewBox="0 0 12 12" fill="none">
@@ -259,6 +299,263 @@ export function LinearIssueEditSection({
     </svg>
   )
 
+  if (layout === 'properties') {
+    const propertyRowClass =
+      'flex min-h-9 w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-80'
+    const propertyIconClass = 'size-4 shrink-0 text-muted-foreground'
+
+    return (
+      <div className="space-y-3">
+        <section className="rounded-xl border border-border/60 bg-card text-card-foreground shadow-xs">
+          <div className="flex h-10 items-center gap-1 border-b border-border/50 px-4 text-sm font-medium text-muted-foreground">
+            <span>Properties</span>
+            <ChevronDown className="size-3.5" />
+          </div>
+          <div className="space-y-1 p-3">
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  disabled={statePending}
+                  className={propertyRowClass}
+                  aria-busy={statePending || states.loading}
+                >
+                  <span
+                    className="inline-block size-2.5 shrink-0 rounded-full"
+                    style={getLinearStateMarkerStyle(localState.color)}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{localState.name}</span>
+                  <LinearEditChipAdornment loading={states.loading} pending={statePending} />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="popover-scroll-content scrollbar-sleek w-48 p-1"
+                align="start"
+              >
+                {states.error ? (
+                  <div className="px-2 py-3 text-center text-[12px] text-destructive">
+                    {states.error}
+                  </div>
+                ) : states.loading ? (
+                  <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+                    <LoaderCircle className="size-3 animate-spin" />
+                    Loading states
+                  </div>
+                ) : states.data.length > 0 ? (
+                  <div>
+                    {states.data.map((s) => (
+                      <button
+                        key={s.id}
+                        type="button"
+                        onClick={() => handleStateChange(s.id)}
+                        className={cn(
+                          LINEAR_EDIT_MENU_ITEM_WITH_ICON_CLASS,
+                          currentStateId === s.id && 'bg-accent/50'
+                        )}
+                      >
+                        <span
+                          className="inline-block size-2 rounded-full"
+                          style={{ backgroundColor: s.color }}
+                        />
+                        {s.name}
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+                    No states found
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  disabled={priorityPending}
+                  className={propertyRowClass}
+                  aria-busy={priorityPending}
+                >
+                  {localPriority === 1 ? (
+                    <AlertTriangle className="size-4 shrink-0 text-destructive" />
+                  ) : (
+                    <Circle className={propertyIconClass} />
+                  )}
+                  <span className="min-w-0 flex-1 truncate">
+                    {PRIORITY_LABELS[localPriority] ?? `P${localPriority}`}
+                  </span>
+                  <LinearEditChipAdornment pending={priorityPending} />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent className="w-36 p-1" align="start">
+                {[0, 1, 2, 3, 4].map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => handlePriorityChange(String(p))}
+                    className={cn(
+                      LINEAR_EDIT_MENU_ITEM_CLASS,
+                      localPriority === p && 'bg-accent/50'
+                    )}
+                  >
+                    {PRIORITY_LABELS[p]}
+                  </button>
+                ))}
+              </PopoverContent>
+            </Popover>
+
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  disabled={assigneePending}
+                  className={propertyRowClass}
+                  aria-busy={assigneePending || members.loading}
+                >
+                  {localAssignee?.avatarUrl ? (
+                    <img
+                      src={localAssignee.avatarUrl}
+                      alt=""
+                      className="size-4 shrink-0 rounded-full"
+                    />
+                  ) : (
+                    <UserRound className={propertyIconClass} />
+                  )}
+                  <span className="min-w-0 flex-1 truncate">
+                    {localAssignee ? localAssignee.displayName : 'Unassigned'}
+                  </span>
+                  <LinearEditChipAdornment loading={members.loading} pending={assigneePending} />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="popover-scroll-content scrollbar-sleek w-48 p-1"
+                align="start"
+              >
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => handleAssigneeChange('__unassign__')}
+                    className={cn(LINEAR_EDIT_MENU_ITEM_CLASS, !localAssignee && 'bg-accent/50')}
+                  >
+                    Unassigned
+                  </button>
+                  {members.error ? (
+                    <div className="px-2 py-3 text-center text-[12px] text-destructive">
+                      {members.error}
+                    </div>
+                  ) : members.loading ? (
+                    <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+                      <LoaderCircle className="size-3 animate-spin" />
+                      Loading members
+                    </div>
+                  ) : (
+                    members.data.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        onClick={() => handleAssigneeChange(m.id)}
+                        className={cn(
+                          LINEAR_EDIT_MENU_ITEM_CLASS,
+                          localAssignee?.id === m.id && 'bg-accent/50'
+                        )}
+                      >
+                        {m.displayName}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
+
+            <button
+              type="button"
+              className="flex min-h-9 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground"
+              disabled
+            >
+              <AlertTriangle className={propertyIconClass} />
+              <span className="min-w-0 flex-1 truncate">Set estimate</span>
+            </button>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-border/60 bg-card text-card-foreground shadow-xs">
+          <div className="flex h-10 items-center gap-1 border-b border-border/50 px-4 text-sm font-medium text-muted-foreground">
+            <span>Labels</span>
+            <ChevronDown className="size-3.5" />
+          </div>
+          <div className="p-3">
+            <Popover open={labelPopoverOpen} onOpenChange={setLabelPopoverOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  disabled={labelsPending}
+                  className={propertyRowClass}
+                  aria-label={
+                    localLabels.length ? `Labels: ${localLabels.join(', ')}` : 'Add label'
+                  }
+                  aria-busy={labelsPending || labels.loading}
+                >
+                  <Tag className={propertyIconClass} />
+                  <span className="min-w-0 flex-1 truncate">
+                    {localLabels.length ? labelSummary : 'Add label'}
+                  </span>
+                  <LinearEditChipAdornment loading={labels.loading} pending={labelsPending} />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="popover-scroll-content scrollbar-sleek w-52 p-1"
+                align="start"
+              >
+                {labels.error ? (
+                  <div className="px-2 py-3 text-center text-[12px] text-destructive">
+                    {labels.error}
+                  </div>
+                ) : labels.loading ? (
+                  <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+                    <LoaderCircle className="size-3 animate-spin" />
+                    Loading labels
+                  </div>
+                ) : labels.data.length > 0 ? (
+                  <div>
+                    {labels.data.map((label) => (
+                      <button
+                        key={label.id}
+                        type="button"
+                        onClick={() => handleLabelToggle(label.id)}
+                        className={LINEAR_EDIT_MENU_ITEM_WITH_ICON_CLASS}
+                      >
+                        <span
+                          className={cn(
+                            'flex size-3.5 items-center justify-center rounded-sm border',
+                            localLabelIds.includes(label.id)
+                              ? 'border-primary bg-primary text-primary-foreground'
+                              : 'border-input'
+                          )}
+                        >
+                          {localLabelIds.includes(label.id) && checkIcon}
+                        </span>
+                        <span
+                          className="inline-block size-2 rounded-full"
+                          style={{ backgroundColor: label.color }}
+                        />
+                        {label.name}
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+                    No labels found
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          </div>
+        </section>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/60 px-4 py-2.5">
       {/* Status */}
@@ -266,38 +563,52 @@ export function LinearIssueEditSection({
         <PopoverTrigger asChild>
           <button
             type="button"
-            disabled={isPending('state') || states.loading}
-            className="flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:opacity-80 disabled:opacity-50"
-            style={statePillStyle(localState.color)}
+            disabled={statePending}
+            className={LINEAR_EDIT_CHIP_CLASS}
+            style={getLinearStatePillStyle(localState.color)}
+            aria-busy={statePending || states.loading}
           >
             <span
-              className="inline-block size-2 rounded-full"
-              style={{ backgroundColor: localState.color }}
+              className="inline-block size-2 shrink-0 rounded-full"
+              style={getLinearStateMarkerStyle(localState.color)}
             />
-            {localState.name}
-            {isPending('state') && <LoaderCircle className="size-3 animate-spin" />}
+            <span className="truncate">{localState.name}</span>
+            <LinearEditChipAdornment loading={states.loading} pending={statePending} />
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-48 p-1" align="start">
-          <div>
-            {states.data.map((s) => (
-              <button
-                key={s.id}
-                type="button"
-                onClick={() => handleStateChange(s.id)}
-                className={cn(
-                  'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent',
-                  currentStateId === s.id && 'bg-accent/50'
-                )}
-              >
-                <span
-                  className="inline-block size-2 rounded-full"
-                  style={{ backgroundColor: s.color }}
-                />
-                {s.name}
-              </button>
-            ))}
-          </div>
+          {states.error ? (
+            <div className="px-2 py-3 text-center text-[12px] text-destructive">{states.error}</div>
+          ) : states.loading ? (
+            <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+              <LoaderCircle className="size-3 animate-spin" />
+              Loading states
+            </div>
+          ) : states.data.length > 0 ? (
+            <div>
+              {states.data.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => handleStateChange(s.id)}
+                  className={cn(
+                    LINEAR_EDIT_MENU_ITEM_WITH_ICON_CLASS,
+                    currentStateId === s.id && 'bg-accent/50'
+                  )}
+                >
+                  <span
+                    className="inline-block size-2 rounded-full"
+                    style={{ backgroundColor: s.color }}
+                  />
+                  {s.name}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+              No states found
+            </div>
+          )}
         </PopoverContent>
       </Popover>
 
@@ -306,11 +617,14 @@ export function LinearIssueEditSection({
         <PopoverTrigger asChild>
           <button
             type="button"
-            disabled={isPending('priority')}
-            className="rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted/40 disabled:opacity-50"
+            disabled={priorityPending}
+            className={LINEAR_EDIT_CHIP_CLASS}
+            aria-busy={priorityPending}
           >
-            {PRIORITY_LABELS[localPriority] ?? `P${localPriority}`}
-            {isPending('priority') && <LoaderCircle className="ml-1 inline size-3 animate-spin" />}
+            <span className="truncate">
+              {PRIORITY_LABELS[localPriority] ?? `P${localPriority}`}
+            </span>
+            <LinearEditChipAdornment pending={priorityPending} />
           </button>
         </PopoverTrigger>
         <PopoverContent className="w-36 p-1" align="start">
@@ -319,10 +633,7 @@ export function LinearIssueEditSection({
               key={p}
               type="button"
               onClick={() => handlePriorityChange(String(p))}
-              className={cn(
-                'flex w-full items-center rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent',
-                localPriority === p && 'bg-accent/50'
-              )}
+              className={cn(LINEAR_EDIT_MENU_ITEM_CLASS, localPriority === p && 'bg-accent/50')}
             >
               {PRIORITY_LABELS[p]}
             </button>
@@ -335,17 +646,14 @@ export function LinearIssueEditSection({
         <PopoverTrigger asChild>
           <button
             type="button"
-            disabled={isPending('assignee') || members.loading}
-            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] transition hover:bg-muted/40 disabled:opacity-50"
+            disabled={assigneePending}
+            className={LINEAR_EDIT_CHIP_CLASS}
+            aria-busy={assigneePending || members.loading}
           >
-            {localAssignee ? (
-              <span className="text-muted-foreground">{localAssignee.displayName}</span>
-            ) : (
-              <span className="text-muted-foreground">+ Assignee</span>
-            )}
-            {isPending('assignee') && (
-              <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
-            )}
+            <span className="truncate">
+              {localAssignee ? localAssignee.displayName : '+ Assignee'}
+            </span>
+            <LinearEditChipAdornment loading={members.loading} pending={assigneePending} />
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-48 p-1" align="start">
@@ -353,26 +661,34 @@ export function LinearIssueEditSection({
             <button
               type="button"
               onClick={() => handleAssigneeChange('__unassign__')}
-              className={cn(
-                'flex w-full items-center rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent',
-                !localAssignee && 'bg-accent/50'
-              )}
+              className={cn(LINEAR_EDIT_MENU_ITEM_CLASS, !localAssignee && 'bg-accent/50')}
             >
               Unassigned
             </button>
-            {members.data.map((m) => (
-              <button
-                key={m.id}
-                type="button"
-                onClick={() => handleAssigneeChange(m.id)}
-                className={cn(
-                  'flex w-full items-center rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent',
-                  localAssignee?.id === m.id && 'bg-accent/50'
-                )}
-              >
-                {m.displayName}
-              </button>
-            ))}
+            {members.error ? (
+              <div className="px-2 py-3 text-center text-[12px] text-destructive">
+                {members.error}
+              </div>
+            ) : members.loading ? (
+              <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+                <LoaderCircle className="size-3 animate-spin" />
+                Loading members
+              </div>
+            ) : (
+              members.data.map((m) => (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => handleAssigneeChange(m.id)}
+                  className={cn(
+                    LINEAR_EDIT_MENU_ITEM_CLASS,
+                    localAssignee?.id === m.id && 'bg-accent/50'
+                  )}
+                >
+                  {m.displayName}
+                </button>
+              ))
+            )}
           </div>
         </PopoverContent>
       </Popover>
@@ -382,37 +698,31 @@ export function LinearIssueEditSection({
         <PopoverTrigger asChild>
           <button
             type="button"
-            disabled={isPending('labels') || labels.loading}
-            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] transition hover:bg-muted/40 disabled:opacity-50"
+            disabled={labelsPending}
+            className={LINEAR_EDIT_CHIP_CLASS}
+            aria-label={localLabels.length ? `Labels: ${localLabels.join(', ')}` : 'Add label'}
+            aria-busy={labelsPending || labels.loading}
           >
-            {localLabelIds.length === 0 ? (
-              <span className="text-muted-foreground">+ Label</span>
-            ) : (
-              localLabels.map((name) => (
-                <span
-                  key={name}
-                  className="rounded-full border border-border/50 bg-background/60 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                >
-                  {name}
-                </span>
-              ))
-            )}
-            {isPending('labels') && (
-              <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
-            )}
+            <span className="truncate">{labelSummary}</span>
+            <LinearEditChipAdornment loading={labels.loading} pending={labelsPending} />
           </button>
         </PopoverTrigger>
         <PopoverContent className="popover-scroll-content scrollbar-sleek w-52 p-1" align="start">
           {labels.error ? (
             <div className="px-2 py-3 text-center text-[12px] text-destructive">{labels.error}</div>
-          ) : (
+          ) : labels.loading ? (
+            <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+              <LoaderCircle className="size-3 animate-spin" />
+              Loading labels
+            </div>
+          ) : labels.data.length > 0 ? (
             <div>
               {labels.data.map((label) => (
                 <button
                   key={label.id}
                   type="button"
                   onClick={() => handleLabelToggle(label.id)}
-                  className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent"
+                  className={LINEAR_EDIT_MENU_ITEM_WITH_ICON_CLASS}
                 >
                   <span
                     className={cn(
@@ -432,6 +742,10 @@ export function LinearIssueEditSection({
                 </button>
               ))}
             </div>
+          ) : (
+            <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+              No labels found
+            </div>
           )}
         </PopoverContent>
       </Popover>
@@ -444,11 +758,13 @@ export type LinearLocalComment = { id: string; body: string; createdAt: string }
 export function LinearIssueCommentFooter({
   issueId,
   workspaceId,
-  onCommentAdded
+  onCommentAdded,
+  variant = 'compact'
 }: {
   issueId: string
   workspaceId?: string | null
   onCommentAdded: (comment: LinearLocalComment) => void
+  variant?: 'compact' | 'linear-page'
 }): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const [body, setBody] = useState('')
@@ -500,6 +816,42 @@ export function LinearIssueCommentFooter({
     },
     [handleSubmit]
   )
+
+  if (variant === 'linear-page') {
+    return (
+      <div className="rounded-xl border border-border/70 bg-background shadow-xs">
+        <textarea
+          ref={textareaRef}
+          value={body}
+          onChange={(e) => {
+            setBody(e.target.value)
+            autoGrow()
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="Leave a comment..."
+          rows={3}
+          className="scrollbar-sleek min-h-24 max-h-40 w-full resize-none overflow-y-auto rounded-t-xl bg-transparent px-5 py-4 text-sm placeholder:text-muted-foreground focus-visible:outline-none"
+        />
+        <div className="flex items-center justify-between px-4 pb-3">
+          <span className="text-[11px] text-muted-foreground">
+            {IS_MAC ? '⌘' : 'Ctrl'} Enter to comment
+          </span>
+          <Button
+            size="icon-sm"
+            onClick={handleSubmit}
+            disabled={!body.trim() || submitting}
+            aria-label="Send comment"
+          >
+            {submitting ? (
+              <LoaderCircle className="size-3.5 animate-spin" />
+            ) : (
+              <Send className="size-3.5" />
+            )}
+          </Button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex items-end gap-2 border-t border-border/60 bg-background/40 px-4 py-3">

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -5,6 +5,7 @@ place while this surface is still evolving. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import {
+  ArrowDownUp,
   ArrowRight,
   ChevronDown,
   ChevronLeft,
@@ -15,11 +16,15 @@ import {
   Github,
   Gitlab,
   GitPullRequest,
+  Eye,
+  LayoutGrid,
+  List,
   LoaderCircle,
   Lock,
   Plus,
   RefreshCw,
   Search,
+  SlidersHorizontal,
   X
 } from 'lucide-react'
 import { toast } from 'sonner'
@@ -46,8 +51,13 @@ import {
 } from '@/components/ui/dialog'
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -58,6 +68,10 @@ import RepoDotLabel from '@/components/repo/RepoDotLabel'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import IssueSourceSelector, { issueSourceChipClass } from '@/components/github/IssueSourceSelector'
 import { reconcileLinearTeamSelection } from '@/components/task-page-linear-team-selection'
+import {
+  getLinearStateMarkerStyle,
+  getLinearStatePillStyle
+} from '@/components/linear-state-pill-style'
 import { stripRepoQualifiers } from '../../../shared/task-query'
 import GitHubItemDialog from '@/components/GitHubItemDialog'
 import GitLabItemDialog from '@/components/GitLabItemDialog'
@@ -91,7 +105,13 @@ import type {
   TaskViewPresetId
 } from '../../../shared/types'
 import { shouldSuppressEnterSubmit } from '@/lib/new-workspace-enter-guard'
-import { linearCreateIssue, linearGetIssue, linearListTeams } from '@/runtime/runtime-linear-client'
+import { useTeamStates } from '@/hooks/useIssueMetadata'
+import {
+  linearCreateIssue,
+  linearGetIssue,
+  linearListTeams,
+  linearUpdateIssue
+} from '@/runtime/runtime-linear-client'
 import {
   normalizeVisibleTaskProviders,
   resolveVisibleTaskProvider
@@ -237,18 +257,292 @@ const LINEAR_PRIORITY_LABELS: Record<number, string> = {
   4: 'Low'
 }
 
+type LinearViewMode = 'list' | 'board'
+type LinearGroupBy = 'none' | 'status' | 'assignee' | 'priority' | 'team'
+type LinearOrderBy = 'priority' | 'updated' | 'identifier'
+type LinearDisplayProperty = 'state' | 'priority' | 'assignee' | 'team' | 'labels' | 'updated'
+
+type LinearGroupSection = {
+  key: string
+  label: string
+  issues: LinearIssue[]
+}
+
+const LINEAR_VIEW_OPTIONS: {
+  id: LinearViewMode
+  label: string
+  Icon: typeof List
+}[] = [
+  { id: 'list', label: 'List', Icon: List },
+  { id: 'board', label: 'Board', Icon: LayoutGrid }
+]
+
+const LINEAR_GROUP_OPTIONS: { id: LinearGroupBy; label: string }[] = [
+  { id: 'none', label: 'No grouping' },
+  { id: 'status', label: 'Status' },
+  { id: 'assignee', label: 'Assignee' },
+  { id: 'priority', label: 'Priority' },
+  { id: 'team', label: 'Team' }
+]
+
+const LINEAR_ORDER_OPTIONS: { id: LinearOrderBy; label: string }[] = [
+  { id: 'priority', label: 'Priority' },
+  { id: 'updated', label: 'Updated' },
+  { id: 'identifier', label: 'Identifier' }
+]
+
+const LINEAR_DISPLAY_PROPERTIES: { id: LinearDisplayProperty; label: string }[] = [
+  { id: 'state', label: 'Status' },
+  { id: 'priority', label: 'Priority' },
+  { id: 'assignee', label: 'Assignee' },
+  { id: 'team', label: 'Team' },
+  { id: 'labels', label: 'Labels' },
+  { id: 'updated', label: 'Updated' }
+]
+
+const DEFAULT_LINEAR_DISPLAY_PROPERTIES: LinearDisplayProperty[] = [
+  'state',
+  'priority',
+  'assignee',
+  'team',
+  'labels',
+  'updated'
+]
+
 function getLinearPriorityLabel(priority: number): string {
   return LINEAR_PRIORITY_LABELS[priority] ?? `P${priority}`
 }
 
-// Why: Linear state colors come from the user's workspace, so derive the
-// quiet pill tint from the source color instead of inventing app-local tones.
-function getLinearStatePillStyle(color: string): React.CSSProperties {
-  return {
-    borderColor: `color-mix(in srgb, ${color} 28%, transparent)`,
-    backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
-    color
+function LinearStateCell({
+  issue,
+  className
+}: {
+  issue: LinearIssue
+  className?: string
+}): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const patchLinearIssue = useAppStore((s) => s.patchLinearIssue)
+  const states = useTeamStates(issue.team.id, settings, issue.workspaceId)
+  const [open, setOpen] = useState(false)
+  const [pending, setPending] = useState(false)
+  const reqRef = useRef(0)
+
+  const currentStateId = states.data.find(
+    (s) => s.name === issue.state.name && s.type === issue.state.type
+  )?.id
+
+  const handleStateChange = useCallback(
+    (stateId: string) => {
+      const newState = states.data.find((s) => s.id === stateId)
+      if (!newState || stateId === currentStateId || pending) {
+        return
+      }
+
+      reqRef.current += 1
+      const reqId = reqRef.current
+      const previousState = issue.state
+      const nextState: LinearIssue['state'] = {
+        name: newState.name,
+        type: newState.type,
+        color: newState.color
+      }
+
+      setPending(true)
+      patchLinearIssue(issue.id, { state: nextState })
+      void linearUpdateIssue(settings, issue.id, { stateId }, issue.workspaceId)
+        .then((result) => {
+          if (reqId !== reqRef.current) {
+            return
+          }
+          if (result.ok === false) {
+            patchLinearIssue(issue.id, { state: previousState })
+            toast.error(result.error ?? 'Failed to update Linear state')
+          }
+        })
+        .catch(() => {
+          if (reqId !== reqRef.current) {
+            return
+          }
+          patchLinearIssue(issue.id, { state: previousState })
+          toast.error('Failed to update Linear state')
+        })
+        .finally(() => {
+          if (reqId === reqRef.current) {
+            setPending(false)
+          }
+        })
+    },
+    [
+      currentStateId,
+      issue.id,
+      issue.state,
+      issue.workspaceId,
+      patchLinearIssue,
+      pending,
+      settings,
+      states.data
+    ]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={pending}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'inline-flex min-w-0 cursor-pointer! items-center gap-1 rounded-full border text-[11px] font-medium transition-[background-color,border-color,color,box-shadow] hover:[--linear-state-pill-current-background:var(--linear-state-pill-hover-background)] hover:[--linear-state-pill-current-border:var(--linear-state-pill-hover-border)] hover:[--linear-state-pill-current-foreground:var(--linear-state-pill-hover-foreground)] hover:ring-1 hover:ring-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-default! disabled:opacity-80 [&_*]:cursor-pointer! disabled:[&_*]:cursor-default!',
+            className
+          )}
+          style={{
+            ...getLinearStatePillStyle(issue.state.color),
+            cursor: pending ? 'default' : 'pointer'
+          }}
+          aria-label={`Change Linear state from ${issue.state.name}`}
+          aria-busy={pending || states.loading}
+        >
+          <span
+            className="size-1.5 shrink-0 rounded-full"
+            style={getLinearStateMarkerStyle(issue.state.color)}
+          />
+          <span className="truncate">{issue.state.name}</span>
+          {pending || states.loading ? (
+            <LoaderCircle className="size-3 shrink-0 animate-spin opacity-70" />
+          ) : (
+            <ChevronDown className="size-3 shrink-0 opacity-55" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="popover-scroll-content scrollbar-sleek w-48 p-1"
+        align="start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {states.error ? (
+          <div className="px-2 py-3 text-center text-[12px] text-destructive">{states.error}</div>
+        ) : states.loading ? (
+          <div className="flex items-center gap-2 px-2 py-3 text-[12px] text-muted-foreground">
+            <LoaderCircle className="size-3 animate-spin" />
+            Loading states
+          </div>
+        ) : states.data.length > 0 ? (
+          states.data.map((state) => (
+            <button
+              key={state.id}
+              type="button"
+              onClick={() => {
+                handleStateChange(state.id)
+                setOpen(false)
+              }}
+              className={cn(
+                'flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent',
+                currentStateId === state.id && 'bg-accent/50'
+              )}
+            >
+              <span
+                className="inline-block size-2 rounded-full"
+                style={{ backgroundColor: state.color }}
+              />
+              {state.name}
+            </button>
+          ))
+        ) : (
+          <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
+            No states found
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function getLinearPriorityRank(priority: number): number {
+  return priority === 0 ? 5 : priority
+}
+
+function compareLinearIssues(a: LinearIssue, b: LinearIssue, orderBy: LinearOrderBy): number {
+  if (orderBy === 'updated') {
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
   }
+  if (orderBy === 'identifier') {
+    return a.identifier.localeCompare(b.identifier, undefined, { numeric: true })
+  }
+
+  const priorityDelta = getLinearPriorityRank(a.priority) - getLinearPriorityRank(b.priority)
+  if (priorityDelta !== 0) {
+    return priorityDelta
+  }
+  return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+}
+
+function getLinearIssueGroup(
+  issue: LinearIssue,
+  groupBy: LinearGroupBy
+): { key: string; label: string } {
+  if (groupBy === 'status') {
+    return { key: `status:${issue.state.name}`, label: issue.state.name }
+  }
+  if (groupBy === 'assignee') {
+    return {
+      key: `assignee:${issue.assignee?.id ?? 'unassigned'}`,
+      label: issue.assignee?.displayName ?? 'Unassigned'
+    }
+  }
+  if (groupBy === 'priority') {
+    return {
+      key: `priority:${issue.priority}`,
+      label: getLinearPriorityLabel(issue.priority)
+    }
+  }
+  if (groupBy === 'team') {
+    return { key: `team:${issue.team.id}`, label: issue.team.name }
+  }
+  return { key: 'all', label: 'Issues' }
+}
+
+function groupLinearIssues(
+  issues: LinearIssue[],
+  groupBy: LinearGroupBy,
+  orderBy: LinearOrderBy
+): LinearGroupSection[] {
+  const sorted = [...issues].sort((a, b) => compareLinearIssues(a, b, orderBy))
+  if (groupBy === 'none') {
+    return [{ key: 'all', label: 'Issues', issues: sorted }]
+  }
+
+  const sections = new Map<string, LinearGroupSection>()
+  for (const issue of sorted) {
+    const group = getLinearIssueGroup(issue, groupBy)
+    const section = sections.get(group.key)
+    if (section) {
+      section.issues.push(issue)
+    } else {
+      sections.set(group.key, { key: group.key, label: group.label, issues: [issue] })
+    }
+  }
+  return [...sections.values()]
+}
+
+function getLinearIssueGridTemplate(visibleProperties: ReadonlySet<LinearDisplayProperty>): string {
+  const columns = ['96px', 'minmax(180px,1.4fr)']
+  if (visibleProperties.has('state')) {
+    columns.push('140px')
+  }
+  if (visibleProperties.has('priority')) {
+    columns.push('92px')
+  }
+  if (visibleProperties.has('assignee')) {
+    columns.push('150px')
+  }
+  if (visibleProperties.has('team')) {
+    columns.push('160px')
+  }
+  if (visibleProperties.has('updated')) {
+    columns.push('100px')
+  }
+  columns.push('72px')
+  return columns.join(' ')
 }
 
 function GHStatusCell({
@@ -335,7 +629,7 @@ function GHStatusCell({
           type="button"
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'group/status inline-flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-[10px] font-medium transition hover:brightness-125 hover:ring-1 hover:ring-white/10',
+            'group/status inline-flex cursor-pointer items-center gap-0.5 rounded-full border px-2 py-0.5 text-[10px] font-medium transition hover:brightness-125 hover:ring-1 hover:ring-white/10',
             localState === 'closed'
               ? 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
               : 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
@@ -889,6 +1183,13 @@ export default function TaskPage(): React.JSX.Element {
   const [linearSearchInput, setLinearSearchInput] = useState('')
   const [appliedLinearSearch, setAppliedLinearSearch] = useState('')
   const [activeLinearPreset, setActiveLinearPreset] = useState<LinearPresetId>('all')
+  const [linearViewMode, setLinearViewMode] = useState<LinearViewMode>('list')
+  const [linearGroupBy, setLinearGroupBy] = useState<LinearGroupBy>('none')
+  const [linearOrderBy, setLinearOrderBy] = useState<LinearOrderBy>('priority')
+  const [linearDisplayProperties, setLinearDisplayProperties] = useState<
+    ReadonlySet<LinearDisplayProperty>
+  >(() => new Set(DEFAULT_LINEAR_DISPLAY_PROPERTIES))
+  const [linearTeamPropertyTouched, setLinearTeamPropertyTouched] = useState(false)
   const [linearRefreshNonce, setLinearRefreshNonce] = useState(0)
 
   useEffect(() => {
@@ -1111,15 +1412,6 @@ export default function TaskPage(): React.JSX.Element {
     return new Set(defaultLinearTeamSelection)
   })
 
-  // Why: team IDs belong to one Linear workspace. Switching workspaces while a
-  // saved subset exists must not leave the task list filtered by stale team IDs.
-  useEffect(() => {
-    if (availableTeams.length === 0) {
-      return
-    }
-    setLinearTeamSelection(reconcileLinearTeamSelection(availableTeams, defaultLinearTeamSelection))
-  }, [availableTeams, defaultLinearTeamSelection])
-
   const displayedLinearIssues = useMemo(
     () =>
       linearIssues.map(
@@ -1133,10 +1425,93 @@ export default function TaskPage(): React.JSX.Element {
     [linearIssues, linearCacheSnapshot.issueCache, linearCacheSnapshot.searchCache]
   )
 
+  const linearIssueTeams = useMemo(() => {
+    const seen = new Set<string>()
+    const teams: LinearTeam[] = []
+    for (const issue of displayedLinearIssues) {
+      if (!issue.team.id || seen.has(issue.team.id)) {
+        continue
+      }
+      seen.add(issue.team.id)
+      teams.push({
+        id: issue.team.id,
+        workspaceId: issue.workspaceId,
+        workspaceName: issue.workspaceName,
+        name: issue.team.name,
+        key: issue.team.key
+      })
+    }
+    return teams.sort((a, b) => a.name.localeCompare(b.name))
+  }, [displayedLinearIssues])
+
+  // Why: the full Linear team fetch is async and can temporarily be empty.
+  // Keep the selector usable from issue metadata until the complete list lands.
+  const linearTeamOptions = availableTeams.length > 0 ? availableTeams : linearIssueTeams
+
+  // Why: team IDs belong to one Linear workspace. Switching workspaces while a
+  // saved subset exists must not leave the task list filtered by stale team IDs.
+  useEffect(() => {
+    if (linearTeamOptions.length === 0) {
+      return
+    }
+    setLinearTeamSelection(
+      reconcileLinearTeamSelection(linearTeamOptions, defaultLinearTeamSelection)
+    )
+  }, [linearTeamOptions, defaultLinearTeamSelection])
+
   const filteredLinearIssues = useMemo(
     () => displayedLinearIssues.filter((issue) => linearTeamSelection.has(issue.team.id)),
     [displayedLinearIssues, linearTeamSelection]
   )
+  const effectiveLinearDisplayProperties = useMemo(() => {
+    const next = new Set(linearDisplayProperties)
+    // Why: a Team column repeats the same value when one team is selected.
+    // Keep it hidden until the user explicitly opts back into that property.
+    if (linearTeamSelection.size <= 1 && !linearTeamPropertyTouched) {
+      next.delete('team')
+    } else if (linearTeamSelection.size > 1 && !linearTeamPropertyTouched) {
+      next.add('team')
+    }
+    return next
+  }, [linearDisplayProperties, linearTeamPropertyTouched, linearTeamSelection.size])
+  const linearIssueGridTemplate = useMemo(
+    () => getLinearIssueGridTemplate(effectiveLinearDisplayProperties),
+    [effectiveLinearDisplayProperties]
+  )
+  const linearIssueGridStyle = useMemo(
+    () =>
+      ({
+        '--linear-grid-template': linearIssueGridTemplate
+      }) as React.CSSProperties,
+    [linearIssueGridTemplate]
+  )
+  const linearIssueSections = useMemo(
+    () => groupLinearIssues(filteredLinearIssues, linearGroupBy, linearOrderBy),
+    [filteredLinearIssues, linearGroupBy, linearOrderBy]
+  )
+  const linearBoardSections = useMemo(
+    () =>
+      groupLinearIssues(
+        filteredLinearIssues,
+        linearGroupBy === 'none' ? 'status' : linearGroupBy,
+        linearOrderBy
+      ),
+    [filteredLinearIssues, linearGroupBy, linearOrderBy]
+  )
+  const toggleLinearDisplayProperty = useCallback((property: LinearDisplayProperty): void => {
+    if (property === 'team') {
+      setLinearTeamPropertyTouched(true)
+    }
+    setLinearDisplayProperties((prev) => {
+      const next = new Set(prev)
+      if (next.has(property)) {
+        next.delete(property)
+      } else {
+        next.add(property)
+      }
+      return next
+    })
+  }, [])
   // New Linear issue dialog state
   const [newLinearIssueOpen, setNewLinearIssueOpen] = useState(false)
   const [newLinearIssueTitle, setNewLinearIssueTitle] = useState('')
@@ -2035,31 +2410,27 @@ export default function TaskPage(): React.JSX.Element {
                           </SelectContent>
                         </Select>
                       ) : null}
-                      {availableTeams.length > 0 ? (
-                        <div className="w-[200px]">
-                          <TeamMultiCombobox
-                            teams={availableTeams}
-                            selected={linearTeamSelection}
-                            onChange={(next) => {
-                              setLinearTeamSelection(next)
-                              void updateSettings({ defaultLinearTeamSelection: [...next] }).catch(
-                                () => {
-                                  toast.error('Failed to save team selection.')
-                                }
-                              )
-                            }}
-                            onSelectAll={() => {
-                              setLinearTeamSelection(new Set(availableTeams.map((t) => t.id)))
-                              void updateSettings({ defaultLinearTeamSelection: null }).catch(
-                                () => {
-                                  toast.error('Failed to save team selection.')
-                                }
-                              )
-                            }}
-                            triggerClassName="h-8 w-full rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
-                          />
-                        </div>
-                      ) : null}
+                      <div className="w-[200px]">
+                        <TeamMultiCombobox
+                          teams={linearTeamOptions}
+                          selected={linearTeamSelection}
+                          onChange={(next) => {
+                            setLinearTeamSelection(next)
+                            void updateSettings({ defaultLinearTeamSelection: [...next] }).catch(
+                              () => {
+                                toast.error('Failed to save team selection.')
+                              }
+                            )
+                          }}
+                          onSelectAll={() => {
+                            setLinearTeamSelection(new Set(linearTeamOptions.map((t) => t.id)))
+                            void updateSettings({ defaultLinearTeamSelection: null }).catch(() => {
+                              toast.error('Failed to save team selection.')
+                            })
+                          }}
+                          triggerClassName="h-8 w-full rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
+                        />
+                      </div>
                     </div>
                   ) : null}
                 </div>
@@ -3009,21 +3380,131 @@ export default function TaskPage(): React.JSX.Element {
                 <div className="min-w-0 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                   Linear issues
                 </div>
-                <div className="shrink-0 text-[11px] text-muted-foreground">
-                  {filteredLinearIssues.length} shown
+                <div className="flex shrink-0 items-center gap-2">
+                  <div
+                    className="hidden items-center rounded-md border border-border/50 bg-background/70 p-0.5 md:flex"
+                    aria-label="Linear view mode"
+                  >
+                    {LINEAR_VIEW_OPTIONS.map(({ id, label, Icon }) => {
+                      const active = linearViewMode === id
+                      return (
+                        <Tooltip key={id}>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              onClick={() => setLinearViewMode(id)}
+                              aria-label={`${label} view`}
+                              aria-pressed={active}
+                              className={cn(
+                                'inline-flex size-6 items-center justify-center rounded text-muted-foreground transition hover:text-foreground',
+                                active && 'bg-accent text-accent-foreground shadow-xs'
+                              )}
+                            >
+                              <Icon className="size-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            {label} view
+                          </TooltipContent>
+                        </Tooltip>
+                      )
+                    })}
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        className="gap-1 border-border/50 bg-background/70 text-[11px]"
+                      >
+                        <SlidersHorizontal className="size-3.5" />
+                        View
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-56">
+                      <DropdownMenuLabel className="flex items-center gap-2">
+                        <List className="size-3.5" />
+                        View
+                      </DropdownMenuLabel>
+                      <DropdownMenuRadioGroup
+                        value={linearViewMode}
+                        onValueChange={(value) => setLinearViewMode(value as LinearViewMode)}
+                      >
+                        {LINEAR_VIEW_OPTIONS.map(({ id, label, Icon }) => (
+                          <DropdownMenuRadioItem key={id} value={id}>
+                            <Icon className="size-3.5" />
+                            {label}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel className="flex items-center gap-2">
+                        <SlidersHorizontal className="size-3.5" />
+                        Grouping
+                      </DropdownMenuLabel>
+                      <DropdownMenuRadioGroup
+                        value={linearGroupBy}
+                        onValueChange={(value) => setLinearGroupBy(value as LinearGroupBy)}
+                      >
+                        {LINEAR_GROUP_OPTIONS.map((option) => (
+                          <DropdownMenuRadioItem key={option.id} value={option.id}>
+                            {option.label}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel className="flex items-center gap-2">
+                        <ArrowDownUp className="size-3.5" />
+                        Ordering
+                      </DropdownMenuLabel>
+                      <DropdownMenuRadioGroup
+                        value={linearOrderBy}
+                        onValueChange={(value) => setLinearOrderBy(value as LinearOrderBy)}
+                      >
+                        {LINEAR_ORDER_OPTIONS.map((option) => (
+                          <DropdownMenuRadioItem key={option.id} value={option.id}>
+                            {option.label}
+                          </DropdownMenuRadioItem>
+                        ))}
+                      </DropdownMenuRadioGroup>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel className="flex items-center gap-2">
+                        <Eye className="size-3.5" />
+                        Display properties
+                      </DropdownMenuLabel>
+                      {LINEAR_DISPLAY_PROPERTIES.map((property) => (
+                        <DropdownMenuCheckboxItem
+                          key={property.id}
+                          checked={effectiveLinearDisplayProperties.has(property.id)}
+                          onSelect={(event) => event.preventDefault()}
+                          onCheckedChange={() => toggleLinearDisplayProperty(property.id)}
+                        >
+                          {property.label}
+                        </DropdownMenuCheckboxItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  <div className="text-[11px] text-muted-foreground">
+                    {filteredLinearIssues.length} shown
+                  </div>
                 </div>
               </div>
 
-              <div className="grid h-8 flex-none grid-cols-[86px_minmax(0,1fr)_128px_92px_96px_64px] items-center gap-3 border-b border-border/50 bg-muted/25 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground max-md:!hidden lg:grid-cols-[92px_minmax(0,1.2fr)_132px_92px_136px_96px_64px] xl:grid-cols-[96px_minmax(0,1.4fr)_140px_92px_150px_160px_100px_72px]">
-                <span>Key</span>
-                <span>Issue</span>
-                <span>State</span>
-                <span>Priority</span>
-                <span className="block max-lg:!hidden">Assignee</span>
-                <span className="block max-xl:!hidden">Context</span>
-                <span>Updated</span>
-                <span />
-              </div>
+              {linearViewMode === 'list' ? (
+                <div
+                  className="grid h-8 flex-none items-center gap-3 border-b border-border/50 bg-muted/25 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground max-lg:!hidden lg:grid-cols-[var(--linear-grid-template)] [&>span]:min-w-0 [&>span]:truncate"
+                  style={linearIssueGridStyle}
+                >
+                  <span>Key</span>
+                  <span>Issue</span>
+                  {effectiveLinearDisplayProperties.has('state') ? <span>Status</span> : null}
+                  {effectiveLinearDisplayProperties.has('priority') ? <span>Priority</span> : null}
+                  {effectiveLinearDisplayProperties.has('assignee') ? <span>Assignee</span> : null}
+                  {effectiveLinearDisplayProperties.has('team') ? <span>Team</span> : null}
+                  {effectiveLinearDisplayProperties.has('updated') ? <span>Updated</span> : null}
+                  <span />
+                </div>
+              ) : null}
 
               <div
                 className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek"
@@ -3068,183 +3549,308 @@ export default function TaskPage(): React.JSX.Element {
                   </div>
                 ) : null}
 
-                <div className="divide-y divide-border/50">
-                  {filteredLinearIssues.map((issue) => {
-                    const selected = issue.id === selectedLinearIssueId
-                    const labels = issue.labels.slice(0, 3)
-                    const contextLabel =
-                      selectedLinearWorkspaceId === 'all' && issue.workspaceName
-                        ? `${issue.workspaceName} / ${issue.team.name}`
-                        : issue.team.name
-                    return (
-                      <div
-                        key={issue.id}
-                        role="button"
-                        tabIndex={0}
-                        aria-current={selected ? 'true' : undefined}
-                        data-current={selected ? 'true' : undefined}
-                        onClick={() => {
-                          setSelectedLinearIssue(issue)
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.target !== e.currentTarget) {
-                            return
-                          }
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault()
-                            setSelectedLinearIssue(issue)
-                          }
-                        }}
-                        className={cn(
-                          'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:grid-cols-[86px_minmax(0,1fr)_128px_92px_96px_64px] lg:grid-cols-[92px_minmax(0,1.2fr)_132px_92px_136px_96px_64px] xl:grid-cols-[96px_minmax(0,1.4fr)_140px_92px_150px_160px_100px_72px]',
-                          selected && 'bg-accent'
-                        )}
+                {linearViewMode === 'board' ? (
+                  <div className="grid min-w-0 gap-3 p-3 md:grid-cols-2 xl:grid-cols-3">
+                    {linearBoardSections.map((section) => (
+                      <section
+                        key={section.key}
+                        className="min-h-0 rounded-md border border-border/50 bg-muted/20"
                       >
-                        <span className="block truncate font-mono text-[12px] text-muted-foreground max-md:!hidden">
-                          {issue.identifier}
-                        </span>
-
-                        <div className="min-w-0">
-                          <div className="flex min-w-0 items-center gap-2">
-                            <span className="shrink-0 font-mono text-[11px] text-muted-foreground md:hidden">
+                        <div className="flex h-9 items-center justify-between border-b border-border/50 px-3">
+                          <span className="truncate text-xs font-medium text-foreground">
+                            {section.label}
+                          </span>
+                          <span className="text-[11px] text-muted-foreground">
+                            {section.issues.length}
+                          </span>
+                        </div>
+                        <div className="space-y-2 p-2">
+                          {section.issues.map((issue) => {
+                            const selected = issue.id === selectedLinearIssueId
+                            const labels = issue.labels.slice(0, 2)
+                            const teamLabel =
+                              selectedLinearWorkspaceId === 'all' && issue.workspaceName
+                                ? `${issue.workspaceName} / ${issue.team.name}`
+                                : issue.team.name
+                            return (
+                              <div
+                                key={issue.id}
+                                role="button"
+                                tabIndex={0}
+                                aria-current={selected ? 'true' : undefined}
+                                data-current={selected ? 'true' : undefined}
+                                onClick={() => setSelectedLinearIssue(issue)}
+                                onKeyDown={(e) => {
+                                  if (e.target !== e.currentTarget) {
+                                    return
+                                  }
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    setSelectedLinearIssue(issue)
+                                  }
+                                }}
+                                className={cn(
+                                  'group/row cursor-pointer rounded-md border border-border/50 bg-background px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                                  selected && 'bg-accent'
+                                )}
+                              >
+                                <div className="flex min-w-0 items-start justify-between gap-2">
+                                  <div className="min-w-0">
+                                    <div className="font-mono text-[11px] text-muted-foreground">
+                                      {issue.identifier}
+                                    </div>
+                                    <h3 className="mt-1 line-clamp-2 text-[13px] font-medium leading-snug text-foreground">
+                                      {issue.title}
+                                    </h3>
+                                  </div>
+                                  <div className="flex shrink-0 items-center gap-1 opacity-70 transition-opacity group-hover/row:opacity-100 group-focus-within/row:opacity-100">
+                                    <Button
+                                      variant="ghost"
+                                      size="icon-xs"
+                                      onClick={(event) => {
+                                        event.stopPropagation()
+                                        handleUseLinearItem(issue)
+                                      }}
+                                      aria-label={`Start workspace from ${issue.identifier}`}
+                                    >
+                                      <ArrowRight className="size-3.5" />
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon-xs"
+                                      onClick={(event) => {
+                                        event.stopPropagation()
+                                        window.api.shell.openUrl(issue.url)
+                                      }}
+                                      aria-label={`Open ${issue.identifier} in Linear`}
+                                    >
+                                      <ExternalLink className="size-3.5" />
+                                    </Button>
+                                  </div>
+                                </div>
+                                <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+                                  {effectiveLinearDisplayProperties.has('state') ? (
+                                    <LinearStateCell issue={issue} className="px-1.5 py-0.5" />
+                                  ) : null}
+                                  {effectiveLinearDisplayProperties.has('priority') ? (
+                                    <span>{getLinearPriorityLabel(issue.priority)}</span>
+                                  ) : null}
+                                  {effectiveLinearDisplayProperties.has('assignee') ? (
+                                    <span>{issue.assignee?.displayName ?? 'Unassigned'}</span>
+                                  ) : null}
+                                  {effectiveLinearDisplayProperties.has('team') ? (
+                                    <span className="truncate">{teamLabel}</span>
+                                  ) : null}
+                                  {effectiveLinearDisplayProperties.has('updated') ? (
+                                    <span>{formatRelativeTime(issue.updatedAt)}</span>
+                                  ) : null}
+                                </div>
+                                {effectiveLinearDisplayProperties.has('labels') &&
+                                issue.labels.length > 0 ? (
+                                  <div className="mt-2 flex min-w-0 flex-wrap items-center gap-1">
+                                    {labels.map((label) => (
+                                      <span
+                                        key={label}
+                                        className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                                      >
+                                        {label}
+                                      </span>
+                                    ))}
+                                    {issue.labels.length > labels.length ? (
+                                      <span className="text-[10px] text-muted-foreground">
+                                        +{issue.labels.length - labels.length}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                ) : null}
+                              </div>
+                            )
+                          })}
+                        </div>
+                      </section>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border/50">
+                    {linearIssueSections
+                      .flatMap((section) => section.issues)
+                      .map((issue) => {
+                        const selected = issue.id === selectedLinearIssueId
+                        const labels = issue.labels.slice(0, 3)
+                        const teamLabel =
+                          selectedLinearWorkspaceId === 'all' && issue.workspaceName
+                            ? `${issue.workspaceName} / ${issue.team.name}`
+                            : issue.team.name
+                        return (
+                          <div
+                            key={issue.id}
+                            role="button"
+                            tabIndex={0}
+                            aria-current={selected ? 'true' : undefined}
+                            data-current={selected ? 'true' : undefined}
+                            onClick={() => {
+                              setSelectedLinearIssue(issue)
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.target !== e.currentTarget) {
+                                return
+                              }
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                setSelectedLinearIssue(issue)
+                              }
+                            }}
+                            className={cn(
+                              'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring lg:grid-cols-[var(--linear-grid-template)]',
+                              selected && 'bg-accent'
+                            )}
+                            style={linearIssueGridStyle}
+                          >
+                            <span className="block truncate font-mono text-[12px] text-muted-foreground max-lg:!hidden">
                               {issue.identifier}
                             </span>
-                            <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
-                              {issue.title}
-                            </h3>
-                          </div>
-                          <div className="mt-1 flex min-w-0 items-center gap-1.5 md:!hidden">
-                            <span
-                              className="inline-flex min-w-0 items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] font-medium"
-                              style={getLinearStatePillStyle(issue.state.color)}
-                            >
-                              <span
-                                className="size-1.5 shrink-0 rounded-full"
-                                style={{ backgroundColor: issue.state.color }}
-                              />
-                              <span className="truncate">{issue.state.name}</span>
-                            </span>
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {getLinearPriorityLabel(issue.priority)}
-                            </span>
-                            <span className="min-w-0 truncate text-[11px] text-muted-foreground">
-                              {issue.assignee?.displayName ?? 'Unassigned'}
-                            </span>
-                          </div>
-                          <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
-                            <span className="max-w-[160px] truncate text-[10px] text-muted-foreground xl:!hidden">
-                              {contextLabel}
-                            </span>
-                            {labels.map((label) => (
-                              <span
-                                key={label}
-                                className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
-                              >
-                                {label}
-                              </span>
-                            ))}
-                            {issue.labels.length > labels.length ? (
-                              <span className="text-[10px] text-muted-foreground">
-                                +{issue.labels.length - labels.length}
+
+                            <div className="min-w-0">
+                              <div className="flex min-w-0 items-center gap-2">
+                                <span className="shrink-0 font-mono text-[11px] text-muted-foreground lg:hidden">
+                                  {issue.identifier}
+                                </span>
+                                <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
+                                  {issue.title}
+                                </h3>
+                              </div>
+                              <div className="mt-1 flex min-w-0 items-center gap-1.5 lg:!hidden">
+                                {effectiveLinearDisplayProperties.has('state') ? (
+                                  <LinearStateCell issue={issue} className="px-1.5 py-0.5" />
+                                ) : null}
+                                {effectiveLinearDisplayProperties.has('priority') ? (
+                                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                                    {getLinearPriorityLabel(issue.priority)}
+                                  </span>
+                                ) : null}
+                                {effectiveLinearDisplayProperties.has('assignee') ? (
+                                  <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+                                    {issue.assignee?.displayName ?? 'Unassigned'}
+                                  </span>
+                                ) : null}
+                                {effectiveLinearDisplayProperties.has('team') ? (
+                                  <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+                                    {teamLabel}
+                                  </span>
+                                ) : null}
+                              </div>
+                              {effectiveLinearDisplayProperties.has('labels') ? (
+                                <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
+                                  {labels.map((label) => (
+                                    <span
+                                      key={label}
+                                      className="max-w-[140px] truncate rounded-full border border-border/50 bg-muted/35 px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                                    >
+                                      {label}
+                                    </span>
+                                  ))}
+                                  {issue.labels.length > labels.length ? (
+                                    <span className="text-[10px] text-muted-foreground">
+                                      +{issue.labels.length - labels.length}
+                                    </span>
+                                  ) : null}
+                                </div>
+                              ) : null}
+                            </div>
+
+                            {effectiveLinearDisplayProperties.has('state') ? (
+                              <div className="flex min-w-0 max-lg:!hidden">
+                                <LinearStateCell issue={issue} className="max-w-full px-2 py-0.5" />
+                              </div>
+                            ) : null}
+
+                            {effectiveLinearDisplayProperties.has('priority') ? (
+                              <span className="block truncate text-[12px] text-muted-foreground max-lg:!hidden">
+                                {getLinearPriorityLabel(issue.priority)}
                               </span>
                             ) : null}
-                          </div>
-                        </div>
 
-                        <div className="flex min-w-0 max-md:!hidden">
-                          <span
-                            className="inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium"
-                            style={getLinearStatePillStyle(issue.state.color)}
-                          >
-                            <span
-                              className="size-1.5 shrink-0 rounded-full"
-                              style={{ backgroundColor: issue.state.color }}
-                            />
-                            <span className="truncate">{issue.state.name}</span>
-                          </span>
-                        </div>
+                            {effectiveLinearDisplayProperties.has('assignee') ? (
+                              <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
+                                {issue.assignee?.avatarUrl ? (
+                                  <img
+                                    src={issue.assignee.avatarUrl}
+                                    alt={issue.assignee.displayName}
+                                    className="size-5 shrink-0 rounded-full"
+                                  />
+                                ) : (
+                                  <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-[10px]">
+                                    {issue.assignee?.displayName?.slice(0, 1) ?? '-'}
+                                  </span>
+                                )}
+                                <span className="truncate">
+                                  {issue.assignee?.displayName ?? 'Unassigned'}
+                                </span>
+                              </div>
+                            ) : null}
 
-                        <span className="block truncate text-[12px] text-muted-foreground max-md:!hidden">
-                          {getLinearPriorityLabel(issue.priority)}
-                        </span>
+                            {effectiveLinearDisplayProperties.has('team') ? (
+                              <div className="block min-w-0 text-[12px] text-muted-foreground max-lg:!hidden">
+                                <div className="truncate">{teamLabel}</div>
+                              </div>
+                            ) : null}
 
-                        <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
-                          {issue.assignee?.avatarUrl ? (
-                            <img
-                              src={issue.assignee.avatarUrl}
-                              alt={issue.assignee.displayName}
-                              className="size-5 shrink-0 rounded-full"
-                            />
-                          ) : (
-                            <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/40 text-[10px]">
-                              {issue.assignee?.displayName?.slice(0, 1) ?? '-'}
-                            </span>
-                          )}
-                          <span className="truncate">
-                            {issue.assignee?.displayName ?? 'Unassigned'}
-                          </span>
-                        </div>
+                            {effectiveLinearDisplayProperties.has('updated') ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-lg:!hidden">
+                                    {formatRelativeTime(issue.updatedAt)}
+                                  </div>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" sideOffset={6}>
+                                  {new Date(issue.updatedAt).toLocaleString()}
+                                </TooltipContent>
+                              </Tooltip>
+                            ) : null}
 
-                        <div className="block min-w-0 text-[12px] text-muted-foreground max-xl:!hidden">
-                          {selectedLinearWorkspaceId === 'all' && issue.workspaceName ? (
-                            <div className="truncate">{issue.workspaceName}</div>
-                          ) : null}
-                          <div className="truncate">{issue.team.name}</div>
-                        </div>
-
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-md:!hidden">
-                              {formatRelativeTime(issue.updatedAt)}
+                            <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      handleUseLinearItem(issue)
+                                    }}
+                                    aria-label={`Start workspace from ${issue.identifier}`}
+                                  >
+                                    <ArrowRight className="size-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" sideOffset={6}>
+                                  Start workspace
+                                </TooltipContent>
+                              </Tooltip>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      window.api.shell.openUrl(issue.url)
+                                    }}
+                                    aria-label={`Open ${issue.identifier} in Linear`}
+                                  >
+                                    <ExternalLink className="size-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" sideOffset={6}>
+                                  Open in Linear
+                                </TooltipContent>
+                              </Tooltip>
                             </div>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" sideOffset={6}>
-                            {new Date(issue.updatedAt).toLocaleString()}
-                          </TooltipContent>
-                        </Tooltip>
-
-                        <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon-xs"
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  handleUseLinearItem(issue)
-                                }}
-                                aria-label={`Start workspace from ${issue.identifier}`}
-                              >
-                                <ArrowRight className="size-3.5" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom" sideOffset={6}>
-                              Start workspace
-                            </TooltipContent>
-                          </Tooltip>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon-xs"
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  window.api.shell.openUrl(issue.url)
-                                }}
-                                aria-label={`Open ${issue.identifier} in Linear`}
-                              >
-                                <ExternalLink className="size-3.5" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom" sideOffset={6}>
-                              Open in Linear
-                            </TooltipContent>
-                          </Tooltip>
-                        </div>
-                      </div>
-                    )
-                  })}
-                </div>
+                          </div>
+                        )
+                      })}
+                  </div>
+                )}
               </div>
               <LinearIssueWorkspace
                 issue={selectedLinearIssue}

--- a/src/renderer/src/components/github-project/ProjectCell.tsx
+++ b/src/renderer/src/components/github-project/ProjectCell.tsx
@@ -417,7 +417,10 @@ function SingleSelectCell({
           const colors = singleSelectChipColors(value.color)
           return (
             <span
-              className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium leading-none text-[var(--github-project-chip-fg-light)] dark:text-[var(--github-project-chip-fg-dark)]"
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium leading-none text-[var(--github-project-chip-fg-light)] dark:text-[var(--github-project-chip-fg-dark)]',
+                editable && 'cursor-pointer'
+              )}
               style={chipStyle(colors)}
             >
               {value.name}

--- a/src/renderer/src/components/linear-state-pill-style.ts
+++ b/src/renderer/src/components/linear-state-pill-style.ts
@@ -1,0 +1,33 @@
+import type { CSSProperties } from 'react'
+
+type LinearStatePillStyle = CSSProperties & {
+  '--linear-state-pill-background': string
+  '--linear-state-pill-border': string
+  '--linear-state-pill-foreground': string
+  '--linear-state-pill-hover-background': string
+  '--linear-state-pill-hover-border': string
+  '--linear-state-pill-hover-foreground': string
+}
+
+// Why: Linear workspace colors can be very light in light mode. Mixing the
+// visible parts toward foreground preserves hue while keeping labels readable.
+export function getLinearStatePillStyle(color: string): LinearStatePillStyle {
+  return {
+    '--linear-state-pill-background': `color-mix(in srgb, ${color} 12%, transparent)`,
+    '--linear-state-pill-border': `color-mix(in srgb, ${color} 24%, var(--border))`,
+    '--linear-state-pill-foreground': `color-mix(in srgb, ${color} 28%, var(--foreground))`,
+    '--linear-state-pill-hover-background': `color-mix(in srgb, ${color} 18%, transparent)`,
+    '--linear-state-pill-hover-border': `color-mix(in srgb, ${color} 32%, var(--border))`,
+    '--linear-state-pill-hover-foreground': `color-mix(in srgb, ${color} 28%, var(--foreground))`,
+    borderColor: 'var(--linear-state-pill-current-border, var(--linear-state-pill-border))',
+    backgroundColor:
+      'var(--linear-state-pill-current-background, var(--linear-state-pill-background))',
+    color: 'var(--linear-state-pill-current-foreground, var(--linear-state-pill-foreground))'
+  }
+}
+
+export function getLinearStateMarkerStyle(color: string): CSSProperties {
+  return {
+    backgroundColor: `color-mix(in srgb, ${color} 42%, var(--foreground))`
+  }
+}

--- a/src/renderer/src/components/ui/team-multi-combobox.tsx
+++ b/src/renderer/src/components/ui/team-multi-combobox.tsx
@@ -22,7 +22,7 @@ type TeamMultiComboboxProps = {
 
 function renderTriggerLabel(teams: LinearTeam[], selected: ReadonlySet<string>): React.JSX.Element {
   if (teams.length === 0) {
-    return <span className="text-muted-foreground">No teams</span>
+    return <span className="inline-flex min-w-0 items-center gap-1.5">All teams</span>
   }
   if (selected.size === teams.length) {
     return <span className="inline-flex min-w-0 items-center gap-1.5">All teams</span>

--- a/src/renderer/src/hooks/useRadixBodyPointerEventsRecovery.ts
+++ b/src/renderer/src/hooks/useRadixBodyPointerEventsRecovery.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+
+const ACTIVE_RADIX_MODAL_SELECTOR = [
+  '[data-slot="dialog-content"][data-state="open"]',
+  '[data-slot="dialog-overlay"][data-state="open"]',
+  '[data-slot="sheet-content"][data-state="open"]',
+  '[data-slot="sheet-overlay"][data-state="open"]'
+].join(',')
+
+function hasActiveRadixModal(): boolean {
+  return document.querySelector(ACTIVE_RADIX_MODAL_SELECTOR) !== null
+}
+
+function clearStaleBodyPointerEvents(): void {
+  if (document.body.style.pointerEvents !== 'none' || hasActiveRadixModal()) {
+    return
+  }
+  document.body.style.pointerEvents = ''
+}
+
+export function useRadixBodyPointerEventsRecovery(): void {
+  useEffect(() => {
+    let frameId: number | null = null
+
+    const scheduleRecovery = (): void => {
+      if (frameId !== null) {
+        return
+      }
+      frameId = requestAnimationFrame(() => {
+        frameId = null
+        clearStaleBodyPointerEvents()
+      })
+    }
+
+    scheduleRecovery()
+
+    const observer = new MutationObserver(scheduleRecovery)
+    // Why: Radix can leave body pointer-events locked after a modal unmounts.
+    // Watch both body style and portal removal so the app recovers immediately.
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['style'],
+      childList: true,
+      subtree: true
+    })
+
+    return () => {
+      observer.disconnect()
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId)
+      }
+    }
+  }, [])
+}

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   linearCreateIssue,
+  linearCreateSubIssue,
+  linearListProjects,
   linearListTeams,
   linearSearchIssues,
   linearSelectWorkspace,
@@ -20,6 +22,7 @@ const linearSearchIssuesLocal = vi.fn()
 const linearCreateIssueLocal = vi.fn()
 const linearUpdateIssueLocal = vi.fn()
 const linearListTeamsLocal = vi.fn()
+const linearListProjectsLocal = vi.fn()
 const linearSelectWorkspaceLocal = vi.fn()
 
 beforeEach(() => {
@@ -31,6 +34,7 @@ beforeEach(() => {
   linearCreateIssueLocal.mockReset()
   linearUpdateIssueLocal.mockReset()
   linearListTeamsLocal.mockReset()
+  linearListProjectsLocal.mockReset()
   linearSelectWorkspaceLocal.mockReset()
   runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
     return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
@@ -44,6 +48,7 @@ beforeEach(() => {
         createIssue: linearCreateIssueLocal,
         updateIssue: linearUpdateIssueLocal,
         listTeams: linearListTeamsLocal,
+        listProjects: linearListProjectsLocal,
         selectWorkspace: linearSelectWorkspaceLocal
       }
     }
@@ -54,6 +59,13 @@ describe('runtime linear client', () => {
   it('uses local Linear IPC when no runtime environment is active', async () => {
     linearStatusLocal.mockResolvedValue({ connected: false, viewer: null })
     linearSearchIssuesLocal.mockResolvedValue([{ id: 'issue-1' }])
+    linearCreateIssueLocal.mockResolvedValue({
+      ok: true,
+      id: 'issue-2',
+      identifier: 'ENG-2',
+      title: 'Child task',
+      url: 'https://linear.app/ENG-2'
+    })
 
     await expect(linearStatus({ activeRuntimeEnvironmentId: null })).resolves.toEqual({
       connected: false,
@@ -62,6 +74,10 @@ describe('runtime linear client', () => {
     await expect(
       linearSearchIssues({ activeRuntimeEnvironmentId: null }, 'bug', 10)
     ).resolves.toEqual([{ id: 'issue-1' }])
+    await linearCreateSubIssue(
+      { activeRuntimeEnvironmentId: null },
+      { parentIssueId: 'issue-1', teamId: 'team-1', title: 'Child task' }
+    )
 
     expect(linearStatusLocal).toHaveBeenCalled()
     expect(linearSearchIssuesLocal).toHaveBeenCalledWith({
@@ -69,7 +85,20 @@ describe('runtime linear client', () => {
       limit: 10,
       workspaceId: undefined
     })
+    expect(linearCreateIssueLocal).toHaveBeenCalledWith({
+      parentIssueId: 'issue-1',
+      teamId: 'team-1',
+      title: 'Child task'
+    })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when an older local preload lacks project listing', async () => {
+    delete (window.api.linear as { listProjects?: unknown }).listProjects
+
+    await expect(
+      linearListProjects({ activeRuntimeEnvironmentId: null }, 'roadmap', 10, 'workspace-1')
+    ).resolves.toEqual([])
   })
 
   it('routes Linear reads through the selected runtime environment', async () => {
@@ -111,7 +140,13 @@ describe('runtime linear client', () => {
       .mockResolvedValueOnce({
         id: 'rpc-create',
         ok: true,
-        result: { ok: true, id: 'issue-1', identifier: 'ENG-1', url: 'https://linear.app/ENG-1' },
+        result: {
+          ok: true,
+          id: 'issue-1',
+          identifier: 'ENG-1',
+          title: 'Fix bug',
+          url: 'https://linear.app/ENG-1'
+        },
         _meta: { runtimeId: 'runtime-1' }
       })
       .mockResolvedValueOnce({
@@ -121,9 +156,27 @@ describe('runtime linear client', () => {
         _meta: { runtimeId: 'runtime-1' }
       })
       .mockResolvedValueOnce({
+        id: 'rpc-subissue',
+        ok: true,
+        result: {
+          ok: true,
+          id: 'issue-2',
+          identifier: 'ENG-2',
+          title: 'Child task',
+          url: 'https://linear.app/ENG-2'
+        },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+      .mockResolvedValueOnce({
         id: 'rpc-teams',
         ok: true,
         result: [{ id: 'team-1' }],
+        _meta: { runtimeId: 'runtime-1' }
+      })
+      .mockResolvedValueOnce({
+        id: 'rpc-projects',
+        ok: true,
+        result: [{ id: 'project-1' }],
         _meta: { runtimeId: 'runtime-1' }
       })
       .mockResolvedValueOnce({
@@ -143,7 +196,18 @@ describe('runtime linear client', () => {
       { priority: 2 },
       'workspace-1'
     )
+    await linearCreateSubIssue(
+      { activeRuntimeEnvironmentId: 'env-1' },
+      {
+        parentIssueId: 'issue-1',
+        teamId: 'team-1',
+        title: 'Child task',
+        workspaceId: 'workspace-1',
+        projectId: 'project-1'
+      }
+    )
     await linearListTeams({ activeRuntimeEnvironmentId: 'env-1' }, 'all')
+    await linearListProjects({ activeRuntimeEnvironmentId: 'env-1' }, 'roadmap', 10, 'workspace-1')
     await linearSelectWorkspace({ activeRuntimeEnvironmentId: 'env-1' }, 'workspace-1')
 
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
@@ -160,11 +224,29 @@ describe('runtime linear client', () => {
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
       selector: 'env-1',
+      method: 'linear.createIssue',
+      params: {
+        parentIssueId: 'issue-1',
+        teamId: 'team-1',
+        title: 'Child task',
+        workspaceId: 'workspace-1',
+        projectId: 'project-1'
+      },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
+      selector: 'env-1',
       method: 'linear.listTeams',
       params: { workspaceId: 'all' },
       timeoutMs: 30_000
     })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
+      selector: 'env-1',
+      method: 'linear.listProjects',
+      params: { query: 'roadmap', limit: 10, workspaceId: 'workspace-1' },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
       selector: 'env-1',
       method: 'linear.selectWorkspace',
       params: { workspaceId: 'workspace-1' },

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: the renderer Linear client mirrors the
+   preload/RPC Linear namespace so local and remote runtime routing stays in
+   one auditable boundary. */
 import type {
   GlobalSettings,
   LinearComment,
@@ -6,6 +9,7 @@ import type {
   LinearIssueUpdate,
   LinearLabel,
   LinearMember,
+  LinearProjectSummary,
   LinearTeam,
   LinearViewer,
   LinearWorkspaceSelection,
@@ -21,7 +25,7 @@ export type RuntimeLinearSettings =
 export type LinearIssueFilter = 'assigned' | 'created' | 'all' | 'completed'
 export type LinearConnectResult = { ok: true; viewer: LinearViewer } | { ok: false; error: string }
 export type LinearCreateIssueResult =
-  | { ok: true; id: string; identifier: string; url: string }
+  | { ok: true; id: string; identifier: string; title: string; url: string }
   | { ok: false; error: string }
 export type LinearMutationResult = { ok: true } | { ok: false; error: string }
 export type LinearCommentResult = { ok: true; id: string } | { ok: false; error: string }
@@ -143,7 +147,14 @@ export async function linearListIssues(
 
 export async function linearCreateIssue(
   settings: RuntimeLinearSettings,
-  args: { teamId: string; title: string; description?: string; workspaceId?: string }
+  args: {
+    teamId: string
+    title: string
+    description?: string
+    workspaceId?: string
+    parentIssueId?: string
+    projectId?: string | null
+  }
 ): Promise<LinearCreateIssueResult> {
   const target = getActiveRuntimeTarget(settings)
   return target.kind === 'environment'
@@ -151,6 +162,20 @@ export async function linearCreateIssue(
         timeoutMs: 30_000
       })
     : window.api.linear.createIssue(args)
+}
+
+export async function linearCreateSubIssue(
+  settings: RuntimeLinearSettings,
+  args: {
+    parentIssueId: string
+    teamId: string
+    title: string
+    description?: string
+    workspaceId?: string
+    projectId?: string | null
+  }
+): Promise<LinearCreateIssueResult> {
+  return linearCreateIssue(settings, args)
 }
 
 export async function linearGetIssue(
@@ -232,6 +257,25 @@ export async function linearListTeams(
         { timeoutMs: 30_000 }
       )
     : window.api.linear.listTeams(workspaceId ? { workspaceId } : undefined)
+}
+
+export async function linearListProjects(
+  settings: RuntimeLinearSettings,
+  query?: string,
+  limit?: number,
+  workspaceId?: LinearWorkspaceSelection | null
+): Promise<LinearProjectSummary[]> {
+  const target = getActiveRuntimeTarget(settings)
+  return target.kind === 'environment'
+    ? callRuntimeRpc<LinearProjectSummary[]>(
+        target,
+        'linear.listProjects',
+        { query, limit, workspaceId: workspaceId ?? undefined },
+        { timeoutMs: 30_000 }
+      )
+    : typeof window.api.linear.listProjects === 'function'
+      ? window.api.linear.listProjects({ query, limit, workspaceId: workspaceId ?? undefined })
+      : []
 }
 
 export async function linearTeamStates(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -774,6 +774,8 @@ export type LinearIssue = {
     name: string
     key: string
   }
+  project?: LinearProjectSummary
+  subIssues?: LinearIssueChildSummary[]
   labels: string[]
   labelIds: string[]
   assignee?: {
@@ -783,6 +785,20 @@ export type LinearIssue = {
   }
   priority: number
   updatedAt: string
+}
+
+export type LinearProjectSummary = {
+  id: string
+  name: string
+  url?: string
+  color?: string
+}
+
+export type LinearIssueChildSummary = {
+  id: string
+  identifier: string
+  title: string
+  url: string
 }
 
 export type LinearComment = {
@@ -817,6 +833,7 @@ export type LinearIssueUpdate = {
   assigneeId?: string | null
   priority?: number
   labelIds?: string[]
+  projectId?: string | null
 }
 
 export type ClassifiedError = {


### PR DESCRIPTION
## Summary
- add Linear project and sub-issue support across main/preload/runtime APIs
- refresh the Linear issue workspace, drawer, and task page UI for project/sub-issue workflows
- avoid list/search N+1 hydration by loading project and child issue details only for issue detail fetches

## Verification
- pnpm typecheck
- pnpm test src/main/runtime/rpc/methods/linear.test.ts src/renderer/src/runtime/runtime-linear-client.test.ts

## Review
- ran 2-round review-and-submit review loop
- fixed Medium findings from both rounds
