### PR TITLE
Move workspace board button near new workspace

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -114,24 +114,6 @@ const SidebarHeader = React.memo(function SidebarHeader() {
           <span className="pl-2 pr-0.5 text-[10.5px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80 select-none">
             Workspaces
           </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant={workspaceBoardOpen ? 'secondary' : 'ghost'}
-                size="icon-xs"
-                className="text-muted-foreground"
-                aria-label="Workspace board"
-                aria-pressed={workspaceBoardOpen}
-                data-workspace-board-trigger=""
-                onClick={handleWorkspaceBoardToggle}
-              >
-                <Kanban className="size-3.5" strokeWidth={2.25} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6}>
-              {workspaceBoardOpen ? 'Close workspace board' : 'Workspace board'}
-            </TooltipContent>
-          </Tooltip>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
           <SidebarFilter preserveWorkspaceBoardOpen onMenuOpenChange={setWorkspaceBoardMenuOpen} />
@@ -233,6 +215,25 @@ const SidebarHeader = React.memo(function SidebarHeader() {
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={workspaceBoardOpen ? 'secondary' : 'ghost'}
+                size="icon-xs"
+                className="text-muted-foreground"
+                aria-label="Workspace board"
+                aria-pressed={workspaceBoardOpen}
+                data-workspace-board-trigger=""
+                onClick={handleWorkspaceBoardToggle}
+              >
+                <Kanban className="size-3.5" strokeWidth={2.25} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              {workspaceBoardOpen ? 'Close workspace board' : 'Workspace board'}
+            </TooltipContent>
+          </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- move the Workspace board button into the right-side sidebar actions directly before New Workspace
- keep the existing board tooltip, active state, and drawer behavior unchanged

## Tests
- pnpm typecheck
- pnpm lint
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/SidebarHeader.tsx