### PR TITLE
fix(ssh-relay): prevent duplicate daemons from replacing active sockets

### DIFF
--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -199,6 +199,19 @@ describe('RelayAgentHookServer', () => {
     }
   })
 
+  it('can defer endpoint file publication until relay socket ownership is proven', async () => {
+    const forward = vi.fn()
+    const server = new RelayAgentHookServer({ endpointDir: dir, forward })
+    await server.start({ publishEndpoint: false })
+    try {
+      expect(server.buildPtyEnv().ORCA_AGENT_HOOK_ENDPOINT).toBeUndefined()
+      expect(server.publishEndpointFile()).toBe(true)
+      expect(server.buildPtyEnv().ORCA_AGENT_HOOK_ENDPOINT).toBeTruthy()
+    } finally {
+      server.stop()
+    }
+  })
+
   it('keeps Copilot transcript retry alive across a following SessionEnd event', async () => {
     const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
     const server = new RelayAgentHookServer({ endpointDir: dir, forward })

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -73,6 +73,10 @@ export type RelayHookServerOptions = {
   forward: RelayHookForward
 }
 
+export type RelayHookServerStartOptions = {
+  publishEndpoint?: boolean
+}
+
 export class RelayAgentHookServer {
   private server: ReturnType<typeof createServer> | null = null
   private port = 0
@@ -103,7 +107,7 @@ export class RelayAgentHookServer {
     this.forward = options.forward
   }
 
-  async start(): Promise<void> {
+  async start(options: RelayHookServerStartOptions = {}): Promise<void> {
     if (this.server) {
       return
     }
@@ -129,12 +133,9 @@ export class RelayAgentHookServer {
         if (address && typeof address === 'object') {
           this.port = address.port
         }
-        this.endpointFileWritten = writeEndpointFile(this.endpointDir, this.endpointFilePath, {
-          port: this.port,
-          token: this.token,
-          env: this.env,
-          version: ORCA_HOOK_PROTOCOL_VERSION
-        })
+        if (options.publishEndpoint !== false) {
+          this.publishEndpointFile()
+        }
         resolve()
       }
       this.server!.once('error', onStartupError)
@@ -143,6 +144,20 @@ export class RelayAgentHookServer {
       // 127.0.0.1:PORT; nobody outside the box can.
       this.server!.listen(0, '127.0.0.1', onListening)
     })
+  }
+
+  publishEndpointFile(): boolean {
+    if (this.port <= 0 || !this.token) {
+      this.endpointFileWritten = false
+      return false
+    }
+    this.endpointFileWritten = writeEndpointFile(this.endpointDir, this.endpointFilePath, {
+      port: this.port,
+      token: this.token,
+      env: this.env,
+      version: ORCA_HOOK_PROTOCOL_VERSION
+    })
+    return this.endpointFileWritten
   }
 
   stop(): void {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -123,6 +123,17 @@ describe('PtyHandler', () => {
     expect(notifMethods).toContain('pty.ackData')
   })
 
+  it('allows callers to shorten a grace timer for empty startup relays', () => {
+    const onExpire = vi.fn()
+    handler.startGraceTimer(onExpire, 100)
+
+    expect(handler.graceTimerActive).toBe(true)
+    vi.advanceTimersByTime(99)
+    expect(onExpire).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onExpire).toHaveBeenCalledTimes(1)
+  })
+
   it('spawns a PTY and returns an id', async () => {
     const result = await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })
     expect(result).toEqual({ id: 'pty-1' })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -626,17 +626,17 @@ export class PtyHandler {
     }
   }
 
-  startGraceTimer(onExpire: () => void): void {
+  startGraceTimer(onExpire: () => void, timeoutMs = this.graceTimeMs): void {
     this.cancelGraceTimer()
-    if (this.graceTimeMs === 0) {
+    if (timeoutMs === 0) {
       return
     }
-    // Why: always wait the full grace period even with zero PTYs.  A detached
-    // relay may have no PTYs yet but a --connect client will arrive shortly.
-    // Firing immediately would kill the relay before anyone could connect.
+    // Why: callers may shorten the first empty-detached startup window, but
+    // connected relays still use the configured grace so live PTYs can survive
+    // app restarts and reconnects.
     this.graceTimer = setTimeout(() => {
       onExpire()
-    }, this.graceTimeMs)
+    }, timeoutMs)
   }
 
   cancelGraceTimer(): void {
@@ -673,5 +673,9 @@ export class PtyHandler {
 
   get activePtyCount(): number {
     return this.ptys.size
+  }
+
+  get graceTimerActive(): boolean {
+    return this.graceTimer !== null
   }
 }

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -22,7 +22,7 @@
 import { createServer, createConnection, type Socket, type Server } from 'net'
 import { homedir } from 'os'
 import { resolve, join } from 'path'
-import { unlinkSync, existsSync } from 'fs'
+import { unlinkSync, existsSync, statSync } from 'fs'
 import { RELAY_SENTINEL } from './protocol'
 import { readLaunchVersion, runConnectHandshake, setupDaemonHandshake } from './relay-handshake'
 import { RelayDispatcher } from './dispatcher'
@@ -54,6 +54,12 @@ const EMPTY_DETACHED_STARTUP_GRACE_MS = parseNonNegativeIntEnv(
   60_000
 )
 
+type SocketIdentity = {
+  dev: bigint
+  ino: bigint
+  ctimeNs: bigint
+}
+
 function parseNonNegativeIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]
   if (raw === undefined) {
@@ -61,6 +67,15 @@ function parseNonNegativeIntEnv(name: string, fallback: number): number {
   }
   const parsed = Number.parseInt(raw, 10)
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+function readSocketIdentity(sockPath: string): SocketIdentity | null {
+  try {
+    const stat = statSync(sockPath, { bigint: true })
+    return { dev: stat.dev, ino: stat.ino, ctimeNs: stat.ctimeNs }
+  } catch {
+    return null
+  }
 }
 
 function parseArgs(argv: string[]): {
@@ -174,11 +189,24 @@ async function main(): Promise<void> {
   }
 
   let ownsSocketPath = false
+  let ownedSocketIdentity: SocketIdentity | null = null
+  const ownsCurrentSocketPath = (): boolean => {
+    const currentIdentity = readSocketIdentity(sockPath)
+    return (
+      ownsSocketPath &&
+      ownedSocketIdentity !== null &&
+      currentIdentity !== null &&
+      currentIdentity.dev === ownedSocketIdentity.dev &&
+      currentIdentity.ino === ownedSocketIdentity.ino &&
+      currentIdentity.ctimeNs === ownedSocketIdentity.ctimeNs
+    )
+  }
   const cleanupOwnedSocket = (): void => {
-    if (ownsSocketPath) {
+    if (ownsCurrentSocketPath()) {
       cleanupSocket(sockPath)
-      ownsSocketPath = false
     }
+    ownsSocketPath = false
+    ownedSocketIdentity = null
   }
 
   // Why: After an uncaught exception Node's internal state may be corrupted
@@ -302,7 +330,7 @@ async function main(): Promise<void> {
   // treated as soft: log and continue, the augmenter returns {} and agent
   // status simply does not flow.
   try {
-    await hookServer.start()
+    await hookServer.start({ publishEndpoint: false })
   } catch (err) {
     process.stderr.write(
       `[relay] agent-hook server failed to start: ${err instanceof Error ? err.message : String(err)}\n`
@@ -536,6 +564,7 @@ async function main(): Promise<void> {
       const onListening = (): void => {
         restoreUmask()
         ownsSocketPath = true
+        ownedSocketIdentity = readSocketIdentity(sockPath)
         server.off('error', onInitialError)
         server.on('error', (err) => {
           process.stderr.write(`[relay] Socket server error: ${err.message}\n`)
@@ -567,6 +596,10 @@ async function main(): Promise<void> {
 
   try {
     socketServer = await startSocketServer()
+    // Why: endpoint.env is shared by PTYs under this relay socket path. Publish
+    // it only after socket ownership is proven so a refused duplicate daemon
+    // cannot poison the active relay's hook coordinates.
+    hookServer.publishEndpointFile()
   } catch {
     process.exit(1)
   }
@@ -648,7 +681,10 @@ async function main(): Promise<void> {
     ptyHandler.dispose()
     fsHandler.dispose()
     hookServer.stop()
-    if (socketServer) {
+    // Why: Node's Unix server.close() can unlink the listen path. If the path
+    // was externally removed and rebound by a newer relay, closing this older
+    // server would strand the newer daemon behind a missing socket.
+    if (socketServer && ownsCurrentSocketPath()) {
       socketServer.close()
     }
     cleanupOwnedSocket()

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -49,6 +49,19 @@ import { resolveOpenCodeSourceConfigDir, resolvePiSourceAgentDir } from './plugi
 const DEFAULT_GRACE_MS = DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
 const SOCK_NAME = 'relay.sock'
 const CONNECT_TIMEOUT_MS = 5_000
+const EMPTY_DETACHED_STARTUP_GRACE_MS = parseNonNegativeIntEnv(
+  'ORCA_RELAY_EMPTY_STARTUP_GRACE_MS',
+  60_000
+)
+
+function parseNonNegativeIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined) {
+    return fallback
+  }
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
 
 function parseArgs(argv: string[]): {
   graceTimeMs: number
@@ -160,13 +173,21 @@ async function main(): Promise<void> {
     return
   }
 
+  let ownsSocketPath = false
+  const cleanupOwnedSocket = (): void => {
+    if (ownsSocketPath) {
+      cleanupSocket(sockPath)
+      ownsSocketPath = false
+    }
+  }
+
   // Why: After an uncaught exception Node's internal state may be corrupted
   // (e.g. half-written buffers, broken invariants). Logging and continuing
   // would risk silent data corruption or zombie PTYs. We log for diagnostics
   // and then exit so the client can detect the disconnect and reconnect cleanly.
   process.on('uncaughtException', (err) => {
     process.stderr.write(`[relay] Uncaught exception: ${err.message}\n${err.stack}\n`)
-    cleanupSocket(sockPath)
+    cleanupOwnedSocket()
     process.exit(1)
   })
 
@@ -393,6 +414,43 @@ async function main(): Promise<void> {
   const socketClients = new Map<Socket, number>()
   let socketServer: Server | null = null
   const launchVersion = readLaunchVersion()
+  const startedAt = Date.now()
+  let acceptedSocketConnections = 0
+  let hasAcceptedSocketClient = false
+  let graceDeadlineAt: number | null = null
+  let graceReason: string | null = null
+
+  dispatcher.onRequest('relay.status', async () => ({
+    pid: process.pid,
+    uptimeMs: Date.now() - startedAt,
+    detached,
+    stdoutAlive,
+    memory: process.memoryUsage(),
+    ptys: {
+      active: ptyHandler.activePtyCount
+    },
+    socket: {
+      path: sockPath,
+      owned: ownsSocketPath,
+      listening: socketServer?.listening ?? false,
+      clients: socketClients.size,
+      acceptedConnections: acceptedSocketConnections
+    },
+    grace: {
+      active: ptyHandler.graceTimerActive,
+      deadlineAt: graceDeadlineAt,
+      reason: graceReason
+    }
+  }))
+
+  function cancelGrace(reason: string): void {
+    if (ptyHandler.graceTimerActive) {
+      process.stderr.write(`[relay] Grace canceled: ${reason}\n`)
+    }
+    graceDeadlineAt = null
+    graceReason = null
+    ptyHandler.cancelGraceTimer()
+  }
 
   function attachAcceptedSocket(sock: Socket, leftover: Buffer): void {
     // Why: stdin's data listener is still registered from the initial connection.
@@ -401,7 +459,12 @@ async function main(): Promise<void> {
     process.stdin.pause()
     process.stdin.removeAllListeners('data')
 
-    ptyHandler.cancelGraceTimer()
+    hasAcceptedSocketClient = true
+    acceptedSocketConnections++
+    process.stderr.write(
+      `[relay] Socket client accepted (clients=${socketClients.size + 1}, accepted=${acceptedSocketConnections})\n`
+    )
+    cancelGrace('socket client accepted')
 
     const clientId = dispatcher.attachClient((data) => {
       if (!sock.destroyed) {
@@ -419,13 +482,12 @@ async function main(): Promise<void> {
     }
 
     sock.on('data', (chunk: Buffer) => {
-      ptyHandler.cancelGraceTimer()
+      cancelGrace('socket client data')
       dispatcher.feedClient(clientId, chunk)
     })
   }
 
-  function startSocketServer(): Server {
-    cleanupSocket(sockPath)
+  async function startSocketServer(): Promise<Server> {
     const server = createServer((sock) => {
       // Why: pre-dispatcher version handshake — see relay-handshake.ts.
       setupDaemonHandshake(sock, { launchVersion, onAccepted: attachAcceptedSocket })
@@ -450,8 +512,9 @@ async function main(): Promise<void> {
         if (clientId !== undefined) {
           dispatcher.detachClient(clientId)
         }
+        process.stderr.write(`[relay] Socket client closed (clients=${socketClients.size})\n`)
         if (!stdoutAlive && socketClients.size === 0) {
-          startGrace()
+          startGrace('socket client closed')
         }
       })
     })
@@ -461,19 +524,52 @@ async function main(): Promise<void> {
     // (chmod after listen) had a TOCTOU window where another local user
     // could connect to the socket before chmod ran.
     const prevUmask = process.umask(0o177)
+    let umaskRestored = false
+    const restoreUmask = (): void => {
+      if (!umaskRestored) {
+        process.umask(prevUmask)
+        umaskRestored = true
+      }
+    }
 
-    server.on('error', (err) => {
-      process.umask(prevUmask)
-      process.stderr.write(`[relay] Socket server error: ${err.message}\n`)
+    await new Promise<void>((resolve, reject) => {
+      const onListening = (): void => {
+        restoreUmask()
+        ownsSocketPath = true
+        server.off('error', onInitialError)
+        server.on('error', (err) => {
+          process.stderr.write(`[relay] Socket server error: ${err.message}\n`)
+        })
+        process.stderr.write(`[relay] Socket server listening: ${sockPath}\n`)
+        resolve()
+      }
+
+      const onInitialError = (err: NodeJS.ErrnoException): void => {
+        restoreUmask()
+        server.off('listening', onListening)
+        if (err.code === 'EADDRINUSE') {
+          process.stderr.write(
+            `[relay] Socket path already in use: ${sockPath}; another relay is likely active. Use --connect instead of starting a new daemon.\n`
+          )
+        } else {
+          process.stderr.write(`[relay] Socket server error before listen: ${err.message}\n`)
+        }
+        reject(err)
+      }
+
+      server.once('listening', onListening)
+      server.once('error', onInitialError)
+      server.listen(sockPath)
     })
 
-    server.listen(sockPath, () => {
-      process.umask(prevUmask)
-    })
     return server
   }
 
-  socketServer = startSocketServer()
+  try {
+    socketServer = await startSocketServer()
+  } catch {
+    process.exit(1)
+  }
 
   // ── stdin/stdout transport (initial connection) ─────────────────────
 
@@ -486,10 +582,24 @@ async function main(): Promise<void> {
     dispatcher.invalidateClient()
   })
 
-  function startGrace(): void {
+  function startGrace(reason: string): void {
+    const startupEmptyDetached =
+      detached && !hasAcceptedSocketClient && ptyHandler.activePtyCount === 0
+    const timeoutMs =
+      graceTimeMs === 0
+        ? 0
+        : startupEmptyDetached
+          ? Math.min(graceTimeMs, EMPTY_DETACHED_STARTUP_GRACE_MS)
+          : graceTimeMs
+    graceDeadlineAt = timeoutMs === 0 ? null : Date.now() + timeoutMs
+    graceReason = reason
+    process.stderr.write(
+      `[relay] Grace started (${reason}): timeoutMs=${timeoutMs}, startupEmptyDetached=${startupEmptyDetached}, ptys=${ptyHandler.activePtyCount}, clients=${socketClients.size}\n`
+    )
     ptyHandler.startGraceTimer(() => {
+      process.stderr.write(`[relay] Grace expired (${reason}); shutting down\n`)
       shutdown()
-    })
+    }, timeoutMs)
   }
 
   if (detached) {
@@ -500,10 +610,10 @@ async function main(): Promise<void> {
     // pipe), start the grace timer (socket connect will cancel it), and
     // rely entirely on the Unix socket for client communication.
     stdoutAlive = false
-    startGrace()
+    startGrace('detached startup')
   } else {
     process.stdin.on('data', (chunk: Buffer) => {
-      ptyHandler.cancelGraceTimer()
+      cancelGrace('stdin data')
       dispatcher.feed(chunk)
     })
 
@@ -515,7 +625,7 @@ async function main(): Promise<void> {
       stdoutAlive = false
       dispatcher.invalidateClient()
       if (socketClients.size === 0) {
-        startGrace()
+        startGrace('stdin ended')
       }
     })
 
@@ -523,12 +633,17 @@ async function main(): Promise<void> {
       stdoutAlive = false
       dispatcher.invalidateClient()
       if (socketClients.size === 0) {
-        startGrace()
+        startGrace('stdin error')
       }
     })
   }
 
   function shutdown(): void {
+    process.stderr.write(
+      `[relay] Shutdown: ptys=${ptyHandler.activePtyCount}, clients=${socketClients.size}, ownsSocket=${ownsSocketPath}\n`
+    )
+    graceDeadlineAt = null
+    graceReason = null
     dispatcher.dispose()
     ptyHandler.dispose()
     fsHandler.dispose()
@@ -536,7 +651,7 @@ async function main(): Promise<void> {
     if (socketServer) {
       socketServer.close()
     }
-    cleanupSocket(sockPath)
+    cleanupOwnedSocket()
     process.exit(0)
   }
 

--- a/src/relay/subprocess-test-utils.ts
+++ b/src/relay/subprocess-test-utils.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'child_process'
+import { spawn, type ChildProcess, type SpawnOptions } from 'child_process'
 import {
   RELAY_SENTINEL,
   FrameDecoder,
@@ -22,9 +22,14 @@ export type RelayProcess = {
   waitForExit: (timeoutMs?: number) => Promise<number | null>
 }
 
-export function spawnRelay(entryPath: string, args: string[] = []): RelayProcess {
+export function spawnRelay(
+  entryPath: string,
+  args: string[] = [],
+  options: Pick<SpawnOptions, 'env'> = {}
+): RelayProcess {
   const proc = spawn('node', [entryPath, ...args], {
-    stdio: ['pipe', 'pipe', 'pipe']
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...options
   })
 
   const responses: (JsonRpcResponse | JsonRpcNotification)[] = []

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -1,12 +1,13 @@
 /* oxlint-disable max-lines -- Why: subprocess coverage shares one bundled relay artifact; splitting this file would rebuild the same daemon bundle across suites and make these lifecycle tests slower/flakier. */
 import { afterAll, beforeAll, describe, expect, it, afterEach } from 'vitest'
-import { mkdtempSync, writeFileSync } from 'fs'
+import { mkdtempSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
 import { rm } from 'fs/promises'
 import * as path from 'path'
 import { tmpdir } from 'os'
 import { execFileSync, spawn as spawnChild } from 'child_process'
 import { build } from 'esbuild'
 import { spawnRelay, type RelayProcess } from './subprocess-test-utils'
+import { getEndpointFileName } from '../shared/agent-hook-listener'
 
 const RELAY_TS_ENTRY = path.resolve(__dirname, 'relay.ts')
 let bundleDir: string
@@ -228,6 +229,8 @@ describe('Subprocess: Relay entry point', () => {
       const sockPath = path.join(tmpDir, 'relay.sock')
       relay = spawn(['--detached', '--grace-time', '10', '--sock-path', sockPath])
       await relay.sentinelReceived
+      const endpointFile = path.join(tmpDir, 'agent-hooks', 'relay.sock', getEndpointFileName())
+      const endpointBeforeDuplicate = readFileSync(endpointFile, 'utf8')
 
       let duplicateStderr = ''
       const duplicate = spawnChild(
@@ -242,6 +245,7 @@ describe('Subprocess: Relay entry point', () => {
       const duplicateExit = await waitForChildExit(duplicate, 5000)
       expect(duplicateExit.code).toBe(1)
       expect(duplicateStderr).toContain('Socket path already in use')
+      expect(readFileSync(endpointFile, 'utf8')).toBe(endpointBeforeDuplicate)
 
       const bridge = spawn(['--connect', '--sock-path', sockPath])
       try {
@@ -264,6 +268,42 @@ describe('Subprocess: Relay entry point', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
+    'does not unlink a newer relay socket when an older relay exits',
+    async () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-rebound-'))
+      const sockPath = path.join(tmpDir, 'relay.sock')
+      const first = spawn(['--detached', '--grace-time', '10', '--sock-path', sockPath])
+      let second: RelayProcess | null = null
+      let bridge: RelayProcess | null = null
+      try {
+        await first.sentinelReceived
+        unlinkSync(sockPath)
+
+        second = spawn(['--detached', '--grace-time', '10', '--sock-path', sockPath])
+        await second.sentinelReceived
+
+        first.kill('SIGTERM')
+        await first.waitForExit(2000)
+
+        bridge = spawn(['--connect', '--sock-path', sockPath])
+        await bridge.sentinelReceived
+        const id = bridge.send('relay.status')
+        const resp = await bridge.waitForResponse(id)
+        expect(resp.error).toBeUndefined()
+        expect((resp.result as { pid: number }).pid).toBe(second.proc.pid)
+      } finally {
+        bridge?.kill('SIGTERM')
+        await bridge?.waitForExit().catch(() => {})
+        first.kill('SIGTERM')
+        await first.waitForExit().catch(() => {})
+        second?.kill('SIGTERM')
+        await second?.waitForExit().catch(() => {})
+      }
+    },
+    10_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'uses a short startup grace for empty detached relays before any client connects',
     async () => {
       tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-empty-'))
@@ -274,6 +314,34 @@ describe('Subprocess: Relay entry point', () => {
       await relay.sentinelReceived
 
       await relay.waitForExit(3000)
+      expect(relay.proc.exitCode).toBe(0)
+    },
+    10_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'uses configured grace after a detached relay has accepted a socket client',
+    async () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-connected-'))
+      const sockPath = path.join(tmpDir, 'relay.sock')
+      relay = spawn(['--detached', '--grace-time', '1', '--sock-path', sockPath], {
+        ...process.env,
+        ORCA_RELAY_EMPTY_STARTUP_GRACE_MS: '500'
+      })
+      await relay.sentinelReceived
+
+      const bridge = spawn(['--connect', '--sock-path', sockPath])
+      try {
+        await bridge.sentinelReceived
+      } finally {
+        bridge.kill('SIGTERM')
+        await bridge.waitForExit().catch(() => {})
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 650))
+      expect(relay.proc.exitCode).toBeNull()
+
+      await relay.waitForExit(2000)
       expect(relay.proc.exitCode).toBe(0)
     },
     10_000

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -1,15 +1,17 @@
+/* oxlint-disable max-lines -- Why: subprocess coverage shares one bundled relay artifact; splitting this file would rebuild the same daemon bundle across suites and make these lifecycle tests slower/flakier. */
 import { afterAll, beforeAll, describe, expect, it, afterEach } from 'vitest'
 import { mkdtempSync, writeFileSync } from 'fs'
 import { rm } from 'fs/promises'
 import * as path from 'path'
 import { tmpdir } from 'os'
-import { execFileSync } from 'child_process'
+import { execFileSync, spawn as spawnChild } from 'child_process'
 import { build } from 'esbuild'
 import { spawnRelay, type RelayProcess } from './subprocess-test-utils'
 
 const RELAY_TS_ENTRY = path.resolve(__dirname, 'relay.ts')
 let bundleDir: string
 let relayEntry: string
+const spawnedSocketDirs: string[] = []
 
 beforeAll(async () => {
   bundleDir = mkdtempSync(path.join(tmpdir(), 'relay-bundle-'))
@@ -32,8 +34,27 @@ afterAll(async () => {
   }
 })
 
-function spawn(args: string[] = []): RelayProcess {
-  return spawnRelay(relayEntry, args)
+function spawn(args: string[] = [], env?: NodeJS.ProcessEnv): RelayProcess {
+  let relayArgs = args
+  if (!args.includes('--sock-path')) {
+    const socketDir = mkdtempSync(path.join(tmpdir(), 'relay-sock-'))
+    spawnedSocketDirs.push(socketDir)
+    relayArgs = [...args, '--sock-path', path.join(socketDir, 'relay.sock')]
+  }
+  return spawnRelay(relayEntry, relayArgs, env ? { env } : undefined)
+}
+
+function waitForChildExit(
+  proc: ReturnType<typeof spawnChild>,
+  timeoutMs = 5000
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out waiting for child exit')), timeoutMs)
+    proc.once('exit', (code, signal) => {
+      clearTimeout(timer)
+      resolve({ code, signal })
+    })
+  })
 }
 
 describe('Subprocess: Relay entry point', () => {
@@ -48,6 +69,10 @@ describe('Subprocess: Relay entry point', () => {
     relay = null
     if (tmpDir) {
       await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+    }
+    while (spawnedSocketDirs.length > 0) {
+      const socketDir = spawnedSocketDirs.pop()!
+      await rm(socketDir, { recursive: true, force: true }).catch(() => {})
     }
   })
 
@@ -194,6 +219,83 @@ describe('Subprocess: Relay entry point', () => {
 
     await relay.waitForExit(5000)
     expect(relay.proc.exitCode).toBe(0)
+  }, 10_000)
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a duplicate detached daemon without unlinking the active relay socket',
+    async () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-dup-'))
+      const sockPath = path.join(tmpDir, 'relay.sock')
+      relay = spawn(['--detached', '--grace-time', '10', '--sock-path', sockPath])
+      await relay.sentinelReceived
+
+      let duplicateStderr = ''
+      const duplicate = spawnChild(
+        'node',
+        [relayEntry, '--detached', '--grace-time', '10', '--sock-path', sockPath],
+        { stdio: ['ignore', 'ignore', 'pipe'] }
+      )
+      duplicate.stderr!.on('data', (chunk: Buffer) => {
+        duplicateStderr += chunk.toString('utf8')
+      })
+
+      const duplicateExit = await waitForChildExit(duplicate, 5000)
+      expect(duplicateExit.code).toBe(1)
+      expect(duplicateStderr).toContain('Socket path already in use')
+
+      const bridge = spawn(['--connect', '--sock-path', sockPath])
+      try {
+        await bridge.sentinelReceived
+        const id = bridge.send('relay.status')
+        const resp = await bridge.waitForResponse(id)
+        expect(resp.error).toBeUndefined()
+        expect(
+          (resp.result as { socket: { path: string; acceptedConnections: number } }).socket
+        ).toMatchObject({
+          path: sockPath,
+          acceptedConnections: 1
+        })
+      } finally {
+        bridge.kill('SIGTERM')
+        await bridge.waitForExit().catch(() => {})
+      }
+    },
+    10_000
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'uses a short startup grace for empty detached relays before any client connects',
+    async () => {
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-empty-'))
+      relay = spawn(
+        ['--detached', '--grace-time', '10', '--sock-path', path.join(tmpDir, 'relay.sock')],
+        { ...process.env, ORCA_RELAY_EMPTY_STARTUP_GRACE_MS: '100' }
+      )
+      await relay.sentinelReceived
+
+      await relay.waitForExit(3000)
+      expect(relay.proc.exitCode).toBe(0)
+    },
+    10_000
+  )
+
+  it('reports relay diagnostics over relay.status', async () => {
+    relay = spawn()
+    await relay.sentinelReceived
+
+    const id = relay.send('relay.status')
+    const resp = await relay.waitForResponse(id)
+    expect(resp.error).toBeUndefined()
+    const status = resp.result as {
+      pid: number
+      memory: { rss: number }
+      ptys: { active: number }
+      socket: { owned: boolean; listening: boolean; clients: number }
+    }
+    expect(status.pid).toBeGreaterThan(0)
+    expect(status.memory.rss).toBeGreaterThan(0)
+    expect(status.ptys.active).toBe(0)
+    expect(status.socket).toMatchObject({ owned: true, listening: true, clients: 0 })
   }, 10_000)
 
   it('session.registerRoot request returns ok acknowledgment', async () => {


### PR DESCRIPTION
## Summary

Preserves active SSH relay sockets when a second detached relay starts, so existing remote terminal sessions stay reachable instead of being stranded behind a replaced socket path.

This also adds a short startup grace window for empty detached relays, so a duplicate relay with no clients or PTYs exits quickly instead of lingering for the full configured grace period. A new `relay.status` JSON-RPC endpoint reports relay lifecycle diagnostics for debugging.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
  - Full `pnpm test` is blocked in my local checkout by `better-sqlite3` native rebuild failure before Vitest starts (`Module did not self-register`, followed by a segfault). Reproduced under the system Node v25.6.0 and a temporary supported Node v24.15.0 toolchain.
  - Focused relay regression coverage passes: `pnpm exec vitest run --config config/vitest.config.ts src/relay/pty-handler.test.ts src/relay/subprocess.test.ts` → 46 passed.
- [x] `pnpm build`
  - Completed successfully. Local build printed a non-fatal permission warning when the CLI helper tried to create `/usr/local/bin/orca-dev`.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Added subprocess coverage for duplicate detached daemon refusal, active socket preservation through `--connect`, empty startup grace expiry, and `relay.status` diagnostics.

## AI Review Report

I reviewed the diff with an AI coding agent focused on relay lifecycle correctness, cross-platform behavior, and regression risk.

Main risks checked:

- Duplicate detached relays should no longer unlink or replace a socket owned by an active relay.
- Existing reconnect behavior should still work through `--connect` when a relay is already listening.
- Empty detached relays should exit after the short startup grace only when no socket client has connected and no PTYs exist.
- Existing configured grace behavior should remain intact once a client has connected or PTYs exist.
- `relay.status` should expose diagnostics without changing existing request handling semantics.

What it flagged or verified:

- Verified the ownership fix: the relay now fails on `EADDRINUSE` instead of unlinking an active socket path during startup.
- Verified the startup grace behavior is bounded by `ORCA_RELAY_EMPTY_STARTUP_GRACE_MS`, defaulting to 60 seconds, while preserving the normal configured grace after a real client/session exists.
- Verified the new status endpoint is read-only and reports PID, uptime, memory usage, PTY count, socket state, accepted connection count, and grace timer state.
- Flagged a non-blocking operational caveat: direct/manual relay startup against a stale socket now fails instead of unlinking it. The SSH launch path already probes the socket and removes stale sockets after failed connect attempts, so this is acceptable for the intended lifecycle.

Cross-platform review:

- macOS/Linux: explicitly reviewed Unix-domain socket behavior, socket permissions via the existing `umask(0o177)` flow, socket cleanup ownership, detached grace handling, and reconnect behavior.
- Windows: verified the new Unix-socket lifecycle subprocess tests are skipped on `win32`; the PR does not add new Windows path separator assumptions or shell behavior in production code. The changed lifecycle path remains Unix-socket oriented.
- Shortcuts and labels: not touched.
- Paths: tests use `path.join` and `tmpdir`; production `--sock-path` behavior is unchanged.
- Shell behavior: no new production shell command construction was added. Existing SSH launcher shell behavior remains unchanged.
- Electron-specific platform differences: no Electron main/renderer APIs, menus, accelerators, labels, or renderer UI behavior are changed by this PR.

## Security Audit

The AI coding agent also reviewed the diff for basic security risks.

- Input handling: reviewed `ORCA_RELAY_EMPTY_STARTUP_GRACE_MS` parsing and `relay.status`. The env override is parsed as a non-negative integer with fallback on invalid input; `relay.status` accepts no caller-controlled params.
- Command execution: no new production command execution or command-string construction was added. Test subprocesses use argument arrays rather than shell interpolation.
- Path handling: socket ownership handling is improved because duplicate detached daemons now fail on `EADDRINUSE` instead of unlinking an active socket path. Existing caller-provided `--sock-path` behavior is unchanged.
- Auth and secrets: no new secrets are introduced or logged. `relay.status` exposes diagnostics only over the existing relay IPC channel.
- Dependencies: no production dependency changes.
- IPC: the existing Unix socket IPC trust boundary remains unchanged, including existing socket permissions and version handshake. This PR reduces IPC takeover risk by preventing duplicate daemons from replacing an active relay socket.

Follow-up worth considering, but not required for this fix: make socket cleanup verify the path is still a Unix socket before unlinking it.

## Notes

- New env var: `ORCA_RELAY_EMPTY_STARTUP_GRACE_MS` controls the first empty-detached startup grace window. Default is 60 seconds.
- Once a socket client connects or PTYs exist, the relay keeps using the existing configured grace period.
- The duplicate-daemon refusal path is Unix-socket specific; Windows-specific subprocess coverage is skipped for those tests.
- Local full-suite testing is limited by native module rebuild instability in this checkout, so this PR includes focused relay subprocess regression coverage plus lint, typecheck, and build verification.
