### PR TITLE
Update mobile 0.0.8 release links

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Control your agents from your phone.
 </p>
 
 - **iOS:** [Download from App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.7)
+- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.8)
 
 ---
 

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../../store'
 import { MobilePane, MOBILE_PANE_SEARCH_ENTRIES } from './MobilePane'
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
-const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.7'
+const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.8'
 
 const MOBILE_ENABLE_SEARCH_ENTRY: SettingsSearchEntry = {
   title: 'Mobile',


### PR DESCRIPTION
## Summary
- Point README Android download link at the mobile-v0.0.8 release
- Point the desktop Mobile settings Android APK link at the mobile-v0.0.8 release

## Verification
- git diff --check
- release workflow is running for tag mobile-v0.0.8; merge after it publishes the GitHub release

Made with [Orca](https://github.com/stablyai/orca) 🐋
