### PR TITLE
Track setup script prompt telemetry

### DIFF
--- a/src/main/ipc/telemetry.test.ts
+++ b/src/main/ipc/telemetry.test.ts
@@ -156,6 +156,42 @@ describe('telemetry IPC handlers', () => {
     })
   })
 
+  it('injects cohort for setup script prompt events', () => {
+    registerWith({ installId: 'x', existedBeforeTelemetryRelease: false, optedIn: true })
+    getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 3 })
+    const handler = handlers.get('telemetry:track')!
+    handler({}, 'setup_script_prompt_shown', {
+      mode: 'import_available',
+      provider: 'codex',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: false
+    })
+    handler({}, 'setup_script_prompt_action', {
+      action: 'configure_clicked',
+      mode: 'configure_needed',
+      file_count_bucket: '0',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: true
+    })
+    expect(trackMock).toHaveBeenCalledWith('setup_script_prompt_shown', {
+      mode: 'import_available',
+      provider: 'codex',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: false,
+      nth_repo_added: 3
+    })
+    expect(trackMock).toHaveBeenCalledWith('setup_script_prompt_action', {
+      action: 'configure_clicked',
+      mode: 'configure_needed',
+      file_count_bucket: '0',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: true,
+      nth_repo_added: 3
+    })
+  })
+
   // Fail-soft: a degraded classifier returns `{ nth_repo_added: undefined }`.
   // The schemas declare the field optional, so the event still validates.
   it('forwards undefined cohort when the classifier returns undefined', () => {

--- a/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Download, LoaderCircle, Settings, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { track } from '@/lib/telemetry'
 import { cn } from '@/lib/utils'
 import { getRepositoryLocalCommandsSectionId } from '@/components/settings/repository-settings-targets'
 import {
@@ -17,6 +18,10 @@ import { normalizeHookCommandSourcePolicy } from '../../../../shared/hook-comman
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { Repo, RepoHookSettings } from '../../../../shared/types'
 import type { SetupScriptImportCandidate } from '../../../../shared/setup-script-imports'
+import {
+  buildSetupScriptPromptActionTelemetry,
+  buildSetupScriptPromptTelemetry
+} from '../../../../shared/setup-script-telemetry'
 
 type PromptState = {
   repoId: string
@@ -95,6 +100,7 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
   const dismissSetupScriptPrompt = useAppStore((s) => s.dismissSetupScriptPrompt)
   const [promptState, setPromptState] = useState<PromptState | null>(null)
   const [isImporting, setIsImporting] = useState(false)
+  const trackedPromptKeysRef = useRef<Set<string>>(new Set())
 
   const activeRepo = useMemo(
     () => repos.find((repo) => repo.id === activeRepoId) ?? null,
@@ -171,18 +177,72 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
     [openSettingsPage, openSettingsTarget, setSettingsSearchQuery]
   )
 
+  useEffect(() => {
+    if (
+      !sidebarOpen ||
+      !activeRepo ||
+      !isGitRepoKind(activeRepo) ||
+      isDismissed ||
+      promptState?.repoId !== activeRepo.id ||
+      promptState.hasEffectiveSetup
+    ) {
+      return
+    }
+
+    const telemetry = buildSetupScriptPromptTelemetry(
+      promptState.candidate,
+      promptState.hasSharedHooks
+    )
+    // Why: React may re-render the sidebar often; this event should represent
+    // a distinct prompt exposure for this repo/source, not render churn.
+    const promptKey = [
+      activeRepo.id,
+      telemetry.mode,
+      telemetry.provider ?? 'none',
+      telemetry.file_count_bucket,
+      telemetry.unsupported_field_count_bucket,
+      String(telemetry.has_shared_hooks)
+    ].join(':')
+    if (trackedPromptKeysRef.current.has(promptKey)) {
+      return
+    }
+
+    trackedPromptKeysRef.current.add(promptKey)
+    track('setup_script_prompt_shown', telemetry)
+  }, [activeRepo, isDismissed, promptState, sidebarOpen])
+
   const handleConfigure = useCallback(() => {
     if (!activeRepo) {
       return
     }
+    if (promptState?.repoId === activeRepo.id && !promptState.hasEffectiveSetup) {
+      track(
+        'setup_script_prompt_action',
+        buildSetupScriptPromptActionTelemetry(
+          'configure_clicked',
+          promptState.candidate,
+          promptState.hasSharedHooks
+        )
+      )
+    }
     openLocalCommandSettings(activeRepo.id)
-  }, [activeRepo, openLocalCommandSettings])
+  }, [activeRepo, openLocalCommandSettings, promptState])
 
   const handleDismiss = useCallback(() => {
     if (activeRepo) {
+      if (promptState?.repoId === activeRepo.id && !promptState.hasEffectiveSetup) {
+        track(
+          'setup_script_prompt_action',
+          buildSetupScriptPromptActionTelemetry(
+            'dismissed',
+            promptState.candidate,
+            promptState.hasSharedHooks
+          )
+        )
+      }
       dismissSetupScriptPrompt(activeRepo.id)
     }
-  }, [activeRepo, dismissSetupScriptPrompt])
+  }, [activeRepo, dismissSetupScriptPrompt, promptState])
 
   const handleImport = useCallback(async () => {
     if (!activeRepo || !promptState?.candidate) {
@@ -198,9 +258,25 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
       )
       const didUpdate = await updateRepo(activeRepo.id, { hookSettings: nextSettings })
       if (!didUpdate) {
+        track(
+          'setup_script_prompt_action',
+          buildSetupScriptPromptActionTelemetry(
+            'import_failed',
+            promptState.candidate,
+            promptState.hasSharedHooks
+          )
+        )
         toast.error('Failed to import setup script')
         return
       }
+      track(
+        'setup_script_prompt_action',
+        buildSetupScriptPromptActionTelemetry(
+          'import_completed',
+          promptState.candidate,
+          promptState.hasSharedHooks
+        )
+      )
       setPromptState((current) =>
         current?.repoId === activeRepo.id ? { ...current, hasEffectiveSetup: true } : current
       )
@@ -215,6 +291,17 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
           onClick: () => openLocalCommandSettings(importedRepoId)
         }
       })
+    } catch (error) {
+      track(
+        'setup_script_prompt_action',
+        buildSetupScriptPromptActionTelemetry(
+          'import_failed',
+          promptState.candidate,
+          promptState.hasSharedHooks
+        )
+      )
+      console.warn('[setup-script-prompt] Failed to import setup script:', error)
+      toast.error('Failed to import setup script')
     } finally {
       setIsImporting(false)
     }

--- a/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
+++ b/src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx
@@ -189,10 +189,10 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
       return
     }
 
-    const telemetry = buildSetupScriptPromptTelemetry(
-      promptState.candidate,
-      promptState.hasSharedHooks
-    )
+    const telemetry = buildSetupScriptPromptTelemetry({
+      candidate: promptState.candidate,
+      hasSharedHooks: promptState.hasSharedHooks
+    })
     // Why: React may re-render the sidebar often; this event should represent
     // a distinct prompt exposure for this repo/source, not render churn.
     const promptKey = [
@@ -218,11 +218,11 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
     if (promptState?.repoId === activeRepo.id && !promptState.hasEffectiveSetup) {
       track(
         'setup_script_prompt_action',
-        buildSetupScriptPromptActionTelemetry(
-          'configure_clicked',
-          promptState.candidate,
-          promptState.hasSharedHooks
-        )
+        buildSetupScriptPromptActionTelemetry({
+          action: 'configure_clicked',
+          candidate: promptState.candidate,
+          hasSharedHooks: promptState.hasSharedHooks
+        })
       )
     }
     openLocalCommandSettings(activeRepo.id)
@@ -233,11 +233,11 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
       if (promptState?.repoId === activeRepo.id && !promptState.hasEffectiveSetup) {
         track(
           'setup_script_prompt_action',
-          buildSetupScriptPromptActionTelemetry(
-            'dismissed',
-            promptState.candidate,
-            promptState.hasSharedHooks
-          )
+          buildSetupScriptPromptActionTelemetry({
+            action: 'dismissed',
+            candidate: promptState.candidate,
+            hasSharedHooks: promptState.hasSharedHooks
+          })
         )
       }
       dismissSetupScriptPrompt(activeRepo.id)
@@ -260,22 +260,22 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
       if (!didUpdate) {
         track(
           'setup_script_prompt_action',
-          buildSetupScriptPromptActionTelemetry(
-            'import_failed',
-            promptState.candidate,
-            promptState.hasSharedHooks
-          )
+          buildSetupScriptPromptActionTelemetry({
+            action: 'import_failed',
+            candidate: promptState.candidate,
+            hasSharedHooks: promptState.hasSharedHooks
+          })
         )
         toast.error('Failed to import setup script')
         return
       }
       track(
         'setup_script_prompt_action',
-        buildSetupScriptPromptActionTelemetry(
-          'import_completed',
-          promptState.candidate,
-          promptState.hasSharedHooks
-        )
+        buildSetupScriptPromptActionTelemetry({
+          action: 'import_completed',
+          candidate: promptState.candidate,
+          hasSharedHooks: promptState.hasSharedHooks
+        })
       )
       setPromptState((current) =>
         current?.repoId === activeRepo.id ? { ...current, hasEffectiveSetup: true } : current
@@ -294,11 +294,11 @@ function SetupScriptPromptCard(): React.JSX.Element | null {
     } catch (error) {
       track(
         'setup_script_prompt_action',
-        buildSetupScriptPromptActionTelemetry(
-          'import_failed',
-          promptState.candidate,
-          promptState.hasSharedHooks
-        )
+        buildSetupScriptPromptActionTelemetry({
+          action: 'import_failed',
+          candidate: promptState.candidate,
+          hasSharedHooks: promptState.hasSharedHooks
+        })
       )
       console.warn('[setup-script-prompt] Failed to import setup script:', error)
       toast.error('Failed to import setup script')

--- a/src/shared/setup-script-import-providers.ts
+++ b/src/shared/setup-script-import-providers.ts
@@ -1,0 +1,3 @@
+export const SETUP_SCRIPT_IMPORT_PROVIDERS = ['superset', 'conductor', 'codex', 'cmux'] as const
+
+export type SetupScriptImportProvider = (typeof SETUP_SCRIPT_IMPORT_PROVIDERS)[number]

--- a/src/shared/setup-script-imports.ts
+++ b/src/shared/setup-script-imports.ts
@@ -1,6 +1,5 @@
 import { inspectCodexEnvironmentConfig } from './setup-script-import-codex-environment'
-
-export type SetupScriptImportProvider = 'superset' | 'conductor' | 'codex' | 'cmux'
+import type { SetupScriptImportProvider } from './setup-script-import-providers'
 
 export type SetupScriptImportCandidate = {
   provider: SetupScriptImportProvider

--- a/src/shared/setup-script-telemetry-events.test.ts
+++ b/src/shared/setup-script-telemetry-events.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { eventSchemas, setupScriptImportProviderSchema } from './telemetry-events'
+
+describe('setup script prompt schemas', () => {
+  it('accepts a bucketed import prompt exposure', () => {
+    const parsed = eventSchemas.setup_script_prompt_shown.safeParse({
+      mode: 'import_available',
+      provider: 'codex',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '2-3',
+      has_shared_hooks: false
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts configure prompt actions without a provider', () => {
+    const parsed = eventSchemas.setup_script_prompt_action.safeParse({
+      action: 'configure_clicked',
+      mode: 'configure_needed',
+      file_count_bucket: '0',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: true
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects unknown setup import providers', () => {
+    const parsed = eventSchemas.setup_script_prompt_shown.safeParse({
+      mode: 'import_available',
+      provider: 'made_up_tool',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: false
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects raw setup import details via .strict()', () => {
+    const parsed = eventSchemas.setup_script_prompt_action.safeParse({
+      action: 'import_completed',
+      mode: 'import_available',
+      provider: 'codex',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: false,
+      files: ['.codex/environments/environment.toml'],
+      setup: 'npm install'
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('keeps the provider schema in sync with known setup import providers', () => {
+    expect(setupScriptImportProviderSchema.options).toEqual([
+      'superset',
+      'conductor',
+      'codex',
+      'cmux'
+    ])
+  })
+})

--- a/src/shared/setup-script-telemetry-events.test.ts
+++ b/src/shared/setup-script-telemetry-events.test.ts
@@ -35,6 +35,28 @@ describe('setup script prompt schemas', () => {
     expect(parsed.success).toBe(false)
   })
 
+  it('rejects import prompt exposure without a provider', () => {
+    const parsed = eventSchemas.setup_script_prompt_shown.safeParse({
+      mode: 'import_available',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: false
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects configure prompt actions with a provider', () => {
+    const parsed = eventSchemas.setup_script_prompt_action.safeParse({
+      action: 'configure_clicked',
+      mode: 'configure_needed',
+      provider: 'codex',
+      file_count_bucket: '0',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: false
+    })
+    expect(parsed.success).toBe(false)
+  })
+
   it('rejects raw setup import details via .strict()', () => {
     const parsed = eventSchemas.setup_script_prompt_action.safeParse({
       action: 'import_completed',

--- a/src/shared/setup-script-telemetry.test.ts
+++ b/src/shared/setup-script-telemetry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSetupScriptPromptActionTelemetry,
+  buildSetupScriptPromptTelemetry
+} from './setup-script-telemetry'
+import type { SetupScriptImportCandidate } from './setup-script-imports'
+
+describe('setup script telemetry payload builders', () => {
+  it('builds configure prompt telemetry without provider or raw details', () => {
+    expect(buildSetupScriptPromptTelemetry(null, true)).toEqual({
+      mode: 'configure_needed',
+      file_count_bucket: '0',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: true
+    })
+  })
+
+  it('buckets import prompt counts and preserves only the provider enum', () => {
+    const candidate: SetupScriptImportCandidate = {
+      provider: 'codex',
+      label: 'Codex',
+      files: ['one', 'two', 'three'],
+      setup: 'npm install',
+      unsupportedFields: ['a', 'b', 'c', 'd']
+    }
+
+    expect(buildSetupScriptPromptTelemetry(candidate, false)).toEqual({
+      mode: 'import_available',
+      provider: 'codex',
+      file_count_bucket: '2-3',
+      unsupported_field_count_bucket: '4+',
+      has_shared_hooks: false
+    })
+  })
+
+  it('adds the action without changing the bucketed context', () => {
+    const candidate: SetupScriptImportCandidate = {
+      provider: 'conductor',
+      label: 'Conductor',
+      files: ['conductor.json'],
+      setup: 'pnpm install'
+    }
+
+    expect(buildSetupScriptPromptActionTelemetry('import_completed', candidate, true)).toEqual({
+      action: 'import_completed',
+      mode: 'import_available',
+      provider: 'conductor',
+      file_count_bucket: '1',
+      unsupported_field_count_bucket: '0',
+      has_shared_hooks: true
+    })
+  })
+})

--- a/src/shared/setup-script-telemetry.test.ts
+++ b/src/shared/setup-script-telemetry.test.ts
@@ -7,7 +7,7 @@ import type { SetupScriptImportCandidate } from './setup-script-imports'
 
 describe('setup script telemetry payload builders', () => {
   it('builds configure prompt telemetry without provider or raw details', () => {
-    expect(buildSetupScriptPromptTelemetry(null, true)).toEqual({
+    expect(buildSetupScriptPromptTelemetry({ candidate: null, hasSharedHooks: true })).toEqual({
       mode: 'configure_needed',
       file_count_bucket: '0',
       unsupported_field_count_bucket: '0',
@@ -24,7 +24,7 @@ describe('setup script telemetry payload builders', () => {
       unsupportedFields: ['a', 'b', 'c', 'd']
     }
 
-    expect(buildSetupScriptPromptTelemetry(candidate, false)).toEqual({
+    expect(buildSetupScriptPromptTelemetry({ candidate, hasSharedHooks: false })).toEqual({
       mode: 'import_available',
       provider: 'codex',
       file_count_bucket: '2-3',
@@ -41,7 +41,13 @@ describe('setup script telemetry payload builders', () => {
       setup: 'pnpm install'
     }
 
-    expect(buildSetupScriptPromptActionTelemetry('import_completed', candidate, true)).toEqual({
+    expect(
+      buildSetupScriptPromptActionTelemetry({
+        action: 'import_completed',
+        candidate,
+        hasSharedHooks: true
+      })
+    ).toEqual({
       action: 'import_completed',
       mode: 'import_available',
       provider: 'conductor',

--- a/src/shared/setup-script-telemetry.ts
+++ b/src/shared/setup-script-telemetry.ts
@@ -1,0 +1,50 @@
+import type { EventProps } from './telemetry-events'
+import type { SetupScriptImportCandidate } from './setup-script-imports'
+
+type SetupScriptPromptTelemetry = Omit<EventProps<'setup_script_prompt_shown'>, 'nth_repo_added'>
+type SetupScriptPromptActionTelemetry = Omit<
+  EventProps<'setup_script_prompt_action'>,
+  'nth_repo_added'
+>
+
+export type SetupScriptPromptAction = SetupScriptPromptActionTelemetry['action']
+
+export function buildSetupScriptPromptTelemetry(
+  candidate: SetupScriptImportCandidate | null,
+  hasSharedHooks: boolean
+): SetupScriptPromptTelemetry {
+  const base = {
+    mode: candidate ? 'import_available' : 'configure_needed',
+    file_count_bucket: bucketSetupScriptCount(candidate?.files.length ?? 0),
+    unsupported_field_count_bucket: bucketSetupScriptCount(
+      candidate?.unsupportedFields?.length ?? 0
+    ),
+    has_shared_hooks: hasSharedHooks
+  } satisfies SetupScriptPromptTelemetry
+
+  return candidate ? { ...base, provider: candidate.provider } : base
+}
+
+export function buildSetupScriptPromptActionTelemetry(
+  action: SetupScriptPromptAction,
+  candidate: SetupScriptImportCandidate | null,
+  hasSharedHooks: boolean
+): SetupScriptPromptActionTelemetry {
+  return {
+    ...buildSetupScriptPromptTelemetry(candidate, hasSharedHooks),
+    action
+  }
+}
+
+function bucketSetupScriptCount(count: number): SetupScriptPromptTelemetry['file_count_bucket'] {
+  if (count <= 0) {
+    return '0'
+  }
+  if (count === 1) {
+    return '1'
+  }
+  if (count <= 3) {
+    return '2-3'
+  }
+  return '4+'
+}

--- a/src/shared/setup-script-telemetry.ts
+++ b/src/shared/setup-script-telemetry.ts
@@ -9,10 +9,13 @@ type SetupScriptPromptActionTelemetry = Omit<
 
 export type SetupScriptPromptAction = SetupScriptPromptActionTelemetry['action']
 
-export function buildSetupScriptPromptTelemetry(
-  candidate: SetupScriptImportCandidate | null,
+export function buildSetupScriptPromptTelemetry({
+  candidate,
+  hasSharedHooks
+}: {
+  candidate: SetupScriptImportCandidate | null
   hasSharedHooks: boolean
-): SetupScriptPromptTelemetry {
+}): SetupScriptPromptTelemetry {
   const base = {
     mode: candidate ? 'import_available' : 'configure_needed',
     file_count_bucket: bucketSetupScriptCount(candidate?.files.length ?? 0),
@@ -25,13 +28,17 @@ export function buildSetupScriptPromptTelemetry(
   return candidate ? { ...base, provider: candidate.provider } : base
 }
 
-export function buildSetupScriptPromptActionTelemetry(
-  action: SetupScriptPromptAction,
-  candidate: SetupScriptImportCandidate | null,
+export function buildSetupScriptPromptActionTelemetry({
+  action,
+  candidate,
+  hasSharedHooks
+}: {
+  action: SetupScriptPromptAction
+  candidate: SetupScriptImportCandidate | null
   hasSharedHooks: boolean
-): SetupScriptPromptActionTelemetry {
+}): SetupScriptPromptActionTelemetry {
   return {
-    ...buildSetupScriptPromptTelemetry(candidate, hasSharedHooks),
+    ...buildSetupScriptPromptTelemetry({ candidate, hasSharedHooks }),
     action
   }
 }

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -15,6 +15,7 @@
 
 import { z } from 'zod'
 import { FEATURE_WALL_MAX_DWELL_MS } from './feature-wall-telemetry'
+import { SETUP_SCRIPT_IMPORT_PROVIDERS } from './setup-script-import-providers'
 
 import { AGENT_HOOK_TARGETS } from './agent-hook-types'
 import { ONBOARDING_FINAL_STEP } from './constants'
@@ -110,6 +111,9 @@ export const addRepoExistingWorkspaceSourceSchema = z.enum([
   'create_project'
 ])
 export type AddRepoExistingWorkspaceSource = z.infer<typeof addRepoExistingWorkspaceSourceSchema>
+
+export const setupScriptImportProviderSchema = z.enum(SETUP_SCRIPT_IMPORT_PROVIDERS)
+export type SetupScriptImportProviderTelemetry = z.infer<typeof setupScriptImportProviderSchema>
 
 // Deliberately a separate enum from `errorClassSchema` (PTY-spawn taxonomy):
 // different domain — this one buckets git/filesystem failures thrown by
@@ -334,6 +338,26 @@ const workspaceCreateFailedSchema = z
     source: workspaceSourceSchema,
     error_class: workspaceCreateErrorClassSchema,
     nth_repo_added: nthRepoAddedSchema
+  })
+  .strict()
+
+const setupScriptPromptModeSchema = z.enum(['import_available', 'configure_needed'])
+const setupScriptCountBucketSchema = z.enum(['0', '1', '2-3', '4+'])
+const setupScriptPromptContextSchema = {
+  mode: setupScriptPromptModeSchema,
+  provider: setupScriptImportProviderSchema.optional(),
+  file_count_bucket: setupScriptCountBucketSchema,
+  unsupported_field_count_bucket: setupScriptCountBucketSchema,
+  has_shared_hooks: z.boolean(),
+  nth_repo_added: nthRepoAddedSchema
+} as const
+// Why: setup-import telemetry is for a retention cohort, not debugging a
+// user's repo, so it carries only closed enums and count buckets.
+const setupScriptPromptShownSchema = z.object(setupScriptPromptContextSchema).strict()
+const setupScriptPromptActionSchema = z
+  .object({
+    ...setupScriptPromptContextSchema,
+    action: z.enum(['import_completed', 'import_failed', 'configure_clicked', 'dismissed'])
   })
   .strict()
 
@@ -748,6 +772,8 @@ export const eventSchemas = {
   add_repo_existing_workspaces_detected: addRepoExistingWorkspacesDetectedSchema,
   workspace_created: workspaceCreatedSchema,
   workspace_create_failed: workspaceCreateFailedSchema,
+  setup_script_prompt_shown: setupScriptPromptShownSchema,
+  setup_script_prompt_action: setupScriptPromptActionSchema,
 
   agent_started: agentStartedSchema,
   agent_error: agentErrorSchema,
@@ -830,6 +856,8 @@ type _CohortExtendedRoster =
   | 'add_repo_existing_workspaces_detected'
   | 'workspace_created'
   | 'workspace_create_failed'
+  | 'setup_script_prompt_shown'
+  | 'setup_script_prompt_action'
   | 'agent_started'
   | 'agent_error'
 // Why: `z.object({}).strict()` infers a string index signature, which would

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -345,21 +345,52 @@ const setupScriptPromptModeSchema = z.enum(['import_available', 'configure_neede
 const setupScriptCountBucketSchema = z.enum(['0', '1', '2-3', '4+'])
 const setupScriptPromptContextSchema = {
   mode: setupScriptPromptModeSchema,
+  // Why: cohort injection probes top-level ZodObject shapes; superRefine
+  // keeps that path while still rejecting impossible mode/provider pairs.
   provider: setupScriptImportProviderSchema.optional(),
   file_count_bucket: setupScriptCountBucketSchema,
   unsupported_field_count_bucket: setupScriptCountBucketSchema,
   has_shared_hooks: z.boolean(),
   nth_repo_added: nthRepoAddedSchema
 } as const
+
+type SetupScriptPromptContextTelemetry = {
+  mode: z.infer<typeof setupScriptPromptModeSchema>
+  provider?: z.infer<typeof setupScriptImportProviderSchema>
+}
+
+function validateSetupScriptPromptProvider(
+  props: SetupScriptPromptContextTelemetry,
+  ctx: z.RefinementCtx
+): void {
+  if (props.mode === 'import_available' && props.provider === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['provider'],
+      message: 'provider is required when setup import is available'
+    })
+  }
+  if (props.mode === 'configure_needed' && props.provider !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['provider'],
+      message: 'provider is only valid when setup import is available'
+    })
+  }
+}
 // Why: setup-import telemetry is for a retention cohort, not debugging a
 // user's repo, so it carries only closed enums and count buckets.
-const setupScriptPromptShownSchema = z.object(setupScriptPromptContextSchema).strict()
+const setupScriptPromptShownSchema = z
+  .object(setupScriptPromptContextSchema)
+  .strict()
+  .superRefine(validateSetupScriptPromptProvider)
 const setupScriptPromptActionSchema = z
   .object({
     ...setupScriptPromptContextSchema,
     action: z.enum(['import_completed', 'import_failed', 'configure_clicked', 'dismissed'])
   })
   .strict()
+  .superRefine(validateSetupScriptPromptProvider)
 
 // Managed-hook installer per-agent label. Distinct from `AGENT_KIND_VALUES`:
 // hook installation only targets the agents in `AGENT_HOOK_TARGETS` and the


### PR DESCRIPTION
## Summary
- Add schema-validated setup script prompt shown/action telemetry using provider enums and count buckets only
- Track prompt exposure plus configure, dismiss, import success, and import failure actions from the sidebar prompt
- Share the setup import provider enum between import detection and telemetry validation

## Tests
- pnpm exec oxfmt --write src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx src/shared/setup-script-import-providers.ts src/shared/setup-script-imports.ts src/shared/setup-script-telemetry-events.test.ts src/shared/setup-script-telemetry.test.ts src/shared/setup-script-telemetry.ts src/shared/telemetry-events.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/SetupScriptPromptCard.tsx src/shared/setup-script-import-providers.ts src/shared/setup-script-imports.ts src/shared/setup-script-telemetry-events.test.ts src/shared/setup-script-telemetry.test.ts src/shared/setup-script-telemetry.ts src/shared/telemetry-events.ts
- pnpm exec vitest run --config config/vitest.config.ts src/shared/setup-script-telemetry.test.ts src/shared/setup-script-telemetry-events.test.ts src/shared/setup-script-imports.test.ts src/renderer/src/store/slices/repos-update-serialization.test.ts
- pnpm run typecheck:web
- pnpm run typecheck:node