### PR TITLE
Combine sidebar workspace options

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,48 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Kanban, Plus, SlidersHorizontal } from 'lucide-react'
+import { Kanban, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  DropdownMenuCheckboxItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem
-} from '@/components/ui/dropdown-menu'
-import type { WorktreeCardProperty } from '../../../../shared/types'
-import SidebarFilter from './SidebarFilter'
+import SidebarWorkspaceOptionsMenu from './SidebarWorkspaceOptionsMenu'
 import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
-
-const GROUP_BY_OPTIONS = [
-  { id: 'none', label: 'None' },
-  { id: 'workspace-status', label: 'Status' },
-  { id: 'pr-status', label: 'PR' },
-  { id: 'repo', label: 'Repo' }
-] as const
-
-const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
-  // Why: toggles the inline "Agent activity" list rendered below each
-  // workspace card body (see WorktreeCard -> WorktreeCardAgents). Off hides
-  // the list; there is no alternate surface.
-  { id: 'inline-agents', label: 'Agent activity' }
-]
-
-const SORT_OPTIONS = [
-  { id: 'name', label: 'Name', description: null },
-  {
-    id: 'smart',
-    label: 'Smart',
-    description: 'Agents that need attention, then most recent activity.'
-  },
-  { id: 'recent', label: 'Recent', description: null },
-  { id: 'repo', label: 'Repo', description: null }
-] as const
 
 const isMac = navigator.userAgent.includes('Mac')
 const newWorktreeShortcutLabel = isMac ? '⌘N' : 'Ctrl+N'
@@ -53,13 +16,6 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
   const canCreateWorktree = repos.some((repo) => isGitRepoKind(repo))
-
-  const worktreeCardProperties = useAppStore((s) => s.worktreeCardProperties)
-  const toggleWorktreeCardProperty = useAppStore((s) => s.toggleWorktreeCardProperty)
-  const sortBy = useAppStore((s) => s.sortBy)
-  const setSortBy = useAppStore((s) => s.setSortBy)
-  const groupBy = useAppStore((s) => s.groupBy)
-  const setGroupBy = useAppStore((s) => s.setGroupBy)
 
   const handleWorkspaceBoardOpenChange = useCallback((open: boolean) => {
     setWorkspaceBoardOpen(open)
@@ -116,105 +72,10 @@ const SidebarHeader = React.memo(function SidebarHeader() {
           </span>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
-          <SidebarFilter preserveWorkspaceBoardOpen onMenuOpenChange={setWorkspaceBoardMenuOpen} />
-          <DropdownMenu modal={false} onOpenChange={setWorkspaceBoardMenuOpen}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground"
-                    aria-label="View options"
-                    data-workspace-board-preserve-open=""
-                  >
-                    <SlidersHorizontal className="size-3.5" strokeWidth={2.25} />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                View options
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent
-              side="right"
-              align="start"
-              sideOffset={8}
-              className="w-56 pb-2"
-              data-workspace-board-preserve-open=""
-            >
-              <DropdownMenuLabel>Group by</DropdownMenuLabel>
-              <div className="px-2 pt-0.5 pb-1">
-                <ToggleGroup
-                  type="single"
-                  value={groupBy}
-                  onValueChange={(v) => {
-                    if (v) {
-                      setGroupBy(v as typeof groupBy)
-                    }
-                  }}
-                  variant="outline"
-                  size="sm"
-                  className="h-6 w-full justify-start"
-                >
-                  {GROUP_BY_OPTIONS.map((opt) => (
-                    <ToggleGroupItem
-                      key={opt.id}
-                      value={opt.id}
-                      className="h-6 px-2 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
-                    >
-                      {opt.label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              </div>
-
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={sortBy}
-                onValueChange={(v) => setSortBy(v as typeof sortBy)}
-              >
-                {SORT_OPTIONS.map((opt) => {
-                  const radioItem = (
-                    <DropdownMenuRadioItem
-                      key={opt.id}
-                      value={opt.id}
-                      // Keep the menu open so people can compare sort modes and
-                      // toggle card properties without reopening the same panel.
-                      onSelect={(e) => e.preventDefault()}
-                    >
-                      {opt.label}
-                    </DropdownMenuRadioItem>
-                  )
-                  if (!opt.description) {
-                    return radioItem
-                  }
-                  return (
-                    <Tooltip key={opt.id}>
-                      <TooltipTrigger asChild>{radioItem}</TooltipTrigger>
-                      <TooltipContent side="right" sideOffset={6}>
-                        {opt.description}
-                      </TooltipContent>
-                    </Tooltip>
-                  )
-                })}
-              </DropdownMenuRadioGroup>
-
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>Show properties</DropdownMenuLabel>
-              {PROPERTY_OPTIONS.map((opt) => (
-                <DropdownMenuCheckboxItem
-                  key={opt.id}
-                  checked={worktreeCardProperties.includes(opt.id)}
-                  onCheckedChange={() => toggleWorktreeCardProperty(opt.id)}
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  {opt.label}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <SidebarWorkspaceOptionsMenu
+            preserveWorkspaceBoardOpen
+            onMenuOpenChange={setWorkspaceBoardMenuOpen}
+          />
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Check, FolderPlus, Server } from 'lucide-react'
+import { useAppStore } from '@/store'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import RepoDotLabel from '@/components/repo/RepoDotLabel'
+import { searchRepos } from '@/lib/repo-search'
+
+const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilterSection() {
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
+  const repos = useAppStore((s) => s.repos)
+  const addRepo = useAppStore((s) => s.addRepo)
+
+  const [query, setQuery] = useState('')
+  const [commandValue, setCommandValue] = useState('')
+
+  const canFilterRepos = repos.length > 1
+  // Why: derive from current repos so stale ids (e.g. lingering after a repo
+  // is removed) don't inflate counts or falsely signal an applied filter.
+  const selectedRepoIdSet = useMemo(() => {
+    const set = new Set<string>()
+    for (const repo of repos) {
+      if (filterRepoIds.includes(repo.id)) {
+        set.add(repo.id)
+      }
+    }
+    return set
+  }, [repos, filterRepoIds])
+  const selectedCount = selectedRepoIdSet.size
+  const hasRepoFilter = selectedCount > 0
+  const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
+
+  const handleToggleRepo = useCallback(
+    (repoId: string) => {
+      setFilterRepoIds(
+        filterRepoIds.includes(repoId)
+          ? filterRepoIds.filter((id) => id !== repoId)
+          : [...filterRepoIds, repoId]
+      )
+    },
+    [filterRepoIds, setFilterRepoIds]
+  )
+
+  // Why: with shouldFilter={false} cmdk won't auto-highlight a row, so Enter
+  // has no target. Keep the highlighted value pinned to the first filtered
+  // repo whenever the query changes.
+  useEffect(() => {
+    const first = filteredRepos[0]
+    if (first && !filteredRepos.some((repo) => repo.id === commandValue)) {
+      setCommandValue(first.id)
+    }
+  }, [filteredRepos, commandValue])
+
+  // Why: derive ids from the live repos list at click time so a repo added
+  // while the menu is open is included immediately.
+  const selectAllRepos = useCallback(() => {
+    setFilterRepoIds(repos.map((repo) => repo.id))
+  }, [repos, setFilterRepoIds])
+
+  const clearRepos = useCallback(() => setFilterRepoIds([]), [setFilterRepoIds])
+  const allSelected = canFilterRepos && selectedCount === repos.length
+
+  if (!canFilterRepos) {
+    return (
+      <button
+        type="button"
+        onClick={() => addRepo()}
+        className="inline-flex w-full items-center gap-1.5 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <FolderPlus className="size-3.5" />
+        Add repo
+      </button>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between px-2 py-1">
+        <span className="text-[11px] font-semibold text-muted-foreground">
+          Repositories
+          {hasRepoFilter && (
+            <span className="ml-1.5 normal-case tracking-normal font-medium text-foreground">
+              · {selectedCount}
+            </span>
+          )}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={selectAllRepos}
+            className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
+            disabled={allSelected}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            onClick={clearRepos}
+            className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
+            disabled={!hasRepoFilter}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <Command
+        shouldFilter={false}
+        value={commandValue}
+        onValueChange={setCommandValue}
+        className="bg-transparent"
+      >
+        <CommandInput
+          placeholder="Search repos..."
+          value={query}
+          onValueChange={setQuery}
+          onKeyDown={(event) => event.stopPropagation()}
+          className="h-8 py-2 text-xs"
+          wrapperClassName="mx-1 rounded-[7px] border border-border/70 px-2"
+          iconClassName="h-3.5 w-3.5"
+        />
+        <CommandList className="max-h-40 py-1">
+          <CommandEmpty className="py-4 text-[11px]">No repos match</CommandEmpty>
+          {filteredRepos.map((repo) => {
+            const checked = selectedRepoIdSet.has(repo.id)
+            return (
+              <CommandItem
+                key={repo.id}
+                value={repo.id}
+                onSelect={() => handleToggleRepo(repo.id)}
+                className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
+              >
+                <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                  <RepoDotLabel
+                    name={repo.displayName}
+                    color={repo.badgeColor}
+                    className="max-w-full"
+                  />
+                  {repo.connectionId && (
+                    <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                      <Server className="size-2.5" />
+                      SSH
+                    </span>
+                  )}
+                </span>
+                {checked && <Check className="size-3 shrink-0 text-primary" strokeWidth={3} />}
+              </CommandItem>
+            )
+          })}
+        </CommandList>
+      </Command>
+
+      <button
+        type="button"
+        onClick={() => addRepo()}
+        className="inline-flex w-full items-center gap-1.5 rounded-[5px] px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <FolderPlus className="size-3.5" />
+        Add repo
+      </button>
+    </>
+  )
+})
+
+export default SidebarRepositoryFilterSection

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -201,7 +201,7 @@ function SelectedProjectPills({
   }
 
   return (
-    <div className="mx-1 mb-1 flex max-h-16 flex-wrap gap-1 overflow-y-auto rounded-[7px] border border-border/70 bg-muted/25 p-1">
+    <div className="scrollbar-sleek mx-1 mb-1 flex max-h-16 flex-wrap gap-1 overflow-y-auto rounded-[7px] border border-border/70 bg-muted/25 p-1">
       {selectedRepos.map((repo) => (
         <Badge
           key={repo.id}

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -245,9 +245,12 @@ function ProjectFilterHeader({
       <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground">
         Projects
         {hasRepoFilter && (
-          <span className="ml-0.5 normal-case tracking-normal font-medium text-foreground">
-            · {selectedCount}
-          </span>
+          <Badge
+            variant="outline"
+            className="h-4 min-w-4 px-1 py-0 text-[10px] font-semibold leading-none text-foreground"
+          >
+            {selectedCount}
+          </Badge>
         )}
       </span>
       <button

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -1,21 +1,16 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Check, FolderPlus, Server } from 'lucide-react'
+import { Search, Server, X } from 'lucide-react'
+import { Command as CommandPrimitive } from 'cmdk'
 import { useAppStore } from '@/store'
-import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList
-} from '@/components/ui/command'
+import { Command, CommandEmpty, CommandItem, CommandList } from '@/components/ui/command'
 import RepoDotLabel from '@/components/repo/RepoDotLabel'
 import { searchRepos } from '@/lib/repo-search'
+import type { Repo } from '../../../../shared/types'
 
 const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilterSection() {
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const repos = useAppStore((s) => s.repos)
-  const addRepo = useAppStore((s) => s.addRepo)
 
   const [query, setQuery] = useState('')
   const [commandValue, setCommandValue] = useState('')
@@ -34,15 +29,29 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
   }, [repos, filterRepoIds])
   const selectedCount = selectedRepoIdSet.size
   const hasRepoFilter = selectedCount > 0
+  const selectedRepos = useMemo(
+    () => repos.filter((repo) => selectedRepoIdSet.has(repo.id)),
+    [repos, selectedRepoIdSet]
+  )
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
+  const suggestedRepos = useMemo(
+    () => filteredRepos.filter((repo) => !selectedRepoIdSet.has(repo.id)),
+    [filteredRepos, selectedRepoIdSet]
+  )
 
-  const handleToggleRepo = useCallback(
+  const handleSelectRepo = useCallback(
     (repoId: string) => {
-      setFilterRepoIds(
-        filterRepoIds.includes(repoId)
-          ? filterRepoIds.filter((id) => id !== repoId)
-          : [...filterRepoIds, repoId]
-      )
+      if (!filterRepoIds.includes(repoId)) {
+        setFilterRepoIds([...filterRepoIds, repoId])
+      }
+      setQuery('')
+    },
+    [filterRepoIds, setFilterRepoIds]
+  )
+
+  const handleRemoveRepo = useCallback(
+    (repoId: string) => {
+      setFilterRepoIds(filterRepoIds.filter((id) => id !== repoId))
     },
     [filterRepoIds, setFilterRepoIds]
   )
@@ -51,64 +60,25 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
   // has no target. Keep the highlighted value pinned to the first filtered
   // repo whenever the query changes.
   useEffect(() => {
-    const first = filteredRepos[0]
-    if (first && !filteredRepos.some((repo) => repo.id === commandValue)) {
+    const first = suggestedRepos[0]
+    if (first && !suggestedRepos.some((repo) => repo.id === commandValue)) {
       setCommandValue(first.id)
     }
-  }, [filteredRepos, commandValue])
-
-  // Why: derive ids from the live repos list at click time so a repo added
-  // while the menu is open is included immediately.
-  const selectAllRepos = useCallback(() => {
-    setFilterRepoIds(repos.map((repo) => repo.id))
-  }, [repos, setFilterRepoIds])
+  }, [suggestedRepos, commandValue])
 
   const clearRepos = useCallback(() => setFilterRepoIds([]), [setFilterRepoIds])
-  const allSelected = canFilterRepos && selectedCount === repos.length
 
   if (!canFilterRepos) {
-    return (
-      <button
-        type="button"
-        onClick={() => addRepo()}
-        className="inline-flex w-full items-center gap-1.5 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-      >
-        <FolderPlus className="size-3.5" />
-        Add repo
-      </button>
-    )
+    return null
   }
 
   return (
     <>
-      <div className="flex items-center justify-between px-2 py-1">
-        <span className="text-[11px] font-semibold text-muted-foreground">
-          Repositories
-          {hasRepoFilter && (
-            <span className="ml-1.5 normal-case tracking-normal font-medium text-foreground">
-              · {selectedCount}
-            </span>
-          )}
-        </span>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={selectAllRepos}
-            className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
-            disabled={allSelected}
-          >
-            All
-          </button>
-          <button
-            type="button"
-            onClick={clearRepos}
-            className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
-            disabled={!hasRepoFilter}
-          >
-            Clear
-          </button>
-        </div>
-      </div>
+      <ProjectFilterHeader
+        hasRepoFilter={hasRepoFilter}
+        selectedCount={selectedCount}
+        onClear={clearRepos}
+      />
 
       <Command
         shouldFilter={false}
@@ -116,56 +86,139 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
         onValueChange={setCommandValue}
         className="bg-transparent"
       >
-        <CommandInput
-          placeholder="Search repos..."
+        <ProjectTokenInput
+          selectedRepos={selectedRepos}
           value={query}
           onValueChange={setQuery}
-          onKeyDown={(event) => event.stopPropagation()}
-          className="h-8 py-2 text-xs"
-          wrapperClassName="mx-1 rounded-[7px] border border-border/70 px-2"
-          iconClassName="h-3.5 w-3.5"
+          onRemoveRepo={handleRemoveRepo}
         />
         <CommandList className="max-h-40 py-1">
-          <CommandEmpty className="py-4 text-[11px]">No repos match</CommandEmpty>
-          {filteredRepos.map((repo) => {
-            const checked = selectedRepoIdSet.has(repo.id)
-            return (
-              <CommandItem
-                key={repo.id}
-                value={repo.id}
-                onSelect={() => handleToggleRepo(repo.id)}
-                className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
-              >
-                <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                  <RepoDotLabel
-                    name={repo.displayName}
-                    color={repo.badgeColor}
-                    className="max-w-full"
-                  />
-                  {repo.connectionId && (
-                    <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
-                      <Server className="size-2.5" />
-                      SSH
-                    </span>
-                  )}
-                </span>
-                {checked && <Check className="size-3 shrink-0 text-primary" strokeWidth={3} />}
-              </CommandItem>
-            )
-          })}
+          <CommandEmpty className="py-4 text-[11px]">
+            {hasRepoFilter ? 'All matching projects selected' : 'No projects match'}
+          </CommandEmpty>
+          {suggestedRepos.map((repo) => (
+            <CommandItem
+              key={repo.id}
+              value={repo.id}
+              onSelect={() => handleSelectRepo(repo.id)}
+              className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
+            >
+              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                <RepoDotLabel
+                  name={repo.displayName}
+                  color={repo.badgeColor}
+                  className="max-w-full"
+                />
+                {repo.connectionId && (
+                  <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                    <Server className="size-2.5" />
+                    SSH
+                  </span>
+                )}
+              </span>
+            </CommandItem>
+          ))}
         </CommandList>
       </Command>
-
-      <button
-        type="button"
-        onClick={() => addRepo()}
-        className="inline-flex w-full items-center gap-1.5 rounded-[5px] px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-      >
-        <FolderPlus className="size-3.5" />
-        Add repo
-      </button>
     </>
   )
 })
+
+function ProjectTokenInput({
+  selectedRepos,
+  value,
+  onValueChange,
+  onRemoveRepo
+}: {
+  selectedRepos: Repo[]
+  value: string
+  onValueChange: (value: string) => void
+  onRemoveRepo: (repoId: string) => void
+}) {
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation()
+      if (event.key === 'Backspace' && value === '' && selectedRepos.length > 0) {
+        const lastRepo = selectedRepos.at(-1)
+        if (lastRepo) {
+          onRemoveRepo(lastRepo.id)
+        }
+      }
+    },
+    [onRemoveRepo, selectedRepos, value]
+  )
+
+  return (
+    <div
+      className="mx-1 flex min-h-8 items-center gap-1 rounded-[7px] border border-border/70 px-2 py-1"
+      data-cmdk-input-wrapper=""
+    >
+      <Search className="size-3.5 shrink-0 opacity-50" />
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+        {selectedRepos.map((repo) => (
+          <span
+            key={repo.id}
+            className="inline-flex max-w-full items-center gap-1 rounded-full border border-border/70 bg-muted/45 px-1.5 py-0.5 text-[11px] font-medium text-foreground"
+          >
+            <RepoDotLabel
+              name={repo.displayName}
+              color={repo.badgeColor}
+              className="max-w-[7.5rem]"
+              dotClassName="size-1.5"
+            />
+            <button
+              type="button"
+              aria-label={`Remove ${repo.displayName} filter`}
+              className="-mr-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => onRemoveRepo(repo.id)}
+            >
+              <X className="size-2.5" strokeWidth={2.5} />
+            </button>
+          </span>
+        ))}
+        <CommandPrimitive.Input
+          data-slot="command-input"
+          value={value}
+          onValueChange={onValueChange}
+          onKeyDown={handleKeyDown}
+          placeholder={selectedRepos.length > 0 ? 'Add project...' : 'Filter projects...'}
+          className="min-w-20 flex-1 bg-transparent py-0.5 text-xs outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+    </div>
+  )
+}
+
+function ProjectFilterHeader({
+  hasRepoFilter,
+  selectedCount,
+  onClear
+}: {
+  hasRepoFilter: boolean
+  selectedCount: number
+  onClear: () => void
+}) {
+  return (
+    <div className="flex items-center justify-between px-2 py-1">
+      <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground">
+        Projects
+        {hasRepoFilter && (
+          <span className="ml-0.5 normal-case tracking-normal font-medium text-foreground">
+            · {selectedCount}
+          </span>
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={onClear}
+        className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
+        disabled={!hasRepoFilter}
+      >
+        Clear
+      </button>
+    </div>
+  )
+}
 
 export default SidebarRepositoryFilterSection

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -1,11 +1,38 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Search, Server, X } from 'lucide-react'
-import { Command as CommandPrimitive } from 'cmdk'
+import React, { useCallback, useMemo, useState } from 'react'
+import { Server, X } from 'lucide-react'
 import { useAppStore } from '@/store'
-import { Command, CommandEmpty, CommandItem, CommandList } from '@/components/ui/command'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
 import RepoDotLabel from '@/components/repo/RepoDotLabel'
 import { searchRepos } from '@/lib/repo-search'
 import type { Repo } from '../../../../shared/types'
+
+function projectCommandFilter(_value: string, search: string, keywords?: string[]): number {
+  const query = search.trim().toLowerCase()
+  if (!query) {
+    return 1
+  }
+
+  const [displayName = '', path = ''] = keywords ?? []
+  const displayNameIndex = displayName.toLowerCase().indexOf(query)
+  if (displayNameIndex !== -1) {
+    return 2 + 1 / (displayNameIndex + 1)
+  }
+
+  const pathIndex = path.toLowerCase().indexOf(query)
+  if (pathIndex !== -1) {
+    return 1 + 1 / (pathIndex + 1)
+  }
+
+  return 0
+}
 
 const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilterSection() {
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
@@ -13,7 +40,7 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
   const repos = useAppStore((s) => s.repos)
 
   const [query, setQuery] = useState('')
-  const [commandValue, setCommandValue] = useState('')
+  const [highlightedRepoId, setHighlightedRepoId] = useState('')
 
   const canFilterRepos = repos.length > 1
   // Why: derive from current repos so stale ids (e.g. lingering after a repo
@@ -33,10 +60,13 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
     () => repos.filter((repo) => selectedRepoIdSet.has(repo.id)),
     [repos, selectedRepoIdSet]
   )
-  const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
-  const suggestedRepos = useMemo(
-    () => filteredRepos.filter((repo) => !selectedRepoIdSet.has(repo.id)),
-    [filteredRepos, selectedRepoIdSet]
+  const availableRepos = useMemo(
+    () => repos.filter((repo) => !selectedRepoIdSet.has(repo.id)),
+    [repos, selectedRepoIdSet]
+  )
+  const matchingAvailableRepos = useMemo(
+    () => searchRepos(availableRepos, query),
+    [availableRepos, query]
   )
 
   const handleSelectRepo = useCallback(
@@ -56,17 +86,47 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
     [filterRepoIds, setFilterRepoIds]
   )
 
-  // Why: with shouldFilter={false} cmdk won't auto-highlight a row, so Enter
-  // has no target. Keep the highlighted value pinned to the first filtered
-  // repo whenever the query changes.
-  useEffect(() => {
-    const first = suggestedRepos[0]
-    if (first && !suggestedRepos.some((repo) => repo.id === commandValue)) {
-      setCommandValue(first.id)
-    }
-  }, [suggestedRepos, commandValue])
-
   const clearRepos = useCallback(() => setFilterRepoIds([]), [setFilterRepoIds])
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // Why: this command is embedded in a Radix dropdown; text keys should
+      // stay in the search field instead of triggering menu typeahead.
+      if (event.key === 'Backspace' && query === '' && selectedRepos.length > 0) {
+        const lastRepo = selectedRepos.at(-1)
+        if (lastRepo) {
+          event.preventDefault()
+          event.stopPropagation()
+          handleRemoveRepo(lastRepo.id)
+        }
+        return
+      }
+
+      if (event.key === 'Enter') {
+        const highlightedRepo = availableRepos.find((repo) => repo.id === highlightedRepoId)
+        const repo = highlightedRepo ?? matchingAvailableRepos[0]
+        if (repo) {
+          event.preventDefault()
+          event.stopPropagation()
+          handleSelectRepo(repo.id)
+        }
+        return
+      }
+
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+        event.stopPropagation()
+      }
+    },
+    [
+      availableRepos,
+      handleRemoveRepo,
+      handleSelectRepo,
+      highlightedRepoId,
+      matchingAvailableRepos,
+      query,
+      selectedRepos
+    ]
+  )
 
   if (!canFilterRepos) {
     return null
@@ -81,25 +141,30 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
       />
 
       <Command
-        shouldFilter={false}
-        value={commandValue}
-        onValueChange={setCommandValue}
+        filter={projectCommandFilter}
+        onValueChange={setHighlightedRepoId}
         className="bg-transparent"
       >
-        <ProjectTokenInput
-          selectedRepos={selectedRepos}
+        <SelectedProjectPills selectedRepos={selectedRepos} onRemoveRepo={handleRemoveRepo} />
+        <CommandInput
+          autoFocus
+          placeholder={selectedRepos.length > 0 ? 'Add project...' : 'Filter projects...'}
           value={query}
           onValueChange={setQuery}
-          onRemoveRepo={handleRemoveRepo}
+          onKeyDown={handleInputKeyDown}
+          className="h-8 py-2 text-xs"
+          wrapperClassName="mx-1 rounded-[7px] border border-border/70 px-2"
+          iconClassName="h-3.5 w-3.5"
         />
         <CommandList className="max-h-40 py-1">
           <CommandEmpty className="py-4 text-[11px]">
-            {hasRepoFilter ? 'All matching projects selected' : 'No projects match'}
+            {hasRepoFilter ? 'No unselected projects match' : 'No projects match'}
           </CommandEmpty>
-          {suggestedRepos.map((repo) => (
+          {availableRepos.map((repo) => (
             <CommandItem
               key={repo.id}
               value={repo.id}
+              keywords={[repo.displayName, repo.path]}
               onSelect={() => handleSelectRepo(repo.id)}
               className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
             >
@@ -124,68 +189,44 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
   )
 })
 
-function ProjectTokenInput({
+function SelectedProjectPills({
   selectedRepos,
-  value,
-  onValueChange,
   onRemoveRepo
 }: {
   selectedRepos: Repo[]
-  value: string
-  onValueChange: (value: string) => void
   onRemoveRepo: (repoId: string) => void
 }) {
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      event.stopPropagation()
-      if (event.key === 'Backspace' && value === '' && selectedRepos.length > 0) {
-        const lastRepo = selectedRepos.at(-1)
-        if (lastRepo) {
-          onRemoveRepo(lastRepo.id)
-        }
-      }
-    },
-    [onRemoveRepo, selectedRepos, value]
-  )
+  if (selectedRepos.length === 0) {
+    return null
+  }
 
   return (
-    <div
-      className="mx-1 flex min-h-8 items-center gap-1 rounded-[7px] border border-border/70 px-2 py-1"
-      data-cmdk-input-wrapper=""
-    >
-      <Search className="size-3.5 shrink-0 opacity-50" />
-      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
-        {selectedRepos.map((repo) => (
-          <span
-            key={repo.id}
-            className="inline-flex max-w-full items-center gap-1 rounded-full border border-border/70 bg-muted/45 px-1.5 py-0.5 text-[11px] font-medium text-foreground"
+    <div className="mx-1 mb-1 flex max-h-16 flex-wrap gap-1 overflow-y-auto rounded-[7px] border border-border/70 bg-muted/25 p-1">
+      {selectedRepos.map((repo) => (
+        <Badge
+          key={repo.id}
+          variant="outline"
+          className="h-5 max-w-full gap-1 border-border/70 bg-background px-1.5 py-0 text-[11px] font-medium"
+        >
+          <RepoDotLabel
+            name={repo.displayName}
+            color={repo.badgeColor}
+            className="max-w-[8rem]"
+            dotClassName="size-1.5"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={`Remove ${repo.displayName} filter`}
+            className="-mr-1 size-4 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => onRemoveRepo(repo.id)}
           >
-            <RepoDotLabel
-              name={repo.displayName}
-              color={repo.badgeColor}
-              className="max-w-[7.5rem]"
-              dotClassName="size-1.5"
-            />
-            <button
-              type="button"
-              aria-label={`Remove ${repo.displayName} filter`}
-              className="-mr-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => onRemoveRepo(repo.id)}
-            >
-              <X className="size-2.5" strokeWidth={2.5} />
-            </button>
-          </span>
-        ))}
-        <CommandPrimitive.Input
-          data-slot="command-input"
-          value={value}
-          onValueChange={onValueChange}
-          onKeyDown={handleKeyDown}
-          placeholder={selectedRepos.length > 0 ? 'Add project...' : 'Filter projects...'}
-          className="min-w-20 flex-1 bg-transparent py-0.5 text-xs outline-none placeholder:text-muted-foreground"
-        />
-      </div>
+            <X className="size-2.5" strokeWidth={2.5} />
+          </Button>
+        </Badge>
+      ))}
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React from 'react'
 import { Activity, GitBranch } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -8,41 +8,11 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
   const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
-  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
-  const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
-  const repos = useAppStore((s) => s.repos)
-
-  const selectedRepoCount = useMemo(() => {
-    let count = 0
-    for (const repo of repos) {
-      if (filterRepoIds.includes(repo.id)) {
-        count += 1
-      }
-    }
-    return count
-  }, [repos, filterRepoIds])
-
-  const hasAnyFilter = showActiveOnly || hideDefaultBranchWorkspace || selectedRepoCount > 0
-
-  const clearAll = useCallback(() => {
-    setShowActiveOnly(false)
-    setHideDefaultBranchWorkspace(false)
-    setFilterRepoIds([])
-  }, [setShowActiveOnly, setHideDefaultBranchWorkspace, setFilterRepoIds])
 
   return (
     <>
       <div className="flex items-center justify-between px-2 py-1">
         <span className="text-[11px] font-semibold text-muted-foreground">Filters</span>
-        {hasAnyFilter && (
-          <button
-            type="button"
-            onClick={clearAll}
-            className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            Reset
-          </button>
-        )}
       </div>
       <FilterToggleRow
         icon={<Activity className="size-3.5" />}

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useMemo } from 'react'
+import { Activity, GitBranch } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { cn } from '@/lib/utils'
+
+const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilterSection() {
+  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
+  const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
+  const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
+  const repos = useAppStore((s) => s.repos)
+
+  const selectedRepoCount = useMemo(() => {
+    let count = 0
+    for (const repo of repos) {
+      if (filterRepoIds.includes(repo.id)) {
+        count += 1
+      }
+    }
+    return count
+  }, [repos, filterRepoIds])
+
+  const hasAnyFilter = showActiveOnly || hideDefaultBranchWorkspace || selectedRepoCount > 0
+
+  const clearAll = useCallback(() => {
+    setShowActiveOnly(false)
+    setHideDefaultBranchWorkspace(false)
+    setFilterRepoIds([])
+  }, [setShowActiveOnly, setHideDefaultBranchWorkspace, setFilterRepoIds])
+
+  return (
+    <>
+      <div className="flex items-center justify-between px-2 py-1">
+        <span className="text-[11px] font-semibold text-muted-foreground">Filters</span>
+        {hasAnyFilter && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+      <FilterToggleRow
+        icon={<Activity className="size-3.5" />}
+        label="Active only"
+        checked={showActiveOnly}
+        onChange={setShowActiveOnly}
+      />
+      <FilterToggleRow
+        icon={<GitBranch className="size-3.5" />}
+        label="Hide default branch"
+        checked={hideDefaultBranchWorkspace}
+        onChange={setHideDefaultBranchWorkspace}
+      />
+    </>
+  )
+})
+
+function FilterToggleRow({
+  icon,
+  label,
+  checked,
+  onChange
+}: {
+  icon: React.ReactNode
+  label: string
+  checked: boolean
+  onChange: (next: boolean) => void
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className="flex w-full items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      <span className="inline-flex items-center gap-2 text-foreground">
+        <span className="text-muted-foreground">{icon}</span>
+        {label}
+      </span>
+      <span
+        aria-hidden
+        className={cn(
+          'relative h-3.5 w-6 shrink-0 rounded-full transition-colors',
+          checked ? 'bg-primary' : 'bg-muted-foreground/30'
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-0.5 left-0.5 size-2.5 rounded-full bg-background shadow-sm transition-transform',
+            checked && 'translate-x-2.5'
+          )}
+        />
+      </span>
+    </button>
+  )
+}
+
+export default SidebarWorkspaceFilterSection

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -1,0 +1,256 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { SlidersHorizontal } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { WorktreeCardProperty } from '../../../../shared/types'
+import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
+import SidebarWorkspaceFilterSection from './SidebarWorkspaceFilterSection'
+
+type SidebarWorkspaceOptionsMenuProps = {
+  preserveWorkspaceBoardOpen?: boolean
+  onMenuOpenChange?: (open: boolean) => void
+}
+
+const GROUP_BY_OPTIONS = [
+  { id: 'none', label: 'None' },
+  { id: 'workspace-status', label: 'Status' },
+  { id: 'pr-status', label: 'PR' },
+  { id: 'repo', label: 'Repo' }
+] as const
+
+const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
+  // Why: toggles the inline "Agent activity" list rendered below each
+  // workspace card body (see WorktreeCard -> WorktreeCardAgents). Off hides
+  // the list; there is no alternate surface.
+  { id: 'inline-agents', label: 'Agent activity' }
+]
+
+const SORT_OPTIONS = [
+  { id: 'name', label: 'Name', description: null },
+  {
+    id: 'smart',
+    label: 'Smart',
+    description: 'Agents that need attention, then most recent activity.'
+  },
+  { id: 'recent', label: 'Recent', description: null },
+  { id: 'repo', label: 'Repo', description: null }
+] as const
+
+const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsMenu({
+  preserveWorkspaceBoardOpen = false,
+  onMenuOpenChange
+}: SidebarWorkspaceOptionsMenuProps) {
+  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
+  const filterRepoIds = useAppStore((s) => s.filterRepoIds)
+  const repos = useAppStore((s) => s.repos)
+  const worktreeCardProperties = useAppStore((s) => s.worktreeCardProperties)
+  const toggleWorktreeCardProperty = useAppStore((s) => s.toggleWorktreeCardProperty)
+  const sortBy = useAppStore((s) => s.sortBy)
+  const setSortBy = useAppStore((s) => s.setSortBy)
+  const groupBy = useAppStore((s) => s.groupBy)
+  const setGroupBy = useAppStore((s) => s.setGroupBy)
+
+  const [open, setOpen] = useState(false)
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next)
+      onMenuOpenChange?.(next)
+    },
+    [onMenuOpenChange]
+  )
+
+  useEffect(() => {
+    return () => {
+      onMenuOpenChange?.(false)
+    }
+  }, [onMenuOpenChange])
+
+  // Why: derive from current repos so stale ids (e.g. lingering after a repo
+  // is removed) don't inflate counts or falsely signal an applied filter.
+  const selectedCount = useMemo(() => {
+    let count = 0
+    for (const repo of repos) {
+      if (filterRepoIds.includes(repo.id)) {
+        count += 1
+      }
+    }
+    return count
+  }, [repos, filterRepoIds])
+  const hasRepoFilter = selectedCount > 0
+  const hasAnyFilter = showActiveOnly || hideDefaultBranchWorkspace || hasRepoFilter
+  const activeFilterCount =
+    (showActiveOnly ? 1 : 0) + (hideDefaultBranchWorkspace ? 1 : 0) + selectedCount
+  const activeFilterLabel = `${activeFilterCount} ${activeFilterCount === 1 ? 'filter' : 'filters'}`
+  const sortLabel = SORT_OPTIONS.find((opt) => opt.id === sortBy)?.label ?? 'Sort'
+  const visiblePropertyCount = PROPERTY_OPTIONS.filter((opt) =>
+    worktreeCardProperties.includes(opt.id)
+  ).length
+
+  return (
+    <DropdownMenu modal={false} open={open} onOpenChange={handleOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              type="button"
+              className="relative text-muted-foreground"
+              aria-label={
+                hasAnyFilter
+                  ? `Workspace options (${activeFilterLabel} active)`
+                  : 'Workspace options'
+              }
+              data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+            >
+              <SlidersHorizontal className="size-3.5" strokeWidth={2.25} />
+              {hasAnyFilter && (
+                // Why: this combined options button now owns filtering, so it
+                // needs the same at-a-glance signal that the old filter button had.
+                <span
+                  aria-hidden
+                  className="absolute -top-0.5 -right-0.5 flex h-3 min-w-3 items-center justify-center rounded-full bg-primary px-0.5 text-[9px] font-medium leading-none text-primary-foreground"
+                >
+                  {activeFilterCount > 9 ? '9+' : activeFilterCount}
+                </span>
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {hasAnyFilter ? `Workspace options (${activeFilterLabel})` : 'Workspace options'}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="w-72 pb-2"
+        data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+      >
+        <DropdownMenuLabel>Group by</DropdownMenuLabel>
+        <div className="px-2 pt-0.5 pb-1">
+          <ToggleGroup
+            type="single"
+            value={groupBy}
+            onValueChange={(v) => {
+              if (v) {
+                setGroupBy(v as typeof groupBy)
+              }
+            }}
+            variant="outline"
+            size="sm"
+            className="h-6 w-full justify-start"
+          >
+            {GROUP_BY_OPTIONS.map((opt) => (
+              <ToggleGroupItem
+                key={opt.id}
+                value={opt.id}
+                className="h-6 px-2 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
+              >
+                {opt.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </div>
+
+        <DropdownMenuSeparator />
+        <SidebarWorkspaceFilterSection />
+
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span className="flex flex-1 items-center justify-between">
+              <span>Sort by</span>
+              <span className="text-[11px] font-medium text-muted-foreground">{sortLabel}</span>
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent
+            className="w-44"
+            data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+          >
+            <DropdownMenuRadioGroup
+              value={sortBy}
+              onValueChange={(v) => setSortBy(v as typeof sortBy)}
+            >
+              {SORT_OPTIONS.map((opt) => {
+                const radioItem = (
+                  <DropdownMenuRadioItem
+                    key={opt.id}
+                    value={opt.id}
+                    // Keep the menu open so people can compare sort modes and
+                    // toggle card properties without reopening the same panel.
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    {opt.label}
+                  </DropdownMenuRadioItem>
+                )
+                if (!opt.description) {
+                  return radioItem
+                }
+                return (
+                  <Tooltip key={opt.id}>
+                    <TooltipTrigger asChild>{radioItem}</TooltipTrigger>
+                    <TooltipContent side="right" sideOffset={6}>
+                      {opt.description}
+                    </TooltipContent>
+                  </Tooltip>
+                )
+              })}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span className="flex flex-1 items-center justify-between">
+              <span>Show properties</span>
+              {visiblePropertyCount > 0 && (
+                <span className="text-[11px] font-medium text-muted-foreground">
+                  {visiblePropertyCount}
+                </span>
+              )}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent
+            className="w-48"
+            data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+          >
+            {PROPERTY_OPTIONS.map((opt) => (
+              <DropdownMenuCheckboxItem
+                key={opt.id}
+                checked={worktreeCardProperties.includes(opt.id)}
+                onCheckedChange={() => toggleWorktreeCardProperty(opt.id)}
+                onSelect={(e) => e.preventDefault()}
+              >
+                {opt.label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSeparator />
+        <SidebarRepositoryFilterSection />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+})
+
+export default SidebarWorkspaceOptionsMenu

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -172,9 +172,6 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
         </div>
 
         <DropdownMenuSeparator />
-        <SidebarWorkspaceFilterSection />
-
-        <DropdownMenuSeparator />
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             <span className="flex flex-1 items-center justify-between">
@@ -218,6 +215,10 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
           </DropdownMenuSubContent>
         </DropdownMenuSub>
 
+        <DropdownMenuSeparator />
+        <SidebarWorkspaceFilterSection />
+
+        <DropdownMenuSeparator />
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             <span className="flex flex-1 items-center justify-between">

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -157,13 +157,13 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
             }}
             variant="outline"
             size="sm"
-            className="h-6 w-full justify-start"
+            className="h-6 w-full justify-stretch"
           >
             {GROUP_BY_OPTIONS.map((opt) => (
               <ToggleGroupItem
                 key={opt.id}
                 value={opt.id}
-                className="h-6 px-2 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
+                className="h-6 grow basis-0 px-1 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
               >
                 {opt.label}
               </ToggleGroupItem>


### PR DESCRIPTION
## Summary
- combine the workspace filter and view-options controls into one sidebar menu
- keep filters and project filtering inline while nesting sort/properties
- render project filters as removable pills in the project filter input

## Validation
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
- Electron UI check for the combined menu and project filter pills