### PR TITLE
Suppress false crash reports during expected renderer reloads

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  shouldRecordProcessGoneCrash,
+  shouldRecoverRendererAfterProcessGone
+} from './process-gone-classification'
+
+describe('shouldRecordProcessGoneCrash', () => {
+  it('suppresses killed process exits during expected lifecycle teardown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: 'killed',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        reason: 'killed',
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
+  })
+
+  it('records real crash reasons even during expected lifecycle teardown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: 'crashed',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(true)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: 'oom',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(true)
+  })
+
+  it('records killed process exits outside expected lifecycle teardown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: 'killed',
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+  })
+
+  it('records child-process killed events during renderer-only reloads', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        reason: 'killed',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(true)
+  })
+})
+
+describe('shouldRecoverRendererAfterProcessGone', () => {
+  it('does not recover expected renderer reload teardown', () => {
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'killed',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(false)
+  })
+
+  it('recovers real renderer crashes during renderer reload windows', () => {
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'oom',
+        expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(true)
+  })
+
+  it('does not recover during app shutdown', () => {
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'crashed',
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -1,0 +1,35 @@
+export type ProcessGoneSource = 'renderer' | 'child'
+export type ExpectedTeardownScope = 'none' | 'renderer-reload' | 'app-shutdown'
+
+export function shouldRecordProcessGoneCrash({
+  source,
+  reason,
+  expectedTeardown
+}: {
+  source: ProcessGoneSource
+  reason: string
+  expectedTeardown: ExpectedTeardownScope
+}): boolean {
+  // Why: Electron reports intentional reload/update/quit teardown as `killed`.
+  // Real renderer OOMs and Chromium crashes should still reach crash reporting.
+  if (reason !== 'killed') {
+    return true
+  }
+  if (expectedTeardown === 'app-shutdown') {
+    return false
+  }
+  return !(source === 'renderer' && expectedTeardown === 'renderer-reload')
+}
+
+export function shouldRecoverRendererAfterProcessGone({
+  reason,
+  expectedTeardown
+}: {
+  reason: string
+  expectedTeardown: ExpectedTeardownScope
+}): boolean {
+  if (expectedTeardown === 'app-shutdown') {
+    return false
+  }
+  return !(reason === 'killed' && expectedTeardown === 'renderer-reload')
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,6 +79,11 @@ import {
   recordCrashBreadcrumb
 } from './crash-reporting/crash-breadcrumb-store'
 import { CrashReportStore } from './crash-reporting/crash-report-store'
+import {
+  shouldRecordProcessGoneCrash,
+  shouldRecoverRendererAfterProcessGone,
+  type ExpectedTeardownScope
+} from './crash-reporting/process-gone-classification'
 import { isCrashReportReason } from '../shared/crash-reporting'
 
 let mainWindow: BrowserWindow | null = null
@@ -106,6 +111,7 @@ let disposeFeatureWallFirstAgentTour: (() => void) | null = null
 let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
 let automations: AutomationService | null = null
+let expectedRendererReload: { webContentsId: number; until: number } | null = null
 const isServeMode = process.argv.includes('--serve')
 const devInstanceIdentity = getDevInstanceIdentity(is.dev)
 const devAgentHookEndpointNamespace = devInstanceIdentity.isDev
@@ -158,6 +164,32 @@ function focusExistingWindow(): void {
   }
   // Pre-window case: the primary is still booting and will call
   // openMainWindow() from whenReady(). No action needed here.
+}
+
+function markExpectedRendererReload(webContentsId: number, durationMs = 10_000): void {
+  expectedRendererReload = { webContentsId, until: Date.now() + durationMs }
+}
+
+function clearExpectedRendererReload(webContentsId?: number): void {
+  if (webContentsId === undefined || expectedRendererReload?.webContentsId === webContentsId) {
+    expectedRendererReload = null
+  }
+}
+
+function getExpectedTeardownScope(webContentsId?: number): ExpectedTeardownScope {
+  if (isQuitting || isQuittingForUpdate()) {
+    return 'app-shutdown'
+  }
+  if (!expectedRendererReload) {
+    return 'none'
+  }
+  if (Date.now() > expectedRendererReload.until) {
+    expectedRendererReload = null
+    return 'none'
+  }
+  return webContentsId !== undefined && expectedRendererReload.webContentsId === webContentsId
+    ? 'renderer-reload'
+    : 'none'
 }
 
 // Why: the lock must be acquired AFTER configureDevUserDataPath — Electron
@@ -273,13 +305,31 @@ function openMainWindow(): BrowserWindow {
     getIsQuitting: () => isQuitting,
     onQuitAborted: () => {
       isQuitting = false
+      clearExpectedRendererReload()
     },
-    onRendererProcessGone: (details) => {
-      recordProcessGoneCrash('renderer', 'renderer', details.reason, details.exitCode ?? null, {
-        processType: 'renderer'
-      })
+    onRendererProcessGone: (details, webContentsId) => {
+      recordProcessGoneCrash(
+        'renderer',
+        'renderer',
+        details.reason,
+        details.exitCode ?? null,
+        {
+          processType: 'renderer'
+        },
+        webContentsId
+      )
     },
-    shouldRecoverRenderer: () => !isQuitting && !isQuittingForUpdate(),
+    shouldRecordRendererCrash: (details, webContentsId) =>
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: details.reason,
+        expectedTeardown: getExpectedTeardownScope(webContentsId)
+      }),
+    shouldRecoverRenderer: (details, webContentsId) =>
+      shouldRecoverRendererAfterProcessGone({
+        reason: details.reason,
+        expectedTeardown: getExpectedTeardownScope(webContentsId)
+      }),
     deferLoad: true,
     title: devInstanceIdentity.name
   })
@@ -289,7 +339,9 @@ function openMainWindow(): BrowserWindow {
   // `app_opened` to the first main-window load. Existing users in the
   // pending-banner cohort resolve through telemetry/client.ts; this load
   // path only fires once consent is already enabled.
+  const rendererWebContentsId = window.webContents.id
   const onFirstWindowLoad = (): void => {
+    clearExpectedRendererReload(rendererWebContentsId)
     recordCrashBreadcrumb('main_window_loaded')
     if (!store) {
       return
@@ -312,7 +364,7 @@ function openMainWindow(): BrowserWindow {
     codexAccounts,
     claudeAccounts,
     rateLimits,
-    window.webContents.id,
+    rendererWebContentsId,
     automations,
     {
       prepareForCodexLaunch: () =>
@@ -334,7 +386,15 @@ function openMainWindow(): BrowserWindow {
       store!.getSettings().activeCodexManagedAccountId
         ? codexRuntimeHome!.prepareForCodexLaunch()
         : null,
-    () => claudeRuntimeAuth!.prepareForClaudeLaunch()
+    () => claudeRuntimeAuth!.prepareForClaudeLaunch(),
+    {
+      onBeforeRendererReload: ({ ignoreCache, webContentsId }) => {
+        if (window.webContents.id === webContentsId) {
+          markExpectedRendererReload(webContentsId)
+        }
+        recordCrashBreadcrumb('renderer_reload_requested', { ignoreCache })
+      }
+    }
   )
   rateLimits.attach(window)
   rateLimits.start()
@@ -342,6 +402,7 @@ function openMainWindow(): BrowserWindow {
     if (mainWindow === window) {
       mainWindow = null
     }
+    clearExpectedRendererReload(rendererWebContentsId)
     automations?.setWebContents(null)
     // Why: detach the agent hook listener on window close so the server
     // never fires into a destroyed webContents during the gap before
@@ -427,9 +488,25 @@ function recordProcessGoneCrash(
   processType: string,
   reason: string,
   exitCode: number | null,
-  details: Record<string, unknown>
+  details: Record<string, unknown>,
+  webContentsId?: number
 ): void {
   if (!crashReports || !isCrashReportReason(reason)) {
+    return
+  }
+  if (
+    !shouldRecordProcessGoneCrash({
+      source,
+      reason,
+      expectedTeardown: getExpectedTeardownScope(webContentsId)
+    })
+  ) {
+    recordCrashBreadcrumb('process_gone_suppressed', {
+      source,
+      processType,
+      reason,
+      exitCode
+    })
     return
   }
   const key = `${processType}:${reason}:${exitCode ?? 'null'}`
@@ -838,6 +915,12 @@ app.whenReady().then(async () => {
 
   registerAppMenu({
     onCheckForUpdates: (options) => checkForUpdatesFromMenu(options),
+    onBeforeReload: ({ ignoreCache, webContentsId }) => {
+      if (mainWindow?.webContents.id === webContentsId) {
+        markExpectedRendererReload(webContentsId)
+      }
+      recordCrashBreadcrumb('manual_reload_requested', { ignoreCache })
+    },
     onOpenSettings: () => {
       recordCrashBreadcrumb('settings_opened')
       mainWindow?.webContents.send('ui:openSettings')

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -29,6 +29,7 @@ function buildMenuOptions() {
     onOpenSettings: vi.fn(),
     onOpenFeatureTour: vi.fn(),
     onOpenCrashReport: vi.fn(),
+    onBeforeReload: vi.fn(),
     onZoomIn: vi.fn(),
     onZoomOut: vi.fn(),
     onZoomReset: vi.fn(),
@@ -83,33 +84,40 @@ describe('registerAppMenu', () => {
   it('reloads the focused window from the view menu', () => {
     const reloadMock = vi.fn()
     const reloadIgnoringCacheMock = vi.fn()
+    const options = buildMenuOptions()
+    options.onBeforeReload = vi.fn()
     getFocusedWindowMock.mockReturnValue({
       webContents: {
+        id: 101,
         reload: reloadMock,
         reloadIgnoringCache: reloadIgnoringCacheMock
       }
     })
 
-    registerAppMenu(buildMenuOptions())
+    registerAppMenu(options)
 
     const reloadItem = getSubmenu(getTemplate(), 'View').find((item) => item.label === 'Reload')
     reloadItem?.click?.({} as never, {} as never, {} as never)
 
     expect(reloadMock).toHaveBeenCalledTimes(1)
     expect(reloadIgnoringCacheMock).not.toHaveBeenCalled()
+    expect(options.onBeforeReload).toHaveBeenCalledWith({ ignoreCache: false, webContentsId: 101 })
   })
 
   it('force reloads the focused window from the view menu', () => {
     const reloadMock = vi.fn()
     const reloadIgnoringCacheMock = vi.fn()
+    const options = buildMenuOptions()
+    options.onBeforeReload = vi.fn()
     getFocusedWindowMock.mockReturnValue({
       webContents: {
+        id: 102,
         reload: reloadMock,
         reloadIgnoringCache: reloadIgnoringCacheMock
       }
     })
 
-    registerAppMenu(buildMenuOptions())
+    registerAppMenu(options)
 
     const forceReloadItem = getSubmenu(getTemplate(), 'View').find(
       (item) => item.label === 'Force Reload'
@@ -118,6 +126,7 @@ describe('registerAppMenu', () => {
 
     expect(reloadIgnoringCacheMock).toHaveBeenCalledTimes(1)
     expect(reloadMock).not.toHaveBeenCalled()
+    expect(options.onBeforeReload).toHaveBeenCalledWith({ ignoreCache: true, webContentsId: 102 })
   })
 
   it('includes prereleases when Check for Updates is clicked with shift held', () => {

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -13,6 +13,7 @@ type RegisterAppMenuOptions = {
   onOpenFeatureTour: (window?: Electron.BaseWindow | null) => void
   onOpenCrashReport: (window?: Electron.BaseWindow | null) => void
   onCheckForUpdates: (options: { includePrerelease: boolean }) => void
+  onBeforeReload?: (options: { ignoreCache: boolean; webContentsId: number }) => void
   onZoomIn: () => void
   onZoomOut: () => void
   onZoomReset: () => void
@@ -28,6 +29,7 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     onOpenFeatureTour,
     onOpenCrashReport,
     onCheckForUpdates,
+    onBeforeReload,
     onZoomIn,
     onZoomOut,
     onZoomReset,
@@ -45,6 +47,8 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     if (!webContents) {
       return
     }
+
+    onBeforeReload?.({ ignoreCache, webContentsId: webContents.id })
 
     if (ignoreCache) {
       webContents.reloadIgnoringCache()

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: attachMainWindowServices centralizes main-window IPC wiring; keeping its integration-style mocks together avoids brittle cross-file setup. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -6,6 +7,8 @@ const {
   setPermissionRequestHandlerMock,
   setPermissionCheckHandlerMock,
   setDisplayMediaRequestHandlerMock,
+  handleMock,
+  removeHandlerMock,
   systemPreferencesAskForMediaAccessMock,
   systemPreferencesGetMediaAccessStatusMock,
   registerRepoHandlersMock,
@@ -22,6 +25,8 @@ const {
   setPermissionRequestHandlerMock: vi.fn(),
   setPermissionCheckHandlerMock: vi.fn(),
   setDisplayMediaRequestHandlerMock: vi.fn(),
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
   systemPreferencesAskForMediaAccessMock: vi.fn(),
   systemPreferencesGetMediaAccessStatusMock: vi.fn(),
   registerRepoHandlersMock: vi.fn(),
@@ -47,8 +52,8 @@ vi.mock('electron', () => ({
   ipcMain: {
     on: onMock,
     removeAllListeners: removeAllListenersMock,
-    removeHandler: vi.fn(),
-    handle: vi.fn()
+    removeHandler: removeHandlerMock,
+    handle: handleMock
   }
 }))
 
@@ -89,8 +94,11 @@ type MainWindowStub = {
   isDestroyed?: MockFn
   on: MockFn
   webContents: {
+    id?: number
+    isDestroyed?: MockFn
     on: MockFn
     send?: MockFn
+    reload?: MockFn
     session: {
       setPermissionRequestHandler: MockFn
       setPermissionCheckHandler: MockFn
@@ -107,9 +115,13 @@ type RuntimeStub = {
 
 function createMainWindow(extraWebContents: { on?: MockFn; send?: MockFn } = {}): MainWindowStub {
   return {
+    isDestroyed: vi.fn(() => false),
     on: vi.fn(),
     webContents: {
+      id: 1,
+      isDestroyed: vi.fn(() => false),
       on: vi.fn(),
+      reload: vi.fn(),
       session: {
         setPermissionRequestHandler: setPermissionRequestHandlerMock,
         setPermissionCheckHandler: setPermissionCheckHandlerMock
@@ -136,6 +148,8 @@ describe('attachMainWindowServices', () => {
   beforeEach(() => {
     onMock.mockReset()
     removeAllListenersMock.mockReset()
+    handleMock.mockReset()
+    removeHandlerMock.mockReset()
     setPermissionRequestHandlerMock.mockReset()
     setPermissionCheckHandlerMock.mockReset()
     setDisplayMediaRequestHandlerMock.mockReset()
@@ -157,6 +171,101 @@ describe('attachMainWindowServices', () => {
     })
     systemPreferencesAskForMediaAccessMock.mockResolvedValue(true)
     systemPreferencesGetMediaAccessStatusMock.mockReturnValue('granted')
+  })
+
+  it('reloads the app renderer through main and marks expected renderer teardown', async () => {
+    const onBeforeRendererReload = vi.fn()
+    const mainWindow = createMainWindow()
+
+    attachMainWindowServices(
+      mainWindow as never,
+      createStore(),
+      createRuntime() as never,
+      undefined,
+      undefined,
+      { onBeforeRendererReload }
+    )
+
+    expect(removeHandlerMock).toHaveBeenCalledWith('app:reload')
+    const reloadHandler = handleMock.mock.calls.find(([channel]) => channel === 'app:reload')?.[1]
+    expect(reloadHandler).toBeTypeOf('function')
+
+    await reloadHandler?.({ sender: mainWindow.webContents })
+
+    expect(onBeforeRendererReload).toHaveBeenCalledWith({
+      webContentsId: 1,
+      ignoreCache: false
+    })
+    expect(mainWindow.webContents.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores app reload requests from non-main webContents', async () => {
+    const onBeforeRendererReload = vi.fn()
+    const mainWindow = createMainWindow()
+
+    attachMainWindowServices(
+      mainWindow as never,
+      createStore(),
+      createRuntime() as never,
+      undefined,
+      undefined,
+      { onBeforeRendererReload }
+    )
+
+    const reloadHandler = handleMock.mock.calls.find(([channel]) => channel === 'app:reload')?.[1]
+    await reloadHandler?.({ sender: { id: 999 } })
+
+    expect(onBeforeRendererReload).not.toHaveBeenCalled()
+    expect(mainWindow.webContents.reload).not.toHaveBeenCalled()
+  })
+
+  it('ignores app reload requests after the main window is destroyed without rereading webContents', () => {
+    const onBeforeRendererReload = vi.fn()
+    const mainWindow = createMainWindow()
+    const mainWebContents = mainWindow.webContents
+
+    attachMainWindowServices(
+      mainWindow as never,
+      createStore(),
+      createRuntime() as never,
+      undefined,
+      undefined,
+      { onBeforeRendererReload }
+    )
+
+    const reloadHandler = handleMock.mock.calls.find(([channel]) => channel === 'app:reload')?.[1]
+    mainWindow.isDestroyed?.mockReturnValue(true)
+    Object.defineProperty(mainWindow, 'webContents', {
+      get: () => {
+        throw new Error('webContents should not be read after registration')
+      }
+    })
+
+    expect(() => reloadHandler?.({ sender: mainWebContents })).not.toThrow()
+
+    expect(onBeforeRendererReload).not.toHaveBeenCalled()
+    expect(mainWebContents.reload).not.toHaveBeenCalled()
+  })
+
+  it('ignores app reload requests after the main webContents is destroyed', async () => {
+    const onBeforeRendererReload = vi.fn()
+    const mainWindow = createMainWindow()
+
+    attachMainWindowServices(
+      mainWindow as never,
+      createStore(),
+      createRuntime() as never,
+      undefined,
+      undefined,
+      { onBeforeRendererReload }
+    )
+
+    const reloadHandler = handleMock.mock.calls.find(([channel]) => channel === 'app:reload')?.[1]
+    mainWindow.webContents.isDestroyed?.mockReturnValue(true)
+    await reloadHandler?.({ sender: mainWindow.webContents })
+
+    expect(onBeforeRendererReload).not.toHaveBeenCalled()
+    expect(mainWindow.webContents.reload).not.toHaveBeenCalled()
   })
 
   it('only allows the explicit permission allowlist', async () => {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -40,8 +40,12 @@ export function attachMainWindowServices(
   store: Store,
   runtime: OrcaRuntimeService,
   getSelectedCodexHomePath?: () => string | null,
-  prepareClaudeAuth?: () => Promise<ClaudeRuntimeAuthPreparation>
+  prepareClaudeAuth?: () => Promise<ClaudeRuntimeAuthPreparation>,
+  options?: {
+    onBeforeRendererReload?: (args: { webContentsId: number; ignoreCache: boolean }) => void
+  }
 ): void {
+  registerAppReloadHandler(mainWindow, options?.onBeforeRendererReload)
   registerRepoHandlers(mainWindow, store)
   registerWorktreeHandlers(mainWindow, store, runtime)
   registerWorkspaceCleanupHandlers(store, { runtime, getLocalPtyProvider })
@@ -205,6 +209,27 @@ export function attachMainWindowServices(
     // close prevents stale tab→webContents ids from leaking across app relaunch
     // or hot-reload cycles.
     browserManager.unregisterAll()
+  })
+}
+
+function registerAppReloadHandler(
+  mainWindow: BrowserWindow,
+  onBeforeRendererReload?: (args: { webContentsId: number; ignoreCache: boolean }) => void
+): void {
+  // Why: the process-global IPC handler can outlive the BrowserWindow, so keep
+  // the registered WebContents and guard both lifetimes before using it.
+  const mainWebContents = mainWindow.webContents
+  ipcMain.removeHandler('app:reload')
+  ipcMain.handle('app:reload', (event) => {
+    if (
+      mainWindow.isDestroyed() ||
+      mainWebContents.isDestroyed() ||
+      event.sender !== mainWebContents
+    ) {
+      return
+    }
+    onBeforeRendererReload?.({ webContentsId: mainWebContents.id, ignoreCache: false })
+    mainWebContents.reload()
   })
 }
 

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1390,6 +1390,7 @@ describe('createMainWindow', () => {
   it('notifies the caller when the renderer process is gone', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
+      id: 142,
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
@@ -1422,12 +1423,117 @@ describe('createMainWindow', () => {
     const details = { reason: 'crashed', exitCode: 5 } as Electron.RenderProcessGoneDetails
     windowHandlers['render-process-gone']?.({} as never, details)
 
-    expect(onRendererProcessGone).toHaveBeenCalledWith(details)
+    expect(onRendererProcessGone).toHaveBeenCalledWith(details, 142)
+  })
+
+  it('passes the renderer webContents id through crash classification callbacks', () => {
+    vi.useFakeTimers()
+
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      id: 424,
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+    const onRendererProcessGone = vi.fn()
+    const shouldRecordRendererCrash = vi.fn(() => true)
+    const shouldRecoverRenderer = vi.fn(() => true)
+
+    try {
+      createMainWindow(null, {
+        onRendererProcessGone,
+        shouldRecordRendererCrash,
+        shouldRecoverRenderer
+      })
+
+      const details = { reason: 'crashed', exitCode: 5 } as Electron.RenderProcessGoneDetails
+      windowHandlers['render-process-gone']?.({} as never, details)
+      vi.advanceTimersByTime(250)
+
+      expect(shouldRecordRendererCrash).toHaveBeenCalledWith(details, 424)
+      expect(onRendererProcessGone).toHaveBeenCalledWith(details, 424)
+      expect(shouldRecoverRenderer).toHaveBeenCalledWith(details, 424)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('does not notify the crash recorder for an expected renderer teardown', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+    const onRendererProcessGone = vi.fn()
+
+    createMainWindow(null, {
+      onRendererProcessGone,
+      shouldRecordRendererCrash: () => false
+    })
+
+    windowHandlers['render-process-gone']?.(
+      {} as never,
+      {
+        reason: 'killed',
+        exitCode: 15
+      } as Electron.RenderProcessGoneDetails
+    )
+
+    expect(onRendererProcessGone).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
   })
 
   const createRendererRecoveryWindowHarness = () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
+      id: 143,
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -69,11 +69,24 @@ type CreateMainWindowOptions = {
    *  latch must be cleared or later window closes will be misclassified as
    *  quit attempts. */
   onQuitAborted?: () => void
-  onRendererProcessGone?: (details: Electron.RenderProcessGoneDetails) => void
+  onRendererProcessGone?: (
+    details: Electron.RenderProcessGoneDetails,
+    webContentsId: number
+  ) => void
+  /** Returns true when a renderer loss should be reported as a crash. Why:
+   *  intentional reload/update/quit paths can emit crash-like `killed`
+   *  renderer exits, but surfacing those as crash reports is noise. */
+  shouldRecordRendererCrash?: (
+    details: Electron.RenderProcessGoneDetails,
+    webContentsId: number
+  ) => boolean
   /** Returns true when Orca should reload after an unexpected renderer loss.
    *  Why: update relaunch and app quit intentionally tear down child
    *  processes; recovering those paths can fight Electron's shutdown. */
-  shouldRecoverRenderer?: (details: Electron.RenderProcessGoneDetails) => boolean
+  shouldRecoverRenderer?: (
+    details: Electron.RenderProcessGoneDetails,
+    webContentsId: number
+  ) => boolean
   /** Why: main-process startup must register IPC handlers before the renderer
    *  begins booting, or eager renderer calls can race into missing channels. */
   deferLoad?: boolean
@@ -218,6 +231,7 @@ export function createMainWindow(
       webviewTag: true
     }
   })
+  const rendererWebContentsId = mainWindow.webContents.id
 
   if (process.platform === 'darwin') {
     // Why: persistent parked webviews use separate compositor layers, and on
@@ -502,7 +516,7 @@ export function createMainWindow(
       !isCrashReportReason(details.reason) ||
       windowClosing ||
       opts?.getIsQuitting?.() ||
-      opts?.shouldRecoverRenderer?.(details) === false ||
+      opts?.shouldRecoverRenderer?.(details, rendererWebContentsId) === false ||
       mainWindow.isDestroyed()
     ) {
       return
@@ -512,7 +526,7 @@ export function createMainWindow(
       if (
         windowClosing ||
         opts?.getIsQuitting?.() ||
-        opts?.shouldRecoverRenderer?.(details) === false ||
+        opts?.shouldRecoverRenderer?.(details, rendererWebContentsId) === false ||
         mainWindow.isDestroyed()
       ) {
         return
@@ -526,7 +540,9 @@ export function createMainWindow(
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     rendererProcessGone = true
     resetMarkdownEditorFocus()
-    opts?.onRendererProcessGone?.(details)
+    if (opts?.shouldRecordRendererCrash?.(details, rendererWebContentsId) !== false) {
+      opts?.onRendererProcessGone?.(details, rendererWebContentsId)
+    }
     console.error('[window] Renderer process gone; close confirmation will be bypassed', details)
     scheduleRendererRecovery(details)
   })

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -539,6 +539,9 @@ export type AppApi = {
    *  by settings panes that need a full restart to apply changes (e.g. the
    *  terminal-window blur setting in TerminalWindowSection). */
   relaunch: () => Promise<void>
+  /** Reloads the current app renderer through main so expected renderer
+   *  teardown can be classified before Electron emits process-gone events. */
+  reload: () => Promise<void>
   /** Returns the macOS `AppleCurrentKeyboardLayoutInputSourceID` when
    *  available (e.g. `com.apple.keylayout.PolishPro`). Used by the
    *  keyboard-layout probe to distinguish layouts whose base layer matches

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -349,6 +349,7 @@ const api = {
     getFeatureWallAssetBaseUrl: (): Promise<string> =>
       ipcRenderer.invoke('app:getFeatureWallAssetBaseUrl'),
     relaunch: (): Promise<void> => ipcRenderer.invoke('app:relaunch'),
+    reload: (): Promise<void> => ipcRenderer.invoke('app:reload'),
     // Why: on macOS this returns AppleCurrentKeyboardLayoutInputSourceID so
     // the renderer's keyboard-layout probe can distinguish Polish Pro / US
     // Extended / ABC Extended / IME Roman modes from plain US QWERTY (see

--- a/src/renderer/src/components/github-project/GhAuthErrorHelp.tsx
+++ b/src/renderer/src/components/github-project/GhAuthErrorHelp.tsx
@@ -25,6 +25,17 @@ const LOGIN_CMD = 'gh auth login'
 // macOS/Linux vs PowerShell on Windows.
 const IS_WINDOWS = typeof navigator !== 'undefined' && /Win(dows|32|64)/i.test(navigator.userAgent)
 
+function reloadOrcaRenderer(): void {
+  const reload = window.api.app.reload
+  if (typeof reload !== 'function') {
+    window.location.reload()
+    return
+  }
+  void reload().catch(() => {
+    window.location.reload()
+  })
+}
+
 function findEnvVarCommand(varName: string): { label: string; command: string } {
   if (IS_WINDOWS) {
     return {
@@ -228,7 +239,7 @@ export function GhAuthErrorHelp({
               reload the renderer to pick up the new gh token state. */}
           <button
             type="button"
-            onClick={() => window.location.reload()}
+            onClick={reloadOrcaRenderer}
             className="inline-flex items-center gap-1 rounded border border-amber-500/30 px-1.5 py-0.5 text-[11px] hover:bg-amber-500/20"
           >
             <RotateCw className="size-3" /> Reload
@@ -261,7 +272,7 @@ export function GhAuthErrorHelp({
         ) : null}
         {/* Why: after running the refresh command in a terminal, users need to
             reload the renderer to pick up the new gh token state. */}
-        <Button size="sm" variant="outline" onClick={() => window.location.reload()}>
+        <Button size="sm" variant="outline" onClick={reloadOrcaRenderer}>
           <RotateCw className="mr-1 size-3.5" /> Reload
         </Button>
       </div>

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -82,6 +82,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
         }),
       getFeatureWallAssetBaseUrl: () => Promise.resolve('/'),
       relaunch: () => Promise.resolve(window.location.reload()),
+      reload: () => Promise.resolve(window.location.reload()),
       getKeyboardInputSourceId: () => Promise.resolve(null),
       setUnreadDockBadgeCount: () => Promise.resolve(),
       getFloatingTerminalCwd: () => Promise.resolve('~')


### PR DESCRIPTION
## Summary
- classify process-gone events so expected renderer reloads suppress only renderer killed reports while real crashed/oom reports still record and recover
- route app renderer reloads through main with sender validation and scoped webContents ids
- add regression tests for reload classification, IPC reload ownership, and renderer recovery/reporting callbacks

## Auto review-fix
- Iteration 1: 4 review agents found 2 actionable architecture issues
- Fixed stale/global reload state and destroyed-window reload IPC handling
- Iteration 2: 4 verification review agents reported no findings

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/menu/register-app-menu.test.ts src/main/window/createMainWindow.test.ts src/main/window/attach-main-window-services.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm exec oxlint src/main/index.ts src/main/crash-reporting/process-gone-classification.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/menu/register-app-menu.ts src/main/menu/register-app-menu.test.ts src/main/window/createMainWindow.ts src/main/window/createMainWindow.test.ts src/main/window/attach-main-window-services.ts src/main/window/attach-main-window-services.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/web/web-preload-api.ts src/renderer/src/components/github-project/GhAuthErrorHelp.tsx

Note: pnpm reports the existing Node engine warning because this shell is Node 25.9.0 and the repo requests Node 24; all checks passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
