### PR TITLE
Fix Windows agent launch readiness matching

### DIFF
--- a/src/renderer/src/lib/agent-ready-wait.test.ts
+++ b/src/renderer/src/lib/agent-ready-wait.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitForAgentReady } from './agent-ready-wait'
+import { useAppStore } from '@/store'
+import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: vi.fn()
+  }
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: vi.fn()
+}))
+
+vi.mock('@/lib/tui-agent-startup', () => ({
+  isShellProcess: vi.fn(() => false)
+}))
+
+describe('waitForAgentReady', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('window', { setTimeout })
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      runtimePaneTitlesByTabId: {},
+      tabsByWorktree: {},
+      settings: {}
+    } as never)
+  })
+
+  it('recognizes a Windows foreground process reported as a full executable path', async () => {
+    vi.mocked(inspectRuntimeTerminalProcess).mockResolvedValue({
+      foregroundProcess: String.raw`C:\Users\dev\AppData\Roaming\npm\claude.exe`,
+      hasChildProcesses: false
+    })
+
+    await expect(waitForAgentReady('tab-1', 'claude', { timeoutMs: 1 })).resolves.toEqual({
+      ready: true,
+      reason: 'foreground-match'
+    })
+  })
+})

--- a/src/renderer/src/lib/agent-ready-wait.ts
+++ b/src/renderer/src/lib/agent-ready-wait.ts
@@ -1,4 +1,5 @@
 import { detectAgentStatusFromTitle } from '../../../shared/agent-detection'
+import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
 import { isShellProcess } from '@/lib/tui-agent-startup'
 import { useAppStore } from '@/store'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
@@ -92,11 +93,7 @@ export async function waitForAgentReady(
     try {
       const process = await inspectRuntimeTerminalProcess(useAppStore.getState().settings, ptyId)
       const foreground = process.foregroundProcess?.toLowerCase() ?? ''
-      if (
-        foreground === expectedProcess ||
-        foreground.startsWith(`${expectedProcess}.`) ||
-        foreground.endsWith(`/${expectedProcess}`)
-      ) {
+      if (isExpectedAgentProcess(foreground, expectedProcess)) {
         return { ready: true, reason: 'foreground-match' }
       }
 

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -8,6 +8,7 @@ import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import { isShellProcess } from '@/lib/tui-agent-startup'
 import type { OrcaHooks, TaskViewPresetId } from '../../../shared/types'
 import { normalizeHookCommandSourcePolicy } from '../../../shared/hook-command-source-policy'
+import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
 
 /**
  * Why: the TaskPage's preset buttons and the openTaskPage prefetcher both need
@@ -294,11 +295,7 @@ async function waitForAgentForeground(ptyId: string, expectedProcess: string): P
     try {
       const process = await inspectRuntimeTerminalProcess(useAppStore.getState().settings, ptyId)
       const foreground = process.foregroundProcess?.toLowerCase() ?? ''
-      const owns =
-        foreground === expectedProcess ||
-        foreground.startsWith(`${expectedProcess}.`) ||
-        foreground.endsWith(`/${expectedProcess}`)
-      if (owns) {
+      if (isExpectedAgentProcess(foreground, expectedProcess)) {
         return
       }
       if (attempt >= 4 && !isShellProcess(foreground)) {

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isRecognizedAgentType, recognizeAgentProcess } from './agent-process-recognition'
+import {
+  isExpectedAgentProcess,
+  isRecognizedAgentType,
+  recognizeAgentProcess
+} from './agent-process-recognition'
 
 describe('agent process recognition', () => {
   it('recognizes packaged Codex foreground process names', () => {
@@ -8,5 +12,13 @@ describe('agent process recognition', () => {
       processName: 'codex-aarch64-ap'
     })
     expect(isRecognizedAgentType('codex-aarch64-ap')).toBe(true)
+  })
+
+  it('matches expected agents from platform-specific foreground process paths', () => {
+    expect(
+      isExpectedAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\claude.exe`, 'claude')
+    ).toBe(true)
+    expect(isExpectedAgentProcess('/usr/local/bin/claude', 'claude')).toBe(true)
+    expect(isExpectedAgentProcess('powershell.exe', 'claude')).toBe(false)
   })
 })

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -55,6 +55,21 @@ function agentForNormalizedProcess(normalized: string): TuiAgent | undefined {
   return undefined
 }
 
+export function isExpectedAgentProcess(
+  processName: string | null | undefined,
+  expectedProcess: string
+): boolean {
+  const normalizedProcess = normalizeProcessName(processName)
+  const normalizedExpected = normalizeProcessName(expectedProcess)
+  if (!normalizedProcess || !normalizedExpected) {
+    return false
+  }
+  return (
+    normalizedProcess === normalizedExpected ||
+    normalizedProcess.startsWith(`${normalizedExpected}.`)
+  )
+}
+
 export function recognizeAgentProcess(
   processName: string | null | undefined
 ): RecognizedAgentProcess | null {


### PR DESCRIPTION
## Summary

Fixes #2367 by normalizing foreground process names before the agent launch readiness watchdog compares them with the expected agent binary. Windows full paths such as `C:\Users\dev\AppData\Roaming\npm\claude.exe` now match `claude`, so the quick-launch timeout toast does not fire after a successful agent launch.

The same shared matcher is used by the new-workspace followup wait path to keep launch readiness behavior consistent.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional targeted checks run:

- [x] Reproduced the bug first with `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-ready-wait.test.ts`; before the fix, the Windows full-path foreground process timed out.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-ready-wait.test.ts src/shared/agent-process-recognition.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/tui-agent-startup.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/agent-ready-wait.test.ts src/shared/agent-process-recognition.test.ts`
- [x] `pnpm exec oxlint src/shared/agent-process-recognition.ts src/shared/agent-process-recognition.test.ts src/renderer/src/lib/agent-ready-wait.ts src/renderer/src/lib/agent-ready-wait.test.ts src/renderer/src/lib/new-workspace.ts`

## AI Review Report

Reviewed the launch readiness paths that compare `foregroundProcess` to `expectedProcess`. The main risk was fixing only the quick-launch watchdog while leaving the duplicated new-workspace followup wait with slash-sensitive matching, so both now call the same shared matcher.

Cross-platform compatibility checked: the matcher strips either `/` or `\` path separators and common Windows executable/script extensions while preserving existing macOS/Linux basename behavior. No keyboard shortcuts, shortcut labels, shell command construction, IPC contracts, or Electron platform APIs were changed.

## Security Audit

This change only normalizes a process-name string returned by existing terminal inspection before comparison. It does not execute commands, expand paths, read files, change auth/secrets handling, add dependencies, or introduce new IPC. The process string is treated as untrusted display/inspection data and is not used for command construction.

## Notes

`pnpm typecheck` completed successfully but warned that the local shell is using Node `v25.9.0` while the repo declares Node `24`.