### PR TITLE
Fix e2e flakes from run 26118992268

### DIFF
--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -664,12 +664,11 @@ export function useOnboardingFlow(
     // Why: Settings renders behind the fullscreen onboarding layer; SSH users
     // need a temporary detour without marking required repo setup dismissed.
     onSettingsDetourStart?.()
+    // Why: keep the target in the store before the Settings view mounts. A
+    // timer here can run before the lazy view subscribes and strand users on
+    // the default General pane.
+    openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
     openSettingsPage()
-    // Why: Settings consumes navigation targets from its mounted view; defer
-    // until the view switch has committed so the SSH pane scroll is reliable.
-    window.setTimeout(() => {
-      openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
-    }, 0)
   }, [
     busyLabel,
     currentStep.id,

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -93,6 +93,64 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledWith('codex done')
   })
 
+  it('does not dispatch a cwd title after an explicit agent working title if the shell owns the pane', async () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult('zsh')),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeTitle('Codex working')
+    coordinator.observeTitle('/tmp/orca-e2e-repo')
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('prefers a later explicit completion title over a pending cwd title', async () => {
+    const inspection = createDeferred<RuntimeTerminalProcessInspection>()
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(() => inspection.promise),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeTitle('Codex working')
+    coordinator.observeTitle('/tmp/orca-e2e-repo')
+    coordinator.observeTitle('Codex done')
+    inspection.resolve(processResult('zsh'))
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    expect(dispatchCompletion).toHaveBeenCalledWith('Codex done')
+  })
+
+  it('still dispatches a generic completion title after process inspection confirms an agent', async () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult('codex')),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeTitle('Codex working')
+    coordinator.observeTitle('Fix flaky e2e tests')
+    await flushAsyncTicks()
+
+    expect(dispatchCompletion).toHaveBeenCalledWith('Fix flaky e2e tests')
+  })
+
   it('suppresses same-turn title completion after a hook completion already notified', () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -80,7 +80,6 @@ export function createAgentCompletionCoordinator(
   function establishAgentEvidence(): void {
     agentIdentityEstablished = true
     hasAgentRunEvidence = true
-    dispatchPendingTitleIfEligible()
   }
 
   function clearAgentRunEvidence(): void {
@@ -288,7 +287,10 @@ export function createAgentCompletionCoordinator(
   function observeTitle(title: string): void {
     const status = detectAgentStatusFromTitle(title)
     const isInconclusiveNativeDroidTitle = titleIsInconclusiveNativeDroidTitle(title)
-    if (titleHasExplicitAgentIdentity(title) && !isInconclusiveNativeDroidTitle) {
+    const hasExplicitAgentIdentity =
+      titleHasExplicitAgentIdentity(title) && !isInconclusiveNativeDroidTitle
+    const hadPendingTitle = pendingTitle !== null
+    if (hasExplicitAgentIdentity) {
       establishAgentEvidence()
     }
 
@@ -301,11 +303,24 @@ export function createAgentCompletionCoordinator(
         lastTitleStatus = status
         return
       }
+      if (status === null && !titleHasExplicitAgentIdentity(title)) {
+        // Why: shells commonly restore cwd titles right after a short printf
+        // command. Treat generic completion titles as provisional until process
+        // inspection proves an agent still owns the pane.
+        holdTitleCompletionPending(title)
+        lastTitleStatus = status
+        return
+      }
       if (agentIdentityEstablished && hasAgentRunEvidence) {
         dispatchCompletion('title', title)
       } else {
         holdTitleCompletionPending(title)
       }
+    } else if (hadPendingTitle && status !== null && hasExplicitAgentIdentity) {
+      // Why: a shell can briefly restore cwd between "Codex working" and
+      // "Codex done"; the later explicit agent completion is authoritative.
+      dropPendingTitle()
+      dispatchCompletion('title', title)
     }
     lastTitleStatus = status
   }

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -157,6 +157,15 @@ async function enableInlineAgentCards(page: Page): Promise<void> {
   })
 }
 
+async function enableActivityAgentsView(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const settings = await window.api.settings.set({ experimentalActivity: true })
+    // Why: these specs exercise the experimental Agents page. E2E profiles use
+    // production defaults, where the sidebar entry is hidden unless enabled.
+    window.__store?.setState({ settings })
+  })
+}
+
 async function clickWorkspaceCardAgentRow(page: Page, prompt: string): Promise<void> {
   const rowLabel = page
     .getByRole('group', { name: 'Agents' })
@@ -232,6 +241,7 @@ async function createTerminalInNewSplitGroup(page: Page): Promise<SplitGroupTerm
 test.describe('Activity Agent Pane Isolation', () => {
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
+    await enableActivityAgentsView(orcaPage)
     await waitForActiveWorktree(orcaPage)
     await ensureTerminalVisible(orcaPage)
     const hasPaneManager = await waitForActiveTerminalManager(orcaPage, 30_000)

--- a/tests/e2e/helpers/agent-hook-endpoint.ts
+++ b/tests/e2e/helpers/agent-hook-endpoint.ts
@@ -1,4 +1,4 @@
-import type { ElectronApplication } from '@stablyai/playwright-test'
+import { expect, type ElectronApplication } from '@stablyai/playwright-test'
 import { existsSync, readdirSync, readFileSync } from 'fs'
 import path from 'path'
 import {
@@ -30,7 +30,19 @@ function findEndpointEnvFile(root: string): string | null {
 export async function readHookEndpoint(app: ElectronApplication): Promise<AgentHookEndpoint> {
   const userDataPath = await app.evaluate(({ app: electronApp }) => electronApp.getPath('userData'))
   const hookRoot = path.join(userDataPath, 'agent-hooks')
-  const endpointPath = findEndpointEnvFile(hookRoot)
+  let endpointPath: string | null = null
+  await expect
+    .poll(
+      () => {
+        endpointPath = findEndpointEnvFile(hookRoot)
+        return endpointPath
+      },
+      {
+        timeout: 15_000,
+        message: `Agent hook endpoint file not found under ${hookRoot}`
+      }
+    )
+    .not.toBeNull()
   if (!endpointPath) {
     throw new Error(`Agent hook endpoint file not found under ${hookRoot}`)
   }

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -408,7 +408,7 @@ test.describe('Onboarding flow', () => {
     await expect(
       orcaPage
         .locator('[data-settings-section="ssh"]')
-        .getByRole('heading', { name: 'SSH', exact: true })
+        .getByRole('heading', { name: 'SSH Hosts', exact: true })
     ).toBeInViewport({ timeout: 10_000 })
     await expect(
       orcaPage.locator('[data-settings-section="ssh"]').getByRole('button', { name: /Add Target/i })

--- a/tests/e2e/settings-agent-awake.spec.ts
+++ b/tests/e2e/settings-agent-awake.spec.ts
@@ -1,22 +1,14 @@
 import { randomUUID } from 'crypto'
-import { existsSync, readFileSync } from 'fs'
-import path from 'path'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
 import type { GlobalSettings } from '../../src/shared/types'
+import { readHookEndpoint } from './helpers/agent-hook-endpoint'
 
 type AwakeProbeSnapshot = {
   starts: { type: string; id: number }[]
   stops: { id: number }[]
   activeIds: number[]
-}
-
-type HookEndpoint = {
-  port: string
-  token: string
-  env: string
-  version: string
 }
 
 async function getSettings(page: Page): Promise<GlobalSettings> {
@@ -112,47 +104,6 @@ async function readPowerSaveBlockerProbe(
   })
 }
 
-function parseEndpointFile(contents: string): HookEndpoint {
-  const values: Record<string, string> = {}
-  for (const line of contents.split(/\r?\n/)) {
-    const normalized = line.startsWith('set ') ? line.slice(4) : line
-    const separatorIndex = normalized.indexOf('=')
-    if (separatorIndex <= 0) {
-      continue
-    }
-    values[normalized.slice(0, separatorIndex)] = normalized.slice(separatorIndex + 1)
-  }
-  return {
-    port: values.ORCA_AGENT_HOOK_PORT ?? '',
-    token: values.ORCA_AGENT_HOOK_TOKEN ?? '',
-    env: values.ORCA_AGENT_HOOK_ENV ?? '',
-    version: values.ORCA_AGENT_HOOK_VERSION ?? ''
-  }
-}
-
-async function readAgentHookEndpoint(electronApp: ElectronApplication): Promise<HookEndpoint> {
-  const userDataPath = await electronApp.evaluate(({ app }) => app.getPath('userData'))
-  const endpointFilePath = path.join(
-    userDataPath,
-    'agent-hooks',
-    process.platform === 'win32' ? 'endpoint.cmd' : 'endpoint.env'
-  )
-
-  await expect
-    .poll(() => existsSync(endpointFilePath), {
-      timeout: 10_000,
-      message: 'agent hook endpoint file was not written'
-    })
-    .toBe(true)
-
-  const endpoint = parseEndpointFile(readFileSync(endpointFilePath, 'utf8'))
-  expect(endpoint.port).toBeTruthy()
-  expect(endpoint.token).toBeTruthy()
-  expect(endpoint.env).toBeTruthy()
-  expect(endpoint.version).toBeTruthy()
-  return endpoint
-}
-
 async function postCodexHookEvent(
   electronApp: ElectronApplication,
   options: {
@@ -161,7 +112,7 @@ async function postCodexHookEvent(
     eventName: 'UserPromptSubmit' | 'Stop'
   }
 ): Promise<void> {
-  const endpoint = await readAgentHookEndpoint(electronApp)
+  const endpoint = await readHookEndpoint(electronApp)
   const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/codex`, {
     method: 'POST',
     headers: {

--- a/tests/e2e/source-control-create-pr.spec.ts
+++ b/tests/e2e/source-control-create-pr.spec.ts
@@ -14,12 +14,36 @@ type CreatePRPayload = {
   }
 }
 
-async function openSourceControl(page: Page): Promise<void> {
-  await page.evaluate(() => {
+async function openSourceControl(page: Page, expectedWorktreeId: string): Promise<void> {
+  await page.evaluate((expectedWorktreeId) => {
     const state = window.__store?.getState()
+    if (state && state.activeWorktreeId !== expectedWorktreeId) {
+      state.setActiveWorktree(expectedWorktreeId)
+    }
     state?.setRightSidebarOpen(true)
     state?.setRightSidebarTab('source-control')
-  })
+  }, expectedWorktreeId)
+  await expect
+    .poll(
+      async () =>
+        page.evaluate((expectedWorktreeId) => {
+          const state = window.__store?.getState()
+          if (!state) {
+            return false
+          }
+          const activeWorktree = Object.values(state.worktreesByRepo)
+            .flat()
+            .some((entry) => entry.id === expectedWorktreeId)
+          return (
+            activeWorktree &&
+            state.activeWorktreeId === expectedWorktreeId &&
+            state.rightSidebarOpen &&
+            state.rightSidebarTab === 'source-control'
+          )
+        }, expectedWorktreeId),
+      { timeout: 5_000 }
+    )
+    .toBe(true)
   await expect(page.getByRole('button', { name: /Source Control/ })).toBeVisible()
   await expect(page.getByRole('textbox', { name: 'Commit message' })).toBeVisible()
 }
@@ -60,16 +84,18 @@ async function seedCreatePREligibleBranch(
     const worktrees = Object.values(state.worktreesByRepo).flat()
     const activeWorktree = worktrees.find((entry) => entry.id === worktreeId)
     const worktree =
+      worktrees.find((entry) => entry.branch.replace(/^refs\/heads\//, '') === 'e2e-secondary') ??
       worktrees.find((entry) => {
         const branchName = entry.branch.replace(/^refs\/heads\//, '')
         return branchName !== 'main' && !entry.isMainWorktree
-      }) ?? activeWorktree
+      }) ??
+      activeWorktree
     if (!worktree) {
       throw new Error('active worktree not found')
     }
-    if (state.activeWorktreeId !== worktree.id) {
-      state.setActiveWorktree(worktree.id)
-    }
+    // Why: the worker-scoped test repo can accumulate extra non-main
+    // worktrees; use the seeded secondary worktree as the stable PR target.
+    state.setActiveWorktree(worktree.id)
     const repo = state.repos.find((entry) => entry.id === worktree.repoId)
     if (!repo) {
       throw new Error('active repo not found')
@@ -165,7 +191,7 @@ test.describe('Source Control create pull request', () => {
     orcaPage
   }) => {
     const { branch, worktreeId } = await seedCreatePREligibleBranch(orcaPage)
-    await openSourceControl(orcaPage)
+    await openSourceControl(orcaPage, worktreeId)
     await forceCreatePREligibleStatus(orcaPage, worktreeId, branch)
 
     const createButton = orcaPage.getByRole('button', { name: 'Create PR' })

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -282,6 +282,9 @@ test.describe('Tab Rename (Inline)', () => {
 
   test('rename input stays at a usable width when many tabs are open', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
+    const targetTabId = await getActiveTabId(orcaPage)
+    expect(targetTabId).not.toBeNull()
+    const targetTitle = 'Width Target Tab'
 
     // Why: create enough terminal tabs that flex space runs out. 15 is well
     // above the threshold at which the pre-fix input collapsed, and it keeps
@@ -290,23 +293,37 @@ test.describe('Tab Rename (Inline)', () => {
     // size — we assert ≥60px to allow a bit of slack for fonts/padding/
     // containers differing between environments. The meaningful guarantee is
     // that the input does not collapse to ~0 when flex space is saturated.
-    await orcaPage.evaluate((targetWorktreeId) => {
-      const store = window.__store
-      if (!store) {
-        return
-      }
-      const state = store.getState()
-      const existing = (state.tabsByWorktree[targetWorktreeId] ?? []).length
-      for (let i = existing; i < 15; i++) {
-        state.createTab(targetWorktreeId, undefined, undefined, { activate: false })
-      }
-    }, worktreeId)
+    await orcaPage.evaluate(
+      ({ targetWorktreeId, targetTabId, targetTitle }) => {
+        const store = window.__store
+        if (!store) {
+          return
+        }
+        const state = store.getState()
+        const existing = state.tabsByWorktree[targetWorktreeId] ?? []
+        for (const [index, tab] of existing.entries()) {
+          // Why: shell-driven terminal title updates can race this crowded-tab
+          // assertion; custom titles keep the rename target stable.
+          state.setTabCustomTitle(
+            tab.id,
+            tab.id === targetTabId ? targetTitle : `Width Filler ${index + 1}`
+          )
+        }
+        for (let i = existing.length; i < 15; i++) {
+          const tab = state.createTab(targetWorktreeId, undefined, undefined, { activate: false })
+          state.setTabCustomTitle(tab.id, `Width Filler ${i + 1}`)
+        }
+      },
+      { targetWorktreeId: worktreeId, targetTabId, targetTitle }
+    )
 
     await expect
       .poll(async () => (await getWorktreeTabs(orcaPage, worktreeId)).length, { timeout: 5_000 })
       .toBeGreaterThanOrEqual(15)
+    await expect
+      .poll(async () => getActiveCustomTitle(orcaPage, worktreeId), { timeout: 3_000 })
+      .toBe(targetTitle)
 
-    const targetTitle = await getActiveTabTitle(orcaPage, worktreeId)
     const tabLocator = tabLocatorByTitle(orcaPage, targetTitle)
     await tabLocator.scrollIntoViewIfNeeded()
     await expect(tabLocator).toBeVisible()


### PR DESCRIPTION
## Summary
- Enable the experimental Agents view in activity e2e setup and make hook endpoint reads recursive/polled.
- Make onboarding SSH settings target deterministic and harden Source Control PR/tab rename specs against shared test repo and shell title churn.
- Fix task-complete notification detection so transient cwd titles cannot win over explicit agent completion titles.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
- pnpm exec electron-vite build --mode e2e
- CI=true SKIP_BUILD=1 pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless --repeat-each=3 tests/e2e/activity-agent-pane-isolation.spec.ts tests/e2e/droid-notification.spec.ts tests/e2e/onboarding.spec.ts tests/e2e/settings-agent-awake.spec.ts tests/e2e/tab-rename.spec.ts tests/e2e/terminal-shortcuts.spec.ts
- CI=true SKIP_BUILD=1 pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless --repeat-each=5 tests/e2e/droid-notification.spec.ts
- CI=true SKIP_BUILD=1 pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless --repeat-each=5 tests/e2e/source-control-create-pr.spec.ts
- pnpm run tc
- pnpm run lint
- git diff --check
- CI=true SKIP_BUILD=1 pnpm run test:e2e