### PR TITLE
Improve workspace card details affordances

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.test.tsx
@@ -1,0 +1,62 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { DashboardAgentHoverCardContent } from './DashboardAgentHoverCardContent'
+import type { DashboardAgentRow } from './useDashboardData'
+
+function makeAgentRow(): DashboardAgentRow {
+  const now = Date.UTC(2026, 4, 20)
+  const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+  const prompt = 'Review **markdown** formatting'
+
+  return {
+    paneKey,
+    agentType: 'codex',
+    state: 'working',
+    startedAt: now - 60_000,
+    tab: {
+      id: 'tab-1',
+      ptyId: null,
+      worktreeId: 'wt-1',
+      title: 'Codex',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: now
+    },
+    entry: {
+      state: 'working',
+      prompt,
+      updatedAt: now,
+      stateStartedAt: now - 60_000,
+      agentType: 'codex',
+      paneKey,
+      stateHistory: [{ state: 'working', prompt, startedAt: now - 60_000 }],
+      toolName: 'Bash',
+      toolInput: 'pnpm test',
+      lastAssistantMessage: 'Rendered **markdown** in the hover card.'
+    }
+  }
+}
+
+describe('DashboardAgentHoverCardContent', () => {
+  it('renders prompt and assistant markdown in structured sections', () => {
+    const markup = renderToStaticMarkup(
+      <DashboardAgentHoverCardContent
+        agent={makeAgentRow()}
+        dotState="working"
+        prompt="Review **markdown** formatting"
+        isWorking
+        toolName="Bash"
+        toolInput="pnpm test"
+        lastAssistantMessage="Rendered **markdown** in the hover card."
+        tsParts={['started 1m ago']}
+      />
+    )
+
+    expect(markup).toContain('Prompt')
+    expect(markup).toContain('Current tool')
+    expect(markup).toContain('Latest message')
+    expect(markup).toContain('<strong>markdown</strong>')
+    expect(markup).toContain('pnpm test')
+  })
+})

--- a/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
+
+type AgentHoverSectionProps = {
+  title: string
+  children: React.ReactNode
+}
+
+function AgentHoverSection({ title, children }: AgentHoverSectionProps): React.JSX.Element {
+  return (
+    <section className="space-y-1.5">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+        {title}
+      </div>
+      <div className="text-[12px] leading-relaxed text-popover-foreground">{children}</div>
+    </section>
+  )
+}
+
+type DashboardAgentHoverCardContentProps = {
+  agent: DashboardAgentRowData
+  dotState: AgentDotState
+  prompt: string
+  isWorking: boolean
+  toolName: string
+  toolInput: string
+  lastAssistantMessage: string
+  tsParts: readonly string[]
+}
+
+export function DashboardAgentHoverCardContent({
+  agent,
+  dotState,
+  prompt,
+  isWorking,
+  toolName,
+  toolInput,
+  lastAssistantMessage,
+  tsParts
+}: DashboardAgentHoverCardContentProps): React.JSX.Element {
+  const agentLabel = formatAgentTypeLabel(agent.agentType)
+  const statusLabel = agent.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)
+  const hasToolDetails = isWorking && (toolName.length > 0 || toolInput.length > 0)
+  const hasBodyDetails = prompt.length > 0 || hasToolDetails || lastAssistantMessage.length > 0
+
+  return (
+    <div
+      className="max-h-[min(70vh,520px)] overflow-y-auto"
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <div className="border-b border-border/60 px-3 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <AgentStateDot state={dotState} size="md" />
+          <span className="inline-flex shrink-0 text-foreground">
+            <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={16} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-popover-foreground">
+              {agentLabel}
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              {[statusLabel, ...tsParts].join(' • ')}
+            </div>
+          </div>
+          {agent.entry.interrupted && (
+            <span className="shrink-0 rounded-sm bg-destructive/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-destructive">
+              interrupted
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="space-y-3 px-3 py-3">
+        {prompt && (
+          <AgentHoverSection title="Prompt">
+            <CommentMarkdown
+              content={prompt}
+              variant="document"
+              className="text-[12px] leading-relaxed"
+            />
+          </AgentHoverSection>
+        )}
+        {hasToolDetails && (
+          <AgentHoverSection title="Current tool">
+            <div className="space-y-1.5">
+              {toolName && (
+                <code className="rounded bg-accent px-1.5 py-0.5 font-mono text-[11px] text-accent-foreground">
+                  {toolName}
+                </code>
+              )}
+              {toolInput && (
+                <pre className="max-h-40 overflow-auto rounded-md bg-accent p-2 font-mono text-[11px] leading-snug text-accent-foreground [overflow-wrap:anywhere]">
+                  {toolInput}
+                </pre>
+              )}
+            </div>
+          </AgentHoverSection>
+        )}
+        {lastAssistantMessage && (
+          <AgentHoverSection title="Latest message">
+            <CommentMarkdown
+              content={lastAssistantMessage}
+              variant="document"
+              className="text-[12px] leading-relaxed"
+            />
+          </AgentHoverSection>
+        )}
+        {!hasBodyDetails && (
+          <div className="text-xs text-muted-foreground">No agent details yet.</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -5,6 +5,8 @@ import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { DashboardAgentHoverCardContent } from './DashboardAgentHoverCardContent'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
 
@@ -160,13 +162,14 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const startedAt = agent.startedAt > 0 ? agent.startedAt : null
   const doneAt = lastEnteredDoneAt(agent)
   const prompt = agent.entry.prompt.trim()
+  const dotState = asDotState(agent.state)
   // Why: `agent.entry.prompt` is normalized to '' when the prompt is unknown
   // (fresh agent, missing telemetry). Rendering the row with an empty primary
   // slot would collapse the text column and leave the row with no human-
   // readable label — just a state dot and icon. Fall back to the state label
   // ("Working", "Done", "Waiting", …) so every row is identifiable at a
   // glance.
-  const displayLabel = prompt || agentStateLabel(asDotState(agent.state))
+  const displayLabel = prompt || agentStateLabel(dotState)
   // Why: the tool row describes what the agent is *currently* doing; once it
   // leaves working, that line goes stale and misleads (a done row showing
   // "Bash: pnpm test" reads as if the command is still running). Gate tool
@@ -191,10 +194,10 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
     tsParts.push(`done ${formatTimeAgo(doneAt, now)}`)
   }
 
-  return (
+  const row = (
     // Why: NOT role="button" / tabIndex={0}. The row contains real <button>
-    // children (dismiss X, expand chevron) and tooltip triggers that forward
-    // button semantics to their children — nesting them inside an outer
+    // children (dismiss X, expand chevron) and is itself the hover-card
+    // trigger — nesting them inside an outer
     // role=button violates ARIA's "no interactive content inside interactive
     // content" rule and breaks keyboard/AT navigation. Keyboard users reach
     // the agent via the child buttons and the tab switcher; the outer <div>
@@ -211,7 +214,6 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
         // active-state pattern) so the lift is symmetric across themes.
         'cursor-pointer rounded-sm hover:bg-black/[0.06] dark:hover:bg-accent/30'
       )}
-      title={tsParts.length > 0 ? tsParts.join(' • ') : undefined}
     >
       <div className="flex items-center gap-1.5">
         {/* Why: state indicator lives in the leading gutter so the user's
@@ -223,9 +225,9 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             overpowering the prompt text. */}
         <span
           className="inline-flex shrink-0 items-center justify-center"
-          title={agent.entry.interrupted ? 'Interrupted' : agentStateLabel(asDotState(agent.state))}
+          aria-label={agent.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)}
         >
-          <AgentStateDot state={asDotState(agent.state)} size={stateDotSize} />
+          <AgentStateDot state={dotState} size={stateDotSize} />
         </span>
         {/* Why: identity (Claude/Codex/Gemini/…) sits inline with the prompt
             so the reader gets "state → who → what they said" left-to-right
@@ -234,7 +236,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             them — keeping the icon only on the prompt row lets the sub-rows
             indent under the prompt text cleanly. */}
         {!hideIdentityIcon && (
-          <span className="inline-flex shrink-0" title={formatAgentTypeLabel(agent.agentType)}>
+          <span className="inline-flex shrink-0" aria-label={formatAgentTypeLabel(agent.agentType)}>
             <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={14} />
           </span>
         )}
@@ -262,9 +264,6 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             expanded ? 'h-auto whitespace-pre-wrap break-words' : 'h-[1lh] truncate',
             isUnvisited ? 'font-semibold text-foreground' : 'font-normal text-muted-foreground'
           )}
-          // Why: tooltip should only reveal truncated prompt text — not echo state-word fallbacks
-          // (e.g. "Working"/"Done") that already fit on one line and never overflow.
-          title={expanded || !prompt ? undefined : displayLabel}
         >
           {displayLabel}
         </span>
@@ -398,9 +397,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
                 <Wrench className="size-2.5 shrink-0" />
                 <code className="shrink-0 font-mono text-[10px]">{toolName}</code>
                 {!expanded && toolInput && (
-                  <span className="min-w-0 truncate text-muted-foreground/60" title={toolInput}>
-                    {toolInput}
-                  </span>
+                  <span className="min-w-0 truncate text-muted-foreground/60">{toolInput}</span>
                 )}
               </div>
               {/* Why: grid-rows [0fr]→[1fr] is the CSS-only height animation
@@ -461,7 +458,6 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             !expanded &&
               'truncate whitespace-nowrap [&_*]:inline [&_*]:!whitespace-nowrap [&_*]:!m-0 [&_*]:!p-0 [&_ul]:list-none [&_ol]:list-none [&_br]:hidden'
           )}
-          title={!expanded ? lastAssistantMessage : undefined}
         />
       ) : (
         !expanded && (
@@ -469,6 +465,29 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
         )
       )}
     </div>
+  )
+
+  return (
+    <HoverCard openDelay={250} closeDelay={120}>
+      <HoverCardTrigger asChild>{row}</HoverCardTrigger>
+      <HoverCardContent
+        side="right"
+        align="start"
+        sideOffset={10}
+        className="w-96 max-w-[calc(100vw-2rem)] p-0"
+      >
+        <DashboardAgentHoverCardContent
+          agent={agent}
+          dotState={dotState}
+          prompt={prompt}
+          isWorking={isWorking}
+          toolName={toolName}
+          toolInput={toolInput}
+          lastAssistantMessage={lastAssistantMessage}
+          tsParts={tsParts}
+        />
+      </HoverCardContent>
+    </HoverCard>
   )
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -427,6 +427,10 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
         >
           {!isMultiContext && (
             <>
+              <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
+                <Pencil className="size-3.5" />
+                Edit details
+              </DropdownMenuItem>
               <WorktreeOpenInSubMenu
                 worktreePath={worktree.path}
                 connectionId={repo?.connectionId ?? null}
@@ -503,12 +507,6 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          {!isMultiContext && (
-            <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
-              <Pencil className="size-3.5" />
-              Update
-            </DropdownMenuItem>
-          )}
           <DropdownMenuSeparator />
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Rename the workspace card context menu action to Edit details and move it to the top
- Replace inline agent native text tooltips with a right-side hover card
- Render prompt/latest-message details with Markdown in the hover card

## Verification
- pnpm lint
- pnpm typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.test.tsx src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
- Electron CDP validation of the right-side agent hover card