### PR TITLE
feat: add notification sound volume slider

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -81,7 +81,8 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
       agentTaskComplete: true,
       terminalBell: false,
       suppressWhenFocused: true,
-      customSoundPath: null
+      customSoundPath: null,
+      customSoundVolume: 100
     },
     promptCacheTimerEnabled: false,
     promptCacheTtlMs: 300_000,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -74,7 +74,8 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
       agentTaskComplete: true,
       terminalBell: false,
       suppressWhenFocused: true,
-      customSoundPath: null
+      customSoundPath: null,
+      customSoundVolume: 100
     },
     promptCacheTimerEnabled: false,
     promptCacheTtlMs: 300_000,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -227,6 +227,7 @@ describe('Store', () => {
     expect(settings.floatingTerminalEnabled).toBe(true)
     expect(settings.floatingTerminalDefaultedForAllUsers).toBe(true)
     expect(settings.notifications.customSoundPath).toBeNull()
+    expect(settings.notifications.customSoundVolume).toBe(100)
   })
 
   it('returns default UI state when no data file exists', async () => {
@@ -719,8 +720,47 @@ describe('Store', () => {
       agentTaskComplete: true,
       terminalBell: false,
       suppressWhenFocused: true,
-      customSoundPath: '/Users/kaylee/Downloads/Note_block_pling.ogg'
+      customSoundPath: '/Users/kaylee/Downloads/Note_block_pling.ogg',
+      customSoundVolume: 100
     })
+  })
+
+  it('clamps notification custom sound volume from persisted settings', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        notifications: {
+          customSoundVolume: 250
+        }
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().notifications.customSoundVolume).toBe(100)
+  })
+
+  it('defaults invalid notification custom sound volume from persisted settings', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        notifications: {
+          customSoundVolume: Number.NaN
+        }
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().notifications.customSoundVolume).toBe(100)
   })
 
   it('preserves editorAutoSaveDelayMs when set in persisted data', async () => {
@@ -958,6 +998,20 @@ describe('Store', () => {
     expect(updated.openInApplications).toEqual([
       { id: 'cursor', label: 'Cursor', command: 'cursor' }
     ])
+  })
+
+  it('updateSettings deep-merges and clamps notification custom sound volume', async () => {
+    const store = await createStore()
+    const updated = store.updateSettings({
+      notifications: {
+        ...store.getSettings().notifications,
+        customSoundVolume: -20
+      }
+    })
+
+    expect(updated.notifications.customSoundVolume).toBe(0)
+    expect(updated.notifications.enabled).toBe(true)
+    expect(updated.notifications.customSoundPath).toBeNull()
   })
 
   it('updateSettings toggles editorAutoSave', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -36,6 +36,7 @@ import type {
   WorktreeMeta,
   WorktreeLineage,
   GlobalSettings,
+  NotificationSettings,
   OnboardingChecklistState,
   OnboardingOutcome,
   OnboardingState,
@@ -181,6 +182,22 @@ function normalizeSortBy(sortBy: unknown): 'name' | 'smart' | 'recent' | 'repo' 
     return sortBy
   }
   return getDefaultUIState().sortBy
+}
+
+function normalizeNotificationSettings(value: unknown): NotificationSettings {
+  const defaults = getDefaultNotificationSettings()
+  const candidate =
+    value && typeof value === 'object' ? (value as Partial<NotificationSettings>) : {}
+  const rawVolume = candidate.customSoundVolume
+  const customSoundVolume =
+    typeof rawVolume === 'number' && Number.isFinite(rawVolume)
+      ? Math.min(100, Math.max(0, rawVolume))
+      : defaults.customSoundVolume
+  return {
+    ...defaults,
+    ...candidate,
+    customSoundVolume
+  }
 }
 
 function normalizeAutomationRunWorkspaceDisplayName(value: string | null): string | null {
@@ -1242,10 +1259,7 @@ export class Store {
               parsed.settings?.visibleTaskProviders
             ),
             openInApplications: normalizeOpenInApplications(parsed.settings?.openInApplications),
-            notifications: {
-              ...getDefaultNotificationSettings(),
-              ...parsed.settings?.notifications
-            },
+            notifications: normalizeNotificationSettings(parsed.settings?.notifications),
             voice: {
               ...getDefaultVoiceSettings(),
               ...parsed.settings?.voice
@@ -2137,10 +2151,10 @@ export class Store {
     this.state.settings = {
       ...this.state.settings,
       ...sanitizedUpdates,
-      notifications: {
+      notifications: normalizeNotificationSettings({
         ...this.state.settings.notifications,
         ...sanitizedUpdates.notifications
-      },
+      }),
       ...(mergedTelemetry !== undefined ? { telemetry: mergedTelemetry } : {})
     }
     this.scheduleSave()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1186,7 +1186,7 @@ export type PreloadApi = {
     openSystemSettings: () => Promise<void>
     getPermissionStatus: () => Promise<NotificationPermissionStatusResult>
     requestPermission: () => Promise<NotificationPermissionStatusResult>
-    playSound: (options?: { force?: boolean }) => Promise<NotificationSoundResult>
+    playSound: (options?: { force?: boolean; volume?: number }) => Promise<NotificationSoundResult>
   }
   onboarding: {
     get: () => Promise<OnboardingState>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1254,7 +1254,10 @@ const api = {
       ipcRenderer.invoke('notifications:getPermissionStatus'),
     requestPermission: (): Promise<NotificationPermissionStatusResult> =>
       ipcRenderer.invoke('notifications:requestPermission'),
-    playSound: async (options?: { force?: boolean }): Promise<NotificationSoundResult> => {
+    playSound: async (options?: {
+      force?: boolean
+      volume?: number
+    }): Promise<NotificationSoundResult> => {
       try {
         // Why: drop replays while the sound is still ringing. The "test"
         // button bypasses with force so the user always hears a confirmation.
@@ -1295,6 +1298,9 @@ const api = {
         // the sound from the start instead of stacking overlapping copies.
         // Matches GNOME canberra and VS Code AccessibilitySignalService.
         audio.currentTime = 0
+        if (typeof options?.volume === 'number' && Number.isFinite(options.volume)) {
+          audio.volume = Math.min(1, Math.max(0, options.volume / 100))
+        }
         isNotificationSoundPlaying = true
         const release = (): void => {
           isNotificationSoundPlaying = false

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -1,10 +1,11 @@
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { GlobalSettings } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
-import { BellRing, Bot, FileAudio, Siren, X } from 'lucide-react'
+import { Slider } from '../ui/slider'
+import { BellRing, Bot, FileAudio, Siren, Volume2, X } from 'lucide-react'
 import type { SettingsSearchEntry } from './settings-search'
 import { basename } from '@/lib/path'
 
@@ -34,6 +35,11 @@ export const NOTIFICATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     description:
       'Choose one local audio file (MP3, WAV, OGG, M4A, AAC, or FLAC) for all delivered desktop notifications.',
     keywords: ['notifications', 'sound', 'audio', 'mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac']
+  },
+  {
+    title: 'Notification Volume',
+    description: 'Playback volume for the custom notification sound.',
+    keywords: ['notifications', 'sound', 'volume', 'loudness']
   },
   {
     title: 'Send Test Notification',
@@ -82,6 +88,36 @@ export function NotificationsPane({
     })
   }
 
+  // Why: the slider fires onValueChange on every step while dragging. Persisting
+  // through IPC on every tick laggs the drag. Mirror the value locally for
+  // instant visual feedback and commit to settings 200ms after the last change,
+  // restarting the timer on each tick (autosave-style).
+  const [volumeDraft, setVolumeDraft] = useState(notificationSettings.customSoundVolume)
+  const volumeCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    setVolumeDraft(notificationSettings.customSoundVolume)
+  }, [notificationSettings.customSoundVolume])
+
+  useEffect(() => {
+    return () => {
+      if (volumeCommitTimer.current) {
+        clearTimeout(volumeCommitTimer.current)
+      }
+    }
+  }, [])
+
+  const handleVolumeChange = (value: number): void => {
+    setVolumeDraft(value)
+    if (volumeCommitTimer.current) {
+      clearTimeout(volumeCommitTimer.current)
+    }
+    volumeCommitTimer.current = setTimeout(() => {
+      volumeCommitTimer.current = null
+      updateNotificationSettings({ customSoundVolume: value })
+    }, 200)
+  }
+
   const handleSendTestNotification = async (): Promise<void> => {
     // Why: Electron main cannot reliably read macOS notification authorization,
     // but the renderer exposes it. Without this check, dev builds can report
@@ -103,7 +139,10 @@ export function NotificationsPane({
       // it twice in quick succession — the in-flight dedupe is for incidental
       // bursts of real notifications, not for an explicit user action.
       const soundResult = notificationSettings.customSoundPath
-        ? await window.api.notifications.playSound({ force: true })
+        ? await window.api.notifications.playSound({
+            force: true,
+            volume: notificationSettings.customSoundVolume
+          })
         : null
       if (notificationSettings.customSoundPath && soundResult && !soundResult.played) {
         toast.error('Custom notification sound could not be played')
@@ -232,6 +271,24 @@ export function NotificationsPane({
             </Button>
           ) : null}
         </div>
+        {selectedSoundPath ? (
+          <div className="flex items-center gap-3 pt-1">
+            <Volume2 className="size-4 text-muted-foreground" />
+            <Slider
+              value={[volumeDraft]}
+              min={0}
+              max={100}
+              step={5}
+              disabled={!notificationSettings.enabled}
+              onValueChange={([value]) => handleVolumeChange(value)}
+              className="flex-1"
+              aria-label="Notification sound volume"
+            />
+            <span className="w-10 text-right font-mono text-xs tabular-nums text-muted-foreground">
+              {volumeDraft}%
+            </span>
+          </div>
+        ) : null}
       </div>
 
       <Separator />

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -77,45 +77,31 @@ export function NotificationsPane({
   updateSettings
 }: NotificationsPaneProps): React.JSX.Element {
   const notificationSettings = settings.notifications
+  const notificationSettingsRef = useRef(notificationSettings)
   const [isPickingSound, setIsPickingSound] = useState(false)
 
   const updateNotificationSettings = (updates: Partial<GlobalSettings['notifications']>): void => {
     updateSettings({
       notifications: {
-        ...notificationSettings,
+        ...notificationSettingsRef.current,
         ...updates
       }
     })
   }
 
-  // Why: the slider fires onValueChange on every step while dragging. Persisting
-  // through IPC on every tick laggs the drag. Mirror the value locally for
-  // instant visual feedback and commit to settings 200ms after the last change,
-  // restarting the timer on each tick (autosave-style).
+  // Why: keep dragging local and persist only on Radix's commit event. That
+  // avoids IPC on every tick without a debounce timer that can race settings updates.
   const [volumeDraft, setVolumeDraft] = useState(notificationSettings.customSoundVolume)
-  const volumeCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    notificationSettingsRef.current = notificationSettings
     setVolumeDraft(notificationSettings.customSoundVolume)
-  }, [notificationSettings.customSoundVolume])
+  }, [notificationSettings])
 
-  useEffect(() => {
-    return () => {
-      if (volumeCommitTimer.current) {
-        clearTimeout(volumeCommitTimer.current)
-      }
-    }
-  }, [])
-
-  const handleVolumeChange = (value: number): void => {
-    setVolumeDraft(value)
-    if (volumeCommitTimer.current) {
-      clearTimeout(volumeCommitTimer.current)
-    }
-    volumeCommitTimer.current = setTimeout(() => {
-      volumeCommitTimer.current = null
+  const handleVolumeCommit = (value: number): void => {
+    if (notificationSettingsRef.current.customSoundVolume !== value) {
       updateNotificationSettings({ customSoundVolume: value })
-    }, 200)
+    }
   }
 
   const handleSendTestNotification = async (): Promise<void> => {
@@ -141,7 +127,7 @@ export function NotificationsPane({
       const soundResult = notificationSettings.customSoundPath
         ? await window.api.notifications.playSound({
             force: true,
-            volume: notificationSettings.customSoundVolume
+            volume: volumeDraft
           })
         : null
       if (notificationSettings.customSoundPath && soundResult && !soundResult.played) {
@@ -280,7 +266,8 @@ export function NotificationsPane({
               max={100}
               step={5}
               disabled={!notificationSettings.enabled}
-              onValueChange={([value]) => handleVolumeChange(value)}
+              onValueChange={([value]) => setVolumeDraft(value)}
+              onValueCommit={([value]) => handleVolumeCommit(value)}
               className="flex-1"
               aria-label="Notification sound volume"
             />

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -144,6 +144,7 @@ export function dispatchTerminalNotification(
   const worktree = getWorktreeMapFromState(state).get(worktreeId)
   const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
   const customSoundPath = state.settings?.notifications?.customSoundPath ?? null
+  const customSoundVolume = state.settings?.notifications?.customSoundVolume ?? null
   const agentStatus =
     event.source === 'agent-task-complete' && event.paneKey
       ? state.agentStatusByPaneKey[event.paneKey]
@@ -177,7 +178,7 @@ export function dispatchTerminalNotification(
     })
     .then((result) => {
       if (result.delivered) {
-        void playDesktopNotificationSound(customSoundPath)
+        void playDesktopNotificationSound(customSoundPath, customSoundVolume)
       }
     })
     .catch((err) => {

--- a/src/renderer/src/components/ui/slider.tsx
+++ b/src/renderer/src/components/ui/slider.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { Slider as SliderPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Slider({
+  className,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>): React.ReactElement {
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      className={cn(
+        'relative flex w-full touch-none select-none items-center',
+        'data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20"
+      >
+        <SliderPrimitive.Range data-slot="slider-range" className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        data-slot="slider-thumb"
+        className={cn(
+          'block size-4 rounded-full border border-primary/40 bg-background shadow-sm',
+          'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          'disabled:pointer-events-none disabled:opacity-50'
+        )}
+      />
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/src/renderer/src/lib/desktop-notification-sound.ts
+++ b/src/renderer/src/lib/desktop-notification-sound.ts
@@ -1,12 +1,15 @@
 export async function playDesktopNotificationSound(
-  customSoundPath: string | null | undefined
+  customSoundPath: string | null | undefined,
+  customSoundVolume?: number | null
 ): Promise<boolean> {
   if (!customSoundPath) {
     return false
   }
 
   try {
-    const result = await window.api.notifications.playSound()
+    const result = await window.api.notifications.playSound({
+      volume: customSoundVolume ?? undefined
+    })
     // Why: 'deduped' is expected when bursts of notifications coalesce — not a failure.
     if (!result.played && result.reason !== 'deduped') {
       console.warn('Failed to play custom notification sound:', result.reason)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -117,7 +117,8 @@ export function getDefaultNotificationSettings(): NotificationSettings {
     agentTaskComplete: true,
     terminalBell: false,
     suppressWhenFocused: true,
-    customSoundPath: null
+    customSoundPath: null,
+    customSoundVolume: 100
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1205,6 +1205,7 @@ export type NotificationSettings = {
   terminalBell: boolean
   suppressWhenFocused: boolean
   customSoundPath: string | null
+  customSoundVolume: number
 }
 
 export type CodexManagedAccount = {


### PR DESCRIPTION
## Summary

Add a 0-100% volume slider to Settings → Notifications. When a custom sound is selected, the chosen volume is applied to the cached `HTMLAudioElement` in the preload before each play, including the Test button. Slider is debounced (200ms) so dragging stays smooth without thrashing the settings store.

## Why

Quality-of-life. Custom audio files vary widely in loudness, and the playback path does no normalization — a "hot" mastered sample can be much louder than expected next to the rest of the system. Adjusting volume from the app is faster than re-encoding the file.

## Screenshots

<img width="1000" height="532" alt="image" src="https://github.com/user-attachments/assets/033ac48c-62e4-4d44-b5d7-455ac9f74388" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] No new automated tests added — the change wires a numeric setting into an existing `HTMLAudioElement.volume` assignment. Type-level coverage already exists; the rest is UI wiring. Manually verified via terminal bell at multiple volume levels.

## AI Review Report

Cross-platform checked: no platform branches added, no new keyboard shortcuts, no path handling. Volume slider is rendered only when a custom sound is set, otherwise the OS default sound is used (which Electron cannot control on any platform). Persistence path uses the existing deep-merge in `persistence.ts`, so installs with older settings are auto-filled with the new default (100). No new IPC surface beyond a `volume` field on the existing `playSound` payload.

## Security Audit

`customSoundVolume` is clamped to `[0, 1]` via `Math.min(1, Math.max(0, volume / 100))` in the preload before assignment to `HTMLAudioElement.volume`. No path handling, command execution, secrets, or auth surface touched. The settings sanitizer in `persistence.updateSettings` continues to deep-merge `notifications`, so a partial update from the renderer cannot clobber sibling fields.