### PR TITLE
fix: normalize windows paths in git blob readers

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -213,6 +213,18 @@ describe('getDiff', () => {
     })
   })
 
+  it('normalizes Windows separators before reading git blobs', async () => {
+    gitExecFileAsyncBufferMock.mockResolvedValueOnce({ stdout: Buffer.from('index-content\n') })
+    readFileMock.mockResolvedValue(Buffer.from('working-tree-content'))
+
+    await getDiff('/repo', 'src\\file.ts', false)
+
+    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
+      cwd: '/repo',
+      maxBuffer: 10 * 1024 * 1024
+    })
+  })
+
   it('falls back to HEAD for unstaged diffs when the file is not in the index', async () => {
     gitExecFileAsyncBufferMock
       .mockRejectedValueOnce(new Error('missing index'))

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -811,8 +811,10 @@ async function readGitBlobAtIndexPath(
   worktreePath: string,
   filePath: string
 ): Promise<GitBlobReadResult> {
+  // Why: Git's `:<path>` syntax expects forward slashes even on Windows.
+  const gitPath = filePath.replace(/\\/g, '/')
   try {
-    const { stdout } = await gitExecFileAsyncBuffer(['show', `:${filePath}`], {
+    const { stdout } = await gitExecFileAsyncBuffer(['show', `:${gitPath}`], {
       cwd: worktreePath,
       maxBuffer: MAX_GIT_SHOW_BYTES
     })
@@ -828,9 +830,11 @@ async function readGitBlobAtOidPath(
   oid: string,
   filePath: string
 ): Promise<GitBlobReadResult> {
+  // Why: Git's `<oid>:<path>` syntax expects forward slashes even on Windows.
+  const gitPath = filePath.replace(/\\/g, '/')
   try {
     const { stdout } = await gitExecFileAsyncBuffer(
-      ['show', '--end-of-options', `${oid}:${filePath}`],
+      ['show', '--end-of-options', `${oid}:${gitPath}`],
       {
         cwd: worktreePath,
         maxBuffer: MAX_GIT_SHOW_BYTES

--- a/src/relay/git-handler-blob-readers.test.ts
+++ b/src/relay/git-handler-blob-readers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readBlobAtIndex, readBlobAtOid, type GitBufferExec } from './git-handler-ops'
+
+describe('git blob readers', () => {
+  it('normalizes Windows separators before reading OID blobs', async () => {
+    const gitBuffer = vi.fn<GitBufferExec>().mockResolvedValue(Buffer.from('head-content'))
+
+    const result = await readBlobAtOid(gitBuffer, '/repo', 'HEAD', 'src\\file.ts')
+
+    expect(gitBuffer).toHaveBeenCalledWith(
+      ['show', '--end-of-options', 'HEAD:src/file.ts'],
+      '/repo'
+    )
+    expect(result.content).toBe('head-content')
+  })
+
+  it('normalizes Windows separators before reading index blobs', async () => {
+    const gitBuffer = vi.fn<GitBufferExec>().mockResolvedValue(Buffer.from('index-content'))
+
+    const result = await readBlobAtIndex(gitBuffer, '/repo', 'src\\file.ts')
+
+    expect(gitBuffer).toHaveBeenCalledWith(['show', '--end-of-options', ':src/file.ts'], '/repo')
+    expect(result.content).toBe('index-content')
+  })
+})

--- a/src/relay/git-handler-ops.ts
+++ b/src/relay/git-handler-ops.ts
@@ -23,8 +23,10 @@ export async function readBlobAtOid(
   oid: string,
   filePath: string
 ): Promise<{ content: string; isBinary: boolean }> {
+  // Why: Git's `<oid>:<path>` syntax expects forward slashes even on Windows.
+  const gitPath = filePath.replace(/\\/g, '/')
   try {
-    const buf = await gitBuffer(['show', `${oid}:${filePath}`], cwd)
+    const buf = await gitBuffer(['show', '--end-of-options', `${oid}:${gitPath}`], cwd)
     return bufferToBlob(buf, filePath)
   } catch {
     return { content: '', isBinary: false }
@@ -36,8 +38,10 @@ export async function readBlobAtIndex(
   cwd: string,
   filePath: string
 ): Promise<{ content: string; isBinary: boolean }> {
+  // Why: Git's `:<path>` syntax expects forward slashes even on Windows.
+  const gitPath = filePath.replace(/\\/g, '/')
   try {
-    const buf = await gitBuffer(['show', `:${filePath}`], cwd)
+    const buf = await gitBuffer(['show', '--end-of-options', `:${gitPath}`], cwd)
     return bufferToBlob(buf, filePath)
   } catch {
     return { content: '', isBinary: false }


### PR DESCRIPTION
## Summary
- Normalize Windows backslash paths before reading Git blobs with `git show`.
- Apply the fix to local and relay blob readers so diff views can load both index and OID content.
- Add regression coverage for Windows-style paths.

Fixes stablyai/orca#2147

## Validation
- `npx vitest run --config config/vitest.config.ts src/main/git/status.test.ts src/relay/git-handler-blob-readers.test.ts`

X: [@leynier41](https://x.com/leynier41)