### PR TITLE
Improve agent hovercard interactions

### DIFF
--- a/src/main/window/editable-context-menu.test.ts
+++ b/src/main/window/editable-context-menu.test.ts
@@ -1,4 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
+
+const { writeTextMock } = vi.hoisted(() => ({
+  writeTextMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  clipboard: { writeText: writeTextMock }
+}))
+
 import { buildEditableContextMenuTemplate } from './editable-context-menu'
 import { richMarkdownContextMenuCommandChannel } from '../../shared/rich-markdown-context-menu'
 
@@ -137,6 +146,31 @@ describe('buildEditableContextMenuTemplate', () => {
         webContents
       )
     ).toEqual([])
+  })
+
+  it('builds a native read-only text menu for selected markdown text and links', () => {
+    const template = buildEditableContextMenuTemplate(
+      contextParams({
+        isEditable: false,
+        linkURL: 'https://example.com/docs',
+        selectionText: 'https://example.com/docs'
+      }),
+      {
+        replaceMisspelling: vi.fn(),
+        send: vi.fn(),
+        session: { addWordToSpellCheckerDictionary: vi.fn() } as unknown as Electron.Session
+      }
+    )
+
+    expect(template.map((item) => item.label ?? item.role ?? item.type)).toEqual([
+      'Copy URL',
+      'separator',
+      'copy',
+      'selectAll'
+    ])
+
+    template[0].click?.({} as Electron.MenuItem, {} as Electron.BrowserWindow, {} as KeyboardEvent)
+    expect(writeTextMock).toHaveBeenCalledWith('https://example.com/docs')
   })
 
   it('keeps regular text inputs to spelling and native edit actions', () => {

--- a/src/main/window/editable-context-menu.ts
+++ b/src/main/window/editable-context-menu.ts
@@ -1,3 +1,4 @@
+import { clipboard } from 'electron'
 import {
   richMarkdownContextMenuCommandChannel,
   type RichMarkdownContextMenuCommand,
@@ -83,12 +84,34 @@ function buildNativeEditMenuTemplate(): Electron.MenuItemConstructorOptions[] {
   ]
 }
 
+function buildReadOnlyTextMenuTemplate(
+  params: Electron.ContextMenuParams
+): Electron.MenuItemConstructorOptions[] {
+  const template: Electron.MenuItemConstructorOptions[] = []
+  if (params.linkURL) {
+    template.push({
+      label: 'Copy URL',
+      click: () => clipboard.writeText(params.linkURL)
+    })
+  }
+  if (params.selectionText) {
+    if (template.length > 0) {
+      template.push({ type: 'separator' })
+    }
+    template.push({ role: 'copy' })
+  }
+  if (template.length > 0) {
+    template.push({ role: 'selectAll' })
+  }
+  return template
+}
+
 export function buildEditableContextMenuTemplate(
   params: Electron.ContextMenuParams,
   webContents: EditableContextMenuWebContents
 ): Electron.MenuItemConstructorOptions[] {
   if (!params.isEditable) {
-    return []
+    return buildReadOnlyTextMenuTemplate(params)
   }
 
   const suggestions = params.dictionarySuggestions.slice(0, 5)

--- a/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { DashboardAgentHoverCardContent } from './DashboardAgentHoverCardContent'
 import type { DashboardAgentRow } from './useDashboardData'
 
@@ -41,23 +42,30 @@ function makeAgentRow(): DashboardAgentRow {
 describe('DashboardAgentHoverCardContent', () => {
   it('renders prompt and assistant markdown in structured sections', () => {
     const markup = renderToStaticMarkup(
-      <DashboardAgentHoverCardContent
-        agent={makeAgentRow()}
-        dotState="working"
-        prompt="Review **markdown** formatting"
-        isWorking
-        toolName="Bash"
-        toolInput="pnpm test"
-        lastAssistantMessage="Rendered **markdown** in the hover card."
-        tsParts={['started 1m ago']}
-      />
+      <TooltipProvider>
+        <DashboardAgentHoverCardContent
+          agent={makeAgentRow()}
+          dotState="working"
+          prompt="Review **markdown** formatting"
+          isWorking
+          toolName="Bash"
+          toolInput="pnpm test"
+          lastAssistantMessage="Rendered **markdown** in the hover card."
+          headerTimestamp="1m ago"
+          onActivate={() => {}}
+        />
+      </TooltipProvider>
     )
 
     expect(markup).toContain('Prompt')
     expect(markup).toContain('Current tool')
     expect(markup).toContain('Latest message')
+    expect(markup).toContain('Copy prompt')
+    expect(markup).toContain('Copy latest message')
     expect(markup).toContain('data-slot="scroll-area"')
     expect(markup).toContain('data-slot="scroll-area-viewport"')
+    expect(markup).toContain('whitespace-pre')
+    expect(markup).toContain('[&amp;_pre]:max-w-none')
     expect(markup).not.toContain('overflow-auto')
     expect(markup).toContain('<strong>markdown</strong>')
     expect(markup).toContain('pnpm test')

--- a/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.tsx
@@ -1,21 +1,56 @@
 import React from 'react'
-import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import { ArrowRight, Check, Copy } from 'lucide-react'
+import { AgentStateDot, type AgentDotState } from '@/components/AgentStateDot'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import { WORKTREE_CONTEXT_MENU_SCOPE_ATTR } from '@/components/sidebar/worktree-context-menu-scope'
+import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
 
 type AgentHoverSectionProps = {
   title: string
   children: React.ReactNode
+  copyLabel?: string
+  copied?: boolean
+  onCopy?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-function AgentHoverSection({ title, children }: AgentHoverSectionProps): React.JSX.Element {
+function AgentHoverSection({
+  title,
+  children,
+  copyLabel,
+  copied = false,
+  onCopy
+}: AgentHoverSectionProps): React.JSX.Element {
   return (
     <section className="space-y-1.5">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-        {title}
+      <div className="flex min-w-0 items-center gap-1.5">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+          {title}
+        </div>
+        {onCopy && copyLabel && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="size-5 text-muted-foreground hover:text-foreground"
+                onClick={onCopy}
+                onMouseDown={(event) => event.stopPropagation()}
+                aria-label={copyLabel}
+              >
+                {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              {copied ? 'Copied' : copyLabel}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
       <div className="text-[12px] leading-relaxed text-popover-foreground">{children}</div>
     </section>
@@ -30,7 +65,8 @@ type DashboardAgentHoverCardContentProps = {
   toolName: string
   toolInput: string
   lastAssistantMessage: string
-  tsParts: readonly string[]
+  headerTimestamp: string | null
+  onActivate: (event: React.SyntheticEvent) => void
 }
 
 export function DashboardAgentHoverCardContent({
@@ -41,81 +77,142 @@ export function DashboardAgentHoverCardContent({
   toolName,
   toolInput,
   lastAssistantMessage,
-  tsParts
+  headerTimestamp,
+  onActivate
 }: DashboardAgentHoverCardContentProps): React.JSX.Element {
+  const copyResetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [copiedSection, setCopiedSection] = React.useState<'prompt' | 'latest' | null>(null)
   const agentLabel = formatAgentTypeLabel(agent.agentType)
-  const statusLabel = agent.entry.interrupted ? 'Interrupted' : agentStateLabel(dotState)
   const hasToolDetails = isWorking && (toolName.length > 0 || toolInput.length > 0)
   const hasBodyDetails = prompt.length > 0 || hasToolDetails || lastAssistantMessage.length > 0
+  const copySectionText = React.useCallback((section: 'prompt' | 'latest', text: string) => {
+    return async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      await window.api.ui.writeClipboardText(text)
+      setCopiedSection(section)
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current)
+      }
+      copyResetTimerRef.current = setTimeout(() => setCopiedSection(null), 1200)
+    }
+  }, [])
+  const handleHeaderKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      onActivate(event)
+    },
+    [onActivate]
+  )
+
+  React.useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current) {
+        clearTimeout(copyResetTimerRef.current)
+      }
+    }
+  }, [])
 
   return (
-    <ScrollArea
-      className="max-h-[min(70vh,520px)]"
-      type="auto"
-      viewportClassName="max-h-[min(70vh,520px)]"
+    <div
+      className="flex max-h-[min(70vh,520px)] flex-col"
       onClick={(event) => event.stopPropagation()}
       onMouseDown={(event) => event.stopPropagation()}
+      onContextMenuCapture={(event) => event.stopPropagation()}
+      {...{ [WORKTREE_CONTEXT_MENU_SCOPE_ATTR]: 'agent-hover-card' }}
     >
-      <div className="border-b border-border/60 px-3 py-2.5">
-        <div className="flex min-w-0 items-center gap-2">
+      <div
+        role="button"
+        tabIndex={0}
+        className="group/header flex h-10 shrink-0 cursor-pointer items-center border-b border-border/60 bg-popover px-3 text-left transition-colors hover:bg-accent/70 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        onClick={onActivate}
+        onKeyDown={handleHeaderKeyDown}
+      >
+        <div className="flex min-w-0 w-full items-center gap-2">
           <AgentStateDot state={dotState} size="md" />
-          <span className="inline-flex shrink-0 text-foreground">
+          <span className="inline-flex size-4 shrink-0 items-center justify-center text-foreground">
             <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={16} />
           </span>
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold text-popover-foreground">
-              {agentLabel}
-            </div>
-            <div className="truncate text-xs text-muted-foreground">
-              {[statusLabel, ...tsParts].join(' • ')}
-            </div>
+          <div className="min-w-0 flex-1 truncate text-sm font-semibold leading-4 text-popover-foreground">
+            {agentLabel}
           </div>
           {agent.entry.interrupted && (
             <span className="shrink-0 rounded-sm bg-destructive/15 px-1.5 py-0.5 text-[10px] font-medium leading-none text-destructive">
               interrupted
             </span>
           )}
+          <span className="ml-auto grid shrink-0 grid-cols-1 grid-rows-1 items-center justify-items-end">
+            {headerTimestamp && (
+              <span className="[grid-area:1/1] text-xs font-normal text-muted-foreground transition-opacity group-hover/header:opacity-0">
+                {headerTimestamp}
+              </span>
+            )}
+            <span className="[grid-area:1/1] inline-flex items-center gap-1 text-xs font-medium text-muted-foreground opacity-0 transition-opacity group-hover/header:opacity-100">
+              <ArrowRight className="size-3" />
+              Open
+            </span>
+          </span>
         </div>
       </div>
-      <div className="space-y-3 px-3 py-3">
-        {prompt && (
-          <AgentHoverSection title="Prompt">
-            <CommentMarkdown
-              content={prompt}
-              variant="document"
-              className="text-[12px] leading-relaxed"
-            />
-          </AgentHoverSection>
-        )}
-        {hasToolDetails && (
-          <AgentHoverSection title="Current tool">
-            <div className="space-y-1.5">
-              {toolName && (
-                <code className="rounded bg-accent px-1.5 py-0.5 font-mono text-[11px] text-accent-foreground">
-                  {toolName}
-                </code>
-              )}
-              {toolInput && (
-                <pre className="whitespace-pre-wrap rounded-md bg-accent p-2 font-mono text-[11px] leading-snug text-accent-foreground [overflow-wrap:anywhere]">
-                  {toolInput}
-                </pre>
-              )}
-            </div>
-          </AgentHoverSection>
-        )}
-        {lastAssistantMessage && (
-          <AgentHoverSection title="Latest message">
-            <CommentMarkdown
-              content={lastAssistantMessage}
-              variant="document"
-              className="text-[12px] leading-relaxed"
-            />
-          </AgentHoverSection>
-        )}
-        {!hasBodyDetails && (
-          <div className="text-xs text-muted-foreground">No agent details yet.</div>
-        )}
-      </div>
-    </ScrollArea>
+      <ScrollArea
+        className="min-h-0 max-h-[calc(min(70vh,520px)-2.5rem)] flex-1"
+        viewportClassName="max-h-[calc(min(70vh,520px)-2.5rem)]"
+        type="auto"
+        scrollbars="both"
+      >
+        <div className="min-w-full space-y-3 px-3 py-3 [&_pre]:max-w-none [&_table]:min-w-max">
+          {prompt && (
+            <AgentHoverSection
+              title="Prompt"
+              copyLabel="Copy prompt"
+              copied={copiedSection === 'prompt'}
+              onCopy={copySectionText('prompt', prompt)}
+            >
+              <CommentMarkdown
+                content={prompt}
+                variant="document"
+                className="text-[12px] leading-relaxed"
+              />
+            </AgentHoverSection>
+          )}
+          {hasToolDetails && (
+            <AgentHoverSection title="Current tool">
+              <div className="space-y-1.5">
+                {toolName && (
+                  <code className="rounded bg-accent px-1.5 py-0.5 font-mono text-[11px] text-accent-foreground">
+                    {toolName}
+                  </code>
+                )}
+                {toolInput && (
+                  <pre className="whitespace-pre rounded-md bg-accent p-2 font-mono text-[11px] leading-snug text-accent-foreground">
+                    {toolInput}
+                  </pre>
+                )}
+              </div>
+            </AgentHoverSection>
+          )}
+          {lastAssistantMessage && (
+            <AgentHoverSection
+              title="Latest message"
+              copyLabel="Copy latest message"
+              copied={copiedSection === 'latest'}
+              onCopy={copySectionText('latest', lastAssistantMessage)}
+            >
+              <CommentMarkdown
+                content={lastAssistantMessage}
+                variant="document"
+                className="text-[12px] leading-relaxed"
+              />
+            </AgentHoverSection>
+          )}
+          {!hasBodyDetails && (
+            <div className="text-xs text-muted-foreground">No agent details yet.</div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
   )
 }

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -117,6 +117,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   hideExpand = false
 }: Props) {
   const [expanded, setExpanded] = useState(false)
+  const [hoverCardOpen, setHoverCardOpen] = useState(false)
   // Why: stop propagation so clicking the X doesn't also fire the worktree
   // card's click handler (which navigates away from the dashboard).
   const handleDismiss = useCallback(
@@ -159,6 +160,14 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
     },
     [onActivate, agent.tab.id, agent.paneKey]
   )
+  const handleHoverCardActivate = useCallback(
+    (e: React.SyntheticEvent) => {
+      e.stopPropagation()
+      setHoverCardOpen(false)
+      onActivate(agent.tab.id, agent.paneKey)
+    },
+    [onActivate, agent.tab.id, agent.paneKey]
+  )
   const startedAt = agent.startedAt > 0 ? agent.startedAt : null
   const doneAt = lastEnteredDoneAt(agent)
   const prompt = agent.entry.prompt.trim()
@@ -193,6 +202,12 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   if (doneAt !== null) {
     tsParts.push(`done ${formatTimeAgo(doneAt, now)}`)
   }
+  const headerTimestamp =
+    doneAt !== null
+      ? formatTimeAgo(doneAt, now)
+      : startedAt !== null
+        ? formatTimeAgo(startedAt, now)
+        : null
 
   const row = (
     // Why: NOT role="button" / tabIndex={0}. The row contains real <button>
@@ -469,7 +484,12 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   )
 
   return (
-    <HoverCard openDelay={250} closeDelay={120}>
+    <HoverCard
+      open={hoverCardOpen}
+      onOpenChange={setHoverCardOpen}
+      openDelay={250}
+      closeDelay={120}
+    >
       <HoverCardTrigger asChild>{row}</HoverCardTrigger>
       <HoverCardContent
         side="right"
@@ -485,7 +505,8 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
           toolName={toolName}
           toolInput={toolInput}
           lastAssistantMessage={lastAssistantMessage}
-          tsParts={tsParts}
+          headerTimestamp={headerTimestamp}
+          onActivate={handleHoverCardActivate}
         />
       </HoverCardContent>
     </HoverCard>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -39,6 +39,7 @@ import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedSc
 import { getLineageRenderInfo } from './worktree-list-groups'
 import { getWorkspaceStatus, getWorkspaceStatusVisualMeta } from './workspace-status'
 import { WorktreeOpenInSubMenu } from './WorktreeOpenInMenu'
+import { WORKTREE_CONTEXT_MENU_SCOPE_ATTR } from './worktree-context-menu-scope'
 
 type Props = {
   worktree: Worktree
@@ -50,7 +51,6 @@ type Props = {
 }
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
-const WORKTREE_CONTEXT_MENU_SCOPE_ATTR = 'data-worktree-context-menu-scope'
 const CONTEXT_MENU_CLICK_SUPPRESSION_MS = 500
 
 function shouldIgnoreNestedWorktreeContextMenuScope(

--- a/src/renderer/src/components/sidebar/worktree-context-menu-scope.ts
+++ b/src/renderer/src/components/sidebar/worktree-context-menu-scope.ts
@@ -1,0 +1,1 @@
+export const WORKTREE_CONTEXT_MENU_SCOPE_ATTR = 'data-worktree-context-menu-scope'

--- a/src/renderer/src/components/ui/scroll-area.tsx
+++ b/src/renderer/src/components/ui/scroll-area.tsx
@@ -8,6 +8,7 @@ function ScrollArea({
   viewportClassName,
   viewportRef,
   viewportTabIndex,
+  scrollbars = 'vertical',
   children,
   ...props
 }: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
@@ -15,6 +16,7 @@ function ScrollArea({
   viewportRef?: React.Ref<HTMLDivElement>
   /** Set e.g. -1 so the viewport can receive programmatic focus (explorer keyboard shortcuts after inline rename). */
   viewportTabIndex?: number
+  scrollbars?: 'vertical' | 'horizontal' | 'both'
 }) {
   return (
     <ScrollAreaPrimitive.Root
@@ -33,7 +35,10 @@ function ScrollArea({
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
-      <ScrollBar />
+      {(scrollbars === 'vertical' || scrollbars === 'both') && <ScrollBar />}
+      {(scrollbars === 'horizontal' || scrollbars === 'both') && (
+        <ScrollBar orientation="horizontal" />
+      )}
       <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
   )


### PR DESCRIPTION
## Summary
- refine dashboard agent hovercard header, jump affordance, copy actions, and scrolling
- preserve native text/link context menus from hovercard markdown
- add two-axis scroll support for the shared ScrollArea primitive

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.test.tsx src/main/window/editable-context-menu.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/dashboard/DashboardAgentHoverCardContent.tsx src/renderer/src/components/dashboard/DashboardAgentRow.tsx src/renderer/src/components/ui/scroll-area.tsx