### PR TITLE
Create PRs from Source Control

### DIFF
--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -70,6 +70,21 @@ describe('git remote operations', () => {
     ])
   })
 
+  it('passes --force-with-lease when requested', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'feature\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'origin\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'refs/heads/feature\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await gitPush('/repo', false, undefined, { forceWithLease: true })
+
+    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
+      ['push', '--force-with-lease', '--set-upstream', 'origin', 'HEAD:feature'],
+      { cwd: '/repo' }
+    )
+  })
+
   it('maps non-fast-forward push failures to an actionable message', async () => {
     gitExecFileAsyncMock
       .mockRejectedValueOnce(new Error('no branch'))

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -42,7 +42,8 @@ function explicitPushTarget(target: GitPushTarget): { remote: string; refspec: s
 export async function gitPush(
   worktreePath: string,
   _publish = false,
-  pushTarget?: GitPushTarget
+  pushTarget?: GitPushTarget,
+  options: { forceWithLease?: boolean } = {}
 ): Promise<void> {
   try {
     if (pushTarget) {
@@ -61,9 +62,12 @@ export async function gitPush(
     const target = pushTarget
       ? explicitPushTarget(pushTarget)
       : await getConfiguredPushTarget(worktreePath)
-    const args = target
-      ? ['push', '--set-upstream', target.remote, target.refspec]
-      : ['push', '--set-upstream', 'origin', 'HEAD']
+    const args = [
+      'push',
+      ...(options.forceWithLease ? ['--force-with-lease'] : []),
+      '--set-upstream',
+      ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
+    ]
     await gitExecFileAsync(args, { cwd: worktreePath })
   } catch (error) {
     throw new Error(normalizeGitErrorMessage(error, 'push'))

--- a/src/main/git/upstream.test.ts
+++ b/src/main/git/upstream.test.ts
@@ -25,6 +25,7 @@ describe('getUpstreamStatus', () => {
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'origin/main\n' })
       .mockResolvedValueOnce({ stdout: '2\t3\n' })
+      .mockResolvedValueOnce({ stdout: '+ abc123 remote work\n' })
 
     const result = await getUpstreamStatus('/repo')
 
@@ -32,7 +33,29 @@ describe('getUpstreamStatus', () => {
       hasUpstream: true,
       upstreamName: 'origin/main',
       ahead: 2,
-      behind: 3
+      behind: 3,
+      behindCommitsArePatchEquivalent: false
+    })
+  })
+
+  it('marks diverged upstream commits as patch-equivalent after a rebase', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'origin/feature\n' })
+      .mockResolvedValueOnce({ stdout: '14\t3\n' })
+      .mockResolvedValueOnce({
+        stdout:
+          '= ac503deae Stabilize pull request creation flow\n' +
+          '= 7dc0fc1a6 Clean up fork PR remotes after worktree deletion\n'
+      })
+
+    const result = await getUpstreamStatus('/repo')
+
+    expect(result).toEqual({
+      hasUpstream: true,
+      upstreamName: 'origin/feature',
+      ahead: 14,
+      behind: 3,
+      behindCommitsArePatchEquivalent: true
     })
   })
 

--- a/src/main/git/upstream.ts
+++ b/src/main/git/upstream.ts
@@ -1,6 +1,21 @@
 import type { GitUpstreamStatus } from '../../shared/types'
+import { upstreamOnlyCommitsArePatchEquivalent } from '../../shared/git-upstream-status'
 import { isNoUpstreamError, normalizeGitErrorMessage } from '../../shared/git-remote-error'
 import { gitExecFileAsync } from './runner'
+
+async function getBehindCommitsArePatchEquivalent(worktreePath: string): Promise<boolean> {
+  try {
+    const { stdout } = await gitExecFileAsync(
+      ['log', '--oneline', '--cherry-mark', '--right-only', 'HEAD...@{u}', '--'],
+      { cwd: worktreePath }
+    )
+    return upstreamOnlyCommitsArePatchEquivalent(stdout)
+  } catch {
+    // Why: patch-equivalence is an optimization for the rebase case. If the
+    // probe fails, keep the conservative pull-first behavior.
+    return false
+  }
+}
 
 export async function getUpstreamStatus(worktreePath: string): Promise<GitUpstreamStatus> {
   try {
@@ -35,11 +50,15 @@ export async function getUpstreamStatus(worktreePath: string): Promise<GitUpstre
       throw new Error(`Unparseable git rev-list counts: ${JSON.stringify(countsStdout)}`)
     }
 
+    const behindCommitsArePatchEquivalent =
+      ahead > 0 && behind > 0 ? await getBehindCommitsArePatchEquivalent(worktreePath) : undefined
+
     return {
       hasUpstream: true,
       upstreamName,
       ahead,
-      behind
+      behind,
+      ...(behindCommitsArePatchEquivalent !== undefined ? { behindCommitsArePatchEquivalent } : {})
     }
   } catch (error) {
     // Why: we only swallow clearly-no-upstream signals — that's an expected

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -2,7 +2,7 @@ import { resolve, relative, dirname, basename, isAbsolute } from 'path'
 import { realpathSync } from 'fs'
 import { realpath } from 'fs/promises'
 import type { Store } from '../persistence'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { isRepoRoot, listRepoWorktrees } from '../repo-worktrees'
 
 export const PATH_ACCESS_DENIED_MESSAGE =
   'Access denied: path resolves outside allowed directories. If this blocks a legitimate workflow, please file a GitHub issue.'
@@ -271,12 +271,9 @@ async function isPathAllowedIncludingRegisteredWorktrees(
 /**
  * Resolve and verify that a worktree path belongs to a registered repo.
  *
- * Why this doesn't use resolveAuthorizedPath: linked worktrees can live
- * anywhere on disk (e.g. ~/.codex/worktrees/), far outside the repo root
- * and workspaceDir that resolveAuthorizedPath allows.  The security boundary
- * for git operations is *worktree registration* — the path must match a
- * worktree reported by `git worktree list` for a known repo — not
- * directory containment within allowed roots.
+ * Why this doesn't use resolveAuthorizedPath: linked worktrees can live outside
+ * repo/workspace roots. Git operations trust exact worktree registration from
+ * `git worktree list`, not directory containment.
  */
 export async function resolveRegisteredWorktreePath(
   worktreePath: string,
@@ -289,8 +286,7 @@ export async function resolveRegisteredWorktreePath(
   }
 
   const resolvedTarget = resolve(worktreePath)
-
-  if (registeredWorktreeRoots.has(resolvedTarget)) {
+  if (registeredWorktreeRoots.has(resolvedTarget) || isRepoRoot(store.getRepos(), resolvedTarget)) {
     return resolvedTarget
   }
 

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -510,6 +510,18 @@ describe('registerFilesystemHandlers', () => {
     expect(getStatusMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, { includeIgnored: false })
   })
 
+  it('allows git operations on the known repo root without rebuilding the worktree cache', async () => {
+    getStatusMock.mockResolvedValue({ entries: [] })
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:status')!(null, { worktreePath: REPO_PATH })
+
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(realpathMock).not.toHaveBeenCalledWith(REPO_PATH)
+    expect(getStatusMock).toHaveBeenCalledWith(REPO_PATH, { includeIgnored: false })
+  })
+
   it('forwards includeIgnored through local and SSH git status IPC', async () => {
     registerWorktreeRootsForRepo(store as never, 'repo-1', [REPO_PATH, WORKTREE_FEATURE_PATH])
     getStatusMock.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -930,6 +930,7 @@ export function registerFilesystemHandlers(
       args: {
         worktreePath: string
         publish?: boolean
+        forceWithLease?: boolean
         connectionId?: string
         pushTarget?: GitPushTarget
       }
@@ -946,13 +947,17 @@ export function registerFilesystemHandlers(
         if (!provider) {
           throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
         }
-        return provider.pushBranch(args.worktreePath, publish, args.pushTarget)
+        return provider.pushBranch(args.worktreePath, publish, args.pushTarget, {
+          forceWithLease: args.forceWithLease === true
+        })
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       if (args.pushTarget) {
         await validateGitPushTarget(worktreePath, args.pushTarget)
       }
-      await gitPush(worktreePath, publish, args.pushTarget)
+      await gitPush(worktreePath, publish, args.pushTarget, {
+        forceWithLease: args.forceWithLease === true
+      })
     }
   )
 

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -44,6 +44,7 @@ import {
   mergeWorktree,
   areWorktreePathsEqual
 } from './worktree-logic'
+import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import { createWorktreeSymlinks } from './worktree-symlinks'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
@@ -140,17 +141,34 @@ async function ensureUniqueRemoteName(repoPath: string, preferred: string): Prom
 
 export async function prepareWorktreePushTarget(
   repoPath: string,
-  target: GitPushTarget
+  target: GitPushTarget,
+  store?: WorktreePushTargetStore,
+  repoId?: string
 ): Promise<GitPushTarget> {
   await validateGitPushTarget(repoPath, target)
+  const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   let remoteName = target.remoteName
+  let remoteCreated = false
   if (target.remoteUrl) {
     const existingRemote = await findRemoteForUrl(repoPath, target.remoteUrl)
     if (existingRemote) {
       remoteName = existingRemote
+      // Why: if a later PR worktree reuses an Orca-created fork remote, it
+      // must inherit ownership so deleting the final user can remove it.
+      remoteCreated = store
+        ? isPushTargetRemoteCreatedByKnownWorktree(
+            store,
+            {
+              ...target,
+              remoteName: existingRemote
+            },
+            repoId
+          )
+        : false
     } else {
       remoteName = await ensureUniqueRemoteName(repoPath, target.remoteName)
       await gitExecFileAsync(['remote', 'add', remoteName, target.remoteUrl], { cwd: repoPath })
+      remoteCreated = true
     }
   }
 
@@ -163,8 +181,152 @@ export async function prepareWorktreePushTarget(
     { cwd: repoPath }
   )
   return {
-    ...target,
-    remoteName
+    ...sanitizedTarget,
+    remoteName,
+    ...(remoteCreated ? { remoteCreated: true } : {})
+  }
+}
+
+type GitRemoteExec = (args: string[], cwd: string) => Promise<{ stdout: string; stderr?: string }>
+type WorktreePushTargetStore = Pick<Store, 'getAllWorktreeMeta'>
+
+function sameGitHubRemoteUrl(left: string, right: string): boolean {
+  if (left === right) {
+    return true
+  }
+  const parsedLeft = parseGitHubOwnerRepo(left)
+  const parsedRight = parseGitHubOwnerRepo(right)
+  return Boolean(
+    parsedLeft &&
+    parsedRight &&
+    parsedLeft.owner.toLowerCase() === parsedRight.owner.toLowerCase() &&
+    parsedLeft.repo.toLowerCase() === parsedRight.repo.toLowerCase()
+  )
+}
+
+function isPushTargetUsedByAnotherWorktree(
+  store: WorktreePushTargetStore,
+  removedWorktreeId: string,
+  target: GitPushTarget
+): boolean {
+  const removedRepoId = getRepoIdFromWorktreeId(removedWorktreeId)
+  return Object.entries(store.getAllWorktreeMeta()).some(([worktreeId, meta]) => {
+    // Why: git remotes are repo-local; matching metadata from another repo
+    // must not pin this repo's fork remote forever.
+    const belongsToSameRepo = getRepoIdFromWorktreeId(worktreeId) === removedRepoId
+    if (worktreeId === removedWorktreeId || !belongsToSameRepo || !meta.pushTarget) {
+      return false
+    }
+    const otherRemoteUrl = meta.pushTarget.remoteUrl
+    const targetRemoteUrl = target.remoteUrl
+    return (
+      meta.pushTarget.remoteName === target.remoteName ||
+      (typeof otherRemoteUrl === 'string' &&
+        typeof targetRemoteUrl === 'string' &&
+        sameGitHubRemoteUrl(otherRemoteUrl, targetRemoteUrl))
+    )
+  })
+}
+
+function isPushTargetRemoteCreatedByKnownWorktree(
+  store: WorktreePushTargetStore,
+  target: GitPushTarget,
+  repoId?: string
+): boolean {
+  return Object.entries(store.getAllWorktreeMeta()).some(([worktreeId, meta]) => {
+    if (repoId && getRepoIdFromWorktreeId(worktreeId) !== repoId) {
+      return false
+    }
+    if (!meta.pushTarget?.remoteCreated) {
+      return false
+    }
+    const otherRemoteUrl = meta.pushTarget.remoteUrl
+    const targetRemoteUrl = target.remoteUrl
+    return (
+      meta.pushTarget.remoteName === target.remoteName ||
+      (typeof otherRemoteUrl === 'string' &&
+        typeof targetRemoteUrl === 'string' &&
+        sameGitHubRemoteUrl(otherRemoteUrl, targetRemoteUrl))
+    )
+  })
+}
+
+async function hasBranchConfigUsingRemote(
+  execGit: GitRemoteExec,
+  repoPath: string,
+  target: GitPushTarget
+): Promise<boolean> {
+  try {
+    const { stdout } = await execGit(
+      ['config', '--get-regexp', '^branch\\..*\\.(remote|pushRemote)$'],
+      repoPath
+    )
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .some((line) => {
+        const value = line.split(/\s+/).slice(1).join(' ')
+        return value === target.remoteName || value === target.remoteUrl
+      })
+  } catch {
+    return false
+  }
+}
+
+async function cleanupUnusedWorktreePushTargetRemoteWithExec(
+  repoPath: string,
+  removedWorktreeId: string,
+  target: GitPushTarget | undefined,
+  store: WorktreePushTargetStore,
+  execGit: GitRemoteExec
+): Promise<void> {
+  if (
+    !target?.remoteCreated ||
+    !target.remoteUrl ||
+    target.remoteName === 'origin' ||
+    target.remoteName === 'upstream'
+  ) {
+    return
+  }
+  if (isPushTargetUsedByAnotherWorktree(store, removedWorktreeId, target)) {
+    return
+  }
+  if (await hasBranchConfigUsingRemote(execGit, repoPath, target)) {
+    return
+  }
+
+  let configuredRemoteUrl: string
+  try {
+    configuredRemoteUrl = (
+      await execGit(['remote', 'get-url', target.remoteName], repoPath)
+    ).stdout.trim()
+  } catch {
+    return
+  }
+  if (!sameGitHubRemoteUrl(configuredRemoteUrl, target.remoteUrl)) {
+    return
+  }
+
+  await execGit(['remote', 'remove', target.remoteName], repoPath)
+}
+
+export async function cleanupUnusedWorktreePushTargetRemote(
+  repoPath: string,
+  removedWorktreeId: string,
+  target: GitPushTarget | undefined,
+  store: WorktreePushTargetStore
+): Promise<void> {
+  try {
+    await cleanupUnusedWorktreePushTargetRemoteWithExec(
+      repoPath,
+      removedWorktreeId,
+      target,
+      store,
+      (args, cwd) => gitExecFileAsync(args, { cwd })
+    )
+  } catch (error) {
+    console.warn(`[worktrees] Failed to clean up fork PR remote for ${removedWorktreeId}`, error)
   }
 }
 
@@ -244,18 +406,35 @@ async function ensureUniqueRemoteNameSsh(
 async function prepareWorktreePushTargetSsh(
   provider: SshGitProvider,
   repoPath: string,
-  target: GitPushTarget
+  target: GitPushTarget,
+  store?: WorktreePushTargetStore,
+  repoId?: string
 ): Promise<GitPushTarget> {
   assertGitPushTargetShape(target)
+  const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
   let remoteName = target.remoteName
+  let remoteCreated = false
   if (target.remoteUrl) {
     const existingRemote = await findRemoteForUrlSsh(provider, repoPath, target.remoteUrl)
     if (existingRemote) {
       remoteName = existingRemote
+      // Why: if a later PR worktree reuses an Orca-created fork remote, it
+      // must inherit ownership so deleting the final user can remove it.
+      remoteCreated = store
+        ? isPushTargetRemoteCreatedByKnownWorktree(
+            store,
+            {
+              ...target,
+              remoteName: existingRemote
+            },
+            repoId
+          )
+        : false
     } else {
       remoteName = await ensureUniqueRemoteNameSsh(provider, repoPath, target.remoteName)
       await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+      remoteCreated = true
     }
   }
   await provider.exec(
@@ -266,7 +445,30 @@ async function prepareWorktreePushTargetSsh(
     ],
     repoPath
   )
-  return { ...target, remoteName }
+  return { ...sanitizedTarget, remoteName, ...(remoteCreated ? { remoteCreated: true } : {}) }
+}
+
+export async function cleanupUnusedWorktreePushTargetRemoteSsh(
+  provider: SshGitProvider,
+  repoPath: string,
+  removedWorktreeId: string,
+  target: GitPushTarget | undefined,
+  store: WorktreePushTargetStore
+): Promise<void> {
+  try {
+    await cleanupUnusedWorktreePushTargetRemoteWithExec(
+      repoPath,
+      removedWorktreeId,
+      target,
+      store,
+      (args, cwd) => provider.exec(args, cwd)
+    )
+  } catch (error) {
+    console.warn(
+      `[worktrees] Failed to clean up remote fork PR remote for ${removedWorktreeId}`,
+      error
+    )
+  }
 }
 
 async function configureCreatedWorktreePushTargetSsh(
@@ -444,7 +646,13 @@ export async function createRemoteWorktree(
   if (args.pushTarget) {
     // Why: fork-PR SSH worktrees need the same contributor-remote setup as
     // local worktrees before creation, otherwise Push/Sync can target origin.
-    preparedPushTarget = await prepareWorktreePushTargetSsh(provider, repo.path, args.pushTarget)
+    preparedPushTarget = await prepareWorktreePushTargetSsh(
+      provider,
+      repo.path,
+      args.pushTarget,
+      store,
+      repo.id
+    )
   }
 
   const mux = getActiveMultiplexer(repo.connectionId!)
@@ -779,7 +987,7 @@ export async function createLocalWorktree(
     // Why: validate and fetch the contributor remote before creating the
     // worktree. If this fails, retrying won't hit branch/path conflicts from a
     // half-created worktree.
-    preparedPushTarget = await prepareWorktreePushTarget(repo.path, args.pushTarget)
+    preparedPushTarget = await prepareWorktreePushTarget(repo.path, args.pushTarget, store, repo.id)
   }
 
   await (sparseDirectories.length > 0

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -621,11 +621,69 @@ describe('registerWorktreeHandlers', () => {
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/improve-dashboard',
       expect.objectContaining({
-        pushTarget: {
+        pushTarget: expect.objectContaining({
           remoteName: 'pr-prateek-orca',
           branchName: 'prateek/fix-sidebar-agents-toggle',
-          remoteUrl: 'git@github.com:prateek/orca.git'
-        }
+          remoteUrl: 'git@github.com:prateek/orca.git',
+          remoteCreated: true
+        })
+      })
+    )
+  })
+
+  it('keeps the Orca-created marker when a new worktree reuses an Orca-created fork remote', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'refs/heads/improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const existingPushTarget = {
+      remoteName: 'pr-contributor-orca',
+      branchName: 'contributor/previous-fix',
+      remoteUrl: 'https://github.com/contributor/orca.git',
+      remoteCreated: true
+    }
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-1::/workspace/previous-fix': makeWorktreeMeta({ pushTarget: existingPushTarget })
+    })
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: 'pr-contributor-orca\n', stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: 'https://github.com/contributor/orca.git\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'improve-dashboard',
+      pushTarget: {
+        remoteName: 'pr-contributor-orca',
+        branchName: 'contributor/new-fix',
+        remoteUrl: 'https://github.com/contributor/orca.git'
+      }
+    })
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalledWith(
+      ['remote', 'add', expect.any(String), expect.any(String)],
+      expect.any(Object)
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/workspace/improve-dashboard',
+      expect.objectContaining({
+        pushTarget: expect.objectContaining({
+          remoteName: 'pr-contributor-orca',
+          branchName: 'contributor/new-fix',
+          remoteUrl: 'https://github.com/contributor/orca.git',
+          remoteCreated: true
+        })
       })
     )
   })
@@ -2033,6 +2091,106 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/feature-wt',
       false
     )
+  })
+
+  it('removes an unused Orca-created fork remote after deleting its worktree', async () => {
+    mockKnownFeatureWorktree()
+    removeWorktreeMock.mockResolvedValue(undefined)
+    const pushTarget = {
+      remoteName: 'pr-contributor-orca',
+      branchName: 'feature/from-fork',
+      remoteUrl: 'https://github.com/contributor/orca.git',
+      remoteCreated: true
+    }
+    store.getWorktreeMeta.mockReturnValue(makeWorktreeMeta({ pushTarget }))
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-1::/workspace/feature-wt': makeWorktreeMeta({ pushTarget })
+    })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'config') {
+        throw new Error('no branch config')
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: 'https://github.com/contributor/orca.git\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt'
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], {
+      cwd: '/workspace/repo'
+    })
+  })
+
+  it('keeps an Orca-created fork remote while another worktree still uses it', async () => {
+    mockKnownFeatureWorktree()
+    removeWorktreeMock.mockResolvedValue(undefined)
+    const pushTarget = {
+      remoteName: 'pr-contributor-orca',
+      branchName: 'feature/from-fork',
+      remoteUrl: 'https://github.com/contributor/orca.git',
+      remoteCreated: true
+    }
+    store.getWorktreeMeta.mockReturnValue(makeWorktreeMeta({ pushTarget }))
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-1::/workspace/feature-wt': makeWorktreeMeta({ pushTarget }),
+      'repo-1::/workspace/other-wt': makeWorktreeMeta({
+        pushTarget: {
+          ...pushTarget,
+          branchName: 'other-branch'
+        }
+      })
+    })
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt'
+    })
+
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalledWith(
+      ['remote', 'remove', 'pr-contributor-orca'],
+      expect.any(Object)
+    )
+  })
+
+  it('ignores matching push targets from other repos when deciding fork remote cleanup', async () => {
+    mockKnownFeatureWorktree()
+    removeWorktreeMock.mockResolvedValue(undefined)
+    const pushTarget = {
+      remoteName: 'pr-contributor-orca',
+      branchName: 'feature/from-fork',
+      remoteUrl: 'https://github.com/contributor/orca.git',
+      remoteCreated: true
+    }
+    store.getWorktreeMeta.mockReturnValue(makeWorktreeMeta({ pushTarget }))
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-1::/workspace/feature-wt': makeWorktreeMeta({ pushTarget }),
+      'repo-2::/workspace/other-wt': makeWorktreeMeta({
+        pushTarget: {
+          ...pushTarget,
+          branchName: 'other-branch'
+        }
+      })
+    })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'config') {
+        throw new Error('no branch config')
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: 'https://github.com/contributor/orca.git\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt'
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], {
+      cwd: '/workspace/repo'
+    })
   })
 
   it('rejects unregistered delete paths before teardown, hooks, or git removal', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -51,6 +51,8 @@ import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import {
   createLocalWorktree,
   createRemoteWorktree,
+  cleanupUnusedWorktreePushTargetRemote,
+  cleanupUnusedWorktreePushTargetRemoteSsh,
   notifyWorktreesChanged
 } from './worktree-remote'
 import {
@@ -603,9 +605,17 @@ export function registerWorktreeHandlers(
         worktreePath,
         registeredWorktrees
       ).path
+      const removedPushTarget = store.getWorktreeMeta(args.worktreeId)?.pushTarget
 
       if (repo.connectionId) {
         await provider!.removeWorktree(canonicalWorktreePath, args.force)
+        await cleanupUnusedWorktreePushTargetRemoteSsh(
+          provider!,
+          repo.path,
+          args.worktreeId,
+          removedPushTarget,
+          store
+        )
         runtime.clearOptimisticReconcileToken(args.worktreeId)
         store.removeWorktreeMeta(args.worktreeId)
         deleteWorktreeHistoryDir(args.worktreeId)
@@ -685,6 +695,12 @@ export function registerWorktreeHandlers(
           // list` continues to show the stale entry and the branch it had checked out
           // remains locked — other worktrees cannot check it out.
           await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
+          await cleanupUnusedWorktreePushTargetRemote(
+            repo.path,
+            args.worktreeId,
+            removedPushTarget,
+            store
+          )
           runtime.clearOptimisticReconcileToken(args.worktreeId)
           store.removeWorktreeMeta(args.worktreeId)
           deleteWorktreeHistoryDir(args.worktreeId)
@@ -696,6 +712,12 @@ export function registerWorktreeHandlers(
           formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
         )
       }
+      await cleanupUnusedWorktreePushTargetRemote(
+        repo.path,
+        args.worktreeId,
+        removedPushTarget,
+        store
+      )
       runtime.clearOptimisticReconcileToken(args.worktreeId)
       store.removeWorktreeMeta(args.worktreeId)
       deleteWorktreeHistoryDir(args.worktreeId)

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -290,6 +290,17 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('pushBranch forwards force-with-lease mode', async () => {
+    await provider.pushBranch('/home/user/repo', false, undefined, { forceWithLease: true })
+
+    expect(mux.request).toHaveBeenCalledWith('git.push', {
+      worktreePath: '/home/user/repo',
+      publish: false,
+      pushTarget: undefined,
+      forceWithLease: true
+    })
+  })
+
   it('pullBranch sends git.pull request', async () => {
     await provider.pullBranch('/home/user/repo')
     expect(mux.request).toHaveBeenCalledWith('git.pull', {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -186,9 +186,15 @@ export class SshGitProvider implements IGitProvider {
   async pushBranch(
     worktreePath: string,
     publish = false,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    options: { forceWithLease?: boolean } = {}
   ): Promise<void> {
-    await this.mux.request('git.push', { worktreePath, publish, pushTarget })
+    await this.mux.request('git.push', {
+      worktreePath,
+      publish,
+      pushTarget,
+      ...(options.forceWithLease === true ? { forceWithLease: true } : {})
+    })
   }
 
   async pullBranch(worktreePath: string): Promise<void> {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -167,7 +167,12 @@ export type IGitProvider = {
   getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult>
   getCommitCompare(worktreePath: string, commitId: string): Promise<GitCommitCompareResult>
   getUpstreamStatus(worktreePath: string): Promise<GitUpstreamStatus>
-  pushBranch(worktreePath: string, publish?: boolean, pushTarget?: GitPushTarget): Promise<void>
+  pushBranch(
+    worktreePath: string,
+    publish?: boolean,
+    pushTarget?: GitPushTarget,
+    options?: { forceWithLease?: boolean }
+  ): Promise<void>
   pullBranch(worktreePath: string): Promise<void>
   fetchRemote(worktreePath: string): Promise<void>
   getBranchDiff(

--- a/src/main/repo-worktrees.ts
+++ b/src/main/repo-worktrees.ts
@@ -1,7 +1,12 @@
 import type { GitWorktreeInfo, Repo } from '../shared/types'
+import { resolve } from 'path'
 import { listWorktrees } from './git/worktree'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
+
+export function isRepoRoot(repos: Repo[], resolvedTarget: string): boolean {
+  return repos.some((repo) => !repo.connectionId && resolve(repo.path) === resolvedTarget)
+}
 
 export function createFolderWorktree(repo: Repo): GitWorktreeInfo {
   return {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -239,7 +239,8 @@ export class RuntimeGitCommands {
   async pushRuntimeGit(
     worktreeSelector: string,
     publish?: boolean,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    forceWithLease?: boolean
   ): Promise<{ ok: true }> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
@@ -247,10 +248,14 @@ export class RuntimeGitCommands {
       if (!provider) {
         throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      await provider.pushBranch(target.worktree.path, publish === true, pushTarget)
+      await provider.pushBranch(target.worktree.path, publish === true, pushTarget, {
+        forceWithLease: forceWithLease === true
+      })
       return { ok: true }
     }
-    await gitPush(target.worktree.path, publish === true, pushTarget)
+    await gitPush(target.worktree.path, publish === true, pushTarget, {
+      forceWithLease: forceWithLease === true
+    })
     return { ok: true }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -269,6 +269,8 @@ import { DEFAULT_REPO_BADGE_COLOR, getDefaultVoiceSettings } from '../../shared/
 import { listRepoWorktrees } from '../repo-worktrees'
 import { createWorktreeSymlinks } from '../ipc/worktree-symlinks'
 import {
+  cleanupUnusedWorktreePushTargetRemote,
+  cleanupUnusedWorktreePushTargetRemoteSsh,
   createRemoteWorktree,
   configureCreatedWorktreePushTarget,
   prepareWorktreePushTarget
@@ -5989,7 +5991,12 @@ export class OrcaRuntimeService {
       // Why: fork-PR worktrees created through a remote runtime need the same
       // upstream target setup as local desktop creates, or Push would publish
       // to the wrong remote after the client/server split.
-      preparedPushTarget = await prepareWorktreePushTarget(repo.path, args.pushTarget)
+      preparedPushTarget = await prepareWorktreePushTarget(
+        repo.path,
+        args.pushTarget,
+        this.store,
+        repo.id
+      )
     }
 
     await (sparseDirectories.length > 0
@@ -6818,6 +6825,13 @@ export class OrcaRuntimeService {
     if (repo.connectionId) {
       const provider = requireSshGitProvider(repo.connectionId)
       await provider.removeWorktree(worktree.path, force)
+      await cleanupUnusedWorktreePushTargetRemoteSsh(
+        provider,
+        repo.path,
+        worktree.id,
+        worktree.pushTarget,
+        this.store
+      )
       this.clearOptimisticReconcileToken(worktree.id)
       this.store.removeWorktreeMeta(worktree.id)
       this.invalidateResolvedWorktreeCache()
@@ -6894,6 +6908,12 @@ export class OrcaRuntimeService {
         // list` continues to show the stale entry and the branch it had checked out
         // remains locked — other worktrees cannot check it out.
         await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
+        await cleanupUnusedWorktreePushTargetRemote(
+          repo.path,
+          worktree.id,
+          worktree.pushTarget,
+          this.store
+        )
         this.clearOptimisticReconcileToken(worktree.id)
         this.store.removeWorktreeMeta(worktree.id)
         this.invalidateResolvedWorktreeCache()
@@ -6906,6 +6926,12 @@ export class OrcaRuntimeService {
       throw new Error(formatWorktreeRemovalError(error, worktree.path, force))
     }
 
+    await cleanupUnusedWorktreePushTargetRemote(
+      repo.path,
+      worktree.id,
+      worktree.pushTarget,
+      this.store
+    )
     this.clearOptimisticReconcileToken(worktree.id)
     this.store.removeWorktreeMeta(worktree.id)
     this.invalidateResolvedWorktreeCache()

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -124,6 +124,7 @@ export const GitBulkPaths = WorktreeSelector.extend({
 
 export const GitPush = WorktreeSelector.extend({
   publish: z.boolean().optional(),
+  forceWithLease: z.boolean().optional(),
   pushTarget: z.unknown().optional()
 })
 

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -237,8 +237,30 @@ describe('git RPC methods', () => {
       agentCmdOverrides: { cursor: 'cursor-agent' }
     })
     expect(runtime.cancelRuntimeGenerateCommitMessage).toHaveBeenCalledWith('id:wt-1')
-    expect(runtime.pushRuntimeGit).toHaveBeenCalledWith('id:wt-1', true, { remote: 'origin' })
+    expect(runtime.pushRuntimeGit).toHaveBeenCalledWith(
+      'id:wt-1',
+      true,
+      { remote: 'origin' },
+      undefined
+    )
     expect(response).toMatchObject({ ok: true, result: 'https://example.com/file#L3' })
+  })
+
+  it('forwards force-with-lease push mode to the runtime', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      pushRuntimeGit: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('git.push', {
+        worktree: 'id:wt-1',
+        forceWithLease: true
+      })
+    )
+
+    expect(runtime.pushRuntimeGit).toHaveBeenCalledWith('id:wt-1', undefined, undefined, true)
   })
 
   it('forwards commit-message settings to the runtime', async () => {

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -91,7 +91,12 @@ export const GIT_METHODS: RpcMethod[] = [
     name: 'git.push',
     params: GitPush,
     handler: async (params, { runtime }) =>
-      runtime.pushRuntimeGit(params.worktree, params.publish, params.pushTarget as never)
+      runtime.pushRuntimeGit(
+        params.worktree,
+        params.publish,
+        params.pushTarget as never,
+        params.forceWithLease
+      )
   }),
   defineMethod({
     name: 'git.branchDiff',

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -1016,7 +1016,7 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(selectCodexAccount).toHaveBeenCalledWith(null)
     expect(readTerminal).toHaveBeenCalledWith('term-1', { cursor: undefined })
     expect(getRuntimeGitStatus).toHaveBeenCalledWith('id:wt-1')
-    expect(pushRuntimeGit).toHaveBeenCalledWith('id:wt-1', true, undefined)
+    expect(pushRuntimeGit).toHaveBeenCalledWith('id:wt-1', true, undefined, undefined)
     expect(getRuntimeGitUpstreamStatus).toHaveBeenCalledWith('id:wt-1')
     expect(bulkStageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['a.ts', 'b.ts'])
     expect(bulkUnstageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['c.ts'])
@@ -1099,7 +1099,7 @@ describe('OrcaRuntimeRpcServer', () => {
     )
 
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_push', ok: true }))
-    expect(pushRuntimeGit).toHaveBeenCalledWith('id:wt-1', undefined, undefined)
+    expect(pushRuntimeGit).toHaveBeenCalledWith('id:wt-1', undefined, undefined, undefined)
   })
 
   it('leaves the last published metadata in place when a runtime stops', async () => {

--- a/src/main/text-generation/pull-request-context.test.ts
+++ b/src/main/text-generation/pull-request-context.test.ts
@@ -17,7 +17,7 @@ function createContextInput(base = 'main') {
 }
 
 describe('getPullRequestDraftContext', () => {
-  it('fetches and rebases onto the resolved remote base before collecting PR context', async () => {
+  it('fetches the resolved remote base before collecting PR context without mutating HEAD', async () => {
     const execGit = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
@@ -27,12 +27,6 @@ describe('getPullRequestDraftContext', () => {
       }
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/HEAD\norigin/main\nupstream/main\n', stderr: '' }
-      }
-      if (args[0] === 'rebase') {
-        return { stdout: 'Current branch feature is up to date.\n', stderr: '' }
-      }
-      if (args[0] === 'rev-parse') {
-        return { stdout: 'unchanged-head\n', stderr: '' }
       }
       if (args[0] === 'branch') {
         return { stdout: 'feature/pr-details\n', stderr: '' }
@@ -65,12 +59,15 @@ describe('getPullRequestDraftContext', () => {
       ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
       expect.any(Object)
     )
-    expect(execGit).toHaveBeenCalledWith(['rebase', 'origin/main'], expect.any(Object))
+    expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
+    expect(execGit).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['rev-parse']),
+      expect.anything()
+    )
     expect(execGit).toHaveBeenCalledWith(['merge-base', 'origin/main', 'HEAD'], expect.any(Object))
 
     const commandNames = execGit.mock.calls.map(([args]) => args[0])
-    expect(commandNames.indexOf('fetch')).toBeLessThan(commandNames.indexOf('rebase'))
-    expect(commandNames.indexOf('rebase')).toBeLessThan(commandNames.indexOf('merge-base'))
+    expect(commandNames.indexOf('fetch')).toBeLessThan(commandNames.indexOf('merge-base'))
   })
 
   it('fetches the preferred remote base even when the tracking ref is absent locally', async () => {
@@ -83,9 +80,6 @@ describe('getPullRequestDraftContext', () => {
       }
       if (args[0] === 'for-each-ref') {
         return { stdout: '', stderr: '' }
-      }
-      if (args[0] === 'rebase' || args[0] === 'rev-parse') {
-        return { stdout: 'unchanged-head\n', stderr: '' }
       }
       if (args[0] === 'branch') {
         return { stdout: 'feature/pr-details\n', stderr: '' }
@@ -108,7 +102,7 @@ describe('getPullRequestDraftContext', () => {
       ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
       expect.any(Object)
     )
-    expect(execGit).toHaveBeenCalledWith(['rebase', 'origin/main'], expect.any(Object))
+    expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
   })
 
   it('does not fetch unrelated fork remotes before generating PR context', async () => {
@@ -126,9 +120,6 @@ describe('getPullRequestDraftContext', () => {
           stdout: 'origin/main\nstale-fork/feature/from-stale-fork\n',
           stderr: ''
         }
-      }
-      if (args[0] === 'rebase' || args[0] === 'rev-parse') {
-        return { stdout: 'unchanged-head\n', stderr: '' }
       }
       if (args[0] === 'branch') {
         return { stdout: 'feature/pr-details\n', stderr: '' }
@@ -167,13 +158,6 @@ describe('getPullRequestDraftContext', () => {
       if (args[0] === 'for-each-ref') {
         return { stdout: 'contributor-a/main\ncontributor-b/main\n', stderr: '' }
       }
-      if (args[0] === 'rebase') {
-        expect(args[1]).toBe('main')
-        return { stdout: '', stderr: '' }
-      }
-      if (args[0] === 'rev-parse') {
-        return { stdout: 'unchanged-head\n', stderr: '' }
-      }
       if (args[0] === 'branch') {
         return { stdout: 'feature\n', stderr: '' }
       }
@@ -200,12 +184,12 @@ describe('getPullRequestDraftContext', () => {
       expect.arrayContaining(['contributor-b']),
       expect.any(Object)
     )
+    expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
   })
 
-  it('reports when preparation changes HEAD', async () => {
-    let revParseCount = 0
+  it('reports no branch change because PR context preparation is read-only', async () => {
     const execGit = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'fetch' || args[0] === 'rebase') {
+      if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
       }
       if (args[0] === 'remote') {
@@ -213,10 +197,6 @@ describe('getPullRequestDraftContext', () => {
       }
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/main\n', stderr: '' }
-      }
-      if (args[0] === 'rev-parse') {
-        revParseCount += 1
-        return { stdout: `${revParseCount === 1 ? 'old-head' : 'new-head'}\n`, stderr: '' }
       }
       if (args[0] === 'branch') {
         return { stdout: 'feature\n', stderr: '' }
@@ -235,12 +215,17 @@ describe('getPullRequestDraftContext', () => {
 
     const context = await getPullRequestDraftContext(execGit, createContextInput())
 
-    expect(context?.branchChangedByPreparation).toBe(true)
+    expect(context?.branchChangedByPreparation).toBe(false)
+    expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
+    expect(execGit).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['rev-parse']),
+      expect.anything()
+    )
   })
 
   it('keeps a remote-qualified base when the selected base includes the remote', async () => {
     const execGit = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'fetch' || args[0] === 'rebase') {
+      if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
       }
       if (args[0] === 'remote') {
@@ -251,9 +236,6 @@ describe('getPullRequestDraftContext', () => {
       }
       if (args[0] === 'branch') {
         return { stdout: 'feature\n', stderr: '' }
-      }
-      if (args[0] === 'rev-parse') {
-        return { stdout: 'abc123\n', stderr: '' }
       }
       if (args[0] === 'merge-base') {
         return { stdout: 'abc123\n', stderr: '' }
@@ -273,14 +255,14 @@ describe('getPullRequestDraftContext', () => {
       ['fetch', '--no-tags', 'upstream', '+refs/heads/main:refs/remotes/upstream/main'],
       expect.any(Object)
     )
-    expect(execGit).toHaveBeenCalledWith(['rebase', 'upstream/main'], expect.any(Object))
+    expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
     expect(execGit).toHaveBeenCalledWith(
       ['merge-base', 'upstream/main', 'HEAD'],
       expect.any(Object)
     )
   })
 
-  it('stops generation when the rebase fails', async () => {
+  it('does not run rebase before collecting PR context', async () => {
     const execGit = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
@@ -291,22 +273,28 @@ describe('getPullRequestDraftContext', () => {
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/main\n', stderr: '' }
       }
-      if (args[0] === 'rev-parse') {
-        return { stdout: 'abc123\n', stderr: '' }
+      if (args[0] === 'branch') {
+        return { stdout: 'feature\n', stderr: '' }
       }
       if (args[0] === 'rebase') {
-        throw new Error('Command failed: git rebase origin/main\nCONFLICT (content): README.md')
+        throw new Error('Generate must not rebase the live worktree')
+      }
+      if (args[0] === 'merge-base') {
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      if (args[0] === 'log') {
+        return { stdout: '- feat: change\n', stderr: '' }
+      }
+      if (args[0] === 'diff') {
+        return { stdout: 'M\tREADME.md\n', stderr: '' }
       }
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await expect(getPullRequestDraftContext(execGit, createContextInput())).rejects.toThrow(
-      'Rebase before generating PR details failed: CONFLICT (content): README.md'
-    )
-    expect(execGit).not.toHaveBeenCalledWith(
-      ['merge-base', 'origin/main', 'HEAD'],
-      expect.anything()
-    )
+    await expect(getPullRequestDraftContext(execGit, createContextInput())).resolves.toMatchObject({
+      branch: 'feature'
+    })
+    expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
   })
 
   it('stops generation when the relevant base fetch fails', async () => {

--- a/src/main/text-generation/pull-request-context.test.ts
+++ b/src/main/text-generation/pull-request-context.test.ts
@@ -1,3 +1,7 @@
+/* eslint-disable max-lines */
+// Why: PR context generation depends on command order across remote-state
+// variants; keeping the table of git command mocks together makes regressions
+// easier to audit than splitting the suite by helper.
 import { describe, expect, it, vi } from 'vitest'
 import { getPullRequestDraftContext } from './pull-request-context'
 
@@ -17,6 +21,9 @@ describe('getPullRequestDraftContext', () => {
     const execGit = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\nupstream\n', stderr: '' }
       }
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/HEAD\norigin/main\nupstream/main\n', stderr: '' }
@@ -54,12 +61,145 @@ describe('getPullRequestDraftContext', () => {
       commitSummary: '- feat: summarize branch',
       changeSummary: 'M\tsrc/file.ts'
     })
-    expect(execGit).toHaveBeenCalledWith(['fetch', '--all', '--prune'], expect.any(Object))
+    expect(execGit).toHaveBeenCalledWith(
+      ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+      expect.any(Object)
+    )
     expect(execGit).toHaveBeenCalledWith(['rebase', 'origin/main'], expect.any(Object))
     expect(execGit).toHaveBeenCalledWith(['merge-base', 'origin/main', 'HEAD'], expect.any(Object))
 
     const commandNames = execGit.mock.calls.map(([args]) => args[0])
+    expect(commandNames.indexOf('fetch')).toBeLessThan(commandNames.indexOf('rebase'))
     expect(commandNames.indexOf('rebase')).toBeLessThan(commandNames.indexOf('merge-base'))
+  })
+
+  it('fetches the preferred remote base even when the tracking ref is absent locally', async () => {
+    const execGit = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'fetch') {
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      if (args[0] === 'for-each-ref') {
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'rebase' || args[0] === 'rev-parse') {
+        return { stdout: 'unchanged-head\n', stderr: '' }
+      }
+      if (args[0] === 'branch') {
+        return { stdout: 'feature/pr-details\n', stderr: '' }
+      }
+      if (args[0] === 'merge-base') {
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      if (args[0] === 'log') {
+        return { stdout: '- feat: summarize branch\n', stderr: '' }
+      }
+      if (args[0] === 'diff') {
+        return { stdout: 'M\tREADME.md\n', stderr: '' }
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+
+    await getPullRequestDraftContext(execGit, createContextInput())
+
+    expect(execGit).toHaveBeenCalledWith(
+      ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+      expect.any(Object)
+    )
+    expect(execGit).toHaveBeenCalledWith(['rebase', 'origin/main'], expect.any(Object))
+  })
+
+  it('does not fetch unrelated fork remotes before generating PR context', async () => {
+    const execGit = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'fetch') {
+        expect(args).not.toContain('--all')
+        expect(args[2]).toBe('origin')
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\nstale-fork\n', stderr: '' }
+      }
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout: 'origin/main\nstale-fork/feature/from-stale-fork\n',
+          stderr: ''
+        }
+      }
+      if (args[0] === 'rebase' || args[0] === 'rev-parse') {
+        return { stdout: 'unchanged-head\n', stderr: '' }
+      }
+      if (args[0] === 'branch') {
+        return { stdout: 'feature/pr-details\n', stderr: '' }
+      }
+      if (args[0] === 'merge-base') {
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      if (args[0] === 'log') {
+        return { stdout: '- feat: change\n', stderr: '' }
+      }
+      if (args[0] === 'diff') {
+        return { stdout: 'M\tREADME.md\n', stderr: '' }
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+
+    await expect(getPullRequestDraftContext(execGit, createContextInput())).resolves.toMatchObject({
+      branch: 'feature/pr-details'
+    })
+
+    expect(execGit).not.toHaveBeenCalledWith(['fetch', '--all', '--prune'], expect.any(Object))
+    expect(execGit).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['stale-fork']),
+      expect.any(Object)
+    )
+  })
+
+  it('does not guess between multiple non-preferred remote bases for a bare base name', async () => {
+    const execGit = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'fetch') {
+        throw new Error(`Unexpected fetch: ${args.join(' ')}`)
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'contributor-a\ncontributor-b\n', stderr: '' }
+      }
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'contributor-a/main\ncontributor-b/main\n', stderr: '' }
+      }
+      if (args[0] === 'rebase') {
+        expect(args[1]).toBe('main')
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'unchanged-head\n', stderr: '' }
+      }
+      if (args[0] === 'branch') {
+        return { stdout: 'feature\n', stderr: '' }
+      }
+      if (args[0] === 'merge-base') {
+        expect(args[1]).toBe('main')
+        return { stdout: 'abc123\n', stderr: '' }
+      }
+      if (args[0] === 'log') {
+        return { stdout: '- feat: change\n', stderr: '' }
+      }
+      if (args[0] === 'diff') {
+        return { stdout: 'M\tREADME.md\n', stderr: '' }
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+
+    await getPullRequestDraftContext(execGit, createContextInput())
+
+    expect(execGit).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['contributor-a']),
+      expect.any(Object)
+    )
+    expect(execGit).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['contributor-b']),
+      expect.any(Object)
+    )
   })
 
   it('reports when preparation changes HEAD', async () => {
@@ -67,6 +207,9 @@ describe('getPullRequestDraftContext', () => {
     const execGit = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'fetch' || args[0] === 'rebase') {
         return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
       }
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/main\n', stderr: '' }
@@ -100,6 +243,9 @@ describe('getPullRequestDraftContext', () => {
       if (args[0] === 'fetch' || args[0] === 'rebase') {
         return { stdout: '', stderr: '' }
       }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\nupstream\n', stderr: '' }
+      }
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/main\nupstream/main\n', stderr: '' }
       }
@@ -123,6 +269,10 @@ describe('getPullRequestDraftContext', () => {
 
     await getPullRequestDraftContext(execGit, createContextInput('upstream/main'))
 
+    expect(execGit).toHaveBeenCalledWith(
+      ['fetch', '--no-tags', 'upstream', '+refs/heads/main:refs/remotes/upstream/main'],
+      expect.any(Object)
+    )
     expect(execGit).toHaveBeenCalledWith(['rebase', 'upstream/main'], expect.any(Object))
     expect(execGit).toHaveBeenCalledWith(
       ['merge-base', 'upstream/main', 'HEAD'],
@@ -134,6 +284,9 @@ describe('getPullRequestDraftContext', () => {
     const execGit = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'fetch') {
         return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\n', stderr: '' }
       }
       if (args[0] === 'for-each-ref') {
         return { stdout: 'origin/main\n', stderr: '' }
@@ -153,6 +306,30 @@ describe('getPullRequestDraftContext', () => {
     expect(execGit).not.toHaveBeenCalledWith(
       ['merge-base', 'origin/main', 'HEAD'],
       expect.anything()
+    )
+  })
+
+  it('stops generation when the relevant base fetch fails', async () => {
+    const execGit = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'origin\nstale-fork\n', stderr: '' }
+      }
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'origin/main\nstale-fork/main\n', stderr: '' }
+      }
+      if (args[0] === 'fetch') {
+        if (args[2] !== 'origin') {
+          throw new Error(`Fetched unrelated remote: ${args.join(' ')}`)
+        }
+        throw new Error(
+          'Command failed: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main\nfatal: unable to access origin'
+        )
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+
+    await expect(getPullRequestDraftContext(execGit, createContextInput())).rejects.toThrow(
+      'Fetch before generating PR details failed: fatal: unable to access origin'
     )
   })
 

--- a/src/main/text-generation/pull-request-context.ts
+++ b/src/main/text-generation/pull-request-context.ts
@@ -160,19 +160,11 @@ async function preparePullRequestBranch(
   // Why: PR generation only needs the selected base branch. A repo-wide
   // `fetch --all` makes stale contributor fork remotes block unrelated PRs.
   await fetchComparisonBase(execGit, fetchTarget)
-  const headBeforeRebase = await safeExec(execGit, ['rev-parse', 'HEAD'])
-  // Why: GitHub PR diffs are three-dot based; rebasing first keeps already-landed
-  // branch changes from bleeding into the generated description.
-  await requiredExec(
-    execGit,
-    ['rebase', comparisonBase],
-    'Rebase before generating PR details failed'
-  )
-  const headAfterRebase = await safeExec(execGit, ['rev-parse', 'HEAD'])
   return {
     comparisonBase,
-    branchChanged:
-      Boolean(headBeforeRebase) && Boolean(headAfterRebase) && headBeforeRebase !== headAfterRebase
+    // Why: Generate must be read-only. Rebasing the live worktree can rewrite
+    // files under the running dev app and trigger a full Electron/Vite reload.
+    branchChanged: false
   }
 }
 

--- a/src/main/text-generation/pull-request-context.ts
+++ b/src/main/text-generation/pull-request-context.ts
@@ -43,26 +43,108 @@ async function requiredExec(execGit: GitExec, args: string[], label: string): Pr
   }
 }
 
-async function resolveComparisonBase(execGit: GitExec, base: string): Promise<string> {
-  const refs = (
-    await safeExec(execGit, ['for-each-ref', '--format=%(refname:short)', 'refs/remotes'])
-  )
+type RemoteState = {
+  remotes: string[]
+  refs: string[]
+}
+
+type RemoteBranch = {
+  remote: string
+  branch: string
+  ref: string
+}
+
+function splitGitLines(output: string): string[] {
+  return output
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line && !line.endsWith('/HEAD'))
+    .filter(Boolean)
+}
 
-  if (refs.includes(base)) {
-    return base
+async function getRemoteState(execGit: GitExec): Promise<RemoteState> {
+  const [remoteOutput, refOutput] = await Promise.all([
+    safeExec(execGit, ['remote']),
+    safeExec(execGit, ['for-each-ref', '--format=%(refname:short)', 'refs/remotes'])
+  ])
+  return {
+    remotes: splitGitLines(remoteOutput),
+    refs: splitGitLines(refOutput).filter((line) => !line.endsWith('/HEAD'))
+  }
+}
+
+function parseRemoteBranch(ref: string, remotes: string[]): RemoteBranch | null {
+  const remote = [...remotes]
+    .sort((a, b) => b.length - a.length)
+    .find((candidate) => ref.startsWith(`${candidate}/`))
+  if (!remote) {
+    return null
+  }
+  const branch = ref.slice(remote.length + 1)
+  return branch ? { remote, branch, ref } : null
+}
+
+function parseRemoteRef(ref: string, remotes: string[]): RemoteBranch | null {
+  const parsed = parseRemoteBranch(ref, remotes)
+  if (parsed) {
+    return parsed
+  }
+  const slashIndex = ref.indexOf('/')
+  if (slashIndex <= 0 || slashIndex === ref.length - 1) {
+    return null
+  }
+  return {
+    remote: ref.slice(0, slashIndex),
+    branch: ref.slice(slashIndex + 1),
+    ref
+  }
+}
+
+function resolveComparisonBase(
+  base: string,
+  state: RemoteState
+): {
+  comparisonBase: string
+  fetchTarget: RemoteBranch | null
+} {
+  const qualifiedBase = parseRemoteBranch(base, state.remotes)
+  if (qualifiedBase) {
+    return { comparisonBase: qualifiedBase.ref, fetchTarget: qualifiedBase }
+  }
+  if (state.refs.includes(base)) {
+    return { comparisonBase: base, fetchTarget: parseRemoteRef(base, state.remotes) }
   }
 
   const preferredRemoteRefs = [`origin/${base}`, `upstream/${base}`]
   for (const ref of preferredRemoteRefs) {
-    if (refs.includes(ref)) {
-      return ref
+    const parsed = parseRemoteRef(ref, state.remotes)
+    if (parsed && (state.refs.includes(ref) || state.remotes.includes(parsed.remote))) {
+      return { comparisonBase: ref, fetchTarget: parsed }
     }
   }
 
-  return refs.find((ref) => ref.endsWith(`/${base}`)) ?? base
+  const matchingRefs = state.refs.filter((ref) => ref.endsWith(`/${base}`))
+  if (matchingRefs.length === 1) {
+    const ref = matchingRefs[0]
+    return { comparisonBase: ref, fetchTarget: parseRemoteRef(ref, state.remotes) }
+  }
+
+  return { comparisonBase: base, fetchTarget: null }
+}
+
+async function fetchComparisonBase(execGit: GitExec, target: RemoteBranch | null): Promise<void> {
+  if (!target) {
+    return
+  }
+  await requiredExec(
+    execGit,
+    [
+      'fetch',
+      '--no-tags',
+      target.remote,
+      `+refs/heads/${target.branch}:refs/remotes/${target.remote}/${target.branch}`
+    ],
+    'Fetch before generating PR details failed'
+  )
 }
 
 type PullRequestBranchPreparation = {
@@ -74,12 +156,10 @@ async function preparePullRequestBranch(
   execGit: GitExec,
   base: string
 ): Promise<PullRequestBranchPreparation> {
-  await requiredExec(
-    execGit,
-    ['fetch', '--all', '--prune'],
-    'Fetch before generating PR details failed'
-  )
-  const comparisonBase = await resolveComparisonBase(execGit, base)
+  const { comparisonBase, fetchTarget } = resolveComparisonBase(base, await getRemoteState(execGit))
+  // Why: PR generation only needs the selected base branch. A repo-wide
+  // `fetch --all` makes stale contributor fork remotes block unrelated PRs.
+  await fetchComparisonBase(execGit, fetchTarget)
   const headBeforeRebase = await safeExec(execGit, ['rev-parse', 'HEAD'])
   // Why: GitHub PR diffs are three-dot based; rebasing first keeps already-landed
   // branch changes from bleeding into the generated description.

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1509,6 +1509,7 @@ export type PreloadApi = {
     push: (args: {
       worktreePath: string
       publish?: boolean
+      forceWithLease?: boolean
       connectionId?: string
       pushTarget?: GitPushTarget
     }) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2081,6 +2081,7 @@ const api = {
     push: (args: {
       worktreePath: string
       publish?: boolean
+      forceWithLease?: boolean
       connectionId?: string
       pushTarget?: unknown
     }): Promise<void> => ipcRenderer.invoke('git:push', args),

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { removeWorktreeOp } from './git-handler-worktree-ops'
+
+function worktreeList(...entries: { path: string; branch?: string }[]): string {
+  return entries
+    .map((entry, index) =>
+      [
+        `worktree ${entry.path}`,
+        `HEAD ${index}`,
+        ...(entry.branch ? [`branch refs/heads/${entry.branch}`] : [])
+      ].join('\n')
+    )
+    .join('\n\n')
+}
+
+describe('removeWorktreeOp', () => {
+  it('deletes the now-unused branch after removing an SSH worktree', async () => {
+    const calls: string[] = []
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(`${cwd}$ ${args.join(' ')}`)
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                )
+              : worktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeOp(git, { worktreePath: '/repo-feature' })
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      '/repo$ worktree list --porcelain',
+      '/repo$ worktree remove /repo-feature',
+      '/repo$ worktree prune',
+      '/repo$ worktree list --porcelain',
+      '/repo$ branch -D feature/test'
+    ])
+  })
+
+  it('keeps the branch when another SSH worktree still uses it', async () => {
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args, _cwd) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                )
+              : worktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-other', branch: 'feature/test' }
+                ),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeOp(git, { worktreePath: '/repo-feature' })
+
+    expect(git).not.toHaveBeenCalledWith(['branch', '-D', 'feature/test'], expect.any(String))
+  })
+})

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -6,6 +6,7 @@
  */
 import * as path from 'path'
 import type { GitExec } from './git-handler-ops'
+import { parseWorktreeList } from './git-handler-utils'
 
 // ─── Worktree management ─────────────────────────────────────────────
 
@@ -83,6 +84,12 @@ export async function removeWorktreeOp(
     // fall through with worktreePath as repo
   }
 
+  const worktreesBeforeRemoval = await listRelayWorktrees(git, repoPath)
+  const removedWorktree = worktreesBeforeRemoval.find((worktree) =>
+    areRelayWorktreePathsEqual(worktree.path, worktreePath)
+  )
+  const branchName = normalizeLocalBranchRef(removedWorktree?.branch ?? '')
+
   const args = ['worktree', 'remove']
   if (force) {
     args.push('--force')
@@ -90,6 +97,59 @@ export async function removeWorktreeOp(
   args.push(worktreePath)
   await git(args, repoPath)
   await git(['worktree', 'prune'], repoPath)
+
+  if (!branchName) {
+    return
+  }
+
+  // Why: SSH worktree deletion should mirror local deletion. Dropping the
+  // branch also removes its upstream config, which lets fork-remotes cleanup
+  // after the last PR review worktree is gone.
+  const worktreesAfterPrune = await listRelayWorktrees(git, repoPath)
+  const branchStillInUse = worktreesAfterPrune.some(
+    (worktree) => normalizeLocalBranchRef(worktree.branch ?? '') === branchName
+  )
+  if (branchStillInUse) {
+    return
+  }
+
+  try {
+    await git(['branch', '-D', branchName], repoPath)
+  } catch (error) {
+    console.warn(
+      `relay removeWorktree: failed to delete local branch "${branchName}" after removing worktree`,
+      error
+    )
+  }
+}
+
+type RelayWorktreeInfo = {
+  path: string
+  branch?: string
+}
+
+async function listRelayWorktrees(git: GitExec, repoPath: string): Promise<RelayWorktreeInfo[]> {
+  try {
+    const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+    return parseWorktreeList(stdout)
+      .map((worktree) => ({
+        path: typeof worktree.path === 'string' ? worktree.path : '',
+        branch: typeof worktree.branch === 'string' ? worktree.branch : undefined
+      }))
+      .filter((worktree) => worktree.path.length > 0)
+  } catch {
+    return []
+  }
+}
+
+function normalizeLocalBranchRef(branch: string): string {
+  return branch.replace(/^refs\/heads\//, '')
+}
+
+function areRelayWorktreePathsEqual(leftPath: string, rightPath: string): boolean {
+  const left = path.normalize(path.resolve(leftPath))
+  const right = path.normalize(path.resolve(rightPath))
+  return process.platform === 'win32' ? left.toLowerCase() === right.toLowerCase() : left === right
 }
 
 // ─── Commit ──────────────────────────────────────────────────────────

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -19,6 +19,7 @@ import { commitChangesRelay, addWorktreeOp, removeWorktreeOp } from './git-handl
 import { checkIgnoredPathsOp, detectConflictOperation, getStatusOp } from './git-handler-status-ops'
 import { resolveRelayPushTarget } from './git-handler-push-target'
 import { normalizeGitErrorMessage, isNoUpstreamError } from '../shared/git-remote-error'
+import { upstreamOnlyCommitsArePatchEquivalent } from '../shared/git-upstream-status'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import { buildRelayCommandEnv } from './relay-command-env'
 
@@ -312,11 +313,18 @@ export class GitHandler {
       if (!Number.isFinite(ahead) || !Number.isFinite(behind) || ahead < 0 || behind < 0) {
         throw new Error(`Unparseable git rev-list counts: ${JSON.stringify(countsStdout)}`)
       }
+      const behindCommitsArePatchEquivalent =
+        ahead > 0 && behind > 0
+          ? await this.getBehindCommitsArePatchEquivalent(worktreePath)
+          : undefined
       return {
         hasUpstream: true,
         upstreamName,
         ahead,
-        behind
+        behind,
+        ...(behindCommitsArePatchEquivalent !== undefined
+          ? { behindCommitsArePatchEquivalent }
+          : {})
       }
     } catch (error) {
       // Why: we only swallow the 'no upstream configured' error — that's an
@@ -328,6 +336,20 @@ export class GitHandler {
       // Why: match fetch/push/pull normalization so execFile preamble and local
       // paths don't leak to the renderer.
       throw new Error(normalizeGitErrorMessage(error, 'upstream'))
+    }
+  }
+
+  private async getBehindCommitsArePatchEquivalent(worktreePath: string): Promise<boolean> {
+    try {
+      const { stdout } = await this.git(
+        ['log', '--oneline', '--cherry-mark', '--right-only', 'HEAD...@{u}', '--'],
+        worktreePath
+      )
+      return upstreamOnlyCommitsArePatchEquivalent(stdout)
+    } catch {
+      // Why: this only identifies stale post-rebase upstreams. If the probe
+      // fails over SSH, keep the conservative pull-first sync path.
+      return false
     }
   }
 
@@ -354,9 +376,12 @@ export class GitHandler {
         worktreePath,
         params.pushTarget
       )
-      const args = target
-        ? ['push', '--set-upstream', target.remote, target.refspec]
-        : ['push', '--set-upstream', 'origin', 'HEAD']
+      const args = [
+        'push',
+        ...(params.forceWithLease === true ? ['--force-with-lease'] : []),
+        '--set-upstream',
+        ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
+      ]
       await this.git(args, worktreePath)
     } catch (error) {
       // Why: mirror the local gitPush normalization so SSH users see the same

--- a/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { CommitArea } from './SourceControl'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
 import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
@@ -54,7 +55,13 @@ function buttons(markup: string): string[] {
 }
 
 function renderButtons(props: ReturnType<typeof baseProps>): string[] {
-  return buttons(renderToStaticMarkup(<CommitArea {...props} />))
+  return buttons(
+    renderToStaticMarkup(
+      <TooltipProvider>
+        <CommitArea {...props} />
+      </TooltipProvider>
+    )
+  )
 }
 
 describe('CommitArea chevron spinner', () => {

--- a/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { CommitArea } from './SourceControl'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
 import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
@@ -50,7 +51,11 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
 }
 
 function primaryButton(props: ReturnType<typeof baseProps>): string {
-  const markup = renderToStaticMarkup(<CommitArea {...props} />)
+  const markup = renderToStaticMarkup(
+    <TooltipProvider>
+      <CommitArea {...props} />
+    </TooltipProvider>
+  )
   const match = markup.match(/<button\b[\s\S]*?<\/button>/)
   if (!match) {
     throw new Error('primary button not found')

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { CommitArea, ConflictSummaryCard } from './SourceControl'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
 import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 function buildInputs(overrides: Partial<PrimaryActionInputs> = {}): PrimaryActionInputs {
   return {
@@ -45,7 +46,11 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
 }
 
 function renderCommitArea(props: ReturnType<typeof baseProps>): string {
-  return renderToStaticMarkup(<CommitArea {...props} />)
+  return renderToStaticMarkup(
+    <TooltipProvider>
+      <CommitArea {...props} />
+    </TooltipProvider>
+  )
 }
 
 function firstButton(markup: string): string {

--- a/src/renderer/src/components/right-sidebar/SourceControl.commit-drafts.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.commit-drafts.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeSourceControlViewMode,
   pickDefaultSourceControlAgent,
   readCommitDraftForWorktree,
+  refreshSourceControlAfterRemoteAction,
   requestSourceControlViewModePreferenceWrite,
   shouldRenderCommitArea,
   type SourceControlViewModePreferenceWriteState,
@@ -152,6 +153,41 @@ describe('SourceControl conflict resolution state', () => {
     expect(pickDefaultSourceControlAgent('codex', ['claude', 'codex'])).toBe('codex')
     expect(pickDefaultSourceControlAgent('blank', ['codex'])).toBe('codex')
     expect(pickDefaultSourceControlAgent('claude', [])).toBeNull()
+  })
+})
+
+describe('SourceControl remote action refresh', () => {
+  it('refreshes status, branch compare, and history after remote actions settle', async () => {
+    const refreshGitStatus = vi.fn().mockResolvedValue(undefined)
+    const refreshBranchCompare = vi.fn().mockResolvedValue(undefined)
+    const refreshGitHistory = vi.fn().mockResolvedValue(undefined)
+
+    refreshSourceControlAfterRemoteAction({
+      refreshGitStatus,
+      refreshBranchCompare,
+      refreshGitHistory
+    })
+    await Promise.resolve()
+
+    expect(refreshGitStatus).toHaveBeenCalledTimes(1)
+    expect(refreshBranchCompare).toHaveBeenCalledTimes(1)
+    expect(refreshGitHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes post-remote refresh failures to the provided error handler', async () => {
+    const error = new Error('refresh failed')
+    const onError = vi.fn()
+
+    refreshSourceControlAfterRemoteAction({
+      refreshGitStatus: vi.fn().mockResolvedValue(undefined),
+      refreshBranchCompare: vi.fn().mockRejectedValue(error),
+      refreshGitHistory: vi.fn().mockResolvedValue(undefined),
+      onError
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onError).toHaveBeenCalledWith(error)
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -127,9 +127,10 @@ import {
 } from '@/runtime/runtime-git-client'
 import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { PullRequestIcon } from './checks-panel-content'
-import { CreatePullRequestDialog } from './CreatePullRequestDialog'
+import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
 import type { GitHistoryItem } from '../../../../shared/git-history'
+import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import type {
   DiffComment,
   GitBranchChangeEntry,
@@ -566,6 +567,7 @@ function SourceControlInner(): React.JSX.Element {
   const getHostedReviewCreationEligibility = useAppStore(
     (s) => s.getHostedReviewCreationEligibility
   )
+  const createHostedReview = useAppStore((s) => s.createHostedReview)
   const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const prCache = useAppStore((s) => s.prCache)
   const enqueueGitHubPRRefresh = useAppStore((s) => s.enqueueGitHubPRRefresh)
@@ -773,8 +775,13 @@ function SourceControlInner(): React.JSX.Element {
   const generateError = generateErrors[activeWorktreeId ?? ''] ?? null
   const [hostedReviewCreation, setHostedReviewCreation] =
     useState<HostedReviewCreationEligibility | null>(null)
-  const [createPrDialogOpen, setCreatePrDialogOpen] = useState(false)
-  const [createPrPushFirst, setCreatePrPushFirst] = useState(false)
+  const createPrInFlightRef = useRef<Record<string, boolean>>({})
+  const [createPrInFlightByWorktree, setCreatePrInFlightByWorktree] = useState<
+    Record<string, boolean>
+  >({})
+  const [createPrErrors, setCreatePrErrors] = useState<Record<string, string | null>>({})
+  const isCreatingPr = createPrInFlightByWorktree[activeWorktreeId ?? ''] ?? false
+  const createPrError = createPrErrors[activeWorktreeId ?? ''] ?? null
   const commitMessageAi = useAppStore((s) => s.settings?.commitMessageAi)
   const effectiveCommitMessageAgentId = useMemo(
     () => resolveCommitMessageAgentChoice(commitMessageAi?.agentId, settings?.defaultTuiAgent),
@@ -1258,8 +1265,6 @@ function SourceControlInner(): React.JSX.Element {
     // repos and back to re-trigger the resolver.
     setFilterQuery('')
     setIsExecutingBulk(false)
-    setCreatePrDialogOpen(false)
-    setCreatePrPushFirst(false)
     // Why: no reset for commit-in-flight state — it now lives in a per-worktree
     // map, so it cannot leak across worktrees. Resetting here would actually
     // clear in-flight state for the *incoming* worktree if the user is coming
@@ -1544,44 +1549,6 @@ function SourceControlInner(): React.JSX.Element {
     [handleCommit, runRemoteAction]
   )
 
-  const openCreatePullRequestDialog = useCallback((pushFirst: boolean): void => {
-    setCreatePrPushFirst(pushFirst)
-    setCreatePrDialogOpen(true)
-  }, [])
-
-  const pushBeforeCreatePullRequest = useCallback(async (): Promise<boolean> => {
-    if (!activeWorktreeId || !worktreePath) {
-      return false
-    }
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-    try {
-      await pushBranch(
-        activeWorktreeId,
-        worktreePath,
-        false,
-        connectionId,
-        activeWorktree?.pushTarget
-      )
-      await refreshActiveGitStatusAfterMutation()
-      return true
-    } catch {
-      return false
-    }
-  }, [
-    activeWorktree?.pushTarget,
-    activeWorktreeId,
-    pushBranch,
-    refreshActiveGitStatusAfterMutation,
-    worktreePath
-  ])
-
-  const handleBranchChangedByPullRequestGeneration = useCallback(async (): Promise<void> => {
-    // Why: AI PR detail generation rebases before summarizing; if HEAD moved,
-    // the dialog must not create a PR from stale push/create eligibility.
-    setCreatePrPushFirst(true)
-    await refreshActiveGitStatusAfterMutation()
-  }, [refreshActiveGitStatusAfterMutation])
-
   const handlePullRequestCreated = useCallback(
     async (result: { number: number; url: string }): Promise<void> => {
       if (!activeRepo || !branchName) {
@@ -1628,6 +1595,141 @@ function SourceControlInner(): React.JSX.Element {
     setRightSidebarTab('checks')
   }, [setRightSidebarOpen, setRightSidebarTab])
 
+  const handleBranchChangedByPullRequestGeneration = useCallback(async (): Promise<void> => {
+    // Why: AI PR detail generation may rebase before summarizing; if HEAD moved,
+    // refresh status before letting the user submit the generated draft.
+    await refreshActiveGitStatusAfterMutation()
+  }, [refreshActiveGitStatusAfterMutation])
+
+  const {
+    aiGenerationEnabled: prAiGenerationEnabled,
+    base: prBase,
+    setBase: setPrBase,
+    title: prTitle,
+    setTitle: setPrTitle,
+    body: prBody,
+    setBody: setPrBody,
+    draft: prDraft,
+    setDraft: setPrDraft,
+    baseQuery: prBaseQuery,
+    setBaseQuery: setPrBaseQuery,
+    baseResults: prBaseResults,
+    setBaseResults: setPrBaseResults,
+    baseSearchError: prBaseSearchError,
+    generating: prGenerating,
+    generateError: prGenerateError,
+    generateDisabled: prGenerateDisabled,
+    generateDisabledReason: prGenerateDisabledReason,
+    handleGenerate: handleGeneratePullRequestFields,
+    handleCancelGenerate: handleCancelGeneratePullRequestFields
+  } = useCreatePullRequestDialogFields({
+    open: hostedReviewCreation?.canCreate === true,
+    repoId: activeRepo?.id ?? '',
+    worktreeId: activeWorktreeId,
+    worktreePath: worktreePath ?? '',
+    branch: branchName,
+    eligibility: hostedReviewCreation,
+    settings,
+    submitting: isCreatingPr,
+    onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration
+  })
+
+  const handleCreatePullRequest = useCallback(async (): Promise<void> => {
+    if (
+      !activeRepo ||
+      !activeWorktreeId ||
+      !worktreePath ||
+      !hostedReviewCreation?.canCreate ||
+      createPrInFlightRef.current[activeWorktreeId]
+    ) {
+      return
+    }
+
+    const base = stripBaseRef(prBase).trim()
+    const title = prTitle.trim()
+
+    if (!title) {
+      setCreatePrErrors((prev) => ({
+        ...prev,
+        [activeWorktreeId]: 'Enter a pull request title.'
+      }))
+      return
+    }
+
+    if (!base || stripBaseRef(base).toLowerCase() === stripBaseRef(branchName).toLowerCase()) {
+      setCreatePrErrors((prev) => ({
+        ...prev,
+        [activeWorktreeId]: 'Choose a different base branch before creating a pull request.'
+      }))
+      return
+    }
+
+    createPrInFlightRef.current[activeWorktreeId] = true
+    setCreatePrInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
+    setCreatePrErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+    try {
+      const result = await createHostedReview(activeRepo.path, {
+        provider: 'github',
+        base,
+        head: normalizeHostedReviewHeadRef(branchName),
+        title,
+        body: prBody,
+        draft: prDraft,
+        worktreePath
+      })
+
+      if (result.ok) {
+        toast.success(`Pull request #${result.number} created`, {
+          action: {
+            label: 'Open on GitHub',
+            onClick: () => window.api.shell.openUrl(result.url)
+          }
+        })
+        await handlePullRequestCreated(result)
+        return
+      }
+
+      if (result.existingReview?.url) {
+        const number = result.existingReview.number
+        toast.success(
+          number ? `Pull request #${number} is already open` : 'Pull request is already open',
+          {
+            action: {
+              label: 'Open on GitHub',
+              onClick: () => window.api.shell.openUrl(result.existingReview!.url)
+            }
+          }
+        )
+        if (number) {
+          await handlePullRequestCreated({ number, url: result.existingReview.url })
+          return
+        }
+      }
+
+      setCreatePrErrors((prev) => ({ ...prev, [activeWorktreeId]: result.error }))
+    } catch (error) {
+      setCreatePrErrors((prev) => ({
+        ...prev,
+        [activeWorktreeId]: error instanceof Error ? error.message : 'Failed to create pull request'
+      }))
+    } finally {
+      createPrInFlightRef.current[activeWorktreeId] = false
+      setCreatePrInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
+    }
+  }, [
+    activeRepo,
+    activeWorktreeId,
+    branchName,
+    createHostedReview,
+    handlePullRequestCreated,
+    hostedReviewCreation,
+    prBase,
+    prBody,
+    prDraft,
+    prTitle,
+    worktreePath
+  ])
+
   const hasUnstagedChanges = grouped.unstaged.length > 0 || grouped.untracked.length > 0
   const hasPartiallyStagedChanges = useMemo(() => {
     if (grouped.staged.length === 0 || grouped.unstaged.length === 0) {
@@ -1637,41 +1739,43 @@ function SourceControlInner(): React.JSX.Element {
     return grouped.staged.some((entry) => unstagedPaths.has(entry.path))
   }, [grouped.staged, grouped.unstaged])
 
-  const primaryAction: PrimaryAction = useMemo(
-    () =>
-      resolvePrimaryAction({
-        stagedCount: grouped.staged.length,
-        hasUnstagedChanges,
-        hasPartiallyStagedChanges,
-        hasMessage: commitMessage.trim().length > 0,
-        hasUnresolvedConflicts: unresolvedConflicts.length > 0,
-        isCommitting,
-        isRemoteOperationActive,
-        upstreamStatus: remoteStatus,
-        prState: hostedReview?.state ?? null,
-        isPRStateLoading: isHostedReviewStateLoading,
-        inFlightRemoteOpKind,
-        hostedReviewCreation,
-        branchCommitsAhead:
-          branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined
-      }),
-    [
-      commitMessage,
-      grouped.staged.length,
+  const primaryAction: PrimaryAction = useMemo(() => {
+    const action = resolvePrimaryAction({
+      stagedCount: grouped.staged.length,
       hasUnstagedChanges,
       hasPartiallyStagedChanges,
+      hasMessage: commitMessage.trim().length > 0,
+      hasUnresolvedConflicts: unresolvedConflicts.length > 0,
       isCommitting,
       isRemoteOperationActive,
+      upstreamStatus: remoteStatus,
+      prState: hostedReview?.state ?? null,
+      isPRStateLoading: isHostedReviewStateLoading,
       inFlightRemoteOpKind,
       hostedReviewCreation,
-      isHostedReviewStateLoading,
-      hostedReview?.state,
-      branchSummary?.commitsAhead,
-      branchSummary?.status,
-      remoteStatus,
-      unresolvedConflicts.length
-    ]
-  )
+      branchCommitsAhead:
+        branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined
+    })
+    return isCreatingPr && action.kind === 'create_pr'
+      ? { ...action, title: 'Creating pull request...', disabled: true }
+      : action
+  }, [
+    commitMessage,
+    grouped.staged.length,
+    hasUnstagedChanges,
+    hasPartiallyStagedChanges,
+    isCommitting,
+    isRemoteOperationActive,
+    inFlightRemoteOpKind,
+    hostedReviewCreation,
+    isHostedReviewStateLoading,
+    hostedReview?.state,
+    isCreatingPr,
+    branchSummary?.commitsAhead,
+    branchSummary?.status,
+    remoteStatus,
+    unresolvedConflicts.length
+  ])
 
   const dropdownItems: DropdownEntry[] = useMemo(
     () =>
@@ -1726,10 +1830,10 @@ function SourceControlInner(): React.JSX.Element {
           void runCompoundCommitAction('sync')
           return
         case 'create_pr':
-          openCreatePullRequestDialog(false)
+          void handleCreatePullRequest()
           return
         case 'push_create_pr':
-          openCreatePullRequestDialog(true)
+          void runRemoteAction('push')
           return
         case 'push':
         case 'pull':
@@ -1747,7 +1851,7 @@ function SourceControlInner(): React.JSX.Element {
         }
       }
     },
-    [handleCommit, openCreatePullRequestDialog, runCompoundCommitAction, runRemoteAction]
+    [handleCommit, handleCreatePullRequest, runCompoundCommitAction, runRemoteAction]
   )
 
   const handleOpenDiff = useCallback(
@@ -2052,7 +2156,7 @@ function SourceControlInner(): React.JSX.Element {
 
   // Why: PrimaryActionKind is narrowed to the single-action kinds the
   // primary can emit ('commit' | 'stage' | 'push' | 'pull' | 'sync' |
-  // 'publish') — compound commit_* kinds are dropdown-only. An exhaustive
+  // 'publish' | 'create_pr') — compound commit_* kinds are dropdown-only. An exhaustive
   // switch keeps the mapping honest: if a new PrimaryActionKind is added,
   // TypeScript lights up the missing case instead of silently falling
   // through. 'stage' routes to a dedicated primary-only handler because
@@ -2744,20 +2848,6 @@ function SourceControlInner(): React.JSX.Element {
 
   return (
     <>
-      <CreatePullRequestDialog
-        open={createPrDialogOpen}
-        repoId={activeRepo.id}
-        repoPath={activeRepo.path}
-        worktreeId={currentWorktreeId}
-        worktreePath={activeWorktree.path}
-        branch={branchName}
-        eligibility={hostedReviewCreation}
-        pushBeforeCreate={createPrPushFirst}
-        onOpenChange={setCreatePrDialogOpen}
-        onPushBeforeCreate={pushBeforeCreatePullRequest}
-        onBranchChangedByGeneration={handleBranchChangedByPullRequestGeneration}
-        onCreated={handlePullRequestCreated}
-      />
       <div ref={sourceControlRef} className="relative flex h-full flex-col overflow-hidden">
         <div className="flex items-center px-3 pt-2 border-b border-border">
           {(['all', 'uncommitted'] as const).map((value) => (
@@ -3008,47 +3098,78 @@ function SourceControlInner(): React.JSX.Element {
               clears. Active merge/rebase/cherry-pick operations are the
               exception: commits would be misleading before the user continues
               or aborts the operation. */}
-          {shouldRenderCommitArea(scope, unresolvedConflicts.length, conflictOperation) && (
-            <CommitArea
-              worktreeId={activeWorktreeId}
-              commitMessage={commitMessage}
-              commitError={commitError}
-              remoteActionError={remoteActionError?.message ?? null}
-              isCommitting={isCommitting}
-              aiEnabled={commitMessageAi?.enabled === true}
-              aiAgentConfigured={
-                commitMessageAi?.enabled === true &&
-                effectiveCommitMessageAgentId !== null &&
-                // Why: 'custom' is configured only once the user types a command.
-                // Without this guard, Generate would spawn an empty command and
-                // fail with a confusing error.
-                (!isCustomAgentId(effectiveCommitMessageAgentId) ||
-                  (commitMessageAi.customAgentCommand ?? '').trim().length > 0)
-              }
-              isGenerating={isGenerating}
-              generateError={generateError}
-              stagedCount={grouped.staged.length}
-              hasUnresolvedConflicts={unresolvedConflicts.length > 0}
-              isRemoteOperationActive={isRemoteOperationActive}
-              inFlightRemoteOpKind={inFlightRemoteOpKind}
-              primaryAction={primaryAction}
-              dropdownItems={dropdownItems}
-              onCommitMessageChange={(value) => {
-                if (!activeWorktreeId) {
-                  return
+          {shouldRenderCommitArea(scope, unresolvedConflicts.length, conflictOperation) &&
+            (primaryAction.kind === 'create_pr' ? (
+              <PullRequestComposer
+                branch={branchName}
+                base={prBase}
+                setBase={setPrBase}
+                title={prTitle}
+                setTitle={setPrTitle}
+                body={prBody}
+                setBody={setPrBody}
+                draft={prDraft}
+                setDraft={setPrDraft}
+                baseQuery={prBaseQuery}
+                setBaseQuery={setPrBaseQuery}
+                baseResults={prBaseResults}
+                setBaseResults={setPrBaseResults}
+                baseSearchError={prBaseSearchError}
+                aiGenerationEnabled={prAiGenerationEnabled}
+                generating={prGenerating}
+                generateDisabled={prGenerateDisabled}
+                generateDisabledReason={prGenerateDisabledReason}
+                generateError={prGenerateError}
+                createError={createPrError}
+                isCreating={isCreatingPr}
+                primaryAction={primaryAction}
+                dropdownItems={dropdownItems}
+                onGenerate={() => void handleGeneratePullRequestFields()}
+                onCancelGenerate={handleCancelGeneratePullRequestFields}
+                onPrimaryAction={handlePrimaryClick}
+                onDropdownAction={handleActionInvoke}
+              />
+            ) : (
+              <CommitArea
+                worktreeId={activeWorktreeId}
+                commitMessage={commitMessage}
+                commitError={commitError}
+                remoteActionError={remoteActionError?.message ?? null}
+                isCommitting={isCommitting}
+                aiEnabled={commitMessageAi?.enabled === true}
+                aiAgentConfigured={
+                  commitMessageAi?.enabled === true &&
+                  effectiveCommitMessageAgentId !== null &&
+                  // Why: 'custom' is configured only once the user types a command.
+                  // Without this guard, Generate would spawn an empty command and
+                  // fail with a confusing error.
+                  (!isCustomAgentId(effectiveCommitMessageAgentId) ||
+                    (commitMessageAi.customAgentCommand ?? '').trim().length > 0)
                 }
-                setCommitDrafts((prev) =>
-                  writeCommitDraftForWorktree(prev, activeWorktreeId, value)
-                )
-              }}
-              onGenerate={() => {
-                void handleGenerate()
-              }}
-              onCancelGenerate={handleCancelGenerate}
-              onPrimaryAction={handlePrimaryClick}
-              onDropdownAction={handleActionInvoke}
-            />
-          )}
+                isGenerating={isGenerating}
+                generateError={generateError}
+                stagedCount={grouped.staged.length}
+                hasUnresolvedConflicts={unresolvedConflicts.length > 0}
+                isRemoteOperationActive={isRemoteOperationActive}
+                inFlightRemoteOpKind={inFlightRemoteOpKind}
+                primaryAction={primaryAction}
+                dropdownItems={dropdownItems}
+                onCommitMessageChange={(value) => {
+                  if (!activeWorktreeId) {
+                    return
+                  }
+                  setCommitDrafts((prev) =>
+                    writeCommitDraftForWorktree(prev, activeWorktreeId, value)
+                  )
+                }}
+                onGenerate={() => {
+                  void handleGenerate()
+                }}
+                onCancelGenerate={handleCancelGenerate}
+                onPrimaryAction={handlePrimaryClick}
+                onDropdownAction={handleActionInvoke}
+              />
+            ))}
 
           {(scope === 'all' || scope === 'uncommitted') && hasFilteredUncommittedEntries && (
             <>
@@ -3463,12 +3584,266 @@ function SourceControlInner(): React.JSX.Element {
 const SourceControl = React.memo(SourceControlInner)
 export default SourceControl
 
+type PullRequestComposerProps = {
+  branch: string
+  base: string
+  setBase: (value: string) => void
+  title: string
+  setTitle: (value: string) => void
+  body: string
+  setBody: (value: string) => void
+  draft: boolean
+  setDraft: (value: boolean) => void
+  baseQuery: string
+  setBaseQuery: (value: string) => void
+  baseResults: string[]
+  setBaseResults: (value: string[]) => void
+  baseSearchError: string | null
+  aiGenerationEnabled: boolean
+  generating: boolean
+  generateDisabled: boolean
+  generateDisabledReason?: string
+  generateError: string | null
+  createError: string | null
+  isCreating: boolean
+  primaryAction: PrimaryAction
+  dropdownItems: DropdownEntry[]
+  onGenerate: () => void
+  onCancelGenerate: () => void
+  onPrimaryAction: () => void
+  onDropdownAction: (kind: DropdownActionKind) => void
+}
+
+function PullRequestComposer({
+  branch,
+  base,
+  setBase,
+  title,
+  setTitle,
+  body,
+  setBody,
+  draft,
+  setDraft,
+  baseQuery,
+  setBaseQuery,
+  baseResults,
+  setBaseResults,
+  baseSearchError,
+  aiGenerationEnabled,
+  generating,
+  generateDisabled,
+  generateDisabledReason,
+  generateError,
+  createError,
+  isCreating,
+  primaryAction,
+  dropdownItems,
+  onGenerate,
+  onCancelGenerate,
+  onPrimaryAction,
+  onDropdownAction
+}: PullRequestComposerProps): React.JSX.Element {
+  const normalizedBase = stripBaseRef(base)
+  const createDisabled =
+    primaryAction.disabled ||
+    generating ||
+    title.trim().length === 0 ||
+    normalizedBase.trim().length === 0 ||
+    normalizedBase.toLowerCase() === stripBaseRef(branch).toLowerCase()
+
+  return (
+    <div className="px-3 pb-2">
+      <div className="space-y-2">
+        <div className="flex min-w-0 items-center justify-between gap-2">
+          <div className="min-w-0 truncate text-[11px] text-muted-foreground">
+            <span className="font-medium text-foreground">Create Pull Request</span>
+            <span className="mx-1">·</span>
+            <span>
+              {branch} → {normalizedBase || 'base'}
+            </span>
+          </div>
+          {aiGenerationEnabled ? (
+            generating ? (
+              <button
+                type="button"
+                onClick={() => onCancelGenerate()}
+                className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                title="Stop generating"
+                aria-label="Stop generating pull request details"
+              >
+                <RefreshCw className="size-3.5 animate-spin" />
+                Generating
+                <Square className="size-3 fill-current" />
+              </button>
+            ) : (
+              <button
+                type="button"
+                disabled={generateDisabled}
+                onClick={() => onGenerate()}
+                className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-background"
+                title={generateDisabledReason ?? 'Generate pull request details with AI'}
+                aria-label="Generate pull request details with AI"
+              >
+                <Sparkles className="size-3.5" />
+                Generate
+              </button>
+            )
+          ) : null}
+        </div>
+
+        <div className="grid grid-cols-[minmax(0,1fr)_96px] gap-1.5">
+          <input
+            aria-label="Pull request title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Title"
+            className="h-8 min-w-0 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
+          />
+          <div className="relative">
+            <input
+              aria-label="Pull request base branch"
+              value={baseQuery || base}
+              onChange={(event) => {
+                setBaseQuery(event.target.value)
+                setBase(event.target.value)
+              }}
+              placeholder="main"
+              className="h-8 w-full min-w-0 rounded-md border border-border bg-background px-2 pr-6 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
+            />
+            <ChevronDown className="pointer-events-none absolute right-1.5 top-2 size-3.5 text-muted-foreground" />
+          </div>
+        </div>
+
+        {baseResults.length > 0 ? (
+          <div className="max-h-28 overflow-auto rounded-md border border-border p-1 scrollbar-sleek">
+            {baseResults.map((ref) => (
+              <button
+                key={ref}
+                type="button"
+                className={cn(
+                  'flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent',
+                  stripBaseRef(base) === ref && 'bg-accent text-accent-foreground'
+                )}
+                onClick={() => {
+                  setBase(ref)
+                  setBaseQuery('')
+                  setBaseResults([])
+                }}
+              >
+                <span className="truncate">{ref}</span>
+                {stripBaseRef(base) === ref ? <Check className="size-3" /> : null}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <textarea
+          aria-label="Pull request description"
+          rows={6}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder="Description"
+          className="w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
+        />
+
+        <div className="flex items-center justify-between gap-2">
+          <label className="inline-flex items-center gap-1.5 text-xs text-foreground">
+            <input
+              type="checkbox"
+              checked={draft}
+              onChange={(event) => setDraft(event.target.checked)}
+              className="size-3.5 rounded border-border accent-primary"
+            />
+            Draft
+          </label>
+          <span className="truncate text-[11px] text-muted-foreground">
+            {normalizedBase || 'base'}
+          </span>
+        </div>
+
+        <div className="flex items-stretch">
+          <Button
+            type="button"
+            size="xs"
+            disabled={createDisabled}
+            onClick={() => onPrimaryAction()}
+            className="flex-1 rounded-r-none px-3 text-[11px]"
+            title={primaryAction.title}
+          >
+            {isCreating ? (
+              <RefreshCw className="size-3.5 animate-spin" />
+            ) : (
+              <GitPullRequestArrow className="size-3.5" />
+            )}
+            Create PR
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                size="xs"
+                className={cn(
+                  'rounded-l-none border-l border-primary-foreground/20 px-1.5 shrink-0',
+                  createDisabled && 'opacity-50'
+                )}
+                aria-label="More pull request and remote actions"
+                title="More actions"
+              >
+                <ChevronDown className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-[14rem]">
+              {dropdownItems.map((entry, index) =>
+                entry.kind === 'separator' ? (
+                  <DropdownMenuSeparator key={`sep-${index}`} />
+                ) : (
+                  <DropdownMenuItem
+                    key={entry.kind}
+                    disabled={entry.disabled}
+                    title={entry.title}
+                    onSelect={(event) => {
+                      if (entry.disabled) {
+                        event.preventDefault()
+                        return
+                      }
+                      onDropdownAction(entry.kind)
+                    }}
+                  >
+                    <span className="flex min-w-0 flex-col">
+                      <span>{entry.label}</span>
+                      {entry.hint ? (
+                        <span className="truncate text-[10px] text-muted-foreground">
+                          {entry.hint}
+                        </span>
+                      ) : null}
+                    </span>
+                  </DropdownMenuItem>
+                )
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {normalizedBase.toLowerCase() === stripBaseRef(branch).toLowerCase() ? (
+          <p className="text-[11px] text-destructive">
+            Choose a different base branch before creating a pull request.
+          </p>
+        ) : null}
+        {baseSearchError ? <p className="text-[11px] text-destructive">{baseSearchError}</p> : null}
+        {generateError ? <p className="text-[11px] text-destructive">{generateError}</p> : null}
+        {createError ? <p className="text-[11px] text-destructive">{createError}</p> : null}
+      </div>
+    </div>
+  )
+}
+
 type CommitAreaProps = {
   worktreeId: string | null
   commitMessage: string
   commitError: string | null
   remoteActionError: string | null
   isCommitting: boolean
+  isCreatingPr?: boolean
   aiEnabled: boolean
   aiAgentConfigured: boolean
   isGenerating: boolean
@@ -3492,6 +3867,7 @@ export function CommitArea({
   commitError,
   remoteActionError,
   isCommitting,
+  isCreatingPr = false,
   aiEnabled,
   aiAgentConfigured,
   isGenerating,
@@ -3522,9 +3898,11 @@ export function CommitArea({
   // signal there. Commit still spins on isCommitting because that path
   // doesn't go through inFlightRemoteOpKind.
   const showSpinner =
-    primaryAction.kind === 'commit'
-      ? isCommitting
-      : isRemoteOperationActive && primaryAction.kind === inFlightRemoteOpKind
+    primaryAction.kind === 'create_pr'
+      ? isCreatingPr
+      : primaryAction.kind === 'commit'
+        ? isCommitting
+        : isRemoteOperationActive && primaryAction.kind === inFlightRemoteOpKind
   // Why: when the primary doesn't host the in-flight op (e.g. Fetch, or any
   // dropdown action that mismatches the primary's natural label) the click
   // would otherwise be silent — the toast only fires on failure and a
@@ -3532,7 +3910,8 @@ export function CommitArea({
   // the user immediate feedback that the action they picked is running,
   // while still leaving the menu reachable to read the disabled-row
   // tooltips.
-  const showChevronSpinner = (isCommitting || isRemoteOperationActive) && !showSpinner
+  const showChevronSpinner =
+    (isCommitting || isCreatingPr || isRemoteOperationActive) && !showSpinner
   const commitFailureSummary = useMemo(
     () => (commitError ? summarizeCommitFailure(commitError) : null),
     [commitError]

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -482,6 +482,23 @@ function resolveRemoteActionError(kind: RemoteOpKind, error: unknown): string {
   })
 }
 
+export function refreshSourceControlAfterRemoteAction({
+  refreshGitStatus,
+  refreshBranchCompare,
+  refreshGitHistory,
+  onError = (error) => console.warn('[SourceControl] post-remote refresh failed', error)
+}: {
+  refreshGitStatus: () => Promise<void>
+  refreshBranchCompare: () => Promise<void>
+  refreshGitHistory: () => Promise<void>
+  onError?: (error: unknown) => void
+}): void {
+  // Why: fetch/sync can move the remote base ref without changing local files.
+  // Refresh all three visible git projections so the branch comparison table
+  // re-runs against the newly fetched base instead of waiting for polling.
+  void Promise.all([refreshGitStatus(), refreshBranchCompare(), refreshGitHistory()]).catch(onError)
+}
+
 function HostedReviewIcon({
   review,
   className
@@ -970,53 +987,12 @@ function SourceControlInner(): React.JSX.Element {
     linkedGitLabMR
   ])
 
-  useEffect(() => {
-    if (!isBranchVisible || !activeRepo || isFolder || !branchName) {
-      setHostedReviewCreation(null)
-      return
-    }
-    let stale = false
-    void getHostedReviewCreationEligibility({
-      repoPath: activeRepo.path,
-      ...(worktreePath ? { worktreePath } : {}),
-      branch: branchName,
-      base: effectiveBaseRef ?? null,
-      hasUncommittedChanges: hasUncommittedEntries,
-      hasUpstream: remoteStatus?.hasUpstream,
-      ahead: remoteStatus?.ahead,
-      behind: remoteStatus?.behind,
-      linkedGitHubPR,
-      linkedGitLabMR
-    })
-      .then((result) => {
-        if (!stale) {
-          setHostedReviewCreation(result)
-        }
-      })
-      .catch((error) => {
-        console.warn('[SourceControl] hosted review creation eligibility failed', error)
-        if (!stale) {
-          setHostedReviewCreation(null)
-        }
-      })
-    return () => {
-      stale = true
-    }
-  }, [
-    activeRepo,
-    branchName,
-    effectiveBaseRef,
-    getHostedReviewCreationEligibility,
-    hasUncommittedEntries,
-    isBranchVisible,
-    isFolder,
-    linkedGitHubPR,
-    linkedGitLabMR,
-    remoteStatus?.ahead,
-    remoteStatus?.behind,
-    remoteStatus?.hasUpstream,
-    worktreePath
-  ])
+  // Why: eligibility is recomputed below, after prGenerating / isCreatingPr are
+  // available, so the effect can pause refetches while a user-initiated PR flow
+  // is in flight. AI generation runs `git fetch` + `git rebase`, which mutates
+  // ahead/behind counts; without this guard the next refetch would return
+  // canCreate:false (typically needs_push), flip primaryAction.kind off
+  // create_pr, unmount the composer, and cancel the in-flight generation.
 
   const grouped = useMemo(() => {
     const groups = {
@@ -1517,7 +1493,11 @@ function SourceControlInner(): React.JSX.Element {
           }
         }))
       } finally {
-        void refreshGitHistoryRef.current()
+        refreshSourceControlAfterRemoteAction({
+          refreshGitStatus: refreshActiveGitStatusAfterMutation,
+          refreshBranchCompare: refreshBranchCompareRef.current,
+          refreshGitHistory: refreshGitHistoryRef.current
+        })
       }
     },
     [
@@ -1526,6 +1506,7 @@ function SourceControlInner(): React.JSX.Element {
       fetchBranch,
       pullBranch,
       pushBranch,
+      refreshActiveGitStatusAfterMutation,
       syncBranch,
       worktreePath
     ]
@@ -1634,12 +1615,72 @@ function SourceControlInner(): React.JSX.Element {
     onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration
   })
 
+  useEffect(() => {
+    if (!isBranchVisible || !activeRepo || isFolder || !branchName) {
+      setHostedReviewCreation(null)
+      return
+    }
+    // Why: skip refetches while the user's PR flow is mid-flight. AI generation
+    // rebases the branch (changing ahead/behind), and submission runs network
+    // calls that briefly perturb the same counts. Either flip can switch
+    // canCreate to false and tear down the composer underneath the user. The
+    // post-completion eligibility refresh in handlePullRequestCreated /
+    // onBranchChangedByGeneration restores the truth once the work settles.
+    if (prGenerating || isCreatingPr) {
+      return
+    }
+    let stale = false
+    void getHostedReviewCreationEligibility({
+      repoPath: activeRepo.path,
+      ...(worktreePath ? { worktreePath } : {}),
+      branch: branchName,
+      base: effectiveBaseRef ?? null,
+      hasUncommittedChanges: hasUncommittedEntries,
+      hasUpstream: remoteStatus?.hasUpstream,
+      ahead: remoteStatus?.ahead,
+      behind: remoteStatus?.behind,
+      linkedGitHubPR,
+      linkedGitLabMR
+    })
+      .then((result) => {
+        if (!stale) {
+          setHostedReviewCreation(result)
+        }
+      })
+      .catch((error) => {
+        console.warn('[SourceControl] hosted review creation eligibility failed', error)
+        if (!stale) {
+          setHostedReviewCreation(null)
+        }
+      })
+    return () => {
+      stale = true
+    }
+  }, [
+    activeRepo,
+    branchName,
+    effectiveBaseRef,
+    getHostedReviewCreationEligibility,
+    hasUncommittedEntries,
+    isBranchVisible,
+    isCreatingPr,
+    isFolder,
+    linkedGitHubPR,
+    linkedGitLabMR,
+    prGenerating,
+    remoteStatus?.ahead,
+    remoteStatus?.behind,
+    remoteStatus?.hasUpstream,
+    worktreePath
+  ])
+
   const handleCreatePullRequest = useCallback(async (): Promise<void> => {
     if (
       !activeRepo ||
       !activeWorktreeId ||
       !worktreePath ||
       !hostedReviewCreation?.canCreate ||
+      prGenerating ||
       createPrInFlightRef.current[activeWorktreeId]
     ) {
       return
@@ -1726,6 +1767,7 @@ function SourceControlInner(): React.JSX.Element {
     prBase,
     prBody,
     prDraft,
+    prGenerating,
     prTitle,
     worktreePath
   ])
@@ -1792,6 +1834,7 @@ function SourceControlInner(): React.JSX.Element {
         isPRStateLoading: isHostedReviewStateLoading,
         inFlightRemoteOpKind,
         hostedReviewCreation,
+        isPullRequestOperationActive: prGenerating || isCreatingPr,
         branchCommitsAhead:
           branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined
       }),
@@ -1804,8 +1847,10 @@ function SourceControlInner(): React.JSX.Element {
       isRemoteOperationActive,
       inFlightRemoteOpKind,
       hostedReviewCreation,
+      isCreatingPr,
       isHostedReviewStateLoading,
       hostedReview?.state,
+      prGenerating,
       branchSummary?.commitsAhead,
       branchSummary?.status,
       remoteStatus,
@@ -1819,6 +1864,9 @@ function SourceControlInner(): React.JSX.Element {
   // pure remote actions go through runRemoteAction.
   const handleActionInvoke = useCallback(
     (kind: DropdownActionKind): void => {
+      if (prGenerating || isCreatingPr) {
+        return
+      }
       switch (kind) {
         case 'commit':
           void handleCommit()
@@ -1851,7 +1899,14 @@ function SourceControlInner(): React.JSX.Element {
         }
       }
     },
-    [handleCommit, handleCreatePullRequest, runCompoundCommitAction, runRemoteAction]
+    [
+      handleCommit,
+      handleCreatePullRequest,
+      isCreatingPr,
+      prGenerating,
+      runCompoundCommitAction,
+      runRemoteAction
+    ]
   )
 
   const handleOpenDiff = useCallback(
@@ -3644,23 +3699,42 @@ function PullRequestComposer({
   onDropdownAction
 }: PullRequestComposerProps): React.JSX.Element {
   const normalizedBase = stripBaseRef(base)
+  const strippedBranch = stripBaseRef(branch)
+  const baseSameAsBranch = normalizedBase.toLowerCase() === strippedBranch.toLowerCase()
   const createDisabled =
     primaryAction.disabled ||
     generating ||
     title.trim().length === 0 ||
     normalizedBase.trim().length === 0 ||
-    normalizedBase.toLowerCase() === stripBaseRef(branch).toLowerCase()
+    baseSameAsBranch
+  // Why: surface a concrete reason on the disabled Create PR button so the
+  // user knows what's blocking submission instead of a silent gray state.
+  let createDisabledReason: string | undefined
+  if (generating) {
+    createDisabledReason = 'Wait for AI generation to finish.'
+  } else if (title.trim().length === 0) {
+    createDisabledReason = 'Enter a pull request title.'
+  } else if (normalizedBase.trim().length === 0) {
+    createDisabledReason = 'Choose a base branch.'
+  } else if (baseSameAsBranch) {
+    createDisabledReason = 'Base branch must differ from the head branch.'
+  }
+
+  // Why: lock the title/body/base inputs while AI generation is running so
+  // the user can't race the request — the hook otherwise rejects the result
+  // with "Fields changed while generating" and silently drops the draft.
+  const fieldsLocked = generating
 
   return (
     <div className="px-3 pb-2">
-      <div className="space-y-2">
+      <div className="space-y-2.5">
         <div className="flex min-w-0 items-center justify-between gap-2">
-          <div className="min-w-0 truncate text-[11px] text-muted-foreground">
-            <span className="font-medium text-foreground">Create Pull Request</span>
-            <span className="mx-1">·</span>
-            <span>
-              {branch} → {normalizedBase || 'base'}
-            </span>
+          <div className="flex min-w-0 items-center gap-1.5 text-xs">
+            <GitPullRequestArrow
+              className="size-3.5 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <span className="font-medium text-foreground">New pull request</span>
           </div>
           {aiGenerationEnabled ? (
             generating ? (
@@ -3671,47 +3745,118 @@ function PullRequestComposer({
                 title="Stop generating"
                 aria-label="Stop generating pull request details"
               >
-                <RefreshCw className="size-3.5 animate-spin" />
-                Generating
-                <Square className="size-3 fill-current" />
+                <RefreshCw className="size-3 animate-spin" />
+                <span>Generating…</span>
+                <Square className="size-2.5 fill-current" />
               </button>
             ) : (
               <button
                 type="button"
                 disabled={generateDisabled}
                 onClick={() => onGenerate()}
-                className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-background"
+                className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-background"
                 title={generateDisabledReason ?? 'Generate pull request details with AI'}
                 aria-label="Generate pull request details with AI"
               >
-                <Sparkles className="size-3.5" />
+                <Sparkles className="size-3" />
                 Generate
               </button>
             )
           ) : null}
         </div>
 
-        <div className="grid grid-cols-[minmax(0,1fr)_96px] gap-1.5">
+        {/* Why: a single line that shows the head→base flow plain-language so
+            the user can sanity-check the merge direction at a glance. */}
+        <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+          <span className="truncate font-mono text-foreground" title={strippedBranch}>
+            {strippedBranch}
+          </span>
+          <ArrowDownUp className="size-3 rotate-90 shrink-0 opacity-60" aria-hidden="true" />
+          <span
+            className={cn(
+              'truncate font-mono',
+              baseSameAsBranch ? 'text-destructive' : 'text-foreground'
+            )}
+            title={normalizedBase || 'base'}
+          >
+            {normalizedBase || 'base'}
+          </span>
+        </div>
+
+        <div className="relative space-y-2">
           <input
             aria-label="Pull request title"
             value={title}
+            disabled={fieldsLocked}
             onChange={(event) => setTitle(event.target.value)}
             placeholder="Title"
-            className="h-8 min-w-0 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
+            className="h-8 w-full min-w-0 rounded-md border border-border bg-background px-2 text-xs font-medium text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
           />
-          <div className="relative">
+
+          <textarea
+            aria-label="Pull request description"
+            rows={6}
+            value={body}
+            disabled={fieldsLocked}
+            onChange={(event) => setBody(event.target.value)}
+            placeholder="Description (optional)"
+            className="min-h-[7.5rem] w-full resize-y rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 scrollbar-sleek"
+          />
+
+          {generating ? (
+            // Why: visible scrim + status row so the user understands the
+            // title and description fields will be replaced when generation
+            // finishes; locking the inputs above also prevents the
+            // "Fields changed while generating" race in the hook.
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-md bg-background/40"
+              aria-hidden="true"
+            >
+              <div className="pointer-events-auto flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-[11px] text-muted-foreground shadow-sm">
+                <Sparkles className="size-3 animate-pulse text-foreground" />
+                <span>Generating title & description…</span>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Why: base picker as its own labeled row so the title input can use
+            the full width. The dropdown chevron makes the picker affordance
+            obvious; the inline label clarifies that this is the merge target. */}
+        <div className="flex items-center gap-2">
+          <span className="shrink-0 text-[11px] text-muted-foreground">Base</span>
+          <div className="relative min-w-0 flex-1">
             <input
               aria-label="Pull request base branch"
               value={baseQuery || base}
+              disabled={fieldsLocked}
               onChange={(event) => {
                 setBaseQuery(event.target.value)
                 setBase(event.target.value)
               }}
               placeholder="main"
-              className="h-8 w-full min-w-0 rounded-md border border-border bg-background px-2 pr-6 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
+              className="h-7 w-full min-w-0 rounded-md border border-border bg-background px-2 pr-6 font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
             />
-            <ChevronDown className="pointer-events-none absolute right-1.5 top-2 size-3.5 text-muted-foreground" />
+            <ChevronDown
+              className="pointer-events-none absolute right-1.5 top-1.5 size-3.5 text-muted-foreground"
+              aria-hidden="true"
+            />
           </div>
+          <label
+            className={cn(
+              'inline-flex shrink-0 items-center gap-1.5 text-[11px]',
+              fieldsLocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer text-foreground'
+            )}
+          >
+            <input
+              type="checkbox"
+              checked={draft}
+              disabled={fieldsLocked}
+              onChange={(event) => setDraft(event.target.checked)}
+              className="size-3.5 rounded border-border accent-primary"
+            />
+            Draft
+          </label>
         </div>
 
         {baseResults.length > 0 ? (
@@ -3721,7 +3866,7 @@ function PullRequestComposer({
                 key={ref}
                 type="button"
                 className={cn(
-                  'flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent',
+                  'flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left font-mono text-xs hover:bg-accent',
                   stripBaseRef(base) === ref && 'bg-accent text-accent-foreground'
                 )}
                 onClick={() => {
@@ -3737,45 +3882,21 @@ function PullRequestComposer({
           </div>
         ) : null}
 
-        <textarea
-          aria-label="Pull request description"
-          rows={6}
-          value={body}
-          onChange={(event) => setBody(event.target.value)}
-          placeholder="Description"
-          className="w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
-        />
-
-        <div className="flex items-center justify-between gap-2">
-          <label className="inline-flex items-center gap-1.5 text-xs text-foreground">
-            <input
-              type="checkbox"
-              checked={draft}
-              onChange={(event) => setDraft(event.target.checked)}
-              className="size-3.5 rounded border-border accent-primary"
-            />
-            Draft
-          </label>
-          <span className="truncate text-[11px] text-muted-foreground">
-            {normalizedBase || 'base'}
-          </span>
-        </div>
-
-        <div className="flex items-stretch">
+        <div className="flex items-stretch pt-0.5">
           <Button
             type="button"
             size="xs"
             disabled={createDisabled}
             onClick={() => onPrimaryAction()}
-            className="flex-1 rounded-r-none px-3 text-[11px]"
-            title={primaryAction.title}
+            className="h-7 flex-1 rounded-r-none px-3 text-xs"
+            title={createDisabledReason ?? primaryAction.title}
           >
             {isCreating ? (
               <RefreshCw className="size-3.5 animate-spin" />
             ) : (
               <GitPullRequestArrow className="size-3.5" />
             )}
-            Create PR
+            {isCreating ? 'Creating…' : draft ? 'Create draft PR' : 'Create PR'}
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -3783,7 +3904,7 @@ function PullRequestComposer({
                 type="button"
                 size="xs"
                 className={cn(
-                  'rounded-l-none border-l border-primary-foreground/20 px-1.5 shrink-0',
+                  'h-7 rounded-l-none border-l border-primary-foreground/20 px-1.5 shrink-0',
                   createDisabled && 'opacity-50'
                 )}
                 aria-label="More pull request and remote actions"
@@ -3824,14 +3945,30 @@ function PullRequestComposer({
           </DropdownMenu>
         </div>
 
-        {normalizedBase.toLowerCase() === stripBaseRef(branch).toLowerCase() ? (
-          <p className="text-[11px] text-destructive">
-            Choose a different base branch before creating a pull request.
+        {baseSameAsBranch ? (
+          <p className="flex items-start gap-1 text-[11px] text-destructive">
+            <TriangleAlert className="mt-px size-3 shrink-0" aria-hidden="true" />
+            <span>Choose a different base branch before creating a pull request.</span>
           </p>
         ) : null}
-        {baseSearchError ? <p className="text-[11px] text-destructive">{baseSearchError}</p> : null}
-        {generateError ? <p className="text-[11px] text-destructive">{generateError}</p> : null}
-        {createError ? <p className="text-[11px] text-destructive">{createError}</p> : null}
+        {baseSearchError ? (
+          <p className="flex items-start gap-1 text-[11px] text-destructive">
+            <TriangleAlert className="mt-px size-3 shrink-0" aria-hidden="true" />
+            <span>{baseSearchError}</span>
+          </p>
+        ) : null}
+        {generateError ? (
+          <p className="flex items-start gap-1 text-[11px] text-destructive">
+            <TriangleAlert className="mt-px size-3 shrink-0" aria-hidden="true" />
+            <span>{generateError}</span>
+          </p>
+        ) : null}
+        {createError ? (
+          <p className="flex items-start gap-1 text-[11px] text-destructive">
+            <TriangleAlert className="mt-px size-3 shrink-0" aria-hidden="true" />
+            <span>{createError}</span>
+          </p>
+        ) : null}
       </div>
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -131,6 +131,7 @@ import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullR
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
 import type { GitHistoryItem } from '../../../../shared/git-history'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
+import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
 import type {
   DiffComment,
   GitBranchChangeEntry,
@@ -1461,12 +1462,14 @@ function SourceControlInner(): React.JSX.Element {
           return
         }
         if (kind === 'push') {
+          const forceWithLease = shouldForcePushWithLeaseForUpstream(remoteStatus)
           await pushBranch(
             activeWorktreeId,
             worktreePath,
             false,
             connectionId,
-            activeWorktree?.pushTarget
+            activeWorktree?.pushTarget,
+            forceWithLease ? { forceWithLease: true } : undefined
           )
           return
         }
@@ -1507,6 +1510,7 @@ function SourceControlInner(): React.JSX.Element {
       pullBranch,
       pushBranch,
       refreshActiveGitStatusAfterMutation,
+      remoteStatus,
       syncBranch,
       worktreePath
     ]
@@ -4188,71 +4192,98 @@ export function CommitArea({
             and chevron share a single rounded rectangle — rounded-r-none on
             the primary and rounded-l-none + border-l on the chevron make the
             pair read as one split button instead of two detached buttons. */}
-        <Button
-          type="button"
-          size="xs"
-          disabled={primaryAction.disabled}
-          onClick={() => onPrimaryAction()}
-          className="flex-1 rounded-r-none px-3 text-[11px]"
-          title={primaryAction.title}
-        >
-          {showSpinner ? (
-            <RefreshCw className="size-3.5 animate-spin" />
-          ) : PrimaryIcon ? (
-            <PrimaryIcon className="size-3.5" aria-hidden="true" />
-          ) : null}
-          {primaryAction.label}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex flex-1">
+              <Button
+                type="button"
+                size="xs"
+                disabled={primaryAction.disabled}
+                onClick={() => onPrimaryAction()}
+                className="w-full rounded-r-none px-3 text-[11px]"
+                title={primaryAction.title}
+              >
+                {showSpinner ? (
+                  <RefreshCw className="size-3.5 animate-spin" />
+                ) : PrimaryIcon ? (
+                  <PrimaryIcon className="size-3.5" aria-hidden="true" />
+                ) : null}
+                {primaryAction.label}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={6} className="max-w-72">
+            {primaryAction.title}
+          </TooltipContent>
+        </Tooltip>
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              size="xs"
-              className={cn(
-                'rounded-l-none border-l border-primary-foreground/20 px-1.5 shrink-0',
-                // Why: mirror the primary's disabled dimming so the split
-                // button reads as one unit when Commit is unavailable. The
-                // chevron itself stays clickable — its dropdown exposes
-                // independently-gated remote actions (push / fetch / pull)
-                // that are still valid when the primary is disabled.
-                primaryAction.disabled && 'opacity-50'
-              )}
-              aria-label="More commit and remote actions"
-              title="More actions"
-            >
-              {showChevronSpinner ? (
-                <RefreshCw className="size-3.5 animate-spin" />
-              ) : (
-                <ChevronDown className="size-3.5" />
-              )}
-            </Button>
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex shrink-0">
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    size="xs"
+                    className={cn(
+                      'rounded-l-none border-l border-primary-foreground/20 px-1.5 shrink-0',
+                      // Why: mirror the primary's disabled dimming so the split
+                      // button reads as one unit when Commit is unavailable. The
+                      // chevron itself stays clickable — its dropdown exposes
+                      // independently-gated remote actions (push / fetch / pull)
+                      // that are still valid when the primary is disabled.
+                      primaryAction.disabled && 'opacity-50'
+                    )}
+                    aria-label="More commit and remote actions"
+                    title="More actions"
+                  >
+                    {showChevronSpinner ? (
+                      <RefreshCw className="size-3.5 animate-spin" />
+                    ) : (
+                      <ChevronDown className="size-3.5" />
+                    )}
+                  </Button>
+                </DropdownMenuTrigger>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={6}>
+              More commit and remote actions
+            </TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end" className="min-w-[14rem]">
             {dropdownItems.map((entry, index) =>
               entry.kind === 'separator' ? (
                 <DropdownMenuSeparator key={`sep-${index}`} />
               ) : (
-                <DropdownMenuItem
-                  key={entry.kind}
-                  disabled={entry.disabled}
-                  title={entry.title}
-                  onSelect={(event) => {
-                    if (entry.disabled) {
-                      event.preventDefault()
-                      return
-                    }
-                    onDropdownAction(entry.kind)
-                  }}
-                >
-                  <span className="flex min-w-0 flex-col">
-                    <span>{entry.label}</span>
-                    {entry.hint ? (
-                      <span className="truncate text-[10px] text-muted-foreground">
-                        {entry.hint}
-                      </span>
-                    ) : null}
-                  </span>
-                </DropdownMenuItem>
+                <Tooltip key={entry.kind}>
+                  <TooltipTrigger asChild>
+                    <div className="block">
+                      <DropdownMenuItem
+                        disabled={entry.disabled}
+                        title={entry.title}
+                        className="w-full"
+                        onSelect={(event) => {
+                          if (entry.disabled) {
+                            event.preventDefault()
+                            return
+                          }
+                          onDropdownAction(entry.kind)
+                        }}
+                      >
+                        <span className="flex min-w-0 flex-col">
+                          <span>{entry.label}</span>
+                          {entry.hint ? (
+                            <span className="truncate text-[10px] text-muted-foreground">
+                              {entry.hint}
+                            </span>
+                          ) : null}
+                        </span>
+                      </DropdownMenuItem>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="left" sideOffset={8} className="max-w-72">
+                    {entry.title}
+                  </TooltipContent>
+                </Tooltip>
               )
             )}
           </DropdownMenuContent>

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -26,7 +26,8 @@ describe('refreshGitStatusForWorktree', () => {
         hasUpstream: true,
         upstreamName: 'origin/feature',
         ahead: 2,
-        behind: 1
+        behind: 1,
+        behindCommitsArePatchEquivalent: false
       }
     }
     const gitStatus = vi.fn().mockResolvedValue(status)
@@ -51,6 +52,31 @@ describe('refreshGitStatusForWorktree', () => {
     })
     expect(deps.setUpstreamStatus).toHaveBeenCalledWith('wt-1', status.upstreamStatus)
     expect(deps.fetchUpstreamStatus).not.toHaveBeenCalled()
+  })
+
+  it('refreshes explicit upstream details for diverged porcelain-only status', async () => {
+    const status: GitStatusResult = {
+      entries: [],
+      conflictOperation: 'unknown',
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 14,
+        behind: 3
+      }
+    }
+    const gitStatus = vi.fn().mockResolvedValue(status)
+    vi.stubGlobal('window', { api: { git: { status: gitStatus } } })
+    const deps = makeDeps()
+
+    await refreshGitStatusForWorktree({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      deps
+    })
+
+    expect(deps.setUpstreamStatus).toHaveBeenCalledWith('wt-1', status.upstreamStatus)
+    expect(deps.fetchUpstreamStatus).toHaveBeenCalledWith('wt-1', '/repo', undefined)
   })
 
   it('falls back to explicit upstream refresh for legacy status payloads', async () => {

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -44,6 +44,16 @@ export async function refreshGitStatusForWorktree({
   })
   if (status.upstreamStatus) {
     deps.setUpstreamStatus(worktreeId, status.upstreamStatus)
+    // Why: porcelain status has counts but cannot tell stale post-rebase
+    // upstream commits from real remote work. A diverged branch needs the
+    // richer explicit probe before the UI offers Pull/Sync.
+    if (
+      status.upstreamStatus.ahead > 0 &&
+      status.upstreamStatus.behind > 0 &&
+      status.upstreamStatus.behindCommitsArePatchEquivalent === undefined
+    ) {
+      await deps.fetchUpstreamStatus(worktreeId, worktreePath, connectionId)
+    }
     return
   }
   await deps.fetchUpstreamStatus(worktreeId, worktreePath, connectionId)

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -259,7 +259,7 @@ describe('resolveDropdownItems', () => {
     expect(byKind.sync.label).toBe('Sync (↓3 ↑2)')
   })
 
-  it('enables Push & Create PR when review creation is only blocked by unpushed commits', () => {
+  it('enables the push-before-PR recovery action when review creation is only blocked by unpushed commits', () => {
     const items = resolveDropdownItems(
       inputs({
         upstreamStatus: { hasUpstream: true, ahead: 2, behind: 0 },
@@ -277,6 +277,7 @@ describe('resolveDropdownItems', () => {
     )
     expect(byKind.create_pr.disabled).toBe(true)
     expect(byKind.create_pr.hint).toBe('Push first')
+    expect(byKind.push_create_pr.label).toBe('Push before PR')
     expect(byKind.push_create_pr.disabled).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: the dropdown priority table is easier to audit when the row-state cases live together. */
 import { describe, expect, it } from 'vitest'
 import { resolveDropdownItems, type DropdownActionInputs } from './source-control-dropdown-items'
 
@@ -132,6 +133,56 @@ describe('resolveDropdownItems', () => {
     expect(byKind.commit_push.title).toBe('Use Commit & Sync to pull remote changes before pushing')
     expect(byKind.sync.disabled).toBe(false)
     expect(byKind.commit_sync.disabled).toBe(false)
+  })
+
+  it('offers force-push-with-lease when remote-only commits are patch-equivalent', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        hasMessage: true,
+        branchCommitsAhead: 4,
+        upstreamStatus: {
+          hasUpstream: true,
+          upstreamName: 'origin/feature',
+          ahead: 14,
+          behind: 3,
+          behindCommitsArePatchEquivalent: true
+        },
+        hostedReviewCreation: {
+          provider: 'github',
+          review: null,
+          canCreate: false,
+          blockedReason: 'needs_sync',
+          nextAction: 'sync'
+        }
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+
+    expect(byKind.push.label).toBe('Force Push (4)')
+    expect(byKind.push.disabled).toBe(false)
+    expect(byKind.push.title).toBe(
+      'Remote only has older copies of local commits. Force push 4 branch commits with lease to update origin/feature.'
+    )
+    expect(byKind.commit_push.label).toBe('Commit & Force Push')
+    expect(byKind.commit_push.disabled).toBe(false)
+    expect(byKind.commit_push.title).toBe('Commit staged changes and force push with lease')
+    expect(byKind.pull.disabled).toBe(true)
+    expect(byKind.pull.title).toBe(
+      'Nothing new to pull — remote only has older copies of local commits'
+    )
+    expect(byKind.commit_sync.label).toBe('Commit & Sync')
+    expect(byKind.commit_sync.disabled).toBe(true)
+    expect(byKind.commit_sync.title).toBe(
+      'Use Commit & Force Push — remote only has older copies of local commits'
+    )
+    expect(byKind.sync.disabled).toBe(true)
+    expect(byKind.sync.title).toBe('Use Force Push — remote only has older copies of local commits')
+    expect(byKind.create_pr.hint).toBe('Force Push first')
+    expect(byKind.push_create_pr.label).toBe('Force Push before PR')
+    expect(byKind.push_create_pr.disabled).toBe(false)
   })
 
   it('omits counts from labels when ahead/behind are 0', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { resolveDropdownItems } from './source-control-dropdown-items'
-import type { PrimaryActionInputs } from './source-control-primary-action'
+import { resolveDropdownItems, type DropdownActionInputs } from './source-control-dropdown-items'
 
 // Why: a shared defaults object keeps each case row terse while making the
 // "this is the one knob that differs from the baseline" intent obvious.
-function inputs(overrides: Partial<PrimaryActionInputs> = {}): PrimaryActionInputs {
+function inputs(overrides: Partial<DropdownActionInputs> = {}): DropdownActionInputs {
   return {
     stagedCount: 0,
     hasUnstagedChanges: false,
@@ -115,6 +114,26 @@ describe('resolveDropdownItems', () => {
     expect(byKind.sync.label).toBe('Sync (↓2 ↑3)')
   })
 
+  it('disables push-only actions on diverged branches so users sync first', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        hasMessage: true,
+        upstreamStatus: { hasUpstream: true, ahead: 2, behind: 3 }
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+
+    expect(byKind.push.disabled).toBe(true)
+    expect(byKind.push.title).toBe('Sync first to pull remote changes before pushing')
+    expect(byKind.commit_push.disabled).toBe(true)
+    expect(byKind.commit_push.title).toBe('Use Commit & Sync to pull remote changes before pushing')
+    expect(byKind.sync.disabled).toBe(false)
+    expect(byKind.commit_sync.disabled).toBe(false)
+  })
+
   it('omits counts from labels when ahead/behind are 0', () => {
     const items = resolveDropdownItems(
       inputs({ upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 } })
@@ -139,6 +158,29 @@ describe('resolveDropdownItems', () => {
     for (const entry of items) {
       if (entry.kind !== 'separator') {
         expect(entry.disabled).toBe(true)
+      }
+    }
+  })
+
+  it('locks every item while a pull request operation is running', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        isPullRequestOperationActive: true,
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 },
+        hostedReviewCreation: {
+          provider: 'github',
+          review: null,
+          canCreate: true,
+          blockedReason: null,
+          nextAction: null
+        }
+      })
+    )
+
+    for (const entry of items) {
+      if (entry.kind !== 'separator') {
+        expect(entry.disabled).toBe(true)
+        expect(entry.title).toBe('Pull request operation in progress…')
       }
     }
   })

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -301,8 +301,10 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     hostedReviewCreation.blockedReason === 'needs_push'
   const pushCreatePRItem: DropdownItem = {
     kind: 'push_create_pr',
-    label: 'Push & Create PR',
-    title: canPushAndCreate ? 'Push local commits, then create a pull request' : createBlockedHint,
+    label: 'Push before PR',
+    title: canPushAndCreate
+      ? 'Push local commits before creating a pull request'
+      : createBlockedHint,
     hint: canPushAndCreate ? undefined : createBlockedHint,
     disabled: !canPushAndCreate
   }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -1,6 +1,8 @@
+/* eslint-disable max-lines -- Why: this dropdown state machine keeps every action row in one table so priority and disabled-state regressions stay visible in tests. */
 // Why: split from source-control-primary-action because the primary and dropdown are independent derivations with different priority ladders; together they exceed the max-lines budget and tangle unrelated concerns.
 
 import type { PrimaryActionInputs } from './source-control-primary-action'
+import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
 
 export type DropdownActionInputs = PrimaryActionInputs & {
   isPullRequestOperationActive?: boolean
@@ -53,6 +55,14 @@ function formatSyncLabel(base: string, ahead: number, behind: number): string {
   return `${base} (↓${behind} ↑${ahead})`
 }
 
+function formatForcePushTitle(branchCommitsAhead: number | undefined, upstreamName?: string) {
+  const countText =
+    branchCommitsAhead && branchCommitsAhead > 0
+      ? `${branchCommitsAhead} branch commit${branchCommitsAhead === 1 ? '' : 's'}`
+      : 'this branch'
+  return `Remote only has older copies of local commits. Force push ${countText} with lease to update ${upstreamName ?? 'the remote branch'}.`
+}
+
 /**
  * Resolve the chevron dropdown items. Every item is always rendered so the
  * menu shape stays stable across states; inapplicable rows are disabled
@@ -89,6 +99,10 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
   const publishBlockedByNoBranchCommits = !hasUpstream && branchCommitsAhead === 0
   const ahead = upstreamStatus?.ahead ?? 0
   const behind = upstreamStatus?.behind ?? 0
+  const shouldForcePushWithLease = shouldForcePushWithLeaseForUpstream(upstreamStatus)
+  const pushLabelCount =
+    shouldForcePushWithLease && branchCommitsAhead !== undefined ? branchCommitsAhead : ahead
+  const forcePushTitle = formatForcePushTitle(branchCommitsAhead, upstreamStatus?.upstreamName)
 
   // Why: any in-flight commit or remote operation should lock the whole menu.
   // A running push shouldn't let a second pull/sync click queue up behind it
@@ -134,18 +148,20 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
         : !hasUpstream
           ? 'Publish the branch first to push commits'
           : (commitDisabledReason ??
-            (behind > 0
-              ? 'Use Commit & Sync to pull remote changes before pushing'
-              : 'Commit staged changes and push'))
+            (shouldForcePushWithLease
+              ? 'Commit staged changes and force push with lease'
+              : behind > 0
+                ? 'Use Commit & Sync to pull remote changes before pushing'
+                : 'Commit staged changes and push'))
   const commitPushItem: DropdownItem = {
     kind: 'commit_push',
-    label: 'Commit & Push',
+    label: shouldForcePushWithLease ? 'Commit & Force Push' : 'Commit & Push',
     title: commitPushTitle,
     disabled:
       globalBusy ||
       upstreamLoading ||
       !hasUpstream ||
-      behind > 0 ||
+      (behind > 0 && !shouldForcePushWithLease) ||
       publishBlockedByPRLoading ||
       publishBlockedByMergedPR ||
       commitDisabledReason !== null
@@ -167,6 +183,12 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
       // nonexistent compound action.
       return 'Publish the branch first to sync commits'
     }
+    if (shouldForcePushWithLease) {
+      return (
+        commitDisabledReason ??
+        'Use Commit & Force Push — remote only has older copies of local commits'
+      )
+    }
     if (behind === 0) {
       return 'Nothing to pull — use Commit & Push instead'
     }
@@ -177,12 +199,17 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     label: 'Commit & Sync',
     title: commitSyncTitle,
     disabled:
-      globalBusy || upstreamLoading || !hasUpstream || behind === 0 || commitDisabledReason !== null
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      shouldForcePushWithLease ||
+      behind === 0 ||
+      commitDisabledReason !== null
   }
 
   const pushItem: DropdownItem = {
     kind: 'push',
-    label: formatCountLabel('Push', ahead),
+    label: formatCountLabel(shouldForcePushWithLease ? 'Force Push' : 'Push', pushLabelCount),
     title: upstreamLoading
       ? 'Checking branch status…'
       : publishBlockedByPRLoading
@@ -191,12 +218,19 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
           ? 'PR is already merged'
           : !hasUpstream
             ? 'Publish the branch first to push commits'
-            : behind > 0 && ahead > 0
-              ? 'Sync first to pull remote changes before pushing'
-              : ahead === 0
-                ? 'Nothing to push'
-                : describePushCount(ahead),
-    disabled: globalBusy || upstreamLoading || !hasUpstream || ahead === 0 || behind > 0
+            : shouldForcePushWithLease
+              ? forcePushTitle
+              : behind > 0 && ahead > 0
+                ? 'Sync first to pull remote changes before pushing'
+                : ahead === 0
+                  ? 'Nothing to push'
+                  : describePushCount(ahead),
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      ahead === 0 ||
+      (behind > 0 && !shouldForcePushWithLease)
   }
 
   const pullItem: DropdownItem = {
@@ -210,10 +244,13 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
           ? 'PR is already merged'
           : !hasUpstream
             ? 'Publish the branch first to pull commits'
-            : behind === 0
-              ? 'Nothing to pull'
-              : describePullCount(behind),
-    disabled: globalBusy || upstreamLoading || !hasUpstream || behind === 0
+            : shouldForcePushWithLease
+              ? 'Nothing new to pull — remote only has older copies of local commits'
+              : behind === 0
+                ? 'Nothing to pull'
+                : describePullCount(behind),
+    disabled:
+      globalBusy || upstreamLoading || !hasUpstream || behind === 0 || shouldForcePushWithLease
   }
 
   const syncItem: DropdownItem = {
@@ -227,10 +264,17 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
           ? 'PR is already merged'
           : !hasUpstream
             ? 'Publish the branch first to sync commits'
-            : ahead === 0 && behind === 0
-              ? 'Branch is up to date'
-              : describeSyncCounts(ahead, behind),
-    disabled: globalBusy || upstreamLoading || !hasUpstream || (ahead === 0 && behind === 0)
+            : shouldForcePushWithLease
+              ? 'Use Force Push — remote only has older copies of local commits'
+              : ahead === 0 && behind === 0
+                ? 'Branch is up to date'
+                : describeSyncCounts(ahead, behind),
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      shouldForcePushWithLease ||
+      (ahead === 0 && behind === 0)
   }
 
   const fetchItem: DropdownItem = {
@@ -281,7 +325,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
       case 'needs_push':
         return 'Push first'
       case 'needs_sync':
-        return 'Sync first'
+        return shouldForcePushWithLease ? 'Force Push first' : 'Sync first'
       case 'auth_required':
         return 'Run gh auth login in this environment'
       case 'unsupported_provider':
@@ -309,12 +353,15 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     !globalBusy &&
     !upstreamLoading &&
     hostedReviewCreation?.provider === 'github' &&
-    hostedReviewCreation.blockedReason === 'needs_push'
+    (hostedReviewCreation.blockedReason === 'needs_push' ||
+      (hostedReviewCreation.blockedReason === 'needs_sync' && shouldForcePushWithLease))
   const pushCreatePRItem: DropdownItem = {
     kind: 'push_create_pr',
-    label: 'Push before PR',
+    label: shouldForcePushWithLease ? 'Force Push before PR' : 'Push before PR',
     title: canPushAndCreate
-      ? 'Push local commits before creating a pull request'
+      ? shouldForcePushWithLease
+        ? 'Force push with lease before creating a pull request'
+        : 'Push local commits before creating a pull request'
       : createBlockedHint,
     hint: canPushAndCreate ? undefined : createBlockedHint,
     disabled: !canPushAndCreate

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -2,6 +2,10 @@
 
 import type { PrimaryActionInputs } from './source-control-primary-action'
 
+export type DropdownActionInputs = PrimaryActionInputs & {
+  isPullRequestOperationActive?: boolean
+}
+
 export type DropdownActionKind =
   | 'commit'
   | 'commit_push'
@@ -54,7 +58,7 @@ function formatSyncLabel(base: string, ahead: number, behind: number): string {
  * menu shape stays stable across states; inapplicable rows are disabled
  * with a tooltip reason rather than hidden.
  */
-export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry[] {
+export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntry[] {
   const {
     stagedCount,
     hasPartiallyStagedChanges,
@@ -66,7 +70,8 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     prState,
     isPRStateLoading,
     hostedReviewCreation,
-    branchCommitsAhead
+    branchCommitsAhead,
+    isPullRequestOperationActive = false
   } = inputs
 
   const hasStaged = stagedCount > 0
@@ -88,7 +93,7 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
   // Why: any in-flight commit or remote operation should lock the whole menu.
   // A running push shouldn't let a second pull/sync click queue up behind it
   // on a stale status snapshot.
-  const globalBusy = isCommitting || isRemoteOperationActive
+  const globalBusy = isCommitting || isRemoteOperationActive || isPullRequestOperationActive
 
   const commitDisabledReason = (() => {
     if (hasUnresolvedConflicts) {
@@ -128,7 +133,10 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
         ? 'PR is already merged'
         : !hasUpstream
           ? 'Publish the branch first to push commits'
-          : (commitDisabledReason ?? 'Commit staged changes and push')
+          : (commitDisabledReason ??
+            (behind > 0
+              ? 'Use Commit & Sync to pull remote changes before pushing'
+              : 'Commit staged changes and push'))
   const commitPushItem: DropdownItem = {
     kind: 'commit_push',
     label: 'Commit & Push',
@@ -137,6 +145,7 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
       globalBusy ||
       upstreamLoading ||
       !hasUpstream ||
+      behind > 0 ||
       publishBlockedByPRLoading ||
       publishBlockedByMergedPR ||
       commitDisabledReason !== null
@@ -182,10 +191,12 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
           ? 'PR is already merged'
           : !hasUpstream
             ? 'Publish the branch first to push commits'
-            : ahead === 0
-              ? 'Nothing to push'
-              : describePushCount(ahead),
-    disabled: globalBusy || upstreamLoading || !hasUpstream || ahead === 0
+            : behind > 0 && ahead > 0
+              ? 'Sync first to pull remote changes before pushing'
+              : ahead === 0
+                ? 'Nothing to push'
+                : describePushCount(ahead),
+    disabled: globalBusy || upstreamLoading || !hasUpstream || ahead === 0 || behind > 0
   }
 
   const pullItem: DropdownItem = {
@@ -309,7 +320,7 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     disabled: !canPushAndCreate
   }
 
-  return [
+  const entries: DropdownEntry[] = [
     commitItem,
     commitPushItem,
     commitSyncItem,
@@ -322,4 +333,16 @@ export function resolveDropdownItems(inputs: PrimaryActionInputs): DropdownEntry
     fetchItem,
     publishItem
   ]
+  if (!isPullRequestOperationActive) {
+    return entries
+  }
+  return entries.map((entry) =>
+    entry.kind === 'separator'
+      ? entry
+      : {
+          ...entry,
+          title: 'Pull request operation in progress…',
+          disabled: true
+        }
+  )
 }

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts
@@ -218,6 +218,28 @@ describe('resolvePrimaryAction', () => {
     })
   })
 
+  it('returns Force Push when remote-only commits are patch-equivalent after a rebase', () => {
+    const result = resolvePrimaryAction(
+      inputs({
+        branchCommitsAhead: 4,
+        upstreamStatus: {
+          hasUpstream: true,
+          upstreamName: 'origin/feature',
+          ahead: 14,
+          behind: 3,
+          behindCommitsArePatchEquivalent: true
+        }
+      })
+    )
+    expect(result).toEqual({
+      kind: 'push',
+      label: 'Force Push',
+      title:
+        'Remote only has older copies of local commits. Force push 4 branch commits with lease to update origin/feature.',
+      disabled: false
+    })
+  })
+
   it('returns Pull when clean + behind-only', () => {
     const result = resolvePrimaryAction(
       inputs({ upstreamStatus: { hasUpstream: true, ahead: 0, behind: 4 } })

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -2,6 +2,7 @@
 
 import type { HostedReviewCreationEligibility } from '../../../../shared/hosted-review'
 import type { GitUpstreamStatus, PRState } from '../../../../shared/types'
+import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
 
 // Why: this module owns the pure state-machine logic for the Source Control
 // primary action (split button). Keeping the logic outside the React component
@@ -81,6 +82,12 @@ function describePullCount(behind: number): string {
 
 function describeSyncCounts(ahead: number, behind: number): string {
   return `Pull ${behind}, push ${ahead}`
+}
+
+function describeForcePushWithLease(count: number | undefined, upstreamName?: string): string {
+  const countText =
+    count && count > 0 ? `${count} branch commit${count === 1 ? '' : 's'}` : 'this branch'
+  return `Remote only has older copies of local commits. Force push ${countText} with lease to update ${upstreamName ?? 'the remote branch'}.`
 }
 
 /**
@@ -286,6 +293,14 @@ export function resolvePrimaryAction(inputs: PrimaryActionInputs): PrimaryAction
   }
 
   if (upstreamStatus.ahead > 0 && upstreamStatus.behind > 0) {
+    if (shouldForcePushWithLeaseForUpstream(upstreamStatus)) {
+      return {
+        kind: 'push',
+        label: 'Force Push',
+        title: describeForcePushWithLease(branchCommitsAhead, upstreamStatus.upstreamName),
+        disabled: false
+      }
+    }
     return {
       kind: 'sync',
       label: 'Sync',

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.test.ts
@@ -121,7 +121,7 @@ describe('useGitStatusPolling', () => {
         hasUpstream: true,
         upstreamName: 'origin/main',
         ahead: 2,
-        behind: 1
+        behind: 0
       }
     })
 
@@ -129,7 +129,7 @@ describe('useGitStatusPolling', () => {
       hasUpstream: true,
       upstreamName: 'origin/main',
       ahead: 2,
-      behind: 1
+      behind: 0
     })
     expect(state.fetchUpstreamStatus).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -273,22 +273,28 @@ export async function pullRuntimeGit(context: RuntimeGitContext): Promise<void> 
 
 export async function pushRuntimeGit(
   context: RuntimeGitContext,
-  args: { publish?: boolean; pushTarget?: GitPushTarget } = {}
+  args: { publish?: boolean; pushTarget?: GitPushTarget; forceWithLease?: boolean } = {}
 ): Promise<void> {
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
     await window.api.git.push({
       worktreePath: context.worktreePath,
-      publish: args.publish,
-      pushTarget: args.pushTarget,
-      connectionId: context.connectionId
+      connectionId: context.connectionId,
+      ...(args.publish !== undefined ? { publish: args.publish } : {}),
+      ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
+      ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {})
     })
     return
   }
   await callRuntimeRpc(
     target,
     'git.push',
-    { worktree: context.worktreeId, publish: args.publish, pushTarget: args.pushTarget },
+    {
+      worktree: context.worktreeId,
+      ...(args.publish !== undefined ? { publish: args.publish } : {}),
+      ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
+      ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {})
+    },
     { timeoutMs: 30_000 }
   )
 }

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1340,6 +1340,36 @@ describe('createEditorSlice remote branch actions', () => {
     expect(listener).not.toHaveBeenCalled()
   })
 
+  it('updates subscribers when explicit upstream status adds patch equivalence', () => {
+    const store = createEditorStore()
+    store.getState().setUpstreamStatus('wt-1', {
+      hasUpstream: true,
+      upstreamName: 'origin/feature',
+      ahead: 14,
+      behind: 3
+    })
+    const listener = vi.fn()
+    const unsubscribe = store.subscribe(listener)
+
+    store.getState().setUpstreamStatus('wt-1', {
+      hasUpstream: true,
+      upstreamName: 'origin/feature',
+      ahead: 14,
+      behind: 3,
+      behindCommitsArePatchEquivalent: true
+    })
+    unsubscribe()
+
+    expect(listener).toHaveBeenCalled()
+    expect(store.getState().remoteStatusesByWorktree['wt-1']).toEqual({
+      hasUpstream: true,
+      upstreamName: 'origin/feature',
+      ahead: 14,
+      behind: 3,
+      behindCommitsArePatchEquivalent: true
+    })
+  })
+
   it('runs pull and refreshes status + upstream on success', async () => {
     const store = createEditorStore()
     store.getState().setGitStatus('wt-1', {
@@ -1657,18 +1687,48 @@ describe('createEditorSlice remote branch actions', () => {
     // Why: guards against a no-op push round-trip after a pure fast-forward
     // pull. See syncBranch's ahead>0 guard in editor.ts.
     const store = createEditorStore()
-    gitUpstreamStatusMock.mockResolvedValueOnce({
-      hasUpstream: true,
-      upstreamName: 'origin/main',
-      ahead: 0,
-      behind: 0
-    })
+    gitUpstreamStatusMock
+      .mockResolvedValueOnce({
+        hasUpstream: true,
+        upstreamName: 'origin/main',
+        ahead: 0,
+        behind: 1
+      })
+      .mockResolvedValueOnce({
+        hasUpstream: true,
+        upstreamName: 'origin/main',
+        ahead: 0,
+        behind: 0
+      })
 
     await store.getState().syncBranch('wt-1', '/repo')
 
     expect(gitFetchMock).toHaveBeenCalled()
     expect(gitPullMock).toHaveBeenCalled()
     expect(gitPushMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('force-pushes with lease instead of pulling when sync sees a stale rebased upstream', async () => {
+    const store = createEditorStore()
+    gitUpstreamStatusMock.mockResolvedValueOnce({
+      hasUpstream: true,
+      upstreamName: 'origin/feature',
+      ahead: 14,
+      behind: 3,
+      behindCommitsArePatchEquivalent: true
+    })
+
+    await store.getState().syncBranch('wt-1', '/repo')
+
+    expect(gitFetchMock).toHaveBeenCalled()
+    expect(gitPullMock).not.toHaveBeenCalled()
+    expect(gitPushMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined,
+      forceWithLease: true
+    })
+    expect(gitUpstreamStatusMock).toHaveBeenCalledTimes(2)
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -30,6 +30,7 @@ import type {
 import { stripCredentialsFromMessage } from '../../../../shared/git-remote-error'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { RemoteOpKind } from '@/components/right-sidebar/source-control-primary-action'
+import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
 import {
   fetchRuntimeGit,
   getRuntimeGitUpstreamStatus,
@@ -418,7 +419,8 @@ export type EditorSlice = {
     worktreePath: string,
     publish?: boolean,
     connectionId?: string,
-    pushTarget?: GitPushTarget
+    pushTarget?: GitPushTarget,
+    options?: { forceWithLease?: boolean }
   ) => Promise<void>
   pullBranch: (worktreeId: string, worktreePath: string, connectionId?: string) => Promise<void>
   syncBranch: (
@@ -2674,7 +2676,14 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       console.error('fetchUpstreamStatus failed', error)
     }
   },
-  pushBranch: async (worktreeId, worktreePath, publish = false, connectionId, pushTarget) => {
+  pushBranch: async (
+    worktreeId,
+    worktreePath,
+    publish = false,
+    connectionId,
+    pushTarget,
+    options = {}
+  ) => {
     // Why: don't *await* a post-op git status / upstream refresh here.
     // Chaining awaited refreshes inside the mutation extends the gap before
     // compound flows (runCompoundCommitAction → runRemoteAction) reach the
@@ -2688,7 +2697,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     try {
       await pushRuntimeGit(
         { settings: get().settings, worktreeId, worktreePath, connectionId },
-        { publish, pushTarget }
+        { publish, pushTarget, forceWithLease: options.forceWithLease }
       )
     } catch (error) {
       toast.error(resolveRemoteOperationErrorMessage(error, { publish, isPush: true }))
@@ -2732,23 +2741,35 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     try {
       const context = { settings: get().settings, worktreeId, worktreePath, connectionId }
       await fetchRuntimeGit(context)
-      await pullRuntimeGit(context)
-      // Why: push only if the pull left local commits that aren't on the
-      // remote. After a merge pull the ahead count can be >0 (local commits +
-      // the new merge commit) or 0 (pure fast-forward), and we avoid a
-      // no-op push round-trip in the fast-forward case.
-      const upstreamStatus = await getRuntimeGitUpstreamStatus(context)
-      if (upstreamStatus.ahead > 0) {
+      const upstreamStatusBeforePull = await getRuntimeGitUpstreamStatus(context)
+      if (shouldForcePushWithLeaseForUpstream(upstreamStatusBeforePull)) {
         try {
-          await pushRuntimeGit(context, { pushTarget })
+          await pushRuntimeGit(context, { pushTarget, forceWithLease: true })
           pushed = true
         } catch (error) {
-          // Why: format under the user-facing operation (sync) rather than
-          // the inner step (push) — the user clicked Sync and shouldn't see
-          // a "Push failed" toast for a step they didn't directly invoke.
           toast.error(resolveRemoteOperationErrorMessage(error, { isSync: true }))
           pushStageToastShown = true
           throw error
+        }
+      } else {
+        await pullRuntimeGit(context)
+        // Why: push only if the pull left local commits that aren't on the
+        // remote. After a merge pull the ahead count can be >0 (local commits +
+        // the new merge commit) or 0 (pure fast-forward), and we avoid a
+        // no-op push round-trip in the fast-forward case.
+        const upstreamStatus = await getRuntimeGitUpstreamStatus(context)
+        if (upstreamStatus.ahead > 0) {
+          try {
+            await pushRuntimeGit(context, { pushTarget })
+            pushed = true
+          } catch (error) {
+            // Why: format under the user-facing operation (sync) rather than
+            // the inner step (push) — the user clicked Sync and shouldn't see
+            // a "Push failed" toast for a step they didn't directly invoke.
+            toast.error(resolveRemoteOperationErrorMessage(error, { isSync: true }))
+            pushStageToastShown = true
+            throw error
+          }
         }
       }
     } catch (error) {
@@ -3324,7 +3345,8 @@ function areUpstreamStatusesEqual(
     prev.hasUpstream === next.hasUpstream &&
     prev.upstreamName === next.upstreamName &&
     prev.ahead === next.ahead &&
-    prev.behind === next.behind
+    prev.behind === next.behind &&
+    prev.behindCommitsArePatchEquivalent === next.behindCommitsArePatchEquivalent
   )
 }
 

--- a/src/shared/git-status-types.ts
+++ b/src/shared/git-status-types.ts
@@ -56,6 +56,10 @@ export type GitUpstreamStatus = {
   upstreamName?: string
   ahead: number
   behind: number
+  // Why: when a branch was rebased, the upstream-only commits can be older
+  // patch-equivalent copies. Pulling them reintroduces stale history; a
+  // lease-protected force push is the correct reconciliation.
+  behindCommitsArePatchEquivalent?: boolean
 }
 
 export type GitBranchChangeStatus = 'modified' | 'added' | 'deleted' | 'renamed' | 'copied'

--- a/src/shared/git-upstream-status.ts
+++ b/src/shared/git-upstream-status.ts
@@ -1,0 +1,20 @@
+import type { GitUpstreamStatus } from './git-status-types'
+
+export function upstreamOnlyCommitsArePatchEquivalent(cherryMarkOutput: string): boolean {
+  const lines = cherryMarkOutput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+  return lines.length > 0 && lines.every((line) => line.startsWith('='))
+}
+
+export function shouldForcePushWithLeaseForUpstream(
+  status: GitUpstreamStatus | undefined
+): boolean {
+  return (
+    status?.hasUpstream === true &&
+    status.ahead > 0 &&
+    status.behind > 0 &&
+    status.behindCommitsArePatchEquivalent === true
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -194,6 +194,8 @@ export type GitPushTarget = {
   remoteName: string
   branchName: string
   remoteUrl?: string
+  /** True when Orca added this remote while preparing a fork-PR worktree. */
+  remoteCreated?: boolean
 }
 
 // ─── Worktree metadata (persisted user-authored fields only) ─────────

--- a/tests/e2e/source-control-create-pr.spec.ts
+++ b/tests/e2e/source-control-create-pr.spec.ts
@@ -45,7 +45,6 @@ async function openSourceControl(page: Page, expectedWorktreeId: string): Promis
     )
     .toBe(true)
   await expect(page.getByRole('button', { name: /Source Control/ })).toBeVisible()
-  await expect(page.getByRole('textbox', { name: 'Commit message' })).toBeVisible()
 }
 
 async function forceCreatePREligibleStatus(
@@ -181,9 +180,7 @@ test.describe('Source Control create pull request', () => {
     await waitForActiveWorktree(orcaPage)
   })
 
-  test('opens the PR dialog from Source Control and creates the pull request', async ({
-    orcaPage
-  }) => {
+  test('creates the pull request from the Source Control primary action', async ({ orcaPage }) => {
     const { branch, worktreeId } = await seedCreatePREligibleBranch(orcaPage)
     await openSourceControl(orcaPage, worktreeId)
     await forceCreatePREligibleStatus(orcaPage, worktreeId, branch)
@@ -191,19 +188,28 @@ test.describe('Source Control create pull request', () => {
     const createButton = orcaPage.getByRole('button', { name: 'Create PR' })
     await expect(createButton).toBeVisible({ timeout: 10_000 })
     await expect(createButton).toBeEnabled()
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request title' })).toHaveValue(
+      'Create PR from E2E'
+    )
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request base branch' })).toHaveValue(
+      'main'
+    )
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request description' })).toHaveValue(
+      '- Initial commit for E2E'
+    )
     await createButton.click()
 
-    const dialog = orcaPage.getByRole('dialog', { name: 'Create Pull Request' })
-    await expect(dialog).toBeVisible()
-    await expect(dialog).toContainText(branch)
-    await expect(dialog.getByLabel('Base branch')).toHaveValue('main')
-    await expect(dialog.getByLabel('Title')).toHaveValue('Create PR from E2E')
-    await expect(dialog.getByLabel('Description')).toHaveValue('- Initial commit for E2E')
-
-    await dialog.getByRole('button', { name: 'Create PR' }).click()
-
-    await expect(dialog).toBeHidden({ timeout: 10_000 })
-    await expect(orcaPage.getByText('Create PR from E2E')).toBeVisible({ timeout: 10_000 })
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(
+            () =>
+              (window as unknown as { __createPRPayloads: CreatePRPayload[] }).__createPRPayloads
+                .length
+          ),
+        { timeout: 10_000 }
+      )
+      .toBe(1)
 
     const payloads = await orcaPage.evaluate(
       () => (window as unknown as { __createPRPayloads: CreatePRPayload[] }).__createPRPayloads


### PR DESCRIPTION
## Summary
- add Source Control create-PR flow with fork/upstream remote handling
- carry upstream status through git/runtime/preload APIs
- build PR context generation as read-only and add coverage for worktree cleanup and source-control actions

## Test Plan
- pnpm typecheck
- review-and-submit round 1 review agent: no issues found