### PR TITLE
Allow local file preview navigation in browser tabs

### DIFF
--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -131,6 +131,53 @@ describe('browserManager', () => {
     })
   })
 
+  it('blocks file popup URLs from remote guests', () => {
+    const rendererSendMock = vi.fn()
+    const guest = {
+      id: 108,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      getURL: vi.fn(() => 'https://example.com/'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockImplementation((id: number) => {
+      if (id === guest.id) {
+        return guest
+      }
+      if (id === rendererWebContentsId) {
+        return { isDestroyed: vi.fn(() => false), send: rendererSendMock }
+      }
+      return null
+    })
+
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'browser-1',
+      webContentsId: guest.id,
+      rendererWebContentsId
+    })
+
+    const handler = guestSetWindowOpenHandlerMock.mock.calls[0][0] as (details: {
+      url: string
+    }) => { action: 'deny' }
+    expect(handler({ url: 'file:///tmp/orca-mockups/index.html' })).toEqual({ action: 'deny' })
+
+    expect(shellOpenExternalMock).not.toHaveBeenCalled()
+    expect(rendererSendMock).not.toHaveBeenCalledWith(
+      'browser:open-link-in-orca-tab',
+      expect.anything()
+    )
+    expect(rendererSendMock).toHaveBeenCalledWith('browser:popup', {
+      browserPageId: 'browser-1',
+      origin: 'null',
+      action: 'blocked'
+    })
+  })
+
   it('falls back to opening popup URLs externally before a guest is registered', () => {
     const guest = {
       id: 105,
@@ -516,6 +563,131 @@ describe('browserManager', () => {
     const preventDefault = vi.fn()
     willNavigateHandler?.({ preventDefault }, 'file:///etc/passwd')
     expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows local file guest navigations inside the initially opened folder', () => {
+    let currentUrl = 'file:///tmp/orca-mockups/index.html'
+    const guest = {
+      id: 205,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      getURL: vi.fn(() => currentUrl),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+
+    const willNavigateHandler = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-navigate'
+    )?.[1] as ((event: { preventDefault: () => void }, url: string) => void) | undefined
+
+    expect(willNavigateHandler).toBeTypeOf('function')
+    const siblingPreventDefault = vi.fn()
+    willNavigateHandler?.(
+      { preventDefault: siblingPreventDefault },
+      'file:///tmp/orca-mockups/mockup-01-command-center.html'
+    )
+    expect(siblingPreventDefault).not.toHaveBeenCalled()
+
+    currentUrl = 'file:///tmp/orca-mockups/nested/page.html'
+    const rootPreventDefault = vi.fn()
+    willNavigateHandler?.(
+      { preventDefault: rootPreventDefault },
+      'file:///tmp/orca-mockups/index.html'
+    )
+    expect(rootPreventDefault).not.toHaveBeenCalled()
+  })
+
+  it('blocks local file guest navigations outside the initially opened folder', () => {
+    const guest = {
+      id: 206,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      getURL: vi.fn(() => 'file:///tmp/orca-mockups/index.html'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+
+    const willNavigateHandler = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-navigate'
+    )?.[1] as ((event: { preventDefault: () => void }, url: string) => void) | undefined
+
+    const preventDefault = vi.fn()
+    willNavigateHandler?.({ preventDefault }, 'file:///tmp/secret.html')
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks remote guest navigations to local files', () => {
+    const guest = {
+      id: 207,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      getURL: vi.fn(() => 'https://example.com/'),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+
+    const willNavigateHandler = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-navigate'
+    )?.[1] as ((event: { preventDefault: () => void }, url: string) => void) | undefined
+
+    const preventDefault = vi.fn()
+    willNavigateHandler?.({ preventDefault }, 'file:///tmp/orca-mockups/index.html')
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks file navigations after a local guest has moved to a remote page', () => {
+    let currentUrl = 'file:///tmp/orca-mockups/index.html'
+    const guest = {
+      id: 209,
+      isDestroyed: vi.fn(() => false),
+      getType: vi.fn(() => 'webview'),
+      getURL: vi.fn(() => currentUrl),
+      setBackgroundThrottling: guestSetBackgroundThrottlingMock,
+      setWindowOpenHandler: guestSetWindowOpenHandlerMock,
+      on: guestOnMock,
+      off: guestOffMock,
+      openDevTools: guestOpenDevToolsMock
+    }
+    webContentsFromIdMock.mockReturnValue(guest)
+
+    browserManager.attachGuestPolicies(guest as never)
+
+    const willNavigateHandler = guestOnMock.mock.calls.find(
+      ([event]) => event === 'will-navigate'
+    )?.[1] as ((event: { preventDefault: () => void }, url: string) => void) | undefined
+
+    const initialPreventDefault = vi.fn()
+    willNavigateHandler?.(
+      { preventDefault: initialPreventDefault },
+      'file:///tmp/orca-mockups/mockup-01-command-center.html'
+    )
+    expect(initialPreventDefault).not.toHaveBeenCalled()
+
+    currentUrl = 'https://example.com/'
+    const remotePreventDefault = vi.fn()
+    willNavigateHandler?.(
+      { preventDefault: remotePreventDefault },
+      'file:///tmp/orca-mockups/mockup-02-repo-radar.html'
+    )
+    expect(remotePreventDefault).toHaveBeenCalledTimes(1)
   })
 
   it('unregisterAll clears tracked guests and context-menu listeners', () => {

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -3,6 +3,8 @@ single privileged facade for guest registration, authorization, and lifecycle
 cleanup even after extracting the grab/session helpers. Keeping that ownership
 in one file avoids scattering the browser security boundary across modules. */
 import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { shell, webContents } from 'electron'
 import {
@@ -88,6 +90,36 @@ function safeOrigin(rawUrl: string): string {
   }
 }
 
+function localFilePathFromUrl(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl)
+    return parsed.protocol === 'file:' ? path.resolve(fileURLToPath(parsed)) : null
+  } catch {
+    return null
+  }
+}
+
+function trustedRootForCurrentFileUrl(rawUrl: string | null): string | null {
+  if (!rawUrl) {
+    return null
+  }
+  const localPath = localFilePathFromUrl(rawUrl)
+  return localPath ? path.dirname(localPath) : null
+}
+
+function isPathInsideRoot(rootPath: string, targetPath: string): boolean {
+  const relativePath = path.relative(rootPath, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+}
+
+function getGuestUrl(guest: Electron.WebContents): string | null {
+  try {
+    return typeof guest.getURL === 'function' ? guest.getURL() || null : null
+  } catch {
+    return null
+  }
+}
+
 export class BrowserManager {
   private readonly webContentsIdByTabId = new Map<string, number>()
   // Why: reverse map enables O(1) guest→tab lookups instead of O(N) linear
@@ -109,6 +141,7 @@ export class BrowserManager {
   private readonly worktreeIdByTabId = new Map<string, string>()
   private readonly policyAttachedGuestIds = new Set<number>()
   private readonly policyCleanupByGuestId = new Map<number, () => void>()
+  private readonly trustedFileNavigationRootByGuestId = new Map<number, string>()
   private readonly pendingLoadFailuresByGuestId = new Map<
     number,
     { code: number; description: string; validatedUrl: string }
@@ -420,6 +453,10 @@ export class BrowserManager {
     // webviews vs real Chrome. Inject overrides on every page load so manual
     // browsing passes challenges even without the CDP debugger attached.
     const disposeAntiDetection = this.injectAntiDetection(guest)
+    const initialFileNavigationRoot = trustedRootForCurrentFileUrl(getGuestUrl(guest))
+    if (initialFileNavigationRoot) {
+      this.trustedFileNavigationRootByGuestId.set(guest.id, initialFileNavigationRoot)
+    }
 
     // Why: background throttling must be disabled so agent-driven screenshots
     // (Page.captureScreenshot via CDP proxy) can capture frames even when the
@@ -430,6 +467,9 @@ export class BrowserManager {
       const browserTabId = this.resolveBrowserTabIdForGuestWebContentsId(guest.id)
       const browserUrl = normalizeBrowserNavigationUrl(url)
       const externalUrl = normalizeExternalBrowserUrl(url)
+      const canOpenInOrca =
+        browserUrl &&
+        (!browserUrl.startsWith('file:') || this.canGuestNavigateToFileUrl(guest, browserUrl))
 
       // Why: popup-capable guests are required for OAuth and target=_blank
       // flows, but Orca still does not host child windows itself. For normal
@@ -437,7 +477,7 @@ export class BrowserManager {
       // the user stays in the IDE. Only fall back to the system browser when
       // Orca cannot safely host the destination or when the guest is not yet
       // associated with a trusted browser tab/renderer.
-      if (browserTabId && browserUrl && this.openLinkInOrcaTab(browserTabId, browserUrl)) {
+      if (browserTabId && canOpenInOrca && this.openLinkInOrcaTab(browserTabId, browserUrl)) {
         this.forwardOrQueuePopupEvent(guest.id, {
           origin: safeOrigin(browserUrl),
           action: 'opened-in-orca'
@@ -469,13 +509,13 @@ export class BrowserManager {
       if (url.startsWith('blob:https://') || url.startsWith('blob:http://')) {
         return
       }
-      // Why: file:// is permitted at `will-attach-webview` so the preview pane
-      // can render local HTML the user explicitly opened. After that initial
-      // load, a page must not be able to redirect the guest to file:// — that
-      // would let a remote page probe the local filesystem. Keep the in-guest
-      // navigation guard strict even though initial attach is permissive.
+      // Why: local preview pages need relative links, but remote pages must not
+      // be able to redirect a trusted guest into the user's filesystem. Allow
+      // file-to-file navigation only within the initially opened local folder.
       if (url.startsWith('file:')) {
-        event.preventDefault()
+        if (!this.canGuestNavigateToFileUrl(guest, url)) {
+          event.preventDefault()
+        }
         return
       }
       if (!normalizeBrowserNavigationUrl(url)) {
@@ -516,7 +556,32 @@ export class BrowserManager {
         guest.off('will-redirect', navigationGuard)
         guest.off('did-fail-load', didFailLoadHandler)
       }
+      this.trustedFileNavigationRootByGuestId.delete(guest.id)
     })
+  }
+
+  private canGuestNavigateToFileUrl(guest: Electron.WebContents, targetUrl: string): boolean {
+    const targetPath = localFilePathFromUrl(targetUrl)
+    if (!targetPath) {
+      return false
+    }
+
+    const currentPath = localFilePathFromUrl(getGuestUrl(guest) ?? '')
+    if (!currentPath) {
+      return false
+    }
+
+    let trustedRoot = this.trustedFileNavigationRootByGuestId.get(guest.id) ?? null
+    if (!trustedRoot) {
+      trustedRoot = path.dirname(currentPath)
+      if (trustedRoot) {
+        // Why: this freezes the local preview's trust boundary at the first
+        // opened folder instead of widening it after each successful navigation.
+        this.trustedFileNavigationRootByGuestId.set(guest.id, trustedRoot)
+      }
+    }
+
+    return isPathInsideRoot(trustedRoot, currentPath) && isPathInsideRoot(trustedRoot, targetPath)
   }
 
   private retireStaleGuestWebContents(previousWebContentsId: number): void {
@@ -532,6 +597,7 @@ export class BrowserManager {
       this.policyCleanupByGuestId.delete(previousWebContentsId)
     }
     this.policyAttachedGuestIds.delete(previousWebContentsId)
+    this.trustedFileNavigationRootByGuestId.delete(previousWebContentsId)
     this.pendingLoadFailuresByGuestId.delete(previousWebContentsId)
     this.pendingPermissionEventsByGuestId.delete(previousWebContentsId)
     this.pendingPopupEventsByGuestId.delete(previousWebContentsId)
@@ -623,6 +689,7 @@ export class BrowserManager {
         this.policyCleanupByGuestId.delete(guestWebContentsId)
       }
       this.policyAttachedGuestIds.delete(guestWebContentsId)
+      this.trustedFileNavigationRootByGuestId.delete(guestWebContentsId)
     }
 
     const cleanup = this.contextMenuCleanupByTabId.get(browserTabId)
@@ -671,6 +738,7 @@ export class BrowserManager {
       this.unregisterGuest(browserTabId)
     }
     this.policyAttachedGuestIds.clear()
+    this.trustedFileNavigationRootByGuestId.clear()
     // Why: unregisterGuest only cleans up guests that were registered (have an
     // entry in webContentsIdByTabId). Guests that went through
     // attachGuestPolicies but were never registered still have cleanup closures

--- a/tests/e2e/browser-tab.spec.ts
+++ b/tests/e2e/browser-tab.spec.ts
@@ -6,6 +6,14 @@
  */
 
 import { test, expect } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
+import { rmSync } from 'node:fs'
+import {
+  createHttpFixturePage,
+  createLocalBrowserFixture,
+  executeInBrowserGuest,
+  getBrowserGuestUrl
+} from './helpers/browser-guest-fixtures'
 import {
   waitForSessionReady,
   waitForActiveWorktree,
@@ -18,22 +26,26 @@ import {
   ensureTerminalVisible
 } from './helpers/store'
 
-async function createBrowserTab(
-  page: Parameters<typeof getActiveWorktreeId>[0],
-  worktreeId: string
-): Promise<void> {
-  await page.evaluate((targetWorktreeId) => {
-    const store = window.__store
-    if (!store) {
-      return
-    }
+async function createBrowserTab(page: Page, worktreeId: string, url?: string): Promise<void> {
+  await page.evaluate(
+    ({ targetWorktreeId, targetUrl }) => {
+      const store = window.__store
+      if (!store) {
+        return
+      }
 
-    const state = store.getState()
-    state.createBrowserTab(targetWorktreeId, state.browserDefaultUrl ?? 'about:blank', {
-      title: 'New Browser Tab',
-      activate: true
-    })
-  }, worktreeId)
+      const state = store.getState()
+      state.createBrowserTab(
+        targetWorktreeId,
+        targetUrl ?? state.browserDefaultUrl ?? 'about:blank',
+        {
+          title: 'New Browser Tab',
+          activate: true
+        }
+      )
+    },
+    { targetWorktreeId: worktreeId, targetUrl: url }
+  )
 }
 
 async function switchToTerminalTab(
@@ -190,5 +202,89 @@ test.describe('Browser Tab', () => {
     // Browser tabs should still be preserved
     const browserTabsAfter = await getBrowserTabs(orcaPage, worktreeId)
     expect(browserTabsAfter.length).toBe(browserTabsBefore.length)
+  })
+
+  test('local file preview links navigate inside the embedded browser', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const fixture = createLocalBrowserFixture()
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+
+      await createBrowserTab(orcaPage, worktreeId, fixture.indexUrl)
+      await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('browser')
+
+      await expect
+        .poll(async () => getBrowserGuestUrl(electronApp, orcaPage), {
+          timeout: 10_000,
+          message: 'Browser guest did not load the local index page'
+        })
+        .toBe(fixture.indexUrl)
+
+      await executeInBrowserGuest<void>(
+        electronApp,
+        orcaPage,
+        `document.querySelector('#go')?.click()`
+      )
+
+      await expect
+        .poll(async () => getBrowserGuestUrl(electronApp, orcaPage), {
+          timeout: 10_000,
+          message: 'Clicking a local preview link did not navigate to the linked file'
+        })
+        .toBe(fixture.targetUrl)
+      await expect
+        .poll(
+          async () =>
+            executeInBrowserGuest<string>(
+              electronApp,
+              orcaPage,
+              `document.querySelector('main')?.textContent ?? ''`
+            ),
+          { timeout: 5_000 }
+        )
+        .toContain('Reached target')
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true })
+    }
+  })
+
+  test('remote pages are still blocked from navigating the embedded browser to local files', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const fixture = createLocalBrowserFixture()
+    const remote = await createHttpFixturePage(fixture.targetUrl)
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+
+      await createBrowserTab(orcaPage, worktreeId, remote.url)
+      await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('browser')
+      await expect
+        .poll(async () => getBrowserGuestUrl(electronApp, orcaPage), {
+          timeout: 10_000,
+          message: 'Browser guest did not load the remote fixture page'
+        })
+        .toBe(remote.url)
+
+      await executeInBrowserGuest<void>(
+        electronApp,
+        orcaPage,
+        `document.querySelector('#go')?.click()`
+      )
+
+      // Why: this is the original security purpose of the file-navigation
+      // guard. A remote page may render a file:// link, but clicking it must
+      // not move the guest into the user's local filesystem.
+      await orcaPage.waitForTimeout(750)
+      expect(await getBrowserGuestUrl(electronApp, orcaPage)).toBe(remote.url)
+      expect(await executeInBrowserGuest<string>(electronApp, orcaPage, `document.title`)).toBe(
+        'Remote Page'
+      )
+    } finally {
+      await remote.close()
+      rmSync(fixture.dir, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/e2e/helpers/browser-guest-fixtures.ts
+++ b/tests/e2e/helpers/browser-guest-fixtures.ts
@@ -1,0 +1,110 @@
+import { expect, type ElectronApplication, type Page } from '@stablyai/playwright-test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+async function getActiveBrowserGuestWebContentsId(page: Page): Promise<number> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const webview = document.querySelector('webview') as
+            | (Element & { getWebContentsId?: () => number })
+            | null
+          return webview?.getWebContentsId?.() ?? null
+        }),
+      { timeout: 10_000, message: 'Browser webview did not register a guest WebContents id' }
+    )
+    .not.toBeNull()
+
+  const id = await page.evaluate(() => {
+    const webview = document.querySelector('webview') as
+      | (Element & { getWebContentsId?: () => number })
+      | null
+    return webview?.getWebContentsId?.() ?? null
+  })
+  if (id === null) {
+    throw new Error('Browser webview did not expose a guest WebContents id')
+  }
+  return id
+}
+
+export async function executeInBrowserGuest<T>(
+  app: ElectronApplication,
+  page: Page,
+  expression: string
+): Promise<T> {
+  const webContentsId = await getActiveBrowserGuestWebContentsId(page)
+  return app.evaluate(
+    async ({ webContents }, args) => {
+      const guest = webContents.fromId(args.webContentsId)
+      if (!guest || guest.isDestroyed()) {
+        throw new Error(`Browser guest ${args.webContentsId} is not available`)
+      }
+      return guest.executeJavaScript(args.expression, true)
+    },
+    { webContentsId, expression }
+  ) as Promise<T>
+}
+
+export async function getBrowserGuestUrl(app: ElectronApplication, page: Page): Promise<string> {
+  const webContentsId = await getActiveBrowserGuestWebContentsId(page)
+  return app.evaluate(({ webContents }, id) => {
+    const guest = webContents.fromId(id)
+    if (!guest || guest.isDestroyed()) {
+      throw new Error(`Browser guest ${id} is not available`)
+    }
+    return guest.getURL()
+  }, webContentsId)
+}
+
+export function createLocalBrowserFixture(): { dir: string; indexUrl: string; targetUrl: string } {
+  const dir = path.join(
+    tmpdir(),
+    `orca-browser-file-e2e-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  )
+  mkdirSync(dir, { recursive: true })
+  const indexPath = path.join(dir, 'index.html')
+  const targetPath = path.join(dir, 'target.html')
+  writeFileSync(
+    indexPath,
+    '<!doctype html><title>Local Index</title><a id="go" href="./target.html">Open target</a>'
+  )
+  writeFileSync(targetPath, '<!doctype html><title>Local Target</title><main>Reached target</main>')
+  return {
+    dir,
+    indexUrl: pathToFileURL(indexPath).toString(),
+    targetUrl: pathToFileURL(targetPath).toString()
+  }
+}
+
+export async function createHttpFixturePage(linkTargetUrl: string): Promise<{
+  url: string
+  close: () => Promise<void>
+}> {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    res.end(
+      `<!doctype html><title>Remote Page</title><a id="go" href="${linkTargetUrl}">Open local file</a>`
+    )
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('HTTP fixture server did not bind to a TCP port')
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+  }
+}


### PR DESCRIPTION
## Summary
- allow embedded browser file previews to follow relative file:// links within the initially opened folder
- keep remote pages blocked from navigating browser guests into local files
- add unit and Playwright coverage for the local-file reproducer and security regression case

## Tests
- pnpm vitest run --config config/vitest.config.ts src/main/browser/browser-manager.test.ts
- pnpm run typecheck:node
- pnpm exec electron-vite build --mode e2e
- SKIP_BUILD=1 pnpm run test:e2e --grep "local file preview links navigate|remote pages are still blocked"
- SKIP_BUILD=1 pnpm exec playwright test tests/e2e/browser-tab.spec.ts --config tests/playwright.config.ts --project electron-headless

Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.