### PR TITLE
Fix filesystem watcher crash on large event batches

### DIFF
--- a/src/main/ipc/filesystem-watcher-event-batch.ts
+++ b/src/main/ipc/filesystem-watcher-event-batch.ts
@@ -1,0 +1,12 @@
+import type { Event as WatcherEvent } from '@parcel/watcher'
+
+export function appendWatcherEvents(
+  batchEvents: WatcherEvent[],
+  incomingEvents: WatcherEvent[]
+): void {
+  // Why: worktree deletion can deliver enough events that `push(...events)`
+  // exceeds V8's argument limit and crashes the main process.
+  for (const event of incomingEvents) {
+    batchEvents.push(event)
+  }
+}

--- a/src/main/ipc/filesystem-watcher-large-batch.test.ts
+++ b/src/main/ipc/filesystem-watcher-large-batch.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock } = vi.hoisted(() => ({
+  handleMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('fs/promises', () => ({
+  stat: vi.fn()
+}))
+
+vi.mock('@parcel/watcher', () => ({
+  subscribe: vi.fn()
+}))
+
+vi.mock('./filesystem-watcher-wsl', () => ({
+  createWslWatcher: vi.fn()
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+import { closeAllWatchers, registerFilesystemWatcherHandlers } from './filesystem-watcher'
+import { stat } from 'fs/promises'
+import { subscribe as subscribeParcelWatcher } from '@parcel/watcher'
+import type { Event as WatcherEvent } from '@parcel/watcher'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
+
+describe('local filesystem watcher large batches', () => {
+  const handlers: HandlerMap = {}
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    handleMock.mockReset()
+    vi.mocked(stat).mockReset()
+    vi.mocked(subscribeParcelWatcher).mockReset()
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+    registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  it('accepts a large local watcher event batch without overflowing V8 arguments', async () => {
+    vi.useFakeTimers()
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
+    let watcherCallback: ((err: Error | null, events: WatcherEvent[]) => void) | undefined
+    vi.mocked(subscribeParcelWatcher).mockImplementation(async (_root, callback) => {
+      watcherCallback = callback as typeof watcherCallback
+      return { unsubscribe: vi.fn() } as never
+    })
+
+    await handlers['fs:watchWorktree'](
+      { sender: { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 } },
+      { worktreePath: '/tmp/repo' }
+    )
+
+    const events = Array.from(
+      { length: 200_000 },
+      (_, index): WatcherEvent => ({ type: 'delete', path: `/tmp/repo/file-${index}` })
+    )
+
+    expect(() => watcherCallback?.(null, events)).not.toThrow()
+    await closeAllWatchers()
+    vi.useRealTimers()
+  })
+})

--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -142,4 +142,18 @@ describe('createWslWatcher', () => {
     expect(readPaths).not.toContain(path.join(rootPath, 'package.json'))
     await root.subscription.unsubscribe()
   })
+
+  it('accepts a large WSL poll event batch without overflowing V8 arguments', async () => {
+    const scheduleBatchFlush = vi.fn()
+    const initialEntries = Array.from({ length: 200_000 }, (_, index) => dirent(`file-${index}.ts`))
+
+    readdirMock.mockResolvedValueOnce(initialEntries).mockResolvedValueOnce([])
+
+    const root = await createWslWatcher(rootKey, rootPath, deps(scheduleBatchFlush))
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(scheduleBatchFlush).toHaveBeenCalledOnce()
+    expect(root.batch.events).toHaveLength(200_000)
+    await root.subscription.unsubscribe()
+  })
 })

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -14,6 +14,7 @@ import { readdir } from 'fs/promises'
 import * as path from 'path'
 import type { WebContents } from 'electron'
 import type { Event as WatcherEvent } from '@parcel/watcher'
+import { appendWatcherEvents } from './filesystem-watcher-event-batch'
 
 export type WatcherSubscription = {
   unsubscribe(): Promise<void>
@@ -155,7 +156,7 @@ export async function createWslWatcher(
       prevSnapshot = nextSnapshot
 
       if (events.length > 0) {
-        root.batch.events.push(...events)
+        appendWatcherEvents(root.batch.events, events)
         deps.scheduleBatchFlush(rootKey, root)
       }
     } catch {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -12,6 +12,7 @@ import { isWslPath } from '../wsl'
 import { createWslWatcher } from './filesystem-watcher-wsl'
 import type { WatchedRoot } from './filesystem-watcher-wsl'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import { appendWatcherEvents } from './filesystem-watcher-event-batch'
 
 // ── Ignore patterns ──────────────────────────────────────────────────
 // Why: high-churn directories are suppressed at the native watcher level
@@ -285,7 +286,7 @@ async function createWatcher(rootKey: string, rootPath: string): Promise<Watched
           return
         }
 
-        root.batch.events.push(...events)
+        appendWatcherEvents(root.batch.events, events)
         scheduleBatchFlush(rootKey, root)
       },
       watcherOptions


### PR DESCRIPTION
## Summary
- replace watcher batch spread pushes with a non-variadic append helper so large deletion bursts do not exceed V8's argument limit
- apply the same fix to the local Parcel watcher and WSL polling watcher
- add large-batch regressions covering 200,000 delete events

Fixes #2409

## Verification
- Reproduced the raw failure with a 200,000-event array: `batch.push(...events)` throws `RangeError: Maximum call stack size exceeded`
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-wsl.test.ts src/main/ipc/filesystem-watcher-large-batch.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher-wsl.ts src/main/ipc/filesystem-watcher-event-batch.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-wsl.test.ts src/main/ipc/filesystem-watcher-large-batch.test.ts`
- `pnpm test`

Made with [Orca](https://github.com/stablyai/orca) 🐋
