### PR TITLE
Suppress false-positive Chromium child crash reports

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -54,6 +54,60 @@ describe('shouldRecordProcessGoneCrash', () => {
     ).toBe(false)
   })
 
+  it('skips Windows control termination killed events outside expected lifecycle teardown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        reason: 'killed',
+        exitCode: -1073741510,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        reason: 'killed',
+        exitCode: 1073807364,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+  })
+
+  it('skips non-fatal Chromium child process exits', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'crashed',
+        exitCode: 34,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'network.mojom.NetworkService',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+  })
+
+  it('still records unknown child process crashes', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'com.orca.unexpected',
+        reason: 'crashed',
+        exitCode: 5,
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
+  })
+
   it('records non-SIGTERM killed process exits outside expected lifecycle teardown', () => {
     expect(
       shouldRecordProcessGoneCrash({

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -1,25 +1,68 @@
 export type ProcessGoneSource = 'renderer' | 'child'
 export type ExpectedTeardownScope = 'none' | 'renderer-reload' | 'app-shutdown'
 
+const WINDOWS_CONTROL_TERMINATION_EXIT_CODES = new Set([0xc000013a, 0x40010004])
+const NON_FATAL_CHILD_PROCESS_TYPES = new Set(['GPU'])
+const NON_FATAL_UTILITY_SERVICE_NAMES = new Set(['network.mojom.NetworkService'])
+
+function isWindowsControlTerminationExitCode(exitCode: number | null): boolean {
+  if (exitCode === null) {
+    return false
+  }
+  return WINDOWS_CONTROL_TERMINATION_EXIT_CODES.has(exitCode >>> 0)
+}
+
+function isNonFatalChromiumChildProcess({
+  source,
+  processType,
+  serviceName
+}: {
+  source: ProcessGoneSource
+  processType?: string
+  serviceName?: string
+}): boolean {
+  if (source !== 'child') {
+    return false
+  }
+  if (processType && NON_FATAL_CHILD_PROCESS_TYPES.has(processType)) {
+    return true
+  }
+  return (
+    processType === 'Utility' &&
+    serviceName !== undefined &&
+    NON_FATAL_UTILITY_SERVICE_NAMES.has(serviceName)
+  )
+}
+
 export function shouldRecordProcessGoneCrash({
   source,
+  processType,
+  serviceName,
   reason,
   exitCode,
   expectedTeardown
 }: {
   source: ProcessGoneSource
+  processType?: string
+  serviceName?: string
   reason: string
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
 }): boolean {
+  // Why: GPU and Chromium Network Service exits are recoverable child-process
+  // churn, not Orca renderer crashes. Recording them opens noisy crash prompts.
+  if (isNonFatalChromiumChildProcess({ source, processType, serviceName })) {
+    return false
+  }
   // Why: Electron reports intentional reload/update/quit teardown as `killed`.
   // Real renderer OOMs and Chromium crashes should still reach crash reporting.
   if (reason !== 'killed') {
     return true
   }
   // Why: Electron reports expected Chromium teardown during reload/update as
-  // `killed` + SIGTERM. Treat real crash reasons as reportable, but skip this.
-  if (exitCode === 15) {
+  // `killed` + SIGTERM or Windows control termination statuses. Treat real
+  // crash reasons as reportable, but skip these normal termination shapes.
+  if (exitCode === 15 || isWindowsControlTerminationExitCode(exitCode)) {
     return false
   }
   if (expectedTeardown === 'app-shutdown') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -323,6 +323,7 @@ function openMainWindow(): BrowserWindow {
     shouldRecordRendererCrash: (details, webContentsId) =>
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: details.reason,
         exitCode: details.exitCode ?? null,
         expectedTeardown: getExpectedTeardownScope(webContentsId)
@@ -499,6 +500,8 @@ function recordProcessGoneCrash(
   if (
     !shouldRecordProcessGoneCrash({
       source,
+      processType,
+      serviceName: typeof details.serviceName === 'string' ? details.serviceName : undefined,
       reason,
       exitCode,
       expectedTeardown: getExpectedTeardownScope(webContentsId)


### PR DESCRIPTION
Summary
- Suppress recoverable Chromium GPU child-process exits from crash-report prompts.
- Suppress Chromium Network Service utility exits from crash-report prompts.
- Treat Windows control-termination killed statuses as normal termination rather than app crashes.

Slack evidence
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779197206081009
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779264381926569
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779266879117849
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779279587587199
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779239096524529
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779279925595249
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1779277932097269

Validation
- pnpm vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/window/createMainWindow.test.ts src/main/crash-reporting/crash-report-store.test.ts src/main/ipc/crash-reporting.test.ts src/shared/crash-reporting.test.ts
- pnpm run typecheck:node
- pnpm lint

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.