### PR TITLE
Guard session restore on incomplete worktree hydration

### DIFF
--- a/docs/workspace-session-restore-hydration.md
+++ b/docs/workspace-session-restore-hydration.md
@@ -1,0 +1,86 @@
+# Workspace Session Restore and Incomplete Worktree Hydration
+
+## Problem
+
+A user reported that after reloading while Orca was updating, their workspaces did not load or were not interactable. The crash-report portion was a separate false positive caused by intentional Electron process teardown. The workspace symptom points at renderer startup state instead: persisted session state can be mounted against an incomplete worktree list.
+
+Orca startup restores state in this order:
+
+1. Load settings.
+2. Load repos.
+3. Fetch all worktrees.
+4. Load persisted UI.
+5. Load the workspace session.
+6. Hydrate terminal, editor, tab, and browser state.
+7. Reconnect persisted terminals.
+8. Mark hydration successful so the session writer can save again.
+
+The risky edge is between steps 3 and 6. `hydrateWorkspaceSession` validates persisted worktree IDs against `worktreesByRepo`. For local repos, a missing worktree ID is treated as deleted and the corresponding saved tabs/workspace state is filtered out.
+
+That is correct only when the worktree list is authoritative.
+
+## Failure Mode
+
+`fetchAllWorktrees` already had a safety gate for the hydration-time purge: if any repo's `worktrees.list` call fails, or if every repo returns an empty list, it defers purging stale `tabsByWorktree` entries. That prevents disk-backed saved tabs from being deleted by a transient Git or IPC problem.
+
+However, startup still continued into session hydration after that degraded fetch. If the saved session referenced local workspaces and `worktreesByRepo` was empty or partial, `hydrateWorkspaceSession` classified those saved local workspaces as invalid in memory.
+
+The likely user-visible result:
+
+- The app shell mounts.
+- The saved active worktree is missing.
+- Terminal/editor/browser state for that worktree may be filtered out.
+- The terminal surface can be hidden or inert because there is no active worktree.
+- If reconnect completes, startup may mark hydration successful, allowing later session writes from the degraded in-memory state.
+
+This matches the report better than a native crash: the app could restart, but the restored workspace model was empty or not actionable.
+
+## Fix
+
+`fetchAllWorktrees` now returns a small startup signal:
+
+```ts
+type FetchAllWorktreesResult = {
+  canHydrateSession: boolean
+}
+```
+
+The result separates two questions that used to be conflated:
+
+- Can the hydration-time stale-state purge run?
+- Is the current worktree map complete enough to validate a persisted session?
+
+Startup now reads the persisted session after UI hydration, then asks `shouldDeferSessionHydrationUntilWorktreesLoaded` whether local session state would be validated against incomplete worktree data. If so, startup throws into the existing session-restore failure path.
+
+That failure path intentionally:
+
+- leaves the persisted session on disk untouched;
+- keeps `hydrationSucceeded` false so the debounced session writer is gated;
+- flips `workspaceSessionReady` so the app shell remains usable;
+- shows the existing sticky "Session restore failed" toast with a restart action.
+
+This is preferable to hydrating a partially empty session and treating it as a successful restore.
+
+## SSH and Floating Terminal
+
+The guard only defers when incomplete worktree hydration would affect local workspace state.
+
+SSH-backed workspaces are exempt because they are reconstructed after SSH reconnect. Their worktree IDs can be valid even when `worktreesByRepo` is initially empty.
+
+The floating terminal is also exempt because it is intentionally not a repo worktree and should not depend on repo worktree discovery.
+
+## Tests
+
+The regression tests cover:
+
+- local workspace session state defers when worktree hydration is incomplete;
+- local editor/browser/tab state keyed by worktree ID also defers;
+- SSH-backed workspaces and the floating terminal can still hydrate during incomplete local worktree startup;
+- `fetchAllWorktrees` reports `canHydrateSession=false` when every repo returns empty during initial hydration;
+- existing purge behavior still defers stale-state cleanup until worktree lists are authoritative.
+
+## Non-Goals
+
+This change does not attempt to retry worktree hydration in place before session restore. A retry loop may be useful later, but the immediate safety requirement is to avoid successful hydration from incomplete data.
+
+This change also does not alter the separate crash-report filtering for Electron SIGTERM process teardown. That fix lives in the crash-reporting path and addresses the false crash prompt, not the workspace restore state.

--- a/docs/workspace-session-restore-hydration.md
+++ b/docs/workspace-session-restore-hydration.md
@@ -4,6 +4,46 @@
 
 A user reported that after reloading while Orca was updating, their workspaces did not load or were not interactable. The crash-report portion was a separate false positive caused by intentional Electron process teardown. The workspace symptom points at renderer startup state instead: persisted session state can be mounted against an incomplete worktree list.
 
+## Original User Report
+
+The report came from Orca `1.4.4` on macOS `25.4.0` arm64. The submitted crash report had:
+
+- report ID `58535131-6384-4d30-a3dc-75d9b590544d`;
+- reason `killed`;
+- exit code `15`;
+- submitted at `2026-05-19T19:26:41.784Z`;
+- Electron `41.5.0`;
+- Chrome `146.0.7680.216`.
+
+The user feedback was:
+
+```text
+reload while was updating and it crashes
+```
+
+The crash breadcrumbs showed repeated Claude agent state changes followed by two main-window reloads:
+
+```text
+2026-05-19T19:03:35.386Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:04:09.363Z agent_state_changed (agentType=claude, state=done)
+2026-05-19T19:04:38.275Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:04:55.528Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:04:55.634Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:05:05.455Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:06:08.980Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:06:09.118Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:06:16.802Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:07:06.856Z main_window_loaded
+2026-05-19T19:07:14.583Z main_window_loaded
+2026-05-19T19:08:17.053Z agent_state_changed (agentType=claude, state=working)
+2026-05-19T19:08:22.818Z agent_state_changed (agentType=claude, state=working)
+```
+
+Follow-up investigation separated this into two issues:
+
+- the crash dialog was likely caused by expected Electron process teardown during reload/update;
+- the user-visible "workspaces did not load / were not interactable" symptom likely came from session restore proceeding with incomplete worktree hydration.
+
 Orca startup restores state in this order:
 
 1. Load settings.

--- a/docs/workspace-session-restore-hydration.md
+++ b/docs/workspace-session-restore-hydration.md
@@ -82,6 +82,7 @@ This matches the report better than a native crash: the app could restart, but t
 ```ts
 type FetchAllWorktreesResult = {
   canHydrateSession: boolean
+  repoIdsReadyForSessionHydration: string[]
 }
 ```
 
@@ -90,7 +91,7 @@ The result separates two questions that used to be conflated:
 - Can the hydration-time stale-state purge run?
 - Is the current worktree map complete enough to validate a persisted session?
 
-Startup now reads the persisted session after UI hydration, then asks `shouldDeferSessionHydrationUntilWorktreesLoaded` whether local session state would be validated against incomplete worktree data. If so, startup throws into the existing session-restore failure path.
+Startup now reads the persisted session after UI hydration, then asks `shouldDeferSessionHydrationUntilWorktreesLoaded` whether local session state would be validated against incomplete worktree data for the repo IDs referenced by that session. If so, startup throws into the existing session-restore failure path.
 
 That failure path intentionally:
 
@@ -116,7 +117,7 @@ The regression tests cover:
 - local workspace session state defers when worktree hydration is incomplete;
 - local editor/browser/tab state keyed by worktree ID also defers;
 - SSH-backed workspaces and the floating terminal can still hydrate during incomplete local worktree startup;
-- `fetchAllWorktrees` reports `canHydrateSession=false` when every repo returns empty during initial hydration;
+- `fetchAllWorktrees` reports which repo IDs have worktree lists ready for session validation so unrelated empty repos do not block restore;
 - existing purge behavior still defers stale-state cleanup until worktree lists are authoritative.
 
 ## Non-Goals

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -88,6 +88,7 @@ import {
   getStartupErrorFallbackUI,
   hydratePersistedUIAfterStartupRead
 } from './lib/startup-ui-hydration'
+import { shouldDeferSessionHydrationUntilWorktreesLoaded } from './lib/startup-worktree-hydration'
 import { applyDocumentTheme } from './lib/document-theme'
 import { isEditableTarget } from './lib/editable-target'
 import { getSelectedTextForFileSearch } from './lib/file-search-selection'
@@ -487,7 +488,7 @@ function App(): React.JSX.Element {
         // the local filesystem and then hydrate stale local workspace state.
         await actions.fetchSettings()
         await actions.fetchRepos()
-        await actions.fetchAllWorktrees()
+        const worktreeHydration = await actions.fetchAllWorktrees()
         await actions.fetchWorktreeLineage()
         const persistedUI = await window.api.ui.get()
         uiHydrated = hydratePersistedUIAfterStartupRead({
@@ -496,6 +497,15 @@ function App(): React.JSX.Element {
           hydratePersistedUI: actions.hydratePersistedUI
         })
         const session = await window.api.session.get()
+        if (
+          shouldDeferSessionHydrationUntilWorktreesLoaded({
+            repos: useAppStore.getState().repos,
+            session,
+            worktreeHydration
+          })
+        ) {
+          throw new Error('worktree hydration incomplete during startup')
+        }
         if (!cancelled) {
           actions.hydrateWorkspaceSession(session)
           actions.hydrateTabsSession(session)

--- a/src/renderer/src/lib/startup-worktree-hydration.test.ts
+++ b/src/renderer/src/lib/startup-worktree-hydration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { Repo, WorkspaceSessionState } from '../../../shared/types'
+import { shouldDeferSessionHydrationUntilWorktreesLoaded } from './startup-worktree-hydration'
+
+const localRepo: Repo = {
+  id: 'repo-local',
+  path: '/repos/local',
+  displayName: 'local',
+  badgeColor: '#000',
+  addedAt: 0
+}
+
+const sshRepo: Repo = {
+  id: 'repo-ssh',
+  path: '/repos/ssh',
+  displayName: 'ssh',
+  badgeColor: '#111',
+  addedAt: 0,
+  connectionId: 'ssh-target'
+}
+
+function makeSession(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+describe('shouldDeferSessionHydrationUntilWorktreesLoaded', () => {
+  it('allows hydration after worktree lists are complete', () => {
+    const session = makeSession({
+      activeWorktreeId: 'repo-local::/repos/local/wt',
+      tabsByWorktree: { 'repo-local::/repos/local/wt': [] }
+    })
+
+    expect(
+      shouldDeferSessionHydrationUntilWorktreesLoaded({
+        repos: [localRepo],
+        session,
+        worktreeHydration: { canHydrateSession: true }
+      })
+    ).toBe(false)
+  })
+
+  it('defers hydration when a saved local workspace would be validated against incomplete lists', () => {
+    const session = makeSession({
+      activeWorktreeId: 'repo-local::/repos/local/wt',
+      tabsByWorktree: { 'repo-local::/repos/local/wt': [] }
+    })
+
+    expect(
+      shouldDeferSessionHydrationUntilWorktreesLoaded({
+        repos: [localRepo],
+        session,
+        worktreeHydration: { canHydrateSession: false }
+      })
+    ).toBe(true)
+  })
+
+  it('defers hydration for editor and browser state keyed by local worktrees', () => {
+    const session = makeSession({
+      openFilesByWorktree: { 'repo-local::/repos/local/wt': [] },
+      browserTabsByWorktree: { 'repo-local::/repos/local/wt': [] },
+      unifiedTabs: { 'repo-local::/repos/local/wt': [] }
+    })
+
+    expect(
+      shouldDeferSessionHydrationUntilWorktreesLoaded({
+        repos: [localRepo],
+        session,
+        worktreeHydration: { canHydrateSession: false }
+      })
+    ).toBe(true)
+  })
+
+  it('allows incomplete startup lists for SSH and floating terminal session state', () => {
+    const session = makeSession({
+      activeWorktreeId: 'repo-ssh::/srv/app',
+      tabsByWorktree: {
+        'repo-ssh::/srv/app': [],
+        [FLOATING_TERMINAL_WORKTREE_ID]: []
+      }
+    })
+
+    expect(
+      shouldDeferSessionHydrationUntilWorktreesLoaded({
+        repos: [sshRepo],
+        session,
+        worktreeHydration: { canHydrateSession: false }
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/startup-worktree-hydration.test.ts
+++ b/src/renderer/src/lib/startup-worktree-hydration.test.ts
@@ -32,6 +32,11 @@ function makeSession(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceS
 }
 
 describe('shouldDeferSessionHydrationUntilWorktreesLoaded', () => {
+  const completeHydration = {
+    canHydrateSession: true,
+    repoIdsReadyForSessionHydration: ['repo-local']
+  }
+
   it('allows hydration after worktree lists are complete', () => {
     const session = makeSession({
       activeWorktreeId: 'repo-local::/repos/local/wt',
@@ -42,7 +47,7 @@ describe('shouldDeferSessionHydrationUntilWorktreesLoaded', () => {
       shouldDeferSessionHydrationUntilWorktreesLoaded({
         repos: [localRepo],
         session,
-        worktreeHydration: { canHydrateSession: true }
+        worktreeHydration: completeHydration
       })
     ).toBe(false)
   })
@@ -57,7 +62,10 @@ describe('shouldDeferSessionHydrationUntilWorktreesLoaded', () => {
       shouldDeferSessionHydrationUntilWorktreesLoaded({
         repos: [localRepo],
         session,
-        worktreeHydration: { canHydrateSession: false }
+        worktreeHydration: {
+          canHydrateSession: false,
+          repoIdsReadyForSessionHydration: []
+        }
       })
     ).toBe(true)
   })
@@ -73,9 +81,39 @@ describe('shouldDeferSessionHydrationUntilWorktreesLoaded', () => {
       shouldDeferSessionHydrationUntilWorktreesLoaded({
         repos: [localRepo],
         session,
-        worktreeHydration: { canHydrateSession: false }
+        worktreeHydration: {
+          canHydrateSession: false,
+          repoIdsReadyForSessionHydration: []
+        }
       })
     ).toBe(true)
+  })
+
+  it('allows hydration when only an unrelated local repo has incomplete worktrees', () => {
+    const session = makeSession({
+      activeWorktreeId: 'repo-local::/repos/local/wt',
+      tabsByWorktree: { 'repo-local::/repos/local/wt': [] }
+    })
+
+    expect(
+      shouldDeferSessionHydrationUntilWorktreesLoaded({
+        repos: [
+          localRepo,
+          {
+            id: 'repo-empty',
+            path: '/repos/empty',
+            displayName: 'empty',
+            badgeColor: '#222',
+            addedAt: 0
+          }
+        ],
+        session,
+        worktreeHydration: {
+          canHydrateSession: false,
+          repoIdsReadyForSessionHydration: ['repo-local']
+        }
+      })
+    ).toBe(false)
   })
 
   it('allows incomplete startup lists for SSH and floating terminal session state', () => {
@@ -91,7 +129,10 @@ describe('shouldDeferSessionHydrationUntilWorktreesLoaded', () => {
       shouldDeferSessionHydrationUntilWorktreesLoaded({
         repos: [sshRepo],
         session,
-        worktreeHydration: { canHydrateSession: false }
+        worktreeHydration: {
+          canHydrateSession: false,
+          repoIdsReadyForSessionHydration: []
+        }
       })
     ).toBe(false)
   })

--- a/src/renderer/src/lib/startup-worktree-hydration.ts
+++ b/src/renderer/src/lib/startup-worktree-hydration.ts
@@ -1,0 +1,64 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { Repo, WorkspaceSessionState } from '../../../shared/types'
+import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
+
+type WorktreeHydrationResult = {
+  canHydrateSession: boolean
+}
+
+type SessionHydrationDeferInput = {
+  repos: Repo[]
+  session: WorkspaceSessionState
+  worktreeHydration: WorktreeHydrationResult
+}
+
+function addRecordKeys(ids: Set<string>, record: Record<string, unknown> | undefined): void {
+  if (!record) {
+    return
+  }
+  for (const id of Object.keys(record)) {
+    ids.add(id)
+  }
+}
+
+function collectSessionWorktreeIds(session: WorkspaceSessionState): Set<string> {
+  const ids = new Set<string>()
+  if (session.activeWorktreeId) {
+    ids.add(session.activeWorktreeId)
+  }
+  addRecordKeys(ids, session.tabsByWorktree)
+  addRecordKeys(ids, session.openFilesByWorktree)
+  addRecordKeys(ids, session.activeFileIdByWorktree)
+  addRecordKeys(ids, session.browserTabsByWorktree)
+  addRecordKeys(ids, session.activeBrowserTabIdByWorktree)
+  addRecordKeys(ids, session.activeTabTypeByWorktree)
+  addRecordKeys(ids, session.activeTabIdByWorktree)
+  addRecordKeys(ids, session.unifiedTabs)
+  addRecordKeys(ids, session.tabGroups)
+  addRecordKeys(ids, session.tabGroupLayouts)
+  addRecordKeys(ids, session.activeGroupIdByWorktree)
+  return ids
+}
+
+export function shouldDeferSessionHydrationUntilWorktreesLoaded({
+  repos,
+  session,
+  worktreeHydration
+}: SessionHydrationDeferInput): boolean {
+  if (worktreeHydration.canHydrateSession) {
+    return false
+  }
+
+  const sshRepoIds = new Set(repos.filter((repo) => repo.connectionId).map((repo) => repo.id))
+  for (const worktreeId of collectSessionWorktreeIds(session)) {
+    if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+      continue
+    }
+    // Why: local workspaces are validated from the fetched worktree list. If
+    // that list is degraded, hydrating would classify saved workspaces as gone.
+    if (!sshRepoIds.has(getRepoIdFromWorktreeId(worktreeId))) {
+      return true
+    }
+  }
+  return false
+}

--- a/src/renderer/src/lib/startup-worktree-hydration.ts
+++ b/src/renderer/src/lib/startup-worktree-hydration.ts
@@ -4,6 +4,7 @@ import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 
 type WorktreeHydrationResult = {
   canHydrateSession: boolean
+  repoIdsReadyForSessionHydration: string[]
 }
 
 type SessionHydrationDeferInput = {
@@ -50,13 +51,19 @@ export function shouldDeferSessionHydrationUntilWorktreesLoaded({
   }
 
   const sshRepoIds = new Set(repos.filter((repo) => repo.connectionId).map((repo) => repo.id))
+  const repoIdsReadyForSessionHydration = new Set(worktreeHydration.repoIdsReadyForSessionHydration)
   for (const worktreeId of collectSessionWorktreeIds(session)) {
     if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
       continue
     }
+    const repoId = getRepoIdFromWorktreeId(worktreeId)
+    if (sshRepoIds.has(repoId)) {
+      continue
+    }
     // Why: local workspaces are validated from the fetched worktree list. If
-    // that list is degraded, hydrating would classify saved workspaces as gone.
-    if (!sshRepoIds.has(getRepoIdFromWorktreeId(worktreeId))) {
+    // that repo's list is degraded, hydrating would classify saved workspaces
+    // as gone. Unrelated empty repos must not block a valid saved workspace.
+    if (!repoIdsReadyForSessionHydration.has(repoId)) {
       return true
     }
   }

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -20,6 +20,10 @@ export type WorktreeDeleteState = {
   canForceDelete: boolean
 }
 
+export type FetchAllWorktreesResult = {
+  canHydrateSession: boolean
+}
+
 export type WorktreeSlice = {
   worktreesByRepo: Record<string, Worktree[]>
   worktreeLineageById: Record<string, WorktreeLineage>
@@ -64,7 +68,7 @@ export type WorktreeSlice = {
    */
   hasHydratedWorktreePurge: boolean
   fetchWorktrees: (repoId: string) => Promise<void>
-  fetchAllWorktrees: () => Promise<void>
+  fetchAllWorktrees: () => Promise<FetchAllWorktreesResult>
   fetchWorktreeLineage: () => Promise<void>
   updateWorktreeLineage: (
     worktreeId: string,

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -22,6 +22,7 @@ export type WorktreeDeleteState = {
 
 export type FetchAllWorktreesResult = {
   canHydrateSession: boolean
+  repoIdsReadyForSessionHydration: string[]
 }
 
 export type WorktreeSlice = {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1581,8 +1581,9 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().fetchAllWorktrees()
+    const degradedResult = await store.getState().fetchAllWorktrees()
 
+    expect(degradedResult.canHydrateSession).toBe(true)
     expect(store.getState().hasHydratedWorktreePurge).toBe(false)
     expect(store.getState().tabsByWorktree).toEqual({
       'repoA::/a/stale': [{ id: 'tab-A-stale', worktreeId: 'repoA::/a/stale' }],
@@ -1597,8 +1598,9 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
       return [wtB]
     })
 
-    await store.getState().fetchAllWorktrees()
+    const recoveredResult = await store.getState().fetchAllWorktrees()
 
+    expect(recoveredResult.canHydrateSession).toBe(true)
     expect(store.getState().hasHydratedWorktreePurge).toBe(true)
     expect(store.getState().tabsByWorktree).toEqual({
       'repoB::/b/wt1': [{ id: 'tab-B', worktreeId: 'repoB::/b/wt1' }]
@@ -1620,8 +1622,9 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().fetchAllWorktrees()
+    const result = await store.getState().fetchAllWorktrees()
 
+    expect(result.canHydrateSession).toBe(false)
     expect(store.getState().hasHydratedWorktreePurge).toBe(false)
     expect(store.getState().tabsByWorktree).toEqual({
       'repoA::/a/wt1': [{ id: 'tab-A', worktreeId: 'repoA::/a/wt1' }]
@@ -1651,8 +1654,9 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
       }
     } as unknown as Partial<AppState>)
 
-    await store.getState().fetchAllWorktrees()
+    const result = await store.getState().fetchAllWorktrees()
 
+    expect(result.canHydrateSession).toBe(true)
     expect(store.getState().hasHydratedWorktreePurge).toBe(true)
     expect(mockApi.worktrees.list).toHaveBeenCalledTimes(2)
     expect(store.getState().tabsByWorktree).toEqual({

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1631,6 +1631,33 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
     })
   })
 
+  it('reports repo-specific session hydration readiness when an unrelated repo is empty', async () => {
+    const store = createTestStore()
+    const wtA = makeWorktree({ id: 'repoA::/a/wt1', repoId: 'repoA', path: '/a/wt1' })
+
+    mockApi.worktrees.list.mockImplementation(async ({ repoId }: { repoId: string }) =>
+      repoId === 'repoA' ? [wtA] : []
+    )
+
+    store.setState({
+      repos: [repoA, repoB],
+      tabsByWorktree: {
+        'repoA::/a/wt1': [{ id: 'tab-A', worktreeId: 'repoA::/a/wt1' }]
+      }
+    } as unknown as Partial<AppState>)
+
+    const result = await store.getState().fetchAllWorktrees()
+
+    expect(result).toEqual({
+      canHydrateSession: false,
+      repoIdsReadyForSessionHydration: ['repoA']
+    })
+    expect(store.getState().hasHydratedWorktreePurge).toBe(false)
+    expect(store.getState().tabsByWorktree).toEqual({
+      'repoA::/a/wt1': [{ id: 'tab-A', worktreeId: 'repoA::/a/wt1' }]
+    })
+  })
+
   it('fires the purge once when every repo returns successfully with ≥1 worktree', async () => {
     const store = createTestStore()
     const wtA = makeWorktree({ id: 'repoA::/a/wt1', repoId: 'repoA', path: '/a/wt1' })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -440,7 +440,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // double-probe the IPC for the per-repo success signal.
     if (get().hasHydratedWorktreePurge) {
       await Promise.all(repos.map((r) => get().fetchWorktrees(r.id)))
-      return
+      return { canHydrateSession: true }
     }
 
     // Why: users upgrading from a pre-fix build may have persisted
@@ -468,18 +468,28 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
               sortEpoch: s.sortEpoch + 1
             }))
           }
-          return { repoId: r.id, ok: list.length > 0 }
+          return {
+            repoId: r.id,
+            ok: list.length > 0,
+            hasWorktreesForSession: list.length > 0 || Boolean(current && current.length > 0)
+          }
         } catch (err) {
           console.error(`Failed to fetch worktrees for repo ${r.id}:`, err)
-          return { repoId: r.id, ok: false as const }
+          const current = get().worktreesByRepo[r.id]
+          return {
+            repoId: r.id,
+            ok: false as const,
+            hasWorktreesForSession: Boolean(current && current.length > 0)
+          }
         }
       })
     )
 
+    const canHydrateSession = results.every((r) => r.hasWorktreesForSession)
     const allSucceeded = results.length > 0 && results.every((r) => r.ok)
     if (!allSucceeded) {
       // Defer; try again on the next fetchAllWorktrees call.
-      return
+      return { canHydrateSession }
     }
     const validIds = new Set<string>()
     for (const list of Object.values(get().worktreesByRepo)) {
@@ -496,6 +506,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       get().purgeWorktreeTerminalState(stale)
     }
     set({ hasHydratedWorktreePurge: true })
+    return { canHydrateSession: true }
   },
 
   fetchWorktreeLineage: async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -440,7 +440,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // double-probe the IPC for the per-repo success signal.
     if (get().hasHydratedWorktreePurge) {
       await Promise.all(repos.map((r) => get().fetchWorktrees(r.id)))
-      return { canHydrateSession: true }
+      return {
+        canHydrateSession: true,
+        repoIdsReadyForSessionHydration: repos.map((repo) => repo.id)
+      }
     }
 
     // Why: users upgrading from a pre-fix build may have persisted
@@ -485,11 +488,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       })
     )
 
+    const repoIdsReadyForSessionHydration = results
+      .filter((r) => r.hasWorktreesForSession)
+      .map((r) => r.repoId)
     const canHydrateSession = results.every((r) => r.hasWorktreesForSession)
     const allSucceeded = results.length > 0 && results.every((r) => r.ok)
     if (!allSucceeded) {
       // Defer; try again on the next fetchAllWorktrees call.
-      return { canHydrateSession }
+      return { canHydrateSession, repoIdsReadyForSessionHydration }
     }
     const validIds = new Set<string>()
     for (const list of Object.values(get().worktreesByRepo)) {
@@ -506,7 +512,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       get().purgeWorktreeTerminalState(stale)
     }
     set({ hasHydratedWorktreePurge: true })
-    return { canHydrateSession: true }
+    return {
+      canHydrateSession: true,
+      repoIdsReadyForSessionHydration: repos.map((repo) => repo.id)
+    }
   },
 
   fetchWorktreeLineage: async () => {


### PR DESCRIPTION
## Summary
- report whether startup worktree listing is complete enough to validate persisted session workspaces
- defer local session hydration when worktree lists are incomplete, avoiding in-memory empty workspace state and no-op interactions
- preserve SSH and floating-terminal restore paths that are intentionally reconstructed later

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/startup-worktree-hydration.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/app-startup-routing.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web

Made with [Orca](https://github.com/stablyai/orca) 🐋


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.