### PR TITLE
Fix terminal cursor after snapshot reattach

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1108,7 +1108,6 @@ export function connectPanePty(
     // sequences don't leak into the shell. xterm.write() buffers internally
     // regardless of DOM visibility and the guard stays engaged via the
     // write-completion callback until xterm finishes parsing.
-    let replayEndsWithLineBreak = true
     const writeReplayData = (data: string): void => {
       // Why: drain any queued background bytes BEFORE the replay paint, so the
       // scheduler's deferred drain cannot land older bytes on top of the replay.
@@ -1117,12 +1116,6 @@ export function connectPanePty(
         manager.markPaneHasComplexScriptOutput(pane.id)
       }
       replayIntoTerminal(pane, deps.replayingPanesRef, data)
-      replayEndsWithLineBreak = /[\r\n]$/.test(data)
-    }
-    const terminateReplayLine = (): void => {
-      if (!replayEndsWithLineBreak) {
-        writeReplayData('\r\n')
-      }
     }
 
     const replayDataCallback = (data: string): void => {
@@ -1226,7 +1219,6 @@ export function connectPanePty(
       if (connectResult?.snapshot) {
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.snapshot)
-        terminateReplayLine()
         // Snapshot reattach keeps a live session, so avoid the broader mode
         // reset. Focus reporting is the unsafe exception: preserving `?1004h`
         // can make restored shells ring BEL on pane focus/blur.
@@ -1245,7 +1237,6 @@ export function connectPanePty(
         // bits in the replayed data.
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.replay)
-        terminateReplayLine()
         writeReplayData(POST_REPLAY_FOCUS_REPORTING_RESET)
         if (connectResult.coldRestore) {
           if (!isRemoteRuntimePtyId(ptyId)) {

--- a/tests/e2e/terminal-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-restart-persistence.spec.ts
@@ -135,6 +135,38 @@ async function getTabCustomTitle(
   )
 }
 
+async function readTerminalActiveLine(page: Page): Promise<string | null> {
+  const tabId = await getActiveTabId(page)
+  if (!tabId) {
+    return null
+  }
+  return page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const buffer = pane?.terminal?.buffer.active
+    if (!buffer) {
+      return null
+    }
+    const cursorLine = buffer.baseY + buffer.cursorY
+    return buffer.getLine(cursorLine)?.translateToString(true) ?? null
+  }, tabId)
+}
+
+async function waitForTerminalActiveLine(page: Page, expectedText: string): Promise<string> {
+  await expect
+    .poll(async () => (await readTerminalActiveLine(page))?.includes(expectedText), {
+      timeout: 15_000,
+      message: `Terminal cursor line did not contain "${expectedText}"`
+    })
+    .toBe(true)
+
+  const activeLine = await readTerminalActiveLine(page)
+  if (activeLine === null) {
+    throw new Error('Terminal cursor line disappeared after settling')
+  }
+  return activeLine
+}
+
 async function expectSavedLayoutToContainTitle(
   page: Page,
   tabId: string,
@@ -205,6 +237,52 @@ test.describe('Terminal restart persistence', () => {
           message: 'Restored terminal did not contain the pre-quit scrollback marker'
         })
         .toBe(true)
+    } finally {
+      if (secondApp) {
+        await session.close(secondApp)
+      }
+      if (firstApp) {
+        await session.close(firstApp)
+      }
+      await session.dispose()
+    }
+  })
+
+  test('daemon snapshot relaunch preserves the cursor on the shell prompt', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+  {}, testInfo) => {
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
+
+    const session = createRestartSession(testInfo)
+    let firstApp: ElectronApplication | null = null
+    let secondApp: ElectronApplication | null = null
+
+    try {
+      const firstLaunch = await session.launch()
+      firstApp = firstLaunch.app
+      const { worktreeId, ptyId } = await bootstrapFirstLaunch(firstLaunch.page, repoPath)
+      expect(ptyId).toContain(PTY_SESSION_ID_SEPARATOR)
+
+      const prompt = `ORCA_RESTART_PROMPT_${Date.now()}_GT `
+      const marker = `ORCA_CURSOR_RESTART_${Date.now()}`
+      await execInTerminal(firstLaunch.page, ptyId, `export PS1='${prompt}'; PROMPT='${prompt}'`)
+      await waitForTerminalActiveLine(firstLaunch.page, prompt.trim())
+      await execInTerminal(firstLaunch.page, ptyId, `echo ${marker}`)
+      await waitForTerminalOutput(firstLaunch.page, marker)
+
+      const beforeActiveLine = await waitForTerminalActiveLine(firstLaunch.page, prompt.trim())
+      await session.close(firstApp)
+      firstApp = null
+
+      const secondLaunch = await session.launch()
+      secondApp = secondLaunch.app
+      await bootstrapRestoredLaunch(secondLaunch.page, worktreeId)
+      await waitForTerminalOutput(secondLaunch.page, marker, 15_000)
+
+      await expect.poll(() => readTerminalActiveLine(secondLaunch.page)).toBe(beforeActiveLine)
     } finally {
       if (secondApp) {
         await session.close(secondApp)


### PR DESCRIPTION
## Summary
- preserve the restored cursor line when repainting daemon snapshot/replay output
- keep cold-restore newline behavior unchanged
- add an e2e regression that relaunches against a daemon-backed terminal and asserts the cursor remains on the prompt line

## Reproduction
- reproduced on current main with a two-launch Electron session: before relaunch the cursor was on the prompt line; after relaunch the prompt moved to the previous line and the active line was blank

## Verification
- pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts tests/e2e/terminal-restart-persistence.spec.ts
- pnpm run tc:web
- npx playwright test tests/e2e/terminal-restart-persistence.spec.ts --config tests/playwright.config.ts --project electron-headless -g "daemon snapshot relaunch preserves the cursor"
- npx playwright test tests/e2e/terminal-restart-persistence.spec.ts --config tests/playwright.config.ts --project electron-headless