### PR TITLE
fix(daemon): strip ELECTRON_RUN_AS_NODE from spawned PTY env

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -214,6 +214,28 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
   })
 
+  it('does not inherit ELECTRON_RUN_AS_NODE from the daemon process env', () => {
+    // Why: the daemon is forked with ELECTRON_RUN_AS_NODE=1. If that flag
+    // reaches user shells, nested Electron commands run as plain Node.
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const previous = process.env.ELECTRON_RUN_AS_NODE
+    process.env.ELECTRON_RUN_AS_NODE = '1'
+
+    try {
+      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ELECTRON_RUN_AS_NODE
+      } else {
+        process.env.ELECTRON_RUN_AS_NODE = previous
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
+  })
+
   it('does not inherit parent agent hook endpoint for development hook env', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -79,6 +79,12 @@ function removeInheritedDevAgentHookEndpoint(
   }
 }
 
+function removeInheritedElectronRunAsNode(env: Record<string, string>): void {
+  // Why: the daemon needs ELECTRON_RUN_AS_NODE=1 internally, but user shells
+  // must not inherit it or nested Electron commands run as plain Node.
+  delete env.ELECTRON_RUN_AS_NODE
+}
+
 function formatMissingDaemonPathError(kind: 'helper' | 'cwd', path: string): DaemonProtocolError {
   const detailName = kind === 'helper' ? 'helper' : 'cwd'
   const step = kind === 'helper' ? 'posix_spawn' : 'daemon_cwd'
@@ -182,6 +188,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   // of the terminal that launched `pn dev`; each PTY must opt into its own.
   removeUnspecifiedPaneIdentityEnv(env, opts.env)
   removeInheritedDevAgentHookEndpoint(env, opts.env)
+  removeInheritedElectronRunAsNode(env)
   removeInheritedNoColor(env)
 
   env.LANG ??= 'en_US.UTF-8'


### PR DESCRIPTION
## Summary

- The daemon process is forked from Electron with `ELECTRON_RUN_AS_NODE=1` so the forked daemon runs as plain Node and avoids Electron display/GPU initialization around node-pty startup.
- That flag was leaking into daemon-backed terminal shells because `createPtySubprocess` spreads the daemon process env into the PTY child env.
- This strips the daemon-internal flag at the daemon -> PTY boundary before `pty.spawn`, while keeping the daemon process itself unchanged.

Fixes #2414.

## Security / compatibility review

- Security: this reduces parent-process env leakage into user shells. It does not add a new trust boundary, command path, or dependency.
- Explicit child env is scrubbed too. Renderer/main callers have no legitimate reason to seed `ELECTRON_RUN_AS_NODE` into an interactive user shell, and preserving it would keep the reported Electron-as-Node footgun open.
- Cross-platform: the variable has the same Electron meaning on macOS, Linux, and Windows, so the scrub is intentionally platform-agnostic.
- SSH: the change is limited to daemon-backed local PTY subprocess creation. It does not inject host-local paths into SSH PTYs or change SSH relay env handling.

## Validation

- [x] Regression test fails before the fix with `expected '1' to be undefined`.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/pty-subprocess.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/main/daemon/pty-subprocess.ts src/main/daemon/pty-subprocess.test.ts`
- [x] Live `createPtySubprocess` harness with parent `ELECTRON_RUN_AS_NODE=1` prints `ORCA_REPRO:unset` from the spawned shell.
- [x] `pnpm test` (893 files passed, 1 skipped; 9349 tests passed, 10 skipped)