### PR TITLE
Remove sidebar lineage parent badge

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.lineage.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.lineage.test.tsx
@@ -93,33 +93,27 @@ function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
   }
 }
 
-describe('WorktreeCard lineage chip', () => {
+describe('WorktreeCard lineage indicators', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     worktreeCardProperties = []
   })
 
-  it('labels valid lineage as a parent workspace instead of a git source branch', async () => {
+  it('does not render parent lineage badge copy on workspace cards', async () => {
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
     const markup = renderToStaticMarkup(
-      <WorktreeCard
-        worktree={makeWorktree()}
-        repo={makeRepo()}
-        isActive={false}
-        parentLabel="master"
-        lineageState="valid"
-      />
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
     )
 
-    expect(markup).toContain('aria-label="Parent workspace: master"')
-    expect(markup).toContain('parent:')
-    expect(markup).toContain('master')
-    expect(markup).toContain('overflow-hidden')
+    expect(markup).not.toContain('Parent workspace')
+    expect(markup).not.toContain('parent:')
     expect(markup).not.toContain('from master')
+    expect(markup).not.toContain('Missing parent')
+    expect(markup).toContain('overflow-hidden')
   })
 
-  it('preserves the missing-parent chip copy', async () => {
+  it('keeps the child workspace toggle chip', async () => {
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
     const markup = renderToStaticMarkup(
@@ -127,12 +121,14 @@ describe('WorktreeCard lineage chip', () => {
         worktree={makeWorktree()}
         repo={makeRepo()}
         isActive={false}
-        parentLabel="Missing parent"
-        lineageState="missing"
+        lineageChildCount={1}
+        lineageCollapsed={false}
+        onLineageToggle={vi.fn()}
       />
     )
 
-    expect(markup).toContain('aria-label="Parent workspace unavailable"')
-    expect(markup).toContain('Missing parent')
+    expect(markup).toContain('aria-label="Hide 1 child workspace"')
+    expect(markup).toContain('1 child')
+    expect(markup).not.toContain('Parent workspace')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -42,8 +42,6 @@ type WorktreeCardProps = {
   isMultiSelected?: boolean
   selectedWorktrees?: readonly Worktree[]
   hideRepoBadge?: boolean
-  parentLabel?: string
-  lineageState?: 'valid' | 'missing'
   lineageChildCount?: number
   lineageCollapsed?: boolean
   lineageChildren?: React.ReactNode
@@ -75,8 +73,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
   onContextMenuSelect,
   nativeDragEnabled = true,
   hideRepoBadge,
-  parentLabel,
-  lineageState,
   lineageChildCount = 0,
   lineageCollapsed = false,
   lineageChildren,
@@ -353,12 +349,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
     lineageChildCount === 1 ? 'child' : 'children'
   }`
   const showLineageChildChip = lineageChildCount > 0 && onLineageToggle !== undefined
-  const lineageParentTooltip =
-    lineageState === 'missing'
-      ? 'Parent workspace unavailable'
-      : parentLabel
-        ? `Parent workspace: ${parentLabel}`
-        : ''
 
   const handleDragStart = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
@@ -595,36 +585,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
             )}
 
             <CacheTimer worktreeId={worktree.id} />
-
-            {parentLabel && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    aria-label={lineageParentTooltip}
-                    className={cn(
-                      'h-[16px] min-w-0 max-w-[7rem] justify-start px-1.5 text-[10px] font-medium rounded shrink gap-1 leading-none',
-                      lineageState === 'missing'
-                        ? 'text-muted-foreground border-border bg-muted/40'
-                        : 'text-muted-foreground border-border bg-accent/50'
-                    )}
-                  >
-                    <Workflow className="size-2.5 shrink-0" />
-                    {lineageState === 'missing' ? (
-                      <span className="max-w-[7rem] truncate">Missing parent</span>
-                    ) : (
-                      <>
-                        <span className="shrink-0 text-muted-foreground/80">parent:</span>
-                        <span className="min-w-0 truncate">{parentLabel}</span>
-                      </>
-                    )}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  {lineageParentTooltip}
-                </TooltipContent>
-              </Tooltip>
-            )}
           </div>
 
           {hasDetails ? (

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1437,12 +1437,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     onSelectionGesture={onSelectionGesture}
                     onContextMenuSelect={(event) => onContextMenuSelect(event, itemRow.worktree)}
                     hideRepoBadge={groupBy === 'repo'}
-                    parentLabel={
-                      itemRow.depth > 0 && itemRow.lineageState === 'valid'
-                        ? undefined
-                        : itemRow.parentLabel
-                    }
-                    lineageState={itemRow.lineageState}
                     lineageChildCount={itemRow.lineageChildCount}
                     lineageCollapsed={itemRow.lineageCollapsed}
                     lineageChildren={lineageChildren}
@@ -1964,7 +1958,8 @@ const WorktreeList = React.memo(function WorktreeList({
       browserTabsByWorktree,
       activeWorktreeId,
       hideDefaultBranchWorkspace,
-      repoMap
+      repoMap,
+      worktreeLineageById
     })
     return ids.map((id) => worktreeMap.get(id)).filter((w): w is Worktree => w != null)
   }, [
@@ -1978,6 +1973,7 @@ const WorktreeList = React.memo(function WorktreeList({
     browserTabsByWorktree,
     sortedIds,
     worktreeMap,
+    worktreeLineageById,
     worktreesByRepo
   ])
 

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -37,7 +37,10 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         browserTabsByWorktree,
         activeWorktreeId,
         hideDefaultBranchWorkspace,
-        repoMap
+        repoMap,
+        // Why: the board has no nested lineage presentation. Ancestor injection
+        // would make filtered-out parents appear as ordinary cards.
+        worktreeLineageById: {}
       })
     )
   }, [

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -6,7 +6,7 @@ import {
   isDefaultBranchWorkspace,
   sidebarHasActiveFilters
 } from './visible-worktrees'
-import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
+import type { Repo, TerminalTab, Worktree, WorktreeLineage } from '../../../../shared/types'
 
 function makeTab(id: string, worktreeId: string, ptyId: string | null): TerminalTab {
   return {
@@ -21,9 +21,10 @@ function makeTab(id: string, worktreeId: string, ptyId: string | null): Terminal
   }
 }
 
-function makeWorktree(id: string, repoId = 'repo1'): Worktree {
+function makeWorktree(id: string, repoId = 'repo1'): Worktree & { instanceId: string } {
   return {
     id,
+    instanceId: `${id}-instance`,
     repoId,
     path: `/tmp/${id}`,
     head: 'abc123',
@@ -40,6 +41,23 @@ function makeWorktree(id: string, repoId = 'repo1'): Worktree {
     isPinned: false,
     sortOrder: 0,
     lastActivityAt: 0
+  }
+}
+
+function makeWorktreeLineage(
+  child: Worktree & { instanceId: string },
+  parent: Worktree & { instanceId: string },
+  overrides: Partial<WorktreeLineage> = {}
+): WorktreeLineage {
+  return {
+    worktreeId: child.id,
+    worktreeInstanceId: child.instanceId,
+    parentWorktreeId: parent.id,
+    parentWorktreeInstanceId: parent.instanceId,
+    origin: 'cli',
+    capture: { source: 'terminal-context', confidence: 'inferred' },
+    createdAt: 1,
+    ...overrides
   }
 }
 
@@ -64,6 +82,7 @@ function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions
     activeWorktreeId: null,
     hideDefaultBranchWorkspace: false,
     repoMap,
+    worktreeLineageById: {},
     ...overrides
   }
 }
@@ -238,6 +257,101 @@ describe('computeVisibleWorktreeIds', () => {
     )
 
     expect(result).toEqual([feature2.id])
+  })
+
+  it('includes valid lineage parents even when another filter would hide the parent', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+    const lineage = makeWorktreeLineage(child, parent)
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent, child] },
+      [child.id, parent.id],
+      visibleOptions({
+        showActiveOnly: true,
+        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+        ptyIdsByTabId: { 't-child': ['p-child'] },
+        worktreeLineageById: { [child.id]: lineage }
+      })
+    )
+
+    expect(result).toEqual([parent.id, child.id])
+  })
+
+  it('does not resurrect stale lineage parents', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+    const lineage = makeWorktreeLineage(child, parent, {
+      parentWorktreeInstanceId: 'old-parent-instance'
+    })
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent, child] },
+      [child.id, parent.id],
+      visibleOptions({
+        showActiveOnly: true,
+        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+        ptyIdsByTabId: { 't-child': ['p-child'] },
+        worktreeLineageById: { [child.id]: lineage }
+      })
+    )
+
+    expect(result).toEqual([child.id])
+  })
+
+  it('does not resurrect archived lineage parents', () => {
+    const parent = makeWorktree('parent')
+    parent.isArchived = true
+    const child = makeWorktree('child')
+    const lineage = makeWorktreeLineage(child, parent)
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent, child] },
+      [child.id, parent.id],
+      visibleOptions({
+        showActiveOnly: true,
+        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+        ptyIdsByTabId: { 't-child': ['p-child'] },
+        worktreeLineageById: { [child.id]: lineage }
+      })
+    )
+
+    expect(result).toEqual([child.id])
+  })
+
+  it('includes default-branch parents hidden by the explicit setting when a visible child needs them', () => {
+    const parent = makeWorktree('parent')
+    parent.isMainWorktree = true
+    const child = makeWorktree('child')
+    const lineage = makeWorktreeLineage(child, parent)
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent, child] },
+      [child.id, parent.id],
+      visibleOptions({
+        hideDefaultBranchWorkspace: true,
+        worktreeLineageById: { [child.id]: lineage }
+      })
+    )
+
+    expect(result).toEqual([parent.id, child.id])
+  })
+
+  it('includes cross-repo parents when repo filtering leaves their valid child visible', () => {
+    const parent = makeWorktree('parent', 'repo1')
+    const child = makeWorktree('child', 'repo2')
+    const lineage = makeWorktreeLineage(child, parent)
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent], repo2: [child] },
+      [child.id, parent.id],
+      visibleOptions({
+        filterRepoIds: ['repo2'],
+        worktreeLineageById: { [child.id]: lineage }
+      })
+    )
+
+    expect(result).toEqual([parent.id, child.id])
   })
 })
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -1,4 +1,4 @@
-import type { Worktree, Repo, TerminalTab } from '../../../../shared/types'
+import type { Worktree, Repo, TerminalTab, WorktreeLineage } from '../../../../shared/types'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
@@ -90,12 +90,17 @@ export function computeVisibleWorktreeIds(
     // forgetting to pass it.
     hideDefaultBranchWorkspace: boolean
     repoMap: Map<string, Repo>
+    worktreeLineageById: Record<string, WorktreeLineage>
   }
 ): string[] {
   let all: Worktree[] = getAllWorktreesFromState({ worktreesByRepo })
 
   // Filter archived
   all = all.filter((w) => !w.isArchived)
+
+  // Why: sidebar lineage is structural. Archived workspaces stay hidden, but
+  // every other valid ancestor can bypass filters so children never orphan.
+  const lineageAncestorById = new Map(all.map((w) => [w.id, w]))
 
   if (opts.hideDefaultBranchWorkspace) {
     all = all.filter((w) => !isDefaultBranchWorkspace(w))
@@ -138,7 +143,53 @@ export function computeVisibleWorktreeIds(
     return ai - bi
   })
 
-  return all.map((w) => w.id)
+  return addVisibleLineageAncestors(
+    all.map((w) => w.id),
+    lineageAncestorById,
+    opts.worktreeLineageById
+  )
+}
+
+function addVisibleLineageAncestors(
+  ids: string[],
+  worktreeById: Map<string, Worktree>,
+  lineageById: Record<string, WorktreeLineage>
+): string[] {
+  const result: string[] = []
+  const included = new Set<string>()
+  const visiting = new Set<string>()
+
+  const addWithAncestors = (id: string): void => {
+    if (included.has(id) || visiting.has(id)) {
+      return
+    }
+    const worktree = worktreeById.get(id)
+    if (!worktree) {
+      return
+    }
+    visiting.add(id)
+    const lineage = lineageById[id]
+    const parent = lineage ? worktreeById.get(lineage.parentWorktreeId) : undefined
+    if (
+      parent &&
+      worktree.instanceId === lineage.worktreeInstanceId &&
+      parent.instanceId === lineage.parentWorktreeInstanceId
+    ) {
+      // Why: sidebar lineage is structural. If a filtered child is visible,
+      // its valid parent must be rendered too so the hierarchy remains legible.
+      addWithAncestors(parent.id)
+    }
+    visiting.delete(id)
+    if (!included.has(id)) {
+      included.add(id)
+      result.push(id)
+    }
+  }
+
+  for (const id of ids) {
+    addWithAncestors(id)
+  }
+  return result
 }
 
 /**
@@ -214,6 +265,7 @@ export function getVisibleWorktreeIds(): string[] {
     browserTabsByWorktree: state.browserTabsByWorktree,
     activeWorktreeId: state.activeWorktreeId,
     hideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
-    repoMap
+    repoMap,
+    worktreeLineageById: state.worktreeLineageById
   })
 }

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -455,8 +455,7 @@ describe('buildRows workspace lineage nesting', () => {
     expect(items[1]).toMatchObject({
       type: 'item',
       worktree: { id: child.id },
-      depth: 1,
-      parentLabel: 'coordinator'
+      depth: 1
     })
   })
 
@@ -530,7 +529,7 @@ describe('buildRows workspace lineage nesting', () => {
     })
   })
 
-  it('marks stale instance links as missing without creating a parent group', () => {
+  it('does not create a parent group for stale instance links', () => {
     const staleLineage = { ...lineage, parentWorktreeInstanceId: 'old-parent-instance' }
     const rows = buildRows(
       'none',
@@ -553,7 +552,7 @@ describe('buildRows workspace lineage nesting', () => {
     expect(items[0]).toMatchObject({
       type: 'item',
       worktree: { id: child.id },
-      lineageState: 'missing'
+      depth: 0
     })
   })
 
@@ -571,7 +570,7 @@ describe('buildRows workspace lineage nesting', () => {
     expect(info).toMatchObject({ state: 'missing' })
   })
 
-  it('keeps pinned children in Pinned with parent context', () => {
+  it('keeps pinned children in Pinned without a parent badge', () => {
     const pinnedChild = { ...child, isPinned: true }
     const rows = buildRows(
       'none',
@@ -593,9 +592,9 @@ describe('buildRows workspace lineage nesting', () => {
     expect(rows[0]).toMatchObject({ type: 'header', key: 'pinned' })
     expect(rows[1]).toMatchObject({
       type: 'item',
-      worktree: { id: child.id },
-      parentLabel: 'coordinator'
+      worktree: { id: child.id }
     })
+    expect(rows[1]).not.toHaveProperty('parentLabel')
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -53,8 +53,6 @@ export type WorktreeRow = {
   lineageChildCount: number
   lineageGroupKey?: string
   lineageCollapsed?: boolean
-  parentLabel?: string
-  lineageState?: 'valid' | 'missing'
 }
 export type Row = GroupHeaderRow | WorktreeRow
 
@@ -111,10 +109,6 @@ export const ALL_GROUP_META = {
   label: 'All',
   tone: 'text-foreground',
   icon: List
-} as const
-
-export const MISSING_PARENT_GROUP_META = {
-  label: 'Missing parent'
 } as const
 
 export const LINEAGE_GROUP_PREFIX = 'lineage:'
@@ -186,8 +180,7 @@ function emitPinnedGroup(
   lineageById: Record<string, WorktreeLineage>,
   worktreeMap: Map<string, Worktree>,
   collapsedGroups: Set<string>,
-  result: Row[],
-  showLineageContext: boolean
+  result: Row[]
 ): Set<string> {
   const pinned = worktrees.filter((w) => w.isPinned)
   if (pinned.length === 0) {
@@ -205,7 +198,6 @@ function emitPinnedGroup(
   if (!collapsedGroups.has(PINNED_GROUP_KEY)) {
     appendWorktreeRows(result, pinned, repoMap, lineageById, worktreeMap, {
       nestLineage: false,
-      showLineageContext,
       collapsedGroups
     })
   }
@@ -215,18 +207,12 @@ function emitPinnedGroup(
 function buildWorktreeRow(
   worktree: Worktree,
   repoMap: Map<string, Repo>,
-  lineageById: Record<string, WorktreeLineage>,
-  worktreeMap: Map<string, Worktree>,
-  showLineageContext: boolean,
   depth: number,
   lineageTrail: boolean[],
   isLastLineageChild: boolean,
   lineageChildCount: number,
   lineageCollapsed: boolean
 ): WorktreeRow {
-  const lineage = showLineageContext
-    ? getLineageRenderInfo(worktree, lineageById, worktreeMap)
-    : { state: 'none' as const }
   return {
     type: 'item',
     worktree,
@@ -236,12 +222,7 @@ function buildWorktreeRow(
     isLastLineageChild,
     lineageChildCount,
     ...(lineageChildCount > 0 ? { lineageGroupKey: getLineageGroupKey(worktree.id) } : {}),
-    ...(lineageChildCount > 0 ? { lineageCollapsed } : {}),
-    ...(lineage.state === 'valid'
-      ? { parentLabel: lineage.parent.displayName, lineageState: 'valid' as const }
-      : lineage.state === 'missing'
-        ? { parentLabel: MISSING_PARENT_GROUP_META.label, lineageState: 'missing' as const }
-        : {})
+    ...(lineageChildCount > 0 ? { lineageCollapsed } : {})
   }
 }
 
@@ -253,27 +234,13 @@ function appendWorktreeRows(
   worktreeMap: Map<string, Worktree>,
   options: {
     nestLineage: boolean
-    showLineageContext: boolean
     collapsedGroups: Set<string>
   }
 ): void {
-  const { nestLineage, showLineageContext, collapsedGroups } = options
+  const { nestLineage, collapsedGroups } = options
   if (!nestLineage) {
     for (const worktree of worktrees) {
-      result.push(
-        buildWorktreeRow(
-          worktree,
-          repoMap,
-          lineageById,
-          worktreeMap,
-          showLineageContext,
-          0,
-          [],
-          false,
-          0,
-          false
-        )
-      )
+      result.push(buildWorktreeRow(worktree, repoMap, 0, [], false, 0, false))
     }
     return
   }
@@ -310,9 +277,6 @@ function appendWorktreeRows(
       buildWorktreeRow(
         worktree,
         repoMap,
-        lineageById,
-        worktreeMap,
-        showLineageContext,
         depth,
         lineageTrail,
         isLastChild,
@@ -375,8 +339,7 @@ export function buildRows(
     lineageById,
     worktreeMap,
     collapsedGroups,
-    result,
-    nestLineage
+    result
   )
   const unpinned = pinnedIds.size > 0 ? worktrees.filter((w) => !pinnedIds.has(w.id)) : worktrees
 
@@ -393,7 +356,6 @@ export function buildRows(
       if (!collapsedGroups.has(ALL_GROUP_KEY)) {
         appendWorktreeRows(result, unpinned, repoMap, lineageById, worktreeMap, {
           nestLineage,
-          showLineageContext: nestLineage,
           collapsedGroups
         })
       }
@@ -516,7 +478,6 @@ export function buildRows(
     if (!isCollapsed) {
       appendWorktreeRows(result, group.items, repoMap, lineageById, worktreeMap, {
         nestLineage,
-        showLineageContext: nestLineage,
         collapsedGroups
       })
     }

--- a/tests/e2e/worktree-lineage-state.ts
+++ b/tests/e2e/worktree-lineage-state.ts
@@ -1,0 +1,162 @@
+import type { Page } from '@stablyai/playwright-test'
+
+export type LineageScenario = {
+  parentId: string
+  childId: string
+}
+
+export async function seedLineageScenario(page: Page): Promise<LineageScenario> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    state.setActiveView('terminal')
+    state.setSidebarOpen(true)
+    state.setGroupBy('none')
+    state.setSortBy('recent')
+
+    const worktrees = Object.values(state.worktreesByRepo)
+      .flat()
+      .filter((worktree) => !worktree.isArchived)
+    if (worktrees.length < 2) {
+      throw new Error('Worktree lineage E2E needs at least two worktrees')
+    }
+
+    const [parent, child] = worktrees
+    if (!parent.instanceId || !child.instanceId) {
+      throw new Error('Worktree lineage E2E needs instance-stamped worktrees')
+    }
+    store.setState((current) => ({
+      worktreesByRepo: Object.fromEntries(
+        Object.entries(current.worktreesByRepo).map(([repoId, repoWorktrees]) => [
+          repoId,
+          repoWorktrees.map((worktree) => {
+            if (worktree.id === parent.id) {
+              return { ...worktree, displayName: 'E2E lineage parent', sortOrder: 0 }
+            }
+            if (worktree.id === child.id) {
+              return { ...worktree, displayName: 'E2E lineage child', sortOrder: 1 }
+            }
+            return worktree
+          })
+        ])
+      ),
+      worktreeLineageById: {
+        ...current.worktreeLineageById,
+        [child.id]: {
+          worktreeId: child.id,
+          worktreeInstanceId: child.instanceId,
+          parentWorktreeId: parent.id,
+          parentWorktreeInstanceId: parent.instanceId,
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: Date.now()
+        }
+      }
+    }))
+
+    store.getState().setActiveWorktree(parent.id)
+    return { parentId: parent.id, childId: child.id }
+  })
+}
+
+export async function seedWorkspaceAgentStatus(
+  page: Page,
+  worktreeId: string,
+  label: string
+): Promise<string> {
+  return page.evaluate(
+    ({ worktreeId, label }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+
+      const state = store.getState()
+      if (!state.worktreeCardProperties.includes('inline-agents')) {
+        state.toggleWorktreeCardProperty('inline-agents')
+      }
+      if ((state.tabsByWorktree[worktreeId] ?? []).length === 0) {
+        state.createTab(worktreeId)
+      }
+
+      const next = store.getState()
+      const tab = next.tabsByWorktree[worktreeId]?.[0]
+      if (!tab) {
+        throw new Error(`Worktree lineage E2E failed to create a ${label} workspace tab`)
+      }
+
+      const prompt = `LINEAGE_${label}_AGENT_${Date.now()}`
+      const leafId = crypto.randomUUID()
+      const now = Date.now()
+      next.setAgentStatus(
+        `${tab.id}:${leafId}`,
+        { state: 'working', prompt, agentType: 'codex' },
+        'codex',
+        { updatedAt: now, stateStartedAt: now }
+      )
+      return prompt
+    },
+    { worktreeId, label }
+  )
+}
+
+export async function seedWorkspaceLiveTerminal(page: Page, worktreeId: string): Promise<string> {
+  return page.evaluate((worktreeId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    if ((state.tabsByWorktree[worktreeId] ?? []).length === 0) {
+      state.createTab(worktreeId)
+    }
+
+    const next = store.getState()
+    const tab = next.tabsByWorktree[worktreeId]?.[0]
+    if (!tab) {
+      throw new Error('Worktree lineage E2E failed to create a live terminal tab')
+    }
+
+    next.dropAgentStatusByWorktree(worktreeId)
+    store.setState((current) => ({
+      ptyIdsByTabId: {
+        ...current.ptyIdsByTabId,
+        [tab.id]: [`e2e-live-pty-${Date.now()}`]
+      },
+      browserTabsByWorktree: {
+        ...current.browserTabsByWorktree,
+        [worktreeId]: []
+      }
+    }))
+    return tab.id
+  }, worktreeId)
+}
+
+export async function markWorkspaceTerminalSlept(
+  page: Page,
+  args: { worktreeId: string; tabId: string }
+): Promise<void> {
+  await page.evaluate(({ worktreeId, tabId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    store.getState().dropAgentStatusByWorktree(worktreeId)
+    store.setState((current) => ({
+      ptyIdsByTabId: {
+        ...current.ptyIdsByTabId,
+        [tabId]: []
+      },
+      browserTabsByWorktree: {
+        ...current.browserTabsByWorktree,
+        [worktreeId]: []
+      }
+    }))
+  }, args)
+}

--- a/tests/e2e/worktree-lineage.spec.ts
+++ b/tests/e2e/worktree-lineage.spec.ts
@@ -1,170 +1,15 @@
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
-
-type LineageScenario = {
-  parentId: string
-  childId: string
-}
+import {
+  markWorkspaceTerminalSlept,
+  seedLineageScenario,
+  seedWorkspaceAgentStatus,
+  seedWorkspaceLiveTerminal
+} from './worktree-lineage-state'
 
 function worktreeOption(page: Page, worktreeId: string) {
   return page.locator(`[id="worktree-list-option-${encodeURIComponent(worktreeId)}"]`)
-}
-
-async function seedLineageScenario(page: Page): Promise<LineageScenario> {
-  return page.evaluate(() => {
-    const store = window.__store
-    if (!store) {
-      throw new Error('window.__store is not available')
-    }
-
-    const state = store.getState()
-    state.setActiveView('terminal')
-    state.setSidebarOpen(true)
-    state.setGroupBy('none')
-    state.setSortBy('recent')
-
-    const worktrees = Object.values(state.worktreesByRepo)
-      .flat()
-      .filter((worktree) => !worktree.isArchived)
-    if (worktrees.length < 2) {
-      throw new Error('Worktree lineage E2E needs at least two worktrees')
-    }
-
-    const [parent, child] = worktrees
-    if (!parent.instanceId || !child.instanceId) {
-      throw new Error('Worktree lineage E2E needs instance-stamped worktrees')
-    }
-    store.setState((current) => ({
-      worktreesByRepo: Object.fromEntries(
-        Object.entries(current.worktreesByRepo).map(([repoId, repoWorktrees]) => [
-          repoId,
-          repoWorktrees.map((worktree) => {
-            if (worktree.id === parent.id) {
-              return { ...worktree, displayName: 'E2E lineage parent', sortOrder: 0 }
-            }
-            if (worktree.id === child.id) {
-              return { ...worktree, displayName: 'E2E lineage child', sortOrder: 1 }
-            }
-            return worktree
-          })
-        ])
-      ),
-      worktreeLineageById: {
-        ...current.worktreeLineageById,
-        [child.id]: {
-          worktreeId: child.id,
-          worktreeInstanceId: child.instanceId,
-          parentWorktreeId: parent.id,
-          parentWorktreeInstanceId: parent.instanceId,
-          origin: 'manual',
-          capture: { source: 'manual-action', confidence: 'explicit' },
-          createdAt: Date.now()
-        }
-      }
-    }))
-
-    store.getState().setActiveWorktree(parent.id)
-    return { parentId: parent.id, childId: child.id }
-  })
-}
-
-async function seedWorkspaceAgentStatus(
-  page: Page,
-  worktreeId: string,
-  label: string
-): Promise<string> {
-  return page.evaluate(
-    ({ worktreeId, label }) => {
-      const store = window.__store
-      if (!store) {
-        throw new Error('window.__store is not available')
-      }
-
-      const state = store.getState()
-      if (!state.worktreeCardProperties.includes('inline-agents')) {
-        state.toggleWorktreeCardProperty('inline-agents')
-      }
-      if ((state.tabsByWorktree[worktreeId] ?? []).length === 0) {
-        state.createTab(worktreeId)
-      }
-
-      const next = store.getState()
-      const tab = next.tabsByWorktree[worktreeId]?.[0]
-      if (!tab) {
-        throw new Error(`Worktree lineage E2E failed to create a ${label} workspace tab`)
-      }
-
-      const prompt = `LINEAGE_${label}_AGENT_${Date.now()}`
-      const leafId = crypto.randomUUID()
-      const now = Date.now()
-      next.setAgentStatus(
-        `${tab.id}:${leafId}`,
-        { state: 'working', prompt, agentType: 'codex' },
-        'codex',
-        { updatedAt: now, stateStartedAt: now }
-      )
-      return prompt
-    },
-    { worktreeId, label }
-  )
-}
-
-async function seedWorkspaceLiveTerminal(page: Page, worktreeId: string): Promise<string> {
-  return page.evaluate((worktreeId) => {
-    const store = window.__store
-    if (!store) {
-      throw new Error('window.__store is not available')
-    }
-
-    const state = store.getState()
-    if ((state.tabsByWorktree[worktreeId] ?? []).length === 0) {
-      state.createTab(worktreeId)
-    }
-
-    const next = store.getState()
-    const tab = next.tabsByWorktree[worktreeId]?.[0]
-    if (!tab) {
-      throw new Error('Worktree lineage E2E failed to create a live terminal tab')
-    }
-
-    next.dropAgentStatusByWorktree(worktreeId)
-    store.setState((current) => ({
-      ptyIdsByTabId: {
-        ...current.ptyIdsByTabId,
-        [tab.id]: [`e2e-live-pty-${Date.now()}`]
-      },
-      browserTabsByWorktree: {
-        ...current.browserTabsByWorktree,
-        [worktreeId]: []
-      }
-    }))
-    return tab.id
-  }, worktreeId)
-}
-
-async function markWorkspaceTerminalSlept(
-  page: Page,
-  args: { worktreeId: string; tabId: string }
-): Promise<void> {
-  await page.evaluate(({ worktreeId, tabId }) => {
-    const store = window.__store
-    if (!store) {
-      throw new Error('window.__store is not available')
-    }
-
-    store.getState().dropAgentStatusByWorktree(worktreeId)
-    store.setState((current) => ({
-      ptyIdsByTabId: {
-        ...current.ptyIdsByTabId,
-        [tabId]: []
-      },
-      browserTabsByWorktree: {
-        ...current.browserTabsByWorktree,
-        [worktreeId]: []
-      }
-    }))
-  }, args)
 }
 
 test.describe('Worktree Lineage', () => {
@@ -230,6 +75,68 @@ test.describe('Worktree Lineage', () => {
     await expect(
       orcaPage.getByRole('menuitem', { name: 'Group under Active Workspace' })
     ).toHaveCount(0)
+  })
+
+  test('injects filtered parents structurally without showing a parent badge', async ({
+    orcaPage
+  }) => {
+    const { parentId, childId } = await seedLineageScenario(orcaPage)
+
+    await orcaPage.evaluate(
+      ({ parentId, childId }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        store.setState((current) => ({
+          worktreesByRepo: Object.fromEntries(
+            Object.entries(current.worktreesByRepo).map(([repoId, repoWorktrees]) => [
+              repoId,
+              repoWorktrees.map((worktree) =>
+                worktree.id === parentId
+                  ? {
+                      ...worktree,
+                      branch: worktree.branch || 'refs/heads/main',
+                      isMainWorktree: true
+                    }
+                  : worktree
+              )
+            ])
+          )
+        }))
+        const state = store.getState()
+        state.setHideDefaultBranchWorkspace(true)
+        state.setShowActiveOnly(true)
+        state.setActiveWorktree(childId)
+      },
+      { parentId, childId }
+    )
+
+    const parentRow = worktreeOption(orcaPage, parentId)
+    const childRow = worktreeOption(orcaPage, childId)
+
+    await expect(parentRow).toContainText('E2E lineage parent')
+    await expect(childRow).toContainText('E2E lineage child')
+    await expect(orcaPage.getByText('from E2E lineage parent')).toHaveCount(0)
+
+    const positions = await orcaPage.evaluate(
+      ({ parentId, childId }) => {
+        const parent = document.getElementById(
+          `worktree-list-option-${encodeURIComponent(parentId)}`
+        )
+        const child = document.getElementById(`worktree-list-option-${encodeURIComponent(childId)}`)
+        if (!parent || !child) {
+          return null
+        }
+        return {
+          parentTop: parent.getBoundingClientRect().top,
+          childTop: child.getBoundingClientRect().top
+        }
+      },
+      { parentId, childId }
+    )
+    expect(positions).not.toBeNull()
+    expect(positions!.childTop).toBeGreaterThan(positions!.parentTop)
   })
 
   test('updates nested child preview status when the child terminal sleeps', async ({


### PR DESCRIPTION
## Summary
- remove the sidebar parent lineage badge text entirely
- keep visible child workspaces from becoming orphaned by injecting valid non-archived ancestors through filters
- keep Kanban filtering from showing injected lineage parents as ordinary cards
- add unit and Electron E2E coverage for filtered parent injection and badge removal

## Verification
- pnpm run lint
- pnpm run typecheck
- git diff --check
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm exec playwright test tests/e2e/worktree-lineage.spec.ts --config tests/playwright.config.ts --project electron-headless

## Manual Electron validation
- launched the exact PR worktree with CDP and verified app identity for brennanb2025/from-master-text
- tested against demo-project
- confirmed a filtered parent renders above its visible child while the old "from <parent>" badge text is absent

Made with [Orca](https://github.com/stablyai/orca) 🐋
