### PR TITLE
Fix deferred terminal pane work when rAF is suspended

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -246,6 +246,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
     // stays a plain clickable surface for pointer activation.
     <div
       onClick={handleActivate}
+      data-testid="dashboard-agent-row"
       className={cn(
         // Why: this row owns the timestamp/X hover boundary; anonymous
         // ancestor groups from workspace cards must not reveal every row's X.

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -574,6 +574,41 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('uses transport viewport defaults when the timeout fallback finds zero terminal dimensions', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    vi.useFakeTimers()
+    globalThis.requestAnimationFrame = vi.fn(() => 42) as never
+    globalThis.cancelAnimationFrame = vi.fn()
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+    const pane = createPane(1)
+    pane.terminal.cols = 0
+    pane.terminal.rows = 0
+    const deps = createDeps()
+
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+
+    vi.advanceTimersByTime(100)
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+    const connectOptions = transport.connect.mock.calls[0]?.[0] as
+      | { cols?: number; rows?: number }
+      | undefined
+    expect(connectOptions?.cols).toBeUndefined()
+    expect(connectOptions?.rows).toBeUndefined()
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+      pane.id,
+      expect.stringContaining('Terminal has zero dimensions')
+    )
+    disposable.dispose()
+  })
+
   it('keeps the surviving split pane mounted when an intentional pane-close PTY exit arrives', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-pane-2')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -542,6 +542,38 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('connects through a timeout fallback when animation frames are suspended', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    vi.useFakeTimers()
+    globalThis.requestAnimationFrame = vi.fn(() => 42) as never
+    globalThis.cancelAnimationFrame = vi.fn()
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    }
+
+    const disposable = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps() as never
+    )
+
+    expect(transport.connect).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(99)
+    await flushAsyncTicks()
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    await flushAsyncTicks()
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42)
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+    disposable.dispose()
+  })
+
   it('keeps the surviving split pane mounted when an intentional pane-close PTY exit arrives', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-pane-2')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1173,16 +1173,22 @@ export function connectPanePty(
       return
     }
     safeFit(pane)
-    const cols = pane.terminal.cols
-    const rows = pane.terminal.rows
+    const measuredCols = pane.terminal.cols
+    const measuredRows = pane.terminal.rows
+    const hasUsableViewport =
+      Number.isFinite(measuredCols) &&
+      Number.isFinite(measuredRows) &&
+      measuredCols > 0 &&
+      measuredRows > 0
+    const transportViewport = hasUsableViewport ? { cols: measuredCols, rows: measuredRows } : {}
 
     // Why: if fitAddon resolved to 0×0, the container likely has no layout
-    // dimensions (display:none, unmounted, or zero-size parent). Surface a
-    // diagnostic so the user sees something instead of a blank pane.
-    if (cols === 0 || rows === 0) {
+    // dimensions (display:none, unmounted, or zero-size parent). Do not pass
+    // invalid geometry into spawn/attach; transports already own safe defaults.
+    if (!hasUsableViewport) {
       deps.onPtyErrorRef?.current?.(
         pane.id,
-        `Terminal has zero dimensions (${cols}×${rows}). The pane container may not be visible.`
+        `Terminal has zero dimensions (${measuredCols}×${measuredRows}). The pane container may not be visible.`
       )
     }
 
@@ -1265,8 +1271,7 @@ export function connectPanePty(
 
       const spawnedRaw = transport.connect({
         url: '',
-        cols,
-        rows,
+        ...transportViewport,
         callbacks: {
           onData: dataCallback,
           onReplayData: replayDataCallback,
@@ -1860,8 +1865,8 @@ export function connectPanePty(
       // Why: when a mobile-fit override is active, skip sending desktop dims
       // to the PTY — the PTY is already at phone dimensions and must stay there.
       const reattachPtyId = transport.getPtyId()
-      if (!reattachPtyId || !getFitOverrideForPty(reattachPtyId)) {
-        transport.resize(cols, rows)
+      if (hasUsableViewport && (!reattachPtyId || !getFitOverrideForPty(reattachPtyId))) {
+        transport.resize(measuredCols, measuredRows)
       }
       // Why: POSIX only delivers SIGWINCH when terminal dimensions actually
       // change. Sending it explicitly guarantees restored TUIs repaint at
@@ -2039,8 +2044,7 @@ export function connectPanePty(
             let expiredReattachError = false
             const reattachPromise = transport.connect({
               url: '',
-              cols,
-              rows,
+              ...transportViewport,
               sessionId: pendingSessionId,
               callbacks: {
                 onData: dataCallback,
@@ -2173,8 +2177,7 @@ export function connectPanePty(
       let expiredReattachError = false
       const reattachPromise = transport.connect({
         url: '',
-        cols,
-        rows,
+        ...transportViewport,
         sessionId: deferredReattachSessionId,
         callbacks: {
           onData: dataCallback,
@@ -2254,8 +2257,7 @@ export function connectPanePty(
       try {
         transport.attach({
           existingPtyId: attachPtyId,
-          cols,
-          rows,
+          ...transportViewport,
           callbacks: {
             onData: dataCallback,
             onReplayData: replayDataCallback,
@@ -2304,8 +2306,7 @@ export function connectPanePty(
             deps.updateTabPtyId(deps.tabId, spawnedPtyId)
             transport.attach({
               existingPtyId: spawnedPtyId,
-              cols,
-              rows,
+              ...transportViewport,
               callbacks: {
                 onData: dataCallback,
                 onReplayData: replayDataCallback,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -38,6 +38,10 @@ import {
 import { isLocalNativeWindowsPty } from '@/lib/pane-manager/windows-pty-compatibility'
 import { recordTerminalOutput, restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
+import {
+  scheduleAfterAnimationFrameOrTimeout,
+  type ScheduledAnimationFrameFallback
+} from '@/lib/schedule-after-animation-frame-or-timeout'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { e2eConfig } from '@/lib/e2e-config'
@@ -235,7 +239,7 @@ export function connectPanePty(
   deps: PtyConnectionDeps
 ): IDisposable {
   let disposed = false
-  let connectFrame: number | null = null
+  let connectSchedule: ScheduledAnimationFrameFallback | null = null
   let unregisterBacklogRecovery: (() => void) | null = null
   let unregisterDocumentVisibilityRecovery: (() => void) | null = null
   let startupInjectTimer: ReturnType<typeof setTimeout> | null = null
@@ -1160,9 +1164,11 @@ export function connectPanePty(
   }
 
   // Defer PTY spawn/attach to next frame so FitAddon has time to calculate
-  // the correct terminal dimensions from the laid-out container.
-  connectFrame = requestAnimationFrame(() => {
-    connectFrame = null
+  // dimensions from the laid-out container. Hidden/headless Electron windows
+  // can pause rAF before first paint, so the timeout prevents a permanent
+  // disconnected pane.
+  connectSchedule = scheduleAfterAnimationFrameOrTimeout(() => {
+    connectSchedule = null
     if (disposed) {
       return
     }
@@ -2355,13 +2361,13 @@ export function connectPanePty(
         agentTaskCompleteSettingsUnsubscribe()
         agentTaskCompleteSettingsUnsubscribe = null
       }
-      if (connectFrame !== null) {
+      if (connectSchedule !== null) {
         // Why: StrictMode and split-group remounts can dispose a pane binding
         // before its deferred PTY attach/spawn work runs. Cancel that queued
         // frame so stale bindings cannot reattach the PTY and steal the live
         // handler wiring from the current pane.
-        cancelAnimationFrame(connectFrame)
-        connectFrame = null
+        connectSchedule.cancel()
+        connectSchedule = null
       }
       onDataDisposable.dispose()
       onResizeDisposable.dispose()

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FOCUS_TERMINAL_PANE_EVENT, type FocusTerminalPaneDetail } from '@/constants/terminal'
 import { activateTabAndFocusPane } from './activate-tab-and-focus-pane'
 
 const setActiveTab = vi.hoisted(() => vi.fn())
@@ -11,22 +12,67 @@ vi.mock('@/store', () => ({
   }
 }))
 
+class MockCustomEvent<T = unknown> {
+  readonly type: string
+  readonly detail: T | undefined
+
+  constructor(type: string, init?: { detail?: T }) {
+    this.type = type
+    this.detail = init?.detail
+  }
+}
+
 describe('activateTabAndFocusPane', () => {
+  const dispatchEvent = vi.fn()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setActiveTab.mockClear()
+    dispatchEvent.mockClear()
+    vi.stubGlobal('window', { dispatchEvent })
+    vi.stubGlobal('CustomEvent', MockCustomEvent)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 42)
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
-    vi.clearAllMocks()
+  })
+
+  it('dispatches the pane focus event through a timeout fallback when animation frames are suspended', () => {
+    activateTabAndFocusPane('tab-1', 'leaf-1', {
+      ackPaneKeyOnSuccess: 'tab-1:leaf-1',
+      flashFocusedPane: true
+    })
+
+    expect(setActiveTab).toHaveBeenCalledWith('tab-1')
+    expect(dispatchEvent).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(99)
+    expect(dispatchEvent).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42)
+    expect(dispatchEvent).toHaveBeenCalledTimes(1)
+    const event = dispatchEvent.mock.calls[0]?.[0] as MockCustomEvent<FocusTerminalPaneDetail>
+    expect(event.type).toBe(FOCUS_TERMINAL_PANE_EVENT)
+    expect(event.detail).toEqual({
+      tabId: 'tab-1',
+      leafId: 'leaf-1',
+      ackPaneKeyOnSuccess: 'tab-1:leaf-1',
+      flashFocusedPane: true
+    })
   })
 
   it('cancels a pending pane focus frame when a newer activation starts', () => {
-    const cancelAnimationFrame = vi.fn()
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      vi.fn(() => 12)
-    )
-    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
-    vi.stubGlobal('window', {
-      dispatchEvent: vi.fn()
-    })
+    const requestAnimationFrame = vi.fn()
+    requestAnimationFrame.mockReturnValueOnce(12).mockReturnValueOnce(13)
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame)
 
     activateTabAndFocusPane('tab-1', 'leaf-1')
     activateTabAndFocusPane('tab-2', 'leaf-2')
@@ -34,5 +80,6 @@ describe('activateTabAndFocusPane', () => {
     expect(setActiveTab).toHaveBeenNthCalledWith(1, 'tab-1')
     expect(setActiveTab).toHaveBeenNthCalledWith(2, 'tab-2')
     expect(cancelAnimationFrame).toHaveBeenCalledWith(12)
+    expect(dispatchEvent).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.ts
@@ -1,13 +1,15 @@
 import { useAppStore } from '@/store'
 import { FOCUS_TERMINAL_PANE_EVENT, type FocusTerminalPaneDetail } from '@/constants/terminal'
+import {
+  scheduleAfterAnimationFrameOrTimeout,
+  type ScheduledAnimationFrameFallback
+} from './schedule-after-animation-frame-or-timeout'
 
-let pendingFocusPaneFrameId: number | null = null
+let pendingFocusPaneFrame: ScheduledAnimationFrameFallback | null = null
 
 function cancelPendingFocusPaneFrame(): void {
-  if (pendingFocusPaneFrameId !== null) {
-    cancelAnimationFrame(pendingFocusPaneFrameId)
-    pendingFocusPaneFrameId = null
-  }
+  pendingFocusPaneFrame?.cancel()
+  pendingFocusPaneFrame = null
 }
 
 export function activateTabAndFocusPane(
@@ -24,10 +26,10 @@ export function activateTabAndFocusPane(
   if (leafId === null) {
     return
   }
-  // Why: defer one frame so the new TerminalPane has mounted its
-  // FOCUS_TERMINAL_PANE_EVENT listener before we dispatch.
-  pendingFocusPaneFrameId = requestAnimationFrame(() => {
-    pendingFocusPaneFrameId = null
+  // Why: defer one frame so the new TerminalPane has mounted its listener.
+  // Hidden/headless Electron windows can pause rAF, so the timeout keeps focus usable.
+  pendingFocusPaneFrame = scheduleAfterAnimationFrameOrTimeout(() => {
+    pendingFocusPaneFrame = null
     const detail: FocusTerminalPaneDetail = {
       tabId,
       leafId,

--- a/src/renderer/src/lib/schedule-after-animation-frame-or-timeout.test.ts
+++ b/src/renderer/src/lib/schedule-after-animation-frame-or-timeout.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { scheduleAfterAnimationFrameOrTimeout } from './schedule-after-animation-frame-or-timeout'
+
+describe('scheduleAfterAnimationFrameOrTimeout', () => {
+  let frameCallback: FrameRequestCallback | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    frameCallback = null
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallback = callback
+        return 7
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('runs once on the animation frame and ignores the timeout fallback afterward', () => {
+    const callback = vi.fn()
+
+    scheduleAfterAnimationFrameOrTimeout(callback)
+    frameCallback?.(16)
+    vi.advanceTimersByTime(100)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(cancelAnimationFrame).not.toHaveBeenCalled()
+  })
+
+  it('runs once through the timeout fallback when the animation frame does not fire', () => {
+    const callback = vi.fn()
+
+    scheduleAfterAnimationFrameOrTimeout(callback)
+    vi.advanceTimersByTime(99)
+    expect(callback).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    frameCallback?.(16)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(7)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run after cancellation', () => {
+    const callback = vi.fn()
+
+    const scheduled = scheduleAfterAnimationFrameOrTimeout(callback)
+    scheduled.cancel()
+    vi.advanceTimersByTime(100)
+    frameCallback?.(16)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(7)
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/schedule-after-animation-frame-or-timeout.ts
+++ b/src/renderer/src/lib/schedule-after-animation-frame-or-timeout.ts
@@ -1,0 +1,61 @@
+export type ScheduledAnimationFrameFallback = {
+  cancel: () => void
+}
+
+export function scheduleAfterAnimationFrameOrTimeout(
+  callback: () => void,
+  timeoutMs = 100
+): ScheduledAnimationFrameFallback {
+  let settled = false
+  let frameId: number | null = null
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const cancelFrame = (): void => {
+    if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(frameId)
+    }
+    frameId = null
+  }
+
+  timeoutId = setTimeout(() => {
+    if (settled) {
+      return
+    }
+    settled = true
+    timeoutId = null
+    cancelFrame()
+    callback()
+  }, timeoutMs)
+
+  if (typeof requestAnimationFrame === 'function') {
+    const nextFrameId = requestAnimationFrame(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      frameId = null
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      callback()
+    })
+    if (!settled) {
+      frameId = nextFrameId
+    }
+  }
+
+  return {
+    cancel: () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+        timeoutId = null
+      }
+      cancelFrame()
+    }
+  }
+}

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -172,7 +172,11 @@ async function clickWorkspaceCardAgentRow(page: Page, prompt: string): Promise<v
     .locator(`span[title="${prompt}"]`)
     .first()
   await expect(rowLabel).toBeVisible({ timeout: 10_000 })
-  await rowLabel.click()
+  const row = rowLabel.locator('xpath=ancestor::*[@data-testid="dashboard-agent-row"][1]')
+  // Why: the inline row contains height-transitioning text. In headless
+  // Electron, Playwright can wait forever for a fully stable box even though
+  // the user-visible row is ready for pointer activation.
+  await row.click({ force: true })
 }
 
 async function readActivePaneSelection(page: Page): Promise<ActivePaneSelection> {


### PR DESCRIPTION
## Summary
- Add a shared `requestAnimationFrame` + timeout scheduler for renderer work that must run after the next paint but must not hang when rAF is suspended.
- Use the scheduler for deferred terminal PTY attach/spawn and workspace-card agent pane focus dispatch.
- Make the matching E2E click the stable dashboard agent row target instead of an animated label.

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/activate-tab-and-focus-pane.test.ts src/renderer/src/lib/schedule-after-animation-frame-or-timeout.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/focus-terminal-pane-event.test.ts`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless tests/e2e/terminal-panes.spec.ts -g "split panes persist PTY bindings by stable UUID leaf id" --retries=0 --workers=1`
- `SKIP_BUILD=1 pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless tests/e2e/activity-agent-pane-isolation.spec.ts -g "workspace card agent rows focus the matching terminal split pane" --retries=0 --repeat-each=5 --workers=1`


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.

## ELI5

When the browser suspends animation frames (background/minimized), terminal attach and focus work could hang forever. A timeout fallback runs that work anyway.
