### PR TITLE
Rename delete worktree copy to workspace

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1009,7 +1009,7 @@ export default function ChecksPanel(): React.JSX.Element {
           </div>
         )}
 
-        {/* Merge / Delete Worktree actions */}
+        {/* Merge / Delete Workspace actions */}
         {activeWorktree && repo && (
           <PRActions pr={pr} repo={repo} worktree={activeWorktree} onRefreshPR={handleRefreshPR} />
         )}

--- a/src/renderer/src/components/right-sidebar/PRActions.tsx
+++ b/src/renderer/src/components/right-sidebar/PRActions.tsx
@@ -187,7 +187,7 @@ export default function PRActions({
         ) : (
           <Trash2 className="size-3.5" />
         )}
-        {isDeletingWorktree ? 'Deleting…' : 'Delete Worktree'}
+        {isDeletingWorktree ? 'Deleting…' : 'Delete Workspace'}
       </Button>
     )
   }

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -278,16 +278,16 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             breaks that toast action even though this pane still renders fine. */}
         <div id="general-skip-delete-worktree-confirm" className="scroll-mt-6">
           <SearchableSetting
-            title="Ask Before Deleting Worktrees"
-            description="Show a confirmation dialog before deleting a worktree."
+            title="Ask Before Deleting Workspaces"
+            description="Show a confirmation dialog before deleting a workspace."
             keywords={['delete', 'worktree', 'confirm', 'dialog', 'skip', 'prompt']}
             className="flex items-center justify-between gap-4 px-1 py-2"
           >
             <div className="space-y-0.5">
-              <Label>Ask Before Deleting Worktrees</Label>
+              <Label>Ask Before Deleting Workspaces</Label>
               <p className="text-xs text-muted-foreground">
-                Show a confirmation before deleting a worktree from the context menu. Failed deletes
-                still surface a Force Delete fallback.
+                Show a confirmation before deleting a workspace from the context menu. Failed
+                deletes still surface a Force Delete fallback.
               </p>
             </div>
             <button

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -12,8 +12,8 @@ export const GENERAL_WORKSPACE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['nested', 'subfolder', 'directory']
   },
   {
-    title: 'Ask Before Deleting Worktrees',
-    description: 'Show a confirmation dialog before deleting a worktree.',
+    title: 'Ask Before Deleting Workspaces',
+    description: 'Show a confirmation dialog before deleting a workspace.',
     keywords: ['delete', 'worktree', 'confirm', 'dialog', 'skip', 'prompt']
   },
   {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -174,7 +174,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             onDeleted?.([worktreeId])
           })
           .catch((err: unknown) => {
-            toast.error('Failed to delete worktree', {
+            toast.error('Failed to delete workspace', {
               description: err instanceof Error ? err.message : String(err)
             })
           })
@@ -222,14 +222,14 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
       >
         <DialogHeader>
           <DialogTitle className="text-sm">
-            {isBatchDelete ? 'Delete Worktrees' : 'Delete Worktree'}
+            {isBatchDelete ? 'Delete Workspaces' : 'Delete Workspace'}
           </DialogTitle>
           <DialogDescription className="text-xs">
             {isBatchDelete ? (
               <>
                 Remove{' '}
-                <span className="font-medium text-foreground">{worktrees.length} worktrees</span>{' '}
-                from git and delete their working tree folders.
+                <span className="font-medium text-foreground">{worktrees.length} workspaces</span>{' '}
+                from git and delete their workspace folders.
               </>
             ) : (
               <>
@@ -237,7 +237,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
                 <span className="break-all font-medium text-foreground">
                   {worktree?.displayName}
                 </span>{' '}
-                from git and delete its working tree folder.
+                from git and delete its workspace folder.
               </>
             )}
           </DialogDescription>

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -109,7 +109,7 @@ export function runWorktreeDeleteWithToast(
                     }
                   })
                   .catch((err: unknown) => {
-                    toast.error('Failed to delete worktree', {
+                    toast.error('Failed to delete workspace', {
                       description: err instanceof Error ? err.message : String(err),
                       action: {
                         label: 'View',
@@ -124,7 +124,7 @@ export function runWorktreeDeleteWithToast(
       return false
     })
     .catch((err: unknown) => {
-      toast.error('Failed to delete worktree', {
+      toast.error('Failed to delete workspace', {
         description: err instanceof Error ? err.message : String(err)
       })
       return false

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.test.ts
@@ -4,7 +4,7 @@ import { getDeleteWorktreeToastCopy } from './delete-worktree-toast'
 describe('getDeleteWorktreeToastCopy', () => {
   it('uses direct guidance when force delete is available', () => {
     expect(getDeleteWorktreeToastCopy('feature/foo', true, 'branch has changes')).toEqual({
-      title: 'Failed to delete worktree feature/foo',
+      title: 'Failed to delete workspace feature/foo',
       description: 'It has changed files. Use Force Delete to delete it anyway.',
       isDestructive: false
     })
@@ -12,7 +12,7 @@ describe('getDeleteWorktreeToastCopy', () => {
 
   it('preserves the raw error when force delete is unavailable', () => {
     expect(getDeleteWorktreeToastCopy('feature/foo', false, 'permission denied')).toEqual({
-      title: 'Failed to delete worktree feature/foo',
+      title: 'Failed to delete workspace feature/foo',
       description: 'permission denied',
       isDestructive: true
     })

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.ts
@@ -11,7 +11,7 @@ export function getDeleteWorktreeToastCopy(
 ): DeleteWorktreeToastCopy {
   if (canForceDelete) {
     return {
-      title: `Failed to delete worktree ${worktreeName}`,
+      title: `Failed to delete workspace ${worktreeName}`,
       description: 'It has changed files. Use Force Delete to delete it anyway.',
       // Why: git commonly refuses the first delete when the worktree still has
       // modified or untracked files. Showing raw stderr in a destructive toast
@@ -22,7 +22,7 @@ export function getDeleteWorktreeToastCopy(
   }
 
   return {
-    title: `Failed to delete worktree ${worktreeName}`,
+    title: `Failed to delete workspace ${worktreeName}`,
     description: error,
     isDestructive: true
   }


### PR DESCRIPTION
## Summary
- rename the delete-worktree user-facing copy to workspace in the delete dialog, toasts, PR action, and related settings/search text
- keep internal worktree modal/store/API keys unchanged to avoid a broad plumbing rename
- update the focused toast expectations to match the new copy

## Testing
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/delete-worktree-toast.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
