### PR TITLE
Add xterm write flow control

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -142,6 +142,44 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     })
   })
 
+  describe('acknowledgeDataEvent', () => {
+    it('drops ACKs during recovery while still queueing durable writes', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      const never = new Promise<void>(() => {})
+      const internals = adapter as unknown as {
+        recoveryPromise: Promise<void> | null
+        pendingNotifications: unknown[]
+      }
+
+      internals.recoveryPromise = never
+      adapter.acknowledgeDataEvent(id, 123)
+      adapter.write(id, 'durable\n')
+
+      expect(internals.pendingNotifications).toEqual([
+        { type: 'write', payload: { sessionId: id, data: 'durable\n' } }
+      ])
+      internals.recoveryPromise = null
+    })
+
+    it('does not queue ACKs when notification delivery fails', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      const internals = adapter as unknown as {
+        client: { notify: (type: string, payload: unknown) => boolean }
+        pendingNotifications: unknown[]
+      }
+      const notifySpy = vi.spyOn(internals.client, 'notify').mockReturnValue(false)
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        adapter.acknowledgeDataEvent(id, 123)
+
+        expect(internals.pendingNotifications).toEqual([])
+      } finally {
+        notifySpy.mockRestore()
+        warn.mockRestore()
+      }
+    })
+  })
+
   describe('shutdown', () => {
     it('kills the session', async () => {
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -34,7 +34,7 @@ const MAX_TOMBSTONES = 1000
 const MAX_PENDING_DAEMON_NOTIFICATIONS = 512
 
 type PendingDaemonNotification = {
-  type: 'write' | 'resize' | 'acknowledgeDataEvent'
+  type: 'write' | 'resize'
   payload: unknown
 }
 
@@ -320,7 +320,18 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   acknowledgeDataEvent(id: string, charCount: number): void {
-    this.sendNotification('acknowledgeDataEvent', { sessionId: id, charCount })
+    if (charCount <= 0 || this.recoveryPromise) {
+      return
+    }
+    if (this.client.notify('acknowledgeDataEvent', { sessionId: id, charCount })) {
+      return
+    }
+    // Why: ACKs describe bytes parsed by the currently attached stream. After
+    // a stream failure/recovery they are stale, so trigger recovery but never
+    // queue/replay them like durable write/resize notifications.
+    void this.recoverActiveSessionsAfterDisconnect().catch((err) =>
+      console.warn('[daemon] reconnect after acknowledgement failure failed:', err)
+    )
   }
 
   async hasChildProcesses(_id: string): Promise<boolean> {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -34,7 +34,7 @@ const MAX_TOMBSTONES = 1000
 const MAX_PENDING_DAEMON_NOTIFICATIONS = 512
 
 type PendingDaemonNotification = {
-  type: 'write' | 'resize'
+  type: 'write' | 'resize' | 'acknowledgeDataEvent'
   payload: unknown
 }
 
@@ -319,8 +319,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.markSessionDirty(id)
   }
 
-  acknowledgeDataEvent(_id: string, _charCount: number): void {
-    // No flow control for daemon-backed terminals
+  acknowledgeDataEvent(id: string, charCount: number): void {
+    this.sendNotification('acknowledgeDataEvent', { sessionId: id, charCount })
   }
 
   async hasChildProcesses(_id: string): Promise<boolean> {

--- a/src/main/daemon/daemon-pty-provider.ts
+++ b/src/main/daemon/daemon-pty-provider.ts
@@ -62,6 +62,10 @@ export class DaemonPtyProvider {
     this.client.notify('resize', { sessionId: id, cols, rows })
   }
 
+  acknowledgeDataEvent(id: string, charCount: number): void {
+    this.client.notify('acknowledgeDataEvent', { sessionId: id, charCount })
+  }
+
   async shutdown(id: string, _opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
     await this.client.request('kill', { sessionId: id })
   }

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -13,23 +13,39 @@ function createTestDir(): string {
   return mkdtempSync(join(tmpdir(), 'daemon-server-test-'))
 }
 
-function createMockSubprocess(): SubprocessHandle {
+type MockSubprocess = Omit<SubprocessHandle, 'pause' | 'resume'> & {
+  pause: ReturnType<typeof vi.fn<() => void>>
+  resume: ReturnType<typeof vi.fn<() => void>>
+  simulateData(data: string): void
+}
+
+let spawnedSubprocesses: MockSubprocess[] = []
+
+function createMockSubprocess(): MockSubprocess {
+  let onDataCb: ((data: string) => void) | null = null
   let onExitCb: ((code: number) => void) | null = null
-  return {
+  const subprocess: MockSubprocess = {
     pid: 55555,
     write: vi.fn(),
     resize: vi.fn(),
+    pause: vi.fn<() => void>(),
+    resume: vi.fn<() => void>(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
     forceKill: vi.fn(),
     signal: vi.fn(),
-    onData(_cb) {
-      /* stored for future tests */
+    onData(cb) {
+      onDataCb = cb
     },
     onExit(cb) {
       onExitCb = cb
     },
-    dispose: vi.fn()
+    dispose: vi.fn(),
+    simulateData(data: string) {
+      onDataCb?.(data)
+    }
   }
+  spawnedSubprocesses.push(subprocess)
+  return subprocess
 }
 
 describe('DaemonServer', () => {
@@ -43,6 +59,7 @@ describe('DaemonServer', () => {
     dir = createTestDir()
     socketPath = join(dir, 'test.sock')
     tokenPath = join(dir, 'test.token')
+    spawnedSubprocesses = []
   })
 
   afterEach(async () => {
@@ -129,6 +146,26 @@ describe('DaemonServer', () => {
         isNew: true,
         pid: 55555
       })
+    })
+
+    it('detaches sessions and clears flow control when a client disconnects', async () => {
+      await startServer()
+      const c = await connectClient()
+
+      await c.request('createOrAttach', {
+        sessionId: 'test-session',
+        cols: 80,
+        rows: 24
+      })
+
+      const subprocess = spawnedSubprocesses[0]
+      subprocess.simulateData('x'.repeat(100_001))
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+
+      c.disconnect()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
     })
 
     it('handles listSessions', async () => {

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: daemon RPC routing and stream lifecycle
+tests share socket/client setup that is easiest to audit in one harness. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connect, type Socket } from 'net'
 import { tmpdir } from 'os'
@@ -68,11 +70,13 @@ describe('DaemonServer', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  async function startServer(): Promise<void> {
+  async function startServer(
+    spawnSubprocess = (): MockSubprocess => createMockSubprocess()
+  ): Promise<void> {
     server = new DaemonServer({
       socketPath,
       tokenPath,
-      spawnSubprocess: () => createMockSubprocess()
+      spawnSubprocess
     })
     await server.start()
   }
@@ -166,6 +170,161 @@ describe('DaemonServer', () => {
       await new Promise((resolve) => setTimeout(resolve, 20))
 
       expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps daemon flow-control ACK debt per connected client', async () => {
+      await startServer()
+      const firstClient = new DaemonClient({ socketPath, tokenPath })
+      const secondClient = new DaemonClient({ socketPath, tokenPath })
+      try {
+        await firstClient.ensureConnected()
+        await secondClient.ensureConnected()
+
+        await firstClient.request('createOrAttach', {
+          sessionId: 'test-session',
+          cols: 80,
+          rows: 24
+        })
+        await secondClient.request('createOrAttach', {
+          sessionId: 'test-session',
+          cols: 80,
+          rows: 24
+        })
+
+        const subprocess = spawnedSubprocesses[0]
+        subprocess.simulateData('x'.repeat(100_001))
+        expect(subprocess.pause).toHaveBeenCalledTimes(1)
+
+        expect(
+          firstClient.notify('acknowledgeDataEvent', {
+            sessionId: 'test-session',
+            charCount: 100_001
+          })
+        ).toBe(true)
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        expect(subprocess.resume).not.toHaveBeenCalled()
+
+        expect(
+          secondClient.notify('acknowledgeDataEvent', {
+            sessionId: 'test-session',
+            charCount: 100_001
+          })
+        ).toBe(true)
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        expect(subprocess.resume).toHaveBeenCalledTimes(1)
+      } finally {
+        firstClient.disconnect()
+        secondClient.disconnect()
+      }
+    })
+
+    it('detaches sessions when the stream socket closes but control remains open', async () => {
+      await startServer()
+      const c = await connectClient()
+
+      await c.request('createOrAttach', {
+        sessionId: 'test-session',
+        cols: 80,
+        rows: 24
+      })
+
+      const streamSocket = (c as unknown as { streamSocket: Socket | null }).streamSocket
+      streamSocket?.destroy()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      const subprocess = spawnedSubprocesses[0]
+      subprocess.simulateData('x'.repeat(100_001))
+
+      expect(subprocess.pause).not.toHaveBeenCalled()
+    })
+
+    it('detaches a session if the stream socket closes during createOrAttach', async () => {
+      await startServer(() => {
+        const clientRecord = (
+          server as unknown as {
+            clients: Map<string, { streamSocket: Socket | null }>
+          }
+        ).clients.get('stale-during-attach')
+        clientRecord?.streamSocket?.destroy()
+        return createMockSubprocess()
+      })
+      const control = await connectRawSocket('control', 'stale-during-attach')
+      const stream = await connectRawSocket('stream', 'stale-during-attach')
+      try {
+        control.write(
+          encodeNdjson({
+            id: 'req-attach',
+            type: 'createOrAttach',
+            payload: { sessionId: 'test-session', cols: 80, rows: 24 }
+          })
+        )
+
+        await expect(readSocketLine(control)).resolves.toContain('Client stream disconnected')
+
+        const subprocess = spawnedSubprocesses[0]
+        subprocess.simulateData('x'.repeat(100_001))
+        expect(subprocess.pause).not.toHaveBeenCalled()
+      } finally {
+        stream.destroy()
+        control.destroy()
+      }
+    })
+
+    it('disconnects a client and resumes paused PTYs when stream writes throw', async () => {
+      await startServer()
+      const c = await connectClient()
+      const clientId = (c as unknown as { clientId: string }).clientId
+
+      await c.request('createOrAttach', {
+        sessionId: 'test-session',
+        cols: 80,
+        rows: 24
+      })
+
+      const clientRecord = (
+        server as unknown as {
+          clients: Map<
+            string,
+            { streamSocket: (Socket & { write: ReturnType<typeof vi.fn> }) | null }
+          >
+        }
+      ).clients.get(clientId)
+      if (!clientRecord?.streamSocket) {
+        throw new Error('missing daemon stream socket')
+      }
+      vi.spyOn(clientRecord.streamSocket, 'write').mockImplementation(() => {
+        throw new Error('stream write failed')
+      })
+
+      const subprocess = spawnedSubprocesses[0]
+      subprocess.simulateData('x'.repeat(100_001))
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+      expect((server as unknown as { clients: Map<string, unknown> }).clients.has(clientId)).toBe(
+        false
+      )
+    })
+
+    it('rejects session attachment when the client has no stream socket', async () => {
+      await startServer()
+      const control = await connectRawSocket('control', 'raw-client-without-stream')
+      try {
+        control.write(
+          encodeNdjson({
+            id: 'req-attach',
+            type: 'createOrAttach',
+            payload: { sessionId: 'test-session', cols: 80, rows: 24 }
+          })
+        )
+
+        await expect(readSocketLine(control)).resolves.toContain('Stream socket is not connected')
+        expect(spawnedSubprocesses).toHaveLength(0)
+      } finally {
+        control.destroy()
+      }
     })
 
     it('handles listSessions', async () => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: daemon socket routing, client/session
+ownership, and stream cleanup share lifecycle state and must stay auditable. */
 import { createServer, type Server, type Socket } from 'net'
 import { randomUUID } from 'crypto'
 import { writeFileSync, chmodSync, unlinkSync } from 'fs'
@@ -31,6 +33,7 @@ type ConnectedClient = {
   clientId: string
   controlSocket: Socket
   streamSocket: Socket | null
+  attachTokens: Map<string, symbol>
 }
 
 export class DaemonServer {
@@ -143,7 +146,8 @@ export class DaemonServer {
       const client: ConnectedClient = {
         clientId: hello.clientId,
         controlSocket: socket,
-        streamSocket: null
+        streamSocket: null,
+        attachTokens: new Map()
       }
       this.clients.set(hello.clientId, client)
       this.setupControlSocket(socket, hello.clientId)
@@ -229,6 +233,11 @@ export class DaemonServer {
             }
           }
         })
+        const existingToken = client?.attachTokens.get(p.sessionId)
+        if (existingToken) {
+          this.host.detach(p.sessionId, existingToken)
+        }
+        client?.attachTokens.set(p.sessionId, result.attachToken)
         return {
           isNew: result.isNew,
           snapshot: result.snapshot,
@@ -278,8 +287,13 @@ export class DaemonServer {
         return {}
 
       case 'detach':
-        // Note: detach token handling is simplified here — full implementation
-        // would track tokens per client
+        {
+          const token = client?.attachTokens.get(request.payload.sessionId)
+          if (token) {
+            this.host.detach(request.payload.sessionId, token)
+            client?.attachTokens.delete(request.payload.sessionId)
+          }
+        }
         return {}
 
       case 'getCwd':
@@ -331,6 +345,12 @@ export class DaemonServer {
     }
     this.streamDataBatcher.clear(clientId)
     this.clients.delete(clientId)
+    if (client) {
+      for (const [sessionId, token] of client.attachTokens) {
+        this.host.detach(sessionId, token)
+      }
+      client.attachTokens.clear()
+    }
     client?.streamSocket?.destroy()
     client?.controlSocket.destroy()
   }

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -157,6 +157,7 @@ export class DaemonServer {
         this.streamDataBatcher.clear(hello.clientId)
         client.streamSocket?.destroy()
         client.streamSocket = socket
+        this.setupStreamSocket(socket, hello.clientId)
       }
       // Stream socket is receive-only from daemon's perspective (for events)
     }
@@ -177,6 +178,18 @@ export class DaemonServer {
       if (client?.controlSocket === socket) {
         this.disconnectClient(clientId, client)
       }
+    })
+  }
+
+  private setupStreamSocket(socket: Socket, clientId: string): void {
+    socket.on('close', () => {
+      const client = this.clients.get(clientId)
+      if (client?.streamSocket === socket) {
+        this.disconnectClient(clientId, client)
+      }
+    })
+    socket.on('error', () => {
+      socket.destroy()
     })
   }
 
@@ -210,6 +223,10 @@ export class DaemonServer {
 
     switch (request.type) {
       case 'createOrAttach': {
+        if (!client?.streamSocket || client.streamSocket.destroyed) {
+          throw new Error('Stream socket is not connected')
+        }
+        const streamSocket = client.streamSocket
         const p = request.payload
         const result = await this.host.createOrAttach({
           sessionId: p.sessionId,
@@ -233,6 +250,14 @@ export class DaemonServer {
             }
           }
         })
+        if (
+          this.clients.get(clientId) !== client ||
+          client.streamSocket !== streamSocket ||
+          streamSocket.destroyed
+        ) {
+          this.host.detach(p.sessionId, result.attachToken)
+          throw new Error('Client stream disconnected')
+        }
         const existingToken = client?.attachTokens.get(p.sessionId)
         if (existingToken) {
           this.host.detach(p.sessionId, existingToken)
@@ -270,7 +295,14 @@ export class DaemonServer {
 
       case 'acknowledgeDataEvent':
         try {
-          this.host.acknowledgeDataEvent(request.payload.sessionId, request.payload.charCount)
+          const token = client?.attachTokens.get(request.payload.sessionId)
+          if (token) {
+            this.host.acknowledgeDataEvent(
+              request.payload.sessionId,
+              token,
+              request.payload.charCount
+            )
+          }
         } catch (err) {
           if (!(err instanceof SessionNotFoundError)) {
             throw err

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -259,6 +259,16 @@ export class DaemonServer {
         }
         return {}
 
+      case 'acknowledgeDataEvent':
+        try {
+          this.host.acknowledgeDataEvent(request.payload.sessionId, request.payload.charCount)
+        } catch (err) {
+          if (!(err instanceof SessionNotFoundError)) {
+            throw err
+          }
+        }
+        return {}
+
       case 'kill':
         this.host.kill(request.payload.sessionId)
         return {}

--- a/src/main/daemon/daemon-stream-data-batcher.test.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.test.ts
@@ -172,6 +172,33 @@ describe('DaemonStreamDataBatcher', () => {
     expect(fake.write.mock.calls[1]?.[0]).toContain('second')
   })
 
+  it('fails the stream when socket write throws synchronously', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const fake = createFakeSocket([true])
+      const writeError = new Error('socket is not writable')
+      fake.write.mockImplementation(() => {
+        throw writeError
+      })
+      const onStreamFailure = vi.fn()
+      const batcher = new DaemonStreamDataBatcher(() => ({ streamSocket: fake.socket }), {
+        onStreamFailure
+      })
+
+      batcher.enqueue('client-1', 'session-a', 'first')
+      batcher.flush('client-1')
+
+      expect(onStreamFailure).toHaveBeenCalledWith('client-1')
+      expect(warn).toHaveBeenCalledWith(
+        '[daemon] PTY stream socket write failed',
+        expect.objectContaining({ clientId: 'client-1', error: writeError.message })
+      )
+      expect(fake.write).toHaveBeenCalledTimes(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('queues additional output while waiting for drain', () => {
     const fake = createFakeSocket([false, true])
     const batcher = new DaemonStreamDataBatcher(() => ({ streamSocket: fake.socket }))

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -159,7 +159,17 @@ export class DaemonStreamDataBatcher {
               sessionId: entry.sessionId,
               payload: { code: entry.code }
             }
-      const ok = streamSocket.write(encodeNdjson(payload))
+      let ok: boolean
+      try {
+        ok = streamSocket.write(encodeNdjson(payload))
+      } catch (err) {
+        console.warn('[daemon] PTY stream socket write failed', {
+          clientId,
+          error: err instanceof Error ? err.message : String(err)
+        })
+        this.failStream(clientId)
+        return
+      }
       if (!ok) {
         batch.waitingForDrain = true
         this.compactQueue(batch)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: subprocess spawn, Windows shell parity, and
+native PTY teardown hazards need to stay co-located for safe lifecycle changes. */
 import * as pty from 'node-pty'
 import { statSync } from 'fs'
 import { win32 as pathWin32 } from 'path'
@@ -301,6 +303,26 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       }
       try {
         proc.resize(cols, rows)
+      } catch {
+        dead = true
+      }
+    },
+    pause: () => {
+      if (dead) {
+        return
+      }
+      try {
+        proc.pause()
+      } catch {
+        dead = true
+      }
+    },
+    resume: () => {
+      if (dead) {
+        return
+      }
+      try {
+        proc.resume()
       } catch {
         dead = true
       }

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -172,6 +172,29 @@ describe('Session', () => {
 
       expect(subprocess.pause).not.toHaveBeenCalled()
     })
+
+    it('resumes and clears flow control when the last client detaches', () => {
+      createSession()
+      const token = session.attachClient({ onData: () => {}, onExit: () => {} })
+      subprocess.simulateData('x'.repeat(100_001))
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+
+      session.detachClient(token)
+
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
+
+    it('resumes and clears flow control when all clients detach', () => {
+      createSession()
+      session.attachClient({ onData: () => {}, onExit: () => {} })
+      session.attachClient({ onData: () => {}, onExit: () => {} })
+      subprocess.simulateData('x'.repeat(100_001))
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+
+      session.detachAllClients()
+
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('write', () => {

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -156,12 +156,69 @@ describe('Session', () => {
 
     it('pauses and resumes output from renderer parse acknowledgements', () => {
       createSession()
-      session.attachClient({ onData: () => {}, onExit: () => {} })
+      const token = session.attachClient({ onData: () => {}, onExit: () => {} })
       subprocess.simulateData('x'.repeat(100_001))
 
       expect(subprocess.pause).toHaveBeenCalledTimes(1)
       expect(subprocess.resume).not.toHaveBeenCalled()
-      session.acknowledgeDataEvent(95_002)
+      session.acknowledgeDataEvent(token, 95_002)
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
+
+    it('waits for every attached client to acknowledge its own delivered bytes', () => {
+      createSession()
+      const token1 = session.attachClient({ onData: () => {}, onExit: () => {} })
+      const token2 = session.attachClient({ onData: () => {}, onExit: () => {} })
+      subprocess.simulateData('x'.repeat(100_001))
+
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+
+      session.acknowledgeDataEvent(token1, 100_001)
+      expect(subprocess.resume).not.toHaveBeenCalled()
+
+      session.acknowledgeDataEvent(token2, 100_001)
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses per-client watermarks so healthy attached clients do not lower the pause threshold', () => {
+      createSession()
+      session.attachClient({ onData: () => {}, onExit: () => {} })
+      session.attachClient({ onData: () => {}, onExit: () => {} })
+
+      subprocess.simulateData('x'.repeat(60_000))
+
+      expect(subprocess.pause).not.toHaveBeenCalled()
+    })
+
+    it('does not keep phantom debt for clients detached during data broadcast', () => {
+      createSession()
+      let token2!: symbol
+      const token1 = session.attachClient({
+        onData: () => session.detachClient(token2),
+        onExit: () => {}
+      })
+      const secondClientData = vi.fn()
+      token2 = session.attachClient({ onData: secondClientData, onExit: () => {} })
+
+      subprocess.simulateData('x'.repeat(100_001))
+
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+      expect(secondClientData).not.toHaveBeenCalled()
+
+      session.acknowledgeDataEvent(token1, 100_001)
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
+
+    it('resumes when the only slow attached client detaches', () => {
+      createSession()
+      const token1 = session.attachClient({ onData: () => {}, onExit: () => {} })
+      const token2 = session.attachClient({ onData: () => {}, onExit: () => {} })
+      subprocess.simulateData('x'.repeat(100_001))
+
+      session.acknowledgeDataEvent(token1, 100_001)
+      expect(subprocess.resume).not.toHaveBeenCalled()
+
+      session.detachClient(token2)
       expect(subprocess.resume).toHaveBeenCalledTimes(1)
     })
 

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: Session state, flow-control, and teardown
+tests share one subprocess harness and are easier to audit together. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Session } from './session'
 import type { SessionState, ShellReadyState } from './types'
@@ -6,6 +8,8 @@ import type { SessionState, ShellReadyState } from './types'
 function createMockSubprocess() {
   const written: string[] = []
   const signals: string[] = []
+  const pause = vi.fn()
+  const resume = vi.fn()
   let onData: ((data: string) => void) | null = null
   let onExit: ((code: number) => void) | null = null
   let killed = false
@@ -24,6 +28,8 @@ function createMockSubprocess() {
       written.push(data)
     },
     resize(_cols: number, _rows: number) {},
+    pause,
+    resume,
     kill() {
       killed = true
       // Simulate async exit
@@ -146,6 +152,25 @@ describe('Session', () => {
       subprocess.simulateData('broadcast')
       expect(received1).toEqual(['broadcast'])
       expect(received2).toEqual(['broadcast'])
+    })
+
+    it('pauses and resumes output from renderer parse acknowledgements', () => {
+      createSession()
+      session.attachClient({ onData: () => {}, onExit: () => {} })
+      subprocess.simulateData('x'.repeat(100_001))
+
+      expect(subprocess.pause).toHaveBeenCalledTimes(1)
+      expect(subprocess.resume).not.toHaveBeenCalled()
+      session.acknowledgeDataEvent(95_002)
+      expect(subprocess.resume).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not pause waiting for renderer acknowledgements when no client is attached', () => {
+      createSession()
+
+      subprocess.simulateData('x'.repeat(100_001))
+
+      expect(subprocess.pause).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -190,10 +190,14 @@ export class Session {
     if (idx !== -1) {
       this.attachedClients.splice(idx, 1)
     }
+    if (this.attachedClients.length === 0) {
+      this.clearFlowControlState()
+    }
   }
 
   detachAllClients(): void {
     this.attachedClients.length = 0
+    this.clearFlowControlState()
   }
 
   getSnapshot(): TerminalSnapshot | null {
@@ -357,6 +361,19 @@ export class Session {
       this.subprocess.pause()
       this.subprocessPaused = true
     }
+  }
+
+  private clearFlowControlState(): void {
+    this.unacknowledgedChars = 0
+    if (
+      this.subprocessPaused &&
+      !this._disposed &&
+      this._state !== 'exited' &&
+      this.subprocess.resume
+    ) {
+      this.subprocess.resume()
+    }
+    this.subprocessPaused = false
   }
 
   private handleSubprocessExit(code: number): void {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -54,7 +54,7 @@ export class Session {
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
   private markerBuffer = ''
-  private unacknowledgedChars = 0
+  private unacknowledgedCharsByClient = new Map<symbol, number>()
   private subprocessPaused = false
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
@@ -140,21 +140,21 @@ export class Session {
     this.subprocess.resize(cols, rows)
   }
 
-  acknowledgeDataEvent(charCount: number): void {
+  acknowledgeDataEvent(clientToken: symbol, charCount: number): void {
     if (charCount <= 0) {
       return
     }
-    this.unacknowledgedChars = Math.max(0, this.unacknowledgedChars - charCount)
-    if (
-      this.subprocessPaused &&
-      this.unacknowledgedChars < FLOW_CONTROL_LOW_WATERMARK_CHARS &&
-      !this._disposed &&
-      this._state !== 'exited' &&
-      this.subprocess.resume
-    ) {
-      this.subprocess.resume()
-      this.subprocessPaused = false
+    const current = this.unacknowledgedCharsByClient.get(clientToken)
+    if (current === undefined) {
+      return
     }
+    const next = Math.max(0, current - charCount)
+    if (next === 0) {
+      this.unacknowledgedCharsByClient.delete(clientToken)
+    } else {
+      this.unacknowledgedCharsByClient.set(clientToken, next)
+    }
+    this.resumeIfFlowBelowWatermark()
   }
 
   kill(): void {
@@ -190,8 +190,11 @@ export class Session {
     if (idx !== -1) {
       this.attachedClients.splice(idx, 1)
     }
+    this.unacknowledgedCharsByClient.delete(token)
     if (this.attachedClients.length === 0) {
       this.clearFlowControlState()
+    } else {
+      this.resumeIfFlowBelowWatermark()
     }
   }
 
@@ -247,7 +250,7 @@ export class Session {
 
     this.attachedClients = []
     this.preReadyStdinQueue = []
-    this.unacknowledgedChars = 0
+    this.unacknowledgedCharsByClient.clear()
     this.subprocessPaused = false
     this.postReadyFlushGate.clear()
     this.emulator.dispose()
@@ -328,11 +331,10 @@ export class Session {
       return
     }
 
+    const clients = this.attachedClients.slice()
+
     // Feed data to headless emulator for state tracking
     this.emulator.write(data)
-    if (this.attachedClients.length > 0) {
-      this.observeUnacknowledgedData(data.length)
-    }
 
     if (this._shellState === 'pending') {
       this.scanForShellMarker(data)
@@ -341,19 +343,26 @@ export class Session {
     }
 
     // Broadcast to attached clients
-    for (const client of this.attachedClients) {
+    for (const client of clients) {
+      if (!this.isClientAttached(client.token)) {
+        continue
+      }
+      this.observeUnacknowledgedData(client.token, data.length)
       client.onData(data)
     }
   }
 
-  private observeUnacknowledgedData(charCount: number): void {
+  private observeUnacknowledgedData(clientToken: symbol, charCount: number): void {
     if (charCount <= 0) {
       return
     }
-    this.unacknowledgedChars += charCount
+    this.unacknowledgedCharsByClient.set(
+      clientToken,
+      (this.unacknowledgedCharsByClient.get(clientToken) ?? 0) + charCount
+    )
     if (
       !this.subprocessPaused &&
-      this.unacknowledgedChars > FLOW_CONTROL_HIGH_WATERMARK_CHARS &&
+      this.maxUnacknowledgedChars() > FLOW_CONTROL_HIGH_WATERMARK_CHARS &&
       this.subprocess.pause
     ) {
       // Why: renderer ACKs arrive after xterm parses output. Pausing here
@@ -363,16 +372,34 @@ export class Session {
     }
   }
 
-  private clearFlowControlState(): void {
-    this.unacknowledgedChars = 0
+  private isClientAttached(clientToken: symbol): boolean {
+    return this.attachedClients.some((client) => client.token === clientToken)
+  }
+
+  private maxUnacknowledgedChars(): number {
+    let max = 0
+    for (const count of this.unacknowledgedCharsByClient.values()) {
+      max = Math.max(max, count)
+    }
+    return max
+  }
+
+  private resumeIfFlowBelowWatermark(): void {
     if (
       this.subprocessPaused &&
+      this.maxUnacknowledgedChars() < FLOW_CONTROL_LOW_WATERMARK_CHARS &&
       !this._disposed &&
       this._state !== 'exited' &&
       this.subprocess.resume
     ) {
       this.subprocess.resume()
+      this.subprocessPaused = false
     }
+  }
+
+  private clearFlowControlState(): void {
+    this.unacknowledgedCharsByClient.clear()
+    this.resumeIfFlowBelowWatermark()
     this.subprocessPaused = false
   }
 
@@ -393,7 +420,7 @@ export class Session {
       this.shellReadyTimer = null
     }
     this.postReadyFlushGate.clear()
-    this.unacknowledgedChars = 0
+    this.unacknowledgedCharsByClient.clear()
     this.subprocessPaused = false
 
     // Why: release the ptmx fd on the natural-exit path. Without this, the
@@ -485,7 +512,7 @@ export class Session {
     const clients = this.attachedClients
     this.attachedClients = []
     this.preReadyStdinQueue = []
-    this.unacknowledgedChars = 0
+    this.unacknowledgedCharsByClient.clear()
     this.subprocessPaused = false
     this.postReadyFlushGate.clear()
     this.emulator.dispose()

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -7,11 +7,15 @@ import type { SessionState, ShellReadyState, TerminalSnapshot } from './types'
 const SHELL_READY_TIMEOUT_MS = 15_000
 const KILL_TIMEOUT_MS = 5_000
 const SHELL_READY_MARKER = '\x1b]777;orca-shell-ready\x07'
+const FLOW_CONTROL_HIGH_WATERMARK_CHARS = 100_000
+const FLOW_CONTROL_LOW_WATERMARK_CHARS = 5_000
 
 export type SubprocessHandle = {
   pid: number
   write(data: string): void
   resize(cols: number, rows: number): void
+  pause?(): void
+  resume?(): void
   kill(): void
   forceKill(): void
   signal(sig: string): void
@@ -50,6 +54,8 @@ export class Session {
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
   private markerBuffer = ''
+  private unacknowledgedChars = 0
+  private subprocessPaused = false
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
   private postReadyFlushGate: PostReadyFlushGate
@@ -132,6 +138,23 @@ export class Session {
     }
     this.emulator.resize(cols, rows)
     this.subprocess.resize(cols, rows)
+  }
+
+  acknowledgeDataEvent(charCount: number): void {
+    if (charCount <= 0) {
+      return
+    }
+    this.unacknowledgedChars = Math.max(0, this.unacknowledgedChars - charCount)
+    if (
+      this.subprocessPaused &&
+      this.unacknowledgedChars < FLOW_CONTROL_LOW_WATERMARK_CHARS &&
+      !this._disposed &&
+      this._state !== 'exited' &&
+      this.subprocess.resume
+    ) {
+      this.subprocess.resume()
+      this.subprocessPaused = false
+    }
   }
 
   kill(): void {
@@ -220,6 +243,8 @@ export class Session {
 
     this.attachedClients = []
     this.preReadyStdinQueue = []
+    this.unacknowledgedChars = 0
+    this.subprocessPaused = false
     this.postReadyFlushGate.clear()
     this.emulator.dispose()
 
@@ -301,6 +326,9 @@ export class Session {
 
     // Feed data to headless emulator for state tracking
     this.emulator.write(data)
+    if (this.attachedClients.length > 0) {
+      this.observeUnacknowledgedData(data.length)
+    }
 
     if (this._shellState === 'pending') {
       this.scanForShellMarker(data)
@@ -311,6 +339,23 @@ export class Session {
     // Broadcast to attached clients
     for (const client of this.attachedClients) {
       client.onData(data)
+    }
+  }
+
+  private observeUnacknowledgedData(charCount: number): void {
+    if (charCount <= 0) {
+      return
+    }
+    this.unacknowledgedChars += charCount
+    if (
+      !this.subprocessPaused &&
+      this.unacknowledgedChars > FLOW_CONTROL_HIGH_WATERMARK_CHARS &&
+      this.subprocess.pause
+    ) {
+      // Why: renderer ACKs arrive after xterm parses output. Pausing here
+      // keeps daemon-hosted PTYs from outrunning the renderer indefinitely.
+      this.subprocess.pause()
+      this.subprocessPaused = true
     }
   }
 
@@ -331,6 +376,8 @@ export class Session {
       this.shellReadyTimer = null
     }
     this.postReadyFlushGate.clear()
+    this.unacknowledgedChars = 0
+    this.subprocessPaused = false
 
     // Why: release the ptmx fd on the natural-exit path. Without this, the
     // node-pty wrapper's _socket stays alive until GC and the master fd leaks
@@ -421,6 +468,8 @@ export class Session {
     const clients = this.attachedClients
     this.attachedClients = []
     this.preReadyStdinQueue = []
+    this.unacknowledgedChars = 0
+    this.subprocessPaused = false
     this.postReadyFlushGate.clear()
     this.emulator.dispose()
 

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -99,6 +99,28 @@ describe('TerminalHost', () => {
       expect(spawnFn).toHaveBeenCalledOnce()
     })
 
+    it('keeps existing attached clients when another client attaches', async () => {
+      const firstOnData = vi.fn()
+      const secondOnData = vi.fn()
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        streamClient: { onData: firstOnData, onExit: vi.fn() }
+      })
+      await host.createOrAttach({
+        sessionId: 'session-1',
+        cols: 80,
+        rows: 24,
+        streamClient: { onData: secondOnData, onExit: vi.fn() }
+      })
+
+      lastSubprocess._onDataCb?.('broadcast')
+
+      expect(firstOnData).toHaveBeenCalledWith('broadcast')
+      expect(secondOnData).toHaveBeenCalledWith('broadcast')
+    })
+
     it('returns snapshot when attaching to existing session', async () => {
       await host.createOrAttach({
         sessionId: 'session-1',

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -69,7 +69,6 @@ export class TerminalHost {
     // finally exits. Treat terminating sessions the same as fully-exited ones.
     if (existing && existing.isAlive && !existing.isTerminating) {
       const snapshot = existing.getSnapshot()
-      existing.detachAllClients()
       const token = existing.attachClient(opts.streamClient)
       return {
         isNew: false,
@@ -144,8 +143,8 @@ export class TerminalHost {
     this.getAliveSession(sessionId).resize(cols, rows)
   }
 
-  acknowledgeDataEvent(sessionId: string, charCount: number): void {
-    this.getAliveSession(sessionId).acknowledgeDataEvent(charCount)
+  acknowledgeDataEvent(sessionId: string, clientToken: symbol, charCount: number): void {
+    this.getAliveSession(sessionId).acknowledgeDataEvent(clientToken, charCount)
   }
 
   kill(sessionId: string): void {

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -144,6 +144,10 @@ export class TerminalHost {
     this.getAliveSession(sessionId).resize(cols, rows)
   }
 
+  acknowledgeDataEvent(sessionId: string, charCount: number): void {
+    this.getAliveSession(sessionId).acknowledgeDataEvent(charCount)
+  }
+
   kill(sessionId: string): void {
     const session = this.getAliveSession(sessionId)
     this.recordTombstone(sessionId)

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -1,10 +1,10 @@
 // ─── Protocol Version ────────────────────────────────────────────────
 // Why: daemons can survive app updates. Bump for IPC wire-shape changes, or
 // when daemon-baked behavior cannot be delivered by on-disk wrapper refresh.
-// Why: bumped from 6 -> 7 so existing daemons restart with the headless
-// emulator's mouse-mode snapshot tracking for mobile alternate-screen TUIs.
-export const PROTOCOL_VERSION = 7
-export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6] as const
+// Why: bumped from 7 -> 8 so existing daemons restart with renderer-ACKed
+// PTY flow control instead of accepting the new notifications as no-ops.
+export const PROTOCOL_VERSION = 8
+export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
 export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'
@@ -106,6 +106,15 @@ export type ResizeRequest = {
   }
 }
 
+export type AcknowledgeDataEventRequest = {
+  id: string
+  type: 'acknowledgeDataEvent'
+  payload: {
+    sessionId: string
+    charCount: number
+  }
+}
+
 export type KillRequest = {
   id: string
   type: 'kill'
@@ -178,6 +187,7 @@ export type DaemonRequest =
   | CancelCreateOrAttachRequest
   | WriteRequest
   | ResizeRequest
+  | AcknowledgeDataEventRequest
   | KillRequest
   | SignalRequest
   | ListSessionsRequest

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -729,7 +729,7 @@ function sendSyntheticTitle(ptyId: string, data: string): void {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return
   }
-  mainWindow.webContents.send('pty:data', { id: ptyId, data })
+  mainWindow.webContents.send('pty:data', { id: ptyId, data, synthetic: true })
 }
 
 function stopSyntheticTitleSpinner(paneKey: string): void {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -326,6 +326,51 @@ describe('registerPtyHandlers', () => {
     }
   }
 
+  function createForwardingProvider() {
+    let dataHandler: ((payload: { id: string; data: string }) => void) | null = null
+    let exitHandler: ((payload: { id: string; code: number }) => void) | null = null
+    const provider = {
+      spawn: vi.fn(async (options: { sessionId?: string }) => ({
+        id: options.sessionId ?? 'forwarded-pty',
+        pid: 123
+      })),
+      attach: vi.fn(async () => undefined),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+      sendSignal: vi.fn(async () => undefined),
+      getCwd: vi.fn(async () => ''),
+      getInitialCwd: vi.fn(async () => ''),
+      clearBuffer: vi.fn(async () => undefined),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(async () => false),
+      getForegroundProcess: vi.fn(async () => null),
+      serialize: vi.fn(async () => ''),
+      revive: vi.fn(async () => undefined),
+      listProcesses: vi.fn(async () => []),
+      getDefaultShell: vi.fn(async () => 'zsh'),
+      getProfiles: vi.fn(async () => []),
+      onData: vi.fn((handler: (payload: { id: string; data: string }) => void) => {
+        dataHandler = handler
+        return vi.fn()
+      }),
+      onReplay: vi.fn(() => vi.fn()),
+      onExit: vi.fn((handler: (payload: { id: string; code: number }) => void) => {
+        exitHandler = handler
+        return vi.fn()
+      })
+    }
+    return {
+      provider,
+      emitData(payload: { id: string; data: string }) {
+        dataHandler?.(payload)
+      },
+      emitExit(payload: { id: string; code: number }) {
+        exitHandler?.(payload)
+      }
+    }
+  }
+
   function getPtyWriteListener(): (event: unknown, args: { id: string; data: string }) => void {
     const writeCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:write')
     if (!writeCall) {
@@ -2464,6 +2509,155 @@ describe('registerPtyHandlers', () => {
         id: spawnResult.id,
         data: 'x'.repeat(64 * 1024)
       })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('acks batched PTY output dropped because the window was destroyed before flush', async () => {
+    vi.useFakeTimers()
+    const { provider, emitData } = createForwardingProvider()
+    const isDestroyedSpy = vi.spyOn(mainWindow, 'isDestroyed')
+    setLocalPtyProvider(provider as never)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      emitData({ id: spawnResult.id, data: 'queued output' })
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+
+      isDestroyedSpy.mockReturnValue(true)
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledWith(
+        spawnResult.id,
+        'queued output'.length
+      )
+    } finally {
+      isDestroyedSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('acks pending and current PTY output when data arrives after window destruction', async () => {
+    vi.useFakeTimers()
+    const { provider, emitData } = createForwardingProvider()
+    const isDestroyedSpy = vi.spyOn(mainWindow, 'isDestroyed')
+    setLocalPtyProvider(provider as never)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+
+      emitData({ id: spawnResult.id, data: 'pending' })
+      isDestroyedSpy.mockReturnValue(true)
+      emitData({ id: spawnResult.id, data: 'after destroy' })
+
+      expect(provider.acknowledgeDataEvent.mock.calls).toEqual([
+        [spawnResult.id, 'pending'.length],
+        [spawnResult.id, 'after destroy'.length]
+      ])
+      vi.advanceTimersByTime(8)
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledTimes(2)
+    } finally {
+      isDestroyedSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('acks pending PTY output when the process exits after window destruction', async () => {
+    vi.useFakeTimers()
+    const { provider, emitData, emitExit } = createForwardingProvider()
+    const isDestroyedSpy = vi.spyOn(mainWindow, 'isDestroyed')
+    setLocalPtyProvider(provider as never)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+
+      emitData({ id: spawnResult.id, data: 'final output' })
+      isDestroyedSpy.mockReturnValue(true)
+      emitExit({ id: spawnResult.id, code: 0 })
+
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledWith(
+        spawnResult.id,
+        'final output'.length
+      )
+      vi.advanceTimersByTime(8)
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledTimes(1)
+    } finally {
+      isDestroyedSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('acks PTY output when Electron rejects renderer delivery', async () => {
+    vi.useFakeTimers()
+    const { provider, emitData } = createForwardingProvider()
+    setLocalPtyProvider(provider as never)
+    mainWindow.webContents.send.mockImplementation(() => {
+      throw new Error('window is gone')
+    })
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+
+      writeListener(null, { id: spawnResult.id, data: 'a' })
+      emitData({ id: spawnResult.id, data: 'redraw' })
+
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledWith(spawnResult.id, 'redraw'.length)
+      vi.advanceTimersByTime(8)
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('acks the unsent remainder when a large IPC chunk send fails', async () => {
+    vi.useFakeTimers()
+    const { provider, emitData } = createForwardingProvider()
+    setLocalPtyProvider(provider as never)
+    mainWindow.webContents.send.mockImplementation(() => {
+      throw new Error('window is gone')
+    })
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+
+      const largeOutput = 'x'.repeat(2 * 64 * 1024)
+      emitData({ id: spawnResult.id, data: largeOutput })
+      vi.advanceTimersByTime(8)
+
+      expect(provider.acknowledgeDataEvent.mock.calls).toEqual([
+        [spawnResult.id, 64 * 1024],
+        [spawnResult.id, 64 * 1024]
+      ])
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -266,6 +266,8 @@ describe('registerPtyHandlers', () => {
 
   afterEach(() => {
     unregisterSshPtyProvider('ssh-1')
+    unregisterSshPtyProvider('ssh-a')
+    unregisterSshPtyProvider('ssh-b')
     setLocalPtyProvider(new LocalPtyProvider())
     if (savedOpenCodeConfigDir !== undefined) {
       process.env.OPENCODE_CONFIG_DIR = savedOpenCodeConfigDir
@@ -1687,6 +1689,111 @@ describe('registerPtyHandlers', () => {
 
     await expect(handlers.get('pty:kill')!(null, { id: 'remote-pty' })).resolves.toBeUndefined()
     expect(store.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'remote-pty', 'terminated')
+  })
+
+  it('routes source-tagged PTY ACKs to the SSH provider even without local ownership', () => {
+    const provider = {
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    }
+    registerSshPtyProvider('ssh-1', provider as never)
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const call = onMock.mock.calls.find((entry: unknown[]) => entry[0] === 'pty:ackData')
+      if (!call) {
+        throw new Error('missing pty:ackData listener')
+      }
+      const ackListener = call[1] as (
+        event: unknown,
+        args: { id: string; charCount: number; connectionId?: string }
+      ) => void
+
+      ackListener(null, { id: 'remote-pty', charCount: 42, connectionId: 'ssh-1' })
+
+      expect(provider.acknowledgeDataEvent).toHaveBeenCalledWith('remote-pty', 42)
+    } finally {
+      unregisterSshPtyProvider('ssh-1')
+    }
+  })
+
+  it('routes source-tagged PTY input, resize, and kill to the requested SSH provider', async () => {
+    const providerA = createForwardingProvider().provider
+    const providerB = createForwardingProvider().provider
+    registerSshPtyProvider('ssh-a', providerA as never)
+    registerSshPtyProvider('ssh-b', providerB as never)
+    registerPtyHandlers(mainWindow as never, undefined, undefined, undefined, undefined, {
+      markSshRemotePtyLease: vi.fn()
+    } as never)
+
+    const listenerFor = (channel: string): ((event: unknown, args: unknown) => void) => {
+      const call = onMock.mock.calls.find((entry: unknown[]) => entry[0] === channel)
+      if (!call) {
+        throw new Error(`missing ${channel} listener`)
+      }
+      return call[1] as (event: unknown, args: unknown) => void
+    }
+
+    listenerFor('pty:write')(null, { id: 'pty-1', data: 'x', connectionId: 'ssh-b' })
+    listenerFor('pty:resize')(null, { id: 'pty-1', cols: 100, rows: 30, connectionId: 'ssh-b' })
+    listenerFor('pty:signal')(null, { id: 'pty-1', signal: 'SIGWINCH', connectionId: 'ssh-b' })
+    await handlers.get('pty:kill')!(null, {
+      id: 'pty-1',
+      keepHistory: false,
+      connectionId: 'ssh-b'
+    })
+
+    expect(providerA.write).not.toHaveBeenCalled()
+    expect(providerA.resize).not.toHaveBeenCalled()
+    expect(providerA.sendSignal).not.toHaveBeenCalled()
+    expect(providerA.shutdown).not.toHaveBeenCalled()
+    expect(providerB.write).toHaveBeenCalledWith('pty-1', 'x')
+    expect(providerB.resize).toHaveBeenCalledWith('pty-1', 100, 30)
+    expect(providerB.sendSignal).toHaveBeenCalledWith('pty-1', 'SIGWINCH')
+    expect(providerB.shutdown).toHaveBeenCalledWith('pty-1', {
+      immediate: true,
+      keepHistory: false
+    })
+  })
+
+  it('does not fall back to pty ownership when a source-tagged ACK has no provider', () => {
+    const { provider } = createForwardingProvider()
+    setLocalPtyProvider(provider as never)
+    setPtyOwnership('remote-pty', null)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const call = onMock.mock.calls.find((entry: unknown[]) => entry[0] === 'pty:ackData')
+      if (!call) {
+        throw new Error('missing pty:ackData listener')
+      }
+      const ackListener = call[1] as (
+        event: unknown,
+        args: { id: string; charCount: number; connectionId?: string }
+      ) => void
+
+      ackListener(null, { id: 'remote-pty', charCount: 42, connectionId: 'missing-ssh' })
+
+      expect(provider.acknowledgeDataEvent).not.toHaveBeenCalled()
+    } finally {
+      deletePtyOwnership('remote-pty')
+    }
   })
 
   it('injects ORCA_TERMINAL_HANDLE for non-local PTY providers', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -650,14 +650,36 @@ export function registerPtyHandlers(
   const PTY_IPC_CHUNK_CHARS = 64 * 1024
   const PTY_MAX_IPC_CHUNKS_PER_FLUSH = 8
 
-  const sendPtyData = (id: string, data: string): void => {
-    mainWindow.webContents.send('pty:data', { id, data })
+  const acknowledgeDroppedPtyData = (id: string, charCount: number): void => {
+    if (charCount <= 0) {
+      return
+    }
+    tryGetProviderForPty(id)?.acknowledgeDataEvent(id, charCount)
+  }
+
+  const acknowledgePendingPtyData = (): void => {
+    for (const [id, data] of pendingData) {
+      acknowledgeDroppedPtyData(id, data.length)
+    }
+    pendingData.clear()
+  }
+
+  const sendPtyData = (id: string, data: string): boolean => {
+    try {
+      mainWindow.webContents.send('pty:data', { id, data })
+      return true
+    } catch {
+      // Why: the provider already counted these bytes for flow control. If
+      // Electron rejects delivery during teardown, no renderer can parse/ACK them.
+      acknowledgeDroppedPtyData(id, data.length)
+      return false
+    }
   }
 
   const flushPendingData = (): void => {
     flushTimer = null
     if (mainWindow.isDestroyed()) {
-      pendingData.clear()
+      acknowledgePendingPtyData()
       return
     }
 
@@ -672,11 +694,15 @@ export function registerPtyHandlers(
       if (data.length <= PTY_IPC_CHUNK_CHARS) {
         sendPtyData(id, data)
       } else {
-        sendPtyData(id, data.slice(0, PTY_IPC_CHUNK_CHARS))
+        const chunk = data.slice(0, PTY_IPC_CHUNK_CHARS)
         // Why: a single noisy PTY can otherwise serialize megabytes of IPC in
         // one main-process turn. Requeue the remainder behind other PTYs so
         // active terminal redraws and control IPC keep getting turns.
-        pendingData.set(id, data.slice(PTY_IPC_CHUNK_CHARS))
+        if (sendPtyData(id, chunk)) {
+          pendingData.set(id, data.slice(PTY_IPC_CHUNK_CHARS))
+        } else {
+          acknowledgeDroppedPtyData(id, data.length - chunk.length)
+        }
       }
       sentChunks++
     }
@@ -722,7 +748,8 @@ export function registerPtyHandlers(
           clearTimeout(flushTimer)
           flushTimer = null
         }
-        pendingData.clear()
+        acknowledgePendingPtyData()
+        acknowledgeDroppedPtyData(payload.id, payload.data.length)
         return
       }
       const existing = pendingData.get(payload.id)
@@ -763,6 +790,12 @@ export function registerPtyHandlers(
         }
         lastInputAtByPty.delete(payload.id)
         mainWindow.webContents.send('pty:exit', payload)
+      } else {
+        if (flushTimer) {
+          clearTimeout(flushTimer)
+          flushTimer = null
+        }
+        acknowledgePendingPtyData()
       }
     })
   }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -189,6 +189,16 @@ function tryGetProviderForPty(ptyId: string): IPtyProvider | undefined {
   }
 }
 
+function tryGetProviderForPtyRequest(
+  ptyId: string,
+  connectionId: string | undefined
+): IPtyProvider | undefined {
+  if (connectionId) {
+    return sshProviders.get(connectionId)
+  }
+  return ptyOwnership.has(ptyId) ? tryGetProviderForPty(ptyId) : undefined
+}
+
 function normalizeNodePtySpawnError(err: unknown): Error {
   const rawMessage = err instanceof Error ? err.message : String(err)
   const hintedMessage = addNodePtyRecoveryHint(rawMessage)
@@ -1641,7 +1651,7 @@ export function registerPtyHandlers(
     }
   )
 
-  ipcMain.on('pty:write', (_event, args: { id: string; data: string }) => {
+  ipcMain.on('pty:write', (_event, args: { id: string; data: string; connectionId?: string }) => {
     // Why: defense-in-depth for the mobile-presence lock. The renderer's
     // xterm.onData guard already drops desktop keystrokes when mobile is
     // driving, but a stale view between the main-side state flip and the
@@ -1651,7 +1661,7 @@ export function registerPtyHandlers(
     if (runtime?.getDriver(args.id).kind === 'mobile') {
       return
     }
-    const provider = ptyOwnership.has(args.id) ? tryGetProviderForPty(args.id) : undefined
+    const provider = tryGetProviderForPtyRequest(args.id, args.connectionId)
     if (!provider) {
       return
     }
@@ -1660,41 +1670,51 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:ackData')
-  ipcMain.on('pty:ackData', (_event, args: { id: string; charCount: number }) => {
-    const charCount = Math.max(0, Math.floor(Number(args.charCount) || 0))
-    if (charCount <= 0) {
-      return
+  ipcMain.on(
+    'pty:ackData',
+    (_event, args: { id: string; charCount: number; connectionId?: string }) => {
+      const charCount = Math.max(0, Math.floor(Number(args.charCount) || 0))
+      if (charCount <= 0) {
+        return
+      }
+      const ackProvider =
+        typeof args.connectionId === 'string'
+          ? sshProviders.get(args.connectionId)
+          : tryGetProviderForPty(args.id)
+      ackProvider?.acknowledgeDataEvent(args.id, charCount)
     }
-    tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, charCount)
-  })
+  )
 
   // Why: resize is fire-and-forget — the renderer doesn't need a reply.
   // Using ipcMain.on (not .handle) halves IPC traffic by avoiding the
   // empty acknowledgement message back to the renderer.
   ipcMain.removeAllListeners('pty:resize')
-  ipcMain.on('pty:resize', (_event, args: { id: string; cols: number; rows: number }) => {
-    // Why: after a desktop-fit override change, the desktop renderer's
-    // re-render cascade runs safeFit on ALL panes (not just the affected
-    // one). Background-tab panes get measured at full-width (214) instead
-    // of their correct split width. Suppressing ALL pty:resize during
-    // this window prevents the cascade from corrupting PTY dimensions.
-    if (runtime?.isResizeSuppressed()) {
-      return
+  ipcMain.on(
+    'pty:resize',
+    (_event, args: { id: string; cols: number; rows: number; connectionId?: string }) => {
+      // Why: after a desktop-fit override change, the desktop renderer's
+      // re-render cascade runs safeFit on ALL panes (not just the affected
+      // one). Background-tab panes get measured at full-width (214) instead
+      // of their correct split width. Suppressing ALL pty:resize during
+      // this window prevents the cascade from corrupting PTY dimensions.
+      if (runtime?.isResizeSuppressed()) {
+        return
+      }
+      // Why: presence-lock defense-in-depth. While mobile is driving,
+      // desktop-side resizes (auto-fit on window resize, split drag) must
+      // not reach the PTY. The renderer guard checks the driver state too,
+      // but this is the load-bearing layer because the renderer mirror lags
+      // by one IPC hop. Note: BOTH guards apply — isResizeSuppressed handles
+      // the safeFit cascade after take-back; this driver check handles the
+      // ongoing locked state. See docs/mobile-presence-lock.md.
+      if (runtime?.getDriver(args.id).kind === 'mobile') {
+        return
+      }
+      ptySizes.set(args.id, { cols: args.cols, rows: args.rows })
+      tryGetProviderForPtyRequest(args.id, args.connectionId)?.resize(args.id, args.cols, args.rows)
+      runtime?.onExternalPtyResize(args.id, args.cols, args.rows)
     }
-    // Why: presence-lock defense-in-depth. While mobile is driving,
-    // desktop-side resizes (auto-fit on window resize, split drag) must
-    // not reach the PTY. The renderer guard checks the driver state too,
-    // but this is the load-bearing layer because the renderer mirror lags
-    // by one IPC hop. Note: BOTH guards apply — isResizeSuppressed handles
-    // the safeFit cascade after take-back; this driver check handles the
-    // ongoing locked state. See docs/mobile-presence-lock.md.
-    if (runtime?.getDriver(args.id).kind === 'mobile') {
-      return
-    }
-    ptySizes.set(args.id, { cols: args.cols, rows: args.rows })
-    tryGetProviderForPty(args.id)?.resize(args.id, args.cols, args.rows)
-    runtime?.onExternalPtyResize(args.id, args.cols, args.rows)
-  })
+  )
 
   // Why: pty:reportGeometry is a measurement-only sibling of pty:resize.
   // pty:resize means "I want the PTY at this size" (a write/intent — gated
@@ -1723,41 +1743,52 @@ export function registerPtyHandlers(
   })
 
   ipcMain.removeAllListeners('pty:signal')
-  ipcMain.on('pty:signal', (_event, args: { id: string; signal: string }) => {
-    tryGetProviderForPty(args.id)
-      ?.sendSignal(args.id, args.signal)
-      .catch(() => {})
-  })
+  ipcMain.on(
+    'pty:signal',
+    (_event, args: { id: string; signal: string; connectionId?: string }) => {
+      tryGetProviderForPtyRequest(args.id, args.connectionId)
+        ?.sendSignal(args.id, args.signal)
+        .catch(() => {})
+    }
+  )
 
-  ipcMain.handle('pty:kill', async (_event, args: { id: string; keepHistory?: boolean }) => {
-    const connectionId = ptyOwnership.get(args.id)
-    const provider = tryGetProviderForPty(args.id)
-    if (!provider && connectionId) {
-      // Why: detached SSH PTYs intentionally keep ownership after their
-      // provider is unregistered. If the user closes the pane while detached,
-      // make the lease non-restorable instead of reviving it on reconnect.
-      finishPtyShutdown(args.id, connectionId, store)
-      return
-    }
-    try {
-      await (provider ?? getProviderForPty(args.id)).shutdown(args.id, {
-        immediate: true,
-        keepHistory: args.keepHistory ?? false
-      })
-    } catch (err) {
-      if (!isPtyAlreadyGoneError(err)) {
-        // Why: a failed SSH shutdown can leave the remote process alive in
-        // the relay grace window; daemon failures have the same risk locally.
-        // Keep ownership/lease state so the user can retry.
-        throw err
+  ipcMain.handle(
+    'pty:kill',
+    async (
+      _event,
+      args: { id: string; keepHistory?: boolean; connectionId?: string }
+    ): Promise<void> => {
+      const connectionId = args.connectionId ?? ptyOwnership.get(args.id)
+      const provider = args.connectionId
+        ? sshProviders.get(args.connectionId)
+        : tryGetProviderForPty(args.id)
+      if (!provider && connectionId) {
+        // Why: detached SSH PTYs intentionally keep ownership after their
+        // provider is unregistered. If the user closes the pane while detached,
+        // make the lease non-restorable instead of reviving it on reconnect.
+        finishPtyShutdown(args.id, connectionId, store)
+        return
       }
-      /* session already dead — cleanup below handles the rest */
+      try {
+        await (provider ?? getProviderForPty(args.id)).shutdown(args.id, {
+          immediate: true,
+          keepHistory: args.keepHistory ?? false
+        })
+      } catch (err) {
+        if (!isPtyAlreadyGoneError(err)) {
+          // Why: a failed SSH shutdown can leave the remote process alive in
+          // the relay grace window; daemon failures have the same risk locally.
+          // Keep ownership/lease state so the user can retry.
+          throw err
+        }
+        /* session already dead — cleanup below handles the rest */
+      }
+      // Why: onExit clears provider state for LocalPtyProvider, but remote SSH
+      // and daemon shutdown paths do not emit onExit through the local provider's
+      // listener. Explicit cleanup is idempotent and covers already-dead PTYs.
+      finishPtyShutdown(args.id, connectionId, store)
     }
-    // Why: onExit clears provider state for LocalPtyProvider, but remote SSH
-    // and daemon shutdown paths do not emit onExit through the local provider's
-    // listener. Explicit cleanup is idempotent and covers already-dead PTYs.
-    finishPtyShutdown(args.id, connectionId, store)
-  })
+  )
 
   ipcMain.handle(
     'pty:listSessions',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -584,6 +584,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:settlePaneSerializer')
   ipcMain.removeHandler('pty:clearPendingPaneSerializer')
   ipcMain.removeAllListeners('pty:write')
+  ipcMain.removeAllListeners('pty:ackData')
   ipcMain.removeAllListeners('pty:ackColdRestore')
   ipcMain.removeAllListeners('pty:serializeBuffer:response')
 
@@ -1623,6 +1624,15 @@ export function registerPtyHandlers(
     }
     lastInputAtByPty.set(args.id, performance.now())
     provider.write(args.id, args.data)
+  })
+
+  ipcMain.removeAllListeners('pty:ackData')
+  ipcMain.on('pty:ackData', (_event, args: { id: string; charCount: number }) => {
+    const charCount = Math.max(0, Math.floor(Number(args.charCount) || 0))
+    if (charCount <= 0) {
+      return
+    }
+    tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, charCount)
   })
 
   // Why: resize is fire-and-forget — the renderer doesn't need a reply.

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -374,6 +374,20 @@ describe('LocalPtyProvider', () => {
 
       expect(mockProc.resume).toHaveBeenCalledTimes(1)
     })
+
+    it('clears flow-control state when shutdown bypasses natural exit cleanup', async () => {
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+      const onDataCb = mockProc.onData.mock.calls[0][0]
+
+      onDataCb('x'.repeat(100_001))
+      expect(mockProc.pause).toHaveBeenCalledTimes(1)
+
+      await provider.shutdown(id, { immediate: true })
+      mockProc.resume.mockClear()
+      provider.acknowledgeDataEvent(id, 95_002)
+
+      expect(mockProc.resume).not.toHaveBeenCalled()
+    })
   })
 
   describe('listProcesses', () => {

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -50,6 +50,8 @@ describe('LocalPtyProvider', () => {
     onExit: ReturnType<typeof vi.fn>
     write: ReturnType<typeof vi.fn>
     resize: ReturnType<typeof vi.fn>
+    pause: ReturnType<typeof vi.fn>
+    resume: ReturnType<typeof vi.fn>
     kill: ReturnType<typeof vi.fn>
     process: string
     pid: number
@@ -75,6 +77,8 @@ describe('LocalPtyProvider', () => {
       }),
       write: vi.fn(),
       resize: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
       kill: vi.fn(() => {
         exitCb?.({ exitCode: -1 })
       }),
@@ -355,6 +359,20 @@ describe('LocalPtyProvider', () => {
       onDataCb('hello')
 
       expect(dataHandler).not.toHaveBeenCalled()
+    })
+
+    it('pauses and resumes PTY output based on renderer parse acknowledgements', async () => {
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+      const onDataCb = mockProc.onData.mock.calls[0][0]
+
+      onDataCb('x'.repeat(100_001))
+
+      expect(mockProc.pause).toHaveBeenCalledTimes(1)
+      expect(mockProc.resume).not.toHaveBeenCalled()
+
+      provider.acknowledgeDataEvent(id, 95_002)
+
+      expect(mockProc.resume).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -488,11 +488,9 @@ export class LocalPtyProvider implements IPtyProvider {
     if (!proc) {
       return
     }
-    // Why: disposePtyListeners removes the onExit callback, so the natural
-    // exit cleanup path from node-pty won't fire. Cleanup and notification
-    // must happen unconditionally after the try/catch.
-    // Note: clearPtyState calls disposePtyListeners internally, so we only
-    // need to call it once via clearPtyState after killing the process.
+    // Why: dispose listeners before kill because node-pty/test doubles may
+    // fire exit synchronously. clearPtyState later also clears flow-control
+    // debt so late ACKs cannot resume a killed PTY object.
     disposePtyListeners(id)
     try {
       proc.kill()
@@ -500,9 +498,7 @@ export class LocalPtyProvider implements IPtyProvider {
       /* Process may already be dead */
     }
     destroyPtyProcess(proc)
-    ptyProcesses.delete(id)
-    ptyShellName.delete(id)
-    ptyLoadGeneration.delete(id)
+    clearPtyState(id)
     this.opts.onExit?.(id, -1)
     for (const cb of exitListeners) {
       cb({ id, code: -1 })

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -32,6 +32,8 @@ import {
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 
 const PANE_IDENTITY_ENV_KEYS = ['ORCA_PANE_KEY', 'ORCA_TAB_ID', 'ORCA_WORKTREE_ID'] as const
+const FLOW_CONTROL_HIGH_WATERMARK_CHARS = 100_000
+const FLOW_CONTROL_LOW_WATERMARK_CHARS = 5_000
 
 let ptyCounter = 0
 const ptyProcesses = new Map<string, pty.IPty>()
@@ -41,6 +43,7 @@ const ptyShellName = new Map<string, string>()
 // stale callbacks survive into node::FreeEnvironment() where NAPI attempts
 // to invoke/clean them up on a destroyed environment, triggering a SIGABRT.
 const ptyDisposables = new Map<string, { dispose: () => void }[]>()
+const ptyFlowState = new Map<string, { unacknowledgedChars: number; paused: boolean }>()
 
 let loadGeneration = 0
 const ptyLoadGeneration = new Map<string, number>()
@@ -94,6 +97,38 @@ function clearPtyState(id: string): void {
   ptyProcesses.delete(id)
   ptyShellName.delete(id)
   ptyLoadGeneration.delete(id)
+  ptyFlowState.delete(id)
+}
+
+function pausePty(proc: pty.IPty): void {
+  try {
+    ;(proc as unknown as { pause?: () => void }).pause?.()
+  } catch {
+    /* best effort */
+  }
+}
+
+function resumePty(proc: pty.IPty): void {
+  try {
+    ;(proc as unknown as { resume?: () => void }).resume?.()
+  } catch {
+    /* best effort */
+  }
+}
+
+function observeUnacknowledgedPtyData(id: string, proc: pty.IPty, dataLength: number): void {
+  if (dataLength <= 0) {
+    return
+  }
+  const state = ptyFlowState.get(id) ?? { unacknowledgedChars: 0, paused: false }
+  state.unacknowledgedChars += dataLength
+  if (!state.paused && state.unacknowledgedChars > FLOW_CONTROL_HIGH_WATERMARK_CHARS) {
+    // Why: xterm parse completion is the consumer signal. If the renderer falls
+    // behind, pause the producing PTY instead of buffering unbounded output.
+    pausePty(proc)
+    state.paused = true
+  }
+  ptyFlowState.set(id, state)
 }
 
 function destroyPtyProcess(proc: pty.IPty): void {
@@ -382,6 +417,7 @@ export class LocalPtyProvider implements IPtyProvider {
       if (data.length === 0) {
         return
       }
+      observeUnacknowledgedPtyData(id, proc, data.length)
       this.opts.onData?.(id, data, Date.now())
       for (const cb of dataListeners) {
         cb({ id, data })
@@ -506,8 +542,20 @@ export class LocalPtyProvider implements IPtyProvider {
   async clearBuffer(_id: string): Promise<void> {
     /* handled client-side in xterm.js */
   }
-  acknowledgeDataEvent(_id: string, _charCount: number): void {
-    /* no flow control for local */
+  acknowledgeDataEvent(id: string, charCount: number): void {
+    const state = ptyFlowState.get(id)
+    if (!state || charCount <= 0) {
+      return
+    }
+    state.unacknowledgedChars = Math.max(0, state.unacknowledgedChars - charCount)
+    const proc = ptyProcesses.get(id)
+    if (state.paused && state.unacknowledgedChars < FLOW_CONTROL_LOW_WATERMARK_CHARS && proc) {
+      resumePty(proc)
+      state.paused = false
+    }
+    if (state.unacknowledgedChars === 0 && !state.paused) {
+      ptyFlowState.delete(id)
+    }
   }
 
   async hasChildProcesses(id: string): Promise<boolean> {

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -41,6 +41,7 @@ vi.mock('../providers/ssh-pty-provider', () => ({
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})
     onExit = vi.fn().mockReturnValue(() => {})
+    acknowledgeDataEvent = vi.fn()
     attach = vi.fn().mockResolvedValue(undefined)
     dispose = vi.fn()
   }
@@ -156,6 +157,51 @@ describe('SshRelaySession', () => {
     expect(registerSshPtyProvider).toHaveBeenCalledWith('target-1', expect.anything())
     expect(registerSshFilesystemProvider).toHaveBeenCalledWith('target-1', expect.anything())
     expect(registerSshGitProvider).toHaveBeenCalledWith('target-1', expect.anything())
+  })
+
+  it('forwards SSH PTY data to the renderer without main-process ACK when the window is alive', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow, mockWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    const provider = vi.mocked(registerSshPtyProvider).mock.calls[0][1] as unknown as {
+      onData: ReturnType<typeof vi.fn>
+      acknowledgeDataEvent: ReturnType<typeof vi.fn>
+    }
+    const onData = provider.onData.mock.calls[0][0] as (payload: {
+      id: string
+      data: string
+    }) => void
+
+    onData({ id: 'pty-1', data: 'visible output' })
+
+    expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+      id: 'pty-1',
+      data: 'visible output'
+    })
+    expect(provider.acknowledgeDataEvent).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges SSH PTY data dropped while no renderer window can receive it', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    getMainWindow.mockReturnValue(null)
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    const provider = vi.mocked(registerSshPtyProvider).mock.calls[0][1] as unknown as {
+      onData: ReturnType<typeof vi.fn>
+      acknowledgeDataEvent: ReturnType<typeof vi.fn>
+    }
+    const onData = provider.onData.mock.calls[0][0] as (payload: {
+      id: string
+      data: string
+    }) => void
+
+    onData({ id: 'pty-1', data: 'dropped output' })
+
+    expect(provider.acknowledgeDataEvent).toHaveBeenCalledWith('pty-1', 'dropped output'.length)
   })
 
   it('installs remote managed hooks and relay-owned plugin assets before registering the SSH PTY provider', async () => {

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -178,7 +178,8 @@ describe('SshRelaySession', () => {
 
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
       id: 'pty-1',
-      data: 'visible output'
+      data: 'visible output',
+      connectionId: 'target-1'
     })
     expect(provider.acknowledgeDataEvent).not.toHaveBeenCalled()
   })
@@ -461,7 +462,8 @@ describe('SshRelaySession', () => {
     expect(deletePtyOwnership).toHaveBeenCalledWith('pty-stale')
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
       id: 'pty-stale',
-      code: -1
+      code: -1,
+      connectionId: 'target-1'
     })
   })
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -740,8 +740,18 @@ export class SshRelaySession {
       this.runtime?.onPtyData(payload.id, payload.data, Date.now())
       const win = getWin()
       if (win && !win.isDestroyed()) {
-        win.webContents.send('pty:data', payload)
+        try {
+          win.webContents.send('pty:data', payload)
+          return
+        } catch {
+          // Fall through and ACK below; the renderer cannot parse bytes that
+          // Electron rejected during window teardown.
+        }
       }
+      // Why: the SSH relay already counted these bytes as delivered to this
+      // client. If no renderer can receive them, ACK the intentional drop so
+      // remote PTY flow control cannot remain paused forever.
+      ptyProvider.acknowledgeDataEvent(payload.id, payload.data.length)
     })
     ptyProvider.onReplay((payload) => {
       const win = getWin()

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -741,7 +741,9 @@ export class SshRelaySession {
       const win = getWin()
       if (win && !win.isDestroyed()) {
         try {
-          win.webContents.send('pty:data', payload)
+          // Why: non-owning Orca clients can receive relay broadcasts during
+          // SSH reconnection. Tag the source so drop ACKs route to this relay.
+          win.webContents.send('pty:data', { ...payload, connectionId: this.targetId })
           return
         } catch {
           // Fall through and ACK below; the renderer cannot parse bytes that
@@ -756,7 +758,7 @@ export class SshRelaySession {
     ptyProvider.onReplay((payload) => {
       const win = getWin()
       if (win && !win.isDestroyed()) {
-        win.webContents.send('pty:replay', payload)
+        win.webContents.send('pty:replay', { ...payload, connectionId: this.targetId })
       }
     })
     ptyProvider.onExit((payload) => {
@@ -766,7 +768,7 @@ export class SshRelaySession {
       this.runtime?.onPtyExit(payload.id, payload.code)
       const win = getWin()
       if (win && !win.isDestroyed()) {
-        win.webContents.send('pty:exit', payload)
+        win.webContents.send('pty:exit', { ...payload, connectionId: this.targetId })
       }
     })
   }
@@ -811,7 +813,7 @@ export class SshRelaySession {
         // instead of keeping a cursor-only terminal.
         const win = this.getMainWindow()
         if (win && !win.isDestroyed()) {
-          win.webContents.send('pty:exit', { id: ptyId, code: -1 })
+          win.webContents.send('pty:exit', { id: ptyId, code: -1, connectionId: this.targetId })
         }
       }
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -718,7 +718,9 @@ export type PreloadApi = {
     getForegroundProcess: (id: string) => Promise<string | null>
     getCwd: (id: string) => Promise<string>
     listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
-    onData: (callback: (data: { id: string; data: string }) => void) => () => void
+    onData: (
+      callback: (data: { id: string; data: string; synthetic?: boolean }) => void
+    ) => () => void
     onReplay: (callback: (data: { id: string; data: string }) => void) => () => void
     onExit: (callback: (data: { id: string; code: number }) => void) => () => void
     onSerializeBufferRequest: (

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -707,22 +707,31 @@ export type PreloadApi = {
       sessionExpired?: boolean
       coldRestore?: { scrollback: string; cwd: string }
     }>
-    write: (id: string, data: string) => void
-    ackData: (id: string, charCount: number) => void
-    resize: (id: string, cols: number, rows: number) => void
+    write: (id: string, data: string, connectionId?: string) => void
+    ackData: (id: string, charCount: number, connectionId?: string) => void
+    resize: (id: string, cols: number, rows: number, connectionId?: string) => void
     reportGeometry: (id: string, cols: number, rows: number) => void
-    signal: (id: string, signal: string) => void
-    kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
+    signal: (id: string, signal: string, connectionId?: string) => void
+    kill: (id: string, opts?: { keepHistory?: boolean; connectionId?: string }) => Promise<void>
     ackColdRestore: (id: string) => void
     hasChildProcesses: (id: string) => Promise<boolean>
     getForegroundProcess: (id: string) => Promise<string | null>
     getCwd: (id: string) => Promise<string>
     listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
     onData: (
-      callback: (data: { id: string; data: string; synthetic?: boolean }) => void
+      callback: (data: {
+        id: string
+        data: string
+        synthetic?: boolean
+        connectionId?: string
+      }) => void
     ) => () => void
-    onReplay: (callback: (data: { id: string; data: string }) => void) => () => void
-    onExit: (callback: (data: { id: string; code: number }) => void) => () => void
+    onReplay: (
+      callback: (data: { id: string; data: string; connectionId?: string }) => void
+    ) => () => void
+    onExit: (
+      callback: (data: { id: string; code: number; connectionId?: string }) => void
+    ) => () => void
     onSerializeBufferRequest: (
       callback: (data: {
         requestId: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -708,6 +708,7 @@ export type PreloadApi = {
       coldRestore?: { scrollback: string; cwd: string }
     }>
     write: (id: string, data: string) => void
+    ackData: (id: string, charCount: number) => void
     resize: (id: string, cols: number, rows: number) => void
     reportGeometry: (id: string, cols: number, rows: number) => void
     signal: (id: string, signal: string) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -602,16 +602,16 @@ const api = {
       coldRestore?: { scrollback: string; cwd: string }
     }> => ipcRenderer.invoke('pty:spawn', opts),
 
-    write: (id: string, data: string): void => {
-      ipcRenderer.send('pty:write', { id, data })
+    write: (id: string, data: string, connectionId?: string): void => {
+      ipcRenderer.send('pty:write', { id, data, connectionId })
     },
 
-    ackData: (id: string, charCount: number): void => {
-      ipcRenderer.send('pty:ackData', { id, charCount })
+    ackData: (id: string, charCount: number, connectionId?: string): void => {
+      ipcRenderer.send('pty:ackData', { id, charCount, connectionId })
     },
 
-    resize: (id: string, cols: number, rows: number): void => {
-      ipcRenderer.send('pty:resize', { id, cols, rows })
+    resize: (id: string, cols: number, rows: number, connectionId?: string): void => {
+      ipcRenderer.send('pty:resize', { id, cols, rows, connectionId })
     },
 
     /** Why: measurement-only sibling of resize. Fires when a desktop pane
@@ -623,16 +623,20 @@ const api = {
       ipcRenderer.send('pty:reportGeometry', { id, cols, rows })
     },
 
-    signal: (id: string, signal: string): void => {
-      ipcRenderer.send('pty:signal', { id, signal })
+    signal: (id: string, signal: string, connectionId?: string): void => {
+      ipcRenderer.send('pty:signal', { id, signal, connectionId })
     },
 
     ackColdRestore: (id: string): void => {
       ipcRenderer.send('pty:ackColdRestore', { id })
     },
 
-    kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
-      ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
+    kill: (id: string, opts?: { keepHistory?: boolean; connectionId?: string }): Promise<void> =>
+      ipcRenderer.invoke('pty:kill', {
+        id,
+        keepHistory: opts?.keepHistory ?? false,
+        connectionId: opts?.connectionId
+      }),
 
     listSessions: (): Promise<{ id: string; cwd: string; title: string }[]> =>
       ipcRenderer.invoke('pty:listSessions'),
@@ -650,23 +654,35 @@ const api = {
      *  Returns `''` when the id is unknown or the platform cannot resolve one. */
     getCwd: (id: string): Promise<string> => ipcRenderer.invoke('pty:getCwd', { id }),
 
-    onData: (callback: (data: { id: string; data: string }) => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: { id: string; data: string }) =>
-        callback(data)
+    onData: (
+      callback: (data: { id: string; data: string; connectionId?: string }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { id: string; data: string; connectionId?: string }
+      ) => callback(data)
       ipcRenderer.on('pty:data', listener)
       return () => ipcRenderer.removeListener('pty:data', listener)
     },
 
-    onReplay: (callback: (data: { id: string; data: string }) => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: { id: string; data: string }) =>
-        callback(data)
+    onReplay: (
+      callback: (data: { id: string; data: string; connectionId?: string }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { id: string; data: string; connectionId?: string }
+      ) => callback(data)
       ipcRenderer.on('pty:replay', listener)
       return () => ipcRenderer.removeListener('pty:replay', listener)
     },
 
-    onExit: (callback: (data: { id: string; code: number }) => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: { id: string; code: number }) =>
-        callback(data)
+    onExit: (
+      callback: (data: { id: string; code: number; connectionId?: string }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { id: string; code: number; connectionId?: string }
+      ) => callback(data)
       ipcRenderer.on('pty:exit', listener)
       return () => ipcRenderer.removeListener('pty:exit', listener)
     },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -606,6 +606,10 @@ const api = {
       ipcRenderer.send('pty:write', { id, data })
     },
 
+    ackData: (id: string, charCount: number): void => {
+      ipcRenderer.send('pty:ackData', { id, charCount })
+    },
+
     resize: (id: string, cols: number, rows: number): void => {
       ipcRenderer.send('pty:resize', { id, cols, rows })
     },

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -260,6 +260,31 @@ describe('RelayDispatcher', () => {
     expect(written.length).toBe(before)
   })
 
+  it('does not report notifications as delivered to an invalidated primary client', () => {
+    dispatcher.invalidateClient()
+    const before = written.length
+
+    const deliveredClientIds = dispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+
+    expect(deliveredClientIds).toEqual([])
+    expect(written).toHaveLength(before)
+  })
+
+  it('detaches the primary client when its write callback throws', () => {
+    const failingDispatcher = new RelayDispatcher(() => {
+      throw new Error('stdout closed')
+    })
+    const listener = vi.fn()
+    failingDispatcher.onClientDetached(listener)
+
+    const deliveredClientIds = failingDispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+
+    expect(deliveredClientIds).toEqual([])
+    expect(listener).toHaveBeenCalledWith(1)
+    expect(failingDispatcher.hasOpenClient()).toBe(false)
+    failingDispatcher.dispose()
+  })
+
   it('drops in-flight responses after client invalidation', async () => {
     let resolveHandler!: () => void
     const handler = vi.fn(
@@ -317,5 +342,15 @@ describe('RelayDispatcher', () => {
     dispatcher.invalidateClient()
 
     expect(listener).toHaveBeenCalledWith(1)
+  })
+
+  it('notifies primary detach listeners only once across repeated invalidations', () => {
+    const listener = vi.fn()
+    dispatcher.onClientDetached(listener)
+
+    dispatcher.invalidateClient()
+    dispatcher.invalidateClient()
+
+    expect(listener).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: dispatcher protocol, reconnect, and
+request-lifetime tests share one frame decoder harness. */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { RelayDispatcher } from './dispatcher'
 import {
@@ -333,6 +335,73 @@ describe('RelayDispatcher', () => {
     expect(observedSignal?.aborted).toBe(true)
     resolveHandler()
     await vi.advanceTimersByTimeAsync(0)
+  })
+
+  it('aborts in-flight request contexts after write failure detaches the client', async () => {
+    const failingDispatcher = new RelayDispatcher(() => {
+      throw new Error('stdout closed')
+    })
+    let observedSignal: AbortSignal | undefined
+    let resolveHandler!: () => void
+    failingDispatcher.onRequest(
+      'slow.method',
+      (_params, context) =>
+        new Promise((resolve) => {
+          observedSignal = context.signal
+          resolveHandler = () => resolve(null)
+        })
+    )
+
+    const req: JsonRpcRequest = { jsonrpc: '2.0', id: 101, method: 'slow.method' }
+    failingDispatcher.feed(encodeJsonRpcFrame(req, 1, 0))
+    await vi.advanceTimersByTimeAsync(0)
+    failingDispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+
+    expect(observedSignal?.aborted).toBe(true)
+    resolveHandler()
+    await vi.advanceTimersByTimeAsync(0)
+    failingDispatcher.dispose()
+  })
+
+  it('ignores inbound frames after a primary client write failure closes it', async () => {
+    const failingDispatcher = new RelayDispatcher(() => {
+      throw new Error('stdout closed')
+    })
+    const handler = vi.fn().mockResolvedValue(null)
+    failingDispatcher.onRequest('mutate.after-close', handler)
+
+    failingDispatcher.notify('pty.data', { id: 'pty-1', data: 'x' })
+    failingDispatcher.feed(
+      encodeJsonRpcFrame({ jsonrpc: '2.0', id: 102, method: 'mutate.after-close' }, 1, 0)
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(handler).not.toHaveBeenCalled()
+    failingDispatcher.dispose()
+  })
+
+  it('stops processing buffered frames after a write failure closes the client', async () => {
+    const failingDispatcher = new RelayDispatcher(() => {
+      throw new Error('stdout closed')
+    })
+    const handler = vi.fn().mockResolvedValue(null)
+    failingDispatcher.onRequest('mutate.after-close', handler)
+
+    const firstFrame = encodeJsonRpcFrame(
+      { jsonrpc: '2.0', id: 103, method: 'missing.method' },
+      1,
+      0
+    )
+    const secondFrame = encodeJsonRpcFrame(
+      { jsonrpc: '2.0', id: 104, method: 'mutate.after-close' },
+      2,
+      0
+    )
+    failingDispatcher.feed(Buffer.concat([firstFrame, secondFrame]))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(handler).not.toHaveBeenCalled()
+    failingDispatcher.dispose()
   })
 
   it('notifies listeners when the primary client is invalidated', () => {

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -76,10 +76,13 @@ export class RelayDispatcher {
   // disconnects even if no replacement has connected yet. Otherwise a late
   // pty.spawn/fs.watch completion can create remote state nobody can own.
   invalidateClient(): void {
+    const wasClosed = this.primaryClient.closed
     this.requestAborts.abortClient(this.primaryClient.id)
     this.primaryClient.generation++
     this.primaryClient.closed = true
-    this.notifyClientDetached(this.primaryClient.id)
+    if (!wasClosed) {
+      this.notifyClientDetached(this.primaryClient.id)
+    }
   }
 
   // Why: synced remote workspaces can have more than one Orca client attached
@@ -150,18 +153,22 @@ export class RelayDispatcher {
     }
   }
 
-  notify(method: string, params?: Record<string, unknown>): void {
+  notify(method: string, params?: Record<string, unknown>): number[] {
     if (this.disposed) {
-      return
+      return []
     }
     const msg: JsonRpcNotification = {
       jsonrpc: '2.0',
       method,
       ...(params !== undefined ? { params } : {})
     }
+    const deliveredClientIds: number[] = []
     for (const client of this.clients.values()) {
-      this.sendFrame(client, msg)
+      if (this.sendFrame(client, msg)) {
+        deliveredClientIds.push(client.id)
+      }
     }
+    return deliveredClientIds
   }
 
   dispose(): void {
@@ -305,13 +312,13 @@ export class RelayDispatcher {
   private sendFrame(
     client: RelayClient,
     msg: JsonRpcRequest | JsonRpcResponse | JsonRpcNotification
-  ): void {
+  ): boolean {
     if (this.disposed || client.closed) {
-      return
+      return false
     }
     const seq = client.nextOutgoingSeq++
     const frame = encodeJsonRpcFrame(msg, seq, client.highestReceivedSeq)
-    this.writeFrame(client, frame)
+    return this.writeFrame(client, frame)
   }
 
   private startKeepalive(): void {
@@ -334,19 +341,21 @@ export class RelayDispatcher {
     this.keepaliveTimer.unref()
   }
 
-  private writeFrame(client: RelayClient, frame: Buffer): void {
+  private writeFrame(client: RelayClient, frame: Buffer): boolean {
     try {
       client.write(frame)
+      return true
     } catch (err) {
       client.closed = true
       client.generation++
       if (client !== this.primaryClient) {
         this.clients.delete(client.id)
-        this.notifyClientDetached(client.id)
       }
+      this.notifyClientDetached(client.id)
       process.stderr.write(
         `[relay] Client write failed: ${err instanceof Error ? err.message : String(err)}\n`
       )
+      return false
     }
   }
 

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -141,7 +141,7 @@ export class RelayDispatcher {
   }
 
   private feedForClient(client: RelayClient, data: Buffer): void {
-    if (this.disposed) {
+    if (this.disposed || client.closed) {
       return
     }
     try {
@@ -205,6 +205,10 @@ export class RelayDispatcher {
   }
 
   private handleFrame(client: RelayClient, frame: DecodedFrame): void {
+    if (this.disposed || client.closed) {
+      return
+    }
+
     if (frame.id > client.highestReceivedSeq) {
       client.highestReceivedSeq = frame.id
     }
@@ -257,7 +261,10 @@ export class RelayDispatcher {
     const context: RequestContext = {
       clientId: client.id,
       isStale: () =>
-        client.generation !== gen || !this.clients.has(client.id) || abortController.signal.aborted,
+        client.closed ||
+        client.generation !== gen ||
+        !this.clients.has(client.id) ||
+        abortController.signal.aborted,
       signal: abortController.signal
     }
     try {
@@ -290,7 +297,7 @@ export class RelayDispatcher {
       const gen = client.generation
       handler(notif.params ?? {}, {
         clientId: client.id,
-        isStale: () => client.generation !== gen || !this.clients.has(client.id)
+        isStale: () => client.closed || client.generation !== gen || !this.clients.has(client.id)
       })
     }
   }
@@ -346,6 +353,7 @@ export class RelayDispatcher {
       client.write(frame)
       return true
     } catch (err) {
+      this.requestAborts.abortClient(client.id)
       client.closed = true
       client.generation++
       if (client !== this.primaryClient) {

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: relay framing, client liveness, and request
+routing share sequence state; splitting would make protocol ordering harder to audit. */
 import {
   FrameDecoder,
   MessageType,
@@ -120,6 +122,15 @@ export class RelayDispatcher {
   onClientDetached(listener: (clientId: number) => void): () => void {
     this.clientDetachListeners.add(listener)
     return () => this.clientDetachListeners.delete(listener)
+  }
+
+  hasOpenClient(): boolean {
+    for (const client of this.clients.values()) {
+      if (!client.closed) {
+        return true
+      }
+    }
+    return false
   }
 
   feed(data: Buffer): void {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -32,10 +32,17 @@ function createMockDispatcher() {
     string,
     (params: Record<string, unknown>, context?: { isStale: () => boolean }) => Promise<unknown>
   >()
-  const notificationHandlers = new Map<string, (params: Record<string, unknown>) => void>()
+  const notificationHandlers = new Map<
+    string,
+    (
+      params: Record<string, unknown>,
+      context?: { clientId: number; isStale: () => boolean }
+    ) => void
+  >()
   const notifications: { method: string; params?: Record<string, unknown> }[] = []
   const clientDetachListeners = new Set<(clientId: number) => void>()
   let hasOpenClient = true
+  let deliveredClientIds = [1]
 
   const dispatcher = {
     onRequest: vi.fn(
@@ -54,6 +61,7 @@ function createMockDispatcher() {
     }),
     notify: vi.fn((method: string, params?: Record<string, unknown>) => {
       notifications.push({ method, params })
+      return hasOpenClient ? deliveredClientIds : []
     }),
     onClientDetached: vi.fn((listener: (clientId: number) => void) => {
       clientDetachListeners.add(listener)
@@ -66,6 +74,9 @@ function createMockDispatcher() {
     _notifications: notifications,
     _setHasOpenClient(value: boolean) {
       hasOpenClient = value
+    },
+    _setDeliveredClientIds(clientIds: number[]) {
+      deliveredClientIds = clientIds
     },
     _detachClient(clientId = 1) {
       for (const listener of clientDetachListeners) {
@@ -83,12 +94,12 @@ function createMockDispatcher() {
       }
       return handler(params, context)
     },
-    callNotification(method: string, params: Record<string, unknown> = {}) {
+    callNotification(method: string, params: Record<string, unknown> = {}, clientId = 1) {
       const handler = notificationHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
-      handler(params)
+      handler(params, { clientId, isStale: () => false })
     }
   }
 
@@ -354,6 +365,60 @@ describe('PtyHandler', () => {
 
     dispatcher._setHasOpenClient(false)
     dispatcher._detachClient()
+
+    expect(mockResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks acknowledgements per relay client before resuming output', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    const mockResume = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      resume: mockResume,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    dispatcher._setDeliveredClientIds([1, 2])
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(60_000))
+
+    expect(mockPause).toHaveBeenCalledTimes(1)
+
+    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 60_000 }, 1)
+    expect(mockResume).not.toHaveBeenCalled()
+
+    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 56_000 }, 2)
+    expect(mockResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let a detached relay client block another client from resuming output', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    const mockResume = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      resume: mockResume,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    dispatcher._setDeliveredClientIds([1, 2])
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(60_000))
+    dataCallback!('y'.repeat(45_000))
+
+    expect(mockPause).toHaveBeenCalledTimes(1)
+
+    dispatcher._detachClient(1)
+    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 101_000 }, 2)
 
     expect(mockResume).toHaveBeenCalledTimes(1)
   })

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -345,6 +345,26 @@ describe('PtyHandler', () => {
     expect(mockPause).not.toHaveBeenCalled()
   })
 
+  it('does not pause when relay output is delivered to no clients after write failure', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    dispatcher._setHasOpenClient(true)
+    dispatcher._setDeliveredClientIds([])
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(120 * 1024))
+
+    expect(mockPause).not.toHaveBeenCalled()
+  })
+
   it('clears paused flow-control state when the last relay client detaches', async () => {
     let dataCallback: ((data: string) => void) | undefined
     const mockPause = vi.fn()
@@ -385,15 +405,34 @@ describe('PtyHandler', () => {
 
     dispatcher._setDeliveredClientIds([1, 2])
     await dispatcher.callRequest('pty.spawn', {})
-    dataCallback!('x'.repeat(60_000))
+    dataCallback!('x'.repeat(100_001))
 
     expect(mockPause).toHaveBeenCalledTimes(1)
 
-    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 60_000 }, 1)
+    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 100_001 }, 1)
     expect(mockResume).not.toHaveBeenCalled()
 
-    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 56_000 }, 2)
+    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 100_001 }, 2)
     expect(mockResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses per-client watermarks so healthy relay clients do not lower the pause threshold', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    dispatcher._setDeliveredClientIds([1, 2])
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(60_000))
+
+    expect(mockPause).not.toHaveBeenCalled()
   })
 
   it('does not let a detached relay client block another client from resuming output', async () => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -13,6 +13,8 @@ const { mockPtySpawn, mockPtyInstance } = vi.hoisted(() => ({
     onExit: vi.fn(),
     write: vi.fn(),
     resize: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
     kill: vi.fn(),
     clear: vi.fn()
   }
@@ -32,6 +34,8 @@ function createMockDispatcher() {
   >()
   const notificationHandlers = new Map<string, (params: Record<string, unknown>) => void>()
   const notifications: { method: string; params?: Record<string, unknown> }[] = []
+  const clientDetachListeners = new Set<(clientId: number) => void>()
+  let hasOpenClient = true
 
   const dispatcher = {
     onRequest: vi.fn(
@@ -51,10 +55,23 @@ function createMockDispatcher() {
     notify: vi.fn((method: string, params?: Record<string, unknown>) => {
       notifications.push({ method, params })
     }),
+    onClientDetached: vi.fn((listener: (clientId: number) => void) => {
+      clientDetachListeners.add(listener)
+      return () => clientDetachListeners.delete(listener)
+    }),
+    hasOpenClient: vi.fn(() => hasOpenClient),
     // Helpers for tests
     _requestHandlers: requestHandlers,
     _notificationHandlers: notificationHandlers,
     _notifications: notifications,
+    _setHasOpenClient(value: boolean) {
+      hasOpenClient = value
+    },
+    _detachClient(clientId = 1) {
+      for (const listener of clientDetachListeners) {
+        listener(clientId)
+      }
+    },
     async callRequest(
       method: string,
       params: Record<string, unknown> = {},
@@ -89,6 +106,8 @@ describe('PtyHandler', () => {
     mockPtyInstance.onExit.mockReset()
     mockPtyInstance.write.mockReset()
     mockPtyInstance.resize.mockReset()
+    mockPtyInstance.pause.mockReset()
+    mockPtyInstance.resume.mockReset()
     mockPtyInstance.kill.mockReset()
     mockPtyInstance.clear.mockReset()
 
@@ -269,6 +288,74 @@ describe('PtyHandler', () => {
     await dispatcher.callRequest('pty.spawn', {})
     dispatcher.callNotification('pty.resize', { id: 'pty-1', cols: 120, rows: 40 })
     expect(mockResize).toHaveBeenCalledWith(120, 40)
+  })
+
+  it('pauses and resumes remote PTY output based on renderer parse acknowledgements', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    const mockResume = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      resume: mockResume,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(100_001))
+
+    expect(mockPause).toHaveBeenCalledTimes(1)
+    expect(mockResume).not.toHaveBeenCalled()
+
+    dispatcher.callNotification('pty.ackData', { id: 'pty-1', charCount: 95_002 })
+
+    expect(mockResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not pause remote PTYs while no relay client can acknowledge output', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    dispatcher._setHasOpenClient(false)
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(120 * 1024))
+
+    expect(mockPause).not.toHaveBeenCalled()
+  })
+
+  it('clears paused flow-control state when the last relay client detaches', async () => {
+    let dataCallback: ((data: string) => void) | undefined
+    const mockPause = vi.fn()
+    const mockResume = vi.fn()
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      pause: mockPause,
+      resume: mockResume,
+      onData: vi.fn((cb: (data: string) => void) => {
+        dataCallback = cb
+      }),
+      onExit: vi.fn()
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+    dataCallback!('x'.repeat(120 * 1024))
+    expect(mockPause).toHaveBeenCalledTimes(1)
+
+    dispatcher._setHasOpenClient(false)
+    dispatcher._detachClient()
+
+    expect(mockResume).toHaveBeenCalledTimes(1)
   })
 
   it('kills PTY on shutdown with SIGTERM by default', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -51,7 +51,7 @@ type ManagedPty = {
   paneKey?: string
   tabId?: string
   worktreeId?: string
-  unacknowledgedChars?: number
+  unacknowledgedCharsByClient?: Map<number, number>
   flowPaused?: boolean
 }
 
@@ -146,7 +146,8 @@ export class PtyHandler {
   constructor(dispatcher: RelayDispatcher, graceTimeMs = DEFAULT_GRACE_TIME_MS) {
     this.dispatcher = dispatcher
     this.graceTimeMs = graceTimeMs
-    this.dispatcher.onClientDetached(() => {
+    this.dispatcher.onClientDetached((clientId) => {
+      this.clearFlowControlForDetachedClient(clientId)
       if (!this.dispatcher.hasOpenClient()) {
         this.clearFlowControlForDetachedClients()
       }
@@ -204,14 +205,12 @@ export class PtyHandler {
   private wireAndStore(managed: ManagedPty): void {
     this.ptys.set(managed.id, managed)
     managed.pty.onData((data: string) => {
-      if (this.dispatcher.hasOpenClient()) {
-        this.observeUnacknowledgedData(managed, data.length)
-      }
       managed.buffered += data
       if (managed.buffered.length > REPLAY_BUFFER_MAX) {
         managed.buffered = managed.buffered.slice(-REPLAY_BUFFER_MAX)
       }
-      this.dispatcher.notify('pty.data', { id: managed.id, data })
+      const deliveredClientIds = this.dispatcher.notify('pty.data', { id: managed.id, data })
+      this.observeUnacknowledgedData(managed, data.length, deliveredClientIds)
     })
     managed.pty.onExit(({ exitCode }: { exitCode: number }) => {
       if (managed.disposed) {
@@ -282,7 +281,7 @@ export class PtyHandler {
 
     this.dispatcher.onNotification('pty.data', (p) => this.writeData(p))
     this.dispatcher.onNotification('pty.resize', (p) => this.resize(p))
-    this.dispatcher.onNotification('pty.ackData', (p) => this.ackData(p))
+    this.dispatcher.onNotification('pty.ackData', (p, context) => this.ackData(p, context))
   }
 
   private async spawn(
@@ -404,12 +403,22 @@ export class PtyHandler {
     }
   }
 
-  private observeUnacknowledgedData(managed: ManagedPty, charCount: number): void {
-    if (charCount <= 0 || managed.disposed) {
+  private observeUnacknowledgedData(
+    managed: ManagedPty,
+    charCount: number,
+    clientIds: number[]
+  ): void {
+    if (charCount <= 0 || clientIds.length === 0 || managed.disposed) {
       return
     }
-    managed.unacknowledgedChars = (managed.unacknowledgedChars ?? 0) + charCount
-    if (!managed.flowPaused && managed.unacknowledgedChars > FLOW_CONTROL_HIGH_WATERMARK_CHARS) {
+    const byClient = this.getFlowState(managed)
+    for (const clientId of clientIds) {
+      byClient.set(clientId, (byClient.get(clientId) ?? 0) + charCount)
+    }
+    if (
+      !managed.flowPaused &&
+      this.totalUnacknowledgedChars(managed) > FLOW_CONTROL_HIGH_WATERMARK_CHARS
+    ) {
       // Why: renderer ACKs arrive after xterm parses output. Pausing remote
       // node-pty prevents one SSH PTY from filling the relay/socket queues.
       managed.pty.pause()
@@ -417,30 +426,69 @@ export class PtyHandler {
     }
   }
 
-  private ackData(params: Record<string, unknown>): void {
+  private ackData(params: Record<string, unknown>, context?: RequestContext): void {
     const id = params.id as string
     const managed = this.ptys.get(id)
-    if (!managed || managed.disposed) {
+    if (!managed || managed.disposed || !context) {
       return
     }
     const charCount = Math.max(0, Math.floor(Number(params.charCount) || 0))
-    this.ackManagedData(managed, charCount)
+    this.ackManagedData(managed, context.clientId, charCount)
   }
 
-  private ackManagedData(managed: ManagedPty, charCount: number): void {
+  private ackManagedData(managed: ManagedPty, clientId: number, charCount: number): void {
     if (charCount <= 0) {
       return
     }
-    managed.unacknowledgedChars = Math.max(0, (managed.unacknowledgedChars ?? 0) - charCount)
-    if (managed.flowPaused && managed.unacknowledgedChars < FLOW_CONTROL_LOW_WATERMARK_CHARS) {
+    const byClient = managed.unacknowledgedCharsByClient
+    if (!byClient) {
+      return
+    }
+    const next = Math.max(0, (byClient.get(clientId) ?? 0) - charCount)
+    if (next === 0) {
+      byClient.delete(clientId)
+    } else {
+      byClient.set(clientId, next)
+    }
+    if (
+      managed.flowPaused &&
+      this.totalUnacknowledgedChars(managed) < FLOW_CONTROL_LOW_WATERMARK_CHARS
+    ) {
       managed.pty.resume()
       managed.flowPaused = false
     }
   }
 
+  private getFlowState(managed: ManagedPty): Map<number, number> {
+    managed.unacknowledgedCharsByClient ??= new Map()
+    return managed.unacknowledgedCharsByClient
+  }
+
+  private totalUnacknowledgedChars(managed: ManagedPty): number {
+    let total = 0
+    for (const count of managed.unacknowledgedCharsByClient?.values() ?? []) {
+      total += count
+    }
+    return total
+  }
+
+  private clearFlowControlForDetachedClient(clientId: number): void {
+    for (const managed of this.ptys.values()) {
+      managed.unacknowledgedCharsByClient?.delete(clientId)
+      if (
+        managed.flowPaused &&
+        !managed.disposed &&
+        this.totalUnacknowledgedChars(managed) < FLOW_CONTROL_LOW_WATERMARK_CHARS
+      ) {
+        managed.pty.resume()
+        managed.flowPaused = false
+      }
+    }
+  }
+
   private clearFlowControlForDetachedClients(): void {
     for (const managed of this.ptys.values()) {
-      managed.unacknowledgedChars = 0
+      managed.unacknowledgedCharsByClient?.clear()
       if (managed.flowPaused && !managed.disposed) {
         managed.pty.resume()
         managed.flowPaused = false

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -417,7 +417,7 @@ export class PtyHandler {
     }
     if (
       !managed.flowPaused &&
-      this.totalUnacknowledgedChars(managed) > FLOW_CONTROL_HIGH_WATERMARK_CHARS
+      this.maxUnacknowledgedChars(managed) > FLOW_CONTROL_HIGH_WATERMARK_CHARS
     ) {
       // Why: renderer ACKs arrive after xterm parses output. Pausing remote
       // node-pty prevents one SSH PTY from filling the relay/socket queues.
@@ -452,7 +452,7 @@ export class PtyHandler {
     }
     if (
       managed.flowPaused &&
-      this.totalUnacknowledgedChars(managed) < FLOW_CONTROL_LOW_WATERMARK_CHARS
+      this.maxUnacknowledgedChars(managed) < FLOW_CONTROL_LOW_WATERMARK_CHARS
     ) {
       managed.pty.resume()
       managed.flowPaused = false
@@ -464,12 +464,12 @@ export class PtyHandler {
     return managed.unacknowledgedCharsByClient
   }
 
-  private totalUnacknowledgedChars(managed: ManagedPty): number {
-    let total = 0
+  private maxUnacknowledgedChars(managed: ManagedPty): number {
+    let max = 0
     for (const count of managed.unacknowledgedCharsByClient?.values() ?? []) {
-      total += count
+      max = Math.max(max, count)
     }
-    return total
+    return max
   }
 
   private clearFlowControlForDetachedClient(clientId: number): void {
@@ -478,7 +478,7 @@ export class PtyHandler {
       if (
         managed.flowPaused &&
         !managed.disposed &&
-        this.totalUnacknowledgedChars(managed) < FLOW_CONTROL_LOW_WATERMARK_CHARS
+        this.maxUnacknowledgedChars(managed) < FLOW_CONTROL_LOW_WATERMARK_CHARS
       ) {
         managed.pty.resume()
         managed.flowPaused = false

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -51,6 +51,8 @@ type ManagedPty = {
   paneKey?: string
   tabId?: string
   worktreeId?: string
+  unacknowledgedChars?: number
+  flowPaused?: boolean
 }
 
 function disposeManagedPty(managed: ManagedPty): void {
@@ -84,6 +86,8 @@ function disposeManagedPty(managed: ManagedPty): void {
 }
 const DEFAULT_GRACE_TIME_MS = DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
 export const REPLAY_BUFFER_MAX = 100 * 1024
+const FLOW_CONTROL_HIGH_WATERMARK_CHARS = 100_000
+const FLOW_CONTROL_LOW_WATERMARK_CHARS = 5_000
 const ALLOWED_SIGNALS = new Set([
   'SIGINT',
   'SIGTERM',
@@ -142,6 +146,11 @@ export class PtyHandler {
   constructor(dispatcher: RelayDispatcher, graceTimeMs = DEFAULT_GRACE_TIME_MS) {
     this.dispatcher = dispatcher
     this.graceTimeMs = graceTimeMs
+    this.dispatcher.onClientDetached(() => {
+      if (!this.dispatcher.hasOpenClient()) {
+        this.clearFlowControlForDetachedClients()
+      }
+    })
     this.registerHandlers()
   }
 
@@ -195,6 +204,9 @@ export class PtyHandler {
   private wireAndStore(managed: ManagedPty): void {
     this.ptys.set(managed.id, managed)
     managed.pty.onData((data: string) => {
+      if (this.dispatcher.hasOpenClient()) {
+        this.observeUnacknowledgedData(managed, data.length)
+      }
       managed.buffered += data
       if (managed.buffered.length > REPLAY_BUFFER_MAX) {
         managed.buffered = managed.buffered.slice(-REPLAY_BUFFER_MAX)
@@ -270,9 +282,7 @@ export class PtyHandler {
 
     this.dispatcher.onNotification('pty.data', (p) => this.writeData(p))
     this.dispatcher.onNotification('pty.resize', (p) => this.resize(p))
-    this.dispatcher.onNotification('pty.ackData', (_p) => {
-      /* flow control ack -- not yet enforced */
-    })
+    this.dispatcher.onNotification('pty.ackData', (p) => this.ackData(p))
   }
 
   private async spawn(
@@ -391,6 +401,50 @@ export class PtyHandler {
     const managed = this.ptys.get(id)
     if (managed && !managed.disposed) {
       managed.pty.write(data)
+    }
+  }
+
+  private observeUnacknowledgedData(managed: ManagedPty, charCount: number): void {
+    if (charCount <= 0 || managed.disposed) {
+      return
+    }
+    managed.unacknowledgedChars = (managed.unacknowledgedChars ?? 0) + charCount
+    if (!managed.flowPaused && managed.unacknowledgedChars > FLOW_CONTROL_HIGH_WATERMARK_CHARS) {
+      // Why: renderer ACKs arrive after xterm parses output. Pausing remote
+      // node-pty prevents one SSH PTY from filling the relay/socket queues.
+      managed.pty.pause()
+      managed.flowPaused = true
+    }
+  }
+
+  private ackData(params: Record<string, unknown>): void {
+    const id = params.id as string
+    const managed = this.ptys.get(id)
+    if (!managed || managed.disposed) {
+      return
+    }
+    const charCount = Math.max(0, Math.floor(Number(params.charCount) || 0))
+    this.ackManagedData(managed, charCount)
+  }
+
+  private ackManagedData(managed: ManagedPty, charCount: number): void {
+    if (charCount <= 0) {
+      return
+    }
+    managed.unacknowledgedChars = Math.max(0, (managed.unacknowledgedChars ?? 0) - charCount)
+    if (managed.flowPaused && managed.unacknowledgedChars < FLOW_CONTROL_LOW_WATERMARK_CHARS) {
+      managed.pty.resume()
+      managed.flowPaused = false
+    }
+  }
+
+  private clearFlowControlForDetachedClients(): void {
+    for (const managed of this.ptys.values()) {
+      managed.unacknowledgedChars = 0
+      if (managed.flowPaused && !managed.disposed) {
+        managed.pty.resume()
+        managed.flowPaused = false
+      }
     }
   }
 

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -181,12 +181,14 @@ async function main(): Promise<void> {
   // socket client reconnects, setWrite swaps the callback to the socket.
   let stdoutAlive = true
   const dispatcher = new RelayDispatcher((data) => {
-    if (stdoutAlive) {
-      try {
-        process.stdout.write(data)
-      } catch {
-        stdoutAlive = false
-      }
+    if (!stdoutAlive) {
+      throw new Error('stdout is not writable')
+    }
+    try {
+      process.stdout.write(data)
+    } catch (err) {
+      stdoutAlive = false
+      throw err
     }
   })
 
@@ -500,6 +502,7 @@ async function main(): Promise<void> {
     // pipe), start the grace timer (socket connect will cancel it), and
     // rely entirely on the Unix socket for client communication.
     stdoutAlive = false
+    dispatcher.invalidateClient()
     startGrace()
   } else {
     process.stdin.on('data', (chunk: Buffer) => {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -406,8 +406,14 @@ async function main(): Promise<void> {
     ptyHandler.cancelGraceTimer()
 
     const clientId = dispatcher.attachClient((data) => {
-      if (!sock.destroyed) {
+      try {
+        if (sock.destroyed || !sock.writable) {
+          throw new Error('socket is not writable')
+        }
         sock.write(data)
+      } catch (err) {
+        sock.destroy()
+        throw err
       }
     })
     socketClients.set(sock, clientId)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -69,7 +69,7 @@ type StoreState = {
 }
 
 type ConnectCallbacks = {
-  onData?: (data: string) => void
+  onData?: (data: string, sourceCharCount?: number) => void
   onError?: (msg: string) => void
 }
 
@@ -992,6 +992,115 @@ describe('connectPanePty', () => {
     } finally {
       globalThis.setTimeout = originalSetTimeout
     }
+  })
+
+  it('acknowledges active pane PTY bytes after xterm write callback', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: {
+      current: ((data: string, sourceCharCount?: number) => void) | null
+    } = {
+      current: null
+    }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('hello')
+
+    expect(transport.acknowledgeDataEvent).toHaveBeenCalledWith('hello'.length)
+  })
+
+  it('acknowledges stripped control bytes separately from parsed terminal bytes', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: {
+      current: ((data: string, sourceCharCount?: number) => void) | null
+    } = {
+      current: null
+    }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('hello', 10)
+
+    expect(transport.acknowledgeDataEvent.mock.calls).toEqual([[5], [5]])
+  })
+
+  it('renders synthetic PTY data without acknowledging provider-owned bytes', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: {
+      current: ((data: string, sourceCharCount?: number) => void) | null
+    } = {
+      current: null
+    }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('\x1b]0;⠋ Cursor Agent\x07', 0)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b]0;⠋ Cursor Agent\x07',
+      expect.any(Function)
+    )
+    expect(transport.acknowledgeDataEvent).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges source bytes immediately when control parsing removes all terminal data', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: {
+      current: ((data: string, sourceCharCount?: number) => void) | null
+    } = {
+      current: null
+    }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('', 10)
+
+    expect(transport.acknowledgeDataEvent).toHaveBeenCalledWith(10)
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('', expect.any(Function))
   })
 
   it('queues visible inactive split-pane PTY bytes so active pane input stays responsive', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2182,7 +2182,7 @@ describe('connectPanePty', () => {
       POST_REPLAY_FOCUS_REPORTING_RESET,
       expect.any(Function)
     )
-    expect(api.pty.signal).toHaveBeenCalledWith('leaf-session', 'SIGWINCH')
+    expect(api.pty.signal).toHaveBeenCalledWith('leaf-session', 'SIGWINCH', 'conn-1')
   })
 
   it('does not auto-reconnect after a user cancels deferred SSH passphrase auth', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -81,6 +81,7 @@ type MockTransport = {
     ) => unknown
   }
   sendInput: ReturnType<typeof vi.fn>
+  acknowledgeDataEvent: ReturnType<typeof vi.fn>
   resize: ReturnType<typeof vi.fn>
   getPtyId: ReturnType<typeof vi.fn>
 }
@@ -193,6 +194,7 @@ function createMockTransport(initialPtyId: string | null = null): MockTransport 
       return ptyId
     }),
     sendInput: vi.fn(() => true),
+    acknowledgeDataEvent: vi.fn(),
     resize: vi.fn(() => true),
     getPtyId: vi.fn(() => ptyId)
   } as MockTransport
@@ -207,7 +209,9 @@ function createPane(paneId: number) {
     terminal: {
       cols: 120,
       rows: 40,
-      write: vi.fn(),
+      write: vi.fn((_data: string, callback?: () => void) => {
+        callback?.()
+      }),
       onData: vi.fn(() => ({ dispose: vi.fn() })),
       onResize: vi.fn(() => ({ dispose: vi.fn() })),
       onTitleChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -978,13 +982,13 @@ describe('connectPanePty', () => {
 
       expect(capturedDataCallback.current).not.toBeNull()
       capturedDataCallback.current?.('hello\r\n')
-      expect(pane.terminal.write).not.toHaveBeenCalledWith('hello\r\n')
+      expect(pane.terminal.write).not.toHaveBeenCalledWith('hello\r\n', expect.any(Function))
 
       for (const fn of pendingTimeouts) {
         fn()
       }
 
-      expect(pane.terminal.write).toHaveBeenCalledWith('hello\r\n')
+      expect(pane.terminal.write).toHaveBeenCalledWith('hello\r\n', expect.any(Function))
     } finally {
       globalThis.setTimeout = originalSetTimeout
     }
@@ -1022,13 +1026,19 @@ describe('connectPanePty', () => {
 
       expect(capturedDataCallback.current).not.toBeNull()
       capturedDataCallback.current?.('visible split output\r\n')
-      expect(pane.terminal.write).not.toHaveBeenCalledWith('visible split output\r\n')
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        'visible split output\r\n',
+        expect.any(Function)
+      )
 
       for (const fn of pendingTimeouts) {
         fn()
       }
 
-      expect(pane.terminal.write).toHaveBeenCalledWith('visible split output\r\n')
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        'visible split output\r\n',
+        expect.any(Function)
+      )
     } finally {
       globalThis.setTimeout = originalSetTimeout
     }
@@ -1057,7 +1067,10 @@ describe('connectPanePty', () => {
     expect(capturedDataCallback.current).not.toBeNull()
     capturedDataCallback.current?.('active split output\r\n')
 
-    expect(pane.terminal.write).toHaveBeenCalledWith('active split output\r\n')
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'active split output\r\n',
+      expect.any(Function)
+    )
   })
 
   it('marks panes that receive Arabic output for DOM rendering', async () => {
@@ -1080,7 +1093,10 @@ describe('connectPanePty', () => {
     capturedDataCallback.current?.('Arabic: السلام عليكم\r\n')
 
     expect(manager.markPaneHasComplexScriptOutput).toHaveBeenCalledWith(1)
-    expect(pane.terminal.write).toHaveBeenCalledWith('Arabic: السلام عليكم\r\n')
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'Arabic: السلام عليكم\r\n',
+      expect.any(Function)
+    )
   })
 
   it('reattaches via daemon sessionId when an in-session PTY is live', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -883,21 +883,22 @@ export function connectPanePty(
       if (terminalOutputPrefersDomRenderer(data)) {
         manager.markPaneHasComplexScriptOutput(pane.id)
       }
+      const strippedCharCount = Math.max(0, sourceCharCount - data.length)
+      if (strippedCharCount > 0) {
+        transport.acknowledgeDataEvent(strippedCharCount)
+      }
+      let remainingParsedAckChars = Math.min(data.length, sourceCharCount)
       // Why: the active split pane owns keyboard latency. Visible inactive
       // panes still drain, but through the shared scheduler so a build log in
       // another split cannot monopolize xterm writes while the user types.
       const activePaneId = manager.getActivePane()?.id ?? pane.id
-      let ackedSourceChunk = false
       writeTerminalOutput(pane.terminal, data, {
         foreground: deps.isVisibleRef.current && activePaneId === pane.id,
         onParsed: (charCount) => {
-          if (sourceCharCount === data.length) {
-            transport.acknowledgeDataEvent(charCount)
-            return
-          }
-          if (!ackedSourceChunk) {
-            ackedSourceChunk = true
-            transport.acknowledgeDataEvent(sourceCharCount)
+          const ackChars = Math.min(charCount, remainingParsedAckChars)
+          remainingParsedAckChars -= ackChars
+          if (ackChars > 0) {
+            transport.acknowledgeDataEvent(ackChars)
           }
         }
       })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1039,7 +1039,11 @@ export function connectPanePty(
       // change. Sending it explicitly guarantees restored TUIs repaint at
       // the correct cursor position after snapshot replay.
       if (!isRemoteRuntimePtyId(ptyId)) {
-        window.api.pty.signal(ptyId, 'SIGWINCH')
+        if (connectionId) {
+          window.api.pty.signal(ptyId, 'SIGWINCH', connectionId)
+        } else {
+          window.api.pty.signal(ptyId, 'SIGWINCH')
+        }
       }
 
       scheduleRuntimeGraphSync()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -848,14 +848,14 @@ export function connectPanePty(
     // regardless of DOM visibility and the guard stays engaged via the
     // write-completion callback until xterm finishes parsing.
     let replayEndsWithLineBreak = true
-    const writeReplayData = (data: string): void => {
+    const writeReplayData = (data: string, onParsed?: (charCount: number) => void): void => {
       // Why: drain any queued background bytes BEFORE the replay paint, so the
       // scheduler's deferred drain cannot land older bytes on top of the replay.
       flushTerminalOutput(pane.terminal)
       if (terminalOutputPrefersDomRenderer(data)) {
         manager.markPaneHasComplexScriptOutput(pane.id)
       }
-      replayIntoTerminal(pane, deps.replayingPanesRef, data)
+      replayIntoTerminal(pane, deps.replayingPanesRef, data, onParsed)
       replayEndsWithLineBreak = /[\r\n]$/.test(data)
     }
     const terminateReplayLine = (): void => {
@@ -864,16 +864,22 @@ export function connectPanePty(
       }
     }
 
-    const replayDataCallback = (data: string): void => {
+    const replayDataCallback = (data: string, onParsed?: (charCount: number) => void): void => {
       // Relay replay buffer holds the last 100 KB of output, which may
       // overlap with content already rendered in xterm before the
       // disconnect. Clear first to prevent duplication on SSH reconnect.
       writeReplayData('\x1b[2J\x1b[3J\x1b[H')
-      writeReplayData(data)
+      writeReplayData(data, onParsed)
     }
 
-    const dataCallback = (data: string): void => {
+    const dataCallback = (data: string, sourceCharCount = data.length): void => {
       commandLifecycle.handlePtyData(data)
+      if (!data) {
+        if (sourceCharCount > 0) {
+          transport.acknowledgeDataEvent(sourceCharCount)
+        }
+        return
+      }
       if (terminalOutputPrefersDomRenderer(data)) {
         manager.markPaneHasComplexScriptOutput(pane.id)
       }
@@ -881,8 +887,19 @@ export function connectPanePty(
       // panes still drain, but through the shared scheduler so a build log in
       // another split cannot monopolize xterm writes while the user types.
       const activePaneId = manager.getActivePane()?.id ?? pane.id
+      let ackedSourceChunk = false
       writeTerminalOutput(pane.terminal, data, {
-        foreground: deps.isVisibleRef.current && activePaneId === pane.id
+        foreground: deps.isVisibleRef.current && activePaneId === pane.id,
+        onParsed: (charCount) => {
+          if (sourceCharCount === data.length) {
+            transport.acknowledgeDataEvent(charCount)
+            return
+          }
+          if (!ackedSourceChunk) {
+            ackedSourceChunk = true
+            transport.acknowledgeDataEvent(sourceCharCount)
+          }
+        }
       })
 
       if (pendingStartupCommand) {

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -13,7 +13,9 @@ import type { EventProps } from '../../../../shared/telemetry-events'
 // PTY ID. Eliminates the N-listener problem that triggers
 // MaxListenersExceededWarning with many panes/tabs.
 
-export const ptyDataHandlers = new Map<string, (data: string) => void>()
+export type PtyDataPayload = { id: string; data: string; synthetic?: boolean }
+
+export const ptyDataHandlers = new Map<string, (data: string, sourceCharCount?: number) => void>()
 /** Sidecar subscriptions that observe PTY data without owning the primary
  *  handler. Used by features that need to react to the live byte stream
  *  (e.g. agent-paste-draft watching for DECSET 2004 / bracketed-paste-
@@ -81,7 +83,15 @@ export function ensurePtyDispatcher(): void {
   }
   ptyDispatcherAttached = true
   window.api.pty.onData((payload) => {
-    ptyDataHandlers.get(payload.id)?.(payload.data)
+    const sourceCharCount = payload.synthetic ? 0 : payload.data.length
+    const primaryHandler = ptyDataHandlers.get(payload.id)
+    if (primaryHandler) {
+      primaryHandler(payload.data, sourceCharCount)
+    } else if (payload.data.length > 0 && !payload.synthetic) {
+      // Why: detach/remount gaps intentionally have no xterm consumer. ACK
+      // dropped bytes so upstream PTYs cannot remain paused waiting on parsing.
+      window.api.pty.ackData(payload.id, payload.data.length)
+    }
     const sidecars = ptyDataSidecars.get(payload.id)
     if (sidecars && sidecars.size > 0) {
       // Why: snapshot the Set before iterating because watchers commonly

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -13,9 +13,17 @@ import type { EventProps } from '../../../../shared/telemetry-events'
 // PTY ID. Eliminates the N-listener problem that triggers
 // MaxListenersExceededWarning with many panes/tabs.
 
-export type PtyDataPayload = { id: string; data: string; synthetic?: boolean }
+export type PtyDataPayload = {
+  id: string
+  data: string
+  synthetic?: boolean
+  connectionId?: string
+}
 
-export const ptyDataHandlers = new Map<string, (data: string, sourceCharCount?: number) => void>()
+export const ptyDataHandlers = new Map<
+  string,
+  (data: string, sourceCharCount?: number, connectionId?: string) => void
+>()
 /** Sidecar subscriptions that observe PTY data without owning the primary
  *  handler. Used by features that need to react to the live byte stream
  *  (e.g. agent-paste-draft watching for DECSET 2004 / bracketed-paste-
@@ -24,25 +32,45 @@ export const ptyDataHandlers = new Map<string, (data: string, sourceCharCount?: 
  *  active subscription; removal is by Set.delete inside the unsubscribe fn. */
 export const ptyDataSidecars = new Map<string, Set<(data: string) => void>>()
 
+const LOCAL_PTY_SCOPE = 'local'
+
+export function ptyHandlerKey(ptyId: string, connectionId?: string | null): string {
+  return `${connectionId || LOCAL_PTY_SCOPE}\u0000${ptyId}`
+}
+
+function deletePtyScopedEntries<T>(map: Map<string, T>, ptyId: string): void {
+  map.delete(ptyHandlerKey(ptyId))
+  for (const key of map.keys()) {
+    if (key.endsWith(`\u0000${ptyId}`)) {
+      map.delete(key)
+    }
+  }
+}
+
 /** Register a side-channel data watcher for a PTY without taking ownership
  *  of the primary handler. Returns an unsubscribe fn. ensurePtyDispatcher()
  *  is called automatically so the underlying IPC stream is wired up. */
-export function subscribeToPtyData(ptyId: string, watcher: (data: string) => void): () => void {
+export function subscribeToPtyData(
+  ptyId: string,
+  watcher: (data: string) => void,
+  connectionId?: string | null
+): () => void {
   ensurePtyDispatcher()
-  let set = ptyDataSidecars.get(ptyId)
+  const key = ptyHandlerKey(ptyId, connectionId)
+  let set = ptyDataSidecars.get(key)
   if (!set) {
     set = new Set()
-    ptyDataSidecars.set(ptyId, set)
+    ptyDataSidecars.set(key, set)
   }
   set.add(watcher)
   return () => {
-    const current = ptyDataSidecars.get(ptyId)
+    const current = ptyDataSidecars.get(key)
     if (!current) {
       return
     }
     current.delete(watcher)
     if (current.size === 0) {
-      ptyDataSidecars.delete(ptyId)
+      ptyDataSidecars.delete(key)
     }
   }
 }
@@ -70,10 +98,26 @@ let ptyDispatcherAttached = false
  */
 export function unregisterPtyDataHandlers(ptyIds: string[]): void {
   for (const id of ptyIds) {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
-    ptyTeardownHandlers.get(id)?.()
-    ptyTeardownHandlers.delete(id)
+    deletePtyScopedEntries(ptyDataHandlers, id)
+    deletePtyScopedEntries(ptyReplayHandlers, id)
+    for (const [key, teardown] of ptyTeardownHandlers) {
+      if (key.endsWith(`\u0000${id}`)) {
+        teardown()
+      }
+    }
+    deletePtyScopedEntries(ptyTeardownHandlers, id)
+  }
+}
+
+export function unregisterScopedPtyDataHandlers(
+  entries: { ptyId: string; connectionId?: string | null }[]
+): void {
+  for (const { ptyId, connectionId } of entries) {
+    const key = ptyHandlerKey(ptyId, connectionId)
+    ptyDataHandlers.delete(key)
+    ptyReplayHandlers.delete(key)
+    ptyTeardownHandlers.get(key)?.()
+    ptyTeardownHandlers.delete(key)
   }
 }
 
@@ -84,15 +128,20 @@ export function ensurePtyDispatcher(): void {
   ptyDispatcherAttached = true
   window.api.pty.onData((payload) => {
     const sourceCharCount = payload.synthetic ? 0 : payload.data.length
-    const primaryHandler = ptyDataHandlers.get(payload.id)
+    const key = ptyHandlerKey(payload.id, payload.connectionId)
+    const primaryHandler = ptyDataHandlers.get(key)
     if (primaryHandler) {
-      primaryHandler(payload.data, sourceCharCount)
+      primaryHandler(payload.data, sourceCharCount, payload.connectionId)
     } else if (payload.data.length > 0 && !payload.synthetic) {
       // Why: detach/remount gaps intentionally have no xterm consumer. ACK
       // dropped bytes so upstream PTYs cannot remain paused waiting on parsing.
-      window.api.pty.ackData(payload.id, payload.data.length)
+      if (payload.connectionId) {
+        window.api.pty.ackData(payload.id, payload.data.length, payload.connectionId)
+      } else {
+        window.api.pty.ackData(payload.id, payload.data.length)
+      }
     }
-    const sidecars = ptyDataSidecars.get(payload.id)
+    const sidecars = ptyDataSidecars.get(key)
     if (sidecars && sidecars.size > 0) {
       // Why: snapshot the Set before iterating because watchers commonly
       // unsubscribe themselves on the very chunk that satisfies them
@@ -108,14 +157,15 @@ export function ensurePtyDispatcher(): void {
     }
   })
   window.api.pty.onReplay((payload) => {
-    ptyReplayHandlers.get(payload.id)?.(payload.data)
+    ptyReplayHandlers.get(ptyHandlerKey(payload.id, payload.connectionId))?.(payload.data)
   })
   window.api.pty.onExit((payload) => {
-    ptyExitHandlers.get(payload.id)?.(payload.code)
-    const sidecars = ptyExitSidecars.get(payload.id)
+    const key = ptyHandlerKey(payload.id, payload.connectionId)
+    ptyExitHandlers.get(key)?.(payload.code)
+    const sidecars = ptyExitSidecars.get(key)
     if (sidecars && sidecars.size > 0) {
       const snapshot = Array.from(sidecars)
-      ptyExitSidecars.delete(payload.id)
+      ptyExitSidecars.delete(key)
       for (const sidecar of snapshot) {
         sidecar(payload.code)
       }
@@ -123,22 +173,27 @@ export function ensurePtyDispatcher(): void {
   })
 }
 
-export function subscribeToPtyExit(ptyId: string, watcher: (code: number) => void): () => void {
+export function subscribeToPtyExit(
+  ptyId: string,
+  watcher: (code: number) => void,
+  connectionId?: string | null
+): () => void {
   ensurePtyDispatcher()
-  let set = ptyExitSidecars.get(ptyId)
+  const key = ptyHandlerKey(ptyId, connectionId)
+  let set = ptyExitSidecars.get(key)
   if (!set) {
     set = new Set()
-    ptyExitSidecars.set(ptyId, set)
+    ptyExitSidecars.set(key, set)
   }
   set.add(watcher)
   return () => {
-    const current = ptyExitSidecars.get(ptyId)
+    const current = ptyExitSidecars.get(key)
     if (!current) {
       return
     }
     current.delete(watcher)
     if (current.size === 0) {
-      ptyExitSidecars.delete(ptyId)
+      ptyExitSidecars.delete(key)
     }
   }
 }
@@ -151,8 +206,11 @@ export function subscribeToPtyExit(ptyId: string, watcher: (code: number) => voi
 export type EagerPtyHandle = { flush: () => string; dispose: () => void }
 const eagerPtyHandles = new Map<string, EagerPtyHandle>()
 
-export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefined {
-  return eagerPtyHandles.get(ptyId)
+export function getEagerPtyBufferHandle(
+  ptyId: string,
+  connectionId?: string | null
+): EagerPtyHandle | undefined {
+  return eagerPtyHandles.get(ptyHandlerKey(ptyId, connectionId))
 }
 
 // Why: 512 KB matches the scrollback buffer cap used by TerminalPane's
@@ -162,19 +220,31 @@ const EAGER_BUFFER_MAX_BYTES = 512 * 1024
 
 export function registerEagerPtyBuffer(
   ptyId: string,
-  onExit: (ptyId: string, code: number) => void
+  onExit: (ptyId: string, code: number) => void,
+  connectionId?: string | null
 ): EagerPtyHandle {
   ensurePtyDispatcher()
 
   const buffer: string[] = []
   let bufferBytes = 0
+  const key = ptyHandlerKey(ptyId, connectionId)
 
-  const dataHandler = (data: string): void => {
+  const dataHandler = (
+    data: string,
+    sourceCharCount = data.length,
+    connectionId?: string
+  ): void => {
     buffer.push(data)
     bufferBytes += data.length
     // Why: no xterm exists yet for eager/background PTYs. Once the renderer
-    // owns the bytes in this bounded buffer, upstream flow control can resume.
-    window.api.pty.ackData(ptyId, data.length)
+    // owns provider bytes in this bounded buffer, upstream flow control can resume.
+    if (sourceCharCount > 0) {
+      if (connectionId) {
+        window.api.pty.ackData(ptyId, sourceCharCount, connectionId)
+      } else {
+        window.api.pty.ackData(ptyId, sourceCharCount)
+      }
+    }
     // Trim from the front when the buffer exceeds the cap, keeping the
     // most recent output which contains the shell prompt.
     while (bufferBytes > EAGER_BUFFER_MAX_BYTES && buffer.length > 1) {
@@ -185,15 +255,15 @@ export function registerEagerPtyBuffer(
   const exitHandler = (code: number): void => {
     // Shell died before TerminalPane attached — clean up and notify the store
     // so the tab's ptyId is cleared and connectPanePty falls through to connect().
-    ptyDataHandlers.delete(ptyId)
-    ptyReplayHandlers.delete(ptyId)
-    ptyExitHandlers.delete(ptyId)
-    eagerPtyHandles.delete(ptyId)
+    ptyDataHandlers.delete(key)
+    ptyReplayHandlers.delete(key)
+    ptyExitHandlers.delete(key)
+    eagerPtyHandles.delete(key)
     onExit(ptyId, code)
   }
 
-  ptyDataHandlers.set(ptyId, dataHandler)
-  ptyExitHandlers.set(ptyId, exitHandler)
+  ptyDataHandlers.set(key, dataHandler)
+  ptyExitHandlers.set(key, exitHandler)
 
   const handle: EagerPtyHandle = {
     flush() {
@@ -204,18 +274,18 @@ export function registerEagerPtyBuffer(
     dispose() {
       // Only remove if the current handler is still the temp one (compare by
       // reference). After attach() replaces the handler this becomes a no-op.
-      if (ptyDataHandlers.get(ptyId) === dataHandler) {
-        ptyDataHandlers.delete(ptyId)
-        ptyReplayHandlers.delete(ptyId)
+      if (ptyDataHandlers.get(key) === dataHandler) {
+        ptyDataHandlers.delete(key)
+        ptyReplayHandlers.delete(key)
       }
-      if (ptyExitHandlers.get(ptyId) === exitHandler) {
-        ptyExitHandlers.delete(ptyId)
+      if (ptyExitHandlers.get(key) === exitHandler) {
+        ptyExitHandlers.delete(key)
       }
-      eagerPtyHandles.delete(ptyId)
+      eagerPtyHandles.delete(key)
     }
   }
 
-  eagerPtyHandles.set(ptyId, handle)
+  eagerPtyHandles.set(key, handle)
   return handle
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -162,10 +162,14 @@ export function registerEagerPtyBuffer(
   const dataHandler = (data: string): void => {
     buffer.push(data)
     bufferBytes += data.length
+    // Why: no xterm exists yet for eager/background PTYs. Once the renderer
+    // owns the bytes in this bounded buffer, upstream flow control can resume.
+    window.api.pty.ackData(ptyId, data.length)
     // Trim from the front when the buffer exceeds the cap, keeping the
     // most recent output which contains the shell prompt.
     while (bufferBytes > EAGER_BUFFER_MAX_BYTES && buffer.length > 1) {
-      bufferBytes -= buffer.shift()!.length
+      const dropped = buffer.shift()!
+      bufferBytes -= dropped.length
     }
   }
   const exitHandler = (code: number): void => {
@@ -230,12 +234,12 @@ export type PtyTransport = {
     callbacks: {
       onConnect?: () => void
       onDisconnect?: () => void
-      onData?: (data: string) => void
+      onData?: (data: string, sourceCharCount?: number) => void
       /** Replay bytes from a prior session (eager buffers, attach-time screen
        *  clears). Routed separately from onData so the renderer can engage
        *  the replay guard — otherwise xterm auto-replies to embedded query
        *  sequences leak into the shell. See replay-guard.ts. */
-      onReplayData?: (data: string) => void
+      onReplayData?: (data: string, onParsed?: (charCount: number) => void) => void
       onStatus?: (shell: string) => void
       onError?: (message: string, errors?: string[]) => void
       onExit?: (code: number) => void
@@ -254,9 +258,9 @@ export type PtyTransport = {
     callbacks: {
       onConnect?: () => void
       onDisconnect?: () => void
-      onData?: (data: string) => void
+      onData?: (data: string, sourceCharCount?: number) => void
       /** See note on connect.callbacks.onReplayData. */
-      onReplayData?: (data: string) => void
+      onReplayData?: (data: string, onParsed?: (charCount: number) => void) => void
       onStatus?: (shell: string) => void
       onError?: (message: string, errors?: string[]) => void
       onExit?: (code: number) => void
@@ -264,6 +268,7 @@ export type PtyTransport = {
   }) => void
   disconnect: () => void
   sendInput: (data: string) => boolean
+  acknowledgeDataEvent: (charCount: number) => void
   resize: (
     cols: number,
     rows: number,

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -12,7 +12,7 @@ import { createTerminalSessionStateSaveFailureMessage } from '../../../../shared
 
 describe('createIpcPtyTransport', () => {
   const originalWindow = (globalThis as { window?: typeof window }).window
-  let onData: ((payload: { id: string; data: string }) => void) | null = null
+  let onData: ((payload: { id: string; data: string; synthetic?: boolean }) => void) | null = null
   let onExit: ((payload: { id: string; code: number }) => void) | null = null
 
   beforeEach(() => {
@@ -31,10 +31,12 @@ describe('createIpcPtyTransport', () => {
           resize: vi.fn(),
           ackData: vi.fn(),
           kill: vi.fn(),
-          onData: vi.fn((callback: (payload: { id: string; data: string }) => void) => {
-            onData = callback
-            return () => {}
-          }),
+          onData: vi.fn(
+            (callback: (payload: { id: string; data: string; synthetic?: boolean }) => void) => {
+              onData = callback
+              return () => {}
+            }
+          ),
           onReplay: vi.fn(() => () => {}),
           onExit: vi.fn((callback: (payload: { id: string; code: number }) => void) => {
             onExit = callback
@@ -187,6 +189,26 @@ describe('createIpcPtyTransport', () => {
 
     expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-restored', first.length)
     expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-restored', second.length)
+    expect(window.api.pty.ackData).toHaveBeenCalledTimes(2)
+  })
+
+  it('acknowledges PTY bytes dropped during detach/remount gaps', async () => {
+    const { ensurePtyDispatcher } = await import('./pty-transport')
+    ensurePtyDispatcher()
+
+    onData?.({ id: 'pty-detached', data: 'lost output' })
+
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-detached', 'lost output'.length)
+    expect(window.api.pty.ackData).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not acknowledge synthetic title bytes during detach/remount gaps', async () => {
+    const { ensurePtyDispatcher } = await import('./pty-transport')
+    ensurePtyDispatcher()
+
+    onData?.({ id: 'pty-detached', data: '\x1b]0;⠋ Cursor Agent\x07', synthetic: true })
+
+    expect(window.api.pty.ackData).not.toHaveBeenCalled()
   })
 
   it('routes the attach-time clear sequence through onReplayData for non-alternate-screen sessions', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -12,7 +12,9 @@ import { createTerminalSessionStateSaveFailureMessage } from '../../../../shared
 
 describe('createIpcPtyTransport', () => {
   const originalWindow = (globalThis as { window?: typeof window }).window
-  let onData: ((payload: { id: string; data: string; synthetic?: boolean }) => void) | null = null
+  let onData:
+    | ((payload: { id: string; data: string; synthetic?: boolean; connectionId?: string }) => void)
+    | null = null
   let onExit: ((payload: { id: string; code: number }) => void) | null = null
 
   beforeEach(() => {
@@ -32,7 +34,14 @@ describe('createIpcPtyTransport', () => {
           ackData: vi.fn(),
           kill: vi.fn(),
           onData: vi.fn(
-            (callback: (payload: { id: string; data: string; synthetic?: boolean }) => void) => {
+            (
+              callback: (payload: {
+                id: string
+                data: string
+                synthetic?: boolean
+                connectionId?: string
+              }) => void
+            ) => {
               onData = callback
               return () => {}
             }
@@ -192,6 +201,41 @@ describe('createIpcPtyTransport', () => {
     expect(window.api.pty.ackData).toHaveBeenCalledTimes(2)
   })
 
+  it('routes eager-buffer ACKs back to the source SSH connection', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const data = 'ssh output before pane mount'
+
+    registerEagerPtyBuffer('pty-restored', vi.fn(), 'ssh-1')
+    onData?.({ id: 'pty-restored', data, connectionId: 'ssh-1' })
+
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-restored', data.length, 'ssh-1')
+  })
+
+  it('keeps eager buffers with identical remote PTY ids isolated by SSH connection', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+
+    const handleA = registerEagerPtyBuffer('pty-1', vi.fn(), 'ssh-a')
+    const handleB = registerEagerPtyBuffer('pty-1', vi.fn(), 'ssh-b')
+    onData?.({ id: 'pty-1', data: 'from-a', connectionId: 'ssh-a' })
+    onData?.({ id: 'pty-1', data: 'from-b', connectionId: 'ssh-b' })
+
+    expect(handleA.flush()).toBe('from-a')
+    expect(handleB.flush()).toBe('from-b')
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-1', 'from-a'.length, 'ssh-a')
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-1', 'from-b'.length, 'ssh-b')
+  })
+
+  it('buffers synthetic eager data without acknowledging provider-owned bytes', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const synthetic = '\x1b]0;⠋ Cursor Agent\x07'
+
+    const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
+    onData?.({ id: 'pty-restored', data: synthetic, synthetic: true })
+
+    expect(handle.flush()).toBe(synthetic)
+    expect(window.api.pty.ackData).not.toHaveBeenCalled()
+  })
+
   it('acknowledges PTY bytes dropped during detach/remount gaps', async () => {
     const { ensurePtyDispatcher } = await import('./pty-transport')
     ensurePtyDispatcher()
@@ -200,6 +244,84 @@ describe('createIpcPtyTransport', () => {
 
     expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-detached', 'lost output'.length)
     expect(window.api.pty.ackData).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes dropped SSH relay bytes back to the source connection', async () => {
+    const { ensurePtyDispatcher } = await import('./pty-transport')
+    ensurePtyDispatcher()
+
+    onData?.({ id: 'pty-detached', data: 'lost output', connectionId: 'ssh-1' })
+
+    expect(window.api.pty.ackData).toHaveBeenCalledWith(
+      'pty-detached',
+      'lost output'.length,
+      'ssh-1'
+    )
+  })
+
+  it('routes active transport ACKs through the configured SSH connection', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const transport = createIpcPtyTransport({ connectionId: 'ssh-1' })
+
+    await transport.connect({ url: '', callbacks: {} })
+    transport.acknowledgeDataEvent(42)
+
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-1', 42, 'ssh-1')
+  })
+
+  it('routes active transport input, resize, and kill through the configured SSH connection', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const transport = createIpcPtyTransport({ connectionId: 'ssh-1' })
+
+    await transport.connect({ url: '', callbacks: {} })
+    expect(transport.sendInput('ls\r')).toBe(true)
+    expect(transport.resize(100, 30)).toBe(true)
+    transport.disconnect()
+
+    expect(window.api.pty.write).toHaveBeenCalledWith('pty-1', 'ls\r', 'ssh-1')
+    expect(window.api.pty.resize).toHaveBeenCalledWith('pty-1', 100, 30, 'ssh-1')
+    expect(window.api.pty.kill).toHaveBeenCalledWith('pty-1', { connectionId: 'ssh-1' })
+  })
+
+  it('keeps identical remote PTY ids isolated by SSH connection', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onDataA = vi.fn()
+    const onDataB = vi.fn()
+    const transportA = createIpcPtyTransport({ connectionId: 'ssh-a' })
+    const transportB = createIpcPtyTransport({ connectionId: 'ssh-b' })
+
+    await transportA.connect({ url: '', callbacks: { onData: onDataA } })
+    await transportB.connect({ url: '', callbacks: { onData: onDataB } })
+
+    onData?.({ id: 'pty-1', data: 'from-a', connectionId: 'ssh-a' })
+    onData?.({ id: 'pty-1', data: 'from-b', connectionId: 'ssh-b' })
+    onData?.({ id: 'pty-1', data: 'from-c', connectionId: 'ssh-c' })
+
+    expect(onDataA).toHaveBeenCalledWith('from-a', 'from-a'.length)
+    expect(onDataB).toHaveBeenCalledWith('from-b', 'from-b'.length)
+    expect(onDataA).not.toHaveBeenCalledWith('from-b', 'from-b'.length)
+    expect(onDataB).not.toHaveBeenCalledWith('from-a', 'from-a'.length)
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-1', 'from-c'.length, 'ssh-c')
+  })
+
+  it('unregisters only the matching SSH-scoped PTY data handler', async () => {
+    const { createIpcPtyTransport, unregisterScopedPtyDataHandlers } =
+      await import('./pty-transport')
+    const onDataA = vi.fn()
+    const onDataB = vi.fn()
+    const transportA = createIpcPtyTransport({ connectionId: 'ssh-a' })
+    const transportB = createIpcPtyTransport({ connectionId: 'ssh-b' })
+
+    await transportA.connect({ url: '', callbacks: { onData: onDataA } })
+    await transportB.connect({ url: '', callbacks: { onData: onDataB } })
+
+    unregisterScopedPtyDataHandlers([{ ptyId: 'pty-1', connectionId: 'ssh-a' }])
+    onData?.({ id: 'pty-1', data: 'from-a', connectionId: 'ssh-a' })
+    onData?.({ id: 'pty-1', data: 'from-b', connectionId: 'ssh-b' })
+
+    expect(onDataA).not.toHaveBeenCalled()
+    expect(onDataB).toHaveBeenCalledWith('from-b', 'from-b'.length)
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-1', 'from-a'.length, 'ssh-a')
   })
 
   it('does not acknowledge synthetic title bytes during detach/remount gaps', async () => {
@@ -408,6 +530,32 @@ describe('createIpcPtyTransport', () => {
     expect(killMock).toHaveBeenCalledWith('pty-late')
     expect(onPtySpawn).not.toHaveBeenCalled()
     expect(transport.getPtyId()).toBeNull()
+  })
+
+  it('kills a late SSH spawn through the configured connection after destroy', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawnControls: { resolve: ((value: { id: string }) => void) | null } = { resolve: null }
+    window.api.pty.spawn = vi.fn(
+      () =>
+        new Promise<{ id: string }>((resolve) => {
+          spawnControls.resolve = resolve
+        })
+    )
+
+    const transport = createIpcPtyTransport({ connectionId: 'ssh-1' })
+    const connectPromise = transport.connect({
+      url: '',
+      callbacks: {}
+    })
+
+    transport.destroy?.()
+    if (!spawnControls.resolve) {
+      throw new Error('Expected spawn resolver to be captured')
+    }
+    spawnControls.resolve({ id: 'pty-late' })
+    await connectPromise
+
+    expect(window.api.pty.kill).toHaveBeenCalledWith('pty-late', { connectionId: 'ssh-1' })
   })
 
   it('unregisterPtyDataHandlers prevents final data burst from triggering notifications', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -29,6 +29,7 @@ describe('createIpcPtyTransport', () => {
           spawn: vi.fn().mockResolvedValue({ id: 'pty-1' }),
           write: vi.fn(),
           resize: vi.fn(),
+          ackData: vi.fn(),
           kill: vi.fn(),
           onData: vi.fn((callback: (payload: { id: string; data: string }) => void) => {
             onData = callback
@@ -173,6 +174,19 @@ describe('createIpcPtyTransport', () => {
     expect(handle.flush()).toBe('')
     expect(onReplayData).toHaveBeenCalledWith(bufferedPayload)
     expect(onDataCallback).not.toHaveBeenCalledWith(bufferedPayload)
+  })
+
+  it('acknowledges eager-buffered bytes as soon as the renderer stores them', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const first = 'x'.repeat(400 * 1024)
+    const second = 'y'.repeat(200 * 1024)
+
+    registerEagerPtyBuffer('pty-restored', vi.fn())
+    onData?.({ id: 'pty-restored', data: first })
+    onData?.({ id: 'pty-restored', data: second })
+
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-restored', first.length)
+    expect(window.api.pty.ackData).toHaveBeenCalledWith('pty-restored', second.length)
   })
 
   it('routes the attach-time clear sequence through onReplayData for non-alternate-screen sessions', async () => {
@@ -767,7 +781,7 @@ describe('createRemoteRuntimePtyTransport', () => {
 
     expect(onReplayData).toHaveBeenCalledWith('hello')
     expect(onConnect).toHaveBeenCalled()
-    expect(onData).toHaveBeenCalledWith(' world')
+    expect(onData).toHaveBeenCalledWith(' world', 6)
   })
 
   it('forwards input and cleanup through runtime RPC', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -60,6 +60,7 @@ type ProcessPtyOutputOptions = {
   replayingBufferedData?: boolean
   suppressAttentionEvents?: boolean
   onParsed?: (charCount: number) => void
+  sourceCharCount?: number
 }
 
 export function createPtyOutputProcessor({
@@ -127,7 +128,7 @@ export function createPtyOutputProcessor({
     callbacks: PtyOutputCallbacks,
     options: ProcessPtyOutputOptions = {}
   ): void {
-    const sourceCharCount = data.length
+    const sourceCharCount = options.sourceCharCount ?? data.length
     const suppressAttentionEvents = options.suppressAttentionEvents === true
     // Why: OSC 9999 is a renderer-only control protocol. Parse it before
     // xterm sees the bytes, and keep parser state across chunks so partial
@@ -280,10 +281,11 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         storedCallbacks.onData?.(data, 0)
       }
     })
-    ptyDataHandlers.set(id, (data) => {
+    ptyDataHandlers.set(id, (data, sourceCharCount) => {
       outputProcessor.processData(data, storedCallbacks, {
         replayingBufferedData,
-        suppressAttentionEvents
+        suppressAttentionEvents,
+        sourceCharCount
       })
     })
   }

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -15,7 +15,8 @@ import {
   ptyExitHandlers,
   ptyTeardownHandlers,
   ensurePtyDispatcher,
-  getEagerPtyBufferHandle
+  getEagerPtyBufferHandle,
+  ptyHandlerKey
 } from './pty-dispatcher'
 import type { PtyTransport, IpcPtyTransportOptions, PtyConnectResult } from './pty-dispatcher'
 import { createBellDetector } from './bell-detector'
@@ -28,6 +29,7 @@ export {
   getEagerPtyBufferHandle,
   registerEagerPtyBuffer,
   subscribeToPtyExit,
+  unregisterScopedPtyDataHandlers,
   unregisterPtyDataHandlers
 } from './pty-dispatcher'
 export type {
@@ -250,16 +252,50 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   })
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
 
+  function writePty(id: string, data: string): void {
+    if (connectionId) {
+      window.api.pty.write(id, data, connectionId)
+    } else {
+      window.api.pty.write(id, data)
+    }
+  }
+
+  function resizePty(id: string, cols: number, rows: number): void {
+    if (connectionId) {
+      window.api.pty.resize(id, cols, rows, connectionId)
+    } else {
+      window.api.pty.resize(id, cols, rows)
+    }
+  }
+
+  function killPty(id: string): void {
+    if (connectionId) {
+      void window.api.pty.kill(id, { connectionId })
+    } else {
+      void window.api.pty.kill(id)
+    }
+  }
+
+  function ackPtyData(id: string, charCount: number): void {
+    if (connectionId) {
+      window.api.pty.ackData(id, charCount, connectionId)
+    } else {
+      window.api.pty.ackData(id, charCount)
+    }
+  }
+
   function unregisterPtyHandlers(id: string): void {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
-    ptyExitHandlers.delete(id)
-    ptyTeardownHandlers.delete(id)
+    const key = ptyHandlerKey(id, connectionId)
+    ptyDataHandlers.delete(key)
+    ptyReplayHandlers.delete(key)
+    ptyExitHandlers.delete(key)
+    ptyTeardownHandlers.delete(key)
   }
 
   function unregisterPtyDataAndStatusHandlers(id: string): void {
-    ptyDataHandlers.delete(id)
-    ptyReplayHandlers.delete(id)
+    const key = ptyHandlerKey(id, connectionId)
+    ptyDataHandlers.delete(key)
+    ptyReplayHandlers.delete(key)
   }
 
   // Why: true while we're replaying buffered/attach-time bytes into the
@@ -271,17 +307,18 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   // Why: shared by connect() and attach() to avoid duplicating title/bell/exit
   // logic across the two code paths that register a PTY.
   function registerPtyDataHandler(id: string): void {
+    const key = ptyHandlerKey(id, connectionId)
     // Why: relay pty.attach sends replay data via a dedicated pty:replay IPC
     // channel. Route it through onReplayData so the renderer engages the
     // replay guard and xterm auto-replies do not leak into the shell.
-    ptyReplayHandlers.set(id, (data) => {
+    ptyReplayHandlers.set(key, (data) => {
       if (storedCallbacks.onReplayData) {
         storedCallbacks.onReplayData(data)
       } else {
         storedCallbacks.onData?.(data, 0)
       }
     })
-    ptyDataHandlers.set(id, (data, sourceCharCount) => {
+    ptyDataHandlers.set(key, (data, sourceCharCount) => {
       outputProcessor.processData(data, storedCallbacks, {
         replayingBufferedData,
         suppressAttentionEvents,
@@ -295,7 +332,8 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   }
 
   function registerPtyExitHandler(id: string): void {
-    ptyExitHandlers.set(id, (code) => {
+    const key = ptyHandlerKey(id, connectionId)
+    ptyExitHandlers.set(key, (code) => {
       clearAccumulatedState()
       connected = false
       ptyId = null
@@ -310,7 +348,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     // accumulated closure state (staleTitleTimer, agent tracker) that
     // would otherwise fire stale notifications after the data handler
     // is removed but before the exit event arrives.
-    ptyTeardownHandlers.set(id, clearAccumulatedState)
+    ptyTeardownHandlers.set(key, clearAccumulatedState)
   }
 
   return {
@@ -341,7 +379,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
         // If destroyed while spawn was in flight, kill the new pty and bail
         if (destroyed) {
-          window.api.pty.kill(spawnResult.id)
+          killPty(spawnResult.id)
           return
         }
 
@@ -431,7 +469,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       // Why: replay buffered data through the real handler so title/bell/agent
       // tracking (including OSC 9999 agent status) processes the output —
       // otherwise restored tabs keep a default title.
-      const bufferHandle = getEagerPtyBufferHandle(id)
+      const bufferHandle = getEagerPtyBufferHandle(id, connectionId)
       if (bufferHandle) {
         const buffered = bufferHandle.flush()
         if (buffered) {
@@ -491,7 +529,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
 
       if (options.cols && options.rows) {
-        window.api.pty.resize(id, options.cols, options.rows)
+        resizePty(id, options.cols, options.rows)
       }
 
       storedCallbacks.onConnect?.()
@@ -502,7 +540,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       clearAccumulatedState()
       if (ptyId) {
         const id = ptyId
-        window.api.pty.kill(id)
+        killPty(id)
         connected = false
         ptyId = null
         unregisterPtyHandlers(id)
@@ -529,7 +567,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       if (!connected || !ptyId) {
         return false
       }
-      window.api.pty.write(ptyId, data)
+      writePty(ptyId, data)
       return true
     },
 
@@ -537,14 +575,14 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       if (!connected || !ptyId || charCount <= 0) {
         return
       }
-      window.api.pty.ackData(ptyId, charCount)
+      ackPtyData(ptyId, charCount)
     },
 
     resize(cols: number, rows: number): boolean {
       if (!connected || !ptyId) {
         return false
       }
-      window.api.pty.resize(ptyId, cols, rows)
+      resizePty(ptyId, cols, rows)
       return true
     },
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -59,6 +59,7 @@ type PtyOutputProcessorOptions = Pick<
 type ProcessPtyOutputOptions = {
   replayingBufferedData?: boolean
   suppressAttentionEvents?: boolean
+  onParsed?: (charCount: number) => void
 }
 
 export function createPtyOutputProcessor({
@@ -126,6 +127,7 @@ export function createPtyOutputProcessor({
     callbacks: PtyOutputCallbacks,
     options: ProcessPtyOutputOptions = {}
   ): void {
+    const sourceCharCount = data.length
     const suppressAttentionEvents = options.suppressAttentionEvents === true
     // Why: OSC 9999 is a renderer-only control protocol. Parse it before
     // xterm sees the bytes, and keep parser state across chunks so partial
@@ -142,9 +144,15 @@ export function createPtyOutputProcessor({
       }
     }
     if (options.replayingBufferedData && callbacks.onReplayData) {
-      callbacks.onReplayData(data)
+      if (data.length === 0) {
+        options.onParsed?.(sourceCharCount)
+      } else if (options.onParsed) {
+        callbacks.onReplayData(data, () => options.onParsed?.(sourceCharCount))
+      } else {
+        callbacks.onReplayData(data)
+      }
     } else {
-      callbacks.onData?.(data)
+      callbacks.onData?.(data, sourceCharCount)
     }
     if (onTitleChange) {
       // Why: feed EVERY OSC title in the chunk through the observer, not just
@@ -269,7 +277,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       if (storedCallbacks.onReplayData) {
         storedCallbacks.onReplayData(data)
       } else {
-        storedCallbacks.onData?.(data)
+        storedCallbacks.onData?.(data, 0)
       }
     })
     ptyDataHandlers.set(id, (data) => {
@@ -439,7 +447,10 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           suppressAttentionEvents = true
           replayingBufferedData = true
           try {
-            ptyDataHandlers.get(id)?.(buffered)
+            outputProcessor.processData(buffered, storedCallbacks, {
+              replayingBufferedData: true,
+              suppressAttentionEvents: true
+            })
           } finally {
             replayingBufferedData = false
             suppressAttentionEvents = false
@@ -518,6 +529,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       }
       window.api.pty.write(ptyId, data)
       return true
+    },
+
+    acknowledgeDataEvent(charCount: number): void {
+      if (!connected || !ptyId || charCount <= 0) {
+        return
+      }
+      window.api.pty.ackData(ptyId, charCount)
     },
 
     resize(cols: number, rows: number): boolean {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -520,7 +520,10 @@ describe('createRemoteRuntimePtyTransport', () => {
       prompt: 'ship it',
       agentType: 'codex'
     })
-    expect(onData).toHaveBeenCalledWith('beforeafter\x1b]0;. Claude working\x07\x07')
+    expect(onData).toHaveBeenCalledWith(
+      'beforeafter\x1b]0;. Claude working\x07\x07',
+      expect.any(Number)
+    )
     expect(onTitleChange).toHaveBeenCalledWith('. Claude working', '. Claude working')
     expect(onBell).toHaveBeenCalledTimes(1)
   })
@@ -551,7 +554,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       prompt: 'ship it',
       agentType: 'codex'
     })
-    expect(onData).toHaveBeenCalledWith('beforeafter')
+    expect(onData).toHaveBeenCalledWith('beforeafter', expect.any(Number))
   })
 
   it('resubscribes without surfacing a PTY error when the remote runtime subscription closes', async () => {
@@ -810,6 +813,6 @@ describe('createRemoteRuntimePtyTransport', () => {
       'Remote terminal snapshot exceeded the 2 MiB replay limit; live output will continue.'
     )
     expect(onConnect).toHaveBeenCalled()
-    expect(onData).toHaveBeenCalledWith('live-after-overflow')
+    expect(onData).toHaveBeenCalledWith('live-after-overflow', 'live-after-overflow'.length)
   })
 })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -458,6 +458,10 @@ export function createRemoteRuntimePtyTransport(
       return true
     },
 
+    acknowledgeDataEvent(_charCount: number): void {
+      // Remote runtime terminal streams own their upstream flow control.
+    },
+
     resize(cols: number, rows: number): boolean {
       if (!connected || !handle) {
         return false

--- a/src/renderer/src/components/terminal-pane/replay-guard.ts
+++ b/src/renderer/src/components/terminal-pane/replay-guard.ts
@@ -1,4 +1,5 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import { enqueueTerminalWrite } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 
 // Why: xterm.js auto-responds to terminal query sequences (DA1 `CSI c`,
 // DECRQM `CSI ? Ps $ p`, OSC 10/11 color queries, focus events, CPR) by
@@ -37,27 +38,30 @@ export function isPaneReplaying(ref: ReplayingPanesRef, paneId: number): boolean
 export function replayIntoTerminal(
   pane: ManagedPane,
   replayingPanesRef: ReplayingPanesRef,
-  data: string
+  data: string,
+  onParsed?: (charCount: number) => void
 ): void {
   if (!data) {
     return
   }
   const map = replayingPanesRef.current
   map.set(pane.id, (map.get(pane.id) ?? 0) + 1)
-  pane.terminal.write(data, () => {
+  enqueueTerminalWrite(pane.terminal, data, () => {
     const remaining = (map.get(pane.id) ?? 1) - 1
     if (remaining <= 0) {
       map.delete(pane.id)
     } else {
       map.set(pane.id, remaining)
     }
+    onParsed?.(data.length)
   })
 }
 
 export function replayIntoTerminalAsync(
   pane: ManagedPane,
   replayingPanesRef: ReplayingPanesRef,
-  data: string
+  data: string,
+  onParsed?: (charCount: number) => void
 ): Promise<void> {
   if (!data) {
     return Promise.resolve()
@@ -65,13 +69,14 @@ export function replayIntoTerminalAsync(
   const map = replayingPanesRef.current
   map.set(pane.id, (map.get(pane.id) ?? 0) + 1)
   return new Promise((resolve) => {
-    pane.terminal.write(data, () => {
+    enqueueTerminalWrite(pane.terminal, data, () => {
       const remaining = (map.get(pane.id) ?? 1) - 1
       if (remaining <= 0) {
         map.delete(pane.id)
       } else {
         map.set(pane.id, remaining)
       }
+      onParsed?.(data.length)
       resolve()
     })
   })

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -4,7 +4,10 @@ import { pasteDraftWhenAgentReady } from './agent-paste-draft'
 const testState = vi.hoisted(() => ({
   appState: {
     settings: {},
-    ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    tabsByWorktree: { 'repo-1::/wt': [{ id: 'tab-1' }] },
+    worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/wt', repoId: 'repo-1' }] },
+    repos: [{ id: 'repo-1', connectionId: null as string | null }]
   },
   ptyObserver: null as ((data: string) => void) | null,
   unsubscribe: vi.fn(),
@@ -47,6 +50,9 @@ describe('pasteDraftWhenAgentReady', () => {
     })
     testState.appState.settings = {}
     testState.appState.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+    testState.appState.tabsByWorktree = { 'repo-1::/wt': [{ id: 'tab-1' }] }
+    testState.appState.worktreesByRepo = { 'repo-1': [{ id: 'repo-1::/wt', repoId: 'repo-1' }] }
+    testState.appState.repos = [{ id: 'repo-1', connectionId: null }]
     testState.ptyObserver = null
     testState.unsubscribe.mockReset()
     testState.subscribeToPtyData.mockReset()
@@ -125,6 +131,33 @@ describe('pasteDraftWhenAgentReady', () => {
 
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInput).toHaveBeenCalledWith({}, 'pty-1', PASTED_ISSUE_URL)
+  })
+
+  it('subscribes and writes through the tab SSH connection', async () => {
+    testState.appState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'codex'
+    })
+    await flushMicrotasks()
+
+    expect(testState.subscribeToPtyData).toHaveBeenCalledWith(
+      'pty-1',
+      expect.any(Function),
+      'ssh-1'
+    )
+
+    testState.ptyObserver?.(`${DECSET_BRACKETED_PASTE}${CODEX_COMPOSER_PROMPT_RENDER}`)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInput).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL,
+      'ssh-1'
+    )
   })
 
   it('does not paste for agents that already use native draft prefill', async () => {

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -4,6 +4,7 @@ import { useAppStore } from '@/store'
 import { subscribeToPtyData } from '@/components/terminal-pane/pty-dispatcher'
 import { isRemoteRuntimePtyId, sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { subscribeToRuntimeTerminalData } from '@/runtime/runtime-terminal-stream'
+import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 
 // Why: bracketed paste markers let modern TUIs (Claude Code / Codex / Pi /
 // OpenCode / Gemini / cursor-agent / copilot) treat the inserted text as a
@@ -87,18 +88,37 @@ export async function pasteDraftWhenAgentReady(args: {
     return false
   }
 
-  const ready = await waitForInputBoxReady(ptyId, budget, readySignal)
+  const connectionId = getConnectionIdForTab(tabId)
+  const ready = await waitForInputBoxReady(ptyId, budget, readySignal, connectionId)
   if (!ready) {
     onTimeout?.()
     return false
   }
 
-  sendRuntimePtyInput(
-    useAppStore.getState().settings,
-    ptyId,
-    `${BRACKETED_PASTE_BEGIN}${content}${BRACKETED_PASTE_END}${submit ? '\r' : ''}`
-  )
+  const paste = `${BRACKETED_PASTE_BEGIN}${content}${BRACKETED_PASTE_END}${submit ? '\r' : ''}`
+  if (connectionId) {
+    sendRuntimePtyInput(useAppStore.getState().settings, ptyId, paste, connectionId)
+  } else {
+    sendRuntimePtyInput(useAppStore.getState().settings, ptyId, paste)
+  }
   return true
+}
+
+function getConnectionIdForTab(tabId: string): string | null {
+  const state = useAppStore.getState()
+  const tabEntry = Object.entries(state.tabsByWorktree ?? {}).find(([, tabs]) =>
+    tabs.some((tab) => tab.id === tabId)
+  )
+  const worktreeId = tabEntry?.[0]
+  if (!worktreeId) {
+    return null
+  }
+  const worktree = Object.values(state.worktreesByRepo ?? {})
+    .flat()
+    .find((entry) => entry.id === worktreeId)
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+  const repo = state.repos?.find((entry) => entry.id === repoId)
+  return repo?.connectionId ?? null
 }
 
 /**
@@ -118,7 +138,8 @@ export async function pasteDraftWhenAgentReady(args: {
 function waitForInputBoxReady(
   ptyId: string,
   timeoutMs: number,
-  readySignal: DraftPasteReadySignal
+  readySignal: DraftPasteReadySignal,
+  connectionId: string | null
 ): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     let settled = false
@@ -213,7 +234,7 @@ function waitForInputBoxReady(
         })
         .catch(() => finish(false))
     } else {
-      unsubscribe = subscribeToPtyData(ptyId, observeData)
+      unsubscribe = subscribeToPtyData(ptyId, observeData, connectionId)
     }
 
     if (!settled) {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -100,6 +100,7 @@ export async function launchAgentBackgroundSession(
     ORCA_WORKTREE_ID: worktreeId
   }
   const runtimeTarget = getActiveRuntimeTarget(store.settings)
+  const connectionId = repo?.connectionId ?? null
   let ptyId: string
   try {
     if (runtimeTarget.kind === 'environment') {
@@ -127,7 +128,7 @@ export async function launchAgentBackgroundSession(
         cwd: worktree.path,
         command: startupPlan.launchCommand,
         env: paneEnv,
-        connectionId: repo?.connectionId ?? null,
+        connectionId,
         worktreeId,
         tabId: tab.id,
         leafId,
@@ -187,12 +188,19 @@ export async function launchAgentBackgroundSession(
       .then((result) => handleExit(ptyId, result.wait.exitCode ?? 0))
       .catch(() => {})
   } else {
-    registerEagerPtyBuffer(ptyId, handleExit)
-    unsubscribeData = subscribeToPtyData(ptyId, handleData)
+    if (connectionId) {
+      registerEagerPtyBuffer(ptyId, handleExit, connectionId)
+      unsubscribeData = subscribeToPtyData(ptyId, handleData, connectionId)
+    } else {
+      registerEagerPtyBuffer(ptyId, handleExit)
+      unsubscribeData = subscribeToPtyData(ptyId, handleData)
+    }
     // Why: opening the workspace attaches a real terminal transport and disposes
     // the eager exit handler. This sidecar keeps automation completion tracking
     // alive regardless of whether the tab is hidden or mounted.
-    unsubscribeExit = subscribeToPtyExit(ptyId, (code) => handleExit(ptyId, code))
+    unsubscribeExit = connectionId
+      ? subscribeToPtyExit(ptyId, (code) => handleExit(ptyId, code), connectionId)
+      : subscribeToPtyExit(ptyId, (code) => handleExit(ptyId, code))
   }
 
   if (pasteDraftAfterLaunch !== null) {

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -6,6 +6,7 @@ import {
 } from '@/runtime/runtime-terminal-inspection'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import { isShellProcess } from '@/lib/tui-agent-startup'
+import { getConnectionId } from '@/lib/connection-context'
 import type { OrcaHooks, TaskViewPresetId } from '../../../shared/types'
 import { normalizeHookCommandSourcePolicy } from '../../../shared/hook-command-source-policy'
 
@@ -267,7 +268,13 @@ export async function ensureAgentStartupInTerminal(args: {
   // session and submitted. Wait until the agent owns the PTY before writing.
   if (startup.followupPrompt) {
     await waitForAgentForeground(ptyId, startup.expectedProcess)
-    sendRuntimePtyInput(useAppStore.getState().settings, ptyId, `${startup.followupPrompt}\r`)
+    const connectionId = getConnectionId(worktreeId) ?? undefined
+    sendRuntimePtyInput(
+      useAppStore.getState().settings,
+      ptyId,
+      `${startup.followupPrompt}\r`,
+      connectionId
+    )
   }
 
   // Why: draftPrompt uses bracketed-paste so the URL lands atomically in the

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -236,6 +236,20 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['stuck', 'after'])
   })
 
+  it('does not send empty parse barriers to xterm writes', async () => {
+    vi.useFakeTimers()
+    const { waitForTerminalOutputParsed, writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    const parsed = waitForTerminalOutputParsed(terminal)
+    writeTerminalOutput(terminal, 'after', { foreground: true })
+
+    await parsed
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['after'])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('survives a write to a disposed terminal during background drain', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -8,6 +8,10 @@ function createTerminal() {
   }
 }
 
+function writtenData(terminal: ReturnType<typeof createTerminal>): string[] {
+  return terminal.write.mock.calls.map(([data]) => data)
+}
+
 async function loadScheduler() {
   vi.resetModules()
   return import('./pane-terminal-output-scheduler')
@@ -24,7 +28,7 @@ describe('pane terminal output scheduler', () => {
 
     writeTerminalOutput(terminal, 'foreground', { foreground: true })
 
-    expect(terminal.write).toHaveBeenCalledWith('foreground')
+    expect(writtenData(terminal)).toEqual(['foreground'])
   })
 
   it('coalesces background output until the shared drain runs', async () => {
@@ -39,7 +43,7 @@ describe('pane terminal output scheduler', () => {
     vi.advanceTimersByTime(50)
 
     expect(terminal.write).toHaveBeenCalledTimes(1)
-    expect(terminal.write).toHaveBeenCalledWith('ab')
+    expect(writtenData(terminal)).toEqual(['ab'])
   })
 
   it('limits how many background terminals begin xterm writes per drain tick', async () => {
@@ -52,12 +56,12 @@ describe('pane terminal output scheduler', () => {
     })
 
     vi.advanceTimersByTime(50)
-    expect(terminals[0].write).toHaveBeenCalledWith('pane-0')
-    expect(terminals[1].write).toHaveBeenCalledWith('pane-1')
+    expect(writtenData(terminals[0])).toEqual(['pane-0'])
+    expect(writtenData(terminals[1])).toEqual(['pane-1'])
     expect(terminals[2].write).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(16)
-    expect(terminals[2].write).toHaveBeenCalledWith('pane-2')
+    expect(writtenData(terminals[2])).toEqual(['pane-2'])
   })
 
   it('rotates terminals with remaining backlog behind untouched queued terminals', async () => {
@@ -72,14 +76,14 @@ describe('pane terminal output scheduler', () => {
 
     vi.advanceTimersByTime(50)
     expect(terminals[0].write).toHaveBeenCalledTimes(1)
-    expect(terminals[1].write).toHaveBeenCalledWith('pane-1')
+    expect(writtenData(terminals[1])).toEqual(['pane-1'])
     expect(terminals[2].write).not.toHaveBeenCalled()
 
     // Why: a terminal with leftover bytes is deleted/re-set after each drain
     // chunk, moving it to the back of the Map so a big burst cannot starve
     // other queued panes.
     vi.advanceTimersByTime(16)
-    expect(terminals[2].write).toHaveBeenCalledWith('pane-2')
+    expect(writtenData(terminals[2])).toEqual(['pane-2'])
     expect(terminals[0].write).toHaveBeenCalledTimes(2)
   })
 
@@ -94,16 +98,142 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['old', 'new'])
   })
 
+  it('waits for xterm write callbacks before starting the next write for a terminal', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const callbacks: (() => void)[] = []
+    const terminal = {
+      write: vi.fn((_data: string, callback?: () => void) => {
+        if (callback) {
+          callbacks.push(callback)
+        }
+      })
+    }
+
+    writeTerminalOutput(terminal, 'first', { foreground: true })
+    writeTerminalOutput(terminal, 'second', { foreground: true })
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['first'])
+
+    callbacks.shift()?.()
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['first', 'second'])
+  })
+
+  it('acknowledges background chunks only after xterm parses each split write', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const callbacks: (() => void)[] = []
+    const terminal = {
+      write: vi.fn((_data: string, callback?: () => void) => {
+        if (callback) {
+          callbacks.push(callback)
+        }
+      })
+    }
+    const onParsed = vi.fn()
+
+    writeTerminalOutput(terminal, 'x'.repeat(20 * 1024), { foreground: false, onParsed })
+
+    vi.advanceTimersByTime(50)
+    expect(terminal.write.mock.calls.map(([data]) => data.length)).toEqual([16 * 1024])
+    expect(onParsed).not.toHaveBeenCalled()
+
+    callbacks.shift()?.()
+    expect(onParsed).toHaveBeenCalledWith(16 * 1024)
+
+    vi.advanceTimersByTime(16)
+    expect(terminal.write.mock.calls.map(([data]) => data.length)).toEqual([16 * 1024, 4 * 1024])
+
+    callbacks.shift()?.()
+    expect(onParsed).toHaveBeenLastCalledWith(4 * 1024)
+  })
+
   it('discards queued output for disposed terminals', async () => {
     vi.useFakeTimers()
     const { discardTerminalOutput, writeTerminalOutput } = await loadScheduler()
     const terminal = createTerminal()
+    const onParsed = vi.fn()
 
-    writeTerminalOutput(terminal, 'stale', { foreground: false })
+    writeTerminalOutput(terminal, 'stale', { foreground: false, onParsed })
     discardTerminalOutput(terminal)
     vi.advanceTimersByTime(50)
 
     expect(terminal.write).not.toHaveBeenCalled()
+    expect(onParsed).toHaveBeenCalledWith('stale'.length)
+  })
+
+  it('does not continue queued writes after discard during an in-flight xterm write', async () => {
+    vi.useFakeTimers()
+    const { discardTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const callbacks: (() => void)[] = []
+    const terminal = {
+      write: vi.fn((_data: string, callback?: () => void) => {
+        if (callback) {
+          callbacks.push(callback)
+        }
+      })
+    }
+    const onParsed = vi.fn()
+
+    writeTerminalOutput(terminal, 'first', { foreground: true, onParsed })
+    writeTerminalOutput(terminal, 'second', { foreground: true, onParsed })
+    discardTerminalOutput(terminal)
+
+    callbacks.shift()?.()
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['first'])
+    expect(onParsed.mock.calls).toEqual([[5], [6]])
+  })
+
+  it('ignores stale callbacks from a discarded write state after new output starts', async () => {
+    vi.useFakeTimers()
+    const { discardTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const callbacks: (() => void)[] = []
+    const terminal = {
+      write: vi.fn((_data: string, callback?: () => void) => {
+        if (callback) {
+          callbacks.push(callback)
+        }
+      })
+    }
+
+    writeTerminalOutput(terminal, 'old-first', { foreground: true })
+    writeTerminalOutput(terminal, 'old-second', { foreground: true })
+    discardTerminalOutput(terminal)
+    writeTerminalOutput(terminal, 'new-first', { foreground: true })
+    writeTerminalOutput(terminal, 'new-second', { foreground: true })
+
+    callbacks[0]?.()
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['old-first', 'new-first'])
+
+    callbacks[1]?.()
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual([
+      'old-first',
+      'new-first',
+      'new-second'
+    ])
+  })
+
+  it('acknowledges an abandoned write when xterm never calls back', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = {
+      write: vi.fn()
+    }
+    const onParsed = vi.fn()
+
+    writeTerminalOutput(terminal, 'stuck', { foreground: true, onParsed })
+    writeTerminalOutput(terminal, 'after', { foreground: true, onParsed })
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['stuck'])
+
+    vi.advanceTimersByTime(30_000)
+
+    expect(onParsed).toHaveBeenCalledWith('stuck'.length)
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['stuck', 'after'])
   })
 
   it('survives a write to a disposed terminal during background drain', async () => {
@@ -125,5 +255,24 @@ describe('pane terminal output scheduler', () => {
     // Advancing further must not rediscover the dead entry.
     vi.advanceTimersByTime(100)
     expect(throwing.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves callbacks when xterm throws synchronously', async () => {
+    vi.useFakeTimers()
+    const { waitForTerminalOutputParsed } = await loadScheduler()
+    const throwing = {
+      write: vi.fn(() => {
+        throw new Error('terminal disposed')
+      })
+    }
+    let resolved = false
+
+    void waitForTerminalOutputParsed(throwing).then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+
+    expect(resolved).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -209,6 +209,14 @@ function pumpTerminalWriteQueue(
 
   state.writing = true
   state.current = next
+  if (next.data.length === 0) {
+    try {
+      invokeWriteCallback(next)
+    } finally {
+      finishTerminalWrite(terminal, state)
+    }
+    return
+  }
   let settled = false
   const finish = (): void => {
     if (settled) {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable max-lines -- Why: queueing, parse callbacks, and discard
+semantics share ACK state; keeping them together makes liveness easier to audit. */
 import { e2eConfig } from '@/lib/e2e-config'
 
 type TerminalOutputTarget = {
@@ -6,7 +8,24 @@ type TerminalOutputTarget = {
 
 type QueueEntry = {
   terminal: TerminalOutputTarget
-  chunks: string[]
+  chunks: QueueChunk[]
+}
+
+type QueueChunk = {
+  data: string
+  onParsed?: (charCount: number) => void
+}
+
+type WriteQueueEntry = {
+  data: string
+  callback?: () => void
+  callbackInvoked?: boolean
+}
+
+type TerminalWriteState = {
+  queue: WriteQueueEntry[]
+  writing: boolean
+  current?: WriteQueueEntry
 }
 
 const BACKGROUND_FLUSH_DELAY_MS = 50
@@ -14,8 +33,10 @@ const BACKGROUND_DRAIN_INTERVAL_MS = 16
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_DRAIN = 2
 const PARSE_SETTLE_TIMEOUT_MS = 250
+const WRITE_CALLBACK_TIMEOUT_MS = 30_000
 
 const queuedByTerminal = new Map<TerminalOutputTarget, QueueEntry>()
+const writesByTerminal = new Map<TerminalOutputTarget, TerminalWriteState>()
 let drainTimer: ReturnType<typeof setTimeout> | null = null
 const debugEnabled = e2eConfig.exposeStore
 
@@ -84,41 +105,167 @@ function scheduleDrain(delayMs: number): void {
   drainTimer = setTimeout(drainQueuedOutput, delayMs)
 }
 
-function takeQueuedChunk(entry: QueueEntry, limit: number): string {
+function takeQueuedChunk(entry: QueueEntry, limit: number): { data: string; onParsed: () => void } {
   let remaining = limit
   let data = ''
+  const parsedCallbacks: (() => void)[] = []
 
   while (remaining > 0 && entry.chunks.length > 0) {
     const chunk = entry.chunks[0]
-    if (chunk.length <= remaining) {
-      data += chunk
-      remaining -= chunk.length
+    if (chunk.data.length <= remaining) {
+      data += chunk.data
+      remaining -= chunk.data.length
+      const consumed = chunk.data.length
+      if (chunk.onParsed && consumed > 0) {
+        parsedCallbacks.push(() => chunk.onParsed?.(consumed))
+      }
       entry.chunks.shift()
       continue
     }
 
-    data += chunk.slice(0, remaining)
-    entry.chunks[0] = chunk.slice(remaining)
+    const consumed = remaining
+    data += chunk.data.slice(0, remaining)
+    entry.chunks[0] = { ...chunk, data: chunk.data.slice(remaining) }
+    if (chunk.onParsed && consumed > 0) {
+      parsedCallbacks.push(() => chunk.onParsed?.(consumed))
+    }
     remaining = 0
   }
 
-  return data
+  return {
+    data,
+    onParsed: () => {
+      for (const callback of parsedCallbacks) {
+        callback()
+      }
+    }
+  }
+}
+
+function getWriteState(terminal: TerminalOutputTarget): TerminalWriteState {
+  let state = writesByTerminal.get(terminal)
+  if (!state) {
+    state = { queue: [], writing: false }
+    writesByTerminal.set(terminal, state)
+  }
+  return state
+}
+
+function invokeWriteCallback(entry: WriteQueueEntry): void {
+  if (entry.callbackInvoked) {
+    return
+  }
+  entry.callbackInvoked = true
+  entry.callback?.()
+}
+
+function invokeQueuedChunkCallbacks(entry: QueueEntry): void {
+  for (const chunk of entry.chunks) {
+    if (chunk.data.length > 0) {
+      chunk.onParsed?.(chunk.data.length)
+    }
+  }
+  entry.chunks.length = 0
+}
+
+function discardWriteState(state: TerminalWriteState): void {
+  if (state.current) {
+    invokeWriteCallback(state.current)
+    state.current = undefined
+  }
+  for (const entry of state.queue) {
+    invokeWriteCallback(entry)
+  }
+  state.queue.length = 0
+  state.writing = false
+}
+
+function finishTerminalWrite(terminal: TerminalOutputTarget, state: TerminalWriteState): void {
+  if (writesByTerminal.get(terminal) !== state) {
+    return
+  }
+  state.current = undefined
+  state.writing = false
+  if (state.queue.length === 0) {
+    writesByTerminal.delete(terminal)
+    return
+  }
+  pumpTerminalWriteQueue(terminal, state)
+}
+
+function pumpTerminalWriteQueue(
+  terminal: TerminalOutputTarget,
+  state = writesByTerminal.get(terminal)
+): void {
+  if (!state || state.writing) {
+    return
+  }
+
+  const next = state.queue.shift()
+  if (!next) {
+    writesByTerminal.delete(terminal)
+    return
+  }
+
+  state.writing = true
+  state.current = next
+  let settled = false
+  const finish = (): void => {
+    if (settled) {
+      return
+    }
+    settled = true
+    if (timeout !== null) {
+      clearTimeout(timeout)
+    }
+    finishTerminalWrite(terminal, state)
+  }
+  let timeout: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+    // Why: if xterm never calls back, these bytes have no future ACK path.
+    // Treat them as abandoned so upstream PTYs cannot remain paused forever.
+    try {
+      invokeWriteCallback(next)
+    } finally {
+      finish()
+    }
+  }, WRITE_CALLBACK_TIMEOUT_MS)
+  try {
+    terminal.write(next.data, () => {
+      try {
+        invokeWriteCallback(next)
+      } finally {
+        finish()
+      }
+    })
+  } catch {
+    // Why: xterm throws when disposed and can throw its overflow guard if a
+    // caller bypassed flow control earlier. Drop this terminal's pending writes
+    // so one dead pane cannot poison the global scheduler.
+    if (timeout !== null) {
+      clearTimeout(timeout)
+      timeout = null
+    }
+    discardWriteState(state)
+    writesByTerminal.delete(terminal)
+  }
+}
+
+export function enqueueTerminalWrite(
+  terminal: TerminalOutputTarget,
+  data: string,
+  callback?: () => void
+): void {
+  const state = getWriteState(terminal)
+  state.queue.push({ data, callback })
+  pumpTerminalWriteQueue(terminal, state)
 }
 
 function writeQueuedChunk(entry: QueueEntry): boolean {
-  const data = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
+  const { data, onParsed } = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
   if (!data) {
     return false
   }
-  try {
-    entry.terminal.write(data)
-  } catch {
-    // Why: pane.terminal.dispose() can race with a queued late-arriving PTY ping;
-    // a write to a disposed terminal throws. Drop the entry rather than crashing
-    // the scheduler for other panes still draining.
-    entry.chunks.length = 0
-    return false
-  }
+  enqueueTerminalWrite(entry.terminal, data, onParsed)
   return true
 }
 
@@ -155,7 +302,7 @@ function drainQueuedOutput(): void {
 export function writeTerminalOutput(
   terminal: TerminalOutputTarget,
   data: string,
-  options: { foreground: boolean }
+  options: { foreground: boolean; onParsed?: (charCount: number) => void }
 ): void {
   exposeDebugApi()
   if (!data) {
@@ -167,7 +314,7 @@ export function writeTerminalOutput(
     if (debugEnabled) {
       debugState.foregroundWriteCount++
     }
-    terminal.write(data)
+    enqueueTerminalWrite(terminal, data, () => options.onParsed?.(data.length))
     return
   }
 
@@ -176,7 +323,7 @@ export function writeTerminalOutput(
     entry = { terminal, chunks: [] }
     queuedByTerminal.set(terminal, entry)
   }
-  entry.chunks.push(data)
+  entry.chunks.push({ data, onParsed: options.onParsed })
   if (debugEnabled) {
     debugState.backgroundEnqueueCount++
   }
@@ -195,18 +342,11 @@ export function flushTerminalOutput(terminal: TerminalOutputTarget): void {
   queuedByTerminal.delete(terminal)
 
   let data = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
-  while (data) {
+  while (data.data) {
     if (debugEnabled) {
       debugState.flushWriteCount++
     }
-    try {
-      terminal.write(data)
-    } catch {
-      // Why: pane.terminal.dispose() can race with a queued late-arriving PTY ping;
-      // a write to a disposed terminal throws. Drop the entry rather than crashing
-      // the scheduler for other panes still draining.
-      return
-    }
+    enqueueTerminalWrite(terminal, data.data, data.onParsed)
     data = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
   }
 }
@@ -228,17 +368,22 @@ export function waitForTerminalOutputParsed(terminal: TerminalOutputTarget): Pro
       resolve()
     }
     timer = setTimeout(finish, PARSE_SETTLE_TIMEOUT_MS)
-    try {
-      terminal.write('', finish)
-    } catch {
-      finish()
-    }
+    enqueueTerminalWrite(terminal, '', finish)
   })
 }
 
 export function discardTerminalOutput(terminal: TerminalOutputTarget): void {
   exposeDebugApi()
-  queuedByTerminal.delete(terminal)
+  const queuedEntry = queuedByTerminal.get(terminal)
+  if (queuedEntry) {
+    invokeQueuedChunkCallbacks(queuedEntry)
+    queuedByTerminal.delete(terminal)
+  }
+  const writeState = writesByTerminal.get(terminal)
+  if (writeState) {
+    discardWriteState(writeState)
+  }
+  writesByTerminal.delete(terminal)
 }
 
 exposeDebugApi()

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -71,7 +71,8 @@ export async function inspectRuntimeTerminalProcess(
 export function sendRuntimePtyInput(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   ptyId: string,
-  data: string
+  data: string,
+  connectionId?: string
 ): boolean {
   const ownerEnvironmentId = getRemoteRuntimePtyEnvironmentId(ptyId)
   const target = ownerEnvironmentId
@@ -79,7 +80,11 @@ export function sendRuntimePtyInput(
     : getActiveRuntimeTarget(settings)
   const terminal = getRemoteRuntimeTerminalHandle(ptyId)
   if (target.kind !== 'environment' || !terminal) {
-    window.api.pty.write(ptyId, data)
+    if (connectionId) {
+      window.api.pty.write(ptyId, data, connectionId)
+    } else {
+      window.api.pty.write(ptyId, data)
+    }
     return true
   }
 

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -202,13 +202,14 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   removeRepo: async (repoId) => {
     try {
+      const repo = get().repos.find((entry) => entry.id === repoId)
       const target = getActiveRuntimeTarget(get().settings)
       await (target.kind === 'local'
         ? window.api.repos.remove({ repoId })
         : callRuntimeRpc(target, 'repo.rm', { repo: repoId }, { timeoutMs: 15_000 }))
 
       get().clearOrcaHookTrustForRepo(repoId)
-      const repoPath = get().repos.find((repo) => repo.id === repoId)?.path
+      const repoPath = repo?.path
       get().evictGitHubRepoCaches(repoId, repoPath)
       const { clearRepoSlugCacheEntry } = await import('../../lib/repo-slug-index')
       clearRepoSlugCacheEntry(repoId)
@@ -231,7 +232,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           for (const ptyId of get().ptyIdsByTabId[tab.id] ?? []) {
             killedPtyIds.add(ptyId)
             if (!ptyId.startsWith('remote:')) {
-              window.api.pty.kill(ptyId)
+              if (repo?.connectionId) {
+                void window.api.pty.kill(ptyId, { connectionId: repo.connectionId })
+              } else {
+                void window.api.pty.kill(ptyId)
+              }
             }
           }
         }

--- a/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
+++ b/src/renderer/src/store/slices/runtime-pane-title-sort-epoch.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/runtime/sync-runtime-graph', () => ({
 vi.mock('@/components/terminal-pane/pty-transport', () => ({
   registerEagerPtyBuffer: vi.fn(),
   ensurePtyDispatcher: vi.fn(),
+  unregisterScopedPtyDataHandlers: vi.fn(),
   unregisterPtyDataHandlers: vi.fn()
 }))
 vi.mock('@/components/terminal-pane/shutdown-buffer-captures', () => ({

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1142,7 +1142,8 @@ describe('terminal slice behaviors', () => {
 // Mock pty-transport's eager buffer registration
 vi.mock('@/components/terminal-pane/pty-transport', () => ({
   registerEagerPtyBuffer: vi.fn().mockReturnValue({ flush: () => '', dispose: () => {} }),
-  ensurePtyDispatcher: vi.fn()
+  ensurePtyDispatcher: vi.fn(),
+  unregisterScopedPtyDataHandlers: vi.fn()
 }))
 
 describe('reconnectPersistedTerminals', () => {

--- a/src/renderer/src/store/slices/terminal-tab-id-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-id-hydration.test.ts
@@ -8,7 +8,8 @@ vi.mock('@/runtime/sync-runtime-graph', () => ({
 }))
 vi.mock('@/components/terminal-pane/pty-transport', () => ({
   registerEagerPtyBuffer: vi.fn(),
-  ensurePtyDispatcher: vi.fn()
+  ensurePtyDispatcher: vi.fn(),
+  unregisterScopedPtyDataHandlers: vi.fn()
 }))
 
 const apiProxy = (): unknown =>

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -6,7 +6,8 @@ vi.mock('@/runtime/sync-runtime-graph', () => ({
 }))
 vi.mock('@/components/terminal-pane/pty-transport', () => ({
   registerEagerPtyBuffer: vi.fn(),
-  ensurePtyDispatcher: vi.fn()
+  ensurePtyDispatcher: vi.fn(),
+  unregisterScopedPtyDataHandlers: vi.fn()
 }))
 
 const mockApi = {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -26,7 +26,7 @@ import {
 } from './tab-group-state'
 import {
   ensurePtyDispatcher,
-  unregisterPtyDataHandlers
+  unregisterScopedPtyDataHandlers
 } from '@/components/terminal-pane/pty-transport'
 import { normalizeTerminalLayoutSnapshot } from '@/components/terminal-pane/terminal-layout-leaf-ids'
 import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
@@ -87,21 +87,28 @@ function resolveCreatedTabShellOverride(
   return undefined
 }
 
-function worktreeUsesRemoteConnection(
+function getWorktreeConnectionId(
   state: Pick<AppState, 'repos' | 'worktreesByRepo'>,
   worktreeId: string
-): boolean {
+): string | null {
   const directRepoId = getRepoIdFromWorktreeId(worktreeId)
   const directRepo = state.repos.find((repo) => repo.id === directRepoId)
   if (directRepo) {
-    return Boolean(directRepo.connectionId)
+    return directRepo.connectionId ?? null
   }
 
   const worktree = Object.values(state.worktreesByRepo)
     .flat()
     .find((entry) => entry.id === worktreeId)
   const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
-  return Boolean(repo?.connectionId)
+  return repo?.connectionId ?? null
+}
+
+function worktreeUsesRemoteConnection(
+  state: Pick<AppState, 'repos' | 'worktreesByRepo'>,
+  worktreeId: string
+): boolean {
+  return Boolean(getWorktreeConnectionId(state, worktreeId))
 }
 
 export type TerminalSlice = {
@@ -1159,6 +1166,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     const keepIdentifiers = opts?.keepIdentifiers ?? false
     const tabs = get().tabsByWorktree[worktreeId] ?? []
     const ptyIds = tabs.flatMap((tab) => get().ptyIdsByTabId[tab.id] ?? [])
+    const connectionId = getWorktreeConnectionId(get(), worktreeId)
 
     // Why: the main process flushes any remaining batched PTY data before
     // sending the exit event (pty.ts onExit handler). Without this, that
@@ -1167,7 +1175,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     // notifications for a worktree that is already being torn down —
     // the "phantom alerts" users see after shutting down worktrees.
     // Removing the data handlers first ensures the final flush is a no-op.
-    unregisterPtyDataHandlers(ptyIds)
+    unregisterScopedPtyDataHandlers(ptyIds.map((ptyId) => ({ ptyId, connectionId })))
 
     // Why (ordering invariant — DESIGN_DOC §3.3.c): on sleep, capture every
     // pane's serializer buffer into terminalLayoutsByTabId[tab].buffersByLeafId
@@ -1334,7 +1342,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     await Promise.allSettled(
       ptyIds
         .filter((ptyId) => !ptyId.startsWith('remote:'))
-        .map((ptyId) => window.api.pty.kill(ptyId, { keepHistory: keepIdentifiers }))
+        .map((ptyId) =>
+          window.api.pty.kill(ptyId, {
+            keepHistory: keepIdentifiers,
+            ...(connectionId ? { connectionId } : {})
+          })
+        )
     )
   },
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1080,6 +1080,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
   return {
     spawn: () => Promise.reject(new Error('Local PTYs are unavailable in the web client.')),
     write: () => {},
+    ackData: () => {},
     resize: () => {},
     reportGeometry: () => {},
     signal: () => {},


### PR DESCRIPTION
## Summary
- add a per-terminal xterm write queue that waits for xterm write callbacks before sending the next chunk
- route foreground writes, background drains, flushes, and parsed-output waits through the same flow-control path
- clear pending writes when terminal output is discarded/disposed

## Why
DevTools showed repeated `write data discarded, use flow control to avoid losing data` errors from xterm. That means Orca was feeding a terminal faster than xterm could parse it, causing data loss and possible TUI corruption/freezes.

## Validation
- `pnpm test src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Note: validation commands emit the existing Node engine warning because this shell is Node 25 while the repo wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
