### PR TITLE
Fix replayed terminal cursor style reset

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -32,6 +32,9 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
 // so replayed mode bits do not leak into the fresh shell. ghostty achieves
 // the same end by not restoring state at all.
 //
+//   0 SP q              — DECSCUSR cursor style/blink reset (raw replay can
+//                         carry a stale steady cursor override; reset to the
+//                         user's configured xterm cursor)
 //   25                  — DECTCEM cursor visibility (SerializeAddon captures
 //                         `?25l` when the cursor was hidden at snapshot time;
 //                         without an explicit `?25h` here the cursor stays
@@ -40,12 +43,17 @@ export const EMPTY_LAYOUT: TerminalLayoutSnapshot = {
 //   1004                — focus event reporting (the actual bug source)
 //   2004                — bracketed paste
 export const POST_REPLAY_MODE_RESET =
-  '\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l'
+  '\x1b[0 q\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1006l\x1b[?2004l'
 
 // Why: daemon snapshot restore reattaches to a live session, so we avoid the
 // full POST_REPLAY_MODE_RESET bundle there — a still-running TUI may still
-// rely on mouse or bracketed-paste modes. Two exceptions are safe to reset:
+// rely on mouse or bracketed-paste modes. Three exceptions are safe to reset:
 //
+//   0 q  — DECSCUSR cursor style/blink reset: raw replay can contain a stale
+//          steady cursor override, while SerializeAddon does not preserve an
+//          authoritative current cursor style. Reset to the user's configured
+//          xterm cursor; the post-reattach SIGWINCH lets live TUIs repaint if
+//          they need a different cursor.
 //   25   — DECTCEM cursor visibility: SerializeAddon bakes `?25l` into the
 //          snapshot when the cursor was hidden at capture time. Without `?25h`
 //          here the cursor stays invisible after reattach. If a TUI is still
@@ -55,7 +63,7 @@ export const POST_REPLAY_MODE_RESET =
 //   1004 — focus event reporting: preserving `?1004h` makes restored shells
 //          ring BEL on pane focus/blur (shells like zsh treat `\e[I`/`\e[O`
 //          as unbound key input).
-export const POST_REPLAY_FOCUS_REPORTING_RESET = '\x1b[?25h\x1b[?1004l'
+export const POST_REPLAY_REATTACH_RESET = '\x1b[0 q\x1b[?25h\x1b[?1004l'
 
 // Cross-platform monospace fallback chain ensures the terminal always has a
 // usable font regardless of OS.  macOS-only fonts like SF Mono and Menlo are

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines */
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { POST_REPLAY_FOCUS_REPORTING_RESET, POST_REPLAY_MODE_RESET } from './layout-serialization'
+import { POST_REPLAY_MODE_RESET, POST_REPLAY_REATTACH_RESET } from './layout-serialization'
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 
@@ -1837,7 +1837,7 @@ describe('connectPanePty', () => {
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-ssh-pty')
   })
 
-  it('resets focus reporting after daemon snapshot replay without applying the full mode reset', async () => {
+  it('resets reattach cursor/focus state after daemon snapshot replay without applying the full mode reset', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -1873,7 +1873,7 @@ describe('connectPanePty', () => {
       expect.any(Function)
     )
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      POST_REPLAY_FOCUS_REPORTING_RESET,
+      POST_REPLAY_REATTACH_RESET,
       expect.any(Function)
     )
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
@@ -3065,7 +3065,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
     expect(pane.terminal.write).toHaveBeenCalledWith('restored-ssh-output', expect.any(Function))
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      POST_REPLAY_FOCUS_REPORTING_RESET,
+      POST_REPLAY_REATTACH_RESET,
       expect.any(Function)
     )
     expect(api.pty.signal).toHaveBeenCalledWith('leaf-session', 'SIGWINCH')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -18,7 +18,7 @@ import { getFitOverrideForPty, bindPanePtyId } from '@/lib/pane-manager/mobile-f
 import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
 import { isPaneReplaying, replayIntoTerminal } from './replay-guard'
 import { terminalOutputPrefersDomRenderer } from '@/lib/pane-manager/terminal-complex-script'
-import { POST_REPLAY_MODE_RESET, POST_REPLAY_FOCUS_REPORTING_RESET } from './layout-serialization'
+import { POST_REPLAY_MODE_RESET, POST_REPLAY_REATTACH_RESET } from './layout-serialization'
 import { warnTerminalLifecycleAnomaly } from './terminal-lifecycle-diagnostics'
 import { registerPtySerializer, registerPtyTitleSource } from './pty-buffer-serializer'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
@@ -1220,9 +1220,9 @@ export function connectPanePty(
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.snapshot)
         // Snapshot reattach keeps a live session, so avoid the broader mode
-        // reset. Focus reporting is the unsafe exception: preserving `?1004h`
-        // can make restored shells ring BEL on pane focus/blur.
-        writeReplayData(POST_REPLAY_FOCUS_REPORTING_RESET)
+        // reset. We only drop stale cursor/focus state that should not leak
+        // from replay bytes into the restored renderer terminal.
+        writeReplayData(POST_REPLAY_REATTACH_RESET)
         if (connectResult.coldRestore) {
           // Snapshot superseded the cold-restore payload — ack it so the
           // daemon does not redeliver it on the next reattach.
@@ -1233,11 +1233,11 @@ export function connectPanePty(
       } else if (connectResult?.replay) {
         // Relay replay holds the last 100 KB of raw output. The xterm may
         // already hold pre-disconnect content; clear first to avoid
-        // duplication. Focus-reporting reset prevents BEL from stale mode
-        // bits in the replayed data.
+        // duplication. The reattach reset prevents stale cursor/focus mode
+        // bits in the replayed data from leaking into the restored terminal.
         writeReplayData('\x1b[2J\x1b[3J\x1b[H')
         writeReplayData(connectResult.replay)
-        writeReplayData(POST_REPLAY_FOCUS_REPORTING_RESET)
+        writeReplayData(POST_REPLAY_REATTACH_RESET)
         if (connectResult.coldRestore) {
           if (!isRemoteRuntimePtyId(ptyId)) {
             window.api.pty.ackColdRestore(ptyId)

--- a/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
+import { POST_REPLAY_MODE_RESET, POST_REPLAY_REATTACH_RESET } from './layout-serialization'
+
+const OLD_REATTACH_RESET_WITHOUT_CURSOR_STYLE = '\x1b[?25h\x1b[?1004l'
+
+type DecPrivateCursorState = {
+  cursorStyle?: string
+  cursorBlink?: boolean
+}
+
+type XtermWithCoreService = Terminal & {
+  _core?: {
+    coreService?: {
+      decPrivateModes?: DecPrivateCursorState
+    }
+    _coreService?: {
+      decPrivateModes?: DecPrivateCursorState
+    }
+  }
+}
+
+function readDecPrivateCursorState(term: Terminal): DecPrivateCursorState {
+  const core = (term as XtermWithCoreService)._core
+  const cursorState = core?.coreService?.decPrivateModes ?? core?._coreService?.decPrivateModes
+  return cursorState ? { ...cursorState } : {}
+}
+
+function writeTerminal(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve))
+}
+
+describe('terminal replay cursor state reset', () => {
+  it('clears stale DECSCUSR cursor overrides after live reattach replay', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true,
+      cursorStyle: 'bar',
+      cursorBlink: true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b[2 q')
+      expect(readDecPrivateCursorState(term)).toMatchObject({
+        cursorStyle: 'block',
+        cursorBlink: false
+      })
+
+      await writeTerminal(term, OLD_REATTACH_RESET_WITHOUT_CURSOR_STYLE)
+      expect(readDecPrivateCursorState(term)).toMatchObject({
+        cursorStyle: 'block',
+        cursorBlink: false
+      })
+
+      await writeTerminal(term, POST_REPLAY_REATTACH_RESET)
+      const cursorState = readDecPrivateCursorState(term)
+      expect(cursorState.cursorStyle).toBeUndefined()
+      expect(cursorState.cursorBlink).toBeUndefined()
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('clears stale DECSCUSR cursor overrides after cold-restore replay', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      allowProposedApi: true,
+      cursorStyle: 'bar',
+      cursorBlink: true
+    })
+
+    try {
+      await writeTerminal(term, '\x1b[6 q')
+      expect(readDecPrivateCursorState(term)).toMatchObject({
+        cursorStyle: 'bar',
+        cursorBlink: false
+      })
+
+      await writeTerminal(term, POST_REPLAY_MODE_RESET)
+      const cursorState = readDecPrivateCursorState(term)
+      expect(cursorState.cursorStyle).toBeUndefined()
+      expect(cursorState.cursorBlink).toBeUndefined()
+    } finally {
+      term.dispose()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Reset replayed DECSCUSR cursor style/blink state with `CSI 0 SP q` after terminal replay.
- Keep the reattach reset narrow: cursor presentation, cursor visibility, and focus reporting only.
- Add a regression test that reproduces the old solid-cursor state and verifies the reset clears it back to Orca's configured cursor.

## Proof
Old reset leaves xterm's DEC cursor override as steady block:

![Old reset leaves solid cursor](https://gist.githubusercontent.com/nwparker/8aadc2002eb255ef8f101a24cd9cf8cd/raw/d928f4434e43e392c1278e302d94decda454f945/01-old-reset-solid-cursor.svg)

Fixed reset clears the override so the configured blinking bar cursor is used:

![Fixed reset restores bar cursor](https://gist.githubusercontent.com/nwparker/8aadc2002eb255ef8f101a24cd9cf8cd/raw/44b57a42f8df3bc0ea977bb3151c0ac13c66d817/02-fixed-reset-bar-cursor.svg)

Cursor-state probe output: https://gist.githubusercontent.com/nwparker/8aadc2002eb255ef8f101a24cd9cf8cd/raw/04df33a341aa35c30422aa7e1df8aaf532ec1d25/cursor-state.json

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm oxlint src/renderer/src/components/terminal-pane/layout-serialization.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/terminal-replay-cursor-state.test.ts`
- `pnpm run typecheck:web`
- `npx electron-vite build --mode e2e`
- `SKIP_BUILD=1 npx playwright test tests/e2e/terminal-restart-persistence.spec.ts --config tests/playwright.config.ts --project electron-headless -g "daemon snapshot relaunch preserves the cursor on the shell prompt"`
