### PR TITLE
Reduce interactive PTY redraw latency

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -326,6 +326,14 @@ describe('registerPtyHandlers', () => {
     }
   }
 
+  function getPtyWriteListener(): (event: unknown, args: { id: string; data: string }) => void {
+    const writeCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:write')
+    if (!writeCall) {
+      throw new Error('missing pty:write listener')
+    }
+    return writeCall[1] as (event: unknown, args: { id: string; data: string }) => void
+  }
+
   /** Helper: trigger pty:spawn and return the env passed to node-pty. */
   async function spawnAndGetEnv(
     argsEnv?: Record<string, string>,
@@ -2265,6 +2273,197 @@ describe('registerPtyHandlers', () => {
       await Promise.resolve()
       vi.runAllTimers()
       expect(mockProc.proc.write).toHaveBeenCalledWith('codex\n')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('batches PTY output when it is not responding to recent input', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('background output')
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(7)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(1)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'background output'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('sends small PTY redraws immediately after terminal input', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+
+      writeListener(null, {
+        id: spawnResult.id,
+        data: 'a'
+      })
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('\x1b[20;2Hredraw')
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: '\x1b[20;2Hredraw'
+      })
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores PTY input for unknown sessions', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })
+      const writeListener = getPtyWriteListener()
+
+      writeListener(null, {
+        id: 'missing-pty',
+        data: 'a'
+      })
+
+      expect(mockProc.proc.write).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('batches large PTY output even after recent terminal input', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+
+      writeListener(null, {
+        id: spawnResult.id,
+        data: 'a'
+      })
+      mainWindow.webContents.send.mockClear()
+
+      const largeOutput = 'x'.repeat(1025)
+      mockProc.emitData(largeOutput)
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: largeOutput
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('batches combined pending output that exceeds the interactive size limit', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+
+      const pendingOutput = 'x'.repeat(1020)
+      mockProc.emitData(pendingOutput)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+
+      writeListener(null, {
+        id: spawnResult.id,
+        data: 'a'
+      })
+      mockProc.emitData('redraw')
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: `${pendingOutput}redraw`
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('batches stale PTY output after the interactive window expires', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+
+      writeListener(null, {
+        id: spawnResult.id,
+        data: 'a'
+      })
+      vi.advanceTimersByTime(101)
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('stale redraw')
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'stale redraw'
+      })
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -64,6 +64,10 @@ const ptyOwnership = new Map<string, string | null>()
 // Why: mobile clients must mirror desktop PTY geometry even when the renderer
 // cannot provide an xterm snapshot yet, such as immediately after tab creation.
 const ptySizes = new Map<string, { cols: number; rows: number }>()
+// Why: PTY data batching is window-bound, but the "recent user input" signal
+// is PTY-scoped and must be cleared by every teardown path, including SSH and
+// daemon shutdowns that do not flow through the local provider exit listener.
+const lastInputAtByPty = new Map<string, number>()
 // Why: the agent-hooks server caches per-paneKey state (last prompt, last
 // tool) that otherwise grows unbounded as panes come and go. Track the
 // spawn-time paneKey so clearProviderPtyState can clear that cache on PTY
@@ -450,6 +454,7 @@ export function clearProviderPtyState(id: string): void {
   openCodeHookService.clearPty(id)
   piTitlebarExtensionService.clearPty(id)
   ptySizes.delete(id)
+  lastInputAtByPty.delete(id)
   const paneKey = ptyPaneKey.get(id)
   const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY does not keep
@@ -620,11 +625,16 @@ export function registerPtyHandlers(
 
   // Why: batching PTY data into short flush windows (8ms ≈ half a frame)
   // reduces IPC round-trips from hundreds/sec to ~120/sec under high
-  // throughput, with no perceptible latency increase for interactive use.
+  // throughput. Keystroke echo/redraws bypass this below because agent TUIs
+  // already spend tens of ms producing their redraw.
   const pendingData = new Map<string, string>()
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
   const PTY_BATCH_INTERVAL_MS = 8
+  // Why: keep the immediate path bounded to keystroke-sized TUI redraws;
+  // large output and non-interactive output must still use the batcher.
+  const INTERACTIVE_OUTPUT_WINDOW_MS = 100
+  const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
 
   const flushPendingData = (): void => {
     flushTimer = null
@@ -636,6 +646,14 @@ export function registerPtyHandlers(
       mainWindow.webContents.send('pty:data', { id, data })
     }
     pendingData.clear()
+  }
+
+  const clearFlushTimerIfIdle = (): void => {
+    if (pendingData.size > 0 || flushTimer === null) {
+      return
+    }
+    clearTimeout(flushTimer)
+    flushTimer = null
   }
 
   // Why: extracted so the "Restart daemon" flow can rebind against the fresh
@@ -670,7 +688,24 @@ export function registerPtyHandlers(
         return
       }
       const existing = pendingData.get(payload.id)
-      pendingData.set(payload.id, existing ? existing + payload.data : payload.data)
+      const nextData = existing ? existing + payload.data : payload.data
+      const lastInputAt = lastInputAtByPty.get(payload.id)
+      const isInteractiveOutput =
+        nextData.length <= INTERACTIVE_OUTPUT_MAX_CHARS &&
+        lastInputAt !== undefined &&
+        performance.now() - lastInputAt <= INTERACTIVE_OUTPUT_WINDOW_MS
+      if (isInteractiveOutput) {
+        pendingData.delete(payload.id)
+        clearFlushTimerIfIdle()
+        // Why: agent TUIs redraw small prompt regions after every keystroke.
+        // Waiting for the throughput batch timer adds visible input latency.
+        mainWindow.webContents.send('pty:data', {
+          id: payload.id,
+          data: nextData
+        })
+        return
+      }
+      pendingData.set(payload.id, nextData)
       if (!flushTimer) {
         flushTimer = setTimeout(flushPendingData, PTY_BATCH_INTERVAL_MS)
       }
@@ -691,6 +726,7 @@ export function registerPtyHandlers(
           mainWindow.webContents.send('pty:data', { id: payload.id, data: remaining })
           pendingData.delete(payload.id)
         }
+        lastInputAtByPty.delete(payload.id)
         mainWindow.webContents.send('pty:exit', payload)
       }
     })
@@ -1547,7 +1583,12 @@ export function registerPtyHandlers(
     if (runtime?.getDriver(args.id).kind === 'mobile') {
       return
     }
-    tryGetProviderForPty(args.id)?.write(args.id, args.data)
+    const provider = ptyOwnership.has(args.id) ? tryGetProviderForPty(args.id) : undefined
+    if (!provider) {
+      return
+    }
+    lastInputAtByPty.set(args.id, performance.now())
+    provider.write(args.id, args.data)
   })
 
   // Why: resize is fire-and-forget — the renderer doesn't need a reply.


### PR DESCRIPTION
## Summary
- bypass the 8ms PTY output batch for small redraws that arrive shortly after terminal input
- keep existing batching for background/high-throughput PTY output
- add focused IPC tests for both the batched and immediate paths

## Root cause
Codex redraws its prompt after every keystroke. Orca was receiving those small redraw chunks from node-pty about 30ms after input, then holding them for the main-process 8ms PTY batch timer before forwarding to the renderer. That extra wait made Codex typing feel slower in Orca even though input reached the PTY quickly.

## Verification
- pnpm exec vitest run src/main/ipc/pty.test.ts
- pnpm run typecheck:node
- Electron dev app with Codex terminal: typed prompt text updates in the real terminal after the fix, with temporary debug instrumentation removed

Made with [Orca](https://github.com/stablyai/orca) 🐋
