### PR TITLE
Add continuing activation re-entry

### DIFF
--- a/docs/design/continuing-activation-reentry.md
+++ b/docs/design/continuing-activation-reentry.md
@@ -15,7 +15,7 @@ Included candidates:
 - `agent_needs_input`: an agent is waiting for input or permission. Backed by live explicit agent status when available, with terminal-title permission status as a fallback.
 - `agent_ready_for_review`: an agent reached an idle/done state and the user has not reviewed it. Backed by explicit done status when available and by a local-only cue recorded from Orca's existing working-to-idle agent transition.
 
-The local cue stores only `kind`, `worktreeId`, `tabId`, and timestamps in the existing workspace session. It does not store prompt text, command output, paths, repo names, branch names, file names, or terminal titles. `worktreeId` remains local session state; telemetry never includes it.
+The local cue stores only `kind`, `tabId`, and timestamps in the existing workspace session. It does not store prompt text, command output, paths, repo names, branch names, file names, worktree ids, or terminal titles. Telemetry never includes target ids.
 
 ## Deferred candidates
 

--- a/docs/design/continuing-activation-reentry.md
+++ b/docs/design/continuing-activation-reentry.md
@@ -1,0 +1,71 @@
+# Continuing activation re-entry
+
+Date: 2026-05-20
+
+## Problem
+
+Fresh and shallow Orca users often add a project or start an agent, then leave before forming a habit. The retention bet is not generic session memory. It is a small in-app nudge toward the next concrete activation action when Orca already has reliable state for that action.
+
+## V1 scope
+
+V1 ranks and surfaces one next action in the existing sidebar. It does not interrupt the user and does not add new OS notifications.
+
+Included candidates:
+
+- `agent_needs_input`: an agent is waiting for input or permission. Backed by live explicit agent status when available, with terminal-title permission status as a fallback.
+- `agent_ready_for_review`: an agent reached an idle/done state and the user has not reviewed it. Backed by explicit done status when available and by a local-only cue recorded from Orca's existing working-to-idle agent transition.
+
+The local cue stores only `kind`, `worktreeId`, `tabId`, and timestamps in the existing workspace session. It does not store prompt text, command output, paths, repo names, branch names, file names, or terminal titles. `worktreeId` remains local session state; telemetry never includes it.
+
+## Deferred candidates
+
+- Blocked setup or integration retry: current setup-script recovery state is not reliable enough to distinguish failed setup from generic terminal output.
+- Selected issue/PR/task not started: task caches are not user intent, and composer modal state is not a durable activation signal.
+- Configured but unused onboarding feature: no trustworthy persisted feature-used state was found in this branch.
+- First workspace after repo add: residual project setup is already in progress and should not be re-scoped here.
+- Competitor setup import: already in progress and maps to `orca.yaml`, not Add Project setup actions.
+
+## Surface
+
+The sidebar gets a compact “Next action” row between the global nav and workspace list. The row shows one high-confidence candidate and offers:
+
+- Open: activates the target workspace and tab through the existing activation helper.
+- Dismiss: hides the cue for the current session or persisted cue.
+
+The surface is intentionally small and only appears when the target is not already the active visible terminal tab.
+
+## Ranking
+
+Highest priority wins:
+
+1. Agent needs input or permission.
+2. Agent output is ready for review.
+
+Within a priority bucket, newer state wins. Candidate generation validates that the worktree and tab still exist before surfacing a cue.
+
+## Telemetry gate
+
+Question: Do continuing-activation candidates create meaningful second-session action, or are they ignored/dismissed?
+
+Decision owner/use: Product uses this to decide whether to expand next-action re-entry beyond agent attention into setup recovery or task-start candidates.
+
+Dashboard: Orca retention dashboard, proposed “Continuing activation candidate funnel” tile.
+
+Action: If shown-to-click or clicked-to-landed is weak, keep the surface narrow or remove it. If it is strong, add the next reliable candidate class.
+
+Telemetry volume estimate:
+
+- Trigger: candidate shown, clicked, dismissed, landed.
+- Expected events/user/day: 0-4 for most users with active agents.
+- Max events/user/day: bounded by visible top-candidate changes and explicit user actions; power users can create more, but this is not timer-based.
+- At 1,000 DAU: expected under 4,000 events/day.
+- Monthly at 1,000 DAU: expected under 120,000 events/month.
+- Approval note: events are low-cardinality enums only and answer whether this retention surface should expand.
+
+Payload contains only candidate kind and surface enum. It never includes prompts, repo/workspace names, paths, branch names, file names, URLs, commands, hostnames, or ids.
+
+Candidate IDs and runtime dismissal keys are also privacy-neutral. They use candidate kind, source, tab id, pane id, cue id, and timestamps only; they do not include terminal titles, prompts, repo/workspace names, branches, paths, or file names.
+
+## SSH and platform notes
+
+Candidate actions use `activateAndRevealWorktree`, which already handles SSH-backed worktrees through the standard renderer state and terminal activation path. No path parsing is added. Keyboard labels are not introduced.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -95,6 +95,7 @@ function App(): React.JSX.Element {
       hydrateTabsSession: s.hydrateTabsSession,
       hydrateEditorSession: s.hydrateEditorSession,
       hydrateBrowserSession: s.hydrateBrowserSession,
+      hydrateContinuingActivationSession: s.hydrateContinuingActivationSession,
       fetchBrowserSessionProfiles: s.fetchBrowserSessionProfiles,
       reconnectPersistedTerminals: s.reconnectPersistedTerminals,
       setDeferredSshReconnectTargets: s.setDeferredSshReconnectTargets,
@@ -105,7 +106,8 @@ function App(): React.JSX.Element {
       toggleRightSidebar: s.toggleRightSidebar,
       setRightSidebarOpen: s.setRightSidebarOpen,
       setRightSidebarTab: s.setRightSidebarTab,
-      updateSettings: s.updateSettings
+      updateSettings: s.updateSettings,
+      clearContinuingActivationCuesForTarget: s.clearContinuingActivationCuesForTarget
     }))
   )
 
@@ -232,6 +234,7 @@ function App(): React.JSX.Element {
           actions.hydrateTabsSession(session)
           actions.hydrateEditorSession(session)
           actions.hydrateBrowserSession(session)
+          actions.hydrateContinuingActivationSession(session)
           await actions.fetchBrowserSessionProfiles()
 
           // Why: SSH connections must be re-established BEFORE terminal
@@ -342,13 +345,16 @@ function App(): React.JSX.Element {
             dismissedUpdateVersion: null,
             lastUpdateCheckAt: null
           })
-          actions.hydrateWorkspaceSession({
+          const emptySession = {
             activeRepoId: null,
             activeWorktreeId: null,
             activeTabId: null,
             tabsByWorktree: {},
-            terminalLayoutsByTabId: {}
-          })
+            terminalLayoutsByTabId: {},
+            continuingActivationCues: {}
+          }
+          actions.hydrateWorkspaceSession(emptySession)
+          actions.hydrateContinuingActivationSession(emptySession)
           // Why: hydrateWorkspaceSession no longer sets workspaceSessionReady.
           // The error path has no worktrees to reconnect, but must still flip
           // the flag so auto-tab-creation and session writes are unblocked.
@@ -525,6 +531,32 @@ function App(): React.JSX.Element {
   const effectiveActiveTabExpanded = effectiveActiveTabId
     ? (expandedPaneByTabId[effectiveActiveTabId] ?? false)
     : false
+
+  useEffect(() => {
+    const clearViewedContinuingActivationCue = (): void => {
+      if (activeView !== 'terminal' || !activeWorktreeId || !effectiveActiveTabId) {
+        return
+      }
+      if (document.visibilityState !== 'visible' || !document.hasFocus()) {
+        return
+      }
+      // Why: review cues are local breadcrumbs; landing on the tab by any path
+      // should satisfy them so they do not reappear after a manual visit.
+      actions.clearContinuingActivationCuesForTarget({
+        worktreeId: activeWorktreeId,
+        tabId: effectiveActiveTabId
+      })
+    }
+
+    clearViewedContinuingActivationCue()
+    window.addEventListener('focus', clearViewedContinuingActivationCue)
+    document.addEventListener('visibilitychange', clearViewedContinuingActivationCue)
+    return () => {
+      window.removeEventListener('focus', clearViewedContinuingActivationCue)
+      document.removeEventListener('visibilitychange', clearViewedContinuingActivationCue)
+    }
+  }, [activeView, activeWorktreeId, effectiveActiveTabId, actions])
+
   const showTitlebarExpandButton =
     activeView === 'terminal' &&
     activeWorktreeId !== null &&

--- a/src/renderer/src/components/sidebar/ContinuingActivationCard.tsx
+++ b/src/renderer/src/components/sidebar/ContinuingActivationCard.tsx
@@ -1,0 +1,174 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import { ArrowRight, CheckCircle2, CircleAlert, X } from 'lucide-react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import {
+  getTopContinuingActivationCandidate,
+  type ContinuingActivationCandidate
+} from '@/lib/continuing-activation-candidates'
+import {
+  createContinuingActivationShownRecorder,
+  trackContinuingActivationCandidate
+} from '@/lib/continuing-activation-telemetry'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { cn } from '@/lib/utils'
+
+const SURFACE = 'sidebar_next_action' as const
+
+const CANDIDATE_COPY = {
+  agent_needs_input: {
+    eyebrow: 'Next action',
+    title: 'Respond to agent',
+    detail: 'An agent is waiting for input.',
+    cta: 'Open',
+    icon: CircleAlert
+  },
+  agent_ready_for_review: {
+    eyebrow: 'Next action',
+    title: 'Review agent output',
+    detail: 'New agent output is ready.',
+    cta: 'Review',
+    icon: CheckCircle2
+  }
+} as const
+
+function ContinuingActivationCard(): React.JSX.Element | null {
+  const candidateState = useAppStore(
+    useShallow((s) => ({
+      activeView: s.activeView,
+      activeWorktreeId: s.activeWorktreeId,
+      activeTabId: s.activeTabId,
+      worktreesByRepo: s.worktreesByRepo,
+      tabsByWorktree: s.tabsByWorktree,
+      runtimePaneTitlesByTabId: s.runtimePaneTitlesByTabId,
+      agentStatusByPaneKey: s.agentStatusByPaneKey,
+      retainedAgentsByPaneKey: s.retainedAgentsByPaneKey,
+      continuingActivationCues: s.continuingActivationCues,
+      acknowledgedAgentsByPaneKey: s.acknowledgedAgentsByPaneKey,
+      dismissedContinuingActivationCandidateIds: s.dismissedContinuingActivationCandidateIds,
+      agentStatusEpoch: s.agentStatusEpoch
+    }))
+  )
+  const dismissContinuingActivationCandidate = useAppStore(
+    (s) => s.dismissContinuingActivationCandidate
+  )
+  const dismissContinuingActivationCue = useAppStore((s) => s.dismissContinuingActivationCue)
+  const clearContinuingActivationCue = useAppStore((s) => s.clearContinuingActivationCue)
+  const acknowledgeAgents = useAppStore((s) => s.acknowledgeAgents)
+
+  const candidate = useMemo(
+    () => getTopContinuingActivationCandidate(candidateState, Date.now()),
+    // agentStatusEpoch is read only to force freshness-boundary recomputes.
+    [candidateState]
+  )
+  const shownRecorderRef = useRef(createContinuingActivationShownRecorder())
+
+  useEffect(() => {
+    if (candidate) {
+      shownRecorderRef.current(candidate, SURFACE)
+    }
+  }, [candidate])
+
+  const openCandidate = useCallback(
+    (target: ContinuingActivationCandidate): void => {
+      trackContinuingActivationCandidate('continuing_activation_candidate_clicked', target, SURFACE)
+      const result = activateAndRevealWorktree(target.worktreeId)
+      if (!result) {
+        return
+      }
+      const state = useAppStore.getState()
+      if (target.tabId) {
+        const tabs = state.tabsByWorktree[target.worktreeId] ?? []
+        if (tabs.some((tab) => tab.id === target.tabId)) {
+          state.setActiveTab(target.tabId)
+        }
+      }
+      if (target.paneKey) {
+        acknowledgeAgents([target.paneKey])
+      }
+      if (target.cueId) {
+        clearContinuingActivationCue(target.cueId)
+      }
+      trackContinuingActivationCandidate('continuing_activation_candidate_landed', target, SURFACE)
+    },
+    [acknowledgeAgents, clearContinuingActivationCue]
+  )
+
+  const worktree = candidate
+    ? findWorktreeById(candidateState.worktreesByRepo, candidate.worktreeId)
+    : undefined
+  if (!candidate || !worktree) {
+    return null
+  }
+
+  const copy = CANDIDATE_COPY[candidate.kind]
+  const Icon = copy.icon
+
+  const handleDismiss = (event: React.MouseEvent): void => {
+    event.stopPropagation()
+    if (candidate.cueId) {
+      dismissContinuingActivationCue(candidate.cueId)
+    } else {
+      dismissContinuingActivationCandidate(candidate.id)
+    }
+    trackContinuingActivationCandidate(
+      'continuing_activation_candidate_dismissed',
+      candidate,
+      SURFACE
+    )
+  }
+
+  const handleOpen = (): void => {
+    openCandidate(candidate)
+  }
+
+  return (
+    <div className="px-2 pb-2">
+      <div className="rounded-md border border-sidebar-border/70 bg-sidebar-accent/35 p-2 shadow-sm">
+        <div className="mb-1.5 flex items-center gap-1.5">
+          <Icon
+            className={cn(
+              'size-3.5 shrink-0',
+              candidate.kind === 'agent_needs_input' ? 'text-red-500' : 'text-emerald-500'
+            )}
+            aria-hidden
+          />
+          <div className="min-w-0 flex-1">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80">
+              {copy.eyebrow}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss next action"
+            className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-foreground"
+          >
+            <X className="size-3" aria-hidden />
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="group flex w-full items-center gap-2 rounded px-1.5 py-1 text-left transition-colors hover:bg-sidebar-accent/70"
+        >
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[13px] font-medium text-sidebar-foreground">
+              {copy.title}
+            </span>
+            <span className="block truncate text-[11px] text-muted-foreground">
+              {worktree.displayName ? `${copy.detail} ${worktree.displayName}` : copy.detail}
+            </span>
+          </span>
+          <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground transition-colors group-hover:text-foreground">
+            {copy.cta}
+            <ArrowRight className="size-3" aria-hidden />
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default React.memo(ContinuingActivationCard)

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import SidebarHeader from './SidebarHeader'
 import SidebarNav from './SidebarNav'
+import ContinuingActivationCard from './ContinuingActivationCard'
 import WorktreeList from './WorktreeList'
 import SidebarToolbar from './SidebarToolbar'
 import WorktreeMetaDialog from './WorktreeMetaDialog'
@@ -48,6 +49,7 @@ function Sidebar(): React.JSX.Element {
       >
         {/* Fixed controls */}
         <SidebarNav />
+        <ContinuingActivationCard />
         <SidebarHeader />
 
         <WorktreeList />

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1005,7 +1005,6 @@ describe('connectPanePty', () => {
 
     expect(mockStoreState.recordContinuingActivationCue).toHaveBeenCalledWith({
       kind: 'agent_ready_for_review',
-      worktreeId: 'wt-1',
       tabId: 'tab-1'
     })
     expect(deps.markWorktreeUnread).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -25,6 +25,7 @@ type StoreState = {
   removeDeferredSshSessionId: ReturnType<typeof vi.fn>
   consumePendingColdRestore: ReturnType<typeof vi.fn>
   consumePendingSnapshot: ReturnType<typeof vi.fn>
+  recordContinuingActivationCue: ReturnType<typeof vi.fn>
 }
 
 type ConnectCallbacks = {
@@ -227,6 +228,7 @@ describe('connectPanePty', () => {
       removeDeferredSshSessionId: vi.fn(),
       consumePendingColdRestore: vi.fn(() => null),
       consumePendingSnapshot: vi.fn(() => null),
+      recordContinuingActivationCue: vi.fn(),
       removeAgentStatus: vi.fn()
     } as StoreState
     ;(globalThis as unknown as { window: unknown }).window = {
@@ -1001,6 +1003,11 @@ describe('connectPanePty', () => {
 
     idleHandler('* Claude done')
 
+    expect(mockStoreState.recordContinuingActivationCue).toHaveBeenCalledWith({
+      kind: 'agent_ready_for_review',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1'
+    })
     expect(deps.markWorktreeUnread).not.toHaveBeenCalled()
     expect(deps.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(window.api.notifications.dispatch).toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -265,7 +265,6 @@ export function connectPanePty(
       // existing completion signal, never the terminal title or output.
       useAppStore.getState().recordContinuingActivationCue({
         kind: 'agent_ready_for_review',
-        worktreeId: deps.worktreeId,
         tabId: deps.tabId
       })
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1,7 +1,11 @@
 /* oxlint-disable max-lines */
 import type { PaneManager, ManagedPane } from '@/lib/pane-manager/pane-manager'
 import type { IDisposable } from '@xterm/xterm'
-import { isGeminiTerminalTitle, isClaudeAgent } from '@/lib/agent-status'
+import {
+  detectAgentStatusFromTitle,
+  isGeminiTerminalTitle,
+  isClaudeAgent
+} from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { toast } from 'sonner'
@@ -256,6 +260,15 @@ export function connectPanePty(
   // Double-firing with a concurrent BEL is handled by the 5 s per-worktree
   // dedupe in main/ipc/notifications.ts.
   const onAgentBecameIdle = (title: string): void => {
+    if (detectAgentStatusFromTitle(title) === 'idle') {
+      // Why: re-entry should persist only neutral target ids from this
+      // existing completion signal, never the terminal title or output.
+      useAppStore.getState().recordContinuingActivationCue({
+        kind: 'agent_ready_for_review',
+        worktreeId: deps.worktreeId,
+        tabId: deps.tabId
+      })
+    }
     // Why: only start the prompt-cache countdown for Claude agents — other
     // agents have different (or no) prompt-caching semantics and showing a
     // timer for them would be misleading.

--- a/src/renderer/src/lib/continuing-activation-candidate-ids.ts
+++ b/src/renderer/src/lib/continuing-activation-candidate-ids.ts
@@ -1,0 +1,13 @@
+export function buildTerminalTitlePaneCandidateId({
+  tabId,
+  paneId
+}: {
+  tabId: string
+  paneId: string | number
+}): string {
+  return `agent_needs_input:terminal_title:${tabId}:${paneId}`
+}
+
+export function buildTerminalTitleTabCandidateId({ tabId }: { tabId: string }): string {
+  return `agent_needs_input:terminal_title:${tabId}:tab`
+}

--- a/src/renderer/src/lib/continuing-activation-candidates.test.ts
+++ b/src/renderer/src/lib/continuing-activation-candidates.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import type { ContinuingActivationCue, TerminalTab, Worktree } from '../../../shared/types'
+import {
+  getContinuingActivationCandidates,
+  getTopContinuingActivationCandidate,
+  type ContinuingActivationCandidateState
+} from './continuing-activation-candidates'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+
+function makeWorktree(overrides: Partial<Worktree> & { id: string }): Worktree {
+  const { id, ...rest } = overrides
+  return {
+    id,
+    repoId: 'repo-1',
+    path: '/private/repo/worktree',
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Customer Repo',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...rest
+  }
+}
+
+function makeTab(
+  overrides: Partial<TerminalTab> & { id: string; worktreeId: string }
+): TerminalTab {
+  return {
+    ptyId: 'pty-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 100,
+    ...overrides
+  }
+}
+
+function makeEntry(overrides: Partial<AgentStatusEntry>): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: '',
+    updatedAt: 1_000,
+    stateStartedAt: 1_000,
+    paneKey: 'tab-1:1',
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+function makeState(
+  overrides: Partial<ContinuingActivationCandidateState> = {}
+): ContinuingActivationCandidateState {
+  const worktree = makeWorktree({ id: 'wt-1' })
+  const tab = makeTab({ id: 'tab-1', worktreeId: worktree.id })
+  return {
+    activeView: 'terminal',
+    activeWorktreeId: null,
+    activeTabId: null,
+    worktreesByRepo: { [worktree.repoId]: [worktree] },
+    tabsByWorktree: { [worktree.id]: [tab] },
+    runtimePaneTitlesByTabId: {},
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    continuingActivationCues: {},
+    acknowledgedAgentsByPaneKey: {},
+    dismissedContinuingActivationCandidateIds: {},
+    ...overrides
+  }
+}
+
+describe('getContinuingActivationCandidates', () => {
+  it('prioritizes agent input over review candidates', () => {
+    const state = makeState({
+      agentStatusByPaneKey: {
+        'tab-1:1': makeEntry({
+          state: 'done',
+          paneKey: 'tab-1:1',
+          stateStartedAt: 1_000
+        }),
+        'tab-1:2': makeEntry({
+          state: 'waiting',
+          paneKey: 'tab-1:2',
+          stateStartedAt: 900
+        })
+      }
+    })
+
+    expect(getTopContinuingActivationCandidate(state, 1_100)?.kind).toBe('agent_needs_input')
+  })
+
+  it('omits raw terminal-title text from fallback candidate ids', () => {
+    const sensitiveTitle = 'Cursor - action required in /Users/alice/secret-project'
+    const state = makeState({
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          7: sensitiveTitle
+        }
+      }
+    })
+
+    const candidate = getTopContinuingActivationCandidate(state, 1_100)
+    expect(candidate).toMatchObject({
+      kind: 'agent_needs_input',
+      source: 'terminal_title',
+      id: 'agent_needs_input:terminal_title:tab-1:7'
+    })
+    expect(candidate?.id).not.toContain('secret-project')
+    expect(candidate?.id).not.toContain('/Users')
+    expect(candidate?.id).not.toContain('action required')
+  })
+
+  it('uses content-neutral ids for tab-title fallback candidates too', () => {
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-1': [
+          makeTab({
+            id: 'tab-1',
+            worktreeId: 'wt-1',
+            title: 'Claude needs permission for C:\\Users\\Alice\\secret'
+          })
+        ]
+      }
+    })
+
+    const candidate = getTopContinuingActivationCandidate(state, 1_100)
+    expect(candidate?.id).toBe('agent_needs_input:terminal_title:tab-1:tab')
+    expect(candidate?.id).not.toContain('Alice')
+    expect(candidate?.id).not.toContain('secret')
+  })
+
+  it('hides candidates already visible in the active terminal tab', () => {
+    const state = makeState({
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-1',
+      agentStatusByPaneKey: {
+        'tab-1:1': makeEntry({ state: 'waiting', paneKey: 'tab-1:1' })
+      }
+    })
+
+    expect(getContinuingActivationCandidates(state, 1_100)).toEqual([])
+  })
+
+  it('treats the first tab as visible when no active tab id is stored', () => {
+    const state = makeState({
+      activeWorktreeId: 'wt-1',
+      activeTabId: null,
+      agentStatusByPaneKey: {
+        'tab-1:1': makeEntry({ state: 'waiting', paneKey: 'tab-1:1' })
+      }
+    })
+
+    expect(getContinuingActivationCandidates(state, 1_100)).toEqual([])
+  })
+
+  it('surfaces local review cues and respects cue dismissal', () => {
+    const cue: ContinuingActivationCue = {
+      id: 'agent_ready_for_review:tab-1',
+      kind: 'agent_ready_for_review',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      createdAt: 1_000
+    }
+    const state = makeState({ continuingActivationCues: { [cue.id]: cue } })
+    expect(getTopContinuingActivationCandidate(state, 1_100)?.source).toBe('agent_completion_cue')
+
+    const dismissed = makeState({
+      continuingActivationCues: { [cue.id]: { ...cue, dismissedAt: 1_050 } }
+    })
+    expect(getTopContinuingActivationCandidate(dismissed, 1_100)).toBeNull()
+  })
+
+  it('does not resurface acknowledged retained done rows', () => {
+    const entry = makeEntry({
+      state: 'done',
+      paneKey: 'tab-1:1',
+      stateStartedAt: 1_000
+    })
+    const retained: RetainedAgentEntry = {
+      entry,
+      worktreeId: 'wt-1',
+      tab: makeTab({ id: 'tab-1', worktreeId: 'wt-1' }),
+      agentType: 'claude',
+      startedAt: 900
+    }
+
+    const state = makeState({
+      retainedAgentsByPaneKey: { 'tab-1:1': retained },
+      acknowledgedAgentsByPaneKey: { 'tab-1:1': 1_001 }
+    })
+
+    expect(getTopContinuingActivationCandidate(state, 1_100)).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/continuing-activation-candidates.test.ts
+++ b/src/renderer/src/lib/continuing-activation-candidates.test.ts
@@ -167,7 +167,6 @@ describe('getContinuingActivationCandidates', () => {
     const cue: ContinuingActivationCue = {
       id: 'agent_ready_for_review:tab-1',
       kind: 'agent_ready_for_review',
-      worktreeId: 'wt-1',
       tabId: 'tab-1',
       createdAt: 1_000
     }
@@ -178,6 +177,25 @@ describe('getContinuingActivationCandidates', () => {
       continuingActivationCues: { [cue.id]: { ...cue, dismissedAt: 1_050 } }
     })
     expect(getTopContinuingActivationCandidate(dismissed, 1_100)).toBeNull()
+  })
+
+  it('derives cue targets from the tab index instead of persisted worktree ids', () => {
+    const cue: ContinuingActivationCue = {
+      id: 'agent_ready_for_review:tab-1',
+      kind: 'agent_ready_for_review',
+      tabId: 'tab-1',
+      createdAt: 1_000
+    }
+    const candidate = getTopContinuingActivationCandidate(
+      makeState({ continuingActivationCues: { [cue.id]: cue } }),
+      1_100
+    )
+
+    expect(candidate).toMatchObject({
+      source: 'agent_completion_cue',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1'
+    })
   })
 
   it('does not resurface acknowledged retained done rows', () => {

--- a/src/renderer/src/lib/continuing-activation-candidates.ts
+++ b/src/renderer/src/lib/continuing-activation-candidates.ts
@@ -1,0 +1,256 @@
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../shared/agent-status-types'
+import type { ContinuingActivationCue, TerminalTab, Worktree } from '../../../shared/types'
+import { detectAgentStatusFromTitle, isExplicitAgentStatusFresh } from './agent-status'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+
+export type ContinuingActivationCandidateKind = 'agent_needs_input' | 'agent_ready_for_review'
+
+export type ContinuingActivationCandidateSource =
+  | 'live_agent_status'
+  | 'retained_agent_status'
+  | 'terminal_title'
+  | 'agent_completion_cue'
+
+export type ContinuingActivationCandidate = {
+  id: string
+  kind: ContinuingActivationCandidateKind
+  source: ContinuingActivationCandidateSource
+  worktreeId: string
+  tabId: string | null
+  paneKey?: string
+  cueId?: string
+  rank: number
+  updatedAt: number
+}
+
+export type ContinuingActivationCandidateState = {
+  activeView: 'terminal' | 'settings' | 'tasks'
+  activeWorktreeId: string | null
+  activeTabId: string | null
+  worktreesByRepo: Record<string, Worktree[]>
+  tabsByWorktree: Record<string, TerminalTab[]>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
+  continuingActivationCues: Record<string, ContinuingActivationCue>
+  acknowledgedAgentsByPaneKey: Record<string, number>
+  dismissedContinuingActivationCandidateIds: Record<string, true>
+}
+
+type TabIndexEntry = {
+  worktreeId: string
+  tab: TerminalTab
+}
+
+function collectLiveWorktreeIds(worktreesByRepo: Record<string, Worktree[]>): Set<string> {
+  const ids = new Set<string>()
+  for (const worktrees of Object.values(worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      if (!worktree.isArchived) {
+        ids.add(worktree.id)
+      }
+    }
+  }
+  return ids
+}
+
+function buildTabIndex(tabsByWorktree: Record<string, TerminalTab[]>): Map<string, TabIndexEntry> {
+  const index = new Map<string, TabIndexEntry>()
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs) {
+      index.set(tab.id, { worktreeId, tab })
+    }
+  }
+  return index
+}
+
+function tabIdFromPaneKey(paneKey: string): string | null {
+  const sepIdx = paneKey.indexOf(':')
+  return sepIdx > 0 ? paneKey.slice(0, sepIdx) : null
+}
+
+function isVisibleTarget(
+  state: ContinuingActivationCandidateState,
+  worktreeId: string,
+  tabId: string | null
+): boolean {
+  if (state.activeView !== 'terminal' || state.activeWorktreeId !== worktreeId) {
+    return false
+  }
+  const visibleTabId = state.activeTabId ?? state.tabsByWorktree[worktreeId]?.[0]?.id ?? null
+  return tabId === null || visibleTabId === tabId
+}
+
+function isUnvisitedAgentState(
+  entry: Pick<AgentStatusEntry, 'stateStartedAt'>,
+  paneKey: string,
+  acknowledgedAgentsByPaneKey: Record<string, number>
+): boolean {
+  return (acknowledgedAgentsByPaneKey[paneKey] ?? 0) < entry.stateStartedAt
+}
+
+function candidateSort(
+  left: ContinuingActivationCandidate,
+  right: ContinuingActivationCandidate
+): number {
+  return (
+    right.rank - left.rank || right.updatedAt - left.updatedAt || left.id.localeCompare(right.id)
+  )
+}
+
+export function getContinuingActivationCandidates(
+  state: ContinuingActivationCandidateState,
+  now: number = Date.now()
+): ContinuingActivationCandidate[] {
+  const liveWorktreeIds = collectLiveWorktreeIds(state.worktreesByRepo)
+  const tabIndex = buildTabIndex(state.tabsByWorktree)
+  const candidates = new Map<string, ContinuingActivationCandidate>()
+
+  const addCandidate = (candidate: ContinuingActivationCandidate): void => {
+    if (!liveWorktreeIds.has(candidate.worktreeId)) {
+      return
+    }
+    if (candidate.tabId && !tabIndex.has(candidate.tabId)) {
+      return
+    }
+    if (isVisibleTarget(state, candidate.worktreeId, candidate.tabId)) {
+      return
+    }
+    if (state.dismissedContinuingActivationCandidateIds[candidate.id]) {
+      return
+    }
+    const existing = candidates.get(candidate.id)
+    if (!existing || candidateSort(candidate, existing) < 0) {
+      candidates.set(candidate.id, candidate)
+    }
+  }
+
+  for (const [paneKey, entry] of Object.entries(state.agentStatusByPaneKey)) {
+    if (!isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+      continue
+    }
+    const tabId = tabIdFromPaneKey(paneKey)
+    const target = tabId ? tabIndex.get(tabId) : null
+    if (!target) {
+      continue
+    }
+    if (entry.state === 'blocked' || entry.state === 'waiting') {
+      addCandidate({
+        id: `agent_needs_input:${paneKey}:${entry.stateStartedAt}`,
+        kind: 'agent_needs_input',
+        source: 'live_agent_status',
+        worktreeId: target.worktreeId,
+        tabId,
+        paneKey,
+        rank: 100,
+        updatedAt: entry.stateStartedAt
+      })
+      continue
+    }
+    if (
+      entry.state === 'done' &&
+      !entry.interrupted &&
+      isUnvisitedAgentState(entry, paneKey, state.acknowledgedAgentsByPaneKey)
+    ) {
+      addCandidate({
+        id: `agent_ready_for_review:${paneKey}:${entry.stateStartedAt}`,
+        kind: 'agent_ready_for_review',
+        source: 'live_agent_status',
+        worktreeId: target.worktreeId,
+        tabId,
+        paneKey,
+        rank: 85,
+        updatedAt: entry.stateStartedAt
+      })
+    }
+  }
+
+  for (const [paneKey, retained] of Object.entries(state.retainedAgentsByPaneKey)) {
+    const tabId = retained.tab.id
+    if (!tabIndex.has(tabId)) {
+      continue
+    }
+    if (
+      retained.entry.interrupted ||
+      !isUnvisitedAgentState(retained.entry, paneKey, state.acknowledgedAgentsByPaneKey)
+    ) {
+      continue
+    }
+    addCandidate({
+      id: `agent_ready_for_review:${paneKey}:${retained.entry.stateStartedAt}`,
+      kind: 'agent_ready_for_review',
+      source: 'retained_agent_status',
+      worktreeId: retained.worktreeId,
+      tabId,
+      paneKey,
+      rank: 82,
+      updatedAt: retained.entry.stateStartedAt
+    })
+  }
+
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    for (const tab of tabs) {
+      if (!tab.ptyId) {
+        continue
+      }
+      const paneTitles = state.runtimePaneTitlesByTabId[tab.id]
+      if (paneTitles && Object.keys(paneTitles).length > 0) {
+        for (const [paneId, title] of Object.entries(paneTitles)) {
+          if (detectAgentStatusFromTitle(title) !== 'permission') {
+            continue
+          }
+          addCandidate({
+            id: `agent_needs_input:terminal_title:${tab.id}:${paneId}`,
+            kind: 'agent_needs_input',
+            source: 'terminal_title',
+            worktreeId,
+            tabId: tab.id,
+            paneKey: `${tab.id}:${paneId}`,
+            rank: 95,
+            updatedAt: tab.createdAt
+          })
+        }
+        continue
+      }
+      if (detectAgentStatusFromTitle(tab.title) === 'permission') {
+        addCandidate({
+          id: `agent_needs_input:terminal_title:${tab.id}:tab`,
+          kind: 'agent_needs_input',
+          source: 'terminal_title',
+          worktreeId,
+          tabId: tab.id,
+          rank: 90,
+          updatedAt: tab.createdAt
+        })
+      }
+    }
+  }
+
+  for (const cue of Object.values(state.continuingActivationCues)) {
+    if (cue.dismissedAt) {
+      continue
+    }
+    addCandidate({
+      id: `agent_ready_for_review:${cue.id}:${cue.createdAt}`,
+      kind: 'agent_ready_for_review',
+      source: 'agent_completion_cue',
+      worktreeId: cue.worktreeId,
+      tabId: cue.tabId,
+      cueId: cue.id,
+      rank: 75,
+      updatedAt: cue.createdAt
+    })
+  }
+
+  return [...candidates.values()].sort(candidateSort)
+}
+
+export function getTopContinuingActivationCandidate(
+  state: ContinuingActivationCandidateState,
+  now: number = Date.now()
+): ContinuingActivationCandidate | null {
+  return getContinuingActivationCandidates(state, now)[0] ?? null
+}

--- a/src/renderer/src/lib/continuing-activation-candidates.ts
+++ b/src/renderer/src/lib/continuing-activation-candidates.ts
@@ -5,6 +5,10 @@ import {
 import type { ContinuingActivationCue, TerminalTab, Worktree } from '../../../shared/types'
 import { detectAgentStatusFromTitle, isExplicitAgentStatusFresh } from './agent-status'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import {
+  buildTerminalTitlePaneCandidateId,
+  buildTerminalTitleTabCandidateId
+} from './continuing-activation-candidate-ids'
 
 export type ContinuingActivationCandidateKind = 'agent_needs_input' | 'agent_ready_for_review'
 
@@ -203,7 +207,7 @@ export function getContinuingActivationCandidates(
             continue
           }
           addCandidate({
-            id: `agent_needs_input:terminal_title:${tab.id}:${paneId}`,
+            id: buildTerminalTitlePaneCandidateId({ tabId: tab.id, paneId }),
             kind: 'agent_needs_input',
             source: 'terminal_title',
             worktreeId,
@@ -217,7 +221,7 @@ export function getContinuingActivationCandidates(
       }
       if (detectAgentStatusFromTitle(tab.title) === 'permission') {
         addCandidate({
-          id: `agent_needs_input:terminal_title:${tab.id}:tab`,
+          id: buildTerminalTitleTabCandidateId({ tabId: tab.id }),
           kind: 'agent_needs_input',
           source: 'terminal_title',
           worktreeId,
@@ -233,11 +237,15 @@ export function getContinuingActivationCandidates(
     if (cue.dismissedAt) {
       continue
     }
+    const target = tabIndex.get(cue.tabId)
+    if (!target) {
+      continue
+    }
     addCandidate({
       id: `agent_ready_for_review:${cue.id}:${cue.createdAt}`,
       kind: 'agent_ready_for_review',
       source: 'agent_completion_cue',
-      worktreeId: cue.worktreeId,
+      worktreeId: target.worktreeId,
       tabId: cue.tabId,
       cueId: cue.id,
       rank: 75,

--- a/src/renderer/src/lib/continuing-activation-telemetry.test.ts
+++ b/src/renderer/src/lib/continuing-activation-telemetry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createContinuingActivationShownRecorder,
+  trackContinuingActivationCandidate,
+  type TrackContinuingActivation
+} from './continuing-activation-telemetry'
+import type { ContinuingActivationCandidate } from './continuing-activation-candidates'
+
+function makeCandidate(
+  overrides: Partial<ContinuingActivationCandidate> = {}
+): ContinuingActivationCandidate {
+  return {
+    id: 'agent_needs_input:terminal_title:tab-1:7',
+    kind: 'agent_needs_input',
+    source: 'terminal_title',
+    worktreeId: 'wt-1',
+    tabId: 'tab-1',
+    paneKey: 'tab-1:7',
+    rank: 100,
+    updatedAt: 1_000,
+    ...overrides
+  }
+}
+
+describe('continuing activation telemetry', () => {
+  it('deduplicates shown events by surface and candidate id', () => {
+    const trackFn: TrackContinuingActivation = vi.fn()
+    const recordShown = createContinuingActivationShownRecorder(trackFn)
+    const candidate = makeCandidate()
+
+    recordShown(candidate, 'sidebar_next_action')
+    recordShown(candidate, 'sidebar_next_action')
+
+    expect(trackFn).toHaveBeenCalledTimes(1)
+    expect(trackFn).toHaveBeenCalledWith('continuing_activation_candidate_shown', {
+      candidate_kind: 'agent_needs_input',
+      surface: 'sidebar_next_action'
+    })
+  })
+
+  it('does not emit candidate ids or target ids in event payloads', () => {
+    const trackFn: TrackContinuingActivation = vi.fn()
+    const candidate = makeCandidate({
+      id: 'agent_ready_for_review:agent_ready_for_review:tab-1:1700000000000',
+      kind: 'agent_ready_for_review',
+      source: 'agent_completion_cue',
+      worktreeId: 'wt-secret',
+      tabId: 'tab-secret',
+      cueId: 'agent_ready_for_review:tab-secret'
+    })
+
+    trackContinuingActivationCandidate(
+      'continuing_activation_candidate_clicked',
+      candidate,
+      'sidebar_next_action',
+      trackFn
+    )
+
+    expect(trackFn).toHaveBeenCalledWith('continuing_activation_candidate_clicked', {
+      candidate_kind: 'agent_ready_for_review',
+      surface: 'sidebar_next_action'
+    })
+    expect(trackFn).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        id: expect.any(String),
+        candidate_id: expect.any(String),
+        worktree_id: expect.any(String),
+        tab_id: expect.any(String)
+      })
+    )
+  })
+})

--- a/src/renderer/src/lib/continuing-activation-telemetry.ts
+++ b/src/renderer/src/lib/continuing-activation-telemetry.ts
@@ -1,0 +1,61 @@
+import type {
+  ContinuingActivationCandidateKind as TelemetryCandidateKind,
+  ContinuingActivationSurface,
+  EventMap
+} from '../../../shared/telemetry-events'
+import type { ContinuingActivationCandidate } from './continuing-activation-candidates'
+import { track } from './telemetry'
+
+export type ContinuingActivationTelemetryEvent =
+  | 'continuing_activation_candidate_shown'
+  | 'continuing_activation_candidate_clicked'
+  | 'continuing_activation_candidate_dismissed'
+  | 'continuing_activation_candidate_landed'
+
+type ContinuingActivationTelemetryProps = EventMap['continuing_activation_candidate_shown']
+
+export type TrackContinuingActivation = (
+  name: ContinuingActivationTelemetryEvent,
+  props: ContinuingActivationTelemetryProps
+) => void
+
+function toTelemetryProps(
+  candidate: Pick<ContinuingActivationCandidate, 'kind'>,
+  surface: ContinuingActivationSurface
+): ContinuingActivationTelemetryProps {
+  return {
+    candidate_kind: candidate.kind as TelemetryCandidateKind,
+    surface
+  }
+}
+
+export function trackContinuingActivationCandidate(
+  name: ContinuingActivationTelemetryEvent,
+  candidate: Pick<ContinuingActivationCandidate, 'kind'>,
+  surface: ContinuingActivationSurface,
+  trackFn: TrackContinuingActivation = track
+): void {
+  trackFn(name, toTelemetryProps(candidate, surface))
+}
+
+export function createContinuingActivationShownRecorder(
+  trackFn: TrackContinuingActivation = track
+): (
+  candidate: Pick<ContinuingActivationCandidate, 'id' | 'kind'>,
+  surface: ContinuingActivationSurface
+) => void {
+  const shownKeys = new Set<string>()
+  return (candidate, surface) => {
+    const key = `${surface}:${candidate.id}`
+    if (shownKeys.has(key)) {
+      return
+    }
+    shownKeys.add(key)
+    trackContinuingActivationCandidate(
+      'continuing_activation_candidate_shown',
+      candidate,
+      surface,
+      trackFn
+    )
+  }
+}

--- a/src/renderer/src/lib/workspace-session.test.ts
+++ b/src/renderer/src/lib/workspace-session.test.ts
@@ -139,4 +139,30 @@ describe('buildWorkspaceSessionPayload', () => {
     expect(payload.activeFileIdByWorktree).toEqual({})
     expect(payload.activeTabTypeByWorktree).toEqual({ 'wt-2': 'terminal' })
   })
+
+  it('persists continuing activation cues as local ids and timestamps only', () => {
+    const payload = buildWorkspaceSessionPayload(
+      createSnapshot({
+        continuingActivationCues: {
+          'agent_ready_for_review:tab-1': {
+            id: 'agent_ready_for_review:tab-1',
+            kind: 'agent_ready_for_review',
+            worktreeId: 'wt-1',
+            tabId: 'tab-1',
+            createdAt: 1_700_000_000_000
+          }
+        }
+      })
+    )
+
+    expect(payload.continuingActivationCues).toEqual({
+      'agent_ready_for_review:tab-1': {
+        id: 'agent_ready_for_review:tab-1',
+        kind: 'agent_ready_for_review',
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        createdAt: 1_700_000_000_000
+      }
+    })
+  })
 })

--- a/src/renderer/src/lib/workspace-session.test.ts
+++ b/src/renderer/src/lib/workspace-session.test.ts
@@ -147,7 +147,6 @@ describe('buildWorkspaceSessionPayload', () => {
           'agent_ready_for_review:tab-1': {
             id: 'agent_ready_for_review:tab-1',
             kind: 'agent_ready_for_review',
-            worktreeId: 'wt-1',
             tabId: 'tab-1',
             createdAt: 1_700_000_000_000
           }
@@ -159,7 +158,6 @@ describe('buildWorkspaceSessionPayload', () => {
       'agent_ready_for_review:tab-1': {
         id: 'agent_ready_for_review:tab-1',
         kind: 'agent_ready_for_review',
-        worktreeId: 'wt-1',
         tabId: 'tab-1',
         createdAt: 1_700_000_000_000
       }

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -31,6 +31,7 @@ type WorkspaceSessionSnapshot = Pick<
   | 'repos'
   | 'worktreesByRepo'
   | 'lastKnownRelayPtyIdByTabId'
+  | 'continuingActivationCues'
 >
 
 /** Build the editor-file portion of the workspace session for persistence.
@@ -216,6 +217,7 @@ export function buildWorkspaceSessionPayload(
     activeGroupIdByWorktree: snapshot.activeGroupIdByWorktree,
     activeConnectionIdsAtShutdown: connectedTargetIds.length > 0 ? connectedTargetIds : undefined,
     remoteSessionIdsByTabId:
-      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined
+      Object.keys(remoteSessionIdsByTabId).length > 0 ? remoteSessionIdsByTabId : undefined,
+    continuingActivationCues: snapshot.continuingActivationCues
   }
 }

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -21,6 +21,7 @@ import { createAgentStatusSlice } from './slices/agent-status'
 import { createDiffCommentsSlice } from './slices/diffComments'
 import { createDetectedAgentsSlice } from './slices/detected-agents'
 import { createWorktreeNavHistorySlice } from './slices/worktree-nav-history'
+import { createContinuingActivationSlice } from './slices/continuing-activation'
 import { e2eConfig } from '@/lib/e2e-config'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
@@ -45,7 +46,8 @@ export const useAppStore = create<AppState>()((...a) => ({
   ...createAgentStatusSlice(...a),
   ...createDiffCommentsSlice(...a),
   ...createDetectedAgentsSlice(...a),
-  ...createWorktreeNavHistorySlice(...a)
+  ...createWorktreeNavHistorySlice(...a),
+  ...createContinuingActivationSlice(...a)
 }))
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/slices/continuing-activation.test.ts
+++ b/src/renderer/src/store/slices/continuing-activation.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildTerminalTitlePaneCandidateId,
+  buildTerminalTitleTabCandidateId
+} from '@/lib/continuing-activation-candidate-ids'
+import { createTestStore, makeTab, seedStore } from './store-test-helpers'
+
+function stubDocumentVisibility({
+  isFocused,
+  visibilityState
+}: {
+  isFocused: boolean
+  visibilityState: 'hidden' | 'visible'
+}): void {
+  vi.stubGlobal('document', {
+    visibilityState,
+    hasFocus: () => isFocused
+  })
+}
+
+describe('continuing activation slice', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not record a review cue for the visible focused terminal tab', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      activeView: 'terminal',
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-1',
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })] }
+    })
+    stubDocumentVisibility({ isFocused: true, visibilityState: 'visible' })
+
+    store.getState().recordContinuingActivationCue({
+      kind: 'agent_ready_for_review',
+      tabId: 'tab-1',
+      createdAt: 1_700_000_000_000
+    })
+
+    expect(store.getState().continuingActivationCues).toEqual({})
+  })
+
+  it('records review cues without persisting path-bearing worktree ids', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      activeView: 'terminal',
+      activeWorktreeId: 'repo-1::/private/worktree',
+      activeTabId: 'tab-1',
+      tabsByWorktree: {
+        'repo-1::/private/worktree': [
+          makeTab({ id: 'tab-1', worktreeId: 'repo-1::/private/worktree' })
+        ]
+      }
+    })
+    stubDocumentVisibility({ isFocused: false, visibilityState: 'hidden' })
+
+    store.getState().recordContinuingActivationCue({
+      kind: 'agent_ready_for_review',
+      tabId: 'tab-1',
+      createdAt: 1_700_000_000_000
+    })
+
+    expect(store.getState().continuingActivationCues).toEqual({
+      'agent_ready_for_review:tab-1': {
+        id: 'agent_ready_for_review:tab-1',
+        kind: 'agent_ready_for_review',
+        tabId: 'tab-1',
+        createdAt: 1_700_000_000_000
+      }
+    })
+  })
+
+  it('clears all cues for a worktree by deriving ownership from tabs', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      tabsByWorktree: {
+        'wt-1': [
+          makeTab({ id: 'tab-1', worktreeId: 'wt-1' }),
+          makeTab({ id: 'tab-2', worktreeId: 'wt-1' })
+        ],
+        'wt-2': [makeTab({ id: 'tab-3', worktreeId: 'wt-2' })]
+      },
+      continuingActivationCues: {
+        'agent_ready_for_review:tab-1': {
+          id: 'agent_ready_for_review:tab-1',
+          kind: 'agent_ready_for_review',
+          tabId: 'tab-1',
+          createdAt: 1
+        },
+        'agent_ready_for_review:tab-2': {
+          id: 'agent_ready_for_review:tab-2',
+          kind: 'agent_ready_for_review',
+          tabId: 'tab-2',
+          createdAt: 2
+        },
+        'agent_ready_for_review:tab-3': {
+          id: 'agent_ready_for_review:tab-3',
+          kind: 'agent_ready_for_review',
+          tabId: 'tab-3',
+          createdAt: 3
+        }
+      }
+    })
+
+    store.getState().clearContinuingActivationCuesForTarget({ worktreeId: 'wt-1' })
+
+    expect(Object.keys(store.getState().continuingActivationCues)).toEqual([
+      'agent_ready_for_review:tab-3'
+    ])
+  })
+
+  it('allows a dismissed pane-title permission candidate to return after the title clears', () => {
+    const store = createTestStore()
+    const candidateId = buildTerminalTitlePaneCandidateId({ tabId: 'tab-1', paneId: 7 })
+    seedStore(store, {
+      runtimePaneTitlesByTabId: { 'tab-1': { 7: 'Claude permission required' } },
+      dismissedContinuingActivationCandidateIds: { [candidateId]: true }
+    })
+
+    store.getState().setRuntimePaneTitle('tab-1', 7, 'bash')
+
+    expect(store.getState().dismissedContinuingActivationCandidateIds[candidateId]).toBeUndefined()
+  })
+
+  it('allows a dismissed tab-title permission candidate to return after the title clears', () => {
+    const store = createTestStore()
+    const candidateId = buildTerminalTitleTabCandidateId({ tabId: 'tab-1' })
+    seedStore(store, {
+      tabsByWorktree: {
+        'wt-1': [
+          makeTab({
+            id: 'tab-1',
+            worktreeId: 'wt-1',
+            title: 'Claude permission required'
+          })
+        ]
+      },
+      dismissedContinuingActivationCandidateIds: { [candidateId]: true }
+    })
+
+    store.getState().updateTabTitle('tab-1', 'bash')
+
+    expect(store.getState().dismissedContinuingActivationCandidateIds[candidateId]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/continuing-activation.ts
+++ b/src/renderer/src/store/slices/continuing-activation.ts
@@ -15,7 +15,6 @@ export type ContinuingActivationSlice = {
   hydrateContinuingActivationSession: (session: WorkspaceSessionState) => void
   recordContinuingActivationCue: (cue: {
     kind: ContinuingActivationCueKind
-    worktreeId: string
     tabId: string
     createdAt?: number
   }) => void
@@ -27,6 +26,26 @@ export type ContinuingActivationSlice = {
 
 function buildCueId(kind: ContinuingActivationCueKind, tabId: string): string {
   return `${kind}:${tabId}`
+}
+
+function isVisibleDocumentFocused(): boolean {
+  if (typeof document === 'undefined') {
+    return false
+  }
+  return document.visibilityState === 'visible' && document.hasFocus()
+}
+
+function isActiveVisibleTab(state: AppState, tabId: string): boolean {
+  if (state.activeView !== 'terminal' || !state.activeWorktreeId || !isVisibleDocumentFocused()) {
+    return false
+  }
+  const visibleTabId =
+    state.activeTabId ?? state.tabsByWorktree[state.activeWorktreeId]?.[0]?.id ?? null
+  return visibleTabId === tabId
+}
+
+function tabIdsForWorktree(state: AppState, worktreeId: string): Set<string> {
+  return new Set((state.tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id))
 }
 
 function pruneCues(
@@ -61,20 +80,27 @@ export const createContinuingActivationSlice: StateCreator<
     })
   },
 
-  recordContinuingActivationCue: ({ kind, worktreeId, tabId, createdAt }) => {
+  recordContinuingActivationCue: ({ kind, tabId, createdAt }) => {
     const now = createdAt ?? Date.now()
     const id = buildCueId(kind, tabId)
-    set((s) => ({
-      // Why: a fresh completion in the same tab should re-open the cue even
-      // if the user dismissed an earlier turn from that tab.
-      continuingActivationCues: pruneCues(
-        {
-          ...s.continuingActivationCues,
-          [id]: { id, kind, worktreeId, tabId, createdAt: now }
-        },
-        now
-      )
-    }))
+    set((s) => {
+      // Why: if the user is already looking at the completed tab, there is no
+      // re-entry breadcrumb to preserve for later.
+      if (isActiveVisibleTab(s, tabId)) {
+        return s
+      }
+      return {
+        // Why: a fresh completion in the same tab should re-open the cue even
+        // if the user dismissed an earlier turn from that tab.
+        continuingActivationCues: pruneCues(
+          {
+            ...s.continuingActivationCues,
+            [id]: { id, kind, tabId, createdAt: now }
+          },
+          now
+        )
+      }
+    })
   },
 
   dismissContinuingActivationCue: (cueId) => {
@@ -118,12 +144,13 @@ export const createContinuingActivationSlice: StateCreator<
 
   clearContinuingActivationCuesForTarget: ({ worktreeId, tabId }) => {
     set((s) => {
+      const worktreeTabIds = tabId ? undefined : tabIdsForWorktree(s, worktreeId)
       const next = Object.fromEntries(
         Object.entries(s.continuingActivationCues).filter(([, cue]) => {
-          if (cue.worktreeId !== worktreeId) {
-            return true
+          if (tabId) {
+            return cue.tabId !== tabId
           }
-          return tabId ? cue.tabId !== tabId : false
+          return !worktreeTabIds?.has(cue.tabId)
         })
       )
       return Object.keys(next).length === Object.keys(s.continuingActivationCues).length

--- a/src/renderer/src/store/slices/continuing-activation.ts
+++ b/src/renderer/src/store/slices/continuing-activation.ts
@@ -1,0 +1,134 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type {
+  ContinuingActivationCue,
+  ContinuingActivationCueKind,
+  WorkspaceSessionState
+} from '../../../../shared/types'
+
+const MAX_CUES = 40
+const CUE_RETENTION_MS = 14 * 24 * 60 * 60 * 1000
+
+export type ContinuingActivationSlice = {
+  continuingActivationCues: Record<string, ContinuingActivationCue>
+  dismissedContinuingActivationCandidateIds: Record<string, true>
+  hydrateContinuingActivationSession: (session: WorkspaceSessionState) => void
+  recordContinuingActivationCue: (cue: {
+    kind: ContinuingActivationCueKind
+    worktreeId: string
+    tabId: string
+    createdAt?: number
+  }) => void
+  dismissContinuingActivationCue: (cueId: string) => void
+  dismissContinuingActivationCandidate: (candidateId: string) => void
+  clearContinuingActivationCue: (cueId: string) => void
+  clearContinuingActivationCuesForTarget: (target: { worktreeId: string; tabId?: string }) => void
+}
+
+function buildCueId(kind: ContinuingActivationCueKind, tabId: string): string {
+  return `${kind}:${tabId}`
+}
+
+function pruneCues(
+  cues: Record<string, ContinuingActivationCue>,
+  now: number
+): Record<string, ContinuingActivationCue> {
+  const fresh = Object.values(cues).filter((cue) => now - cue.createdAt <= CUE_RETENTION_MS)
+  if (fresh.length <= MAX_CUES) {
+    return Object.fromEntries(fresh.map((cue) => [cue.id, cue]))
+  }
+  return Object.fromEntries(
+    fresh
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, MAX_CUES)
+      .map((cue) => [cue.id, cue])
+  )
+}
+
+export const createContinuingActivationSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  ContinuingActivationSlice
+> = (set) => ({
+  continuingActivationCues: {},
+  dismissedContinuingActivationCandidateIds: {},
+
+  hydrateContinuingActivationSession: (session) => {
+    set({
+      continuingActivationCues: pruneCues(session.continuingActivationCues ?? {}, Date.now()),
+      dismissedContinuingActivationCandidateIds: {}
+    })
+  },
+
+  recordContinuingActivationCue: ({ kind, worktreeId, tabId, createdAt }) => {
+    const now = createdAt ?? Date.now()
+    const id = buildCueId(kind, tabId)
+    set((s) => ({
+      // Why: a fresh completion in the same tab should re-open the cue even
+      // if the user dismissed an earlier turn from that tab.
+      continuingActivationCues: pruneCues(
+        {
+          ...s.continuingActivationCues,
+          [id]: { id, kind, worktreeId, tabId, createdAt: now }
+        },
+        now
+      )
+    }))
+  },
+
+  dismissContinuingActivationCue: (cueId) => {
+    set((s) => {
+      const cue = s.continuingActivationCues[cueId]
+      if (!cue || cue.dismissedAt) {
+        return s
+      }
+      return {
+        continuingActivationCues: {
+          ...s.continuingActivationCues,
+          [cueId]: { ...cue, dismissedAt: Date.now() }
+        }
+      }
+    })
+  },
+
+  dismissContinuingActivationCandidate: (candidateId) => {
+    set((s) =>
+      s.dismissedContinuingActivationCandidateIds[candidateId]
+        ? s
+        : {
+            dismissedContinuingActivationCandidateIds: {
+              ...s.dismissedContinuingActivationCandidateIds,
+              [candidateId]: true
+            }
+          }
+    )
+  },
+
+  clearContinuingActivationCue: (cueId) => {
+    set((s) => {
+      if (!(cueId in s.continuingActivationCues)) {
+        return s
+      }
+      const next = { ...s.continuingActivationCues }
+      delete next[cueId]
+      return { continuingActivationCues: next }
+    })
+  },
+
+  clearContinuingActivationCuesForTarget: ({ worktreeId, tabId }) => {
+    set((s) => {
+      const next = Object.fromEntries(
+        Object.entries(s.continuingActivationCues).filter(([, cue]) => {
+          if (cue.worktreeId !== worktreeId) {
+            return true
+          }
+          return tabId ? cue.tabId !== tabId : false
+        })
+      )
+      return Object.keys(next).length === Object.keys(s.continuingActivationCues).length
+        ? s
+        : { continuingActivationCues: next }
+    })
+  }
+})

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -110,6 +110,7 @@ import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
+import { createContinuingActivationSlice } from './continuing-activation'
 
 function createTestStore() {
   return create<AppState>()((...a) => ({
@@ -133,7 +134,8 @@ function createTestStore() {
     ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
-    ...createWorktreeNavHistorySlice(...a)
+    ...createWorktreeNavHistorySlice(...a),
+    ...createContinuingActivationSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -29,6 +29,7 @@ import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
+import { createContinuingActivationSlice } from './continuing-activation'
 
 export const TEST_REPO = {
   id: 'repo1',
@@ -60,7 +61,8 @@ export function createTestStore() {
     ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
-    ...createWorktreeNavHistorySlice(...a)
+    ...createWorktreeNavHistorySlice(...a),
+    ...createContinuingActivationSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -105,6 +105,7 @@ import { createAgentStatusSlice } from './agent-status'
 import { createDiffCommentsSlice } from './diffComments'
 import { createDetectedAgentsSlice } from './detected-agents'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
+import { createContinuingActivationSlice } from './continuing-activation'
 
 const WT = 'repo1::/tmp/feature'
 
@@ -130,7 +131,8 @@ function createTestStore() {
     ...createAgentStatusSlice(...a),
     ...createDiffCommentsSlice(...a),
     ...createDetectedAgentsSlice(...a),
-    ...createWorktreeNavHistorySlice(...a)
+    ...createWorktreeNavHistorySlice(...a),
+    ...createContinuingActivationSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -24,6 +24,10 @@ import {
   ensurePtyDispatcher,
   unregisterPtyDataHandlers
 } from '@/components/terminal-pane/pty-transport'
+import {
+  buildTerminalTitlePaneCandidateId,
+  buildTerminalTitleTabCandidateId
+} from '@/lib/continuing-activation-candidate-ids'
 
 function getNextTerminalOrdinal(tabs: TerminalTab[]): number {
   const usedOrdinals = new Set<number>()
@@ -49,6 +53,18 @@ function getFallbackTabTitle(tab: TerminalTab, index?: number): string {
     tab.title ||
     `Terminal ${(index ?? 0) + 1}`
   )
+}
+
+function clearContinuingActivationDismissal(
+  dismissedIds: Record<string, true>,
+  candidateId: string
+): Record<string, true> {
+  if (!(candidateId in dismissedIds)) {
+    return dismissedIds
+  }
+  const next = { ...dismissedIds }
+  delete next[candidateId]
+  return next
 }
 
 export type TerminalSlice = {
@@ -650,6 +666,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // worktrees on every OSC title frame.
       let ownerWorktreeId: string | null = null
       let ownerTabs: TerminalTab[] | null = null
+      let nextDismissedCandidateIds = s.dismissedContinuingActivationCandidateIds
       for (const [wId, tabs] of Object.entries(s.tabsByWorktree)) {
         const idx = tabs.findIndex((t) => t.id === tabId)
         if (idx === -1) {
@@ -659,6 +676,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         const nextTitle = title.trim() || getFallbackTabTitle(t)
         if (t.title === nextTitle) {
           return s
+        }
+        if (
+          detectAgentStatusFromTitle(t.title) === 'permission' &&
+          detectAgentStatusFromTitle(nextTitle) !== 'permission'
+        ) {
+          nextDismissedCandidateIds = clearContinuingActivationDismissal(
+            nextDismissedCandidateIds,
+            buildTerminalTitleTabCandidateId({ tabId })
+          )
         }
         ownerWorktreeId = wId
         ownerTabs = tabs.map((tab) =>
@@ -690,9 +716,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // title update). Bumping sortEpoch here would reorder the sidebar
       // on click — the exact bug PR #209 intended to fix.
       const isActive = ownerWorktreeId === s.activeWorktreeId
-      return isActive
-        ? { tabsByWorktree: nextTabsByWorktree }
-        : { tabsByWorktree: nextTabsByWorktree, sortEpoch: s.sortEpoch + 1 }
+      return {
+        tabsByWorktree: nextTabsByWorktree,
+        ...(nextDismissedCandidateIds !== s.dismissedContinuingActivationCandidateIds
+          ? { dismissedContinuingActivationCandidateIds: nextDismissedCandidateIds }
+          : {}),
+        ...(isActive ? {} : { sortEpoch: s.sortEpoch + 1 })
+      }
     })
     const item = Object.values(get().unifiedTabsByWorktree)
       .flat()
@@ -712,11 +742,24 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       if (currentByPane[paneId] === title) {
         return s
       }
+      const currentTitle = currentByPane[paneId]
+      const nextDismissedCandidateIds =
+        currentTitle != null &&
+        detectAgentStatusFromTitle(currentTitle) === 'permission' &&
+        detectAgentStatusFromTitle(title) !== 'permission'
+          ? clearContinuingActivationDismissal(
+              s.dismissedContinuingActivationCandidateIds,
+              buildTerminalTitlePaneCandidateId({ tabId, paneId })
+            )
+          : s.dismissedContinuingActivationCandidateIds
       return {
         runtimePaneTitlesByTabId: {
           ...s.runtimePaneTitlesByTabId,
           [tabId]: { ...currentByPane, [paneId]: title }
-        }
+        },
+        ...(nextDismissedCandidateIds !== s.dismissedContinuingActivationCandidateIds
+          ? { dismissedContinuingActivationCandidateIds: nextDismissedCandidateIds }
+          : {})
       }
     })
   },
@@ -727,6 +770,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       if (!currentByPane || !(paneId in currentByPane)) {
         return s
       }
+      const nextDismissedCandidateIds =
+        detectAgentStatusFromTitle(currentByPane[paneId]) === 'permission'
+          ? clearContinuingActivationDismissal(
+              s.dismissedContinuingActivationCandidateIds,
+              buildTerminalTitlePaneCandidateId({ tabId, paneId })
+            )
+          : s.dismissedContinuingActivationCandidateIds
       const nextByPane = { ...currentByPane }
       delete nextByPane[paneId]
 
@@ -737,7 +787,12 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         delete next[tabId]
       }
 
-      return { runtimePaneTitlesByTabId: next }
+      return {
+        runtimePaneTitlesByTabId: next,
+        ...(nextDismissedCandidateIds !== s.dismissedContinuingActivationCandidateIds
+          ? { dismissedContinuingActivationCandidateIds: nextDismissedCandidateIds }
+          : {})
+      }
     })
   },
 

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -19,6 +19,7 @@ import type { AgentStatusSlice } from './slices/agent-status'
 import type { DiffCommentsSlice } from './slices/diffComments'
 import type { DetectedAgentsSlice } from './slices/detected-agents'
 import type { WorktreeNavHistorySlice } from './slices/worktree-nav-history'
+import type { ContinuingActivationSlice } from './slices/continuing-activation'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -40,4 +41,5 @@ export type AppState = RepoSlice &
   AgentStatusSlice &
   DiffCommentsSlice &
   DetectedAgentsSlice &
-  WorktreeNavHistorySlice
+  WorktreeNavHistorySlice &
+  ContinuingActivationSlice

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -266,6 +266,7 @@ export function getDefaultWorkspaceSession(): WorkspaceSessionState {
     activeBrowserTabIdByWorktree: {},
     activeFileIdByWorktree: {},
     activeTabTypeByWorktree: {},
-    browserUrlHistory: []
+    browserUrlHistory: [],
+    continuingActivationCues: {}
   }
 }

--- a/src/shared/telemetry-events.test.ts
+++ b/src/shared/telemetry-events.test.ts
@@ -139,6 +139,53 @@ describe('settings_changed schema', () => {
   })
 })
 
+describe('continuing_activation_candidate schemas', () => {
+  const eventNames = [
+    'continuing_activation_candidate_shown',
+    'continuing_activation_candidate_clicked',
+    'continuing_activation_candidate_dismissed',
+    'continuing_activation_candidate_landed'
+  ] as const
+
+  it('accepts only low-cardinality candidate kind and surface', () => {
+    for (const name of eventNames) {
+      const parsed = eventSchemas[name].safeParse({
+        candidate_kind: 'agent_needs_input',
+        surface: 'sidebar_next_action'
+      })
+      expect(parsed.success).toBe(true)
+    }
+  })
+
+  it('rejects candidate ids and content-bearing fields via .strict()', () => {
+    for (const name of eventNames) {
+      const parsed = eventSchemas[name].safeParse({
+        candidate_kind: 'agent_ready_for_review',
+        surface: 'sidebar_next_action',
+        candidate_id: 'agent_ready_for_review:tab-1:1700000000000',
+        path: '/Users/alice/private-repo',
+        title: 'permission needed for deploy'
+      })
+      expect(parsed.success).toBe(false)
+    }
+  })
+
+  it('rejects unknown enum values', () => {
+    expect(
+      eventSchemas.continuing_activation_candidate_shown.safeParse({
+        candidate_kind: 'setup_retry',
+        surface: 'sidebar_next_action'
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.continuing_activation_candidate_shown.safeParse({
+        candidate_kind: 'agent_needs_input',
+        surface: 'toast'
+      }).success
+    ).toBe(false)
+  })
+})
+
 describe('commonPropsSchema', () => {
   it('round-trips a realistic payload', () => {
     const parsed = commonPropsSchema.safeParse({

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -99,6 +99,17 @@ export type LaunchSource = z.infer<typeof launchSourceSchema>
 export const requestKindSchema = z.enum(['new', 'resume', 'followup'])
 export type RequestKind = z.infer<typeof requestKindSchema>
 
+export const continuingActivationCandidateKindSchema = z.enum([
+  'agent_needs_input',
+  'agent_ready_for_review'
+])
+export type ContinuingActivationCandidateKind = z.infer<
+  typeof continuingActivationCandidateKindSchema
+>
+
+export const continuingActivationSurfaceSchema = z.enum(['sidebar_next_action'])
+export type ContinuingActivationSurface = z.infer<typeof continuingActivationSurfaceSchema>
+
 // `env_var` is deliberately absent — env-var and CI paths override consent at
 // runtime only (see consent.ts); they never mutate `optedIn` and therefore
 // never fire a `telemetry_opted_in/out` event. If a future path explicitly
@@ -185,6 +196,13 @@ const settingsChangedSchema = z
 const telemetryOptedInSchema = z.object({ via: optInViaSchema }).strict()
 const telemetryOptedOutSchema = z.object({ via: optInViaSchema }).strict()
 
+const continuingActivationCandidateSchema = z
+  .object({
+    candidate_kind: continuingActivationCandidateKindSchema,
+    surface: continuingActivationSurfaceSchema
+  })
+  .strict()
+
 // ── Event registry: the one record the validator consumes ───────────────
 //
 // The validator does `eventSchemas[name].safeParse(props)`. `EventMap` is
@@ -210,7 +228,12 @@ export const eventSchemas = {
   settings_changed: settingsChangedSchema,
 
   telemetry_opted_in: telemetryOptedInSchema,
-  telemetry_opted_out: telemetryOptedOutSchema
+  telemetry_opted_out: telemetryOptedOutSchema,
+
+  continuing_activation_candidate_shown: continuingActivationCandidateSchema,
+  continuing_activation_candidate_clicked: continuingActivationCandidateSchema,
+  continuing_activation_candidate_dismissed: continuingActivationCandidateSchema,
+  continuing_activation_candidate_landed: continuingActivationCandidateSchema
 } as const
 
 export type EventMap = { [N in keyof typeof eventSchemas]: z.infer<(typeof eventSchemas)[N]> }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -405,7 +405,7 @@ export type WorkspaceSessionState = {
   remoteSessionIdsByTabId?: Record<string, string>
   /** Local-only activation cues recorded from reliable app-owned state.
    *  These drive next-action re-entry without storing prompts, paths, titles,
-   *  branch names, file names, or command output. */
+   *  branch names, file names, worktree ids, or command output. */
   continuingActivationCues?: Record<string, ContinuingActivationCue>
 }
 
@@ -414,7 +414,6 @@ export type ContinuingActivationCueKind = 'agent_ready_for_review'
 export type ContinuingActivationCue = {
   id: string
   kind: ContinuingActivationCueKind
-  worktreeId: string
   tabId: string
   createdAt: number
   dismissedAt?: number

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -403,6 +403,21 @@ export type WorkspaceSessionState = {
    *  shutdown from renderer state so remote PTYs can be reattached via
    *  the relay's pty.attach RPC on startup. */
   remoteSessionIdsByTabId?: Record<string, string>
+  /** Local-only activation cues recorded from reliable app-owned state.
+   *  These drive next-action re-entry without storing prompts, paths, titles,
+   *  branch names, file names, or command output. */
+  continuingActivationCues?: Record<string, ContinuingActivationCue>
+}
+
+export type ContinuingActivationCueKind = 'agent_ready_for_review'
+
+export type ContinuingActivationCue = {
+  id: string
+  kind: ContinuingActivationCueKind
+  worktreeId: string
+  tabId: string
+  createdAt: number
+  dismissedAt?: number
 }
 
 // ─── GitHub ──────────────────────────────────────────────────────────

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -45,9 +45,40 @@ describe('parseWorkspaceSession', () => {
           ptyIdsByLeafId: { 'pane:1': 'daemon-session-A' }
         }
       },
-      activeWorktreeIdsOnShutdown: ['repo1::/path/wt1']
+      activeWorktreeIdsOnShutdown: ['repo1::/path/wt1'],
+      continuingActivationCues: {
+        'agent_ready_for_review:tab1': {
+          id: 'agent_ready_for_review:tab1',
+          kind: 'agent_ready_for_review',
+          worktreeId: 'repo1::/path/wt1',
+          tabId: 'tab1',
+          createdAt: 1_700_000_000_100
+        }
+      }
     })
     expect(result.ok).toBe(true)
+  })
+
+  it('rejects continuing activation cue content fields', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      continuingActivationCues: {
+        'agent_ready_for_review:tab1': {
+          id: 'agent_ready_for_review:tab1',
+          kind: 'agent_ready_for_review',
+          worktreeId: 'wt1',
+          tabId: 'tab1',
+          createdAt: 1_700_000_000_100,
+          title: 'permission needed in /Users/alice/private',
+          path: '/Users/alice/private'
+        }
+      }
+    })
+    expect(result.ok).toBe(false)
   })
 
   it('rejects a session where ptyId is a number (schema drift)', () => {

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -50,7 +50,6 @@ describe('parseWorkspaceSession', () => {
         'agent_ready_for_review:tab1': {
           id: 'agent_ready_for_review:tab1',
           kind: 'agent_ready_for_review',
-          worktreeId: 'repo1::/path/wt1',
           tabId: 'tab1',
           createdAt: 1_700_000_000_100
         }
@@ -70,11 +69,30 @@ describe('parseWorkspaceSession', () => {
         'agent_ready_for_review:tab1': {
           id: 'agent_ready_for_review:tab1',
           kind: 'agent_ready_for_review',
-          worktreeId: 'wt1',
           tabId: 'tab1',
           createdAt: 1_700_000_000_100,
           title: 'permission needed in /Users/alice/private',
           path: '/Users/alice/private'
+        }
+      }
+    })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects path-bearing worktree ids inside continuing activation cues', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      continuingActivationCues: {
+        'agent_ready_for_review:tab1': {
+          id: 'agent_ready_for_review:tab1',
+          kind: 'agent_ready_for_review',
+          worktreeId: 'repo1::/Users/alice/private',
+          tabId: 'tab1',
+          createdAt: 1_700_000_000_100
         }
       }
     })

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -182,6 +182,19 @@ const browserHistoryEntrySchema = z.object({
   visitCount: z.number()
 })
 
+// ─── Continuing activation ──────────────────────────────────────────
+
+const continuingActivationCueSchema = z
+  .object({
+    id: z.string(),
+    kind: z.literal('agent_ready_for_review'),
+    worktreeId: z.string(),
+    tabId: z.string(),
+    createdAt: z.number(),
+    dismissedAt: z.number().optional()
+  })
+  .strict()
+
 // ─── Workspace session ──────────────────────────────────────────────
 
 export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.object({
@@ -204,7 +217,8 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
   tabGroupLayouts: z.record(z.string(), tabGroupLayoutNodeSchema).optional(),
   activeGroupIdByWorktree: z.record(z.string(), z.string()).optional(),
   activeConnectionIdsAtShutdown: z.array(z.string()).optional(),
-  remoteSessionIdsByTabId: z.record(z.string(), z.string()).optional()
+  remoteSessionIdsByTabId: z.record(z.string(), z.string()).optional(),
+  continuingActivationCues: z.record(z.string(), continuingActivationCueSchema).optional()
 })
 
 export type ParsedWorkspaceSession =

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -188,7 +188,6 @@ const continuingActivationCueSchema = z
   .object({
     id: z.string(),
     kind: z.literal('agent_ready_for_review'),
-    worktreeId: z.string(),
     tabId: z.string(),
     createdAt: z.number(),
     dismissedAt: z.number().optional()


### PR DESCRIPTION
## Summary
- Add a narrow continuing-activation candidate model for agent input/permission and agent output review.
- Persist local review cues in workspace session using only neutral ids and timestamps, and surface the top candidate as a compact sidebar Next action card.
- Add product-gated telemetry for shown/clicked/dismissed/landed with low-cardinality `candidate_kind` and `surface` only.
- Pin privacy behavior so terminal-title fallback IDs and dismissal keys never include raw titles, paths, prompts, branch names, repo/workspace names, or file names.

## Validation
- `pnpm tc`
- `pnpm lint`
- `pnpm test src/shared/workspace-session-schema.test.ts src/renderer/src/lib/workspace-session.test.ts src/renderer/src/lib/continuing-activation-candidates.test.ts src/renderer/src/lib/continuing-activation-telemetry.test.ts src/shared/telemetry-events.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/store/slices/tabs.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts`
- Electron smoke via dev/CDP: injected a terminal-title permission candidate, verified the sidebar card rendered, dismiss produced `agent_needs_input:terminal_title:tab-ca-e2e:1`, and dev telemetry logged only `candidate_kind` plus `surface`. The injected fake worktree also produced expected access-denied noise, so this was a surface/privacy smoke test rather than a real-worktree activation test.

## Intentionally deferred
- Blocked setup or integration retry: no reliable setup failure state distinct from generic terminal output in this branch.
- Selected issue/PR/task not started: existing task caches do not prove durable user intent.
- Configured-but-unused onboarding feature: no trustworthy persisted feature-used state found.
- First workspace after repo add: residual project setup/repo-add completion is already separate in-progress scope.
- Competitor setup import: maps to `orca.yaml`, not Orca setup-action telemetry.

## Notes
- `docs/reference/*` were context-only inputs and are not included in this PR.
- `STYLEGUIDE.md` was not present in this worktree; the sidebar surface follows the existing sidebar component style.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.