### PR TITLE
Support system SSH transport for fdpass proxies

### DIFF
--- a/src/main/ssh/ssh-config-parser.test.ts
+++ b/src/main/ssh/ssh-config-parser.test.ts
@@ -77,15 +77,17 @@ Host myserver
     expect(hosts[0].identityFile).toBe('/home/testuser/.ssh/id_ed25519')
   })
 
-  it('parses ProxyCommand and ProxyJump', () => {
+  it('parses ProxyCommand, ProxyUseFdpass, and ProxyJump', () => {
     const config = `
 Host internal
   HostName 10.0.0.5
   ProxyCommand ssh -W %h:%p bastion
+  ProxyUseFdpass yes
   ProxyJump bastion.example.com
 `
     const hosts = parseSshConfig(config)
     expect(hosts[0].proxyCommand).toBe('ssh -W %h:%p bastion')
+    expect(hosts[0].proxyUseFdpass).toBe(true)
     expect(hosts[0].proxyJump).toBe('bastion.example.com')
   })
 
@@ -200,6 +202,7 @@ describe('sshConfigHostsToTargets', () => {
         hostname: '10.0.0.5',
         identityFile: '/home/user/.ssh/id_rsa',
         proxyCommand: 'ssh -W %h:%p bastion',
+        proxyUseFdpass: true,
         proxyJump: 'bastion.example.com'
       }
     ]
@@ -291,6 +294,16 @@ describe('parseSshGOutput', () => {
     const noneOutput = 'hostname example.com\nproxycommand none\nport 22'
     const noneResult = parseSshGOutput(noneOutput)
     expect(noneResult.proxyCommand).toBeUndefined()
+  })
+
+  it('parses proxyusefdpass yes', () => {
+    const output = 'hostname example.com\nproxyusefdpass yes\nport 22'
+    const result = parseSshGOutput(output)
+    expect(result.proxyUseFdpass).toBe(true)
+
+    const noneOutput = 'hostname example.com\nproxyusefdpass no\nport 22'
+    const noneResult = parseSshGOutput(noneOutput)
+    expect(noneResult.proxyUseFdpass).toBe(false)
   })
 
   it('parses proxyjump and filters "none"', () => {

--- a/src/main/ssh/ssh-config-parser.ts
+++ b/src/main/ssh/ssh-config-parser.ts
@@ -11,6 +11,7 @@ export type SshConfigHost = {
   user?: string
   identityFile?: string
   proxyCommand?: string
+  proxyUseFdpass?: boolean
   proxyJump?: string
 }
 
@@ -83,6 +84,9 @@ export function parseSshConfig(content: string): SshConfigHost[] {
         break
       case 'proxycommand':
         current.proxyCommand = value
+        break
+      case 'proxyusefdpass':
+        current.proxyUseFdpass = value.toLowerCase() === 'yes'
         break
       case 'proxyjump':
         current.proxyJump = value
@@ -160,6 +164,7 @@ export type SshResolvedConfig = {
   identityFile: string[]
   forwardAgent: boolean
   proxyCommand?: string
+  proxyUseFdpass: boolean
   proxyJump?: string
 }
 
@@ -215,6 +220,7 @@ export function parseSshGOutput(stdout: string): SshResolvedConfig {
     identityFile: identityFiles,
     forwardAgent: map.get('forwardagent') === 'yes',
     proxyCommand,
+    proxyUseFdpass: map.get('proxyusefdpass') === 'yes',
     proxyJump
   }
 }

--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -238,6 +238,7 @@ function makeResolved(overrides?: Partial<SshResolvedConfig>): SshResolvedConfig
     port: 22,
     identityFile: [],
     forwardAgent: false,
+    proxyUseFdpass: false,
     ...overrides
   }
 }

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { Socket } from 'net'
+import { EventEmitter } from 'events'
 
 let eventHandlers: Map<string, (...args: unknown[]) => void>
 let connectBehavior: 'ready' | 'error' = 'ready'
@@ -46,6 +47,10 @@ vi.mock('ssh2', () => {
   return { Client: MockSshClient }
 })
 
+const { spawnSystemSshCommandMock } = vi.hoisted(() => ({
+  spawnSystemSshCommandMock: vi.fn()
+}))
+
 vi.mock('./ssh-system-fallback', () => ({
   spawnSystemSsh: vi.fn().mockReturnValue({
     stdin: {},
@@ -54,14 +59,22 @@ vi.mock('./ssh-system-fallback', () => ({
     kill: vi.fn(),
     onExit: vi.fn(),
     pid: 99999
-  })
+  }),
+  spawnSystemSshCommand: spawnSystemSshCommandMock,
+  uploadDirectoryViaSystemSsh: vi.fn(),
+  writeFileViaSystemSsh: vi.fn()
 }))
 
 vi.mock('./ssh-config-parser', () => ({
   resolveWithSshG: vi.fn().mockResolvedValue(null)
 }))
 
-import { SshConnection, SshConnectionManager, type SshConnectionCallbacks } from './ssh-connection'
+import {
+  SshConnection,
+  SshConnectionManager,
+  shouldUseSystemSshTransport,
+  type SshConnectionCallbacks
+} from './ssh-connection'
 import { resolveWithSshG } from './ssh-config-parser'
 import type { SshTarget } from '../../shared/ssh-types'
 
@@ -83,12 +96,37 @@ function createCallbacks(overrides?: Partial<SshConnectionCallbacks>): SshConnec
   }
 }
 
+function createSystemCommandChannel(): EventEmitter & {
+  stdin: { end: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn> }
+  stderr: EventEmitter
+  close: ReturnType<typeof vi.fn>
+} {
+  const channel = new EventEmitter() as EventEmitter & {
+    stdin: { end: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn> }
+    stderr: EventEmitter
+    close: ReturnType<typeof vi.fn>
+  }
+  channel.stdin = { end: vi.fn(), write: vi.fn() }
+  channel.stderr = new EventEmitter()
+  channel.close = vi.fn()
+  queueMicrotask(() => {
+    channel.emit('data', Buffer.from('ORCA-SYSTEM-SSH-OK'))
+    channel.emit('close', 0)
+  })
+  return channel
+}
+
 describe('SshConnection', () => {
   beforeEach(() => {
     eventHandlers = new Map()
     connectBehavior = 'ready'
     connectErrorMessage = ''
     clientInstances = []
+    spawnSystemSshCommandMock.mockReset()
+    spawnSystemSshCommandMock.mockImplementation(() => createSystemCommandChannel())
+    vi.mocked(resolveWithSshG).mockReset()
+    vi.mocked(resolveWithSshG).mockResolvedValue(null)
+    vi.unstubAllEnvs()
   })
 
   it('transitions to connected on successful connect', async () => {
@@ -220,6 +258,39 @@ describe('SshConnection', () => {
     expect(clientInstances[0].lastExecCommand).toBe(
       "exec /bin/sh -c 'cd '\\''/tmp'\\'' && ('\\''/usr/bin/node'\\'' -e '\\''console.log(1)'\\'' || echo MISSING)'"
     )
+  })
+
+  it('uses system SSH transport when ProxyUseFdpass is resolved by OpenSSH', async () => {
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce({
+      hostname: 'example.com',
+      port: 22,
+      identityFile: [],
+      forwardAgent: false,
+      proxyUseFdpass: true
+    })
+    const conn = new SshConnection(createTarget({ configHost: 'fdpass-host' }), createCallbacks())
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+    expect(clientInstances).toHaveLength(0)
+    expect(spawnSystemSshCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ configHost: 'fdpass-host' }),
+      'printf ORCA-SYSTEM-SSH-OK'
+    )
+  })
+})
+
+describe('shouldUseSystemSshTransport', () => {
+  it('uses system transport for target or resolved ProxyUseFdpass', () => {
+    expect(shouldUseSystemSshTransport(createTarget(), { proxyUseFdpass: true })).toBe(true)
+    expect(shouldUseSystemSshTransport(createTarget(), { proxyUseFdpass: false })).toBe(false)
+  })
+
+  it('allows an environment override for e2e coverage', () => {
+    vi.stubEnv('ORCA_SSH_FORCE_SYSTEM_TRANSPORT', '1')
+    expect(shouldUseSystemSshTransport(createTarget(), null)).toBe(true)
   })
 })
 

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -4,8 +4,14 @@ import { Client as SshClient } from 'ssh2'
 import type { ChildProcess } from 'child_process'
 import type { ClientChannel, ConnectConfig, SFTPWrapper } from 'ssh2'
 import type { SshTarget, SshConnectionState, SshConnectionStatus } from '../../shared/ssh-types'
-import { spawnSystemSsh, type SystemSshProcess } from './ssh-system-fallback'
-import { resolveWithSshG } from './ssh-config-parser'
+import {
+  spawnSystemSsh,
+  spawnSystemSshCommand,
+  uploadDirectoryViaSystemSsh,
+  writeFileViaSystemSsh,
+  type SystemSshProcess
+} from './ssh-system-fallback'
+import { resolveWithSshG, type SshResolvedConfig } from './ssh-config-parser'
 import {
   INITIAL_RETRY_ATTEMPTS,
   INITIAL_RETRY_DELAY_MS,
@@ -27,6 +33,9 @@ export class SshConnection {
   private client: SshClient | null = null
   private proxyProcess: ChildProcess | null = null
   private systemSsh: SystemSshProcess | null = null
+  private systemCommandChannels = new Set<ClientChannel>()
+  private systemOperationAbortController = new AbortController()
+  private useSystemSshTransport = false
   private state: SshConnectionState
   private callbacks: SshConnectionCallbacks
   private target: SshTarget
@@ -53,6 +62,9 @@ export class SshConnection {
   getClient(): SshClient | null {
     return this.client
   }
+  usesSystemSshTransport(): boolean {
+    return this.useSystemSshTransport
+  }
   getTarget(): SshTarget {
     return { ...this.target }
   }
@@ -68,6 +80,12 @@ export class SshConnection {
   }
 
   async exec(cmd: string): Promise<ClientChannel> {
+    if (this.useSystemSshTransport) {
+      if (this.disposed || this.state.status !== 'connected') {
+        throw new Error('Not connected')
+      }
+      return this.spawnTrackedSystemSshCommand(cmd)
+    }
     if (!this.client) {
       throw new Error('Not connected')
     }
@@ -77,10 +95,77 @@ export class SshConnection {
   }
 
   async sftp(): Promise<SFTPWrapper> {
+    if (this.useSystemSshTransport) {
+      throw new Error('SFTP is not available when using system SSH transport')
+    }
     if (!this.client) {
       throw new Error('Not connected')
     }
     return new Promise((res, rej) => this.client!.sftp((e, s) => (e ? rej(e) : res(s))))
+  }
+
+  async uploadDirectory(localDir: string, remoteDir: string): Promise<void> {
+    if (!this.useSystemSshTransport) {
+      const sftp = await this.sftp()
+      try {
+        const { uploadDirectory } = await import('./ssh-relay-deploy-helpers')
+        await uploadDirectory(sftp, localDir, remoteDir)
+      } finally {
+        sftp.end()
+      }
+      return
+    }
+    await uploadDirectoryViaSystemSsh(this.target, localDir, remoteDir, {
+      signal: this.systemOperationAbortController.signal
+    })
+  }
+
+  async writeFile(remotePath: string, contents: string): Promise<void> {
+    if (!this.useSystemSshTransport) {
+      const sftp = await this.sftp()
+      const swallowLateSftpError = (): void => {}
+      sftp.on('error', swallowLateSftpError)
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const ws = sftp.createWriteStream(remotePath)
+          let settled = false
+          const cleanup = (): void => {
+            ws.removeListener('close', onClose)
+            ws.removeListener('error', onError)
+          }
+          const onClose = (): void => {
+            if (settled) {
+              return
+            }
+            settled = true
+            cleanup()
+            resolve()
+          }
+          const onError = (err: Error): void => {
+            sftp.removeListener('error', onError)
+            if (settled) {
+              return
+            }
+            settled = true
+            cleanup()
+            reject(err)
+          }
+          sftp.prependOnceListener('error', onError)
+          ws.once('close', onClose)
+          ws.once('error', onError)
+          ws.end(contents)
+        })
+      } finally {
+        sftp.end()
+        setImmediate(() => {
+          sftp.removeListener('error', swallowLateSftpError)
+        })
+      }
+      return
+    }
+    await writeFileViaSystemSsh(this.target, remotePath, contents, {
+      signal: this.systemOperationAbortController.signal
+    })
   }
 
   async connect(): Promise<void> {
@@ -127,6 +212,11 @@ export class SshConnection {
     const resolved = await resolveWithSshG(this.target.configHost || this.target.label).catch(
       () => null
     )
+    if (shouldUseSystemSshTransport(this.target, resolved)) {
+      await this.doSystemSshProbe(connectGeneration)
+      return
+    }
+
     const config = buildConnectConfig(this.target, resolved)
 
     // Why: ssh2 doesn't support ProxyCommand/ProxyJump natively. Spawn the
@@ -186,6 +276,77 @@ export class SshConnection {
       this.proxyProcess = null
       throw err
     }
+  }
+
+  private async doSystemSshProbe(connectGeneration: number): Promise<void> {
+    this.useSystemSshTransport = true
+    this.client = null
+    this.proxyProcess?.kill()
+    this.proxyProcess = null
+
+    const channel = this.spawnTrackedSystemSshCommand('printf ORCA-SYSTEM-SSH-OK')
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let stdout = ''
+        let stderr = ''
+        let settled = false
+        const timeout = setTimeout(() => {
+          settled = true
+          channel.close()
+          reject(new Error('System SSH connection timed out'))
+        }, CONNECT_TIMEOUT_MS)
+
+        channel.on('data', (data: Buffer) => {
+          stdout += data.toString('utf-8')
+        })
+        channel.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString('utf-8')
+        })
+        channel.on('error', (err: Error) => {
+          if (settled) {
+            return
+          }
+          settled = true
+          clearTimeout(timeout)
+          reject(err)
+        })
+        channel.on('close', (code: number | null) => {
+          if (settled) {
+            return
+          }
+          settled = true
+          clearTimeout(timeout)
+          if (this.disposed || connectGeneration !== this.connectGeneration) {
+            reject(new Error('SSH connection attempt was cancelled'))
+            return
+          }
+          if (code !== 0 || !stdout.includes('ORCA-SYSTEM-SSH-OK')) {
+            reject(
+              new Error(
+                `System SSH probe failed${code != null ? ` (exit ${code})` : ''}.${stderr ? ` stderr: ${stderr.trim()}` : ''}`
+              )
+            )
+            return
+          }
+          this.setState('connected')
+          resolve()
+        })
+      })
+    } catch (err) {
+      this.useSystemSshTransport = false
+      throw err
+    }
+  }
+
+  private spawnTrackedSystemSshCommand(command: string): ClientChannel {
+    const channel = spawnSystemSshCommand(this.target, command)
+    this.systemCommandChannels.add(channel)
+    const cleanup = (): void => {
+      this.systemCommandChannels.delete(channel)
+    }
+    channel.once('close', cleanup)
+    channel.once('error', cleanup)
+    return channel
   }
 
   // Why: ssh2 may destroy the proxy socket on auth failure, so credential
@@ -384,8 +545,15 @@ export class SshConnection {
     this.client = null
     this.proxyProcess?.kill()
     this.proxyProcess = null
+    this.systemOperationAbortController.abort()
+    this.systemOperationAbortController = new AbortController()
+    for (const channel of this.systemCommandChannels) {
+      channel.close()
+    }
+    this.systemCommandChannels.clear()
     this.systemSsh?.kill()
     this.systemSsh = null
+    this.useSystemSshTransport = false
     this.setState('disconnected')
   }
 
@@ -393,6 +561,13 @@ export class SshConnection {
     this.state = { ...this.state, status, error: error ?? null }
     this.callbacks.onStateChange(this.target.id, { ...this.state })
   }
+}
+
+export function shouldUseSystemSshTransport(
+  _target: SshTarget,
+  resolved: Pick<SshResolvedConfig, 'proxyUseFdpass'> | null
+): boolean {
+  return process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT === '1' || resolved?.proxyUseFdpass === true
 }
 
 export { SshConnectionManager } from './ssh-connection-manager'

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -193,14 +193,7 @@ async function uploadRelay(
   // Create remote directory
   await execCommand(conn, `mkdir -p ${shellEscape(remoteDir)}`)
 
-  // Upload via SFTP
-  const sftp = await conn.sftp()
-
-  try {
-    await uploadDirectory(sftp, localRelayDir, remoteDir)
-  } finally {
-    sftp.end()
-  }
+  await uploadDirectoryForConnection(conn, localRelayDir, remoteDir)
 
   // Make the node binary executable
   await execCommand(conn, `chmod +x ${shellEscape(`${remoteDir}/node`)} 2>/dev/null; true`)
@@ -208,16 +201,50 @@ async function uploadRelay(
   // Why: write `.version` via SFTP rather than shell to avoid quoting issues
   // with content-hashed version strings. The remote daemon reads this same
   // file on startup so the wire-handshake validates against it.
-  const versionSftp = await conn.sftp()
+  await writeRemoteFile(conn, `${remoteDir}/.version`, fullVersion)
+}
+
+async function uploadDirectoryForConnection(
+  conn: SshConnection,
+  localRelayDir: string,
+  remoteDir: string
+): Promise<void> {
+  if (typeof conn.uploadDirectory === 'function') {
+    await conn.uploadDirectory(localRelayDir, remoteDir)
+    return
+  }
+
+  const sftp = await conn.sftp()
+  try {
+    await uploadDirectory(sftp, localRelayDir, remoteDir)
+  } finally {
+    sftp.end()
+  }
+}
+
+async function writeRemoteFile(
+  conn: SshConnection,
+  remotePath: string,
+  contents: string
+): Promise<void> {
+  if (typeof conn.writeFile === 'function') {
+    await conn.writeFile(remotePath, contents)
+    return
+  }
+
+  const sftp = await conn.sftp()
   try {
     await new Promise<void>((resolve, reject) => {
-      const ws = versionSftp.createWriteStream(`${remoteDir}/.version`)
-      ws.on('close', resolve)
-      ws.on('error', reject)
-      ws.end(fullVersion)
+      const ws = sftp.createWriteStream(remotePath)
+      // .once: a session 'error' arriving after we've already resolved/rejected
+      // would otherwise become an unhandled error and crash main.
+      sftp.once('error', reject)
+      ws.once('close', resolve)
+      ws.once('error', reject)
+      ws.end(contents)
     })
   } finally {
-    versionSftp.end()
+    sftp.end()
   }
 }
 
@@ -303,20 +330,7 @@ async function installNativeDeps(
     type: 'commonjs',
     dependencies: RELAY_NATIVE_DEPS
   })}\n`
-  const sftpPkg = await conn.sftp()
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const ws = sftpPkg.createWriteStream(`${remoteDir}/package.json`)
-      // .once: a session 'error' arriving after we've already resolved/rejected
-      // would otherwise become an unhandled error and crash main.
-      sftpPkg.once('error', reject)
-      ws.once('close', resolve)
-      ws.once('error', reject)
-      ws.end(pkgJson)
-    })
-  } finally {
-    sftpPkg.end()
-  }
+  await writeRemoteFile(conn, `${remoteDir}/package.json`, pkgJson)
 
   try {
     const installArgs = Object.entries(RELAY_NATIVE_DEPS)

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -13,7 +13,12 @@ vi.mock('child_process', () => ({
   spawn: spawnMock
 }))
 
-import { findSystemSsh, spawnSystemSsh } from './ssh-system-fallback'
+import {
+  buildSshArgs,
+  findSystemSsh,
+  spawnSystemSsh,
+  spawnSystemSshCommand
+} from './ssh-system-fallback'
 import type { SshTarget } from '../../shared/ssh-types'
 
 function createTarget(overrides?: Partial<SshTarget>): SshTarget {
@@ -45,9 +50,13 @@ describe('findSystemSsh', () => {
 
 describe('spawnSystemSsh', () => {
   let mockProc: {
-    stdin: object
-    stdout: object
-    stderr: object
+    stdin: {
+      write: ReturnType<typeof vi.fn>
+      end: ReturnType<typeof vi.fn>
+      on: ReturnType<typeof vi.fn>
+    }
+    stdout: { on: ReturnType<typeof vi.fn> }
+    stderr: { on: ReturnType<typeof vi.fn> }
     pid: number
     on: ReturnType<typeof vi.fn>
     kill: ReturnType<typeof vi.fn>
@@ -58,7 +67,7 @@ describe('spawnSystemSsh', () => {
     spawnMock.mockReset()
 
     mockProc = {
-      stdin: { write: vi.fn(), end: vi.fn() },
+      stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
       pid: 12345,
@@ -116,6 +125,43 @@ describe('spawnSystemSsh', () => {
     const args = spawnMock.mock.calls[0][1] as string[]
     expect(args).toContain('-o')
     expect(args).toContain('ProxyCommand=ssh -W %h:%p bastion')
+  })
+
+  it('uses configHost without resolved field overrides so OpenSSH sees the Host block', () => {
+    const args = buildSshArgs(
+      createTarget({
+        configHost: 'fdpass-host',
+        host: 'resolved.example.com',
+        port: 2222,
+        username: 'deploy',
+        identityFile: '/tmp/key',
+        proxyCommand: 'ignored'
+      })
+    )
+
+    expect(args).toContain('deploy@fdpass-host')
+    expect(args).not.toContain('resolved.example.com')
+    expect(args).not.toContain('-p')
+    expect(args).not.toContain('-i')
+    expect(args).not.toContain('ProxyCommand=ignored')
+  })
+
+  it('spawns a remote command through the system ssh target', () => {
+    spawnSystemSshCommand(createTarget({ configHost: 'fdpass-host' }), 'echo hello')
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/bin/ssh',
+      expect.arrayContaining(['--', 'deploy@fdpass-host', "exec /bin/sh -c 'echo hello'"]),
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    )
+  })
+
+  it('exposes child stdin so remote commands receive EOF', () => {
+    const channel = spawnSystemSshCommand(createTarget(), 'cat > /tmp/file')
+
+    channel.stdin.end('contents')
+
+    expect(mockProc.stdin.end).toHaveBeenCalledWith('contents')
   })
 
   it('throws when no system ssh is found', () => {

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -1,6 +1,10 @@
 import { spawn, type ChildProcess } from 'child_process'
 import { existsSync } from 'fs'
+import { Duplex } from 'stream'
+import { pipeline } from 'stream/promises'
+import type { ClientChannel } from 'ssh2'
 import type { SshTarget } from '../../shared/ssh-types'
+import { wrapRemoteCommandForPosixShell, shellEscape } from './ssh-connection-utils'
 
 const SYSTEM_SSH_PATHS =
   process.platform === 'win32'
@@ -16,10 +20,21 @@ export type SystemSshProcess = {
   pid: number | undefined
 }
 
+type SystemSshCommandChannel = ClientChannel & {
+  _process?: ChildProcess
+}
+
+type SystemSshOperationOptions = {
+  signal?: AbortSignal
+}
+
 /**
  * Find the system ssh binary path. Returns null if not found.
  */
 export function findSystemSsh(): string | null {
+  if (process.env.ORCA_SYSTEM_SSH_PATH) {
+    return process.env.ORCA_SYSTEM_SSH_PATH
+  }
   for (const candidate of SYSTEM_SSH_PATHS) {
     if (existsSync(candidate)) {
       return candidate
@@ -52,30 +67,126 @@ export function spawnSystemSsh(target: SshTarget): SystemSshProcess {
   return wrapChildProcess(proc)
 }
 
-function buildSshArgs(target: SshTarget): string[] {
+export function spawnSystemSshCommand(target: SshTarget, command: string): ClientChannel {
+  const sshPath = findSystemSsh()
+  if (!sshPath) {
+    throw new Error(
+      'No system ssh binary found. Install OpenSSH to use ProxyUseFdpass, FIDO2 keys, or ControlMaster.'
+    )
+  }
+
+  const proc = spawn(sshPath, [...buildSshArgs(target), wrapRemoteCommandForPosixShell(command)], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true
+  })
+  return wrapCommandProcess(proc)
+}
+
+export async function uploadDirectoryViaSystemSsh(
+  target: SshTarget,
+  localDir: string,
+  remoteDir: string,
+  options?: SystemSshOperationOptions
+): Promise<void> {
+  throwIfAborted(options?.signal)
+  const sshPath = findSystemSsh()
+  if (!sshPath) {
+    throw new Error('No system ssh binary found. Install OpenSSH to use system SSH transport.')
+  }
+
+  const tarCreate = spawn('tar', ['-czf', '-', '-C', localDir, '.'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true
+  })
+  const remoteCommand = `mkdir -p ${shellEscape(remoteDir)} && tar -xzf - -C ${shellEscape(remoteDir)}`
+  const sshExtract = spawn(
+    sshPath,
+    [...buildSshArgs(target), wrapRemoteCommandForPosixShell(remoteCommand)],
+    {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true
+    }
+  )
+
+  const abort = (): void => {
+    killProcess(tarCreate)
+    killProcess(sshExtract)
+  }
+  options?.signal?.addEventListener('abort', abort, { once: true })
+  let tarResult: ProcessResult | null = null
+  let sshResult: ProcessResult | null = null
+  try {
+    ;[tarResult, sshResult] = await Promise.all([
+      waitForProcess(tarCreate, 'local tar relay upload'),
+      waitForProcess(sshExtract, 'system ssh relay upload'),
+      pipeline(tarCreate.stdout!, sshExtract.stdin!)
+    ]).then(([tar, ssh]) => [tar, ssh])
+  } catch (err) {
+    killProcess(tarCreate)
+    killProcess(sshExtract)
+    throw err
+  } finally {
+    options?.signal?.removeEventListener('abort', abort)
+  }
+
+  if (tarResult?.stderr.trim()) {
+    console.warn(`[ssh-system] ${tarResult.label} stderr: ${tarResult.stderr.trim()}`)
+  }
+  if (sshResult?.stderr.trim()) {
+    console.warn(`[ssh-system] ${sshResult.label} stderr: ${sshResult.stderr.trim()}`)
+  }
+}
+
+export async function writeFileViaSystemSsh(
+  target: SshTarget,
+  remotePath: string,
+  contents: string,
+  options?: SystemSshOperationOptions
+): Promise<void> {
+  throwIfAborted(options?.signal)
+  const channel = spawnSystemSshCommand(target, `cat > ${shellEscape(remotePath)}`)
+  const abort = (): void => {
+    channel.close()
+  }
+  options?.signal?.addEventListener('abort', abort, { once: true })
+  const closePromise = waitForChannelClose(channel, `write ${remotePath}`)
+  channel.stdin.end(contents)
+  try {
+    await closePromise
+  } finally {
+    options?.signal?.removeEventListener('abort', abort)
+  }
+}
+
+export function buildSshArgs(target: SshTarget): string[] {
   const args: string[] = []
 
   args.push('-o', 'BatchMode=no')
   // Forward stdin/stdout for relay communication
   args.push('-T')
 
-  if (target.port !== 22) {
+  // Why: configHost preserves OpenSSH-only directives such as ProxyUseFdpass.
+  // Passing resolved host/port/proxy flags would bypass the user's Host block.
+  const useConfigHost = Boolean(target.configHost)
+
+  if (!useConfigHost && target.port !== 22) {
     args.push('-p', String(target.port))
   }
 
-  if (target.identityFile) {
+  if (!useConfigHost && target.identityFile) {
     args.push('-i', target.identityFile)
   }
 
-  if (target.jumpHost) {
+  if (!useConfigHost && target.jumpHost) {
     args.push('-J', target.jumpHost)
   }
 
-  if (target.proxyCommand) {
+  if (!useConfigHost && target.proxyCommand) {
     args.push('-o', `ProxyCommand=${target.proxyCommand}`)
   }
 
-  const userHost = target.username ? `${target.username}@${target.host}` : target.host
+  const host = target.configHost || target.host
+  const userHost = target.username ? `${target.username}@${host}` : host
   args.push('--', userHost)
 
   return args
@@ -98,4 +209,98 @@ function wrapChildProcess(proc: ChildProcess): SystemSshProcess {
       proc.on('exit', (code) => cb(code))
     }
   }
+}
+
+function wrapCommandProcess(proc: ChildProcess): SystemSshCommandChannel {
+  const duplex = new Duplex({
+    read() {},
+    write(chunk, encoding, cb) {
+      proc.stdin!.write(chunk, encoding, cb)
+    }
+  })
+  const channel = duplex as unknown as SystemSshCommandChannel
+
+  const mutableChannel = channel as unknown as {
+    stdin: NodeJS.WritableStream
+    stderr: NodeJS.ReadableStream
+    _process?: ChildProcess
+    close: () => void
+  }
+  mutableChannel.stdin = proc.stdin!
+  mutableChannel.stderr = proc.stderr!
+  mutableChannel._process = proc
+  mutableChannel.close = () => {
+    try {
+      proc.kill('SIGTERM')
+    } catch {
+      // Process may already be dead
+    }
+  }
+
+  proc.stdout!.on('data', (data) => duplex.push(data))
+  proc.stdout!.on('end', () => duplex.push(null))
+  proc.on('exit', (code, signal) => channel.emit('exit', code, signal))
+  proc.on('close', (code, signal) => channel.emit('close', code, signal))
+  proc.on('error', (err) => duplex.destroy(err))
+  proc.stdin!.on('error', (err) => duplex.destroy(err))
+  proc.stdout!.on('error', (err) => duplex.destroy(err))
+
+  return channel
+}
+
+function waitForChannelClose(channel: SystemSshCommandChannel, label: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stderr = ''
+    channel.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString('utf-8')
+    })
+    channel.on('error', reject)
+    channel.on('close', (code: number | null, signal?: NodeJS.Signals | null) => {
+      if (code !== 0) {
+        const detail = code === null ? `signal ${signal ?? 'unknown'}` : `exit ${code}`
+        reject(new Error(`${label} failed (${detail}): ${stderr.trim()}`))
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+type ProcessResult = { label: string; stderr: string }
+
+function waitForProcess(proc: ChildProcess, label: string): Promise<ProcessResult> {
+  return new Promise((resolve, reject) => {
+    let stderr = ''
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString('utf-8')
+    })
+    proc.on('error', reject)
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`${label} failed (exit ${code}): ${stderr.trim()}`))
+        return
+      }
+      resolve({ label, stderr })
+    })
+  })
+}
+
+function killProcess(proc: ChildProcess): void {
+  if (proc.exitCode !== null || proc.killed) {
+    return
+  }
+  try {
+    proc.kill('SIGTERM')
+  } catch {
+    // Process may already be dead
+  }
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return
+  }
+  const error = new Error('System SSH operation was cancelled') as Error & { name: string }
+  error.name = 'AbortError'
+  throw error
 }

--- a/src/main/ssh/ssh-system-transport.integration.test.ts
+++ b/src/main/ssh/ssh-system-transport.integration.test.ts
@@ -1,0 +1,232 @@
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+import { SshConnection } from './ssh-connection'
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
+import { uploadDirectoryViaSystemSsh } from './ssh-system-fallback'
+import type { SshTarget } from '../../shared/ssh-types'
+
+const RELAY_VERSION = '0.1.0+systemtransport'
+
+function makeTarget(): SshTarget {
+  return {
+    id: 'system-transport-target',
+    label: 'System Transport Target',
+    configHost: 'fdpass-host',
+    host: 'ignored.example.com',
+    port: 22,
+    username: ''
+  }
+}
+
+function writeFakeSsh(dir: string): string {
+  const path = join(dir, 'fake-ssh')
+  writeFileSync(
+    path,
+    `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o|-p|-i|-J) shift 2 ;;
+    -T) shift ;;
+    --) shift; break ;;
+    -*) shift ;;
+    *) break ;;
+  esac
+done
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+cmd="$1"
+if [ -z "$cmd" ]; then
+  exit 0
+fi
+exec /bin/sh -c "$cmd"
+`
+  )
+  chmodSync(path, 0o755)
+  return path
+}
+
+function writeFakeRelay(dir: string): void {
+  writeFileSync(
+    join(dir, 'relay.js'),
+    `
+const fs = require('fs');
+const net = require('net');
+const sentinel = 'ORCA-RELAY v0.1.0 READY\\n';
+const sockPath = process.argv[process.argv.indexOf('--sock-path') + 1];
+
+function encode(msg) {
+  const payload = Buffer.from(JSON.stringify(msg), 'utf8');
+  const header = Buffer.alloc(13);
+  header[0] = 1;
+  header.writeUInt32BE(1, 1);
+  header.writeUInt32BE(0, 5);
+  header.writeUInt32BE(payload.length, 9);
+  return Buffer.concat([header, payload]);
+}
+
+function serve(socket) {
+  socket.write(sentinel);
+  let buffer = Buffer.alloc(0);
+  socket.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 13) {
+      const type = buffer[0];
+      const length = buffer.readUInt32BE(9);
+      if (buffer.length < 13 + length) return;
+      const payload = buffer.subarray(13, 13 + length);
+      buffer = buffer.subarray(13 + length);
+      if (type !== 1) continue;
+      const message = JSON.parse(payload.toString('utf8'));
+      if (message.method === 'session.resolveHome') {
+        socket.write(encode({ jsonrpc: '2.0', id: message.id, result: process.env.HOME }));
+      }
+    }
+  });
+}
+
+if (process.argv.includes('--detached')) {
+  try { fs.unlinkSync(sockPath); } catch {}
+  const server = net.createServer(serve);
+  server.listen(sockPath);
+  setTimeout(() => process.exit(0), 20000).unref();
+} else if (process.argv.includes('--connect')) {
+  process.stdout.write(sentinel);
+  let buffer = Buffer.alloc(0);
+  process.stdin.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 13) {
+      const type = buffer[0];
+      const length = buffer.readUInt32BE(9);
+      if (buffer.length < 13 + length) return;
+      const payload = buffer.subarray(13, 13 + length);
+      buffer = buffer.subarray(13 + length);
+      if (type !== 1) continue;
+      const message = JSON.parse(payload.toString('utf8'));
+      if (message.method === 'session.resolveHome') {
+        process.stdout.write(encode({ jsonrpc: '2.0', id: message.id, result: process.env.HOME }));
+      }
+    }
+  });
+}
+`
+  )
+}
+
+function createRelayTree(root: string, remoteHome: string): void {
+  const platforms = ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64']
+  for (const platform of platforms) {
+    const localDir = join(root, platform)
+    mkdirSync(localDir, { recursive: true })
+    writeFileSync(join(localDir, '.version'), RELAY_VERSION)
+    writeFakeRelay(localDir)
+  }
+
+  const remoteDir = join(remoteHome, '.orca-remote', `relay-${RELAY_VERSION}`)
+  mkdirSync(join(remoteDir, 'node_modules', 'node-pty'), { recursive: true })
+  mkdirSync(join(remoteDir, 'node_modules', '@parcel', 'watcher'), { recursive: true })
+  writeFileSync(join(remoteDir, 'node_modules', 'node-pty', 'index.js'), '')
+  writeFileSync(join(remoteDir, 'node_modules', '@parcel', 'watcher', 'index.js'), '')
+  writeFileSync(join(remoteDir, '.install-complete'), '')
+  writeFakeRelay(remoteDir)
+}
+
+describe('system SSH transport integration', () => {
+  let tempDir: string
+  let oldHome: string | undefined
+  let oldRelayPath: string | undefined
+  let oldSystemSshPath: string | undefined
+  let oldForceSystemTransport: string | undefined
+
+  beforeEach(() => {
+    if (process.platform === 'win32') {
+      return
+    }
+    tempDir = mkdtempSync(join('/tmp', 'orca-ssh-'))
+    oldHome = process.env.HOME
+    oldRelayPath = process.env.ORCA_RELAY_PATH
+    oldSystemSshPath = process.env.ORCA_SYSTEM_SSH_PATH
+    oldForceSystemTransport = process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT
+    const remoteHome = join(tempDir, 'remote-home')
+    const relayRoot = join(tempDir, 'relay')
+    mkdirSync(remoteHome, { recursive: true })
+    createRelayTree(relayRoot, remoteHome)
+    process.env.HOME = remoteHome
+    process.env.ORCA_RELAY_PATH = relayRoot
+    process.env.ORCA_SYSTEM_SSH_PATH = writeFakeSsh(tempDir)
+    process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT = '1'
+  })
+
+  afterEach(() => {
+    if (process.platform === 'win32') {
+      return
+    }
+    if (oldHome === undefined) {
+      delete process.env.HOME
+    } else {
+      process.env.HOME = oldHome
+    }
+    if (oldRelayPath === undefined) {
+      delete process.env.ORCA_RELAY_PATH
+    } else {
+      process.env.ORCA_RELAY_PATH = oldRelayPath
+    }
+    if (oldSystemSshPath === undefined) {
+      delete process.env.ORCA_SYSTEM_SSH_PATH
+    } else {
+      process.env.ORCA_SYSTEM_SSH_PATH = oldSystemSshPath
+    }
+    if (oldForceSystemTransport === undefined) {
+      delete process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT
+    } else {
+      process.env.ORCA_SSH_FORCE_SYSTEM_TRANSPORT = oldForceSystemTransport
+    }
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // Why: this fixture writes a POSIX fake ssh script to exercise stdin/stdout
+  // transport semantics; Windows coverage stays in argument/unit tests.
+  it.skipIf(process.platform === 'win32')(
+    'deploys and speaks relay RPC over a system ssh process for ProxyUseFdpass targets',
+    async () => {
+      const conn = new SshConnection(makeTarget(), { onStateChange: vi.fn() })
+      await conn.connect()
+      expect(conn.usesSystemSshTransport()).toBe(true)
+
+      const result = await deployAndLaunchRelay(conn, undefined, 60, makeTarget().id)
+      const mux = new SshChannelMultiplexer(result.transport)
+      try {
+        await expect(mux.request('session.resolveHome', { path: '~' })).resolves.toBe(
+          join(tempDir, 'remote-home')
+        )
+      } finally {
+        mux.dispose()
+        await conn.disconnect()
+      }
+    },
+    20_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'uploads a directory through the system ssh stdin/stdout path',
+    async () => {
+      const source = join(tempDir, 'source')
+      const destination = join(tempDir, 'uploaded')
+      mkdirSync(source, { recursive: true })
+      writeFileSync(join(source, 'payload.txt'), 'uploaded over system ssh')
+
+      await uploadDirectoryViaSystemSsh(makeTarget(), source, destination)
+
+      expect(readFileSync(join(destination, 'payload.txt'), 'utf8')).toBe(
+        'uploaded over system ssh'
+      )
+    }
+  )
+})


### PR DESCRIPTION
## Summary
- detect `ProxyUseFdpass yes` from resolved `ssh -G` config and automatically use system OpenSSH transport for those targets
- run relay exec, file writes, and relay upload over system SSH while preserving normal `ssh2` behavior for other targets
- add process lifecycle cleanup, abort handling, and integration coverage for the system-SSH stdin/stdout relay path

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh src/shared/ssh-types.test.ts`
- `pnpm run typecheck`
- `pnpm exec oxlint src/main/ssh/ssh-system-fallback.ts src/main/ssh/ssh-connection.ts src/main/ssh/ssh-system-transport.integration.test.ts src/main/ssh/ssh-config-parser.ts src/main/ssh/ssh-relay-deploy.ts`
- real SSH e2e over localhost sshd using system transport: `SKIP_BUILD=1 ORCA_E2E_SSH_LOCALHOST=1 ORCA_SSH_FORCE_SYSTEM_TRANSPORT=1 ORCA_E2E_SSH_CONFIG_HOST=<temp-localhost-alias> npx stably test tests/e2e/ssh-localhost.spec.ts --config tests/playwright.config.ts --project electron-headless`
- manual, non-harness fdpass e2e driven through the live Electron app: temporary `~/.ssh/config` Host `orca-fdpass-e2e-96517` used `ProxyUseFdpass yes` plus a real fd-passing `ProxyCommand`; `ssh -G` resolved `proxyusefdpass yes`; `ssh <alias>` connected to local sshd; Orca added the target/repo, deployed the relay through `/usr/bin/ssh ... @orca-fdpass-e2e-96517 ... relay.js --connect`, remote PTY printed cwd/pane/host, and a remote hook POST updated the renderer `codex` agent-status store.
- `$auto-review-fix` completed with final confirmation reviewers reporting no findings

Closes #2271