### PR TITLE
Keep renderer focus when switching worktrees

### DIFF
--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -122,6 +122,23 @@ describe('webview registry drag listeners', () => {
     expect(window.focus).toHaveBeenCalledTimes(1)
   })
 
+  it('moves focus back to the renderer before a focused registered webview is hidden', async () => {
+    const { moveFocusToRendererBeforeFocusedWebviewHidden, registerPersistentWebview } =
+      await import('./webview-registry')
+    const inactiveWebview = createWebview()
+    const focusedWebview = createWebview()
+    vi.stubGlobal('document', { activeElement: focusedWebview })
+
+    registerPersistentWebview('page-1', inactiveWebview)
+    registerPersistentWebview('page-2', focusedWebview)
+
+    moveFocusToRendererBeforeFocusedWebviewHidden()
+
+    expect(inactiveWebview.blur).not.toHaveBeenCalled()
+    expect(focusedWebview.blur).toHaveBeenCalledTimes(1)
+    expect(window.focus).toHaveBeenCalledTimes(1)
+  })
+
   it('leaves focus alone before detaching an unfocused webview', async () => {
     const { moveFocusToRendererBeforeWebviewDetach } = await import('./webview-registry')
     const activeElement = { blur: vi.fn() } as unknown as HTMLElement

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -100,15 +100,34 @@ export function unregisterPersistentWebview(browserTabId: string): void {
   }
 }
 
-export function moveFocusToRendererBeforeWebviewDetach(webview: Electron.WebviewTag): void {
-  // Why: if this webview currently owns focus, removing it lets macOS hand
-  // activation back to the previously-active app (Slack, etc.) because the
-  // focused webContents is gone with no replacement. Move focus back into the
-  // main renderer first so Electron keeps focus inside the Orca window.
-  if (webview === document.activeElement || webview.contains(document.activeElement)) {
-    ;(document.activeElement as HTMLElement | null)?.blur?.()
-    window.focus()
+function moveFocusToRendererIfWebviewOwnsFocus(webview: Electron.WebviewTag): boolean {
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return false
   }
+  const activeElement = document.activeElement as HTMLElement | null
+  if (!activeElement) {
+    return false
+  }
+  // Why: hiding/removing a focused webview can let macOS reactivate the
+  // previously-frontmost app. Give focus back to Orca's renderer first.
+  if (webview === activeElement || webview.contains(activeElement)) {
+    activeElement.blur?.()
+    window.focus()
+    return true
+  }
+  return false
+}
+
+export function moveFocusToRendererBeforeFocusedWebviewHidden(): void {
+  for (const webview of webviewRegistry.values()) {
+    if (moveFocusToRendererIfWebviewOwnsFocus(webview)) {
+      return
+    }
+  }
+}
+
+export function moveFocusToRendererBeforeWebviewDetach(webview: Electron.WebviewTag): void {
+  moveFocusToRendererIfWebviewOwnsFocus(webview)
 }
 
 export function destroyPersistentWebview(browserTabId: string): void {

--- a/src/renderer/src/store/slices/browser-webview-cleanup.ts
+++ b/src/renderer/src/store/slices/browser-webview-cleanup.ts
@@ -1,5 +1,10 @@
 import type { BrowserPage, BrowserWorkspace } from '../../../../shared/types'
-import { destroyPersistentWebview } from '../../components/browser-pane/webview-registry'
+import {
+  destroyPersistentWebview,
+  moveFocusToRendererBeforeFocusedWebviewHidden
+} from '../../components/browser-pane/webview-registry'
+
+export { moveFocusToRendererBeforeFocusedWebviewHidden }
 
 export function collectBrowserWebviewIds(
   browserTabsByWorktree: Record<string, BrowserWorkspace[]>,

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -40,6 +40,10 @@ globalThis.window = { api: mockApi }
 
 import { createWorktreeSlice } from './worktrees'
 import { getHostedReviewCacheKey } from './hosted-review'
+import {
+  registerPersistentWebview,
+  unregisterPersistentWebview
+} from '../../components/browser-pane/webview-registry'
 
 function resetRemoteRuntimeMocks() {
   clearRuntimeCompatibilityCacheForTests()
@@ -121,6 +125,16 @@ function makeWorktree(overrides: Partial<Worktree> & { id: string; repoId: strin
   }
 }
 
+function createWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.WebviewTag {
+  return {
+    style: {},
+    blur: vi.fn(),
+    remove: vi.fn(),
+    contains: vi.fn(() => false),
+    ...overrides
+  } as unknown as Electron.WebviewTag
+}
+
 function makeLineage(overrides: Partial<WorktreeLineage> = {}): WorktreeLineage {
   return {
     worktreeId: 'repo1::/path/child',
@@ -133,6 +147,63 @@ function makeLineage(overrides: Partial<WorktreeLineage> = {}): WorktreeLineage 
     ...overrides
   }
 }
+
+describe('setActiveWorktree focus handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRemoteRuntimeMocks()
+  })
+
+  it('moves focus out of a registered webview before switching worktrees', () => {
+    const store = createTestStore()
+    const current = makeWorktree({ id: 'repo1::/path/current', repoId: 'repo1' })
+    const next = makeWorktree({ id: 'repo1::/path/next', repoId: 'repo1' })
+    const webview = createWebview()
+    const focusRenderer = vi.fn(() => {
+      expect(store.getState().activeWorktreeId).toBe(current.id)
+    })
+    const previousDocument = Object.getOwnPropertyDescriptor(globalThis, 'document')
+    const testWindow = globalThis.window as unknown as { focus?: () => void }
+    const previousFocus = testWindow.focus
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: { activeElement: webview }
+    })
+    testWindow.focus = focusRenderer
+    registerPersistentWebview('page-1', webview)
+
+    try {
+      store.setState({
+        worktreesByRepo: { repo1: [current, next] },
+        activeWorktreeId: current.id,
+        reconcileWorktreeTabModel: vi.fn(() => ({
+          activeRenderableTabId: null,
+          renderableTabCount: 0
+        })),
+        refreshGitHubForWorktreeIfStale: vi.fn()
+      } as unknown as Partial<AppState>)
+
+      store.getState().setActiveWorktree(next.id)
+
+      expect(webview.blur).toHaveBeenCalledTimes(1)
+      expect(focusRenderer).toHaveBeenCalledTimes(1)
+      expect(store.getState().activeWorktreeId).toBe(next.id)
+    } finally {
+      unregisterPersistentWebview('page-1')
+      if (previousDocument) {
+        Object.defineProperty(globalThis, 'document', previousDocument)
+      } else {
+        delete (globalThis as unknown as { document?: unknown }).document
+      }
+      if (previousFocus) {
+        testWindow.focus = previousFocus
+      } else {
+        delete testWindow.focus
+      }
+    }
+  })
+})
 
 describe('fetchWorktrees', () => {
   beforeEach(() => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -17,6 +17,7 @@ import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
 import { getHostedReviewCacheKey } from './hosted-review'
+import { moveFocusToRendererBeforeFocusedWebviewHidden } from './browser-webview-cleanup'
 export type { WorktreeSlice, WorktreeDeleteState } from './worktree-helpers'
 
 // Why: the runtime RPC default is intentionally bounded for CLI calls, but the
@@ -1282,6 +1283,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   },
 
   setActiveWorktree: (worktreeId) => {
+    if (get().activeWorktreeId !== worktreeId) {
+      moveFocusToRendererBeforeFocusedWebviewHidden()
+    }
     const reconciledActiveTabId = worktreeId
       ? get().reconcileWorktreeTabModel(worktreeId).activeRenderableTabId
       : null


### PR DESCRIPTION
- Keep renderer focus when switching worktrees