### PR TITLE
Simplify workspace property menu

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1118,6 +1118,20 @@ describe('Store', () => {
     expect(ui.dismissedUpdateVersion).toBeNull()
   })
 
+  it('updateUI restores retired card properties from direct UI writes', async () => {
+    const store = await createStore()
+    store.updateUI({ worktreeCardProperties: ['inline-agents'] })
+
+    expect(store.getUI().worktreeCardProperties).toEqual([
+      'status',
+      'unread',
+      'issue',
+      'pr',
+      'comment',
+      'inline-agents'
+    ])
+  })
+
   it('persists updater reminder metadata in UI state', async () => {
     const store = await createStore()
     store.updateUI({ dismissedUpdateVersion: '1.0.99', lastUpdateCheckAt: 1234 })
@@ -1569,6 +1583,53 @@ describe('Store', () => {
     const props = store.getUI().worktreeCardProperties
     expect(props.filter((p) => p === 'inline-agents')).toHaveLength(1)
     expect(store.getUI()._inlineAgentsDefaultedForAllUsers).toBe(true)
+  })
+
+  it('restores retired card properties when loading old user choices', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {
+        worktreeCardProperties: ['inline-agents'],
+        _inlineAgentsDefaultedForAllUsers: true
+      },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getUI().worktreeCardProperties).toEqual([
+      'status',
+      'unread',
+      'issue',
+      'pr',
+      'comment',
+      'inline-agents'
+    ])
+  })
+
+  it('keeps Agent activity opt-out while restoring retired card properties', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {
+        worktreeCardProperties: [],
+        _inlineAgentsDefaultedForAllUsers: true
+      },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getUI().worktreeCardProperties).toEqual([
+      'status',
+      'unread',
+      'issue',
+      'pr',
+      'comment'
+    ])
   })
 
   it('preserves a deliberate uncheck from the experimental-toggle era (Case B)', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -57,6 +57,7 @@ import {
   getDefaultUIState,
   getDefaultRepoHookSettings,
   getDefaultWorkspaceSession,
+  normalizeWorktreeCardProperties,
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
@@ -1320,10 +1321,25 @@ export class Store {
               !deliberateUncheck &&
               Array.isArray(rawCardProps) &&
               !rawCardProps.includes('inline-agents')
-            const migratedCardProps =
-              needsInlineAgentsMigration && Array.isArray(rawCardProps)
+            const migratedCardProps = (() => {
+              if (!Array.isArray(rawCardProps)) {
+                return undefined
+              }
+              const candidate = needsInlineAgentsMigration
                 ? [...rawCardProps, 'inline-agents' as const]
-                : undefined
+                : rawCardProps
+              // Why: only Agent activity remains configurable; older hidden
+              // card fields must be restored because users can no longer
+              // toggle them back on from the sidebar menu.
+              const normalized = normalizeWorktreeCardProperties(candidate)
+              const changed =
+                normalized.length !== rawCardProps.length ||
+                normalized.some((property, index) => property !== rawCardProps[index])
+              return changed ? normalized : undefined
+            })()
+            if (migratedCardProps !== undefined || !inlineAgentsMigrated) {
+              this.loadNeedsSave = true
+            }
             return {
               ...defaults.ui,
               ...parsed.ui,
@@ -2134,6 +2150,9 @@ export class Store {
       ...this.state.ui,
       groupBy: normalizeGroupBy(this.state.ui?.groupBy),
       sortBy: normalizeSortBy(this.state.ui?.sortBy),
+      worktreeCardProperties: normalizeWorktreeCardProperties(
+        this.state.ui?.worktreeCardProperties
+      ),
       workspaceStatuses: normalizeWorkspaceStatuses(this.state.ui?.workspaceStatuses),
       workspaceBoardOpacity: clampWorkspaceBoardOpacity(this.state.ui?.workspaceBoardOpacity),
       workspaceBoardCompact: normalizeWorkspaceBoardCompact(this.state.ui?.workspaceBoardCompact),
@@ -2153,6 +2172,10 @@ export class Store {
       sortBy: updates.sortBy
         ? normalizeSortBy(updates.sortBy)
         : normalizeSortBy(this.state.ui?.sortBy),
+      worktreeCardProperties:
+        updates.worktreeCardProperties !== undefined
+          ? normalizeWorktreeCardProperties(updates.worktreeCardProperties)
+          : normalizeWorktreeCardProperties(this.state.ui?.worktreeCardProperties),
       workspaceStatuses:
         updates.workspaceStatuses !== undefined
           ? normalizeWorkspaceStatuses(updates.workspaceStatuses)

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -27,11 +27,6 @@ const GROUP_BY_OPTIONS = [
 ] as const
 
 const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
-  { id: 'status', label: 'Terminal status' },
-  { id: 'unread', label: 'Unread indicator' },
-  { id: 'issue', label: 'Linked issue' },
-  { id: 'pr', label: 'Linked PR' },
-  { id: 'comment', label: 'Comment' },
   // Why: toggles the inline "Agent activity" list rendered below each
   // workspace card body (see WorktreeCard -> WorktreeCardAgents). Off hides
   // the list; there is no alternate surface.

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -116,6 +116,25 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().hideDefaultBranchWorkspace).toBe(true)
   })
 
+  it('restores retired card properties during hydration', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        worktreeCardProperties: ['inline-agents']
+      })
+    )
+
+    expect(store.getState().worktreeCardProperties).toEqual([
+      'status',
+      'unread',
+      'issue',
+      'pr',
+      'comment',
+      'inline-agents'
+    ])
+  })
+
   it('restores compact workspace board mode only from an explicit true', () => {
     const store = createUIStore()
 
@@ -417,6 +436,19 @@ describe('createUISlice hydratePersistedUI', () => {
     const expected = { githubMode: 'project', linearPreset: 'all', githubItemsPreset: 'my-prs' }
     expect(store.getState().taskResumeState).toEqual(expected)
     expect(setUI).toHaveBeenCalledWith({ taskResumeState: expected })
+  })
+
+  it('keeps retired card properties enabled when toggling Agent activity', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.setState({ worktreeCardProperties: ['inline-agents'] })
+    store.getState().toggleWorktreeCardProperty('inline-agents')
+
+    const expected = ['status', 'unread', 'issue', 'pr', 'comment']
+    expect(store.getState().worktreeCardProperties).toEqual(expected)
+    expect(setUI).toHaveBeenCalledWith({ worktreeCardProperties: expected })
   })
 })
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -28,7 +28,8 @@ import {
 } from '../../../../shared/task-providers'
 import {
   DEFAULT_STATUS_BAR_ITEMS,
-  DEFAULT_WORKTREE_CARD_PROPERTIES
+  DEFAULT_WORKTREE_CARD_PROPERTIES,
+  normalizeWorktreeCardProperties
 } from '../../../../shared/constants'
 import {
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
@@ -764,10 +765,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
   toggleWorktreeCardProperty: (prop) =>
     set((s) => {
-      const current = s.worktreeCardProperties || DEFAULT_WORKTREE_CARD_PROPERTIES
-      const updated = current.includes(prop)
-        ? current.filter((p) => p !== prop)
-        : [...current, prop]
+      const current = normalizeWorktreeCardProperties(s.worktreeCardProperties)
+      const next = current.includes(prop) ? current.filter((p) => p !== prop) : [...current, prop]
+      // Why: retired property toggles no longer exist, so their fields must
+      // stay visible even if an older saved preference hid them.
+      const updated = normalizeWorktreeCardProperties(next)
       window.api.ui.set({ worktreeCardProperties: updated }).catch(console.error)
       return { worktreeCardProperties: updated }
     }),
@@ -938,7 +940,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         collapsedGroups: new Set(ui.collapsedGroups ?? []),
         uiZoomLevel: ui.uiZoomLevel ?? 0,
         editorFontZoomLevel: ui.editorFontZoomLevel ?? 0,
-        worktreeCardProperties: ui.worktreeCardProperties ?? [...DEFAULT_WORKTREE_CARD_PROPERTIES],
+        worktreeCardProperties: normalizeWorktreeCardProperties(ui.worktreeCardProperties),
         workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardCompact: normalizeWorkspaceBoardCompact(ui.workspaceBoardCompact),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -6,8 +6,7 @@ import type {
   PersistedState,
   PersistedUIState,
   RepoHookSettings,
-  WorkspaceSessionState,
-  WorktreeCardProperty
+  WorkspaceSessionState
 } from './types'
 import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
@@ -15,8 +14,14 @@ import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 import type { VoiceSettings } from './speech-types'
 import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
 import { TASK_PROVIDERS } from './task-providers'
+import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree-card-properties'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
+export {
+  ALWAYS_VISIBLE_WORKTREE_CARD_PROPERTIES,
+  DEFAULT_WORKTREE_CARD_PROPERTIES,
+  normalizeWorktreeCardProperties
+} from './worktree-card-properties'
 
 export const SCHEMA_VERSION = 1
 export const DEFAULT_APP_FONT_FAMILY = 'Geist'
@@ -82,19 +87,6 @@ export const MAX_EDITOR_AUTO_SAVE_DELAY_MS = 10_000
 // without starring — e.g. 35 → 70 → 140 → 280. Past dismissals are encoded
 // in starNagNextThreshold, so this constant is only the first-time seed.
 export const STAR_NAG_INITIAL_THRESHOLD = 35
-
-export const DEFAULT_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = [
-  'status',
-  'unread',
-  'issue',
-  'pr',
-  'comment',
-  // Why: agent activity is the primary reason users opt into the feature, so
-  // show it inline on each card by default. Unchecking this from the
-  // Workspaces view options hides the inline list entirely — there is no
-  // alternative agent-activity surface in the sidebar.
-  'inline-agents'
-]
 
 /** Synthetic worktree id used by the memory collector to bucket PTYs that
  *  are not associated with any worktree. Shared across main and renderer so

--- a/src/shared/worktree-card-properties.ts
+++ b/src/shared/worktree-card-properties.ts
@@ -1,0 +1,30 @@
+import type { WorktreeCardProperty } from './types'
+
+export const ALWAYS_VISIBLE_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = [
+  'status',
+  'unread',
+  'issue',
+  'pr',
+  'comment'
+]
+
+export const DEFAULT_WORKTREE_CARD_PROPERTIES: WorktreeCardProperty[] = [
+  ...ALWAYS_VISIBLE_WORKTREE_CARD_PROPERTIES,
+  // Why: agent activity is the primary reason users opt into the feature, so
+  // show it inline on each card by default. Unchecking this from the
+  // Workspaces view options hides the inline list entirely.
+  'inline-agents'
+]
+
+export function normalizeWorktreeCardProperties(
+  properties: readonly WorktreeCardProperty[] | null | undefined
+): WorktreeCardProperty[] {
+  const normalized = [...ALWAYS_VISIBLE_WORKTREE_CARD_PROPERTIES]
+  const source = properties ?? DEFAULT_WORKTREE_CARD_PROPERTIES
+  for (const property of source) {
+    if (!normalized.includes(property)) {
+      normalized.push(property)
+    }
+  }
+  return normalized
+}


### PR DESCRIPTION
## Summary
- Remove retired property toggles from the Workspaces view-options dropdown, leaving only Agent activity configurable
- Restore retired card properties as always-on when loading or writing UI state, including direct UI writes
- Add focused regression coverage for persistence, renderer hydration, and Agent activity toggling

## Verification
- `pnpm exec oxlint src/shared/constants.ts src/shared/worktree-card-properties.ts src/renderer/src/components/sidebar/SidebarHeader.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/store/slices/ui.test.ts src/main/persistence.ts src/main/persistence.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts src/renderer/src/store/slices/ui.test.ts` (156 tests)
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run typecheck:cli`
- Electron proof captured: view-options menu shows only Agent activity under Show properties; retired labels are absent.
