### PR TITLE
Fix SSH automation background launch

### DIFF
--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -6,6 +6,7 @@ import {
 import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
 
 const mockSpawn = vi.fn()
+const mockWrite = vi.fn()
 const mockRuntimeEnvironmentCall = vi.fn()
 const mockRuntimeEnvironmentTransportCall = vi.fn()
 const mockRuntimeEnvironmentSubscribe = vi.fn()
@@ -34,7 +35,7 @@ function expectStablePaneSpawn(): string {
 
 const state = {
   settings: { agentCmdOverrides: {}, activeRuntimeEnvironmentId: null as string | null },
-  repos: [{ id: 'repo-1', connectionId: null }],
+  repos: [{ id: 'repo-1', connectionId: null as string | null }],
   allWorktrees: vi.fn(() => [
     { id: 'wt-1', repoId: 'repo-1', path: '/repo/worktree', displayName: 'main' }
   ]),
@@ -80,6 +81,7 @@ describe('launchAgentBackgroundSession', () => {
       }
     )
     state.settings = { agentCmdOverrides: {}, activeRuntimeEnvironmentId: null }
+    state.repos = [{ id: 'repo-1', connectionId: null }]
     mockCreateTab.mockReturnValue({ id: 'tab-1', title: 'Terminal 1' })
     mockSpawn.mockResolvedValue({ id: 'pty-1' })
     mockRuntimeEnvironmentCall.mockResolvedValue({
@@ -95,7 +97,8 @@ describe('launchAgentBackgroundSession', () => {
     vi.stubGlobal('window', {
       api: {
         pty: {
-          spawn: mockSpawn
+          spawn: mockSpawn,
+          write: mockWrite
         },
         agentTrust: {
           markTrusted: mockMarkTrusted
@@ -250,6 +253,30 @@ describe('launchAgentBackgroundSession', () => {
         submit: true
       })
     )
+  })
+
+  it('injects startup commands into SSH background sessions after shell output arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      state.repos = [{ id: 'repo-1', connectionId: 'ssh-1' }]
+      const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+      await launchAgentBackgroundSession({
+        agent: 'claude',
+        worktreeId: 'wt-1',
+        prompt: 'run the automation',
+        title: 'Nightly audit'
+      })
+
+      expect(mockSpawn.mock.calls[0]?.[0]?.command).toBeUndefined()
+      const dataSidecar = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+      dataSidecar('user@remote repo % ')
+      vi.advanceTimersByTime(50)
+
+      expect(mockWrite).toHaveBeenCalledWith('pty-1', "claude 'run the automation'\r")
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('creates background sessions on the active runtime environment', async () => {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -110,6 +110,34 @@ export async function launchAgentBackgroundSession(
     ORCA_TAB_ID: tab.id,
     ORCA_WORKTREE_ID: worktreeId
   }
+  const sshConnectionId = repo?.connectionId ?? null
+  let pendingSshStartupCommand = sshConnectionId ? startupPlan.launchCommand : null
+  let sshStartupInjectTimer: ReturnType<typeof setTimeout> | null = null
+  const clearSshStartupInjectTimer = (): void => {
+    if (sshStartupInjectTimer !== null) {
+      clearTimeout(sshStartupInjectTimer)
+      sshStartupInjectTimer = null
+    }
+  }
+  const scheduleSshStartupInjection = (ptyId: string): void => {
+    if (!pendingSshStartupCommand) {
+      return
+    }
+    clearSshStartupInjectTimer()
+    sshStartupInjectTimer = setTimeout(() => {
+      sshStartupInjectTimer = null
+      const command = pendingSshStartupCommand
+      if (!command) {
+        return
+      }
+      pendingSshStartupCommand = null
+      // Why: the SSH relay ignores spawn.command for interactive PTYs; hidden
+      // automation tabs must type the startup command themselves after shell output.
+      const submittedCommand =
+        command.endsWith('\r') || command.endsWith('\n') ? command : `${command}\r`
+      window.api.pty.write(ptyId, submittedCommand)
+    }, 50)
+  }
   const runtimeTarget = getActiveRuntimeTarget(store.settings)
   let ptyId: string
   try {
@@ -136,9 +164,9 @@ export async function launchAgentBackgroundSession(
         cols: 120,
         rows: 40,
         cwd: worktree.path,
-        command: startupPlan.launchCommand,
+        ...(sshConnectionId ? {} : { command: startupPlan.launchCommand }),
         env: paneEnv,
-        connectionId: repo?.connectionId ?? null,
+        connectionId: sshConnectionId,
         worktreeId,
         tabId: tab.id,
         leafId,
@@ -166,12 +194,14 @@ export async function launchAgentBackgroundSession(
     exitHandled = true
     unsubscribeExit()
     unsubscribeData()
+    clearSshStartupInjectTimer()
     useAppStore.getState().clearTabPtyId(tab.id, ptyId)
     onExit?.(ptyId, code)
   }
   const processAgentStatus = createAgentStatusOscProcessor()
   const handleData = (data: string): void => {
     onData?.(data)
+    scheduleSshStartupInjection(ptyId)
     const processed = processAgentStatus(data)
     for (const payload of processed.payloads) {
       useAppStore.getState().setAgentStatus(paneKey, payload, undefined)


### PR DESCRIPTION
## Summary
- Fix SSH-backed background automation runs so the run-linked PTY receives the agent startup command
- Keep local/runtime environment launches using spawn command injection, while SSH hidden sessions type the command after shell output because the SSH relay ignores `spawn.command`
- Add regression coverage that reproduced the empty shell behavior before the fix

Fixes #2439

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/providers/ssh-pty-provider.test.ts src/main/automations/service.test.ts src/renderer/src/components/automations/automation-run-output-snapshot.test.ts src/renderer/src/components/automations/automation-run-view-state.test.ts --reporter=dot`
- `pnpm run typecheck:web`
- `git diff --check`

Made with [Orca](https://github.com/stablyai/orca) 🐋
