### PR TITLE
Keep conflict review tree visible while editing

### DIFF
--- a/src/renderer/src/components/editor/ConflictComponents.test.tsx
+++ b/src/renderer/src/components/editor/ConflictComponents.test.tsx
@@ -56,6 +56,8 @@ describe('ConflictReviewPanel', () => {
           createLiveEntry('src/renderer/src/store/slices/linear.ts')
         ]}
         onOpenEntry={vi.fn()}
+        selectedFile={null}
+        selectedContent={null}
         onDismiss={vi.fn()}
         onRefreshSnapshot={vi.fn()}
         onReturnToSourceControl={vi.fn()}

--- a/src/renderer/src/components/editor/ConflictComponents.tsx
+++ b/src/renderer/src/components/editor/ConflictComponents.tsx
@@ -108,6 +108,8 @@ export function ConflictReviewPanel({
   file,
   liveEntries,
   onOpenEntry,
+  selectedFile,
+  selectedContent,
   onDismiss,
   onRefreshSnapshot,
   onReturnToSourceControl
@@ -115,6 +117,8 @@ export function ConflictReviewPanel({
   file: OpenFile
   liveEntries: GitStatusEntry[]
   onOpenEntry: (entry: GitStatusEntry) => void
+  selectedFile: OpenFile | null
+  selectedContent: React.ReactNode
   onDismiss: () => void
   onRefreshSnapshot: () => void
   onReturnToSourceControl: () => void
@@ -177,6 +181,7 @@ export function ConflictReviewPanel({
         entries={treeEntries}
         collapsed={fileTreeCollapsed}
         onCollapsedChange={setFileTreeCollapsed}
+        selectedPath={selectedFile?.relativePath ?? null}
         onOpenEntry={onOpenEntry}
       />
       <div className="flex min-w-0 flex-1 flex-col">
@@ -214,33 +219,42 @@ export function ConflictReviewPanel({
             Refresh
           </Button>
         </div>
-        <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-center">
-          <div className="max-w-md space-y-3">
-            <div className="mx-auto flex size-10 items-center justify-center rounded-md border border-border bg-card text-muted-foreground">
-              <GitMerge className="size-4" />
-            </div>
-            <div className="text-sm font-medium text-foreground">
-              Select a conflict from the file tree
-            </div>
-            <div className="text-xs text-muted-foreground">
-              Open each unresolved file, edit the conflict markers, then refresh this snapshot.
-            </div>
-            {resolvedCount > 0 && (
-              <div className="text-xs text-muted-foreground">
-                {resolvedCount} conflict{resolvedCount === 1 ? '' : 's'} no longer live in Git.
+        <div className="min-h-0 flex-1">
+          {selectedContent ?? (
+            <div className="flex h-full min-h-0 items-center justify-center px-6 text-center">
+              <div className="max-w-md space-y-3">
+                <div className="mx-auto flex size-10 items-center justify-center rounded-md border border-border bg-card text-muted-foreground">
+                  <GitMerge className="size-4" />
+                </div>
+                <div className="text-sm font-medium text-foreground">
+                  Select a conflict from the file tree
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Open each unresolved file, edit the conflict markers, then refresh this snapshot.
+                </div>
+                {resolvedCount > 0 && (
+                  <div className="text-xs text-muted-foreground">
+                    {resolvedCount} conflict{resolvedCount === 1 ? '' : 's'} no longer live in Git.
+                  </div>
+                )}
+                <div className="flex items-center justify-center gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={onReturnToSourceControl}
+                  >
+                    <GitMerge className="size-3.5" />
+                    Source Control
+                  </Button>
+                  <Button type="button" size="sm" variant="ghost" onClick={onDismiss}>
+                    <X className="size-3.5" />
+                    Dismiss
+                  </Button>
+                </div>
               </div>
-            )}
-            <div className="flex items-center justify-center gap-2">
-              <Button type="button" size="sm" variant="outline" onClick={onReturnToSourceControl}>
-                <GitMerge className="size-3.5" />
-                Source Control
-              </Button>
-              <Button type="button" size="sm" variant="ghost" onClick={onDismiss}>
-                <X className="size-3.5" />
-                Dismiss
-              </Button>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/editor/ConflictReviewFileTree.tsx
+++ b/src/renderer/src/components/editor/ConflictReviewFileTree.tsx
@@ -36,11 +36,13 @@ export function ConflictReviewFileTree({
   entries,
   collapsed,
   onCollapsedChange,
+  selectedPath,
   onOpenEntry
 }: {
   entries: readonly ConflictReviewTreeEntry[]
   collapsed: boolean
   onCollapsedChange: (collapsed: boolean) => void
+  selectedPath: string | null
   onOpenEntry: (entry: GitStatusEntry) => void
 }): React.JSX.Element | null {
   const [collapsedDirectoryKeys, setCollapsedDirectoryKeys] = React.useState<Set<string>>(
@@ -96,6 +98,7 @@ export function ConflictReviewFileTree({
               key={node.key}
               node={node}
               isCollapsed={collapsedDirectoryKeys.has(node.key)}
+              isSelected={node.type === 'file' && node.entry.path === selectedPath}
               onToggleDirectory={toggleDirectory}
               onOpenEntry={onOpenEntry}
             />
@@ -109,11 +112,13 @@ export function ConflictReviewFileTree({
 function ConflictReviewFileTreeRow({
   node,
   isCollapsed,
+  isSelected,
   onToggleDirectory,
   onOpenEntry
 }: {
   node: ConflictReviewTreeNode
   isCollapsed: boolean
+  isSelected: boolean
   onToggleDirectory: (key: string) => void
   onOpenEntry: (entry: GitStatusEntry) => void
 }): React.JSX.Element {
@@ -151,7 +156,10 @@ function ConflictReviewFileTreeRow({
   return (
     <button
       type="button"
-      className="group flex w-full min-w-0 cursor-pointer items-center gap-1 py-1 pr-3 text-left text-xs transition-colors hover:bg-accent/40 disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent"
+      className={cn(
+        'group flex w-full min-w-0 cursor-pointer items-center gap-1 py-1 pr-3 text-left text-xs transition-colors hover:bg-accent/40 disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent',
+        isSelected && 'bg-accent/60 text-accent-foreground hover:bg-accent/70'
+      )}
       style={{
         paddingLeft: `${node.depth * CONFLICT_REVIEW_TREE_INDENT_PX + CONFLICT_REVIEW_FILE_PADDING_PX}px`
       }}

--- a/src/renderer/src/components/editor/EditorContent.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.test.tsx
@@ -32,6 +32,7 @@ describe('EditorContent', () => {
         }}
         diffContents={{}}
         editBuffers={{}}
+        openFiles={[activeFile]}
         worktreeEntries={[]}
         resolvedLanguage="notebook"
         isMarkdown={false}
@@ -43,8 +44,10 @@ describe('EditorContent', () => {
         sideBySide={false}
         pendingEditorReveal={null}
         handleContentChange={vi.fn()}
+        handleContentChangeForFile={vi.fn()}
         handleDirtyStateHint={vi.fn()}
         handleSave={vi.fn()}
+        handleSaveForFile={vi.fn()}
         reloadFileContent={vi.fn()}
       />
     )

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -74,6 +74,7 @@ export function EditorContent({
   fileContents,
   diffContents,
   editBuffers,
+  openFiles,
   worktreeEntries,
   resolvedLanguage,
   isMarkdown,
@@ -88,8 +89,10 @@ export function EditorContent({
   onCloseMarkdownTableOfContents = () => {},
   pendingEditorReveal,
   handleContentChange,
+  handleContentChangeForFile,
   handleDirtyStateHint,
   handleSave,
+  handleSaveForFile,
   reloadFileContent
 }: {
   activeFile: OpenFile
@@ -97,6 +100,7 @@ export function EditorContent({
   fileContents: Record<string, FileContent>
   diffContents: Record<string, GitDiffResult>
   editBuffers: Record<string, string>
+  openFiles: OpenFile[]
   worktreeEntries: GitStatusEntry[]
   resolvedLanguage: string
   isMarkdown: boolean
@@ -116,8 +120,10 @@ export function EditorContent({
     matchLength?: number
   } | null
   handleContentChange: (content: string) => void
+  handleContentChangeForFile: (file: OpenFile, content: string) => void
   handleDirtyStateHint: (dirty: boolean) => void
   handleSave: (content: string) => Promise<void>
+  handleSaveForFile: (file: OpenFile, content: string) => Promise<void>
   reloadFileContent: (file: OpenFile) => void
 }): React.JSX.Element {
   const editorViewStateKey =
@@ -132,13 +138,17 @@ export function EditorContent({
       : `${activeFile.id}::${viewStateScopeId}:preview`
   const monacoLanguage = resolvedLanguage === 'notebook' ? 'json' : resolvedLanguage
 
-  const openConflictFile = useAppStore((s) => s.openConflictFile)
+  const openConflictReviewFile = useAppStore((s) => s.openConflictReviewFile)
   const openConflictReview = useAppStore((s) => s.openConflictReview)
   const closeFile = useAppStore((s) => s.closeFile)
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
   const md = useMarkdownDocuments(activeFile, isMarkdown, mdViewMode, handleSave)
   const activeConflictEntry =
     worktreeEntries.find((entry) => entry.path === activeFile.relativePath) ?? null
+  const selectedConflictReviewFile =
+    activeFile.mode === 'conflict-review' && activeFile.conflictReview?.selectedFileId
+      ? (openFiles.find((file) => file.id === activeFile.conflictReview?.selectedFileId) ?? null)
+      : null
 
   const isCombinedDiff =
     activeFile.mode === 'diff' &&
@@ -306,18 +316,105 @@ export function EditorContent({
     return <div className="h-full min-h-0">{renderMonacoEditor(fc)}</div>
   }
 
+  const renderConflictReviewSelectedContent = (selectedFile: OpenFile): React.JSX.Element => {
+    if (selectedFile.conflict?.kind === 'conflict-placeholder') {
+      return <ConflictPlaceholderView file={selectedFile} />
+    }
+
+    const fc = fileContents[selectedFile.id]
+    if (!fc) {
+      return (
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+          Loading...
+        </div>
+      )
+    }
+    if (fc.loadError) {
+      return (
+        <FileLoadErrorView message={fc.loadError} onRetry={() => reloadFileContent(selectedFile)} />
+      )
+    }
+    if (fc.isBinary) {
+      if (fc.isImage) {
+        return (
+          <ImageViewer
+            content={fc.content}
+            filePath={selectedFile.filePath}
+            mimeType={fc.mimeType}
+          />
+        )
+      }
+      return (
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+          Binary file — cannot display
+        </div>
+      )
+    }
+
+    const selectedConflictEntry =
+      worktreeEntries.find((entry) => entry.path === selectedFile.relativePath) ?? null
+    const selectedLanguage = detectLanguage(selectedFile.relativePath)
+    const monacoSelectedLanguage = selectedLanguage === 'notebook' ? 'json' : selectedLanguage
+    const selectedViewStateKey = `${selectedFile.filePath}::${viewStateScopeId}`
+
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        {selectedFile.conflict && (
+          <ConflictBanner file={selectedFile} entry={selectedConflictEntry} />
+        )}
+        <div className="min-h-0 flex-1">
+          <MonacoEditor
+            key={`${viewStateScopeId}:${selectedFile.id}`}
+            filePath={selectedFile.filePath}
+            viewStateKey={selectedViewStateKey}
+            relativePath={selectedFile.relativePath}
+            content={editBuffers[selectedFile.id] ?? fc.content}
+            language={monacoSelectedLanguage}
+            onContentChange={(content) => handleContentChangeForFile(selectedFile, content)}
+            onSave={(content) => handleSaveForFile(selectedFile, content)}
+            worktreeId={selectedFile.worktreeId}
+            markdownAnnotationsEnabled={false}
+            conflictDecorationsEnabled={selectedFile.conflict?.conflictStatus === 'unresolved'}
+            revealLine={
+              pendingEditorReveal?.filePath === selectedFile.filePath
+                ? pendingEditorReveal.line
+                : undefined
+            }
+            revealColumn={
+              pendingEditorReveal?.filePath === selectedFile.filePath
+                ? pendingEditorReveal.column
+                : undefined
+            }
+            revealMatchLength={
+              pendingEditorReveal?.filePath === selectedFile.filePath
+                ? pendingEditorReveal.matchLength
+                : undefined
+            }
+          />
+        </div>
+      </div>
+    )
+  }
+
   if (activeFile.mode === 'conflict-review') {
     return (
       <ConflictReviewPanel
         file={activeFile}
         liveEntries={worktreeEntries}
         onOpenEntry={(entry) =>
-          openConflictFile(
+          openConflictReviewFile(
+            activeFile.id,
             activeFile.worktreeId,
             activeFile.filePath,
             entry,
             detectLanguage(entry.path)
           )
+        }
+        selectedFile={selectedConflictReviewFile}
+        selectedContent={
+          selectedConflictReviewFile
+            ? renderConflictReviewSelectedContent(selectedConflictReviewFile)
+            : null
         }
         onDismiss={() => closeFile(activeFile.id)}
         onRefreshSnapshot={() =>

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -101,28 +101,35 @@ function EditorPanelInner({
     return () => window.clearTimeout(timeout)
   }, [copiedPathToast])
 
-  const handleContentChange = useCallback(
-    (content: string) => {
-      if (!activeFile) {
+  const handleContentChangeForFile = useCallback(
+    (file: typeof activeFile, content: string) => {
+      if (!file) {
         return
       }
-      setEditorDraft(activeFile.id, content)
+      setEditorDraft(file.id, content)
       const normalize =
-        activeFile.language === 'markdown'
+        file.language === 'markdown'
           ? (value: string): string => value.trimEnd()
           : (value: string): string => value
-      if (activeFile.mode === 'edit') {
+      if (file.mode === 'edit') {
         markFileDirty(
-          activeFile.id,
-          normalize(content) !== normalize(fileContents[activeFile.id]?.content ?? '')
+          file.id,
+          normalize(content) !== normalize(fileContents[file.id]?.content ?? '')
         )
         return
       }
-      const diffContent = diffContents[activeFile.id]
+      const diffContent = diffContents[file.id]
       const original = diffContent?.kind === 'text' ? diffContent.modifiedContent : ''
-      markFileDirty(activeFile.id, normalize(content) !== normalize(original))
+      markFileDirty(file.id, normalize(content) !== normalize(original))
     },
-    [activeFile, diffContents, fileContents, markFileDirty, setEditorDraft]
+    [diffContents, fileContents, markFileDirty, setEditorDraft]
+  )
+
+  const handleContentChange = useCallback(
+    (content: string) => {
+      handleContentChangeForFile(activeFile, content)
+    },
+    [activeFile, handleContentChangeForFile]
   )
 
   const handleDirtyStateHint = useCallback(
@@ -134,18 +141,18 @@ function EditorPanelInner({
     [activeFile, markFileDirty]
   )
 
-  const handleSave = useCallback(
-    async (content: string) => {
-      if (!activeFile) {
+  const handleSaveForFile = useCallback(
+    async (file: typeof activeFile, content: string) => {
+      if (!file) {
         return
       }
       const saveTargetFile =
-        activeFile.mode === 'markdown-preview'
+        file.mode === 'markdown-preview'
           ? (openFiles.find(
               (openFile) =>
-                openFile.id === activeFile.markdownPreviewSourceFileId && openFile.mode === 'edit'
+                openFile.id === file.markdownPreviewSourceFileId && openFile.mode === 'edit'
             ) ?? null)
-          : activeFile
+          : file
       if (!saveTargetFile) {
         return
       }
@@ -157,7 +164,14 @@ function EditorPanelInner({
         await requestEditorFileSave({ fileId: saveTargetFile.id, fallbackContent: content })
       } catch {}
     },
-    [activeFile, openFiles, requestRenameForFile]
+    [openFiles, requestRenameForFile]
+  )
+
+  const handleSave = useCallback(
+    async (content: string) => {
+      await handleSaveForFile(activeFile, content)
+    },
+    [activeFile, handleSaveForFile]
   )
   useEditorCmdSaveRequest({ activeFile, openFiles, fileContents, handleSave })
 
@@ -275,6 +289,7 @@ function EditorPanelInner({
       showMarkdownTableOfContents={showMarkdownTableOfContents}
       markdownReviewToolsEnabled={markdownReviewToolsEnabled}
       sideBySide={sideBySide}
+      openFiles={openFiles}
       fileContents={fileContents}
       diffContents={diffContents}
       editorDrafts={editorDrafts}
@@ -293,8 +308,10 @@ function EditorPanelInner({
       onToggleMarkdownReviewTools={handleToggleMarkdownReviewTools}
       onExportMarkdownToPdf={() => void exportActiveMarkdownToPdf()}
       onContentChange={handleContentChange}
+      onContentChangeForFile={handleContentChangeForFile}
       onDirtyStateHint={handleDirtyStateHint}
       onSave={handleSave}
+      onSaveForFile={handleSaveForFile}
       onReloadFileContent={reloadFileContent}
       onCloseMarkdownTableOfContents={() => setShowMarkdownTableOfContents(false)}
       onCloseRenameDialog={closeRenameDialog}

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -20,6 +20,7 @@ type EditorPanelShellProps = {
   showMarkdownTableOfContents: boolean
   markdownReviewToolsEnabled: boolean
   sideBySide: boolean
+  openFiles: OpenFile[]
   fileContents: Record<string, FileContent>
   diffContents: Record<string, DiffContent>
   editorDrafts: Record<string, string>
@@ -38,8 +39,10 @@ type EditorPanelShellProps = {
   onToggleMarkdownReviewTools: () => void
   onExportMarkdownToPdf: () => void
   onContentChange: (content: string) => void
+  onContentChangeForFile: (file: OpenFile, content: string) => void
   onDirtyStateHint: (dirty: boolean) => void
   onSave: (content: string) => Promise<void>
+  onSaveForFile: (file: OpenFile, content: string) => Promise<void>
   onReloadFileContent: (file: OpenFile) => void
   onCloseMarkdownTableOfContents: () => void
   onCloseRenameDialog: () => void
@@ -55,6 +58,7 @@ export function EditorPanelShell({
   showMarkdownTableOfContents,
   markdownReviewToolsEnabled,
   sideBySide,
+  openFiles,
   fileContents,
   diffContents,
   editorDrafts,
@@ -73,8 +77,10 @@ export function EditorPanelShell({
   onToggleMarkdownReviewTools,
   onExportMarkdownToPdf,
   onContentChange,
+  onContentChangeForFile,
   onDirtyStateHint,
   onSave,
+  onSaveForFile,
   onReloadFileContent,
   onCloseMarkdownTableOfContents,
   onCloseRenameDialog,
@@ -123,6 +129,7 @@ export function EditorPanelShell({
           fileContents={fileContents}
           diffContents={diffContents}
           editBuffers={editorDrafts}
+          openFiles={openFiles}
           worktreeEntries={model.worktreeEntries}
           resolvedLanguage={model.resolvedLanguage}
           isMarkdown={model.isMarkdown}
@@ -134,8 +141,10 @@ export function EditorPanelShell({
           sideBySide={sideBySide}
           pendingEditorReveal={pendingEditorReveal}
           handleContentChange={onContentChange}
+          handleContentChangeForFile={onContentChangeForFile}
           handleDirtyStateHint={onDirtyStateHint}
           handleSave={onSave}
+          handleSaveForFile={onSaveForFile}
           reloadFileContent={onReloadFileContent}
           showMarkdownTableOfContents={showMarkdownTableOfContents}
           markdownReviewToolsEnabled={markdownReviewToolsEnabled}

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -1,3 +1,6 @@
+/* oxlint-disable max-lines -- Why: content loading, retry, and external-change
+   subscriptions share in-flight caches and state setters; splitting them would
+   make the hook coordination harder to audit. */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
 import { getConnectionId } from '@/lib/connection-context'
@@ -72,6 +75,10 @@ export function useEditorPanelContentState({
   openFilesRef.current = openFiles
   const editorViewModeRef = useRef(editorViewMode)
   editorViewModeRef.current = editorViewMode
+  const selectedConflictReviewFile =
+    activeFile?.mode === 'conflict-review' && activeFile.conflictReview?.selectedFileId
+      ? (openFiles.find((file) => file.id === activeFile.conflictReview?.selectedFileId) ?? null)
+      : null
 
   const loadFileContent = useCallback(
     async (filePath: string, id: string, worktreeId?: string): Promise<void> => {
@@ -245,30 +252,38 @@ export function useEditorPanelContentState({
   )
 
   useEffect(() => {
-    if (!activeFile || activeFile.mode === 'conflict-review') {
+    const fileToLoad = selectedConflictReviewFile ?? activeFile
+    if (!fileToLoad || (activeFile?.mode === 'conflict-review' && !selectedConflictReviewFile)) {
       return
     }
-    if (activeFile.mode === 'edit' || activeFile.mode === 'markdown-preview') {
-      if (activeFile.conflict?.kind === 'conflict-placeholder') {
+    if (fileToLoad.mode === 'edit' || fileToLoad.mode === 'markdown-preview') {
+      if (fileToLoad.conflict?.kind === 'conflict-placeholder') {
         return
       }
-      if (!fileContents[activeFile.id]) {
-        void loadFileContent(activeFile.filePath, activeFile.id, activeFile.worktreeId)
+      if (!fileContents[fileToLoad.id]) {
+        void loadFileContent(fileToLoad.filePath, fileToLoad.id, fileToLoad.worktreeId)
       }
-      if (isChangesMode && !diffContents[activeFile.id]) {
-        void loadDiffContent(activeFile)
+      if (isChangesMode && !diffContents[fileToLoad.id]) {
+        void loadDiffContent(fileToLoad)
       }
     } else if (
-      activeFile.mode === 'diff' &&
-      activeFile.diffSource !== undefined &&
-      activeFile.diffSource !== 'combined-uncommitted' &&
-      activeFile.diffSource !== 'combined-branch' &&
-      activeFile.diffSource !== 'combined-commit' &&
-      !diffContents[activeFile.id]
+      fileToLoad.mode === 'diff' &&
+      fileToLoad.diffSource !== undefined &&
+      fileToLoad.diffSource !== 'combined-uncommitted' &&
+      fileToLoad.diffSource !== 'combined-branch' &&
+      fileToLoad.diffSource !== 'combined-commit' &&
+      !diffContents[fileToLoad.id]
     ) {
-      void loadDiffContent(activeFile)
+      void loadDiffContent(fileToLoad)
     }
-  }, [activeFile?.id, isChangesMode]) // eslint-disable-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    activeFile?.id,
+    activeFile?.mode,
+    activeFile?.conflictReview?.selectedFileId,
+    selectedConflictReviewFile?.id,
+    isChangesMode
+  ])
 
   useEditorPanelFileLoadRetry({
     activeFile,

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -833,6 +833,47 @@ describe('createEditorSlice conflict status reconciliation', () => {
     ])
   })
 
+  it('keeps the conflict review active when selecting a conflict from its tree', () => {
+    const store = createEditorStore()
+
+    store
+      .getState()
+      .openConflictReview(
+        'wt-1',
+        '/repo',
+        [{ path: 'src/conflict.ts', conflictKind: 'both_modified' }],
+        'live-summary'
+      )
+    store.getState().openConflictReviewFile(
+      'wt-1::conflict-review',
+      'wt-1',
+      '/repo',
+      {
+        path: 'src/conflict.ts',
+        status: 'modified',
+        area: 'unstaged',
+        conflictKind: 'both_modified',
+        conflictStatus: 'unresolved',
+        conflictStatusSource: 'git'
+      },
+      'typescript'
+    )
+
+    const reviewFile = store
+      .getState()
+      .openFiles.find((file) => file.id === 'wt-1::conflict-review')
+
+    expect(store.getState().activeFileId).toBe('wt-1::conflict-review')
+    expect(reviewFile?.conflictReview?.selectedFileId).toBe('/repo/src/conflict.ts')
+    expect(store.getState().openFiles).toContainEqual(
+      expect.objectContaining({
+        id: '/repo/src/conflict.ts',
+        mode: 'edit',
+        conflict: expect.objectContaining({ conflictStatus: 'unresolved' })
+      })
+    )
+  })
+
   it('marks tracked conflicts as resolved locally after live conflict state disappears', () => {
     const store = createEditorStore()
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -101,6 +101,7 @@ export type ConflictReviewState = {
   source: 'live-summary' | 'combined-diff-exclusion'
   snapshotTimestamp: number
   entries: ConflictReviewEntry[]
+  selectedFileId?: string
 }
 
 export type CombinedDiffSkippedConflict = {
@@ -327,6 +328,13 @@ export type EditorSlice = {
     areaFilter?: string
   ) => void
   openConflictFile: (
+    worktreeId: string,
+    worktreePath: string,
+    entry: GitStatusEntry,
+    language: string
+  ) => void
+  openConflictReviewFile: (
+    reviewFileId: string,
     worktreeId: string,
     worktreePath: string,
     entry: GitStatusEntry,
@@ -1852,6 +1860,104 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
     })
     void openWorkspaceEditorItem(get(), absolutePath, worktreeId, entry.path, 'editor')
+  },
+
+  openConflictReviewFile: (reviewFileId, worktreeId, worktreePath, entry, language) => {
+    const absolutePath = joinPath(worktreePath, entry.path)
+    const reviewTab = (get().unifiedTabsByWorktree?.[worktreeId] ?? []).find(
+      (tab) => tab.entityId === reviewFileId && tab.contentType === 'conflict-review'
+    )
+    set((s) => {
+      const conflict = toOpenConflictMetadata(entry)
+      const existing = s.openFiles.find((f) => f.id === absolutePath)
+      const nextTracked =
+        entry.conflictStatus === 'unresolved' && entry.conflictKind
+          ? {
+              ...s.trackedConflictPathsByWorktree[worktreeId],
+              [entry.path]: entry.conflictKind
+            }
+          : s.trackedConflictPathsByWorktree[worktreeId]
+
+      if (!conflict) {
+        return s
+      }
+
+      const nextOpenFiles = existing
+        ? s.openFiles.map((f) =>
+            f.id === absolutePath
+              ? {
+                  ...f,
+                  mode: 'edit' as const,
+                  language,
+                  relativePath: entry.path,
+                  filePath: absolutePath,
+                  conflict,
+                  diffSource: undefined,
+                  skippedConflicts: undefined,
+                  conflictReview: undefined
+                }
+              : f.id === reviewFileId && f.conflictReview
+                ? {
+                    ...f,
+                    conflictReview: {
+                      ...f.conflictReview,
+                      selectedFileId: absolutePath
+                    }
+                  }
+                : f
+          )
+        : [
+            ...s.openFiles.map((f) =>
+              f.id === reviewFileId && f.conflictReview
+                ? {
+                    ...f,
+                    conflictReview: {
+                      ...f.conflictReview,
+                      selectedFileId: absolutePath
+                    }
+                  }
+                : f
+            ),
+            {
+              id: absolutePath,
+              filePath: absolutePath,
+              relativePath: entry.path,
+              worktreeId,
+              language,
+              isDirty: false,
+              mode: 'edit' as const,
+              conflict
+            }
+          ]
+
+      return {
+        openFiles: nextOpenFiles,
+        activeFileId: reviewFileId,
+        activeTabType: 'editor',
+        activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: reviewFileId },
+        activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' },
+        trackedConflictPathsByWorktree:
+          nextTracked === s.trackedConflictPathsByWorktree[worktreeId]
+            ? s.trackedConflictPathsByWorktree
+            : { ...s.trackedConflictPathsByWorktree, [worktreeId]: nextTracked }
+      }
+    })
+
+    // Why: the conflict file needs a normal editor backing tab for save/close
+    // flows, but selecting it from Conflict Review must keep the review tab
+    // visible. Create the backing tab beside the review tab, then restore focus.
+    void openWorkspaceEditorItem(
+      get(),
+      absolutePath,
+      worktreeId,
+      entry.path,
+      'editor',
+      undefined,
+      reviewTab?.groupId
+    )
+    if (reviewTab) {
+      get().activateTab?.(reviewTab.id)
+    }
   },
 
   // Why: Review conflicts is launched from Source Control into the editor area,


### PR DESCRIPTION
## Summary
- Keep the Conflict Review file tree visible when selecting an unresolved conflict file
- Render the selected conflict file inside the review surface while preserving normal save/dirty behavior
- Highlight the selected conflict row and cover the behavior with regression tests

## Validation
- pnpm lint
- pnpm typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/components/editor/ConflictComponents.test.tsx src/renderer/src/components/editor/EditorContent.test.tsx