### PR TITLE
Fix terminal scroll restore after resize reflow

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -1,4 +1,4 @@
-import type { Terminal } from '@xterm/xterm'
+import type { IMarker, Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
 import type { LigaturesAddon } from '@xterm/addon-ligatures'
@@ -83,6 +83,7 @@ export type ScrollState = {
   wasAtBottom: boolean
   viewportY: number
   baseY: number
+  firstVisibleLineMarker?: IMarker
 }
 
 export type ManagedPaneInternal = {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { Terminal } from '@xterm/xterm'
+import type { IMarker, Terminal } from '@xterm/xterm'
 import {
   captureScrollState,
   getTerminalOutputEpoch,
@@ -13,14 +13,19 @@ function createTerminal(args: {
   viewportY: number
   baseY: number
   type?: 'normal' | 'alternate'
+  cursorY?: number
 }): Terminal {
   const active = {
     type: args.type ?? 'normal',
     viewportY: args.viewportY,
-    baseY: args.baseY
+    baseY: args.baseY,
+    cursorY: args.cursorY ?? 5
   }
   return {
     buffer: { active },
+    registerMarker: vi.fn((cursorYOffset: number) =>
+      createMarker(active.baseY + active.cursorY + cursorYOffset)
+    ),
     scrollToBottom: vi.fn(() => {
       active.viewportY = active.baseY
     }),
@@ -33,6 +38,18 @@ function createTerminal(args: {
   } as unknown as Terminal
 }
 
+function createMarker(line: number): IMarker {
+  return {
+    id: line,
+    isDisposed: false,
+    line,
+    dispose: vi.fn(function (this: { isDisposed: boolean }) {
+      this.isDisposed = true
+    }),
+    onDispose: vi.fn()
+  } as unknown as IMarker
+}
+
 describe('scroll state', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -40,14 +57,15 @@ describe('scroll state', () => {
   })
 
   it('captures the numeric viewport position', () => {
-    const terminal = createTerminal({ viewportY: 42, baseY: 100 })
+    const terminal = createTerminal({ viewportY: 42, baseY: 100, cursorY: 7 })
 
-    expect(captureScrollState(terminal)).toEqual({
+    expect(captureScrollState(terminal)).toMatchObject({
       bufferType: 'normal',
       wasAtBottom: false,
       viewportY: 42,
       baseY: 100
     })
+    expect(terminal.registerMarker).toHaveBeenCalledWith(-65)
   })
 
   it('tracks output epochs per terminal', () => {
@@ -75,6 +93,24 @@ describe('scroll state', () => {
 
     expect(terminal.scrollToLine).toHaveBeenCalledWith(42)
     expect(terminal.buffer.active.viewportY).toBe(42)
+  })
+
+  it('uses the visible line marker when resize reflow changes numeric line positions', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 300 })
+    const marker = createMarker(160)
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100,
+      firstVisibleLineMarker: marker
+    }
+
+    restoreScrollState(terminal, state)
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(160)
+    expect(terminal.buffer.active.viewportY).toBe(160)
+    expect(marker.dispose).toHaveBeenCalledTimes(1)
   })
 
   it('reapplies a layout restore after xterm settles asynchronously', () => {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -7,6 +7,7 @@ const deferredScrollRestores = new WeakMap<
   {
     cancelled: boolean
     rafIds: number[]
+    state: ScrollState
     timeoutIds: ReturnType<typeof setTimeout>[]
   }
 >()
@@ -33,34 +34,46 @@ export function cancelDeferredScrollRestore(terminal: Terminal): void {
   for (const timeoutId of pending.timeoutIds) {
     clearTimeout(timeoutId)
   }
+  releaseScrollStateMarker(pending.state)
   deferredScrollRestores.delete(terminal)
 }
 
 export function captureScrollState(terminal: Terminal): ScrollState {
   const buf = terminal.buffer.active
+  const viewportY = buf.viewportY
+  const wasAtBottom = viewportY >= buf.baseY
   return {
     bufferType: buf.type,
-    wasAtBottom: buf.viewportY >= buf.baseY,
-    viewportY: buf.viewportY,
-    baseY: buf.baseY
+    wasAtBottom,
+    viewportY,
+    baseY: buf.baseY,
+    // Why: xterm markers track the same buffer line through resize reflow;
+    // a numeric viewport line alone can point at different content afterward.
+    firstVisibleLineMarker:
+      !wasAtBottom && buf.type === 'normal'
+        ? terminal.registerMarker?.(viewportY - (buf.baseY + buf.cursorY))
+        : undefined
   }
 }
 
 export function restoreScrollState(terminal: Terminal, state: ScrollState): void {
   cancelDeferredScrollRestore(terminal)
   restoreScrollStateNow(terminal, state)
+  releaseScrollStateMarker(state)
 }
 
 export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollState): void {
   cancelDeferredScrollRestore(terminal)
   restoreScrollStateNow(terminal, state)
   if (typeof requestAnimationFrame !== 'function') {
+    releaseScrollStateMarker(state)
     return
   }
 
   const pending = {
     cancelled: false,
     rafIds: [] as number[],
+    state,
     timeoutIds: [] as ReturnType<typeof setTimeout>[]
   }
   const restore = (): void => {
@@ -93,6 +106,7 @@ export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollS
     // authoritative timeout restore has run, stale frame callbacks must not
     // later rewind a user-initiated scroll or follow-output jump.
     cancelPendingRafs()
+    releaseScrollStateMarker(state)
     deferredScrollRestores.delete(terminal)
   }, 80)
   pending.rafIds.push(firstRaf)
@@ -112,8 +126,21 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
     return
   }
 
-  terminal.scrollToLine(Math.min(state.viewportY, buf.baseY))
+  const markerLine =
+    state.firstVisibleLineMarker && !state.firstVisibleLineMarker.isDisposed
+      ? state.firstVisibleLineMarker.line
+      : -1
+  const targetLine = Math.min(markerLine >= 0 ? markerLine : state.viewportY, buf.baseY)
+  state.viewportY = targetLine
+  state.firstVisibleLineMarker?.dispose()
+  state.firstVisibleLineMarker = undefined
+  terminal.scrollToLine(targetLine)
   forceViewportScrollbarSync(terminal)
+}
+
+function releaseScrollStateMarker(state: ScrollState): void {
+  state.firstVisibleLineMarker?.dispose()
+  state.firstVisibleLineMarker = undefined
 }
 
 // Why: xterm 6 can leave its scrollbar thumb stale when ydisp is unchanged.


### PR DESCRIPTION
## Summary
- Track non-bottom terminal scroll restores with xterm line markers so resize reflow returns to the same buffer content.
- Dispose markers after restore/cancel and keep bottom-follow behavior unchanged.
- Add unit coverage for marker-based reflow restore.

## Verification
- pnpm vitest run src/renderer/src/lib/pane-manager/pane-scroll.test.ts src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/renderer/src/lib/pane-manager/pane-fit-resize-observer.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts
- pnpm typecheck:web
- npx electron-vite build --mode e2e
- Electron resize proof: marker `_120` remained top-visible after 112 cols -> 57 cols reflow (`ydisp` 360 -> 600).
- Electron bottom smoke: `bottomDelta` stayed 0 before and after resize.

Screenshots attached in PR comments.