### PR TITLE
Avoid optional Git locks during status checks

### DIFF
--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -212,6 +212,15 @@ type GitExecOptions = {
   env?: NodeJS.ProcessEnv
 }
 
+export function gitOptionalLocksDisabledEnv(
+  env: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0'
+  }
+}
+
 /**
  * Async git command execution. Drop-in replacement for
  * `execFileAsync('git', args, { cwd, encoding, ... })`.

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -13,7 +13,11 @@ const { gitExecFileAsyncMock, gitExecFileAsyncBufferMock, readFileMock, rmMock, 
 
 vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock,
-  gitExecFileAsyncBuffer: gitExecFileAsyncBufferMock
+  gitExecFileAsyncBuffer: gitExecFileAsyncBufferMock,
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0'
+  })
 }))
 
 vi.mock('fs/promises', () => ({
@@ -363,7 +367,7 @@ describe('getStatus', () => {
         '--branch',
         '--untracked-files=all'
       ],
-      { cwd: '/repo' }
+      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
     )
     expect(result.entries).toEqual([
       { path: 'docs/日本語/sample.md', status: 'modified', area: 'unstaged' }
@@ -389,7 +393,7 @@ describe('getStatus', () => {
         '--untracked-files=all',
         '--ignored=matching'
       ],
-      { cwd: '/repo' }
+      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
     )
     expect(result.ignoredPaths).toEqual(['dist/', 'generated/file.js'])
   })
@@ -458,7 +462,7 @@ describe('getStatus', () => {
         '--branch',
         '--untracked-files=all'
       ],
-      { cwd: '/repo' }
+      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
     )
     expect('ignoredPaths' in result).toBe(false)
   })
@@ -482,7 +486,7 @@ describe('getStatus', () => {
         '--untracked-files=all',
         '--ignored=matching'
       ],
-      { cwd: '/repo' }
+      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
     )
     expect(result.ignoredPaths).toEqual(['dist/', '.env', 'coverage/'])
     expect(result.entries).toEqual([])

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -16,7 +16,7 @@ import type {
   GitStatusResult
 } from '../../shared/types'
 import type { CommitMessageDraftContext } from '../../shared/commit-message-generation'
-import { gitExecFileAsync, gitExecFileAsyncBuffer } from './runner'
+import { gitExecFileAsync, gitExecFileAsyncBuffer, gitOptionalLocksDisabledEnv } from './runner'
 
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
@@ -59,7 +59,12 @@ export async function getStatus(
   if (options.includeIgnored) {
     statusArgs.push('--ignored=matching')
   }
-  const statusPromise = gitExecFileAsync(statusArgs, { cwd: worktreePath })
+  const statusPromise = gitExecFileAsync(statusArgs, {
+    cwd: worktreePath,
+    // Why: status polling is read-like; avoid refreshing the index and racing
+    // terminal Git commands on `.git/worktrees/*/index.lock`.
+    env: gitOptionalLocksDisabledEnv()
+  })
   const conflictOperation = await conflictPromise
 
   try {

--- a/src/main/github/client-pr-check-details.test.ts
+++ b/src/main/github/client-pr-check-details.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock, getOwnerRepoMock, rateLimitGuardMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  getOwnerRepoMock: vi.fn(),
+  rateLimitGuardMock: vi.fn(() => ({ blocked: false }))
+}))
+
+vi.mock('./gh-utils', () => ({
+  execFileAsync: vi.fn(),
+  ghExecFileAsync: ghExecFileAsyncMock,
+  githubRepoContext: (repoPath: string, connectionId?: string | null) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  }),
+  ghRepoExecOptions: (context: { repoPath: string }) => ({ cwd: context.repoPath }),
+  getOwnerRepo: getOwnerRepoMock,
+  getIssueOwnerRepo: vi.fn(),
+  extractExecError: vi.fn((err: unknown) => ({ stderr: String(err), stdout: '' })),
+  acquire: vi.fn(),
+  release: vi.fn(),
+  _resetOwnerRepoCache: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: vi.fn()
+}))
+
+vi.mock('./rate-limit', () => ({
+  rateLimitGuard: rateLimitGuardMock,
+  noteRateLimitSpend: vi.fn()
+}))
+
+import { getPRCheckDetails, _resetOwnerRepoCache } from './client'
+
+describe('getPRCheckDetails', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    getOwnerRepoMock.mockReset()
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
+    _resetOwnerRepoCache()
+  })
+
+  it('fetches check-run output, annotations, and workflow jobs for inline details', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    const actionUrl = 'https://github.com/acme/widgets/actions/runs/77/job/88'
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          name: 'track-community-pr',
+          status: 'completed',
+          conclusion: 'success',
+          html_url: actionUrl,
+          details_url: actionUrl,
+          started_at: '2026-05-18T19:00:00Z',
+          completed_at: '2026-05-18T19:02:00Z',
+          output: {
+            title: 'Successful',
+            summary: 'Tracked community PR',
+            text: 'No issues found.'
+          },
+          check_suite: { workflow_run: { id: 77 } }
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            path: '.github/workflows/community.yml',
+            start_line: 12,
+            end_line: 12,
+            annotation_level: 'notice',
+            title: 'Tracked',
+            message: 'Community PR tracked.',
+            raw_details: 'details'
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          jobs: [
+            {
+              name: 'track-community-pr',
+              status: 'completed',
+              conclusion: 'success',
+              started_at: '2026-05-18T19:00:00Z',
+              completed_at: '2026-05-18T19:02:00Z',
+              html_url: actionUrl,
+              steps: [{ name: 'Run tracker', status: 'completed', conclusion: 'success' }]
+            }
+          ]
+        })
+      })
+
+    const details = await getPRCheckDetails('/repo-root', {
+      checkRunId: 88,
+      checkName: 'track-community-pr'
+    })
+
+    expect(details).toMatchObject({
+      name: 'track-community-pr',
+      status: 'completed',
+      conclusion: 'success',
+      title: 'Successful',
+      summary: 'Tracked community PR',
+      text: 'No issues found.',
+      annotations: [
+        {
+          path: '.github/workflows/community.yml',
+          startLine: 12,
+          endLine: 12,
+          annotationLevel: 'notice',
+          title: 'Tracked',
+          message: 'Community PR tracked.',
+          rawDetails: 'details'
+        }
+      ],
+      jobs: [
+        {
+          name: 'track-community-pr',
+          conclusion: 'success',
+          steps: [{ name: 'Run tracker', status: 'completed', conclusion: 'success' }]
+        }
+      ]
+    })
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      ['api', 'repos/acme/widgets/check-runs/88'],
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['api', 'repos/acme/widgets/check-runs/88/annotations?per_page=20'],
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      ['api', 'repos/acme/widgets/actions/runs/77/jobs?per_page=100'],
+      { cwd: '/repo-root' }
+    )
+  })
+})

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -8,6 +8,7 @@ import type {
   PRInfo,
   PRMergeableState,
   PRCheckDetail,
+  PRCheckRunDetails,
   GitHubCommentResult,
   GitHubPRReviewCommentInput,
   PRComment,
@@ -1843,6 +1844,159 @@ export async function getPRChecks(
   } catch (err) {
     console.warn('getPRChecks failed:', err)
     return []
+  } finally {
+    release()
+  }
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function mapCheckAnnotations(raw: unknown): PRCheckRunDetails['annotations'] {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  return raw
+    .filter((annotation): annotation is Record<string, unknown> => Boolean(annotation))
+    .map((annotation) => ({
+      path: nullableString(annotation.path),
+      startLine: nullableNumber(annotation.start_line),
+      endLine: nullableNumber(annotation.end_line),
+      annotationLevel: nullableString(annotation.annotation_level),
+      title: nullableString(annotation.title),
+      message: nullableString(annotation.message) ?? '',
+      rawDetails: nullableString(annotation.raw_details)
+    }))
+}
+
+function mapWorkflowJobs(raw: unknown, checkName?: string): PRCheckRunDetails['jobs'] {
+  if (!raw || typeof raw !== 'object' || !Array.isArray((raw as { jobs?: unknown }).jobs)) {
+    return []
+  }
+  const jobs = (raw as { jobs: unknown[] }).jobs
+    .filter((job): job is Record<string, unknown> => Boolean(job))
+    .map((job) => ({
+      name: nullableString(job.name) ?? 'Unnamed job',
+      status: nullableString(job.status),
+      conclusion: nullableString(job.conclusion),
+      startedAt: nullableString(job.started_at),
+      completedAt: nullableString(job.completed_at),
+      url: nullableString(job.html_url),
+      steps: Array.isArray(job.steps)
+        ? job.steps
+            .filter((step): step is Record<string, unknown> => Boolean(step))
+            .map((step) => ({
+              name: nullableString(step.name) ?? 'Unnamed step',
+              status: nullableString(step.status),
+              conclusion: nullableString(step.conclusion),
+              startedAt: nullableString(step.started_at),
+              completedAt: nullableString(step.completed_at)
+            }))
+        : []
+    }))
+  const exactMatches = checkName ? jobs.filter((job) => job.name === checkName) : []
+  return exactMatches.length > 0 ? exactMatches : jobs
+}
+
+function getWorkflowRunIdFromCheckRun(
+  checkRun: Record<string, unknown> | null
+): number | undefined {
+  const checkSuite = checkRun?.check_suite
+  if (!checkSuite || typeof checkSuite !== 'object') {
+    return undefined
+  }
+  const workflowRun = (checkSuite as { workflow_run?: unknown }).workflow_run
+  if (!workflowRun || typeof workflowRun !== 'object') {
+    return undefined
+  }
+  const id = (workflowRun as { id?: unknown }).id
+  return typeof id === 'number' && Number.isSafeInteger(id) ? id : undefined
+}
+
+export async function getPRCheckDetails(
+  repoPath: string,
+  args: {
+    checkRunId?: number
+    workflowRunId?: number
+    checkName?: string
+    url?: string | null
+    prRepo?: OwnerRepo | null
+  },
+  connectionId?: string | null
+): Promise<PRCheckRunDetails | null> {
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
+  const ownerRepo = args.prRepo ?? (await getOwnerRepo(repoPath, connectionId))
+  if (!ownerRepo) {
+    return null
+  }
+
+  await acquire()
+  try {
+    let checkRun: Record<string, unknown> | null = null
+    let annotations: PRCheckRunDetails['annotations'] = []
+    if (args.checkRunId) {
+      const { stdout } = await ghExecFileAsync(
+        ['api', `repos/${ownerRepo.owner}/${ownerRepo.repo}/check-runs/${args.checkRunId}`],
+        ghOptions
+      )
+      checkRun = JSON.parse(stdout) as Record<string, unknown>
+      try {
+        const annotationsResult = await ghExecFileAsync(
+          [
+            'api',
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/check-runs/${args.checkRunId}/annotations?per_page=20`
+          ],
+          ghOptions
+        )
+        annotations = mapCheckAnnotations(JSON.parse(annotationsResult.stdout))
+      } catch (err) {
+        console.warn('getPRCheckDetails annotations fetch failed:', err)
+      }
+    }
+
+    const workflowRunId = args.workflowRunId ?? getWorkflowRunIdFromCheckRun(checkRun)
+    let jobs: PRCheckRunDetails['jobs'] = []
+    if (workflowRunId) {
+      try {
+        const { stdout } = await ghExecFileAsync(
+          [
+            'api',
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/actions/runs/${workflowRunId}/jobs?per_page=100`
+          ],
+          ghOptions
+        )
+        jobs = mapWorkflowJobs(JSON.parse(stdout), args.checkName)
+      } catch (err) {
+        console.warn('getPRCheckDetails workflow jobs fetch failed:', err)
+      }
+    }
+
+    const output =
+      checkRun?.output && typeof checkRun.output === 'object'
+        ? (checkRun.output as Record<string, unknown>)
+        : null
+    return {
+      name: nullableString(checkRun?.name) ?? args.checkName ?? 'Check',
+      status: nullableString(checkRun?.status),
+      conclusion: nullableString(checkRun?.conclusion),
+      url: nullableString(checkRun?.html_url) ?? args.url ?? null,
+      detailsUrl: nullableString(checkRun?.details_url) ?? args.url ?? null,
+      startedAt: nullableString(checkRun?.started_at),
+      completedAt: nullableString(checkRun?.completed_at),
+      title: nullableString(output?.title),
+      summary: nullableString(output?.summary),
+      text: nullableString(output?.text),
+      annotations,
+      jobs
+    }
+  } catch (err) {
+    console.warn('getPRCheckDetails failed:', err)
+    return null
   } finally {
     release()
   }

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -28,6 +28,7 @@ import {
   listAssignableUsers,
   getAuthenticatedViewer,
   getPRChecks,
+  getPRCheckDetails,
   getPRComments,
   resolveReviewThread,
   setPRFileViewed,
@@ -295,6 +296,34 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
         args.prRepo ?? null,
         {
           noCache: args.noCache
+        },
+        repoConnectionId(repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gh:prCheckDetails',
+    (
+      _event,
+      args: {
+        repoPath: string
+        checkRunId?: number
+        workflowRunId?: number
+        checkName?: string
+        url?: string | null
+        prRepo?: GitHubOwnerRepo | null
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getPRCheckDetails(
+        repo.path,
+        {
+          checkRunId: args.checkRunId,
+          workflowRunId: args.workflowRunId,
+          checkName: args.checkName,
+          url: args.url,
+          prRepo: args.prRepo ?? null
         },
         repoConnectionId(repo)
       )

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -730,6 +730,10 @@ export function registerSshHandlers(
         clearProviderPtyState(ptyId)
         deletePtyOwnership(ptyId)
       }
+      // Why: reset's connect() can trip onCredentialRequest, which adds to
+      // credentialRequestedForTarget. Without this delete, a later doConnect
+      // that doesn't prompt would still persist lastRequiredPassphrase=true.
+      credentialRequestedForTarget.delete(targetId)
       await connectionManager!.disconnect(targetId)
     }
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -124,6 +124,7 @@ import {
   listWorkItems,
   countWorkItems,
   getPRChecks,
+  getPRCheckDetails,
   rerunPRChecks,
   getPRComments,
   getIssue,
@@ -5193,6 +5194,21 @@ export class OrcaRuntimeService {
     const repo = await this.resolveRepoSelector(repoSelector)
     this.assertHostIntegrationRepoIsLocal(repo, 'repo_pr_checks_rerun')
     return rerunPRChecks(repo.path, prNumber, options)
+  }
+
+  async getRepoPRCheckDetails(
+    repoSelector: string,
+    args: {
+      checkRunId?: number
+      workflowRunId?: number
+      checkName?: string
+      url?: string | null
+      prRepo?: GitHubOwnerRepo | null
+    }
+  ): Promise<Awaited<ReturnType<typeof getPRCheckDetails>>> {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    this.assertHostIntegrationRepoIsLocal(repo, 'repo_pr_check_details')
+    return getPRCheckDetails(repo.path, { ...args, prRepo: args.prRepo ?? null })
   }
 
   async getRepoPRComments(

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -63,6 +63,14 @@ const PullRequestChecks = PullRequest.extend({
   headSha: OptionalString
 })
 
+const PullRequestCheckDetails = RepoSelector.extend({
+  checkRunId: z.number().int().positive().optional(),
+  workflowRunId: z.number().int().positive().optional(),
+  checkName: OptionalString,
+  url: OptionalString.nullable().optional(),
+  prRepo: SlugRepo.nullable().optional()
+})
+
 const RerunPullRequestChecks = PullRequest.extend({
   headSha: OptionalString,
   failedOnly: z.boolean().optional()
@@ -313,6 +321,18 @@ export const GITHUB_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) =>
       runtime.getRepoPRChecks(params.repo, params.prNumber, params.headSha, params.prRepo ?? null, {
         noCache: params.noCache
+      })
+  }),
+  defineMethod({
+    name: 'github.prCheckDetails',
+    params: PullRequestCheckDetails,
+    handler: async (params, { runtime }) =>
+      runtime.getRepoPRCheckDetails(params.repo, {
+        checkRunId: params.checkRunId,
+        workflowRunId: params.workflowRunId,
+        checkName: params.checkName,
+        url: params.url,
+        prRepo: params.prRepo ?? null
       })
   }),
   defineMethod({

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -17,6 +17,7 @@ import { getBitbucketRepoSlug } from '../bitbucket/client'
 import { getGiteaRepoSlug } from '../gitea/client'
 import { createGitHubPullRequest, getRepoSlug } from '../github/client'
 import { acquire, ghExecFileAsync, gitExecFileAsync, release } from '../github/gh-utils'
+import { gitOptionalLocksDisabledEnv } from '../git/runner'
 import { resolveDefaultBaseRefViaExec } from '../git/repo'
 import { getUpstreamStatus } from '../git/upstream'
 import { getProjectSlug } from '../gitlab/client'
@@ -104,7 +105,12 @@ async function getCurrentBranch(repoPath: string): Promise<string> {
 }
 
 async function hasUncommittedChanges(repoPath: string): Promise<boolean> {
-  const { stdout } = await gitExecFileAsync(['status', '--porcelain'], { cwd: repoPath })
+  const { stdout } = await gitExecFileAsync(['status', '--porcelain'], {
+    cwd: repoPath,
+    // Why: create-PR validation should not take Git's optional index lock while
+    // the user may be running fetch/pull/rebase from a terminal.
+    env: gitOptionalLocksDisabledEnv()
+  })
   return stdout.trim().length > 0
 }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -80,6 +80,7 @@ import type {
   PathSource,
   PersistedUIState,
   PRCheckDetail,
+  PRCheckRunDetails,
   PRComment,
   PRInfo,
   Repo,
@@ -825,6 +826,15 @@ export type PreloadApi = {
       prRepo?: GitHubOwnerRepo | null
       noCache?: boolean
     }) => Promise<PRCheckDetail[]>
+    prCheckDetails: (args: {
+      repoPath: string
+      repoId?: string
+      checkRunId?: number
+      workflowRunId?: number
+      checkName?: string
+      url?: string | null
+      prRepo?: GitHubOwnerRepo | null
+    }) => Promise<PRCheckRunDetails | null>
     rerunPRChecks: (args: {
       repoPath: string
       repoId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -839,6 +839,16 @@ const api = {
       noCache?: boolean
     }): Promise<unknown[]> => ipcRenderer.invoke('gh:prChecks', args),
 
+    prCheckDetails: (args: {
+      repoPath: string
+      repoId?: string
+      checkRunId?: number
+      workflowRunId?: number
+      checkName?: string
+      url?: string | null
+      prRepo?: { owner: string; repo: string } | null
+    }): Promise<unknown | null> => ipcRenderer.invoke('gh:prCheckDetails', args),
+
     rerunPRChecks: (args: {
       repoPath: string
       repoId?: string

--- a/src/relay/git-handler-ops.ts
+++ b/src/relay/git-handler-ops.ts
@@ -11,7 +11,11 @@ import { bufferToBlob, buildDiffResult, parseBranchDiff } from './git-handler-ut
 
 // ─── Executor types ──────────────────────────────────────────────────
 
-export type GitExec = (args: string[], cwd: string) => Promise<{ stdout: string; stderr: string }>
+export type GitExec = (
+  args: string[],
+  cwd: string,
+  opts?: { maxBuffer?: number; disableOptionalLocks?: boolean }
+) => Promise<{ stdout: string; stderr: string }>
 
 export type GitBufferExec = (args: string[], cwd: string) => Promise<Buffer>
 

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -94,7 +94,11 @@ export async function getStatusOp(
     if (includeIgnored) {
       statusArgs.push('--ignored=matching')
     }
-    const { stdout } = await git(statusArgs, worktreePath)
+    const { stdout } = await git(statusArgs, worktreePath, {
+      // Why: status polling is read-like; avoid refreshing the index and racing
+      // terminal Git commands on `.git/worktrees/*/index.lock`.
+      disableOptionalLocks: true
+    })
     const parsed = parseStatusOutput(stdout)
     entries.push(...parsed.entries)
     head = parsed.head

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -67,11 +67,15 @@ export class GitHandler {
   private async git(
     args: string[],
     cwd: string,
-    opts?: { maxBuffer?: number }
+    opts?: { maxBuffer?: number; disableOptionalLocks?: boolean }
   ): Promise<{ stdout: string; stderr: string }> {
+    const env = buildRelayCommandEnv()
+    if (opts?.disableOptionalLocks) {
+      env.GIT_OPTIONAL_LOCKS = '0'
+    }
     return execFileAsync('git', args, {
       cwd: expandTilde(cwd),
-      env: buildRelayCommandEnv(),
+      env,
       encoding: 'utf-8',
       maxBuffer: opts?.maxBuffer ?? MAX_GIT_BUFFER
     })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,6 +58,7 @@ import {
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { DictationController } from './components/dictation/DictationController'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
+import { ConfirmationDialogProvider } from './components/confirmation-dialog'
 import RecentTabSwitcher from './components/tab-bar/RecentTabSwitcher'
 import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPolling'
 import { useEditorExternalWatch } from './hooks/useEditorExternalWatch'
@@ -1351,66 +1352,67 @@ function App(): React.JSX.Element {
       }
     >
       <TooltipProvider delayDuration={400}>
-        {/* Why: leaf-mounted retention sync keeps agent-status retention
+        <ConfirmationDialogProvider>
+          {/* Why: leaf-mounted retention sync keeps agent-status retention
             subscriptions from re-rendering the App tree. */}
-        <RetainedAgentsSyncGate />
-        <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
-          {/* Why: the non-workspace titlebar lives inside this left+center
+          <RetainedAgentsSyncGate />
+          <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+            {/* Why: the non-workspace titlebar lives inside this left+center
               wrapper so it does not span over the right-sidebar column —
               when the right sidebar is open, its own header anchors at the
               top alongside the titlebar instead of being pushed below it. */}
-          <div className="flex flex-col flex-1 min-w-0 min-h-0">
-            {/* Why: in workspace view (split groups always enabled), the
+            <div className="flex flex-col flex-1 min-w-0 min-h-0">
+              {/* Why: in workspace view (split groups always enabled), the
                 full-width titlebar is removed so tab groups + terminal extend
                 to the top of the window. Left titlebar controls move to a
                 header above the sidebar. Settings, landing, and the tasks
                 page keep the titlebar. */}
-            {!workspaceActive ? (
-              <div className="titlebar">
-                <div
-                  className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0' : ' shrink-0 mr-2'}`}
-                  style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
-                >
-                  {titlebarLeftControls}
-                </div>
-                {activeView === 'activity' ? (
-                  <ActivityTitlebarControls />
-                ) : (
+              {!workspaceActive ? (
+                <div className="titlebar">
                   <div
-                    id="titlebar-tabs"
-                    className={`flex flex-1 min-w-0 self-stretch${activeView !== 'terminal' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
-                  />
-                )}
-                {showTitlebarExpandButton && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        className="titlebar-icon-button"
-                        onClick={handleToggleExpand}
-                        aria-label="Collapse pane"
-                        disabled={!activeTabCanExpand}
-                      >
-                        <Minimize2 size={14} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Collapse pane
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-                {/* Why: when the right sidebar is open, its own header renders
+                    className={`flex items-center${showSidebar && sidebarOpen ? ' overflow-hidden shrink-0' : ' shrink-0 mr-2'}`}
+                    style={{ width: showSidebar && sidebarOpen ? sidebarWidth : undefined }}
+                  >
+                    {titlebarLeftControls}
+                  </div>
+                  {activeView === 'activity' ? (
+                    <ActivityTitlebarControls />
+                  ) : (
+                    <div
+                      id="titlebar-tabs"
+                      className={`flex flex-1 min-w-0 self-stretch${activeView !== 'terminal' || !activeWorktreeId ? ' invisible pointer-events-none' : ''}`}
+                    />
+                  )}
+                  {showTitlebarExpandButton && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          className="titlebar-icon-button"
+                          onClick={handleToggleExpand}
+                          aria-label="Collapse pane"
+                          disabled={!activeTabCanExpand}
+                        >
+                          <Minimize2 size={14} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        Collapse pane
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {/* Why: when the right sidebar is open, its own header renders
                     an identical close button — hide this copy so only one is
                     visible at a time. */}
-                {!rightSidebarOpen && rightSidebarToggle}
-                {/* Why: reserve space so content is not obscured by the
+                  {!rightSidebarOpen && rightSidebarToggle}
+                  {/* Why: reserve space so content is not obscured by the
                     fixed-position window-controls overlay on Windows. */}
-                {isWindows && <div className="window-controls-titlebar-spacer" />}
-              </div>
-            ) : null}
-            <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
-              {showSidebar ? (
-                workspaceActive ? (
-                  /* Why: left column wraps the sidebar with a titlebar-height
+                  {isWindows && <div className="window-controls-titlebar-spacer" />}
+                </div>
+              ) : null}
+              <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+                {showSidebar ? (
+                  workspaceActive ? (
+                    /* Why: left column wraps the sidebar with a titlebar-height
                      header above it. The header holds the same controls
                      (traffic lights, sidebar toggle, "Orca" title, agent badge)
                      that the full-width titlebar held while the center and right
@@ -1418,173 +1420,176 @@ function App(): React.JSX.Element {
                      When the sidebar is collapsed, take this header out of flex
                      layout so the terminal/editor reclaim the left edge instead of
                      leaving behind a content-width blank strip. */
-                  <div
-                    className={`flex min-h-0 flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
-                  >
                     <div
-                      // Why: when the sidebar is collapsed, titlebar-left floats
-                      // absolutely on top of the center column's own `border-l`
-                      // (see TabGroupSplitLayout), occluding that seam. Add a
-                      // `border-r` in the floating state so the vertical line
-                      // between the traffic-light/nav cluster and the tab strip
-                      // stays visible in both states. w-max keeps the floating
-                      // header sized to its own controls instead of the w-0
-                      // sidebar wrapper.
-                      className={`titlebar-left${
-                        sidebarOpen
-                          ? ''
-                          : ' absolute top-0 left-0 z-10 w-max border-r border-border'
-                      }`}
-                      style={{
-                        // Why: the Sidebar resize hook updates the sidebar DOM width
-                        // directly during drag and only persists to Zustand on
-                        // mouseup. In workspace view, size this header from the
-                        // wrapper's live width so it tracks those in-flight resizes
-                        // instead of leaving a stale-width gap until the drag ends.
-                        width: sidebarOpen ? '100%' : undefined
-                      }}
+                      className={`flex min-h-0 flex-col shrink-0${sidebarOpen ? '' : ' relative w-0 overflow-visible'}`}
                     >
-                      {titlebarLeftControls}
-                    </div>
-                    <div className="flex min-h-0 flex-1">
-                      {/* Why: the workspace-view wrapper adds a fixed 36px header
+                      <div
+                        // Why: when the sidebar is collapsed, titlebar-left floats
+                        // absolutely on top of the center column's own `border-l`
+                        // (see TabGroupSplitLayout), occluding that seam. Add a
+                        // `border-r` in the floating state so the vertical line
+                        // between the traffic-light/nav cluster and the tab strip
+                        // stays visible in both states. w-max keeps the floating
+                        // header sized to its own controls instead of the w-0
+                        // sidebar wrapper.
+                        className={`titlebar-left${
+                          sidebarOpen
+                            ? ''
+                            : ' absolute top-0 left-0 z-10 w-max border-r border-border'
+                        }`}
+                        style={{
+                          // Why: the Sidebar resize hook updates the sidebar DOM width
+                          // directly during drag and only persists to Zustand on
+                          // mouseup. In workspace view, size this header from the
+                          // wrapper's live width so it tracks those in-flight resizes
+                          // instead of leaving a stale-width gap until the drag ends.
+                          width: sidebarOpen ? '100%' : undefined
+                        }}
+                      >
+                        {titlebarLeftControls}
+                      </div>
+                      <div className="flex min-h-0 flex-1">
+                        {/* Why: the workspace-view wrapper adds a fixed 36px header
                           above the sidebar. Without a flex-1/min-h-0 slot here,
                           the sidebar falls back to its content height, so the
                           worktree list loses its scroll viewport and the fixed
                           bottom toolbar (including Add Project) gets pushed offscreen. */}
-                      <Sidebar
-                        worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
-                        worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
-                      />
+                        <Sidebar
+                          worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
+                          worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
+                        />
+                      </div>
                     </div>
-                  </div>
-                ) : (
-                  <Sidebar
-                    worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
-                    worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
-                  />
-                )
-              ) : null}
-              <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
-                {/* Why: right sidebar toggle floats at the top-right of the center
+                  ) : (
+                    <Sidebar
+                      worktreeScrollOffsetRef={worktreeSidebarScrollOffsetRef}
+                      worktreeScrollAnchorRef={worktreeSidebarScrollAnchorRef}
+                    />
+                  )
+                ) : null}
+                <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
+                  {/* Why: right sidebar toggle floats at the top-right of the center
                     column so it's always accessible whether the right sidebar is
                     open or closed. Match the RightSidebar header's 36px height and
                     top-0 anchor so the icon's vertical center is identical between
                     open and closed states — otherwise toggling makes the icon jump
                     a few pixels, which reads as layout jitter. */}
-                {workspaceActive && !rightSidebarOpen && (
-                  <div
-                    className="absolute top-0 z-10 flex items-center h-[36px]"
-                    style={
-                      {
-                        // Why: right: var(--window-controls-width) is the single
-                        // mechanism that keeps the toggle clear of the
-                        // fixed-position window-controls overlay on Windows (138px)
-                        // and sits at the right edge on non-Windows (0px). No
-                        // internal spacer needed — adding one would push the button
-                        // a further 138px to the left and cover the pane-actions
-                        // Ellipsis button with an un-clickable div.
-                        right: 'var(--window-controls-width)',
-                        WebkitAppRegion: 'no-drag'
-                      } as React.CSSProperties
-                    }
-                  >
-                    {rightSidebarToggle}
+                  {workspaceActive && !rightSidebarOpen && (
+                    <div
+                      className="absolute top-0 z-10 flex items-center h-[36px]"
+                      style={
+                        {
+                          // Why: right: var(--window-controls-width) is the single
+                          // mechanism that keeps the toggle clear of the
+                          // fixed-position window-controls overlay on Windows (138px)
+                          // and sits at the right edge on non-Windows (0px). No
+                          // internal spacer needed — adding one would push the button
+                          // a further 138px to the left and cover the pane-actions
+                          // Ellipsis button with an un-clickable div.
+                          right: 'var(--window-controls-width)',
+                          WebkitAppRegion: 'no-drag'
+                        } as React.CSSProperties
+                      }
+                    >
+                      {rightSidebarToggle}
+                    </div>
+                  )}
+                  <div className="flex flex-1 min-w-0 min-h-0 flex-col">
+                    <div
+                      className={
+                        activeView !== 'terminal' || !activeWorktreeId
+                          ? 'hidden flex-1 min-w-0 min-h-0'
+                          : 'flex flex-1 min-w-0 min-h-0'
+                      }
+                    >
+                      <Terminal />
+                    </div>
+                    <Suspense fallback={null}>
+                      {activeView === 'settings' ? <Settings /> : null}
+                      {activeView === 'skills' ? <SkillsPage /> : null}
+                      {activeView === 'tasks' ? <TaskPage /> : null}
+                      {activeView === 'automations' ? <AutomationsPage /> : null}
+                      {activeView === 'activity' ? <ActivityPrototypePage /> : null}
+                      {activeView === 'space' ? <WorkspaceSpacePage /> : null}
+                      {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
+                    </Suspense>
                   </div>
-                )}
-                <div className="flex flex-1 min-w-0 min-h-0 flex-col">
-                  <div
-                    className={
-                      activeView !== 'terminal' || !activeWorktreeId
-                        ? 'hidden flex-1 min-w-0 min-h-0'
-                        : 'flex flex-1 min-w-0 min-h-0'
-                    }
-                  >
-                    <Terminal />
-                  </div>
-                  <Suspense fallback={null}>
-                    {activeView === 'settings' ? <Settings /> : null}
-                    {activeView === 'skills' ? <SkillsPage /> : null}
-                    {activeView === 'tasks' ? <TaskPage /> : null}
-                    {activeView === 'automations' ? <AutomationsPage /> : null}
-                    {activeView === 'activity' ? <ActivityPrototypePage /> : null}
-                    {activeView === 'space' ? <WorkspaceSpacePage /> : null}
-                    {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
-                  </Suspense>
+                  {showFloatingTerminalButton ? (
+                    <FloatingTerminalToggleButton
+                      // Why: anchor the floating trigger to the center surface so it
+                      // cannot cover the worktree sidebar or right sidebar.
+                      className="absolute bottom-8 right-3"
+                      open={floatingTerminalOpen}
+                      onToggle={() => setFloatingTerminalOpenWithFocus((open) => !open)}
+                    />
+                  ) : null}
                 </div>
-                {showFloatingTerminalButton ? (
-                  <FloatingTerminalToggleButton
-                    // Why: anchor the floating trigger to the center surface so it
-                    // cannot cover the worktree sidebar or right sidebar.
-                    className="absolute bottom-8 right-3"
-                    open={floatingTerminalOpen}
-                    onToggle={() => setFloatingTerminalOpenWithFocus((open) => !open)}
-                  />
-                ) : null}
               </div>
             </div>
-          </div>
-          {/* Why: keep RightSidebar mounted even when closed so that its
+            {/* Why: keep RightSidebar mounted even when closed so that its
               child components (FileExplorer, SourceControl, etc.) and their
               filesystem watchers + cached directory trees survive across
               open/close toggles. Unmount on the tasks view since that
               surface is intentionally distraction-free. */}
-          {showRightSidebarControls ? <RightSidebar /> : null}
-        </div>
-        {floatingTerminalEnabled ? (
-          <FloatingTerminalPanel
-            open={floatingTerminalOpen}
-            onOpenChange={setFloatingTerminalOpenWithFocus}
-          />
-        ) : null}
-        <StatusBar floatingTerminalOpen={floatingTerminalOpen} />
-        {/* Why: root overlays can render Radix <Tooltip>s; keep them inside
+            {showRightSidebarControls ? <RightSidebar /> : null}
+          </div>
+          {floatingTerminalEnabled ? (
+            <FloatingTerminalPanel
+              open={floatingTerminalOpen}
+              onOpenChange={setFloatingTerminalOpenWithFocus}
+            />
+          ) : null}
+          <StatusBar floatingTerminalOpen={floatingTerminalOpen} />
+          {/* Why: root overlays can render Radix <Tooltip>s; keep them inside
             the shared provider so lazy surfaces mount safely from any entry point. */}
-        <Suspense fallback={null}>
-          {mountedLazyModalIds.has('new-workspace-composer') ? <NewWorkspaceComposerModal /> : null}
-          {mountedLazyModalIds.has('workspace-cleanup') ? <WorkspaceCleanupDialog /> : null}
-        </Suspense>
-        <Suspense fallback={null}>
-          {mountedLazyModalIds.has('quick-open') ? <QuickOpen /> : null}
-          {mountedLazyModalIds.has('worktree-palette') ? <WorktreeJumpPalette /> : null}
-          {mountedLazyModalIds.has('feature-wall') ? <FeatureWallModal /> : null}
-          {mountedLazyModalIds.has('feature-tips') ? <FeatureTipsModal /> : null}
-        </Suspense>
-        {/* Why: mount PetOverlay only when the experimental flag is on AND
+          <Suspense fallback={null}>
+            {mountedLazyModalIds.has('new-workspace-composer') ? (
+              <NewWorkspaceComposerModal />
+            ) : null}
+            {mountedLazyModalIds.has('workspace-cleanup') ? <WorkspaceCleanupDialog /> : null}
+          </Suspense>
+          <Suspense fallback={null}>
+            {mountedLazyModalIds.has('quick-open') ? <QuickOpen /> : null}
+            {mountedLazyModalIds.has('worktree-palette') ? <WorktreeJumpPalette /> : null}
+            {mountedLazyModalIds.has('feature-wall') ? <FeatureWallModal /> : null}
+            {mountedLazyModalIds.has('feature-tips') ? <FeatureTipsModal /> : null}
+          </Suspense>
+          {/* Why: mount PetOverlay only when the experimental flag is on AND
           the user hasn't hit "Hide pet" in the status-bar menu. Both
           conditions must be true — see design doc (pet-overlay.md) on why
           the two toggles are kept independent. */}
-        {petEnabled && petVisible ? (
-          <Suspense fallback={null}>
-            <PetOverlay />
-          </Suspense>
-        ) : null}
-        <UpdateCard />
-        <FeatureTourNudge />
-        <StarNagCard />
-        {/* Why: the existing-user opt-in banner mounts at App root so it
+          {petEnabled && petVisible ? (
+            <Suspense fallback={null}>
+              <PetOverlay />
+            </Suspense>
+          ) : null}
+          <UpdateCard />
+          <FeatureTourNudge />
+          <StarNagCard />
+          {/* Why: the existing-user opt-in banner mounts at App root so it
           renders once per renderer session, not per view. It gates
           internally on the cohort markers populated by the migration,
           so it only shows for users who installed before the telemetry
           release and have not yet resolved consent. New users get no
           first-launch surface — see telemetry-plan.md §First-launch
           experience. */}
-        <TelemetryFirstLaunchSurface />
-        <ZoomOverlay />
-        <SshPassphraseDialog />
-        <DeleteWorktreeDialog />
-        <CrashReportDialog />
-        {onboarding && shouldShowOnboarding(onboarding) && !onboardingSettingsDetour ? (
-          <Suspense fallback={null}>
-            <OnboardingFlow
-              onboarding={onboarding}
-              onOnboardingChange={setOnboarding}
-              onSettingsDetourStart={beginOnboardingSettingsDetour}
-            />
-          </Suspense>
-        ) : null}
-        <DictationController />
-        <RecentTabSwitcher />
+          <TelemetryFirstLaunchSurface />
+          <ZoomOverlay />
+          <SshPassphraseDialog />
+          <DeleteWorktreeDialog />
+          <CrashReportDialog />
+          {onboarding && shouldShowOnboarding(onboarding) && !onboardingSettingsDetour ? (
+            <Suspense fallback={null}>
+              <OnboardingFlow
+                onboarding={onboarding}
+                onOnboardingChange={setOnboarding}
+                onSettingsDetourStart={beginOnboardingSettingsDetour}
+              />
+            </Suspense>
+          ) : null}
+          <DictationController />
+          <RecentTabSwitcher />
+        </ConfirmationDialogProvider>
       </TooltipProvider>
       <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
       {/* Why: rendered last so it sits after all -webkit-app-region:drag elements

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -28,6 +28,7 @@ import {
   GitMerge,
   GitPullRequest,
   LayoutList,
+  ListChecks,
   LoaderCircle,
   MessageSquare,
   MessageSquarePlus,
@@ -35,6 +36,7 @@ import {
   Send,
   UndoDot,
   Users,
+  Wrench,
   X
 } from 'lucide-react'
 import { toast } from 'sonner'
@@ -91,6 +93,12 @@ import {
   getGitHubPRReviewerRows,
   normalizeGitHubReviewerLogins
 } from '@/components/github-pr-reviewer-display'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
+import { getConnectionId } from '@/lib/connection-context'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import { launchWorkItemDirect } from '@/lib/launch-work-item-direct'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import type {
   GitHubOwnerRepo,
   GitHubPRFile,
@@ -101,7 +109,10 @@ import type {
   GitHubAssignableUser,
   GitHubReaction,
   PRCheckDetail,
-  PRComment
+  PRCheckRunDetails,
+  PRComment,
+  TuiAgent,
+  Worktree
 } from '../../../shared/types'
 import { PER_REPO_FETCH_LIMIT } from '../../../shared/work-items'
 
@@ -132,7 +143,7 @@ function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
 const DiffViewer = lazy(() => import('@/components/editor/DiffViewer'))
 const MonacoCodeExcerpt = lazy(() => import('@/components/editor/MonacoCodeExcerpt'))
 
-type ItemDialogTab = 'conversation' | 'files'
+export type ItemDialogTab = 'conversation' | 'checks' | 'files'
 
 type MentionOption = {
   login: string
@@ -161,6 +172,16 @@ const REACTION_EMOJI: Record<GitHubReaction['content'], string> = {
   eyes: '👀'
 }
 
+function normalizeItemDialogTab(
+  item: GitHubWorkItem | null,
+  tab: ItemDialogTab | undefined
+): ItemDialogTab {
+  if (item?.type !== 'pr') {
+    return 'conversation'
+  }
+  return tab ?? 'conversation'
+}
+
 /** Why: Project-origin rows don't always belong to the active local repo.
  *  When set, GHEditSection routes label/assignee/state mutations through
  *  slug-addressed IPCs against `owner`/`repo` instead of through `repoPath`,
@@ -182,6 +203,7 @@ type GitHubItemDialogProps = {
   workItem: GitHubWorkItem | null
   repoPath: string | null
   repoId?: string | null
+  initialTab?: ItemDialogTab
   /** Called when the user clicks the primary CTA to start work from this item. */
   onUse: (item: GitHubWorkItem) => void
   onReviewRequestsChange?: (
@@ -1693,12 +1715,12 @@ function ConversationTab({
   headSha,
   baseSha,
   loading,
+  detailsLoaded,
   checks,
   participants: detailsParticipants,
   localState,
   onStateChange,
   projectOrigin,
-  onUse,
   onMutated,
   onChecksUpdated,
   onCommentAdded,
@@ -1713,12 +1735,12 @@ function ConversationTab({
   headSha: string | undefined
   baseSha: string | undefined
   loading: boolean
+  detailsLoaded: boolean
   checks: GitHubWorkItemDetails['checks']
   participants: GitHubAssignableUser[]
   localState: GitHubWorkItem['state']
   onStateChange: (state: GitHubWorkItem['state']) => void
   projectOrigin: GitHubItemDialogProjectOrigin | undefined
-  onUse: (item: GitHubWorkItem) => void
   onMutated: () => void
   onChecksUpdated: (checks: PRCheckDetail[]) => void
   onCommentAdded: (comment: PRComment) => void
@@ -1789,21 +1811,9 @@ function ConversationTab({
     [item.number, item.repoId, item.type, onCommentAdded, repoPath]
   )
 
-  const startWorkspaceButton = (
-    <Button
-      onClick={() => onUse(item)}
-      className="self-start justify-center gap-2 xl:self-stretch"
-      aria-label={`Start workspace from ${item.type === 'pr' ? 'PR' : 'issue'}`}
-    >
-      {`Start workspace from ${item.type === 'pr' ? 'PR' : 'issue'}`}
-      <ArrowRight className="size-4" />
-    </Button>
-  )
-
   const rightPanel =
     item.type === 'pr' ? (
       <div className="flex h-fit flex-col gap-3 xl:sticky xl:top-4">
-        {startWorkspaceButton}
         <PRActionsPanel
           item={item}
           repoPath={repoPath}
@@ -1819,21 +1829,14 @@ function ConversationTab({
           repoPath={repoPath}
           onReviewersRequested={onReviewersRequested}
         />
-        <aside className="rounded-lg border border-border/50 bg-card/50 shadow-xs">
-          <div className="flex h-10 items-center gap-2 border-b border-border/50 px-3">
-            <CircleDashed className="size-3.5 text-muted-foreground" />
-            <span className="text-[13px] font-medium text-foreground">Checks</span>
-            <span className="ml-auto rounded-full border border-border/50 bg-muted/30 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
-              {(checks ?? []).length}
-            </span>
-          </div>
+        <aside className="overflow-hidden rounded-lg border border-border/50 bg-card/50 shadow-xs">
           <ChecksTab
             item={item}
             repoPath={repoPath}
             repoId={item.repoId}
             headSha={headSha}
             checks={checks}
-            loading={loading}
+            loading={loading || !detailsLoaded}
             onChecksUpdated={onChecksUpdated}
           />
         </aside>
@@ -1844,12 +1847,12 @@ function ConversationTab({
     <div
       key={comment.id}
       className={cn(
-        'rounded-lg border border-border/40 bg-card/50 shadow-xs',
-        isReply && 'ml-6',
+        'min-w-0 overflow-hidden rounded-lg border border-border/40 bg-card/50 shadow-xs',
+        isReply && 'ml-6 max-w-[calc(100%-1.5rem)]',
         comment.isResolved && PR_COMMENT_RESOLVED_CONTAINER_CLASS
       )}
     >
-      <div className="flex items-center gap-2 border-b border-border/40 px-3 py-2">
+      <div className="flex min-w-0 items-center gap-2 border-b border-border/40 px-3 py-2">
         {comment.authorAvatarUrl ? (
           <img
             src={comment.authorAvatarUrl}
@@ -1861,17 +1864,17 @@ function ConversationTab({
         )}
         <span
           className={cn(
-            'text-[13px] font-semibold',
+            'min-w-0 truncate text-[13px] font-semibold',
             comment.isResolved ? PR_COMMENT_RESOLVED_AUTHOR_CLASS : PR_COMMENT_OPEN_AUTHOR_CLASS
           )}
         >
           {comment.author}
         </span>
-        <span className="text-[12px] text-muted-foreground">
+        <span className="shrink-0 text-[12px] text-muted-foreground">
           · {formatRelativeTime(comment.createdAt)}
         </span>
         {comment.path && (
-          <span className="font-mono text-[11px] text-muted-foreground/70">
+          <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground/70">
             {comment.path.split('/').pop()}
             {comment.line ? `:L${comment.line}` : ''}
           </span>
@@ -1881,7 +1884,7 @@ function ConversationTab({
             resolved
           </span>
         )}
-        <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex shrink-0 items-center gap-1">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -1917,7 +1920,7 @@ function ConversationTab({
           )}
         </div>
       </div>
-      <div className="px-3 py-2">
+      <div className="min-w-0 px-3 py-2">
         <CommentCodeContext
           comment={comment}
           repoPath={repoPath}
@@ -1930,7 +1933,7 @@ function ConversationTab({
         <CommentMarkdown
           content={comment.body}
           variant="document"
-          className="text-[13px] leading-relaxed"
+          className="min-w-0 max-w-full overflow-hidden break-words text-[13px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
         />
         <CommentReactions reactions={comment.reactions} />
         {replyingTo === comment.id && (
@@ -1959,7 +1962,7 @@ function ConversationTab({
 
     if (!isResolvedPRCommentGroup(group)) {
       return (
-        <div key={getPRCommentGroupId(group)} className="flex flex-col gap-3">
+        <div key={getPRCommentGroupId(group)} className="flex min-w-0 flex-col gap-3">
           {cards}
         </div>
       )
@@ -1979,7 +1982,7 @@ function ConversationTab({
               {count > 1 ? ` (${count})` : ''}
             </span>
           </AccordionTrigger>
-          <AccordionContent className="flex flex-col gap-3 px-3 pb-3 pt-0">
+          <AccordionContent className="flex min-w-0 flex-col gap-3 px-3 pb-3 pt-0">
             {cards}
           </AccordionContent>
         </AccordionItem>
@@ -1990,8 +1993,8 @@ function ConversationTab({
   return (
     <div
       className={cn(
-        'grid gap-5 px-4 py-4',
-        item.type === 'pr' && 'xl:grid-cols-[minmax(0,1fr)_280px]'
+        'grid min-w-0 gap-5 px-4 py-4',
+        item.type === 'pr' && 'xl:grid-cols-[minmax(0,1fr)_300px]'
       )}
     >
       <div className="flex min-w-0 flex-col gap-4">
@@ -2001,11 +2004,15 @@ function ConversationTab({
             <span>updated {formatRelativeTime(item.updatedAt)}</span>
           </div>
           <div className="px-4 py-4 text-[14px] leading-relaxed text-foreground">
-            {body.trim() ? (
+            {loading && !detailsLoaded ? (
+              <div className="flex items-center justify-center py-5">
+                <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : body.trim() ? (
               <CommentMarkdown
                 content={body}
                 variant="document"
-                className="text-[14px] leading-relaxed"
+                className="min-w-0 max-w-full overflow-hidden break-words text-[14px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
               />
             ) : (
               <span className="italic text-muted-foreground">No description provided.</span>
@@ -2013,56 +2020,58 @@ function ConversationTab({
           </div>
         </div>
 
-        <div className="flex items-center gap-2 pt-1">
-          <MessageSquare className="size-4 text-muted-foreground" />
-          <span className="text-[13px] font-medium text-foreground">Comments</span>
-          {comments.length > 0 && (
-            <span className="rounded-full border border-border/50 bg-muted/30 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
-              {comments.length}
-            </span>
-          )}
-        </div>
+        {detailsLoaded ? (
+          <>
+            <div className="flex items-center gap-2 pt-1">
+              <MessageSquare className="size-4 text-muted-foreground" />
+              <span className="text-[13px] font-medium text-foreground">Comments</span>
+              {comments.length > 0 && (
+                <span className="rounded-full border border-border/50 bg-muted/30 px-1.5 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+                  {comments.length}
+                </span>
+              )}
+            </div>
 
-        {item.type === 'pr' && comments.length > 0 && (
-          <div className="grid grid-cols-3 rounded-lg border border-border/50 bg-background p-0.5">
-            {PR_COMMENT_AUDIENCE_FILTERS.map((filter) => {
-              const isActive = commentFilter === filter.value
-              return (
-                <button
-                  key={filter.value}
-                  type="button"
-                  className={cn(
-                    'flex h-8 items-center justify-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors',
-                    isActive && 'bg-muted text-foreground'
-                  )}
-                  aria-pressed={isActive}
-                  onClick={() => setCommentFilter(filter.value)}
-                >
-                  <span>{filter.label}</span>
-                  <span className="tabular-nums">{commentCounts[filter.value]}</span>
-                </button>
-              )
-            })}
-          </div>
-        )}
+            {item.type === 'pr' && comments.length > 0 && (
+              <div className="grid grid-cols-3 rounded-lg border border-border/50 bg-background p-0.5">
+                {PR_COMMENT_AUDIENCE_FILTERS.map((filter) => {
+                  const isActive = commentFilter === filter.value
+                  return (
+                    <button
+                      key={filter.value}
+                      type="button"
+                      className={cn(
+                        'flex h-8 items-center justify-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors',
+                        isActive && 'bg-muted text-foreground'
+                      )}
+                      aria-pressed={isActive}
+                      onClick={() => setCommentFilter(filter.value)}
+                    >
+                      <span>{filter.label}</span>
+                      <span className="tabular-nums">{commentCounts[filter.value]}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
 
-        {loading && comments.length === 0 ? (
-          <div className="flex items-center justify-center rounded-lg border border-dashed border-border/50 py-8">
-            <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
-          </div>
-        ) : comments.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
-            No comments yet.
-          </div>
-        ) : visibleComments.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
-            {getPRCommentAudienceEmptyLabel(commentFilter)}
-          </div>
-        ) : (
-          <div className="flex flex-col gap-3">{visibleCommentGroups.map(renderCommentGroup)}</div>
-        )}
+            {comments.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
+                No comments yet.
+              </div>
+            ) : visibleComments.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
+                {getPRCommentAudienceEmptyLabel(commentFilter)}
+              </div>
+            ) : (
+              <div className="flex min-w-0 flex-col gap-3">
+                {visibleCommentGroups.map(renderCommentGroup)}
+              </div>
+            )}
+          </>
+        ) : null}
 
-        {repoPath && (
+        {detailsLoaded && repoPath && (
           <GHCommentComposer
             className="mt-1"
             repoPath={repoPath}
@@ -2365,6 +2374,176 @@ function CommentReplyForm({
   )
 }
 
+const CHECK_SORT_ORDER: Record<string, number> = {
+  failure: 0,
+  timed_out: 0,
+  cancelled: 1,
+  pending: 2,
+  neutral: 3,
+  skipped: 4,
+  success: 5
+}
+
+function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
+  return check.conclusion ?? 'pending'
+}
+
+function getCheckStatusLabel(check: PRCheckDetail): string {
+  const conclusion = getCheckConclusion(check)
+  if (conclusion === 'success') {
+    return 'Successful'
+  }
+  if (conclusion === 'failure') {
+    return 'Failed'
+  }
+  if (conclusion === 'cancelled') {
+    return 'Cancelled'
+  }
+  if (conclusion === 'timed_out') {
+    return 'Timed out'
+  }
+  if (conclusion === 'neutral') {
+    return 'Neutral'
+  }
+  if (conclusion === 'skipped') {
+    return 'Skipped'
+  }
+  if (check.status === 'queued') {
+    return 'Queued'
+  }
+  if (check.status === 'in_progress') {
+    return 'In progress'
+  }
+  return 'Pending'
+}
+
+function getCheckCounts(checks: PRCheckDetail[]): {
+  passing: number
+  failing: number
+  pending: number
+  skipped: number
+  neutral: number
+} {
+  return checks.reduce(
+    (counts, check) => {
+      const conclusion = getCheckConclusion(check)
+      if (conclusion === 'success') {
+        counts.passing += 1
+      } else if (['failure', 'cancelled', 'timed_out'].includes(conclusion)) {
+        counts.failing += 1
+      } else if (conclusion === 'skipped') {
+        counts.skipped += 1
+      } else if (conclusion === 'neutral') {
+        counts.neutral += 1
+      } else {
+        counts.pending += 1
+      }
+      return counts
+    },
+    { passing: 0, failing: 0, pending: 0, skipped: 0, neutral: 0 }
+  )
+}
+
+function getChecksSummaryLabel(checks: PRCheckDetail[]): string {
+  const counts = getCheckCounts(checks)
+  if (checks.length === 0) {
+    return 'No checks found'
+  }
+  if (counts.failing > 0) {
+    return `${counts.failing} ${counts.failing === 1 ? 'check' : 'checks'} failing`
+  }
+  if (counts.pending > 0) {
+    return `${counts.pending} ${counts.pending === 1 ? 'check' : 'checks'} pending`
+  }
+  if (counts.passing === checks.length) {
+    return 'All checks passing'
+  }
+  return `${counts.passing} of ${checks.length} checks passing`
+}
+
+function getBrokenChecks(checks: PRCheckDetail[]): PRCheckDetail[] {
+  return checks.filter((check) =>
+    ['failure', 'cancelled', 'timed_out'].includes(getCheckConclusion(check))
+  )
+}
+
+function buildFixBrokenChecksPrompt(item: GitHubWorkItem, checks: PRCheckDetail[]): string {
+  const brokenChecks = getBrokenChecks(checks)
+  const checkLines =
+    brokenChecks.length > 0
+      ? brokenChecks.map((check) => {
+          const details = [
+            getCheckStatusLabel(check),
+            check.checkRunId ? `check run ${check.checkRunId}` : null,
+            check.workflowRunId ? `workflow run ${check.workflowRunId}` : null,
+            check.url ? `details: ${check.url}` : null
+          ]
+            .filter(Boolean)
+            .join(', ')
+          return `- ${check.name}${details ? ` (${details})` : ''}`
+        })
+      : ['- No failing check is currently listed; refresh PR checks first, then inspect CI.']
+
+  return [
+    `Fix the broken checks for PR #${item.number}: ${item.title}`,
+    `PR: ${item.url}`,
+    '',
+    'Broken checks:',
+    ...checkLines,
+    '',
+    'Focus only on making the failing checks pass. Inspect the CI output first, make the smallest correct code or test changes, and do not work on unrelated cleanup.'
+  ].join('\n')
+}
+
+function findWorkspaceAttachedToPR(
+  worktrees: Worktree[],
+  repoId: string,
+  prNumber: number
+): Worktree | null {
+  return (
+    worktrees.find(
+      (worktree) =>
+        worktree.repoId === repoId && worktree.linkedPR === prNumber && !worktree.isArchived
+    ) ?? null
+  )
+}
+
+function pickDefaultAgent(
+  defaultAgent: TuiAgent | 'blank' | null | undefined,
+  detectedAgents: TuiAgent[]
+): TuiAgent | null {
+  if (defaultAgent && defaultAgent !== 'blank' && detectedAgents.includes(defaultAgent)) {
+    return defaultAgent
+  }
+  return AGENT_CATALOG.find((entry) => detectedAgents.includes(entry.id))?.id ?? null
+}
+
+type CheckDetailsLoadState = {
+  loading: boolean
+  details: PRCheckRunDetails | null
+  error: string | null
+}
+
+function getCheckDetailsKey(check: PRCheckDetail): string {
+  return String(check.checkRunId ?? check.workflowRunId ?? check.url ?? check.name)
+}
+
+function formatCheckTimestamp(input: string | null | undefined): string | null {
+  if (!input) {
+    return null
+  }
+  const date = new Date(input)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  })
+}
+
 function ChecksTab({
   item,
   repoPath,
@@ -2372,6 +2551,7 @@ function ChecksTab({
   headSha,
   checks,
   loading,
+  variant = 'compact',
   onChecksUpdated
 }: {
   item: GitHubWorkItem
@@ -2380,18 +2560,49 @@ function ChecksTab({
   headSha: string | undefined
   checks: GitHubWorkItemDetails['checks']
   loading: boolean
+  variant?: 'compact' | 'page'
   onChecksUpdated: (checks: PRCheckDetail[]) => void
 }): React.JSX.Element {
   const [localChecks, setLocalChecks] = useState<PRCheckDetail[] | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [rerunning, setRerunning] = useState(false)
-  const list = localChecks ?? checks ?? []
-  const failedChecks = list.filter((check) =>
-    ['failure', 'cancelled', 'timed_out'].includes(check.conclusion ?? '')
+  const [fixingChecks, setFixingChecks] = useState(false)
+  const [expandedCheckKey, setExpandedCheckKey] = useState<string | null>(null)
+  const [detailsByCheckKey, setDetailsByCheckKey] = useState<Record<string, CheckDetailsLoadState>>(
+    {}
   )
+  const list = useMemo(() => localChecks ?? checks ?? [], [checks, localChecks])
+  const prRepo = useMemo(() => parseOwnerRepoFromItemUrl(item.url), [item.url])
+  const sorted = [...list].sort(
+    (a, b) =>
+      (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
+      (CHECK_SORT_ORDER[getCheckConclusion(b)] ?? 3)
+  )
+  const failedChecks = getBrokenChecks(list)
+  const counts = getCheckCounts(list)
+  const summaryLabel = getChecksSummaryLabel(list)
+  const SummaryIcon =
+    counts.failing > 0
+      ? CHECK_ICON.failure
+      : counts.pending > 0
+        ? CHECK_ICON.pending
+        : list.length > 0
+          ? CHECK_ICON.success
+          : CircleDashed
+  const summaryColor =
+    counts.failing > 0
+      ? CHECK_COLOR.failure
+      : counts.pending > 0
+        ? CHECK_COLOR.pending
+        : list.length > 0
+          ? CHECK_COLOR.success
+          : 'text-muted-foreground'
+  const canFixBrokenChecks = Boolean((repoId ?? item.repoId) && failedChecks.length > 0)
 
   useEffect(() => {
     setLocalChecks(null)
+    setExpandedCheckKey(null)
+    setDetailsByCheckKey({})
   }, [checks])
 
   const handleRefresh = useCallback(async (): Promise<PRCheckDetail[] | null> => {
@@ -2448,8 +2659,130 @@ function ChecksTab({
     [handleRefresh, headSha, item.number, rerunning, repoId, repoPath]
   )
 
-  const toolbar = (
-    <div className="flex items-center justify-end gap-1 border-b border-border/40 px-2 py-1.5">
+  const handleFixBrokenChecks = useCallback(async (): Promise<void> => {
+    const targetRepoId = repoId ?? item.repoId
+    if (!targetRepoId || fixingChecks) {
+      return
+    }
+    if (failedChecks.length === 0) {
+      toast.message('No broken checks to fix.')
+      return
+    }
+
+    setFixingChecks(true)
+    try {
+      const prompt = buildFixBrokenChecksPrompt(item, list)
+      const store = useAppStore.getState()
+      const attachedWorkspace = findWorkspaceAttachedToPR(
+        store.allWorktrees(),
+        targetRepoId,
+        item.number
+      )
+
+      if (!attachedWorkspace) {
+        await launchWorkItemDirect({
+          item: { ...item, pasteContent: prompt },
+          repoId: targetRepoId,
+          launchSource: 'task_page',
+          telemetrySource: 'sidebar',
+          openModalFallback: () => {
+            toast.error('Unable to create a fix workspace automatically.')
+          }
+        })
+        return
+      }
+
+      if (!activateAndRevealWorktree(attachedWorkspace.id)) {
+        toast.error('Unable to open the workspace attached to this pull request.')
+        return
+      }
+
+      const connectionId = getConnectionId(attachedWorkspace.id)
+      if (connectionId === undefined) {
+        toast.error('Unable to resolve the workspace connection.')
+        return
+      }
+
+      const activeStore = useAppStore.getState()
+      const detectedAgents =
+        typeof connectionId === 'string'
+          ? await activeStore.ensureRemoteDetectedAgents(connectionId)
+          : await activeStore.ensureDetectedAgents()
+      const agent = pickDefaultAgent(activeStore.settings?.defaultTuiAgent, detectedAgents)
+      if (!agent) {
+        toast.error('No AI agents detected. Configure a default agent in Settings.')
+        return
+      }
+
+      const result = launchAgentInNewTab({
+        agent,
+        worktreeId: attachedWorkspace.id,
+        prompt,
+        promptDelivery: 'draft',
+        launchSource: 'task_page'
+      })
+      if (!result) {
+        toast.error('Could not build the agent launch command.')
+        return
+      }
+      focusTerminalTabSurface(result.tabId)
+      toast.success('Started an AI agent for the broken checks.')
+    } finally {
+      setFixingChecks(false)
+    }
+  }, [failedChecks.length, fixingChecks, item, list, repoId])
+
+  const handleToggleCheckDetails = useCallback(
+    (check: PRCheckDetail): void => {
+      const key = getCheckDetailsKey(check)
+      setExpandedCheckKey((current) => (current === key ? null : key))
+      if (
+        !repoPath ||
+        detailsByCheckKey[key] ||
+        (!check.checkRunId && !check.workflowRunId && !check.url)
+      ) {
+        return
+      }
+      setDetailsByCheckKey((current) => ({
+        ...current,
+        [key]: { loading: true, details: null, error: null }
+      }))
+      void window.api.gh
+        .prCheckDetails({
+          repoPath,
+          repoId: repoId ?? undefined,
+          checkRunId: check.checkRunId,
+          workflowRunId: check.workflowRunId,
+          checkName: check.name,
+          url: check.url,
+          prRepo
+        })
+        .then((details) => {
+          setDetailsByCheckKey((current) => ({
+            ...current,
+            [key]: {
+              loading: false,
+              details,
+              error: details ? null : 'No inline details are available for this check.'
+            }
+          }))
+        })
+        .catch((err) => {
+          setDetailsByCheckKey((current) => ({
+            ...current,
+            [key]: {
+              loading: false,
+              details: null,
+              error: err instanceof Error ? err.message : 'Failed to load check details.'
+            }
+          }))
+        })
+    },
+    [detailsByCheckKey, prRepo, repoId, repoPath]
+  )
+
+  const actions = (
+    <div className="flex items-center gap-1">
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -2468,16 +2801,44 @@ function ChecksTab({
           Refresh checks
         </TooltipContent>
       </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className="h-7 gap-1 px-2 text-[11px]"
+            disabled={!canFixBrokenChecks || fixingChecks}
+            onClick={() => void handleFixBrokenChecks()}
+          >
+            {fixingChecks ? (
+              <LoaderCircle className="size-3 animate-spin" />
+            ) : (
+              <Wrench className="size-3" />
+            )}
+            Fix broken checks
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {failedChecks.length > 0
+            ? 'Start the default AI agent on these checks'
+            : 'No broken checks to fix'}
+        </TooltipContent>
+      </Tooltip>
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"
-            variant="ghost"
+            variant="outline"
             size="xs"
-            className="h-7 gap-1.5 px-2 text-[11px]"
+            className="h-7 gap-1 px-2 text-[11px]"
             disabled={!repoPath || rerunning || list.length === 0}
           >
-            {rerunning ? <LoaderCircle className="size-3 animate-spin" /> : null}
+            {rerunning ? (
+              <LoaderCircle className="size-3 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3" />
+            )}
             Rerun
             <ChevronDown className="size-3 opacity-60" />
           </Button>
@@ -2498,11 +2859,239 @@ function ChecksTab({
       </DropdownMenu>
     </div>
   )
+  const compactHeader = (
+    <div className="flex min-w-0 items-center gap-2 border-b border-border/50 px-3 py-2">
+      <SummaryIcon
+        className={cn(
+          'size-3.5 shrink-0',
+          summaryColor,
+          counts.pending > 0 && counts.failing === 0 && 'animate-spin'
+        )}
+      />
+      <div className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="text-[13px] font-medium text-foreground">Checks</span>
+        {list.length > 0 && (
+          <span className="truncate text-[11px] text-muted-foreground">{summaryLabel}</span>
+        )}
+      </div>
+      {actions}
+    </div>
+  )
+
+  const renderCheckRow = (check: PRCheckDetail): React.JSX.Element => {
+    const conclusion = getCheckConclusion(check)
+    const Icon = CHECK_ICON[conclusion] ?? CircleDashed
+    const color = CHECK_COLOR[conclusion] ?? 'text-muted-foreground'
+    const statusLabel = getCheckStatusLabel(check)
+    const key = getCheckDetailsKey(check)
+    const expanded = expandedCheckKey === key
+    const detailsState = detailsByCheckKey[key]
+    return (
+      <div key={key} className="min-w-0">
+        <button
+          type="button"
+          onClick={() => handleToggleCheckDetails(check)}
+          aria-expanded={expanded}
+          className={cn(
+            'flex w-full min-w-0 items-center gap-2 rounded-md text-left transition',
+            variant === 'page' ? 'px-3 py-2.5 hover:bg-accent/60' : 'px-2 py-1.5 hover:bg-muted/40'
+          )}
+        >
+          <ChevronDown
+            className={cn(
+              'size-3 shrink-0 text-muted-foreground transition-transform',
+              !expanded && '-rotate-90'
+            )}
+          />
+          <Icon
+            className={cn('size-3.5 shrink-0', color, conclusion === 'pending' && 'animate-spin')}
+          />
+          <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{check.name}</span>
+          <span className="shrink-0 text-[11px] text-muted-foreground">{statusLabel}</span>
+        </button>
+        {expanded && renderCheckDetails(check, detailsState)}
+      </div>
+    )
+  }
+
+  const renderCheckDetails = (
+    check: PRCheckDetail,
+    state: CheckDetailsLoadState | undefined
+  ): React.JSX.Element => {
+    const details = state?.details
+    const openUrl = details?.detailsUrl ?? details?.url ?? check.url
+    const startedAt = formatCheckTimestamp(details?.startedAt)
+    const completedAt = formatCheckTimestamp(details?.completedAt)
+    const detailsStatusCheck: PRCheckDetail = {
+      ...check,
+      status: (details?.status as PRCheckDetail['status'] | undefined) ?? check.status,
+      conclusion:
+        (details?.conclusion as PRCheckDetail['conclusion'] | undefined) ?? check.conclusion
+    }
+    const hasOutput = Boolean(details?.title || details?.summary || details?.text)
+    const hasAnnotations = (details?.annotations.length ?? 0) > 0
+    const hasJobs = (details?.jobs.length ?? 0) > 0
+
+    return (
+      <div className="mx-2 mb-2 mt-1 min-w-0 rounded-md border border-border/50 bg-muted/20 px-3 py-2">
+        {state?.loading ? (
+          <div className="flex items-center gap-2 py-2 text-[12px] text-muted-foreground">
+            <LoaderCircle className="size-3.5 animate-spin" />
+            Loading check details…
+          </div>
+        ) : (
+          <div className="flex min-w-0 flex-col gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+              <span>
+                Status:{' '}
+                {details ? getCheckStatusLabel(detailsStatusCheck) : getCheckStatusLabel(check)}
+              </span>
+              {startedAt && <span>Started {startedAt}</span>}
+              {completedAt && <span>Completed {completedAt}</span>}
+              {check.checkRunId && <span className="font-mono">check #{check.checkRunId}</span>}
+            </div>
+
+            {state?.error && <div className="text-[12px] text-muted-foreground">{state.error}</div>}
+
+            {hasOutput && (
+              <div className="min-w-0 rounded-md border border-border/40 bg-background/70 px-2.5 py-2">
+                {details?.title && (
+                  <div className="mb-1 text-[12px] font-medium text-foreground">
+                    {details.title}
+                  </div>
+                )}
+                {details?.summary && (
+                  <CommentMarkdown
+                    content={details.summary}
+                    variant="document"
+                    className="min-w-0 max-w-full overflow-hidden break-words text-[12px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
+                  />
+                )}
+                {details?.text && (
+                  <CommentMarkdown
+                    content={details.text}
+                    variant="document"
+                    className="mt-2 min-w-0 max-w-full overflow-hidden break-words text-[12px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
+                  />
+                )}
+              </div>
+            )}
+
+            {hasAnnotations && (
+              <div className="min-w-0 rounded-md border border-border/40 bg-background/70">
+                <div className="border-b border-border/40 px-2.5 py-1.5 text-[11px] font-medium text-foreground">
+                  Annotations
+                </div>
+                <div className="flex max-h-48 flex-col overflow-y-auto">
+                  {details!.annotations.map((annotation, index) => (
+                    <div
+                      key={`${annotation.path ?? 'annotation'}-${index}`}
+                      className={cn(
+                        'min-w-0 px-2.5 py-2 text-[12px]',
+                        index > 0 && 'border-t border-border/30'
+                      )}
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+                          {annotation.path ?? 'Annotation'}
+                          {annotation.startLine ? `:${annotation.startLine}` : ''}
+                        </span>
+                        {annotation.annotationLevel && (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {annotation.annotationLevel}
+                          </span>
+                        )}
+                      </div>
+                      {annotation.title && (
+                        <div className="mt-1 text-[12px] font-medium text-foreground">
+                          {annotation.title}
+                        </div>
+                      )}
+                      <div className="mt-1 break-words text-[12px] text-foreground">
+                        {annotation.message}
+                      </div>
+                      {annotation.rawDetails && (
+                        <pre className="mt-1 max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
+                          {annotation.rawDetails}
+                        </pre>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {hasJobs && (
+              <div className="min-w-0 rounded-md border border-border/40 bg-background/70">
+                <div className="border-b border-border/40 px-2.5 py-1.5 text-[11px] font-medium text-foreground">
+                  Jobs
+                </div>
+                <div className="flex max-h-64 flex-col overflow-y-auto">
+                  {details!.jobs.map((job, index) => (
+                    <div
+                      key={`${job.name}-${index}`}
+                      className={cn(
+                        'min-w-0 px-2.5 py-2',
+                        index > 0 && 'border-t border-border/30'
+                      )}
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">
+                          {job.name}
+                        </span>
+                        <span className="shrink-0 text-[11px] text-muted-foreground">
+                          {job.conclusion ?? job.status ?? 'unknown'}
+                        </span>
+                      </div>
+                      {job.steps.length > 0 && (
+                        <div className="mt-1 grid gap-1">
+                          {job.steps.map((step) => (
+                            <div
+                              key={step.name}
+                              className="flex min-w-0 items-center gap-2 text-[11px] text-muted-foreground"
+                            >
+                              <span className="min-w-0 flex-1 truncate">{step.name}</span>
+                              <span className="shrink-0">{step.conclusion ?? step.status}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {!state?.error && !hasOutput && !hasAnnotations && !hasJobs && (
+              <div className="text-[12px] text-muted-foreground">
+                No inline output is available for this check.
+              </div>
+            )}
+
+            {openUrl && (
+              <div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="h-7 gap-1 px-2 text-[11px]"
+                  onClick={() => window.api.shell.openUrl(openUrl)}
+                >
+                  Open in GitHub
+                  <ExternalLink className="size-3" />
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
 
   if (loading && list.length === 0) {
     return (
       <>
-        {toolbar}
+        {variant === 'compact' ? compactHeader : null}
         <div className="flex items-center justify-center py-10">
           <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
         </div>
@@ -2510,50 +3099,93 @@ function ChecksTab({
     )
   }
   if (list.length === 0) {
+    if (variant === 'page') {
+      return (
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <CircleDashed className="size-4 shrink-0 text-muted-foreground" />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="truncate text-[13px] font-medium text-foreground">
+                No checks found
+              </span>
+              <span className="truncate text-[11px] text-muted-foreground">
+                This pull request has no reported checks yet.
+              </span>
+            </div>
+            {actions}
+          </div>
+        </div>
+      )
+    }
     return (
       <>
-        {toolbar}
-        <div className="px-4 py-10 text-center text-[12px] text-muted-foreground">
-          No checks found.
+        {compactHeader}
+        <div className="flex flex-col items-center justify-center gap-1 px-4 py-6 text-center">
+          <CircleDashed className="size-4 text-muted-foreground/60" />
+          <div className="text-[12px] text-muted-foreground">No checks reported yet</div>
         </div>
       </>
     )
   }
+  if (variant === 'page') {
+    const countChips: { label: string; className: string }[] = []
+    if (counts.passing > 0) {
+      countChips.push({ label: `${counts.passing} passing`, className: CHECK_COLOR.success })
+    }
+    if (counts.failing > 0) {
+      countChips.push({ label: `${counts.failing} failing`, className: CHECK_COLOR.failure })
+    }
+    if (counts.pending > 0) {
+      countChips.push({ label: `${counts.pending} pending`, className: CHECK_COLOR.pending })
+    }
+    if (counts.skipped + counts.neutral > 0) {
+      countChips.push({
+        label: `${counts.skipped + counts.neutral} skipped`,
+        className: 'text-muted-foreground'
+      })
+    }
+    return (
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <SummaryIcon
+            className={cn(
+              'size-4 shrink-0',
+              summaryColor,
+              counts.pending > 0 && counts.failing === 0 && 'animate-spin'
+            )}
+          />
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="truncate text-[13px] font-medium text-foreground">{summaryLabel}</span>
+            {countChips.length > 1 && (
+              <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                {countChips.map((chip, i) => (
+                  <React.Fragment key={chip.label}>
+                    {i > 0 && <span className="opacity-40">·</span>}
+                    <span className={chip.className}>{chip.label}</span>
+                  </React.Fragment>
+                ))}
+              </span>
+            )}
+          </div>
+          {actions}
+        </div>
+        <div className="overflow-hidden rounded-lg border border-border/50 bg-card/50 shadow-xs">
+          {sorted.map((check, index) => (
+            <div
+              key={getCheckDetailsKey(check)}
+              className={cn(index > 0 && 'border-t border-border/40')}
+            >
+              {renderCheckRow(check)}
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
   return (
     <>
-      {toolbar}
-      <div className="px-2 py-2">
-        {list.map((check) => {
-          const conclusion = check.conclusion ?? 'pending'
-          const Icon = CHECK_ICON[conclusion] ?? CircleDashed
-          const color = CHECK_COLOR[conclusion] ?? 'text-muted-foreground'
-          return (
-            <button
-              key={check.name}
-              type="button"
-              onClick={() => {
-                if (check.url) {
-                  window.api.shell.openUrl(check.url)
-                }
-              }}
-              className={cn(
-                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition',
-                check.url ? 'hover:bg-muted/40' : ''
-              )}
-            >
-              <Icon
-                className={cn(
-                  'size-3.5 shrink-0',
-                  color,
-                  conclusion === 'pending' && 'animate-spin'
-                )}
-              />
-              <span className="flex-1 truncate text-[12px] text-foreground">{check.name}</span>
-              {check.url && <ExternalLink className="size-3 shrink-0 text-muted-foreground/40" />}
-            </button>
-          )
-        })}
-      </div>
+      {compactHeader}
+      <div className="max-h-[280px] overflow-y-auto p-1">{sorted.map(renderCheckRow)}</div>
     </>
   )
 }
@@ -3425,12 +4057,13 @@ export default function GitHubItemDialog({
   workItem,
   repoPath,
   repoId,
+  initialTab,
   projectOrigin,
   onUse,
   onReviewRequestsChange,
   onClose
 }: GitHubItemDialogProps): React.JSX.Element {
-  const [tab, setTab] = useState<ItemDialogTab>('conversation')
+  const [tab, setTab] = useState<ItemDialogTab>(() => normalizeItemDialogTab(workItem, initialTab))
   const [localState, setLocalState] = useState<GitHubWorkItem['state']>(workItem?.state ?? 'open')
   const [localLabels, setLocalLabels] = useState<string[]>(workItem?.labels ?? [])
   const [diffViewMode, setDiffViewMode] = useState<DiffViewMode>('flat')
@@ -3565,6 +4198,9 @@ export default function GitHubItemDialog({
 
   const loading = !!cachedEntry?.pending && !cachedEntry?.details
   const error = cachedEntry?.error && !cachedEntry?.details ? cachedEntry.error : null
+  const detailsLoaded =
+    Boolean(cachedEntry?.details) ||
+    Boolean(cachedEntry && !cachedEntry.pending && !cachedEntry.error && cachedEntry.fetchedAt > 0)
 
   // Why: if a cross-window mutation invalidates the open drawer's entry
   // (cachedEntry becomes undefined while workItem is still set), the main
@@ -3590,7 +4226,7 @@ export default function GitHubItemDialog({
       optimisticCommentsRef.current = []
     }
     prevItemIdRef.current = workItem.id
-    setTab('conversation')
+    setTab(normalizeItemDialogTab(workItem, initialTab))
 
     const cached = workItemDetailsCache.get(detailsCacheKey)
     const now = Date.now()
@@ -3668,7 +4304,7 @@ export default function GitHubItemDialog({
           error: message
         })
       })
-  }, [repoPath, effectiveRepoId, workItem, detailsCacheKey, refetchTick])
+  }, [repoPath, effectiveRepoId, workItem, detailsCacheKey, initialTab, refetchTick])
 
   const Icon = workItem?.type === 'pr' ? GitPullRequest : CircleDot
   const displayWorkItem = useMemo<GitHubWorkItem | null>(() => {
@@ -3805,7 +4441,7 @@ export default function GitHubItemDialog({
       <SheetContent
         side="right"
         showCloseButton={false}
-        className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-[640px] lg:max-w-[760px] xl:max-w-[900px]"
+        className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-[720px] lg:max-w-[920px] xl:max-w-[1120px] 2xl:max-w-[1240px]"
         onOpenAutoFocus={(event) => {
           // Why: focusing the first actionable element inside the drawer
           // causes the "Start workspace" action to receive focus and
@@ -3855,57 +4491,71 @@ export default function GitHubItemDialog({
                     <WorkItemIssueSourceIndicator url={workItem.url} repoId={effectiveRepoId} />
                   )}
                 </div>
-                <div className="flex shrink-0 items-center gap-1">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => void handleCopyWorkItemLink()}
-                        aria-label="Copy GitHub link"
-                      >
-                        {linkCopied ? (
-                          <Check className="size-4 text-emerald-500" />
-                        ) : (
-                          <Copy className="size-4" />
-                        )}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      {linkCopied ? 'Copied' : 'Copy GitHub link'}
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => window.api.shell.openUrl(workItem.url)}
-                        aria-label="Open on GitHub"
-                      >
-                        <ExternalLink className="size-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Open on GitHub
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={onClose}
-                        aria-label="Close preview"
-                      >
-                        <X className="size-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Close · Esc
-                    </TooltipContent>
-                  </Tooltip>
+                <div className="flex shrink-0 flex-col items-end gap-2">
+                  <div className="flex items-center justify-end gap-1">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => void handleCopyWorkItemLink()}
+                          aria-label="Copy GitHub link"
+                        >
+                          {linkCopied ? (
+                            <Check className="size-4 text-emerald-500" />
+                          ) : (
+                            <Copy className="size-4" />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        {linkCopied ? 'Copied' : 'Copy GitHub link'}
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => window.api.shell.openUrl(workItem.url)}
+                          aria-label="Open on GitHub"
+                        >
+                          <ExternalLink className="size-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        Open on GitHub
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={onClose}
+                          aria-label="Close preview"
+                        >
+                          <X className="size-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        Close · Esc
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  {workItem.type === 'pr' && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => onUse(workItem)}
+                      className="gap-1.5 whitespace-nowrap"
+                      aria-label="Start workspace from PR"
+                    >
+                      Start workspace from PR
+                      <ArrowRight className="size-3.5" />
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>
@@ -3958,15 +4608,26 @@ export default function GitHubItemDialog({
                       Conversation
                     </TabsTrigger>
                     {workItem.type === 'pr' && (
-                      <TabsTrigger value="files" className="px-2">
-                        <FileText className="size-3.5" />
-                        Files
-                        {files.length > 0 && (
-                          <span className="ml-1 text-[10px] text-muted-foreground">
-                            {files.length}
-                          </span>
-                        )}
-                      </TabsTrigger>
+                      <>
+                        <TabsTrigger value="checks" className="px-2">
+                          <ListChecks className="size-3.5" />
+                          Checks
+                          {checks.length > 0 && (
+                            <span className="ml-1 text-[10px] text-muted-foreground">
+                              {checks.length}
+                            </span>
+                          )}
+                        </TabsTrigger>
+                        <TabsTrigger value="files" className="px-2">
+                          <FileText className="size-3.5" />
+                          Files
+                          {files.length > 0 && (
+                            <span className="ml-1 text-[10px] text-muted-foreground">
+                              {files.length}
+                            </span>
+                          )}
+                        </TabsTrigger>
+                      </>
                     )}
                   </TabsList>
 
@@ -3982,12 +4643,12 @@ export default function GitHubItemDialog({
                         headSha={details?.headSha}
                         baseSha={details?.baseSha}
                         loading={loading}
+                        detailsLoaded={detailsLoaded}
                         checks={checks}
                         participants={details?.participants ?? []}
                         localState={localState}
                         onStateChange={setLocalState}
                         projectOrigin={projectOrigin}
-                        onUse={onUse}
                         onMutated={() => {
                           if (repoPath) {
                             invalidateWorkItemDetailsCacheByMatch({
@@ -4017,101 +4678,120 @@ export default function GitHubItemDialog({
                     </TabsContent>
 
                     {workItem.type === 'pr' && (
-                      <TabsContent value="files" className="mt-0">
-                        {loading && files.length === 0 ? (
-                          <div className="flex items-center justify-center py-10">
-                            <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
-                          </div>
-                        ) : files.length === 0 ? (
-                          <div className="px-4 py-10 text-center text-[12px] text-muted-foreground">
-                            No files changed.
-                          </div>
-                        ) : (
-                          <div>
-                            {/* Files-tab toolbar: view-mode toggle */}
-                            <div className="flex items-center justify-between gap-3 border-b border-border/40 px-3 py-1.5">
-                              <span className="text-[11px] text-muted-foreground">
-                                {viewedFileCount} / {files.length} files viewed
-                              </span>
-                              <div className="flex items-center gap-1">
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <button
-                                      id="pr-files-flat-view"
-                                      type="button"
-                                      onClick={() => setDiffViewMode('flat')}
-                                      aria-label="Flat view"
-                                      aria-pressed={diffViewMode === 'flat'}
-                                      className={cn(
-                                        'flex size-6 items-center justify-center rounded transition hover:bg-muted',
-                                        diffViewMode === 'flat'
-                                          ? 'bg-muted text-foreground'
-                                          : 'text-muted-foreground'
-                                      )}
-                                    >
-                                      <AlignJustify className="size-3.5" />
-                                    </button>
-                                  </TooltipTrigger>
-                                  <TooltipContent side="bottom" sideOffset={4}>
-                                    Flat view
-                                  </TooltipContent>
-                                </Tooltip>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <button
-                                      id="pr-files-tree-view"
-                                      type="button"
-                                      onClick={() => setDiffViewMode('tree')}
-                                      aria-label="Tree view"
-                                      aria-pressed={diffViewMode === 'tree'}
-                                      className={cn(
-                                        'flex size-6 items-center justify-center rounded transition hover:bg-muted',
-                                        diffViewMode === 'tree'
-                                          ? 'bg-muted text-foreground'
-                                          : 'text-muted-foreground'
-                                      )}
-                                    >
-                                      <LayoutList className="size-3.5" />
-                                    </button>
-                                  </TooltipTrigger>
-                                  <TooltipContent side="bottom" sideOffset={4}>
-                                    Tree view
-                                  </TooltipContent>
-                                </Tooltip>
-                              </div>
+                      <>
+                        <TabsContent value="checks" className="mt-0">
+                          <ChecksTab
+                            item={workItem}
+                            repoPath={repoPath}
+                            repoId={effectiveRepoId}
+                            headSha={details?.headSha}
+                            checks={checks}
+                            loading={loading || !detailsLoaded}
+                            variant="page"
+                            onChecksUpdated={(nextChecks) => {
+                              if (detailsCacheKey) {
+                                patchCachedPRChecks(detailsCacheKey, nextChecks)
+                              }
+                            }}
+                          />
+                        </TabsContent>
+
+                        <TabsContent value="files" className="mt-0">
+                          {loading && files.length === 0 ? (
+                            <div className="flex items-center justify-center py-10">
+                              <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
                             </div>
-                            {diffViewMode === 'flat' ? (
-                              files.map((file) => (
-                                <PRFileRow
-                                  key={getPRFileRowKey(file)}
-                                  file={file}
+                          ) : files.length === 0 ? (
+                            <div className="px-4 py-10 text-center text-[12px] text-muted-foreground">
+                              No files changed.
+                            </div>
+                          ) : (
+                            <div>
+                              {/* Files-tab toolbar: view-mode toggle */}
+                              <div className="flex items-center justify-between gap-3 border-b border-border/40 px-3 py-1.5">
+                                <span className="text-[11px] text-muted-foreground">
+                                  {viewedFileCount} / {files.length} files viewed
+                                </span>
+                                <div className="flex items-center gap-1">
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <button
+                                        id="pr-files-flat-view"
+                                        type="button"
+                                        onClick={() => setDiffViewMode('flat')}
+                                        aria-label="Flat view"
+                                        aria-pressed={diffViewMode === 'flat'}
+                                        className={cn(
+                                          'flex size-6 items-center justify-center rounded transition hover:bg-muted',
+                                          diffViewMode === 'flat'
+                                            ? 'bg-muted text-foreground'
+                                            : 'text-muted-foreground'
+                                        )}
+                                      >
+                                        <AlignJustify className="size-3.5" />
+                                      </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" sideOffset={4}>
+                                      Flat view
+                                    </TooltipContent>
+                                  </Tooltip>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <button
+                                        id="pr-files-tree-view"
+                                        type="button"
+                                        onClick={() => setDiffViewMode('tree')}
+                                        aria-label="Tree view"
+                                        aria-pressed={diffViewMode === 'tree'}
+                                        className={cn(
+                                          'flex size-6 items-center justify-center rounded transition hover:bg-muted',
+                                          diffViewMode === 'tree'
+                                            ? 'bg-muted text-foreground'
+                                            : 'text-muted-foreground'
+                                        )}
+                                      >
+                                        <LayoutList className="size-3.5" />
+                                      </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" sideOffset={4}>
+                                      Tree view
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </div>
+                              </div>
+                              {diffViewMode === 'flat' ? (
+                                files.map((file) => (
+                                  <PRFileRow
+                                    key={getPRFileRowKey(file)}
+                                    file={file}
+                                    repoPath={repoPath ?? ''}
+                                    repoId={effectiveRepoId ?? ''}
+                                    prNumber={workItem.number}
+                                    headSha={details?.headSha}
+                                    baseSha={details?.baseSha}
+                                    viewed={isPRFileViewed(file)}
+                                    viewedPending={pendingViewedPaths.has(file.path)}
+                                    onCommentAdded={appendOptimisticComment}
+                                    onViewedChange={handlePRFileViewedChange}
+                                  />
+                                ))
+                              ) : (
+                                <PRDiffTreeView
+                                  files={files}
                                   repoPath={repoPath ?? ''}
                                   repoId={effectiveRepoId ?? ''}
                                   prNumber={workItem.number}
                                   headSha={details?.headSha}
                                   baseSha={details?.baseSha}
-                                  viewed={isPRFileViewed(file)}
-                                  viewedPending={pendingViewedPaths.has(file.path)}
+                                  pendingViewedPaths={pendingViewedPaths}
                                   onCommentAdded={appendOptimisticComment}
                                   onViewedChange={handlePRFileViewedChange}
                                 />
-                              ))
-                            ) : (
-                              <PRDiffTreeView
-                                files={files}
-                                repoPath={repoPath ?? ''}
-                                repoId={effectiveRepoId ?? ''}
-                                prNumber={workItem.number}
-                                headSha={details?.headSha}
-                                baseSha={details?.baseSha}
-                                pendingViewedPaths={pendingViewedPaths}
-                                onCommentAdded={appendOptimisticComment}
-                                onViewedChange={handlePRFileViewedChange}
-                              />
-                            )}
-                          </div>
-                        )}
-                      </TabsContent>
+                              )}
+                            </div>
+                          )}
+                        </TabsContent>
+                      </>
                     )}
                   </div>
                 </Tabs>

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -43,6 +43,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { ButtonGroup } from '@/components/ui/button-group'
 import { Input } from '@/components/ui/input'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
 import { VisuallyHidden } from 'radix-ui'
 import {
@@ -2110,6 +2111,7 @@ function PRActionsPanel({
   const [mergePending, setMergePending] = useState(false)
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
+  const confirm = useConfirmationDialog()
   const actionItem = { ...item, state: localState }
   const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
@@ -2144,7 +2146,16 @@ function PRActionsPanel({
       return
     }
     const label = nextState === 'closed' ? 'Close' : 'Reopen'
-    if (!window.confirm(`${label} PR #${item.number}?`)) {
+    const confirmed = await confirm({
+      title: `${label} PR #${item.number}?`,
+      description:
+        nextState === 'closed'
+          ? 'This will close the pull request on GitHub.'
+          : 'This will reopen the pull request on GitHub.',
+      confirmLabel: label,
+      confirmVariant: nextState === 'closed' ? 'destructive' : 'default'
+    })
+    if (!confirmed) {
       return
     }
     const previousState = localState
@@ -2174,7 +2185,12 @@ function PRActionsPanel({
     }
     const label =
       method === 'squash' ? 'Squash and merge' : method === 'rebase' ? 'Rebase and merge' : 'Merge'
-    if (!window.confirm(`${label} PR #${item.number}?`)) {
+    const confirmed = await confirm({
+      title: `${label} PR #${item.number}?`,
+      description: 'This will update the pull request on GitHub.',
+      confirmLabel: label
+    })
+    if (!confirmed) {
       return
     }
     setMergePending(true)

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -76,6 +76,7 @@ import RepoDotLabel from '@/components/repo/RepoDotLabel'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import IssueSourceSelector, { issueSourceChipClass } from '@/components/github/IssueSourceSelector'
 import { reconcileLinearTeamSelection } from '@/components/task-page-linear-team-selection'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import {
   getGitHubPRPrimaryReviewer,
   getGitHubPRReviewLabel,
@@ -1411,6 +1412,7 @@ function PRMergeCell({
   onRefresh: () => void
 }): React.JSX.Element {
   const [merging, setMerging] = useState(false)
+  const confirm = useConfirmationDialog()
   if (item.type !== 'pr') {
     return <span className="text-[11px] text-muted-foreground">Issue</span>
   }
@@ -1425,11 +1427,13 @@ function PRMergeCell({
     if (!repo || mergeDisabled) {
       return
     }
-    const confirmed = window.confirm(
-      method === 'squash'
-        ? `Squash and merge PR #${item.number}?`
-        : `${method === 'rebase' ? 'Rebase and merge' : 'Merge'} PR #${item.number}?`
-    )
+    const label =
+      method === 'squash' ? 'Squash and merge' : method === 'rebase' ? 'Rebase and merge' : 'Merge'
+    const confirmed = await confirm({
+      title: `${label} PR #${item.number}?`,
+      description: 'This will update the pull request on GitHub.',
+      confirmLabel: label
+    })
     if (!confirmed) {
       return
     }

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -89,7 +89,7 @@ import {
 import { stripRepoQualifiers } from '../../../shared/task-query'
 import { parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
-import GitHubItemDialog from '@/components/GitHubItemDialog'
+import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
 import GitLabItemDialog from '@/components/GitLabItemDialog'
 import ProjectViewWrapper from '@/components/github-project/ProjectViewWrapper'
 import LinearIssueWorkspace from '@/components/LinearIssueWorkspace'
@@ -1395,7 +1395,7 @@ function PRChecksCell({
         </button>
       </TooltipTrigger>
       <TooltipContent side="bottom" sideOffset={6}>
-        Open PR conversation and checks
+        Open PR checks
       </TooltipContent>
     </Tooltip>
   )
@@ -1893,11 +1893,12 @@ export default function TaskPage(): React.JSX.Element {
   // this dialog for a read/review surface. The dialog's "Use" button routes
   // through the same direct-launch flow as the row-level "Use" CTA so
   // behavior is consistent regardless of entry point.
-  const [dialogWorkItemKey, setDialogWorkItemKey] = useState<{
-    id: string
-    repoId: string
-  } | null>(null)
-  const [dialogWorkItemFallback, setDialogWorkItemFallback] = useState<GitHubWorkItem | null>(null)
+  const githubTaskDrawerWorkItem = useAppStore((s) => s.githubTaskDrawerWorkItem)
+  const setGithubTaskDrawerWorkItem = useAppStore((s) => s.setGithubTaskDrawerWorkItem)
+  const [dialogInitialTab, setDialogInitialTab] = useState<ItemDialogTab>('conversation')
+  const dialogWorkItemKey = githubTaskDrawerWorkItem
+    ? { id: githubTaskDrawerWorkItem.id, repoId: githubTaskDrawerWorkItem.repoId }
+    : null
 
   const appliedWorkItemsCacheQuery = useMemo(
     () => stripRepoQualifiers(appliedTaskSearch.trim()),
@@ -1923,12 +1924,17 @@ export default function TaskPage(): React.JSX.Element {
   const cachedDialogWorkItem = useAppStore((s) =>
     findTaskPageDialogWorkItem(s.workItemsCache, dialogWorkItemKey)
   )
-  const dialogWorkItem = dialogWorkItemKey ? (cachedDialogWorkItem ?? dialogWorkItemFallback) : null
+  const dialogWorkItem = dialogWorkItemKey
+    ? (cachedDialogWorkItem ?? githubTaskDrawerWorkItem)
+    : null
 
-  const setDialogWorkItem = useCallback((item: GitHubWorkItem | null) => {
-    setDialogWorkItemKey(item ? { id: item.id, repoId: item.repoId } : null)
-    setDialogWorkItemFallback(item)
-  }, [])
+  const setDialogWorkItem = useCallback(
+    (item: GitHubWorkItem | null, initialTab: ItemDialogTab = 'conversation') => {
+      setDialogInitialTab(item ? initialTab : 'conversation')
+      setGithubTaskDrawerWorkItem(item)
+    },
+    [setGithubTaskDrawerWorkItem]
+  )
 
   const patchTaskPageWorkItemRows = useCallback(
     (itemKey: { id: string; repoId: string }, patch: Partial<GitHubWorkItem>): void => {
@@ -4314,7 +4320,10 @@ export default function TaskPage(): React.JSX.Element {
                             </div>
 
                             <div className="flex min-w-0 items-center">
-                              <PRChecksCell item={item} onOpen={() => setDialogWorkItem(item)} />
+                              <PRChecksCell
+                                item={item}
+                                onOpen={() => setDialogWorkItem(item, 'checks')}
+                              />
                             </div>
 
                             <div className="flex min-w-0 items-center">
@@ -5399,6 +5408,7 @@ export default function TaskPage(): React.JSX.Element {
 
       <GitHubItemDialog
         workItem={dialogWorkItem}
+        initialTab={dialogInitialTab}
         repoPath={
           // Why: the dialog is for a single item — resolve its repoPath from the
           // item's own repoId (set when fan-out merged the list) so it works in

--- a/src/renderer/src/components/confirmation-dialog.tsx
+++ b/src/renderer/src/components/confirmation-dialog.tsx
@@ -1,0 +1,114 @@
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+
+type ConfirmationDialogOptions = {
+  title: string
+  description?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  confirmVariant?: 'default' | 'destructive'
+}
+
+type ConfirmationDialogRequest = {
+  id: number
+  options: ConfirmationDialogOptions
+  resolve: (confirmed: boolean) => void
+}
+
+type ConfirmationDialogContextValue = (options: ConfirmationDialogOptions) => Promise<boolean>
+
+const ConfirmationDialogContext = createContext<ConfirmationDialogContextValue | null>(null)
+
+export function ConfirmationDialogProvider({
+  children
+}: {
+  children: React.ReactNode
+}): React.JSX.Element {
+  const nextIdRef = useRef(0)
+  const [queue, setQueue] = useState<ConfirmationDialogRequest[]>([])
+  const activeRequest = queue[0] ?? null
+  const [renderedRequest, setRenderedRequest] = useState<ConfirmationDialogRequest | null>(null)
+  const activeRequestRef = useRef<ConfirmationDialogRequest | null>(activeRequest)
+  const displayedRequest = activeRequest ?? renderedRequest
+
+  useEffect(() => {
+    activeRequestRef.current = activeRequest
+    if (activeRequest) {
+      setRenderedRequest(activeRequest)
+    }
+  }, [activeRequest])
+
+  const confirm = useCallback<ConfirmationDialogContextValue>((options) => {
+    return new Promise((resolve) => {
+      const request: ConfirmationDialogRequest = {
+        id: nextIdRef.current,
+        options,
+        resolve
+      }
+      nextIdRef.current += 1
+      setQueue((currentQueue) => [...currentQueue, request])
+    })
+  }, [])
+
+  const settleActiveRequest = useCallback((confirmed: boolean) => {
+    const request = activeRequestRef.current
+    if (!request) {
+      return
+    }
+    request.resolve(confirmed)
+    setQueue((currentQueue) => {
+      if (currentQueue[0]?.id === request.id) {
+        return currentQueue.slice(1)
+      }
+      return currentQueue.filter((queuedRequest) => queuedRequest.id !== request.id)
+    })
+  }, [])
+
+  return (
+    <ConfirmationDialogContext.Provider value={confirm}>
+      {children}
+      <Dialog
+        open={activeRequest !== null}
+        onOpenChange={(open) => !open && settleActiveRequest(false)}
+      >
+        <DialogContent showCloseButton={false} className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{displayedRequest?.options.title}</DialogTitle>
+            {displayedRequest?.options.description ? (
+              <DialogDescription>{displayedRequest.options.description}</DialogDescription>
+            ) : null}
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => settleActiveRequest(false)}>
+              {displayedRequest?.options.cancelLabel ?? 'Cancel'}
+            </Button>
+            <Button
+              type="button"
+              variant={displayedRequest?.options.confirmVariant ?? 'default'}
+              onClick={() => settleActiveRequest(true)}
+            >
+              {displayedRequest?.options.confirmLabel ?? 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </ConfirmationDialogContext.Provider>
+  )
+}
+
+export function useConfirmationDialog(): ConfirmationDialogContextValue {
+  const confirm = useContext(ConfirmationDialogContext)
+  if (!confirm) {
+    throw new Error('useConfirmationDialog must be used inside ConfirmationDialogProvider')
+  }
+  return confirm
+}

--- a/src/renderer/src/components/right-sidebar/useFileDeletion.ts
+++ b/src/renderer/src/components/right-sidebar/useFileDeletion.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { dirname } from '@/lib/path'
 import { getConnectionId } from '@/lib/connection-context'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
@@ -49,6 +50,7 @@ export function useFileDeletion({
   isMac,
   isWindows
 }: UseFileDeletionParams): UseFileDeletionResult {
+  const confirm = useConfirmationDialog()
   // Why: track in-flight deletes per-path so repeated Del presses on the same
   // node don't issue duplicate IPC calls; the map is a ref to avoid re-renders.
   const inFlightRef = useRef<Set<string>>(new Set())
@@ -82,7 +84,13 @@ export function useFileDeletion({
         const message = node.isDirectory
           ? `Permanently delete '${node.name}' and all its contents? This cannot be undone.`
           : `Permanently delete '${node.name}'? This cannot be undone.`
-        if (!window.confirm(message)) {
+        const confirmed = await confirm({
+          title: `Permanently delete '${node.name}'?`,
+          description: message,
+          confirmLabel: 'Delete',
+          confirmVariant: 'destructive'
+        })
+        if (!confirmed) {
           inFlightRef.current.delete(node.path)
           return
         }
@@ -193,7 +201,16 @@ export function useFileDeletion({
         inFlightRef.current.delete(node.path)
       }
     },
-    [activeWorktreeId, closeFile, isWindows, openFiles, refreshDir, selectedPath, setSelectedPath]
+    [
+      activeWorktreeId,
+      closeFile,
+      confirm,
+      isWindows,
+      openFiles,
+      refreshDir,
+      selectedPath,
+      setSelectedPath
+    ]
   )
 
   const requestDelete = useCallback(

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -31,6 +31,7 @@ import { useAppStore } from '../../store'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { isMacUserAgent, isWindowsUserAgent } from '@/components/terminal-pane/pane-helpers'
 import { applyDocumentTheme } from '@/lib/document-theme'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { SCROLLBACK_PRESETS_MB, getFallbackTerminalFonts } from './SettingsConstants'
 import { DEFAULT_APP_FONT_FAMILY } from '../../../../shared/constants'
 import { GeneralPane, GENERAL_PANE_SEARCH_ENTRIES } from './GeneralPane'
@@ -277,6 +278,7 @@ function Settings(): React.JSX.Element {
   const [pendingNavRequestTick, setPendingNavRequestTick] = useState(0)
   const [hasUnsavedCommitPromptChanges, setHasUnsavedCommitPromptChanges] = useState(false)
   const [commitPromptDiscardSignal, setCommitPromptDiscardSignal] = useState(0)
+  const confirm = useConfirmationDialog()
   // Why: the hidden-experimental group is an unlock — Shift-clicking the
   // Experimental sidebar entry reveals it for the remainder of the session.
   // Not persisted on purpose: it's a power-user affordance we don't want to
@@ -291,22 +293,25 @@ function Settings(): React.JSX.Element {
   const repoHooksRequestSeqRef = useRef(0)
   const repoHooksRuntimeIdentityRef = useRef<string>('local')
 
-  const confirmDiscardCommitPromptChanges = useCallback((): boolean => {
+  const confirmDiscardCommitPromptChanges = useCallback(async (): Promise<boolean> => {
     if (!hasUnsavedCommitPromptChanges) {
       return true
     }
-    const shouldDiscard = window.confirm(
-      'You have unsaved AI commit prompt changes. Leave without saving?'
-    )
+    const shouldDiscard = await confirm({
+      title: 'Discard unsaved commit prompt changes?',
+      description: 'You have unsaved AI commit prompt changes. Leaving will discard them.',
+      confirmLabel: 'Discard',
+      confirmVariant: 'destructive'
+    })
     if (shouldDiscard) {
       setCommitPromptDiscardSignal((signal) => signal + 1)
       setHasUnsavedCommitPromptChanges(false)
     }
     return shouldDiscard
-  }, [hasUnsavedCommitPromptChanges])
+  }, [confirm, hasUnsavedCommitPromptChanges])
 
-  const closeSettingsPageWithPromptGuard = useCallback((): void => {
-    if (!confirmDiscardCommitPromptChanges()) {
+  const closeSettingsPageWithPromptGuard = useCallback(async (): Promise<void> => {
+    if (!(await confirmDiscardCommitPromptChanges())) {
       return
     }
     closeSettingsPage()
@@ -319,8 +324,31 @@ function Settings(): React.JSX.Element {
   const runtimeTargetIdentity = getRuntimeTargetIdentity(settings)
 
   useEffect(() => {
+    const hasVisibleOverlay = (): boolean =>
+      Array.from(
+        document.querySelectorAll('[role="dialog"], [role="listbox"], [role="menu"]')
+      ).some((element) => {
+        if (!(element instanceof HTMLElement)) {
+          return false
+        }
+        if (element.closest('[aria-hidden="true"]')) {
+          return false
+        }
+        const style = window.getComputedStyle(element)
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          element.getClientRects().length > 0
+        )
+      })
+
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape' || event.defaultPrevented) {
+        return
+      }
+      // Why: nested dialogs and menus own Escape before Settings page-level
+      // navigation, including the unsaved commit prompt confirmation dialog.
+      if (hasVisibleOverlay()) {
         return
       }
       // Why: Escape in an editable control usually means "cancel this edit",
@@ -331,7 +359,7 @@ function Settings(): React.JSX.Element {
       if (isEditableTarget(event.target)) {
         return
       }
-      closeSettingsPageWithPromptGuard()
+      void closeSettingsPageWithPromptGuard()
     }
 
     document.addEventListener('keydown', handleKeyDown)
@@ -949,11 +977,11 @@ function Settings(): React.JSX.Element {
   }, [visibleNavSections])
 
   const scrollToSection = useCallback(
-    (
+    async (
       sectionId: string,
       modifiers?: { metaKey: boolean; ctrlKey: boolean; shiftKey: boolean; altKey: boolean }
-    ) => {
-      if (sectionId !== activeSectionId && !confirmDiscardCommitPromptChanges()) {
+    ): Promise<void> => {
+      if (sectionId !== activeSectionId && !(await confirmDiscardCommitPromptChanges())) {
         return
       }
       // Why: Shift-clicking the Experimental sidebar entry unlocks a hidden
@@ -971,8 +999,8 @@ function Settings(): React.JSX.Element {
     [activeSectionId, confirmDiscardCommitPromptChanges]
   )
 
-  const openComputerUseFromBrowser = useCallback(() => {
-    if (!confirmDiscardCommitPromptChanges()) {
+  const openComputerUseFromBrowser = useCallback(async () => {
+    if (!(await confirmDiscardCommitPromptChanges())) {
       return
     }
     pendingNavSectionRef.current = 'computer-use'

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -107,7 +107,7 @@ const documentComponents: Components = {
       href={href}
       target="_blank"
       rel="noreferrer"
-      className="text-primary underline underline-offset-2 hover:text-primary/80"
+      className="break-all text-primary underline underline-offset-2 hover:text-primary/80"
       onClick={(e) => e.stopPropagation()}
     >
       {children}

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -5,6 +5,7 @@ import { findPrevLiveWorktreeHistoryIndex } from './worktree-nav-history'
 import type {
   ChangelogData,
   CustomPet,
+  GitHubWorkItem,
   PersistedTrustedOrcaHooks,
   PersistedUIState,
   StatusBarItem,
@@ -265,6 +266,8 @@ export type UISlice = {
   }
   taskResumeState: TaskResumeState | undefined
   setTaskResumeState: (updates: Partial<TaskResumeState>) => void
+  githubTaskDrawerWorkItem: GitHubWorkItem | null
+  setGithubTaskDrawerWorkItem: (item: GitHubWorkItem | null) => void
   newWorkspaceDraft: {
     repoId: string | null
     name: string
@@ -506,6 +509,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
+  githubTaskDrawerWorkItem: null,
   newWorkspaceDraft: null,
   openTaskPage: (data = {}) => {
     // Why: record a Tasks visit in the shared back/forward history so the
@@ -586,6 +590,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       window.api.ui.set({ taskResumeState: next }).catch(console.error)
       return { taskResumeState: next }
     }),
+  setGithubTaskDrawerWorkItem: (item) => set({ githubTaskDrawerWorkItem: item }),
   closeTaskPage: () =>
     set((state) => {
       // Why: Esc-close from Tasks must rewind the history index if we're

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -696,6 +696,7 @@ function createGitHubApi(): NonNullable<Partial<PreloadApi>['gh']> {
     countWorkItems: direct('github.countWorkItems'),
     listWorkItems: direct('github.listWorkItems'),
     prChecks: direct('github.prChecks'),
+    prCheckDetails: direct('github.prCheckDetails'),
     rerunPRChecks: direct('github.rerunPRChecks'),
     prComments: direct('github.prComments'),
     resolveReviewThread: direct('github.resolveReviewThread'),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -625,6 +625,49 @@ export type PRCheckDetail = {
   workflowRunId?: number
 }
 
+export type PRCheckAnnotation = {
+  path: string | null
+  startLine: number | null
+  endLine: number | null
+  annotationLevel: string | null
+  title: string | null
+  message: string
+  rawDetails: string | null
+}
+
+export type PRCheckStep = {
+  name: string
+  status: string | null
+  conclusion: string | null
+  startedAt: string | null
+  completedAt: string | null
+}
+
+export type PRCheckJob = {
+  name: string
+  status: string | null
+  conclusion: string | null
+  startedAt: string | null
+  completedAt: string | null
+  url: string | null
+  steps: PRCheckStep[]
+}
+
+export type PRCheckRunDetails = {
+  name: string
+  status: PRCheckDetail['status'] | string | null
+  conclusion: PRCheckDetail['conclusion'] | string | null
+  url: string | null
+  detailsUrl: string | null
+  startedAt: string | null
+  completedAt: string | null
+  title: string | null
+  summary: string | null
+  text: string | null
+  annotations: PRCheckAnnotation[]
+  jobs: PRCheckJob[]
+}
+
 export type GitHubRerunPRChecksResult = { ok: true; count: number } | { ok: false; error: string }
 
 export type GitHubReactionContent =

--- a/untitled.md
+++ b/untitled.md
@@ -1,0 +1,6 @@
+TODOs:
+
+- [ ] make the comments not extending all the way 
+- [ ] wider side drawer 
+- [ ] start PR from page
+


### PR DESCRIPTION
## Summary
- disable Git optional locks for local status polling and create-PR dirty checks
- apply the same no-optional-lock behavior to relay Git status calls
- update status tests to assert the lock-avoidance environment

## Tests
- pnpm typecheck
- pnpm lint
- pnpm vitest run --config config/vitest.config.ts src/main/git/status.test.ts src/main/source-control/hosted-review-creation.test.ts src/relay/git-handler.test.ts