### PR TITLE
Fix E2E completed onboarding profile for restarts

### DIFF
--- a/tests/e2e/helpers/e2e-completed-onboarding-profile.ts
+++ b/tests/e2e/helpers/e2e-completed-onboarding-profile.ts
@@ -1,0 +1,25 @@
+import { ONBOARDING_FINAL_STEP } from '../../../src/shared/constants'
+
+const SEEN_FIRST_RUN_FEATURE_TIP_IDS = ['voice-dictation'] as const
+
+export function getE2ECompletedOnboardingProfile() {
+  return {
+    settings: {
+      telemetry: {
+        optedIn: true,
+        installId: '00000000-0000-4000-8000-000000000000',
+        existedBeforeTelemetryRelease: false
+      }
+    },
+    onboarding: {
+      closedAt: 1,
+      outcome: 'completed',
+      lastCompletedStep: ONBOARDING_FINAL_STEP
+    },
+    ui: {
+      // Why: completed-onboarding E2E profiles should not be interrupted by
+      // first-run education modals that cover the UI under test.
+      featureTipsSeenIds: [...SEEN_FIRST_RUN_FEATURE_TIP_IDS]
+    }
+  }
+}

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -27,6 +27,7 @@ import os from 'os'
 import path from 'path'
 import { TEST_REPO_PATH_FILE } from '../global-setup'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
+import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 
 type OrcaTestFixtures = {
   electronApp: ElectronApplication
@@ -173,34 +174,12 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     if (dismissOnboarding) {
       // Why: onboarding renders a fullscreen `fixed inset-0 z-[100]` overlay
       // when persisted `closedAt` is null, which intercepts pointer events for
-      // every other test. Seed explicit fresh-user state: an empty file would
-      // make persistence treat the profile as an existing-user upgrade cohort
-      // and mount the telemetry notice overlay instead.
+      // every other test. Seed a completed-onboarding fresh-install profile:
+      // an empty file would make persistence treat the profile as an
+      // existing-user upgrade cohort and mount the telemetry notice overlay.
       writeFileSync(
         path.join(userDataDir, 'orca-data.json'),
-        `${JSON.stringify(
-          {
-            settings: {
-              telemetry: {
-                optedIn: true,
-                installId: '00000000-0000-4000-8000-000000000000',
-                existedBeforeTelemetryRelease: false
-              }
-            },
-            onboarding: {
-              closedAt: 1,
-              outcome: 'completed',
-              lastCompletedStep: 4
-            },
-            ui: {
-              // Why: unrelated E2Es start from a completed-onboarding profile;
-              // seed first-run feature education too so modals do not cover UI.
-              featureTipsSeenIds: ['voice-dictation']
-            }
-          },
-          null,
-          2
-        )}\n`
+        `${JSON.stringify(getE2ECompletedOnboardingProfile(), null, 2)}\n`
       )
     }
     const headful = shouldLaunchHeadful(testInfo)

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -19,6 +19,7 @@ import { execSync } from 'child_process'
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
+import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
 
 type LaunchedOrca = {
@@ -63,28 +64,11 @@ export function createRestartSession(testInfo: TestInfo): RestartSession {
   const headful = shouldLaunchHeadful(testInfo)
 
   // Why: this helper bypasses the shared `electronApp` fixture, so it must
-  // seed the same dismissed onboarding state or the full-screen overlay covers
-  // both launches and obscures restart failures.
+  // seed the same completed onboarding profile or first-run overlays cover
+  // both launches and obscure restart failures.
   writeFileSync(
     path.join(userDataDir, 'orca-data.json'),
-    `${JSON.stringify(
-      {
-        settings: {
-          telemetry: {
-            optedIn: true,
-            installId: '00000000-0000-4000-8000-000000000000',
-            existedBeforeTelemetryRelease: false
-          }
-        },
-        onboarding: {
-          closedAt: 1,
-          outcome: 'completed',
-          lastCompletedStep: 4
-        }
-      },
-      null,
-      2
-    )}\n`
+    `${JSON.stringify(getE2ECompletedOnboardingProfile(), null, 2)}\n`
   )
 
   const launch = async (): Promise<LaunchedOrca> => {


### PR DESCRIPTION
## Summary
- Add a shared completed-onboarding E2E profile seeded with telemetry, final onboarding step, and seen voice-dictation feature tip state.
- Use that profile from both the default Electron fixture and restart-session helper.
- Fixes the v1.4.7-rc.2 release-cut E2E failure where the Voice Dictation modal intercepted terminal clicks in `terminal-restart-persistence.spec.ts`.

## Evidence
- Release cut `v1.4.7-rc.2` run failed shard 4-of-5 with the voice-dictation dialog overlay intercepting pointer events: https://github.com/stablyai/orca/actions/runs/26072073667

## Validation
- `pnpm exec oxlint tests/e2e/helpers/e2e-completed-onboarding-profile.ts tests/e2e/helpers/orca-app.ts tests/e2e/helpers/orca-restart.ts`
- `SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm exec playwright test --config=tests/playwright.config.ts --project=electron-headless tests/e2e/terminal-restart-persistence.spec.ts -g "restored Set Title pane label survives agent title churn"`

Made with [Orca](https://github.com/stablyai/orca) 🐋
