### PR TITLE
Add GitHub PR filters and search handling

### DIFF
--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -57,7 +57,7 @@ vi.mock('./rate-limit', () => ({
   noteRateLimitSpend: noteRateLimitSpendMock
 }))
 
-import { listWorkItems, _resetOwnerRepoCache } from './client'
+import { countWorkItems, listWorkItems, _resetOwnerRepoCache } from './client'
 
 describe('listWorkItems', () => {
   beforeEach(() => {
@@ -261,6 +261,135 @@ describe('listWorkItems', () => {
         prRepo: { owner: 'acme', repo: 'widgets' }
       }
     ])
+  })
+
+  it('routes merged queries to PR search only and maps MERGED PR state', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        {
+          number: 8,
+          title: 'Merged work',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/8',
+          labels: [],
+          updatedAt: '2026-03-31T00:00:00Z',
+          author: { login: 'octocat' },
+          isDraft: false,
+          headRefName: 'feature/merged',
+          headRefOid: 'head-8',
+          baseRefName: 'main'
+        }
+      ])
+    })
+
+    const { items } = await listWorkItems('/repo-root', 10, 'is:merged')
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'pr',
+        'list',
+        '--limit',
+        '10',
+        '--json',
+        'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRefOid,headRepositoryOwner,reviewRequests',
+        '--repo',
+        'acme/widgets',
+        '--state',
+        'merged'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(items).toMatchObject([
+      {
+        id: 'pr:8',
+        type: 'pr',
+        number: 8,
+        state: 'merged'
+      }
+    ])
+  })
+
+  it('passes state:all through to gh instead of using the default open state', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    await listWorkItems('/repo-root', 10, 'is:pr state:all')
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(expect.arrayContaining(['--state', 'all']), {
+      cwd: '/repo-root'
+    })
+  })
+
+  it('excludes merged PRs from closed PR searches', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        {
+          number: 9,
+          title: 'Closed without merge',
+          state: 'CLOSED',
+          url: 'https://github.com/acme/widgets/pull/9',
+          labels: [],
+          updatedAt: '2026-04-01T00:00:00Z',
+          author: { login: 'octocat' },
+          isDraft: false,
+          headRefName: 'feature/closed',
+          headRefOid: 'head-9',
+          baseRefName: 'main'
+        },
+        {
+          number: 8,
+          title: 'Merged work',
+          state: 'MERGED',
+          url: 'https://github.com/acme/widgets/pull/8',
+          labels: [],
+          updatedAt: '2026-03-31T00:00:00Z',
+          author: { login: 'octocat' },
+          isDraft: false,
+          headRefName: 'feature/merged',
+          headRefOid: 'head-8',
+          baseRefName: 'main'
+        }
+      ])
+    })
+
+    const { items } = await listWorkItems('/repo-root', 10, 'is:pr is:closed')
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['--state', 'closed', '--search', '-is:merged']),
+      { cwd: '/repo-root' }
+    )
+    expect(items).toMatchObject([{ id: 'pr:9', type: 'pr', state: 'closed' }])
+  })
+
+  it('quotes spaced label qualifiers when counting search results', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '12' })
+
+    const count = await countWorkItems('/repo-root', 'is:pr label:"needs review"')
+
+    const apiPath = ghExecFileAsyncMock.mock.calls[0][0][3] as string
+    expect(count).toBe(12)
+    expect(decodeURIComponent(apiPath)).toContain('label:"needs review"')
+  })
+
+  it('does not add the merged exclusion to issue-only closed count queries', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '4' })
+
+    await countWorkItems('/repo-root', 'is:issue is:closed')
+
+    const apiPath = decodeURIComponent(ghExecFileAsyncMock.mock.calls[0][0][3] as string)
+    expect(apiPath).toContain('is:issue is:closed')
+    expect(apiPath).not.toContain('-is:merged')
   })
 
   it('passes review-requested as a --search qualifier (gh CLI has no dedicated flag)', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -588,13 +588,13 @@ function mapPullRequestWorkItem(
     number: Number(item.number),
     title: String(item.title ?? ''),
     state:
-      state === 'closed'
-        ? item.merged_at || item.mergedAt
-          ? 'merged'
-          : 'closed'
-        : item.isDraft || item.draft
-          ? 'draft'
-          : 'open',
+      state === 'merged' || item.merged_at || item.mergedAt
+        ? 'merged'
+        : state === 'closed'
+          ? 'closed'
+          : item.isDraft || item.draft
+            ? 'draft'
+            : 'open',
     url: String(item.html_url ?? item.url ?? ''),
     labels: Array.isArray(item.labels)
       ? item.labels
@@ -718,14 +718,13 @@ function buildWorkItemListArgs(args: {
     out.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
   }
 
-  const state = query.state
-  if (state && !(kind === 'issue' && state === 'merged')) {
-    out.push('--state', state === 'all' ? 'all' : state)
+  if (query.state) {
+    out.push('--state', query.state)
   }
-
-  if (kind === 'pr' && query.state === 'merged') {
-    out.push('--state', 'merged')
-  }
+  // Why: GitHub considers merged PRs as "closed". When the user filters for
+  // closed-only, exclude merged PRs via the search predicate so the displayed
+  // and counted results match the user's intent.
+  const excludeMergedFromClosed = kind === 'pr' && query.state === 'closed'
 
   if (query.assignee) {
     out.push('--assignee', query.assignee)
@@ -746,6 +745,9 @@ function buildWorkItemListArgs(args: {
   }
 
   const searchParts: string[] = []
+  if (excludeMergedFromClosed) {
+    searchParts.push('-is:merged')
+  }
   // Why: cursor-based pagination. GitHub search supports updated:<DATE to
   // fetch items older than the cursor. We use the oldest item's updatedAt
   // from the previous page as the cursor.
@@ -944,7 +946,12 @@ async function listQueriedWorkItems(
   connectionId?: string | null
 ): Promise<PartialWorkItemsResult> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId))
-  const issueScope = query.scope !== 'pr'
+  const hasPrOnlyFilter =
+    query.state === 'merged' ||
+    query.draft ||
+    query.reviewRequested !== null ||
+    query.reviewedBy !== null
+  const issueScope = query.scope !== 'pr' && !hasPrOnlyFilter
   const prScope = query.scope !== 'issue'
 
   // Why: run the issue and PR fetches in parallel but surface the
@@ -985,9 +992,13 @@ async function listQueriedWorkItems(
     })
     try {
       const { stdout } = await ghExecFileAsync(args, ghOptions)
-      return (JSON.parse(stdout) as Record<string, unknown>[]).map((item) =>
+      const mapped = (JSON.parse(stdout) as Record<string, unknown>[]).map((item) =>
         mapPullRequestWorkItem(item, prOwnerRepo)
       )
+      if (query.state === 'closed') {
+        return mapped.filter((item) => item.state !== 'merged')
+      }
+      return mapped
     } catch (err) {
       console.warn('listQueriedWorkItems PRs partial failure:', err)
       return []
@@ -1068,7 +1079,12 @@ function buildSearchQueryString(
   if (query.state === 'open') {
     parts.push('is:open')
   } else if (query.state === 'closed') {
+    // Why: GitHub search treats merged PRs as closed. Exclude merged so the
+    // "Closed" filter actually means closed-without-merge.
     parts.push('is:closed')
+    if (query.scope !== 'issue') {
+      parts.push('-is:merged')
+    }
   } else if (query.state === 'merged') {
     parts.push('is:merged')
   }
@@ -1076,24 +1092,28 @@ function buildSearchQueryString(
     parts.push('draft:true')
   }
   if (query.assignee) {
-    parts.push(`assignee:${query.assignee}`)
+    parts.push(`assignee:${quoteGitHubSearchValue(query.assignee)}`)
   }
   if (query.author) {
-    parts.push(`author:${query.author}`)
+    parts.push(`author:${quoteGitHubSearchValue(query.author)}`)
   }
   if (query.reviewRequested) {
-    parts.push(`review-requested:${query.reviewRequested}`)
+    parts.push(`review-requested:${quoteGitHubSearchValue(query.reviewRequested)}`)
   }
   if (query.reviewedBy) {
-    parts.push(`reviewed-by:${query.reviewedBy}`)
+    parts.push(`reviewed-by:${quoteGitHubSearchValue(query.reviewedBy)}`)
   }
   for (const label of query.labels) {
-    parts.push(`label:${label}`)
+    parts.push(`label:${quoteGitHubSearchValue(label)}`)
   }
   if (query.freeText) {
     parts.push(query.freeText)
   }
   return parts.join(' ')
+}
+
+function quoteGitHubSearchValue(value: string): string {
+  return /\s/.test(value) ? `"${value.replaceAll('"', '\\"')}"` : value
 }
 
 async function countWorkItemsForQuery(

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -302,6 +302,21 @@
   min-height: 28px;
 }
 
+/* Thicker variant for dense data tables where the default 6px-thumb is hard to grab. */
+.scrollbar-sleek-lg {
+  scrollbar-width: auto;
+}
+
+.scrollbar-sleek-lg::-webkit-scrollbar {
+  width: 16px;
+  height: 16px;
+}
+
+.scrollbar-sleek-lg::-webkit-scrollbar-thumb {
+  border-width: 3px;
+  min-height: 36px;
+}
+
 .scrollbar-sleek::-webkit-scrollbar-thumb:hover {
   background-color: color-mix(in srgb, var(--muted-foreground, #737373) 48%, transparent);
 }

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -362,14 +362,14 @@ function getStateTone(item: GitHubWorkItem): string {
 }
 
 function getPRMergeTooltip(item: GitHubWorkItem): string {
-  if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
-    return 'Merge status has not loaded yet'
-  }
   if (item.state === 'merged') {
     return 'This pull request is already merged'
   }
   if (item.state === 'closed') {
     return 'This pull request is closed'
+  }
+  if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
+    return 'Merge status is unavailable for this PR'
   }
   if (item.mergeable === 'CONFLICTING') {
     return 'GitHub reports merge conflicts'

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -87,7 +87,8 @@ import {
   getLinearStateMarkerStyle,
   getLinearStatePillStyle
 } from '@/components/linear-state-pill-style'
-import { stripRepoQualifiers } from '../../../shared/task-query'
+import { parseTaskQuery, stripRepoQualifiers, withQualifier } from '../../../shared/task-query'
+import PRFilterDropdowns, { type PRFilterChange } from '@/components/github/PRFilterDropdowns'
 import { parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
@@ -160,6 +161,21 @@ type TaskQueryPreset = {
 }
 type GitHubTaskKind = 'issues' | 'prs'
 
+const ISSUE_TASK_QUERY_PRESETS: TaskQueryPreset[] = [
+  { id: 'issues', label: 'Open', query: getTaskPresetQuery('issues') },
+  { id: 'my-issues', label: 'Assigned to me', query: getTaskPresetQuery('my-issues') }
+]
+
+const PR_TASK_QUERY_PRESETS: TaskQueryPreset[] = [
+  { id: 'prs', label: 'Open', query: getTaskPresetQuery('prs') },
+  { id: 'my-prs', label: 'Mine', query: getTaskPresetQuery('my-prs') },
+  { id: 'review', label: 'Needs review', query: getTaskPresetQuery('review') }
+]
+
+function getGitHubTaskKindPresets(kind: GitHubTaskKind): TaskQueryPreset[] {
+  return kind === 'prs' ? PR_TASK_QUERY_PRESETS : ISSUE_TASK_QUERY_PRESETS
+}
+
 function getRuntimeTargetForRepoId(repoId: string | null | undefined) {
   if (!repoId) {
     return null
@@ -205,17 +221,6 @@ const SOURCE_OPTIONS: SourceOption[] = [
   }
 ]
 
-const ISSUE_TASK_QUERY_PRESETS: TaskQueryPreset[] = [
-  { id: 'issues', label: 'Open', query: getTaskPresetQuery('issues') },
-  { id: 'my-issues', label: 'Assigned to me', query: getTaskPresetQuery('my-issues') }
-]
-
-const PR_TASK_QUERY_PRESETS: TaskQueryPreset[] = [
-  { id: 'prs', label: 'Open', query: getTaskPresetQuery('prs') },
-  { id: 'my-prs', label: 'Mine', query: getTaskPresetQuery('my-prs') },
-  { id: 'review', label: 'Needs review', query: getTaskPresetQuery('review') }
-]
-
 type LinearPresetId = 'assigned' | 'created' | 'all' | 'completed'
 type LinearPreset = { id: LinearPresetId; label: string }
 
@@ -233,18 +238,24 @@ const PR_CHECKS_EAGER_PREFETCH_LIMIT = 20
 const GITHUB_TASK_GRID_CLASS =
   'min-w-[860px] grid-cols-[72px_minmax(260px,2fr)_minmax(130px,0.8fr)_100px_92px_158px]'
 const GITHUB_PR_TASK_GRID_CLASS =
-  'min-w-[1270px] grid-cols-[72px_minmax(260px,2fr)_minmax(130px,0.8fr)_100px_132px_128px_132px_92px_158px]'
+  'min-w-[1170px] grid-cols-[72px_minmax(260px,2fr)_minmax(130px,0.8fr)_132px_128px_132px_92px_158px]'
 const GITHUB_TASK_ROW_SURFACE_CLASS =
   '[background:color-mix(in_srgb,var(--muted)_50%,var(--background))]'
 const GITHUB_TASK_ROW_HOVER_SURFACE_CLASS =
   'group-hover/github-task-row:[background:color-mix(in_srgb,var(--muted)_70%,var(--background))]'
-const GITHUB_TASK_STICKY_ID_HEADER_CLASS = cn('sticky left-3 z-30', GITHUB_TASK_ROW_SURFACE_CLASS)
+// Why: the row's px-3 left padding leaves a 12px gap between the scroll-viewport
+// edge and the sticky ID column; without a covering ::before, scrolled cell text
+// bleeds through that strip. Same trick as the title column for its 8px gap.
+const GITHUB_TASK_STICKY_ID_HEADER_CLASS = cn(
+  'sticky left-3 z-30 before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
+  GITHUB_TASK_ROW_SURFACE_CLASS
+)
 const GITHUB_TASK_STICKY_TITLE_HEADER_CLASS = cn(
   'sticky left-[92px] z-30 border-r border-border/50 before:absolute before:-left-2 before:top-0 before:bottom-0 before:w-2 before:bg-inherit',
   GITHUB_TASK_ROW_SURFACE_CLASS
 )
 const GITHUB_TASK_STICKY_ID_CELL_CLASS = cn(
-  'sticky left-3 z-20 flex items-center',
+  'sticky left-3 z-20 flex items-center before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
   GITHUB_TASK_ROW_SURFACE_CLASS,
   GITHUB_TASK_ROW_HOVER_SURFACE_CLASS
 )
@@ -266,8 +277,14 @@ function isPRFocusedTaskView(preset: TaskViewPresetId | null, query: string): bo
   if (preset === 'prs' || preset === 'my-prs' || preset === 'review') {
     return true
   }
-  const normalized = query.toLowerCase()
-  return /\bis:pr\b/.test(normalized) && !/\bis:issue\b/.test(normalized)
+  const parsed = parseTaskQuery(query)
+  return (
+    parsed.scope === 'pr' ||
+    parsed.state === 'merged' ||
+    parsed.draft ||
+    parsed.reviewRequested !== null ||
+    parsed.reviewedBy !== null
+  )
 }
 
 function normalizeGitHubTaskPreset(preset: TaskViewPresetId | null | undefined): TaskViewPresetId {
@@ -284,19 +301,17 @@ function getDefaultPresetForGitHubTaskKind(kind: GitHubTaskKind): TaskViewPreset
   return kind === 'prs' ? 'prs' : 'issues'
 }
 
-function getGitHubTaskKindPresets(kind: GitHubTaskKind): TaskQueryPreset[] {
-  return kind === 'prs' ? PR_TASK_QUERY_PRESETS : ISSUE_TASK_QUERY_PRESETS
-}
-
 function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
   const trimmed = query.trim()
   if (!trimmed) {
     return getTaskPresetQuery(getDefaultPresetForGitHubTaskKind(kind))
   }
-  if (/\bis:(?:issue|pr)\b/i.test(trimmed)) {
+  if (/\bis:(?:issue|pr|pull-request)\b/i.test(trimmed)) {
     return trimmed
   }
-  return `${kind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
+  const parsed = parseTaskQuery(trimmed)
+  const inferredKind = parsed.scope === 'pr' ? 'prs' : parsed.scope === 'issue' ? 'issues' : kind
+  return `${inferredKind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
 }
 
 // Why: Intl.RelativeTimeFormat allocation is non-trivial, and previously we
@@ -324,26 +339,6 @@ function formatRelativeTime(input: string): string {
 
   const diffDays = Math.round(diffHours / 24)
   return relativeTimeFormatter.format(diffDays, 'day')
-}
-
-function getTaskStatusLabel(item: GitHubWorkItem): string {
-  if (item.type === 'issue') {
-    return 'Open'
-  }
-  if (item.state === 'draft') {
-    return 'Draft'
-  }
-  return 'Ready'
-}
-
-function getTaskStatusTone(item: GitHubWorkItem): string {
-  if (item.type === 'issue') {
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
-  }
-  if (item.state === 'draft') {
-    return 'border-slate-500/30 bg-slate-500/10 text-slate-600 dark:text-slate-300'
-  }
-  return 'border-cyan-500/30 bg-cyan-500/10 text-cyan-700 dark:text-cyan-200'
 }
 
 // Why: Linear encodes priority as an integer (0–4). Map to human-readable
@@ -737,13 +732,8 @@ function GHStatusCell({
 
   if (item.type !== 'issue' || !repo) {
     return (
-      <span
-        className={cn(
-          'rounded-full border px-2 py-0.5 text-[10px] font-medium opacity-70',
-          getTaskStatusTone(item)
-        )}
-      >
-        {getTaskStatusLabel(item)}
+      <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 opacity-70 dark:text-emerald-200">
+        Open
       </span>
     )
   }
@@ -899,14 +889,14 @@ function sameOptionalGitHubOwnerRepo(
 }
 
 function getMergeLabel(item: GitHubWorkItem): string {
-  if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
-    return 'Merge'
-  }
   if (item.state === 'merged') {
     return 'Merged'
   }
   if (item.state === 'closed') {
     return 'Closed'
+  }
+  if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
+    return 'Merge'
   }
   if (item.mergeable === 'CONFLICTING') {
     return 'Conflicts'
@@ -937,14 +927,14 @@ function getMergeTone(item: GitHubWorkItem): string {
 }
 
 function getMergeTooltip(item: GitHubWorkItem): string {
-  if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
-    return 'Merge status has not loaded yet'
-  }
   if (item.state === 'merged') {
     return 'This pull request is already merged'
   }
   if (item.state === 'closed') {
     return 'This pull request is closed'
+  }
+  if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
+    return 'Merge status is unavailable for this PR'
   }
   if (item.mergeable === 'CONFLICTING') {
     return 'GitHub reports merge conflicts'
@@ -1203,8 +1193,11 @@ function PRReviewCell({
     if (selectedReviewerLogins.has(reviewer.login.toLowerCase())) {
       return
     }
+    // Close the popover immediately so the UI feels responsive; the GitHub
+    // request runs in the background and toasts on completion.
+    setOpen(false)
+    setReviewerInput('')
     await handleRequestReview([reviewer.login])
-    requestAnimationFrame(() => reviewerInputRef.current?.focus())
   }
 
   const handleReviewerPickerOpenChange = (nextOpen: boolean): void => {
@@ -1901,6 +1894,7 @@ export default function TaskPage(): React.JSX.Element {
   )
   const [tasksLoading, setTasksLoading] = useState(false)
   const [tasksRefreshing, setTasksRefreshing] = useState(false)
+  const [tasksFiltering, setTasksFiltering] = useState(false)
   const [tasksError, setTasksError] = useState<string | null>(null)
   // Why: per-repo failure count surfaced through the "N of M" banner. IPC-level
   // rejections populate tasksError instead — the two are mutually exclusive so
@@ -2718,6 +2712,37 @@ export default function TaskPage(): React.JSX.Element {
     () => applyTypeFilter(currentPageItems),
     [applyTypeFilter, currentPageItems]
   )
+  const showGitHubTaskSkeletons = tasksFiltering || (tasksLoading && filteredWorkItems.length === 0)
+  const loadedGitHubAuthorLogins = useMemo(() => {
+    const seen = new Set<string>()
+    const logins: string[] = []
+    for (const page of pages) {
+      for (const item of page) {
+        if (
+          !item.author ||
+          (activeGithubTaskKind === 'prs' ? item.type !== 'pr' : item.type !== 'issue')
+        ) {
+          continue
+        }
+        const key = item.author.toLowerCase()
+        if (seen.has(key)) {
+          continue
+        }
+        seen.add(key)
+        logins.push(item.author)
+      }
+    }
+    return logins
+  }, [activeGithubTaskKind, pages])
+  const primaryGithubFilterSlug = useMemo(() => {
+    for (const state of perRepoSourceState) {
+      const source = activeGithubTaskKind === 'prs' ? state.sources?.prs : state.sources?.issues
+      if (source) {
+        return source
+      }
+    }
+    return null
+  }, [activeGithubTaskKind, perRepoSourceState])
   const showPRManagementColumns = activeGithubTaskKind === 'prs'
   const githubTaskGridClass = showPRManagementColumns
     ? GITHUB_PR_TASK_GRID_CLASS
@@ -2765,13 +2790,28 @@ export default function TaskPage(): React.JSX.Element {
     }
   }, [ensurePRChecksLoaded, filteredWorkItems, githubMode, showPRManagementColumns, taskSource])
 
-  // Why: totalPages is derived from the search API count when available,
-  // so the pagination bar shows the full range (with ellipsis) upfront.
-  // Falls back to the loaded page count when the count hasn't returned yet.
+  // Why: each page is bounded by both the per-repo fetch budget (so a single
+  // repo can yield at most PER_REPO_FETCH_LIMIT rows per page) and the
+  // post-merge display cap. Dividing the total by CROSS_REPO_DISPLAY_LIMIT
+  // alone under-counts pages when the per-repo budget is the tighter bound —
+  // e.g. one repo with 60 open PRs yielded 36 rows on page 0 and ceil(60/100)
+  // = 1 total pages, hiding the pager entirely.
+  const effectivePageSize = Math.max(
+    1,
+    Math.min(PER_REPO_FETCH_LIMIT * Math.max(1, selectedRepos.length), CROSS_REPO_DISPLAY_LIMIT)
+  )
+  // Why: if the search-API count is unavailable (rate-limited, transient
+  // failure — `countWorkItemsAcrossRepos` swallows errors and returns 0),
+  // infer there's at least one more page whenever the last loaded page
+  // filled to the per-page capacity. Otherwise pagination would silently
+  // hide and trap the user on page 0 with no way to advance.
+  const lastPageFull = (pages.at(-1)?.length ?? 0) >= effectivePageSize
   const totalPages =
-    totalItemCount !== null
-      ? Math.max(pages.length, Math.ceil(totalItemCount / CROSS_REPO_DISPLAY_LIMIT))
-      : pages.length
+    totalItemCount && totalItemCount > 0
+      ? Math.max(pages.length, Math.ceil(totalItemCount / effectivePageSize))
+      : lastPageFull
+        ? pages.length + 1
+        : pages.length
 
   // Why: loads the next page using the oldest item's updatedAt as a cursor.
   // When targetPage is provided (from clicking a numbered page beyond loaded
@@ -2835,10 +2875,14 @@ export default function TaskPage(): React.JSX.Element {
       return
     }
     const timeout = window.setTimeout(() => {
-      setAppliedTaskSearch(scopeGitHubTaskSearch(taskSearchInput, activeGithubTaskKind))
+      const scoped = scopeGitHubTaskSearch(taskSearchInput, activeGithubTaskKind)
+      if (scoped !== appliedTaskSearch) {
+        setTasksFiltering(true)
+      }
+      setAppliedTaskSearch(scoped)
     }, TASK_SEARCH_DEBOUNCE_MS)
     return () => window.clearTimeout(timeout)
-  }, [activeGithubTaskKind, taskSearchInput, taskResumeApplied])
+  }, [activeGithubTaskKind, appliedTaskSearch, taskSearchInput, taskResumeApplied])
 
   useEffect(() => {
     if (!taskResumeApplied) {
@@ -2872,11 +2916,13 @@ export default function TaskPage(): React.JSX.Element {
     if (taskSource !== 'github' || githubMode !== 'items') {
       setRetryingRepoPaths(new Set())
       setTasksRefreshing(false)
+      setTasksFiltering(false)
       return
     }
     if (selectedRepos.length === 0) {
       setRetryingRepoPaths(new Set())
       setTasksRefreshing(false)
+      setTasksFiltering(false)
       return
     } // unreachable — multi-combobox forbids empty
 
@@ -2987,6 +3033,7 @@ export default function TaskPage(): React.JSX.Element {
         setFailedCount(failed)
         setTasksLoading(false)
         setTasksRefreshing(false)
+        setTasksFiltering(false)
       })
       .catch((err) => {
         // Why: fetchWorkItemsAcrossRepos swallows per-repo failures, so a
@@ -3014,6 +3061,7 @@ export default function TaskPage(): React.JSX.Element {
         setFailedCount(0) // the per-repo banner would be misleading next to tasksError
         setTasksLoading(false)
         setTasksRefreshing(false)
+        setTasksFiltering(false)
       })
 
     // Why: fire-and-forget count query in parallel with the items fetch.
@@ -3046,12 +3094,66 @@ export default function TaskPage(): React.JSX.Element {
     taskResumeApplied
   ])
 
+  const applyPRFilterChange = useCallback(
+    (change: PRFilterChange): void => {
+      let next = scopeGitHubTaskSearch(taskSearchInput, activeGithubTaskKind)
+      // Why: each filter dropdown contributes an independent qualifier patch.
+      // `withQualifier` round-trips through parseTaskQuery so prior filters and
+      // free-text are preserved.
+      if ('author' in change) {
+        next = withQualifier(next, 'author', change.author ?? null)
+      }
+      if ('assignee' in change) {
+        next = withQualifier(next, 'assignee', change.assignee ?? null)
+      }
+      if ('labels' in change) {
+        next = withQualifier(next, 'labels', change.labels ?? [])
+      }
+      if ('state' in change && change.state) {
+        next = withQualifier(next, 'state', change.state)
+        if (change.state !== 'open') {
+          next = withQualifier(next, 'draft', null)
+        }
+      }
+      if ('draft' in change) {
+        next = withQualifier(next, 'draft', change.draft ? 'true' : 'false')
+      }
+      if ('reviewer' in change) {
+        // Why: the two reviewer qualifiers (review-requested vs reviewed-by) are
+        // mutually exclusive in the PR-list UX — clear the other axis whenever
+        // one is set so the chip's visible state matches the actual query.
+        const reviewer = change.reviewer ?? null
+        if (reviewer === null) {
+          next = withQualifier(next, 'reviewRequested', null)
+          next = withQualifier(next, 'reviewedBy', null)
+        } else if (reviewer.kind === 'requested') {
+          next = withQualifier(next, 'reviewedBy', null)
+          next = withQualifier(next, 'reviewRequested', reviewer.login)
+        } else {
+          next = withQualifier(next, 'reviewRequested', null)
+          next = withQualifier(next, 'reviewedBy', reviewer.login)
+        }
+      }
+      setTaskSearchInput(next)
+      setAppliedTaskSearch(next)
+      setActiveTaskPreset(null)
+      setTaskResumeState({ githubItemsPreset: null, githubItemsQuery: next })
+      // Why: filter changes replace the meaning of every row. Showing stale
+      // rows while the filtered query resolves reads like the filter did
+      // nothing, so render the same skeleton used for an uncached initial load.
+      setTasksFiltering(true)
+      setTaskRefreshNonce((current) => current + 1)
+    },
+    [activeGithubTaskKind, setTaskResumeState, taskSearchInput]
+  )
+
   const handleApplyTaskSearch = useCallback((): void => {
     const scoped = scopeGitHubTaskSearch(taskSearchInput, activeGithubTaskKind)
     setTaskSearchInput(scoped)
     setAppliedTaskSearch(scoped)
     setActiveTaskPreset(null)
     setTaskResumeState({ githubItemsPreset: null, githubItemsQuery: scoped })
+    setTasksFiltering(true)
     setTaskRefreshNonce((current) => current + 1)
   }, [activeGithubTaskKind, setTaskResumeState, taskSearchInput])
 
@@ -3084,6 +3186,7 @@ export default function TaskPage(): React.JSX.Element {
         githubItemsPreset: preset,
         githubItemsQuery: query
       })
+      setTasksFiltering(true)
       setTaskRefreshNonce((current) => current + 1)
     },
     [setTaskResumeState]
@@ -3331,7 +3434,7 @@ export default function TaskPage(): React.JSX.Element {
     setSelectedLinearIssue
   ])
 
-  const githubTasksBusy = tasksLoading || tasksRefreshing
+  const githubTasksBusy = tasksLoading || tasksRefreshing || tasksFiltering
 
   useEffect(() => {
     // Why: when a modal is open, let it own Esc dismissal.
@@ -3775,7 +3878,7 @@ export default function TaskPage(): React.JSX.Element {
                         inert — hide it to avoid suggesting it does
                         something. */}
                     {githubMode !== 'project' && (
-                      <div className="min-w-0 w-full sm:w-[200px]">
+                      <div className="min-w-0 max-w-[220px] shrink-0">
                         <RepoMultiCombobox
                           repos={eligibleRepos}
                           selected={repoSelection}
@@ -3792,7 +3895,7 @@ export default function TaskPage(): React.JSX.Element {
                               toast.error('Failed to save repo selection.')
                             })
                           }}
-                          triggerClassName="h-8 w-full rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
+                          triggerClassName="h-8 w-auto max-w-[220px] rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
                         />
                       </div>
                     )}
@@ -3801,95 +3904,49 @@ export default function TaskPage(): React.JSX.Element {
 
                 {taskSource === 'github' && githubMode === 'items' ? (
                   <div className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 p-3 shadow-sm">
-                    <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
-                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <div className="flex flex-wrap gap-2">
-                          {getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {
-                            const active = activeTaskPreset === option.id
-                            return (
-                              <button
-                                key={option.id}
-                                type="button"
-                                onClick={() => {
-                                  const query = option.query
-                                  setTaskSearchInput(query)
-                                  setAppliedTaskSearch(query)
-                                  setActiveTaskPreset(option.id)
-                                  setTaskResumeState({
-                                    githubItemsPreset: option.id,
-                                    githubItemsQuery: query
-                                  })
-                                  setTaskRefreshNonce((current) => current + 1)
-                                }}
-                                onContextMenu={(event) => {
-                                  event.preventDefault()
-                                  handleSetDefaultTaskPreset(option.id)
-                                }}
-                                className={cn(
-                                  'rounded-md border px-2 py-1 text-xs transition',
-                                  active
-                                    ? 'border-border/50 bg-foreground/90 text-background backdrop-blur-md'
-                                    : 'border-border/50 bg-transparent text-foreground hover:bg-muted/50'
-                                )}
-                              >
-                                {option.label}
-                              </button>
-                            )
-                          })}
-                        </div>
-                      </div>
-
-                      <div className="flex shrink-0 items-center gap-2">
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              onClick={() => {
-                                setNewIssueTitle('')
-                                setNewIssueBody('')
-                                setNewIssueRepoId(primaryRepo?.id ?? null)
-                                setNewIssueOpen(true)
-                              }}
-                              disabled={!newIssueTargetRepo}
-                              aria-label="New GitHub issue"
-                              className="border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
-                            >
-                              <Plus className="size-4" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" sideOffset={6}>
-                            New GitHub issue
-                          </TooltipContent>
-                        </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              onClick={handleRefreshGithubTasks}
-                              disabled={githubTasksBusy}
-                              aria-busy={githubTasksBusy}
-                              aria-label={
-                                githubTasksBusy ? 'Refreshing GitHub work' : 'Refresh GitHub work'
-                              }
-                              className="cursor-pointer border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md disabled:pointer-events-auto disabled:cursor-wait supports-[backdrop-filter]:bg-transparent"
-                            >
-                              {githubTasksBusy ? (
-                                <LoaderCircle className="size-4 animate-spin" />
-                              ) : (
-                                <RefreshCw className="size-4" />
-                              )}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" sideOffset={6}>
-                            {githubTasksBusy ? 'Refreshing GitHub work…' : 'Refresh GitHub work'}
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
+                    <div className="mb-3 flex flex-wrap gap-2">
+                      {getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {
+                        const active = activeTaskPreset === option.id
+                        return (
+                          <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => {
+                              const query = option.query
+                              setTaskSearchInput(query)
+                              setAppliedTaskSearch(query)
+                              setActiveTaskPreset(option.id)
+                              setTaskResumeState({
+                                githubItemsPreset: option.id,
+                                githubItemsQuery: query
+                              })
+                              setTaskRefreshNonce((current) => current + 1)
+                            }}
+                            onContextMenu={(event) => {
+                              event.preventDefault()
+                              handleSetDefaultTaskPreset(option.id)
+                            }}
+                            className={cn(
+                              'rounded-md border px-2 py-1 text-xs transition',
+                              active
+                                ? 'border-border/50 bg-foreground/90 text-background backdrop-blur-md'
+                                : 'border-border/50 bg-transparent text-foreground hover:bg-muted/50'
+                            )}
+                          >
+                            {option.label}
+                          </button>
+                        )
+                      })}
                     </div>
-
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <PRFilterDropdowns
+                        parsed={parseTaskQuery(taskSearchInput)}
+                        kind={activeGithubTaskKind}
+                        authorLogins={loadedGitHubAuthorLogins}
+                        primarySlug={primaryGithubFilterSlug}
+                        settings={settings}
+                        onChange={(change) => applyPRFilterChange(change)}
+                      />
                       <div className="relative min-w-0 flex-1 basis-64">
                         <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
                         <Input
@@ -3915,6 +3972,54 @@ export default function TaskPage(): React.JSX.Element {
                             <X className="size-4" />
                           </button>
                         ) : null}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              onClick={() => {
+                                setNewIssueTitle('')
+                                setNewIssueBody('')
+                                setNewIssueRepoId(primaryRepo?.id ?? null)
+                                setNewIssueOpen(true)
+                              }}
+                              disabled={!newIssueTargetRepo}
+                              aria-label="New GitHub issue"
+                              className="size-8 border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
+                            >
+                              <Plus className="size-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            New GitHub issue
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              onClick={handleRefreshGithubTasks}
+                              disabled={githubTasksBusy}
+                              aria-busy={githubTasksBusy}
+                              aria-label={
+                                githubTasksBusy ? 'Refreshing GitHub work' : 'Refresh GitHub work'
+                              }
+                              className="size-8 cursor-pointer border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md disabled:pointer-events-auto disabled:cursor-wait supports-[backdrop-filter]:bg-transparent"
+                            >
+                              {githubTasksBusy ? (
+                                <LoaderCircle className="size-4 animate-spin" />
+                              ) : (
+                                <RefreshCw className="size-4" />
+                              )}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            {githubTasksBusy ? 'Refreshing GitHub work…' : 'Refresh GitHub work'}
+                          </TooltipContent>
+                        </Tooltip>
                       </div>
                     </div>
 
@@ -4211,7 +4316,7 @@ export default function TaskPage(): React.JSX.Element {
           ) : taskSource === 'github' ? (
             <div className="flex min-h-0 min-w-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-muted/50 shadow-sm">
               <div
-                className="min-h-0 flex-initial overflow-auto scrollbar-sleek"
+                className="min-h-0 flex-initial overflow-auto scrollbar-sleek scrollbar-sleek-lg"
                 style={{ scrollbarGutter: 'stable' }}
               >
                 <div
@@ -4223,14 +4328,15 @@ export default function TaskPage(): React.JSX.Element {
                   <span className={GITHUB_TASK_STICKY_ID_HEADER_CLASS}>ID</span>
                   <span className={GITHUB_TASK_STICKY_TITLE_HEADER_CLASS}>Title / Context</span>
                   <span>Branch</span>
-                  <span>Status</span>
                   {showPRManagementColumns ? (
                     <>
                       <span>Reviewers</span>
                       <span>Checks</span>
                       <span>Merge</span>
                     </>
-                  ) : null}
+                  ) : (
+                    <span>Status</span>
+                  )}
                   <span>Updated</span>
                   <span />
                 </div>
@@ -4296,13 +4402,13 @@ export default function TaskPage(): React.JSX.Element {
                     )
                   })}
 
-                {tasksLoading && filteredWorkItems.length === 0 ? (
-                  // Why: shimmer skeleton stands in for the first ~3 rows while
-                  // the initial fetch is in flight, so the card is never empty
-                  // or collapsed during load. Only shown when we have no cached
-                  // items — on revalidate we keep the stale list visible.
+                {showGitHubTaskSkeletons ? (
+                  // Why: render enough shimmer rows to fill a typical viewport
+                  // so the table doesn't visibly grow when results land. A
+                  // 3-row stub jumps to ~30 real rows; matching the steady-
+                  // state height keeps layout stable across the load.
                   <div className="divide-y divide-border/50">
-                    {Array.from({ length: 3 }).map((_, i) => (
+                    {Array.from({ length: 12 }).map((_, i) => (
                       <div key={i} className={cn('grid gap-2 px-3 py-2', githubTaskGridClass)}>
                         <div className={GITHUB_TASK_STICKY_ID_CELL_CLASS}>
                           <div className="h-7 w-16 animate-pulse rounded-lg bg-muted/70" />
@@ -4313,9 +4419,6 @@ export default function TaskPage(): React.JSX.Element {
                         </div>
                         <div className="flex items-center">
                           <div className="h-3 w-24 animate-pulse rounded bg-muted/60" />
-                        </div>
-                        <div className="flex items-center">
-                          <div className="h-5 w-14 animate-pulse rounded-full bg-muted/70" />
                         </div>
                         {showPRManagementColumns ? (
                           <>
@@ -4329,7 +4432,11 @@ export default function TaskPage(): React.JSX.Element {
                               <div className="h-5 w-20 animate-pulse rounded-full bg-muted/70" />
                             </div>
                           </>
-                        ) : null}
+                        ) : (
+                          <div className="flex items-center">
+                            <div className="h-5 w-14 animate-pulse rounded-full bg-muted/70" />
+                          </div>
+                        )}
                         <div className="flex items-center">
                           <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
                         </div>
@@ -4347,7 +4454,7 @@ export default function TaskPage(): React.JSX.Element {
                     "No matching GitHub work" next to "Couldn't load issues from X/Y"
                     is contradictory and misleads the user into thinking they
                     typed the wrong query. */}
-                {!tasksLoading &&
+                {!showGitHubTaskSkeletons &&
                 filteredWorkItems.length === 0 &&
                 !tasksError &&
                 failedCount === 0 &&
@@ -4361,179 +4468,200 @@ export default function TaskPage(): React.JSX.Element {
                 ) : null}
 
                 <div className="divide-y divide-border/50">
-                  {filteredWorkItems.map((item) => {
-                    const itemRepo = repoMap.get(item.repoId) ?? null
-                    return (
-                      // Why: the row is a clickable container rather than a
-                      // <button> because it holds nested interactive elements
-                      // (Use button, ellipsis DropdownMenuTrigger, Radix
-                      // TooltipTrigger). A <button> ancestor of another
-                      // <button> is invalid HTML and triggers React hydration
-                      // errors that break rendering of the whole page.
-                      <div
-                        // Why: combine repoId with item.id because two selected repos
-                        // that route issues through the same upstream (e.g. fork +
-                        // non-fork both resolving to stablyai/orca) surface the same
-                        // item.id under different repoIds. React treats a bare id as
-                        // a collision and warns + silently drops rows otherwise.
-                        key={`${item.repoId}:${item.id}`}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => setDialogWorkItem(item)}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter' || event.key === ' ') {
-                            event.preventDefault()
-                            setDialogWorkItem(item)
-                          }
-                        }}
-                        className={cn(
-                          'group/github-task-row grid cursor-pointer gap-2 px-3 py-2 text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-                          githubTaskGridClass
-                        )}
-                      >
-                        <div className={GITHUB_TASK_STICKY_ID_CELL_CLASS}>
-                          <span className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5 text-muted-foreground">
-                            {item.type === 'pr' ? (
-                              <GitPullRequest className="size-3" />
-                            ) : (
-                              <CircleDot className="size-3" />
-                            )}
-                            <span className="font-mono text-[11px] font-normal">
-                              #{item.number}
-                            </span>
-                          </span>
-                        </div>
-
-                        <div className={GITHUB_TASK_STICKY_TITLE_CELL_CLASS}>
-                          <div className="flex items-center gap-2">
-                            <h3 className="truncate text-sm font-semibold text-foreground">
-                              {item.title}
-                            </h3>
-                            {selectedRepos.length > 1 && itemRepo ? (
-                              // Why: disambiguate rows when multiple repos are in
-                              // the merged list — a single-repo view doesn't need it.
-                              <RepoDotLabel
-                                name={itemRepo.displayName}
-                                color={itemRepo.badgeColor}
-                                dotClassName="size-1.5"
-                                className="shrink-0 text-[11px] text-muted-foreground"
-                              />
-                            ) : null}
-                          </div>
-                          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-                            <span>{item.author ?? 'unknown author'}</span>
-                            {selectedRepos.length === 1 && itemRepo ? (
-                              <span>{itemRepo.displayName}</span>
-                            ) : null}
-                            {item.type === 'pr' && formatPRDelta(item) ? (
-                              <span className="inline-flex items-center gap-1">
-                                <Files className="size-3" />
-                                {formatPRDelta(item)}
-                              </span>
-                            ) : null}
-                            {item.labels.slice(0, 3).map((label) => (
-                              <span
-                                key={label}
-                                className="rounded-full border border-border/50 bg-background/80 px-1.5 py-0 text-[10px] text-muted-foreground"
-                              >
-                                {label}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-
-                        <div className="min-w-0 flex items-center text-xs text-muted-foreground">
-                          {item.type === 'pr' ? (
-                            <div className="min-w-0">
-                              <div className="truncate text-foreground">
-                                {item.branchName || 'unknown head'}
-                              </div>
-                              <div className="truncate text-[10px] text-muted-foreground">
-                                into {item.baseRefName || 'base'}
-                              </div>
-                            </div>
-                          ) : (
-                            <span className="truncate">workspace/default</span>
+                  {!showGitHubTaskSkeletons &&
+                    filteredWorkItems.map((item) => {
+                      const itemRepo = repoMap.get(item.repoId) ?? null
+                      return (
+                        // Why: the row is a clickable container rather than a
+                        // <button> because it holds nested interactive elements
+                        // (Use button, ellipsis DropdownMenuTrigger, Radix
+                        // TooltipTrigger). A <button> ancestor of another
+                        // <button> is invalid HTML and triggers React hydration
+                        // errors that break rendering of the whole page.
+                        <div
+                          // Why: combine repoId with item.id because two selected repos
+                          // that route issues through the same upstream (e.g. fork +
+                          // non-fork both resolving to stablyai/orca) surface the same
+                          // item.id under different repoIds. React treats a bare id as
+                          // a collision and warns + silently drops rows otherwise.
+                          key={`${item.repoId}:${item.id}`}
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => setDialogWorkItem(item)}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter' || event.key === ' ') {
+                              event.preventDefault()
+                              setDialogWorkItem(item)
+                            }
+                          }}
+                          className={cn(
+                            'group/github-task-row grid cursor-pointer gap-2 px-3 py-2 text-left transition hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                            githubTaskGridClass
                           )}
+                        >
+                          <div className={GITHUB_TASK_STICKY_ID_CELL_CLASS}>
+                            <span
+                              className={cn(
+                                'inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5',
+                                item.state === 'merged'
+                                  ? 'text-purple-600 dark:text-purple-300'
+                                  : item.state === 'closed'
+                                    ? 'text-rose-600 dark:text-rose-300'
+                                    : 'text-muted-foreground'
+                              )}
+                            >
+                              {item.type === 'pr' ? (
+                                <GitPullRequest className="size-3" />
+                              ) : (
+                                <CircleDot className="size-3" />
+                              )}
+                              <span className="font-mono text-[11px] font-normal">
+                                #{item.number}
+                              </span>
+                            </span>
+                          </div>
+
+                          <div className={GITHUB_TASK_STICKY_TITLE_CELL_CLASS}>
+                            <div className="flex items-center gap-2">
+                              <h3 className="truncate text-sm font-semibold text-foreground">
+                                {item.title}
+                              </h3>
+                              {item.type === 'pr' && item.state === 'draft' ? (
+                                <span className="shrink-0 rounded-full border border-slate-500/30 bg-slate-500/10 px-1.5 py-0 text-[10px] font-medium text-slate-600 dark:text-slate-300">
+                                  Draft
+                                </span>
+                              ) : null}
+                              {selectedRepos.length > 1 && itemRepo ? (
+                                // Why: disambiguate rows when multiple repos are in
+                                // the merged list — a single-repo view doesn't need it.
+                                <RepoDotLabel
+                                  name={itemRepo.displayName}
+                                  color={itemRepo.badgeColor}
+                                  dotClassName="size-1.5"
+                                  className="shrink-0 text-[11px] text-muted-foreground"
+                                />
+                              ) : null}
+                            </div>
+                            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                              <span>{item.author ?? 'unknown author'}</span>
+                              {selectedRepos.length === 1 && itemRepo ? (
+                                <span>{itemRepo.displayName}</span>
+                              ) : null}
+                              {item.type === 'pr' && formatPRDelta(item) ? (
+                                <span className="inline-flex items-center gap-1">
+                                  <Files className="size-3" />
+                                  {formatPRDelta(item)}
+                                </span>
+                              ) : null}
+                              {item.labels.slice(0, 3).map((label) => (
+                                <span
+                                  key={label}
+                                  className="rounded-full border border-border/50 bg-background/80 px-1.5 py-0 text-[10px] text-muted-foreground"
+                                >
+                                  {label}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+
+                          <div className="min-w-0 flex items-center text-xs text-muted-foreground">
+                            {item.type === 'pr' ? (
+                              <div className="min-w-0">
+                                <div className="truncate text-foreground">
+                                  {item.branchName || 'unknown head'}
+                                </div>
+                                <div className="truncate text-[10px] text-muted-foreground">
+                                  into {item.baseRefName || 'base'}
+                                </div>
+                              </div>
+                            ) : (
+                              <span className="truncate">workspace/default</span>
+                            )}
+                          </div>
+
+                          {showPRManagementColumns ? (
+                            <>
+                              <div className="flex min-w-0 items-center">
+                                <PRReviewCell item={item} repo={itemRepo ?? null} />
+                              </div>
+
+                              <div className="flex min-w-0 items-center">
+                                <PRChecksCell
+                                  item={item}
+                                  onOpen={() => setDialogWorkItem(item, 'checks')}
+                                  onLoadChecks={() => ensurePRChecksLoaded(item)}
+                                />
+                              </div>
+
+                              <div className="flex min-w-0 items-center">
+                                <PRMergeCell
+                                  item={item}
+                                  repo={itemRepo ?? null}
+                                  onRefresh={() => setTaskRefreshNonce((current) => current + 1)}
+                                />
+                              </div>
+                            </>
+                          ) : (
+                            <div className="flex items-center">
+                              <GHStatusCell item={item} repo={itemRepo ?? null} />
+                            </div>
+                          )}
+
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="flex items-center text-[11px] text-muted-foreground">
+                                {formatRelativeTime(item.updatedAt)}
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom" sideOffset={6}>
+                              {new Date(item.updatedAt).toLocaleString()}
+                            </TooltipContent>
+                          </Tooltip>
+
+                          <div className="flex items-center justify-start gap-1 lg:justify-end">
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                handleUseWorkItem(item)
+                              }}
+                              className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60"
+                            >
+                              Start
+                              <ArrowRight className="size-3" />
+                            </button>
+                            <DropdownMenu modal={false}>
+                              <DropdownMenuTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
+                                  aria-label="More actions"
+                                >
+                                  <EllipsisVertical className="size-4" />
+                                </button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+                                <DropdownMenuItem
+                                  onSelect={() => window.api.shell.openUrl(item.url)}
+                                >
+                                  <ExternalLink className="size-4" />
+                                  Open in browser
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
                         </div>
-
-                        <div className="flex items-center">
-                          <GHStatusCell item={item} repo={itemRepo ?? null} />
-                        </div>
-
-                        {showPRManagementColumns ? (
-                          <>
-                            <div className="flex min-w-0 items-center">
-                              <PRReviewCell item={item} repo={itemRepo ?? null} />
-                            </div>
-
-                            <div className="flex min-w-0 items-center">
-                              <PRChecksCell
-                                item={item}
-                                onOpen={() => setDialogWorkItem(item, 'checks')}
-                                onLoadChecks={() => ensurePRChecksLoaded(item)}
-                              />
-                            </div>
-
-                            <div className="flex min-w-0 items-center">
-                              <PRMergeCell
-                                item={item}
-                                repo={itemRepo ?? null}
-                                onRefresh={() => setTaskRefreshNonce((current) => current + 1)}
-                              />
-                            </div>
-                          </>
-                        ) : null}
-
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div className="flex items-center text-[11px] text-muted-foreground">
-                              {formatRelativeTime(item.updatedAt)}
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom" sideOffset={6}>
-                            {new Date(item.updatedAt).toLocaleString()}
-                          </TooltipContent>
-                        </Tooltip>
-
-                        <div className="flex items-center justify-start gap-1 lg:justify-end">
-                          <button
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation()
-                              handleUseWorkItem(item)
-                            }}
-                            className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60"
-                          >
-                            Start workspace
-                            <ArrowRight className="size-3" />
-                          </button>
-                          <DropdownMenu modal={false}>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type="button"
-                                onClick={(e) => e.stopPropagation()}
-                                className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
-                                aria-label="More actions"
-                              >
-                                <EllipsisVertical className="size-4" />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-                              <DropdownMenuItem onSelect={() => window.api.shell.openUrl(item.url)}>
-                                <ExternalLink className="size-4" />
-                                Open in browser
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
-                      </div>
-                    )
-                  })}
+                      )
+                    })}
                 </div>
+              </div>
 
-                {/* Pagination controls — GitHub-style with ellipsis */}
-                {filteredWorkItems.length > 0 && !tasksLoading && totalPages > 1 ? (
+              {/* Why: pagination sits outside the scroll container so it
+                  remains pinned at the bottom of the panel rather than
+                  hiding below the last row inside the scrolling region. */}
+              {filteredWorkItems.length > 0 && !showGitHubTaskSkeletons && totalPages > 1 ? (
+                <div className="flex-none border-t border-border/50 bg-muted/50">
                   <PaginationBar
                     currentPage={currentPage}
                     totalPages={totalPages}
@@ -4546,8 +4674,8 @@ export default function TaskPage(): React.JSX.Element {
                       }
                     }}
                   />
-                ) : null}
-              </div>
+                </div>
+              ) : null}
             </div>
           ) : taskSource === 'gitlab' && gitlabView === 'todos' ? (
             <div className="flex min-h-0 max-h-full flex-col rounded-md border border-t-0 border-border/50 bg-muted/50 overflow-hidden rounded-t-none shadow-sm">
@@ -4564,7 +4692,7 @@ export default function TaskPage(): React.JSX.Element {
               >
                 {gitlabTodosLoading && gitlabTodos.length === 0 ? (
                   <div className="divide-y divide-border/50">
-                    {Array.from({ length: 3 }).map((_, i) => (
+                    {Array.from({ length: 12 }).map((_, i) => (
                       <div
                         key={i}
                         className="grid w-full gap-3 px-3 py-2 grid-cols-[110px_minmax(0,3fr)_minmax(120px,1.2fr)_110px_50px]"
@@ -4650,9 +4778,11 @@ export default function TaskPage(): React.JSX.Element {
                 ) : null}
                 {gitlabLoading && gitlabItems.length === 0 ? (
                   // Why: matches the GitHub / Linear shimmer pattern so the card
-                  // never flashes empty during the initial fetch.
+                  // never flashes empty during the initial fetch. Row count is
+                  // tuned to fill the viewport so the table doesn't visibly
+                  // grow when real rows land.
                   <div className="divide-y divide-border/50">
-                    {Array.from({ length: 3 }).map((_, i) => (
+                    {Array.from({ length: 12 }).map((_, i) => (
                       <div
                         key={i}
                         className="grid w-full gap-3 px-3 py-2 grid-cols-[80px_minmax(0,3fr)_120px_110px_50px]"
@@ -4892,7 +5022,7 @@ export default function TaskPage(): React.JSX.Element {
 
                 {linearLoading && linearIssues.length === 0 ? (
                   <div className="divide-y divide-border/50">
-                    {Array.from({ length: 6 }).map((_, i) => (
+                    {Array.from({ length: 12 }).map((_, i) => (
                       <div key={i} className="px-3 py-3">
                         <div className="h-4 w-4/5 animate-pulse rounded bg-muted/70" />
                         <div className="mt-2 h-3 w-3/5 animate-pulse rounded bg-muted/60" />
@@ -5236,7 +5366,7 @@ export default function TaskPage(): React.JSX.Element {
                                 </Button>
                               </TooltipTrigger>
                               <TooltipContent side="bottom" sideOffset={6}>
-                                Start workspace
+                                Start
                               </TooltipContent>
                             </Tooltip>
                             <Tooltip>

--- a/src/renderer/src/components/github-project/ProjectCell.tsx
+++ b/src/renderer/src/components/github-project/ProjectCell.tsx
@@ -779,7 +779,7 @@ function AssigneesCell({
             'flex h-full w-full flex-wrap items-center gap-1 cursor-pointer px-1 text-xs text-muted-foreground hover:text-foreground'
           )}
         >
-          {labelContent ?? <EmptyCellPrompt label="Add assignee" />}
+          {labelContent ?? <EmptyCellPrompt label="Assign" />}
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-64 p-1">

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -5,7 +5,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ExternalLink,
-  Loader,
   RefreshCw,
   KanbanSquare,
   Map as MapIcon,
@@ -724,10 +723,7 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
           Choose a project to get started.
         </div>
       ) : loading && !table ? (
-        <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
-          <Loader className="mr-2 size-4 animate-spin" />
-          Loading project view…
-        </div>
+        <ProjectTableSkeleton />
       ) : error ? (
         <ErrorState
           error={error.error}
@@ -1091,6 +1087,49 @@ function ErrorState({
         <Button size="sm" variant="outline" onClick={onOpenInGitHub}>
           <ExternalLink className="mr-1 size-3.5" /> Open in GitHub
         </Button>
+      </div>
+    </div>
+  )
+}
+
+// Why: matches the shape of ProjectViewList's header + rows so the table
+// doesn't visibly jump in height when real data lands. A 12-row stub fills
+// a typical viewport at the table's min-h-10 row height.
+function ProjectTableSkeleton(): React.JSX.Element {
+  const headerCols = 6
+  const bodyCols = 5
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading project view"
+      className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+    >
+      <div className="grid items-center gap-3 border-b border-border/60 bg-background/95 px-3 py-2">
+        <div
+          className="grid items-center gap-3"
+          style={{
+            gridTemplateColumns: `repeat(${headerCols}, minmax(0, 1fr))`
+          }}
+        >
+          {Array.from({ length: headerCols }).map((_, i) => (
+            <div key={i} className="h-3 w-20 animate-pulse rounded bg-muted/70" />
+          ))}
+        </div>
+      </div>
+      <div className="divide-y divide-border/30">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div
+            key={i}
+            className="grid min-h-10 items-center gap-3 px-3 py-2"
+            style={{ gridTemplateColumns: `repeat(${bodyCols}, minmax(0, 1fr))` }}
+          >
+            <div className="h-4 w-3/5 animate-pulse rounded bg-muted/70" />
+            <div className="h-4 w-4/5 animate-pulse rounded bg-muted/70" />
+            <div className="h-4 w-2/5 animate-pulse rounded-full bg-muted/60" />
+            <div className="h-4 w-3/5 animate-pulse rounded bg-muted/60" />
+            <div className="h-4 w-1/2 animate-pulse rounded bg-muted/60" />
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/src/renderer/src/components/github/PRFilterDropdowns.tsx
+++ b/src/renderer/src/components/github/PRFilterDropdowns.tsx
@@ -1,0 +1,269 @@
+// Why: GitHub-style PR filter UI. A single "Filters" button opens a popover
+// containing Author / Label / Reviewer / Assignee sections, mirroring GitHub's
+// own collapsed Filters dropdown so the toolbar stays uncluttered when nothing
+// is set. Active filters surface as inline removable pills next to the button.
+import React, { useEffect, useMemo, useState } from 'react'
+import { ListFilter, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+import { useRepoLabelsBySlug, useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
+import { type PickerOption } from '@/components/github/PRFilterPickers'
+import {
+  SectionDetail,
+  SectionMenu,
+  type PRFilterChange,
+  type SectionKey
+} from '@/components/github/PRFilterSections'
+import type {
+  GitHubAssignableUser,
+  GitHubOwnerRepo,
+  GlobalSettings
+} from '../../../../shared/types'
+import type { ParsedTaskQuery } from '../../../../shared/task-query'
+
+type Props = {
+  parsed: ParsedTaskQuery
+  kind: 'prs' | 'issues'
+  authorLogins: string[]
+  // Why: drive label + assignable-user lookups off the first selected repo.
+  // Cross-repo filters can't enumerate every repo's labels in one popover —
+  // GitHub's own PR list scopes the dropdown to a single repo too.
+  primarySlug: GitHubOwnerRepo | null
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  onChange: (change: PRFilterChange) => void
+}
+
+export type { PRFilterChange } from '@/components/github/PRFilterSections'
+
+function userOptions(users: GitHubAssignableUser[]): PickerOption[] {
+  return users.map((u) => ({ key: u.login, primary: u.login, secondary: u.name ?? undefined }))
+}
+
+function ActivePill({
+  label,
+  value,
+  onClear
+}: {
+  label: string
+  value: string
+  onClear: () => void
+}): React.JSX.Element {
+  return (
+    <span className="inline-flex h-6 items-center gap-1 rounded-full border border-border/60 bg-muted/50 pl-2 pr-1 text-[11px] text-foreground">
+      <span className="text-muted-foreground">{label}:</span>
+      <span className="max-w-[160px] truncate font-medium">{value}</span>
+      <button
+        type="button"
+        aria-label={`Remove ${label} filter`}
+        onClick={onClear}
+        className="rounded-full p-0.5 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+      >
+        <X className="size-3" />
+      </button>
+    </span>
+  )
+}
+
+export default function PRFilterDropdowns({
+  parsed,
+  kind,
+  authorLogins,
+  primarySlug,
+  settings,
+  onChange
+}: Props): React.JSX.Element {
+  const [openSection, setOpenSection] = useState<SectionKey | null>(null)
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const owner = primarySlug?.owner ?? null
+  const repo = primarySlug?.repo ?? null
+  const hasPrimarySlug = popoverOpen && owner !== null && repo !== null
+  const labelsState = useRepoLabelsBySlug(
+    popoverOpen ? owner : null,
+    popoverOpen ? repo : null,
+    settings
+  )
+  const assigneesState = useRepoAssigneesBySlug(
+    popoverOpen ? owner : null,
+    popoverOpen ? repo : null,
+    undefined,
+    settings
+  )
+
+  // Why: surface @me as a first-class option even though it's not a real
+  // login — GitHub's search API resolves it server-side to the authenticated
+  // user, matching the behavior of the built-in "Mine" / "Needs review" presets.
+  const userOpts = useMemo<PickerOption[]>(() => {
+    const meOption: PickerOption = { key: '@me', primary: '@me', secondary: 'Current user' }
+    return [meOption, ...userOptions(hasPrimarySlug ? assigneesState.data : [])]
+  }, [assigneesState.data, hasPrimarySlug])
+  const authorOpts = useMemo<PickerOption[]>(() => {
+    const options = new Map<string, PickerOption>()
+    options.set('@me', { key: '@me', primary: '@me', secondary: 'Current user' })
+    // Why: the Author filter should reflect actual visible item authors.
+    // Assignable-user metadata is repo-collaborator scoped and can omit outside
+    // contributors.
+    for (const login of authorLogins) {
+      options.set(login.toLowerCase(), { key: login, primary: login })
+    }
+    if (parsed.author && !options.has(parsed.author.toLowerCase())) {
+      options.set(parsed.author.toLowerCase(), { key: parsed.author, primary: parsed.author })
+    }
+    return [...options.values()]
+  }, [authorLogins, parsed.author])
+  const labelOpts = useMemo<PickerOption[]>(
+    () => (hasPrimarySlug ? labelsState.data.map((name) => ({ key: name, primary: name })) : []),
+    [hasPrimarySlug, labelsState.data]
+  )
+
+  const reviewerActive = parsed.reviewRequested ?? parsed.reviewedBy ?? null
+  const reviewerKind: 'requested' | 'reviewed-by' = parsed.reviewedBy ? 'reviewed-by' : 'requested'
+  const [reviewerMode, setReviewerMode] = useState<'requested' | 'reviewed-by'>(reviewerKind)
+  // Why: keep mode in sync if the user types qualifier syntax directly.
+  useEffect(() => {
+    setReviewerMode(reviewerKind)
+  }, [reviewerKind])
+
+  // Why: treat anything other than the implicit "open" default as an active
+  // status filter so the user can see (and clear) it via the inline pill.
+  const statusActive = (parsed.state !== null && parsed.state !== 'open') || parsed.draft
+  const statusPillValue = ((): string | null => {
+    const parts: string[] = []
+    if (parsed.state === 'closed') {
+      parts.push('Closed')
+    } else if (parsed.state === 'merged') {
+      parts.push('Merged')
+    } else if (parsed.state === 'all') {
+      parts.push('Any')
+    }
+    if (parsed.draft) {
+      parts.push('Draft')
+    }
+    return parts.length > 0 ? parts.join(' · ') : null
+  })()
+
+  const activeCount =
+    (statusActive ? 1 : 0) +
+    (parsed.author ? 1 : 0) +
+    (parsed.assignee ? 1 : 0) +
+    (reviewerActive ? 1 : 0) +
+    (parsed.labels.length > 0 ? 1 : 0)
+
+  const handleSelect = (change: PRFilterChange): void => {
+    onChange(change)
+    setOpenSection(null)
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <Popover
+        open={popoverOpen}
+        onOpenChange={(next) => {
+          setPopoverOpen(next)
+          if (!next) {
+            setOpenSection(null)
+          }
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              'h-7 gap-1.5 rounded-md border-border/50 px-2 text-xs font-normal',
+              'bg-transparent hover:bg-muted/50',
+              activeCount > 0 && 'border-border'
+            )}
+          >
+            <ListFilter className="size-3.5" />
+            Filters
+            {activeCount > 0 ? (
+              <span className="ml-0.5 rounded-full bg-muted px-1.5 text-[10px] font-medium text-foreground">
+                {activeCount}
+              </span>
+            ) : null}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-72 p-0">
+          {openSection === null ? (
+            <SectionMenu
+              parsed={parsed}
+              kind={kind}
+              reviewerActive={reviewerActive}
+              reviewerKind={reviewerKind}
+              onPick={(s) => setOpenSection(s)}
+              onClearAll={
+                activeCount > 0
+                  ? () => {
+                      onChange({
+                        author: null,
+                        assignee: null,
+                        reviewer: null,
+                        labels: [],
+                        state: 'open',
+                        draft: false
+                      })
+                      setPopoverOpen(false)
+                    }
+                  : null
+              }
+            />
+          ) : (
+            <SectionDetail
+              section={openSection}
+              parsed={parsed}
+              kind={kind}
+              authorOpts={authorOpts}
+              userOpts={userOpts}
+              labelOpts={labelOpts}
+              labelsLoading={hasPrimarySlug && labelsState.loading}
+              labelsError={hasPrimarySlug ? labelsState.error : null}
+              usersLoading={hasPrimarySlug && assigneesState.loading}
+              usersError={hasPrimarySlug ? assigneesState.error : null}
+              reviewerMode={reviewerMode}
+              setReviewerMode={setReviewerMode}
+              onBack={() => setOpenSection(null)}
+              onSelect={handleSelect}
+            />
+          )}
+        </PopoverContent>
+      </Popover>
+      {statusPillValue ? (
+        <ActivePill
+          label="Status"
+          value={statusPillValue}
+          onClear={() => onChange({ state: 'open', draft: false })}
+        />
+      ) : null}
+      {parsed.author ? (
+        <ActivePill
+          label="Author"
+          value={parsed.author}
+          onClear={() => onChange({ author: null })}
+        />
+      ) : null}
+      {parsed.labels.length > 0 ? (
+        <ActivePill
+          label="Label"
+          value={parsed.labels.length === 1 ? parsed.labels[0] : `${parsed.labels.length} labels`}
+          onClear={() => onChange({ labels: [] })}
+        />
+      ) : null}
+      {reviewerActive ? (
+        <ActivePill
+          label={reviewerKind === 'reviewed-by' ? 'Reviewed by' : 'Review from'}
+          value={reviewerActive}
+          onClear={() => onChange({ reviewer: null })}
+        />
+      ) : null}
+      {parsed.assignee ? (
+        <ActivePill
+          label="Assignee"
+          value={parsed.assignee}
+          onClear={() => onChange({ assignee: null })}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/github/PRFilterPickers.tsx
+++ b/src/renderer/src/components/github/PRFilterPickers.tsx
@@ -1,0 +1,190 @@
+// Why: lower-level pickers used by PRFilterDropdowns. Split out so the parent
+// stays under the per-file line cap and so each picker can be tested or reused
+// independently of the qualifier-mapping logic.
+import React, { useMemo, useState } from 'react'
+import { Check } from 'lucide-react'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { cn } from '@/lib/utils'
+
+export type PickerOption = { key: string; primary: string; secondary?: string }
+
+function filterOptions(options: PickerOption[], query: string): PickerOption[] {
+  const q = query.trim().toLowerCase()
+  if (!q) {
+    return options
+  }
+  return options.filter(
+    (o) => o.primary.toLowerCase().includes(q) || (o.secondary ?? '').toLowerCase().includes(q)
+  )
+}
+
+export function SingleSelectList({
+  options,
+  activeValue,
+  loading,
+  error,
+  searchPlaceholder,
+  emptyText,
+  renderOption,
+  allowCustomValue,
+  onSelect
+}: {
+  options: PickerOption[]
+  activeValue: string | null
+  loading: boolean
+  error: string | null
+  searchPlaceholder: string
+  emptyText?: string
+  renderOption?: (opt: PickerOption) => React.ReactNode
+  // Why: PR authors and reviewers can be external contributors who aren't in
+  // `listAssignableUsers` (repo collaborators only). Allowing a typed login as
+  // a fallback lets the user filter by anyone GitHub recognizes.
+  allowCustomValue?: boolean
+  onSelect: (value: string | null) => void
+}): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const filtered = useMemo(() => filterOptions(options, query), [options, query])
+  const trimmed = query.trim()
+  const showCustom =
+    allowCustomValue &&
+    trimmed.length > 0 &&
+    !filtered.some((o) => o.key.toLowerCase() === trimmed.toLowerCase())
+  const fallback = loading
+    ? 'Loading…'
+    : showCustom
+      ? 'Press Enter to use the typed value.'
+      : (error ?? emptyText ?? 'No matches')
+
+  return (
+    <Command shouldFilter={false}>
+      <CommandInput
+        placeholder={searchPlaceholder}
+        value={query}
+        onValueChange={setQuery}
+        className="text-xs"
+      />
+      <CommandList>
+        <CommandEmpty>{fallback}</CommandEmpty>
+        {showCustom ? (
+          <CommandItem
+            value={`__custom__:${trimmed}`}
+            onSelect={() => onSelect(trimmed)}
+            className="items-center gap-2 px-3 py-1.5 text-xs"
+          >
+            <span className="text-muted-foreground">Use</span>
+            <span className="truncate font-medium">{trimmed}</span>
+          </CommandItem>
+        ) : null}
+        {activeValue ? (
+          <CommandItem
+            value="__clear__"
+            onSelect={() => onSelect(null)}
+            className="gap-2 px-3 py-1.5 text-xs text-muted-foreground"
+          >
+            Clear
+          </CommandItem>
+        ) : null}
+        {filtered.map((opt) => {
+          const isActive = opt.key === activeValue
+          return (
+            <CommandItem
+              key={opt.key}
+              value={opt.key}
+              onSelect={() => onSelect(isActive ? null : opt.key)}
+              className="items-center gap-2 px-3 py-1.5 text-xs"
+            >
+              <Check
+                className={cn(
+                  'size-3 text-muted-foreground',
+                  isActive ? 'opacity-70' : 'opacity-0'
+                )}
+              />
+              {renderOption ? renderOption(opt) : <span className="truncate">{opt.primary}</span>}
+            </CommandItem>
+          )
+        })}
+      </CommandList>
+    </Command>
+  )
+}
+
+export function MultiSelectList({
+  options,
+  selected,
+  loading,
+  error,
+  searchPlaceholder,
+  emptyText,
+  onChange
+}: {
+  options: PickerOption[]
+  selected: string[]
+  loading: boolean
+  error: string | null
+  searchPlaceholder: string
+  emptyText?: string
+  onChange: (next: string[]) => void
+}): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const filtered = useMemo(() => filterOptions(options, query), [options, query])
+  const selectedSet = useMemo(() => new Set(selected), [selected])
+  const fallback = loading ? 'Loading…' : (error ?? emptyText ?? 'No matches')
+
+  const toggle = (key: string): void => {
+    const next = new Set(selectedSet)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    onChange([...next])
+  }
+
+  return (
+    <Command shouldFilter={false}>
+      <CommandInput
+        placeholder={searchPlaceholder}
+        value={query}
+        onValueChange={setQuery}
+        className="text-xs"
+      />
+      <CommandList>
+        <CommandEmpty>{fallback}</CommandEmpty>
+        {selected.length > 0 ? (
+          <CommandItem
+            value="__clear__"
+            onSelect={() => onChange([])}
+            className="gap-2 px-3 py-1.5 text-xs text-muted-foreground"
+          >
+            Clear ({selected.length})
+          </CommandItem>
+        ) : null}
+        {filtered.map((opt) => {
+          const isActive = selectedSet.has(opt.key)
+          return (
+            <CommandItem
+              key={opt.key}
+              value={opt.key}
+              onSelect={() => toggle(opt.key)}
+              className="items-center gap-2 px-3 py-1.5 text-xs"
+            >
+              <Check
+                className={cn(
+                  'size-3 text-muted-foreground',
+                  isActive ? 'opacity-70' : 'opacity-0'
+                )}
+              />
+              <span className="truncate">{opt.primary}</span>
+            </CommandItem>
+          )
+        })}
+      </CommandList>
+    </Command>
+  )
+}

--- a/src/renderer/src/components/github/PRFilterSections.tsx
+++ b/src/renderer/src/components/github/PRFilterSections.tsx
@@ -1,0 +1,327 @@
+import React from 'react'
+import { ChevronRight } from 'lucide-react'
+import {
+  MultiSelectList,
+  SingleSelectList,
+  type PickerOption
+} from '@/components/github/PRFilterPickers'
+import { cn } from '@/lib/utils'
+import type { ParsedTaskQuery } from '../../../../shared/task-query'
+
+export type PRFilterChange = {
+  author?: string | null
+  assignee?: string | null
+  reviewer?: { kind: 'requested' | 'reviewed-by'; login: string } | null
+  labels?: string[]
+  state?: 'open' | 'closed' | 'merged' | 'all'
+  draft?: boolean
+}
+
+export type SectionKey = 'status' | 'author' | 'label' | 'reviewer' | 'assignee'
+
+function statusLabel(parsed: ParsedTaskQuery): string {
+  const parts: string[] = []
+  if (parsed.state === 'open') {
+    parts.push('Open')
+  } else if (parsed.state === 'closed') {
+    parts.push('Closed')
+  } else if (parsed.state === 'merged') {
+    parts.push('Merged')
+  } else if (parsed.state === 'all') {
+    parts.push('All')
+  }
+  if (parsed.draft) {
+    parts.push('Draft')
+  }
+  return parts.join(' · ')
+}
+
+function StatusSection({
+  parsed,
+  kind,
+  onSelect
+}: {
+  parsed: ParsedTaskQuery
+  kind: 'prs' | 'issues'
+  onSelect: (change: PRFilterChange) => void
+}): React.JSX.Element {
+  const states: { key: 'open' | 'closed' | 'merged' | 'all'; label: string }[] =
+    kind === 'prs'
+      ? [
+          { key: 'open', label: 'Open' },
+          { key: 'closed', label: 'Closed' },
+          { key: 'merged', label: 'Merged' },
+          { key: 'all', label: 'Any state' }
+        ]
+      : [
+          { key: 'open', label: 'Open' },
+          { key: 'closed', label: 'Closed' },
+          { key: 'all', label: 'Any state' }
+        ]
+  return (
+    <div className="py-1 text-xs">
+      {states.map((s) => {
+        const active = parsed.state === s.key
+        return (
+          <button
+            key={s.key}
+            type="button"
+            onClick={() => onSelect({ state: s.key })}
+            className={cn(
+              'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50',
+              active && 'bg-muted/40 font-medium'
+            )}
+          >
+            <span>{s.label}</span>
+            {active ? <span className="text-[10px] text-muted-foreground">selected</span> : null}
+          </button>
+        )
+      })}
+      {kind !== 'prs' ? null : <DraftToggle parsed={parsed} onSelect={onSelect} />}
+    </div>
+  )
+}
+
+function DraftToggle({
+  parsed,
+  onSelect
+}: {
+  parsed: ParsedTaskQuery
+  onSelect: (change: PRFilterChange) => void
+}): React.JSX.Element {
+  return (
+    <>
+      <div className="my-1 h-px bg-border" />
+      <button
+        type="button"
+        onClick={() => onSelect({ draft: !parsed.draft })}
+        className={cn(
+          'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50',
+          parsed.draft && 'bg-muted/40 font-medium'
+        )}
+      >
+        <span>Draft only</span>
+        {parsed.draft ? (
+          <span className="text-[10px] text-muted-foreground">on</span>
+        ) : (
+          <span className="text-[10px] text-muted-foreground">off</span>
+        )}
+      </button>
+    </>
+  )
+}
+
+function UserOptionRow({ option }: { option: PickerOption }): React.JSX.Element {
+  return (
+    <div className="flex min-w-0 flex-col">
+      <span className="truncate">{option.primary}</span>
+      {option.secondary ? (
+        <span className="truncate text-[10px] text-muted-foreground">{option.secondary}</span>
+      ) : null}
+    </div>
+  )
+}
+
+export function SectionMenu({
+  parsed,
+  kind,
+  reviewerActive,
+  reviewerKind,
+  onPick,
+  onClearAll
+}: {
+  parsed: ParsedTaskQuery
+  kind: 'prs' | 'issues'
+  reviewerActive: string | null
+  reviewerKind: 'requested' | 'reviewed-by'
+  onPick: (s: SectionKey) => void
+  onClearAll: (() => void) | null
+}): React.JSX.Element {
+  const status = statusLabel(parsed)
+  const rows: { key: SectionKey; label: string; value: string | null }[] = [
+    { key: 'status', label: 'Status', value: status || null },
+    { key: 'author', label: 'Author', value: parsed.author },
+    {
+      key: 'label',
+      label: 'Label',
+      value:
+        parsed.labels.length === 0
+          ? null
+          : parsed.labels.length === 1
+            ? parsed.labels[0]
+            : `${parsed.labels.length} labels`
+    },
+    ...(kind === 'prs'
+      ? [
+          {
+            key: 'reviewer' as SectionKey,
+            label: reviewerKind === 'reviewed-by' ? 'Reviewed by' : 'Review from',
+            value: reviewerActive
+          }
+        ]
+      : []),
+    { key: 'assignee', label: 'Assignee', value: parsed.assignee }
+  ]
+  const subject = kind === 'prs' ? 'pull requests' : 'issues'
+  return (
+    <div className="py-1 text-xs">
+      <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Filter {subject}
+      </div>
+      {rows.map((row) => (
+        <button
+          key={row.key}
+          type="button"
+          onClick={() => onPick(row.key)}
+          className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50"
+        >
+          <span>{row.label}</span>
+          <span className="flex items-center gap-1 text-muted-foreground">
+            {row.value ? <span className="max-w-[140px] truncate">{row.value}</span> : null}
+            <ChevronRight className="size-3.5" />
+          </span>
+        </button>
+      ))}
+      {onClearAll ? (
+        <>
+          <div className="my-1 h-px bg-border" />
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="w-full px-3 py-1.5 text-left text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
+          >
+            Clear all filters
+          </button>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export function SectionDetail({
+  section,
+  parsed,
+  kind,
+  authorOpts,
+  userOpts,
+  labelOpts,
+  labelsLoading,
+  labelsError,
+  usersLoading,
+  usersError,
+  reviewerMode,
+  setReviewerMode,
+  onBack,
+  onSelect
+}: {
+  section: SectionKey
+  parsed: ParsedTaskQuery
+  kind: 'prs' | 'issues'
+  authorOpts: PickerOption[]
+  userOpts: PickerOption[]
+  labelOpts: PickerOption[]
+  labelsLoading: boolean
+  labelsError: string | null
+  usersLoading: boolean
+  usersError: string | null
+  reviewerMode: 'requested' | 'reviewed-by'
+  setReviewerMode: (mode: 'requested' | 'reviewed-by') => void
+  onBack: () => void
+  onSelect: (change: PRFilterChange) => void
+}): React.JSX.Element {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex w-full items-center gap-1 border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
+      >
+        <ChevronRight className="size-3 rotate-180" />
+        Back
+      </button>
+      {section === 'status' ? (
+        <StatusSection parsed={parsed} kind={kind} onSelect={onSelect} />
+      ) : null}
+      {section === 'author' ? (
+        <SingleSelectList
+          options={authorOpts}
+          activeValue={parsed.author}
+          loading={false}
+          error={null}
+          searchPlaceholder="Filter or type a login..."
+          emptyText="No authors"
+          allowCustomValue
+          renderOption={(opt) => <UserOptionRow option={opt} />}
+          onSelect={(value) => onSelect({ author: value })}
+        />
+      ) : null}
+      {section === 'assignee' ? (
+        <SingleSelectList
+          options={userOpts}
+          activeValue={parsed.assignee}
+          loading={usersLoading}
+          error={usersError}
+          searchPlaceholder="Filter or type a login..."
+          emptyText="No users"
+          allowCustomValue
+          renderOption={(opt) => <UserOptionRow option={opt} />}
+          onSelect={(value) => onSelect({ assignee: value })}
+        />
+      ) : null}
+      {section === 'label' ? (
+        <MultiSelectList
+          options={labelOpts}
+          selected={parsed.labels}
+          loading={labelsLoading}
+          error={labelsError}
+          searchPlaceholder="Filter labels..."
+          emptyText="No labels"
+          onChange={(next) => onSelect({ labels: next })}
+        />
+      ) : null}
+      {section === 'reviewer' ? (
+        <>
+          <div className="flex gap-1 border-b border-border p-1.5 text-[11px]">
+            <button
+              type="button"
+              onClick={() => setReviewerMode('requested')}
+              className={cn(
+                'flex-1 rounded px-2 py-1 transition',
+                reviewerMode === 'requested'
+                  ? 'bg-foreground/90 text-background'
+                  : 'text-muted-foreground hover:bg-muted/50'
+              )}
+            >
+              Review requested
+            </button>
+            <button
+              type="button"
+              onClick={() => setReviewerMode('reviewed-by')}
+              className={cn(
+                'flex-1 rounded px-2 py-1 transition',
+                reviewerMode === 'reviewed-by'
+                  ? 'bg-foreground/90 text-background'
+                  : 'text-muted-foreground hover:bg-muted/50'
+              )}
+            >
+              Reviewed by
+            </button>
+          </div>
+          <SingleSelectList
+            options={userOpts}
+            activeValue={reviewerMode === 'requested' ? parsed.reviewRequested : parsed.reviewedBy}
+            loading={usersLoading}
+            error={usersError}
+            searchPlaceholder="Filter or type a login..."
+            emptyText="No users"
+            allowCustomValue
+            renderOption={(opt) => <UserOptionRow option={opt} />}
+            onSelect={(login) =>
+              onSelect({ reviewer: login ? { kind: reviewerMode, login } : null })
+            }
+          />
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/ui/repo-multi-combobox.tsx
+++ b/src/renderer/src/components/ui/repo-multi-combobox.tsx
@@ -120,7 +120,14 @@ export default function RepoMultiCombobox({
           <ChevronsUpDown className="size-3.5 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+      {/* Why: trigger width can be as narrow as the "All repos" label, but the
+          popover hosts a search input and repo rows with paths. Use the
+          trigger as a minimum width and let the content expand to a readable
+          size so the search field and repo names aren't truncated. */}
+      <PopoverContent
+        align="start"
+        className="w-[min(320px,calc(100vw-1rem))] min-w-[var(--radix-popover-trigger-width)] p-0"
+      >
         <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
           <CommandInput
             autoFocus

--- a/src/shared/task-query.test.ts
+++ b/src/shared/task-query.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { parseTaskQuery, stripRepoQualifiers, tokenizeSearchQuery } from './task-query'
+import {
+  parseTaskQuery,
+  serializeTaskQuery,
+  stripRepoQualifiers,
+  tokenizeSearchQuery,
+  withQualifier
+} from './task-query'
 
 describe('tokenizeSearchQuery', () => {
   it('splits on whitespace', () => {
@@ -16,6 +22,13 @@ describe('tokenizeSearchQuery', () => {
 
   it('unwraps standalone single-quoted tokens', () => {
     expect(tokenizeSearchQuery("'with spaces' bar")).toEqual(['with spaces', 'bar'])
+  })
+
+  it('keeps quoted qualifier values as one token', () => {
+    expect(tokenizeSearchQuery('label:"needs review" author:alice')).toEqual([
+      'label:needs review',
+      'author:alice'
+    ])
   })
 
   it('returns an empty list for an empty string', () => {
@@ -38,13 +51,31 @@ describe('parseTaskQuery', () => {
     expect(parsed.state).toBe('open')
   })
 
+  it('parses is:pull-request as a PR scope alias', () => {
+    const parsed = parseTaskQuery('is:pull-request is:open')
+    expect(parsed.scope).toBe('pr')
+    expect(parsed.state).toBe('open')
+  })
+
   it('widens scope to all when both is:issue and is:pr are present', () => {
     const parsed = parseTaskQuery('is:issue is:pr')
     expect(parsed.scope).toBe('all')
   })
 
+  it('widens scope to all regardless of issue and PR token order', () => {
+    const parsed = parseTaskQuery('is:pr is:issue')
+    expect(parsed.scope).toBe('all')
+  })
+
   it('is:draft forces scope to pr and state to open', () => {
     const parsed = parseTaskQuery('is:draft')
+    expect(parsed.scope).toBe('pr')
+    expect(parsed.state).toBe('open')
+    expect(parsed.draft).toBe(true)
+  })
+
+  it('keeps draft scoped to open PRs even when a later token says issue', () => {
+    const parsed = parseTaskQuery('is:draft is:issue')
     expect(parsed.scope).toBe('pr')
     expect(parsed.state).toBe('open')
     expect(parsed.draft).toBe(true)
@@ -69,9 +100,21 @@ describe('parseTaskQuery', () => {
     expect(parsed.freeText).toBe('free text')
   })
 
+  it('keeps review qualifiers scoped to PRs even when a later token says issue', () => {
+    const parsed = parseTaskQuery('review-requested:@me is:issue')
+    expect(parsed.scope).toBe('pr')
+    expect(parsed.reviewRequested).toBe('@me')
+  })
+
   it('leaves unknown qualifiers and bare words in freeText', () => {
     const parsed = parseTaskQuery('custom:value hello')
     expect(parsed.freeText).toBe('custom:value hello')
+  })
+
+  it('parses state:all for the Any state filter', () => {
+    const parsed = parseTaskQuery('is:pr state:all')
+    expect(parsed.scope).toBe('pr')
+    expect(parsed.state).toBe('all')
   })
 })
 
@@ -101,5 +144,73 @@ describe('stripRepoQualifiers', () => {
 
   it('preserves a bare word containing no space', () => {
     expect(stripRepoQualifiers('hello repo:a/b world')).toBe('hello world')
+  })
+})
+
+describe('serializeTaskQuery', () => {
+  it('round-trips qualifiers and free text', () => {
+    const raw = 'is:pr is:open author:alice label:bug review-requested:bob hello world'
+    const reserialized = serializeTaskQuery(parseTaskQuery(raw))
+    expect(parseTaskQuery(reserialized)).toEqual(parseTaskQuery(raw))
+  })
+
+  it('quotes label values containing whitespace', () => {
+    const parsed = parseTaskQuery('label:"needs review"')
+    expect(parsed.labels).toEqual(['needs review'])
+    expect(parsed.freeText).toBe('')
+    expect(serializeTaskQuery(parsed)).toContain('label:"needs review"')
+  })
+
+  it('serializes all state so filter changes do not fall back to the default open state', () => {
+    const raw = serializeTaskQuery(parseTaskQuery('is:pr state:all'))
+    expect(raw).toBe('is:pr state:all')
+  })
+})
+
+describe('withQualifier', () => {
+  it('sets and clears the author qualifier without disturbing free text', () => {
+    const set = withQualifier('hello', 'author', 'alice')
+    expect(parseTaskQuery(set).author).toBe('alice')
+    expect(parseTaskQuery(set).freeText).toBe('hello')
+    const cleared = withQualifier(set, 'author', null)
+    expect(parseTaskQuery(cleared).author).toBeNull()
+    expect(parseTaskQuery(cleared).freeText).toBe('hello')
+  })
+
+  it('replaces the labels list', () => {
+    const result = withQualifier('label:bug label:enh', 'labels', ['triage'])
+    expect(parseTaskQuery(result).labels).toEqual(['triage'])
+  })
+
+  it('clears labels when given an empty array', () => {
+    const result = withQualifier('label:bug is:pr', 'labels', [])
+    expect(parseTaskQuery(result).labels).toEqual([])
+    expect(parseTaskQuery(result).scope).toBe('pr')
+  })
+
+  it('sets the all state filter', () => {
+    const result = withQualifier('is:pr is:open', 'state', 'all')
+    expect(parseTaskQuery(result).state).toBe('all')
+    expect(result).toContain('state:all')
+  })
+
+  it('preserves quoted free-text tokens when applying a filter', () => {
+    const result = withQualifier('"exact phrase" milestone:"next release"', 'author', 'alice')
+    expect(result).toContain('"exact phrase"')
+    expect(result).toContain('milestone:"next release"')
+    expect(parseTaskQuery(result).author).toBe('alice')
+  })
+
+  it('keeps PR-only filters scoped to PRs', () => {
+    expect(parseTaskQuery(withQualifier('', 'draft', 'true')).scope).toBe('pr')
+    expect(parseTaskQuery(withQualifier('', 'state', 'merged')).scope).toBe('pr')
+    expect(parseTaskQuery(withQualifier('', 'reviewRequested', '@me')).scope).toBe('pr')
+  })
+
+  it('forces draft filters back to open PRs', () => {
+    const parsed = parseTaskQuery(withQualifier('is:pr is:closed', 'draft', 'true'))
+    expect(parsed.scope).toBe('pr')
+    expect(parsed.state).toBe('open')
+    expect(parsed.draft).toBe(true)
   })
 })

--- a/src/shared/task-query.ts
+++ b/src/shared/task-query.ts
@@ -10,14 +10,48 @@ export type ParsedTaskQuery = {
   freeText: string
 }
 
-export function tokenizeSearchQuery(rawQuery: string): string[] {
-  const tokens: string[] = []
-  const pattern = /"([^"]*)"|'([^']*)'|(\S+)/g
-  let match: RegExpExecArray | null
-  while ((match = pattern.exec(rawQuery)) !== null) {
-    tokens.push(match[1] ?? match[2] ?? match[3] ?? '')
+type SearchQueryToken = {
+  value: string
+  raw: string
+}
+
+function tokenizeSearchQueryWithRaw(rawQuery: string): SearchQueryToken[] {
+  const tokens: SearchQueryToken[] = []
+  let value = ''
+  let raw = ''
+  let quote: '"' | "'" | null = null
+
+  const flush = (): void => {
+    if (value || raw) {
+      tokens.push({ value, raw })
+      value = ''
+      raw = ''
+    }
   }
+
+  for (let i = 0; i < rawQuery.length; i += 1) {
+    const char = rawQuery[i]
+    if (/\s/.test(char) && quote === null) {
+      flush()
+      continue
+    }
+    raw += char
+    if ((char === '"' || char === "'") && quote === null) {
+      quote = char
+      continue
+    }
+    if (char === quote) {
+      quote = null
+      continue
+    }
+    value += char
+  }
+  flush()
   return tokens
+}
+
+export function tokenizeSearchQuery(rawQuery: string): string[] {
+  return tokenizeSearchQueryWithRaw(rawQuery).map((token) => token.value)
 }
 
 export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
@@ -34,17 +68,18 @@ export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
   }
 
   const freeTextTokens: string[] = []
-  for (const token of tokenizeSearchQuery(rawQuery.trim())) {
+  let sawIssueScope = false
+  let sawPRScope = false
+  for (const { value: token, raw } of tokenizeSearchQueryWithRaw(rawQuery.trim())) {
     const normalized = token.toLowerCase()
     if (normalized === 'is:issue') {
-      if (query.scope === 'pr') {
-        continue
-      }
-      query.scope = 'issue'
+      sawIssueScope = true
+      query.scope = sawPRScope ? 'all' : 'issue'
       continue
     }
-    if (normalized === 'is:pr') {
-      query.scope = query.scope === 'issue' ? 'all' : 'pr'
+    if (normalized === 'is:pr' || normalized === 'is:pull-request') {
+      sawPRScope = true
+      query.scope = sawIssueScope ? 'all' : 'pr'
       continue
     }
     if (normalized === 'is:open') {
@@ -70,7 +105,7 @@ export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
     const value = rest.join(':').trim()
     const key = rawKey.toLowerCase()
     if (!value) {
-      freeTextTokens.push(token)
+      freeTextTokens.push(raw)
       continue
     }
 
@@ -96,12 +131,148 @@ export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
       query.labels.push(value)
       continue
     }
+    const normalizedValue = value.toLowerCase()
+    if (
+      key === 'state' &&
+      (normalizedValue === 'open' ||
+        normalizedValue === 'closed' ||
+        normalizedValue === 'merged' ||
+        normalizedValue === 'all')
+    ) {
+      query.state = normalizedValue
+      continue
+    }
 
-    freeTextTokens.push(token)
+    // Why: unknown qualifiers and exact phrases are passed through to GitHub
+    // search as-is; reserializing stripped quotes changes search semantics.
+    freeTextTokens.push(raw)
   }
 
+  if (query.draft) {
+    query.scope = 'pr'
+    query.state = 'open'
+  } else if (
+    query.state === 'merged' ||
+    query.reviewRequested !== null ||
+    query.reviewedBy !== null
+  ) {
+    query.scope = 'pr'
+  }
   query.freeText = freeTextTokens.join(' ').trim()
   return query
+}
+
+function quoteIfNeeded(value: string): string {
+  return /\s/.test(value) ? `"${value.replaceAll('"', '\\"')}"` : value
+}
+
+/**
+ * Serialize a ParsedTaskQuery back to a raw search string. Round-trips with
+ * parseTaskQuery for the qualifiers it understands; freeText is appended last.
+ */
+export function serializeTaskQuery(q: ParsedTaskQuery): string {
+  const parts: string[] = []
+  if (q.scope === 'pr') {
+    parts.push('is:pr')
+  } else if (q.scope === 'issue') {
+    parts.push('is:issue')
+  }
+  if (q.state === 'open') {
+    parts.push('is:open')
+  } else if (q.state === 'closed') {
+    parts.push('is:closed')
+  } else if (q.state === 'merged') {
+    parts.push('is:merged')
+  } else if (q.state === 'all') {
+    parts.push('state:all')
+  }
+  if (q.draft) {
+    parts.push('is:draft')
+  }
+  if (q.author) {
+    parts.push(`author:${quoteIfNeeded(q.author)}`)
+  }
+  if (q.assignee) {
+    parts.push(`assignee:${quoteIfNeeded(q.assignee)}`)
+  }
+  if (q.reviewRequested) {
+    parts.push(`review-requested:${quoteIfNeeded(q.reviewRequested)}`)
+  }
+  if (q.reviewedBy) {
+    parts.push(`reviewed-by:${quoteIfNeeded(q.reviewedBy)}`)
+  }
+  for (const label of q.labels) {
+    parts.push(`label:${quoteIfNeeded(label)}`)
+  }
+  if (q.freeText) {
+    parts.push(q.freeText)
+  }
+  return parts.join(' ')
+}
+
+export type TaskQueryFilterKey =
+  | 'author'
+  | 'assignee'
+  | 'reviewRequested'
+  | 'reviewedBy'
+  | 'labels'
+  | 'state'
+  | 'draft'
+
+/**
+ * Apply a filter change to a raw query string and return the updated raw string.
+ * For single-value keys, pass `null` to clear. For `labels`, pass the full next
+ * array (caller manages add/remove).
+ */
+export function withQualifier(
+  rawQuery: string,
+  key: TaskQueryFilterKey,
+  value: string | string[] | null
+): string {
+  const parsed = parseTaskQuery(rawQuery)
+  switch (key) {
+    case 'author':
+      parsed.author = typeof value === 'string' ? value : null
+      break
+    case 'assignee':
+      parsed.assignee = typeof value === 'string' ? value : null
+      break
+    case 'reviewRequested':
+      parsed.reviewRequested = typeof value === 'string' ? value : null
+      if (parsed.reviewRequested) {
+        parsed.scope = 'pr'
+      }
+      break
+    case 'reviewedBy':
+      parsed.reviewedBy = typeof value === 'string' ? value : null
+      if (parsed.reviewedBy) {
+        parsed.scope = 'pr'
+      }
+      break
+    case 'labels':
+      parsed.labels = Array.isArray(value) ? value : []
+      break
+    case 'state':
+      parsed.state =
+        value === 'open' || value === 'closed' || value === 'merged' || value === 'all'
+          ? value
+          : null
+      if (parsed.state === 'merged') {
+        parsed.scope = 'pr'
+      }
+      if (parsed.state !== 'open') {
+        parsed.draft = false
+      }
+      break
+    case 'draft':
+      parsed.draft = value === 'true'
+      if (parsed.draft) {
+        parsed.scope = 'pr'
+        parsed.state = 'open'
+      }
+      break
+  }
+  return serializeTaskQuery(parsed)
 }
 
 /**


### PR DESCRIPTION
## Summary
- add GitHub task filters for PR status, authors, assignees, labels, and reviewers
- improve task query parsing/serialization for PR-only qualifiers, quoted values, and closed/merged PR handling
- refresh GitHub task table loading, pagination, and PR metadata presentation

## Validation
- pnpm typecheck
- pnpm test -- src/shared/task-query.test.ts src/main/github/client-work-items.test.ts
- pnpm lint
- git diff --check