### PR TITLE
Improve multi-worktree delete flow

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -8,10 +8,11 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { AlertTriangle, Check, LoaderCircle, Trash2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { toast } from 'sonner'
-import { runWorktreeDeletesSequentially } from './delete-worktree-flow'
+import { runWorktreeDeletesInParallel } from './delete-worktree-flow'
 
 const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -50,14 +51,20 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
     const selected = new Set(worktreeIds)
     return allWorktrees().filter((item) => selected.has(item.id))
   }, [allWorktrees, worktreeIds])
-  const deleteState = useAppStore((s) =>
-    worktreeId ? s.deleteStateByWorktreeId[worktreeId] : undefined
-  )
-  const isDeleting = deleteState?.isDeleting ?? false
-  const deleteError = deleteState?.error ?? null
-  const canForceDelete = deleteState?.canForceDelete ?? false
-  const confirmButtonRef = useRef<HTMLButtonElement>(null)
   const isBatchDelete = worktreeIds.length > 1
+  const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
+  const deleteStates = useMemo(
+    () =>
+      worktreeIds
+        .map((id) => deleteStateByWorktreeId[id])
+        .filter((state): state is NonNullable<typeof state> => state != null),
+    [deleteStateByWorktreeId, worktreeIds]
+  )
+  const deleteState = worktreeId ? deleteStateByWorktreeId[worktreeId] : undefined
+  const isDeleting = deleteStates.some((state) => state.isDeleting)
+  const deleteError = !isBatchDelete ? (deleteState?.error ?? null) : null
+  const canForceDelete = !isBatchDelete && (deleteState?.canForceDelete ?? false)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
   const allowSkipConfirm = !isBatchDelete && modalData.allowSkipConfirm !== false
   // Why: the main worktree is the repo's original clone directory — `git worktree remove`
   // always rejects it. We block the delete button upfront so the user doesn't have to
@@ -77,7 +84,9 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
 
   useEffect(() => {
     if (isOpen && worktreeIds.length > 0 && worktrees.length === 0 && !isDeleting) {
-      clearWorktreeDeleteState(worktreeId)
+      for (const id of worktreeIds) {
+        clearWorktreeDeleteState(id)
+      }
       closeModal()
     }
   }, [
@@ -85,7 +94,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
     closeModal,
     isDeleting,
     isOpen,
-    worktreeId,
+    worktreeIds,
     worktreeIds.length,
     worktrees.length
   ])
@@ -98,12 +107,19 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
       const currentState = worktreeId
         ? useAppStore.getState().deleteStateByWorktreeId[worktreeId]
         : undefined
-      if (worktreeId && !currentState?.isDeleting) {
+      if (isBatchDelete) {
+        const state = useAppStore.getState().deleteStateByWorktreeId
+        for (const id of worktreeIds) {
+          if (!state[id]?.isDeleting) {
+            clearWorktreeDeleteState(id)
+          }
+        }
+      } else if (worktreeId && !currentState?.isDeleting) {
         clearWorktreeDeleteState(worktreeId)
       }
       closeModal()
     },
-    [clearWorktreeDeleteState, closeModal, worktreeId]
+    [clearWorktreeDeleteState, closeModal, isBatchDelete, worktreeId, worktreeIds]
   )
 
   const persistDontAskAgainPreference = useCallback((): void => {
@@ -154,6 +170,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
               return
             }
             onDeleted?.([worktreeId])
+            closeModal()
           })
           .catch((err: unknown) => {
             toast.error('Failed to delete worktree', {
@@ -161,13 +178,16 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             })
           })
       } else {
-        void runWorktreeDeletesSequentially(worktrees).then((deletedIds) => {
+        const targetCount = worktrees.length
+        void runWorktreeDeletesInParallel(worktrees).then((deletedIds) => {
           if (deletedIds.length > 0) {
             onDeleted?.(deletedIds)
           }
+          if (deletedIds.length === targetCount) {
+            closeModal()
+          }
         })
       }
-      closeModal()
     },
     [
       closeModal,
@@ -223,14 +243,36 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
         </DialogHeader>
 
         {isBatchDelete ? (
-          <div className="max-h-48 space-y-1 overflow-y-auto rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
-            {worktrees.map((item) => (
-              <div key={item.id} className="min-w-0 border-b border-border/50 py-1 last:border-0">
-                <div className="break-all font-medium text-foreground">{item.displayName}</div>
-                <div className="mt-0.5 break-all text-muted-foreground">{item.path}</div>
-              </div>
-            ))}
-          </div>
+          <ScrollArea className="max-h-48 rounded-md border border-border/70 bg-muted/35 text-xs">
+            <div className="space-y-1 px-3 py-2">
+              {worktrees.map((item) => {
+                const itemDeleteState = deleteStateByWorktreeId[item.id]
+                return (
+                  <div
+                    key={item.id}
+                    className="min-w-0 border-b border-border/50 py-1 last:border-0"
+                  >
+                    <div className="flex min-w-0 items-start gap-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="break-all font-medium text-foreground">
+                          {item.displayName}
+                        </div>
+                        <div className="mt-0.5 break-all text-muted-foreground">{item.path}</div>
+                        {itemDeleteState?.error ? (
+                          <div className="mt-1 whitespace-pre-wrap break-all text-destructive">
+                            {itemDeleteState.error}
+                          </div>
+                        ) : null}
+                      </div>
+                      {itemDeleteState?.isDeleting ? (
+                        <LoaderCircle className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground" />
+                      ) : null}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </ScrollArea>
         ) : worktree ? (
           <div className="rounded-md border border-border/70 bg-muted/35 px-3 py-2 text-xs">
             <div className="break-all font-medium text-foreground">{worktree.displayName}</div>

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -34,7 +34,18 @@ vi.mock('sonner', () => ({
 }))
 
 import { toast } from 'sonner'
-import { runWorktreeBatchDelete } from './delete-worktree-flow'
+import { runWorktreeBatchDelete, runWorktreeDeletesInParallel } from './delete-worktree-flow'
+
+function deferredDeleteResult(): {
+  promise: Promise<{ ok: true }>
+  resolve: (value: { ok: true }) => void
+} {
+  let resolve: (value: { ok: true }) => void = () => {}
+  const promise = new Promise<{ ok: true }>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
 
 function setWorktrees(
   worktrees: { id: string; displayName?: string; isMainWorktree?: boolean }[]
@@ -148,5 +159,37 @@ describe('runWorktreeBatchDelete', () => {
     expect(toast.info).toHaveBeenCalledWith('No deletable workspaces selected', {
       description: 'Refresh Space and try again if the workspace list looks stale.'
     })
+  })
+})
+
+describe('runWorktreeDeletesInParallel', () => {
+  beforeEach(() => {
+    mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
+    mocks.state.deleteStateByWorktreeId = {}
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.info).mockClear()
+  })
+
+  it('starts every selected delete before waiting for earlier deletes to finish', async () => {
+    const first = deferredDeleteResult()
+    const second = deferredDeleteResult()
+    mocks.state.removeWorktree
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const deleted = runWorktreeDeletesInParallel([
+      { id: 'wt-1', displayName: 'one' },
+      { id: 'wt-2', displayName: 'two' }
+    ])
+
+    expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(2)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', false)
+
+    second.resolve({ ok: true })
+    await Promise.resolve()
+    first.resolve({ ok: true })
+
+    await expect(deleted).resolves.toEqual(['wt-1', 'wt-2'])
   })
 })

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -22,19 +22,16 @@ function viewWorktreeDiff(worktreeId: string): void {
   state.setRightSidebarOpen(true)
 }
 
-export async function runWorktreeDeletesSequentially(
+export async function runWorktreeDeletesInParallel(
   targets: readonly Pick<Worktree, 'id' | 'displayName'>[]
 ): Promise<string[]> {
-  const deletedIds: string[] = []
-  for (const target of targets) {
-    // Why: git worktree removals for one repo contend on git lock files.
-    // Running the user-selected batch sequentially avoids partial lock races.
-    const deleted = await runWorktreeDeleteWithToast(target.id, target.displayName)
-    if (deleted) {
-      deletedIds.push(target.id)
-    }
-  }
-  return deletedIds
+  const results = await Promise.all(
+    targets.map(async (target) => ({
+      worktreeId: target.id,
+      deleted: await runWorktreeDeleteWithToast(target.id, target.displayName)
+    }))
+  )
+  return results.filter((result) => result.deleted).map((result) => result.worktreeId)
 }
 
 /**
@@ -181,7 +178,7 @@ export function runWorktreeBatchDelete(
     targets.length === 1 &&
     (state.settings?.skipDeleteWorktreeConfirm ?? false)
   if (skipConfirm) {
-    void runWorktreeDeletesSequentially(targets).then((deletedIds) => {
+    void runWorktreeDeletesInParallel(targets).then((deletedIds) => {
       if (deletedIds.length > 0) {
         options.onDeleted?.(deletedIds)
       }


### PR DESCRIPTION
## Summary
- replace sequential multi-worktree deletion with parallel batch deletion
- keep the delete dialog open while batch deletes run and show per-worktree progress/errors
- switch the batch worktree list to the shared shadcn ScrollArea

## Validation
- corepack pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
- corepack pnpm run typecheck:web
- corepack pnpm exec oxlint src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx src/renderer/src/components/sidebar/delete-worktree-flow.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
- git diff --check

Note: npm test was blocked by the local pnpm store mismatch/native rebuild path, so validation was run through the repo-pinned pnpm directly.