### PR TITLE
Fix sidebar Settings hit target

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -38,6 +38,9 @@ const GITHUB_ISSUES_URL = 'https://github.com/stablyai/orca/issues/'
 const DISCORD_URL = 'https://discord.gg/fzjDKHxv8Q'
 const X_URL = 'https://x.com/orca_build'
 const DOCS_URL = 'https://www.onorca.dev/docs'
+// Why: the sidebar resize handle intentionally keeps a wide right-edge hit
+// target, but the bottom Settings action should remain clickable over it.
+const SETTINGS_ACTION_HIT_TARGET_CLASS = 'relative z-20'
 
 type SubmitIdentity = {
   githubLogin: string | null
@@ -371,7 +374,7 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
                 variant="ghost"
                 size="icon-xs"
                 onClick={openSettingsPage}
-                className="text-muted-foreground"
+                className={`${SETTINGS_ACTION_HIT_TARGET_CLASS} text-muted-foreground`}
               >
                 <Settings className="size-3.5" />
               </Button>


### PR DESCRIPTION
## Summary
- Keep the bottom sidebar Settings button above the wide resize handle when their hit targets overlap
- Match the z-index hit-test priority pattern from PR #2224 for this remaining right-edge sidebar action

## Verification
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/SidebarToolbar.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/SidebarToolbar.tsx
- pnpm typecheck
- pnpm lint
- Electron CDP: elementFromPoint in the overlap between the right-edge resize strip and Settings button resolves to the Settings button, not the resize handle
