### PR TITLE
Align workspace card metadata icons

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -211,7 +211,12 @@ export function WorktreeCardMetaBadges({
   }
 
   return (
-    <div className="ml-auto flex shrink-0 items-center gap-1" aria-label="Workspace metadata">
+    // Why: inline agent rows reserve this same right inset for their dismiss X,
+    // so the card metadata icons align on the same visual rail.
+    <div
+      className="ml-auto flex shrink-0 items-center gap-1 pr-1.5"
+      aria-label="Workspace metadata"
+    >
       {issue && (
         <MetaIconBadge label={`Linked issue #${issue.number}`}>
           <CircleDot className="text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Align the workspace metadata icon rail with inline agent dismiss controls by matching the agent row right inset.

## Perf
- Class-only layout adjustment; no new subscriptions, timers, polling, or DOM work.

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCardMeta.tsx`
- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx`
- `git diff --check origin/main...HEAD`
- Electron verification screenshot attached in PR comment: https://github.com/stablyai/orca/pull/2221#issuecomment-4474733548