### PR TITLE
Add rich markdown file annotations

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -65,6 +65,7 @@
   --color-git-graph-lane-3: var(--git-graph-lane-3);
   --color-git-graph-lane-4: var(--git-graph-lane-4);
   --color-git-graph-lane-5: var(--git-graph-lane-5);
+  --color-annotation-highlight: var(--annotation-highlight);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -131,6 +132,7 @@
   --git-graph-lane-3: #994f00;
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
+  --annotation-highlight: #f59e0b;
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -184,6 +186,7 @@
   --git-graph-lane-3: #ce9178;
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
+  --annotation-highlight: #fbbf24;
 }
 
 /* ── Base Layer ──────────────────────────────────────── */

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -59,6 +59,104 @@
   color: var(--foreground);
 }
 
+.orca-diff-comment-add-btn.rich-markdown-comment-add-btn {
+  display: flex;
+  width: 22px;
+  height: 22px;
+  z-index: 1001;
+}
+
+.rich-markdown-annotation-selection {
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--annotation-highlight) 22%, transparent);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.rich-markdown-editor-shell.has-rich-markdown-review-notes .rich-markdown-editor {
+  padding-right: min(360px, 34%);
+}
+
+.rich-markdown-review-rail-actions {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  z-index: 45;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.rich-markdown-review-rail-toggle,
+.rich-markdown-review-rail-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 6px;
+  background: var(--background);
+  color: var(--muted-foreground);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 12%, transparent);
+}
+
+.rich-markdown-review-rail-toggle {
+  gap: 5px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.rich-markdown-review-rail-send {
+  width: 26px;
+  padding: 0;
+}
+
+.rich-markdown-review-rail-toggle:hover,
+.rich-markdown-review-rail-toggle[aria-expanded='true'],
+.rich-markdown-review-rail-send:hover {
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.rich-markdown-review-note-layer {
+  position: absolute;
+  top: 0;
+  right: 16px;
+  bottom: 0;
+  width: min(300px, 30%);
+  pointer-events: none;
+  z-index: 30;
+}
+
+.rich-markdown-review-note-card {
+  position: absolute;
+  right: 0;
+  width: 100%;
+  pointer-events: auto;
+}
+
+.rich-markdown-review-note-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  pointer-events: auto;
+  position: relative;
+  z-index: 1;
+}
+
+.rich-markdown-review-note-send:hover {
+  border-color: color-mix(in srgb, var(--foreground) 20%, transparent);
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+}
+
 .rich-markdown-search {
   /* Why: overlay the editor like Monaco's find widget instead of occupying
      layout space — otherwise opening cmd+f shifts the document content down. */
@@ -585,12 +683,43 @@
   width: min(300px, calc(100% - 24px));
   max-height: min(440px, calc(100vh - 120px));
   flex-direction: column;
-  overflow-y: auto;
+  overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
   border-radius: 6px;
   background: var(--popover);
   color: var(--popover-foreground);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+}
+
+.rich-markdown-slash-search {
+  display: flex;
+  min-height: 38px;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  padding: 0 10px;
+  color: var(--muted-foreground);
+}
+
+.rich-markdown-slash-search input {
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--popover-foreground);
+  font-size: 13px;
+  line-height: 20px;
+  outline: none;
+}
+
+.rich-markdown-slash-search input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.rich-markdown-slash-results {
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .rich-markdown-slash-section {
@@ -617,6 +746,13 @@
 .rich-markdown-slash-item:hover,
 .rich-markdown-slash-item.is-active {
   background: var(--accent);
+}
+
+.rich-markdown-slash-empty {
+  padding: 18px 12px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  text-align: center;
 }
 
 .rich-markdown-slash-icon {

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -1,5 +1,5 @@
 import { CornerDownLeft, Pencil, Trash } from 'lucide-react'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 
@@ -16,6 +16,7 @@ import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 type Props = {
   lineNumber: number
   startLine?: number
+  label?: string
   body: string
   onDelete: () => void
   // Why: Monaco view zones have a fixed `heightInPx` set at insertion time
@@ -24,15 +25,18 @@ type Props = {
   // it re-syncs the zone height. Without this the editor inputs would clip.
   onContentResize?: () => void
   onSubmitEdit?: (body: string) => Promise<boolean>
+  headerActions?: ReactNode
 }
 
 export function DiffCommentCard({
   lineNumber,
   startLine,
+  label,
   body,
   onDelete,
   onContentResize,
-  onSubmitEdit
+  onSubmitEdit,
+  headerActions
 }: Props): React.JSX.Element {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(body)
@@ -127,9 +131,10 @@ export function DiffCommentCard({
     <div className="orca-diff-comment-card">
       <div className="orca-diff-comment-header">
         <span className="orca-diff-comment-meta">
-          Note · {getDiffCommentLineLabel({ lineNumber, startLine }).toLowerCase()}
+          Note · {label ?? getDiffCommentLineLabel({ lineNumber, startLine }).toLowerCase()}
         </span>
         <div className="orca-diff-comment-actions">
+          {!editing && headerActions}
           {onSubmitEdit && !editing && (
             <button
               type="button"

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -1107,6 +1107,7 @@ export default function CombinedDiffViewer({
                       groupId={activeGroupId ?? file.worktreeId}
                       onFocusTerminal={focusTerminalTabSurface}
                       prompt={diffCommentsPrompt}
+                      promptDelivery="draft"
                       launchSource="notes_send"
                     />
                   </DropdownMenuContent>

--- a/src/renderer/src/components/editor/EditorContent.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import type { OpenFile } from '@/store/slices/editor'
-import { EditorContent } from './EditorContent'
+import { EditorContent, getMarkdownSourceLineOffset } from './EditorContent'
 
 function createOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
   return {
@@ -17,6 +17,12 @@ function createOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
 }
 
 describe('EditorContent', () => {
+  it('maps rich-editor annotation lines after front matter to source lines', () => {
+    expect(getMarkdownSourceLineOffset('---\ntitle: x\n---\n')).toBe(3)
+    expect(getMarkdownSourceLineOffset('+++\ntitle = "x"\n+++\n')).toBe(3)
+    expect(getMarkdownSourceLineOffset('---\r\ntitle: x\r\n---\r\n')).toBe(3)
+  })
+
   it('surfaces file load errors before notebook content is parsed', () => {
     const activeFile = createOpenFile()
     const html = renderToStaticMarkup(

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -36,6 +36,10 @@ const richMarkdownSizeEncoder = new TextEncoder()
 // Uint8Array on every render, reducing GC pressure for large files.
 const richMarkdownSizeBuffer = new Uint8Array(RICH_MARKDOWN_MAX_SIZE_BYTES + 1)
 
+export function getMarkdownSourceLineOffset(frontMatterRaw: string): number {
+  return (frontMatterRaw.match(/\r\n|\r|\n/g) ?? []).length
+}
+
 type FileContent = {
   content: string
   isBinary: boolean
@@ -162,7 +166,7 @@ export function EditorContent({
       onContentChange={handleContentChange}
       onSave={isMarkdown ? md.mdSave : handleSave}
       worktreeId={activeFile.worktreeId}
-      markdownAnnotationsEnabled={markdownReviewToolsEnabled && isMarkdown && mdViewMode !== 'rich'}
+      markdownAnnotationsEnabled={false}
       conflictDecorationsEnabled={activeFile.conflict?.conflictStatus === 'unresolved'}
       revealLine={
         pendingEditorReveal?.filePath === activeFile.filePath ? pendingEditorReveal.line : undefined
@@ -258,6 +262,10 @@ export function EditorContent({
                 markdownDocuments={md.markdownDocuments}
                 showTableOfContents={showMarkdownTableOfContents}
                 onCloseTableOfContents={onCloseMarkdownTableOfContents}
+                markdownAnnotationsEnabled={markdownReviewToolsEnabled}
+                markdownAnnotationFilePath={activeFile.relativePath}
+                markdownSourceLineOffset={fm ? getMarkdownSourceLineOffset(fm.raw) : 0}
+                markdownReviewContent={currentContent}
                 // Why: render the front-matter banner below the editor toolbar
                 // (inside the editor shell) so formatting controls remain at
                 // the top of the pane — the banner is read-only context, not
@@ -291,7 +299,7 @@ export function EditorContent({
               scrollCacheKey={`${editorViewStateKey}:preview`}
               showTableOfContents={showMarkdownTableOfContents}
               onCloseTableOfContents={onCloseMarkdownTableOfContents}
-              markdownAnnotationsEnabled={markdownReviewToolsEnabled && mdViewMode !== 'rich'}
+              markdownAnnotationsEnabled={false}
               {...md.previewProps}
             />
           </div>
@@ -381,7 +389,7 @@ export function EditorContent({
           initialAnchor={activeFile.markdownPreviewAnchor ?? null}
           showTableOfContents={showMarkdownTableOfContents}
           onCloseTableOfContents={onCloseMarkdownTableOfContents}
-          markdownAnnotationsEnabled={markdownReviewToolsEnabled && mdViewMode !== 'rich'}
+          markdownAnnotationsEnabled={false}
           {...md.previewProps}
         />
       </div>
@@ -525,7 +533,7 @@ export function EditorContent({
             scrollCacheKey={`${diffViewStateKey}:preview`}
             showTableOfContents={showMarkdownTableOfContents}
             onCloseTableOfContents={onCloseMarkdownTableOfContents}
-            markdownAnnotationsEnabled={markdownReviewToolsEnabled}
+            markdownAnnotationsEnabled={false}
             {...md.previewProps}
           />
         </div>

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -48,7 +48,6 @@ function EditorPanelInner({
   const editorDrafts = useAppStore((s) => s.editorDrafts)
   const setEditorDraft = useAppStore((s) => s.setEditorDraft)
   const settings = useAppStore((s) => s.settings)
-  const updateSettings = useAppStore((s) => s.updateSettings)
   const panelRef = useRef<HTMLDivElement>(null)
   const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
     null
@@ -254,9 +253,6 @@ function EditorPanelInner({
     }
     window.api.shell.openPath(activeFile.filePath)
   }
-  const handleToggleMarkdownReviewTools = (): void => {
-    void updateSettings({ markdownReviewToolsEnabled: !markdownReviewToolsEnabled })
-  }
   const disableRenameBrowse = Boolean(
     settingsForRuntimeOwner(
       settings,
@@ -290,7 +286,6 @@ function EditorPanelInner({
       onToggleSideBySide={() => setSideBySide((prev) => !prev)}
       onEditorToggleChange={handleEditorToggleChange}
       onToggleMarkdownTableOfContents={() => setShowMarkdownTableOfContents((shown) => !shown)}
-      onToggleMarkdownReviewTools={handleToggleMarkdownReviewTools}
       onExportMarkdownToPdf={() => void exportActiveMarkdownToPdf()}
       onContentChange={handleContentChange}
       onDirtyStateHint={handleDirtyStateHint}

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -58,7 +58,6 @@ type EditorPanelHeaderProps = {
   canShowMarkdownTableOfContents: boolean
   isMarkdownTableOfContentsDisabled: boolean
   showMarkdownTableOfContents: boolean
-  markdownReviewToolsEnabled: boolean
   sideBySide: boolean
   openFileState: EditorHeaderOpenFileState
   onCopyPath: () => void
@@ -69,7 +68,6 @@ type EditorPanelHeaderProps = {
   onToggleSideBySide: () => void
   onEditorToggleChange: (next: EditorToggleValue) => void
   onToggleMarkdownTableOfContents: () => void
-  onToggleMarkdownReviewTools: () => void
   onExportMarkdownToPdf: () => void
 }
 
@@ -91,7 +89,6 @@ export function EditorPanelHeader({
   canShowMarkdownTableOfContents,
   isMarkdownTableOfContentsDisabled,
   showMarkdownTableOfContents,
-  markdownReviewToolsEnabled,
   sideBySide,
   openFileState,
   onCopyPath,
@@ -102,7 +99,6 @@ export function EditorPanelHeader({
   onToggleSideBySide,
   onEditorToggleChange,
   onToggleMarkdownTableOfContents,
-  onToggleMarkdownReviewTools,
   onExportMarkdownToPdf
 }: EditorPanelHeaderProps): React.JSX.Element {
   const [pathMenuOpen, setPathMenuOpen] = useState(false)
@@ -307,10 +303,6 @@ export function EditorPanelHeader({
               onSelect={onExportMarkdownToPdf}
             >
               Export as PDF
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={onToggleMarkdownReviewTools}>
-              {markdownReviewToolsEnabled ? 'Hide Review Notes' : 'Show Review Notes'}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -35,7 +35,6 @@ type EditorPanelShellProps = {
   onToggleSideBySide: () => void
   onEditorToggleChange: (next: EditorToggleValue) => void
   onToggleMarkdownTableOfContents: () => void
-  onToggleMarkdownReviewTools: () => void
   onExportMarkdownToPdf: () => void
   onContentChange: (content: string) => void
   onDirtyStateHint: (dirty: boolean) => void
@@ -70,7 +69,6 @@ export function EditorPanelShell({
   onToggleSideBySide,
   onEditorToggleChange,
   onToggleMarkdownTableOfContents,
-  onToggleMarkdownReviewTools,
   onExportMarkdownToPdf,
   onContentChange,
   onDirtyStateHint,
@@ -101,7 +99,6 @@ export function EditorPanelShell({
           canShowMarkdownTableOfContents={model.canShowMarkdownTableOfContents}
           isMarkdownTableOfContentsDisabled={model.isMarkdownTableOfContentsDisabled}
           showMarkdownTableOfContents={showMarkdownTableOfContents}
-          markdownReviewToolsEnabled={markdownReviewToolsEnabled}
           sideBySide={sideBySide}
           openFileState={model.openFileState}
           onCopyPath={onCopyPath}
@@ -112,7 +109,6 @@ export function EditorPanelShell({
           onToggleSideBySide={onToggleSideBySide}
           onEditorToggleChange={onEditorToggleChange}
           onToggleMarkdownTableOfContents={onToggleMarkdownTableOfContents}
-          onToggleMarkdownReviewTools={onToggleMarkdownReviewTools}
           onExportMarkdownToPdf={onExportMarkdownToPdf}
         />
       )}

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1272,6 +1272,7 @@ export default function MarkdownPreview({
                     groupId={sourceWorktree.id}
                     onFocusTerminal={focusTerminalTabSurface}
                     prompt={markdownReviewPrompt}
+                    promptDelivery="draft"
                     launchSource="notes_send"
                   />
                 </DropdownMenuContent>
@@ -1409,6 +1410,7 @@ function MarkdownReviewNotesPanel({
                 groupId={worktreeId}
                 onFocusTerminal={focusTerminalTabSurface}
                 prompt={prompt}
+                promptDelivery="draft"
                 launchSource="notes_send"
               />
             </DropdownMenuContent>

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -2,7 +2,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import type { Editor } from '@tiptap/react'
-import type { MarkdownDocument } from '../../../../shared/types'
+import type { JSONContent } from '@tiptap/core'
+import type { DiffComment, MarkdownDocument } from '../../../../shared/types'
 import { RichMarkdownSlashMenu } from './RichMarkdownSlashMenu'
 import { RichMarkdownDocLinkMenu } from './RichMarkdownDocLinkMenu'
 import { RichMarkdownEmojiMenu } from './RichMarkdownEmojiMenu'
@@ -51,6 +52,27 @@ import type {
 } from '../../../../shared/rich-markdown-context-menu'
 import { buildMarkdownTableOfContents, type MarkdownTocItem } from './markdown-table-of-contents'
 import { MarkdownTableOfContentsPanel } from './MarkdownTableOfContentsPanel'
+import { getRelativePathInsideRoot, normalizeRelativePath } from '@/lib/path'
+import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
+import { DiffCommentCard } from '../diff-comments/DiffCommentCard'
+import { isMarkdownComment } from '@/lib/diff-comment-compat'
+import { MessageSquare, Plus, Send } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import {
+  formatMarkdownReviewNotes,
+  sortMarkdownReviewNotes,
+  type MarkdownReviewNote
+} from '@/lib/markdown-review-notes'
+import { QuickLaunchAgentMenuItems } from '@/components/tab-bar/QuickLaunchButton'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import {
+  richMarkdownAnnotationHighlightPluginKey,
+  type RichMarkdownAnnotationHighlightRange
+} from './rich-markdown-annotation-highlight'
 
 type RichMarkdownEditorProps = {
   fileId: string
@@ -66,6 +88,10 @@ type RichMarkdownEditorProps = {
   markdownDocuments?: MarkdownDocument[]
   showTableOfContents?: boolean
   onCloseTableOfContents?: () => void
+  markdownAnnotationsEnabled?: boolean
+  markdownAnnotationFilePath?: string
+  markdownSourceLineOffset?: number
+  markdownReviewContent?: string
   // Why: front-matter is stripped from the rich editor's content but we still
   // want it visible to the user. It renders between the toolbar and the editor
   // surface so the formatting toolbar stays at the top of the pane.
@@ -167,6 +193,285 @@ function flattenMarkdownTocItems(items: MarkdownTocItem[]): MarkdownTocItem[] {
   return items.flatMap((item) => [item, ...flattenMarkdownTocItems(item.children)])
 }
 
+type RichMarkdownCommentBlock = {
+  key: string
+  startLine: number
+  endLine: number
+  from: number
+  to: number
+}
+
+type RichMarkdownComposerState = {
+  lineNumber: number
+  startLine?: number
+}
+
+type RichMarkdownAnnotationTarget = RichMarkdownComposerState & {
+  from: number
+  to: number
+  selectedText: string
+  top: number
+  left?: number
+  buttonTop: number
+  buttonLeft: number
+}
+
+type RichMarkdownNotePosition = {
+  comment: DiffComment
+  top: number
+}
+
+function countMarkdownLines(value: string): number {
+  if (value.length === 0) {
+    return 1
+  }
+  return value.split(/\r\n|\r|\n/).length
+}
+
+function serializeRichMarkdownJson(editor: Editor, content: JSONContent[]): string {
+  return (editor.markdown?.serialize({ type: 'doc', content }) ?? '').trimEnd()
+}
+
+function buildRichMarkdownCommentBlocks(editor: Editor): RichMarkdownCommentBlock[] {
+  const jsonContent = editor.getJSON().content ?? []
+  const blocks: RichMarkdownCommentBlock[] = []
+  let nextLine = 1
+  let previousNodeJson: JSONContent | null = null
+  let previousNodeLineCount = 0
+
+  editor.state.doc.forEach((node, nodeOffset, index) => {
+    const nodeJson = jsonContent[index]
+    if (!nodeJson) {
+      return
+    }
+    const nodeMarkdown = serializeRichMarkdownJson(editor, [nodeJson])
+    const nodeLineCount = countMarkdownLines(nodeMarkdown)
+    if (previousNodeJson) {
+      const pairMarkdown = serializeRichMarkdownJson(editor, [previousNodeJson, nodeJson])
+      const separatorLineCount = Math.max(
+        0,
+        countMarkdownLines(pairMarkdown) - previousNodeLineCount - nodeLineCount
+      )
+      nextLine += separatorLineCount
+    }
+    const startLine = nextLine
+    const endLine = Math.max(startLine, startLine + nodeLineCount - 1)
+    const from = nodeOffset + 1
+    blocks.push({
+      key: `${index}:${startLine}-${endLine}`,
+      startLine,
+      endLine,
+      from,
+      to: from + Math.max(0, node.nodeSize - 1)
+    })
+    nextLine = endLine + 1
+    previousNodeJson = nodeJson
+    previousNodeLineCount = nodeLineCount
+  })
+
+  if (blocks.length === 0) {
+    blocks.push({ key: 'empty:1-1', startLine: 1, endLine: 1, from: 1, to: 1 })
+  }
+
+  return blocks
+}
+
+function clampRichMarkdownAnnotationTarget(
+  editor: Editor,
+  target: RichMarkdownAnnotationTarget
+): RichMarkdownAnnotationTarget | null {
+  const maxPos = Math.max(1, editor.state.doc.content.size)
+  const from = Math.max(1, Math.min(target.from, maxPos))
+  const to = Math.max(1, Math.min(target.to, maxPos))
+  const clampedFrom = Math.min(from, to)
+  const clampedTo = Math.max(from, to)
+  if (clampedFrom === clampedTo) {
+    return null
+  }
+  return { ...target, from: clampedFrom, to: clampedTo }
+}
+
+function clearRichMarkdownNotePositions(
+  setNotePositions: React.Dispatch<React.SetStateAction<RichMarkdownNotePosition[]>>
+): void {
+  setNotePositions((current) => (current.length === 0 ? current : []))
+}
+
+type RichMarkdownTextChar = {
+  value: string
+  pos: number | null
+}
+
+function normalizeRichMarkdownTextWithPositions(
+  chars: RichMarkdownTextChar[]
+): RichMarkdownTextChar[] {
+  const normalized: RichMarkdownTextChar[] = []
+  let previousWasWhitespace = false
+  for (const char of chars) {
+    if (/\s/.test(char.value)) {
+      if (!previousWasWhitespace) {
+        normalized.push({ value: ' ', pos: char.pos })
+      }
+      previousWasWhitespace = true
+      continue
+    }
+    normalized.push(char)
+    previousWasWhitespace = false
+  }
+  return normalized
+}
+
+function collectRichMarkdownTextChars(
+  editor: Editor,
+  from = 0,
+  to = editor.state.doc.content.size
+): RichMarkdownTextChar[] {
+  const chars: RichMarkdownTextChar[] = []
+  editor.state.doc.nodesBetween(from, to, (node, pos) => {
+    if (!node.isText || !node.text) {
+      return
+    }
+    if (chars.length > 0) {
+      chars.push({ value: ' ', pos: null })
+    }
+    for (let index = 0; index < node.text.length; index += 1) {
+      chars.push({ value: node.text[index], pos: pos + index })
+    }
+  })
+  return chars
+}
+
+function findRichMarkdownTextRanges(
+  chars: RichMarkdownTextChar[],
+  selectedText: string
+): RichMarkdownAnnotationHighlightRange[] {
+  const normalizedChars = normalizeRichMarkdownTextWithPositions(chars)
+  const haystack = normalizedChars.map((char) => char.value).join('')
+  const needle = normalizeRichMarkdownTextWithPositions(
+    Array.from(selectedText).map((value) => ({ value, pos: null }))
+  )
+    .map((char) => char.value)
+    .join('')
+  const start = haystack.indexOf(needle)
+  if (start === -1) {
+    return []
+  }
+
+  const positions = normalizedChars
+    .slice(start, start + needle.length)
+    .map((char) => char.pos)
+    .filter((pos): pos is number => pos !== null)
+    .sort((left, right) => left - right)
+  if (positions.length === 0) {
+    return []
+  }
+
+  const ranges: RichMarkdownAnnotationHighlightRange[] = []
+  let from = positions[0]
+  let to = positions[0] + 1
+  for (const pos of positions.slice(1)) {
+    if (pos === to) {
+      to += 1
+      continue
+    }
+    ranges.push({ from, to })
+    from = pos
+    to = pos + 1
+  }
+  ranges.push({ from, to })
+  return ranges
+}
+
+function getRichMarkdownAnnotationHighlightRanges(
+  editor: Editor,
+  comments: readonly DiffComment[],
+  markdownSourceLineOffset: number
+): RichMarkdownAnnotationHighlightRange[] {
+  const blocks = buildRichMarkdownCommentBlocks(editor)
+  return comments.flatMap((comment) => {
+    const selectedText = comment.selectedText?.trim()
+    if (!selectedText) {
+      return []
+    }
+    const bodyLineNumber = Math.max(1, comment.lineNumber - markdownSourceLineOffset)
+    const block = blocks.find(
+      (candidate) => candidate.startLine <= bodyLineNumber && bodyLineNumber <= candidate.endLine
+    )
+    if (block) {
+      const blockRanges = findRichMarkdownTextRanges(
+        collectRichMarkdownTextChars(editor, block.from, block.to),
+        selectedText
+      )
+      if (blockRanges.length > 0) {
+        return blockRanges
+      }
+    }
+    return findRichMarkdownTextRanges(collectRichMarkdownTextChars(editor), selectedText)
+  })
+}
+
+function getRichMarkdownSelectionRange(editor: Editor): RichMarkdownComposerState {
+  const blocks = buildRichMarkdownCommentBlocks(editor)
+  const { from, to, empty } = editor.state.selection
+  const selectedBlocks = empty
+    ? blocks.filter((block) => block.from <= from && from <= block.to)
+    : blocks.filter((block) => from <= block.to && to >= block.from)
+  const targetBlocks = selectedBlocks.length > 0 ? selectedBlocks : [blocks[0]]
+  const startLine = Math.min(...targetBlocks.map((block) => block.startLine))
+  const lineNumber = Math.max(...targetBlocks.map((block) => block.endLine))
+  return {
+    lineNumber,
+    startLine: startLine === lineNumber ? undefined : startLine
+  }
+}
+
+function getCurrentRichMarkdownSelectionRect(root: HTMLElement): DOMRect | null {
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return null
+  }
+  const range = selection.getRangeAt(0)
+  if (!root.contains(range.commonAncestorContainer)) {
+    return null
+  }
+  const rect = range.getBoundingClientRect()
+  if (rect.width > 0 || rect.height > 0) {
+    return rect
+  }
+  return Array.from(range.getClientRects()).find((candidate) => candidate.width > 0) ?? null
+}
+
+function getRichMarkdownAnnotationTarget(
+  editor: Editor,
+  root: HTMLElement
+): RichMarkdownAnnotationTarget | null {
+  if (editor.state.selection.empty) {
+    return null
+  }
+  const rect = getCurrentRichMarkdownSelectionRect(root)
+  if (!rect) {
+    return null
+  }
+  const selectedText = window.getSelection()?.toString().trim() ?? ''
+  if (!selectedText) {
+    return null
+  }
+  const rootRect = root.getBoundingClientRect()
+  const popoverWidth = 420
+  const left = Math.max(56, rootRect.width - popoverWidth - 24)
+  const buttonTop = Math.max(8, rect.bottom - rootRect.top + 6)
+  return {
+    ...getRichMarkdownSelectionRange(editor),
+    from: editor.state.selection.from,
+    to: editor.state.selection.to,
+    selectedText,
+    top: buttonTop + 28,
+    left,
+    buttonTop,
+    buttonLeft: Math.max(56, rootRect.width - 42)
+  }
+}
+
 export default function RichMarkdownEditor({
   fileId,
   content,
@@ -181,12 +486,28 @@ export default function RichMarkdownEditor({
   markdownDocuments,
   showTableOfContents = false,
   onCloseTableOfContents,
+  markdownAnnotationsEnabled = false,
+  markdownAnnotationFilePath,
+  markdownSourceLineOffset = 0,
+  markdownReviewContent = content,
   headerSlot
 }: RichMarkdownEditorProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
+  const addDiffComment = useAppStore((s) => s.addDiffComment)
+  const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
+  const updateDiffComment = useAppStore((s) => s.updateDiffComment)
+  const allDiffComments = useAppStore((s): DiffComment[] | undefined => {
+    for (const list of Object.values(s.worktreesByRepo)) {
+      const worktree = list.find((candidate) => candidate.id === worktreeId)
+      if (worktree) {
+        return worktree.diffComments
+      }
+    }
+    return undefined
+  })
   const worktreeRoot = useAppStore((s) => {
     for (const list of Object.values(s.worktreesByRepo)) {
       const wt = list.find((w) => w.id === worktreeId)
@@ -232,8 +553,45 @@ export default function RichMarkdownEditor({
   const isApplyingProgrammaticUpdateRef = useRef(false)
   const [linkBubble, setLinkBubble] = useState<LinkBubbleState | null>(null)
   const [isEditingLink, setIsEditingLink] = useState(false)
+  const [annotationTarget, setAnnotationTarget] = useState<RichMarkdownAnnotationTarget | null>(
+    null
+  )
+  const [annotationPopover, setAnnotationPopover] = useState<RichMarkdownAnnotationTarget | null>(
+    null
+  )
+  const [reviewRailOpen, setReviewRailOpen] = useState(false)
+  const [notePositions, setNotePositions] = useState<RichMarkdownNotePosition[]>([])
+  const annotationPopoverRef = useRef<RichMarkdownAnnotationTarget | null>(null)
+  const canAnnotateRichMarkdownRef = useRef(false)
+  const annotationTargetFrameRef = useRef<number | null>(null)
+  const notePositionsFrameRef = useRef<number | null>(null)
   const isEditingLinkRef = useRef(false)
   const typedEmptyOrderedListMarkerRef = useRef(false)
+  const sourceRelativePath = useMemo(
+    () =>
+      markdownAnnotationFilePath
+        ? normalizeRelativePath(markdownAnnotationFilePath)
+        : getRelativePathInsideRoot(filePath, worktreeRoot),
+    [filePath, markdownAnnotationFilePath, worktreeRoot]
+  )
+  const canAnnotateRichMarkdown = Boolean(markdownAnnotationsEnabled && sourceRelativePath !== null)
+  const markdownComments = useMemo(
+    () =>
+      (allDiffComments ?? []).filter(
+        (comment) => comment.filePath === sourceRelativePath && isMarkdownComment(comment)
+      ),
+    [allDiffComments, sourceRelativePath]
+  )
+  const markdownReviewNotes = useMemo(
+    () => sortMarkdownReviewNotes(markdownComments as MarkdownReviewNote[]),
+    [markdownComments]
+  )
+  const markdownReviewPrompt = useMemo(
+    () => formatMarkdownReviewNotes(markdownReviewNotes, markdownReviewContent),
+    [markdownReviewContent, markdownReviewNotes]
+  )
+  const hasMarkdownComments = markdownComments.length > 0
+  const reviewRailVisible = hasMarkdownComments && reviewRailOpen
   const tableOfContentsItems = useMemo(() => buildMarkdownTableOfContents(content), [content])
   const flatTableOfContentsItems = useMemo(
     () => flattenMarkdownTocItems(tableOfContentsItems),
@@ -248,6 +606,8 @@ export default function RichMarkdownEditor({
   onSaveRef.current = onSave
   onOpenDocLinkRef.current = onOpenDocLink
   isEditingLinkRef.current = isEditingLink
+  annotationPopoverRef.current = annotationPopover
+  canAnnotateRichMarkdownRef.current = canAnnotateRichMarkdown
 
   const flushPendingSerialization = useCallback(() => {
     if (serializeTimerRef.current === null) {
@@ -273,6 +633,85 @@ export default function RichMarkdownEditor({
     // a dirty-without-draft window during the debounce period.
     return registerPendingEditorFlush(fileId, flushPendingSerialization)
   }, [fileId, flushPendingSerialization])
+
+  const syncAnnotationTarget = useCallback((nextEditor: Editor): void => {
+    if (annotationTargetFrameRef.current !== null) {
+      window.cancelAnimationFrame(annotationTargetFrameRef.current)
+    }
+    annotationTargetFrameRef.current = window.requestAnimationFrame(() => {
+      annotationTargetFrameRef.current = null
+      const root = rootRef.current
+      if (!root || annotationPopoverRef.current || !canAnnotateRichMarkdownRef.current) {
+        setAnnotationTarget(null)
+        return
+      }
+      setAnnotationTarget(getRichMarkdownAnnotationTarget(nextEditor, root))
+    })
+  }, [])
+
+  const syncNotePositions = useCallback((): void => {
+    const ed = editorRef.current
+    const root = rootRef.current
+    if (
+      !reviewRailVisible ||
+      !canAnnotateRichMarkdown ||
+      !ed ||
+      !root ||
+      markdownComments.length === 0
+    ) {
+      clearRichMarkdownNotePositions(setNotePositions)
+      return
+    }
+    const rootRect = root.getBoundingClientRect()
+    const blocks = buildRichMarkdownCommentBlocks(ed)
+    const nextPositions = markdownComments
+      .map((comment): RichMarkdownNotePosition | null => {
+        const bodyLineNumber = Math.max(1, comment.lineNumber - markdownSourceLineOffset)
+        const block = blocks.find(
+          (candidate) =>
+            candidate.startLine <= bodyLineNumber && bodyLineNumber <= candidate.endLine
+        )
+        if (!block) {
+          return null
+        }
+        try {
+          const coords = ed.view.coordsAtPos(Math.min(block.to, ed.state.doc.content.size))
+          return {
+            comment,
+            top: Math.max(8, coords.bottom - rootRect.top + 6)
+          }
+        } catch {
+          return null
+        }
+      })
+      .filter((position): position is RichMarkdownNotePosition => position !== null)
+      .sort(
+        (left, right) => left.top - right.top || left.comment.createdAt - right.comment.createdAt
+      )
+    let nextOpenTop = 0
+    setNotePositions(
+      nextPositions.map((position) => {
+        const top = Math.max(position.top, nextOpenTop)
+        const estimatedHeight = 72 + position.comment.body.split('\n').length * 18
+        nextOpenTop = top + estimatedHeight + 8
+        return { ...position, top }
+      })
+    )
+  }, [canAnnotateRichMarkdown, markdownComments, markdownSourceLineOffset, reviewRailVisible])
+
+  const requestSyncNotePositions = useCallback((): void => {
+    if (!reviewRailVisible) {
+      clearRichMarkdownNotePositions(setNotePositions)
+      return
+    }
+    if (notePositionsFrameRef.current !== null) {
+      return
+    }
+    notePositionsFrameRef.current = window.requestAnimationFrame(() => {
+      notePositionsFrameRef.current = null
+      syncNotePositions()
+    })
+  }, [reviewRailVisible, syncNotePositions])
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -425,6 +864,7 @@ export default function RichMarkdownEditor({
     },
     onBlur: () => {
       window.api.ui.setMarkdownEditorFocused(false)
+      setAnnotationTarget(null)
     },
     onCreate: ({ editor: nextEditor }) => {
       // Why: markdown soft line breaks produce paragraphs with embedded `\n` chars.
@@ -483,6 +923,7 @@ export default function RichMarkdownEditor({
     onSelectionUpdate: ({ editor: nextEditor }) => {
       syncSlashMenu(nextEditor, rootRef.current, setSlashMenu)
       syncDocLinkMenu(nextEditor, rootRef.current, setDocLinkMenu)
+      syncAnnotationTarget(nextEditor)
 
       // Sync link bubble: show preview when cursor is on a link, hide otherwise.
       // Any selection change in the editor cancels an in-progress link edit.
@@ -502,6 +943,105 @@ export default function RichMarkdownEditor({
   useEffect(() => {
     editorRef.current = editor ?? null
   }, [editor])
+
+  const clearAnnotationHighlight = useCallback((): void => {
+    const ed = editorRef.current
+    if (!ed) {
+      return
+    }
+    ed.view.dispatch(ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, null))
+  }, [])
+
+  const clearAllAnnotationHighlights = useCallback((): void => {
+    const ed = editorRef.current
+    if (!ed) {
+      return
+    }
+    ed.view.dispatch(
+      ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, {
+        activeRange: null,
+        noteRanges: []
+      })
+    )
+  }, [])
+
+  useEffect(() => {
+    if (canAnnotateRichMarkdown) {
+      return
+    }
+    setAnnotationTarget(null)
+    setAnnotationPopover(null)
+    clearAllAnnotationHighlights()
+  }, [canAnnotateRichMarkdown, clearAllAnnotationHighlights])
+
+  useEffect(() => {
+    return () => clearAllAnnotationHighlights()
+  }, [clearAllAnnotationHighlights])
+
+  useEffect(() => {
+    if (!editor || !canAnnotateRichMarkdown) {
+      return
+    }
+    const noteRanges = getRichMarkdownAnnotationHighlightRanges(
+      editor,
+      markdownComments,
+      markdownSourceLineOffset
+    )
+    editor.view.dispatch(
+      editor.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, { noteRanges })
+    )
+  }, [canAnnotateRichMarkdown, content, editor, markdownComments, markdownSourceLineOffset])
+
+  useEffect(() => {
+    if (!editor) {
+      return
+    }
+    const container = scrollContainerRef.current
+    if (!container) {
+      return
+    }
+    const update = (): void => syncAnnotationTarget(editor)
+    container.addEventListener('scroll', update)
+    window.addEventListener('resize', update)
+    return () => {
+      container.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [editor, syncAnnotationTarget])
+
+  useEffect(() => {
+    requestSyncNotePositions()
+  }, [content, editor, markdownComments, requestSyncNotePositions])
+
+  useEffect(() => {
+    if (!reviewRailVisible) {
+      clearRichMarkdownNotePositions(setNotePositions)
+      return
+    }
+    const container = scrollContainerRef.current
+    if (!container) {
+      return
+    }
+    const update = (): void => requestSyncNotePositions()
+    container.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+    requestSyncNotePositions()
+    return () => {
+      container.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [requestSyncNotePositions, reviewRailVisible])
+
+  useEffect(() => {
+    return () => {
+      if (annotationTargetFrameRef.current !== null) {
+        window.cancelAnimationFrame(annotationTargetFrameRef.current)
+      }
+      if (notePositionsFrameRef.current !== null) {
+        window.cancelAnimationFrame(notePositionsFrameRef.current)
+      }
+    }
+  }, [])
 
   // Why: TipTap's onBlur may not fire on unmount paths (tab close, HMR,
   // component teardown while focused), leaving the main-process flag stale at
@@ -646,6 +1186,90 @@ export default function RichMarkdownEditor({
     setSlashMenu(null)
     setEmojiMenu({ left: menu.left, top: menu.top })
   }, [])
+
+  const submitAnnotation = useCallback(
+    async (body: string): Promise<void> => {
+      if (!annotationPopover || sourceRelativePath === null) {
+        return
+      }
+      const result = await addDiffComment({
+        worktreeId,
+        filePath: sourceRelativePath,
+        source: 'markdown',
+        startLine:
+          annotationPopover.startLine === undefined
+            ? undefined
+            : annotationPopover.startLine + markdownSourceLineOffset,
+        lineNumber: annotationPopover.lineNumber + markdownSourceLineOffset,
+        selectedText: annotationPopover.selectedText,
+        body,
+        side: 'modified'
+      })
+      if (result) {
+        const ed = editorRef.current
+        if (ed) {
+          const noteRanges = getRichMarkdownAnnotationHighlightRanges(
+            ed,
+            [...markdownComments, result],
+            markdownSourceLineOffset
+          )
+          const hasSubmittedRange = noteRanges.some(
+            (range) => range.from <= annotationPopover.from && annotationPopover.to <= range.to
+          )
+          ed.view.dispatch(
+            ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, {
+              activeRange: null,
+              noteRanges: hasSubmittedRange
+                ? noteRanges
+                : [...noteRanges, { from: annotationPopover.from, to: annotationPopover.to }]
+            })
+          )
+        }
+        setAnnotationPopover(null)
+        clearAnnotationHighlight()
+        window.getSelection()?.removeAllRanges()
+      } else {
+        console.error('Failed to add markdown comment — draft preserved')
+      }
+    },
+    [
+      addDiffComment,
+      annotationPopover,
+      clearAnnotationHighlight,
+      markdownComments,
+      markdownSourceLineOffset,
+      sourceRelativePath,
+      worktreeId
+    ]
+  )
+
+  const openAnnotationPopover = useCallback((): void => {
+    if (!annotationTarget || !canAnnotateRichMarkdown) {
+      return
+    }
+    const ed = editorRef.current
+    const root = rootRef.current
+    const liveTarget = ed && root ? getRichMarkdownAnnotationTarget(ed, root) : null
+    const target = ed
+      ? clampRichMarkdownAnnotationTarget(ed, liveTarget ?? annotationTarget)
+      : annotationTarget
+    if (!target) {
+      setAnnotationTarget(null)
+      return
+    }
+    if (ed) {
+      ed.view.dispatch(
+        ed.state.tr.setMeta(richMarkdownAnnotationHighlightPluginKey, {
+          activeRange: {
+            from: target.from,
+            to: target.to
+          }
+        })
+      )
+    }
+    setAnnotationPopover(target)
+    setAnnotationTarget(null)
+  }, [annotationTarget, canAnnotateRichMarkdown])
 
   useEffect(() => {
     handleEmojiPickRef.current = openEmojiMenu
@@ -803,7 +1427,9 @@ export default function RichMarkdownEditor({
     <div className="rich-markdown-editor-layout">
       <div
         ref={rootRef}
-        className="rich-markdown-editor-shell"
+        className={`rich-markdown-editor-shell ${
+          reviewRailVisible ? 'has-rich-markdown-review-notes' : ''
+        }`.trim()}
         style={{ '--editor-font-zoom-level': editorFontZoomLevel } as React.CSSProperties}
       >
         <RichMarkdownToolbar
@@ -854,7 +1480,7 @@ export default function RichMarkdownEditor({
             onOpen={handleLinkOpen}
           />
         ) : null}
-        {slashMenu && filteredSlashCommands.length > 0 ? (
+        {slashMenu ? (
           <RichMarkdownSlashMenu
             editor={editor}
             slashMenu={slashMenu}
@@ -880,6 +1506,135 @@ export default function RichMarkdownEditor({
             totalMatches={docLinkTotalMatches}
             selectedIndex={selectedDocLinkIndex}
           />
+        ) : null}
+        {annotationTarget ? (
+          <button
+            type="button"
+            className="orca-diff-comment-add-btn rich-markdown-comment-add-btn"
+            style={{
+              top: annotationTarget?.buttonTop ?? 56,
+              left: annotationTarget?.buttonLeft ?? 16
+            }}
+            title="Add review note"
+            aria-label="Add review note"
+            onMouseDown={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              openAnnotationPopover()
+            }}
+          >
+            <Plus className="size-3" />
+          </button>
+        ) : null}
+        {annotationPopover ? (
+          <DiffCommentPopover
+            key={`${annotationPopover.startLine ?? annotationPopover.lineNumber}:${annotationPopover.lineNumber}`}
+            lineNumber={annotationPopover.lineNumber + markdownSourceLineOffset}
+            startLine={
+              annotationPopover.startLine === undefined
+                ? undefined
+                : annotationPopover.startLine + markdownSourceLineOffset
+            }
+            top={annotationPopover.top}
+            left={annotationPopover.left}
+            title="Selected text"
+            onCancel={() => {
+              setAnnotationPopover(null)
+              clearAnnotationHighlight()
+            }}
+            onSubmit={submitAnnotation}
+          />
+        ) : null}
+        {hasMarkdownComments ? (
+          <div className="rich-markdown-review-rail-actions">
+            <button
+              type="button"
+              className="rich-markdown-review-rail-toggle"
+              aria-label={reviewRailOpen ? 'Hide review notes' : 'Show review notes'}
+              aria-expanded={reviewRailOpen}
+              title={reviewRailOpen ? 'Hide review notes' : 'Show review notes'}
+              onClick={() => setReviewRailOpen((open) => !open)}
+            >
+              <MessageSquare className="size-3.5" />
+              <span>{markdownComments.length}</span>
+            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="rich-markdown-review-rail-send"
+                  title="Send notes to a new agent"
+                  aria-label="Send notes to a new agent"
+                >
+                  <Send className="size-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[180px]">
+                <QuickLaunchAgentMenuItems
+                  worktreeId={worktreeId}
+                  groupId={worktreeId}
+                  onFocusTerminal={focusTerminalTabSurface}
+                  prompt={markdownReviewPrompt}
+                  promptDelivery="draft"
+                  launchSource="notes_send"
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ) : null}
+        {reviewRailVisible && notePositions.length > 0 ? (
+          <div className="rich-markdown-review-note-layer" aria-label="Review notes">
+            {notePositions.map(({ comment, top }) => (
+              <div
+                key={comment.id}
+                className="rich-markdown-review-note-card"
+                style={{ top }}
+                onMouseDown={(event) => event.stopPropagation()}
+              >
+                <DiffCommentCard
+                  lineNumber={comment.lineNumber}
+                  startLine={comment.startLine}
+                  body={comment.body}
+                  onDelete={() => void deleteDiffComment(worktreeId, comment.id)}
+                  onSubmitEdit={(body) => updateDiffComment(worktreeId, comment.id, body)}
+                  onContentResize={syncNotePositions}
+                  headerActions={
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className="rich-markdown-review-note-send"
+                          title="Send note to a new agent"
+                          aria-label="Send note to a new agent"
+                          onMouseDown={(event) => event.stopPropagation()}
+                          onClick={(event) => event.stopPropagation()}
+                        >
+                          <Send className="size-3.5" />
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="min-w-[180px]">
+                        <QuickLaunchAgentMenuItems
+                          worktreeId={worktreeId}
+                          groupId={worktreeId}
+                          onFocusTerminal={focusTerminalTabSurface}
+                          prompt={formatMarkdownReviewNotes(
+                            [comment as MarkdownReviewNote],
+                            markdownReviewContent
+                          )}
+                          promptDelivery="draft"
+                          launchSource="notes_send"
+                        />
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  }
+                />
+              </div>
+            ))}
+          </div>
         ) : null}
       </div>
       {showTableOfContents ? (

--- a/src/renderer/src/components/editor/RichMarkdownSlashMenu.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSlashMenu.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { RichMarkdownSlashMenu } from './RichMarkdownSlashMenu'
+
+describe('RichMarkdownSlashMenu', () => {
+  it('keeps a visible search field when there are no matching blocks', () => {
+    const html = renderToStaticMarkup(
+      <RichMarkdownSlashMenu
+        editor={null}
+        slashMenu={{ query: 'zzz', from: 1, to: 5, left: 0, top: 0 }}
+        filteredCommands={[]}
+        selectedIndex={0}
+        onImagePick={() => {}}
+        onEmojiPick={() => {}}
+      />
+    )
+
+    expect(html).toContain('aria-label="Search blocks"')
+    expect(html).toContain('value="zzz"')
+    expect(html).toContain('No blocks found')
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownSlashMenu.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSlashMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Editor } from '@tiptap/react'
+import { Search } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { runSlashCommand } from './rich-markdown-commands'
 import type { SlashCommand, SlashMenuState } from './rich-markdown-commands'
@@ -25,40 +26,62 @@ export function RichMarkdownSlashMenu({
 
   return (
     <div
-      className="rich-markdown-slash-menu scrollbar-sleek"
+      className="rich-markdown-slash-menu"
       style={{ left: slashMenu.left, top: slashMenu.top }}
-      role="listbox"
+      role="dialog"
       aria-label="Slash commands"
     >
-      {filteredCommands.map((command, index) => {
-        const showGroup = command.group !== currentGroup
-        currentGroup = command.group
-        return (
-          <React.Fragment key={command.id}>
-            {showGroup ? <div className="rich-markdown-slash-section">{command.group}</div> : null}
-            <button
-              type="button"
-              title={command.description}
-              className={cn('rich-markdown-slash-item', index === selectedIndex && 'is-active')}
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() =>
-                editor && runSlashCommand(editor, slashMenu, command, onImagePick, onEmojiPick)
-              }
-            >
-              <span className="rich-markdown-slash-icon">
-                {command.icon.kind === 'component' ? (
-                  <command.icon.component className="size-3.5" />
-                ) : (
-                  <span className="text-sm leading-none">{command.icon.value}</span>
-                )}
-              </span>
-              <span className="flex min-w-0 flex-1 flex-col items-start">
-                <span className="truncate text-[13px] font-medium leading-5">{command.label}</span>
-              </span>
-            </button>
-          </React.Fragment>
-        )
-      })}
+      <div className="rich-markdown-slash-search" onMouseDown={(event) => event.preventDefault()}>
+        <Search className="size-3.5" />
+        <input
+          aria-label="Search blocks"
+          readOnly
+          type="text"
+          value={slashMenu.query}
+          placeholder="Search blocks..."
+        />
+      </div>
+      <div className="rich-markdown-slash-results scrollbar-sleek" role="listbox">
+        {filteredCommands.length === 0 ? (
+          <div className="rich-markdown-slash-empty">No blocks found</div>
+        ) : (
+          filteredCommands.map((command, index) => {
+            const showGroup = command.group !== currentGroup
+            currentGroup = command.group
+            return (
+              <React.Fragment key={command.id}>
+                {showGroup ? (
+                  <div className="rich-markdown-slash-section">{command.group}</div>
+                ) : null}
+                <button
+                  type="button"
+                  title={command.description}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  className={cn('rich-markdown-slash-item', index === selectedIndex && 'is-active')}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() =>
+                    editor && runSlashCommand(editor, slashMenu, command, onImagePick, onEmojiPick)
+                  }
+                >
+                  <span className="rich-markdown-slash-icon">
+                    {command.icon.kind === 'component' ? (
+                      <command.icon.component className="size-3.5" />
+                    ) : (
+                      <span className="text-sm leading-none">{command.icon.value}</span>
+                    )}
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col items-start">
+                    <span className="truncate text-[13px] font-medium leading-5">
+                      {command.label}
+                    </span>
+                  </span>
+                </button>
+              </React.Fragment>
+            )
+          })
+        )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/editor/rich-markdown-annotation-highlight.ts
+++ b/src/renderer/src/components/editor/rich-markdown-annotation-highlight.ts
@@ -1,0 +1,102 @@
+import { Extension } from '@tiptap/core'
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+type RichMarkdownAnnotationHighlightState = {
+  activeRange: RichMarkdownAnnotationHighlightRange | null
+  noteRanges: RichMarkdownAnnotationHighlightRange[]
+  decorations: DecorationSet
+}
+
+export type RichMarkdownAnnotationHighlightRange = {
+  from: number
+  to: number
+}
+
+type RichMarkdownAnnotationHighlightMeta = {
+  activeRange?: RichMarkdownAnnotationHighlightRange | null
+  noteRanges?: RichMarkdownAnnotationHighlightRange[]
+} | null
+
+export const richMarkdownAnnotationHighlightPluginKey =
+  new PluginKey<RichMarkdownAnnotationHighlightState>('richMarkdownAnnotationHighlight')
+
+function createAnnotationDecorations(
+  doc: ProseMirrorNode,
+  activeRange: RichMarkdownAnnotationHighlightRange | null,
+  noteRanges: RichMarkdownAnnotationHighlightRange[]
+): DecorationSet {
+  const decorations = [...noteRanges, ...(activeRange ? [activeRange] : [])]
+    .map((range) => {
+      const from = Math.min(range.from, range.to)
+      const to = Math.max(range.from, range.to)
+      return from === to
+        ? null
+        : Decoration.inline(from, to, {
+            class: 'rich-markdown-annotation-selection'
+          })
+    })
+    .filter((decoration): decoration is Decoration => decoration !== null)
+  return decorations.length === 0 ? DecorationSet.empty : DecorationSet.create(doc, decorations)
+}
+
+function createRichMarkdownAnnotationHighlightPlugin(): Plugin<RichMarkdownAnnotationHighlightState> {
+  return new Plugin<RichMarkdownAnnotationHighlightState>({
+    key: richMarkdownAnnotationHighlightPluginKey,
+    state: {
+      init: () => ({
+        activeRange: null,
+        noteRanges: [],
+        decorations: DecorationSet.empty
+      }),
+      apply: (tr, pluginState) => {
+        const meta = tr.getMeta(richMarkdownAnnotationHighlightPluginKey) as
+          | RichMarkdownAnnotationHighlightMeta
+          | undefined
+        if (meta === null) {
+          return {
+            activeRange: null,
+            noteRanges: pluginState.noteRanges,
+            decorations: createAnnotationDecorations(tr.doc, null, pluginState.noteRanges)
+          }
+        }
+        if (meta) {
+          const activeRange =
+            meta.activeRange === undefined ? pluginState.activeRange : meta.activeRange
+          const noteRanges =
+            meta.noteRanges === undefined ? pluginState.noteRanges : meta.noteRanges
+          return {
+            activeRange,
+            noteRanges,
+            decorations: createAnnotationDecorations(tr.doc, activeRange, noteRanges)
+          }
+        }
+        if (tr.docChanged) {
+          return {
+            ...pluginState,
+            decorations: pluginState.decorations.map(tr.mapping, tr.doc)
+          }
+        }
+        return pluginState
+      }
+    },
+    props: {
+      decorations(state) {
+        return (
+          richMarkdownAnnotationHighlightPluginKey.getState(state)?.decorations ??
+          DecorationSet.empty
+        )
+      }
+    }
+  })
+}
+
+export function createRichMarkdownAnnotationHighlightExtension(): Extension {
+  return Extension.create({
+    name: 'richMarkdownAnnotationHighlight',
+    addProseMirrorPlugins() {
+      return [createRichMarkdownAnnotationHighlightPlugin()]
+    }
+  })
+}

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -20,6 +20,7 @@ import { MarkdownDocLink } from './rich-markdown-doc-link'
 import { RichMarkdownCodeBlock } from './RichMarkdownCodeBlock'
 import { safeReactNodeViewRenderer } from './safe-react-node-view-renderer'
 import { DragSelectionGuard } from './drag-selection-guard'
+import { createRichMarkdownAnnotationHighlightExtension } from './rich-markdown-annotation-highlight'
 
 const lowlight = createLowlight(common)
 
@@ -165,7 +166,8 @@ export function createRichMarkdownExtensions({
       markedOptions: {
         gfm: true
       }
-    })
+    }),
+    createRichMarkdownAnnotationHighlightExtension()
   ]
 
   if (includePlaceholder) {

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
@@ -145,4 +145,26 @@ describe('rich markdown key handler', () => {
       editor.destroy()
     }
   })
+
+  it('dismisses the slash menu on Escape even when search has no matches', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: '/zzz' }] }]
+    })
+
+    try {
+      editor.commands.setTextSelection(5)
+      const ctx = createContext(editor, false)
+      ctx.slashMenuRef.current = { query: 'zzz', from: 1, to: 5, left: 0, top: 0 }
+      ctx.filteredSlashCommandsRef.current = []
+      ctx.setSlashMenu = vi.fn()
+      const event = keyEvent('Escape')
+
+      expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(ctx.setSlashMenu).toHaveBeenCalledWith(null)
+    } finally {
+      editor.destroy()
+    }
+  })
 })

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -234,6 +234,12 @@ export function createRichMarkdownKeyHandler(
 
     const currentFilteredSlashCommands = ctx.filteredSlashCommandsRef.current
 
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      ctx.setSlashMenu(null)
+      return true
+    }
+
     if (currentFilteredSlashCommands.length === 0) {
       return false
     }
@@ -277,12 +283,6 @@ export function createRichMarkdownKeyHandler(
       }
       return true
     }
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      ctx.setSlashMenu(null)
-      return true
-    }
-
     return false
   }
 }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2518,6 +2518,7 @@ function SourceControlInner(): React.JSX.Element {
                     groupId={activeGroupId ?? activeWorktreeId}
                     onFocusTerminal={focusTerminalTabSurface}
                     prompt={diffCommentsPrompt}
+                    promptDelivery="draft"
                     launchSource="notes_send"
                   />
                 </DropdownMenuContent>

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -618,14 +618,14 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
 
         <SearchableSetting
           title="Markdown Review Notes"
-          description="Show local markdown review note controls and the review panel."
+          description="Show local markdown review note controls in rich editor mode."
           keywords={['markdown', 'review', 'notes', 'annotations', 'agents']}
           className="flex items-center justify-between gap-4 px-1 py-2"
         >
           <div className="space-y-0.5">
             <Label>Markdown Review Notes</Label>
             <p className="text-xs text-muted-foreground">
-              Show local markdown note controls, the review panel, and agent handoff actions.
+              Show local markdown note controls in rich editor mode and agent handoff actions.
             </p>
           </div>
           <button

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -56,7 +56,7 @@ export const GENERAL_EDITOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   },
   {
     title: 'Markdown Review Notes',
-    description: 'Show local markdown review note controls and the review panel.',
+    description: 'Show local markdown review note controls in rich editor mode.',
     keywords: ['markdown', 'review', 'notes', 'annotations', 'agents']
   }
 ]

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -21,6 +21,8 @@ export type QuickLaunchAgentMenuItemsProps = {
    *  the picked agent boots with this prompt — argv/flag agents auto-submit,
    *  followup-path agents land it as a draft for the user to confirm. */
   prompt?: string
+  /** Use `'draft'` for generated context that must not become shell syntax. */
+  promptDelivery?: 'auto-submit' | 'draft'
   /** Telemetry surface for `agent_started.launch_source`. Defaults to
    *  `'tab_bar_quick_launch'` so the existing tab-bar `+` callsite is
    *  unchanged. */
@@ -51,6 +53,7 @@ function QuickLaunchAgentMenuItemsInner({
   groupId,
   onFocusTerminal,
   prompt,
+  promptDelivery,
   launchSource
 }: QuickLaunchAgentMenuItemsProps): React.JSX.Element | null {
   // Why: must be a reactive selector (not getConnectionId() which reads a
@@ -85,6 +88,7 @@ function QuickLaunchAgentMenuItemsInner({
         worktreeId,
         groupId,
         ...(prompt !== undefined ? { prompt } : {}),
+        ...(promptDelivery !== undefined ? { promptDelivery } : {}),
         ...(launchSource !== undefined ? { launchSource } : {})
       })
       if (!result) {
@@ -117,7 +121,7 @@ function QuickLaunchAgentMenuItemsInner({
         toast.message(`Couldn't launch ${label} — the terminal is still open.`)
       })
     },
-    [worktreeId, groupId, onFocusTerminal, prompt, launchSource]
+    [worktreeId, groupId, onFocusTerminal, prompt, promptDelivery, launchSource]
   )
 
   const agents = detectedIds ? orderAgents(defaultAgent, detectedIds) : []

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -1,6 +1,10 @@
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
-import { buildAgentStartupPlan, type AgentStartupPlan } from '@/lib/tui-agent-startup'
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  type AgentStartupPlan
+} from '@/lib/tui-agent-startup'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
 import { track, tuiAgentToAgentKind } from '@/lib/telemetry'
@@ -19,6 +23,9 @@ export type LaunchAgentInNewTabArgs = {
    *  `promptInjectionMode`: argv/flag agents auto-submit via the launch
    *  command; followup-path agents land the prompt as an unsent draft. */
   prompt?: string
+  /** Force prompt text to land as an editable draft instead of being embedded
+   *  into the shell launch command. Used for generated review-note context. */
+  promptDelivery?: 'auto-submit' | 'draft'
   /** Telemetry surface that initiated this launch. Defaults to the tab-bar
    *  quick-launch entry point so existing callers stay unchanged. */
   launchSource?: LaunchSource
@@ -53,7 +60,7 @@ export type LaunchAgentInNewTabResult = {
  * surface that as a launch failure (see `QuickLaunchButton.runLaunch`).
  */
 export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentInNewTabResult {
-  const { agent, worktreeId, groupId, prompt, launchSource } = args
+  const { agent, worktreeId, groupId, prompt, promptDelivery = 'auto-submit', launchSource } = args
   const store = useAppStore.getState()
   const cmdOverrides = store.settings?.agentCmdOverrides ?? {}
   const trimmedPrompt = prompt?.trim() ?? ''
@@ -70,7 +77,32 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   let startupPlan: AgentStartupPlan | null = null
   let pasteDraftAfterLaunch: string | null = null
 
-  if (hasPrompt && isFollowupPath) {
+  if (hasPrompt && promptDelivery === 'draft') {
+    const draftLaunchPlan = buildAgentDraftLaunchPlan({
+      agent,
+      draft: trimmedPrompt,
+      cmdOverrides,
+      platform: CLIENT_PLATFORM
+    })
+    if (draftLaunchPlan) {
+      startupPlan = {
+        agent: draftLaunchPlan.agent,
+        launchCommand: draftLaunchPlan.launchCommand,
+        expectedProcess: draftLaunchPlan.expectedProcess,
+        followupPrompt: null,
+        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
+      }
+    } else {
+      startupPlan = buildAgentStartupPlan({
+        agent,
+        prompt: '',
+        cmdOverrides,
+        platform: CLIENT_PLATFORM,
+        allowEmptyPromptLaunch: true
+      })
+      pasteDraftAfterLaunch = trimmedPrompt
+    }
+  } else if (hasPrompt && isFollowupPath) {
     startupPlan = buildAgentStartupPlan({
       agent,
       prompt: '',

--- a/src/renderer/src/lib/markdown-review-notes.test.ts
+++ b/src/renderer/src/lib/markdown-review-notes.test.ts
@@ -3,6 +3,7 @@ import type { DiffComment } from '../../../shared/types'
 import {
   formatMarkdownReviewNotes,
   getMarkdownReviewExcerpt,
+  getMarkdownReviewHighlightedText,
   sortMarkdownReviewNotes,
   type MarkdownReviewNote
 } from './markdown-review-notes'
@@ -42,6 +43,24 @@ describe('markdown review notes', () => {
     expect(excerpt).toBe('> two\n> three')
   })
 
+  it('prefers exact selected text for card highlights', () => {
+    const highlighted = getMarkdownReviewHighlightedText(
+      'one\ntwo broad line\nthree',
+      note({ selectedText: 'broad' })
+    )
+
+    expect(highlighted).toBe('broad')
+  })
+
+  it('falls back to unquoted line context for card highlights', () => {
+    const highlighted = getMarkdownReviewHighlightedText(
+      'one\ntwo\nthree',
+      note({ startLine: 2, lineNumber: 3 })
+    )
+
+    expect(highlighted).toBe('two\nthree')
+  })
+
   it('formats a deterministic prompt for terminal agents', () => {
     const formatted = formatMarkdownReviewNotes(
       [note({ startLine: 2, lineNumber: 3, body: 'replace "maybe"\nwith specifics' })],
@@ -59,5 +78,14 @@ describe('markdown review notes', () => {
         'User comment: "replace \\"maybe\\"\\nwith specifics"'
       ].join('\n')
     )
+  })
+
+  it('formats exact selected text when available', () => {
+    const formatted = formatMarkdownReviewNotes(
+      [note({ selectedText: 'specific phrase', lineNumber: 2, body: 'reword this' })],
+      'one\nspecific phrase in a longer line'
+    )
+
+    expect(formatted).toContain('Excerpt:\n> specific phrase')
   })
 })

--- a/src/renderer/src/lib/markdown-review-notes.ts
+++ b/src/renderer/src/lib/markdown-review-notes.ts
@@ -49,6 +49,22 @@ export function getMarkdownReviewExcerpt(
   return excerpt.map((line) => `> ${line}`).join('\n')
 }
 
+export function getMarkdownReviewHighlightedText(
+  content: string,
+  note: Pick<DiffComment, 'lineNumber' | 'selectedText' | 'startLine'>
+): string {
+  const selectedText = note.selectedText?.trim()
+  if (selectedText) {
+    return selectedText
+  }
+  const excerpt = getMarkdownReviewExcerpt(content, note)
+  return excerpt
+    .split('\n')
+    .map((line) => line.replace(/^> ?/, ''))
+    .join('\n')
+    .trim()
+}
+
 export function formatMarkdownReviewNotes(
   notes: readonly MarkdownReviewNote[],
   content: string
@@ -60,7 +76,12 @@ export function formatMarkdownReviewNotes(
         .replace(/"/g, '\\"')
         .replace(/\r/g, '\\r')
         .replace(/\n/g, '\\n')
-      const excerpt = getMarkdownReviewExcerpt(content, note)
+      const excerpt = note.selectedText
+        ? getMarkdownReviewHighlightedText(content, note)
+            .split(/\r\n|\r|\n/)
+            .map((line) => `> ${line}`)
+            .join('\n')
+        : getMarkdownReviewExcerpt(content, note)
       const parts = [
         `File: ${note.filePath}`,
         'Source: markdown',

--- a/src/renderer/src/lib/path.test.ts
+++ b/src/renderer/src/lib/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { dirname, joinPath } from './path'
+import { dirname, getRelativePathInsideRoot, joinPath } from './path'
 
 describe('dirname', () => {
   it('keeps the POSIX root when resolving a file in the filesystem root', () => {
@@ -18,5 +18,21 @@ describe('dirname', () => {
 describe('joinPath', () => {
   it('joins onto a Windows drive root returned by dirname', () => {
     expect(joinPath(dirname('C:\\README.md'), 'image.png')).toBe('C:/image.png')
+  })
+})
+
+describe('getRelativePathInsideRoot', () => {
+  it('matches Windows drive paths case-insensitively', () => {
+    expect(getRelativePathInsideRoot('C:\\Repo\\Docs\\Plan.md', 'c:\\repo')).toBe('Docs/Plan.md')
+  })
+
+  it('matches Windows UNC paths case-insensitively', () => {
+    expect(
+      getRelativePathInsideRoot('\\\\Server\\Share\\Repo\\Docs\\Plan.md', '\\\\server\\share\\repo')
+    ).toBe('Docs/Plan.md')
+  })
+
+  it('keeps POSIX path checks case-sensitive', () => {
+    expect(getRelativePathInsideRoot('/Repo/Docs/Plan.md', '/repo')).toBeNull()
   })
 })

--- a/src/renderer/src/lib/path.ts
+++ b/src/renderer/src/lib/path.ts
@@ -14,6 +14,53 @@ export function normalizeRelativePath(path: string): string {
   return stripLeadingSeparators(path).replace(/[\\/]+/g, '/')
 }
 
+function normalizeAbsolutePath(path: string): string {
+  const isUncPath = /^[\\/]{2}[^\\/]/.test(path)
+  const normalized = path.replace(/[\\/]+/g, '/')
+  return isUncPath && !normalized.startsWith('//') ? `/${normalized}` : normalized
+}
+
+function stripTrailingAbsoluteSeparators(path: string): string {
+  if (path === '/') {
+    return path
+  }
+  return path.replace(/\/+$/, '')
+}
+
+function isCaseInsensitiveAbsolutePath(path: string): boolean {
+  return /^[A-Za-z]:(?:\/|$)/.test(path) || path.startsWith('//')
+}
+
+export function getRelativePathInsideRoot(
+  filePath: string,
+  rootPath: string | null
+): string | null {
+  if (!rootPath) {
+    return null
+  }
+
+  const normalizedFilePath = normalizeAbsolutePath(filePath)
+  const normalizedRoot = stripTrailingAbsoluteSeparators(normalizeAbsolutePath(rootPath))
+  const comparisonFilePath = isCaseInsensitiveAbsolutePath(normalizedFilePath)
+    ? normalizedFilePath.toLowerCase()
+    : normalizedFilePath
+  const comparisonRoot = isCaseInsensitiveAbsolutePath(normalizedRoot)
+    ? normalizedRoot.toLowerCase()
+    : normalizedRoot
+
+  if (comparisonFilePath === comparisonRoot) {
+    return ''
+  }
+
+  const rootPrefix = normalizedRoot === '/' ? '/' : `${comparisonRoot}/`
+  if (!comparisonFilePath.startsWith(rootPrefix)) {
+    return null
+  }
+
+  const sliceStart = normalizedRoot === '/' ? 1 : normalizedRoot.length + 1
+  return normalizeRelativePath(normalizedFilePath.slice(sliceStart))
+}
+
 export function basename(path: string): string {
   const normalizedPath = stripTrailingSeparators(path)
   const lastSeparatorIndex = Math.max(

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -29,11 +29,18 @@ function normalizeDiffComment(comment: DiffComment): DiffComment {
     rawStartLine <= comment.lineNumber
       ? rawStartLine
       : undefined
+  const rawSelectedText = (comment as { selectedText?: unknown }).selectedText
+  const selectedText =
+    typeof rawSelectedText === 'string' && rawSelectedText.trim().length > 0
+      ? rawSelectedText.trim()
+      : undefined
 
   return {
     ...comment,
     ...(source !== undefined ? { source } : {}),
     ...(source === undefined ? { source: undefined } : {}),
+    ...(selectedText !== undefined ? { selectedText } : {}),
+    ...(selectedText === undefined ? { selectedText: undefined } : {}),
     ...(startLine !== undefined ? { startLine } : {}),
     ...(startLine === undefined ? { startLine: undefined } : {})
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -261,6 +261,8 @@ export type DiffComment = {
   filePath: string
   /** Undefined means a legacy diff note. */
   source?: DiffCommentSource
+  /** Exact text selected when creating a markdown note, when available. */
+  selectedText?: string
   /** Inclusive range start. Must be <= lineNumber when present. */
   startLine?: number
   lineNumber: number


### PR DESCRIPTION
## Summary
- add rich markdown annotation support and note highlighting
- wire annotation state through markdown editor, preview, and diff surfaces
- add regression coverage for rich markdown menus, review notes, path handling, key handling, and front-matter line offsets

## Validation
- pnpm typecheck
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/EditorContent.test.tsx
- review round 2: no Critical/High/Medium issues found