### PR TITLE
Update sleeping workspace filter

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -55,6 +55,8 @@ const UiUpdate = z
     showWorkspaceLineage: z.boolean().optional(),
     sortBy: z.enum(['name', 'smart', 'recent', 'repo']).optional(),
     showActiveOnly: z.boolean().optional(),
+    showSleepingWorkspaces: z.boolean().optional(),
+    showInactiveWorkspaces: z.boolean().optional(),
     hideDefaultBranchWorkspace: z.boolean().optional(),
     filterRepoIds: StringArray.optional(),
     collapsedGroups: StringArray.optional(),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -355,7 +355,7 @@ function App(): React.JSX.Element {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)
   const groupBy = useAppStore((s) => s.groupBy)
   const sortBy = useAppStore((s) => s.sortBy)
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
@@ -872,7 +872,8 @@ function App(): React.JSX.Element {
         rightSidebarWidth,
         groupBy,
         sortBy,
-        showActiveOnly,
+        showActiveOnly: false,
+        showSleepingWorkspaces,
         hideDefaultBranchWorkspace,
         filterRepoIds,
         // Why: rides the same debounced save so dashboard auto-acks (which fire
@@ -891,7 +892,7 @@ function App(): React.JSX.Element {
     rightSidebarWidth,
     groupBy,
     sortBy,
-    showActiveOnly,
+    showSleepingWorkspaces,
     hideDefaultBranchWorkspace,
     filterRepoIds,
     acknowledgedAgentsByPaneKey

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -17,6 +17,7 @@ import { getLinkedWorkItemSuggestedName } from '@/lib/new-workspace'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { sortWorktreesSmart } from '@/components/sidebar/smart-sort'
 import { isDefaultBranchWorkspace } from '@/components/sidebar/visible-worktrees'
+import { isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
 import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
@@ -169,6 +170,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const browserPagesByWorkspace = useAppStore((s) => s.browserPagesByWorkspace)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
   const workspacePortScan = useAppStore((s) => s.workspacePortScan?.result ?? null)
 
@@ -189,9 +191,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   const hasQuery = deferredQuery.trim().length > 0
 
-  // Why: keep the jump palette aligned with the sidebar. If the user
-  // opted to hide the default-branch workspace, surfacing it here via
-  // Cmd+J would reintroduce the entry they asked to remove.
+  // Why: keep the jump palette aligned with the sidebar. Surfacing hidden
+  // default-branch or sleeping workspaces here would reintroduce entries the
+  // user asked the workspace navigation surfaces to omit.
   // Drift warning: this check must stay in lockstep with the sidebar's
   // filter in computeVisibleWorktreeIds (visible-worktrees.ts). Both
   // surfaces share isDefaultBranchWorkspace so the predicate can't drift,
@@ -207,9 +209,22 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         if (hideDefaultBranchWorkspace && isDefaultBranchWorkspace(worktree)) {
           return false
         }
+        if (
+          !showSleepingWorkspaces &&
+          isInactiveWorkspace(worktree.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
+        ) {
+          return false
+        }
         return true
       }),
-    [allWorktrees, hideDefaultBranchWorkspace]
+    [
+      allWorktrees,
+      browserTabsByWorktree,
+      hideDefaultBranchWorkspace,
+      ptyIdsByTabId,
+      showSleepingWorkspaces,
+      tabsByWorktree
+    ]
   )
 
   // Why: empty-query rows use focus-recency (lastVisitedAtByWorktreeId) with

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Activity, Check, FolderPlus, GitBranch, ListFilter, Server } from 'lucide-react'
+import { Check, FolderPlus, GitBranch, ListFilter, Moon, Server } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import {
@@ -33,8 +33,8 @@ const SidebarFilter = React.memo(function SidebarFilter({
   contentSide = 'right',
   onMenuOpenChange
 }: SidebarFilterProps) {
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
-  const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const setShowSleepingWorkspaces = useAppStore((s) => s.setShowSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
@@ -88,9 +88,9 @@ const SidebarFilter = React.memo(function SidebarFilter({
   }, [repos, filterRepoIds])
   const selectedCount = selectedRepoIdSet.size
   const hasRepoFilter = selectedCount > 0
-  const hasAnyFilter = showActiveOnly || hideDefaultBranchWorkspace || hasRepoFilter
+  const hasAnyFilter = showSleepingWorkspaces || hideDefaultBranchWorkspace || hasRepoFilter
   const activeFilterCount =
-    (showActiveOnly ? 1 : 0) + (hideDefaultBranchWorkspace ? 1 : 0) + selectedCount
+    (showSleepingWorkspaces ? 1 : 0) + (hideDefaultBranchWorkspace ? 1 : 0) + selectedCount
 
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
 
@@ -106,10 +106,10 @@ const SidebarFilter = React.memo(function SidebarFilter({
   const allSelected = canFilterRepos && selectedCount === repos.length
 
   const clearAll = useCallback(() => {
-    setShowActiveOnly(false)
+    setShowSleepingWorkspaces(false)
     setHideDefaultBranchWorkspace(false)
     setFilterRepoIds([])
-  }, [setShowActiveOnly, setHideDefaultBranchWorkspace, setFilterRepoIds])
+  }, [setShowSleepingWorkspaces, setHideDefaultBranchWorkspace, setFilterRepoIds])
 
   // Why: derive ids from the live repos list at click time so a repo added
   // while the popover is open is included immediately.
@@ -160,10 +160,10 @@ const SidebarFilter = React.memo(function SidebarFilter({
         data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
       >
         <FilterToggleRow
-          icon={<Activity className="size-3.5" />}
-          label="Active only"
-          checked={showActiveOnly}
-          onChange={setShowActiveOnly}
+          icon={<Moon className="size-3.5" />}
+          label="Show sleeping"
+          checked={showSleepingWorkspaces}
+          onChange={setShowSleepingWorkspaces}
         />
         <FilterToggleRow
           icon={<GitBranch className="size-3.5" />}

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Activity, GitBranch } from 'lucide-react'
+import { GitBranch, Moon } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 
 const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilterSection() {
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
-  const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const setShowSleepingWorkspaces = useAppStore((s) => s.setShowSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
 
@@ -15,10 +15,10 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
         <span className="text-[11px] font-semibold text-muted-foreground">Filters</span>
       </div>
       <FilterToggleRow
-        icon={<Activity className="size-3.5" />}
-        label="Active only"
-        checked={showActiveOnly}
-        onChange={setShowActiveOnly}
+        icon={<Moon className="size-3.5" />}
+        label="Show sleeping"
+        checked={showSleepingWorkspaces}
+        onChange={setShowSleepingWorkspaces}
       />
       <FilterToggleRow
         icon={<GitBranch className="size-3.5" />}

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -55,7 +55,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   preserveWorkspaceBoardOpen = false,
   onMenuOpenChange
 }: SidebarWorkspaceOptionsMenuProps) {
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const repos = useAppStore((s) => s.repos)
@@ -94,9 +94,9 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     return count
   }, [repos, filterRepoIds])
   const hasRepoFilter = selectedCount > 0
-  const hasAnyFilter = showActiveOnly || hideDefaultBranchWorkspace || hasRepoFilter
+  const hasAnyFilter = showSleepingWorkspaces || hideDefaultBranchWorkspace || hasRepoFilter
   const activeFilterCount =
-    (showActiveOnly ? 1 : 0) + (hideDefaultBranchWorkspace ? 1 : 0) + selectedCount
+    (showSleepingWorkspaces ? 1 : 0) + (hideDefaultBranchWorkspace ? 1 : 0) + selectedCount
   const activeFilterLabel = `${activeFilterCount} ${activeFilterCount === 1 ? 'filter' : 'filters'}`
   const sortLabel = SORT_OPTIONS.find((opt) => opt.id === sortBy)?.label ?? 'Sort'
   const visiblePropertyCount = PROPERTY_OPTIONS.filter((opt) =>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -64,7 +64,6 @@ export default function WorkspaceKanbanDrawer({
   const { canCreateWorktree, createWorktreeForStatus } = useWorkspaceKanbanCreateWorktree()
   const visibleWorktreeIdSet = useVisibleWorkspaceKanbanWorktreeIds({
     allWorktrees,
-    activeWorktreeId,
     repoMap
   })
   const worktreesByStatus = useMemo(() => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1511,7 +1511,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const groupBy = useAppStore((s) => s.groupBy)
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sortBy = useAppStore((s) => s.sortBy)
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const openModal = useAppStore((s) => s.openModal)
@@ -1523,11 +1523,11 @@ const WorktreeList = React.memo(function WorktreeList({
   const clearPendingRevealWorktreeId = useAppStore((s) => s.clearPendingRevealWorktreeId)
 
   // Read tabsByWorktree when needed for filtering or sorting
-  const needsTabs = showActiveOnly || sortBy === 'smart'
-  const tabsByWorktree = useAppStore((s) => (needsTabs ? s.tabsByWorktree : null))
-  const ptyIdsByTabId = useAppStore((s) => (needsTabs ? s.ptyIdsByTabId : null))
+  const needsActivityMaps = !showSleepingWorkspaces || sortBy === 'smart'
+  const tabsByWorktree = useAppStore((s) => (needsActivityMaps ? s.tabsByWorktree : null))
+  const ptyIdsByTabId = useAppStore((s) => (needsActivityMaps ? s.ptyIdsByTabId : null))
   const browserTabsByWorktree = useAppStore((s) =>
-    showActiveOnly ? s.browserTabsByWorktree : null
+    !showSleepingWorkspaces ? s.browserTabsByWorktree : null
   )
 
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
@@ -1780,11 +1780,10 @@ const WorktreeList = React.memo(function WorktreeList({
   const visibleWorktrees = useMemo(() => {
     const ids = computeVisibleWorktreeIds(worktreesByRepo, sortedIds, {
       filterRepoIds,
-      showActiveOnly,
+      showSleepingWorkspaces,
       tabsByWorktree,
       ptyIdsByTabId,
       browserTabsByWorktree,
-      activeWorktreeId,
       hideDefaultBranchWorkspace,
       repoMap,
       worktreeLineageById
@@ -1792,8 +1791,7 @@ const WorktreeList = React.memo(function WorktreeList({
     return ids.map((id) => worktreeMap.get(id)).filter((w): w is Worktree => w != null)
   }, [
     filterRepoIds,
-    showActiveOnly,
-    activeWorktreeId,
+    showSleepingWorkspaces,
     hideDefaultBranchWorkspace,
     repoMap,
     tabsByWorktree,
@@ -2045,18 +2043,18 @@ const WorktreeList = React.memo(function WorktreeList({
   // worktree is a default-branch row and who just toggled hide on would see
   // "No workspaces found" with no way back short of reopening the filter menu.
   const filterState = useMemo(
-    () => ({ showActiveOnly, filterRepoIds, hideDefaultBranchWorkspace }),
-    [showActiveOnly, filterRepoIds, hideDefaultBranchWorkspace]
+    () => ({ showSleepingWorkspaces, filterRepoIds, hideDefaultBranchWorkspace }),
+    [showSleepingWorkspaces, filterRepoIds, hideDefaultBranchWorkspace]
   )
   const hasFilters = sidebarHasActiveFilters(filterState)
-  const setShowActiveOnly = useAppStore((s) => s.setShowActiveOnly)
+  const setShowSleepingWorkspaces = useAppStore((s) => s.setShowSleepingWorkspaces)
   const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
 
   const clearFilters = useCallback(() => {
     const actions = computeClearFilterActions(filterState)
-    if (actions.resetShowActiveOnly) {
-      setShowActiveOnly(false)
+    if (actions.resetShowSleepingWorkspaces) {
+      setShowSleepingWorkspaces(false)
     }
     if (actions.resetFilterRepoIds) {
       setFilterRepoIds([])
@@ -2064,7 +2062,7 @@ const WorktreeList = React.memo(function WorktreeList({
     if (actions.resetHideDefaultBranchWorkspace) {
       setHideDefaultBranchWorkspace(false)
     }
-  }, [setShowActiveOnly, setFilterRepoIds, setHideDefaultBranchWorkspace, filterState])
+  }, [setShowSleepingWorkspaces, setFilterRepoIds, setHideDefaultBranchWorkspace, filterState])
 
   if (worktrees.length === 0) {
     return (

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -5,23 +5,21 @@ import { computeVisibleWorktreeIds } from './visible-worktrees'
 
 type UseVisibleWorkspaceKanbanWorktreeIdsParams = {
   allWorktrees: readonly Worktree[]
-  activeWorktreeId: string | null
   repoMap: Map<string, Repo>
 }
 
 export function useVisibleWorkspaceKanbanWorktreeIds({
   allWorktrees,
-  activeWorktreeId,
   repoMap
 }: UseVisibleWorkspaceKanbanWorktreeIdsParams): ReadonlySet<string> {
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
-  const showActiveOnly = useAppStore((s) => s.showActiveOnly)
+  const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
-  const tabsByWorktree = useAppStore((s) => (showActiveOnly ? s.tabsByWorktree : null))
-  const ptyIdsByTabId = useAppStore((s) => (showActiveOnly ? s.ptyIdsByTabId : null))
+  const tabsByWorktree = useAppStore((s) => (!showSleepingWorkspaces ? s.tabsByWorktree : null))
+  const ptyIdsByTabId = useAppStore((s) => (!showSleepingWorkspaces ? s.ptyIdsByTabId : null))
   const browserTabsByWorktree = useAppStore((s) =>
-    showActiveOnly ? s.browserTabsByWorktree : null
+    !showSleepingWorkspaces ? s.browserTabsByWorktree : null
   )
 
   return useMemo(() => {
@@ -31,11 +29,10 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     return new Set(
       computeVisibleWorktreeIds(worktreesByRepo, sortedIds, {
         filterRepoIds,
-        showActiveOnly,
+        showSleepingWorkspaces,
         tabsByWorktree,
         ptyIdsByTabId,
         browserTabsByWorktree,
-        activeWorktreeId,
         hideDefaultBranchWorkspace,
         repoMap,
         // Why: the board has no nested lineage presentation. Ancestor injection
@@ -44,14 +41,13 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
       })
     )
   }, [
-    activeWorktreeId,
     allWorktrees,
     browserTabsByWorktree,
     filterRepoIds,
     hideDefaultBranchWorkspace,
     ptyIdsByTabId,
     repoMap,
-    showActiveOnly,
+    showSleepingWorkspaces,
     tabsByWorktree,
     worktreesByRepo
   ])

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -75,11 +75,10 @@ type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
 function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
   return {
     filterRepoIds: [],
-    showActiveOnly: false,
+    showSleepingWorkspaces: true,
     tabsByWorktree: {},
     ptyIdsByTabId: {},
     browserTabsByWorktree: {},
-    activeWorktreeId: null,
     hideDefaultBranchWorkspace: false,
     repoMap,
     worktreeLineageById: {},
@@ -91,7 +90,7 @@ type FilterState = Parameters<typeof sidebarHasActiveFilters>[0]
 
 function filterState(overrides: Partial<FilterState> = {}): FilterState {
   return {
-    showActiveOnly: false,
+    showSleepingWorkspaces: false,
     filterRepoIds: [],
     hideDefaultBranchWorkspace: false,
     ...overrides
@@ -99,14 +98,14 @@ function filterState(overrides: Partial<FilterState> = {}): FilterState {
 }
 
 describe('computeVisibleWorktreeIds', () => {
-  it('treats browser-tab worktrees as active for the active-only filter', () => {
+  it('keeps browser-tab worktrees visible when sleeping workspaces are hidden', () => {
     const wt = makeWorktree('wt-browser')
 
     const result = computeVisibleWorktreeIds(
       { repo1: [wt] },
       [wt.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         browserTabsByWorktree: { [wt.id]: [{ id: 'browser-1' }] }
       })
     )
@@ -114,29 +113,28 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([wt.id])
   })
 
-  it('keeps the currently active worktree visible even without PTYs', () => {
-    const wt = makeWorktree('wt-active')
+  it('hides sleeping worktrees when show sleeping is off', () => {
+    const wt = makeWorktree('wt-sleeping')
 
     const result = computeVisibleWorktreeIds(
       { repo1: [wt] },
       [wt.id],
       visibleOptions({
-        showActiveOnly: true,
-        activeWorktreeId: wt.id
+        showSleepingWorkspaces: false
       })
     )
 
-    expect(result).toEqual([wt.id])
+    expect(result).toEqual([])
   })
 
-  it('does not treat slept wake-hint tabs as active terminals', () => {
+  it('does not treat slept wake-hint tabs as live surfaces', () => {
     const wt = makeWorktree('wt-slept')
 
     const result = computeVisibleWorktreeIds(
       { repo1: [wt] },
       [wt.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         tabsByWorktree: { [wt.id]: [makeTab('tab-slept', wt.id, 'wake-hint-session')] },
         // Sleep preserves tab.ptyId as the wake hint but clears live PTY ids.
         ptyIdsByTabId: { 'tab-slept': [] }
@@ -153,7 +151,7 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [wt] },
       [wt.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         tabsByWorktree: { [wt.id]: [makeTab('web-terminal-host-tab-1', wt.id, null)] },
         ptyIdsByTabId: {}
       })
@@ -171,7 +169,6 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [main, feature] },
       [main.id, feature.id],
       visibleOptions({
-        activeWorktreeId: main.id,
         hideDefaultBranchWorkspace: true
       })
     )
@@ -210,23 +207,21 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([feature1.id, feature2.id])
   })
 
-  it('composes with showActiveOnly: the hidden main is dropped even if it is the active worktree', () => {
+  it('composes with sleeping visibility: hidden mains stay hidden while live features remain', () => {
     const main = makeWorktree('main')
     main.isMainWorktree = true
     const feature = makeWorktree('feature')
 
-    // Why: verifies filter ordering — hide runs before showActiveOnly, so
-    // main doesn't slip back in via the "active worktree is always visible"
-    // exception that showActiveOnly grants. Feature stays because it has a
-    // live PTY.
+    // Why: verifies filter ordering — the default-branch hide runs before
+    // sleeping visibility, so the hidden main does not slip back in while the
+    // feature survives because it has a live PTY.
     const result = computeVisibleWorktreeIds(
       { repo1: [main, feature] },
       [main.id, feature.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         tabsByWorktree: { [feature.id]: [makeTab('t1', feature.id, 'p1')] },
         ptyIdsByTabId: { t1: ['p1'] },
-        activeWorktreeId: main.id,
         hideDefaultBranchWorkspace: true
       })
     )
@@ -268,7 +263,7 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [parent, child] },
       [child.id, parent.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
         ptyIdsByTabId: { 't-child': ['p-child'] },
         worktreeLineageById: { [child.id]: lineage }
@@ -289,7 +284,7 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [parent, child] },
       [child.id, parent.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
         ptyIdsByTabId: { 't-child': ['p-child'] },
         worktreeLineageById: { [child.id]: lineage }
@@ -309,7 +304,7 @@ describe('computeVisibleWorktreeIds', () => {
       { repo1: [parent, child] },
       [child.id, parent.id],
       visibleOptions({
-        showActiveOnly: true,
+        showSleepingWorkspaces: false,
         tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
         ptyIdsByTabId: { 't-child': ['p-child'] },
         worktreeLineageById: { [child.id]: lineage }
@@ -387,8 +382,8 @@ describe('sidebarHasActiveFilters', () => {
     expect(sidebarHasActiveFilters(filterState({ hideDefaultBranchWorkspace: true }))).toBe(true)
   })
 
-  it('returns true when only showActiveOnly is active', () => {
-    expect(sidebarHasActiveFilters(filterState({ showActiveOnly: true }))).toBe(true)
+  it('returns true when only showSleepingWorkspaces is active', () => {
+    expect(sidebarHasActiveFilters(filterState({ showSleepingWorkspaces: true }))).toBe(true)
   })
 
   it('returns true when only filterRepoIds is non-empty', () => {
@@ -399,7 +394,7 @@ describe('sidebarHasActiveFilters', () => {
 describe('computeClearFilterActions', () => {
   it('returns no-op actions when nothing is set', () => {
     expect(computeClearFilterActions(filterState())).toEqual({
-      resetShowActiveOnly: false,
+      resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
       resetHideDefaultBranchWorkspace: false
     })
@@ -410,7 +405,7 @@ describe('computeClearFilterActions', () => {
     // flag. A regression here would leave users stuck on "No workspaces found"
     // because the only active filter would never clear.
     expect(computeClearFilterActions(filterState({ hideDefaultBranchWorkspace: true }))).toEqual({
-      resetShowActiveOnly: false,
+      resetShowSleepingWorkspaces: false,
       resetFilterRepoIds: false,
       resetHideDefaultBranchWorkspace: true
     })
@@ -421,12 +416,12 @@ describe('computeClearFilterActions', () => {
     // in the common case where hide was never on.
     const actions = computeClearFilterActions(
       filterState({
-        showActiveOnly: true,
+        showSleepingWorkspaces: true,
         filterRepoIds: ['repo1']
       })
     )
     expect(actions.resetHideDefaultBranchWorkspace).toBe(false)
-    expect(actions.resetShowActiveOnly).toBe(true)
+    expect(actions.resetShowSleepingWorkspaces).toBe(true)
     expect(actions.resetFilterRepoIds).toBe(true)
   })
 
@@ -434,13 +429,13 @@ describe('computeClearFilterActions', () => {
     expect(
       computeClearFilterActions(
         filterState({
-          showActiveOnly: true,
+          showSleepingWorkspaces: true,
           filterRepoIds: ['repo1', 'repo2'],
           hideDefaultBranchWorkspace: true
         })
       )
     ).toEqual({
-      resetShowActiveOnly: true,
+      resetShowSleepingWorkspaces: true,
       resetFilterRepoIds: true,
       resetHideDefaultBranchWorkspace: true
     })

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -1,7 +1,6 @@
 import type { Worktree, Repo, TerminalTab, WorktreeLineage } from '../../../../shared/types'
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
-import { tabHasLivePty } from '@/lib/tab-has-live-pty'
-import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
+import { isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
 
@@ -18,9 +17,9 @@ export function isDefaultBranchWorkspace(worktree: Worktree): boolean {
   return worktree.isMainWorktree && worktree.branch.trim() !== ''
 }
 
-/** Inputs describing every sidebar filter that can leave the list empty. */
+/** Inputs describing sidebar filter settings that the Clear Filters path owns. */
 export type SidebarFilterState = {
-  showActiveOnly: boolean
+  showSleepingWorkspaces: boolean
   filterRepoIds: readonly string[]
   hideDefaultBranchWorkspace: boolean
 }
@@ -35,13 +34,17 @@ export type SidebarFilterState = {
  * "No workspaces found" message with no in-sidebar recovery path.
  */
 export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
-  return state.showActiveOnly || state.filterRepoIds.length > 0 || state.hideDefaultBranchWorkspace
+  return (
+    state.showSleepingWorkspaces ||
+    state.filterRepoIds.length > 0 ||
+    state.hideDefaultBranchWorkspace
+  )
 }
 
 /** Describes which mutators the Clear Filters button must invoke, separated
  *  from the mutators themselves so the decision logic is testable. */
 export type ClearFilterActions = {
-  resetShowActiveOnly: boolean
+  resetShowSleepingWorkspaces: boolean
   resetFilterRepoIds: boolean
   resetHideDefaultBranchWorkspace: boolean
 }
@@ -58,7 +61,7 @@ export type ClearFilterActions = {
  */
 export function computeClearFilterActions(state: SidebarFilterState): ClearFilterActions {
   return {
-    resetShowActiveOnly: state.showActiveOnly,
+    resetShowSleepingWorkspaces: state.showSleepingWorkspaces,
     resetFilterRepoIds: state.filterRepoIds.length > 0,
     resetHideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace
   }
@@ -79,11 +82,10 @@ export function computeVisibleWorktreeIds(
   sortedIds: string[],
   opts: {
     filterRepoIds: string[]
-    showActiveOnly: boolean
+    showSleepingWorkspaces: boolean
     tabsByWorktree: Record<string, TerminalTab[]> | null
     ptyIdsByTabId: Record<string, string[]> | null
     browserTabsByWorktree?: Record<string, { id: string }[]> | null
-    activeWorktreeId?: string | null
     // Why required: every caller (WorktreeList, getVisibleWorktreeIds
     // fallback, tests) reads the flag from the UI store. Making the field
     // required prevents a future caller from silently dropping the filter by
@@ -112,26 +114,16 @@ export function computeVisibleWorktreeIds(
     all = all.filter((w) => selectedRepoIds.has(w.repoId))
   }
 
-  // Filter active only
-  if (opts.showActiveOnly) {
-    all = all.filter((w) => {
-      const tabs = opts.tabsByWorktree?.[w.id] ?? []
-      const hasLiveTerminal = tabs.some((tab) =>
-        opts.ptyIdsByTabId ? tabHasLivePty(opts.ptyIdsByTabId, tab.id) : false
-      )
-      const hasHostMirroredTerminal = tabs.some((tab) => isWebTerminalSurfaceTabId(tab.id))
-      const hasBrowserTabs = (opts.browserTabsByWorktree?.[w.id] ?? []).length > 0
-      // Why: "Active only" should reflect the surfaces Orca can actually
-      // restore into, not just PTY-backed terminals. A browser-tab worktree is
-      // still active from the user's point of view even if it has no live PTY,
-      // and the currently selected worktree should never vanish from the list.
-      return (
-        hasLiveTerminal ||
-        hasHostMirroredTerminal ||
-        hasBrowserTabs ||
-        opts.activeWorktreeId === w.id
-      )
-    })
+  if (!opts.showSleepingWorkspaces) {
+    all = all.filter(
+      (w) =>
+        !isInactiveWorkspace(
+          w.id,
+          opts.tabsByWorktree,
+          opts.ptyIdsByTabId,
+          opts.browserTabsByWorktree
+        )
+    )
   }
 
   // Apply cached sort order. Items not yet in the cache (e.g. brand-new
@@ -259,11 +251,10 @@ export function getVisibleWorktreeIds(): string[] {
 
   return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
-    showActiveOnly: state.showActiveOnly,
+    showSleepingWorkspaces: state.showSleepingWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
     ptyIdsByTabId: state.ptyIdsByTabId,
     browserTabsByWorktree: state.browserTabsByWorktree,
-    activeWorktreeId: state.activeWorktreeId,
     hideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
     repoMap,
     worktreeLineageById: state.worktreeLineageById

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -37,6 +37,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     groupBy: 'workspace-status',
     sortBy: 'name',
     showActiveOnly: false,
+    showSleepingWorkspaces: false,
     hideDefaultBranchWorkspace: false,
     filterRepoIds: [],
     collapsedGroups: [],

--- a/src/renderer/src/lib/worktree-activity-state.test.ts
+++ b/src/renderer/src/lib/worktree-activity-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { hasActiveWorkspaceActivity, isInactiveWorkspace } from './worktree-activity-state'
+import type { TerminalTab } from '../../../shared/types'
+
+function makeTab(id: string): Pick<TerminalTab, 'id'> {
+  return { id }
+}
+
+describe('worktree activity state', () => {
+  it('treats a slept wake-hint workspace as inactive', () => {
+    expect(isInactiveWorkspace('wt-1', { 'wt-1': [makeTab('tab-1')] }, { 'tab-1': [] }, {})).toBe(
+      true
+    )
+  })
+
+  it('treats a never-opened workspace as inactive', () => {
+    expect(isInactiveWorkspace('wt-1', {}, {}, {})).toBe(true)
+  })
+
+  it('treats live terminal workspaces as active', () => {
+    const tabsByWorktree = { 'wt-1': [makeTab('tab-1')] }
+    const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+
+    expect(isInactiveWorkspace('wt-1', tabsByWorktree, ptyIdsByTabId, {})).toBe(false)
+    expect(hasActiveWorkspaceActivity('wt-1', tabsByWorktree, ptyIdsByTabId, {})).toBe(true)
+  })
+
+  it('treats browser workspaces as active', () => {
+    expect(
+      isInactiveWorkspace(
+        'wt-1',
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': [] },
+        { 'wt-1': [{ id: 'browser-1' }] }
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -1,0 +1,38 @@
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
+import type { TerminalTab } from '../../../shared/types'
+
+type TerminalLikeTab = Pick<TerminalTab, 'id'>
+type BrowserLikeTab = { id: string }
+
+type TabsByWorktree = Record<string, readonly TerminalLikeTab[]>
+type PtyIdsByTabId = Record<string, string[]>
+type BrowserTabsByWorktree = Record<string, readonly BrowserLikeTab[]>
+
+export function hasActiveWorkspaceActivity(
+  worktreeId: string,
+  tabsByWorktree: TabsByWorktree | null | undefined,
+  ptyIdsByTabId: PtyIdsByTabId | null | undefined,
+  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined
+): boolean {
+  const tabs = tabsByWorktree?.[worktreeId] ?? []
+  const hasLiveTerminal =
+    ptyIdsByTabId != null && tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
+  const hasHostMirroredTerminal = tabs.some((tab) => isWebTerminalSurfaceTabId(tab.id))
+  const hasBrowser = (browserTabsByWorktree?.[worktreeId] ?? []).length > 0
+  return hasLiveTerminal || hasHostMirroredTerminal || hasBrowser
+}
+
+export function isInactiveWorkspace(
+  worktreeId: string,
+  tabsByWorktree: TabsByWorktree | null | undefined,
+  ptyIdsByTabId: PtyIdsByTabId | null | undefined,
+  browserTabsByWorktree: BrowserTabsByWorktree | null | undefined
+): boolean {
+  return !hasActiveWorkspaceActivity(
+    worktreeId,
+    tabsByWorktree,
+    ptyIdsByTabId,
+    browserTabsByWorktree
+  )
+}

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -118,6 +118,7 @@ export const useModalData = () => useAppStore((s) => s.modalData)
 export const useGroupBy = () => useAppStore((s) => s.groupBy)
 export const useSortBy = () => useAppStore((s) => s.sortBy)
 export const useShowActiveOnly = () => useAppStore((s) => s.showActiveOnly)
+export const useShowSleepingWorkspaces = () => useAppStore((s) => s.showSleepingWorkspaces)
 export const useFilterRepoIds = () => useAppStore((s) => s.filterRepoIds)
 
 // ─── GitHub ─────────────────────────────────────────────────────────

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -97,7 +97,7 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().rightSidebarWidth).toBe(360)
   })
 
-  it('restores the active-only filter from persisted UI state', () => {
+  it('does not restore the retired active-only filter from persisted UI state', () => {
     const store = createUIStore()
 
     store.getState().hydratePersistedUI(
@@ -106,7 +106,32 @@ describe('createUISlice hydratePersistedUI', () => {
       })
     )
 
-    expect(store.getState().showActiveOnly).toBe(true)
+    expect(store.getState().showActiveOnly).toBe(false)
+  })
+
+  it('restores the show-sleeping filter from persisted UI state', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        showSleepingWorkspaces: true
+      })
+    )
+
+    expect(store.getState().showSleepingWorkspaces).toBe(true)
+  })
+
+  it('restores the legacy show-inactive filter as show-sleeping', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        showSleepingWorkspaces: undefined,
+        showInactiveWorkspaces: true
+      })
+    )
+
+    expect(store.getState().showSleepingWorkspaces).toBe(true)
   })
 
   it('restores the hide-default-branch filter from persisted UI state', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -391,6 +391,8 @@ export type UISlice = {
   setSortBy: (s: UISlice['sortBy']) => void
   showActiveOnly: boolean
   setShowActiveOnly: (v: boolean) => void
+  showSleepingWorkspaces: boolean
+  setShowSleepingWorkspaces: (v: boolean) => void
   hideDefaultBranchWorkspace: boolean
   setHideDefaultBranchWorkspace: (v: boolean) => void
   filterRepoIds: string[]
@@ -847,6 +849,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   showActiveOnly: false,
   setShowActiveOnly: (v) => set({ showActiveOnly: v }),
 
+  showSleepingWorkspaces: false,
+  setShowSleepingWorkspaces: (v) => set({ showSleepingWorkspaces: v }),
+
   hideDefaultBranchWorkspace: false,
   setHideDefaultBranchWorkspace: (v) => set({ hideDefaultBranchWorkspace: v }),
 
@@ -1055,10 +1060,15 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ),
         groupBy: (ui.groupBy as UISlice['groupBy'] | 'parent') === 'parent' ? 'repo' : ui.groupBy,
         sortBy,
-        // Why: "Active only" is part of the user's sidebar working set, not a
-        // transient render detail. Restoring it on launch keeps the filtered
-        // worktree list stable across restarts instead of silently widening it.
-        showActiveOnly: ui.showActiveOnly,
+        // Why: Active-only was retired. Force the old persisted flag off so an
+        // old profile cannot invisibly keep narrowing the workspace list.
+        showActiveOnly: false,
+        // Why: a short-lived build called this "inactive"; keep that key as a
+        // fallback so the renamed sleeping filter preserves user intent.
+        showSleepingWorkspaces:
+          ui.showSleepingWorkspaces ??
+          (ui as PersistedUIState & { showInactiveWorkspaces?: boolean }).showInactiveWorkspaces ??
+          false,
         hideDefaultBranchWorkspace: ui.hideDefaultBranchWorkspace ?? false,
         filterRepoIds: (ui.filterRepoIds ?? []).filter((repoId) => validRepoIds.has(repoId)),
         collapsedGroups: new Set(ui.collapsedGroups ?? []),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -344,6 +344,7 @@ export function getDefaultUIState(): PersistedUIState {
     groupBy: 'workspace-status',
     sortBy: 'recent',
     showActiveOnly: false,
+    showSleepingWorkspaces: false,
     hideDefaultBranchWorkspace: false,
     filterRepoIds: [],
     collapsedGroups: [],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1975,12 +1975,16 @@ export type PersistedUIState = {
   rightSidebarWidth: number
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   sortBy: 'name' | 'smart' | 'recent' | 'repo'
+  /** Deprecated; the Active only filter is retired and ignored on hydration. */
   showActiveOnly: boolean
+  /** Off by default: sleeping/inactive workspaces stay hidden until shown. */
+  showSleepingWorkspaces?: boolean
+  /** Legacy name for the same setting used by a short-lived build. */
+  showInactiveWorkspaces?: boolean
   /** Hide the repo's original checked-out branch from workspace navigation
    *  (sidebar and Cmd+J jump palette). Folder-mode repos are unaffected —
    *  the predicate in visible-worktrees.ts excludes worktrees with an empty
-   *  branch. Lives alongside showActiveOnly because both are user-facing
-   *  sidebar filters reached through the same dropdown. */
+   *  branch. */
   hideDefaultBranchWorkspace: boolean
   filterRepoIds: string[]
   collapsedGroups: string[]


### PR DESCRIPTION
## Summary
- replace the retired Active only filter with Show sleeping
- hide inactive/sleeping workspaces by default across sidebar, board, shortcuts, and jump palette
- persist the new show-sleeping preference with legacy show-inactive hydration fallback

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-activity-state.test.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/lib/startup-ui-hydration.test.ts src/main/runtime/rpc/methods/client-ui.test.ts
- pnpm run tc:web
- pnpm run lint
- Electron dev validation via CDP