### PR TITLE
Fix terminal bottom scroll during resize

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -200,6 +200,7 @@ describe('scroll state', () => {
     restoreScrollState(terminal, state)
 
     expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1)
+    expect(terminal.scrollLines).not.toHaveBeenCalled()
     expect(terminal.buffer.active.viewportY).toBe(250)
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -147,6 +147,11 @@ function releaseScrollStateMarker(state: ScrollState): void {
 // A synchronous one-line jiggle updates the scrollbar without a visible paint.
 function forceViewportScrollbarSync(terminal: Terminal): void {
   const buf = terminal.buffer.active
+  if (buf.viewportY >= buf.baseY) {
+    // Why: jiggle-scrolling at bottom makes xterm stop following active output
+    // after split-pane resizes; scrollToBottom already places the thumb there.
+    return
+  }
   if (buf.viewportY > 0) {
     terminal.scrollLines(-1)
     terminal.scrollLines(1)


### PR DESCRIPTION
## Summary
- Skip the xterm scrollbar jiggle when a restored terminal is already at bottom.
- Add a unit assertion so at-bottom restores do not call scrollLines.

## Reproduction proof
- Before fix: Electron split-pane resize repro failed with `bottomDelta=13` (`baseY=71`, `viewportY=58`).
- Before screenshot: `/tmp/orca-scroll-proof-before/before-resize-scroll.png`
- Before metrics: `/tmp/orca-scroll-proof-before/before-resize-scroll-metrics.json`

## Verification proof
- After fix: the same Electron split-pane resize repro passed with `bottomDelta=0` throughout the final samples.
- After screenshot: `/tmp/orca-scroll-proof-after/after-resize-scroll.png`
- After metrics: `/tmp/orca-scroll-proof-after/after-resize-scroll-metrics.json`

## Tests
- `npx playwright test tests/e2e/terminal-scroll-resize-proof.spec.ts --config tests/playwright.config.ts --project=electron-headless` (temporary local repro spec; not committed)
- `npx vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-scroll.test.ts`