### PR TITLE
Fix Claude usage polling against expired metadata

### DIFF
--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -217,14 +217,15 @@ function createClaudeCredentialsJson(
 
 function createClaudeCredentialsWithoutEmail(
   accessToken: string,
-  organizationUuid: string | null = null
+  organizationUuid: string | null = null,
+  options: { expiresAt?: number; refreshToken?: string } = {}
 ): string {
   return `${JSON.stringify({
     claudeAiOauth: {
       ...(organizationUuid ? { organizationUuid } : {}),
       accessToken,
-      refreshToken: `${accessToken}-refresh`,
-      expiresAt: Date.now() + 60_000
+      refreshToken: options.refreshToken ?? `${accessToken}-refresh`,
+      expiresAt: options.expiresAt ?? Date.now() + 60_000
     }
   })}\n`
 }
@@ -1094,6 +1095,92 @@ describe('ClaudeRuntimeAuthService', () => {
 
     expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(originalCredentials)
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(originalCredentials)
+  })
+
+  it('reads back identity-less refreshed credentials when the refresh token matches', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const refreshToken = 'same-managed-refresh-token'
+    const originalCredentials = createClaudeCredentialsWithoutEmail('original', null, {
+      expiresAt: 1_000,
+      refreshToken
+    })
+    const refreshedCredentials = createClaudeCredentialsWithoutEmail('refreshed', null, {
+      expiresAt: 2_000,
+      refreshToken
+    })
+    const managedAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      originalCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath, { organizationUuid: 'org-from-account' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, refreshedCredentials, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(refreshedCredentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(refreshedCredentials)
+  })
+
+  it('rules out other identity-less accounts with different refresh tokens', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const account1RefreshToken = 'account-1-refresh-token'
+    const account1OriginalCredentials = createClaudeCredentialsWithoutEmail('account-1', null, {
+      expiresAt: 1_000,
+      refreshToken: account1RefreshToken
+    })
+    const account1RefreshedCredentials = createClaudeCredentialsWithoutEmail(
+      'account-1-refreshed',
+      null,
+      {
+        expiresAt: 2_000,
+        refreshToken: account1RefreshToken
+      }
+    )
+    const account2Credentials = createClaudeCredentialsWithoutEmail('account-2', null, {
+      refreshToken: 'account-2-refresh-token'
+    })
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      account1OriginalCredentials
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      account2Credentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1),
+        createClaudeAccount('account-2', managedAuthPath2, { email: 'other@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    writeFileSync(runtimeCredentialsPath, account1RefreshedCredentials, 'utf-8')
+    await service.syncForCurrentSelection()
+
+    expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(
+      account1RefreshedCredentials
+    )
+    expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(account2Credentials)
+    expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account1RefreshedCredentials)
   })
 
   it('restores the system default after rejecting unverifiable managed credentials', async () => {

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -60,6 +60,7 @@ type ClaudeKeychainReadResult =
 type ClaudeKeychainSnapshotValue =
   | { status: 'captured'; credentialsJson: string | null }
   | { status: 'unknown' }
+type ClaudeRefreshTokenComparison = 'same' | 'different' | 'missing'
 
 const RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR = Symbol('runtime-oauth-account-parse-error')
 
@@ -517,14 +518,24 @@ export class ClaudeRuntimeAuthService {
         managedIdentity?.organizationUuid ??
         managedOauthIdentity.organizationUuid
     )
+    const refreshTokenComparison = this.compareRefreshTokens(
+      runtimeCredentialsJson,
+      managedCredentialsJson
+    )
     if (!identity.email) {
+      if (refreshTokenComparison === 'same') {
+        return 'match'
+      }
+      if (!identity.organizationUuid && refreshTokenComparison === 'different') {
+        return 'mismatch'
+      }
       return 'unverifiable'
     }
     if (account.email && this.normalizeField(account.email) !== identity.email) {
       return 'mismatch'
     }
     if (selectedOrganizationUuid && !identity.organizationUuid) {
-      return 'unverifiable'
+      return refreshTokenComparison === 'same' ? 'match' : 'unverifiable'
     }
     if (
       selectedOrganizationUuid &&
@@ -534,7 +545,7 @@ export class ClaudeRuntimeAuthService {
       return 'mismatch'
     }
     if (!selectedOrganizationUuid && identity.organizationUuid) {
-      return 'unverifiable'
+      return refreshTokenComparison === 'same' ? 'match' : 'unverifiable'
     }
 
     return 'match'
@@ -654,6 +665,28 @@ export class ClaudeRuntimeAuthService {
       this.readNumber(oauth, 'expiry') ??
       this.readNumber(oauth, 'expires')
     )
+  }
+
+  private compareRefreshTokens(
+    runtimeCredentialsJson: string,
+    managedCredentialsJson: string
+  ): ClaudeRefreshTokenComparison {
+    const runtimeRefreshToken = this.readRefreshTokenFromCredentials(runtimeCredentialsJson)
+    const managedRefreshToken = this.readRefreshTokenFromCredentials(managedCredentialsJson)
+    if (!runtimeRefreshToken || !managedRefreshToken) {
+      return 'missing'
+    }
+    return runtimeRefreshToken === managedRefreshToken ? 'same' : 'different'
+  }
+
+  private readRefreshTokenFromCredentials(credentialsJson: string): string | null {
+    try {
+      const parsed = JSON.parse(credentialsJson) as Record<string, unknown>
+      const oauth = this.asRecord(parsed.claudeAiOauth)
+      return this.normalizeField(this.readString(oauth, 'refreshToken'))
+    } catch {
+      return null
+    }
   }
 
   private readIdentityFromOauthAccount(oauthAccount: unknown): ClaudeAuthIdentity {

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -214,7 +214,7 @@ describe('fetchClaudeRateLimits', () => {
     )
   })
 
-  it('tries PTY usage when OAuth credentials are expired but refreshable', async () => {
+  it('tries OAuth usage even when local credential metadata is expired', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {
       configDir,
@@ -235,12 +235,58 @@ describe('fetchClaudeRateLimits', () => {
     await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
       provider: 'claude',
       status: 'ok',
-      session: { usedPercent: 56 }
+      session: { usedPercent: 12 }
     })
 
-    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(netFetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer expired-oauth-token'
+        })
+      })
+    )
     expect(readFileMock).not.toHaveBeenCalled()
-    expect(fetchViaPty).toHaveBeenCalledWith({ authPreparation })
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
+  it('does not mask OAuth usage rate limits with the PTY fallback', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'expired-oauth-token',
+          refreshToken: 'refresh-token',
+          expiresAt: Date.now() - 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { type: 'rate_limit_error' } }), { status: 429 })
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude usage is rate limited right now.'
+    })
+
+    expect(netFetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/api/oauth/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer expired-oauth-token'
+        })
+      })
+    )
+    expect(fetchViaPty).not.toHaveBeenCalled()
   })
 
   it('does not read inactive managed credentials from unowned auth paths', async () => {

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: this module keeps Claude credential source
+ordering, OAuth usage fetch semantics, and PTY fallback behavior together so
+subscription usage state cannot drift across code paths. */
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
@@ -14,6 +17,7 @@ import {
   readClaudeManagedAuthFile,
   resolveOwnedClaudeManagedAuthPath
 } from '../claude-accounts/managed-auth-path'
+import { createOAuthUsageError, OAuthUsageError } from './claude-oauth-usage-error'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -83,26 +87,36 @@ type OAuthCredentialReadResult = {
 }
 
 // Why: factored out so both the active-account Keychain reader and the
-// managed-account reader share the same JSON parsing + expiry check.
+// managed-account reader share the same JSON parsing + refreshability check.
 function parseOAuthCredentialsJson(raw: string): OAuthCredentialReadResult {
   try {
     const parsed = JSON.parse(raw) as KeychainCredentials
     const oauth = parsed?.claudeAiOauth
     const token = oauth?.accessToken
-    if (!token || typeof token !== 'string') {
-      return { token: null, hasRefreshableCredentials: false }
-    }
     const refreshToken = oauth?.refreshToken
-    const expiresAt = oauth?.expiresAt
-    if (typeof expiresAt === 'number' && expiresAt < Date.now()) {
+    const hasRefreshableCredentials = typeof refreshToken === 'string' && refreshToken.trim() !== ''
+    if (!token || typeof token !== 'string') {
       return {
         token: null,
-        hasRefreshableCredentials: typeof refreshToken === 'string' && refreshToken.trim() !== ''
+        hasRefreshableCredentials
       }
     }
-    return { token, hasRefreshableCredentials: true }
+    // Why: Claude's local expiresAt metadata is not authoritative for the
+    // /api/oauth/usage endpoint. Real Claude Code 2.1 credentials have been
+    // observed authenticating there after expiresAt, so let the server decide.
+    return {
+      token,
+      hasRefreshableCredentials
+    }
   } catch {
-    return { token: null, hasRefreshableCredentials: false }
+    return emptyOAuthCredentialReadResult()
+  }
+}
+
+function emptyOAuthCredentialReadResult(): OAuthCredentialReadResult {
+  return {
+    token: null,
+    hasRefreshableCredentials: false
   }
 }
 
@@ -113,7 +127,7 @@ function parseOAuthCredentialsJson(raw: string): OAuthCredentialReadResult {
  */
 async function readFromKeychain(configDir?: string): Promise<OAuthCredentialReadResult> {
   if (process.platform !== 'darwin') {
-    return { token: null, hasRefreshableCredentials: false }
+    return emptyOAuthCredentialReadResult()
   }
 
   if (configDir) {
@@ -128,20 +142,14 @@ async function readFromKeychain(configDir?: string): Promise<OAuthCredentialRead
     if (legacyCredentials.token) {
       return legacyCredentials
     }
-    return {
-      token: null,
-      hasRefreshableCredentials:
-        scopedCredentials.hasRefreshableCredentials || legacyCredentials.hasRefreshableCredentials
-    }
+    return scopedCredentials.hasRefreshableCredentials ? scopedCredentials : legacyCredentials
   }
 
   try {
     const credentials = await readActiveClaudeKeychainCredentials(configDir)
-    return credentials
-      ? parseOAuthCredentialsJson(credentials)
-      : { token: null, hasRefreshableCredentials: false }
+    return credentials ? parseOAuthCredentialsJson(credentials) : emptyOAuthCredentialReadResult()
   } catch {
-    return { token: null, hasRefreshableCredentials: false }
+    return emptyOAuthCredentialReadResult()
   }
 }
 
@@ -150,11 +158,9 @@ async function readCredentialsFromStrictKeychain(
 ): Promise<OAuthCredentialReadResult> {
   try {
     const credentials = await readActiveClaudeKeychainCredentialsStrict(configDir)
-    return credentials
-      ? parseOAuthCredentialsJson(credentials)
-      : { token: null, hasRefreshableCredentials: false }
+    return credentials ? parseOAuthCredentialsJson(credentials) : emptyOAuthCredentialReadResult()
   } catch {
-    return { token: null, hasRefreshableCredentials: false }
+    return emptyOAuthCredentialReadResult()
   }
 }
 
@@ -169,7 +175,7 @@ async function readFromCredentialsFile(configDir?: string): Promise<OAuthCredent
     const raw = await readFile(credPath, 'utf-8')
     return parseOAuthCredentialsJson(raw)
   } catch {
-    return { token: null, hasRefreshableCredentials: false }
+    return emptyOAuthCredentialReadResult()
   }
 }
 
@@ -194,12 +200,11 @@ async function readOAuthCredentials(configDir?: string): Promise<OAuthCredential
   if (fromFile.token) {
     return fromFile
   }
-
-  return {
-    token: null,
-    hasRefreshableCredentials:
-      fromKeychain.hasRefreshableCredentials || fromFile.hasRefreshableCredentials
+  if (fromFile.hasRefreshableCredentials) {
+    return fromFile
   }
+
+  return emptyOAuthCredentialReadResult()
 }
 
 // ---------------------------------------------------------------------------
@@ -276,7 +281,7 @@ async function fetchViaOAuth(token: string): Promise<ProviderRateLimits> {
     })
 
     if (!res.ok) {
-      throw new Error(`OAuth API returned ${res.status}`)
+      throw await createOAuthUsageError(res)
     }
 
     const data = (await res.json()) as OAuthUsageResponse
@@ -306,15 +311,25 @@ export async function fetchClaudeRateLimits(options?: {
   if (oauthCredentials.token) {
     try {
       return await fetchViaOAuth(oauthCredentials.token)
-    } catch {
+    } catch (err) {
+      if (err instanceof OAuthUsageError && err.skipPtyFallback) {
+        return {
+          provider: 'claude',
+          session: null,
+          weekly: null,
+          updatedAt: Date.now(),
+          error: err.message,
+          status: 'error'
+        }
+      }
       // OAuth API failed — fall through to PTY scraping as a backup
       // for subscription users whose token may still be valid for the CLI.
     }
   }
 
   // Path B: PTY fallback — only for subscription plan users (Max/Pro)
-  // whose OAuth credentials exist. The CLI can refresh expired OAuth tokens,
-  // so an expired access token should not be treated like API-key billing.
+  // whose OAuth credentials exist. This remains a fallback for older Claude
+  // auth shapes and transient OAuth failures.
   if (oauthCredentials.token || oauthCredentials.hasRefreshableCredentials) {
     try {
       return await fetchViaPty({ authPreparation: options?.authPreparation })

--- a/src/main/rate-limits/claude-oauth-usage-error.ts
+++ b/src/main/rate-limits/claude-oauth-usage-error.ts
@@ -1,0 +1,34 @@
+export class OAuthUsageError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly skipPtyFallback: boolean
+  ) {
+    super(message)
+  }
+}
+
+export async function createOAuthUsageError(res: Response): Promise<OAuthUsageError> {
+  return new OAuthUsageError(
+    await describeOAuthUsageError(res),
+    res.status,
+    // Why: 429 is already the user-visible Claude usage API answer.
+    // Falling through to /usage masks it with Claude 2.1's session-stats UI.
+    res.status === 429
+  )
+}
+
+async function describeOAuthUsageError(res: Response): Promise<string> {
+  if (res.status === 429) {
+    return 'Claude usage is rate limited right now.'
+  }
+  try {
+    const data = (await res.json()) as { error?: { message?: string } }
+    if (typeof data.error?.message === 'string' && data.error.message.trim()) {
+      return data.error.message
+    }
+  } catch {
+    // Ignore malformed error bodies and use the status fallback below.
+  }
+  return `OAuth API returned ${res.status}`
+}

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -19,12 +19,12 @@ export type InactiveCodexAccountInfo = {
   managedHomePath: string
 }
 
-// Why: quota state does not need near-real-time polling, and a less aggressive
-// default reduces avoidable Claude /usage pressure. We intentionally use a
-// slower cadence here rather than polling every 2 minutes.
-const DEFAULT_POLL_MS = 5 * 60 * 1000 // 5 minutes
-const MIN_REFETCH_MS = 30 * 1000 // 30 seconds — debounce rapid refresh requests
-const STALE_THRESHOLD_MS = 10 * 60 * 1000 // 10 minutes — after this, stale data is dropped
+// Why: Claude's subscription usage endpoint has a tight request budget. Quota
+// state is informational, so prefer keeping a recent snapshot over polling it
+// into 429s during long focused Orca sessions.
+const DEFAULT_POLL_MS = 15 * 60 * 1000 // 15 minutes
+const MIN_REFETCH_MS = 5 * 60 * 1000 // 5 minutes — debounce resume/manual refresh bursts
+const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — after this, stale data is dropped
 const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
 
 // Why: the internal state only tracks claude and codex. The inactiveClaudeAccounts


### PR DESCRIPTION
## Summary
- Treat Claude credential expiresAt as advisory for the OAuth usage endpoint and let the server decide whether the token is valid
- Preserve OAuth usage 429s instead of falling through to the Claude 2.1 /usage TUI fallback, which masks the real failure
- Reduce background quota polling pressure to avoid driving Claude usage into rate limits during long focused sessions

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/rate-limits/claude-fetcher.test.ts src/main/rate-limits/service.test.ts
- pnpm run typecheck:node
- App-level smoke via dev Electron + real token: window.api.rateLimits.refresh() returned Claude error "Claude usage is rate limited right now." instead of the Claude 2.1 /usage session-stats fallback message

Made with [Orca](https://github.com/stablyai/orca) 🐋
