### PR TITLE
Fix terminal pane title input focus

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -24,6 +24,7 @@ import {
 } from './pane-fit-resize-observer'
 import { buildDefaultTerminalOptions } from './pane-terminal-options'
 import { ENABLE_WEBGL_RENDERER, attachWebgl, disposeWebgl } from './pane-webgl-renderer'
+import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
 
 // ---------------------------------------------------------------------------
 // Pane creation, terminal open/close, addon management
@@ -41,7 +42,7 @@ export function createPaneDOM(
   options: PaneManagerOptions,
   dragState: DragReorderState,
   dragCallbacks: DragReorderCallbacks,
-  onPointerDown: (id: number) => void,
+  onPointerDown: (id: number, options?: { focusTerminal?: boolean }) => void,
   onMouseEnter: (id: number, event: MouseEvent) => void
 ): ManagedPaneInternal {
   // Create .pane container
@@ -134,8 +135,10 @@ export function createPaneDOM(
   // the terminal. We must call focus: true here because after DOM reparenting
   // (e.g. splitPane moves the original pane into a flex container), xterm.js's
   // native click-to-focus on its internal textarea may not fire reliably.
-  container.addEventListener('pointerdown', () => {
-    onPointerDown(id)
+  container.addEventListener('pointerdown', (event) => {
+    onPointerDown(id, {
+      focusTerminal: shouldFocusTerminalFromPanePointerDown(event.target)
+    })
   })
 
   // Focus-follows-mouse handler: when the setting is enabled, hovering a

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -277,9 +277,9 @@ export class PaneManager {
       this.getDragCallbacks(),
       // Why: always re-focus even if already active — after splits the
       // browser's real textarea focus can lag the manager's activePaneId.
-      (paneId) => {
+      (paneId, options) => {
         if (!this.destroyed) {
-          this.setActivePane(paneId, { focus: true })
+          this.setActivePane(paneId, { focus: options?.focusTerminal !== false })
         }
       },
       (paneId, event) => {

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
+
+class FakeElement {
+  constructor(private readonly closestResult: FakeElement | null = null) {}
+
+  closest(): FakeElement | null {
+    return this.closestResult
+  }
+}
+
+describe('shouldFocusTerminalFromPanePointerDown', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Element', FakeElement)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('focuses the terminal for non-element targets', () => {
+    expect(shouldFocusTerminalFromPanePointerDown({} as EventTarget)).toBe(true)
+  })
+
+  it('focuses the terminal for ordinary pane surface clicks', () => {
+    const target = new FakeElement()
+
+    expect(shouldFocusTerminalFromPanePointerDown(target as unknown as Element)).toBe(true)
+  })
+
+  it('does not steal focus from pane-local controls', () => {
+    const control = new FakeElement()
+    const target = new FakeElement(control)
+
+    expect(shouldFocusTerminalFromPanePointerDown(target as unknown as Element)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
@@ -1,0 +1,21 @@
+const APP_CONTROL_SELECTOR = [
+  'input:not(.xterm-helper-textarea)',
+  'textarea:not(.xterm-helper-textarea)',
+  'select',
+  'button',
+  '[role="textbox"]',
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[contenteditable="plaintext-only"]',
+  '[data-pane-prevent-terminal-focus]'
+].join(',')
+
+export function shouldFocusTerminalFromPanePointerDown(target: EventTarget | null): boolean {
+  if (typeof Element === 'undefined' || !(target instanceof Element)) {
+    return true
+  }
+
+  // Why: pane-local app controls (for example the title editor) are portaled
+  // into the pane container; focusing xterm from their pointerdown blurs them.
+  return target.closest(APP_CONTROL_SELECTOR) === null
+}

--- a/tests/e2e/terminal-panes.spec.ts
+++ b/tests/e2e/terminal-panes.spec.ts
@@ -244,6 +244,29 @@ test.describe('Terminal Panes', () => {
     await expect(orcaPage.locator('.pane-title-text', { hasText: title })).toHaveCount(1)
   })
 
+  test('Set Title input stays open when clicked in a split terminal', async ({ orcaPage }) => {
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    await waitForPaneCount(orcaPage, 2)
+    await splitActiveTerminalPane(orcaPage, 'horizontal')
+    await waitForPaneCount(orcaPage, 3)
+
+    await openTerminalContextMenu(orcaPage)
+    await orcaPage.getByText('Set Title…', { exact: true }).click()
+
+    const titleInput = orcaPage.locator('.pane-title-input').first()
+    await expect(titleInput).toBeVisible()
+    await expect(titleInput).toBeFocused()
+
+    // Why: pane-level pointerdown focuses xterm for terminal clicks. Pane-local
+    // controls must be excluded or clicking the already-open title input blurs
+    // it and commits an empty title, which looks like the editor flashed closed.
+    await titleInput.click({ position: { x: 10, y: 10 } })
+    await orcaPage.waitForTimeout(250)
+
+    await expect(titleInput).toBeVisible()
+    await expect(titleInput).toBeFocused()
+  })
+
   test('Set Title survives an early blur during first focus handoff', async ({ orcaPage }) => {
     await openTerminalContextMenu(orcaPage)
     await orcaPage.evaluate(() => {


### PR DESCRIPTION
## Summary
- keep pane-local controls from being blurred by the terminal pane pointerdown focus handler
- preserve xterm focus behavior for normal terminal surface clicks
- add unit and e2e regression coverage for Set Title staying open when clicked in split panes

## Validation
- Reproduced in Electron via CDP before the fix: clicking the pane title input in a crowded split terminal closed it immediately.
- Verified in Electron via CDP after the fix: input remains visible and focused after click.
- pnpm exec vitest run src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
- pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-pointer-focus.ts src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-manager.ts tests/e2e/terminal-panes.spec.ts
- pnpm run typecheck:node
- pnpm run typecheck:web

## Note
- Targeted Playwright E2E was attempted, but the suite timed out during global setup/e2e build before the test body ran.

Made with [Orca](https://github.com/stablyai/orca) 🐋
