### PR TITLE
Harden Codex terminal readiness detection

### DIFF
--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -102,6 +102,11 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       }
     )
     printResult(result, json, formatTerminalWait)
+    if (result.result.wait.satisfied === false) {
+      // Why: callers commonly chain `terminal wait && terminal send`; a
+      // structured blocked result is still an unsatisfied wait condition.
+      process.exitCode = 1
+    }
   },
   'terminal stop': async ({ flags, client, cwd, json }) => {
     const result = await client.call<{ stopped: number }>('terminal.stop', {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1381,6 +1381,47 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('exits nonzero when terminal wait returns an unsatisfied blocked result', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_worker'
+    callMock.mockResolvedValueOnce({
+      id: 'req_terminal_wait',
+      ok: true,
+      result: {
+        wait: {
+          handle: 'term_worker',
+          condition: 'tui-idle',
+          satisfied: false,
+          status: 'running',
+          exitCode: null,
+          blockedReason: 'codex-cwd-prompt'
+        }
+      },
+      _meta: {
+        runtimeId: 'runtime-1'
+      }
+    })
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['terminal', 'wait', '--terminal', 'term_worker', '--for', 'tui-idle'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith(
+      'terminal.wait',
+      {
+        terminal: 'term_worker',
+        for: 'tui-idle',
+        timeoutMs: undefined
+      },
+      {
+        timeoutMs: 300000
+      }
+    )
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('blockedReason: codex-cwd-prompt')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('does not force remote Codex terminal creates through a local renderer path', async () => {
     queueFixtures(
       callMock,

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1677,6 +1677,34 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('falls back to background terminal creation for renderer-backed requests without a renderer window', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await expect(
+      runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        command: 'codex',
+        rendererBacked: true
+      })
+    ).resolves.toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      surface: 'background'
+    })
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'codex',
+        cwd: TEST_WORKTREE_PATH,
+        worktreeId: TEST_WORKTREE_ID
+      })
+    )
+  })
+
   it('splits visible pty-backed terminal sessions through the parent renderer tab', async () => {
     const spawn = vi
       .fn()
@@ -1919,8 +1947,7 @@ describe('OrcaRuntimeService', () => {
       [
         ' >_ OpenAI Codex (v0.131.0)\n',
         ' model:       gpt-5.5 high   /model to change\n',
-        ' directory:   ~/orca/workspaces/orca/cli-debug\n',
-        ' permissions: YOLO mode\n'
+        ' directory:   ~/orca/workspaces/orca/cli-debug\n'
       ].join(''),
       Date.now()
     )
@@ -1950,7 +1977,6 @@ describe('OrcaRuntimeService', () => {
         ' >_ OpenAI Codex (v0.132.0)\n',
         ' model:       gpt-5.5 high   /model to change\n',
         ' directory:   ~/orca/workspaces/orca/cli-debug\n',
-        ' permissions: YOLO mode\n',
         [
           'Starting MCP servers (0/2): codex_apps, computer-use (2s  esc to interrupt)',
           'Run /review on my current changes gpt-5.5 high ~/orca/workspaces/orca/cli-debug',
@@ -1958,6 +1984,37 @@ describe('OrcaRuntimeService', () => {
           'Run /review on my current changes gpt-5.5 high ~/orca/workspaces/orca/cli-debug',
           'Run /review on my current changes gpt-5.5 high ~/orca/workspaces/orca/cli-debug\n'
         ].join('')
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running'
+    })
+  })
+
+  it('resolves tui-idle when a stale Codex prompt is followed by the ready header', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        'Choose working directory to resume this session\n',
+        'Press enter to continue\n',
+        ' >_ OpenAI Codex (v0.132.0)\n',
+        ' model:       gpt-5.5 high   /model to change\n',
+        ' directory:   ~/orca/workspaces/orca/cli-debug\n'
       ].join(''),
       Date.now()
     )
@@ -2027,6 +2084,157 @@ describe('OrcaRuntimeService', () => {
       status: 'running',
       blockedReason: 'codex-trust-workspace'
     })
+  })
+
+  it('returns a blocked wait result for Codex cwd selection prompts', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'codex'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        'Choose working directory to resume this session\n',
+        '  Session = latest cwd recorded in the resumed session\n',
+        '  Current = your current working directory\n',
+        '  Press enter to continue\n'
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      blockedReason: 'codex-cwd-prompt'
+    })
+  })
+
+  it('returns a blocked wait result for Codex model migration prompts', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'codex'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        'Codex just got an upgrade. Introducing gpt-5.1-codex-max.\n',
+        'We recommend switching from gpt-5-codex to gpt-5.1-codex-max.\n',
+        'Press enter to continue\n'
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      blockedReason: 'codex-model-migration-prompt'
+    })
+  })
+
+  it('returns a blocked wait result for Codex startup hook review prompts', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'codex'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        'Hooks need review\n',
+        '2 hooks are new or changed.\n',
+        '1. Review hooks\n',
+        '2. Trust all and continue\n',
+        'Press enter to confirm or esc to go back\n'
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      blockedReason: 'codex-hooks-review-prompt'
+    })
+  })
+
+  it('returns a blocked wait result for generic Codex interactive prompts', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'codex'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      [
+        'Would you like to grant these permissions?\n',
+        '1. Yes, grant these permissions for this turn\n',
+        '2. No, continue without permissions\n',
+        'Press enter to confirm or esc to cancel\n'
+      ].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      blockedReason: 'codex-interactive-prompt'
+    })
+  })
+
+  it('does not classify unrelated press-enter prompts as Codex blocked prompts', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-bg', 'Press enter to continue\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 1_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('resolves tui-idle for quiet background PTY agents without OSC titles', async () => {
@@ -2544,9 +2752,7 @@ describe('OrcaRuntimeService', () => {
 
     runtime.onPtyData(
       'pty-bg',
-      ['OpenAI Codex', 'Model: gpt-5.4', 'Directory: /tmp/worktree-a', 'Permissions: full'].join(
-        '\n'
-      ),
+      ['OpenAI Codex', 'Model: gpt-5.4', 'Directory: /tmp/worktree-a'].join('\n'),
       100
     )
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6951,7 +6951,17 @@ export class OrcaRuntimeService {
     // when no selector was provided. The new background-spawn branch hard-
     // requires a resolvable selector, so route the no-selector case through
     // the renderer IPC path to preserve that behavior.
-    if (opts.focus !== true && opts.rendererBacked !== true && worktreeSelector) {
+    const rendererWindow =
+      opts.rendererBacked === true ? this.getAvailableAuthoritativeWindow() : null
+    const shouldCreateInBackground =
+      worktreeSelector !== undefined &&
+      ((opts.focus !== true && opts.rendererBacked !== true) ||
+        // Why: `orca serve` exposes the local runtime without a renderer
+        // window. Renderer-backed Codex terminals are preferred for the app,
+        // but headless CLI users still need a usable terminal handle.
+        (opts.rendererBacked === true && rendererWindow === null))
+
+    if (shouldCreateInBackground) {
       if (!this.ptyController?.spawn) {
         throw new Error('runtime_unavailable')
       }
@@ -7021,7 +7031,7 @@ export class OrcaRuntimeService {
     }
 
     this.assertGraphReady()
-    const win = this.getAuthoritativeWindow()
+    const win = rendererWindow ?? this.getAuthoritativeWindow()
     // Why: mirrors browserTabCreate — when no worktree is specified, pass
     // undefined so the renderer uses its current active worktree.
     const worktreeId = worktreeSelector
@@ -10180,34 +10190,99 @@ function detectExplicitIdleStatusFromTitle(title: string): AgentStatus | null {
 
 function isCodexReadyPromptPreview(preview: string): boolean {
   const normalized = preview.toLowerCase()
-  if (!normalized.includes('openai codex')) {
+  const readyIndex = findCodexReadyPromptIndex(normalized)
+  if (readyIndex === null) {
     return false
   }
-  if (detectTerminalWaitBlockedReason(preview) !== null) {
+  const blockedSignal = findTerminalWaitBlockedSignal(normalized)
+  if (blockedSignal !== null && blockedSignal.index > readyIndex) {
     return false
   }
-  return (
-    normalized.includes('model:') &&
-    normalized.includes('directory:') &&
-    normalized.includes('permissions:')
-  )
+  return true
 }
 
 function detectTerminalWaitBlockedReason(preview: string): RuntimeTerminalWaitBlockedReason | null {
   const normalized = preview.toLowerCase()
-  if (normalized.includes('update available') && normalized.includes('press enter to continue')) {
-    return 'codex-update-prompt'
+  const blockedSignal = findTerminalWaitBlockedSignal(normalized)
+  if (blockedSignal === null) {
+    return null
   }
+  const readyIndex = findCodexReadyPromptIndex(normalized)
+  // Why: retained terminal tails can include stale startup modals. If Codex's
+  // ready header appears after that modal, the latest signal is ready.
+  if (readyIndex !== null && readyIndex > blockedSignal.index) {
+    return null
+  }
+  return blockedSignal.reason
+}
+
+function findCodexReadyPromptIndex(normalized: string): number | null {
+  const headerIndex = normalized.lastIndexOf('openai codex')
+  if (headerIndex === -1) {
+    return null
+  }
+  const readySegment = normalized.slice(headerIndex)
+  // Why: current Codex prints permissions only in YOLO mode. The stable ready
+  // header is OpenAI Codex + model + directory.
+  return readySegment.includes('model:') && readySegment.includes('directory:') ? headerIndex : null
+}
+
+function findTerminalWaitBlockedSignal(
+  normalized: string
+): { reason: RuntimeTerminalWaitBlockedReason; index: number } | null {
+  const updateIndex = normalized.lastIndexOf('update available')
+  if (updateIndex !== -1 && normalized.includes('press enter to continue', updateIndex)) {
+    return { reason: 'codex-update-prompt', index: updateIndex }
+  }
+  const cwdIndex = normalized.lastIndexOf('choose working directory to')
+  if (cwdIndex !== -1 && normalized.includes('press enter to continue', cwdIndex)) {
+    return { reason: 'codex-cwd-prompt', index: cwdIndex }
+  }
+  const modelMigrationIndex = normalized.lastIndexOf('codex just got an upgrade')
   if (
-    (normalized.includes('do you trust') ||
-      normalized.includes('trust this') ||
-      normalized.includes('trusted workspace')) &&
-    (normalized.includes('workspace') ||
-      normalized.includes('folder') ||
-      normalized.includes('directory') ||
-      normalized.includes('repo'))
+    modelMigrationIndex !== -1 &&
+    normalized.includes('press enter to continue', modelMigrationIndex)
   ) {
-    return 'codex-trust-workspace'
+    return { reason: 'codex-model-migration-prompt', index: modelMigrationIndex }
+  }
+  const hooksIndex = normalized.lastIndexOf('hooks need review')
+  if (hooksIndex !== -1 && normalized.includes('press enter to confirm', hooksIndex)) {
+    return { reason: 'codex-hooks-review-prompt', index: hooksIndex }
+  }
+  const trustIndex = Math.max(
+    normalized.lastIndexOf('do you trust'),
+    normalized.lastIndexOf('trust this'),
+    normalized.lastIndexOf('trusted workspace')
+  )
+  const trustSegment = trustIndex === -1 ? '' : normalized.slice(trustIndex)
+  if (
+    trustIndex !== -1 &&
+    (trustSegment.includes('workspace') ||
+      trustSegment.includes('folder') ||
+      trustSegment.includes('directory') ||
+      trustSegment.includes('repo'))
+  ) {
+    return { reason: 'codex-trust-workspace', index: trustIndex }
+  }
+  const interactivePromptIndex = Math.max(
+    normalized.lastIndexOf('press enter to confirm'),
+    normalized.lastIndexOf('press enter to continue'),
+    normalized.lastIndexOf('press enter to view'),
+    normalized.lastIndexOf('press enter to insert'),
+    normalized.lastIndexOf('press t to trust')
+  )
+  const interactivePromptContext =
+    interactivePromptIndex === -1
+      ? ''
+      : normalized.slice(Math.max(0, interactivePromptIndex - 600), interactivePromptIndex + 200)
+  const hasCodexInteractiveContext =
+    interactivePromptContext.includes('codex') ||
+    interactivePromptContext.includes('permission') ||
+    interactivePromptContext.includes('sandbox') ||
+    interactivePromptContext.includes('trust') ||
+    interactivePromptContext.includes('hook')
+  if (interactivePromptIndex !== -1 && hasCodexInteractiveContext) {
+    return { reason: 'codex-interactive-prompt', index: interactivePromptIndex }
   }
   return null
 }

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -351,7 +351,13 @@ export type RuntimeTerminalClose = {
 }
 
 export type RuntimeTerminalWaitCondition = 'exit' | 'tui-idle'
-export type RuntimeTerminalWaitBlockedReason = 'codex-update-prompt' | 'codex-trust-workspace'
+export type RuntimeTerminalWaitBlockedReason =
+  | 'codex-update-prompt'
+  | 'codex-trust-workspace'
+  | 'codex-cwd-prompt'
+  | 'codex-model-migration-prompt'
+  | 'codex-hooks-review-prompt'
+  | 'codex-interactive-prompt'
 
 export type RuntimeTerminalWait = {
   handle: string


### PR DESCRIPTION
## Summary\n- Detect current Codex ready prompts without requiring YOLO-only permissions output\n- Return structured blocked wait results for Codex cwd, migration, hook review, and interactive prompts\n- Make terminal wait exit nonzero for unsatisfied blocked results\n- Fall back to background PTY creation for renderer-backed Codex requests in headless local serve\n\n## Verification\n- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/cli/index.test.ts\n- pnpm run typecheck\n- pnpm run lint\n- pnpm test\n- pnpm run build:electron-vite\n- pnpm run build:cli\n- local orca-dev serve smoke: real codex wait satisfied=true exit 0; cwd prompt blockedReason=codex-cwd-prompt exit 1