### PR TITLE
fix: preserve terminal scroll on worktree switch

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -3,10 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useTerminalPaneGlobalEffects } from './use-terminal-pane-global-effects'
 
 const mocks = vi.hoisted(() => ({
+  captureScrollViewportPosition: vi.fn(),
   fitAndFocusPanes: vi.fn(),
   fitPanes: vi.fn(),
   flushTerminalOutput: vi.fn(),
-  handleTerminalFileDrop: vi.fn()
+  handleTerminalFileDrop: vi.fn(),
+  restoreScrollViewportPosition: vi.fn()
 }))
 
 vi.mock('react', async (importOriginal) => {
@@ -27,6 +29,11 @@ vi.mock('./pane-helpers', () => ({
 
 vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
   flushTerminalOutput: mocks.flushTerminalOutput
+}))
+
+vi.mock('@/lib/pane-manager/pane-scroll', () => ({
+  captureScrollViewportPosition: mocks.captureScrollViewportPosition,
+  restoreScrollViewportPosition: mocks.restoreScrollViewportPosition
 }))
 
 vi.mock('./terminal-drop-handler', () => ({
@@ -128,6 +135,13 @@ describe('useTerminalPaneGlobalEffects', () => {
     mocks.flushTerminalOutput.mockImplementation((terminal: { name: string }) => {
       order.push(`flush:${terminal.name}`)
     })
+    mocks.captureScrollViewportPosition.mockImplementation((terminal: { name: string }) => {
+      order.push(`capture:${terminal.name}`)
+      return { terminalName: terminal.name }
+    })
+    mocks.restoreScrollViewportPosition.mockImplementation((terminal: { name: string }) => {
+      order.push(`restore:${terminal.name}`)
+    })
     mocks.fitAndFocusPanes.mockImplementation(() => order.push('fit-focus'))
 
     const isActiveRef = { current: false }
@@ -145,7 +159,16 @@ describe('useTerminalPaneGlobalEffects', () => {
       toggleExpandPane: vi.fn()
     })
 
-    expect(order).toEqual(['flush:terminal-a', 'flush:terminal-b', 'resume', 'fit-focus'])
+    expect(order).toEqual([
+      'capture:terminal-a',
+      'capture:terminal-b',
+      'flush:terminal-a',
+      'flush:terminal-b',
+      'resume',
+      'fit-focus',
+      'restore:terminal-a',
+      'restore:terminal-b'
+    ])
     expect(mocks.fitPanes).not.toHaveBeenCalled()
     expect(isActiveRef.current).toBe(true)
     expect(isVisibleRef.current).toBe(true)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -15,6 +15,10 @@ import { flushTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-sch
 import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
 import { surfaceStaleAgentRow } from './stale-agent-row'
 import { useAppStore } from '@/store'
+import {
+  captureScrollViewportPosition,
+  restoreScrollViewportPosition
+} from '@/lib/pane-manager/pane-scroll'
 
 type UseTerminalPaneGlobalEffectsArgs = {
   tabId: string
@@ -59,6 +63,15 @@ export function useTerminalPaneGlobalEffects({
       return
     }
     if (isVisible) {
+      // Why: WebGL resume can disturb xterm's viewport bookkeeping before the
+      // post-resume fit runs. Capture numeric viewport positions first; the
+      // restore path avoids content matching so duplicate agent log lines do
+      // not jump to the wrong history entry.
+      const viewportPositions = new Map(
+        manager
+          .getPanes()
+          .map((pane) => [pane.id, captureScrollViewportPosition(pane.terminal)] as const)
+      )
       // Why: background PTY output is throttled while a pane is not focused;
       // flush it before fitting so newly visible terminals paint current state.
       for (const pane of manager.getPanes()) {
@@ -76,6 +89,12 @@ export function useTerminalPaneGlobalEffects({
         fitAndFocusPanes(manager)
       } else {
         fitPanes(manager)
+      }
+      for (const pane of manager.getPanes()) {
+        const position = viewportPositions.get(pane.id)
+        if (position) {
+          restoreScrollViewportPosition(pane.terminal, position)
+        }
       }
     } else if (wasVisibleRef.current) {
       // Suspend WebGL when going hidden. xterm.write() continues to land in

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import {
+  captureScrollViewportPosition,
+  restoreScrollViewportPosition,
+  type ScrollViewportPosition
+} from './pane-scroll'
+
+function createTerminal(args: {
+  viewportY: number
+  baseY: number
+  cols: number
+  rows: number
+  type?: 'normal' | 'alternate'
+}): Terminal {
+  const active = {
+    type: args.type ?? 'normal',
+    viewportY: args.viewportY,
+    baseY: args.baseY
+  }
+  return {
+    cols: args.cols,
+    rows: args.rows,
+    buffer: { active },
+    scrollToBottom: vi.fn(() => {
+      active.viewportY = active.baseY
+    }),
+    scrollToLine: vi.fn((line: number) => {
+      active.viewportY = line
+    }),
+    scrollLines: vi.fn((delta: number) => {
+      active.viewportY = Math.max(0, Math.min(active.baseY, active.viewportY + delta))
+    })
+  } as unknown as Terminal
+}
+
+describe('scroll viewport position', () => {
+  it('captures the numeric viewport position', () => {
+    const terminal = createTerminal({ viewportY: 42, baseY: 100, cols: 120, rows: 32 })
+
+    expect(captureScrollViewportPosition(terminal)).toEqual({
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100,
+      cols: 120,
+      rows: 32
+    })
+  })
+
+  it('restores the same viewport line when the terminal grid did not reflow', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 100, cols: 120, rows: 32 })
+    const state: ScrollViewportPosition = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100,
+      cols: 120,
+      rows: 32
+    }
+
+    restoreScrollViewportPosition(terminal, state)
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(42)
+    expect(terminal.buffer.active.viewportY).toBe(42)
+  })
+
+  it('clamps the restored viewport line to the current buffer bottom', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 30, cols: 120, rows: 32 })
+    const state: ScrollViewportPosition = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100,
+      cols: 120,
+      rows: 32
+    }
+
+    restoreScrollViewportPosition(terminal, state)
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(30)
+    expect(terminal.buffer.active.viewportY).toBe(30)
+  })
+
+  it('does not restore across normal and alternate buffers', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 100, cols: 120, rows: 32 })
+    const state: ScrollViewportPosition = {
+      bufferType: 'alternate',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100,
+      cols: 120,
+      rows: 32
+    }
+
+    restoreScrollViewportPosition(terminal, state)
+
+    expect(terminal.scrollToLine).not.toHaveBeenCalled()
+    expect(terminal.buffer.active.viewportY).toBe(10)
+  })
+
+  it('scrolls to the current bottom when the pane was previously at bottom', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 250, cols: 120, rows: 32 })
+    const state: ScrollViewportPosition = {
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 100,
+      baseY: 100,
+      cols: 120,
+      rows: 32
+    }
+
+    restoreScrollViewportPosition(terminal, state)
+
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1)
+    expect(terminal.buffer.active.viewportY).toBe(250)
+  })
+
+  it('does not numerically restore a non-bottom viewport after a grid reflow', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 100, cols: 80, rows: 32 })
+    const state: ScrollViewportPosition = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100,
+      cols: 120,
+      rows: 32
+    }
+
+    restoreScrollViewportPosition(terminal, state)
+
+    expect(terminal.scrollToLine).not.toHaveBeenCalled()
+    expect(terminal.buffer.active.viewportY).toBe(10)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -1,6 +1,15 @@
 import type { Terminal } from '@xterm/xterm'
 import type { ScrollState } from './pane-manager-types'
 
+export type ScrollViewportPosition = {
+  bufferType: 'normal' | 'alternate'
+  wasAtBottom: boolean
+  viewportY: number
+  baseY: number
+  cols: number
+  rows: number
+}
+
 // ---------------------------------------------------------------------------
 // Scroll restoration after reflow
 // ---------------------------------------------------------------------------
@@ -71,6 +80,44 @@ export function restoreScrollState(terminal: Terminal, state: ScrollState): void
     terminal.scrollToLine(target)
     forceViewportScrollbarSync(terminal)
   }
+}
+
+export function captureScrollViewportPosition(terminal: Terminal): ScrollViewportPosition {
+  const buf = terminal.buffer.active
+  return {
+    bufferType: buf.type,
+    wasAtBottom: buf.viewportY >= buf.baseY,
+    viewportY: buf.viewportY,
+    baseY: buf.baseY,
+    cols: terminal.cols,
+    rows: terminal.rows
+  }
+}
+
+export function restoreScrollViewportPosition(
+  terminal: Terminal,
+  state: ScrollViewportPosition
+): void {
+  const buf = terminal.buffer.active
+  if (buf.type !== state.bufferType) {
+    return
+  }
+
+  if (state.wasAtBottom) {
+    terminal.scrollToBottom()
+    forceViewportScrollbarSync(terminal)
+    return
+  }
+
+  if (terminal.cols !== state.cols || terminal.rows !== state.rows) {
+    return
+  }
+
+  // Why: worktree switches can resume WebGL with the same terminal grid but
+  // stale viewport internals. Restore by numeric viewport only when the grid
+  // did not reflow, avoiding duplicate-content matching in long agent logs.
+  terminal.scrollToLine(Math.min(state.viewportY, buf.baseY))
+  forceViewportScrollbarSync(terminal)
 }
 
 // Why: xterm 6's Viewport._sync() updates scrollDimensions after resize but


### PR DESCRIPTION
## Summary
- Capture terminal viewport positions before visible resume during worktree switches
- Restore numeric viewport positions after WebGL resume and fit when the grid did not reflow
- Add focused coverage for viewport restore ordering and edge cases

## Review
- Reviewed changed terminal resume path for correctness, duplicate-log scroll matching hazards, and grid reflow behavior
- No blocking issues found

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-scroll.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
- pnpm run typecheck:web
- git diff --check
- $electron deterministic repro: forced resumeRendering() to corrupt viewport from line 420 to 419 during a workspace switch; patched code restored line 420 / scroll-0420
- $electron natural loop: 12 mid-scroll switches preserved scroll-0320; 8 bottom-position switches preserved scroll-0839

CI intentionally not waited on per request.