### PR TITLE
Fix failing E2E assertions

### DIFF
--- a/tests/e2e/tasks-page.spec.ts
+++ b/tests/e2e/tasks-page.spec.ts
@@ -2,7 +2,7 @@
  * E2E tests for the Tasks page.
  *
  * Verifies that opening the tasks view renders correctly and that the
- * repo selector, preset tabs, and close affordance are all present.
+ * repo selector, mode tabs, and close affordance are all present.
  */
 
 import { test, expect } from './helpers/orca-app'
@@ -28,13 +28,17 @@ test.describe('Tasks page', () => {
       .poll(async () => getStoreState<string>(orcaPage, 'activeView'), { timeout: 5_000 })
       .toBe('tasks')
 
-    // Titlebar label, close button, and preset tabs should all render.
+    // Titlebar label, close button, and mode tabs should all render.
     await expect(orcaPage.getByRole('button', { name: 'Close tasks' })).toBeVisible({
       timeout: 10_000
     })
     await expect(orcaPage.getByRole('button', { name: 'GitHub', exact: true })).toBeVisible()
-    await expect(orcaPage.getByRole('button', { name: 'All', exact: true })).toBeVisible()
-    await expect(orcaPage.getByPlaceholder(/GitHub search/i)).toBeVisible()
+    await expect(orcaPage.getByRole('button', { name: 'Issues', exact: true })).toBeVisible()
+    await expect(orcaPage.getByRole('button', { name: 'PRs', exact: true })).toBeVisible()
+    await expect(orcaPage.getByRole('button', { name: 'Projects', exact: true })).toBeVisible()
+    await expect(
+      orcaPage.getByRole('textbox', { name: /Search GitHub (issues|PRs)/i })
+    ).toBeVisible()
   })
 
   test('closing the tasks page returns to the previous view', async ({ orcaPage }) => {

--- a/tests/e2e/terminal-panes.spec.ts
+++ b/tests/e2e/terminal-panes.spec.ts
@@ -53,6 +53,14 @@ async function setPaneTitleFromTerminalMenu(page: Page, title: string): Promise<
   await expect(titleInput).toBeVisible()
   await titleInput.fill(title)
   await titleInput.press('Enter')
+  // Why: CI can dispatch Enter before React has committed the filled value;
+  // blurring exercises the same submit path and makes the helper deterministic.
+  try {
+    await expect(titleInput).toHaveCount(0, { timeout: 500 })
+  } catch {
+    await titleInput.evaluateAll(([input]) => (input as HTMLElement | undefined)?.blur())
+  }
+  await expect(titleInput).toHaveCount(0)
 }
 
 async function getTabCustomTitle(
@@ -217,8 +225,12 @@ test.describe('Terminal Panes', () => {
 
     await orcaPage.getByRole('button', { name: `Edit pane title: ${paneTitle}` }).focus()
     await orcaPage.keyboard.press('Enter')
-    await expect(orcaPage.getByRole('textbox', { name: 'Pane title' })).toBeVisible()
+    const paneTitleInput = orcaPage.getByRole('textbox', { name: 'Pane title' })
+    await expect(paneTitleInput).toBeVisible()
+    await expect(paneTitleInput).toBeFocused()
     await orcaPage.keyboard.press('Escape')
+    await expect(paneTitleInput).toHaveCount(0)
+    await expect(orcaPage.locator('.pane-title-text', { hasText: paneTitle })).toBeVisible()
 
     await orcaPage.evaluate(
       ({ targetTabId, title }) => {

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -363,13 +363,14 @@ test.describe('Terminal Shortcuts', () => {
       keyupSent: true
     })
     await expect
-      .poll(async () => (await getPtyWrites(electronApp)).includes('Ф'), {
+      .poll(async () => (await getPtyWrites(electronApp)).some((write) => write.includes('Ф')), {
         timeout: 5_000,
         message: 'Shift+Russian layout text did not reach the PTY as Cyrillic'
       })
       .toBe(true)
     const writes = await getPtyWrites(electronApp)
-    expect(writes).not.toContain('\x1b[97:1060;2;1060u')
-    expect(writes).not.toContain('\x1b[97:1060;2:3u')
+    const joinedWrites = writes.join('')
+    expect(joinedWrites).not.toContain('\x1b[97:1060;2;1060u')
+    expect(joinedWrites).not.toContain('\x1b[97:1060;2:3u')
   })
 })

--- a/tests/e2e/worktree-lineage.spec.ts
+++ b/tests/e2e/worktree-lineage.spec.ts
@@ -23,7 +23,6 @@ async function seedLineageScenario(page: Page): Promise<LineageScenario> {
     state.setSidebarOpen(true)
     state.setGroupBy('none')
     state.setSortBy('recent')
-    state.setShowWorkspaceLineage(true)
 
     const worktrees = Object.values(state.worktreesByRepo)
       .flat()


### PR DESCRIPTION
## Summary
- Update Tasks page E2E assertions for the current GitHub mode tabs and search textbox
- Remove obsolete workspace-lineage test store call
- Harden terminal pane title and Russian-layout keyboard assertions against CI timing/batched writes

## Verification
- SKIP_BUILD=1 pnpm run test:e2e -- tests/e2e/tasks-page.spec.ts tests/e2e/worktree-lineage.spec.ts tests/e2e/terminal-shortcuts.spec.ts tests/e2e/terminal-panes.spec.ts
- pnpm typecheck
- pnpm lint