### PR TITLE
Add Jira "coming soon" row to onboarding integrations

### DIFF
--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -327,6 +327,15 @@ export function IntegrationsStep(): React.JSX.Element {
       <div className="space-y-3">
         <GitHubRow />
         <LinearRow />
+        <div className="mt-4 flex items-center justify-between rounded-xl border border-border bg-muted/10 px-5 py-3.5">
+          <div className="flex items-center gap-3">
+            <span className="text-[14px] font-medium text-foreground/70">Jira</span>
+            <span className="text-[13px] text-muted-foreground">
+              Issues, sprints, and assignees.
+            </span>
+          </div>
+          <StatusPill tone="neutral">Coming soon</StatusPill>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Replaces the small "(Jira - upcoming)" caption under the Linear card on onboarding step 4 with a proper teaser row that matches the GitHub/Linear card layout: title, short description, and a neutral "Coming soon" status pill.
- Uses the existing `StatusPill` and design tokens — no new colors or sizes — and adds a small top margin so the row sits below the connected integrations rather than crammed against the Linear card.

## Test plan
- [ ] Launch a fresh-profile dev build and step through onboarding to step 4 — verify the Jira row renders below GitHub/Linear with the "Coming soon" pill, matching the integrations style.
- [ ] Toggle between light and dark mode — verify the border, background, and pill stay legible in both.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<img width="837" height="134" alt="image" src="https://github.com/user-attachments/assets/667cddd4-f7ca-412a-91e9-141ccd60ac18" />
