### PR TITLE
Fix workspace sidebar scroll jitter

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -394,7 +394,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     },
     [isCurrentVirtualRowElement]
   )
-  const markDirectScrollInput = useCallback(() => {
+  const markScrollMovement = useCallback(() => {
     suppressMeasurementAdjustmentUntilRef.current =
       window.performance.now() + USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS
   }, [])
@@ -800,8 +800,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       aria-multiselectable="true"
       aria-activedescendant={activeDescendantId}
       onKeyDown={handleContainerKeyDown}
-      onTouchMove={markDirectScrollInput}
-      onWheel={markDirectScrollInput}
+      // Why: trackpad momentum can continue as sparse scroll events after the
+      // original wheel/touch event stream quiets down. Keep measurement-based
+      // scroll correction suppressed until the viewport itself has stopped.
+      onScroll={markScrollMovement}
+      onTouchMove={markScrollMovement}
+      onWheel={markScrollMovement}
       className="worktree-sidebar-scrollbar flex-1 overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
       style={WORKTREE_SIDEBAR_SCROLL_STYLE}
     >

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -299,6 +299,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 }: VirtualizedWorktreeViewportProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const suppressMeasurementAdjustmentUntilRef = useRef(0)
+  const directScrollInputUntilRef = useRef(0)
   const [dragOverStatus, setDragOverStatus] = useState<WorkspaceStatus | null>(null)
   const [pinDragOver, setPinDragOver] = useState(false)
   const [lineageReconnectWorktreeId, setLineageReconnectWorktreeId] = useState<string | null>(null)
@@ -398,8 +399,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     suppressMeasurementAdjustmentUntilRef.current =
       window.performance.now() + USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS
   }, [])
+  const markDirectScrollInput = useCallback(() => {
+    const suppressUntil = window.performance.now() + USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS
+    suppressMeasurementAdjustmentUntilRef.current = suppressUntil
+    directScrollInputUntilRef.current = suppressUntil
+  }, [])
+  const hasDirectScrollInput = useCallback(
+    () => window.performance.now() < directScrollInputUntilRef.current,
+    []
+  )
+  // Why: programmatic scrolls should keep measurement correction quiet, but
+  // only direct input should block anchor restoration retries.
   const shouldSkipScrollAnchorRestore = useCallback(
-    () => window.performance.now() < suppressMeasurementAdjustmentUntilRef.current,
+    () => window.performance.now() < directScrollInputUntilRef.current,
     []
   )
 
@@ -566,6 +578,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     rows: renderRows,
     scrollElementRef: scrollRef,
     scrollOffsetRef,
+    hasDirectScrollInput,
     shouldSkipRestore: shouldSkipScrollAnchorRestore,
     totalSize,
     virtualizer
@@ -665,6 +678,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       }
 
       if (mod && e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+        markDirectScrollInput()
         navigateWorktree(e.key === 'ArrowUp' ? 'up' : 'down')
         e.preventDefault()
       }
@@ -672,7 +686,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
     window.addEventListener('keydown', handleKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true })
-  }, [activeModal, navigateWorktree])
+  }, [activeModal, markDirectScrollInput, navigateWorktree])
 
   // Why: lightweight nested cards do not mount WorktreeCard, so the viewport
   // owns the SSH reconnect prompt for an active lineage child.
@@ -688,6 +702,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         if (e.target !== e.currentTarget) {
           return
         }
+        markDirectScrollInput()
         navigateWorktree(e.key === 'ArrowUp' ? 'up' : 'down')
         e.preventDefault()
       } else if (e.key === 'Enter') {
@@ -698,9 +713,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           helper.focus()
         }
         e.preventDefault()
+      } else if (['PageUp', 'PageDown', 'Home', 'End', ' '].includes(e.key)) {
+        markDirectScrollInput()
       }
     },
-    [navigateWorktree]
+    [markDirectScrollInput, navigateWorktree]
+  )
+
+  const handleScrollPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const scrollbarWidth = event.currentTarget.offsetWidth - event.currentTarget.clientWidth
+      if (scrollbarWidth <= 0) {
+        return
+      }
+      const rect = event.currentTarget.getBoundingClientRect()
+      if (event.clientX >= rect.right - scrollbarWidth) {
+        markDirectScrollInput()
+      }
+    },
+    [markDirectScrollInput]
   )
 
   const firstHeaderIndex = useMemo(
@@ -804,8 +835,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       // original wheel/touch event stream quiets down. Keep measurement-based
       // scroll correction suppressed until the viewport itself has stopped.
       onScroll={markScrollMovement}
-      onTouchMove={markScrollMovement}
-      onWheel={markScrollMovement}
+      onPointerDown={handleScrollPointerDown}
+      onTouchMove={markDirectScrollInput}
+      onWheel={markDirectScrollInput}
       className="worktree-sidebar-scrollbar flex-1 overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset pt-px"
       style={WORKTREE_SIDEBAR_SCROLL_STYLE}
     >

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.test.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { shouldCancelVirtualizedScrollOffsetRestore } from './useVirtualizedScrollAnchor'
+
+describe('shouldCancelVirtualizedScrollOffsetRestore', () => {
+  it('keeps a pending restore when there is no direct user scroll input', () => {
+    expect(
+      shouldCancelVirtualizedScrollOffsetRestore({
+        restoring: true,
+        shouldSkipRestore: () => false
+      })
+    ).toBe(false)
+  })
+
+  it('does not cancel when there is no pending restore', () => {
+    expect(
+      shouldCancelVirtualizedScrollOffsetRestore({
+        restoring: false,
+        shouldSkipRestore: () => true
+      })
+    ).toBe(false)
+  })
+
+  it('cancels a pending restore while direct user scroll input is active', () => {
+    expect(
+      shouldCancelVirtualizedScrollOffsetRestore({
+        restoring: true,
+        shouldSkipRestore: () => true
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.test.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, it } from 'vitest'
 import { shouldCancelVirtualizedScrollOffsetRestore } from './useVirtualizedScrollAnchor'
 
 describe('shouldCancelVirtualizedScrollOffsetRestore', () => {
-  it('keeps a pending restore when there is no direct user scroll input', () => {
+  it('keeps a pending restore when direct user scroll input is not tracked', () => {
     expect(
       shouldCancelVirtualizedScrollOffsetRestore({
-        restoring: true,
-        shouldSkipRestore: () => false
+        restoring: true
+      })
+    ).toBe(false)
+  })
+
+  it('keeps a pending restore during programmatic scroll movement', () => {
+    expect(
+      shouldCancelVirtualizedScrollOffsetRestore({
+        hasDirectScrollInput: () => false,
+        restoring: true
       })
     ).toBe(false)
   })
@@ -14,8 +22,8 @@ describe('shouldCancelVirtualizedScrollOffsetRestore', () => {
   it('does not cancel when there is no pending restore', () => {
     expect(
       shouldCancelVirtualizedScrollOffsetRestore({
-        restoring: false,
-        shouldSkipRestore: () => true
+        hasDirectScrollInput: () => true,
+        restoring: false
       })
     ).toBe(false)
   })
@@ -23,8 +31,8 @@ describe('shouldCancelVirtualizedScrollOffsetRestore', () => {
   it('cancels a pending restore while direct user scroll input is active', () => {
     expect(
       shouldCancelVirtualizedScrollOffsetRestore({
-        restoring: true,
-        shouldSkipRestore: () => true
+        hasDirectScrollInput: () => true,
+        restoring: true
       })
     ).toBe(true)
   })

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -9,6 +9,13 @@ export type VirtualizedScrollAnchor = {
 export const VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT = 'orca-record-virtualized-scroll-anchor'
 const RECORD_ANCHOR_SCROLL_IDLE_DELAY_MS = 150
 
+export function shouldCancelVirtualizedScrollOffsetRestore(args: {
+  restoring: boolean
+  shouldSkipRestore?: () => boolean
+}): boolean {
+  return args.restoring && args.shouldSkipRestore?.() === true
+}
+
 type UseVirtualizedScrollAnchorOptions<
   TRow,
   TScrollElement extends Element,
@@ -178,6 +185,19 @@ export function useVirtualizedScrollAnchor<
       recordScrollAnchor(el.scrollTop)
     }
     const onScroll = (): void => {
+      if (
+        shouldCancelVirtualizedScrollOffsetRestore({
+          restoring,
+          shouldSkipRestore
+        })
+      ) {
+        // Why: direct wheel/touch input means the user has taken control of the
+        // viewport. Treat the current offset as intentional instead of snapping
+        // back to a stale persisted offset while restoration is still pending.
+        restoring = false
+        recordCurrentAnchor()
+        return
+      }
       if (restoring) {
         // Why: during a fresh virtualizer mount, total height may still be
         // estimate-based. Avoid persisting a browser-clamped offset as the
@@ -210,7 +230,13 @@ export function useVirtualizedScrollAnchor<
       el.removeEventListener(VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT, recordCurrentAnchor)
       el.removeEventListener('scroll', onScroll)
     }
-  }, [recordScrollAnchor, recordVirtualScrollAnchor, scrollElementRef, scrollOffsetRef])
+  }, [
+    recordScrollAnchor,
+    recordVirtualScrollAnchor,
+    scrollElementRef,
+    scrollOffsetRef,
+    shouldSkipRestore
+  ])
 
   useLayoutEffect(() => {
     const anchor = anchorRef.current

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -10,10 +10,10 @@ export const VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT = 'orca-record-virtualized-s
 const RECORD_ANCHOR_SCROLL_IDLE_DELAY_MS = 150
 
 export function shouldCancelVirtualizedScrollOffsetRestore(args: {
+  hasDirectScrollInput?: () => boolean
   restoring: boolean
-  shouldSkipRestore?: () => boolean
 }): boolean {
-  return args.restoring && args.shouldSkipRestore?.() === true
+  return args.restoring && args.hasDirectScrollInput?.() === true
 }
 
 type UseVirtualizedScrollAnchorOptions<
@@ -24,6 +24,7 @@ type UseVirtualizedScrollAnchorOptions<
   anchorRef: MutableRefObject<VirtualizedScrollAnchor>
   getItemElementKey?: (element: TItemElement) => string | null
   getRowKey: (row: TRow) => string
+  hasDirectScrollInput?: () => boolean
   itemElementSelector?: string
   rows: readonly TRow[]
   scrollElementRef: RefObject<TScrollElement | null>
@@ -49,6 +50,7 @@ export function useVirtualizedScrollAnchor<
   anchorRef,
   getItemElementKey,
   getRowKey,
+  hasDirectScrollInput,
   itemElementSelector,
   rows,
   scrollElementRef,
@@ -187,8 +189,8 @@ export function useVirtualizedScrollAnchor<
     const onScroll = (): void => {
       if (
         shouldCancelVirtualizedScrollOffsetRestore({
-          restoring,
-          shouldSkipRestore
+          hasDirectScrollInput,
+          restoring
         })
       ) {
         // Why: direct wheel/touch input means the user has taken control of the
@@ -235,7 +237,7 @@ export function useVirtualizedScrollAnchor<
     recordVirtualScrollAnchor,
     scrollElementRef,
     scrollOffsetRef,
-    shouldSkipRestore
+    hasDirectScrollInput
   ])
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- suppress virtualized row measurement scroll correction for the full duration of sidebar scroll movement, including trackpad momentum
- cancel stale virtualized offset restoration when direct scroll input takes over
- keep programmatic restore scrolls from being mistaken for direct user input
- add regression coverage for restore cancellation logic

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useVirtualizedScrollAnchor.test.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/sidebar/smart-sort.test.ts
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/useVirtualizedScrollAnchor.test.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
- pnpm run typecheck
- pnpm lint
- Electron dev verification on brennanb2025/workspace-scroll-jitter: confirmed app identity, exercised worktree sidebar wheel scrolling, PageDown/Home/End keyboard scrolling, global Cmd+Shift+Arrow worktree navigation, and scrollbar pointer path; no browser console errors

Made with [Orca](https://github.com/stablyai/orca)