### PR TITLE
Fix occasional PR checks fallback failure

### DIFF
--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -6,6 +6,7 @@ const {
   getOwnerRepoMock,
   getIssueOwnerRepoMock,
   gitExecFileAsyncMock,
+  extractExecErrorMock,
   rateLimitGuardMock,
   noteRateLimitSpendMock,
   acquireMock,
@@ -16,6 +17,16 @@ const {
   getOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
   gitExecFileAsyncMock: vi.fn(),
+  extractExecErrorMock: vi.fn((err: unknown) => {
+    if (err && typeof err === 'object') {
+      const e = err as { stderr?: unknown; stdout?: unknown; message?: unknown }
+      return {
+        stderr: typeof e.stderr === 'string' ? e.stderr : String(e.message ?? err),
+        stdout: typeof e.stdout === 'string' ? e.stdout : ''
+      }
+    }
+    return { stderr: String(err), stdout: '' }
+  }),
   rateLimitGuardMock: vi.fn(() => ({ blocked: false })),
   noteRateLimitSpendMock: vi.fn(),
   acquireMock: vi.fn(),
@@ -32,6 +43,7 @@ vi.mock('./gh-utils', () => ({
   ghRepoExecOptions: (context: { repoPath: string }) => ({ cwd: context.repoPath }),
   getOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: getIssueOwnerRepoMock,
+  extractExecError: extractExecErrorMock,
   acquire: acquireMock,
   release: releaseMock,
   _resetOwnerRepoCache: vi.fn()
@@ -55,6 +67,7 @@ describe('getPRChecks', () => {
     getOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
     gitExecFileAsyncMock.mockReset()
+    extractExecErrorMock.mockClear()
     rateLimitGuardMock.mockReset()
     rateLimitGuardMock.mockReturnValue({ blocked: false })
     noteRateLimitSpendMock.mockReset()
@@ -123,6 +136,48 @@ describe('getPRChecks', () => {
         workflowRunId: undefined
       }
     ])
+  })
+
+  it('treats gh pr checks "no checks reported" as an empty check list', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Command failed: gh pr checks 42'), {
+          stderr: "no checks reported on the 'codex/keybindings-toml' branch\n",
+          stdout: ''
+        })
+      )
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(checks).toEqual([])
+    expect(consoleWarnSpy).not.toHaveBeenCalled()
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('keeps unexpected gh pr checks fallback failures inside the empty-checks contract', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ check_runs: [] }) })
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Command failed: gh pr checks 42'), {
+          stderr: 'GraphQL: Could not resolve to a PullRequest',
+          stdout: ''
+        })
+      )
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(checks).toEqual([])
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'getPRChecks via head SHA failed, falling back to gh pr checks:',
+      expect.any(Error)
+    )
+    expect(consoleWarnSpy).toHaveBeenCalledWith('getPRChecks failed:', expect.any(Error))
+    consoleWarnSpy.mockRestore()
   })
 
   it('falls back to gh pr checks when the cached head SHA no longer resolves', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1769,7 +1769,15 @@ export async function getPRChecks(
     if (ownerRepo) {
       fallbackArgs.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
     }
-    const { stdout } = await ghExecFileAsync(fallbackArgs, ghOptions)
+    const { stdout } = await ghExecFileAsync(fallbackArgs, ghOptions).catch((err: unknown) => {
+      const { stderr } = extractExecError(err)
+      // Why: `gh pr checks` exits non-zero when a PR genuinely has no check
+      // runs yet. Treat that as an empty optional section, not a load failure.
+      if (stderr.toLowerCase().includes('no checks reported')) {
+        return { stdout: '[]', stderr }
+      }
+      throw err
+    })
     const data = JSON.parse(stdout) as { name: string; state: string; link: string }[]
     return data.map((d) => ({
       name: d.name,
@@ -1805,7 +1813,8 @@ export async function getPRChecks(
           }[]
         }
         if (data.check_runs.length === 0) {
-          return fallbackToPRChecks()
+          const fallbackChecks = await fallbackToPRChecks()
+          return fallbackChecks
         }
         return data.check_runs.map((d) => ({
           name: d.name,
@@ -1823,7 +1832,8 @@ export async function getPRChecks(
       }
     }
     // Fallback: no branch provided, empty check-runs, or non-GitHub remote.
-    return fallbackToPRChecks()
+    const fallbackChecks = await fallbackToPRChecks()
+    return fallbackChecks
   } catch (err) {
     console.warn('getPRChecks failed:', err)
     return []

--- a/src/main/github/work-item-details-file-viewed.test.ts
+++ b/src/main/github/work-item-details-file-viewed.test.ts
@@ -167,4 +167,73 @@ describe('getWorkItemDetails PR file viewed state', () => {
       undefined
     )
   })
+
+  it('keeps PR details loadable when checks lookup fails', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'pr:42',
+      type: 'pr',
+      number: 42,
+      title: 'Review files',
+      state: 'open',
+      url: 'https://github.com/stablyai/orca/pull/42',
+      labels: [],
+      updatedAt: '2026-04-01T00:00:00Z',
+      author: null
+    })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    getPRCommentsMock.mockResolvedValue([])
+    getPRChecksMock.mockRejectedValue(
+      Object.assign(new Error('Command failed: gh pr checks 42'), {
+        stderr: "no checks reported on the 'codex/keybindings-toml' branch\n",
+        stdout: ''
+      })
+    )
+    ghExecFileAsyncMock.mockImplementation((args: string[]) => {
+      const query = args.find((arg) => arg.startsWith('query=')) ?? ''
+      if (query.includes('viewerViewedState')) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  id: 'PR_kwDO123',
+                  files: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] }
+                }
+              }
+            }
+          })
+        })
+      }
+      if (query.includes('participants')) {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            data: { repository: { pullRequest: { participants: { nodes: [] } } } }
+          })
+        })
+      }
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/stablyai/orca/pulls/42') {
+        return Promise.resolve({
+          stdout: JSON.stringify({
+            body: 'PR body',
+            head: { sha: 'head-sha' },
+            base: { sha: 'base-sha' }
+          })
+        })
+      }
+      if (endpoint === 'repos/stablyai/orca/pulls/42/files?per_page=100') {
+        return Promise.resolve({ stdout: '[]' })
+      }
+      return Promise.reject(new Error(`unexpected gh call: ${args.join(' ')}`))
+    })
+
+    const details = await getWorkItemDetails('/repo-root', 42, 'pr')
+
+    expect(details?.body).toBe('PR body')
+    expect(details?.headSha).toBe('head-sha')
+    expect(details?.checks).toEqual([])
+    expect(consoleWarnSpy).toHaveBeenCalledOnce()
+    consoleWarnSpy.mockRestore()
+  })
 })

--- a/src/main/github/work-item-details.ts
+++ b/src/main/github/work-item-details.ts
@@ -8,6 +8,7 @@ import type {
   GitHubPRFileViewedState,
   GitHubWorkItem,
   GitHubWorkItemDetails,
+  PRCheckDetail,
   PRComment
 } from '../../shared/types'
 import {
@@ -670,6 +671,22 @@ async function getMentionParticipants(
   return mergeGitHubUsers([...participants, ...graphQlUsers])
 }
 
+async function getPRChecksForDetails(
+  repoPath: string,
+  prNumber: number,
+  headSha: string | undefined,
+  connectionId?: string | null
+): Promise<PRCheckDetail[]> {
+  try {
+    return await getPRChecks(repoPath, prNumber, headSha, null, undefined, connectionId)
+  } catch (err) {
+    // Why: checks are auxiliary PR metadata; a gh CLI edge case must not block
+    // the user from opening the PR review drawer and reading the files/comments.
+    console.warn('getWorkItemDetails PR checks failed:', err)
+    return []
+  }
+}
+
 export async function getWorkItemDetails(
   repoPath: string,
   number: number,
@@ -740,9 +757,7 @@ export async function getWorkItemDetails(
     // Promise.all above, so there's no ordering requirement between them.
     const [mentionParticipants, checks] = await Promise.all([
       getMentionParticipants(repoPath, item, comments, participants, connectionId),
-      shas?.headSha
-        ? getPRChecks(repoPath, item.number, shas.headSha, null, undefined, connectionId)
-        : getPRChecks(repoPath, item.number, undefined, null, undefined, connectionId)
+      getPRChecksForDetails(repoPath, item.number, shas?.headSha, connectionId)
     ])
 
     return {


### PR DESCRIPTION
## Summary
- Treat gh pr checks 'no checks reported' failures as an empty checks list
- Keep PR details loadable when checks lookup fails
- Add regression coverage for both fallback paths

## Tests
- pnpm test -- src/main/github/client-pr-checks.test.ts src/main/github/work-item-details-file-viewed.test.ts