### PR TITLE
Add experimental multi-repo workspace selection

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -110,6 +110,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalPet: false,
     experimentalActivity: true,
     experimentalWorktreeSymlinks: false,
+    experimentalMultiRepoWorkspaces: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -103,6 +103,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalPet: false,
     experimentalActivity: true,
     experimentalWorktreeSymlinks: false,
+    experimentalMultiRepoWorkspaces: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',
     enableGitHubAttribution: true,

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -252,6 +252,28 @@ describe('mergeWorktree', () => {
     })
   })
 
+  it('normalizes persisted repo associations', () => {
+    const result = mergeWorktree('repo1', baseGit, {
+      displayName: '',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      linkedGitLabMR: null,
+      linkedGitLabIssue: null,
+      repoIds: ['repo2', 'repo1', 'repo3', 'repo2'],
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      workspaceStatus: 'in-progress',
+      diffComments: []
+    })
+
+    expect(result.repoIds).toEqual(['repo1', 'repo2', 'repo3'])
+  })
+
   it('uses defaults when metadata is undefined', () => {
     const result = mergeWorktree('repo1', baseGit, undefined)
     expect(result.displayName).toBe('feature-x')

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -1,6 +1,7 @@
 import { basename, join, resolve, relative, isAbsolute, posix, win32 } from 'path'
 import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
 import { splitWorktreeId } from '../../shared/worktree-id'
+import { normalizeWorktreeRepoIds } from '../../shared/worktree-repo-ids'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { getWslHome, parseWslPath } from '../wsl'
 
@@ -174,10 +175,12 @@ export function mergeWorktree(
   defaultDisplayName?: string
 ): Worktree {
   const branchShort = git.branch.replace(/^refs\/heads\//, '')
+  const repoIds = normalizeWorktreeRepoIds(repoId, meta?.repoIds)
   return {
     id: `${repoId}::${git.path}`,
     ...(meta?.instanceId !== undefined ? { instanceId: meta.instanceId } : {}),
     repoId,
+    ...(repoIds.length > 1 ? { repoIds } : {}),
     path: git.path,
     head: git.head,
     branch: git.branch,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -24,6 +24,7 @@ import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
 import { getGitUsername, getDefaultBaseRef, getBranchConflictKind } from '../git/repo'
 import { validateGitPushTarget } from '../git/push-target-validation'
 import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
+import { normalizeWorktreeRepoIds } from '../../shared/worktree-repo-ids'
 import { gitExecFileAsync } from '../git/runner'
 import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
@@ -516,6 +517,7 @@ export async function createRemoteWorktree(
       preparedPushTarget
     )
   }
+  const repoIds = normalizeWorktreeRepoIds(repo.id, args.repoIds)
   const metaUpdates: Partial<WorktreeMeta> = {
     // Why: path-derived worktree IDs can be reused after external deletion.
     // Fresh creations must rotate instance identity so stale lineage cannot
@@ -530,6 +532,7 @@ export async function createRemoteWorktree(
     // window elapses. See smart-sort.ts `CREATE_GRACE_MS`.
     createdAt: now,
     baseRef: baseBranch,
+    ...(repoIds.length > 1 ? { repoIds } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
     ...(requestedDisplayName
       ? { displayName: requestedDisplayName }
@@ -821,6 +824,7 @@ export async function createLocalWorktree(
 
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
+  const repoIds = normalizeWorktreeRepoIds(repo.id, args.repoIds)
   const metaUpdates: Partial<WorktreeMeta> = {
     // Why: path-derived worktree IDs can be reused after external deletion.
     // Fresh creations must rotate instance identity so stale lineage cannot
@@ -834,6 +838,7 @@ export async function createLocalWorktree(
     // worktree from ambient PTY bumps in other worktrees for CREATE_GRACE_MS.
     createdAt: now,
     baseRef: baseBranch,
+    ...(repoIds.length > 1 ? { repoIds } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
     ...(requestedDisplayName
       ? { displayName: requestedDisplayName }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -44,6 +44,7 @@ import type {
   TuiAgent
 } from '../../shared/types'
 import { splitWorktreeId } from '../../shared/worktree-id'
+import { normalizeWorktreeRepoIds } from '../../shared/worktree-repo-ids'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { buildSetupRunnerCommand } from '../../shared/setup-runner-command'
 import { FIRST_PANE_ID } from '../../shared/pane-key'
@@ -5748,6 +5749,7 @@ export class OrcaRuntimeService {
 
   async createManagedWorktree(args: {
     repoSelector: string
+    repoIds?: string[]
     name: string
     baseBranch?: string
     branchNameOverride?: string
@@ -5909,6 +5911,7 @@ export class OrcaRuntimeService {
 
     const worktreeId = `${repo.id}::${created.path}`
     const now = Date.now()
+    const repoIds = normalizeWorktreeRepoIds(repo.id, args.repoIds)
     const displayNameMeta = requestedDisplayName
       ? { displayName: requestedDisplayName }
       : shouldSetDisplayName(requestedName, branchName, sanitizedName)
@@ -5925,6 +5928,7 @@ export class OrcaRuntimeService {
       // push it down before the user has had a chance to notice it. Smart-sort
       // uses max(lastActivityAt, createdAt + CREATE_GRACE_MS).
       createdAt: now,
+      ...(repoIds.length > 1 ? { repoIds } : {}),
       ...displayNameMeta,
       baseRef: baseBranch,
       ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
@@ -6134,6 +6138,7 @@ export class OrcaRuntimeService {
     repo: Repo,
     args: {
       name: string
+      repoIds?: string[]
       baseBranch?: string
       branchNameOverride?: string
       linkedIssue?: number | null
@@ -6164,6 +6169,7 @@ export class OrcaRuntimeService {
     const result = await createRemoteWorktree(
       {
         repoId: repo.id,
+        ...(args.repoIds ? { repoIds: args.repoIds } : {}),
         name: args.name,
         ...(args.displayName ? { displayName: args.displayName } : {}),
         ...(args.baseBranch ? { baseBranch: args.baseBranch } : {}),

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -19,6 +19,7 @@ describe('worktree RPC methods', () => {
     await dispatcher.dispatch(
       makeRequest('worktree.create', {
         repo: 'repo-1',
+        repoIds: ['repo-1', 'repo-2'],
         name: 'feature',
         branchNameOverride: 'feature/something',
         baseBranch: 'origin/main',
@@ -35,6 +36,7 @@ describe('worktree RPC methods', () => {
 
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith({
       repoSelector: 'repo-1',
+      repoIds: ['repo-1', 'repo-2'],
       name: 'feature',
       branchNameOverride: 'feature/something',
       baseBranch: 'origin/main',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -35,6 +35,7 @@ const WorktreeCreate = z
       .unknown()
       .transform((v) => (typeof v === 'string' ? v : ''))
       .pipe(z.string().min(1, 'Missing repo selector')),
+    repoIds: z.array(z.string()).optional(),
     name: OptionalString,
     baseBranch: OptionalString,
     branchNameOverride: OptionalString,
@@ -96,6 +97,7 @@ const WorktreeCreate = z
   })
 
 const WorktreeSet = WorktreeSelector.extend({
+  repoIds: z.array(z.string()).optional(),
   displayName: OptionalString,
   // Why: empty comments are meaningful metadata updates, so use the plain
   // string parser instead of OptionalString's empty-as-undefined behavior.
@@ -190,6 +192,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) =>
       runtime.createManagedWorktree({
         repoSelector: params.repo,
+        repoIds: params.repoIds,
         name: params.name ?? '',
         baseBranch: params.baseBranch,
         branchNameOverride: params.branchNameOverride,
@@ -220,6 +223,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     params: WorktreeSet,
     handler: async (params, { runtime }) => ({
       worktree: await runtime.updateManagedWorktreeMeta(params.worktree, {
+        repoIds: params.repoIds,
         displayName: params.displayName,
         linkedIssue: params.linkedIssue,
         linkedPR: params.linkedPR,

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -30,6 +30,7 @@ import SparseCheckoutPresetSelect from '@/components/sparse/SparseCheckoutPreset
 import SmartWorkspaceNameField, {
   type SmartWorkspaceNameSelection
 } from '@/components/new-workspace/SmartWorkspaceNameField'
+import WorkspaceRepoPillSelect from '@/components/new-workspace/WorkspaceRepoPillSelect'
 import type { SetupConfig } from '@/lib/new-workspace'
 import type { WorkspaceCreateErrorDisplay } from '@/lib/workspace-create-error-format'
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
@@ -46,7 +47,10 @@ type NewWorkspaceComposerCardProps = {
   onQuickAgentChange: (agent: TuiAgent | null) => void
   eligibleRepos: RepoOption[]
   repoId: string
+  repoIds: string[]
   onRepoChange: (value: string) => void
+  onRepoIdsChange: (value: string[]) => void
+  multiRepoSelectionEnabled: boolean
   name: string
   onNameValueChange: (value: string) => void
   onSmartGitHubItemSelect: (item: GitHubWorkItem) => void
@@ -208,7 +212,10 @@ export default function NewWorkspaceComposerCard({
   onQuickAgentChange,
   eligibleRepos,
   repoId,
+  repoIds,
   onRepoChange,
+  onRepoIdsChange,
+  multiRepoSelectionEnabled,
   name,
   onNameValueChange,
   onSmartGitHubItemSelect,
@@ -305,7 +312,16 @@ export default function NewWorkspaceComposerCard({
       <div className="min-w-0 space-y-4 pt-3">
         <div className="space-y-1">
           <div className="flex items-center justify-between gap-2">
-            <label className="text-xs font-medium text-muted-foreground">Project</label>
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                {multiRepoSelectionEnabled ? 'Projects' : 'Project'}
+              </label>
+              {multiRepoSelectionEnabled ? (
+                <span className="rounded-full border border-border bg-muted/45 px-1.5 py-0.5 text-[9px] font-medium uppercase leading-none text-muted-foreground">
+                  experimental
+                </span>
+              ) : null}
+            </div>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -324,21 +340,30 @@ export default function NewWorkspaceComposerCard({
               </TooltipContent>
             </Tooltip>
           </div>
-          <RepoCombobox
-            repos={eligibleRepos}
-            value={repoId}
-            onValueChange={onRepoChange}
-            onValueSelected={focusNameInput}
-            placeholder="Choose project"
-            // Why: programmatic .focus() from the Dialog's onOpenAutoFocus
-            // handler does not reliably trigger :focus-visible in Chromium.
-            // Mirror the Input component's standard ring (border-ring +
-            // ring-ring/50, 3px) onto :focus so the autofocused repo trigger
-            // paints the familiar field ring instead of leaving no visible
-            // focus state.
-            triggerClassName="h-9 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
-            showStandaloneAddButton={false}
-          />
+          {multiRepoSelectionEnabled ? (
+            <WorkspaceRepoPillSelect
+              repos={eligibleRepos}
+              value={repoIds}
+              onValueChange={onRepoIdsChange}
+              placeholder="Choose projects"
+            />
+          ) : (
+            <RepoCombobox
+              repos={eligibleRepos}
+              value={repoId}
+              onValueChange={onRepoChange}
+              onValueSelected={focusNameInput}
+              placeholder="Choose project"
+              // Why: programmatic .focus() from the Dialog's onOpenAutoFocus
+              // handler does not reliably trigger :focus-visible in Chromium.
+              // Mirror the Input component's standard ring (border-ring +
+              // ring-ring/50, 3px) onto :focus so the autofocused repo trigger
+              // paints the familiar field ring instead of leaving no visible
+              // focus state.
+              triggerClassName="h-9 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+              showStandaloneAddButton={false}
+            />
+          )}
           {selectedRepoRequiresConnection && selectedRepoConnectionId ? (
             <div
               role="status"

--- a/src/renderer/src/components/new-workspace/WorkspaceRepoPillSelect.tsx
+++ b/src/renderer/src/components/new-workspace/WorkspaceRepoPillSelect.tsx
@@ -1,0 +1,241 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import { Check, ChevronsUpDown, Server, X } from 'lucide-react'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { searchRepos } from '@/lib/repo-search'
+import { cn } from '@/lib/utils'
+import type { Repo } from '../../../../shared/types'
+import RepoDotLabel from '@/components/repo/RepoDotLabel'
+
+type WorkspaceRepoPillSelectProps = {
+  repos: Repo[]
+  value: readonly string[]
+  onValueChange: (repoIds: string[]) => void
+  placeholder?: string
+  triggerClassName?: string
+}
+
+function normalizeRepoIds(repos: Repo[], repoIds: readonly string[]): string[] {
+  const validRepoIds = new Set(repos.map((repo) => repo.id))
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const repoId of repoIds) {
+    if (!validRepoIds.has(repoId) || seen.has(repoId)) {
+      continue
+    }
+    seen.add(repoId)
+    result.push(repoId)
+  }
+  return result
+}
+
+export default function WorkspaceRepoPillSelect({
+  repos,
+  value,
+  onValueChange,
+  placeholder = 'Choose projects',
+  triggerClassName
+}: WorkspaceRepoPillSelectProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [commandValue, setCommandValue] = useState('')
+  const normalizedValue = useMemo(() => normalizeRepoIds(repos, value), [repos, value])
+  const selectedRepoIds = useMemo(() => new Set(normalizedValue), [normalizedValue])
+  const selectedRepos = useMemo(
+    () =>
+      normalizedValue
+        .map((repoId) => repos.find((repo) => repo.id === repoId))
+        .filter((repo): repo is Repo => repo !== undefined),
+    [normalizedValue, repos]
+  )
+  const filteredRepos = useMemo(() => searchRepos(repos, query), [query, repos])
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      setQuery('')
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (!open) {
+      return
+    }
+    const frame = requestAnimationFrame(() => {
+      const input = document.querySelector<HTMLInputElement>(
+        '[data-workspace-repo-pill-select-content="true"] [data-slot="command-input"]'
+      )
+      input?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [open])
+
+  const toggleRepo = useCallback(
+    (repoId: string): void => {
+      if (selectedRepoIds.has(repoId)) {
+        if (normalizedValue.length <= 1) {
+          return
+        }
+        onValueChange(normalizedValue.filter((id) => id !== repoId))
+        return
+      }
+      onValueChange([...normalizedValue, repoId])
+    },
+    [normalizedValue, onValueChange, selectedRepoIds]
+  )
+
+  const removeRepo = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>, repoId: string): void => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (normalizedValue.length <= 1) {
+        return
+      }
+      onValueChange(normalizedValue.filter((id) => id !== repoId))
+    },
+    [normalizedValue, onValueChange]
+  )
+
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>): void => {
+      if (open) {
+        return
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setOpen(true)
+        return
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (event.key.length === 1 && /\S/.test(event.key)) {
+        event.preventDefault()
+        setQuery(event.key)
+        setOpen(true)
+      }
+    },
+    [open]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <div
+          role="combobox"
+          aria-expanded={open}
+          tabIndex={0}
+          data-repo-combobox-root="true"
+          onKeyDown={handleTriggerKeyDown}
+          className={cn(
+            'flex min-h-9 w-full cursor-pointer items-center gap-1.5 rounded-md border border-input bg-transparent px-2 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none',
+            'focus:border-ring focus:ring-[3px] focus:ring-ring/50',
+            'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+            triggerClassName
+          )}
+        >
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+            {selectedRepos.length === 0 ? (
+              <span className="px-1 text-muted-foreground">{placeholder}</span>
+            ) : (
+              selectedRepos.map((repo, index) => (
+                <span
+                  key={repo.id}
+                  className="inline-flex max-w-full items-center gap-1 rounded-md border border-border bg-muted/55 px-1.5 py-0.5 text-xs text-foreground"
+                >
+                  <RepoDotLabel
+                    name={repo.displayName}
+                    color={repo.badgeColor}
+                    className="max-w-[9rem]"
+                    dotClassName="size-1.5"
+                  />
+                  {index === 0 ? (
+                    <span className="rounded bg-background px-1 py-0.5 text-[9px] font-medium uppercase leading-none text-muted-foreground">
+                      primary
+                    </span>
+                  ) : null}
+                  {repo.connectionId ? (
+                    <Server className="size-2.5 shrink-0 text-muted-foreground" />
+                  ) : null}
+                  <button
+                    type="button"
+                    className={cn(
+                      'ml-0.5 inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground',
+                      normalizedValue.length <= 1 && 'cursor-not-allowed opacity-40'
+                    )}
+                    aria-label={`Remove ${repo.displayName}`}
+                    disabled={normalizedValue.length <= 1}
+                    onClick={(event) => removeRepo(event, repo.id)}
+                  >
+                    <X className="size-2.5" />
+                  </button>
+                </span>
+              ))
+            )}
+          </div>
+          <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground opacity-70" />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0"
+        data-workspace-repo-pill-select-content="true"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
+          <CommandInput
+            placeholder="Search projects..."
+            value={query}
+            onValueChange={setQuery}
+            className="text-xs"
+          />
+          <CommandList>
+            <CommandEmpty>No projects match your search.</CommandEmpty>
+            {filteredRepos.map((repo) => {
+              const isSelected = selectedRepoIds.has(repo.id)
+              const isLastSelected = isSelected && normalizedValue.length <= 1
+              return (
+                <CommandItem
+                  key={repo.id}
+                  value={repo.id}
+                  onSelect={() => toggleRepo(repo.id)}
+                  disabled={isLastSelected}
+                  className="items-center gap-2 px-3 py-2"
+                >
+                  <Check
+                    className={cn(
+                      'size-4 text-foreground',
+                      isSelected ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <span className="inline-flex items-center gap-1.5">
+                      <RepoDotLabel
+                        name={repo.displayName}
+                        color={repo.badgeColor}
+                        className="max-w-full"
+                      />
+                      {repo.connectionId ? (
+                        <span className="inline-flex shrink-0 items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                          <Server className="size-2.5" />
+                          SSH
+                        </span>
+                      ) : null}
+                    </span>
+                    <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{repo.path}</p>
+                  </div>
+                </CommandItem>
+              )
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -27,6 +27,9 @@ export function ExperimentalPane({
   const showWorktreeSymlinks = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.symlinks
   ])
+  const showMultiRepoWorkspaces = matchesSettingsSearch(searchQuery, [
+    EXPERIMENTAL_SEARCH_ENTRY.multiRepoWorkspaces
+  ])
 
   return (
     <div className="space-y-4">
@@ -139,6 +142,46 @@ export function ExperimentalPane({
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
                   settings.experimentalWorktreeSymlinks ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showMultiRepoWorkspaces ? (
+        <SearchableSetting
+          title="Multi-repo workspaces"
+          description="Associate one workspace with multiple repos for sidebar organization."
+          keywords={EXPERIMENTAL_SEARCH_ENTRY.multiRepoWorkspaces.keywords}
+          className="space-y-3 px-1 py-2"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>Multi-repo workspaces</Label>
+              <p className="text-xs text-muted-foreground">
+                Adds an ordered project picker to the new workspace dialog. The first project is
+                used for the worktree location; the rest organize sidebar badges and repo groups.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.experimentalMultiRepoWorkspaces}
+              onClick={() =>
+                updateSettings({
+                  experimentalMultiRepoWorkspaces: !settings.experimentalMultiRepoWorkspaces
+                })
+              }
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                settings.experimentalMultiRepoWorkspaces
+                  ? 'bg-foreground'
+                  : 'bg-muted-foreground/30'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+                  settings.experimentalMultiRepoWorkspaces ? 'translate-x-4' : 'translate-x-0.5'
                 }`}
               />
             </button>

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -47,6 +47,22 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'env',
       'node_modules'
     ]
+  },
+  {
+    title: 'Multi-repo workspaces',
+    description:
+      'Allow the new workspace composer to associate one workspace with multiple repos for sidebar organization.',
+    keywords: [
+      'experimental',
+      'multi repo',
+      'multiple repos',
+      'workspace',
+      'workspaces',
+      'projects',
+      'project',
+      'repo groups',
+      'organization'
+    ]
   }
 ]
 
@@ -64,5 +80,6 @@ function findEntry(title: string): SettingsSearchEntry {
 export const EXPERIMENTAL_SEARCH_ENTRY = {
   pet: findEntry('Pet'),
   activity: findEntry('Agents View'),
-  symlinks: findEntry('Symlinks on worktrees')
+  symlinks: findEntry('Symlinks on worktrees'),
+  multiRepoWorkspaces: findEntry('Multi-repo workspaces')
 } as const

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { cn } from '@/lib/utils'
 import type { Repo, Worktree } from '../../../../shared/types'
+import { getWorktreeRepoIds } from '../../../../shared/worktree-repo-ids'
 import WorktreeCard from './WorktreeCard'
 import { WorktreeActivityStatusIndicator } from './WorktreeActivityStatusIndicator'
 import WorktreeContextMenu from './WorktreeContextMenu'
@@ -19,6 +20,7 @@ type WorkspaceKanbanCardProps = {
   isActive: boolean
   isSelected: boolean
   selectedWorktrees?: readonly Worktree[]
+  associatedRepos?: readonly Repo[]
   compact: boolean
   nativeDragEnabled?: boolean
   onActivate: () => void
@@ -41,11 +43,20 @@ function WorkspaceKanbanCard({
   onSelectionGesture,
   onContextMenuSelect
 }: WorkspaceKanbanCardProps): React.JSX.Element {
+  const allRepos = useAppStore((s) => s.repos)
+  const associatedRepos = useMemo(() => {
+    const repoMap = new Map(allRepos.map((entry) => [entry.id, entry]))
+    return getWorktreeRepoIds(worktree)
+      .map((repoId) => repoMap.get(repoId))
+      .filter((entry): entry is Repo => entry !== undefined)
+  }, [allRepos, worktree])
+
   if (compact) {
     return (
       <WorkspaceKanbanCompactCard
         worktree={worktree}
         repo={repo}
+        associatedRepos={associatedRepos}
         isActive={isActive}
         isSelected={isSelected}
         selectedWorktrees={selectedWorktrees}
@@ -80,6 +91,7 @@ function WorkspaceKanbanCard({
       <WorktreeCard
         worktree={worktree}
         repo={repo}
+        repos={associatedRepos}
         isActive={isActive}
         isMultiSelected={isSelected}
         selectedWorktrees={contextWorktrees}
@@ -97,6 +109,7 @@ export default React.memo(WorkspaceKanbanCard)
 function WorkspaceKanbanCompactCard({
   worktree,
   repo,
+  associatedRepos,
   isActive,
   isSelected,
   selectedWorktrees,
@@ -221,24 +234,27 @@ function WorkspaceKanbanCompactCard({
           >
             <WorktreeActivityStatusIndicator worktreeId={worktree.id} className="mr-1" />
             <span className="min-w-0 flex-1 truncate">{worktree.displayName}</span>
-            {repo ? (
+            {associatedRepos && associatedRepos.length > 0 ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span
                     className="ml-2 flex max-w-[25%] shrink-0 items-center gap-1 rounded-[4px] border border-border bg-accent px-1.5 py-0.5 leading-none dark:border-border/60 dark:bg-accent/50"
                     data-workspace-board-repo-badge=""
                   >
-                    <span
-                      className="size-1.5 shrink-0 rounded-full"
-                      style={{ backgroundColor: repo.badgeColor }}
-                    />
+                    {associatedRepos.slice(0, 3).map((entry) => (
+                      <span
+                        key={entry.id}
+                        className="size-1.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: entry.badgeColor }}
+                      />
+                    ))}
                     <span className="min-w-0 truncate text-[10px] font-semibold lowercase text-foreground">
-                      {repo.displayName}
+                      {associatedRepos.map((entry) => entry.displayName).join(' + ')}
                     </span>
                   </span>
                 </TooltipTrigger>
                 <TooltipContent side="top" sideOffset={4}>
-                  {repo.displayName}
+                  {associatedRepos.map((entry) => entry.displayName).join(' + ')}
                 </TooltipContent>
               </Tooltip>
             ) : null}
@@ -253,6 +269,7 @@ function WorkspaceKanbanCompactCard({
           <WorktreeCard
             worktree={worktree}
             repo={repo}
+            repos={associatedRepos}
             isActive={isActive}
             onActivate={onActivate}
           />

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -37,6 +37,7 @@ import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
 type WorktreeCardProps = {
   worktree: Worktree
   repo: Repo | undefined
+  repos?: readonly Repo[]
   isActive: boolean
   isActiveSurface?: boolean
   isMultiSelected?: boolean
@@ -64,6 +65,7 @@ function isWebClient(): boolean {
 const WorktreeCard = React.memo(function WorktreeCard({
   worktree,
   repo,
+  repos,
   isActive,
   isActiveSurface = isActive,
   isMultiSelected = false,
@@ -145,6 +147,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   )
 
   const branch = branchDisplayName(worktree.branch)
+  const associatedRepos = repos && repos.length > 0 ? repos : repo ? [repo] : []
   const isFolder = repo ? isFolderRepo(repo) : false
   const hostedReviewCacheKey =
     repo && branch ? getHostedReviewCacheKey(repo.path, branch, settings, repo.id) : ''
@@ -545,17 +548,22 @@ const WorktreeCard = React.memo(function WorktreeCard({
              so long lineage labels truncate instead of painting underneath icons. */}
         <div className="flex items-center gap-1.5 min-w-0">
           <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-            {repo && !hideRepoBadge && (
-              <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
-                <div
-                  className="size-1.5 rounded-full"
-                  style={{ backgroundColor: repo.badgeColor }}
-                />
-                <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
-                  {repo.displayName}
-                </span>
-              </div>
-            )}
+            {associatedRepos.length > 0 && (!hideRepoBadge || associatedRepos.length > 1)
+              ? associatedRepos.map((associatedRepo) => (
+                  <div
+                    key={associatedRepo.id}
+                    className="flex shrink-0 items-center gap-1.5 rounded-[4px] border border-border bg-accent px-1.5 py-0.5 dark:bg-accent/50 dark:border-border/60"
+                  >
+                    <div
+                      className="size-1.5 rounded-full"
+                      style={{ backgroundColor: associatedRepo.badgeColor }}
+                    />
+                    <span className="max-w-[6rem] truncate text-[10px] font-semibold leading-none text-foreground lowercase">
+                      {associatedRepo.displayName}
+                    </span>
+                  </div>
+                ))
+              : null}
 
             {isFolder ? (
               <Badge

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1169,6 +1169,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 firstHeaderIndex
               })
               const isRepoHeader = groupBy === 'repo' && row.repo !== undefined
+              const repoHeaderRepos =
+                groupBy === 'repo' ? (row.repos ?? (row.repo ? [row.repo] : [])) : []
               const repoIdForHeader = isRepoHeader ? row.repo!.id : undefined
               const isDraggingThis =
                 canReorderRepoHeaders &&
@@ -1234,7 +1236,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       // headers keep their spacer measured while the painted
                       // header stays flush to the scrollport top.
                       isActiveStickyHeader && hasHeaderTopSpacing && '-translate-y-2',
-                      row.repo && 'overflow-hidden'
+                      repoHeaderRepos.length > 0 && 'overflow-hidden'
                     )}
                     onDragOver={
                       isPinnedHeader
@@ -1272,18 +1274,35 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         }
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                          row.repo ? 'text-muted-foreground' : row.tone
+                          repoHeaderRepos.length > 0 ? 'text-muted-foreground' : row.tone
                         )}
                       >
-                        <row.icon className={row.repo ? 'size-3.5' : 'size-3'} />
+                        <row.icon className={repoHeaderRepos.length > 0 ? 'size-3.5' : 'size-3'} />
                       </div>
                     ) : null}
 
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-1.5">
-                        <div className="truncate text-[13px] font-semibold leading-none">
-                          {row.label}
-                        </div>
+                        {repoHeaderRepos.length > 0 ? (
+                          <div className="flex min-w-0 items-center gap-1 overflow-hidden">
+                            {repoHeaderRepos.map((repo) => (
+                              <span
+                                key={repo.id}
+                                className="inline-flex min-w-0 max-w-[7rem] items-center gap-1.5 rounded-[4px] border border-sidebar-border bg-sidebar-accent/55 px-1.5 py-0.5 text-[11px] font-semibold leading-none text-sidebar-foreground"
+                              >
+                                <span
+                                  className="size-1.5 shrink-0 rounded-full"
+                                  style={{ backgroundColor: repo.badgeColor }}
+                                />
+                                <span className="truncate lowercase">{repo.displayName}</span>
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="truncate text-[13px] font-semibold leading-none">
+                            {row.label}
+                          </div>
+                        )}
                         <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
                           {row.count}
                         </div>
@@ -1428,6 +1447,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   <WorktreeCard
                     worktree={itemRow.worktree}
                     repo={itemRow.repo}
+                    repos={itemRow.repos}
                     isActive={activeWorktreeId === itemRow.worktree.id}
                     // Why: a child-active parent should look active without
                     // running active-card side effects such as SSH reconnect UI.
@@ -1506,17 +1526,22 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           {child.worktree.displayName}
                         </div>
                         <div className="mt-1 flex min-w-0 items-center gap-1.5">
-                          {child.repo && groupBy !== 'repo' ? (
-                            <span className="flex h-[16px] shrink-0 items-center gap-1.5 rounded-[4px] border border-border bg-accent px-1.5 text-[10px] font-semibold leading-none text-foreground dark:bg-accent/50 dark:border-border/60">
-                              <span
-                                className="size-1.5 rounded-full"
-                                style={{ backgroundColor: child.repo.badgeColor }}
-                              />
-                              <span className="max-w-[6rem] truncate lowercase">
-                                {child.repo.displayName}
-                              </span>
-                            </span>
-                          ) : null}
+                          {child.repos.length > 0 && (groupBy !== 'repo' || child.repos.length > 1)
+                            ? child.repos.map((repo) => (
+                                <span
+                                  key={repo.id}
+                                  className="flex h-[16px] shrink-0 items-center gap-1.5 rounded-[4px] border border-border bg-accent px-1.5 text-[10px] font-semibold leading-none text-foreground dark:bg-accent/50 dark:border-border/60"
+                                >
+                                  <span
+                                    className="size-1.5 rounded-full"
+                                    style={{ backgroundColor: repo.badgeColor }}
+                                  />
+                                  <span className="max-w-[6rem] truncate lowercase">
+                                    {repo.displayName}
+                                  </span>
+                                </span>
+                              ))
+                            : null}
                           <span className="truncate text-[10.5px] leading-none text-muted-foreground">
                             {branchDisplayName(child.worktree.branch)}
                           </span>

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -259,6 +259,22 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([feature2.id])
   })
 
+  it('keeps multi-repo workspaces visible when filtering by a secondary repo', () => {
+    const multiRepo = makeWorktree('multi-repo', 'repo1')
+    multiRepo.repoIds = ['repo1', 'repo2']
+    const repo1Only = makeWorktree('repo1-only', 'repo1')
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [multiRepo, repo1Only] },
+      [multiRepo.id, repo1Only.id],
+      visibleOptions({
+        filterRepoIds: ['repo2']
+      })
+    )
+
+    expect(result).toEqual([multiRepo.id])
+  })
+
   it('includes valid lineage parents even when another filter would hide the parent', () => {
     const parent = makeWorktree('parent')
     const child = makeWorktree('child')

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -4,6 +4,7 @@ import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
+import { getWorktreeRepoIds } from '../../../../shared/worktree-repo-ids'
 
 /**
  * Whether a worktree represents the repo's default-branch row that the
@@ -109,7 +110,7 @@ export function computeVisibleWorktreeIds(
   // Filter by repo
   if (opts.filterRepoIds.length > 0) {
     const selectedRepoIds = new Set(opts.filterRepoIds)
-    all = all.filter((w) => selectedRepoIds.has(w.repoId))
+    all = all.filter((w) => getWorktreeRepoIds(w).some((repoId) => selectedRepoIds.has(repoId)))
   }
 
   // Filter active only

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -352,6 +352,51 @@ describe('buildRows repo grouping order', () => {
     const headerKeys = rows.filter((r) => r.type === 'header').map((r) => r.key)
     expect(headerKeys).toEqual(['repo:repo-b', 'repo:repo-a', 'repo:repo-c'])
   })
+
+  it('groups the same repo set together even when physical primary order differs', () => {
+    const repoOrder = new Map([
+      [repoA.id, 0],
+      [repoB.id, 1],
+      [repoC.id, 2]
+    ])
+    const wAB: Worktree = {
+      ...wA,
+      id: 'wt-ab',
+      repoId: repoA.id,
+      repoIds: [repoA.id, repoB.id]
+    }
+    const wBA: Worktree = {
+      ...wB,
+      id: 'wt-ba',
+      repoId: repoB.id,
+      repoIds: [repoB.id, repoA.id]
+    }
+
+    const rows = buildRows('repo', [wAB, wBA], map, null, new Set(), repoOrder)
+
+    expect(rows).toMatchObject([
+      {
+        type: 'header',
+        key: 'repo:repo-a+repo-b',
+        label: 'alpha + beta',
+        count: 2,
+        repos: [{ id: repoA.id }, { id: repoB.id }]
+      },
+      {
+        type: 'item',
+        worktree: { id: 'wt-ab', repoId: repoA.id },
+        repos: [{ id: repoA.id }, { id: repoB.id }]
+      },
+      {
+        type: 'item',
+        worktree: { id: 'wt-ba', repoId: repoB.id },
+        repos: [{ id: repoB.id }, { id: repoA.id }]
+      }
+    ])
+    expect(getGroupKeyForWorktree('repo', wAB, map, null)).toBe(
+      getGroupKeyForWorktree('repo', wBA, map, null)
+    )
+  })
 })
 
 describe('getRepoGroupOrdering', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -20,6 +20,7 @@ import {
   ConductorReviewIcon
 } from './workspace-status-icons'
 import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
+import { getWorktreeRepoGroupKey, getWorktreeRepoIds } from '../../../../shared/worktree-repo-ids'
 import type { SortBy } from './smart-sort'
 
 export { branchName }
@@ -41,12 +42,14 @@ export type GroupHeaderRow = {
   tone: string
   icon?: React.ComponentType<{ className?: string }>
   repo?: Repo
+  repos?: Repo[]
 }
 
 export type WorktreeRow = {
   type: 'item'
   worktree: Worktree
   repo: Repo | undefined
+  repos: Repo[]
   depth: number
   lineageTrail: boolean[]
   isLastLineageChild: boolean
@@ -204,6 +207,41 @@ function emitPinnedGroup(
   return new Set(pinned.map((w) => w.id))
 }
 
+function getAssociatedRepos(worktree: Worktree, repoMap: Map<string, Repo>): Repo[] {
+  return getWorktreeRepoIds(worktree)
+    .map((repoId) => repoMap.get(repoId))
+    .filter((repo): repo is Repo => repo !== undefined)
+}
+
+function getCanonicalAssociatedRepos(
+  worktree: Worktree,
+  repoMap: Map<string, Repo>,
+  repoOrder?: Map<string, number>
+): Repo[] {
+  const repos = getAssociatedRepos(worktree, repoMap)
+
+  if (repos.length <= 1) {
+    return repos
+  }
+
+  return [...repos].sort((a, b) => {
+    const aRank = repoOrder?.get(a.id) ?? Number.POSITIVE_INFINITY
+    const bRank = repoOrder?.get(b.id) ?? Number.POSITIVE_INFINITY
+    if (aRank !== bRank) {
+      return aRank - bRank
+    }
+    return a.displayName.localeCompare(b.displayName)
+  })
+}
+
+function buildRepoGroupKey(worktree: Worktree, repoMap: Map<string, Repo>): string {
+  const knownRepoIds = getWorktreeRepoIds(worktree).filter((repoId) => repoMap.has(repoId))
+  return getWorktreeRepoGroupKey({
+    repoId: knownRepoIds[0] ?? worktree.repoId,
+    repoIds: knownRepoIds.length > 0 ? knownRepoIds : [worktree.repoId]
+  })
+}
+
 function buildWorktreeRow(
   worktree: Worktree,
   repoMap: Map<string, Repo>,
@@ -217,6 +255,7 @@ function buildWorktreeRow(
     type: 'item',
     worktree,
     repo: repoMap.get(worktree.repoId),
+    repos: getAssociatedRepos(worktree, repoMap),
     depth,
     lineageTrail,
     isLastLineageChild,
@@ -363,15 +402,20 @@ export function buildRows(
     return result
   }
 
-  const grouped = new Map<string, { label: string; items: Worktree[]; repo?: Repo }>()
+  const grouped = new Map<
+    string,
+    { label: string; items: Worktree[]; repo?: Repo; repos?: Repo[] }
+  >()
   for (const w of unpinned) {
     let key: string
     let label: string
     let repo: Repo | undefined
+    let repos: Repo[] | undefined
     if (groupBy === 'repo') {
-      repo = repoMap.get(w.repoId)
-      key = `repo:${w.repoId}`
-      label = repo?.displayName ?? 'Unknown'
+      repos = getCanonicalAssociatedRepos(w, repoMap, repoOrder)
+      repo = repos.length === 1 ? repos[0] : undefined
+      key = buildRepoGroupKey(w, repoMap)
+      label = repos.length > 0 ? repos.map((entry) => entry.displayName).join(' + ') : 'Unknown'
     } else if (groupBy === 'workspace-status') {
       const workspaceStatus = getWorkspaceStatus(w, workspaceStatuses)
       key = getWorkspaceStatusGroupKey(workspaceStatus)
@@ -383,12 +427,15 @@ export function buildRows(
       label = PR_GROUP_META[prGroup].label
     }
     if (!grouped.has(key)) {
-      grouped.set(key, { label, items: [], repo })
+      grouped.set(key, { label, items: [], repo, repos })
     }
     grouped.get(key)!.items.push(w)
   }
 
-  const orderedGroups: [string, { label: string; items: Worktree[]; repo?: Repo }][] = []
+  const orderedGroups: [
+    string,
+    { label: string; items: Worktree[]; repo?: Repo; repos?: Repo[] }
+  ][] = []
   if (groupBy === 'pr-status') {
     for (const prGroup of PR_GROUP_ORDER) {
       const key = `pr:${prGroup}`
@@ -413,14 +460,14 @@ export function buildRows(
     // order so repo-header drag has a stable source of truth.
     const entries = Array.from(grouped.entries())
     if (repoGroupOrdering === 'manual' && repoOrder) {
-      const rankFor = (key: string): number => {
-        const repoId = key.startsWith('repo:') ? key.slice('repo:'.length) : key
-        const rank = repoOrder.get(repoId)
+      const rankFor = (group: { repo?: Repo; repos?: Repo[] }): number => {
+        const repoId = group.repo?.id ?? group.repos?.[0]?.id
+        const rank = repoId ? repoOrder.get(repoId) : undefined
         return rank === undefined ? Number.POSITIVE_INFINITY : rank
       }
       entries.sort((a, b) => {
-        const ra = rankFor(a[0])
-        const rb = rankFor(b[0])
+        const ra = rankFor(a[1])
+        const rb = rankFor(b[1])
         if (ra !== rb) {
           return ra - rb
         }
@@ -442,7 +489,8 @@ export function buildRows(
             count: group.items.length,
             tone: REPO_GROUP_META.tone,
             icon: REPO_GROUP_META.icon,
-            repo
+            repo,
+            repos: group.repos
           }
         : groupBy === 'workspace-status'
           ? (() => {
@@ -500,7 +548,7 @@ export function getGroupKeyForWorktree(
     return getWorkspaceStatusGroupKey(getWorkspaceStatus(worktree, workspaceStatuses))
   }
   if (groupBy === 'repo') {
-    return `repo:${worktree.repoId}`
+    return buildRepoGroupKey(worktree, repoMap)
   }
   return `pr:${getPRGroupKey(worktree, repoMap, prCache)}`
 }

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -33,6 +33,7 @@ import type {
   WorkspaceCreateTelemetrySource
 } from '../../../shared/types'
 import { isWorkspaceStatusId } from '../../../shared/workspace-statuses'
+import { normalizeWorktreeRepoIds } from '../../../shared/worktree-repo-ids'
 import {
   ADD_ATTACHMENT_SHORTCUT,
   CLIENT_PLATFORM,
@@ -114,7 +115,10 @@ export type UseComposerStateOptions = {
 export type ComposerCardProps = {
   eligibleRepos: ReturnType<typeof useAppStore.getState>['repos']
   repoId: string
+  repoIds: string[]
   onRepoChange: (value: string) => void
+  onRepoIdsChange: (value: string[]) => void
+  multiRepoSelectionEnabled: boolean
   name: string
   onNameValueChange: (value: string) => void
   onSmartGitHubItemSelect: (item: GitHubWorkItem) => void
@@ -302,7 +306,20 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           : (eligibleRepos[0]?.id ?? '')
 
   const [internalRepoId, setInternalRepoId] = useState<string>(resolvedInitialRepoId)
+  const [associatedRepoIds, setAssociatedRepoIds] = useState<string[]>([resolvedInitialRepoId])
   const repoId = repoIdOverride ?? internalRepoId
+  const multiRepoSelectionEnabled =
+    settings?.experimentalMultiRepoWorkspaces === true && !repoIdOverride
+  const selectedRepoIds = useMemo(() => {
+    if (!multiRepoSelectionEnabled) {
+      return repoId ? [repoId] : []
+    }
+    const eligibleRepoIds = new Set(eligibleRepos.map((repo) => repo.id))
+    const normalized = normalizeWorktreeRepoIds(repoId, associatedRepoIds).filter((id) =>
+      eligibleRepoIds.has(id)
+    )
+    return normalized.length > 0 ? normalized : repoId ? [repoId] : []
+  }, [associatedRepoIds, eligibleRepos, multiRepoSelectionEnabled, repoId])
   const selectedRepo = eligibleRepos.find((repo) => repo.id === repoId)
   const selectedRepoConnectionId = selectedRepo?.connectionId ?? null
   const selectedRepoSshState = selectedRepoConnectionId
@@ -747,6 +764,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   useEffect(() => {
     if (!repoId && eligibleRepos[0]?.id) {
       setRepoId(eligibleRepos[0].id)
+      setAssociatedRepoIds([eligibleRepos[0].id])
     }
   }, [eligibleRepos, repoId, setRepoId])
 
@@ -1344,7 +1362,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     [handleAddAttachment]
   )
 
-  const handleRepoChange = useCallback(
+  const applyPrimaryRepoChange = useCallback(
     (value: string): void => {
       if (value === repoId) {
         setRepoId(value)
@@ -1383,6 +1401,30 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       setStartFromResetHint(hint)
     },
     [baseBranch, linkedWorkItem, repoId, setRepoId]
+  )
+
+  const handleRepoChange = useCallback(
+    (value: string): void => {
+      applyPrimaryRepoChange(value)
+      setAssociatedRepoIds(value ? [value] : [])
+    },
+    [applyPrimaryRepoChange]
+  )
+
+  const handleRepoIdsChange = useCallback(
+    (values: string[]): void => {
+      const eligibleRepoIds = new Set(eligibleRepos.map((repo) => repo.id))
+      const normalized = values.filter((repoId, index) => {
+        return eligibleRepoIds.has(repoId) && values.indexOf(repoId) === index
+      })
+      const nextPrimaryRepoId = normalized[0]
+      if (!nextPrimaryRepoId) {
+        return
+      }
+      applyPrimaryRepoChange(nextPrimaryRepoId)
+      setAssociatedRepoIds(normalized)
+    },
+    [applyPrimaryRepoChange, eligibleRepos]
   )
 
   const handleSparseSelectPreset = useCallback((preset: SparsePreset | null): void => {
@@ -1713,7 +1755,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         tuiAgent,
         linkedLinearIssue,
         effectiveBranchNameOverride,
-        resolvedInitialWorkspaceStatus
+        resolvedInitialWorkspaceStatus,
+        selectedRepoIds
       )
       const worktree = result.worktree
 
@@ -1813,6 +1856,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     resolvedSetupDecision,
     resolvedInitialWorkspaceStatus,
     selectedRepo,
+    selectedRepoIds,
     selectedRepoRequiresConnection,
     settings?.agentCmdOverrides,
     settings?.rightSidebarOpenByDefault,
@@ -1911,7 +1955,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           agent ?? undefined,
           linkedLinearIssue,
           effectiveBranchNameOverride,
-          resolvedInitialWorkspaceStatus
+          resolvedInitialWorkspaceStatus,
+          selectedRepoIds
         )
         const worktree = result.worktree
 
@@ -2054,6 +2099,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       resolvedSetupDecision,
       resolvedInitialWorkspaceStatus,
       selectedRepo,
+      selectedRepoIds,
       selectedRepoRequiresConnection,
       settings?.agentCmdOverrides,
       settings?.rightSidebarOpenByDefault,
@@ -2092,7 +2138,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const cardProps: ComposerCardProps = {
     eligibleRepos,
     repoId,
+    repoIds: selectedRepoIds,
     onRepoChange: handleRepoChange,
+    onRepoIdsChange: handleRepoIdsChange,
+    multiRepoSelectionEnabled,
     name,
     onNameValueChange: handleNameValueChange,
     onSmartGitHubItemSelect: handleSmartGitHubItemSelect,

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -87,7 +87,8 @@ export type WorktreeSlice = {
     createdWithAgent?: TuiAgent,
     linkedLinearIssue?: string,
     branchNameOverride?: string,
-    workspaceStatus?: WorkspaceStatus
+    workspaceStatus?: WorkspaceStatus,
+    repoIds?: string[]
   ) => Promise<CreateWorktreeResult>
   removeWorktree: (
     worktreeId: string,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -67,6 +67,7 @@ function areWorktreesEqual(current: Worktree[] | undefined, next: Worktree[]): b
       worktree.id === candidate.id &&
       worktree.instanceId === candidate.instanceId &&
       worktree.repoId === candidate.repoId &&
+      arraysShallowEqual(worktree.repoIds, candidate.repoIds) &&
       worktree.path === candidate.path &&
       worktree.head === candidate.head &&
       worktree.branch === candidate.branch &&
@@ -613,7 +614,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     createdWithAgent,
     linkedLinearIssue,
     branchNameOverride,
-    workspaceStatus
+    workspaceStatus,
+    repoIds
   ) => {
     const retryableConflictPatterns = [
       /already exists locally/i,
@@ -649,7 +651,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(pushTarget ? { pushTarget } : {}),
             ...(createdWithAgent ? { createdWithAgent } : {}),
             ...(linkedLinearIssue !== undefined ? { linkedLinearIssue } : {}),
-            ...(workspaceStatus !== undefined ? { workspaceStatus } : {})
+            ...(workspaceStatus !== undefined ? { workspaceStatus } : {}),
+            ...(repoIds && repoIds.length > 1 ? { repoIds } : {})
           }
           const target = getActiveRuntimeTarget(get().settings)
           const result =
@@ -673,7 +676,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                     ...(pushTarget ? { pushTarget } : {}),
                     ...(createdWithAgent ? { createdWithAgent } : {}),
                     ...(linkedLinearIssue !== undefined ? { linkedLinearIssue } : {}),
-                    ...(workspaceStatus !== undefined ? { workspaceStatus } : {})
+                    ...(workspaceStatus !== undefined ? { workspaceStatus } : {}),
+                    ...(repoIds && repoIds.length > 1 ? { repoIds } : {})
                   },
                   { timeoutMs: 10 * 60_000 }
                 )

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -255,6 +255,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalActivity: false,
     experimentalActivityDefaultedOffForAllUsers: true,
     experimentalWorktreeSymlinks: false,
+    experimentalMultiRepoWorkspaces: false,
     // Why: local desktop remains the default server until the user explicitly
     // selects a saved runtime environment.
     activeRuntimeEnvironmentId: null,

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -209,6 +209,7 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalPet',
   'experimentalActivity',
   'experimentalWorktreeSymlinks',
+  'experimentalMultiRepoWorkspaces',
   'geminiCliOAuthEnabled'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]
 export const settingsChangedKeySchema = z.enum(SETTINGS_CHANGED_WHITELIST)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -148,6 +148,10 @@ export type Worktree = {
   id: string // `${repoId}::${path}`
   instanceId?: string
   repoId: string
+  /** Ordered repo associations for experimental multi-repo workspaces. The
+   *  first ID is the physical worktree repo and always matches `repoId`;
+   *  later IDs are organization-only secondary repos. */
+  repoIds?: string[]
   displayName: string
   comment: string
   linkedIssue: number | null
@@ -200,6 +204,8 @@ export type GitPushTarget = {
 export type WorktreeMeta = {
   /** Immutable per-workspace-instance ID used to reject stale lineage after path reuse. */
   instanceId?: string
+  /** See {@link Worktree.repoIds}. Persisted to orca-data.json. */
+  repoIds?: string[]
   displayName: string
   comment: string
   linkedIssue: number | null
@@ -1227,6 +1233,10 @@ export type SparsePreset = {
 
 export type CreateWorktreeArgs = {
   repoId: string
+  /** Ordered repo associations for experimental multi-repo workspaces. The
+   *  first ID must be the physical `repoId`; additional IDs are used only for
+   *  sidebar organization and badge display. */
+  repoIds?: string[]
   name: string
   /** Optional user-facing label to persist separately from the git-safe
    *  branch/path seed. Used when a workspace is created from a GitHub or
@@ -1737,6 +1747,10 @@ export type GlobalSettings = {
    *  configuration surface and edge cases (conflicts with existing paths,
    *  cleanup on worktree delete) are still being worked out. */
   experimentalWorktreeSymlinks: boolean
+  /** Experimental: allow the new workspace composer to associate a workspace
+   *  with multiple repos. Only the first repo determines the physical worktree
+   *  location; secondary repos are organizational metadata. */
+  experimentalMultiRepoWorkspaces: boolean
   /** Active non-local runtime environment for client-routed RPC. `null`
    *  preserves the current local desktop behavior. */
   activeRuntimeEnvironmentId?: string | null

--- a/src/shared/worktree-repo-ids.ts
+++ b/src/shared/worktree-repo-ids.ts
@@ -1,0 +1,41 @@
+export type WorktreeRepoAssociation = {
+  repoId: string
+  repoIds?: readonly string[] | null
+}
+
+export function normalizeWorktreeRepoIds(
+  primaryRepoId: string,
+  repoIds?: readonly string[] | null
+): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  const add = (repoId: string | null | undefined): void => {
+    const trimmed = repoId?.trim()
+    if (!trimmed || seen.has(trimmed)) {
+      return
+    }
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+
+  add(primaryRepoId)
+  for (const repoId of repoIds ?? []) {
+    add(repoId)
+  }
+  return result
+}
+
+export function getWorktreeRepoIds(worktree: WorktreeRepoAssociation): string[] {
+  return normalizeWorktreeRepoIds(worktree.repoId, worktree.repoIds)
+}
+
+export function getWorktreeRepoGroupKey(worktree: WorktreeRepoAssociation): string {
+  const repoIds = getWorktreeRepoIds(worktree)
+  if (repoIds.length <= 1) {
+    return `repo:${repoIds[0] ?? worktree.repoId}`
+  }
+
+  // Why: the first repo decides the physical worktree location, but repo
+  // grouping is organizational. Sort IDs so A+B and B+A share one group.
+  return `repo:${repoIds.map(encodeURIComponent).sort().join('+')}`
+}


### PR DESCRIPTION
## Summary
- add an experimental multi-repo project picker to the new workspace dialog using ordered pills
- persist ordered repo associations while keeping the first repo as the physical worktree location
- show all associated repo badges and group combined repo sets together in sidebar/board views

## Test Plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/store/slices/worktrees.test.ts src/main/runtime/rpc/methods/worktree.test.ts src/main/ipc/worktree-logic.test.ts
- pnpm run typecheck
- pnpm run lint
- git diff --check
- Electron smoke test: enabled experiment, opened Create Workspace, selected a secondary repo pill, restored setting, stopped dev app

Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.