### PR TITLE
Pin Linux package icon source explicitly

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -182,6 +182,9 @@ module.exports = {
     // Why: Ubuntu 26 ships GNOME Orca as the `orca` package and /usr/bin/orca.
     // The Linux installer should not claim those system package/file names.
     executableName: 'orca-ide',
+    // Why: pin the Linux app icon source so AppImage/deb icon payloads stay
+    // deterministic if electron-builder defaults or resource discovery change.
+    icon: 'resources/build/icon.png',
     extraResources: [
       relayExtraResource,
       {


### PR DESCRIPTION
## Summary
Make Linux packaging use an explicit Orca icon source in electron-builder config.

Closes #2240.

## What changed
- Added `linux.icon = 'resources/build/icon.png'` in `config/electron-builder.config.cjs`.

## Why
Linux artifacts already packaged icons, but icon source selection was implicit. Pinning the path avoids regressions if electron-builder defaults or resource discovery behavior changes.

## Local verification
Ran locally on Ubuntu:

```bash
pnpm build:linux
```

Produced:
- `dist/orca-linux.AppImage`
- `dist/orca-ide_1.4.5_amd64.deb`

Verified `.deb` desktop entry includes:
- `Icon=orca-ide`
- `Exec=/opt/Orca/orca-ide %U`

(Behavior change is packaging-config only; no UI changes.)
