### PR TITLE
Fix primary selection paste inside Orca

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -36,6 +36,7 @@ import { isMarkdownComment } from '@/lib/diff-comment-compat'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
 import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover-position'
+import { isLinuxUserAgent } from '../terminal-pane/pane-helpers'
 
 type MonacoEditorProps = {
   filePath: string
@@ -640,7 +641,11 @@ export default function MonacoEditor({
             addExtraSpaceOnTop: false,
             autoFindInSelection: 'never',
             seedSearchStringFromSelection: 'never'
-          }
+          },
+          // Why: Monaco has its own Linux primary-selection integration; keep
+          // it aligned with Orca's app-level opt-out instead of relying on the
+          // global DOM hook, which does not own Monaco's rendered line surface.
+          selectionClipboard: settings?.primarySelectionMiddleClickPaste ?? isLinuxUserAgent()
         }}
         path={filePath}
         // Why: keepCurrentModel preserves the Monaco text model so undo/redo

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.ts
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.ts
@@ -45,12 +45,21 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
       return target === pendingMiddleTarget || pendingMiddleTarget.contains(target)
     }
 
-    const rememberPendingTarget = (event: MouseEvent): boolean => {
+    const rememberPendingTarget = (
+      event: MouseEvent,
+      options?: { allowNativeLinuxPaste?: boolean }
+    ): boolean => {
       if (event.button !== 1) {
         return false
       }
       const target = findEditablePrimarySelectionPasteTarget(event.target)
       if (!target) {
+        return false
+      }
+      if (options?.allowNativeLinuxPaste && isLinuxUserAgent()) {
+        // Why: Chromium already implements X11 primary paste for editable DOM
+        // controls. Suppressing that native path can turn a working OS paste
+        // into a no-op before Orca's async fallback runs.
         return false
       }
       pendingMiddleTarget = target
@@ -127,7 +136,7 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
     }
 
     const onMouseDown = (event: MouseEvent): void => {
-      rememberPendingTarget(event)
+      rememberPendingTarget(event, { allowNativeLinuxPaste: true })
     }
 
     const onMouseUp = (event: MouseEvent): void => {
@@ -152,9 +161,14 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
     }
 
     const onAuxClick = (event: MouseEvent): void => {
-      if (event.button === 1 && findEditablePrimarySelectionPasteTarget(event.target)) {
-        suppressEvent(event)
+      if (event.button !== 1) {
+        return
       }
+      const target = findEditablePrimarySelectionPasteTarget(event.target)
+      if (!target || isLinuxUserAgent()) {
+        return
+      }
+      suppressEvent(event)
     }
 
     document.addEventListener('selectionchange', scheduleCapture)


### PR DESCRIPTION
## Summary
- fix Linux middle-click paste in native Orca text controls by letting Chromium handle the native primary-selection paste path instead of suppressing it and replacing it with Orca's async fallback
- align Monaco's built-in Linux `selectionClipboard` option with Orca's middle-click paste setting so editor surfaces respect the same opt-out

Fixes follow-up from #1898: https://github.com/stablyai/orca/issues/1898#issuecomment-4474793120
Refs previous implementation PR #1915.

## Reference research
- Synced `$ref-oss` repos with `sync-ref-oss.sh --all`.
- VS Code/Monaco has a first-class `selectionClipboard` editor option for Linux primary-selection behavior, so this patch uses Monaco's native path for editor surfaces instead of trying to route rendered line clicks through the global DOM hook.
- Tabby handles terminal middle-click paste at the terminal pane level; Orca already does this for xterm panes, so this patch leaves that path intact.

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/primary-selection.test.ts src/shared/constants.test.ts src/main/window/clipboard-ipc-handlers.test.ts`
- `pnpm exec oxlint src/renderer/src/hooks/usePrimarySelectionPaste.ts src/renderer/src/components/editor/MonacoEditor.tsx src/renderer/src/lib/primary-selection.ts src/renderer/src/lib/primary-selection-paste.ts src/renderer/src/lib/primary-selection-capture.ts`
- `pnpm run tc`
- `git diff --check`