### PR TITLE
Scope workspace metadata hover to attachment group

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -150,6 +150,7 @@ describe('WorktreeCard linked PR display', () => {
     expect(markup).not.toContain('Loading issue')
     expect(markup).not.toContain('Loading PR')
     expect(markup).not.toContain('Reviewer handoff note')
+    expect(markup.indexOf('Workspace notes')).toBeLessThan(markup.indexOf('Linked issue #123'))
   })
 
   it('does not render the standalone CI badge and colors a failing linked PR icon red', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -607,12 +607,30 @@ const WorktreeCard = React.memo(function WorktreeCard({
             )}
           </div>
 
-          <WorktreeCardMetaBadges
-            issue={metaIssue}
-            linearIssue={metaLinearIssue}
-            review={metaReview}
-            comment={metaComment}
-          />
+          {hasDetails ? (
+            <WorktreeCardDetailsHover
+              issue={metaIssue}
+              linearIssue={metaLinearIssue}
+              review={metaReview}
+              comment={metaComment}
+              onEditIssue={handleEditIssue}
+              onEditComment={handleEditComment}
+            >
+              <WorktreeCardMetaBadges
+                issue={metaIssue}
+                linearIssue={metaLinearIssue}
+                review={metaReview}
+                comment={metaComment}
+              />
+            </WorktreeCardDetailsHover>
+          ) : (
+            <WorktreeCardMetaBadges
+              issue={metaIssue}
+              linearIssue={metaLinearIssue}
+              review={metaReview}
+              comment={metaComment}
+            />
+          )}
         </div>
 
         {remoteBranchConflict && (
@@ -676,20 +694,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         selectedWorktrees={selectedWorktrees}
         onContextMenuSelect={onContextMenuSelect}
       >
-        {hasDetails ? (
-          <WorktreeCardDetailsHover
-            issue={metaIssue}
-            linearIssue={metaLinearIssue}
-            review={metaReview}
-            comment={metaComment}
-            onEditIssue={handleEditIssue}
-            onEditComment={handleEditComment}
-          >
-            {cardBody}
-          </WorktreeCardDetailsHover>
-        ) : (
-          cardBody
-        )}
+        {cardBody}
       </WorktreeContextMenu>
 
       {repo?.connectionId && (

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -42,6 +42,9 @@ type WorktreeCardMetaBadgesProps = {
   comment: string | null
 }
 
+type WorktreeCardMetaBadgesRootProps = WorktreeCardMetaBadgesProps &
+  React.HTMLAttributes<HTMLDivElement>
+
 type WorktreeCardDetailsHoverProps = WorktreeCardMetaBadgesProps & {
   children: React.ReactElement
   onEditIssue: (event: React.MouseEvent) => void
@@ -200,23 +203,31 @@ function MetadataActionIcon({
   )
 }
 
-export function WorktreeCardMetaBadges({
-  issue,
-  linearIssue,
-  review,
-  comment
-}: WorktreeCardMetaBadgesProps): React.JSX.Element | null {
+export const WorktreeCardMetaBadges = React.forwardRef<
+  HTMLDivElement,
+  WorktreeCardMetaBadgesRootProps
+>(function WorktreeCardMetaBadges(
+  { issue, linearIssue, review, comment, className, ...props },
+  ref
+): React.JSX.Element | null {
   if (!hasWorktreeCardDetails({ issue, linearIssue, review, comment })) {
     return null
   }
 
   return (
-    // Why: inline agent rows reserve this same right inset for their dismiss X,
-    // so the card metadata icons align on the same visual rail.
+    // Why: Radix HoverCardTrigger uses `asChild`, so this group must forward
+    // trigger props/ref to the actual DOM node for attachment-only hover.
     <div
-      className="ml-auto flex shrink-0 items-center gap-1 pr-1.5"
+      ref={ref}
+      {...props}
+      className={cn('ml-auto flex shrink-0 items-center gap-1 pr-1.5', className)}
       aria-label="Workspace metadata"
     >
+      {hasComment(comment) && (
+        <MetaIconBadge label="Workspace notes">
+          <StickyNote className="text-muted-foreground" />
+        </MetaIconBadge>
+      )}
       {issue && (
         <MetaIconBadge label={`Linked issue #${issue.number}`}>
           <CircleDot className="text-muted-foreground" />
@@ -232,14 +243,9 @@ export function WorktreeCardMetaBadges({
           <ReviewIcon review={review} />
         </MetaIconBadge>
       )}
-      {hasComment(comment) && (
-        <MetaIconBadge label="Workspace notes">
-          <StickyNote className="text-muted-foreground" />
-        </MetaIconBadge>
-      )}
     </div>
   )
-}
+})
 
 export function WorktreeCardDetailsHover({
   issue,


### PR DESCRIPTION
## Summary
- Move the workspace details hover trigger from the whole card to the metadata attachment icon group
- Render workspace notes at the start of the metadata icon group
- Add a regression assertion for note icon ordering

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json