### PR TITLE
Disable WebGL for affected Claude Code versions

### DIFF
--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -58,11 +58,15 @@ vi.mock('../gitea/client', () => ({
 import {
   _resetPreflightCache,
   detectInstalledAgents,
+  getInstalledAgentVersion,
   registerPreflightHandlers,
   runPreflightCheck
 } from './preflight'
 
-type HandlerMap = Record<string, (_event?: unknown, args?: { force?: boolean }) => Promise<unknown>>
+type HandlerMap = Record<
+  string,
+  (_event?: unknown, args?: Record<string, unknown>) => Promise<unknown>
+>
 
 describe('preflight', () => {
   const originalPlatform = process.platform
@@ -379,6 +383,59 @@ describe('preflight', () => {
     })
 
     await expect(detectInstalledAgents({ wslDistro: 'Ubuntu' })).resolves.toEqual(['claude'])
+  })
+
+  it('gets a known agent version from stdout and stderr', async () => {
+    execFileAsyncMock.mockResolvedValueOnce({
+      stdout: '2.1.143 (Claude Code)\n',
+      stderr: ''
+    })
+
+    await expect(getInstalledAgentVersion({ agent: 'claude' })).resolves.toBe(
+      '2.1.143 (Claude Code)'
+    )
+    expect(execFileAsyncMock).toHaveBeenCalledWith('claude', ['--version'], {
+      encoding: 'utf-8',
+      timeout: 5000
+    })
+  })
+
+  it('returns null for unknown agents instead of executing arbitrary commands', async () => {
+    await expect(getInstalledAgentVersion({ agent: 'rm -rf /' })).resolves.toBeNull()
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('gets a known agent version through the selected WSL distro', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    execFileAsyncMock.mockResolvedValueOnce({
+      stdout: '2.1.143 (Claude Code)\n',
+      stderr: ''
+    })
+
+    await expect(getInstalledAgentVersion({ agent: 'claude', wslDistro: 'Ubuntu' })).resolves.toBe(
+      '2.1.143 (Claude Code)'
+    )
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'bash', '-lc', "'claude' --version"],
+      { encoding: 'utf-8', timeout: 5000 }
+    )
+  })
+
+  it('registers the agent version IPC handler', async () => {
+    execFileAsyncMock.mockResolvedValueOnce({
+      stdout: '2.1.143 (Claude Code)\n',
+      stderr: ''
+    })
+
+    registerPreflightHandlers()
+
+    await expect(handlers['preflight:getAgentVersion'](null, { agent: 'claude' })).resolves.toBe(
+      '2.1.143 (Claude Code)'
+    )
   })
 
   it('refreshes via preflight:refreshAgents by re-hydrating PATH before re-detecting', async () => {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -16,6 +16,10 @@ type PreflightRuntimeContext = {
   wslDistro?: string | null
 }
 
+type AgentVersionRequest = PreflightRuntimeContext & {
+  agent: string
+}
+
 export type PreflightStatus = {
   git: { installed: boolean }
   gh: { installed: boolean; authenticated: boolean }
@@ -98,6 +102,10 @@ const KNOWN_AGENT_COMMANDS = Object.entries(TUI_AGENT_CONFIG).map(([id, config])
   cmd: config.detectCmd
 }))
 
+const KNOWN_AGENT_COMMAND_BY_ID = new Map(
+  Object.entries(TUI_AGENT_CONFIG).map(([id, config]) => [id, config.detectCmd])
+)
+
 function getPreflightWslDistro(context?: PreflightRuntimeContext): string | null {
   const distro = context?.wslDistro?.trim()
   return process.platform === 'win32' && distro ? distro : null
@@ -127,6 +135,27 @@ export async function detectInstalledAgents(context?: PreflightRuntimeContext): 
     }))
   )
   return checks.filter((c) => c.installed).map((c) => c.id)
+}
+
+export async function getInstalledAgentVersion(
+  request: AgentVersionRequest
+): Promise<string | null> {
+  const command = KNOWN_AGENT_COMMAND_BY_ID.get(request.agent)
+  if (!command) {
+    return null
+  }
+  const wslDistro = getPreflightWslDistro(request)
+  try {
+    const result = wslDistro
+      ? await execCommandInWsl(wslDistro, `${shellQuote(command)} --version`)
+      : ((await execFileAsync(command, ['--version'], {
+          encoding: 'utf-8',
+          timeout: 5000
+        })) as { stdout: string; stderr: string })
+    return `${result.stdout ?? ''}${result.stderr ?? ''}`.trim() || null
+  } catch {
+    return null
+  }
 }
 
 export type RefreshAgentsResult = {
@@ -279,6 +308,13 @@ export function registerPreflightHandlers(): void {
     'preflight:detectAgents',
     async (_event, args?: PreflightRuntimeContext): Promise<string[]> => {
       return detectInstalledAgents(args)
+    }
+  )
+
+  ipcMain.handle(
+    'preflight:getAgentVersion',
+    async (_event, args: AgentVersionRequest): Promise<string | null> => {
+      return getInstalledAgentVersion(args)
     }
   )
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -392,6 +392,7 @@ export type RefreshAgentsResult = {
 export type PreflightApi = {
   check: (args?: { force?: boolean; wslDistro?: string | null }) => Promise<PreflightStatus>
   detectAgents: (args?: { wslDistro?: string | null }) => Promise<string[]>
+  getAgentVersion: (args: { agent: string; wslDistro?: string | null }) => Promise<string | null>
   refreshAgents: (args?: { wslDistro?: string | null }) => Promise<RefreshAgentsResult>
   detectRemoteAgents: (args: { connectionId: string }) => Promise<string[]>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1233,6 +1233,8 @@ const api = {
     }> => ipcRenderer.invoke('preflight:check', args),
     detectAgents: (args?: { wslDistro?: string | null }): Promise<string[]> =>
       ipcRenderer.invoke('preflight:detectAgents', args),
+    getAgentVersion: (args: { agent: string; wslDistro?: string | null }): Promise<string | null> =>
+      ipcRenderer.invoke('preflight:getAgentVersion', args),
     refreshAgents: (args?: { wslDistro?: string | null }): Promise<RefreshAgentsResult> =>
       ipcRenderer.invoke('preflight:refreshAgents', args),
     detectRemoteAgents: (args: { connectionId: string }): Promise<string[]> =>

--- a/src/renderer/src/components/terminal-pane/claude-code-webgl-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/claude-code-webgl-guard.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isClaudeCodeVersionAffectedByWebglGlyphBug,
+  resetClaudeCodeWebglGuardCacheForTests,
+  shouldSuppressWebglForLocalClaudeCode
+} from './claude-code-webgl-guard'
+
+describe('claude-code-webgl-guard', () => {
+  beforeEach(() => {
+    resetClaudeCodeWebglGuardCacheForTests()
+    ;(globalThis as unknown as { window: unknown }).window = {
+      api: {
+        preflight: {
+          getAgentVersion: vi.fn().mockResolvedValue(null)
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    resetClaudeCodeWebglGuardCacheForTests()
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it.each([
+    ['2.1.143 (Claude Code)', true],
+    ['2.1.144 (Claude Code)', false],
+    ['2.0.99 (Claude Code)', true],
+    ['3.0.0 (Claude Code)', false],
+    [null, false],
+    ['Claude Code dev', false]
+  ] as const)('classifies %s as affected=%s', (versionOutput, expected) => {
+    expect(isClaudeCodeVersionAffectedByWebglGlyphBug(versionOutput)).toBe(expected)
+  })
+
+  it('suppresses WebGL for affected local Claude Code versions', async () => {
+    vi.mocked(window.api.preflight.getAgentVersion).mockResolvedValue('2.1.143 (Claude Code)')
+
+    await expect(shouldSuppressWebglForLocalClaudeCode()).resolves.toBe(true)
+    await expect(shouldSuppressWebglForLocalClaudeCode()).resolves.toBe(true)
+    expect(window.api.preflight.getAgentVersion).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps WebGL enabled when the version cannot be checked', async () => {
+    vi.mocked(window.api.preflight.getAgentVersion).mockRejectedValue(new Error('not found'))
+
+    await expect(shouldSuppressWebglForLocalClaudeCode()).resolves.toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/claude-code-webgl-guard.ts
+++ b/src/renderer/src/components/terminal-pane/claude-code-webgl-guard.ts
@@ -1,0 +1,59 @@
+const AFFECTED_CLAUDE_CODE_VERSION = [2, 1, 143] as const
+
+let cachedLocalClaudeCodeWebglSuppressed: boolean | null = null
+let pendingLocalClaudeCodeWebglSuppressed: Promise<boolean> | null = null
+
+function parseSemverPrefix(output: string | null | undefined): [number, number, number] | null {
+  const match = output?.match(/\b(\d+)\.(\d+)\.(\d+)\b/)
+  if (!match) {
+    return null
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+function compareSemver(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number]
+): number {
+  for (let i = 0; i < 3; i++) {
+    const diff = left[i] - right[i]
+    if (diff !== 0) {
+      return diff
+    }
+  }
+  return 0
+}
+
+export function isClaudeCodeVersionAffectedByWebglGlyphBug(
+  versionOutput: string | null | undefined
+): boolean {
+  const version = parseSemverPrefix(versionOutput)
+  return version !== null && compareSemver(version, AFFECTED_CLAUDE_CODE_VERSION) <= 0
+}
+
+export async function shouldSuppressWebglForLocalClaudeCode(): Promise<boolean> {
+  if (cachedLocalClaudeCodeWebglSuppressed !== null) {
+    return cachedLocalClaudeCodeWebglSuppressed
+  }
+  if (!pendingLocalClaudeCodeWebglSuppressed) {
+    pendingLocalClaudeCodeWebglSuppressed = (async (): Promise<boolean> => {
+      try {
+        const version = await window.api.preflight.getAgentVersion({ agent: 'claude' })
+        const shouldSuppress = isClaudeCodeVersionAffectedByWebglGlyphBug(version)
+        cachedLocalClaudeCodeWebglSuppressed = shouldSuppress
+        return shouldSuppress
+      } catch {
+        cachedLocalClaudeCodeWebglSuppressed = false
+        return false
+      } finally {
+        pendingLocalClaudeCodeWebglSuppressed = null
+      }
+    })()
+  }
+  return pendingLocalClaudeCodeWebglSuppressed
+}
+
+export function resetClaudeCodeWebglGuardCacheForTests(): void {
+  cachedLocalClaudeCodeWebglSuppressed = null
+  pendingLocalClaudeCodeWebglSuppressed = null
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -329,6 +329,9 @@ describe('connectPanePty', () => {
         notifications: {
           dispatch: vi.fn().mockResolvedValue({ delivered: true }),
           playSound: vi.fn().mockResolvedValue({ played: true })
+        },
+        preflight: {
+          getAgentVersion: vi.fn().mockResolvedValue(null)
         }
       }
     }
@@ -412,6 +415,58 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalledWith(
       expect.stringContaining("claude 'say test'")
     )
+  })
+
+  it('disables pane WebGL after launching an affected local Claude Code version', async () => {
+    const agentStatus = await import('@/lib/agent-status')
+    vi.mocked(agentStatus.isClaudeAgent).mockReturnValue(true)
+    vi.mocked(window.api.preflight.getAgentVersion).mockResolvedValue('2.1.143 (Claude Code)')
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+    const manager = createManager(1)
+
+    connectPanePty(createPane(1) as never, manager as never, createDeps() as never)
+    ;(createdTransportOptions[0].onTitleChange as (title: string, rawTitle: string) => void)(
+      '* Claude working',
+      '* Claude working'
+    )
+    await flushAsyncTicks()
+
+    expect(window.api.preflight.getAgentVersion).toHaveBeenCalledWith({ agent: 'claude' })
+    expect(manager.setPaneGpuRendering).toHaveBeenCalledWith(1, false)
+  })
+
+  it('does not run the local Claude version guard for SSH worktrees', async () => {
+    const agentStatus = await import('@/lib/agent-status')
+    vi.mocked(agentStatus.isClaudeAgent).mockReturnValue(true)
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'ssh-1' }]
+    }
+    const manager = createManager(1)
+
+    connectPanePty(createPane(1) as never, manager as never, createDeps() as never)
+    ;(createdTransportOptions[0].onTitleChange as (title: string, rawTitle: string) => void)(
+      '* Claude working',
+      '* Claude working'
+    )
+    await flushAsyncTicks()
+
+    expect(window.api.preflight.getAgentVersion).not.toHaveBeenCalled()
+    expect(manager.setPaneGpuRendering).toHaveBeenCalledWith(1, true)
+    expect(manager.setPaneGpuRendering).not.toHaveBeenCalledWith(1, false)
   })
 
   it('does not reuse a sibling split pane pending spawn after remount', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -29,6 +29,8 @@ import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { e2eConfig } from '@/lib/e2e-config'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
+import { getConnectionId } from '@/lib/connection-context'
+import { shouldSuppressWebglForLocalClaudeCode } from './claude-code-webgl-guard'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -169,6 +171,8 @@ export function connectPanePty(
   let agentTaskCompleteStatusUnsubscribe: (() => void) | null = null
   let terminalBellNotificationTimer: ReturnType<typeof setTimeout> | null = null
   let pendingTerminalBellNotification = false
+  let disableGpuForOldClaudeCode = false
+  let checkedClaudeCodeVersionForPty = false
   // Why: passphrase-gate waits register a teardown here so dispose() can
   // actively unsubscribe + resolve them. Without this, a pane disposed
   // mid-wait leaks its zustand subscriber and the surrounding async IIFE
@@ -242,8 +246,39 @@ export function connectPanePty(
   let hasConsideredInitialCacheTimerSeed = false
   let allowInitialIdleCacheSeed = false
 
+  const applyPaneGpuRenderingPolicy = (rawTitle: string): void => {
+    manager.setPaneGpuRendering(
+      pane.id,
+      !isGeminiTerminalTitle(rawTitle) && !disableGpuForOldClaudeCode
+    )
+  }
+
+  const maybeDisableWebglForOldLocalClaudeCode = (rawTitle: string): void => {
+    if (checkedClaudeCodeVersionForPty || !isClaudeAgent(rawTitle)) {
+      return
+    }
+    if (isRemoteRuntimePtyId(deps.restoredPtyIdByLeafId?.[pane.leafId])) {
+      return
+    }
+    const connectionId = getConnectionId(deps.worktreeId)
+    if (connectionId !== null) {
+      return
+    }
+    checkedClaudeCodeVersionForPty = true
+    void shouldSuppressWebglForLocalClaudeCode().then((shouldSuppress) => {
+      if (disposed || !shouldSuppress) {
+        return
+      }
+      // Why: Claude Code 2.1.143 and older can corrupt repeated glyph columns
+      // in xterm's WebGL renderer during long chats. Keep only this pane on DOM.
+      disableGpuForOldClaudeCode = true
+      applyPaneGpuRenderingPolicy(rawTitle)
+    })
+  }
+
   const onTitleChange = (title: string, rawTitle: string): void => {
-    manager.setPaneGpuRendering(pane.id, !isGeminiTerminalTitle(rawTitle))
+    maybeDisableWebglForOldLocalClaudeCode(rawTitle)
+    applyPaneGpuRenderingPolicy(rawTitle)
     deps.setRuntimePaneTitle(deps.tabId, pane.id, title)
     // Why: only the focused pane should drive the tab title — otherwise two
     // agents in split panes cause rapid title flickering as each emits OSC

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -897,6 +897,7 @@ function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight']> {
       }
       return callRuntimeResult<string[]>('preflight.detectAgents').catch(() => [])
     },
+    getAgentVersion: async () => null,
     refreshAgents: () =>
       requireActiveEnvironmentOrNull()
         ? callRuntimeResult('preflight.refreshAgents')


### PR DESCRIPTION
## Summary
- Add a preflight version probe for known TUI agents via their configured detect command.
- When a local pane title indicates Claude Code, check the installed Claude version once and disable pane WebGL only for affected versions (2.1.143 and older).
- Keep SSH/remote-runtime panes out of the local version guard.

## Validation
- pnpm test src/renderer/src/components/terminal-pane/claude-code-webgl-guard.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/ipc/preflight.test.ts
- pnpm run typecheck
- pnpm exec oxlint src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/web/web-preload-api.ts src/renderer/src/components/terminal-pane/claude-code-webgl-guard.ts src/renderer/src/components/terminal-pane/claude-code-webgl-guard.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts

Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.