### PR TITLE
Fix PR worktree start point fallback

### DIFF
--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -42,9 +42,11 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
       })
       socket.once('data', (data) => {
         const request = JSON.parse(String(data).trim()) as { id: string }
+        // Why: full-suite load can delay short timers; keep the response past
+        // the client timeout while leaving enough margin between keepalives.
         keepalive = setInterval(() => {
           socket.write('{"_keepalive":true}\n')
-        }, 15)
+        }, 50)
         setTimeout(() => {
           if (keepalive) {
             clearInterval(keepalive)
@@ -58,7 +60,7 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
               _meta: { runtimeId: 'runtime-1' }
             })}\n`
           )
-        }, 90)
+        }, 500)
       })
     })
     servers.add(server)
@@ -75,7 +77,7 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
       metadata,
       'terminal.wait',
       undefined,
-      40
+      200
     )
 
     expect(response).toMatchObject({

--- a/src/main/github/pr-start-point.test.ts
+++ b/src/main/github/pr-start-point.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getPullRequestPushTargetMock, getWorkItemMock } = vi.hoisted(() => ({
+  getPullRequestPushTargetMock: vi.fn(),
+  getWorkItemMock: vi.fn()
+}))
+
+vi.mock('./client', () => ({
+  getPullRequestPushTarget: getPullRequestPushTargetMock,
+  getWorkItem: getWorkItemMock
+}))
+
+import { resolveGitHubPrStartPoint } from './pr-start-point'
+
+describe('resolveGitHubPrStartPoint', () => {
+  beforeEach(() => {
+    getPullRequestPushTargetMock.mockReset()
+    getWorkItemMock.mockReset()
+  })
+
+  it('falls back to the GitHub PR head ref when a direct branch fetch fails', async () => {
+    getPullRequestPushTargetMock.mockResolvedValue({
+      remoteName: 'pr-contributor-orca',
+      branchName: 'feat/onboarding-model-choice-782',
+      remoteUrl: 'git@github.com:contributor/orca.git'
+    })
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'fetch' && String(args[2]).startsWith('+refs/heads/')) {
+        throw new Error('fatal: could not find remote ref')
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'def456\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 1849,
+      headRefName: 'feat/onboarding-model-choice-782',
+      gitExec,
+      resolveRemote: async () => 'origin'
+    })
+
+    expect(gitExec).toHaveBeenCalledWith([
+      'fetch',
+      'origin',
+      '+refs/heads/feat/onboarding-model-choice-782:refs/remotes/origin/feat/onboarding-model-choice-782'
+    ])
+    expect(gitExec).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/1849/head'])
+    expect(result).toEqual({
+      baseBranch: 'def456',
+      pushTarget: {
+        remoteName: 'pr-contributor-orca',
+        branchName: 'feat/onboarding-model-choice-782',
+        remoteUrl: 'git@github.com:contributor/orca.git'
+      }
+    })
+  })
+
+  it('keeps the PR head ref fallback when push-target discovery also fails', async () => {
+    getPullRequestPushTargetMock.mockRejectedValue(new Error('head repo is unavailable'))
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'fetch' && String(args[2]).startsWith('+refs/heads/')) {
+        throw new Error('fatal: could not find remote ref')
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'def456\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 1849,
+      headRefName: 'feat/onboarding-model-choice-782',
+      gitExec,
+      resolveRemote: async () => 'origin'
+    })
+
+    expect(getPullRequestPushTargetMock).toHaveBeenCalledWith('/repo-root', 1849, null)
+    expect(result).toEqual({ baseBranch: 'def456' })
+  })
+
+  it('resolves an inaccessible fork PR even when push-target discovery fails', async () => {
+    getPullRequestPushTargetMock.mockRejectedValue(new Error('head repo is unavailable'))
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 1849,
+      headRefName: 'feat/onboarding-model-choice-782',
+      isCrossRepository: true,
+      gitExec,
+      resolveRemote: async () => 'origin'
+    })
+
+    expect(getPullRequestPushTargetMock).toHaveBeenCalledWith('/repo-root', 1849, null)
+    expect(gitExec).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/1849/head'])
+    expect(result).toEqual({ baseBranch: 'abc123' })
+  })
+
+  it('uses PR metadata when the caller did not pass a head ref', async () => {
+    getWorkItemMock.mockResolvedValue({
+      type: 'pr',
+      branchName: 'contributor/fix',
+      isCrossRepository: true
+    })
+    getPullRequestPushTargetMock.mockResolvedValue({
+      remoteName: 'pr-contributor-orca',
+      branchName: 'contributor/fix',
+      remoteUrl: 'git@github.com:contributor/orca.git'
+    })
+    const gitExec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 1738,
+      gitExec,
+      resolveRemote: async () => 'origin'
+    })
+
+    expect(getWorkItemMock).toHaveBeenCalledWith('/repo-root', 1738, 'pr', null)
+    expect(result).toEqual({
+      baseBranch: 'abc123',
+      pushTarget: {
+        remoteName: 'pr-contributor-orca',
+        branchName: 'contributor/fix',
+        remoteUrl: 'git@github.com:contributor/orca.git'
+      }
+    })
+  })
+
+  it('returns a tracking ref and push target when same-repo branch fetch succeeds', async () => {
+    const gitExec = vi.fn(async () => ({ stdout: '', stderr: '' }))
+
+    const result = await resolveGitHubPrStartPoint({
+      repoPath: '/repo-root',
+      prNumber: 42,
+      headRefName: 'feature/add-feature',
+      gitExec,
+      resolveRemote: async () => 'origin'
+    })
+
+    expect(gitExec).toHaveBeenCalledWith([
+      'fetch',
+      'origin',
+      '+refs/heads/feature/add-feature:refs/remotes/origin/feature/add-feature'
+    ])
+    expect(gitExec).toHaveBeenCalledWith(['rev-parse', '--verify', 'origin/feature/add-feature'])
+    expect(result).toEqual({
+      baseBranch: 'origin/feature/add-feature',
+      pushTarget: { remoteName: 'origin', branchName: 'feature/add-feature' }
+    })
+  })
+})

--- a/src/main/github/pr-start-point.ts
+++ b/src/main/github/pr-start-point.ts
@@ -1,0 +1,127 @@
+import type { GitPushTarget } from '../../shared/types'
+import { getPullRequestPushTarget, getWorkItem } from './client'
+
+type GitExec = (args: string[]) => Promise<{ stdout: string; stderr: string }>
+
+type ResolveGitHubPrStartPointArgs = {
+  repoPath: string
+  prNumber: number
+  headRefName?: string
+  isCrossRepository?: boolean
+  connectionId?: string | null
+  gitExec: GitExec
+  resolveRemote: () => Promise<string>
+}
+
+type ResolveGitHubPrStartPointResult =
+  | { baseBranch: string; pushTarget?: GitPushTarget }
+  | { error: string }
+
+export async function resolveGitHubPrStartPoint(
+  args: ResolveGitHubPrStartPointArgs
+): Promise<ResolveGitHubPrStartPointResult> {
+  let headRefName = args.headRefName?.trim() ?? ''
+  let isCrossRepository = args.isCrossRepository === true
+  let pushTarget: GitPushTarget | undefined
+
+  const resolvePushTarget = async (): Promise<void> => {
+    if (pushTarget) {
+      return
+    }
+    try {
+      pushTarget =
+        (await getPullRequestPushTarget(args.repoPath, args.prNumber, args.connectionId ?? null)) ??
+        undefined
+    } catch {
+      // Why: deleted/inaccessible fork metadata can prevent push-target
+      // discovery, but GitHub still exposes the PR head ref for checkout.
+      pushTarget = undefined
+    }
+  }
+
+  if (!headRefName) {
+    const item = await getWorkItem(args.repoPath, args.prNumber, 'pr', args.connectionId ?? null)
+    if (!item || item.type !== 'pr') {
+      return { error: `PR #${args.prNumber} not found.` }
+    }
+    headRefName = (item.branchName ?? '').trim()
+    if (!headRefName) {
+      return { error: `PR #${args.prNumber} has no head branch.` }
+    }
+    if (item.isCrossRepository === true) {
+      isCrossRepository = true
+    }
+  }
+
+  if (isCrossRepository) {
+    await resolvePushTarget()
+  }
+
+  let remote: string
+  try {
+    remote = await args.resolveRemote()
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
+  }
+
+  const fetchPullRequestHeadSha = async (): Promise<{ baseBranch: string } | { error: string }> => {
+    const pullRef = `refs/pull/${args.prNumber}/head`
+    try {
+      await args.gitExec(['fetch', remote, pullRef])
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        error: `Failed to fetch ${pullRef}: ${message.split('\n')[0]}`
+      }
+    }
+    let sha: string
+    try {
+      const { stdout } = await args.gitExec(['rev-parse', '--verify', 'FETCH_HEAD'])
+      sha = stdout.trim()
+    } catch {
+      return { error: `Could not resolve fork PR #${args.prNumber} head after fetch.` }
+    }
+    if (!sha) {
+      return { error: `Empty SHA resolving fork PR #${args.prNumber} head.` }
+    }
+    return { baseBranch: sha }
+  }
+
+  // Why: fork PR heads live on a remote we don't have configured, so
+  // `git fetch <remote> <headRefName>` would fail. GitHub exposes every
+  // PR head (fork or same-repo) as refs/pull/<N>/head on the upstream repo.
+  if (isCrossRepository) {
+    const result = await fetchPullRequestHeadSha()
+    if ('error' in result) {
+      return result
+    }
+    return { ...result, ...(pushTarget ? { pushTarget } : {}) }
+  }
+
+  try {
+    await args.gitExec([
+      'fetch',
+      remote,
+      `+refs/heads/${headRefName}:refs/remotes/${remote}/${headRefName}`
+    ])
+  } catch {
+    const result = await fetchPullRequestHeadSha()
+    if ('error' in result) {
+      return result
+    }
+    await resolvePushTarget()
+    return { ...result, ...(pushTarget ? { pushTarget } : {}) }
+  }
+
+  const remoteRef = `${remote}/${headRefName}`
+  try {
+    await args.gitExec(['rev-parse', '--verify', remoteRef])
+  } catch {
+    return { error: `Remote ref ${remoteRef} does not exist after fetch.` }
+  }
+
+  return {
+    baseBranch: remoteRef,
+    pushTarget: { remoteName: remote, branchName: headRefName }
+  }
+}

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -652,6 +652,63 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('resolves a fork PR base even when the push target cannot be discovered', async () => {
+    getPullRequestPushTargetMock.mockRejectedValue(new Error('head repo is unavailable'))
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await handlers['worktrees:resolvePrBase'](null, {
+      repoId: 'repo-1',
+      prNumber: 1849,
+      headRefName: 'feat/onboarding-model-choice-782',
+      isCrossRepository: true
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/1849/head'], {
+      cwd: '/workspace/repo'
+    })
+    expect(result).toEqual({
+      baseBranch: 'abc123'
+    })
+  })
+
+  it('falls back to the PR head ref when direct branch fetch fails', async () => {
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'fetch' && String(args[2]).startsWith('+refs/heads/')) {
+        throw new Error('fatal: could not find remote ref')
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'def456\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await handlers['worktrees:resolvePrBase'](null, {
+      repoId: 'repo-1',
+      prNumber: 1849,
+      headRefName: 'feat/onboarding-model-choice-782'
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'fetch',
+        'origin',
+        '+refs/heads/feat/onboarding-model-choice-782:refs/remotes/origin/feat/onboarding-model-choice-782'
+      ],
+      { cwd: '/workspace/repo' }
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['fetch', 'origin', 'refs/pull/1849/head'], {
+      cwd: '/workspace/repo'
+    })
+    expect(result).toEqual({
+      baseBranch: 'def456'
+    })
+  })
+
   it('persists linked issue, PR, and selected agent metadata during remote create', async () => {
     const repo = {
       id: 'repo-ssh',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -21,7 +21,7 @@ import {
 } from '../git/worktree'
 import { gitExecFileAsync } from '../git/runner'
 import { getDefaultRemote } from '../git/repo'
-import { getPullRequestPushTarget, getWorkItem } from '../github/client'
+import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
 import { getProjectRef as getGlabProjectRef, getGlabKnownHosts } from '../gitlab/gl-utils'
 import { getWorkItemByProjectRef as getGitLabWorkItemByProjectRef } from '../gitlab/client'
 import { listRepoWorktrees, createFolderWorktree } from '../repo-worktrees'
@@ -443,115 +443,26 @@ export function registerWorktreeHandlers(
         return provider.exec(args, repo.path)
       }
 
-      let headRefName = args.headRefName?.trim() ?? ''
-      let isCrossRepository = args.isCrossRepository === true
-      let pushTarget: CreateWorktreeArgs['pushTarget'] | undefined
-
-      // Skip the gh lookup when both hints are present (picker already has them).
-      if (!headRefName) {
-        // Why: the caller already knows this is a PR number, so scope the
-        // lookup to `type: 'pr'` and skip the speculative issue-first probe
-        // that would hit the upstream issue tracker for fork checkouts.
-        const item = await getWorkItem(repo.path, args.prNumber, 'pr', repo.connectionId ?? null)
-        if (!item || item.type !== 'pr') {
-          return { error: `PR #${args.prNumber} not found.` }
-        }
-        headRefName = (item.branchName ?? '').trim()
-        if (!headRefName) {
-          return { error: `PR #${args.prNumber} has no head branch.` }
-        }
-        if (item.isCrossRepository === true) {
-          isCrossRepository = true
-        }
-      }
-      if (isCrossRepository) {
-        try {
-          pushTarget =
-            (await getPullRequestPushTarget(repo.path, args.prNumber, repo.connectionId ?? null)) ??
-            undefined
-        } catch (error) {
-          return {
-            error:
-              error instanceof Error
-                ? error.message
-                : `Could not resolve PR #${args.prNumber} head push target.`
+      return resolveGitHubPrStartPoint({
+        repoPath: repo.path,
+        prNumber: args.prNumber,
+        headRefName: args.headRefName,
+        isCrossRepository: args.isCrossRepository,
+        connectionId: repo.connectionId ?? null,
+        gitExec,
+        resolveRemote: async () => {
+          if (repo.connectionId) {
+            const { stdout } = await gitExec(['remote'])
+            return (
+              stdout
+                .split('\n')
+                .map((line) => line.trim())
+                .find(Boolean) ?? 'origin'
+            )
           }
+          return getDefaultRemote(repo.path)
         }
-        if (!pushTarget) {
-          return { error: `Could not resolve PR #${args.prNumber} head push target.` }
-        }
-      }
-
-      let remote: string
-      try {
-        if (repo.connectionId) {
-          const { stdout } = await gitExec(['remote'])
-          remote =
-            stdout
-              .split('\n')
-              .map((line) => line.trim())
-              .find(Boolean) ?? 'origin'
-        } else {
-          remote = await getDefaultRemote(repo.path)
-        }
-      } catch (error) {
-        return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
-      }
-
-      // Why: fork PR heads live on a remote we don't have configured, so
-      // `git fetch <remote> <headRefName>` would fail. GitHub exposes every
-      // PR head (fork or same-repo) as refs/pull/<N>/head on the upstream
-      // repo. Fetch that and snapshot the SHA — the new worktree branch is
-      // derived from the workspace name, so there's no tracking ref to set
-      // up, which makes SHA semantics ("branch from this commit") cleaner
-      // than returning a ref that would go stale on force-push.
-      if (isCrossRepository) {
-        const pullRef = `refs/pull/${args.prNumber}/head`
-        try {
-          await gitExec(['fetch', remote, pullRef])
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error)
-          return {
-            error: `Failed to fetch ${pullRef}: ${message.split('\n')[0]}`
-          }
-        }
-        let sha: string
-        try {
-          const { stdout } = await gitExec(['rev-parse', '--verify', 'FETCH_HEAD'])
-          sha = stdout.trim()
-        } catch {
-          return { error: `Could not resolve fork PR #${args.prNumber} head after fetch.` }
-        }
-        if (!sha) {
-          return { error: `Empty SHA resolving fork PR #${args.prNumber} head.` }
-        }
-        return { baseBranch: sha, ...(pushTarget ? { pushTarget } : {}) }
-      }
-
-      try {
-        await gitExec([
-          'fetch',
-          remote,
-          `+refs/heads/${headRefName}:refs/remotes/${remote}/${headRefName}`
-        ])
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return {
-          error: `Failed to fetch ${remote}/${headRefName}: ${message.split('\n')[0]}`
-        }
-      }
-
-      const remoteRef = `${remote}/${headRefName}`
-      try {
-        await gitExec(['rev-parse', '--verify', remoteRef])
-      } catch {
-        return { error: `Remote ref ${remoteRef} does not exist after fetch.` }
-      }
-
-      if (!pushTarget) {
-        pushTarget = { remoteName: remote, branchName: headRefName }
-      }
-      return { baseBranch: remoteRef, pushTarget }
+      })
     }
   )
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -96,7 +96,6 @@ import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import { BrowserError } from '../browser/cdp-bridge'
 import {
   getPRForBranch,
-  getPullRequestPushTarget,
   getRepoSlug,
   getWorkItem,
   listWorkItems,
@@ -120,6 +119,7 @@ import {
   listLabels,
   listAssignableUsers
 } from '../github/client'
+import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
 import { getWorkItemDetails, getPRFileContents } from '../github/work-item-details'
 import { getRateLimit } from '../github/rate-limit'
 import type {
@@ -6215,90 +6215,14 @@ export class OrcaRuntimeService {
       return { error: 'Folder mode does not support creating worktrees.' }
     }
 
-    let headRefName = args.headRefName?.trim() ?? ''
-    let isCrossRepository = args.isCrossRepository === true
-    let pushTarget: GitPushTarget | undefined
-
-    if (!headRefName) {
-      const item = await getWorkItem(repo.path, args.prNumber, 'pr')
-      if (!item || item.type !== 'pr') {
-        return { error: `PR #${args.prNumber} not found.` }
-      }
-      headRefName = (item.branchName ?? '').trim()
-      if (!headRefName) {
-        return { error: `PR #${args.prNumber} has no head branch.` }
-      }
-      if (item.isCrossRepository === true) {
-        isCrossRepository = true
-      }
-    }
-
-    if (isCrossRepository) {
-      try {
-        pushTarget = (await getPullRequestPushTarget(repo.path, args.prNumber)) ?? undefined
-      } catch (error) {
-        return {
-          error:
-            error instanceof Error
-              ? error.message
-              : `Could not resolve PR #${args.prNumber} head push target.`
-        }
-      }
-      if (!pushTarget) {
-        return { error: `Could not resolve PR #${args.prNumber} head push target.` }
-      }
-    }
-
-    let remote: string
-    try {
-      remote = await getDefaultRemote(repo.path)
-    } catch (error) {
-      return { error: error instanceof Error ? error.message : 'Could not resolve git remote.' }
-    }
-
-    if (isCrossRepository) {
-      const pullRef = `refs/pull/${args.prNumber}/head`
-      try {
-        await gitExecFileAsync(['fetch', remote, pullRef], { cwd: repo.path })
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        return { error: `Failed to fetch ${pullRef}: ${message.split('\n')[0]}` }
-      }
-      try {
-        const { stdout } = await gitExecFileAsync(['rev-parse', '--verify', 'FETCH_HEAD'], {
-          cwd: repo.path
-        })
-        const sha = stdout.trim()
-        if (!sha) {
-          return { error: `Empty SHA resolving fork PR #${args.prNumber} head.` }
-        }
-        return { baseBranch: sha, ...(pushTarget ? { pushTarget } : {}) }
-      } catch {
-        return { error: `Could not resolve fork PR #${args.prNumber} head after fetch.` }
-      }
-    }
-
-    try {
-      await gitExecFileAsync(
-        ['fetch', remote, `+refs/heads/${headRefName}:refs/remotes/${remote}/${headRefName}`],
-        { cwd: repo.path }
-      )
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      return { error: `Failed to fetch ${remote}/${headRefName}: ${message.split('\n')[0]}` }
-    }
-
-    const remoteRef = `${remote}/${headRefName}`
-    try {
-      await gitExecFileAsync(['rev-parse', '--verify', remoteRef], { cwd: repo.path })
-    } catch {
-      return { error: `Remote ref ${remoteRef} does not exist after fetch.` }
-    }
-
-    return {
-      baseBranch: remoteRef,
-      pushTarget: pushTarget ?? { remoteName: remote, branchName: headRefName }
-    }
+    return resolveGitHubPrStartPoint({
+      repoPath: repo.path,
+      prNumber: args.prNumber,
+      headRefName: args.headRefName,
+      isCrossRepository: args.isCrossRepository,
+      gitExec: (gitArgs) => gitExecFileAsync(gitArgs, { cwd: repo.path }),
+      resolveRemote: () => getDefaultRemote(repo.path)
+    })
   }
 
   async removeManagedWorktree(

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -41,11 +41,6 @@ function createTestState(overrides?: Partial<AppState>): {
   return { state, pending }
 }
 
-async function flush(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0))
-  await new Promise((resolve) => setTimeout(resolve, 0))
-}
-
 describe('ensureHooksConfirmed', () => {
   beforeEach(() => {
     hooksCheckMock.mockReset()
@@ -86,9 +81,8 @@ describe('ensureHooksConfirmed', () => {
     })
 
     const promise = ensureHooksConfirmed(state, 'repo-1', 'setup')
-    await flush()
 
-    expect(pending).toHaveLength(1)
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
     expect(pending[0].data.scriptContent).toBe('new script')
     // The dialog uses this flag to tell the user we're re-prompting *because*
     // orca.yaml changed, not because they've never approved this hook.
@@ -151,9 +145,8 @@ describe('ensureHooksConfirmed', () => {
     })
 
     const promise = ensureHooksConfirmed(state, 'repo-1', 'setup')
-    await flush()
 
-    expect(pending).toHaveLength(1)
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
     expect(pending[0].data).toMatchObject({
       repoId: 'repo-1',
       repoName: 'Repo One',


### PR DESCRIPTION
## Summary
- Extract GitHub PR start-point resolution into a shared main-process helper
- Allow PR worktree checkout to fall back to refs/pull/<number>/head when branch or fork metadata is unavailable
- Preserve contributor push targets when they can still be resolved and add regression coverage

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/github/pr-start-point.test.ts src/main/ipc/worktrees.test.ts
- pnpm typecheck