### PR TITLE
Prepare mobile 0.0.8

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/src/browser/MobileBrowserPane.tsx
+++ b/mobile/src/browser/MobileBrowserPane.tsx
@@ -1023,17 +1023,17 @@ export function MobileBrowserPane({
           label="Back"
           onPress={goBack}
         >
-          <ChevronLeft size={18} color={buttonColor(!controlsDisabled && tab.canGoBack)} />
+          <ChevronLeft size={15} color={buttonColor(!controlsDisabled && tab.canGoBack)} />
         </ToolbarIconButton>
         <ToolbarIconButton
           disabled={controlsDisabled || !tab.canGoForward}
           label="Forward"
           onPress={goForward}
         >
-          <ChevronRight size={18} color={buttonColor(!controlsDisabled && tab.canGoForward)} />
+          <ChevronRight size={15} color={buttonColor(!controlsDisabled && tab.canGoForward)} />
         </ToolbarIconButton>
         <ToolbarIconButton disabled={controlsDisabled} label="Reload" onPress={reloadPage}>
-          <RefreshCw size={17} color={buttonColor(!controlsDisabled)} />
+          <RefreshCw size={15} color={buttonColor(!controlsDisabled)} />
         </ToolbarIconButton>
         <TextInput
           style={styles.addressInput}
@@ -1442,19 +1442,19 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgBase
   },
   toolbar: {
-    minHeight: 48,
+    minHeight: 32,
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
     paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
+    paddingVertical: 2,
     borderBottomWidth: 1,
     borderBottomColor: colors.borderSubtle,
     backgroundColor: colors.bgPanel
   },
   toolbarIconButton: {
-    width: 36,
-    height: 36,
+    width: 26,
+    height: 26,
     borderRadius: radii.button,
     alignItems: 'center',
     justifyContent: 'center'
@@ -1465,14 +1465,14 @@ const styles = StyleSheet.create({
   addressInput: {
     flex: 1,
     minWidth: 0,
-    height: 40,
+    height: 28,
     borderRadius: radii.input,
     backgroundColor: colors.bgRaised,
     color: colors.textPrimary,
     paddingHorizontal: spacing.sm,
     paddingVertical: 0,
-    fontSize: 14,
-    lineHeight: 22,
+    fontSize: 12,
+    lineHeight: 16,
     includeFontPadding: false,
     textAlignVertical: 'center',
     fontFamily: typography.monoFamily


### PR DESCRIPTION
## Summary
- Bump the mobile app version to 0.0.8 while keeping build number 1
- Slightly shorten the mobile browser URL toolbar height

## Testing
- cd mobile && pnpm exec oxlint src/browser/MobileBrowserPane.tsx
- cd mobile && pnpm exec oxfmt --check src/browser/MobileBrowserPane.tsx app.json

## App Store notes
- 0.0.8 includes the voice dictation work from #1869. The iOS microphone purpose string is present in mobile/app.json and says the mic is used to record voice dictation and transcribe it on the paired desktop.

Made with [Orca](https://github.com/stablyai/orca) 🐋
