### PR TITLE
Filter SIGTERM process teardown crash reports

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -10,6 +10,7 @@ describe('shouldRecordProcessGoneCrash', () => {
       shouldRecordProcessGoneCrash({
         source: 'renderer',
         reason: 'killed',
+        exitCode: 15,
         expectedTeardown: 'renderer-reload'
       })
     ).toBe(false)
@@ -17,6 +18,7 @@ describe('shouldRecordProcessGoneCrash', () => {
       shouldRecordProcessGoneCrash({
         source: 'child',
         reason: 'killed',
+        exitCode: 15,
         expectedTeardown: 'app-shutdown'
       })
     ).toBe(false)
@@ -27,6 +29,7 @@ describe('shouldRecordProcessGoneCrash', () => {
       shouldRecordProcessGoneCrash({
         source: 'renderer',
         reason: 'crashed',
+        exitCode: 5,
         expectedTeardown: 'renderer-reload'
       })
     ).toBe(true)
@@ -34,26 +37,40 @@ describe('shouldRecordProcessGoneCrash', () => {
       shouldRecordProcessGoneCrash({
         source: 'renderer',
         reason: 'oom',
+        exitCode: null,
         expectedTeardown: 'renderer-reload'
       })
     ).toBe(true)
   })
 
-  it('records killed process exits outside expected lifecycle teardown', () => {
+  it('skips SIGTERM killed events outside expected lifecycle teardown', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'renderer',
         reason: 'killed',
+        exitCode: 15,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+  })
+
+  it('records non-SIGTERM killed process exits outside expected lifecycle teardown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: 'killed',
+        exitCode: 9,
         expectedTeardown: 'none'
       })
     ).toBe(true)
   })
 
-  it('records child-process killed events during renderer-only reloads', () => {
+  it('records non-SIGTERM child-process killed events during renderer-only reloads', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'child',
         reason: 'killed',
+        exitCode: 9,
         expectedTeardown: 'renderer-reload'
       })
     ).toBe(true)

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -4,16 +4,23 @@ export type ExpectedTeardownScope = 'none' | 'renderer-reload' | 'app-shutdown'
 export function shouldRecordProcessGoneCrash({
   source,
   reason,
+  exitCode,
   expectedTeardown
 }: {
   source: ProcessGoneSource
   reason: string
+  exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
 }): boolean {
   // Why: Electron reports intentional reload/update/quit teardown as `killed`.
   // Real renderer OOMs and Chromium crashes should still reach crash reporting.
   if (reason !== 'killed') {
     return true
+  }
+  // Why: Electron reports expected Chromium teardown during reload/update as
+  // `killed` + SIGTERM. Treat real crash reasons as reportable, but skip this.
+  if (exitCode === 15) {
+    return false
   }
   if (expectedTeardown === 'app-shutdown') {
     return false

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -323,6 +323,7 @@ function openMainWindow(): BrowserWindow {
       shouldRecordProcessGoneCrash({
         source: 'renderer',
         reason: details.reason,
+        exitCode: details.exitCode ?? null,
         expectedTeardown: getExpectedTeardownScope(webContentsId)
       }),
     shouldRecoverRenderer: (details, webContentsId) =>
@@ -498,6 +499,7 @@ function recordProcessGoneCrash(
     !shouldRecordProcessGoneCrash({
       source,
       reason,
+      exitCode,
       expectedTeardown: getExpectedTeardownScope(webContentsId)
     })
   ) {


### PR DESCRIPTION
## Summary
- add a central process-gone crash-report filter
- skip reports during normal quit/update shutdown
- skip Electron `killed` + exit 15 SIGTERM teardown events while preserving real crash reasons

## Repro / validation
- Launched Orca dev with a fresh userData profile via `$electron`/CDP
- Sent SIGTERM to the launched renderer process and observed: `Renderer process gone ... { reason: 'killed', exitCode: 15 }`
- Confirmed no `crash-reports.json` was written after the filter

## Tests
- `pnpm vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-filter.test.ts`
- `pnpm run typecheck:node`

Made with [Orca](https://github.com/stablyai/orca) 🐋
