### PR TITLE
Fix file explorer stale directory load races

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { createFileExplorerDirLoadTracker } from './file-explorer-dir-load-tracker'
+
+describe('createFileExplorerDirLoadTracker', () => {
+  it('rejects stale completions for the same directory', () => {
+    const tracker = createFileExplorerDirLoadTracker()
+
+    const firstLoad = tracker.begin('/repo')
+    const secondLoad = tracker.begin('/repo')
+
+    expect(tracker.isCurrent(firstLoad)).toBe(false)
+    expect(tracker.isCurrent(secondLoad)).toBe(true)
+  })
+
+  it('keeps concurrent loads for different directories independent', () => {
+    const tracker = createFileExplorerDirLoadTracker()
+
+    const rootLoad = tracker.begin('/repo')
+    const childLoad = tracker.begin('/repo/src')
+
+    expect(tracker.isCurrent(rootLoad)).toBe(true)
+    expect(tracker.isCurrent(childLoad)).toBe(true)
+  })
+
+  it('invalidates pending loads when the tree reset session changes', () => {
+    const tracker = createFileExplorerDirLoadTracker()
+    const oldSessionLoad = tracker.begin('/repo')
+
+    tracker.reset()
+    const newSessionLoad = tracker.begin('/repo')
+
+    expect(tracker.isCurrent(oldSessionLoad)).toBe(false)
+    expect(tracker.isCurrent(newSessionLoad)).toBe(true)
+  })
+
+  it('invalidates session snapshots only when the tree reset session changes', () => {
+    const tracker = createFileExplorerDirLoadTracker()
+
+    const initialSession = tracker.getSession()
+    tracker.begin('/repo')
+    tracker.begin('/repo/src')
+
+    expect(tracker.isSessionCurrent(initialSession)).toBe(true)
+
+    tracker.reset()
+
+    expect(tracker.isSessionCurrent(initialSession)).toBe(false)
+    expect(tracker.isSessionCurrent(tracker.getSession())).toBe(true)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.ts
@@ -1,0 +1,36 @@
+export type FileExplorerDirLoadToken = {
+  dirPath: string
+  revision: number
+  session: number
+}
+
+export type FileExplorerDirLoadSession = number
+
+export type FileExplorerDirLoadTracker = {
+  begin: (dirPath: string) => FileExplorerDirLoadToken
+  isCurrent: (token: FileExplorerDirLoadToken) => boolean
+  getSession: () => FileExplorerDirLoadSession
+  isSessionCurrent: (session: FileExplorerDirLoadSession) => boolean
+  reset: () => void
+}
+
+export function createFileExplorerDirLoadTracker(): FileExplorerDirLoadTracker {
+  let session = 0
+  const revisionsByDir = new Map<string, number>()
+
+  return {
+    begin: (dirPath) => {
+      const revision = (revisionsByDir.get(dirPath) ?? 0) + 1
+      revisionsByDir.set(dirPath, revision)
+      return { dirPath, revision, session }
+    },
+    isCurrent: (token) =>
+      token.session === session && revisionsByDir.get(token.dirPath) === token.revision,
+    getSession: () => session,
+    isSessionCurrent: (snapshot) => snapshot === session,
+    reset: () => {
+      session += 1
+      revisionsByDir.clear()
+    }
+  }
+}

--- a/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
@@ -20,7 +20,7 @@ type UseFileExplorerRevealParams = {
   rootCache: DirCache | undefined
   rowsByPath: Map<string, TreeNode>
   flatRows: TreeNode[]
-  loadDir: (dirPath: string, depth: number, options?: { force?: boolean }) => Promise<void>
+  loadDir: (dirPath: string, depth: number, options?: { force?: boolean }) => Promise<boolean>
   setSelectedPath: Dispatch<SetStateAction<string | null>>
   setFlashingPath: Dispatch<SetStateAction<string | null>>
   flashTimeoutRef: RefObject<number | null>
@@ -91,10 +91,16 @@ export function useFileExplorerReveal({
     })
 
     void (async () => {
-      await loadDir(worktreePath, -1)
+      const rootLoaded = await loadDir(worktreePath, -1)
+      if (!rootLoaded) {
+        return
+      }
 
       for (let depth = 0; depth < pendingRevealAncestorDirs.length; depth += 1) {
-        await loadDir(pendingRevealAncestorDirs[depth], depth)
+        const ancestorLoaded = await loadDir(pendingRevealAncestorDirs[depth], depth)
+        if (!ancestorLoaded) {
+          return
+        }
       }
     })()
   }, [

--- a/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
@@ -7,6 +7,7 @@ import { splitPathSegments } from './path-tree'
 import { shouldIncludeFileExplorerEntry } from './file-explorer-entries'
 import { readRuntimeDirectory } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
+import { createFileExplorerDirLoadTracker } from './file-explorer-dir-load-tracker'
 
 type UseFileExplorerTreeResult = {
   dirCache: Record<string, DirCache>
@@ -15,7 +16,7 @@ type UseFileExplorerTreeResult = {
   rowsByPath: Map<string, TreeNode>
   rootCache: DirCache | undefined
   rootError: string | null
-  loadDir: (dirPath: string, depth: number, options?: { force?: boolean }) => Promise<void>
+  loadDir: (dirPath: string, depth: number, options?: { force?: boolean }) => Promise<boolean>
   refreshTree: () => Promise<void>
   refreshDir: (dirPath: string) => Promise<void>
   resetAndLoad: () => void
@@ -30,13 +31,15 @@ export function useFileExplorerTree(
   const [rootError, setRootError] = useState<string | null>(null)
   const dirCacheRef = useRef(dirCache)
   dirCacheRef.current = dirCache
+  const dirLoadTrackerRef = useRef(createFileExplorerDirLoadTracker())
 
   const loadDir = useCallback(
     async (dirPath: string, depth: number, options?: { force?: boolean }) => {
       const cache = dirCacheRef.current
       if (!options?.force && (cache[dirPath]?.children.length > 0 || cache[dirPath]?.loading)) {
-        return
+        return true
       }
+      const loadToken = dirLoadTrackerRef.current.begin(dirPath)
       // Why: when force-reloading a directory (e.g. after a file is created,
       // duplicated, or deleted), keep the previous children visible while the
       // fresh listing loads. Clearing to [] would momentarily shrink flatRows,
@@ -59,6 +62,9 @@ export function useFileExplorerTree(
           },
           dirPath
         )
+        if (!dirLoadTrackerRef.current.isCurrent(loadToken)) {
+          return false
+        }
         if (depth === -1) {
           setRootError(null)
         }
@@ -74,7 +80,11 @@ export function useFileExplorerTree(
             depth: depth + 1
           }))
         setDirCache((prev) => ({ ...prev, [dirPath]: { children, loading: false } }))
+        return true
       } catch (error) {
+        if (!dirLoadTrackerRef.current.isCurrent(loadToken)) {
+          return false
+        }
         if (depth === -1) {
           // Why: the old implementation collapsed root read failures into an
           // empty tree, which made authorization/path bugs look like a real
@@ -83,6 +93,7 @@ export function useFileExplorerTree(
           setRootError(error instanceof Error ? error.message : String(error))
         }
         setDirCache((prev) => ({ ...prev, [dirPath]: { children: [], loading: false } }))
+        return true
       }
     },
     [activeWorktreeId, worktreePath]
@@ -96,7 +107,11 @@ export function useFileExplorerTree(
     // causing the virtualizer scroll position to jump to the top. Instead we
     // rely on the force-reload inside loadDir which keeps existing children
     // visible until the fresh listing arrives.
-    await loadDir(worktreePath, -1, { force: true })
+    const refreshSession = dirLoadTrackerRef.current.getSession()
+    const rootLoadCompleted = await loadDir(worktreePath, -1, { force: true })
+    if (!rootLoadCompleted || !dirLoadTrackerRef.current.isSessionCurrent(refreshSession)) {
+      return
+    }
     await Promise.all(
       Array.from(expanded).map(async (dirPath) => {
         const depth = splitPathSegments(dirPath.slice(worktreePath.length + 1)).length - 1
@@ -144,6 +159,9 @@ export function useFileExplorerTree(
   const rootCache = worktreePath ? dirCache[worktreePath] : undefined
 
   const resetAndLoad = useCallback(() => {
+    // Why: stale readDir responses from the previous worktree/reset session
+    // must not repopulate the explorer after the tree has been cleared.
+    dirLoadTrackerRef.current.reset()
     setDirCache({})
     setRootError(null)
     if (worktreePath) {


### PR DESCRIPTION
## Summary
- add per-directory load revisions plus reset-session tracking for Explorer directory reads
- prevent stale async readDir completions from mutating dirCache/root errors
- stop refresh and reveal load chains when their root/ancestor loads are invalidated

Closes #2249

## Repro
- Modeled the reported race with two forced loads for the same directory resolving out of order; before the fix, the older partial response could overwrite the newer complete response.
- Added regression coverage for per-directory stale completion rejection and reset-session invalidation.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.test.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerWatch.test.ts
- pnpm run typecheck:web
- pnpm oxlint src/renderer/src/components/right-sidebar/useFileExplorerTree.ts src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.ts src/renderer/src/components/right-sidebar/file-explorer-dir-load-tracker.test.ts
- git diff --check

Note: local commands passed with the existing engine warning that this shell is Node v25.9.0 while package.json wants Node 24.

## Auto Review-Fix
- Ran 3 iterations.
- Iteration 1 found and fixed stale refreshTree child-load continuation after reset.
- Iteration 2 found and fixed stale reveal child-load continuation after reset.
- Iteration 3 returned no findings from both /review-code and /review-algorithm-architecture.

Made with [Orca](https://github.com/stablyai/orca) 🐋
