### PR TITLE
fix(hooks): SSH code paths read orca.yaml without leading dot

### DIFF
--- a/src/main/ipc/worktree-hooks.ts
+++ b/src/main/ipc/worktree-hooks.ts
@@ -36,7 +36,7 @@ export function registerHooksHandlers(store: Store): void {
         return { hasHooks: false, hooks: null, mayNeedUpdate: false }
       }
       try {
-        const result = await fsProvider.readFile(join(repo.path, '.orca.yaml'))
+        const result = await fsProvider.readFile(join(repo.path, 'orca.yaml'))
         if (result.isBinary) {
           return { hasHooks: false, hooks: null, mayNeedUpdate: false }
         }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1021,7 +1021,7 @@ describe('OrcaRuntimeService', () => {
       unregisterSshFilesystemProvider('ssh-1')
     }
 
-    expect(fsProvider.readFile).toHaveBeenCalledWith('C:\\remote\\repo\\.orca.yaml')
+    expect(fsProvider.readFile).toHaveBeenCalledWith('C:\\remote\\repo\\orca.yaml')
     expect(hasHooksFile).not.toHaveBeenCalled()
     expect(getEffectiveHooks).not.toHaveBeenCalled()
   })
@@ -1042,7 +1042,7 @@ describe('OrcaRuntimeService', () => {
     }
     const fsProvider = {
       readFile: vi.fn(async (filePath: string) => ({
-        content: filePath.includes('.orca.yaml')
+        content: filePath.endsWith('orca.yaml')
           ? 'scripts:\n  setup: pnpm install\n'
           : filePath.endsWith('.gitignore')
             ? 'node_modules\n'
@@ -1073,7 +1073,7 @@ describe('OrcaRuntimeService', () => {
       unregisterSshFilesystemProvider('ssh-1')
     }
 
-    expect(fsProvider.readFile).toHaveBeenCalledWith('C:\\remote\\repo\\.orca.yaml')
+    expect(fsProvider.readFile).toHaveBeenCalledWith('C:\\remote\\repo\\orca.yaml')
     expect(fsProvider.readFile).toHaveBeenCalledWith('C:\\remote\\repo\\.orca\\issue-command')
     expect(fsProvider.createDir).toHaveBeenCalledWith('C:\\remote\\repo\\.orca')
     expect(fsProvider.writeFile).toHaveBeenCalledWith(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5568,7 +5568,7 @@ export class OrcaRuntimeService {
         }
       }
       try {
-        const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, '.orca.yaml'))
+        const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
         const hooks = result.isBinary ? null : parseOrcaYaml(result.content)
         return {
           hasHooksFile: Boolean(hooks),
@@ -5608,7 +5608,7 @@ export class OrcaRuntimeService {
         return { hasHooks: false, hooks: null, mayNeedUpdate: false }
       }
       try {
-        const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, '.orca.yaml'))
+        const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
         if (result.isBinary) {
           return { hasHooks: false, hooks: null, mayNeedUpdate: false }
         }


### PR DESCRIPTION
## Summary

For SSH/remote repos, three code paths read `.orca.yaml` (with a leading dot) via the SSH filesystem provider, while the local-mode code path and the rest of the codebase (including this repo's own `orca.yaml`) use `orca.yaml`. This unifies the SSH paths on the same filename.

## Root cause

`src/main/hooks.ts` (local-mode) reads `orca.yaml`:

```ts
const yamlPath = join(repoPath, 'orca.yaml')
existsSync(join(repoPath, 'orca.yaml'))
```

But the three SSH-mode reads were looking for `.orca.yaml`:

- `src/main/ipc/worktree-hooks.ts:39` — `hooks:check` IPC handler
- `src/main/runtime/orca-runtime.ts:5571` — `getRepoHooks`
- `src/main/runtime/orca-runtime.ts:5611` — `checkRepoHooks`

A fourth SSH read in the same runtime file (`readRemoteSharedIssueCommand`, around line 5695) was already correctly using `orca.yaml` — confirming the leading dot is an unintended inconsistency, not a remote-only convention.

## User impact

When an SSH-connected repo has a tracked `orca.yaml` at its root, the **Settings > Worktree Hooks** panel shows the message:

> No \`orca.yaml\` detected
>
> Add an \`orca.yaml\` file to enable shared setup, archive, or issue-automation defaults for this repo.

…even though the file exists and is correctly named per the in-UI example template. The shared `scripts.setup`, `scripts.archive`, and `issueCommand` never run on worktree creation/archive. Local-mode repos are unaffected.

## Change

- Drop the leading dot in the three SSH `fsProvider.readFile(...)` calls so SSH and local paths agree on `orca.yaml`.
- Update the two assertions in `src/main/runtime/orca-runtime.test.ts` that pinned the buggy filename.

## Test plan

- [ ] `pnpm test src/main/runtime/orca-runtime.test.ts`
- [ ] Manual: connect Orca to an SSH host with a repo that has a tracked `orca.yaml` at root; open Settings > Worktree Hooks; confirm "Using \`orca.yaml\`" is shown (not "No \`orca.yaml\` detected") and the shared setup script runs on new-worktree creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)