### PR TITLE
Improve workspace port visibility

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -57,6 +57,7 @@ import {
 } from './components/floating-terminal/FloatingTerminalPanel'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { DictationController } from './components/dictation/DictationController'
+import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
 import RecentTabSwitcher from './components/tab-bar/RecentTabSwitcher'
@@ -1121,16 +1122,6 @@ function App(): React.JSX.Element {
         e.preventDefault()
         actions.setRightSidebarTab('source-control')
         actions.setRightSidebarOpen(true)
-        return
-      }
-
-      // Cmd+Shift+I — toggle right sidebar / ports tab (macOS only).
-      // Why: Ctrl+Shift+I is the built-in DevTools accelerator on Windows/Linux;
-      // intercepting it would break an essential developer tool.
-      if (isMac && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'i') {
-        e.preventDefault()
-        actions.setRightSidebarTab('ports')
-        actions.setRightSidebarOpen(true)
       }
     }
 
@@ -1358,6 +1349,7 @@ function App(): React.JSX.Element {
     >
       <TooltipProvider delayDuration={400}>
         <ConfirmationDialogProvider>
+          <WorkspacePortScanner />
           {/* Why: leaf-mounted retention sync keeps agent-status retention
             subscriptions from re-rendering the App tree. */}
           <RetainedAgentsSyncGate />

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -28,6 +28,7 @@ import {
   type MatchRange,
   type PaletteSearchResult
 } from '@/lib/worktree-palette-search'
+import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import {
   isBlankBrowserUrl,
   searchBrowserPages,
@@ -169,6 +170,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
+  const workspacePortScan = useAppStore((s) => s.workspacePortScan?.result ?? null)
 
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
@@ -302,8 +304,16 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   )
 
   const worktreeMatches = useMemo(
-    () => searchWorktrees(sortedWorktrees, deferredQuery.trim(), repoMap, prCache, issueCache),
-    [sortedWorktrees, deferredQuery, repoMap, prCache, issueCache]
+    () =>
+      searchWorktrees(
+        sortedWorktrees,
+        deferredQuery.trim(),
+        repoMap,
+        prCache,
+        issueCache,
+        getWorkspacePortsByWorktreeId(workspacePortScan)
+      ),
+    [sortedWorktrees, deferredQuery, repoMap, prCache, issueCache, workspacePortScan]
   )
 
   const browserPageEntries = useMemo<SearchableBrowserPage[]>(() => {
@@ -796,7 +806,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     if ((hasAnyWorktrees || hasAnyBrowserPages) && hasQuery) {
       return {
         title: 'No results match your search',
-        subtitle: 'Try a name, branch, repo, comment, PR, page title, or URL.'
+        subtitle: 'Try a name, branch, repo, port, comment, PR, page title, or URL.'
       }
     }
     // Why: empty-query rows exclude the current worktree, so a single-worktree

--- a/src/renderer/src/components/ports/WorkspacePortScanner.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useAppStore } from '@/store'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import {
+  scanWorkspacePortsForTarget,
+  workspacePortRuntimeTargetKey
+} from '@/lib/workspace-port-actions'
+import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
+
+const WORKSPACE_PORT_SCAN_INTERVAL_MS = 5_000
+
+function makeUnavailableScan(reason: string): WorkspacePortScanResult {
+  return {
+    platform: 'unknown',
+    scannedAt: Date.now(),
+    ports: [],
+    unavailableReason: reason
+  }
+}
+
+export function WorkspacePortScanner(): null {
+  const settings = useAppStore((s) => s.settings)
+  const hasWorktrees = useAppStore((s) =>
+    Object.values(s.worktreesByRepo).some((worktrees) => worktrees.length > 0)
+  )
+  const setWorkspacePortScan = useAppStore((s) => s.setWorkspacePortScan)
+  const setWorkspacePortScanRefreshing = useAppStore((s) => s.setWorkspacePortScanRefreshing)
+  const inFlightRef = useRef<Promise<void> | null>(null)
+  const generationRef = useRef(0)
+
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const scanKey = `${workspacePortRuntimeTargetKey(runtimeTarget)}:all`
+
+  const refresh = useCallback(() => {
+    if (!hasWorktrees) {
+      setWorkspacePortScan(null)
+      setWorkspacePortScanRefreshing(false)
+      return Promise.resolve()
+    }
+    if (inFlightRef.current) {
+      return inFlightRef.current
+    }
+
+    const generation = generationRef.current
+    setWorkspacePortScanRefreshing(true)
+    const promise = scanWorkspacePortsForTarget(runtimeTarget)
+      .then((result) => {
+        if (generation === generationRef.current) {
+          setWorkspacePortScan({ key: scanKey, result })
+        }
+      })
+      .catch((error) => {
+        if (generation !== generationRef.current) {
+          return
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        setWorkspacePortScan({
+          key: scanKey,
+          result: makeUnavailableScan(message || 'Workspace port scan failed.')
+        })
+      })
+      .finally(() => {
+        if (inFlightRef.current === promise) {
+          inFlightRef.current = null
+        }
+        if (generation === generationRef.current) {
+          setWorkspacePortScanRefreshing(false)
+        }
+      })
+    inFlightRef.current = promise
+    return promise
+  }, [hasWorktrees, runtimeTarget, scanKey, setWorkspacePortScan, setWorkspacePortScanRefreshing])
+
+  useEffect(() => {
+    let cancelled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    generationRef.current += 1
+    setWorkspacePortScan(null)
+
+    const run = async (): Promise<void> => {
+      try {
+        if (document.visibilityState === 'visible') {
+          await refresh()
+        }
+      } finally {
+        if (!cancelled) {
+          timeout = setTimeout(() => void run(), WORKSPACE_PORT_SCAN_INTERVAL_MS)
+        }
+      }
+    }
+
+    void run()
+
+    const refreshWhenVisible = (): void => {
+      if (document.visibilityState === 'visible' && document.hasFocus()) {
+        void refresh()
+      }
+    }
+    window.addEventListener('focus', refreshWhenVisible)
+    document.addEventListener('visibilitychange', refreshWhenVisible)
+
+    return () => {
+      cancelled = true
+      generationRef.current += 1
+      inFlightRef.current = null
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      window.removeEventListener('focus', refreshWhenVisible)
+      document.removeEventListener('visibilitychange', refreshWhenVisible)
+    }
+  }, [refresh, setWorkspacePortScan])
+
+  return null
+}

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -18,13 +18,14 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
-  callRuntimeRpc,
-  getActiveRuntimeTarget,
-  RuntimeRpcCallError,
-  type RuntimeClientTarget
-} from '@/runtime/runtime-rpc-client'
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+  addressForPort,
+  killWorkspacePortForTarget,
+  openWorkspacePortInBrowser,
+  scanWorkspacePortsForTarget,
+  workspacePortRuntimeTargetKey
+} from '@/lib/workspace-port-actions'
 import {
   Dialog,
   DialogContent,
@@ -43,11 +44,14 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import type { PortForwardEntry, DetectedPort } from '../../../../shared/ssh-types'
-import type {
-  WorkspacePort,
-  WorkspacePortKillResult,
-  WorkspacePortScanResult
-} from '../../../../shared/workspace-ports'
+import type { WorkspacePort, WorkspacePortScanResult } from '../../../../shared/workspace-ports'
+
+export {
+  browserUrlForPort,
+  killWorkspacePortForTarget,
+  openWorkspacePortInBrowser,
+  scanWorkspacePortsForTarget
+} from '@/lib/workspace-port-actions'
 
 const LOCAL_PORT_SCAN_INTERVAL_MS = 5_000
 const LOCAL_PORT_MENU_CONTENT_CLASS =
@@ -67,127 +71,14 @@ function safeLocalPort(remotePort: number): number {
 
 const HTTPS_PORTS = new Set([443, 8443])
 
-// Why: the scanner reports numeric addresses (127.0.0.1, 0.0.0.0, ::1, ::)
-// while forwards typically use "localhost". Normalize all loopback/wildcard
-// variants to "localhost" so dedup matching works regardless of representation.
+// Why: forwarded SSH ports and detected remote ports may report the same loopback
+// endpoint using different textual hosts. Normalize for deduping only.
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', '::'])
 function normalizeHost(host: string | undefined): string {
   if (!host || LOOPBACK_HOSTS.has(host)) {
     return 'localhost'
   }
   return host
-}
-
-function hostForLocalAction(host: string): string {
-  if (!host) {
-    return 'localhost'
-  }
-  return host.includes(':') ? `[${host}]` : host
-}
-
-function addressForPort(port: WorkspacePort): string {
-  return `${hostForLocalAction(port.connectHost)}:${port.port}`
-}
-
-export function browserUrlForPort(port: WorkspacePort): string {
-  const protocol = port.protocol === 'https' ? 'https' : 'http'
-  return `${protocol}://${addressForPort(port)}`
-}
-
-type BrowserTabCreator = ReturnType<typeof useAppStore.getState>['createBrowserTab']
-type RemoteBrowserPageHandleSetter = ReturnType<
-  typeof useAppStore.getState
->['setRemoteBrowserPageHandle']
-
-export async function openWorkspacePortInBrowser(args: {
-  port: WorkspacePort
-  activeWorktreeId?: string | null
-  runtimeTarget: RuntimeClientTarget
-  createBrowserTab: BrowserTabCreator
-  setRemoteBrowserPageHandle: RemoteBrowserPageHandleSetter
-}): Promise<{ ok: true } | { ok: false; reason: string }> {
-  const worktreeId =
-    args.port.kind === 'workspace' ? args.port.owner.worktreeId : args.activeWorktreeId
-  if (!worktreeId) {
-    return { ok: false, reason: 'No workspace selected for the browser.' }
-  }
-  const url = browserUrlForPort(args.port)
-  activateAndRevealWorktree(worktreeId)
-  if (args.runtimeTarget.kind === 'environment') {
-    try {
-      const remotePage = await callRuntimeRpc<{ browserPageId: string }>(
-        args.runtimeTarget,
-        'browser.tabCreate',
-        { worktree: `id:${worktreeId}`, url },
-        { timeoutMs: 30_000 }
-      )
-      const tab = args.createBrowserTab(worktreeId, url, { activate: true })
-      if (!tab.activePageId) {
-        return { ok: false, reason: 'Failed to create a browser page.' }
-      }
-      args.setRemoteBrowserPageHandle(tab.activePageId, {
-        environmentId: args.runtimeTarget.environmentId,
-        remotePageId: remotePage.browserPageId
-      })
-      return { ok: true }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      return { ok: false, reason: message || 'Failed to open remote browser.' }
-    }
-  }
-  args.createBrowserTab(worktreeId, url, { activate: true })
-  return { ok: true }
-}
-
-function runtimeTargetKey(target: RuntimeClientTarget): string {
-  return target.kind === 'local' ? 'local' : `environment:${target.environmentId}`
-}
-
-export async function scanWorkspacePortsForTarget(
-  target: RuntimeClientTarget,
-  repoId: string
-): Promise<WorkspacePortScanResult> {
-  const params = { repoId }
-  if (target.kind === 'local') {
-    return window.api.workspacePorts.scan(params)
-  }
-  try {
-    return await callRuntimeRpc<WorkspacePortScanResult>(target, 'workspacePorts.scan', params, {
-      timeoutMs: 15_000
-    })
-  } catch (error) {
-    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
-      return {
-        platform: 'unknown',
-        scannedAt: Date.now(),
-        ports: [],
-        unavailableReason: 'The connected runtime does not support workspace port management yet.'
-      }
-    }
-    throw error
-  }
-}
-
-export async function killWorkspacePortForTarget(
-  target: RuntimeClientTarget,
-  args: { repoId: string; pid: number; port: number }
-): Promise<WorkspacePortKillResult> {
-  if (target.kind === 'local') {
-    return window.api.workspacePorts.kill(args)
-  }
-  try {
-    return await callRuntimeRpc<WorkspacePortKillResult>(target, 'workspacePorts.kill', args, {
-      timeoutMs: 15_000
-    })
-  } catch (error) {
-    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
-      return {
-        ok: false,
-        reason: 'The connected runtime does not support workspace port management yet.'
-      }
-    }
-    throw error
-  }
 }
 
 type PortForwardDialogState =
@@ -227,7 +118,7 @@ function LocalWorkspacePortsPanel({ isVisible }: { isVisible: boolean }): React.
   const scanGenerationRef = useRef(0)
 
   const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
-  const scanKey = `${runtimeTargetKey(runtimeTarget)}:${activeRepo?.id ?? ''}`
+  const scanKey = `${workspacePortRuntimeTargetKey(runtimeTarget)}:${activeRepo?.id ?? ''}`
 
   const refresh = useCallback(() => {
     if (!activeRepo) {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Files, Search, GitBranch, ListChecks, Cable, PanelRight } from 'lucide-react'
+import { Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { getRepoMapFromState, useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
@@ -21,7 +21,6 @@ import FileExplorer from './FileExplorer'
 import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
-import PortsPanel from './PortsPanel'
 import { getTopActivityBarLayout } from './activity-bar-overflow'
 import {
   ActivityBarButton,
@@ -94,14 +93,6 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
     title: 'Checks',
     shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}K`,
     gitOnly: true
-  },
-  {
-    id: 'ports',
-    icon: Cable,
-    title: 'Ports',
-    // Why: Ctrl+Shift+I is the DevTools accelerator on Windows/Linux, so this
-    // shortcut is macOS-only. On other platforms the tooltip omits it.
-    shortcut: isMac ? `\u21E7${mod}I` : ''
   }
 ]
 
@@ -170,7 +161,6 @@ function RightSidebarInner(): React.JSX.Element {
         {effectiveTab === 'search' && <SearchPanel />}
         {effectiveTab === 'source-control' && <SourceControl />}
         {effectiveTab === 'checks' && <ChecksPanel />}
-        {effectiveTab === 'ports' && <PortsPanel isVisible={rightSidebarOpen} />}
       </div>
     </div>
   )

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -96,6 +96,14 @@ const STATUS_BAR_TOGGLES: readonly {
     keywords: ['status bar', 'resource', 'manager', 'memory', 'cpu', 'terminal', 'disk', 'space'],
     toggleDescription:
       'Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.'
+  },
+  {
+    id: 'ports',
+    title: 'Ports',
+    description: 'Show live workspace ports in the status bar.',
+    keywords: ['status bar', 'ports', 'localhost', 'server', 'workspace'],
+    toggleDescription:
+      'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
   }
 ]
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -31,8 +31,10 @@ import {
   WorktreeCardMetaBadges,
   hasWorktreeCardDetails
 } from './WorktreeCardMeta'
+import { WorktreeCardPorts } from './WorktreeCardPorts'
 import { writeWorkspaceDragData } from './workspace-status'
 import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
+import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 
 type WorktreeCardProps = {
   worktree: Worktree
@@ -51,6 +53,8 @@ type WorktreeCardProps = {
   onContextMenuSelect?: (event: React.MouseEvent<HTMLElement>) => readonly Worktree[]
   nativeDragEnabled?: boolean
 }
+
+const EMPTY_WORKSPACE_PORTS = []
 
 function formatSparseDirectoryPreview(directories: string[]): string {
   const preview = directories.slice(0, 4).join(', ')
@@ -118,6 +122,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
   const conflictOperation = useAppStore((s) => s.gitConflictOperationByWorktree[worktree.id])
   const remoteBranchConflict = useAppStore((s) => s.remoteBranchConflictByWorktreeId[worktree.id])
+  const workspacePorts = useAppStore(
+    (s) =>
+      getWorkspacePortsByWorktreeId(s.workspacePortScan?.result).get(worktree.id) ??
+      EMPTY_WORKSPACE_PORTS
+  )
 
   // SSH disconnected state
   const sshStatus = useAppStore((s) => {
@@ -587,30 +596,35 @@ const WorktreeCard = React.memo(function WorktreeCard({
             <CacheTimer worktreeId={worktree.id} />
           </div>
 
-          {hasDetails ? (
-            <WorktreeCardDetailsHover
-              issue={metaIssue}
-              linearIssue={metaLinearIssue}
-              review={metaReview}
-              comment={metaComment}
-              onEditIssue={handleEditIssue}
-              onEditComment={handleEditComment}
-            >
+          <div className="ml-auto flex shrink-0 items-center gap-1 pr-1.5">
+            {hasDetails ? (
+              <WorktreeCardDetailsHover
+                issue={metaIssue}
+                linearIssue={metaLinearIssue}
+                review={metaReview}
+                comment={metaComment}
+                onEditIssue={handleEditIssue}
+                onEditComment={handleEditComment}
+              >
+                <WorktreeCardMetaBadges
+                  issue={metaIssue}
+                  linearIssue={metaLinearIssue}
+                  review={metaReview}
+                  comment={metaComment}
+                  className="ml-0 pr-0"
+                />
+              </WorktreeCardDetailsHover>
+            ) : (
               <WorktreeCardMetaBadges
                 issue={metaIssue}
                 linearIssue={metaLinearIssue}
                 review={metaReview}
                 comment={metaComment}
+                className="ml-0 pr-0"
               />
-            </WorktreeCardDetailsHover>
-          ) : (
-            <WorktreeCardMetaBadges
-              issue={metaIssue}
-              linearIssue={metaLinearIssue}
-              review={metaReview}
-              comment={metaComment}
-            />
-          )}
+            )}
+            <WorktreeCardPorts ports={workspacePorts} />
+          </div>
         </div>
 
         {remoteBranchConflict && (

--- a/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
@@ -1,0 +1,186 @@
+import React, { useCallback, useMemo } from 'react'
+import { Cable, Copy, ExternalLink, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import {
+  addressForPort,
+  canStopWorkspacePort,
+  killWorkspacePortForTarget,
+  openWorkspacePortInBrowser,
+  scanWorkspacePortsForTarget,
+  workspacePortRuntimeTargetKey
+} from '@/lib/workspace-port-actions'
+import type { WorkspacePort } from '../../../../shared/workspace-ports'
+
+type WorktreeCardPortsProps = {
+  ports: WorkspacePort[]
+}
+
+function PortAction({
+  label,
+  onClick,
+  children
+}: {
+  label: string
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="size-6 text-muted-foreground hover:text-foreground"
+          aria-label={label}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const createBrowserTab = useAppStore((s) => s.createBrowserTab)
+  const setRemoteBrowserPageHandle = useAppStore((s) => s.setRemoteBrowserPageHandle)
+  const setWorkspacePortScan = useAppStore((s) => s.setWorkspacePortScan)
+  const setWorkspacePortScanRefreshing = useAppStore((s) => s.setWorkspacePortScanRefreshing)
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
+  const canStop = canStopWorkspacePort(port)
+
+  const handleOpen = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      void openWorkspacePortInBrowser({
+        port,
+        runtimeTarget,
+        createBrowserTab,
+        setRemoteBrowserPageHandle
+      }).then((result) => {
+        if (!result.ok) {
+          toast.error('Failed to open browser', { description: result.reason })
+        }
+      })
+    },
+    [createBrowserTab, port, runtimeTarget, setRemoteBrowserPageHandle]
+  )
+
+  const handleCopy = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      void window.api.ui.writeClipboardText(addressForPort(port))
+      toast.success(`Copied :${port.port}`)
+    },
+    [port]
+  )
+
+  const handleStop = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      if (!canStopWorkspacePort(port)) {
+        return
+      }
+      const run = async (): Promise<void> => {
+        const result = await killWorkspacePortForTarget(runtimeTarget, {
+          repoId: port.owner.repoId,
+          pid: port.pid,
+          port: port.port
+        })
+        if (!result.ok) {
+          toast.error(result.reason)
+          return
+        }
+        toast.success(`Stopped process on :${port.port}`)
+        setWorkspacePortScanRefreshing(true)
+        try {
+          const scan = await scanWorkspacePortsForTarget(runtimeTarget)
+          setWorkspacePortScan({
+            key: `${workspacePortRuntimeTargetKey(runtimeTarget)}:all`,
+            result: scan
+          })
+        } finally {
+          setWorkspacePortScanRefreshing(false)
+        }
+      }
+      void run()
+    },
+    [port, runtimeTarget, setWorkspacePortScan, setWorkspacePortScanRefreshing]
+  )
+
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 hover:bg-accent/50">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="shrink-0 font-mono text-[12px] font-semibold text-foreground">
+          :{port.port}
+        </span>
+        <span className="truncate text-[11px] text-muted-foreground">{processLabel}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5">
+        <PortAction label="Open in Orca Browser" onClick={handleOpen}>
+          <ExternalLink className="size-3" />
+        </PortAction>
+        <PortAction label={`Copy ${addressForPort(port)}`} onClick={handleCopy}>
+          <Copy className="size-3" />
+        </PortAction>
+        {canStop && (
+          <PortAction label="Stop Process" onClick={handleStop}>
+            <Trash2 className="size-3" />
+          </PortAction>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function WorktreeCardPorts({ ports }: WorktreeCardPortsProps): React.JSX.Element | null {
+  if (ports.length === 0) {
+    return null
+  }
+
+  return (
+    <HoverCard openDelay={250} closeDelay={120}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-3.5 shrink-0 items-center justify-center rounded text-muted-foreground/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+          aria-label={`${ports.length} live ${ports.length === 1 ? 'port' : 'ports'}`}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Cable className="size-3.5" />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="w-72 p-2 text-xs"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-1.5 flex items-center gap-1.5 px-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+          <Cable className="size-3" />
+          <span>Live Ports</span>
+          <span className="ml-auto font-normal tabular-nums text-muted-foreground/70">
+            {ports.length}
+          </span>
+        </div>
+        <div className="space-y-0.5">
+          {ports.map((port) => (
+            <WorktreePortRow key={port.id} port={port} />
+          ))}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}

--- a/src/renderer/src/components/status-bar/PortsStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/PortsStatusSegment.tsx
@@ -1,0 +1,329 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import {
+  Cable,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  LoaderCircle,
+  Trash2
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
+import { useAppStore } from '@/store'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import {
+  addressForPort,
+  canStopWorkspacePort,
+  killWorkspacePortForTarget,
+  openWorkspacePortInBrowser,
+  scanWorkspacePortsForTarget,
+  workspacePortRuntimeTargetKey
+} from '@/lib/workspace-port-actions'
+import {
+  getExternalWorkspacePorts,
+  getWorkspacePortGroups,
+  type WorkspacePortGroup
+} from '@/lib/workspace-port-groups'
+import { STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS } from './status-bar-context-menu-policy'
+import type { WorkspacePort } from '../../../../shared/workspace-ports'
+
+type PortsStatusSegmentProps = {
+  compact?: boolean
+  iconOnly: boolean
+}
+
+function PortAction({
+  label,
+  onClick,
+  disabled,
+  children
+}: {
+  label: string
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+  disabled?: boolean
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <Tooltip delayDuration={200}>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="size-6 text-muted-foreground hover:text-foreground"
+          aria-label={label}
+          onClick={onClick}
+          disabled={disabled}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function PortRow({
+  port,
+  activeWorktreeId,
+  external
+}: {
+  port: WorkspacePort
+  activeWorktreeId: string | null
+  external?: boolean
+}): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const createBrowserTab = useAppStore((s) => s.createBrowserTab)
+  const setRemoteBrowserPageHandle = useAppStore((s) => s.setRemoteBrowserPageHandle)
+  const setWorkspacePortScan = useAppStore((s) => s.setWorkspacePortScan)
+  const setWorkspacePortScanRefreshing = useAppStore((s) => s.setWorkspacePortScanRefreshing)
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
+  const canOpen = port.kind === 'workspace' || Boolean(activeWorktreeId)
+  const canStop = canStopWorkspacePort(port)
+
+  const handleOpen = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      void openWorkspacePortInBrowser({
+        port,
+        activeWorktreeId,
+        runtimeTarget,
+        createBrowserTab,
+        setRemoteBrowserPageHandle
+      }).then((result) => {
+        if (!result.ok) {
+          toast.error('Failed to open browser', { description: result.reason })
+        }
+      })
+    },
+    [activeWorktreeId, createBrowserTab, port, runtimeTarget, setRemoteBrowserPageHandle]
+  )
+
+  const handleCopy = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      void window.api.ui.writeClipboardText(addressForPort(port))
+      toast.success(`Copied :${port.port}`)
+    },
+    [port]
+  )
+
+  const handleStop = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      if (!canStopWorkspacePort(port)) {
+        return
+      }
+      const run = async (): Promise<void> => {
+        const result = await killWorkspacePortForTarget(runtimeTarget, {
+          repoId: port.owner.repoId,
+          pid: port.pid,
+          port: port.port
+        })
+        if (!result.ok) {
+          toast.error(result.reason)
+          return
+        }
+        toast.success(`Stopped process on :${port.port}`)
+        setWorkspacePortScanRefreshing(true)
+        try {
+          const scan = await scanWorkspacePortsForTarget(runtimeTarget)
+          setWorkspacePortScan({
+            key: `${workspacePortRuntimeTargetKey(runtimeTarget)}:all`,
+            result: scan
+          })
+        } finally {
+          setWorkspacePortScanRefreshing(false)
+        }
+      }
+      void run()
+    },
+    [port, runtimeTarget, setWorkspacePortScan, setWorkspacePortScanRefreshing]
+  )
+
+  return (
+    <div className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/50">
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="font-mono text-[12px] font-semibold text-foreground">:{port.port}</span>
+          <span className="truncate text-[11px] text-muted-foreground">{processLabel}</span>
+        </div>
+        <div className="truncate text-[10px] text-muted-foreground/70">
+          {external ? port.kind : addressForPort(port)}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5">
+        <PortAction label="Open in Orca Browser" onClick={handleOpen} disabled={!canOpen}>
+          <ExternalLink className="size-3" />
+        </PortAction>
+        <PortAction label={`Copy ${addressForPort(port)}`} onClick={handleCopy}>
+          <Copy className="size-3" />
+        </PortAction>
+        {canStop && (
+          <PortAction label="Stop Process" onClick={handleStop}>
+            <Trash2 className="size-3" />
+          </PortAction>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function WorkspaceGroupRows({
+  group,
+  activeWorktreeId
+}: {
+  group: WorkspacePortGroup
+  activeWorktreeId: string | null
+}): React.JSX.Element {
+  return (
+    <section className="border-t border-border/40 first:border-t-0">
+      <div className="flex items-center justify-between gap-2 px-3 py-2">
+        <span className="min-w-0 truncate text-[12px] font-medium text-foreground">
+          {group.displayName}
+        </span>
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
+          {group.ports.length}
+        </span>
+      </div>
+      <div className="px-1 pb-1">
+        {group.ports.map((port) => (
+          <PortRow key={port.id} port={port} activeWorktreeId={activeWorktreeId} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function PortsStatusSegment({ iconOnly }: PortsStatusSegmentProps): React.JSX.Element {
+  const scan = useAppStore((s) => s.workspacePortScan?.result ?? null)
+  const refreshing = useAppStore((s) => s.workspacePortScanRefreshing)
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const [open, setOpen] = useState(false)
+  const [externalOpen, setExternalOpen] = useState(false)
+
+  const workspaceGroups = useMemo(() => getWorkspacePortGroups(scan), [scan])
+  const externalPorts = useMemo(() => getExternalWorkspacePorts(scan), [scan])
+  const workspacePortCount = workspaceGroups.reduce((count, group) => count + group.ports.length, 0)
+  const totalCount = workspacePortCount + externalPorts.length
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              {...STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 hover:bg-accent/70"
+              aria-label={`Ports, ${workspacePortCount} workspace ${workspacePortCount === 1 ? 'port' : 'ports'}`}
+            >
+              {refreshing ? (
+                <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
+              ) : (
+                <Cable className="size-3 text-muted-foreground" />
+              )}
+              {!iconOnly && (
+                <span className="text-[11px] font-medium tabular-nums text-muted-foreground">
+                  {workspacePortCount}
+                </span>
+              )}
+              {iconOnly && totalCount > 0 && (
+                <span className="text-[11px] tabular-nums text-muted-foreground">
+                  {workspacePortCount}
+                </span>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          Ports — {workspacePortCount} workspace
+          {workspacePortCount === 1 ? ' port' : ' ports'}
+          {externalPorts.length > 0 ? ` · ${externalPorts.length} external` : ''}
+        </TooltipContent>
+      </Tooltip>
+
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={8}
+        {...STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS}
+        className="w-[24rem] max-w-[calc(100vw-2rem)] p-0"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
+          <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-foreground">
+            <Cable className="size-3 shrink-0 text-muted-foreground" />
+            <span className="truncate">Ports</span>
+          </div>
+          <span className="text-[11px] tabular-nums text-muted-foreground">
+            {workspacePortCount} workspace · {externalPorts.length} external
+          </span>
+        </div>
+
+        {scan?.unavailableReason ? (
+          <div className="px-3 py-3 text-xs text-muted-foreground">
+            Port scan unavailable on {scan.platform}: {scan.unavailableReason}
+          </div>
+        ) : (
+          <div className="max-h-[28rem] overflow-y-auto scrollbar-sleek">
+            {workspaceGroups.length > 0 ? (
+              workspaceGroups.map((group) => (
+                <WorkspaceGroupRows
+                  key={group.worktreeId}
+                  group={group}
+                  activeWorktreeId={activeWorktreeId}
+                />
+              ))
+            ) : (
+              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                {refreshing ? 'Scanning for workspace ports...' : 'No workspace ports detected'}
+              </div>
+            )}
+
+            <section className="border-t border-border/60">
+              <button
+                type="button"
+                className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.05em] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                aria-expanded={externalOpen}
+                onClick={() => setExternalOpen((value) => !value)}
+              >
+                {externalOpen ? (
+                  <ChevronDown className="size-3" />
+                ) : (
+                  <ChevronRight className="size-3" />
+                )}
+                <span>External Ports</span>
+                <span className="ml-auto font-mono text-[10px]">{externalPorts.length}</span>
+              </button>
+              {externalOpen && (
+                <div className="px-1 pb-1">
+                  {externalPorts.length > 0 ? (
+                    externalPorts.map((port) => (
+                      <PortRow
+                        key={port.id}
+                        port={port}
+                        activeWorktreeId={activeWorktreeId}
+                        external
+                      />
+                    ))
+                  ) : (
+                    <div className="px-2 py-2 text-xs text-muted-foreground">
+                      No external ports detected
+                    </div>
+                  )}
+                </div>
+              )}
+            </section>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -4,6 +4,7 @@ states stay consistent across Claude and Codex. */
 import {
   AlertTriangle,
   Activity,
+  Cable,
   ChevronDown,
   ChevronRight,
   RefreshCw,
@@ -34,6 +35,7 @@ import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { SshStatusSegment } from './SshStatusSegment'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { ResourceUsageStatusSegment } from './ResourceUsageStatusSegment'
+import { PortsStatusSegment } from './PortsStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy'
 import { PetStatusSegment } from './PetStatusSegment'
@@ -818,6 +820,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showOpencodeGo = opencodeGo !== null && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
+  const showPorts = statusBarItems.includes('ports')
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   const anyVisible = showClaude || showCodex || showGemini || showOpencodeGo || showResourceUsage
@@ -899,6 +902,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         {petEnabled && <PetStatusSegment />}
         {showResourceUsage && <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />}
+        {showPorts && <PortsStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showSsh && <SshStatusSegment compact={compact} iconOnly={iconOnly} />}
         {showFloatingTerminalToggle && (
           <FloatingTerminalIconContextMenu currentLocation="status-bar" className="relative">
@@ -984,6 +988,13 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
           >
             <Activity className="size-3.5" />
             Resource Manager
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={statusBarItems.includes('ports')}
+            onCheckedChange={() => toggleStatusBarItem('ports')}
+          >
+            <Cable className="size-3.5" />
+            Ports
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -8,6 +8,7 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('ssh', null)).toBe(true)
     expect(isStatusBarItemAvailable('ssh', [])).toBe(true)
     expect(isStatusBarItemAvailable('resource-usage', [])).toBe(true)
+    expect(isStatusBarItemAvailable('ports', [])).toBe(true)
     expect(isStatusBarItemAvailable('opencode-go', [])).toBe(true)
   })
 

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -1,0 +1,132 @@
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import type { useAppStore } from '@/store'
+import {
+  callRuntimeRpc,
+  RuntimeRpcCallError,
+  type RuntimeClientTarget
+} from '@/runtime/runtime-rpc-client'
+import type {
+  WorkspacePort,
+  WorkspacePortKillResult,
+  WorkspacePortScanResult
+} from '../../../shared/workspace-ports'
+
+// Why: the scanner reports numeric addresses (127.0.0.1, 0.0.0.0, ::1, ::)
+// while UI actions should use an address a browser can reliably open.
+function hostForLocalAction(host: string): string {
+  if (!host) {
+    return 'localhost'
+  }
+  return host.includes(':') ? `[${host}]` : host
+}
+
+export function addressForPort(port: WorkspacePort): string {
+  return `${hostForLocalAction(port.connectHost)}:${port.port}`
+}
+
+export function browserUrlForPort(port: WorkspacePort): string {
+  const protocol = port.protocol === 'https' ? 'https' : 'http'
+  return `${protocol}://${addressForPort(port)}`
+}
+
+export function canStopWorkspacePort(
+  port: WorkspacePort
+): port is WorkspacePort & { kind: 'workspace'; pid: number } {
+  return port.kind === 'workspace' && Boolean(port.pid) && port.processName !== 'Electron'
+}
+
+type BrowserTabCreator = ReturnType<typeof useAppStore.getState>['createBrowserTab']
+type RemoteBrowserPageHandleSetter = ReturnType<
+  typeof useAppStore.getState
+>['setRemoteBrowserPageHandle']
+
+export async function openWorkspacePortInBrowser(args: {
+  port: WorkspacePort
+  activeWorktreeId?: string | null
+  runtimeTarget: RuntimeClientTarget
+  createBrowserTab: BrowserTabCreator
+  setRemoteBrowserPageHandle: RemoteBrowserPageHandleSetter
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const worktreeId =
+    args.port.kind === 'workspace' ? args.port.owner.worktreeId : args.activeWorktreeId
+  if (!worktreeId) {
+    return { ok: false, reason: 'No workspace selected for the browser.' }
+  }
+  const url = browserUrlForPort(args.port)
+  activateAndRevealWorktree(worktreeId)
+  if (args.runtimeTarget.kind === 'environment') {
+    try {
+      const remotePage = await callRuntimeRpc<{ browserPageId: string }>(
+        args.runtimeTarget,
+        'browser.tabCreate',
+        { worktree: `id:${worktreeId}`, url },
+        { timeoutMs: 30_000 }
+      )
+      const tab = args.createBrowserTab(worktreeId, url, { activate: true })
+      if (!tab.activePageId) {
+        return { ok: false, reason: 'Failed to create a browser page.' }
+      }
+      args.setRemoteBrowserPageHandle(tab.activePageId, {
+        environmentId: args.runtimeTarget.environmentId,
+        remotePageId: remotePage.browserPageId
+      })
+      return { ok: true }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return { ok: false, reason: message || 'Failed to open remote browser.' }
+    }
+  }
+  args.createBrowserTab(worktreeId, url, { activate: true })
+  return { ok: true }
+}
+
+export function workspacePortRuntimeTargetKey(target: RuntimeClientTarget): string {
+  return target.kind === 'local' ? 'local' : `environment:${target.environmentId}`
+}
+
+export async function scanWorkspacePortsForTarget(
+  target: RuntimeClientTarget,
+  repoId?: string
+): Promise<WorkspacePortScanResult> {
+  const params = repoId ? { repoId } : {}
+  if (target.kind === 'local') {
+    return window.api.workspacePorts.scan(params)
+  }
+  try {
+    return await callRuntimeRpc<WorkspacePortScanResult>(target, 'workspacePorts.scan', params, {
+      timeoutMs: 15_000
+    })
+  } catch (error) {
+    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
+      return {
+        platform: 'unknown',
+        scannedAt: Date.now(),
+        ports: [],
+        unavailableReason: 'The connected runtime does not support workspace port management yet.'
+      }
+    }
+    throw error
+  }
+}
+
+export async function killWorkspacePortForTarget(
+  target: RuntimeClientTarget,
+  args: { repoId: string; pid: number; port: number }
+): Promise<WorkspacePortKillResult> {
+  if (target.kind === 'local') {
+    return window.api.workspacePorts.kill(args)
+  }
+  try {
+    return await callRuntimeRpc<WorkspacePortKillResult>(target, 'workspacePorts.kill', args, {
+      timeoutMs: 15_000
+    })
+  } catch (error) {
+    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
+      return {
+        ok: false,
+        reason: 'The connected runtime does not support workspace port management yet.'
+      }
+    }
+    throw error
+  }
+}

--- a/src/renderer/src/lib/workspace-port-groups.ts
+++ b/src/renderer/src/lib/workspace-port-groups.ts
@@ -1,0 +1,101 @@
+import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+
+export type WorkspacePortGroup = {
+  worktreeId: string
+  repoId: string
+  displayName: string
+  ports: WorkspacePort[]
+}
+
+const portsByWorktreeCache = new WeakMap<WorkspacePortScanResult, Map<string, WorkspacePort[]>>()
+const workspaceGroupsCache = new WeakMap<WorkspacePortScanResult, WorkspacePortGroup[]>()
+const externalPortsCache = new WeakMap<WorkspacePortScanResult, WorkspacePort[]>()
+
+function comparePorts(a: WorkspacePort, b: WorkspacePort): number {
+  return a.port - b.port || (a.processName ?? '').localeCompare(b.processName ?? '')
+}
+
+export function getWorkspacePortsByWorktreeId(
+  scan: WorkspacePortScanResult | null | undefined
+): Map<string, WorkspacePort[]> {
+  if (scan) {
+    const cached = portsByWorktreeCache.get(scan)
+    if (cached) {
+      return cached
+    }
+  }
+  const grouped = new Map<string, WorkspacePort[]>()
+  for (const port of scan?.ports ?? []) {
+    if (port.kind !== 'workspace') {
+      continue
+    }
+    const current = grouped.get(port.owner.worktreeId)
+    if (current) {
+      current.push(port)
+    } else {
+      grouped.set(port.owner.worktreeId, [port])
+    }
+  }
+  for (const ports of grouped.values()) {
+    ports.sort(comparePorts)
+  }
+  if (scan) {
+    portsByWorktreeCache.set(scan, grouped)
+  }
+  return grouped
+}
+
+export function getWorkspacePortGroups(
+  scan: WorkspacePortScanResult | null | undefined
+): WorkspacePortGroup[] {
+  if (scan) {
+    const cached = workspaceGroupsCache.get(scan)
+    if (cached) {
+      return cached
+    }
+  }
+  const groupsByWorktreeId = new Map<string, WorkspacePortGroup>()
+  for (const port of scan?.ports ?? []) {
+    if (port.kind !== 'workspace') {
+      continue
+    }
+    const current = groupsByWorktreeId.get(port.owner.worktreeId)
+    if (current) {
+      current.ports.push(port)
+    } else {
+      groupsByWorktreeId.set(port.owner.worktreeId, {
+        worktreeId: port.owner.worktreeId,
+        repoId: port.owner.repoId,
+        displayName: port.owner.displayName,
+        ports: [port]
+      })
+    }
+  }
+  const groups = [...groupsByWorktreeId.values()]
+    .map((group) => ({ ...group, ports: [...group.ports].sort(comparePorts) }))
+    .sort(
+      (a, b) =>
+        a.displayName.localeCompare(b.displayName) ||
+        (a.ports[0]?.port ?? 0) - (b.ports[0]?.port ?? 0)
+    )
+  if (scan) {
+    workspaceGroupsCache.set(scan, groups)
+  }
+  return groups
+}
+
+export function getExternalWorkspacePorts(
+  scan: WorkspacePortScanResult | null | undefined
+): WorkspacePort[] {
+  if (scan) {
+    const cached = externalPortsCache.get(scan)
+    if (cached) {
+      return cached
+    }
+  }
+  const ports = (scan?.ports ?? []).filter((port) => port.kind !== 'workspace').sort(comparePorts)
+  if (scan) {
+    externalPortsCache.set(scan, ports)
+  }
+  return ports
+}

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -187,4 +187,33 @@ describe('worktree-palette-search', () => {
       matchRange: { start: 7, end: 10 }
     })
   })
+
+  it('matches workspace ports by port number before issue and PR numbers', () => {
+    const results = searchWorktrees(
+      [makeWorktree({ id: 'wt-port', linkedIssue: 3000 })],
+      '3000',
+      repoMap,
+      null,
+      null,
+      new Map([
+        [
+          'wt-port',
+          [
+            {
+              port: 3000,
+              processName: 'vite'
+            }
+          ]
+        ]
+      ])
+    )
+
+    expect(results).toHaveLength(1)
+    expect(results[0].matchedField).toBe('port')
+    expect(results[0].supportingText).toEqual({
+      label: 'Port',
+      text: ':3000 vite',
+      matchRange: { start: 1, end: 5 }
+    })
+  })
 })

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -3,10 +3,17 @@ import type { Repo, Worktree } from '../../../shared/types'
 
 export type MatchRange = { start: number; end: number }
 
-export type PaletteMatchedField = 'displayName' | 'branch' | 'repo' | 'comment' | 'pr' | 'issue'
+export type PaletteMatchedField =
+  | 'displayName'
+  | 'branch'
+  | 'repo'
+  | 'comment'
+  | 'pr'
+  | 'issue'
+  | 'port'
 
 export type PaletteSupportingText = {
-  label: 'Comment' | 'PR' | 'Issue'
+  label: 'Comment' | 'PR' | 'Issue' | 'Port'
   text: string
   matchRange: MatchRange | null
 }
@@ -76,7 +83,8 @@ export function searchWorktrees(
   query: string,
   repoMap: Map<string, Repo>,
   prCache: Record<string, PRCacheEntry> | null,
-  issueCache: Record<string, IssueCacheEntry> | null
+  issueCache: Record<string, IssueCacheEntry> | null,
+  workspacePortsByWorktreeId?: Map<string, { port: number; processName?: string }[]>
 ): PaletteSearchResult[] {
   if (!query) {
     return worktrees.map((worktree) => makeResult(worktree.id, null))
@@ -171,6 +179,33 @@ export function searchWorktrees(
     }
 
     if (!numericQuery) {
+      continue
+    }
+
+    const workspacePorts = workspacePortsByWorktreeId?.get(worktree.id) ?? []
+    let matchedPort = false
+    for (const port of workspacePorts) {
+      const portText = String(port.port)
+      const portIndex = portText.indexOf(numericQuery)
+      if (portIndex !== -1) {
+        const label = `:${portText}${port.processName ? ` ${port.processName}` : ''}`
+        results.push(
+          makeResult(worktree.id, 'port', {
+            supportingText: {
+              label: 'Port',
+              text: label,
+              matchRange: {
+                start: 1 + portIndex,
+                end: 1 + portIndex + numericQuery.length
+              }
+            }
+          })
+        )
+        matchedPort = true
+        break
+      }
+    }
+    if (matchedPort) {
       continue
     }
 

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -135,6 +135,41 @@ describe('createUISlice hydratePersistedUI', () => {
     ])
   })
 
+  it('adds the default-on Ports status item once for older persisted UI', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        statusBarItems: ['claude', 'resource-usage'],
+        _portsStatusBarDefaultAdded: false
+      })
+    )
+
+    expect(store.getState().statusBarItems).toEqual(['claude', 'resource-usage', 'ports'])
+    expect(setUI).toHaveBeenCalledWith({
+      statusBarItems: ['claude', 'resource-usage', 'ports'],
+      _portsStatusBarDefaultAdded: true
+    })
+  })
+
+  it('preserves a user-hidden Ports status item after the one-shot migration ran', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        statusBarItems: ['claude', 'resource-usage'],
+        _portsStatusBarDefaultAdded: true
+      })
+    )
+
+    expect(store.getState().statusBarItems).toEqual(['claude', 'resource-usage'])
+    expect(setUI).not.toHaveBeenCalled()
+  })
+
   it('restores compact workspace board mode only from an explicit true', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -46,6 +46,7 @@ import type { OrcaHookScriptKind } from '../../lib/orca-hook-trust'
 import { DEFAULT_PET_ID, isBundledPetId } from '../../components/pet/pet-models'
 import { revokeCustomPetBlobUrl } from '../../components/pet/pet-blob-cache'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
+import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 
 export type PendingSidebarWorktreeReveal = {
   worktreeId: string
@@ -394,6 +395,10 @@ export type UISlice = {
   toggleStatusBarItem: (item: StatusBarItem) => void
   statusBarVisible: boolean
   setStatusBarVisible: (v: boolean) => void
+  workspacePortScan: { key: string; result: WorkspacePortScanResult } | null
+  workspacePortScanRefreshing: boolean
+  setWorkspacePortScan: (scan: { key: string; result: WorkspacePortScanResult } | null) => void
+  setWorkspacePortScanRefreshing: (refreshing: boolean) => void
   /** Whether the experimental pet overlay is currently visible. Persisted
    *  so "Hide pet" from the status-bar menu survives reload. Independent
    *  of the experimentalPet settings flag — the feature flag gates
@@ -868,6 +873,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     window.api.ui.set({ statusBarVisible: v }).catch(console.error)
     set({ statusBarVisible: v })
   },
+  workspacePortScan: null,
+  workspacePortScanRefreshing: false,
+  setWorkspacePortScan: (scan) => set({ workspacePortScan: scan }),
+  setWorkspacePortScanRefreshing: (refreshing) => set({ workspacePortScanRefreshing: refreshing }),
 
   // Why: default true so a user who enables experimentalPet sees the
   // pet immediately. Hide pet from the status-bar menu flips this
@@ -970,6 +979,16 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       //     flag — not here — so that users who intentionally select the new
       //     'recent' sort keep it across restarts.
       const sortBy = ui.sortBy
+      const migratedStatusBarItems = migrateStatusBarItems(ui.statusBarItems)
+      const statusBarItems =
+        ui._portsStatusBarDefaultAdded || migratedStatusBarItems.includes('ports')
+          ? migratedStatusBarItems
+          : [...migratedStatusBarItems, 'ports' as const]
+      if (!ui._portsStatusBarDefaultAdded && typeof window !== 'undefined') {
+        window.api.ui
+          .set({ statusBarItems, _portsStatusBarDefaultAdded: true })
+          .catch(console.error)
+      }
       return {
         // Why: persisted UI data comes from disk and may be stale, corrupted,
         // or manually edited. Clamp widths during hydration so invalid values
@@ -1001,7 +1020,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardCompact: normalizeWorkspaceBoardCompact(ui.workspaceBoardCompact),
         workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
-        statusBarItems: migrateStatusBarItems(ui.statusBarItems),
+        statusBarItems,
         statusBarVisible: ui.statusBarVisible ?? true,
         // Why: absent → true so existing users see the pet the first time
         // they enable the experimental flag. Only an explicit Hide pet

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -6,5 +6,6 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'gemini',
   'opencode-go',
   'ssh',
-  'resource-usage'
+  'resource-usage',
+  'ports'
 ]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1943,7 +1943,14 @@ export type WorktreeCardProperty =
   // view options.
   | 'inline-agents'
 
-export type StatusBarItem = 'claude' | 'codex' | 'gemini' | 'opencode-go' | 'ssh' | 'resource-usage'
+export type StatusBarItem =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'opencode-go'
+  | 'ssh'
+  | 'resource-usage'
+  | 'ports'
 export type FloatingTerminalTriggerLocation = 'floating-button' | 'status-bar'
 
 export type TaskResumeState = {
@@ -1988,6 +1995,8 @@ export type PersistedUIState = {
   /** One-shot migration flag for the old default blue/violet/emerald status
    *  visuals. Once stamped, valid user-authored colors/icons are preserved. */
   _workspaceStatusesDefaultVisualsMigrated?: boolean
+  /** One-shot migration flag for adding the default-on Ports status item. */
+  _portsStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   dismissedUpdateVersion: string | null


### PR DESCRIPTION
## Summary
- add a shared live workspace port snapshot used by workspace cards, the status bar, and Cmd+J
- show per-workspace ports as a hover affordance on workspace cards, including open/copy/stop actions
- add a default-enabled Ports status bar popover grouped by workspace with expandable external ports
- remove Ports from the right sidebar activity bar and make Cmd+J match workspace port numbers

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm test src/renderer/src/store/slices/ui.test.ts src/renderer/src/lib/worktree-palette-search.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts src/renderer/src/components/right-sidebar/PortsPanel.test.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋
