### PR TITLE
Fix SSH browse ls alias handling

### DIFF
--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from 'events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerSshBrowseHandler } from './ssh-browse'
+
+const { handleMock, removeHandlerMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}))
+
+type BrowseHandler = (
+  event: unknown,
+  args: { targetId: string; dirPath: string }
+) => Promise<unknown>
+
+function createMockChannel(): EventEmitter & { stderr: EventEmitter } {
+  return Object.assign(new EventEmitter(), {
+    stderr: new EventEmitter()
+  })
+}
+
+describe('registerSshBrowseHandler', () => {
+  let handler: BrowseHandler
+
+  beforeEach(() => {
+    handleMock.mockReset()
+    removeHandlerMock.mockReset()
+    handleMock.mockImplementation((_channel: string, registeredHandler: BrowseHandler) => {
+      handler = registeredHandler
+    })
+  })
+
+  it('bypasses remote ls aliases when listing a directory', async () => {
+    const channel = createMockChannel()
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '~' })
+    await Promise.resolve()
+    channel.emit('data', Buffer.from('/home/user\nsrc/\nREADME.md\nnotes file.txt\n'))
+    channel.emit('exit', 0)
+    channel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: '/home/user',
+      entries: [
+        { name: 'src', isDirectory: true },
+        { name: 'notes file.txt', isDirectory: false },
+        { name: 'README.md', isDirectory: false }
+      ]
+    })
+    expect(exec).toHaveBeenCalledWith('cd "$HOME" && pwd && command ls -1Ap')
+  })
+
+  it('escapes remote browse paths before invoking command ls', async () => {
+    const channel = createMockChannel()
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: "/tmp/it's here" })
+    await Promise.resolve()
+    channel.emit('data', Buffer.from("/tmp/it's here\n"))
+    channel.emit('exit', 0)
+    channel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: "/tmp/it's here",
+      entries: []
+    })
+    expect(exec).toHaveBeenCalledWith("cd '/tmp/it'\\''s here' && pwd && command ls -1Ap")
+  })
+})

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -30,14 +30,14 @@ export function registerSshBrowseHandler(
         throw new Error(`SSH connection "${args.targetId}" not found`)
       }
 
-      // Why: using printf with a delimiter instead of ls avoids issues with
-      // filenames containing spaces or special characters. The -1 flag outputs
-      // one entry per line. The -p flag appends / to directories.
+      // Why: using one line per entry preserves filenames containing spaces.
+      // `command ls` bypasses user aliases/functions like `ls='eza ...'`.
+      // The -1 flag outputs one entry per line. The -p flag appends / to directories.
       // We resolve ~ and get the absolute path via `cd <path> && pwd`.
       // `cd` and `ls` are chained with `&&` so a failing `ls` (e.g. permission
       // denied after a readable `cd ... && pwd`) propagates as a non-zero exit
       // code rather than being indistinguishable from an empty directory.
-      const command = `cd ${shellEscape(args.dirPath)} && pwd && ls -1ap`
+      const command = `cd ${shellEscape(args.dirPath)} && pwd && command ls -1Ap`
       const channel = await conn.exec(command)
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

`ls -1ap` -> `command ls -1Ap`

- Wrap ls with `command`
- `-a` -> `-A`

Before:

Breaks on remote aliases e.g. `ls="eza ..."`

`Error invoking remote method 'ssh:browseDir': Error: eza: Unknown argument -p`

- `ls -1ap`
- emits:
    - `./`
    - `../`
    - hidden files
    - normal files
    - dirs with `/`
- code then skips `./` and `../`

After:

- `command ls -1Ap`
- emits:
    - hidden files
    - normal files
    - dirs with `/`
- does not emit `./` or `../` (We already have upper arrow button)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed