### PR TITLE
Add source control abort merge action

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -30,6 +30,7 @@ vi.mock('fs', () => ({
 }))
 
 import {
+  abortMerge,
   bulkStageFiles,
   bulkDiscardChanges,
   bulkUnstageFiles,
@@ -186,6 +187,20 @@ describe('bulk git helpers', () => {
 
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
     expect(rmMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('abortMerge', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('runs git merge --abort in the worktree', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+
+    await abortMerge('/repo')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['merge', '--abort'], { cwd: '/repo' })
   })
 })
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -967,6 +967,13 @@ export async function unstageFile(worktreePath: string, filePath: string): Promi
   await gitExecFileAsync(['restore', '--staged', '--', filePath], { cwd: worktreePath })
 }
 
+/**
+ * Abort an in-progress merge.
+ */
+export async function abortMerge(worktreePath: string): Promise<void> {
+  await gitExecFileAsync(['merge', '--abort'], { cwd: worktreePath })
+}
+
 export async function getStagedCommitContext(
   worktreePath: string
 ): Promise<CommitMessageDraftContext | null> {

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -23,6 +23,7 @@ const {
   bulkStageFilesMock,
   unstageFileMock,
   bulkUnstageFilesMock,
+  abortMergeMock,
   bulkDiscardChangesMock,
   discardChangesMock,
   checkIgnoredPathsMock,
@@ -54,6 +55,7 @@ const {
   bulkStageFilesMock: vi.fn(),
   unstageFileMock: vi.fn(),
   bulkUnstageFilesMock: vi.fn(),
+  abortMergeMock: vi.fn(),
   bulkDiscardChangesMock: vi.fn(),
   discardChangesMock: vi.fn(),
   checkIgnoredPathsMock: vi.fn(),
@@ -97,6 +99,7 @@ vi.mock('../git/status', () => ({
   bulkStageFiles: bulkStageFilesMock,
   unstageFile: unstageFileMock,
   bulkUnstageFiles: bulkUnstageFilesMock,
+  abortMerge: abortMergeMock,
   bulkDiscardChanges: bulkDiscardChangesMock,
   discardChanges: discardChangesMock
 }))
@@ -206,6 +209,7 @@ describe('registerFilesystemHandlers', () => {
       bulkStageFilesMock,
       unstageFileMock,
       bulkUnstageFilesMock,
+      abortMergeMock,
       bulkDiscardChangesMock,
       discardChangesMock,
       listWorktreesMock,
@@ -624,6 +628,18 @@ describe('registerFilesystemHandlers', () => {
       path.join('src', 'file.ts'),
       path.join('nested', 'child.ts')
     ])
+  })
+
+  it('runs abort merge for a registered worktree', async () => {
+    abortMergeMock.mockResolvedValue(undefined)
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:abortMerge')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH
+    })
+
+    expect(abortMergeMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH)
   })
 
   it('rejects bulk unstage requests that escape the selected worktree', async () => {
@@ -1236,6 +1252,21 @@ describe('registerFilesystemHandlers', () => {
 
     expect(sshBulkDiscardMock).toHaveBeenCalledWith('/remote/repo', ['a.ts', 'b.ts'])
     expect(bulkDiscardChangesMock).not.toHaveBeenCalled()
+  })
+
+  it('routes ssh git:abortMerge through the SSH provider', async () => {
+    const sshAbortMergeMock = vi.fn().mockResolvedValue(undefined)
+    getSshGitProviderMock.mockReturnValue({ abortMerge: sshAbortMergeMock })
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:abortMerge')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'conn-1'
+    })
+
+    expect(sshAbortMergeMock).toHaveBeenCalledWith('/remote/repo')
+    expect(abortMergeMock).not.toHaveBeenCalled()
   })
 
   it('rejects git:commit with empty message and does not call commitChanges', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -36,6 +36,7 @@ import {
   commitChanges,
   stageFile,
   unstageFile,
+  abortMerge,
   bulkStageFiles,
   bulkUnstageFiles,
   bulkDiscardChanges,
@@ -1117,6 +1118,21 @@ export function registerFilesystemHandlers(
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
       await discardChanges(worktreePath, filePath)
+    }
+  )
+
+  ipcMain.handle(
+    'git:abortMerge',
+    async (_event, args: { worktreePath: string; connectionId?: string }): Promise<void> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.abortMerge(args.worktreePath)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      await abortMerge(worktreePath)
     }
   )
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -227,6 +227,13 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('abortMerge sends git.abortMerge request', async () => {
+    await provider.abortMerge('/home/user/repo')
+    expect(mux.request).toHaveBeenCalledWith('git.abortMerge', {
+      worktreePath: '/home/user/repo'
+    })
+  })
+
   it('discardChanges sends git.discard request', async () => {
     await provider.discardChanges('/home/user/repo', 'src/file.ts')
     expect(mux.request).toHaveBeenCalledWith('git.discard', {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -149,6 +149,10 @@ export class SshGitProvider implements IGitProvider {
     await this.mux.request('git.bulkUnstage', { worktreePath, filePaths })
   }
 
+  async abortMerge(worktreePath: string): Promise<void> {
+    await this.mux.request('git.abortMerge', { worktreePath })
+  }
+
   async discardChanges(worktreePath: string, filePath: string): Promise<void> {
     await this.mux.request('git.discard', { worktreePath, filePath })
   }

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -161,6 +161,7 @@ export type IGitProvider = {
   unstageFile(worktreePath: string, filePath: string): Promise<void>
   bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void>
   bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void>
+  abortMerge(worktreePath: string): Promise<void>
   discardChanges(worktreePath: string, filePath: string): Promise<void>
   bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void>
   detectConflictOperation(worktreePath: string): Promise<GitConflictOperation>

--- a/src/main/runtime/orca-runtime-git.test.ts
+++ b/src/main/runtime/orca-runtime-git.test.ts
@@ -8,6 +8,7 @@ import type * as CommitMessageTextGenerationModule from '../text-generation/comm
 import { RuntimeGitCommands, type ResolvedRuntimeGitWorktree } from './orca-runtime-git'
 
 const mocks = vi.hoisted(() => ({
+  abortMerge: vi.fn(),
   getStagedCommitContext: vi.fn(),
   generateCommitMessageFromContext: vi.fn(),
   resolveCommitMessageSettings: vi.fn(),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../git/status', async () => ({
   ...(await vi.importActual<typeof GitStatusModule>('../git/status')),
+  abortMerge: mocks.abortMerge,
   getStagedCommitContext: mocks.getStagedCommitContext
 }))
 
@@ -58,6 +60,7 @@ function makeCommands(worktreePath: string): RuntimeGitCommands {
 describe('RuntimeGitCommands', () => {
   beforeEach(() => {
     mocks.getStagedCommitContext.mockReset()
+    mocks.abortMerge.mockReset()
     mocks.generateCommitMessageFromContext.mockReset()
     mocks.resolveCommitMessageSettings.mockReset()
     mocks.getSshGitProvider.mockReset()
@@ -80,6 +83,32 @@ describe('RuntimeGitCommands', () => {
     await expect(commands.discardRuntimeGitPath('id:wt-1', '///')).rejects.toThrow(
       'invalid_relative_path'
     )
+  })
+
+  it('aborts a local merge through the resolved worktree', async () => {
+    const commands = makeCommands('/repo')
+    mocks.abortMerge.mockResolvedValue(undefined)
+
+    await expect(commands.abortMergeRuntimeGit('id:wt-1')).resolves.toEqual({ ok: true })
+
+    expect(mocks.abortMerge).toHaveBeenCalledWith('/repo')
+  })
+
+  it('aborts a remote merge through the SSH git provider', async () => {
+    const provider = { abortMerge: vi.fn().mockResolvedValue(undefined) }
+    mocks.getSshGitProvider.mockReturnValue(provider)
+    const commands = new RuntimeGitCommands({
+      resolveRuntimeGitTarget: async () => ({
+        worktree: makeWorktree('/home/user/repo'),
+        connectionId: 'conn-1'
+      }),
+      getRuntimeSettings: () => ({}) as GlobalSettings
+    })
+
+    await expect(commands.abortMergeRuntimeGit('id:wt-1')).resolves.toEqual({ ok: true })
+
+    expect(provider.abortMerge).toHaveBeenCalledWith('/home/user/repo')
+    expect(mocks.abortMerge).not.toHaveBeenCalled()
   })
 
   it('prepares the selected local agent environment before generating commit messages', async () => {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -17,6 +17,7 @@ import { getCommitMessageModelDiscoveryHostKey } from '../../shared/commit-messa
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
 import { getRemoteFileUrl } from '../git/repo'
 import {
+  abortMerge,
   bulkDiscardChanges,
   bulkStageFiles,
   bulkUnstageFiles,
@@ -146,6 +147,20 @@ export class RuntimeGitCommands {
       return provider.detectConflictOperation(target.worktree.path)
     }
     return detectConflictOperation(target.worktree.path)
+  }
+
+  async abortMergeRuntimeGit(worktreeSelector: string): Promise<{ ok: true }> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      await provider.abortMerge(target.worktree.path)
+      return { ok: true }
+    }
+    await abortMerge(target.worktree.path)
+    return { ok: true }
   }
 
   async getRuntimeGitDiff(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1743,6 +1743,8 @@ export class OrcaRuntimeService {
     this.gitCommands.bulkDiscardRuntimeGitPaths.bind(this.gitCommands)
   discardRuntimeGitPath: RuntimeGitCommands['discardRuntimeGitPath'] =
     this.gitCommands.discardRuntimeGitPath.bind(this.gitCommands)
+  abortMergeRuntimeGit: RuntimeGitCommands['abortMergeRuntimeGit'] =
+    this.gitCommands.abortMergeRuntimeGit.bind(this.gitCommands)
   getRuntimeGitRemoteFileUrl: RuntimeGitCommands['getRuntimeGitRemoteFileUrl'] =
     this.gitCommands.getRuntimeGitRemoteFileUrl.bind(this.gitCommands)
 

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -142,6 +142,7 @@ describe('git RPC methods', () => {
       getRuntimeId: () => 'test-runtime',
       stageRuntimeGitPath: vi.fn().mockResolvedValue({ ok: true }),
       bulkUnstageRuntimeGitPaths: vi.fn().mockResolvedValue({ ok: true }),
+      abortMergeRuntimeGit: vi.fn().mockResolvedValue({ ok: true }),
       discardRuntimeGitPath: vi.fn().mockResolvedValue({ ok: true }),
       bulkDiscardRuntimeGitPaths: vi.fn().mockResolvedValue({ ok: true })
     } as unknown as OrcaRuntimeService
@@ -153,6 +154,7 @@ describe('git RPC methods', () => {
     await dispatcher.dispatch(
       makeRequest('git.bulkUnstage', { worktree: 'id:wt-1', filePaths: ['src/a.ts', 'b.ts'] })
     )
+    await dispatcher.dispatch(makeRequest('git.abortMerge', { worktree: 'id:wt-1' }))
     await dispatcher.dispatch(
       makeRequest('git.discard', { worktree: 'id:wt-1', filePath: 'src/a.ts' })
     )
@@ -162,6 +164,7 @@ describe('git RPC methods', () => {
 
     expect(runtime.stageRuntimeGitPath).toHaveBeenCalledWith('id:wt-1', 'src/a.ts')
     expect(runtime.bulkUnstageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['src/a.ts', 'b.ts'])
+    expect(runtime.abortMergeRuntimeGit).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.discardRuntimeGitPath).toHaveBeenCalledWith('id:wt-1', 'src/a.ts')
     expect(runtime.bulkDiscardRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['src/a.ts', 'b.ts'])
   })

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -50,6 +50,11 @@ export const GIT_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) => runtime.getRuntimeGitConflictOperation(params.worktree)
   }),
   defineMethod({
+    name: 'git.abortMerge',
+    params: WorktreeSelector,
+    handler: async (params, { runtime }) => runtime.abortMergeRuntimeGit(params.worktree)
+  }),
+  defineMethod({
     name: 'git.diff',
     params: GitDiff,
     handler: async (params, { runtime }) =>

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -762,6 +762,7 @@ describe('OrcaRuntimeRpcServer', () => {
       .mockResolvedValue({ hasUpstream: true, ahead: 1, behind: 0 })
     const bulkStageRuntimeGitPaths = vi.fn().mockResolvedValue({ ok: true })
     const bulkUnstageRuntimeGitPaths = vi.fn().mockResolvedValue({ ok: true })
+    const abortMergeRuntimeGit = vi.fn().mockResolvedValue({ ok: true })
     const getRuntimeGitDiff = vi.fn().mockResolvedValue({
       kind: 'text',
       originalContent: 'before\n',
@@ -791,6 +792,7 @@ describe('OrcaRuntimeRpcServer', () => {
       getRuntimeGitUpstreamStatus,
       bulkStageRuntimeGitPaths,
       bulkUnstageRuntimeGitPaths,
+      abortMergeRuntimeGit,
       getRuntimeGitDiff,
       openMobileDiff,
       browserTabCreate,
@@ -868,6 +870,16 @@ describe('OrcaRuntimeRpcServer', () => {
         method: 'git.bulkUnstage',
         deviceToken: mobile.token,
         params: { worktree: 'id:wt-1', filePaths: ['c.ts'] }
+      }),
+      (response) => replies.push(JSON.parse(response) as Record<string, unknown>),
+      () => {}
+    )
+    await server['handleWebSocketMessage'](
+      JSON.stringify({
+        id: 'req_git_abort_merge',
+        method: 'git.abortMerge',
+        deviceToken: mobile.token,
+        params: { worktree: 'id:wt-1' }
       }),
       (response) => replies.push(JSON.parse(response) as Record<string, unknown>),
       () => {}
@@ -988,6 +1000,7 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(replies).toContainEqual(
       expect.objectContaining({ id: 'req_git_bulk_unstage', ok: true })
     )
+    expect(replies).toContainEqual(expect.objectContaining({ id: 'req_git_abort_merge', ok: true }))
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_select_claude', ok: true }))
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_select_codex', ok: true }))
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_terminal_read', ok: true }))
@@ -1020,6 +1033,7 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(getRuntimeGitUpstreamStatus).toHaveBeenCalledWith('id:wt-1')
     expect(bulkStageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['a.ts', 'b.ts'])
     expect(bulkUnstageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['c.ts'])
+    expect(abortMergeRuntimeGit).toHaveBeenCalledWith('id:wt-1')
     expect(openMobileDiff).toHaveBeenCalledWith('id:wt-1', 'docs/readme.md', true)
     expect(getRuntimeGitDiff).toHaveBeenCalledWith('id:wt-1', 'docs/readme.md', false, undefined)
     expect(browserTabCreate).toHaveBeenCalledWith({ worktree: 'id:wt-1', url: 'about:blank' })

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -144,6 +144,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'files.open',
   'files.openDiff',
   'files.read',
+  'git.abortMerge',
   'git.bulkStage',
   'git.bulkUnstage',
   'git.commit',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1588,6 +1588,7 @@ export type PreloadApi = {
       filePaths: string[]
       connectionId?: string
     }) => Promise<void>
+    abortMerge: (args: { worktreePath: string; connectionId?: string }) => Promise<void>
     discard: (args: {
       worktreePath: string
       filePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2137,6 +2137,8 @@ const api = {
       filePaths: string[]
       connectionId?: string
     }): Promise<void> => ipcRenderer.invoke('git:bulkUnstage', args),
+    abortMerge: (args: { worktreePath: string; connectionId?: string }): Promise<void> =>
+      ipcRenderer.invoke('git:abortMerge', args),
     discard: (args: {
       worktreePath: string
       filePath: string

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -45,6 +45,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.unstage')
     expect(methods).toContain('git.bulkStage')
     expect(methods).toContain('git.bulkUnstage')
+    expect(methods).toContain('git.abortMerge')
     expect(methods).toContain('git.discard')
     expect(methods).toContain('git.bulkDiscard')
     expect(methods).toContain('git.conflictOperation')
@@ -375,6 +376,36 @@ describe('GitHandler', () => {
 
       const result = await dispatcher.callRequest('git.conflictOperation', { worktreePath: tmpDir })
       expect(result).toBe('unknown')
+    })
+  })
+
+  describe('abortMerge', () => {
+    it('aborts an in-progress merge', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'base\n')
+      gitCommit(tmpDir, 'initial')
+      const baseBranch = execFileSync('git', ['branch', '--show-current'], {
+        cwd: tmpDir,
+        encoding: 'utf-8'
+      }).trim()
+
+      execFileSync('git', ['checkout', '-b', 'feature'], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'feature\n')
+      gitCommit(tmpDir, 'feature')
+
+      execFileSync('git', ['checkout', baseBranch], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'main\n')
+      gitCommit(tmpDir, 'main')
+
+      expect(() =>
+        execFileSync('git', ['merge', 'feature'], { cwd: tmpDir, stdio: 'pipe' })
+      ).toThrow()
+      await expect(fs.access(path.join(tmpDir, '.git', 'MERGE_HEAD'))).resolves.toBeUndefined()
+
+      await dispatcher.callRequest('git.abortMerge', { worktreePath: tmpDir })
+
+      await expect(fs.access(path.join(tmpDir, '.git', 'MERGE_HEAD'))).rejects.toThrow()
+      await expect(fs.readFile(path.join(tmpDir, 'file.txt'), 'utf-8')).resolves.toBe('main\n')
     })
   })
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -46,6 +46,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.unstage', (p) => this.unstage(p))
     this.dispatcher.onRequest('git.bulkStage', (p) => this.bulkStage(p))
     this.dispatcher.onRequest('git.bulkUnstage', (p) => this.bulkUnstage(p))
+    this.dispatcher.onRequest('git.abortMerge', (p) => this.abortMerge(p))
     this.dispatcher.onRequest('git.discard', (p) => this.discard(p))
     this.dispatcher.onRequest('git.bulkDiscard', (p) => this.bulkDiscard(p))
     this.dispatcher.onRequest('git.conflictOperation', (p) => this.conflictOperation(p))
@@ -162,6 +163,11 @@ export class GitHandler {
       const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
       await this.git(['restore', '--staged', '--', ...chunk], worktreePath)
     }
+  }
+
+  private async abortMerge(params: Record<string, unknown>) {
+    const worktreePath = params.worktreePath as string
+    await this.git(['merge', '--abort'], worktreePath)
   }
 
   private normalizeGitPathForCompare(filePath: string): string {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -100,6 +100,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { BaseRefPicker } from '@/components/settings/BaseRefPicker'
+import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { formatDiffComment, formatDiffComments } from '@/lib/diff-comments-format'
 import { getDiffCommentLineLabel, getDiffCommentSource } from '@/lib/diff-comment-compat'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
@@ -112,6 +113,7 @@ import {
 } from '@/components/editor/editor-autosave'
 import { getConnectionId } from '@/lib/connection-context'
 import {
+  abortMergeRuntimeGit,
   bulkDiscardRuntimeGitPaths,
   bulkStageRuntimeGitPaths,
   bulkUnstageRuntimeGitPaths,
@@ -775,6 +777,11 @@ function SourceControlInner(): React.JSX.Element {
     useState<HostedReviewCreationEligibility | null>(null)
   const [createPrDialogOpen, setCreatePrDialogOpen] = useState(false)
   const [createPrPushFirst, setCreatePrPushFirst] = useState(false)
+  const [abortMergeInFlightByWorktree, setAbortMergeInFlightByWorktree] = useState<
+    Record<string, boolean>
+  >({})
+  const isAbortingMerge = abortMergeInFlightByWorktree[activeWorktreeId ?? ''] ?? false
+  const confirmAction = useConfirmationDialog()
   const commitMessageAi = useAppStore((s) => s.settings?.commitMessageAi)
   const effectiveCommitMessageAgentId = useMemo(
     () => resolveCommitMessageAgentChoice(commitMessageAi?.agentId, settings?.defaultTuiAgent),
@@ -1216,6 +1223,7 @@ function SourceControlInner(): React.JSX.Element {
     setCommitErrors((prev) => pruneRecord(prev))
     setRemoteActionErrors((prev) => pruneRecord(prev))
     setCommitInFlightByWorktree((prev) => pruneRecord(prev))
+    setAbortMergeInFlightByWorktree((prev) => pruneRecord(prev))
     setGenerateInFlightByWorktree((prev) => pruneRecord(prev))
     setGenerateErrors((prev) => pruneRecord(prev))
     setGitHistoryByWorktree((prev) => pruneRecord(prev))
@@ -1628,6 +1636,48 @@ function SourceControlInner(): React.JSX.Element {
     setRightSidebarTab('checks')
   }, [setRightSidebarOpen, setRightSidebarTab])
 
+  const handleAbortMerge = useCallback(async (): Promise<void> => {
+    if (!activeWorktreeId || !worktreePath || conflictOperation !== 'merge' || isAbortingMerge) {
+      return
+    }
+
+    const confirmed = await confirmAction({
+      title: 'Abort Merge',
+      description:
+        'Abort the in-progress merge and restore the worktree to the state before the merge started.',
+      confirmLabel: 'Abort Merge',
+      confirmVariant: 'destructive'
+    })
+    if (!confirmed) {
+      return
+    }
+
+    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+    setAbortMergeInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
+    try {
+      await abortMergeRuntimeGit({
+        settings: useAppStore.getState().settings,
+        worktreeId: activeWorktreeId,
+        worktreePath,
+        connectionId
+      })
+      await refreshActiveGitStatusAfterMutation()
+      void refreshGitHistoryRef.current()
+      toast.success('Merge aborted.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to abort merge')
+    } finally {
+      setAbortMergeInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
+    }
+  }, [
+    activeWorktreeId,
+    confirmAction,
+    conflictOperation,
+    isAbortingMerge,
+    refreshActiveGitStatusAfterMutation,
+    worktreePath
+  ])
+
   const hasUnstagedChanges = grouped.unstaged.length > 0 || grouped.untracked.length > 0
   const hasPartiallyStagedChanges = useMemo(() => {
     if (grouped.staged.length === 0 || grouped.unstaged.length === 0) {
@@ -1646,7 +1696,7 @@ function SourceControlInner(): React.JSX.Element {
         hasMessage: commitMessage.trim().length > 0,
         hasUnresolvedConflicts: unresolvedConflicts.length > 0,
         isCommitting,
-        isRemoteOperationActive,
+        isRemoteOperationActive: isRemoteOperationActive || isAbortingMerge,
         upstreamStatus: remoteStatus,
         prState: hostedReview?.state ?? null,
         isPRStateLoading: isHostedReviewStateLoading,
@@ -1666,6 +1716,7 @@ function SourceControlInner(): React.JSX.Element {
       hostedReviewCreation,
       isHostedReviewStateLoading,
       hostedReview?.state,
+      isAbortingMerge,
       branchSummary?.commitsAhead,
       branchSummary?.status,
       remoteStatus,
@@ -1682,7 +1733,8 @@ function SourceControlInner(): React.JSX.Element {
         hasMessage: commitMessage.trim().length > 0,
         hasUnresolvedConflicts: unresolvedConflicts.length > 0,
         isCommitting,
-        isRemoteOperationActive,
+        isRemoteOperationActive: isRemoteOperationActive || isAbortingMerge,
+        conflictOperation,
         upstreamStatus: remoteStatus,
         prState: hostedReview?.state ?? null,
         isPRStateLoading: isHostedReviewStateLoading,
@@ -1696,7 +1748,9 @@ function SourceControlInner(): React.JSX.Element {
       grouped.staged.length,
       hasUnstagedChanges,
       hasPartiallyStagedChanges,
+      conflictOperation,
       isCommitting,
+      isAbortingMerge,
       isRemoteOperationActive,
       inFlightRemoteOpKind,
       hostedReviewCreation,
@@ -1716,6 +1770,9 @@ function SourceControlInner(): React.JSX.Element {
   const handleActionInvoke = useCallback(
     (kind: DropdownActionKind): void => {
       switch (kind) {
+        case 'abort_merge':
+          void handleAbortMerge()
+          return
         case 'commit':
           void handleCommit()
           return
@@ -1747,7 +1804,13 @@ function SourceControlInner(): React.JSX.Element {
         }
       }
     },
-    [handleCommit, openCreatePullRequestDialog, runCompoundCommitAction, runRemoteAction]
+    [
+      handleAbortMerge,
+      handleCommit,
+      openCreatePullRequestDialog,
+      runCompoundCommitAction,
+      runRemoteAction
+    ]
   )
 
   const handleOpenDiff = useCallback(
@@ -3720,6 +3783,9 @@ export function CommitArea({
                   key={entry.kind}
                   disabled={entry.disabled}
                   title={entry.title}
+                  className={cn(
+                    entry.variant === 'destructive' && 'text-destructive focus:text-destructive'
+                  )}
                   onSelect={(event) => {
                     if (entry.disabled) {
                       event.preventDefault()

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { resolveDropdownItems } from './source-control-dropdown-items'
-import type { PrimaryActionInputs } from './source-control-primary-action'
 
 // Why: a shared defaults object keeps each case row terse while making the
 // "this is the one knob that differs from the baseline" intent obvious.
-function inputs(overrides: Partial<PrimaryActionInputs> = {}): PrimaryActionInputs {
+function inputs(
+  overrides: Partial<Parameters<typeof resolveDropdownItems>[0]> = {}
+): Parameters<typeof resolveDropdownItems>[0] {
   return {
     stagedCount: 0,
     hasUnstagedChanges: false,
@@ -41,6 +42,27 @@ describe('resolveDropdownItems', () => {
       'fetch',
       'publish'
     ])
+  })
+
+  it('shows Abort Merge only while a merge is in progress', () => {
+    const mergeItems = resolveDropdownItems(
+      inputs({
+        conflictOperation: 'merge',
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      })
+    )
+    expect(mergeItems.map((item) => item.kind).slice(0, 2)).toEqual(['abort_merge', 'separator'])
+    const abortMerge = mergeItems.find((item) => item.kind === 'abort_merge')
+    expect(abortMerge).toMatchObject({
+      label: 'Abort Merge',
+      disabled: false,
+      variant: 'destructive'
+    })
+
+    for (const conflictOperation of ['rebase', 'cherry-pick', 'unknown'] as const) {
+      const items = resolveDropdownItems(inputs({ conflictOperation }))
+      expect(items.some((item) => item.kind === 'abort_merge')).toBe(false)
+    }
   })
 
   it('disables compound commit actions when no staged files', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -1,8 +1,10 @@
 // Why: split from source-control-primary-action because the primary and dropdown are independent derivations with different priority ladders; together they exceed the max-lines budget and tangle unrelated concerns.
 
 import type { PrimaryActionInputs } from './source-control-primary-action'
+import type { GitConflictOperation } from '../../../../shared/types'
 
 export type DropdownActionKind =
+  | 'abort_merge'
   | 'commit'
   | 'commit_push'
   | 'commit_sync'
@@ -20,6 +22,7 @@ export type DropdownItem = {
   title: string
   disabled: boolean
   hint?: string
+  variant?: 'destructive'
 }
 
 export type DropdownSeparator = { kind: 'separator' }
@@ -50,11 +53,15 @@ function formatSyncLabel(base: string, ahead: number, behind: number): string {
 }
 
 /**
- * Resolve the chevron dropdown items. Every item is always rendered so the
- * menu shape stays stable across states; inapplicable rows are disabled
- * with a tooltip reason rather than hidden.
+ * Resolve the chevron dropdown items. Standard actions are always rendered so
+ * the menu shape stays stable; the destructive merge-abort action only appears
+ * while a merge is actually in progress.
  */
-export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry[] {
+type DropdownActionInputs = PrimaryActionInputs & {
+  conflictOperation?: GitConflictOperation
+}
+
+export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntry[] {
   const {
     stagedCount,
     hasPartiallyStagedChanges,
@@ -66,7 +73,8 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     prState,
     isPRStateLoading,
     hostedReviewCreation,
-    branchCommitsAhead
+    branchCommitsAhead,
+    conflictOperation = 'unknown'
   } = inputs
 
   const hasStaged = stagedCount > 0
@@ -89,6 +97,14 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
   // A running push shouldn't let a second pull/sync click queue up behind it
   // on a stale status snapshot.
   const globalBusy = isCommitting || isRemoteOperationActive
+
+  const abortMergeItem: DropdownItem = {
+    kind: 'abort_merge',
+    label: 'Abort Merge',
+    title: globalBusy ? 'Git operation in progress' : 'Abort the in-progress merge',
+    disabled: globalBusy,
+    variant: 'destructive'
+  }
 
   const commitDisabledReason = (() => {
     if (hasUnresolvedConflicts) {
@@ -308,6 +324,7 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
   }
 
   return [
+    ...(conflictOperation === 'merge' ? [abortMergeItem, { kind: 'separator' } as const] : []),
     commitItem,
     commitPushItem,
     commitSyncItem,

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: runtime git routing tests share compatibility-cache and IPC stubs; splitting would hide cross-environment contract drift. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  abortMergeRuntimeGit,
   bulkDiscardRuntimeGitPaths,
   bulkStageRuntimeGitPaths,
   cancelRuntimeGenerateCommitMessage,
@@ -25,6 +26,7 @@ const gitDiff = vi.fn()
 const gitHistory = vi.fn()
 const gitBulkStage = vi.fn()
 const gitBulkDiscard = vi.fn()
+const gitAbortMerge = vi.fn()
 const gitCommit = vi.fn()
 const gitPush = vi.fn()
 const gitGenerateCommitMessage = vi.fn()
@@ -42,6 +44,7 @@ beforeEach(() => {
   gitHistory.mockReset()
   gitBulkStage.mockReset()
   gitBulkDiscard.mockReset()
+  gitAbortMerge.mockReset()
   gitCommit.mockReset()
   gitPush.mockReset()
   gitGenerateCommitMessage.mockReset()
@@ -62,6 +65,7 @@ beforeEach(() => {
         history: gitHistory,
         bulkStage: gitBulkStage,
         bulkDiscard: gitBulkDiscard,
+        abortMerge: gitAbortMerge,
         commit: gitCommit,
         push: gitPush,
         generateCommitMessage: gitGenerateCommitMessage,
@@ -290,6 +294,7 @@ describe('runtime git client', () => {
     }
 
     await bulkStageRuntimeGitPaths(context, ['a.ts', 'b.ts'])
+    await abortMergeRuntimeGit(context)
     await bulkDiscardRuntimeGitPaths(context, ['c.ts', 'd.ts'])
     await commitRuntimeGit(context, 'feat: test')
     await generateRuntimeCommitMessage(context)
@@ -304,29 +309,35 @@ describe('runtime git client', () => {
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
       selector: 'env-1',
+      method: 'git.abortMerge',
+      params: { worktree: 'wt-1' },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
+      selector: 'env-1',
       method: 'git.bulkDiscard',
       params: { worktree: 'wt-1', filePaths: ['c.ts', 'd.ts'] },
       timeoutMs: 15_000
     })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(3, {
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
       selector: 'env-1',
       method: 'git.commit',
       params: { worktree: 'wt-1', message: 'feat: test' },
       timeoutMs: 30_000
     })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
       selector: 'env-1',
       method: 'git.generateCommitMessage',
       params: { worktree: 'wt-1', commitMessageDiscoveryHostKey: 'runtime:env-1' },
       timeoutMs: 75_000
     })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
       selector: 'env-1',
       method: 'git.cancelGenerateCommitMessage',
       params: { worktree: 'wt-1' },
       timeoutMs: 5_000
     })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(7, {
       selector: 'env-1',
       method: 'git.push',
       params: { worktree: 'wt-1', publish: true, pushTarget: { remote: 'origin' } },

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -560,6 +560,23 @@ export async function bulkUnstageRuntimeGitPaths(
   )
 }
 
+export async function abortMergeRuntimeGit(context: RuntimeGitContext): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    await window.api.git.abortMerge({
+      worktreePath: context.worktreePath,
+      connectionId: context.connectionId
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'git.abortMerge',
+    { worktree: context.worktreeId },
+    { timeoutMs: 30_000 }
+  )
+}
+
 export async function bulkDiscardRuntimeGitPaths(
   context: RuntimeGitContext,
   filePaths: string[]

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -605,6 +605,10 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       mutateGitPath('git.unstage', worktreePath, filePath),
     bulkUnstage: async ({ worktreePath, filePaths }) =>
       mutateGitPaths('git.bulkUnstage', worktreePath, filePaths),
+    abortMerge: async ({ worktreePath }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      await callRuntimeResult('git.abortMerge', { worktree: worktree.id })
+    },
     discard: async ({ worktreePath, filePath }) =>
       mutateGitPath('git.discard', worktreePath, filePath),
     bulkDiscard: async ({ worktreePath, filePaths }) => {


### PR DESCRIPTION
## Summary
- add a destructive Source Control dropdown action during merge conflicts
- route merge abort through local IPC, SSH relay, runtime RPC, preload, and web shim
- refresh status after abort and cover routing/dropdown behavior with tests

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/git/status.test.ts src/main/ipc/filesystem.test.ts src/main/providers/ssh-git-provider.test.ts src/relay/git-handler.test.ts src/main/runtime/orca-runtime-git.test.ts src/main/runtime/rpc/methods/git.test.ts src/main/runtime/runtime-rpc.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts src/renderer/src/components/right-sidebar/CommitArea.test.tsx
- pnpm run lint
- pnpm run typecheck
- pnpm test

Fixes #2090