### PR TITLE
Emit OSC 133 C/D from bash shell wrappers (fixes #2422)

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -1,7 +1,11 @@
+/* eslint-disable max-lines -- Why: shell-ready wrapper coverage keeps zsh,
+   bash, marker scanning, and env restoration cases in one suite so the
+   generated wrapper contract is reviewed as a unit. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'child_process'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import type * as ShellReadyModule from './shell-ready'
 
 async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
@@ -10,6 +14,48 @@ async function importFreshShellReady(): Promise<typeof ShellReadyModule> {
 }
 
 const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
+const itWithBash = hasBash ? it : it.skip
+
+function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
+  const rcfile = join(tempDir, 'bash-osc133-rcfile')
+  writeFileSync(rcfile, rcfileContent)
+
+  const result = spawnSync(
+    'bash',
+    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
+    {
+      input: 'true\nfalse\nexit 0\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        ORCA_SHELL_READY_MARKER: '1',
+        TERM: process.env.TERM || 'xterm'
+      },
+      timeout: 5000
+    }
+  )
+
+  expect(result.error).toBeUndefined()
+  expect(result.status).toBe(0)
+  return result.stdout
+}
+
+function expectBashOsc133Lifecycle(output: string): void {
+  const oscA = '\x1b]133;A\x07'
+  const oscC = '\x1b]133;C\x07'
+  const oscD = '\x1b]133;D;'
+  const firstPromptMarker = output.indexOf(oscA)
+
+  expect(firstPromptMarker).toBeGreaterThanOrEqual(0)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscC)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscD)
+  expect(output).toContain(`${oscD}0\x07${oscA}`)
+  expect(output).toContain(`${oscD}1\x07${oscA}`)
+  expect(output.split(oscC)).toHaveLength(4)
+  expect(output.split(oscD)).toHaveLength(3)
+}
 
 describePosix('daemon shell-ready launch config', () => {
   let previousUserDataPath: string | undefined
@@ -204,8 +250,58 @@ describePosix('daemon shell-ready launch config', () => {
 
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    expect(bashRc).toContain(
+      'PROMPT_COMMAND="__orca_osc133_precmd${PROMPT_COMMAND:+;${PROMPT_COMMAND}}"'
+    )
+    expect(bashRc.indexOf("trap '__orca_osc133_preexec' DEBUG")).toBeGreaterThan(
+      bashRc.indexOf('if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then')
+    )
     expect(zshrc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshrc).toContain('printf "\\033]133;C\\007"')
+  })
+
+  itWithBash(
+    'runs the daemon bash wrapper without fake C/D markers before the first prompt',
+    async () => {
+      const { getDaemonBashShellReadyRcfileContent } = await importFreshShellReady()
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+      expectBashOsc133Lifecycle(output)
+    }
+  )
+
+  itWithBash(
+    'preserves prompt hooks and existing DEBUG traps without fake command markers',
+    async () => {
+      const { getDaemonBashShellReadyRcfileContent } = await importFreshShellReady()
+      writeFileSync(
+        join(userDataPath, '.bash_profile'),
+        [
+          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+          'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
+        ].join('\n')
+      )
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+      expect(output).toContain('PROMPT_HOOK')
+      expect(output).toContain('USER_DEBUG_AFTER')
+      expectBashOsc133Lifecycle(output)
+    }
+  )
+
+  itWithBash('normalizes array PROMPT_COMMAND hooks so bash 3.2 still runs cleanup', async () => {
+    const { getDaemonBashShellReadyRcfileContent } = await importFreshShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'PROMPT_COMMAND=(\'AFTER_ARRAY_PROMPT=1; printf "PROMPT_ARRAY\\n"\')\n'
+    )
+
+    const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
+
+    expect(output).toContain('PROMPT_ARRAY')
+    expectBashOsc133Lifecycle(output)
   })
 
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -190,6 +190,24 @@ describePosix('daemon shell-ready launch config', () => {
     expect(bashRc).toContain(piRestoreLine)
   })
 
+  // Why: regression guard for issue #2422. The daemon-side bash wrapper must
+  // emit OSC 133 C/D so SSH/remote bash sessions also clear stale 'working'
+  // agent rows when the foreground command exits.
+  it('emits OSC 133 C/D markers in the daemon bash wrapper', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+
+    getShellReadyLaunchConfig('/bin/zsh')
+    getShellReadyLaunchConfig('/bin/bash')
+
+    const zshrc = readFileSync(join(userDataPath, 'shell-ready', 'zsh', '.zshrc'), 'utf8')
+    const bashRc = readFileSync(join(userDataPath, 'shell-ready', 'bash', 'rcfile'), 'utf8')
+
+    expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
+    expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    expect(zshrc).toContain('printf "\\033]133;D;%s\\007"')
+    expect(zshrc).toContain('printf "\\033]133;C\\007"')
+  })
+
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
     // Why: users who run a custom zsh dotfiles directory legitimately set
     // ZDOTDIR before launching Orca. We only want to reject the self-loop

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -1,3 +1,7 @@
+/* eslint-disable max-lines -- Why: this module owns the daemon-side shell
+   wrapper generation for zsh, bash, and PowerShell plus the launch-config
+   plumbing; keeping them together lets the wrapper/marker contract be
+   reviewed as a unit (mirrors src/main/providers/local-pty-shell-ready.ts). */
 import { tmpdir } from 'os'
 import { basename, dirname, join, win32 as pathWin32 } from 'path'
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'fs'
@@ -72,6 +76,72 @@ function getRequiredShellReadyWrapperPaths(root = getShellReadyWrapperRoot()): s
 
 function shellReadyWrappersExist(): boolean {
   return getRequiredShellReadyWrapperPaths().every((path) => existsSync(path))
+}
+
+export function getDaemonBashShellReadyRcfileContent(): string {
+  return `# Orca daemon bash shell-ready wrapper
+[[ -f /etc/profile ]] && source /etc/profile
+if [[ -f "$HOME/.bash_profile" ]]; then
+  source "$HOME/.bash_profile"
+elif [[ -f "$HOME/.bash_login" ]]; then
+  source "$HOME/.bash_login"
+elif [[ -f "$HOME/.profile" ]]; then
+  source "$HOME/.profile"
+fi
+__orca_restore_attribution_path() {
+  [[ -n "\${ORCA_ATTRIBUTION_SHIM_DIR:-}" ]] || return 0
+  case "$PATH" in
+    "\${ORCA_ATTRIBUTION_SHIM_DIR}"|"\${ORCA_ATTRIBUTION_SHIM_DIR}:"*) return 0 ;;
+  esac
+  export PATH="\${ORCA_ATTRIBUTION_SHIM_DIR}:$PATH"
+}
+__orca_restore_attribution_path
+# Why: user startup files may set the default OpenCode config after Orca's
+# spawn env; restore the PTY-scoped overlay before the first prompt.
+[[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
+# Why: PI_CODING_AGENT_DIR is also a single-root env var users may re-export.
+[[ -n "\${ORCA_PI_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_PI_CODING_AGENT_DIR}"
+# Why: emit OSC 133 C/D so terminal-command-lifecycle can drop stale agent
+# status when the foreground command exits — mirrors the zsh daemon wrapper.
+# Without this, bash users (default on most Linux distros) keep a stuck
+# 'working' spinner after the CLI exits without a Stop/SessionEnd hook.
+__orca_osc133_precmd() {
+  local exit_code=$?
+  if [[ -n "\${__orca_in_command:-}" ]]; then
+    printf "\\033]133;D;%s\\007" "$exit_code"
+    unset __orca_in_command
+  fi
+  printf "\\033]133;A\\007"
+}
+__orca_osc133_preexec() {
+  # Why: bash DEBUG fires for every simple command, including PROMPT_COMMAND
+  # bodies. Skip our own prompt-time helpers so they don't mark the shell as
+  # "in command" before the prompt has even drawn.
+  case "$BASH_COMMAND" in
+    *__orca_osc133_precmd*|*__orca_prompt_mark*) return ;;
+  esac
+  printf "\\033]133;C\\007"
+  __orca_in_command=1
+}
+# Why: prepend so we capture $? before the user's PROMPT_COMMAND chain mutates it.
+PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
+trap '__orca_osc133_preexec' DEBUG
+if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
+  __orca_prompt_mark() {
+    printf "${SHELL_READY_MARKER}"
+  }
+  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+    PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__orca_prompt_mark")
+  else
+    _orca_prev_prompt_command="\${PROMPT_COMMAND}"
+    if [[ -n "\${_orca_prev_prompt_command}" ]]; then
+      PROMPT_COMMAND="\${_orca_prev_prompt_command};__orca_prompt_mark"
+    else
+      PROMPT_COMMAND="__orca_prompt_mark"
+    fi
+  fi
+fi
+`
 }
 
 export function getDaemonZshShellReadyRcfileContent(): string {
@@ -199,44 +269,7 @@ if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
   add-zle-hook-widget line-init __orca_prompt_mark
 fi
 `
-  const bashRc = `# Orca daemon bash shell-ready wrapper
-[[ -f /etc/profile ]] && source /etc/profile
-if [[ -f "$HOME/.bash_profile" ]]; then
-  source "$HOME/.bash_profile"
-elif [[ -f "$HOME/.bash_login" ]]; then
-  source "$HOME/.bash_login"
-elif [[ -f "$HOME/.profile" ]]; then
-  source "$HOME/.profile"
-fi
-__orca_restore_attribution_path() {
-  [[ -n "\${ORCA_ATTRIBUTION_SHIM_DIR:-}" ]] || return 0
-  case "$PATH" in
-    "\${ORCA_ATTRIBUTION_SHIM_DIR}"|"\${ORCA_ATTRIBUTION_SHIM_DIR}:"*) return 0 ;;
-  esac
-  export PATH="\${ORCA_ATTRIBUTION_SHIM_DIR}:$PATH"
-}
-__orca_restore_attribution_path
-# Why: user startup files may set the default OpenCode config after Orca's
-# spawn env; restore the PTY-scoped overlay before the first prompt.
-[[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
-# Why: PI_CODING_AGENT_DIR is also a single-root env var users may re-export.
-[[ -n "\${ORCA_PI_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_PI_CODING_AGENT_DIR}"
-if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
-  __orca_prompt_mark() {
-    printf "${SHELL_READY_MARKER}"
-  }
-  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-    PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__orca_prompt_mark")
-  else
-    _orca_prev_prompt_command="\${PROMPT_COMMAND}"
-    if [[ -n "\${_orca_prev_prompt_command}" ]]; then
-      PROMPT_COMMAND="\${_orca_prev_prompt_command};__orca_prompt_mark"
-    else
-      PROMPT_COMMAND="__orca_prompt_mark"
-    fi
-  fi
-fi
-`
+  const bashRc = getDaemonBashShellReadyRcfileContent()
 
   const files = [
     [join(zshDir, '.zshenv'), zshEnv],

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -107,40 +107,80 @@ __orca_restore_attribution_path
 # 'working' spinner after the CLI exits without a Stop/SessionEnd hook.
 __orca_osc133_precmd() {
   local exit_code=$?
+  __orca_in_prompt_command=1
   if [[ -n "\${__orca_in_command:-}" ]]; then
     printf "\\033]133;D;%s\\007" "$exit_code"
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
 }
+__orca_osc133_prompt_done() {
+  unset __orca_in_prompt_command
+}
+__orca_run_user_debug_trap() {
+  if [[ -n "\${__orca_user_debug_trap:-}" ]]; then
+    eval "$__orca_user_debug_trap" || true
+  fi
+}
 __orca_osc133_preexec() {
+  __orca_run_user_debug_trap
+  [[ -z "\${__orca_in_prompt_command:-}" ]] || return
   # Why: bash DEBUG fires for every simple command, including PROMPT_COMMAND
   # bodies. Skip our own prompt-time helpers so they don't mark the shell as
   # "in command" before the prompt has even drawn.
   case "$BASH_COMMAND" in
-    *__orca_osc133_precmd*|*__orca_prompt_mark*) return ;;
+    *__orca_osc133_precmd*|*__orca_osc133_prompt_done*|*__orca_prompt_mark*) return ;;
   esac
   printf "\\033]133;C\\007"
   __orca_in_command=1
 }
 # Why: prepend so we capture $? before the user's PROMPT_COMMAND chain mutates it.
-PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
-trap '__orca_osc133_preexec' DEBUG
+__orca_normalize_prompt_command() {
+  local __orca_joined="" __orca_prompt_part
+  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+    for __orca_prompt_part in "\${PROMPT_COMMAND[@]}"; do
+      [[ -n "$__orca_prompt_part" ]] || continue
+      if [[ -n "$__orca_joined" ]]; then
+        __orca_joined="$__orca_joined;$__orca_prompt_part"
+      else
+        __orca_joined="$__orca_prompt_part"
+      fi
+    done
+    PROMPT_COMMAND="$__orca_joined"
+  fi
+}
+__orca_prepend_prompt_command() {
+  __orca_normalize_prompt_command
+  PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
+}
+__orca_append_prompt_command() {
+  local command="$1"
+  __orca_normalize_prompt_command
+  if [[ -n "\${PROMPT_COMMAND:-}" ]]; then
+    PROMPT_COMMAND="\${PROMPT_COMMAND};$command"
+  else
+    PROMPT_COMMAND="$command"
+  fi
+}
+__orca_prepend_prompt_command
 if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
   __orca_prompt_mark() {
     printf "${SHELL_READY_MARKER}"
   }
-  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-    PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__orca_prompt_mark")
-  else
-    _orca_prev_prompt_command="\${PROMPT_COMMAND}"
-    if [[ -n "\${_orca_prev_prompt_command}" ]]; then
-      PROMPT_COMMAND="\${_orca_prev_prompt_command};__orca_prompt_mark"
-    else
-      PROMPT_COMMAND="__orca_prompt_mark"
-    fi
-  fi
+  __orca_append_prompt_command "__orca_prompt_mark"
 fi
+__orca_append_prompt_command "__orca_osc133_prompt_done"
+__orca_debug_trap_spec="$(trap -p DEBUG)"
+if [[ -n "$__orca_debug_trap_spec" ]]; then
+  __orca_debug_trap_command="\${__orca_debug_trap_spec#trap -- }"
+  __orca_debug_trap_command="\${__orca_debug_trap_command% DEBUG}"
+  eval "__orca_user_debug_trap=$__orca_debug_trap_command"
+fi
+unset __orca_debug_trap_spec __orca_debug_trap_command
+unset -f __orca_normalize_prompt_command __orca_prepend_prompt_command __orca_append_prompt_command
+# Why: arm DEBUG after wrapper setup; otherwise bash treats our own rcfile
+# commands as a foreground command and emits a fake C/D before the first prompt.
+trap '__orca_osc133_preexec' DEBUG
 `
 }
 

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -2,9 +2,10 @@
    bash, marker scanning, and env restoration cases in one suite so the
    generated wrapper contract is reviewed as a unit. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'child_process'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import type * as pty from 'node-pty'
 import type * as LocalPtyShellReadyModule from './local-pty-shell-ready'
 import { writeStartupCommandWhenShellReady } from './local-pty-shell-ready'
@@ -128,6 +129,48 @@ describe('writeStartupCommandWhenShellReady', () => {
 })
 
 const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
+const itWithBash = hasBash ? it : it.skip
+
+function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
+  const rcfile = join(tempDir, 'bash-osc133-rcfile')
+  writeFileSync(rcfile, rcfileContent)
+
+  const result = spawnSync(
+    'bash',
+    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
+    {
+      input: 'true\nfalse\nexit 0\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: tempDir,
+        ORCA_SHELL_READY_MARKER: '1',
+        TERM: process.env.TERM || 'xterm'
+      },
+      timeout: 5000
+    }
+  )
+
+  expect(result.error).toBeUndefined()
+  expect(result.status).toBe(0)
+  return result.stdout
+}
+
+function expectBashOsc133Lifecycle(output: string): void {
+  const oscA = '\x1b]133;A\x07'
+  const oscC = '\x1b]133;C\x07'
+  const oscD = '\x1b]133;D;'
+  const firstPromptMarker = output.indexOf(oscA)
+
+  expect(firstPromptMarker).toBeGreaterThanOrEqual(0)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscC)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscD)
+  expect(output).toContain(`${oscD}0\x07${oscA}`)
+  expect(output).toContain(`${oscD}1\x07${oscA}`)
+  expect(output.split(oscC)).toHaveLength(4)
+  expect(output.split(oscD)).toHaveLength(3)
+}
 
 describePosix('local PTY shell-ready launch config', () => {
   let userDataPath: string
@@ -283,10 +326,57 @@ describePosix('local PTY shell-ready launch config', () => {
     // parses (133;D for command-finished, 133;C for command-start).
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    expect(bashRc).toContain(
+      'PROMPT_COMMAND="__orca_osc133_precmd${PROMPT_COMMAND:+;${PROMPT_COMMAND}}"'
+    )
+    expect(bashRc.indexOf("trap '__orca_osc133_preexec' DEBUG")).toBeGreaterThan(
+      bashRc.indexOf('if [[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then')
+    )
     // Sanity: zsh wrapper still emits the same markers — both branches must
     // stay in sync.
     expect(zshRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshRc).toContain('printf "\\033]133;C\\007"')
+  })
+
+  itWithBash('runs the bash wrapper without fake C/D markers before the first prompt', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+
+    const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
+
+    expectBashOsc133Lifecycle(output)
+  })
+
+  itWithBash(
+    'preserves prompt hooks and existing DEBUG traps without fake command markers',
+    async () => {
+      const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+      writeFileSync(
+        join(userDataPath, '.bash_profile'),
+        [
+          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+          'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
+        ].join('\n')
+      )
+
+      const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
+
+      expect(output).toContain('PROMPT_HOOK')
+      expect(output).toContain('USER_DEBUG_AFTER')
+      expectBashOsc133Lifecycle(output)
+    }
+  )
+
+  itWithBash('normalizes array PROMPT_COMMAND hooks so bash 3.2 still runs cleanup', async () => {
+    const { getBashShellReadyRcfileContent } = await importFreshLocalPtyShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'PROMPT_COMMAND=(\'AFTER_ARRAY_PROMPT=1; printf "PROMPT_ARRAY\\n"\')\n'
+    )
+
+    const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
+
+    expect(output).toContain('PROMPT_ARRAY')
+    expectBashOsc133Lifecycle(output)
   })
 
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -268,6 +268,27 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(bashRc).toContain(piRestoreLine)
   })
 
+  // Why: regression guard for issue #2422. Without OSC 133 C/D markers in the
+  // bash rc, Linux/bash sessions kept the worktree spinner "working" for up to
+  // 30 min after the agent CLI exited, because the renderer's command
+  // lifecycle never observed a 'D' marker to drop the stale agent row.
+  it('emits OSC 133 C/D markers in the bash wrapper so agent exit cleanup fires', async () => {
+    const { getBashShellReadyRcfileContent, getZshShellReadyRcfileContent } =
+      await importFreshLocalPtyShellReady()
+
+    const bashRc = getBashShellReadyRcfileContent()
+    const zshRc = getZshShellReadyRcfileContent()
+
+    // The exact escape sequences the renderer's terminal-command-lifecycle
+    // parses (133;D for command-finished, 133;C for command-start).
+    expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
+    expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    // Sanity: zsh wrapper still emits the same markers — both branches must
+    // stay in sync.
+    expect(zshRc).toContain('printf "\\033]133;D;%s\\007"')
+    expect(zshRc).toContain('printf "\\033]133;C\\007"')
+  })
+
   it('preserves a real inherited ZDOTDIR as ORCA_ORIG_ZDOTDIR', async () => {
     const previousZdotdir = process.env.ZDOTDIR
     process.env.ZDOTDIR = '/Users/alice/.config/zsh'

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -155,42 +155,82 @@ __orca_restore_attribution_path
 # CLI exits without sending a Stop/SessionEnd hook.
 __orca_osc133_precmd() {
   local exit_code=$?
+  __orca_in_prompt_command=1
   if [[ -n "\${__orca_in_command:-}" ]]; then
     printf "\\033]133;D;%s\\007" "$exit_code"
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
 }
+__orca_osc133_prompt_done() {
+  unset __orca_in_prompt_command
+}
+__orca_run_user_debug_trap() {
+  if [[ -n "\${__orca_user_debug_trap:-}" ]]; then
+    eval "$__orca_user_debug_trap" || true
+  fi
+}
 __orca_osc133_preexec() {
+  __orca_run_user_debug_trap
+  [[ -z "\${__orca_in_prompt_command:-}" ]] || return
   # Why: bash DEBUG fires for every simple command, including PROMPT_COMMAND
   # bodies. Skip our own prompt-time helpers so they don't mark the shell as
   # "in command" before the prompt has even drawn.
   case "$BASH_COMMAND" in
-    *__orca_osc133_precmd*|*__orca_prompt_mark*) return ;;
+    *__orca_osc133_precmd*|*__orca_osc133_prompt_done*|*__orca_prompt_mark*) return ;;
   esac
   printf "\\033]133;C\\007"
   __orca_in_command=1
 }
 # Why: prepend so we capture $? before the user's PROMPT_COMMAND chain mutates it.
-PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
-trap '__orca_osc133_preexec' DEBUG
+__orca_normalize_prompt_command() {
+  local __orca_joined="" __orca_prompt_part
+  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+    for __orca_prompt_part in "\${PROMPT_COMMAND[@]}"; do
+      [[ -n "$__orca_prompt_part" ]] || continue
+      if [[ -n "$__orca_joined" ]]; then
+        __orca_joined="$__orca_joined;$__orca_prompt_part"
+      else
+        __orca_joined="$__orca_prompt_part"
+      fi
+    done
+    PROMPT_COMMAND="$__orca_joined"
+  fi
+}
+__orca_prepend_prompt_command() {
+  __orca_normalize_prompt_command
+  PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
+}
+__orca_append_prompt_command() {
+  local command="$1"
+  __orca_normalize_prompt_command
+  if [[ -n "\${PROMPT_COMMAND:-}" ]]; then
+    PROMPT_COMMAND="\${PROMPT_COMMAND};$command"
+  else
+    PROMPT_COMMAND="$command"
+  fi
+}
+__orca_prepend_prompt_command
 # Why: append the marker through PROMPT_COMMAND so it fires after the login
 # startup files have rebuilt the prompt, without re-running user rc files.
 if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then
   __orca_prompt_mark() {
     printf "${SHELL_READY_MARKER_ESCAPED}"
   }
-  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
-    PROMPT_COMMAND=("\${PROMPT_COMMAND[@]}" "__orca_prompt_mark")
-  else
-    _orca_prev_prompt_command="\${PROMPT_COMMAND}"
-    if [[ -n "\${_orca_prev_prompt_command}" ]]; then
-      PROMPT_COMMAND="\${_orca_prev_prompt_command};__orca_prompt_mark"
-    else
-      PROMPT_COMMAND="__orca_prompt_mark"
-    fi
-  fi
+  __orca_append_prompt_command "__orca_prompt_mark"
 fi
+__orca_append_prompt_command "__orca_osc133_prompt_done"
+__orca_debug_trap_spec="$(trap -p DEBUG)"
+if [[ -n "$__orca_debug_trap_spec" ]]; then
+  __orca_debug_trap_command="\${__orca_debug_trap_spec#trap -- }"
+  __orca_debug_trap_command="\${__orca_debug_trap_command% DEBUG}"
+  eval "__orca_user_debug_trap=$__orca_debug_trap_command"
+fi
+unset __orca_debug_trap_spec __orca_debug_trap_command
+unset -f __orca_normalize_prompt_command __orca_prepend_prompt_command __orca_append_prompt_command
+# Why: arm DEBUG after wrapper setup; otherwise bash treats our own rcfile
+# commands as a foreground command and emits a fake C/D before the first prompt.
+trap '__orca_osc133_preexec' DEBUG
 `
 }
 

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -148,6 +148,32 @@ __orca_restore_attribution_path
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 # Why: PI_CODING_AGENT_DIR is also a single-root env var users may re-export.
 [[ -n "\${ORCA_PI_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_PI_CODING_AGENT_DIR}"
+# Why: emit OSC 133 C/D so terminal-command-lifecycle can drop stale agent
+# status when the foreground command (e.g. an interrupted Claude/Codex CLI)
+# exits — mirrors the zsh wrapper. Without this, bash users (default on most
+# Linux distros) keep a stuck 'working' spinner for up to 30 min after the
+# CLI exits without sending a Stop/SessionEnd hook.
+__orca_osc133_precmd() {
+  local exit_code=$?
+  if [[ -n "\${__orca_in_command:-}" ]]; then
+    printf "\\033]133;D;%s\\007" "$exit_code"
+    unset __orca_in_command
+  fi
+  printf "\\033]133;A\\007"
+}
+__orca_osc133_preexec() {
+  # Why: bash DEBUG fires for every simple command, including PROMPT_COMMAND
+  # bodies. Skip our own prompt-time helpers so they don't mark the shell as
+  # "in command" before the prompt has even drawn.
+  case "$BASH_COMMAND" in
+    *__orca_osc133_precmd*|*__orca_prompt_mark*) return ;;
+  esac
+  printf "\\033]133;C\\007"
+  __orca_in_command=1
+}
+# Why: prepend so we capture $? before the user's PROMPT_COMMAND chain mutates it.
+PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
+trap '__orca_osc133_preexec' DEBUG
 # Why: append the marker through PROMPT_COMMAND so it fires after the login
 # startup files have rebuilt the prompt, without re-running user rc files.
 if [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]]; then

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -1,8 +1,48 @@
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { spawnSync } from 'child_process'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { getRelayShellLaunchConfig } from './pty-shell-launch'
+
+const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
+const itWithBash = hasBash ? it : it.skip
+
+function runInteractiveBashRcfile(rcfile: string, homeDir: string): string {
+  const result = spawnSync(
+    'bash',
+    ['-lc', 'bash --noprofile --rcfile "$1" -i 2>&1', 'bash', rcfile],
+    {
+      input: 'true\nfalse\nexit 0\n',
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        TERM: process.env.TERM || 'xterm'
+      },
+      timeout: 5000
+    }
+  )
+
+  expect(result.error).toBeUndefined()
+  expect(result.status).toBe(0)
+  return result.stdout
+}
+
+function expectBashOsc133Lifecycle(output: string): void {
+  const oscA = '\x1b]133;A\x07'
+  const oscC = '\x1b]133;C\x07'
+  const oscD = '\x1b]133;D;'
+  const firstPromptMarker = output.indexOf(oscA)
+
+  expect(firstPromptMarker).toBeGreaterThanOrEqual(0)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscC)
+  expect(output.slice(0, firstPromptMarker)).not.toContain(oscD)
+  expect(output).toContain(`${oscD}0\x07${oscA}`)
+  expect(output).toContain(`${oscD}1\x07${oscA}`)
+  expect(output.split(oscC)).toHaveLength(4)
+  expect(output.split(oscD)).toHaveLength(3)
+}
 
 describe('getRelayShellLaunchConfig', () => {
   let homeDir: string
@@ -54,5 +94,54 @@ describe('getRelayShellLaunchConfig', () => {
     expect(readFileSync(join(zshRoot, '.zshenv'), 'utf8')).toContain(
       'export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
     )
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'wraps bash even without overlay env for OSC 133 lifecycle markers',
+    () => {
+      const config = getRelayShellLaunchConfig('/bin/bash', { HOME: homeDir })
+      const rcfile = join(homeDir, '.orca-relay', 'shell-ready', 'bash', 'rcfile')
+      const bashRc = readFileSync(rcfile, 'utf8')
+
+      expect(config.args).toEqual(['--rcfile', rcfile])
+      expect(config.env).toEqual({})
+      expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
+      expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    }
+  )
+
+  itWithBash('runs the relay bash wrapper without fake C/D markers before the first prompt', () => {
+    const config = getRelayShellLaunchConfig('/bin/bash', { HOME: homeDir })
+    const output = runInteractiveBashRcfile(config.args[1] as string, homeDir)
+
+    expectBashOsc133Lifecycle(output)
+  })
+
+  itWithBash('preserves relay bash prompt hooks and DEBUG traps without fake markers', () => {
+    writeFileSync(
+      join(homeDir, '.bash_profile'),
+      [
+        'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+        'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
+      ].join('\n')
+    )
+    const config = getRelayShellLaunchConfig('/bin/bash', { HOME: homeDir })
+    const output = runInteractiveBashRcfile(config.args[1] as string, homeDir)
+
+    expect(output).toContain('PROMPT_HOOK')
+    expect(output).toContain('USER_DEBUG_AFTER')
+    expectBashOsc133Lifecycle(output)
+  })
+
+  itWithBash('normalizes relay bash array PROMPT_COMMAND hooks', () => {
+    writeFileSync(
+      join(homeDir, '.bash_profile'),
+      'PROMPT_COMMAND=(\'AFTER_ARRAY_PROMPT=1; printf "PROMPT_ARRAY\\n"\')\n'
+    )
+    const config = getRelayShellLaunchConfig('/bin/bash', { HOME: homeDir })
+    const output = runInteractiveBashRcfile(config.args[1] as string, homeDir)
+
+    expect(output).toContain('PROMPT_ARRAY')
+    expectBashOsc133Lifecycle(output)
   })
 })

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -104,6 +104,74 @@ fi
 # Why: remote startup files can re-export user defaults after relay spawn.
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 [[ -n "\${ORCA_PI_CODING_AGENT_DIR:-}" ]] && export PI_CODING_AGENT_DIR="\${ORCA_PI_CODING_AGENT_DIR}"
+# Why: SSH bash sessions need the same command lifecycle markers as local
+# bash so agent rows stop showing "working" when the foreground command exits.
+__orca_osc133_precmd() {
+  local exit_code=$?
+  __orca_in_prompt_command=1
+  if [[ -n "\${__orca_in_command:-}" ]]; then
+    printf "\\033]133;D;%s\\007" "$exit_code"
+    unset __orca_in_command
+  fi
+  printf "\\033]133;A\\007"
+}
+__orca_osc133_prompt_done() {
+  unset __orca_in_prompt_command
+}
+__orca_run_user_debug_trap() {
+  if [[ -n "\${__orca_user_debug_trap:-}" ]]; then
+    eval "$__orca_user_debug_trap" || true
+  fi
+}
+__orca_osc133_preexec() {
+  __orca_run_user_debug_trap
+  [[ -z "\${__orca_in_prompt_command:-}" ]] || return
+  case "$BASH_COMMAND" in
+    *__orca_osc133_precmd*|*__orca_osc133_prompt_done*) return ;;
+  esac
+  printf "\\033]133;C\\007"
+  __orca_in_command=1
+}
+__orca_normalize_prompt_command() {
+  local __orca_joined="" __orca_prompt_part
+  if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
+    for __orca_prompt_part in "\${PROMPT_COMMAND[@]}"; do
+      [[ -n "$__orca_prompt_part" ]] || continue
+      if [[ -n "$__orca_joined" ]]; then
+        __orca_joined="$__orca_joined;$__orca_prompt_part"
+      else
+        __orca_joined="$__orca_prompt_part"
+      fi
+    done
+    PROMPT_COMMAND="$__orca_joined"
+  fi
+}
+__orca_prepend_prompt_command() {
+  __orca_normalize_prompt_command
+  PROMPT_COMMAND="__orca_osc133_precmd\${PROMPT_COMMAND:+;\${PROMPT_COMMAND}}"
+}
+__orca_append_prompt_command() {
+  local command="$1"
+  __orca_normalize_prompt_command
+  if [[ -n "\${PROMPT_COMMAND:-}" ]]; then
+    PROMPT_COMMAND="\${PROMPT_COMMAND};$command"
+  else
+    PROMPT_COMMAND="$command"
+  fi
+}
+__orca_prepend_prompt_command
+__orca_append_prompt_command "__orca_osc133_prompt_done"
+__orca_debug_trap_spec="$(trap -p DEBUG)"
+if [[ -n "$__orca_debug_trap_spec" ]]; then
+  __orca_debug_trap_command="\${__orca_debug_trap_spec#trap -- }"
+  __orca_debug_trap_command="\${__orca_debug_trap_command% DEBUG}"
+  eval "__orca_user_debug_trap=$__orca_debug_trap_command"
+fi
+unset __orca_debug_trap_spec __orca_debug_trap_command
+unset -f __orca_normalize_prompt_command __orca_prepend_prompt_command __orca_append_prompt_command
+# Why: arm DEBUG after wrapper setup so the relay rcfile itself does not emit
+# fake command-start/end markers before the first prompt.
+trap '__orca_osc133_preexec' DEBUG
 `
 
   const files = [
@@ -136,12 +204,15 @@ export function getRelayShellLaunchConfig(
   shellPath: string,
   env: Record<string, string>
 ): RelayShellLaunchConfig {
-  if (!hasOverlayRestoreEnv(env) || process.platform === 'win32') {
+  if (process.platform === 'win32') {
     return { args: POSIX_LOGIN_ARGS, env: {} }
   }
 
   const shellName = basename(shellPath).toLowerCase()
   if (shellName !== 'zsh' && shellName !== 'bash') {
+    return { args: POSIX_LOGIN_ARGS, env: {} }
+  }
+  if (shellName === 'zsh' && !hasOverlayRestoreEnv(env)) {
     return { args: POSIX_LOGIN_ARGS, env: {} }
   }
 


### PR DESCRIPTION
Fixes #2422.

On Linux/bash, the worktree spinner kept spinning for up to 30 minutes after the user terminated a CLI agent (Claude, Codex, etc.).

**Cause:** the zsh wrappers emit OSC 133 `C`/`D` markers around each command, and the renderer uses the `D` marker to drop stale `working` agent rows when the foreground command exits. The bash wrappers were missing this emission, so on bash the row stuck until the 30-min freshness window decayed it.

**Fix:** add the equivalent OSC 133 `C`/`D` emission to both bash rcfiles (local PTY + daemon/SSH) using `PROMPT_COMMAND` + `trap DEBUG`, with a guard so the DEBUG trap skips our own prompt-time helpers.

## Test plan

- [x] `pnpm vitest run src/main/providers/local-pty-shell-ready.test.ts src/main/daemon/shell-ready.test.ts` — passes, with new regression tests asserting the bash rcfile contains `133;D` and `133;C`.
- [x] `pnpm run tc` clean.
- [x] Manual on Linux/bash: Ctrl+C an agent mid-turn, confirm the spinner clears immediately.