### PR TITLE
Fix SSH relay connect when default shell is fish

### DIFF
--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -72,6 +72,12 @@ export function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`
 }
 
+export function wrapRemoteCommandForPosixShell(command: string): string {
+  // Why: sshd asks the user's login shell to parse exec commands. Orca emits
+  // POSIX sh snippets; `exec` avoids leaving that shell around for relay bridges.
+  return `exec /bin/sh -c ${shellEscape(command)}`
+}
+
 function cmdEscape(s: string): string {
   return `"${s.replace(/"/g, '""')}"`
 }
@@ -200,7 +206,9 @@ export function spawnProxyCommand(
     proxy.kind === 'jump-host'
       ? // Why: ProxyJump is structured input, not a shell snippet. Spawn ssh
         // directly so jump-host values cannot escape through shell parsing.
-        spawn('ssh', ['-W', `${host}:${port}`, '--', proxy.jumpHost], { stdio: ['pipe', 'pipe', 'pipe'] })
+        spawn('ssh', ['-W', `${host}:${port}`, '--', proxy.jumpHost], {
+          stdio: ['pipe', 'pipe', 'pipe']
+        })
       : (() => {
           const escape = process.platform === 'win32' ? cmdEscape : shellEscape
           const expanded = proxy.command

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -8,6 +8,7 @@ let connectErrorMessage = ''
 type MockSshClient = {
   setNoDelay: ReturnType<typeof vi.fn>
   _sock: Socket | undefined
+  lastExecCommand?: string
 }
 let clientInstances: MockSshClient[] = []
 
@@ -18,6 +19,7 @@ vi.mock('ssh2', () => {
     // to decide which log line to emit. A real Socket instance lets the test
     // exercise the "enabled" branch instead of the "skipped (proxy socket)" branch.
     _sock: Socket | undefined = new Socket()
+    lastExecCommand?: string
     constructor() {
       clientInstances.push(this)
     }
@@ -35,7 +37,10 @@ vi.mock('ssh2', () => {
     }
     end() {}
     destroy() {}
-    exec() {}
+    exec(cmd: string, cb: (err: Error | undefined, channel: unknown) => void) {
+      this.lastExecCommand = cmd
+      cb(undefined, {})
+    }
     sftp() {}
   }
   return { Client: MockSshClient }
@@ -204,6 +209,17 @@ describe('SshConnection', () => {
     await conn.connect()
 
     expect(resolveWithSshG).toHaveBeenCalledWith('ssh-alias')
+  })
+
+  it('wraps exec commands in /bin/sh so non-POSIX login shells do not parse relay snippets', async () => {
+    const conn = new SshConnection(createTarget(), createCallbacks())
+    await conn.connect()
+
+    await conn.exec("cd '/tmp' && ('/usr/bin/node' -e 'console.log(1)' || echo MISSING)")
+
+    expect(clientInstances[0].lastExecCommand).toBe(
+      "exec /bin/sh -c 'cd '\\''/tmp'\\'' && ('\\''/usr/bin/node'\\'' -e '\\''console.log(1)'\\'' || echo MISSING)'"
+    )
   })
 })
 

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -18,6 +18,7 @@ import {
   buildConnectConfig,
   resolveEffectiveProxy,
   spawnProxyCommand,
+  wrapRemoteCommandForPosixShell,
   type SshConnectionCallbacks
 } from './ssh-connection-utils'
 export type { SshConnectionCallbacks } from './ssh-connection-utils'
@@ -70,7 +71,9 @@ export class SshConnection {
     if (!this.client) {
       throw new Error('Not connected')
     }
-    return new Promise((res, rej) => this.client!.exec(cmd, (e, ch) => (e ? rej(e) : res(ch))))
+    return new Promise((res, rej) =>
+      this.client!.exec(wrapRemoteCommandForPosixShell(cmd), (e, ch) => (e ? rej(e) : res(ch)))
+    )
   }
 
   async sftp(): Promise<SFTPWrapper> {


### PR DESCRIPTION
## Summary
- Route all `SshConnection.exec` commands through `exec /bin/sh -c` so Orca's POSIX relay deploy snippets are parsed by POSIX sh instead of the remote user's default shell.
- Use `exec` so long-lived relay bridge commands do not leave the user's login shell waiting behind `/bin/sh`.
- Add regression coverage proving the problematic relay-style grouping command is wrapped before it reaches `ssh2`.

Fixes #2234.

## Reproduction
- Reproduced the issue locally with fish 4.7.1 using the relay native-deps probe shape from the issue:
  - `fish -c "export PATH='/usr/bin':$PATH && cd '/tmp' && ('/usr/bin/node' ... || echo MISSING)"`
  - Result before fix: exit 127, `fish: command substitutions not allowed in command position`.

## Verification
- After fix, the same probe shape wrapped as `exec /bin/sh -c ...` under fish returns `ORCA-NPTY-PROBE-OK`.
- Cross-shell wrapper smoke passed locally under fish, csh, tcsh, zsh, and bash.
- `ssh openclaw "exec /bin/sh -c 'echo ORCA_OPENCLAW_WRAP_OK'"`
- `pnpm build:relay`
- `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection-utils.test.ts src/main/ssh/ssh-connection.test.ts src/main/ssh/ssh-relay-native-deps-install.test.ts src/main/ssh/ssh-relay-deploy.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ssh/ssh-connection.ts src/main/ssh/ssh-connection-utils.ts src/main/ssh/ssh-connection.test.ts src/main/ssh/ssh-connection-utils.test.ts`
- `pnpm exec oxfmt --check src/main/ssh/ssh-connection.ts src/main/ssh/ssh-connection-utils.ts src/main/ssh/ssh-connection.test.ts`
- Electron dev app connected to `ssh openclaw` via `window.api.ssh.connect`; result: `status: connected`, relay deployed and started successfully.