### PR TITLE
Render PR review comments inline

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2416,6 +2416,7 @@ export async function getPRComments(
               path: c.path,
               threadId: thread.id,
               isResolved: thread.isResolved,
+              isOutdated: thread.line == null,
               // Why: GitHub nulls out line/startLine when the commented code is
               // outdated (e.g. after a force-push). Fall back to originalLine which
               // always preserves the line numbers from when the comment was created.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1343,6 +1343,63 @@
   letter-spacing: 0.03em;
 }
 
+.orca-diff-comment-author-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 6px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.orca-diff-comment-avatar {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--foreground) 15%, transparent);
+  background: var(--muted);
+}
+
+.orca-diff-comment-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.orca-diff-comment-author {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.orca-diff-comment-created-at {
+  flex: 0 0 auto;
+}
+
+.orca-diff-comment-link {
+  margin-left: auto;
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font: inherit;
+  cursor: pointer;
+}
+
+.orca-diff-comment-link:hover {
+  color: var(--foreground);
+  text-decoration: underline;
+}
+
 /* Why: keep edit + delete close together but visually distinct from the meta
    label. Both share the same subtle button styling; only delete recolours on
    hover (destructive intent). */
@@ -1406,6 +1463,10 @@
   color: var(--foreground);
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.orca-diff-comment-review-body {
+  padding-left: 24px;
 }
 
 /* Why: mirror the saved-note card treatment so the "entering" and "saved"

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -66,6 +66,7 @@ import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import { detectLanguage } from '@/lib/language-detect'
 import { cn } from '@/lib/utils'
 import { DiffSectionItem } from '@/components/editor/DiffSectionItem'
+import type { DecoratedDiffComment } from '@/components/diff-comments/useDiffCommentDecorator'
 import {
   CombinedDiffFileTree,
   createCombinedDiffSectionIndexMap,
@@ -1542,6 +1543,7 @@ function getPRFileDiffResult(contents: GitHubPRFileContents): GitDiffResult {
 
 type PRFilesCombinedDiffViewerProps = {
   files: GitHubPRFile[]
+  comments: PRComment[]
   repoPath: string
   repoId: string
   prNumber: number
@@ -1555,6 +1557,7 @@ type PRFilesCombinedDiffViewerProps = {
 
 function PRFilesCombinedDiffViewer({
   files,
+  comments,
   repoPath,
   repoId,
   prNumber,
@@ -1596,6 +1599,37 @@ function PRFilesCombinedDiffViewer({
     return nextEntries
   }, [diffEntrySignature, files])
   const fileByPath = useMemo(() => new Map(files.map((file) => [file.path, file])), [files])
+  const inlineReviewComments = useMemo<DecoratedDiffComment[]>(
+    () =>
+      comments.flatMap((comment): DecoratedDiffComment[] => {
+        // Why: stale threads keep originalLine for the sidebar, but rendering
+        // that number inline can attach the comment to unrelated current code.
+        if (comment.isOutdated || !comment.path || typeof comment.line !== 'number') {
+          return []
+        }
+        const createdAtMs = new Date(comment.createdAt).getTime()
+        return [
+          {
+            id: `github-pr-comment:${comment.id}`,
+            worktreeId: `github-pr:${repoId}:${prNumber}`,
+            filePath: comment.path,
+            source: 'diff',
+            startLine: comment.startLine,
+            lineNumber: comment.line,
+            body: comment.body,
+            createdAt: Number.isFinite(createdAtMs) ? createdAtMs : Date.now(),
+            side: 'modified',
+            author: comment.author,
+            authorAvatarUrl: comment.authorAvatarUrl,
+            createdAtLabel: formatRelativeTime(comment.createdAt),
+            url: comment.url,
+            canDelete: false,
+            canEdit: false
+          }
+        ]
+      }),
+    [comments, prNumber, repoId]
+  )
   const entrySignature = useMemo(
     () =>
       JSON.stringify({
@@ -1985,6 +2019,7 @@ function PRFilesCombinedDiffViewer({
                     settings={settings}
                     sectionHeight={sectionHeights[virtualItem.index]}
                     worktreeId={`github-pr:${repoId}:${prNumber}`}
+                    inlineComments={inlineReviewComments}
                     loadSection={loadSection}
                     retrySection={retrySection}
                     toggleSection={toggleSection}
@@ -5501,6 +5536,7 @@ export default function GitHubItemDialog({
                           ) : (
                             <PRFilesCombinedDiffViewer
                               files={files}
+                              comments={comments}
                               repoPath={repoPath ?? ''}
                               repoId={effectiveRepoId ?? ''}
                               prNumber={workItem.number}

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -2,6 +2,7 @@ import { CornerDownLeft, Pencil, Trash } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
+import { cn } from '@/lib/utils'
 
 // Why: the saved-note card lives inside a Monaco view zone's DOM node.
 // useDiffCommentDecorator creates a React root per zone and renders this
@@ -19,7 +20,11 @@ type Props = {
   label?: string
   body: string
   sentAt?: number
-  onDelete: () => void
+  author?: string
+  authorAvatarUrl?: string
+  createdAtLabel?: string
+  url?: string
+  onDelete?: () => void
   // Why: Monaco view zones have a fixed `heightInPx` set at insertion time
   // and aren't auto-measured. While the user is in edit mode the textarea
   // grows, so the parent decorator passes a callback we fire on resize and
@@ -35,6 +40,10 @@ export function DiffCommentCard({
   label,
   body,
   sentAt,
+  author,
+  authorAvatarUrl,
+  createdAtLabel,
+  url,
   onDelete,
   onContentResize,
   onSubmitEdit,
@@ -107,6 +116,7 @@ export function DiffCommentCard({
 
   const trimmedDraft = draft.trim()
   const canSubmit = !submitting && trimmedDraft.length > 0 && trimmedDraft !== body
+  const lineLabel = label ?? getDiffCommentLineLabel({ lineNumber, startLine }).toLowerCase()
 
   const handleSubmit = async (): Promise<void> => {
     if (!canSubmit || !onSubmitEdit) {
@@ -133,7 +143,7 @@ export function DiffCommentCard({
     <div className="orca-diff-comment-card">
       <div className="orca-diff-comment-header">
         <span className="orca-diff-comment-meta">
-          Note · {label ?? getDiffCommentLineLabel({ lineNumber, startLine }).toLowerCase()}
+          {author ? 'Review comment' : 'Note'} · {lineLabel}
           {sentAt ? ' · sent' : ''}
         </span>
         <div className="orca-diff-comment-actions">
@@ -154,7 +164,7 @@ export function DiffCommentCard({
               <Pencil className="size-3.5" />
             </button>
           )}
-          {!editing && (
+          {onDelete && !editing && (
             <button
               type="button"
               className="orca-diff-comment-delete"
@@ -172,6 +182,35 @@ export function DiffCommentCard({
           )}
         </div>
       </div>
+      {author ? (
+        <div className="orca-diff-comment-author-row">
+          {authorAvatarUrl ? (
+            <img className="orca-diff-comment-avatar" src={authorAvatarUrl} alt="" />
+          ) : (
+            <span className="orca-diff-comment-avatar orca-diff-comment-avatar-fallback">
+              {author.slice(0, 1).toUpperCase()}
+            </span>
+          )}
+          <span className="orca-diff-comment-author">{author}</span>
+          {createdAtLabel ? (
+            <span className="orca-diff-comment-created-at">{createdAtLabel}</span>
+          ) : null}
+          {url ? (
+            <button
+              type="button"
+              className="orca-diff-comment-link"
+              onMouseDown={(ev) => ev.stopPropagation()}
+              onClick={(ev) => {
+                ev.preventDefault()
+                ev.stopPropagation()
+                void window.api.shell.openUrl(url)
+              }}
+            >
+              Open
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       {editing ? (
         <>
           <textarea
@@ -227,7 +266,9 @@ export function DiffCommentCard({
           </div>
         </>
       ) : (
-        <div className="orca-diff-comment-body">{body}</div>
+        <div className={cn('orca-diff-comment-body', author && 'orca-diff-comment-review-body')}>
+          {body}
+        </div>
       )}
     </div>
   )

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -1,8 +1,12 @@
+/* eslint-disable max-lines -- Why: this hook owns the Monaco view-zone
+lifecycle, inline React roots, range selection, and scroll-to-comment
+coordination so those invariants stay in one place. */
 import { useEffect, useMemo, useRef } from 'react'
 import * as monaco from 'monaco-editor'
 import type { editor as monacoEditor, IDisposable } from 'monaco-editor'
 import { createRoot, type Root } from 'react-dom/client'
 import type { DiffComment } from '../../../../shared/types'
+import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 import { DiffCommentCard } from './DiffCommentCard'
 import { getDiffCommentPopoverTop } from './diff-comment-popover-position'
 
@@ -14,11 +18,20 @@ import { getDiffCommentPopoverTop } from './diff-comment-popover-position'
 // than Monaco decorations, and we get pixel-accurate positioning via Monaco's
 // getTopForLineNumber.
 
+export type DecoratedDiffComment = DiffComment & {
+  author?: string
+  authorAvatarUrl?: string
+  createdAtLabel?: string
+  url?: string
+  canDelete?: boolean
+  canEdit?: boolean
+}
+
 type DecoratorArgs = {
   editor: monacoEditor.ICodeEditor | null
   filePath: string
   worktreeId: string
-  comments: DiffComment[]
+  comments: readonly DecoratedDiffComment[]
   commentableLineNumbers?: readonly number[]
   addButtonLabel?: string
   onAddCommentClick: (args: { lineNumber: number; startLine?: number; top: number }) => void
@@ -44,7 +57,7 @@ type ZoneEntry = {
   // mutating the delegate is the supported way to grow a zone in place.
   delegate: monacoEditor.IViewZone
   root: Root
-  lastBody: string
+  lastRenderSignature: string
   // Why: Monaco invokes IViewZone.onDomNodeTop on every render once the zone
   // is in the layout. The first invocation is our deterministic "this zone is
   // now part of the editor's vertical layout" signal — equivalent in role to
@@ -60,6 +73,19 @@ type ZoneEntry = {
 const ZONE_CHROME_PX = 52
 const ZONE_LINE_PX = 18
 const ZONE_MIN_PX = 72
+
+function getRenderSignature(comment: DecoratedDiffComment): string {
+  return JSON.stringify({
+    body: comment.body,
+    sentAt: comment.sentAt ?? null,
+    author: comment.author ?? null,
+    authorAvatarUrl: comment.authorAvatarUrl ?? null,
+    createdAtLabel: comment.createdAtLabel ?? null,
+    url: comment.url ?? null,
+    canDelete: comment.canDelete ?? null,
+    canEdit: comment.canEdit ?? null
+  })
+}
 
 export function useDiffCommentDecorator({
   editor,
@@ -428,16 +454,23 @@ export function useDiffCommentDecorator({
     // Why: render helper used by BOTH the new-zone branch and the patch-
     // existing-zone branch so the card's prop wiring stays in lockstep — any
     // future prop is added once.
-    const renderCard = (root: Root, comment: DiffComment): void => {
+    const renderCard = (root: Root, comment: DecoratedDiffComment): void => {
       root.render(
         <DiffCommentCard
           lineNumber={comment.lineNumber}
           startLine={comment.startLine}
+          label={comment.author ? getDiffCommentLineLabel(comment).toLowerCase() : undefined}
           body={comment.body}
           sentAt={comment.sentAt}
-          onDelete={() => onDeleteCommentRef.current(comment.id)}
+          author={comment.author}
+          authorAvatarUrl={comment.authorAvatarUrl}
+          createdAtLabel={comment.createdAtLabel}
+          url={comment.url}
+          onDelete={
+            comment.canDelete === false ? undefined : () => onDeleteCommentRef.current(comment.id)
+          }
           onSubmitEdit={
-            onUpdateCommentRef.current
+            onUpdateCommentRef.current && comment.canEdit !== false
               ? async (body) => {
                   const fn = onUpdateCommentRef.current
                   if (!fn) {
@@ -494,7 +527,8 @@ export function useDiffCommentDecorator({
         // padding 12, header+meta ~22, trailing breathing room) and the
         // per-line factor matches the 12px/1.4 body line-height.
         const lineCount = c.body.split('\n').length
-        const heightInPx = Math.max(ZONE_MIN_PX, ZONE_CHROME_PX + lineCount * ZONE_LINE_PX)
+        const chromePx = c.author ? ZONE_CHROME_PX + 24 : ZONE_CHROME_PX
+        const heightInPx = Math.max(ZONE_MIN_PX, chromePx + lineCount * ZONE_LINE_PX)
 
         // Why: suppressMouseDown: false so clicks inside the zone (Delete
         // button) reach our DOM listeners. With true, Monaco intercepts the
@@ -532,23 +566,24 @@ export function useDiffCommentDecorator({
           domNode: dom,
           delegate,
           root,
-          lastBody: c.body,
+          lastRenderSignature: getRenderSignature(c),
           laidOut: false
         })
       }
 
-      // Patch existing zones whose body text changed in place — re-render the
-      // same root with new props instead of removing/re-adding the zone.
+      // Patch existing zones whose visible props changed in place — re-render
+      // the same root instead of removing/re-adding the zone.
       for (const c of relevant) {
         const entry = zones.get(c.id)
         if (!entry) {
           continue
         }
-        if (entry.lastBody === c.body) {
+        const renderSignature = getRenderSignature(c)
+        if (entry.lastRenderSignature === renderSignature) {
           continue
         }
         renderCard(entry.root, c)
-        entry.lastBody = c.body
+        entry.lastRenderSignature = renderSignature
       }
     })
 

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -17,7 +17,10 @@ import { detectLanguage } from '@/lib/language-detect'
 import { useAppStore } from '@/store'
 import { computeEditorFontSize } from '@/lib/editor-font-zoom'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
-import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
+import {
+  useDiffCommentDecorator,
+  type DecoratedDiffComment
+} from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
 import {
   getDiffCommentPopoverLeft,
@@ -53,6 +56,7 @@ export function DiffSectionItem({
   onAddLineComment,
   addLineCommentLabel,
   addLineCommentPlaceholder,
+  inlineComments,
   getCommentableLineNumbers,
   setSectionHeights,
   setSections,
@@ -83,6 +87,7 @@ export function DiffSectionItem({
   ) => Promise<boolean>
   addLineCommentLabel?: string
   addLineCommentPlaceholder?: string
+  inlineComments?: readonly DecoratedDiffComment[]
   getCommentableLineNumbers?: (section: DiffSection) => readonly number[] | undefined
   setSectionHeights: React.Dispatch<React.SetStateAction<Record<number, number>>>
   setSections: React.Dispatch<React.SetStateAction<DiffSection[]>>
@@ -165,7 +170,7 @@ export function DiffSectionItem({
     editor: hasLineCommentAction ? modifiedEditor : null,
     filePath: section.path,
     worktreeId: worktreeId ?? '',
-    comments: worktreeId ? diffComments : [],
+    comments: inlineComments ?? (worktreeId ? diffComments : []),
     commentableLineNumbers: getCommentableLineNumbers?.(section),
     addButtonLabel: addLineCommentLabel,
     onAddCommentClick: ({ lineNumber, startLine, top }) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -784,6 +784,8 @@ export type PRComment = {
   threadId?: string
   /** Whether the review thread has been resolved. Only meaningful when threadId is set. */
   isResolved?: boolean
+  /** True when GitHub no longer maps the thread to the current diff. */
+  isOutdated?: boolean
   /** End line of the review annotation (1-based). */
   line?: number
   /** Start line of the review annotation range (1-based). Absent for single-line comments. */


### PR DESCRIPTION
## Summary
- render GitHub PR review comments inline in the combined Files diff using the existing diff comment card/decorator
- make review-comment cards read-only with author/avatar/timestamp/link metadata
- skip outdated review threads inline while keeping their original-line fallback for the comments list

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/github/pr-review-comment-lines.test.ts src/renderer/src/store/slices/diffComments.test.ts src/renderer/src/store/slices/github.test.ts
- pnpm run typecheck
- pnpm run lint