### PR TITLE
Align workspace terminology in UI copy

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -30,7 +30,8 @@ function getPreflightIssues(status: {
     issues.push({
       id: 'git',
       title: 'Git is not installed',
-      description: 'Git is required for Git repositories, source control, and worktree management.',
+      description:
+        'Git is required for Git repositories, source control, and workspace management.',
       fixLabel: 'Install Git',
       fixUrl: 'https://git-scm.com/downloads'
     })
@@ -250,9 +251,9 @@ export default function Landing(): React.JSX.Element {
     const mod = isMac ? '⌘' : 'Ctrl'
     const shift = isMac ? '⇧' : 'Shift'
     return [
-      { id: 'create', keys: [mod, 'N'], action: 'Create worktree' },
-      { id: 'up', keys: [mod, shift, '↑'], action: 'Move up worktree' },
-      { id: 'down', keys: [mod, shift, '↓'], action: 'Move down worktree' }
+      { id: 'create', keys: [mod, 'N'], action: 'Create workspace' },
+      { id: 'up', keys: [mod, shift, '↑'], action: 'Move up workspace' },
+      { id: 'down', keys: [mod, shift, '↓'], action: 'Move down workspace' }
     ]
   }, [])
 
@@ -272,7 +273,7 @@ export default function Landing(): React.JSX.Element {
 
           <p className="text-sm text-muted-foreground text-center">
             {canCreateWorktree
-              ? 'Select a worktree from the sidebar to begin.'
+              ? 'Select a workspace from the sidebar to begin.'
               : 'Add a project to get started.'}
           </p>
 
@@ -292,7 +293,7 @@ export default function Landing(): React.JSX.Element {
               onClick={() => openModal('new-workspace-composer', { telemetrySource: 'unknown' })}
             >
               <GitBranchPlus className="size-3.5" />
-              Create Worktree
+              Create Workspace
             </button>
           </div>
 

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -427,7 +427,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         entries.push({
           id: '__header_worktrees__',
           type: 'section-header',
-          label: hasQuery ? 'Worktrees' : 'Recent Worktrees'
+          label: hasQuery ? 'Workspaces' : 'Recent Workspaces'
         })
       }
       entries.push(...visibleWorktreeItems)
@@ -435,7 +435,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         entries.push({
           id: '__hint_worktree_cap__',
           type: 'hint',
-          label: `Type to see all ${worktreeItems.length} worktrees`
+          label: `Type to see all ${worktreeItems.length} workspaces`
         })
       }
     }
@@ -592,7 +592,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     (worktreeId: string) => {
       const worktree = findWorktreeById(useAppStore.getState().worktreesByRepo, worktreeId)
       if (!worktree) {
-        toast.error('Worktree no longer exists')
+        toast.error('Workspace no longer exists')
         return
       }
       activateAndRevealWorktree(worktreeId)
@@ -618,7 +618,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       const { worktree, workspace, page } = selection
       const activated = activateAndRevealWorktree(worktree.id)
       if (!activated) {
-        toast.error('Worktree no longer exists')
+        toast.error('Workspace no longer exists')
         return
       }
 
@@ -1109,7 +1109,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="text-[14px] font-semibold tracking-[-0.01em] text-foreground">
-                    {`Create worktree "${createWorktreeName}"`}
+                    {`Create workspace "${createWorktreeName}"`}
                   </div>
                 </div>
               </CommandItem>

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -898,9 +898,9 @@ export default function ChecksPanel(): React.JSX.Element {
   if (!activeWorktree) {
     return (
       <div className="px-4 py-6">
-        <div className="text-sm font-medium text-foreground">No worktree selected</div>
+        <div className="text-sm font-medium text-foreground">No workspace selected</div>
         <div className="mt-1 text-xs text-muted-foreground">
-          Select a worktree to view PR checks
+          Select a workspace to view PR checks
         </div>
       </div>
     )

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -320,7 +320,7 @@ function FileExplorerInner(): React.JSX.Element {
   if (!worktreePath) {
     return (
       <div className="flex h-full items-center justify-center text-[11px] text-muted-foreground px-4 text-center">
-        Select a worktree to browse files
+        Select a workspace to browse files
       </div>
     )
   }

--- a/src/renderer/src/components/right-sidebar/FileExplorerTreeStatus.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerTreeStatus.tsx
@@ -23,7 +23,7 @@ export function FileExplorerTreeStatus({
   if (error) {
     return (
       <div className="flex h-full items-center justify-center px-4 text-center text-[11px] text-muted-foreground">
-        Could not load files for this worktree: {error}
+        Could not load files for this workspace: {error}
       </div>
     )
   }
@@ -31,7 +31,7 @@ export function FileExplorerTreeStatus({
   if (isEmpty) {
     return (
       <div className="flex h-full items-center justify-center px-4 text-center text-[11px] text-muted-foreground">
-        No files in this worktree
+        No files in this workspace
       </div>
     )
   }

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -315,7 +315,7 @@ export default function Search(): React.JSX.Element {
   if (!activeWorktreeId) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-xs">
-        Select a worktree to search
+        Select a workspace to search
       </div>
     )
   }

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -662,7 +662,7 @@ function SourceControlInner(): React.JSX.Element {
 
   const pendingDiffCommentsClearDescription = pendingDiffCommentsClear
     ? pendingDiffCommentsClear.kind === 'all'
-      ? `Clear ${pendingDiffCommentsClearCount} ${pendingDiffCommentsClearCount === 1 ? 'note' : 'notes'} from this worktree?`
+      ? `Clear ${pendingDiffCommentsClearCount} ${pendingDiffCommentsClearCount === 1 ? 'note' : 'notes'} from this workspace?`
       : `Clear ${pendingDiffCommentsClearCount} ${pendingDiffCommentsClearCount === 1 ? 'note' : 'notes'} from ${pendingDiffCommentsClear.filePath}?`
     : ''
 
@@ -2720,7 +2720,7 @@ function SourceControlInner(): React.JSX.Element {
   if (!activeWorktree || !activeRepo || !worktreePath) {
     return (
       <div className="flex items-center justify-center h-full text-xs text-muted-foreground px-4 text-center">
-        Select a worktree to view changes
+        Select a workspace to view changes
       </div>
     )
   }
@@ -2978,7 +2978,7 @@ function SourceControlInner(): React.JSX.Element {
           {scope === 'all' && showGenericEmptyState && !normalizedFilter ? (
             <EmptyState
               heading="No changes on this branch"
-              supportingText={`This worktree is clean and this branch has no changes ahead of ${branchSummary.baseRef}`}
+              supportingText={`This workspace is clean and this branch has no changes ahead of ${branchSummary.baseRef}`}
             />
           ) : null}
 

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -219,13 +219,13 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
         <div className="space-y-1">
           <h3 className="text-sm font-semibold">Workspace</h3>
           <p className="text-xs text-muted-foreground">
-            Configure where new worktrees are created.
+            Configure where new workspaces are created.
           </p>
         </div>
 
         <SearchableSetting
           title="Workspace Directory"
-          description="Root directory where worktree folders are created."
+          description="Root directory where workspace folders are created."
           keywords={['workspace', 'folder', 'path', 'worktree']}
           className="space-y-2"
         >
@@ -247,20 +247,20 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             </Button>
           </div>
           <p className="text-xs text-muted-foreground">
-            Root directory where worktree folders are created.
+            Root directory where workspace folders are created.
           </p>
         </SearchableSetting>
 
         <SearchableSetting
           title="Nest Workspaces"
-          description="Create worktrees inside a repo-named subfolder."
+          description="Create workspaces inside a repo-named subfolder."
           keywords={['nested', 'subfolder', 'directory']}
           className="flex items-center justify-between gap-4 px-1 py-2"
         >
           <div className="space-y-0.5">
             <Label>Nest Workspaces</Label>
             <p className="text-xs text-muted-foreground">
-              Create worktrees inside a repo-named subfolder.
+              Create workspaces inside a repo-named subfolder.
             </p>
           </div>
           <button
@@ -357,7 +357,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
 
         <SearchableSetting
           title="Open In Menu"
-          description="Add custom launchers to the worktree Open in menu."
+          description="Add custom launchers to the workspace Open in menu."
           keywords={['open in', 'editor', 'launcher', 'cursor', 'zed', 'command', 'vscode']}
           className="space-y-3"
         >
@@ -365,7 +365,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             <Label>Open In Menu</Label>
             <p className="text-xs text-muted-foreground">
               VS Code is always included first. Add executables to show extra entries in each
-              worktree&apos;s Open in menu.
+              workspace&apos;s Open in menu.
             </p>
             <p className="text-xs text-muted-foreground">
               Commands are not shell-parsed. Use only an executable command name. For flags, use a

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -80,7 +80,7 @@ const LOCAL_HOOK_FIELDS: {
   {
     name: 'archive',
     label: 'Local archive command',
-    description: 'Runs before a local worktree is archived or removed.',
+    description: 'Runs before a local workspace is archived or removed.',
     placeholder: 'echo "Cleaning up $ORCA_WORKSPACE_NAME"'
   }
 ]

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -38,13 +38,13 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
         keys: ({ mod }) => [mod, 'P']
       },
       {
-        action: 'Switch worktree',
-        searchKeywords: ['shortcut', 'global', 'worktree', 'switch', 'jump'],
+        action: 'Switch workspace',
+        searchKeywords: ['shortcut', 'global', 'workspace', 'worktree', 'switch', 'jump'],
         keys: ({ mod, shift }) => (mod === '⌘' ? [mod, 'J'] : [mod, shift, 'J'])
       },
       {
-        action: 'Create worktree',
-        searchKeywords: ['shortcut', 'global', 'worktree'],
+        action: 'Create workspace',
+        searchKeywords: ['shortcut', 'global', 'workspace', 'worktree'],
         keys: ({ mod }) => [mod, 'N']
       },
       {
@@ -58,13 +58,13 @@ const SHORTCUT_GROUP_DEFINITIONS: ShortcutGroupDefinition[] = [
         keys: ({ mod }) => [mod, 'L']
       },
       {
-        action: 'Move up worktree',
-        searchKeywords: ['shortcut', 'global', 'worktree', 'move'],
+        action: 'Move up workspace',
+        searchKeywords: ['shortcut', 'global', 'workspace', 'worktree', 'move'],
         keys: ({ mod, shift }) => [mod, shift, '↑']
       },
       {
-        action: 'Move down worktree',
-        searchKeywords: ['shortcut', 'global', 'worktree', 'move'],
+        action: 'Move down workspace',
+        searchKeywords: ['shortcut', 'global', 'workspace', 'worktree', 'move'],
         keys: ({ mod, shift }) => [mod, shift, '↓']
       },
       {

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -3,12 +3,12 @@ import type { SettingsSearchEntry } from './settings-search'
 export const GENERAL_WORKSPACE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Workspace Directory',
-    description: 'Root directory where worktree folders are created.',
+    description: 'Root directory where workspace folders are created.',
     keywords: ['workspace', 'folder', 'path', 'worktree']
   },
   {
     title: 'Nest Workspaces',
-    description: 'Create worktrees inside a repo-named subfolder.',
+    description: 'Create workspaces inside a repo-named subfolder.',
     keywords: ['nested', 'subfolder', 'directory']
   },
   {
@@ -23,7 +23,7 @@ export const GENERAL_WORKSPACE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   },
   {
     title: 'Open In Menu',
-    description: 'Add custom launchers to the worktree Open in menu.',
+    description: 'Add custom launchers to the workspace Open in menu.',
     keywords: ['open in', 'editor', 'launcher', 'cursor', 'zed', 'command', 'vscode']
   }
 ]

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1206,7 +1206,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               size="icon-xs"
                               className="size-5 shrink-0 rounded-md text-muted-foreground hover:bg-accent/70 hover:text-foreground transition-opacity"
                               aria-label={
-                                createState?.ariaLabel ?? `Create worktree for ${row.label}`
+                                createState?.ariaLabel ?? `Create workspace for ${row.label}`
                               }
                               onKeyDown={stopRepoHeaderKeyboardToggle}
                               onClick={(event) => {
@@ -1222,7 +1222,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                           )}
                         </TooltipTrigger>
                         <TooltipContent side="bottom" sideOffset={6}>
-                          {createState?.tooltip ?? `Create worktree for ${row.label}`}
+                          {createState?.tooltip ?? `Create workspace for ${row.label}`}
                         </TooltipContent>
                       </Tooltip>
                     ) : null}
@@ -2043,7 +2043,7 @@ const WorktreeList = React.memo(function WorktreeList({
   // empty-sidebar escape hatch (Clear Filters button below) is reachable when
   // it's the only reason the list is empty — otherwise a user whose only
   // worktree is a default-branch row and who just toggled hide on would see
-  // "No worktrees found" with no way back short of reopening the filter menu.
+  // "No workspaces found" with no way back short of reopening the filter menu.
   const filterState = useMemo(
     () => ({ showActiveOnly, filterRepoIds, hideDefaultBranchWorkspace }),
     [showActiveOnly, filterRepoIds, hideDefaultBranchWorkspace]
@@ -2071,7 +2071,7 @@ const WorktreeList = React.memo(function WorktreeList({
       <div data-worktree-sidebar-container className="relative min-h-0 flex-1">
         <div className="worktree-sidebar-scrollbar flex h-full flex-col overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek pt-px">
           <div className="flex flex-col items-center gap-2 px-4 py-6 text-center text-[11px] text-muted-foreground">
-            <span>No worktrees found</span>
+            <span>No workspaces found</span>
             {hasFilters && (
               <button
                 onClick={clearFilters}

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -256,7 +256,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
         <DialogHeader>
           <DialogTitle className="text-sm">Edit Worktree Details</DialogTitle>
           <DialogDescription className="text-xs">
-            Edit GitHub links and notes for this worktree.
+            Edit GitHub links and notes for this workspace.
           </DialogDescription>
         </DialogHeader>
 

--- a/src/renderer/src/components/sidebar/repo-header-create-state.test.ts
+++ b/src/renderer/src/components/sidebar/repo-header-create-state.test.ts
@@ -24,8 +24,8 @@ describe('repo header create state', () => {
       })
     ).toEqual({
       disabled: false,
-      tooltip: 'Create worktree for orca',
-      ariaLabel: 'Create worktree for orca',
+      tooltip: 'Create workspace for orca',
+      ariaLabel: 'Create workspace for orca',
       requiresSshReconnect: false
     })
   })
@@ -53,7 +53,7 @@ describe('repo header create state', () => {
       })
     ).toMatchObject({
       disabled: false,
-      tooltip: 'Create worktree for remote',
+      tooltip: 'Create workspace for remote',
       requiresSshReconnect: false
     })
   })

--- a/src/renderer/src/components/sidebar/repo-header-create-state.ts
+++ b/src/renderer/src/components/sidebar/repo-header-create-state.ts
@@ -39,8 +39,8 @@ export function getRepoHeaderCreateState(input: {
 
   return {
     disabled: false,
-    tooltip: `Create worktree for ${input.label}`,
-    ariaLabel: `Create worktree for ${input.label}`,
+    tooltip: `Create workspace for ${input.label}`,
+    ariaLabel: `Create workspace for ${input.label}`,
     requiresSshReconnect: false
   }
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -383,7 +383,7 @@ describe('sidebarHasActiveFilters', () => {
   it('returns true when only hideDefaultBranchWorkspace is active', () => {
     // Why: regression guard for the empty-sidebar escape hatch. If hide is
     // omitted from the filter union, a user whose only worktree is the
-    // default-branch row sees "No worktrees found" with no way back.
+    // default-branch row sees "No workspaces found" with no way back.
     expect(sidebarHasActiveFilters(filterState({ hideDefaultBranchWorkspace: true }))).toBe(true)
   })
 
@@ -407,7 +407,7 @@ describe('computeClearFilterActions', () => {
 
   it('flags only hideDefaultBranchWorkspace for reset when it is the sole filter', () => {
     // Why: verifies the empty-sidebar escape hatch actually clears the hide
-    // flag. A regression here would leave users stuck on "No worktrees found"
+    // flag. A regression here would leave users stuck on "No workspaces found"
     // because the only active filter would never clear.
     expect(computeClearFilterActions(filterState({ hideDefaultBranchWorkspace: true }))).toEqual({
       resetShowActiveOnly: false,

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -32,7 +32,7 @@ export type SidebarFilterState = {
  *
  * Why include hideDefaultBranchWorkspace here: without it, a user whose only
  * worktree is the default-branch row and who toggles hide-on would see the
- * "No worktrees found" message with no in-sidebar recovery path.
+ * "No workspaces found" message with no in-sidebar recovery path.
  */
 export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
   return state.showActiveOnly || state.filterRepoIds.length > 0 || state.hideDefaultBranchWorkspace


### PR DESCRIPTION
## Summary
- Rename user-facing worktree copy to workspace on the landing screen and shortcut surfaces
- Align adjacent palette, sidebar, settings, and right-sidebar empty-state copy with the workspace convention
- Keep internal worktree identifiers/API names unchanged while preserving worktree as a search keyword where useful

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/repo-header-create-state.test.ts

Note: pnpm printed the existing Node engine warning because this shell is on Node v25.9.0 while the repo wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
