### PR TITLE
Fix Codex Shift+Enter on Windows

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -128,6 +128,7 @@ export function useTerminalKeyboardShortcuts({
     }
 
     const isMac = navigator.userAgent.includes('Mac')
+    const isWindows = navigator.userAgent.includes('Windows')
 
     // Why: KeyboardEvent.location on a character key (e.g. Period) always
     // reports that key's own position (0 = standard), not which modifier is
@@ -199,7 +200,8 @@ export function useTerminalKeyboardShortcuts({
         e,
         isMac,
         macOptionAsAltRef.current,
-        optionKeyLocation
+        optionKeyLocation,
+        isWindows
       )
       if (!action) {
         return

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: the shortcut policy matrix keeps cross-platform terminal chord expectations together. */
 import { describe, expect, it } from 'vitest'
 import {
   resolveTerminalShortcutAction,
@@ -86,6 +87,21 @@ describe('resolveTerminalShortcutAction', () => {
     expect(resolveTerminalShortcutAction(event({ key: 'Backspace', altKey: true }), true)).toEqual({
       type: 'sendInput',
       data: '\x1b\x7f'
+    })
+  })
+
+  it('uses the Codex-compatible Shift+Enter sequence on Windows', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', shiftKey: true }),
+        false,
+        'false',
+        0,
+        true
+      )
+    ).toEqual({
+      type: 'sendInput',
+      data: '\x1b\r'
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -40,7 +40,8 @@ export function resolveTerminalShortcutAction(
   event: TerminalShortcutEvent,
   isMac: boolean,
   macOptionAsAlt: MacOptionAsAlt = 'false',
-  optionKeyLocation: number = 0
+  optionKeyLocation: number = 0,
+  isWindows: boolean = false
 ): TerminalShortcutAction | null {
   const mod = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
   if (!event.repeat && mod && !event.altKey) {
@@ -118,7 +119,9 @@ export function resolveTerminalShortcutAction(
     event.shiftKey &&
     event.key === 'Enter'
   ) {
-    return { type: 'sendInput', data: '\x1b[13;2u' }
+    // Why: Codex on Windows PowerShell treats CSI-u Shift+Enter as inert,
+    // while the Alt+Enter byte path inserts a composer newline.
+    return { type: 'sendInput', data: isWindows ? '\x1b\r' : '\x1b[13;2u' }
   }
 
   if (

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -81,11 +81,10 @@ describe('buildDefaultTerminalOptions', () => {
 
   it('advertises kitty keyboard protocol so CLIs enable enhanced key reporting', () => {
     // Why: Orca already writes CSI-u bytes for extended key chords like
-    // Shift+Enter (see terminal-shortcut-policy.ts). CLIs that gate
-    // enhanced input on a CSI ? u handshake only read those bytes once the
-    // terminal advertises support. Regressing this flag silently breaks
-    // Shift+Enter (and other extended chords) in apps like Claude Code and
-    // Codex, especially when running inside tmux.
+    // Shift+Enter on non-Windows platforms (see terminal-shortcut-policy.ts).
+    // CLIs that gate enhanced input on a CSI ? u handshake only read those
+    // bytes once the terminal advertises support. Regressing this flag
+    // silently breaks enhanced chords, especially inside tmux.
     expect(buildDefaultTerminalOptions().vtExtensions?.kittyKeyboard).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -32,12 +32,10 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     macOptionClickForcesSelection: true,
     drawBoldTextInBrightColors: true,
     // Why: advertise kitty keyboard protocol support so CLIs that probe
-    // (CSI ? u) know Orca accepts enhanced key reporting. Without this,
-    // Orca already writes \x1b[13;2u for Shift+Enter (see
-    // terminal-shortcut-policy.ts), but programs that respect the protocol
-    // handshake fall back to legacy encodings and ignore the CSI-u byte,
-    // making chords like Shift+Enter invisible to the app — especially
-    // noticeable inside tmux. Matches VS Code's xtermTerminal.ts.
+    // (CSI ? u) know Orca accepts enhanced key reporting. Orca still writes
+    // CSI-u for Shift+Enter on non-Windows platforms; programs that respect
+    // the handshake otherwise fall back to legacy encodings and miss it.
+    // Matches VS Code's xtermTerminal.ts.
     vtExtensions: {
       kittyKeyboard: true
     }

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -18,13 +18,13 @@
 import { test, expect } from './helpers/orca-app'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import {
-  discoverActivePtyId,
   execInTerminal,
   countVisibleTerminalPanes,
   waitForActiveTerminalManager,
   waitForTerminalOutput,
   waitForPaneCount,
-  getTerminalContent
+  getTerminalContent,
+  waitForActivePanePtyId
 } from './helpers/terminal'
 import { waitForSessionReady, waitForActiveWorktree, ensureTerminalVisible } from './helpers/store'
 
@@ -274,6 +274,21 @@ test.describe('Terminal Shortcuts', () => {
     await waitForPaneCount(orcaPage, 1, 30_000)
   })
 
+  test('Shift+Enter writes the platform newline chord for terminal TUIs', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    await installMainProcessPtyWriteSpy(electronApp)
+    await waitForActivePanePtyId(orcaPage)
+
+    await pressAndExpectWrite(
+      orcaPage,
+      electronApp,
+      'Shift+Enter',
+      process.platform === 'win32' ? '\x1b\r' : '\x1b[13;2u'
+    )
+  })
+
   test('all terminal chords reach the PTY or fire their action', async ({
     orcaPage,
     electronApp
@@ -281,7 +296,7 @@ test.describe('Terminal Shortcuts', () => {
     await installMainProcessPtyWriteSpy(electronApp)
 
     // Seed the buffer so Cmd+K has something to clear.
-    const ptyId = await discoverActivePtyId(orcaPage)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
     const marker = `SHORTCUT_TEST_${Date.now()}`
     await execInTerminal(orcaPage, ptyId, `echo ${marker}`)
     await waitForTerminalOutput(orcaPage, marker)
@@ -305,8 +320,14 @@ test.describe('Terminal Shortcuts', () => {
     // Ctrl+Backspace → \x17 (unix-word-rubout).
     await pressAndExpectWrite(orcaPage, electronApp, 'Control+Backspace', '\x17')
 
-    // Shift+Enter → CSI-u so agents can distinguish from plain Enter.
-    await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x1b[13;2u')
+    // Shift+Enter → a modified Enter byte path so agents can distinguish it
+    // from plain Enter. Windows uses Esc+CR because Codex ignores CSI-u there.
+    await pressAndExpectWrite(
+      orcaPage,
+      electronApp,
+      'Shift+Enter',
+      process.platform === 'win32' ? '\x1b\r' : '\x1b[13;2u'
+    )
 
     // --- send-input chords (macOS-only) ---
 
@@ -413,7 +434,7 @@ test.describe('Terminal Shortcuts', () => {
     // Why: CI can mount the xterm surface before the pane transport has a
     // live PTY. Probe first so xterm onData cannot race a disconnected
     // sendInput path, then clear the probe writes before the layout assertion.
-    await discoverActivePtyId(orcaPage)
+    await waitForActivePanePtyId(orcaPage)
     await enableKittyKeyboardReporting(orcaPage, 31)
     await clearPtyWriteLog(electronApp)
 


### PR DESCRIPTION
﻿## Summary

Fixes #2412.

On Windows, Orca now sends `Esc+Enter` (`\x1b\r`) for bare `Shift+Enter` in terminal panes instead of the CSI-u `\x1b[13;2u` sequence that Codex ignores inside PowerShell. macOS and Linux keep the existing CSI-u behavior.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional verification run:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
- `pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-shortcuts.spec.ts --config=tests/playwright.config.ts --project=electron-headless -g "Shift\+Enter writes" --reporter=line`
- `pnpm run typecheck:web`
- `git diff --check`
- Manual node-pty repro with real `codex-cli 0.132.0` under Windows PowerShell: old `\x1b[13;2u` produced `helloworld`; new `\x1b\r` rendered `hello` and `world` on separate composer lines.

Note: the broader `all terminal chords reach the PTY or fire their action` Playwright spec still closes the Electron page later during pane action checks in this Windows environment. The new focused regression covers the changed Shift+Enter behavior directly.

## AI Review Report

Reviewed the terminal keyboard routing from the window-level handler through `resolveTerminalShortcutAction` to PTY writes. Main risks checked:

- Windows-only behavior is gated by `navigator.userAgent.includes('Windows')`.
- macOS/Linux keep the previous `\x1b[13;2u` sequence.
- `Cmd/Ctrl+Shift+Enter` pane expand remains separate from bare `Shift+Enter`.
- Remote/SSH input still uses the same PTY send path; only the bytes for this platform-specific chord change.
- Existing kitty keyboard advertisement remains enabled for non-Windows enhanced key sequences.

Added unit and Playwright coverage for the Windows byte sequence and preserved non-Windows expectations.

## Security Audit

No new command execution, auth, filesystem, dependency, IPC channel, or path handling is introduced. The change only alters the string sent to an already-active PTY for a user-initiated terminal key chord. Clipboard/paste handling is unchanged.

## Notes

This does not change paste behavior. Normal terminal paste still goes through xterm/bracketed paste. Orca's agent draft paste path may append a plain Enter when explicitly asked to submit after pasting; that is separate from the interactive `Shift+Enter` keybinding fixed here.
