### PR TITLE
Move Windows sidebar tabs out of titlebar

### DIFF
--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -65,6 +65,8 @@ function getActiveChecksStatus(state: ReturnType<typeof useAppStore.getState>): 
 }
 
 const isMac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+const isWindows =
+  !isMac && typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows')
 const mod = isMac ? '\u2318' : 'Ctrl+'
 
 const ACTIVITY_ITEMS: ActivityBarItem[] = [
@@ -222,17 +224,63 @@ function RightSidebarInner(): React.JSX.Element {
         {activityBarPosition === 'top' ? (
           /* ── Top activity bar: horizontal icon row ── */
           <ContextMenu>
-            <div className="flex items-center border-b border-border h-[36px] min-h-[36px] pl-2 pr-1 right-sidebar-header-inset right-sidebar-header-drag overflow-hidden">
+            <div className="flex h-[36px] min-h-[36px] items-center border-b border-border right-sidebar-header-inset right-sidebar-header-drag overflow-hidden">
+              {!isWindows && (
+                <TooltipProvider delayDuration={400}>
+                  <ContextMenuTrigger asChild>
+                    <div
+                      ref={topActivityStripRef}
+                      className="right-sidebar-activity-strip flex min-w-0 flex-1 items-center overflow-hidden pl-2 right-sidebar-header-no-drag"
+                    >
+                      {/* Why: the top strip shares a narrow titlebar with the close
+                          button and Windows controls. Overflow goes behind More
+                          instead of creating a horizontally scrollable toolbar. */}
+                      <div className="flex min-w-0 shrink">
+                        {topActivityLayout.visibleItems.map((item) => (
+                          <ActivityBarButton
+                            key={item.id}
+                            item={item}
+                            active={effectiveTab === item.id}
+                            onClick={() => setRightSidebarTab(item.id)}
+                            layout="top"
+                            statusIndicator={item.id === 'checks' ? checksStatus : null}
+                          />
+                        ))}
+                      </div>
+                      {topActivityLayout.overflowItems.length > 0 && (
+                        <TopActivityOverflowMenu
+                          items={topActivityLayout.overflowItems}
+                          activeTab={effectiveTab}
+                          onSelect={setRightSidebarTab}
+                          checksStatus={checksStatus}
+                        />
+                      )}
+                    </div>
+                  </ContextMenuTrigger>
+                  <div className="flex shrink-0 items-center pr-1 right-sidebar-header-no-drag">
+                    {closeButton}
+                  </div>
+                </TooltipProvider>
+              )}
+              {isWindows && (
+                <TooltipProvider delayDuration={400}>
+                  <div className="ml-auto flex shrink-0 items-center pr-1 right-sidebar-header-no-drag">
+                    {closeButton}
+                  </div>
+                </TooltipProvider>
+              )}
+            </div>
+            {isWindows && (
               <TooltipProvider delayDuration={400}>
                 <ContextMenuTrigger asChild>
                   <div
                     ref={topActivityStripRef}
-                    className="right-sidebar-activity-strip flex min-w-0 flex-1 items-center overflow-hidden right-sidebar-header-no-drag"
+                    className="right-sidebar-activity-strip flex h-10 min-h-10 items-center border-b border-border px-2 right-sidebar-header-no-drag"
                   >
-                    {/* Why: the top strip shares a narrow titlebar with the close
-                        button and Windows controls. Overflow goes behind More
-                        instead of creating a horizontally scrollable toolbar. */}
-                    <div className="flex min-w-0 shrink">
+                    {/* Why: Windows has fixed native-style controls in the titlebar
+                        area; keep sidebar navigation in the sidebar body so the
+                        titlebar stays visually native instead of crowded. */}
+                    <div className="flex min-w-0 flex-1 shrink">
                       {topActivityLayout.visibleItems.map((item) => (
                         <ActivityBarButton
                           key={item.id}
@@ -254,11 +302,8 @@ function RightSidebarInner(): React.JSX.Element {
                     )}
                   </div>
                 </ContextMenuTrigger>
-                <div className="flex shrink-0 items-center right-sidebar-header-no-drag">
-                  {closeButton}
-                </div>
               </TooltipProvider>
-            </div>
+            )}
             <ActivityBarPositionMenu
               currentPosition={activityBarPosition}
               onChangePosition={setActivityBarPosition}

--- a/tests/e2e/right-sidebar-windows-titlebar.spec.ts
+++ b/tests/e2e/right-sidebar-windows-titlebar.spec.ts
@@ -2,22 +2,16 @@ import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 type RightSidebarHeaderGeometry = {
-  controlsLeft: number
-  stripRight: number
-  closeRight: number
-  stripScrollWidth: number
-  stripClientWidth: number
+  headerBottom: number
+  stripTop: number
+  closeTop: number
+  titlebarActivityButtonCount: number
   firstButtonCenterHitsFirst: boolean
-}
-
-type ScrolledActivityButtonGeometry = {
-  controlsLeft: number
-  lastButtonRight: number
   lastButtonCenterHitsLast: boolean
 }
 
 test.describe('Right sidebar Windows titlebar spacing', () => {
-  test('top activity buttons stay reachable when the right sidebar is narrowed', async ({
+  test('top activity buttons render inside the sidebar instead of the titlebar', async ({
     orcaPage
   }) => {
     await orcaPage.addInitScript(() => {
@@ -63,39 +57,48 @@ test.describe('Right sidebar Windows titlebar spacing', () => {
 
     const measureHeader = async (): Promise<RightSidebarHeaderGeometry | null> =>
       orcaPage.evaluate(() => {
-        const controls = document.querySelector<HTMLElement>('.window-controls')
         const header = document.querySelector<HTMLElement>('.right-sidebar-header-inset')
-        const strip = header?.querySelector<HTMLElement>('.right-sidebar-activity-strip') ?? null
-        const closeButton =
-          header?.querySelector<HTMLButtonElement>('button[aria-label="Toggle right sidebar"]') ??
-          null
-        const activityButtons = Array.from(
+        const strip = document.querySelector<HTMLElement>('.right-sidebar-activity-strip')
+        const closeButton = header?.querySelector<HTMLButtonElement>(
+          'button[aria-label="Toggle right sidebar"]'
+        )
+        const titlebarActivityButtonCount =
           header?.querySelectorAll<HTMLButtonElement>(
+            'button[aria-label]:not([aria-label="Toggle right sidebar"])'
+          ).length ?? 0
+        const activityButtons = Array.from(
+          strip?.querySelectorAll<HTMLButtonElement>(
             'button[aria-label]:not([aria-label="Toggle right sidebar"])'
           ) ?? []
         )
         const firstButton = activityButtons[0]
+        const lastButton = activityButtons.at(-1)
 
-        if (!controls || !header || !strip || !closeButton || !firstButton) {
+        if (!header || !strip || !closeButton || !firstButton || !lastButton) {
           return null
         }
 
-        const controlsRect = controls.getBoundingClientRect()
+        const headerRect = header.getBoundingClientRect()
         const stripRect = strip.getBoundingClientRect()
         const closeRect = closeButton.getBoundingClientRect()
         const firstRect = firstButton.getBoundingClientRect()
         const firstCenterX = firstRect.left + firstRect.width / 2
         const firstCenterY = firstRect.top + firstRect.height / 2
         const elementAtFirstCenter = document.elementFromPoint(firstCenterX, firstCenterY)
+        const lastRect = lastButton.getBoundingClientRect()
+        const lastCenterX = lastRect.left + lastRect.width / 2
+        const lastCenterY = lastRect.top + lastRect.height / 2
+        const elementAtLastCenter = document.elementFromPoint(lastCenterX, lastCenterY)
 
         return {
-          controlsLeft: controlsRect.left,
-          stripRight: stripRect.right,
-          closeRight: closeRect.right,
-          stripScrollWidth: strip.scrollWidth,
-          stripClientWidth: strip.clientWidth,
+          headerBottom: headerRect.bottom,
+          stripTop: stripRect.top,
+          closeTop: closeRect.top,
+          titlebarActivityButtonCount,
           firstButtonCenterHitsFirst:
-            elementAtFirstCenter !== null && firstButton.contains(elementAtFirstCenter)
+            elementAtFirstCenter !== null && firstButton.contains(elementAtFirstCenter),
+          lastButtonCenterHitsLast:
+            elementAtLastCenter !== null && lastButton.contains(elementAtLastCenter)
         }
       })
 
@@ -104,7 +107,7 @@ test.describe('Right sidebar Windows titlebar spacing', () => {
       .poll(
         async () => {
           headerGeometry = await measureHeader()
-          return headerGeometry !== null && headerGeometry.stripClientWidth > 0
+          return headerGeometry !== null
         },
         {
           timeout: 5_000,
@@ -114,53 +117,10 @@ test.describe('Right sidebar Windows titlebar spacing', () => {
       .toBe(true)
 
     expect(headerGeometry).not.toBeNull()
-    expect(headerGeometry!.stripRight).toBeLessThanOrEqual(headerGeometry!.controlsLeft)
-    expect(headerGeometry!.closeRight).toBeLessThanOrEqual(headerGeometry!.controlsLeft)
-    expect(headerGeometry!.stripScrollWidth).toBeGreaterThan(headerGeometry!.stripClientWidth)
+    expect(headerGeometry!.titlebarActivityButtonCount).toBe(0)
+    expect(headerGeometry!.stripTop).toBeGreaterThanOrEqual(headerGeometry!.headerBottom)
+    expect(headerGeometry!.closeTop).toBeLessThan(headerGeometry!.headerBottom)
     expect(headerGeometry!.firstButtonCenterHitsFirst).toBe(true)
-
-    await orcaPage.evaluate(() => {
-      const strip = document.querySelector<HTMLElement>('.right-sidebar-activity-strip')
-      if (!strip) {
-        throw new Error('Right sidebar activity strip is missing')
-      }
-      strip.scrollLeft = strip.scrollWidth
-    })
-    // Why: hidden Electron e2e windows can throttle requestAnimationFrame for a
-    // long time; scrollLeft is synchronous, so a short Playwright-side delay is
-    // enough to let layout settle without depending on renderer frame cadence.
-    await orcaPage.waitForTimeout(50)
-
-    const scrolledGeometry = await orcaPage.evaluate((): ScrolledActivityButtonGeometry | null => {
-      const controls = document.querySelector<HTMLElement>('.window-controls')
-      const header = document.querySelector<HTMLElement>('.right-sidebar-header-inset')
-      const activityButtons = Array.from(
-        header?.querySelectorAll<HTMLButtonElement>(
-          'button[aria-label]:not([aria-label="Toggle right sidebar"])'
-        ) ?? []
-      )
-      const lastButton = activityButtons.at(-1)
-
-      if (!controls || !lastButton) {
-        return null
-      }
-
-      const controlsRect = controls.getBoundingClientRect()
-      const lastRect = lastButton.getBoundingClientRect()
-      const lastCenterX = lastRect.left + lastRect.width / 2
-      const lastCenterY = lastRect.top + lastRect.height / 2
-      const elementAtLastCenter = document.elementFromPoint(lastCenterX, lastCenterY)
-
-      return {
-        controlsLeft: controlsRect.left,
-        lastButtonRight: lastRect.right,
-        lastButtonCenterHitsLast:
-          elementAtLastCenter !== null && lastButton.contains(elementAtLastCenter)
-      }
-    })
-
-    expect(scrolledGeometry).not.toBeNull()
-    expect(scrolledGeometry!.lastButtonRight).toBeLessThanOrEqual(scrolledGeometry!.controlsLeft)
-    expect(scrolledGeometry!.lastButtonCenterHitsLast).toBe(true)
+    expect(headerGeometry!.lastButtonCenterHitsLast).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- move right-sidebar activity buttons out of the Windows titlebar and into the sidebar body
- keep the existing non-Windows top activity bar layout unchanged
- update the Windows titlebar e2e to assert sidebar buttons are below the titlebar and clickable

Fixes #2333

## Verification
- `pnpm run typecheck:web`
- `npx stably test --config=tests/playwright.config.ts --project=electron-headless tests/e2e/right-sidebar-windows-titlebar.spec.ts`
- captured local screenshots: `/tmp/orca-issue-2333-full-window.png`, `/tmp/orca-issue-2333-sidebar-toolbar.png`

Note: Stably reporting was skipped locally because credentials are not configured.