### PR TITLE
feat: add Find in Folder action to file explorer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -92,7 +92,10 @@ import {
 import { applyDocumentTheme } from './lib/document-theme'
 import { isEditableTarget } from './lib/editable-target'
 import { getSelectedTextForFileSearch } from './lib/file-search-selection'
-import { folderRelativePathToIncludeGlob } from './components/right-sidebar/file-search-include-pattern'
+import {
+  folderRelativePathToIncludeGlob,
+  selectedExplorerFolderRelativePath
+} from './components/right-sidebar/file-search-include-pattern'
 import { shouldShowWorktreeHistoryControls } from './lib/titlebar-worktree-history-controls'
 import {
   canGoBackWorktreeHistory,
@@ -1029,16 +1032,11 @@ function App(): React.JSX.Element {
         // Why: when focus is inside the file explorer and a folder is selected,
         // Cmd/Ctrl+Shift+F means "Find in Folder" — seed the include pattern
         // with that folder instead of treating the chord as a text-search seed.
-        const explorerShell =
-          document.activeElement instanceof Element
-            ? document.activeElement.closest('[data-orca-explorer-shell]')
-            : null
-        const selectedFolderEl = explorerShell?.querySelector(
-          '[data-selected-folder-relative-path]'
-        )
         const selectedFolderRelativePath =
-          selectedFolderEl?.getAttribute('data-selected-folder-relative-path') ?? null
-        if (selectedFolderRelativePath && activeWorktreeId) {
+          document.activeElement instanceof Element
+            ? selectedExplorerFolderRelativePath(document.activeElement)
+            : null
+        if (selectedFolderRelativePath !== null && activeWorktreeId) {
           e.preventDefault()
           actions.seedFileSearchIncludePattern(
             activeWorktreeId,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -92,6 +92,7 @@ import {
 import { applyDocumentTheme } from './lib/document-theme'
 import { isEditableTarget } from './lib/editable-target'
 import { getSelectedTextForFileSearch } from './lib/file-search-selection'
+import { folderRelativePathToIncludeGlob } from './components/right-sidebar/file-search-include-pattern'
 import { shouldShowWorktreeHistoryControls } from './lib/titlebar-worktree-history-controls'
 import {
   canGoBackWorktreeHistory,
@@ -262,6 +263,7 @@ function App(): React.JSX.Element {
       setRightSidebarOpen: s.setRightSidebarOpen,
       setRightSidebarTab: s.setRightSidebarTab,
       seedFileSearchQuery: s.seedFileSearchQuery,
+      seedFileSearchIncludePattern: s.seedFileSearchIncludePattern,
       setActiveView: s.setActiveView,
       updateSettings: s.updateSettings,
       pruneLastVisitedTimestamps: s.pruneLastVisitedTimestamps,
@@ -1024,6 +1026,29 @@ function App(): React.JSX.Element {
       }
 
       if (mod && isSearchShortcut && canRevealRightSidebar) {
+        // Why: when focus is inside the file explorer and a folder is selected,
+        // Cmd/Ctrl+Shift+F means "Find in Folder" — seed the include pattern
+        // with that folder instead of treating the chord as a text-search seed.
+        const explorerShell =
+          document.activeElement instanceof Element
+            ? document.activeElement.closest('[data-orca-explorer-shell]')
+            : null
+        const selectedFolderEl = explorerShell?.querySelector(
+          '[data-selected-folder-relative-path]'
+        )
+        const selectedFolderRelativePath =
+          selectedFolderEl?.getAttribute('data-selected-folder-relative-path') ?? null
+        if (selectedFolderRelativePath && activeWorktreeId) {
+          e.preventDefault()
+          actions.seedFileSearchIncludePattern(
+            activeWorktreeId,
+            folderRelativePathToIncludeGlob(selectedFolderRelativePath)
+          )
+          actions.setRightSidebarTab('search')
+          actions.setRightSidebarOpen(true)
+          return
+        }
+
         const selectedText = getSelectedTextForFileSearch()
         if (selectedText) {
           e.preventDefault()

--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -354,6 +354,7 @@ describe('FileExplorerRow collapse folder action', () => {
       onDuplicate: vi.fn(),
       onRequestDelete: vi.fn(),
       onCollapseFolderSubtree,
+      onFindInFolder: vi.fn(),
       onMoveDrop: vi.fn(),
       onDragTargetChange: vi.fn(),
       onDragSourceChange: vi.fn(),

--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -4,7 +4,11 @@ import { Button } from '@/components/ui/button'
 import { DropdownMenuCheckboxItem } from '@/components/ui/dropdown-menu'
 import { WorktreeOpenInMenuItems } from '@/components/sidebar/WorktreeOpenInMenu'
 import { FileExplorerToolbar } from './FileExplorerToolbar'
-import { FileExplorerRow, shouldShowCollapseFolderAction } from './FileExplorerRow'
+import {
+  FileExplorerRow,
+  shouldShowCollapseFolderAction,
+  shouldShowFindInFolderAction
+} from './FileExplorerRow'
 import { FileExplorerVirtualRows } from './FileExplorerVirtualRows'
 import type { TreeNode } from './file-explorer-types'
 
@@ -323,6 +327,19 @@ describe('FileExplorerRow collapse folder action', () => {
     ).toBe(false)
   })
 
+  it('only shows find in folder for directories', () => {
+    expect(shouldShowFindInFolderAction(directoryNode)).toBe(true)
+    expect(
+      shouldShowFindInFolderAction({
+        ...directoryNode,
+        name: 'index.ts',
+        path: '/repo/src/index.ts',
+        relativePath: 'src/index.ts',
+        isDirectory: false
+      })
+    ).toBe(false)
+  })
+
   it('passes the row node to the collapse folder handler', () => {
     const onCollapseFolderSubtree = vi.fn()
     const element = FileExplorerVirtualRows({
@@ -370,5 +387,54 @@ describe('FileExplorerRow collapse folder action', () => {
     ;(row.props.onCollapseFolderSubtree as () => void)()
 
     expect(onCollapseFolderSubtree).toHaveBeenCalledWith(directoryNode)
+  })
+
+  it('passes the row node to the find in folder handler', () => {
+    const onFindInFolder = vi.fn()
+    const element = FileExplorerVirtualRows({
+      virtualizer: {
+        getTotalSize: () => 26,
+        getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],
+        measureElement: vi.fn()
+      } as never,
+      inlineInputIndex: -1,
+      flatRows: [directoryNode],
+      inlineInput: null,
+      handleInlineSubmit: vi.fn(),
+      dismissInlineInput: vi.fn(),
+      folderStatusByRelativePath: new Map(),
+      statusByRelativePath: new Map(),
+      ignoredByRelativePath: new Set(),
+      expanded: new Set([directoryNode.path]),
+      dirCache: {},
+      selectedPaths: new Set(),
+      activeFileId: null,
+      flashingPath: null,
+      deleteShortcutLabel: 'Del',
+      onClick: vi.fn(),
+      onDoubleClick: vi.fn(),
+      onContextMenuSelect: vi.fn(),
+      onCopyPaths: vi.fn(),
+      onStartNew: vi.fn(),
+      onStartRename: vi.fn(),
+      onDuplicate: vi.fn(),
+      onRequestDelete: vi.fn(),
+      onCollapseFolderSubtree: vi.fn(),
+      onFindInFolder,
+      onMoveDrop: vi.fn(),
+      onDragTargetChange: vi.fn(),
+      onDragSourceChange: vi.fn(),
+      onDragExpandDir: vi.fn(),
+      onNativeDragTargetChange: vi.fn(),
+      onNativeDragExpandDir: vi.fn(),
+      dropTargetDir: null,
+      dragSourcePath: null,
+      nativeDropTargetDir: null
+    })
+
+    const row = findFileExplorerRow(element)
+    ;(row.props.onFindInFolder as () => void)()
+
+    expect(onFindInFolder).toHaveBeenCalledWith(directoryNode)
   })
 })

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -4,6 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { basename, dirname } from '@/lib/path'
+import { folderRelativePathToIncludeGlob } from './file-search-include-pattern'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
@@ -316,6 +317,23 @@ function FileExplorerInner(): React.JSX.Element {
     },
     [activeWorktreeId, collapseDirSubtree]
   )
+  const seedFileSearchIncludePattern = useAppStore((s) => s.seedFileSearchIncludePattern)
+  const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
+  const setRightSidebarOpen = useAppStore((s) => s.setRightSidebarOpen)
+  const handleFindInFolder = useCallback(
+    (node: (typeof flatRows)[number]) => {
+      if (!activeWorktreeId || !node.isDirectory) {
+        return
+      }
+      seedFileSearchIncludePattern(
+        activeWorktreeId,
+        folderRelativePathToIncludeGlob(node.relativePath)
+      )
+      setRightSidebarTab('search')
+      setRightSidebarOpen(true)
+    },
+    [activeWorktreeId, seedFileSearchIncludePattern, setRightSidebarTab, setRightSidebarOpen]
+  )
 
   if (!worktreePath) {
     return (
@@ -424,6 +442,7 @@ function FileExplorerInner(): React.JSX.Element {
               onDuplicate={handleDuplicate}
               onRequestDelete={requestDelete}
               onCollapseFolderSubtree={handleCollapseFolderSubtree}
+              onFindInFolder={handleFindInFolder}
               onMoveDrop={handleMoveDrop}
               onDragTargetChange={setDropTargetDir}
               onDragSourceChange={setDragSourcePath}

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -355,7 +355,14 @@ function FileExplorerInner(): React.JSX.Element {
 
   return (
     <>
-      <div ref={explorerShellRef} data-orca-explorer-shell className="flex h-full min-h-0 flex-col">
+      <div
+        ref={explorerShellRef}
+        data-orca-explorer-shell
+        data-selected-folder-relative-path={
+          selectedNode?.isDirectory ? selectedNode.relativePath : undefined
+        }
+        className="flex h-full min-h-0 flex-col"
+      >
         <FileExplorerToolbar
           repoName={repoName}
           worktreePath={worktreePath}

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -16,6 +16,7 @@ import {
   ListCollapse,
   Loader2,
   Pencil,
+  Search,
   Trash2
 } from 'lucide-react'
 import { toast } from 'sonner'
@@ -227,6 +228,7 @@ type FileExplorerRowProps = {
   onDuplicate: (node: TreeNode) => void
   onRequestDelete: () => void
   onCollapseFolderSubtree: () => void
+  onFindInFolder: () => void
   onMoveDrop: (sourcePath: string, destDir: string) => void
   onDragTargetChange: (dir: string | null) => void
   onDragSourceChange: (path: string | null) => void
@@ -261,6 +263,7 @@ export function FileExplorerRow({
   onDuplicate,
   onRequestDelete,
   onCollapseFolderSubtree,
+  onFindInFolder,
   onMoveDrop,
   onDragTargetChange,
   onDragSourceChange,
@@ -304,6 +307,9 @@ export function FileExplorerRow({
           )}
           style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
           data-native-file-drop-dir={rowDropDir}
+          data-selected-folder-relative-path={
+            isSelected && node.isDirectory ? node.relativePath : undefined
+          }
           draggable
           onDragStart={(event) => {
             event.dataTransfer.setData(WORKSPACE_FILE_PATH_MIME, node.path)
@@ -437,6 +443,13 @@ export function FileExplorerRow({
           <ContextMenuItem onSelect={onCollapseFolderSubtree}>
             <ListCollapse />
             Collapse Folder
+          </ContextMenuItem>
+        )}
+        {node.isDirectory && (
+          <ContextMenuItem onSelect={onFindInFolder}>
+            <Search />
+            Find in Folder
+            <ContextMenuShortcut>{isMac ? '⇧⌘F' : 'Ctrl+Shift+F'}</ContextMenuShortcut>
           </ContextMenuItem>
         )}
         <ContextMenuItem

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -241,6 +241,10 @@ export function shouldShowCollapseFolderAction(node: TreeNode, isExpanded: boole
   return node.isDirectory && isExpanded
 }
 
+export function shouldShowFindInFolderAction(node: TreeNode): boolean {
+  return node.isDirectory
+}
+
 export function FileExplorerRow({
   node,
   isExpanded,
@@ -307,9 +311,6 @@ export function FileExplorerRow({
           )}
           style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
           data-native-file-drop-dir={rowDropDir}
-          data-selected-folder-relative-path={
-            isSelected && node.isDirectory ? node.relativePath : undefined
-          }
           draggable
           onDragStart={(event) => {
             event.dataTransfer.setData(WORKSPACE_FILE_PATH_MIME, node.path)
@@ -445,7 +446,7 @@ export function FileExplorerRow({
             Collapse Folder
           </ContextMenuItem>
         )}
-        {node.isDirectory && (
+        {shouldShowFindInFolderAction(node) && (
           <ContextMenuItem onSelect={onFindInFolder}>
             <Search />
             Find in Folder

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -33,6 +33,7 @@ type FileExplorerVirtualRowsProps = {
   onDuplicate: (node: TreeNode) => void
   onRequestDelete: (node: TreeNode) => void
   onCollapseFolderSubtree: (node: TreeNode) => void
+  onFindInFolder: (node: TreeNode) => void
   onMoveDrop: (sourcePath: string, destDir: string) => void
   onDragTargetChange: (dir: string | null) => void
   onDragSourceChange: (path: string | null) => void
@@ -70,6 +71,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
     onDuplicate,
     onRequestDelete,
     onCollapseFolderSubtree,
+    onFindInFolder,
     onMoveDrop,
     onDragTargetChange,
     onDragSourceChange,
@@ -168,6 +170,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
               onDuplicate={onDuplicate}
               onRequestDelete={() => onRequestDelete(n)}
               onCollapseFolderSubtree={() => onCollapseFolderSubtree(n)}
+              onFindInFolder={() => onFindInFolder(n)}
               onMoveDrop={onMoveDrop}
               onDragTargetChange={onDragTargetChange}
               onDragSourceChange={onDragSourceChange}

--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -242,12 +242,13 @@ export default function Search(): React.JSX.Element {
       return
     }
 
-    // Why: Cmd/Ctrl+Shift+F can seed the query before this lazy panel mounts.
-    // The one-shot request lets the mounted panel run the real runtime search.
+    // Why: Cmd/Ctrl+Shift+F can seed the query or the include pattern (Find in
+    // Folder) before this lazy panel mounts. The one-shot request lets the
+    // mounted panel run the real runtime search and steal focus to the input.
     if (fileSearchQuery.trim()) {
       executeSearch(fileSearchQuery)
-      scheduleSeededInputSelection()
     }
+    scheduleSeededInputSelection()
     consumeFileSearchSeedRequest(activeWorktreeId, fileSearchSeedRequestId)
   }, [
     activeWorktreeId,

--- a/src/renderer/src/components/right-sidebar/file-search-include-pattern.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-search-include-pattern.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  folderRelativePathToIncludeGlob,
+  selectedExplorerFolderRelativePath
+} from './file-search-include-pattern'
+
+describe('folderRelativePathToIncludeGlob', () => {
+  it('converts a relative folder path into a recursive include glob', () => {
+    expect(folderRelativePathToIncludeGlob('src')).toBe('src/**')
+    expect(folderRelativePathToIncludeGlob('src/components')).toBe('src/components/**')
+  })
+
+  it('normalizes separators and trailing slashes before appending the recursive glob', () => {
+    expect(folderRelativePathToIncludeGlob('src\\components\\')).toBe('src/components/**')
+    expect(folderRelativePathToIncludeGlob('/src//components///')).toBe('src/components/**')
+  })
+
+  it('returns an empty pattern for the repository root', () => {
+    expect(folderRelativePathToIncludeGlob('')).toBe('')
+    expect(folderRelativePathToIncludeGlob('/')).toBe('')
+  })
+
+  it('escapes literal folder path characters that are meaningful to search globs', () => {
+    expect(folderRelativePathToIncludeGlob('!secret')).toBe('\\!secret/**')
+    expect(folderRelativePathToIncludeGlob('foo,bar')).toBe('foo\\,bar/**')
+    expect(folderRelativePathToIncludeGlob('a[b]/{draft}?')).toBe('a\\[b\\]/\\{draft\\}\\?/**')
+  })
+})
+
+describe('selectedExplorerFolderRelativePath', () => {
+  it('reads the selected folder path from the explorer shell', () => {
+    const shell = {
+      getAttribute: (name: string) => (name === 'data-selected-folder-relative-path' ? 'src' : null)
+    } as Element
+    const child = {
+      closest: (selector: string) => (selector === '[data-orca-explorer-shell]' ? shell : null)
+    } as Element
+
+    expect(selectedExplorerFolderRelativePath(child)).toBe('src')
+  })
+
+  it('treats the repository root empty path as a selected folder', () => {
+    const shell = {
+      getAttribute: (name: string) => (name === 'data-selected-folder-relative-path' ? '' : null)
+    } as Element
+    const child = {
+      closest: (selector: string) => (selector === '[data-orca-explorer-shell]' ? shell : null)
+    } as Element
+
+    expect(selectedExplorerFolderRelativePath(child)).toBe('')
+  })
+
+  it('returns null when focus is outside the explorer or no folder is selected', () => {
+    const outside = {
+      closest: () => null
+    } as unknown as Element
+    const shellWithoutFolder = {
+      getAttribute: () => null
+    } as unknown as Element
+    const child = {
+      closest: () => shellWithoutFolder
+    } as unknown as Element
+
+    expect(selectedExplorerFolderRelativePath(outside)).toBeNull()
+    expect(selectedExplorerFolderRelativePath(child)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-search-include-pattern.ts
+++ b/src/renderer/src/components/right-sidebar/file-search-include-pattern.ts
@@ -1,5 +1,15 @@
 import { normalizeRelativePath } from '@/lib/path'
 
+const SEARCH_GLOB_LITERAL_META = new Set(['\\', '*', '?', '[', ']', '{', '}', '!', ','])
+
+function escapeSearchGlobLiteralSegment(segment: string): string {
+  let escaped = ''
+  for (const ch of segment) {
+    escaped += SEARCH_GLOB_LITERAL_META.has(ch) ? `\\${ch}` : ch
+  }
+  return escaped
+}
+
 /**
  * Convert a folder's relative path into a "Files to include" glob.
  *
@@ -12,5 +22,11 @@ export function folderRelativePathToIncludeGlob(relativePath: string): string {
   if (!normalized) {
     return ''
   }
-  return `${normalized}/**`
+  const escaped = normalized.split('/').map(escapeSearchGlobLiteralSegment).join('/')
+  return `${escaped}/**`
+}
+
+export function selectedExplorerFolderRelativePath(activeElement: Element | null): string | null {
+  const explorerShell = activeElement?.closest('[data-orca-explorer-shell]')
+  return explorerShell?.getAttribute('data-selected-folder-relative-path') ?? null
 }

--- a/src/renderer/src/components/right-sidebar/file-search-include-pattern.ts
+++ b/src/renderer/src/components/right-sidebar/file-search-include-pattern.ts
@@ -1,0 +1,16 @@
+import { normalizeRelativePath } from '@/lib/path'
+
+/**
+ * Convert a folder's relative path into a "Files to include" glob.
+ *
+ * Why: ripgrep and git grep both treat a bare `foo/bar` glob as a path
+ * literal — only `foo/bar/**` recurses into all files beneath it, which is
+ * the user expectation for "Find in Folder".
+ */
+export function folderRelativePathToIncludeGlob(relativePath: string): string {
+  const normalized = normalizeRelativePath(relativePath).replace(/\/+$/, '')
+  if (!normalized) {
+    return ''
+  }
+  return `${normalized}/**`
+}

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -216,6 +216,51 @@ describe('createEditorSlice file search seed state', () => {
     expect(state.collapsedFiles.size).toBe(0)
   })
 
+  it('seeds file search include pattern with a one-shot request id', () => {
+    const store = createEditorStore()
+
+    store.getState().seedFileSearchIncludePattern('wt-1', 'src/**')
+
+    expect(store.getState().fileSearchStateByWorktree['wt-1']).toMatchObject({
+      query: '',
+      includePattern: 'src/**',
+      results: null,
+      loading: false,
+      seedRequestId: 1
+    })
+  })
+
+  it('preserves search query and options while replacing stale scoped results', () => {
+    const store = createEditorStore()
+    store.getState().updateFileSearchState('wt-1', {
+      query: 'needle',
+      caseSensitive: true,
+      wholeWord: true,
+      useRegex: true,
+      includePattern: 'old/**',
+      excludePattern: 'dist/**',
+      results: { files: [], totalMatches: 1, truncated: false },
+      loading: true,
+      collapsedFiles: new Set(['/repo/file.ts'])
+    })
+
+    store.getState().seedFileSearchIncludePattern('wt-1', 'src/**')
+
+    const state = store.getState().fileSearchStateByWorktree['wt-1']
+    expect(state).toMatchObject({
+      query: 'needle',
+      caseSensitive: true,
+      wholeWord: true,
+      useRegex: true,
+      includePattern: 'src/**',
+      excludePattern: 'dist/**',
+      results: null,
+      loading: false,
+      seedRequestId: 1
+    })
+    expect(state.collapsedFiles.size).toBe(0)
+  })
+
   it('consumes only the matching seed request id', () => {
     const store = createEditorStore()
     store.getState().seedFileSearchQuery('wt-1', 'selectedText')

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -461,6 +461,7 @@ export type EditorSlice = {
     updates: Partial<EditorSlice['fileSearchStateByWorktree'][string]>
   ) => void
   seedFileSearchQuery: (worktreeId: string, query: string) => void
+  seedFileSearchIncludePattern: (worktreeId: string, includePattern: string) => void
   consumeFileSearchSeedRequest: (worktreeId: string, seedRequestId: number) => void
   toggleFileSearchCollapsedFile: (worktreeId: string, filePath: string) => void
   clearFileSearch: (worktreeId: string) => void
@@ -2906,6 +2907,33 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           [worktreeId]: {
             ...current,
             query,
+            results: null,
+            loading: false,
+            collapsedFiles: new Set(),
+            seedRequestId: (current.seedRequestId ?? 0) + 1
+          }
+        }
+      }
+    }),
+  seedFileSearchIncludePattern: (worktreeId, includePattern) =>
+    set((s) => {
+      const current = s.fileSearchStateByWorktree[worktreeId] || {
+        query: '',
+        caseSensitive: false,
+        wholeWord: false,
+        useRegex: false,
+        includePattern: '',
+        excludePattern: '',
+        results: null,
+        loading: false,
+        collapsedFiles: new Set()
+      }
+      return {
+        fileSearchStateByWorktree: {
+          ...s.fileSearchStateByWorktree,
+          [worktreeId]: {
+            ...current,
+            includePattern,
             results: null,
             loading: false,
             collapsedFiles: new Set(),

--- a/src/shared/text-search.test.ts
+++ b/src/shared/text-search.test.ts
@@ -9,6 +9,7 @@ import {
   ingestRgJsonLine,
   MAX_LINE_CONTENT_LENGTH,
   normalizeRelativePath,
+  splitSearchGlobPatterns,
   toGitGlobPathspec
 } from './text-search'
 
@@ -43,6 +44,26 @@ describe('buildRgArgs', () => {
     expect(args).toContain('*.ts')
     expect(args).toContain('*.tsx')
     expect(args).toContain('!*.md')
+  })
+
+  it('keeps escaped commas inside a single generated folder glob', () => {
+    const args = buildRgArgs('q', '/r', { includePattern: 'foo\\,bar/**, *.ts' })
+    expect(args).toContain('foo\\,bar/**')
+    expect(args).toContain('*.ts')
+  })
+})
+
+describe('splitSearchGlobPatterns', () => {
+  it('splits comma-separated patterns while preserving escaped commas', () => {
+    expect(splitSearchGlobPatterns('foo\\,bar/**, *.ts, dist/**')).toEqual([
+      'foo\\,bar/**',
+      '*.ts',
+      'dist/**'
+    ])
+  })
+
+  it('preserves trailing escapes as literal glob input', () => {
+    expect(splitSearchGlobPatterns('src\\')).toEqual(['src\\'])
   })
 })
 
@@ -176,6 +197,12 @@ describe('buildGitGrepArgs', () => {
     const args = buildGitGrepArgs('q', { includePattern: '*.ts', excludePattern: 'dist/**' })
     expect(args).toContain(':(glob)**/*.ts')
     expect(args).toContain(':(exclude,glob)dist/**')
+  })
+
+  it('keeps escaped commas inside one generated folder pathspec', () => {
+    const args = buildGitGrepArgs('q', { includePattern: 'foo\\,bar/**, *.ts' })
+    expect(args).toContain(':(glob)foo\\,bar/**')
+    expect(args).toContain(':(glob)**/*.ts')
   })
 })
 

--- a/src/shared/text-search.ts
+++ b/src/shared/text-search.ts
@@ -107,6 +107,40 @@ export type SearchOptionsLike = Pick<
   'caseSensitive' | 'wholeWord' | 'useRegex' | 'includePattern' | 'excludePattern'
 >
 
+export function splitSearchGlobPatterns(patterns: string): string[] {
+  const out: string[] = []
+  let current = ''
+  let escaping = false
+  for (const ch of patterns) {
+    if (escaping) {
+      current += `\\${ch}`
+      escaping = false
+      continue
+    }
+    if (ch === '\\') {
+      escaping = true
+      continue
+    }
+    if (ch === ',') {
+      const trimmed = current.trim()
+      if (trimmed) {
+        out.push(trimmed)
+      }
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  if (escaping) {
+    current += '\\'
+  }
+  const trimmed = current.trim()
+  if (trimmed) {
+    out.push(trimmed)
+  }
+  return out
+}
+
 /**
  * Build the rg argv used by both callers. The returned array is the COMPLETE
  * argv (flags + `--` + query + target); the caller spawns rg with it as-is.
@@ -138,18 +172,12 @@ export function buildRgArgs(query: string, target: string, opts: SearchOptionsLi
     args.push('--fixed-strings')
   }
   if (opts.includePattern) {
-    for (const pat of opts.includePattern
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)) {
+    for (const pat of splitSearchGlobPatterns(opts.includePattern)) {
       args.push('--glob', pat)
     }
   }
   if (opts.excludePattern) {
-    for (const pat of opts.excludePattern
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)) {
+    for (const pat of splitSearchGlobPatterns(opts.excludePattern)) {
       args.push('--glob', `!${pat}`)
     }
   }
@@ -299,19 +327,13 @@ export function buildGitGrepArgs(query: string, opts: SearchOptionsLike): string
 
   let hasPathspecs = false
   if (opts.includePattern) {
-    for (const pat of opts.includePattern
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)) {
+    for (const pat of splitSearchGlobPatterns(opts.includePattern)) {
       gitArgs.push(toGitGlobPathspec(pat))
       hasPathspecs = true
     }
   }
   if (opts.excludePattern) {
-    for (const pat of opts.excludePattern
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)) {
+    for (const pat of splitSearchGlobPatterns(opts.excludePattern)) {
       gitArgs.push(toGitGlobPathspec(pat, true))
       hasPathspecs = true
     }


### PR DESCRIPTION
## Summary

- Adds a **Find in Folder** entry to the file-explorer folder context menu (lucide `Search` icon, placed above _Reveal in Finder_), with the platform-aware shortcut label `⇧⌘F` / `Ctrl+Shift+F`.
- Selecting it opens the right-sidebar Search tab and pre-fills *Files to Include* with the folder's relative path (`<relative-path>/**`, the recursive glob form both ripgrep and `git grep` accept).
- The same chord also triggers Find in Folder when focus is inside the file explorer and a folder is selected; outside the explorer, the chord keeps its existing text-selection seeding behavior (no regression).

## Implementation notes

- New store action `seedFileSearchIncludePattern(worktreeId, pattern)` mirrors `seedFileSearchQuery` (bumps the existing `seedRequestId` so the lazy Search panel re-runs and refocuses on mount).
- Shared helper `folderRelativePathToIncludeGlob` normalizes the relative path and appends `/**` — used by both the menu click handler and the keyboard shortcut path so the two stay in sync.
- The selected folder's row carries a `data-selected-folder-relative-path` attribute; the global `Cmd/Ctrl+Shift+F` handler in `App.tsx` looks it up only when `document.activeElement` is inside the explorer shell, so editor / terminal text-selection seeding is unaffected.

## Cross-platform / security review

- Shortcut detection uses the existing `isMac` runtime check (no hardcoded `metaKey`); menu label switches between `⇧⌘F` and `Ctrl+Shift+F`.
- No new path-string assumptions: relative paths are normalized via the existing `normalizeRelativePath` helper before being turned into a glob.
- No new IPC, no shell execution, no user-supplied data flows into a command line — the include-pattern string just lands in the existing Search state and is consumed by the already-vetted rg / git-grep argument builders in `src/shared/text-search.ts`.
- No SSH-specific code paths touched; behavior identical for local and remote worktrees because everything runs in the renderer against the existing search runtime.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (815 files, 8491 tests pass)
- [x] `pnpm build`
- [ ] Manual: right-click a folder → _Find in Folder_ opens Search with `<folder>/**` in *Files to Include*
- [ ] Manual: click folder, press `⌘⇧F` → same result; press chord while editing text in editor → existing text-search seeding still works
- [ ] Manual: verify on Linux/Windows the label shows `Ctrl+Shift+F` and the chord uses `ctrlKey`

## Visual change

Adds one new entry to the folder context menu (Search-icon `Find in Folder` above `Reveal in Finder`). Screenshot will be attached to the PR conversation.