### PR TITLE
Fix task source fallback for Linear integration

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1798,13 +1798,23 @@ export default function TaskPage(): React.JSX.Element {
     () => normalizeVisibleTaskProviders(settings?.visibleTaskProviders),
     [settings?.visibleTaskProviders]
   )
+  const defaultTaskSource = settings?.defaultTaskSource ?? 'github'
   const visibleTaskProviders = useMemo(
     () =>
-      filterAvailableTaskProviders(preferredVisibleTaskProviders, {
-        gitlabInstalled: preflightStatus?.glab?.installed === true,
-        linearConnected: linearStatus.connected === true
-      }),
-    [linearStatus.connected, preferredVisibleTaskProviders, preflightStatus?.glab?.installed]
+      filterAvailableTaskProviders(
+        preferredVisibleTaskProviders,
+        {
+          gitlabInstalled: preflightStatus?.glab?.installed === true,
+          linearConnected: linearStatus.connected === true
+        },
+        defaultTaskSource
+      ),
+    [
+      defaultTaskSource,
+      linearStatus.connected,
+      preferredVisibleTaskProviders,
+      preflightStatus?.glab?.installed
+    ]
   )
   const visibleSourceOptions = useMemo(
     () => SOURCE_OPTIONS.filter((source) => visibleTaskProviders.includes(source.id)),
@@ -1819,7 +1829,6 @@ export default function TaskPage(): React.JSX.Element {
   const defaultTaskViewPreset = normalizeGitHubTaskPreset(settings?.defaultTaskViewPreset ?? 'all')
   const initialTaskQuery = getTaskPresetQuery(defaultTaskViewPreset)
 
-  const defaultTaskSource = settings?.defaultTaskSource ?? 'github'
   const preferredTaskSource = pageData.taskSource ?? defaultTaskSource
   const [taskSource, setTaskSource] = useState<TaskSource>(
     resolveVisibleTaskProvider(preferredTaskSource, visibleTaskProviders)

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -49,11 +49,20 @@ const SidebarNav = React.memo(function SidebarNav() {
   )
   const visibleTaskProviders = React.useMemo(
     () =>
-      filterAvailableTaskProviders(preferredVisibleTaskProviders, {
-        gitlabInstalled: preflightStatus?.glab?.installed === true,
-        linearConnected: linearStatus.connected === true
-      }),
-    [linearStatus.connected, preferredVisibleTaskProviders, preflightStatus?.glab?.installed]
+      filterAvailableTaskProviders(
+        preferredVisibleTaskProviders,
+        {
+          gitlabInstalled: preflightStatus?.glab?.installed === true,
+          linearConnected: linearStatus.connected === true
+        },
+        defaultTaskSource
+      ),
+    [
+      defaultTaskSource,
+      linearStatus.connected,
+      preferredVisibleTaskProviders,
+      preflightStatus?.glab?.installed
+    ]
   )
   const resolvedDefaultTaskSource = React.useMemo(
     () => resolveVisibleTaskProvider(defaultTaskSource, visibleTaskProviders),

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -30,6 +30,45 @@ describe('task providers', () => {
     ).toEqual(['github', 'linear'])
   })
 
+  it('keeps an available saved default visible when provider visibility drifted', () => {
+    expect(
+      filterAvailableTaskProviders(
+        ['linear'],
+        {
+          gitlabInstalled: false,
+          linearConnected: true
+        },
+        'github'
+      )
+    ).toEqual(['github', 'linear'])
+  })
+
+  it('preserves intentionally narrowed providers when the saved default matches them', () => {
+    expect(
+      filterAvailableTaskProviders(
+        ['linear'],
+        {
+          gitlabInstalled: false,
+          linearConnected: true
+        },
+        'linear'
+      )
+    ).toEqual(['linear'])
+  })
+
+  it('does not restore an unavailable saved default', () => {
+    expect(
+      filterAvailableTaskProviders(
+        ['linear'],
+        {
+          gitlabInstalled: false,
+          linearConnected: true
+        },
+        'gitlab'
+      )
+    ).toEqual(['linear'])
+  })
+
   it('falls back to GitHub when every preferred provider is unavailable', () => {
     expect(
       filterAvailableTaskProviders(['gitlab', 'linear'], {

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -69,6 +69,19 @@ describe('task providers', () => {
     ).toEqual(['linear'])
   })
 
+  it('ignores malformed saved defaults when every preferred provider is unavailable', () => {
+    expect(
+      filterAvailableTaskProviders(
+        ['gitlab'],
+        {
+          gitlabInstalled: false,
+          linearConnected: true
+        },
+        'jira' as never
+      )
+    ).toEqual(['github'])
+  })
+
   it('falls back to GitHub when every preferred provider is unavailable', () => {
     expect(
       filterAvailableTaskProviders(['gitlab', 'linear'], {

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -31,9 +31,10 @@ export type TaskProviderAvailability = {
 
 export function filterAvailableTaskProviders(
   visibleProviders: readonly TaskProvider[],
-  availability: TaskProviderAvailability
+  availability: TaskProviderAvailability,
+  preferredProvider?: TaskProvider | null
 ): TaskProvider[] {
-  const available = visibleProviders.filter((provider) => {
+  const isProviderAvailable = (provider: TaskProvider): boolean => {
     if (provider === 'github') {
       return true
     }
@@ -41,7 +42,21 @@ export function filterAvailableTaskProviders(
       return availability.gitlabInstalled
     }
     return availability.linearConnected
-  })
+  }
+
+  const available = visibleProviders.filter(isProviderAvailable)
+
+  // Why: older or drifted settings can hide the saved default while another
+  // provider becomes available. Keep that default reachable after hydration.
+  if (
+    preferredProvider &&
+    isProviderAvailable(preferredProvider) &&
+    !available.includes(preferredProvider)
+  ) {
+    return TASK_PROVIDERS.filter(
+      (provider) => provider === preferredProvider || available.includes(provider)
+    )
+  }
 
   return available.length > 0 ? available : ['github']
 }

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -34,6 +34,8 @@ export function filterAvailableTaskProviders(
   availability: TaskProviderAvailability,
   preferredProvider?: TaskProvider | null
 ): TaskProvider[] {
+  const normalizedPreferredProvider =
+    preferredProvider && TASK_PROVIDER_SET.has(preferredProvider) ? preferredProvider : null
   const isProviderAvailable = (provider: TaskProvider): boolean => {
     if (provider === 'github') {
       return true
@@ -49,12 +51,12 @@ export function filterAvailableTaskProviders(
   // Why: older or drifted settings can hide the saved default while another
   // provider becomes available. Keep that default reachable after hydration.
   if (
-    preferredProvider &&
-    isProviderAvailable(preferredProvider) &&
-    !available.includes(preferredProvider)
+    normalizedPreferredProvider &&
+    isProviderAvailable(normalizedPreferredProvider) &&
+    !available.includes(normalizedPreferredProvider)
   ) {
     return TASK_PROVIDERS.filter(
-      (provider) => provider === preferredProvider || available.includes(provider)
+      (provider) => provider === normalizedPreferredProvider || available.includes(provider)
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes #2435.

This keeps the saved Tasks default source reachable when task-provider visibility settings have drifted. A stale profile can have `visibleTaskProviders: ['linear']` while `defaultTaskSource: 'github'`; after Linear connects, the previous availability filter stopped falling back to GitHub and the GitHub source icon disappeared.

## Changes

- Thread the saved default task source into task-provider availability filtering.
- Restore an available saved default provider when it is missing from the visible provider list.
- Preserve intentional narrowed setups, such as Linear-only when Linear is also the saved default.
- Add regression coverage for restored defaults, intentional Linear-only settings, and unavailable defaults.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/task-providers.test.ts`
- `pnpm run typecheck:web`
- Manual dev-profile verification against the reported Linear/GitHub source picker scenario on macOS.

## UI / Visuals

No visual styling or layout changes. This only changes which existing Tasks source buttons remain available after provider availability hydration, so no screenshot is attached.

## AI Review, Cross-Platform, and Security

- Codex review: the change is scoped to shared provider filtering plus renderer call sites; it does not add platform-specific shortcuts, labels, filesystem paths, IPC, network calls, or persistence writes.
- Claude Code review: independently reviewed the diff and agreed with the root cause and fix approach. Minor notes from that review were addressed before opening this PR.
- Cross-platform compatibility: behavior is platform-neutral TypeScript state derivation and should apply the same on macOS, Linux, Windows, local, and SSH-backed workspaces.
- Security audit: no new secret handling, shell execution, external URLs, auth flows, or user-controlled file/path operations.

## Platform Notes

The original report and manual verification were on macOS. The fix is shared renderer/state logic with no OS-specific branches.

## Contributor Info

X handle: not provided.