### PR TITLE
Clarify Orca CLI worktree lineage guidance

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -150,24 +150,22 @@ Worktree selectors supported in focused v1:
 
 ### Worktree Lineage
 
-When creating a worktree from inside an Orca-managed worktree, preserve parent lineage unless the new work is independent.
+Worktree lineage records intent; it is not a required flag sequence. When creating a worktree from inside an Orca-managed worktree, decide whether the new work is related to the current work or independent of it.
 
-Use the inferred parent by default. Pass `--parent-worktree active` when the command should make the current worktree relationship explicit.
+For related work, rely on Orca's inferred parent. Use `--parent-worktree active` when the current worktree relationship should be explicit or when the shell context might not make the intended parent obvious.
 
 ```bash
 orca worktree create --repo id:<repoId> --name related-task --json
 orca worktree create --repo id:<repoId> --name related-task --parent-worktree active --json
 ```
 
-Pass `--no-parent` only when the new worktree should stand alone.
+For independent work, pass `--no-parent`.
 
 ```bash
 orca worktree create --repo id:<repoId> --name independent-task --no-parent --json
 ```
 
-Use parent lineage for subtasks, follow-ups, repros, reviews, test runs, implementation slices, or work connected to the current task. Use `--no-parent` for explicit topic switches, unrelated projects/issues, or user requests for an independent workspace.
-
-Do not use `--no-parent` only because the new worktree uses a different branch, issue, or name. Those differences can still describe related child work.
+A different branch, issue, or name is not enough by itself to make the work independent. Treat lineage as a record of why the workspace exists, not as a property of the branch name.
 
 ### Automations
 
@@ -226,8 +224,8 @@ Why: `--direction horizontal` splits the pane **left and right** (new pane appea
 - Prefer `--json` for all machine-driven use.
 - Use `worktree ps` as the first summary view when many worktrees may exist.
 - Use `worktree current` or `--worktree active` when the agent is already running inside the target worktree.
-- When creating a worktree from an existing workspace, preserve parent lineage by default; pass `--parent-worktree active` when the relationship should be explicit.
-- Pass `--no-parent` on `worktree create` only when the new workspace should be independent of the current one.
+- When creating a worktree from an existing workspace, choose lineage based on intent: related work should keep parent context, independent work should use `--no-parent`.
+- Let Orca infer the parent when the current/caller workspace is the right parent; use `--parent-worktree active` when making that relationship explicit is useful.
 - Treat `orca worktree set --worktree active --comment ... --json` as a default coding-agent behavior whenever the agent reaches a meaningful checkpoint in the current Orca-managed worktree; the user does not need to explicitly ask for each update.
 - Update the worktree comment at significant checkpoints, not every trivial command. Good checkpoints include reproducing a bug, confirming a hypothesis, starting a risky migration, finishing a meaningful implementation slice, switching from investigation to fix, or blocking on external input.
 - Write comments as short status snapshots of the current state, for example `debugging AWS CLI profile resolution`, `confirmed flaky test is caused by temp-dir race`, or `fix implemented; running integration tests`.

--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -132,6 +132,8 @@ orca worktree ps --json
 orca worktree current --json
 orca worktree show --worktree id:<worktreeId> --json
 orca worktree create --repo id:<repoId> --name my-task --issue 123 --comment "seed" --json
+orca worktree create --repo id:<repoId> --name related-task --parent-worktree active --json
+orca worktree create --repo id:<repoId> --name independent-task --no-parent --json
 orca worktree set --worktree id:<worktreeId> --display-name "My Task" --json
 orca worktree set --worktree active --comment "reproduced bug; collecting logs from staging" --json
 orca worktree set --worktree active --comment "waiting on review" --json
@@ -145,6 +147,27 @@ Worktree selectors supported in focused v1:
 - `branch:<branch-name>`
 - `issue:<number>`
 - `active` / `current` to resolve the enclosing Orca-managed worktree from the shell `cwd`
+
+### Worktree Lineage
+
+When creating a worktree from inside an Orca-managed worktree, preserve parent lineage unless the new work is independent.
+
+Use the inferred parent by default. Pass `--parent-worktree active` when the command should make the current worktree relationship explicit.
+
+```bash
+orca worktree create --repo id:<repoId> --name related-task --json
+orca worktree create --repo id:<repoId> --name related-task --parent-worktree active --json
+```
+
+Pass `--no-parent` only when the new worktree should stand alone.
+
+```bash
+orca worktree create --repo id:<repoId> --name independent-task --no-parent --json
+```
+
+Use parent lineage for subtasks, follow-ups, repros, reviews, test runs, implementation slices, or work connected to the current task. Use `--no-parent` for explicit topic switches, unrelated projects/issues, or user requests for an independent workspace.
+
+Do not use `--no-parent` only because the new worktree uses a different branch, issue, or name. Those differences can still describe related child work.
 
 ### Automations
 
@@ -203,6 +226,8 @@ Why: `--direction horizontal` splits the pane **left and right** (new pane appea
 - Prefer `--json` for all machine-driven use.
 - Use `worktree ps` as the first summary view when many worktrees may exist.
 - Use `worktree current` or `--worktree active` when the agent is already running inside the target worktree.
+- When creating a worktree from an existing workspace, preserve parent lineage by default; pass `--parent-worktree active` when the relationship should be explicit.
+- Pass `--no-parent` on `worktree create` only when the new workspace should be independent of the current one.
 - Treat `orca worktree set --worktree active --comment ... --json` as a default coding-agent behavior whenever the agent reaches a meaningful checkpoint in the current Orca-managed worktree; the user does not need to explicitly ask for each update.
 - Update the worktree comment at significant checkpoints, not every trivial command. Good checkpoints include reproducing a bug, confirming a hypothesis, starting a risky migration, finishing a meaningful implementation slice, switching from investigation to fix, or blocking on external input.
 - Write comments as short status snapshots of the current state, for example `debugging AWS CLI profile resolution`, `confirmed flaky test is caused by temp-dir race`, or `fix implemented; running integration tests`.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -187,8 +187,8 @@ Selectors:
   --repo <selector>         Registered repo selector such as id:<id>, name:<name>, or path:<path>
   --worktree <selector>     Worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current
   --terminal <handle>       Runtime-issued terminal handle returned by \`orca terminal list --json\`
-  --parent-worktree <selector> Parent worktree selector; create infers one from the Orca terminal or current directory by default
-  --no-parent               Force worktree creation/update to have no parent lineage
+  --parent-worktree <selector> Parent worktree selector; create infers a child of the caller/current worktree by default
+  --no-parent               Force no parent lineage for unrelated worktree creation/update
 
 Terminal Send Options:
   --text <text>             Text to send to the terminal
@@ -355,11 +355,11 @@ export function formatFlagHelp(flag: string): string {
     limit: '--limit <n>            Maximum number of rows to return',
     'mouse-button': '--mouse-button <btn>   Mouse button: left, right, or middle',
     name: '--name <name>          Name for the new worktree or automation',
-    'no-parent': '--no-parent            Force no parent lineage',
+    'no-parent': '--no-parent            Force no parent lineage for unrelated work',
     'no-screenshot': '--no-screenshot       Skip screenshot capture after the operation',
     pages: '--pages <n>           Number of scroll pages',
     'parent-worktree':
-      '--parent-worktree <selector> Parent worktree selector; create infers one by default',
+      '--parent-worktree <selector> Parent selector; create infers the caller/current worktree by default',
     path: '--path <path>          Filesystem path to the repo',
     query: '--query <text>        Search text for matching refs',
     ref: '--ref <ref>            Base ref to persist for the repo',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -106,8 +106,8 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'By default, Orca records the new worktree as a child of the caller workspace when it can infer one from the Orca terminal or current directory.',
-      'For related work, accept the inferred parent or pass --parent-worktree active to make the current workspace relationship explicit.',
-      'Pass --no-parent only when the new worktree should be independent of the current workspace.',
+      'For related work, use the inferred parent or pass --parent-worktree active to make the current workspace relationship explicit.',
+      'Use --no-parent when the new worktree should be independent of the current workspace.',
       'By default this creates the worktree and its first terminal without switching the active Orca workspace.',
       'Repo-defined setup hooks follow the repository setup policy; pass --run-hooks to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -106,11 +106,17 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'By default, Orca records the new worktree as a child of the caller workspace when it can infer one from the Orca terminal or current directory.',
-      'Pass --parent-worktree to choose a parent explicitly, or --no-parent to force no lineage.',
+      'For related work, accept the inferred parent or pass --parent-worktree active to make the current workspace relationship explicit.',
+      'Pass --no-parent only when the new worktree should be independent of the current workspace.',
       'By default this creates the worktree and its first terminal without switching the active Orca workspace.',
       'Repo-defined setup hooks follow the repository setup policy; pass --run-hooks to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',
       'Passing --run-hooks reveals the worktree so the setup hook can run in its first terminal.'
+    ],
+    examples: [
+      'orca worktree create --repo id:<repoId> --name related-task --json',
+      'orca worktree create --repo id:<repoId> --name related-task --parent-worktree active --json',
+      'orca worktree create --repo id:<repoId> --name independent-task --no-parent --json'
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Add durable orca-cli skill guidance for when new worktrees should preserve parent lineage versus use --no-parent
- Align worktree create help notes/examples with related vs independent workspace language
- Tighten root flag help for --parent-worktree and --no-parent

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts src/cli/args.test.ts src/cli/format.test.ts
- pnpm run typecheck:cli

Made with [Orca](https://github.com/stablyai/orca) 🐋
