### PR TITLE
Add 'Add Agent' submenu to workspace context menu

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.add-agent.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.add-agent.test.ts
@@ -229,7 +229,9 @@ describe('WorktreeContextMenu Add Agent submenu', () => {
 
     const onBeforeLaunch = quickLaunch?.props?.onBeforeLaunch as (() => void) | undefined
     onBeforeLaunch?.()
-    expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith(worktree.id)
+    expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith(worktree.id, {
+      skipInitialTerminal: true
+    })
   })
 
   it('hides Add Agent when the context menu targets multiple workspaces', () => {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.add-agent.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.add-agent.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactTypes from 'react'
+import type { Worktree } from '../../../../shared/types'
+import WorktreeContextMenu from './WorktreeContextMenu'
+
+const { activateAndRevealWorktreeMock, focusTerminalTabSurfaceMock, mockRepo, mockState } =
+  vi.hoisted(() => {
+    const repo = {
+      id: 'repo-1',
+      path: '/repo',
+      displayName: 'Repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: null as string | null
+    }
+    return {
+      activateAndRevealWorktreeMock: vi.fn(),
+      focusTerminalTabSurfaceMock: vi.fn(),
+      mockRepo: repo,
+      mockState: {
+        updateWorktreeMeta: vi.fn(),
+        workspaceStatuses: [{ id: 'active', label: 'Active' }],
+        openModal: vi.fn(),
+        projectGroups: [],
+        createProjectGroup: vi.fn(),
+        moveProjectToGroup: vi.fn(),
+        deleteStateByWorktreeId: {},
+        worktreeLineageById: {},
+        updateWorktreeLineage: vi.fn(),
+        tabsByWorktree: {},
+        ptyIdsByTabId: {},
+        browserTabsByWorktree: {},
+        repos: [repo],
+        worktreesByRepo: {} as Record<string, Worktree[]>
+      }
+    }
+  })
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof ReactTypes>('react')
+  return {
+    ...actual,
+    memo: <T>(component: T) => component,
+    useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
+    useEffect: () => {},
+    useMemo: <T>(factory: () => T) => factory(),
+    useRef: <T>(current: T) => ({ current }),
+    useState: <T>(initial: T) => [initial, vi.fn()] as const
+  }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof mockState) => unknown) => selector(mockState)
+}))
+
+vi.mock('@/store/selectors', () => ({
+  useRepoById: () => mockRepo,
+  useRepoMap: () => new Map([[mockRepo.id, mockRepo]]),
+  useWorktreeMap: () =>
+    new Map(
+      Object.values(mockState.worktreesByRepo)
+        .flat()
+        .map((worktree) => [worktree.id, worktree])
+    )
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: activateAndRevealWorktreeMock
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: focusTerminalTabSurfaceMock
+}))
+
+vi.mock('./worktree-list-groups', () => ({
+  getLineageRenderInfo: () => ({ state: 'none' })
+}))
+
+vi.mock('./workspace-status', () => ({
+  getWorkspaceStatus: () => 'active',
+  getWorkspaceStatusVisualMeta: () => ({
+    icon: function StatusIcon() {
+      return null
+    },
+    tone: ''
+  })
+}))
+
+type ReactElementLike = {
+  type: unknown
+  props?: Record<string, unknown>
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: mockRepo.id,
+    path: '/repo/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Workspace 1',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdWithAgent: undefined,
+    ...overrides
+  }
+}
+
+function typeName(type: unknown): string | null {
+  if (typeof type === 'string') {
+    return type
+  }
+  return typeof type === 'function' ? type.name : null
+}
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'boolean') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => visit(child, cb))
+    return
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  const element = node as ReactElementLike
+  cb(element)
+  visit(element.props?.children, cb)
+}
+
+function containsText(node: unknown, text: string): boolean {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node).includes(text)
+  }
+  if (node == null || typeof node === 'boolean') {
+    return false
+  }
+  if (Array.isArray(node)) {
+    return node.some((child) => containsText(child, text))
+  }
+  return containsText((node as ReactElementLike).props?.children, text)
+}
+
+function findQuickLaunchItem(node: unknown): ReactElementLike | null {
+  let match: ReactElementLike | null = null
+  visit(node, (element) => {
+    if (element.props?.launchSource === 'sidebar') {
+      match = element
+    }
+  })
+  return match
+}
+
+function renderMenu(worktree: Worktree, selectedWorktrees: readonly Worktree[] = [worktree]) {
+  const candidate = WorktreeContextMenu as unknown as
+    | ((props: Record<string, unknown>) => unknown)
+    | { type: (props: Record<string, unknown>) => unknown }
+  const Component = typeof candidate === 'function' ? candidate : candidate.type
+  return Component({ worktree, selectedWorktrees, children: 'workspace row' })
+}
+
+function placementTokens(node: unknown): string[] {
+  const tokens: string[] = []
+  visit(node, (element) => {
+    const name = typeName(element.type)
+    if (name === 'WorktreeOpenInSubMenu') {
+      tokens.push('open-in')
+    } else if (
+      name === 'DropdownMenuSubTrigger' &&
+      containsText(element.props?.children, 'Add Agent')
+    ) {
+      tokens.push('add-agent')
+    } else if (name === 'DropdownMenuItem' && containsText(element.props?.children, 'Copy Path')) {
+      tokens.push('copy-path')
+    }
+  })
+  return tokens
+}
+
+beforeEach(() => {
+  activateAndRevealWorktreeMock.mockReset()
+  focusTerminalTabSurfaceMock.mockReset()
+  mockState.updateWorktreeMeta = vi.fn()
+  mockState.openModal = vi.fn()
+  mockState.projectGroups = []
+  mockState.createProjectGroup = vi.fn()
+  mockState.moveProjectToGroup = vi.fn()
+  mockState.deleteStateByWorktreeId = {}
+  mockState.worktreeLineageById = {}
+  mockState.updateWorktreeLineage = vi.fn()
+  mockState.tabsByWorktree = {}
+  mockState.ptyIdsByTabId = {}
+  mockState.browserTabsByWorktree = {}
+  mockState.worktreesByRepo = {}
+})
+
+describe('WorktreeContextMenu Add Agent submenu', () => {
+  it('places Add Agent between Open in and Copy Path for a single workspace', () => {
+    const worktree = makeWorktree()
+    mockState.worktreesByRepo = { [mockRepo.id]: [worktree] }
+
+    const tree = renderMenu(worktree)
+    const placement = placementTokens(tree)
+    const openInIndex = placement.indexOf('open-in')
+    const addAgentIndex = placement.indexOf('add-agent')
+    const copyPathIndex = placement.indexOf('copy-path')
+
+    expect(openInIndex).toBeGreaterThanOrEqual(0)
+    expect(addAgentIndex).toBeGreaterThan(openInIndex)
+    expect(copyPathIndex).toBeGreaterThan(addAgentIndex)
+
+    const quickLaunch = findQuickLaunchItem(tree)
+    expect(quickLaunch?.props).toMatchObject({
+      worktreeId: worktree.id,
+      groupId: worktree.id,
+      launchSource: 'sidebar',
+      onFocusTerminal: focusTerminalTabSurfaceMock
+    })
+
+    const onBeforeLaunch = quickLaunch?.props?.onBeforeLaunch as (() => void) | undefined
+    onBeforeLaunch?.()
+    expect(activateAndRevealWorktreeMock).toHaveBeenCalledWith(worktree.id)
+  })
+
+  it('hides Add Agent when the context menu targets multiple workspaces', () => {
+    const first = makeWorktree()
+    const second = makeWorktree({ id: 'wt-2', path: '/repo/wt-2', displayName: 'Workspace 2' })
+    mockState.worktreesByRepo = { [mockRepo.id]: [first, second] }
+
+    const tree = renderMenu(first, [first, second])
+
+    expect(findQuickLaunchItem(tree)).toBeNull()
+    expect(containsText(tree, 'Add Agent')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -216,6 +216,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const deleteStateByWorktreeId = useAppStore((s) => s.deleteStateByWorktreeId)
   const scopeRef = useRef<HTMLDivElement>(null)
   const contextMenuOpenedAtRef = useRef<number | null>(null)
+  const skipNextCloseAutoFocusRef = useRef(false)
   const activeContextWorktrees = menuOpen ? contextWorktrees : selectedWorktrees
   const isMultiContext = activeContextWorktrees.length > 1
   const sleepableWorktrees = useMemo(
@@ -455,6 +456,10 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     // that focus restore can scroll the virtual list away from the row the
     // user just acted on.
     event.preventDefault()
+    if (skipNextCloseAutoFocusRef.current) {
+      skipNextCloseAutoFocusRef.current = false
+      return
+    }
     const sidebar = scopeRef.current?.closest('[data-worktree-sidebar]')
     if (sidebar instanceof HTMLElement) {
       sidebar.focus({ preventScroll: true })
@@ -523,12 +528,16 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                     onFocusTerminal={focusTerminalTabSurface}
                     launchSource="sidebar"
                     onBeforeLaunch={() => {
+                      // Why: the newly-created terminal owns the next focus
+                      // handoff. Let focusTerminalTabSurface win instead of
+                      // sending focus back to the sidebar as the menu closes.
+                      skipNextCloseAutoFocusRef.current = true
                       // Why: the context menu can fire from a row whose
                       // workspace is not currently active. Activate first so
                       // the new tab and the focusTerminalTabSurface handoff
                       // land on the freshly-mounted pane rather than silently
                       // appending behind a different workspace.
-                      activateAndRevealWorktree(worktree.id)
+                      activateAndRevealWorktree(worktree.id, { skipInitialTerminal: true })
                     }}
                   />
                 </DropdownMenuSubContent>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
+  Bot,
   Copy,
   Bell,
   BellOff,
@@ -43,6 +44,8 @@ import { getLineageRenderInfo } from './worktree-list-groups'
 import { getWorkspaceStatus, getWorkspaceStatusVisualMeta } from './workspace-status'
 import { WorktreeOpenInSubMenu } from './WorktreeOpenInMenu'
 import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
+import { QuickLaunchAgentMenuItems } from '@/components/tab-bar/QuickLaunchButton'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 
 type Props = {
   worktree: Worktree
@@ -508,6 +511,28 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                 connectionId={repo?.connectionId ?? null}
                 disabled={isDeleting}
               />
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger disabled={isDeleting}>
+                  <Bot className="size-3.5" />
+                  Add Agent
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-52">
+                  <QuickLaunchAgentMenuItems
+                    worktreeId={worktree.id}
+                    groupId={worktree.id}
+                    onFocusTerminal={focusTerminalTabSurface}
+                    launchSource="sidebar"
+                    onBeforeLaunch={() => {
+                      // Why: the context menu can fire from a row whose
+                      // workspace is not currently active. Activate first so
+                      // the new tab and the focusTerminalTabSurface handoff
+                      // land on the freshly-mounted pane rather than silently
+                      // appending behind a different workspace.
+                      activateAndRevealWorktree(worktree.id)
+                    }}
+                  />
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
               <DropdownMenuItem onSelect={handleCopyPath} disabled={isDeleting}>
                 <Copy className="size-3.5" />
                 Copy Path

--- a/src/renderer/src/components/tab-bar/QuickLaunchAgentMenuItems.test.ts
+++ b/src/renderer/src/components/tab-bar/QuickLaunchAgentMenuItems.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactTypes from 'react'
+import { QuickLaunchAgentMenuItems } from './QuickLaunchButton'
+
+const {
+  launchAgentInNewTabMock,
+  mockDetectedIds,
+  mockState,
+  openSettingsPageMock,
+  openSettingsTargetMock,
+  refreshDetectedAgentsMock,
+  useDetectedAgentsMock
+} = vi.hoisted(() => ({
+  launchAgentInNewTabMock: vi.fn(),
+  mockDetectedIds: ['codex'] as string[],
+  mockState: {
+    settings: {
+      defaultTuiAgent: 'codex'
+    },
+    repos: [{ id: 'repo-1', connectionId: null as string | null }],
+    worktreesByRepo: {
+      'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+    },
+    activeWorktreeId: 'wt-1',
+    tabsByWorktree: {} as Record<string, { id: string; ptyId: string | null }[]>,
+    ptyIdsByTabId: {} as Record<string, string[]>,
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: vi.fn()
+  },
+  openSettingsPageMock: vi.fn(),
+  openSettingsTargetMock: vi.fn(),
+  refreshDetectedAgentsMock: vi.fn(),
+  useDetectedAgentsMock: vi.fn()
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof ReactTypes>('react')
+  return {
+    ...actual,
+    memo: <T>(component: T) => component,
+    useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback
+  }
+})
+
+vi.mock('lucide-react', () => ({
+  Settings: function Settings() {
+    return null
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    message: vi.fn()
+  }
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenuItem: function DropdownMenuItem() {
+    return null
+  }
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  AGENT_CATALOG: [
+    { id: 'claude', label: 'Claude' },
+    { id: 'codex', label: 'Codex' }
+  ],
+  AgentIcon: function AgentIcon() {
+    return null
+  }
+}))
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (state: typeof mockState) => unknown) => selector(mockState),
+    {
+      getState: () => mockState
+    }
+  )
+  return { useAppStore }
+})
+
+vi.mock('@/hooks/useDetectedAgents', () => ({
+  useDetectedAgents: useDetectedAgentsMock
+}))
+
+vi.mock('@/lib/launch-agent-in-new-tab', () => ({
+  launchAgentInNewTab: launchAgentInNewTabMock
+}))
+
+type ReactElementLike = {
+  type: unknown
+  props?: Record<string, unknown>
+}
+
+function getTypeName(type: unknown): string | null {
+  if (typeof type === 'string') {
+    return type
+  }
+  if (typeof type === 'function') {
+    return type.name
+  }
+  return null
+}
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'boolean') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => visit(child, cb))
+    return
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  const element = node as ReactElementLike
+  cb(element)
+  if (element.props && 'children' in element.props) {
+    visit(element.props.children, cb)
+  }
+}
+
+function containsText(node: unknown, text: string): boolean {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node).includes(text)
+  }
+  if (node == null || typeof node === 'boolean') {
+    return false
+  }
+  if (Array.isArray(node)) {
+    return node.some((child) => containsText(child, text))
+  }
+  const element = node as ReactElementLike
+  return containsText(element.props?.children, text)
+}
+
+function findMenuItemByText(node: unknown, text: string): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (element) => {
+    if (
+      found == null &&
+      getTypeName(element.type) === 'DropdownMenuItem' &&
+      containsText(element.props?.children, text)
+    ) {
+      found = element
+    }
+  })
+  if (!found) {
+    throw new Error(`Menu item not found: ${text}`)
+  }
+  return found
+}
+
+function renderQuickLaunchAgentMenuItems(
+  props: {
+    onFocusTerminal?: (tabId: string) => void
+    onBeforeLaunch?: () => void
+    launchSource?: 'sidebar' | 'tab_bar_quick_launch'
+  } = {}
+): unknown {
+  const candidate = QuickLaunchAgentMenuItems as unknown as
+    | ((props: Record<string, unknown>) => unknown)
+    | { type: (props: Record<string, unknown>) => unknown }
+  const Component = typeof candidate === 'function' ? candidate : candidate.type
+  return Component({
+    worktreeId: 'wt-1',
+    groupId: 'group-1',
+    onFocusTerminal: props.onFocusTerminal ?? vi.fn(),
+    ...(props.onBeforeLaunch ? { onBeforeLaunch: props.onBeforeLaunch } : {}),
+    ...(props.launchSource ? { launchSource: props.launchSource } : {})
+  })
+}
+
+beforeEach(() => {
+  mockDetectedIds.splice(0, mockDetectedIds.length, 'codex')
+  openSettingsPageMock.mockReset()
+  openSettingsTargetMock.mockReset()
+  refreshDetectedAgentsMock.mockReset()
+  launchAgentInNewTabMock.mockReset()
+  useDetectedAgentsMock.mockReset()
+  mockState.settings = { defaultTuiAgent: 'codex' }
+  mockState.repos = [{ id: 'repo-1', connectionId: null }]
+  mockState.worktreesByRepo = { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] }
+  mockState.tabsByWorktree = {}
+  mockState.ptyIdsByTabId = {}
+  mockState.openSettingsPage = openSettingsPageMock
+  mockState.openSettingsTarget = openSettingsTargetMock
+  useDetectedAgentsMock.mockImplementation(() => ({
+    detectedIds: mockDetectedIds,
+    isLoading: false,
+    isRefreshing: false,
+    refresh: refreshDetectedAgentsMock
+  }))
+  launchAgentInNewTabMock.mockImplementation(() => {
+    mockState.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' }] }
+    mockState.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+    return {
+      tabId: 'tab-1',
+      startupPlan: { expectedProcess: 'codex' },
+      pasteDraftAfterLaunch: false
+    }
+  })
+})
+
+describe('QuickLaunchAgentMenuItems', () => {
+  it('activates the caller hook before launch and forwards sidebar telemetry', () => {
+    const order: string[] = []
+    launchAgentInNewTabMock.mockImplementationOnce(() => {
+      order.push('launch')
+      mockState.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' }] }
+      mockState.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+      return {
+        tabId: 'tab-1',
+        startupPlan: { expectedProcess: 'codex' },
+        pasteDraftAfterLaunch: false
+      }
+    })
+    const tree = renderQuickLaunchAgentMenuItems({
+      launchSource: 'sidebar',
+      onBeforeLaunch: () => order.push('before'),
+      onFocusTerminal: () => order.push('focus')
+    })
+
+    const codexItem = findMenuItemByText(tree, 'Codex')
+    ;(codexItem.props?.onSelect as (() => void) | undefined)?.()
+
+    expect(order).toEqual(['before', 'launch', 'focus'])
+    expect(launchAgentInNewTabMock).toHaveBeenCalledWith({
+      agent: 'codex',
+      worktreeId: 'wt-1',
+      groupId: 'group-1',
+      launchSource: 'sidebar'
+    })
+    expect(mockState.ptyIdsByTabId['tab-1']).toEqual(['pty-1'])
+  })
+
+  it('uses the worktree SSH connection when detecting available agents', () => {
+    mockState.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+
+    renderQuickLaunchAgentMenuItems()
+
+    expect(useDetectedAgentsMock).toHaveBeenCalledWith('ssh-1')
+  })
+
+  it('shows the empty placeholder while keeping Agent settings available', () => {
+    mockDetectedIds.splice(0, mockDetectedIds.length)
+    const tree = renderQuickLaunchAgentMenuItems()
+
+    expect(findMenuItemByText(tree, 'No agents detected').props?.disabled).toBe(true)
+
+    const settingsItem = findMenuItemByText(tree, 'Agent settings…')
+    ;(settingsItem.props?.onSelect as (() => void) | undefined)?.()
+
+    expect(openSettingsTargetMock).toHaveBeenCalledWith({ pane: 'agents', repoId: null })
+    expect(openSettingsPageMock).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -29,6 +29,11 @@ export type QuickLaunchAgentMenuItemsProps = {
   launchSource?: LaunchSource
   /** Called after a prompt is queued into the agent, or immediately for argv prompt launches. */
   onPromptDelivered?: () => void
+  /** Fires synchronously before `launchAgentInNewTab` runs. Used by callers
+   *  outside the active workspace (e.g. the sidebar context menu) to activate
+   *  and reveal the target worktree so the new tab and focus handoff land in
+   *  the freshly-mounted pane instead of silently in the background. */
+  onBeforeLaunch?: () => void
 }
 
 function getCatalogEntry(agent: TuiAgent): { id: TuiAgent; label: string } | null {
@@ -95,7 +100,8 @@ function QuickLaunchAgentMenuItemsInner({
   prompt,
   promptDelivery,
   launchSource,
-  onPromptDelivered
+  onPromptDelivered,
+  onBeforeLaunch
 }: QuickLaunchAgentMenuItemsProps): React.JSX.Element | null {
   // Why: must be a reactive selector (not getConnectionId() which reads a
   // snapshot via getState()). This ensures the component re-renders when the
@@ -125,6 +131,10 @@ function QuickLaunchAgentMenuItemsInner({
     (agent: TuiAgent) => {
       const entry = getCatalogEntry(agent)
       const label = entry?.label ?? agent
+      // Why: must run before createTab so the target worktree is the active
+      // one when launchAgentInNewTab flips activeTabType — otherwise the new
+      // tab lands behind a different workspace and the focus handoff misses.
+      onBeforeLaunch?.()
       const result = launchAgentInNewTab({
         agent,
         worktreeId,
@@ -160,7 +170,16 @@ function QuickLaunchAgentMenuItemsInner({
         toast.message(getLaunchWatchdogTimeoutMessage(label))
       })
     },
-    [worktreeId, groupId, onFocusTerminal, prompt, promptDelivery, launchSource, onPromptDelivered]
+    [
+      worktreeId,
+      groupId,
+      onFocusTerminal,
+      prompt,
+      promptDelivery,
+      launchSource,
+      onPromptDelivered,
+      onBeforeLaunch
+    ]
   )
 
   const enabledDetectedIds = detectedIds ? filterEnabledTuiAgents(detectedIds, disabledAgents) : []

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -138,6 +138,54 @@ describe('activateAndRevealWorktree created agent reopen', () => {
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id, { behavior: 'auto' })
   })
 
+  it('can skip the initial terminal when the caller creates its own tab', () => {
+    const worktree = makeWorktree()
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      activeRepoId: 'repo-1',
+      activeView: 'terminal',
+      tabsByWorktree: {},
+      unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      browserTabsByWorktree: {},
+      activeFileIdByWorktree: {},
+      activeBrowserTabIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      activeTabIdByWorktree: {},
+      tabBarOrderByWorktree: {},
+      pendingStartupByTabId: {},
+      settings: {
+        agentCmdOverrides: {},
+        setupScriptLaunchMode: 'new-tab'
+      } as unknown as ReturnType<typeof useAppStore.getState>['settings'],
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      revealWorktreeInSidebar: vi.fn()
+    })
+
+    const result = activateAndRevealWorktree(worktree.id, { skipInitialTerminal: true })
+    const state = useAppStore.getState()
+
+    expect(result).toEqual({ primaryTabId: null })
+    expect(state.activeWorktreeId).toBe(worktree.id)
+    expect(state.tabsByWorktree[worktree.id]).toBeUndefined()
+    expect(state.pendingStartupByTabId).toEqual({})
+  })
+
   it('asks the host runtime to activate the worktree in the paired web client', async () => {
     const worktree = makeWorktree()
     const callRuntimeEnvironment = vi.fn().mockResolvedValue({

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -136,6 +136,8 @@ export function activateAndRevealWorktree(
     setup?: WorktreeSetupLaunch
     issueCommand?: IssueCommandLaunch
     sidebarRevealBehavior?: PendingSidebarWorktreeReveal['behavior']
+    /** Used by explicit new-tab launchers that create their own surface after activation. */
+    skipInitialTerminal?: boolean
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -182,13 +184,15 @@ export function activateAndRevealWorktree(
   }
 
   // 4. Ensure a focusable surface exists for externally-created worktrees
-  const primaryTabId = ensureWorktreeHasInitialTerminal(
-    useAppStore.getState(),
-    worktreeId,
-    opts?.startup ?? buildCreatedAgentReopenStartup(wt),
-    opts?.setup,
-    opts?.issueCommand
-  )
+  const primaryTabId = opts?.skipInitialTerminal
+    ? null
+    : ensureWorktreeHasInitialTerminal(
+        useAppStore.getState(),
+        worktreeId,
+        opts?.startup ?? buildCreatedAgentReopenStartup(wt),
+        opts?.setup,
+        opts?.issueCommand
+      )
 
   // 5. Clear sidebar filters that would hide the target worktree
   // Why: revealWorktreeInSidebar relies on the worktree card being rendered


### PR DESCRIPTION
## Summary

<img width="532" height="403" alt="image" src="https://github.com/user-attachments/assets/6f827e99-e6a9-45d8-a395-867522ed8a83" />


- New `Add Agent ▸` submenu in the workspace right-click menu (left sidebar), positioned between `Open in ▸` and `Copy Path`.
- Reuses `QuickLaunchAgentMenuItems` (from the tab-bar `+` button) so detected agents and the `Agent settings…` entry stay in sync automatically with the rest of the app.
- Activates the target workspace before the launch (`activateAndRevealWorktree`) so the new agent tab and focus handoff land on the freshly-mounted pane even when right-clicking an inactive workspace.
- Hidden in multi-select context — launching a new agent only makes sense for a single workspace.
- Telemetry: launches from this entry point are tagged `launch_source: 'sidebar'`.

## Test plan
- [ ] Right-click any workspace in the left sidebar → `Add Agent ▸` appears between `Open in ▸` and `Copy Path`.
- [ ] Hover the submenu → detected agents (Claude/Codex/etc.) + `Agent settings…` render.
- [ ] Pick an agent on the **active** workspace → new terminal tab opens with that agent; focus lands in the new xterm.
- [ ] Pick an agent on an **inactive** workspace → that workspace activates first, then the new agent tab opens with focus.
- [ ] Shift/Cmd-click multiple workspaces, then right-click → `Add Agent ▸` is hidden.
- [ ] `Agent settings…` opens the agent settings page.
- [ ] No agents detected (fresh env / unreachable SSH) → menu shows the `No agents detected` placeholder, same as the `+` menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.

## ELI5

Workspace right-click menu gets Add Agent ▸ with the same agent list as the tab bar +, so you can launch an agent into that workspace quickly.
