### PR TITLE
Squashed commits

### DIFF
--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -136,7 +136,7 @@ function prepareMacDevElectronApp() {
 
   const title = process.env.ORCA_DEV_DOCK_TITLE || 'Orca: dev'
   const identityKey = process.env.ORCA_DEV_INSTANCE_KEY || repoRoot
-  const bundleLayoutVersion = 'dock-title-app-filename-v2'
+  const bundleLayoutVersion = 'dock-title-app-preserve-framework-symlinks-v3'
   const hash = createHash('sha1')
     .update(
       `${sourceAppPath}\0${electronVersion ?? ''}\0${title}\0${identityKey}\0${bundleLayoutVersion}`
@@ -193,7 +193,9 @@ function prepareMacDevElectronApp() {
 
   rmSync(distDir, { recursive: true, force: true })
   mkdirSync(distDir, { recursive: true })
-  cpSync(sourceAppPath, appPath, { recursive: true })
+  // Why: Electron.framework uses relative symlinks for its bundle resources;
+  // resolving them to pnpm-store absolutes breaks Chromium's bundle lookup.
+  cpSync(sourceAppPath, appPath, { recursive: true, verbatimSymlinks: true })
 
   const plistPath = path.join(appPath, 'Contents', 'Info.plist')
   setPlistValue(plistPath, 'CFBundleName', title)

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, execFileSyncMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+  spawn: spawnMock
+}))
+
+import { commandExecFileAsync } from './runner'
+
+type MockChildProcess = EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  pid: number
+  kill: ReturnType<typeof vi.fn>
+  unref?: ReturnType<typeof vi.fn>
+}
+
+function createMockChildProcess(pid: number): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.pid = pid
+  child.kill = vi.fn()
+  return child
+}
+
+function createMockTaskkillProcess(): MockChildProcess {
+  const child = createMockChildProcess(9000)
+  child.unref = vi.fn()
+  return child
+}
+
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return await fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+describe('commandExecFileAsync Windows command shims', () => {
+  const originalComSpec = process.env.ComSpec
+
+  beforeEach(() => {
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe'
+    execFileMock.mockReset()
+    execFileSyncMock.mockReset()
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalComSpec === undefined) {
+      delete process.env.ComSpec
+    } else {
+      process.env.ComSpec = originalComSpec
+    }
+  })
+
+  it('kills aborted Windows .cmd shim executions as a process tree', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+
+      const controller = new AbortController()
+      const promise = commandExecFileAsync('C:\\tools\\pnpm.cmd', ['--version'], {
+        cwd: 'C:\\repo',
+        signal: controller.signal
+      })
+      const rejection = expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+      controller.abort()
+
+      await rejection
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ stdio: 'ignore', windowsHide: true })
+      )
+      expect(command.kill).not.toHaveBeenCalled()
+    })
+  })
+
+  it('kills timed-out Windows .cmd shim executions as a process tree', async () => {
+    vi.useFakeTimers()
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+
+      const promise = commandExecFileAsync('C:\\tools\\pnpm.cmd', ['store', 'prune'], {
+        cwd: 'C:\\repo',
+        timeout: 1000
+      })
+      const rejection = expect(promise).rejects.toThrow('C:\\tools\\pnpm.cmd timed out.')
+      await vi.advanceTimersByTimeAsync(1000)
+
+      await rejection
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ stdio: 'ignore', windowsHide: true })
+      )
+      expect(command.kill).not.toHaveBeenCalled()
+    })
+  })
+
+  it('kills over-buffer Windows .cmd shim executions as a process tree', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+
+      const promise = commandExecFileAsync('C:\\tools\\pnpm.cmd', ['store', 'prune'], {
+        cwd: 'C:\\repo',
+        maxBuffer: 2
+      })
+      const rejection = expect(promise).rejects.toThrow(
+        'C:\\tools\\pnpm.cmd stdout exceeded maxBuffer.'
+      )
+      command.stdout.emit('data', Buffer.from('too much output'))
+
+      await rejection
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ stdio: 'ignore', windowsHide: true })
+      )
+      expect(command.kill).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -12,6 +12,7 @@ consistent across every repo-scoped subprocess call. */
 import { execFile, execFileSync, spawn, type ChildProcess, type SpawnOptions } from 'child_process'
 import { promisify } from 'util'
 import { getDefaultWslDistro, parseWslPath, toWindowsWslPath, type WslPathInfo } from '../wsl'
+import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
 
 const execFileAsync = promisify(execFile)
 
@@ -212,6 +213,139 @@ type GitExecOptions = {
   env?: NodeJS.ProcessEnv
 }
 
+type CommandExecOptions = {
+  cwd?: string
+  encoding?: BufferEncoding
+  maxBuffer?: number
+  timeout?: number
+  env?: NodeJS.ProcessEnv
+  signal?: AbortSignal
+}
+
+function isMissingCommandError(error: unknown): boolean {
+  return Boolean(
+    error && typeof error === 'object' && (error as { code?: unknown }).code === 'ENOENT'
+  )
+}
+
+function hasPathSeparator(command: string): boolean {
+  return command.includes('/') || command.includes('\\')
+}
+
+function shouldRetryWindowsCommandShim(error: unknown, resolved: ResolvedCommand): boolean {
+  return (
+    process.platform === 'win32' &&
+    resolved.wsl === null &&
+    isMissingCommandError(error) &&
+    !hasPathSeparator(resolved.binary) &&
+    !/\.[A-Za-z0-9]+$/.test(resolved.binary)
+  )
+}
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function killSpawnedCommandTree(child: ChildProcess): void {
+  const pid = child.pid
+  if (!pid || process.platform !== 'win32') {
+    child.kill()
+    return
+  }
+  try {
+    // Why: Windows package-manager CLIs are often .cmd shims. Killing only
+    // cmd.exe leaves the underlying node/npm/pnpm child running.
+    const killer = spawn('taskkill', ['/pid', String(pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    killer.on('error', () => child.kill())
+    killer.unref()
+  } catch {
+    child.kill()
+  }
+}
+
+async function spawnCommandCapture(
+  command: string,
+  args: string[],
+  options: CommandExecOptions
+): Promise<{ stdout: string; stderr: string }> {
+  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, args)
+  return new Promise((resolve, reject) => {
+    if (options.signal?.aborted) {
+      reject(createAbortError())
+      return
+    }
+    let settled = false
+    let stdout = ''
+    let stderr = ''
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    const child = spawn(spawnCmd, spawnArgs, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let timer: NodeJS.Timeout | null = null
+    const onAbort = (): void => {
+      killSpawnedCommandTree(child)
+      finish(createAbortError())
+    }
+    const finish = (error: Error | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      options.signal?.removeEventListener('abort', onAbort)
+      if (error) {
+        reject(Object.assign(error, { stdout, stderr }))
+        return
+      }
+      resolve({ stdout, stderr })
+    }
+    timer = options.timeout
+      ? setTimeout(() => {
+          killSpawnedCommandTree(child)
+          finish(new Error(`${command} timed out.`))
+        }, options.timeout)
+      : null
+    options.signal?.addEventListener('abort', onAbort, { once: true })
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBytes += chunk.byteLength
+      if (options.maxBuffer && stdoutBytes > options.maxBuffer) {
+        killSpawnedCommandTree(child)
+        finish(new Error(`${command} stdout exceeded maxBuffer.`))
+        return
+      }
+      stdout += chunk.toString(options.encoding ?? 'utf-8')
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderrBytes += chunk.byteLength
+      if (options.maxBuffer && stderrBytes > options.maxBuffer) {
+        killSpawnedCommandTree(child)
+        finish(new Error(`${command} stderr exceeded maxBuffer.`))
+        return
+      }
+      stderr += chunk.toString(options.encoding ?? 'utf-8')
+    })
+    child.on('error', finish)
+    child.on('close', (code) => {
+      if (code === 0) {
+        finish(null)
+        return
+      }
+      finish(new Error(`${command} exited with ${code}.`))
+    })
+  })
+}
+
 export function gitOptionalLocksDisabledEnv(
   env: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
@@ -238,6 +372,49 @@ export async function gitExecFileAsync(
     env: options.env
   })
   return { stdout: stdout as string, stderr: stderr as string }
+}
+
+/**
+ * Async command execution with the same WSL cwd translation as repo-scoped git.
+ * Keep this for fixed binary+argv call sites; never pass shell fragments.
+ */
+export async function commandExecFileAsync(
+  command: string,
+  args: string[],
+  options: CommandExecOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+  const resolved = resolveCommand(command, args, options.cwd)
+  const binary =
+    resolved.wsl === null ? resolveWindowsCommand(resolved.binary, options.env) : resolved.binary
+  if (isWindowsBatchScript(binary)) {
+    return spawnCommandCapture(binary, resolved.args, {
+      ...options,
+      cwd: resolved.cwd
+    })
+  }
+  try {
+    const { stdout, stderr } = await execFileAsync(binary, resolved.args, {
+      cwd: resolved.cwd,
+      encoding: options.encoding ?? 'utf-8',
+      maxBuffer: options.maxBuffer,
+      timeout: options.timeout,
+      env: options.env,
+      signal: options.signal
+    })
+    return { stdout: stdout as string, stderr: stderr as string }
+  } catch (error) {
+    if (shouldRetryWindowsCommandShim(error, resolved)) {
+      return spawnCommandCapture(
+        resolveWindowsCommand(`${resolved.binary}.cmd`, options.env),
+        resolved.args,
+        {
+          ...options,
+          cwd: resolved.cwd
+        }
+      )
+    }
+    throw error
+  }
 }
 
 /**

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
   WorkspaceSpaceAnalysis,
   WorkspaceSpaceAnalyzeResult,
@@ -9,6 +9,7 @@ import type { Store } from '../persistence'
 const {
   handlers,
   analyzeWorkspaceSpaceMock,
+  runPackageManagerCacheCleanupMock,
   removeHandlerMock,
   handleMock,
   WorkspaceSpaceScanCancelledErrorMock
@@ -17,6 +18,7 @@ const {
   return {
     handlers,
     analyzeWorkspaceSpaceMock: vi.fn(),
+    runPackageManagerCacheCleanupMock: vi.fn(),
     removeHandlerMock: vi.fn(),
     handleMock: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
       handlers.set(channel, handler)
@@ -37,6 +39,10 @@ vi.mock('../workspace-space-analysis', () => ({
   analyzeWorkspaceSpace: analyzeWorkspaceSpaceMock
 }))
 
+vi.mock('../workspace-package-manager-cache-cleanup', () => ({
+  runPackageManagerCacheCleanup: runPackageManagerCacheCleanupMock
+}))
+
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
 
 function createAnalysis(scannedAt: number): WorkspaceSpaceAnalysis {
@@ -47,6 +53,7 @@ function createAnalysis(scannedAt: number): WorkspaceSpaceAnalysis {
     worktreeCount: 0,
     scannedWorktreeCount: 0,
     unavailableWorktreeCount: 0,
+    packageManagerCaches: [],
     repos: [],
     worktrees: []
   }
@@ -66,6 +73,11 @@ function createEvent() {
 }
 
 describe('registerWorkspaceSpaceHandlers', () => {
+  beforeEach(() => {
+    analyzeWorkspaceSpaceMock.mockReset()
+    runPackageManagerCacheCleanupMock.mockReset()
+  })
+
   it('shares an in-flight analysis request', async () => {
     const store = {} as Store
     let resolveFirstScan: (analysis: WorkspaceSpaceAnalysis) => void = () => {}
@@ -160,5 +172,47 @@ describe('registerWorkspaceSpaceHandlers', () => {
     const analyzeHandler = handlers.get('workspaceSpace:analyze')
 
     await expect(analyzeHandler!(createEvent())).resolves.toEqual({ ok: false, cancelled: true })
+  })
+
+  it('runs package-manager cache cleanup only through the explicit cleanup handler', async () => {
+    const store = {} as Store
+    const cleanupResult = {
+      ok: true,
+      action: {
+        id: 'npm-cache-verify',
+        packageManager: 'npm',
+        safety: 'safe',
+        binary: 'npm',
+        args: ['cache', 'verify'],
+        command: 'npm cache verify',
+        label: 'Verify npm cache',
+        description: 'Verifies cache integrity and garbage-collects unneeded npm cache data.'
+      },
+      stdout: 'verified\n',
+      stderr: '',
+      cachePath: '/home/alice/.npm',
+      cacheSizeBeforeBytes: 4096,
+      cacheSizeAfterBytes: 1024,
+      reclaimedBytes: 3072
+    }
+    runPackageManagerCacheCleanupMock.mockResolvedValueOnce(cleanupResult)
+
+    registerWorkspaceSpaceHandlers(store)
+    const analyzeHandler = handlers.get('workspaceSpace:analyze')
+    const cleanupHandler = handlers.get('workspaceSpace:cleanupPackageManagerCache')
+    analyzeWorkspaceSpaceMock.mockResolvedValueOnce(createAnalysis(1))
+
+    await expect(analyzeHandler!(createEvent())).resolves.toEqual(createAnalyzeResult(1))
+    expect(runPackageManagerCacheCleanupMock).not.toHaveBeenCalled()
+
+    const request = {
+      targetId: 'local:npm:%2Frepo',
+      actionId: 'npm-cache-verify',
+      packageManager: 'npm',
+      connectionId: null,
+      cwd: '/repo'
+    }
+    await expect(cleanupHandler!(createEvent(), request)).resolves.toEqual(cleanupResult)
+    expect(runPackageManagerCacheCleanupMock).toHaveBeenCalledWith(request)
   })
 })

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import type {
+  WorkspacePackageManagerCacheCleanupRequest,
+  WorkspacePackageManagerCacheCleanupResult,
   WorkspaceSpaceAnalyzeResult,
   WorkspaceSpaceScanProgress
 } from '../../shared/workspace-space-types'
@@ -8,6 +10,7 @@ import {
   analyzeWorkspaceSpace,
   WorkspaceSpaceScanCancelledError
 } from '../workspace-space-analysis'
+import { runPackageManagerCacheCleanup } from '../workspace-package-manager-cache-cleanup'
 
 const PROGRESS_EMIT_INTERVAL_MS = 100
 
@@ -22,6 +25,7 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
   let inFlightScan: InFlightWorkspaceSpaceScan | null = null
   ipcMain.removeHandler('workspaceSpace:cancel')
   ipcMain.removeHandler('workspaceSpace:analyze')
+  ipcMain.removeHandler('workspaceSpace:cleanupPackageManagerCache')
   ipcMain.handle('workspaceSpace:analyze', async (event): Promise<WorkspaceSpaceAnalyzeResult> => {
     if (!inFlightScan) {
       const controller = new AbortController()
@@ -104,4 +108,12 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
     }
     return true
   })
+
+  ipcMain.handle(
+    'workspaceSpace:cleanupPackageManagerCache',
+    async (
+      _event,
+      request: WorkspacePackageManagerCacheCleanupRequest
+    ): Promise<WorkspacePackageManagerCacheCleanupResult> => runPackageManagerCacheCleanup(request)
+  )
 }

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -20,6 +20,15 @@ function createMockMux(): MockMultiplexer {
   }
 }
 
+async function waitForRequestCount(mock: ReturnType<typeof vi.fn>, count: number): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (mock.mock.calls.length >= count) {
+      return
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+}
+
 describe('SshGitProvider', () => {
   let mux: MockMultiplexer
   let provider: SshGitProvider
@@ -106,6 +115,33 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(commitResult)
   })
 
+  it('execNonInteractive delegates fixed binary commands to the relay', async () => {
+    const execResult = {
+      stdout: '10.0.0\n',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    }
+    mux.request.mockResolvedValue(execResult)
+
+    const result = await provider.execNonInteractive('pnpm', ['--version'], '/home/user/repo', 8000)
+
+    expect(mux.request).toHaveBeenCalledWith('agent.execNonInteractive', {
+      binary: 'pnpm',
+      args: ['--version'],
+      cwd: '/home/user/repo',
+      stdin: null,
+      timeoutMs: 8000
+    })
+    expect(result).toEqual(execResult)
+  })
+
+  it('cancelNonInteractiveExec sends best-effort relay cancellation', async () => {
+    await provider.cancelNonInteractiveExec('/home/user/repo')
+
+    expect(mux.request).toHaveBeenCalledWith('agent.cancelExec', { cwd: '/home/user/repo' })
+  })
+
   it('getStagedCommitContext reads branch, staged summary, and staged patch remotely', async () => {
     mux.request.mockImplementation(async (method, payload) => {
       expect(method).toBe('git.exec')
@@ -174,6 +210,151 @@ describe('SshGitProvider', () => {
       timeoutMs: 60_000
     })
     expect(result).toEqual(execResult)
+  })
+
+  it('serializes non-interactive relay execs for the same cwd', async () => {
+    const completeRequests: (() => void)[] = []
+    mux.request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          completeRequests.push(() =>
+            resolve({
+              stdout: '',
+              stderr: '',
+              exitCode: 0,
+              timedOut: false
+            })
+          )
+        })
+    )
+
+    const first = provider.execNonInteractive('pnpm', ['store', 'prune'], '/home/user/repo', 8000)
+    const second = provider.executeCommitMessagePlan(
+      {
+        binary: 'codex',
+        args: ['exec', 'PROMPT'],
+        stdinPayload: null,
+        label: 'Codex'
+      },
+      '/home/user/repo',
+      60_000
+    )
+
+    await waitForRequestCount(mux.request, 1)
+    expect(mux.request).toHaveBeenCalledTimes(1)
+
+    completeRequests.shift()?.()
+    await first
+    await waitForRequestCount(mux.request, 2)
+
+    expect(mux.request).toHaveBeenNthCalledWith(2, 'agent.execNonInteractive', {
+      binary: 'codex',
+      args: ['exec', 'PROMPT'],
+      cwd: '/home/user/repo',
+      stdin: null,
+      timeoutMs: 60_000
+    })
+    completeRequests.shift()?.()
+    await second
+  })
+
+  it('cancels a queued non-interactive exec without canceling the active relay child', async () => {
+    const completeRequests: (() => void)[] = []
+    mux.request.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          completeRequests.push(() =>
+            resolve({
+              stdout: '',
+              stderr: '',
+              exitCode: 0,
+              timedOut: false
+            })
+          )
+        })
+    )
+
+    const first = provider.execNonInteractive('pnpm', ['store', 'prune'], '/home/user/repo', 8000)
+    const second = provider.executeCommitMessagePlan(
+      {
+        binary: 'codex',
+        args: ['exec', 'PROMPT'],
+        stdinPayload: null,
+        label: 'Codex'
+      },
+      '/home/user/repo',
+      60_000
+    )
+
+    await waitForRequestCount(mux.request, 1)
+    await provider.cancelNonInteractiveExec('/home/user/repo')
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    expect(mux.request).not.toHaveBeenCalledWith('agent.cancelExec', { cwd: '/home/user/repo' })
+
+    completeRequests.shift()?.()
+    await first
+    const secondResult = await second
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    expect(secondResult).toMatchObject({ canceled: true })
+  })
+
+  it('uses an exec abort signal to cancel the matching active relay child with queued work present', async () => {
+    const completeRequests: (() => void)[] = []
+    mux.request.mockImplementation((method) => {
+      if (method === 'agent.cancelExec') {
+        return Promise.resolve({ canceled: true })
+      }
+      return new Promise((resolve) => {
+        completeRequests.push(() =>
+          resolve({
+            stdout: '',
+            stderr: '',
+            exitCode: 0,
+            timedOut: false
+          })
+        )
+      })
+    })
+
+    const controller = new AbortController()
+    const first = provider.execNonInteractive(
+      'pnpm',
+      ['store', 'prune'],
+      '/home/user/repo',
+      8000,
+      controller.signal
+    )
+    const second = provider.executeCommitMessagePlan(
+      {
+        binary: 'codex',
+        args: ['exec', 'PROMPT'],
+        stdinPayload: null,
+        label: 'Codex'
+      },
+      '/home/user/repo',
+      60_000
+    )
+
+    await waitForRequestCount(mux.request, 1)
+    controller.abort()
+    await waitForRequestCount(mux.request, 2)
+
+    expect(mux.request).toHaveBeenNthCalledWith(2, 'agent.cancelExec', { cwd: '/home/user/repo' })
+
+    completeRequests.shift()?.()
+    await first
+    await waitForRequestCount(mux.request, 3)
+    expect(mux.request).toHaveBeenNthCalledWith(3, 'agent.execNonInteractive', {
+      binary: 'codex',
+      args: ['exec', 'PROMPT'],
+      cwd: '/home/user/repo',
+      stdin: null,
+      timeoutMs: 60_000
+    })
+    completeRequests.shift()?.()
+    await second
   })
 
   it('cancelGenerateCommitMessage sends best-effort relay cancellation', async () => {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -20,9 +20,17 @@ import type { CommitMessageDraftContext } from '../../shared/commit-message-gene
 import type { CommitMessagePlan } from '../../shared/commit-message-plan'
 import type { RemoteCommitMessageExecResult } from '../text-generation/commit-message-text-generation'
 
+type NonInteractiveExecQueueEntry = {
+  started: boolean
+  canceled: boolean
+  done: Promise<void>
+  release: () => void
+}
+
 export class SshGitProvider implements IGitProvider {
   private connectionId: string
   private mux: SshChannelMultiplexer
+  private nonInteractiveExecQueues = new Map<string, NonInteractiveExecQueueEntry[]>()
 
   constructor(connectionId: string, mux: SshChannelMultiplexer) {
     this.connectionId = connectionId
@@ -99,23 +107,130 @@ export class SshGitProvider implements IGitProvider {
     cwd: string,
     timeoutMs: number
   ): Promise<RemoteCommitMessageExecResult> {
-    return (await this.mux.request('agent.execNonInteractive', {
+    return this.runQueuedNonInteractiveExec(cwd, {
       binary: plan.binary,
       args: plan.args,
       cwd,
       stdin: plan.stdinPayload,
       timeoutMs
-    })) as RemoteCommitMessageExecResult
+    })
+  }
+
+  async execNonInteractive(
+    binary: string,
+    args: string[],
+    cwd: string,
+    timeoutMs: number,
+    signal?: AbortSignal
+  ): Promise<RemoteCommitMessageExecResult> {
+    return this.runQueuedNonInteractiveExec(
+      cwd,
+      {
+        binary,
+        args,
+        cwd,
+        stdin: null,
+        timeoutMs
+      },
+      signal
+    )
+  }
+
+  async cancelNonInteractiveExec(cwd: string): Promise<void> {
+    const queue = this.nonInteractiveExecQueues.get(cwd)
+    const queuedEntry = queue?.find((entry) => !entry.started && !entry.canceled)
+    if (queuedEntry) {
+      queuedEntry.canceled = true
+      return
+    }
+    await this.cancelActiveNonInteractiveExec(cwd)
+  }
+
+  private async cancelActiveNonInteractiveExec(cwd: string): Promise<void> {
+    try {
+      await this.mux.request('agent.cancelExec', { cwd })
+    } catch {
+      // Best-effort: callers are already unwinding after cancellation.
+    }
   }
 
   async cancelGenerateCommitMessage(worktreePath: string): Promise<void> {
     // Why: best-effort — the relay returns `{canceled: false}` when there is
     // nothing in flight. Callers should not block UI updates on this.
+    await this.cancelNonInteractiveExec(worktreePath)
+  }
+
+  private async runQueuedNonInteractiveExec(
+    cwd: string,
+    payload: {
+      binary: string
+      args: string[]
+      cwd: string
+      stdin: string | null
+      timeoutMs: number
+    },
+    signal?: AbortSignal
+  ): Promise<RemoteCommitMessageExecResult> {
+    const queue = this.nonInteractiveExecQueues.get(cwd) ?? []
+    const previous = queue.at(-1)?.done ?? Promise.resolve()
+    let releaseEntry!: () => void
+    const entry: NonInteractiveExecQueueEntry = {
+      started: false,
+      canceled: false,
+      done: previous
+        .catch(() => {})
+        .then(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseEntry = resolve
+            })
+        ),
+      release: () => releaseEntry()
+    }
+    queue.push(entry)
+    this.nonInteractiveExecQueues.set(cwd, queue)
+    const abortEntry = (): void => {
+      if (!entry.started) {
+        entry.canceled = true
+        return
+      }
+      void this.cancelActiveNonInteractiveExec(cwd)
+    }
+    if (signal?.aborted) {
+      entry.canceled = true
+    } else {
+      signal?.addEventListener('abort', abortEntry, { once: true })
+    }
+
+    // Why: the SSH relay tracks one non-interactive child per cwd; serializing
+    // here keeps cache cleanup and commit-message generation from overwriting it.
+    await previous.catch(() => {})
     try {
-      await this.mux.request('agent.cancelExec', { cwd: worktreePath })
-    } catch {
-      // Swallow: cancellation is a fire-and-forget user intent. The pending
-      // generateCommitMessage promise will still resolve with the kill result.
+      if (entry.canceled) {
+        return {
+          stdout: '',
+          stderr: '',
+          exitCode: null,
+          timedOut: false,
+          canceled: true
+        }
+      }
+      entry.started = true
+      return (await this.mux.request(
+        'agent.execNonInteractive',
+        payload
+      )) as RemoteCommitMessageExecResult
+    } finally {
+      signal?.removeEventListener('abort', abortEntry)
+      entry.release()
+      const currentQueue = this.nonInteractiveExecQueues.get(cwd)
+      const entryIndex = currentQueue?.indexOf(entry) ?? -1
+      if (entryIndex >= 0) {
+        currentQueue?.splice(entryIndex, 1)
+      }
+      if (currentQueue?.length === 0) {
+        this.nonInteractiveExecQueues.delete(cwd)
+      }
     }
   }
 

--- a/src/main/startup/run-electron-vite-dev.test.ts
+++ b/src/main/startup/run-electron-vite-dev.test.ts
@@ -1,4 +1,6 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+/* eslint-disable max-lines -- Why: this integration-style wrapper suite shares
+   process cleanup and fake Electron CLI fixtures across related regressions. */
+import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { spawn } from 'node:child_process'
@@ -308,5 +310,62 @@ describe('run-electron-vite-dev', () => {
       }
     },
     30000
+  )
+
+  it.skipIf(process.platform !== 'darwin')(
+    'preserves relative Electron framework symlinks in the copied mac dev app',
+    async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'orca-dev-wrapper-'))
+      const pidFile = join(tempDir, 'grandchild.pid')
+      const envFile = join(tempDir, 'env.json')
+      const wrapperPath = resolve('config/scripts/run-electron-vite-dev.mjs')
+      const fakeCliPath = resolve('src/main/startup/__fixtures__/fake-electron-vite-dev-cli.mjs')
+
+      const wrapper = spawn(process.execPath, [wrapperPath, '--remote-debugging-port=9448'], {
+        cwd: resolve('.'),
+        env: devWrapperTestEnv({
+          ORCA_ELECTRON_VITE_CLI: fakeCliPath,
+          ORCA_SKIP_DEV_CLI_PREPARE: '1',
+          ORCA_SKIP_DEV_WEB_PREPARE: '1',
+          ORCA_DEV_WRAPPER_TEST_PID_FILE: pidFile,
+          ORCA_DEV_WRAPPER_TEST_ENV_FILE: envFile,
+          ORCA_DEV_BRANCH: 'feature/framework-symlinks',
+          ORCA_DEV_WORKTREE_NAME: 'symlink-ui'
+        }),
+        stdio: 'ignore'
+      })
+
+      expect(wrapper.pid).toBeTypeOf('number')
+      processesToCleanUp.add(wrapper.pid!)
+
+      await waitFor(() => {
+        try {
+          return readFileSync(envFile, 'utf8').trim().length > 0
+        } catch {
+          return false
+        }
+      })
+
+      const grandchildPid = Number.parseInt(readFileSync(pidFile, 'utf8').trim(), 10)
+      if (Number.isFinite(grandchildPid)) {
+        processesToCleanUp.add(grandchildPid)
+      }
+
+      const envSnapshot = JSON.parse(readFileSync(envFile, 'utf8')) as {
+        electronExecPath: string | null
+      }
+      expect(envSnapshot.electronExecPath).toBeTypeOf('string')
+
+      const appPath = dirname(dirname(dirname(envSnapshot.electronExecPath!)))
+      const frameworkPath = join(appPath, 'Contents', 'Frameworks', 'Electron Framework.framework')
+
+      expect(readlinkSync(join(frameworkPath, 'Resources'))).toBe('Versions/Current/Resources')
+      expect(readlinkSync(join(frameworkPath, 'Electron Framework'))).toBe(
+        'Versions/Current/Electron Framework'
+      )
+      expect(readlinkSync(join(frameworkPath, 'Versions', 'Current'))).toBe('A')
+
+      wrapper.kill('SIGINT')
+    }
   )
 })

--- a/src/main/win32-utils.test.ts
+++ b/src/main/win32-utils.test.ts
@@ -1,5 +1,13 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getSpawnArgsForWindows, isPermissionError, isWindowsBatchScript } from './win32-utils'
+import {
+  getSpawnArgsForWindows,
+  isPermissionError,
+  isWindowsBatchScript,
+  resolveWindowsCommand
+} from './win32-utils'
 
 function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
   const original = process.platform
@@ -85,6 +93,30 @@ describe('getSpawnArgsForWindows', () => {
     withPlatform('win32', () => {
       expect(() => getSpawnArgsForWindows('C:\\bad&path\\agent.cmd', ['login'])).toThrow(
         'UNSAFE_WINDOWS_BATCH_ARGUMENTS'
+      )
+    })
+  })
+})
+
+describe('resolveWindowsCommand', () => {
+  it('finds package-manager .cmd shims on PATH before spawning fixed commands', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'orca-win-command-'))
+    try {
+      const pnpmShim = join(tempDir, 'pnpm.cmd')
+      writeFileSync(pnpmShim, '@echo off\r\n')
+
+      withPlatform('win32', () => {
+        expect(resolveWindowsCommand('pnpm', { PATH: tempDir })).toBe(pnpmShim)
+      })
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves explicit command paths unchanged', () => {
+    withPlatform('win32', () => {
+      expect(resolveWindowsCommand('C:\\tools\\npm.cmd', { PATH: 'C:\\other' })).toBe(
+        'C:\\tools\\npm.cmd'
       )
     })
   })

--- a/src/main/win32-utils.ts
+++ b/src/main/win32-utils.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from 'node:child_process'
+import { delimiter, join } from 'node:path'
+import { existsSync } from 'node:fs'
 
 /**
  * Full path to icacls.exe. Electron's main process may have a stripped PATH
@@ -20,6 +22,33 @@ export function getCmdExePath(): string {
 /** Whether a resolved command path points to a Windows batch script (.cmd/.bat). */
 export function isWindowsBatchScript(commandPath: string): boolean {
   return process.platform === 'win32' && /\.(cmd|bat)$/i.test(commandPath)
+}
+
+export function resolveWindowsCommand(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  if (process.platform !== 'win32') {
+    return command
+  }
+  if (/[\\/]/.test(command) || /\.[a-z0-9]+$/i.test(command)) {
+    return command
+  }
+
+  const pathEnv = env.PATH ?? env.Path
+  if (!pathEnv) {
+    return command
+  }
+
+  for (const directory of pathEnv.split(delimiter).filter(Boolean)) {
+    for (const name of [`${command}.cmd`, `${command}.exe`, `${command}.bat`, command]) {
+      const candidate = join(directory, name)
+      if (existsSync(candidate)) {
+        return candidate
+      }
+    }
+  }
+  return command
 }
 
 export const WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR = 'UNSAFE_WINDOWS_BATCH_ARGUMENTS'

--- a/src/main/workspace-package-manager-cache-cleanup.test.ts
+++ b/src/main/workspace-package-manager-cache-cleanup.test.ts
@@ -1,0 +1,375 @@
+/* eslint-disable max-lines -- Why: cache detection and cleanup regressions share one mocked SSH/runner setup. */
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IFilesystemProvider } from './providers/types'
+
+const { commandExecFileAsyncMock, getSshGitProviderMock } = vi.hoisted(() => ({
+  commandExecFileAsyncMock: vi.fn(),
+  getSshGitProviderMock: vi.fn()
+}))
+
+vi.mock('./git/runner', () => ({
+  commandExecFileAsync: commandExecFileAsyncMock
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+import {
+  buildPackageManagerCacheTargets,
+  detectPackageManagersForDirectoryEntries,
+  detectRemotePackageManagers,
+  runPackageManagerCacheCleanup
+} from './workspace-package-manager-cache-cleanup'
+
+async function waitForCallCount(
+  mock: { mock: { calls: unknown[] } },
+  count: number
+): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (mock.mock.calls.length >= count) {
+      return
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+describe('workspace package-manager cache cleanup', () => {
+  let tempDir: string | null = null
+
+  beforeEach(() => {
+    commandExecFileAsyncMock.mockReset()
+    getSshGitProviderMock.mockReset()
+    tempDir = null
+  })
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('groups lockfile detections by target and CLI availability', async () => {
+    commandExecFileAsyncMock.mockResolvedValue({ stdout: '10.0.0\n', stderr: '' })
+    const detections = detectPackageManagersForDirectoryEntries({
+      entryNames: ['package.json', 'pnpm-lock.yaml', 'package-lock.json'],
+      connectionId: null,
+      isRemote: false,
+      repoDisplayName: 'orca',
+      worktreeId: 'repo-1::/repo',
+      worktreePath: '/repo'
+    })
+
+    const targets = await buildPackageManagerCacheTargets(detections)
+
+    expect(targets).toHaveLength(2)
+    expect(targets.map((target) => target.packageManager).sort()).toEqual(['npm', 'pnpm'])
+    expect(targets.every((target) => target.cliAvailable)).toBe(true)
+    expect(
+      targets.map((target) => ({
+        packageManager: target.packageManager,
+        detectedWorktrees: target.detectedWorktrees
+      }))
+    ).toEqual([
+      {
+        packageManager: 'npm',
+        detectedWorktrees: [{ worktreeId: 'repo-1::/repo', lockfiles: ['package-lock.json'] }]
+      },
+      {
+        packageManager: 'pnpm',
+        detectedWorktrees: [{ worktreeId: 'repo-1::/repo', lockfiles: ['pnpm-lock.yaml'] }]
+      }
+    ])
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'pnpm',
+      ['--version'],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'npm',
+      ['--version'],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+    expect(commandExecFileAsyncMock).not.toHaveBeenCalledWith(
+      'pnpm',
+      ['store', 'prune'],
+      expect.anything()
+    )
+    expect(commandExecFileAsyncMock).not.toHaveBeenCalledWith(
+      'npm',
+      ['cache', 'clean', '--force'],
+      expect.anything()
+    )
+  })
+
+  it('marks detected package managers unavailable when the CLI is missing', async () => {
+    commandExecFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('spawn pnpm ENOENT'), {
+        code: 'ENOENT'
+      })
+    )
+
+    const targets = await buildPackageManagerCacheTargets([
+      {
+        packageManager: 'pnpm',
+        connectionId: null,
+        isRemote: false,
+        repoDisplayName: 'orca',
+        worktreeId: 'repo-1::/repo',
+        worktreePath: '/repo',
+        lockfiles: ['pnpm-lock.yaml']
+      }
+    ])
+
+    expect(targets[0]).toMatchObject({
+      packageManager: 'pnpm',
+      cliAvailable: false,
+      unavailableReason:
+        'pnpm was detected by lockfile, but its CLI was not available on this target.'
+    })
+  })
+
+  it('keeps project-specific npm cache paths as separate cleanup targets', async () => {
+    commandExecFileAsyncMock.mockImplementation(
+      async (binary: string, args: string[], options: { cwd?: string }) => {
+        if (binary === 'npm' && args.join(' ') === '--version') {
+          return { stdout: '10.0.0\n', stderr: '' }
+        }
+        if (binary === 'npm' && args.join(' ') === 'config get cache') {
+          return {
+            stdout: options.cwd === '/repo-a' ? '/cache/a\n' : '/cache/b\n',
+            stderr: ''
+          }
+        }
+        throw new Error(`unexpected command ${binary} ${args.join(' ')}`)
+      }
+    )
+
+    const targets = await buildPackageManagerCacheTargets([
+      {
+        packageManager: 'npm',
+        connectionId: null,
+        isRemote: false,
+        repoDisplayName: 'repo-a',
+        worktreeId: 'repo-a::/repo-a',
+        worktreePath: '/repo-a',
+        lockfiles: ['package-lock.json']
+      },
+      {
+        packageManager: 'npm',
+        connectionId: null,
+        isRemote: false,
+        repoDisplayName: 'repo-b',
+        worktreeId: 'repo-b::/repo-b',
+        worktreePath: '/repo-b',
+        lockfiles: ['package-lock.json']
+      }
+    ])
+
+    expect(targets).toHaveLength(2)
+    expect(targets.map((target) => target.cachePath).sort()).toEqual(['/cache/a', '/cache/b'])
+    expect(targets.map((target) => target.cwd).sort()).toEqual(['/repo-a', '/repo-b'])
+  })
+
+  it('propagates scan cancellation while checking local CLI availability', async () => {
+    const signal = new AbortController().signal
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' })
+    commandExecFileAsyncMock.mockRejectedValue(abortError)
+
+    await expect(
+      buildPackageManagerCacheTargets(
+        [
+          {
+            packageManager: 'pnpm',
+            connectionId: null,
+            isRemote: false,
+            repoDisplayName: 'orca',
+            worktreeId: 'repo-1::/repo',
+            worktreePath: '/repo',
+            lockfiles: ['pnpm-lock.yaml']
+          }
+        ],
+        { signal }
+      )
+    ).rejects.toBe(abortError)
+
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'pnpm',
+      ['--version'],
+      expect.objectContaining({ cwd: '/repo', signal })
+    )
+  })
+
+  it('detects remote lockfiles and checks the remote CLI through SSH', async () => {
+    const provider = {
+      readDir: vi.fn().mockResolvedValue([{ name: 'bun.lock' }])
+    } as unknown as IFilesystemProvider
+    const execNonInteractive = vi.fn().mockResolvedValue({
+      stdout: '1.3.0\n',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    })
+    getSshGitProviderMock.mockReturnValue({ execNonInteractive })
+
+    const detections = await detectRemotePackageManagers({
+      provider,
+      connectionId: 'ssh-1',
+      repoDisplayName: 'remote',
+      worktreeId: 'repo-remote::/remote/repo',
+      worktreePath: '/remote/repo'
+    })
+    const targets = await buildPackageManagerCacheTargets(detections)
+
+    expect(targets[0]).toMatchObject({
+      packageManager: 'bun',
+      connectionId: 'ssh-1',
+      isRemote: true,
+      cliAvailable: true
+    })
+    expect(execNonInteractive).toHaveBeenCalledWith(
+      'bun',
+      ['--version'],
+      '/remote/repo',
+      8000,
+      undefined
+    )
+  })
+
+  it('cancels remote CLI availability checks through the SSH relay', async () => {
+    const controller = new AbortController()
+    const execNonInteractive = vi.fn(
+      () =>
+        new Promise<never>(() => {
+          // Keep the relay request pending until the scan cancellation wins.
+        })
+    )
+    const cancelNonInteractiveExec = vi.fn().mockResolvedValue(undefined)
+    getSshGitProviderMock.mockReturnValue({ execNonInteractive, cancelNonInteractiveExec })
+
+    const promise = buildPackageManagerCacheTargets(
+      [
+        {
+          packageManager: 'pnpm',
+          connectionId: 'ssh-1',
+          isRemote: true,
+          repoDisplayName: 'remote',
+          worktreeId: 'repo-remote::/remote/repo',
+          worktreePath: '/remote/repo',
+          lockfiles: ['pnpm-lock.yaml']
+        }
+      ],
+      { signal: controller.signal }
+    )
+    await waitForCallCount(execNonInteractive, 1)
+    controller.abort()
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(execNonInteractive).toHaveBeenCalledWith(
+      'pnpm',
+      ['--version'],
+      '/remote/repo',
+      8000,
+      controller.signal
+    )
+    expect(cancelNonInteractiveExec).not.toHaveBeenCalled()
+  })
+
+  it('runs only known cleanup commands from a validated action id', async () => {
+    commandExecFileAsyncMock.mockResolvedValue({
+      stdout: 'Removed 1.2 GB\n',
+      stderr: ''
+    })
+
+    const result = await runPackageManagerCacheCleanup({
+      targetId: 'local:pnpm:%2Frepo',
+      actionId: 'pnpm-store-prune',
+      packageManager: 'pnpm',
+      connectionId: null,
+      cwd: '/repo'
+    })
+
+    expect(result).toMatchObject({ ok: true })
+    expect(commandExecFileAsyncMock).toHaveBeenCalledWith(
+      'pnpm',
+      ['store', 'prune'],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+
+    await expect(
+      runPackageManagerCacheCleanup({
+        targetId: 'local:pnpm:%2Frepo',
+        actionId: 'rm-rf-cache',
+        packageManager: 'pnpm',
+        connectionId: null,
+        cwd: '/repo'
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'Unknown package-manager cache cleanup action.'
+    })
+  })
+
+  it('measures pnpm store size before and after cleanup when possible', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-pnpm-store-'))
+    const storePath = join(tempDir, 'store')
+    const packagePath = join(storePath, 'v10', 'files')
+    const packageFile = join(packagePath, 'pkg.tgz')
+    await mkdir(packagePath, { recursive: true })
+    await writeFile(packageFile, Buffer.alloc(4096, 1))
+    commandExecFileAsyncMock.mockImplementation(async (binary: string, args: string[]) => {
+      if (binary === 'pnpm' && args.join(' ') === 'store path') {
+        return { stdout: `${storePath}\n`, stderr: '' }
+      }
+      if (binary === 'pnpm' && args.join(' ') === 'store prune') {
+        await rm(packageFile, { force: true })
+        return { stdout: 'Removed cached package\n', stderr: '' }
+      }
+      throw new Error(`unexpected command ${binary} ${args.join(' ')}`)
+    })
+
+    const result = await runPackageManagerCacheCleanup({
+      targetId: 'local:pnpm:%2Frepo',
+      actionId: 'pnpm-store-prune',
+      packageManager: 'pnpm',
+      connectionId: null,
+      cwd: '/repo'
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      cachePath: storePath
+    })
+    expect(result.ok && result.cacheSizeBeforeBytes).toBeGreaterThan(0)
+    expect(result.ok && result.cacheSizeAfterBytes).toBeGreaterThanOrEqual(0)
+    expect(result.ok && result.reclaimedBytes).toBeGreaterThan(0)
+  })
+
+  it('rejects malformed runtime cleanup requests before spawning commands', async () => {
+    await expect(runPackageManagerCacheCleanup(undefined as never)).resolves.toEqual({
+      ok: false,
+      error: 'Invalid package-manager cache cleanup request.'
+    })
+    await expect(runPackageManagerCacheCleanup(null as never)).resolves.toEqual({
+      ok: false,
+      error: 'Invalid package-manager cache cleanup request.'
+    })
+    await expect(
+      runPackageManagerCacheCleanup({
+        targetId: 'local:pnpm:%2Frepo',
+        actionId: 'pnpm-store-prune',
+        packageManager: 'pnpm',
+        connectionId: null,
+        cwd: ''
+      })
+    ).resolves.toEqual({
+      ok: false,
+      error: 'Invalid package-manager cache cleanup request.'
+    })
+    expect(commandExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/workspace-package-manager-cache-cleanup.ts
+++ b/src/main/workspace-package-manager-cache-cleanup.ts
@@ -1,0 +1,631 @@
+/* eslint-disable max-lines -- Why: package-manager detection, target building,
+and fixed-command execution share one safety boundary. */
+import { lstat, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  createPackageManagerCacheTargetId,
+  detectPackageManagersFromFilenames,
+  getPackageManagerCacheCleanupAction,
+  getPackageManagerCacheCleanupActions,
+  getPackageManagerLabel
+} from '../shared/package-manager-cache-cleanup'
+import type {
+  WorkspacePackageManager,
+  WorkspacePackageManagerCacheCleanupRequest,
+  WorkspacePackageManagerCacheCleanupResult,
+  WorkspacePackageManagerCacheTarget,
+  WorkspacePackageManagerCacheTargetWorktree
+} from '../shared/workspace-space-types'
+import type { IFilesystemProvider } from './providers/types'
+import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import { commandExecFileAsync } from './git/runner'
+
+const CLI_CHECK_TIMEOUT_MS = 8_000
+const CACHE_PATH_TIMEOUT_MS = 8_000
+const CACHE_SIZE_TIMEOUT_MS = 30_000
+const CLEANUP_TIMEOUT_MS = 120_000
+const CLEANUP_MAX_BUFFER_BYTES = 4 * 1024 * 1024
+
+export type WorkspacePackageManagerDetection = {
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  isRemote: boolean
+  repoDisplayName: string
+  worktreeId: string
+  worktreePath: string
+  lockfiles: string[]
+}
+
+type PackageManagerTargetSeed = {
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  isRemote: boolean
+  repoDisplayNames: Set<string>
+  cwd: string
+  cachePath: string | null
+  cliAvailable: boolean
+  lockfiles: Set<string>
+  detectedWorktrees: Map<string, Set<string>>
+  worktreePaths: Set<string>
+}
+
+type ExecResult = {
+  stdout: string
+  stderr: string
+}
+
+type CacheSizeSnapshot = {
+  path: string
+  sizeBytes: number | null
+}
+
+function createTargetLabel(seed: PackageManagerTargetSeed): string {
+  const manager = getPackageManagerLabel(seed.packageManager)
+  const cachePath = seed.cachePath ? ` cache at ${seed.cachePath}` : ''
+  if (!seed.isRemote) {
+    return `${manager}${cachePath || ' on this computer'}`
+  }
+  const repoNames = [...seed.repoDisplayNames].sort((a, b) => a.localeCompare(b))
+  return `${manager}${cachePath || ` on ${repoNames[0] ?? seed.connectionId ?? 'SSH target'}`}`
+}
+
+function isKnownPackageManager(value: unknown): value is WorkspacePackageManager {
+  return value === 'npm' || value === 'pnpm' || value === 'yarn' || value === 'bun'
+}
+
+function normalizeConnectionId(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  return undefined
+}
+
+function validateCleanupRequest(request: unknown):
+  | {
+      ok: true
+      value: {
+        targetId: string
+        actionId: string
+        packageManager: WorkspacePackageManager
+        connectionId: string | null
+        cwd: string
+      }
+    }
+  | { ok: false; error: string } {
+  if (!request || typeof request !== 'object') {
+    return { ok: false, error: 'Invalid package-manager cache cleanup request.' }
+  }
+  const candidate = request as Partial<WorkspacePackageManagerCacheCleanupRequest>
+  const connectionId = normalizeConnectionId(candidate.connectionId)
+  if (
+    typeof candidate.targetId !== 'string' ||
+    candidate.targetId.length === 0 ||
+    typeof candidate.actionId !== 'string' ||
+    candidate.actionId.length === 0 ||
+    !isKnownPackageManager(candidate.packageManager) ||
+    connectionId === undefined ||
+    typeof candidate.cwd !== 'string' ||
+    candidate.cwd.length === 0
+  ) {
+    return { ok: false, error: 'Invalid package-manager cache cleanup request.' }
+  }
+  return {
+    ok: true,
+    value: {
+      targetId: candidate.targetId,
+      actionId: candidate.actionId,
+      packageManager: candidate.packageManager,
+      connectionId,
+      cwd: candidate.cwd
+    }
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const spawnError = (error as { spawnError?: unknown }).spawnError
+    if (typeof spawnError === 'string' && spawnError.trim()) {
+      return spawnError
+    }
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
+function didExecSucceed(result: {
+  exitCode?: number | null
+  timedOut?: boolean
+  spawnError?: string
+}): boolean {
+  return (
+    !result.spawnError &&
+    !result.timedOut &&
+    (result.exitCode === undefined || result.exitCode === 0)
+  )
+}
+
+function isAbortError(error: unknown): boolean {
+  return Boolean(
+    error && typeof error === 'object' && (error as { name?: unknown }).name === 'AbortError'
+  )
+}
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+async function awaitWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+  onAbort?: () => void | Promise<void>
+): Promise<T> {
+  if (!signal) {
+    return promise
+  }
+  if (signal.aborted) {
+    await onAbort?.()
+    throw createAbortError()
+  }
+  let abortHandler: (() => void) | null = null
+  const abortPromise = new Promise<never>((_, reject) => {
+    abortHandler = () => {
+      void onAbort?.()
+      reject(createAbortError())
+    }
+    signal.addEventListener('abort', abortHandler, { once: true })
+  })
+  try {
+    return await Promise.race([promise, abortPromise])
+  } finally {
+    if (abortHandler) {
+      signal.removeEventListener('abort', abortHandler)
+    }
+  }
+}
+
+async function execPackageManagerCommand(args: {
+  connectionId: string | null
+  cwd: string
+  binary: string
+  commandArgs: string[]
+  timeoutMs: number
+  signal?: AbortSignal
+}): Promise<ExecResult> {
+  if (args.connectionId) {
+    const provider = getSshGitProvider(args.connectionId)
+    if (!provider) {
+      throw new Error(`SSH connection "${args.connectionId}" is not connected.`)
+    }
+    if (args.signal?.aborted) {
+      throw createAbortError()
+    }
+    const result = await awaitWithAbort(
+      provider.execNonInteractive(
+        args.binary,
+        args.commandArgs,
+        args.cwd,
+        args.timeoutMs,
+        args.signal
+      ),
+      args.signal
+    )
+    if (result.canceled) {
+      throw createAbortError()
+    }
+    if (!didExecSucceed(result)) {
+      throw new Error(
+        result.timedOut
+          ? `${args.binary} timed out.`
+          : result.spawnError ||
+              result.stderr.trim() ||
+              `${args.binary} exited with ${result.exitCode}.`
+      )
+    }
+    return { stdout: result.stdout, stderr: result.stderr }
+  }
+
+  return commandExecFileAsync(args.binary, args.commandArgs, {
+    cwd: args.cwd,
+    timeout: args.timeoutMs,
+    maxBuffer: CLEANUP_MAX_BUFFER_BYTES,
+    signal: args.signal
+  })
+}
+
+function parseFirstOutputLine(stdout: string): string | null {
+  return (
+    stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? null
+  )
+}
+
+async function resolveCachePath(args: {
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  cwd: string
+  signal?: AbortSignal
+}): Promise<string | null> {
+  const command =
+    args.packageManager === 'pnpm'
+      ? { binary: 'pnpm', commandArgs: ['store', 'path'] }
+      : args.packageManager === 'npm'
+        ? { binary: 'npm', commandArgs: ['config', 'get', 'cache'] }
+        : null
+  if (!command) {
+    return null
+  }
+  try {
+    const result = await execPackageManagerCommand({
+      connectionId: args.connectionId,
+      cwd: args.cwd,
+      binary: command.binary,
+      commandArgs: command.commandArgs,
+      timeoutMs: CACHE_PATH_TIMEOUT_MS,
+      signal: args.signal
+    })
+    return parseFirstOutputLine(result.stdout)
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+    return null
+  }
+}
+
+async function measureLocalDirectorySize(targetPath: string): Promise<number | null> {
+  const pendingPaths = [targetPath]
+  let totalSize = 0
+  while (pendingPaths.length > 0) {
+    const currentPath = pendingPaths.pop()
+    if (!currentPath) {
+      continue
+    }
+    let stats: Awaited<ReturnType<typeof lstat>>
+    try {
+      stats = await lstat(currentPath)
+    } catch (error) {
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? String((error as { code?: unknown }).code)
+          : ''
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        continue
+      }
+      return null
+    }
+    totalSize += stats.size
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      continue
+    }
+    try {
+      const entries = await readdir(currentPath, { withFileTypes: true })
+      for (const entry of entries) {
+        pendingPaths.push(join(currentPath, entry.name))
+      }
+    } catch (error) {
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? String((error as { code?: unknown }).code)
+          : ''
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        return null
+      }
+    }
+  }
+  return totalSize
+}
+
+function parseDuSizeBytes(stdout: string): number | null {
+  const match = /^(\d+)\s+/.exec(stdout.trim())
+  return match ? Number(match[1]) * 1024 : null
+}
+
+async function measureRemoteDirectorySize(args: {
+  connectionId: string
+  cwd: string
+  path: string
+}): Promise<number | null> {
+  try {
+    const result = await execPackageManagerCommand({
+      connectionId: args.connectionId,
+      cwd: args.cwd,
+      binary: 'du',
+      commandArgs: ['-sk', args.path],
+      timeoutMs: CACHE_SIZE_TIMEOUT_MS
+    })
+    return parseDuSizeBytes(result.stdout)
+  } catch {
+    return null
+  }
+}
+
+async function measurePackageManagerCache(args: {
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  cwd: string
+  cachePath?: string | null
+}): Promise<CacheSizeSnapshot | null> {
+  const cachePath =
+    args.cachePath ??
+    (await resolveCachePath({
+      packageManager: args.packageManager,
+      connectionId: args.connectionId,
+      cwd: args.cwd
+    }))
+  if (!cachePath) {
+    return null
+  }
+  const sizeBytes = args.connectionId
+    ? await measureRemoteDirectorySize({
+        connectionId: args.connectionId,
+        cwd: args.cwd,
+        path: cachePath
+      })
+    : await measureLocalDirectorySize(cachePath)
+  return { path: cachePath, sizeBytes }
+}
+
+async function isPackageManagerCliAvailable(args: {
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  cwd: string
+  signal?: AbortSignal
+}): Promise<boolean> {
+  const action = getPackageManagerCacheCleanupActions(args.packageManager)[0]
+  if (!action) {
+    return false
+  }
+  try {
+    await execPackageManagerCommand({
+      ...args,
+      binary: action.binary,
+      commandArgs: ['--version'],
+      timeoutMs: CLI_CHECK_TIMEOUT_MS,
+      signal: args.signal
+    })
+    return true
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+    return false
+  }
+}
+
+export function detectPackageManagersForDirectoryEntries(args: {
+  entryNames: readonly string[]
+  connectionId: string | null
+  isRemote: boolean
+  repoDisplayName: string
+  worktreeId: string
+  worktreePath: string
+}): WorkspacePackageManagerDetection[] {
+  return [...detectPackageManagersFromFilenames(args.entryNames)].map(
+    ([packageManager, lockfiles]) => ({
+      packageManager,
+      connectionId: args.connectionId,
+      isRemote: args.isRemote,
+      repoDisplayName: args.repoDisplayName,
+      worktreeId: args.worktreeId,
+      worktreePath: args.worktreePath,
+      lockfiles
+    })
+  )
+}
+
+export async function detectRemotePackageManagers(args: {
+  provider: IFilesystemProvider
+  connectionId: string
+  repoDisplayName: string
+  worktreeId: string
+  worktreePath: string
+}): Promise<WorkspacePackageManagerDetection[]> {
+  const entries = await args.provider.readDir(args.worktreePath)
+  return detectPackageManagersForDirectoryEntries({
+    entryNames: entries.map((entry) => entry.name),
+    connectionId: args.connectionId,
+    isRemote: true,
+    repoDisplayName: args.repoDisplayName,
+    worktreeId: args.worktreeId,
+    worktreePath: args.worktreePath
+  })
+}
+
+export async function buildPackageManagerCacheTargets(
+  detections: readonly WorkspacePackageManagerDetection[],
+  options: { signal?: AbortSignal } = {}
+): Promise<WorkspacePackageManagerCacheTarget[]> {
+  const perCwdSeeds = new Map<string, PackageManagerTargetSeed>()
+  for (const detection of detections) {
+    const id = createPackageManagerCacheTargetId(
+      detection.connectionId,
+      detection.packageManager,
+      detection.worktreePath
+    )
+    const seed =
+      perCwdSeeds.get(id) ??
+      ({
+        packageManager: detection.packageManager,
+        connectionId: detection.connectionId,
+        isRemote: detection.isRemote,
+        repoDisplayNames: new Set<string>(),
+        cwd: detection.worktreePath,
+        cachePath: null,
+        cliAvailable: false,
+        lockfiles: new Set<string>(),
+        detectedWorktrees: new Map<string, Set<string>>(),
+        worktreePaths: new Set<string>()
+      } satisfies PackageManagerTargetSeed)
+    seed.repoDisplayNames.add(detection.repoDisplayName)
+    seed.worktreePaths.add(detection.worktreePath)
+    for (const lockfile of detection.lockfiles) {
+      seed.lockfiles.add(lockfile)
+    }
+    const worktreeLockfiles = seed.detectedWorktrees.get(detection.worktreeId) ?? new Set<string>()
+    for (const lockfile of detection.lockfiles) {
+      worktreeLockfiles.add(lockfile)
+    }
+    seed.detectedWorktrees.set(detection.worktreeId, worktreeLockfiles)
+    perCwdSeeds.set(id, seed)
+  }
+
+  const resolvedSeeds = await Promise.all(
+    [...perCwdSeeds.values()].map(async (seed) => {
+      seed.cliAvailable = await isPackageManagerCliAvailable({
+        packageManager: seed.packageManager,
+        connectionId: seed.connectionId,
+        cwd: seed.cwd,
+        signal: options.signal
+      })
+      seed.cachePath = seed.cliAvailable
+        ? await resolveCachePath({
+            packageManager: seed.packageManager,
+            connectionId: seed.connectionId,
+            cwd: seed.cwd,
+            signal: options.signal
+          })
+        : null
+      return seed
+    })
+  )
+
+  const targetSeeds = new Map<string, PackageManagerTargetSeed>()
+  for (const seed of resolvedSeeds) {
+    const cacheScope = seed.cachePath ? `cache:${seed.cachePath}` : `cwd:${seed.cwd}`
+    const key = `${seed.connectionId ?? 'local'}\0${seed.packageManager}\0${cacheScope}`
+    const targetSeed =
+      targetSeeds.get(key) ??
+      ({
+        packageManager: seed.packageManager,
+        connectionId: seed.connectionId,
+        isRemote: seed.isRemote,
+        repoDisplayNames: new Set<string>(),
+        cwd: seed.cwd,
+        cachePath: seed.cachePath,
+        cliAvailable: false,
+        lockfiles: new Set<string>(),
+        detectedWorktrees: new Map<string, Set<string>>(),
+        worktreePaths: new Set<string>()
+      } satisfies PackageManagerTargetSeed)
+    targetSeed.cliAvailable ||= seed.cliAvailable
+    for (const repoDisplayName of seed.repoDisplayNames) {
+      targetSeed.repoDisplayNames.add(repoDisplayName)
+    }
+    for (const lockfile of seed.lockfiles) {
+      targetSeed.lockfiles.add(lockfile)
+    }
+    for (const worktreePath of seed.worktreePaths) {
+      targetSeed.worktreePaths.add(worktreePath)
+    }
+    for (const [worktreeId, lockfiles] of seed.detectedWorktrees) {
+      const targetLockfiles = targetSeed.detectedWorktrees.get(worktreeId) ?? new Set<string>()
+      for (const lockfile of lockfiles) {
+        targetLockfiles.add(lockfile)
+      }
+      targetSeed.detectedWorktrees.set(worktreeId, targetLockfiles)
+    }
+    targetSeeds.set(key, targetSeed)
+  }
+
+  const targets = [...targetSeeds.values()].map((seed) => ({
+    id: createPackageManagerCacheTargetId(seed.connectionId, seed.packageManager, seed.cwd),
+    packageManager: seed.packageManager,
+    connectionId: seed.connectionId,
+    isRemote: seed.isRemote,
+    targetLabel: createTargetLabel(seed),
+    cwd: seed.cwd,
+    cachePath: seed.cachePath,
+    detectedWorktreeCount: seed.worktreePaths.size,
+    detectedWorktrees: toDetectedWorktrees(seed.detectedWorktrees),
+    detectedLockfiles: [...seed.lockfiles].sort((a, b) => a.localeCompare(b)),
+    cliAvailable: seed.cliAvailable,
+    unavailableReason: seed.cliAvailable
+      ? null
+      : `${getPackageManagerLabel(seed.packageManager)} was detected by lockfile, but its CLI was not available on this target.`,
+    cleanupActions: getPackageManagerCacheCleanupActions(seed.packageManager)
+  }))
+
+  return targets.sort(
+    (a, b) =>
+      Number(a.isRemote) - Number(b.isRemote) ||
+      a.targetLabel.localeCompare(b.targetLabel) ||
+      a.packageManager.localeCompare(b.packageManager)
+  )
+}
+
+function toDetectedWorktrees(
+  detectedWorktrees: Map<string, Set<string>>
+): WorkspacePackageManagerCacheTargetWorktree[] {
+  return [...detectedWorktrees.entries()]
+    .map(([worktreeId, lockfiles]) => ({
+      worktreeId,
+      lockfiles: [...lockfiles].sort((a, b) => a.localeCompare(b))
+    }))
+    .sort((a, b) => a.worktreeId.localeCompare(b.worktreeId))
+}
+
+export async function runPackageManagerCacheCleanup(
+  request: WorkspacePackageManagerCacheCleanupRequest
+): Promise<WorkspacePackageManagerCacheCleanupResult> {
+  const validated = validateCleanupRequest(request)
+  if (!validated.ok) {
+    return { ok: false, error: validated.error }
+  }
+  const { value } = validated
+  const action = getPackageManagerCacheCleanupAction(value.packageManager, value.actionId)
+  if (!action) {
+    return { ok: false, error: 'Unknown package-manager cache cleanup action.' }
+  }
+  if (
+    value.targetId !==
+    createPackageManagerCacheTargetId(value.connectionId, value.packageManager, value.cwd)
+  ) {
+    return { ok: false, error: 'Package-manager cache cleanup target did not match the request.' }
+  }
+  try {
+    const before = await measurePackageManagerCache({
+      packageManager: value.packageManager,
+      connectionId: value.connectionId,
+      cwd: value.cwd
+    })
+    const result = await execPackageManagerCommand({
+      connectionId: value.connectionId,
+      cwd: value.cwd,
+      binary: action.binary,
+      commandArgs: action.args,
+      timeoutMs: CLEANUP_TIMEOUT_MS
+    })
+    const after = before
+      ? await measurePackageManagerCache({
+          packageManager: value.packageManager,
+          connectionId: value.connectionId,
+          cwd: value.cwd,
+          cachePath: before.path
+        })
+      : null
+    const cacheSizeBeforeBytes = before?.sizeBytes ?? null
+    const cacheSizeAfterBytes = after?.sizeBytes ?? null
+    const reclaimedBytes =
+      cacheSizeBeforeBytes !== null && cacheSizeAfterBytes !== null
+        ? Math.max(0, cacheSizeBeforeBytes - cacheSizeAfterBytes)
+        : null
+    return {
+      ok: true,
+      action,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      cachePath: before?.path ?? null,
+      cacheSizeBeforeBytes,
+      cacheSizeAfterBytes,
+      reclaimedBytes
+    }
+  } catch (error) {
+    return { ok: false, error: toErrorMessage(error) }
+  }
+}

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -318,7 +318,7 @@ describe('analyzeWorkspaceSpace', () => {
       omittedTopLevelItemCount: 0,
       omittedTopLevelSizeBytes: 0
     })
-    const readDir = vi.fn()
+    const readDir = vi.fn().mockResolvedValue([])
     const stat = vi.fn()
     getSshFilesystemProviderMock.mockReturnValue({ scanWorkspaceSpace, readDir, stat })
 
@@ -328,7 +328,7 @@ describe('analyzeWorkspaceSpace', () => {
       '/remote/feature',
       expect.objectContaining({ signal: undefined })
     )
-    expect(readDir).not.toHaveBeenCalled()
+    expect(readDir).toHaveBeenCalledWith('/remote/feature')
     expect(stat).not.toHaveBeenCalled()
     expect(result.worktrees[0]?.sizeBytes).toBe(4096)
   })

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -20,6 +20,12 @@ import type {
   WorkspaceSpaceWorktree
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
+import {
+  buildPackageManagerCacheTargets,
+  detectPackageManagersForDirectoryEntries,
+  detectRemotePackageManagers,
+  type WorkspacePackageManagerDetection
+} from './workspace-package-manager-cache-cleanup'
 import type { IFilesystemProvider } from './providers/types'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
@@ -51,6 +57,12 @@ type WorktreeListResult =
 type RepoScanResult = {
   summary: WorkspaceSpaceRepoSummary
   worktrees: WorkspaceSpaceWorktree[]
+  packageManagerDetections: WorkspacePackageManagerDetection[]
+}
+
+type WorktreeScanResult = {
+  row: WorkspaceSpaceWorktree
+  packageManagerDetections: WorkspacePackageManagerDetection[]
 }
 
 type WorkspaceSpaceAnalyzeOptions = {
@@ -710,6 +722,54 @@ async function scanRemoteWorktree(
   }
 }
 
+async function detectLocalPackageManagers(
+  repo: Repo,
+  worktree: Worktree,
+  row: WorkspaceSpaceWorktree
+): Promise<WorkspacePackageManagerDetection[]> {
+  try {
+    const entries = await readdir(worktree.path, { withFileTypes: true })
+    return detectPackageManagersForDirectoryEntries({
+      entryNames: entries.map((entry) => entry.name),
+      connectionId: null,
+      isRemote: false,
+      repoDisplayName: repo.displayName,
+      worktreeId: row.worktreeId,
+      worktreePath: worktree.path
+    })
+  } catch {
+    return []
+  }
+}
+
+async function detectWorktreePackageManagers(
+  repo: Repo,
+  worktree: Worktree,
+  row: WorkspaceSpaceWorktree,
+  remoteProvider: IFilesystemProvider | undefined
+): Promise<WorkspacePackageManagerDetection[]> {
+  if (row.status !== 'ok') {
+    return []
+  }
+  if (repo.connectionId) {
+    if (!remoteProvider) {
+      return []
+    }
+    try {
+      return await detectRemotePackageManagers({
+        provider: remoteProvider,
+        connectionId: repo.connectionId,
+        repoDisplayName: repo.displayName,
+        worktreeId: row.worktreeId,
+        worktreePath: worktree.path
+      })
+    } catch {
+      return []
+    }
+  }
+  return detectLocalPackageManagers(repo, worktree, row)
+}
+
 async function listWorktreesForSpaceScan(
   repo: Repo,
   signal?: AbortSignal
@@ -782,6 +842,7 @@ async function scanRepo(
       options.onProgress
     )
     return {
+      packageManagerDetections: [],
       worktrees: [],
       summary: {
         repoId: repo.id,
@@ -807,7 +868,7 @@ async function scanRepo(
     options.onProgress
   )
   const remoteProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : undefined
-  const rows = await mapLimit(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
+  const scanResults = await mapLimit(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
     throwIfAborted(options.signal)
     reportProgress(
       progress,
@@ -833,8 +894,15 @@ async function scanRepo(
       { scannedWorktreeCount: progress.scannedWorktreeCount + 1 },
       options.onProgress
     )
-    return row
+    const packageManagerDetections = await detectWorktreePackageManagers(
+      repo,
+      worktree,
+      row,
+      remoteProvider
+    )
+    return { row, packageManagerDetections } satisfies WorktreeScanResult
   })
+  const rows = scanResults.map((result) => result.row)
   reportProgress(
     progress,
     {
@@ -847,6 +915,7 @@ async function scanRepo(
 
   return {
     worktrees: rows,
+    packageManagerDetections: scanResults.flatMap((result) => result.packageManagerDetections),
     summary: {
       repoId: repo.id,
       displayName: repo.displayName,
@@ -890,6 +959,17 @@ export async function analyzeWorkspaceSpace(
   const worktrees = repoResults
     .flatMap((result) => result.worktrees)
     .sort((a, b) => b.sizeBytes - a.sizeBytes || a.displayName.localeCompare(b.displayName))
+  let packageManagerCaches: WorkspaceSpaceAnalysis['packageManagerCaches']
+  try {
+    packageManagerCaches = await buildPackageManagerCacheTargets(
+      repoResults.flatMap((result) => result.packageManagerDetections),
+      { signal: options.signal }
+    )
+  } catch (error) {
+    throwIfAborted(options.signal)
+    throw error
+  }
+  throwIfAborted(options.signal)
 
   return {
     scannedAt,
@@ -900,6 +980,7 @@ export async function analyzeWorkspaceSpace(
     unavailableWorktreeCount:
       worktrees.filter((row) => row.status !== 'ok').length +
       repos.filter((repo) => repo.error !== null).length,
+    packageManagerCaches,
     repos,
     worktrees
   }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -225,6 +225,8 @@ import type {
   SpeechTranscriptEvent
 } from '../shared/speech-types'
 import type {
+  WorkspacePackageManagerCacheCleanupRequest,
+  WorkspacePackageManagerCacheCleanupResult,
   WorkspaceSpaceAnalyzeResult,
   WorkspaceSpaceScanProgress
 } from '../shared/workspace-space-types'
@@ -680,6 +682,9 @@ export type PreloadApi = {
   workspaceSpace: {
     analyze: () => Promise<WorkspaceSpaceAnalyzeResult>
     cancel: () => Promise<boolean>
+    cleanupPackageManagerCache: (
+      request: WorkspacePackageManagerCacheCleanupRequest
+    ) => Promise<WorkspacePackageManagerCacheCleanupResult>
     onProgress: (callback: (progress: WorkspaceSpaceScanProgress) => void) => () => void
   }
   workspacePorts: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,6 +56,8 @@ import type {
 } from '../shared/mobile-markdown-document'
 import type { RateLimitState } from '../shared/rate-limit-types'
 import type {
+  WorkspacePackageManagerCacheCleanupRequest,
+  WorkspacePackageManagerCacheCleanupResult,
   WorkspaceSpaceAnalyzeResult,
   WorkspaceSpaceScanProgress
 } from '../shared/workspace-space-types'
@@ -561,6 +563,10 @@ const api = {
     analyze: (): Promise<WorkspaceSpaceAnalyzeResult> =>
       ipcRenderer.invoke('workspaceSpace:analyze'),
     cancel: (): Promise<boolean> => ipcRenderer.invoke('workspaceSpace:cancel'),
+    cleanupPackageManagerCache: (
+      request: WorkspacePackageManagerCacheCleanupRequest
+    ): Promise<WorkspacePackageManagerCacheCleanupResult> =>
+      ipcRenderer.invoke('workspaceSpace:cleanupPackageManagerCache', request),
     onProgress: (callback: (progress: WorkspaceSpaceScanProgress) => void): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,

--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -1,32 +1,56 @@
 /* eslint-disable max-lines -- Why: the analyzer's private treemap, selection,
    breakdown, and table pieces share one scan state and should evolve as one resource-manager surface. */
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertTriangle,
   ArrowDown,
   ArrowUp,
+  Bot,
   Check,
   Circle,
+  ExternalLink,
+  FileWarning,
   GitBranch,
+  GitPullRequest,
   HardDrive,
   Loader2,
   Minus,
+  Package,
   RefreshCw,
   Search,
   Server,
+  ShieldCheck,
+  Terminal,
   Trash2,
   ZoomIn,
   ZoomOut,
   X
 } from 'lucide-react'
 import type {
+  AgentStatusEntry,
+  MigrationUnsupportedPtyEntry
+} from '../../../../shared/agent-status-types'
+import type { GitStatusResult, TerminalTab, Worktree } from '../../../../shared/types'
+import type {
+  WorkspacePackageManagerCacheCleanupAction,
+  WorkspacePackageManagerCacheCleanupResult,
+  WorkspacePackageManagerCacheTarget,
   WorkspaceSpaceItem,
   WorkspaceSpaceWorktree
 } from '../../../../shared/workspace-space-types'
+import {
+  getPackageManagerCacheSafetyCopy,
+  getPackageManagerLabel
+} from '../../../../shared/package-manager-cache-cleanup'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '../../store'
+import { getWorktreeMapFromState } from '../../store/selectors'
+import { getHostedReviewCacheKey } from '../../store/slices/hosted-review'
+import { refreshGitStatusForWorktree } from '../right-sidebar/git-status-refresh'
 import { runWorktreeBatchDelete } from '../sidebar/delete-worktree-flow'
+import { branchDisplayName } from '../sidebar/WorktreeCardHelpers'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import {
@@ -35,6 +59,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger
 } from '../ui/context-menu'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '../ui/hover-card'
 import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import {
@@ -49,8 +74,11 @@ import {
 import { buildTreemapLayout, type TreemapRect } from './workspace-space-layout'
 import {
   filterWorkspaceSpaceRows,
+  countWorkspaceSpaceActiveAgents,
   getSelectedDeletableWorkspaceIds,
   getVisibleDeletableWorkspaceIds,
+  getWorkspaceSpaceGitStatusRefreshCandidates,
+  isWorkspaceSpaceRowReadyToDelete,
   sortWorkspaceSpaceRows,
   type WorkspaceSpaceSortDirection,
   type WorkspaceSpaceSortKey
@@ -63,6 +91,7 @@ const TREEMAP_FILLS = [
   'color-mix(in srgb, var(--primary) 24%, var(--card))',
   'color-mix(in srgb, var(--chart-1) 38%, var(--card))'
 ]
+const GIT_STATUS_REFRESH_CONCURRENCY = 6
 
 type WorkspaceSpaceDeleteState = {
   isDeleting: boolean
@@ -70,11 +99,210 @@ type WorkspaceSpaceDeleteState = {
   canForceDelete: boolean
 }
 
+type PackageManagerCacheCleanupState = {
+  runningActionId: string | null
+  error: string | null
+  lastOutput: string | null
+}
+
+type WorkspaceGitRefreshState = {
+  isRefreshing: boolean
+  error: string | null
+}
+
+type PackageManagerCacheCleanupSuccess = Extract<
+  WorkspacePackageManagerCacheCleanupResult,
+  { ok: true }
+>
+
+type WorkspaceDecisionDetails = {
+  isActive: boolean
+  canOpenWorkspace: boolean
+  terminalTabCount: number
+  liveTerminalCount: number
+  activeAgentCount: number
+  completedAgentCount: number
+  openEditorFileCount: number
+  dirtyEditorBufferCount: number
+  browserTabCount: number
+  changedFileCount: number | null
+  branchStatus: string | null
+  reviewLabel: string | null
+  issueLabel: string | null
+  linearIssueLabel: string | null
+}
+
+type WorkspaceDecisionInputs = {
+  worktreeMap: Map<string, Worktree>
+  tabsByWorktree: Record<string, TerminalTab[]>
+  ptyIdsByTabId: Record<string, string[]>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  migrationUnsupportedByPtyId: Record<string, MigrationUnsupportedPtyEntry>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  retainedAgentsByPaneKey: Record<string, { worktreeId: string; entry: AgentStatusEntry }>
+  openFiles: { id: string; worktreeId: string; isDirty: boolean }[]
+  editorDrafts: Record<string, string>
+  browserTabsByWorktree: Record<string, unknown[]>
+  gitStatusByWorktree: Record<string, unknown[]>
+  remoteStatusesByWorktree: Record<string, { hasUpstream: boolean; ahead: number; behind: number }>
+  hostedReviewCache: Record<
+    string,
+    { data?: { number: number; state: string; status: string; title: string } | null }
+  >
+  issueCache: Record<string, { data?: { number: number; title: string; state: string } | null }>
+  linearIssueCache: Record<
+    string,
+    { data?: { identifier: string; title: string; state?: { name: string } } | null }
+  >
+  settings: Parameters<typeof getHostedReviewCacheKey>[2]
+  activeWorktreeId: string | null
+  now: number
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`
+}
+
+function formatReviewState(state: string): string {
+  return state.charAt(0).toUpperCase() + state.slice(1)
+}
+
+function countLiveTerminals(
+  tabs: readonly TerminalTab[],
+  ptyIdsByTabId: Record<string, string[]>
+): number {
+  return tabs.filter((tab) => (ptyIdsByTabId[tab.id]?.length ?? 0) > 0).length
+}
+
+function getBranchStatus(
+  status: { hasUpstream: boolean; ahead: number; behind: number } | undefined
+): string | null {
+  if (!status?.hasUpstream) {
+    return null
+  }
+  if (status.ahead === 0 && status.behind === 0) {
+    return 'Synced with upstream'
+  }
+  const parts: string[] = []
+  if (status.ahead > 0) {
+    parts.push(`${status.ahead} ahead`)
+  }
+  if (status.behind > 0) {
+    parts.push(`${status.behind} behind`)
+  }
+  return parts.join(', ')
+}
+
+function getWorkspaceDecisionDetails(
+  worktree: WorkspaceSpaceWorktree,
+  inputs: WorkspaceDecisionInputs
+): WorkspaceDecisionDetails {
+  const workspaceRecord = inputs.worktreeMap.get(worktree.worktreeId)
+  const tabs = inputs.tabsByWorktree[worktree.worktreeId] ?? []
+  const openFiles = inputs.openFiles.filter((file) => file.worktreeId === worktree.worktreeId)
+  const dirtyEditorBufferCount = openFiles.filter(
+    (file) => file.isDirty || inputs.editorDrafts[file.id] !== undefined
+  ).length
+  const gitEntries = inputs.gitStatusByWorktree[worktree.worktreeId]
+  const branch = workspaceRecord
+    ? branchDisplayName(workspaceRecord.branch)
+    : getWorkspaceSpaceBranchLabel(worktree)
+  const reviewCacheKey = getHostedReviewCacheKey(
+    worktree.repoPath,
+    branch,
+    inputs.settings,
+    worktree.repoId
+  )
+  const hostedReview = inputs.hostedReviewCache[reviewCacheKey]?.data
+  const linkedPR = workspaceRecord?.linkedPR ?? null
+  const reviewLabel =
+    hostedReview !== undefined && hostedReview !== null
+      ? `PR #${hostedReview.number} ${formatReviewState(hostedReview.state)}${
+          hostedReview.status && hostedReview.status !== 'none' ? `, ${hostedReview.status}` : ''
+        }`
+      : linkedPR
+        ? `PR #${linkedPR}`
+        : null
+  const linkedIssue = workspaceRecord?.linkedIssue ?? null
+  const issue = linkedIssue ? inputs.issueCache[`${worktree.repoId}::${linkedIssue}`]?.data : null
+  const issueLabel = linkedIssue
+    ? issue
+      ? `#${issue.number} ${issue.state}: ${issue.title}`
+      : `#${linkedIssue}`
+    : null
+  const linkedLinearIssue = workspaceRecord?.linkedLinearIssue ?? null
+  const linearIssue = linkedLinearIssue
+    ? (inputs.linearIssueCache[`selected::${linkedLinearIssue}`]?.data ??
+      inputs.linearIssueCache[linkedLinearIssue]?.data)
+    : null
+  const linearIssueLabel = linkedLinearIssue
+    ? linearIssue
+      ? `${linearIssue.identifier}${
+          linearIssue.state?.name ? ` ${linearIssue.state.name}` : ''
+        }: ${linearIssue.title}`
+      : linkedLinearIssue
+    : null
+
+  return {
+    isActive: inputs.activeWorktreeId === worktree.worktreeId,
+    canOpenWorkspace: workspaceRecord !== undefined,
+    terminalTabCount: tabs.length,
+    liveTerminalCount: countLiveTerminals(tabs, inputs.ptyIdsByTabId),
+    activeAgentCount: countWorkspaceSpaceActiveAgents({
+      worktreeId: worktree.worktreeId,
+      tabs,
+      agentStatusByPaneKey: inputs.agentStatusByPaneKey,
+      migrationUnsupportedByPtyId: inputs.migrationUnsupportedByPtyId,
+      runtimePaneTitlesByTabId: inputs.runtimePaneTitlesByTabId,
+      ptyIdsByTabId: inputs.ptyIdsByTabId,
+      now: inputs.now
+    }),
+    completedAgentCount: Object.values(inputs.retainedAgentsByPaneKey).filter(
+      (entry) => entry.worktreeId === worktree.worktreeId && entry.entry.state === 'done'
+    ).length,
+    openEditorFileCount: openFiles.length,
+    dirtyEditorBufferCount,
+    browserTabCount: inputs.browserTabsByWorktree[worktree.worktreeId]?.length ?? 0,
+    changedFileCount: gitEntries ? gitEntries.length : null,
+    branchStatus: getBranchStatus(inputs.remoteStatusesByWorktree[worktree.worktreeId]),
+    reviewLabel,
+    issueLabel,
+    linearIssueLabel
+  }
+}
+
 function getTreemapFill(rect: TreemapRect, selected: boolean): string {
   if (selected) {
     return 'color-mix(in srgb, var(--ring) 40%, var(--card))'
   }
   return TREEMAP_FILLS[rect.index % TREEMAP_FILLS.length]
+}
+
+function getPackageManagerCleanupSuccessCopy(result: PackageManagerCacheCleanupSuccess): {
+  output: string
+  toastDescription: string
+} {
+  const commandOutput = [result.stdout, result.stderr].filter((part) => part.trim()).join('\n')
+  if (result.reclaimedBytes === null) {
+    return {
+      output: commandOutput || `${result.action.command} completed.`,
+      toastDescription: result.action.command
+    }
+  }
+
+  const summary =
+    result.reclaimedBytes > 0
+      ? `Freed ${formatBytes(result.reclaimedBytes)}`
+      : 'Cleanup completed; measured cache size was unchanged'
+  const measured =
+    result.cacheSizeBeforeBytes !== null && result.cacheSizeAfterBytes !== null
+      ? `${summary} (${formatBytes(result.cacheSizeBeforeBytes)} -> ${formatBytes(result.cacheSizeAfterBytes)}).`
+      : `${summary}.`
+
+  return {
+    output: commandOutput ? `${measured}\n${commandOutput}` : measured,
+    toastDescription: measured
+  }
 }
 
 function Metric({
@@ -194,9 +422,11 @@ function SortIndicator({
 
 function StatusBadge({
   worktree,
+  decisionDetails,
   deleteState
 }: {
   worktree: WorkspaceSpaceWorktree
+  decisionDetails?: WorkspaceDecisionDetails
   deleteState?: WorkspaceSpaceDeleteState
 }): React.JSX.Element {
   if (deleteState?.isDeleting) {
@@ -222,9 +452,246 @@ function StatusBadge({
     )
   }
   if (worktree.isMainWorktree) {
-    return <Badge variant="outline">Main</Badge>
+    return <Badge variant="outline">Keep: main</Badge>
   }
-  return <Badge variant="secondary">Deletable</Badge>
+  if (decisionDetails?.isActive) {
+    return <Badge variant="outline">Keep: active</Badge>
+  }
+  if ((decisionDetails?.changedFileCount ?? 0) > 0) {
+    return <Badge variant="outline">Keep: changed files</Badge>
+  }
+  if (decisionDetails?.changedFileCount === null) {
+    return <Badge variant="outline">Keep: git not checked</Badge>
+  }
+  if ((decisionDetails?.dirtyEditorBufferCount ?? 0) > 0) {
+    return <Badge variant="outline">Keep: unsaved edits</Badge>
+  }
+  if (
+    (decisionDetails?.activeAgentCount ?? 0) > 0 ||
+    (decisionDetails?.liveTerminalCount ?? 0) > 0 ||
+    (decisionDetails?.browserTabCount ?? 0) > 0
+  ) {
+    return <Badge variant="outline">Keep: in use</Badge>
+  }
+  if (
+    decisionDetails?.reviewLabel ||
+    decisionDetails?.issueLabel ||
+    decisionDetails?.linearIssueLabel
+  ) {
+    return <Badge variant="outline">Keep: linked</Badge>
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+    >
+      Can delete
+    </Badge>
+  )
+}
+
+function DecisionLine({
+  icon,
+  label,
+  value,
+  tone = 'default'
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  tone?: 'default' | 'warning'
+}): React.JSX.Element {
+  return (
+    <div className="flex min-w-0 items-start gap-2">
+      <span
+        className={cn(
+          'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/30 text-muted-foreground [&>svg]:size-3',
+          tone === 'warning' && 'border-destructive/25 bg-destructive/8 text-destructive'
+        )}
+      >
+        {icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-medium uppercase tracking-[0.05em] text-muted-foreground">
+          {label}
+        </div>
+        <div className="mt-0.5 truncate text-xs" title={value}>
+          {value}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function getAgentDecisionLabel(details: WorkspaceDecisionDetails): string {
+  if (details.activeAgentCount > 0 && details.completedAgentCount > 0) {
+    return `${pluralize(details.activeAgentCount, 'active agent')}, ${pluralize(
+      details.completedAgentCount,
+      'completed agent'
+    )}`
+  }
+  if (details.activeAgentCount > 0) {
+    return pluralize(details.activeAgentCount, 'active agent')
+  }
+  if (details.completedAgentCount > 0) {
+    return `${pluralize(details.completedAgentCount, 'completed agent')} retained`
+  }
+  return 'No tracked agents running'
+}
+
+function getTerminalDecisionLabel(details: WorkspaceDecisionDetails): string {
+  if (details.terminalTabCount === 0) {
+    return 'No terminal tabs'
+  }
+  return `${details.liveTerminalCount} live of ${pluralize(details.terminalTabCount, 'terminal tab')}`
+}
+
+function getGitDecisionLabel(
+  details: WorkspaceDecisionDetails,
+  gitRefreshState?: WorkspaceGitRefreshState
+): string {
+  if (details.changedFileCount === null) {
+    if (gitRefreshState?.error) {
+      return `Git status unavailable: ${gitRefreshState.error}`
+    }
+    return 'Git status has not loaded yet'
+  }
+  if (details.changedFileCount === 0) {
+    return 'No uncommitted files'
+  }
+  return pluralize(details.changedFileCount, 'changed file')
+}
+
+function getEditorDecisionLabel(details: WorkspaceDecisionDetails): string {
+  if (details.openEditorFileCount === 0) {
+    return 'No editor files open'
+  }
+  if (details.dirtyEditorBufferCount === 0) {
+    return `${pluralize(details.openEditorFileCount, 'editor file')} open`
+  }
+  return `${pluralize(details.dirtyEditorBufferCount, 'dirty editor buffer')} of ${pluralize(
+    details.openEditorFileCount,
+    'open file'
+  )}`
+}
+
+function getDeleteDecisionLabel(
+  worktree: WorkspaceSpaceWorktree,
+  details: WorkspaceDecisionDetails
+): string {
+  if (details.isActive) {
+    return 'This is the active workspace'
+  }
+  if (worktree.status !== 'ok') {
+    return worktree.error ?? getWorkspaceSpaceStatusLabel(worktree.status)
+  }
+  if (worktree.isMainWorktree) {
+    return 'Main worktree is protected'
+  }
+  if (!worktree.canDelete) {
+    return 'Workspace is protected'
+  }
+  return 'Can be deleted after review'
+}
+
+function WorkspaceDecisionHoverCard({
+  worktree,
+  details,
+  gitRefreshState,
+  onOpenWorkspace
+}: {
+  worktree: WorkspaceSpaceWorktree
+  details: WorkspaceDecisionDetails
+  gitRefreshState?: WorkspaceGitRefreshState
+  onOpenWorkspace: () => void
+}): React.JSX.Element {
+  const deleteDecision = getDeleteDecisionLabel(worktree, details)
+  const issueLabel =
+    [details.issueLabel, details.linearIssueLabel].filter(Boolean).join(' · ') || 'No linked issue'
+  return (
+    <HoverCardContent
+      align="end"
+      side="bottom"
+      sideOffset={8}
+      collisionPadding={12}
+      className="max-h-[min(34rem,calc(100vh-1.5rem))] w-[min(24rem,calc(100vw-1.5rem))] overflow-y-auto p-0 scrollbar-sleek"
+    >
+      <div className="border-b border-border/60 px-4 py-3">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{worktree.displayName}</div>
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {worktree.repoDisplayName} · {formatBytes(worktree.sizeBytes)}
+            </div>
+          </div>
+          <StatusBadge worktree={worktree} decisionDetails={details} />
+        </div>
+      </div>
+
+      <div className="space-y-3 px-4 py-3">
+        <DecisionLine
+          icon={<Trash2 />}
+          label="Delete decision"
+          value={deleteDecision}
+          tone={worktree.canDelete && worktree.status === 'ok' ? 'default' : 'warning'}
+        />
+        <DecisionLine icon={<Bot />} label="Agents" value={getAgentDecisionLabel(details)} />
+        <DecisionLine
+          icon={<Terminal />}
+          label="Terminals"
+          value={getTerminalDecisionLabel(details)}
+        />
+        <DecisionLine
+          icon={<FileWarning />}
+          label="Git changes"
+          value={getGitDecisionLabel(details, gitRefreshState)}
+          tone={
+            (details.changedFileCount ?? 0) > 0 || gitRefreshState?.error ? 'warning' : 'default'
+          }
+        />
+        <DecisionLine
+          icon={<FileWarning />}
+          label="Editor buffers"
+          value={getEditorDecisionLabel(details)}
+          tone={details.dirtyEditorBufferCount > 0 ? 'warning' : 'default'}
+        />
+        <DecisionLine
+          icon={<GitBranch />}
+          label="Branch"
+          value={details.branchStatus ?? getWorkspaceSpaceBranchLabel(worktree)}
+        />
+        <DecisionLine
+          icon={<GitPullRequest />}
+          label="Review"
+          value={details.reviewLabel ?? 'No linked PR'}
+        />
+        <DecisionLine icon={<ExternalLink />} label="Issue" value={issueLabel} />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-border/60 px-4 py-3">
+        <div className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+          {details.browserTabCount > 0
+            ? `${pluralize(details.browserTabCount, 'browser tab')} open`
+            : worktree.path}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onOpenWorkspace()
+          }}
+          disabled={!details.canOpenWorkspace}
+          className="shrink-0 gap-1.5"
+        >
+          <ExternalLink className="size-3.5" />
+          Go to workspace
+        </Button>
+      </div>
+    </HoverCardContent>
+  )
 }
 
 function WorkspaceTreemap({
@@ -474,14 +941,157 @@ function BreakdownRow({
   )
 }
 
+function PackageManagerCacheActions({
+  target,
+  state,
+  onRun
+}: {
+  target: WorkspacePackageManagerCacheTarget
+  state?: PackageManagerCacheCleanupState
+  onRun: (
+    target: WorkspacePackageManagerCacheTarget,
+    action: WorkspacePackageManagerCacheCleanupAction
+  ) => void
+}): React.JSX.Element {
+  const runningActionId = state?.runningActionId ?? null
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {target.cleanupActions.map((action) => {
+        const isRunning = runningActionId === action.id
+        return (
+          <Button
+            key={action.id}
+            variant={action.safety === 'aggressive' ? 'destructive' : 'outline'}
+            size="sm"
+            onClick={() => onRun(target, action)}
+            disabled={!target.cliAvailable || runningActionId !== null}
+            className="gap-1.5"
+            title={action.description}
+          >
+            {isRunning ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : action.safety === 'safe' ? (
+              <ShieldCheck className="size-3.5" />
+            ) : (
+              <Trash2 className="size-3.5" />
+            )}
+            {isRunning ? 'Running' : action.label}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}
+
+function PackageManagerCacheSection({
+  targets,
+  stateByTargetId,
+  onRun
+}: {
+  targets: WorkspacePackageManagerCacheTarget[]
+  stateByTargetId: Record<string, PackageManagerCacheCleanupState>
+  onRun: (
+    target: WorkspacePackageManagerCacheTarget,
+    action: WorkspacePackageManagerCacheCleanupAction
+  ) => void
+}): React.JSX.Element | null {
+  if (targets.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="rounded-lg border border-border/70 bg-background/30">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Package className="size-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <div className="text-sm font-semibold">Package Manager Caches</div>
+            <div className="text-xs text-muted-foreground">
+              Detected from lockfiles. Cleanup runs only when you choose an action.
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="divide-y divide-border/50">
+        {targets.map((target) => {
+          const state = stateByTargetId[target.id]
+          const lastOutput = state?.lastOutput?.trim() ?? ''
+          return (
+            <div key={target.id} className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto]">
+              <div className="min-w-0 space-y-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <span className="font-medium">
+                    {getPackageManagerLabel(target.packageManager)}
+                  </span>
+                  <Badge variant={target.cliAvailable ? 'secondary' : 'outline'}>
+                    {target.cliAvailable ? 'CLI found' : 'CLI missing'}
+                  </Badge>
+                  {target.isRemote ? (
+                    <Badge variant="outline" className="gap-1">
+                      <Server className="size-3" />
+                      SSH
+                    </Badge>
+                  ) : null}
+                </div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {target.targetLabel} · {target.detectedWorktreeCount}{' '}
+                  {target.detectedWorktreeCount === 1 ? 'workspace' : 'workspaces'} ·{' '}
+                  {target.detectedLockfiles.join(', ')}
+                </div>
+                <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <Terminal className="size-3 shrink-0" />
+                  <span className="truncate font-mono">
+                    {target.cleanupActions.map((action) => action.command).join(' · ')}
+                  </span>
+                </div>
+                {target.unavailableReason ? (
+                  <div className="text-xs text-muted-foreground">{target.unavailableReason}</div>
+                ) : null}
+                {state?.error ? (
+                  <div className="flex items-start gap-2 rounded-md border border-destructive/35 bg-destructive/8 px-2 py-1.5 text-xs text-destructive">
+                    <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                    <span className="min-w-0 break-words">{state.error}</span>
+                  </div>
+                ) : lastOutput ? (
+                  <div className="truncate rounded-md border border-border/60 bg-muted/20 px-2 py-1.5 font-mono text-[11px] text-muted-foreground">
+                    {lastOutput}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex min-w-0 flex-col items-start gap-2 md:items-end">
+                <div className="flex flex-wrap justify-start gap-1 md:justify-end">
+                  {target.cleanupActions.map((action) => (
+                    <Badge
+                      key={action.id}
+                      variant={action.safety === 'safe' ? 'secondary' : 'outline'}
+                    >
+                      {getPackageManagerCacheSafetyCopy(action.safety)}
+                    </Badge>
+                  ))}
+                </div>
+                <PackageManagerCacheActions target={target} state={state} onRun={onRun} />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 function WorkspaceRow({
   worktree,
   maxSize,
   selected,
   inspected,
+  decisionDetails,
+  gitRefreshState,
   deleteState,
   onToggleSelected,
   onInspect,
+  onOpenWorkspace,
   onDelete,
   onForceDelete
 }: {
@@ -489,16 +1099,19 @@ function WorkspaceRow({
   maxSize: number
   selected: boolean
   inspected: boolean
+  decisionDetails: WorkspaceDecisionDetails
+  gitRefreshState?: WorkspaceGitRefreshState
   deleteState?: WorkspaceSpaceDeleteState
   onToggleSelected: () => void
   onInspect: () => void
+  onOpenWorkspace: () => void
   onDelete: () => void
   onForceDelete: () => void
 }): React.JSX.Element {
   const isDeleting = deleteState?.isDeleting ?? false
   const deleteError = deleteState?.error ?? null
   const canForceDelete = deleteState?.canForceDelete ?? false
-  const canDelete = worktree.canDelete && worktree.status === 'ok' && !isDeleting
+  const canDelete = isWorkspaceSpaceRowReadyToDelete(worktree, decisionDetails) && !isDeleting
   const handleForceDelete = (event: React.MouseEvent<HTMLButtonElement>): void => {
     event.preventDefault()
     event.stopPropagation()
@@ -518,7 +1131,7 @@ function WorkspaceRow({
         onInspect()
       }}
       className={cn(
-        'grid w-full cursor-pointer grid-cols-[1.75rem_minmax(0,1.35fr)_minmax(9rem,0.65fr)_8rem_6rem] items-center gap-3 border-b border-border/45 px-3 py-2.5 text-left text-sm transition-colors last:border-b-0 hover:bg-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'grid w-full cursor-pointer grid-cols-[1.75rem_minmax(0,1.25fr)_minmax(9rem,0.55fr)_8rem_9.5rem] items-center gap-3 border-b border-border/45 px-3 py-2.5 text-left text-sm transition-colors last:border-b-0 hover:bg-accent/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         inspected && 'bg-accent/55',
         isDeleting && 'cursor-wait opacity-50 grayscale hover:bg-transparent'
       )}
@@ -582,7 +1195,27 @@ function WorkspaceRow({
       </div>
 
       <div className="flex justify-end">
-        <StatusBadge worktree={worktree} deleteState={deleteState} />
+        <HoverCard openDelay={250} closeDelay={120}>
+          <HoverCardTrigger asChild>
+            <span
+              className="inline-flex"
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+            >
+              <StatusBadge
+                worktree={worktree}
+                decisionDetails={decisionDetails}
+                deleteState={deleteState}
+              />
+            </span>
+          </HoverCardTrigger>
+          <WorkspaceDecisionHoverCard
+            worktree={worktree}
+            details={decisionDetails}
+            gitRefreshState={gitRefreshState}
+            onOpenWorkspace={onOpenWorkspace}
+          />
+        </HoverCard>
       </div>
     </div>
   )
@@ -614,6 +1247,28 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
   const removeWorkspaceSpaceWorktrees = useAppStore((state) => state.removeWorkspaceSpaceWorktrees)
   const removeWorktree = useAppStore((state) => state.removeWorktree)
   const deleteStateByWorktreeId = useAppStore((state) => state.deleteStateByWorktreeId)
+  const worktreeMap = useAppStore((state) => getWorktreeMapFromState(state))
+  const tabsByWorktree = useAppStore((state) => state.tabsByWorktree)
+  const ptyIdsByTabId = useAppStore((state) => state.ptyIdsByTabId)
+  const agentStatusByPaneKey = useAppStore((state) => state.agentStatusByPaneKey)
+  const migrationUnsupportedByPtyId = useAppStore((state) => state.migrationUnsupportedByPtyId)
+  const runtimePaneTitlesByTabId = useAppStore((state) => state.runtimePaneTitlesByTabId)
+  const agentStatusEpoch = useAppStore((state) => state.agentStatusEpoch)
+  const retainedAgentsByPaneKey = useAppStore((state) => state.retainedAgentsByPaneKey)
+  const openFiles = useAppStore((state) => state.openFiles)
+  const editorDrafts = useAppStore((state) => state.editorDrafts)
+  const browserTabsByWorktree = useAppStore((state) => state.browserTabsByWorktree)
+  const gitStatusByWorktree = useAppStore((state) => state.gitStatusByWorktree)
+  const remoteStatusesByWorktree = useAppStore((state) => state.remoteStatusesByWorktree)
+  const hostedReviewCache = useAppStore((state) => state.hostedReviewCache)
+  const issueCache = useAppStore((state) => state.issueCache)
+  const linearIssueCache = useAppStore((state) => state.linearIssueCache)
+  const settings = useAppStore((state) => state.settings)
+  const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
+  const setGitStatus = useAppStore((state) => state.setGitStatus)
+  const updateWorktreeGitIdentity = useAppStore((state) => state.updateWorktreeGitIdentity)
+  const setUpstreamStatus = useAppStore((state) => state.setUpstreamStatus)
+  const fetchUpstreamStatus = useAppStore((state) => state.fetchUpstreamStatus)
   const [query, setQuery] = useState('')
   const [onlyDeletable, setOnlyDeletable] = useState(false)
   const [sortKey, setSortKey] = useState<WorkspaceSpaceSortKey>('size')
@@ -621,6 +1276,13 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
   const [inspectedWorktreeId, setInspectedWorktreeId] = useState<string | null>(null)
   const [treemapZoomWorktreeId, setTreemapZoomWorktreeId] = useState<string | null>(null)
+  const [cacheCleanupStateByTargetId, setCacheCleanupStateByTargetId] = useState<
+    Record<string, PackageManagerCacheCleanupState>
+  >({})
+  const [gitRefreshStateByWorktreeId, setGitRefreshStateByWorktreeId] = useState<
+    Record<string, WorkspaceGitRefreshState>
+  >({})
+  const inFlightGitStatusRefreshes = useRef<Set<string>>(new Set())
 
   const refresh = useCallback((): void => {
     void refreshWorkspaceSpace().catch(() => {
@@ -633,9 +1295,136 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
   }, [cancelWorkspaceSpaceScan])
 
   const sourceRows = useMemo(() => analysis?.worktrees ?? [], [analysis?.worktrees])
+  const packageManagerCaches = useMemo(
+    () => analysis?.packageManagerCaches ?? [],
+    [analysis?.packageManagerCaches]
+  )
+  const decisionDetailsByWorktreeId = useMemo(() => {
+    // Why: active-agent freshness is time-based. The epoch bumps when fresh
+    // hook entries cross the stale boundary so delete readiness recomputes.
+    void agentStatusEpoch
+    const details = new Map<string, WorkspaceDecisionDetails>()
+    const now = Date.now()
+    for (const worktree of sourceRows) {
+      details.set(
+        worktree.worktreeId,
+        getWorkspaceDecisionDetails(worktree, {
+          worktreeMap,
+          tabsByWorktree,
+          ptyIdsByTabId,
+          agentStatusByPaneKey,
+          migrationUnsupportedByPtyId,
+          runtimePaneTitlesByTabId,
+          retainedAgentsByPaneKey,
+          openFiles,
+          editorDrafts,
+          browserTabsByWorktree,
+          gitStatusByWorktree,
+          remoteStatusesByWorktree,
+          hostedReviewCache,
+          issueCache,
+          linearIssueCache,
+          settings,
+          activeWorktreeId,
+          now
+        })
+      )
+    }
+    return details
+  }, [
+    activeWorktreeId,
+    agentStatusEpoch,
+    agentStatusByPaneKey,
+    browserTabsByWorktree,
+    editorDrafts,
+    gitStatusByWorktree,
+    hostedReviewCache,
+    issueCache,
+    linearIssueCache,
+    openFiles,
+    ptyIdsByTabId,
+    remoteStatusesByWorktree,
+    retainedAgentsByPaneKey,
+    migrationUnsupportedByPtyId,
+    runtimePaneTitlesByTabId,
+    settings,
+    sourceRows,
+    tabsByWorktree,
+    worktreeMap
+  ])
   const isWorktreeDeleting = useCallback(
     (worktreeId: string): boolean => deleteStateByWorktreeId[worktreeId]?.isDeleting ?? false,
     [deleteStateByWorktreeId]
+  )
+  const refreshWorkspaceGitStatus = useCallback(
+    (worktree: WorkspaceSpaceWorktree): Promise<void> => {
+      const currentState = useAppStore.getState()
+      if (currentState.gitStatusByWorktree[worktree.worktreeId] !== undefined) {
+        return Promise.resolve()
+      }
+      if (inFlightGitStatusRefreshes.current.has(worktree.worktreeId)) {
+        return Promise.resolve()
+      }
+      inFlightGitStatusRefreshes.current.add(worktree.worktreeId)
+
+      setGitRefreshStateByWorktreeId((current) => ({
+        ...current,
+        [worktree.worktreeId]: { isRefreshing: true, error: null }
+      }))
+
+      return refreshGitStatusForWorktree({
+        settings,
+        worktreeId: worktree.worktreeId,
+        worktreePath: worktree.path,
+        connectionId:
+          currentState.repos.find((repo) => repo.id === worktree.repoId)?.connectionId ?? undefined,
+        deps: {
+          setGitStatus,
+          updateWorktreeGitIdentity,
+          setUpstreamStatus,
+          fetchUpstreamStatus
+        }
+      })
+        .then(() => {
+          if (useAppStore.getState().gitStatusByWorktree[worktree.worktreeId] === undefined) {
+            setGitStatus(worktree.worktreeId, {
+              conflictOperation: 'unknown',
+              entries: [],
+              ignoredPaths: []
+            } as GitStatusResult)
+          }
+          setGitRefreshStateByWorktreeId((current) => ({
+            ...current,
+            [worktree.worktreeId]: { isRefreshing: false, error: null }
+          }))
+        })
+        .catch((error: unknown) => {
+          setGitRefreshStateByWorktreeId((current) => ({
+            ...current,
+            [worktree.worktreeId]: {
+              isRefreshing: false,
+              error: error instanceof Error ? error.message : String(error)
+            }
+          }))
+        })
+        .finally(() => {
+          inFlightGitStatusRefreshes.current.delete(worktree.worktreeId)
+        })
+    },
+    [fetchUpstreamStatus, setGitStatus, setUpstreamStatus, settings, updateWorktreeGitIdentity]
+  )
+  const isWorktreeUnavailableForDelete = useCallback(
+    (worktreeId: string): boolean => {
+      if (isWorktreeDeleting(worktreeId)) {
+        return true
+      }
+      const worktree = sourceRows.find((row) => row.worktreeId === worktreeId)
+      return (
+        !worktree ||
+        !isWorkspaceSpaceRowReadyToDelete(worktree, decisionDetailsByWorktreeId.get(worktreeId))
+      )
+    },
+    [decisionDetailsByWorktreeId, isWorktreeDeleting, sourceRows]
   )
 
   const rows = useMemo(
@@ -648,6 +1437,32 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
     [onlyDeletable, query, sortDirection, sortKey, sourceRows]
   )
 
+  useEffect(() => {
+    const candidates = getWorkspaceSpaceGitStatusRefreshCandidates(sourceRows)
+    if (candidates.length === 0) {
+      return
+    }
+
+    let cancelled = false
+    let nextIndex = 0
+    const runWorker = async (): Promise<void> => {
+      while (!cancelled) {
+        const worktree = candidates[nextIndex]
+        nextIndex += 1
+        if (!worktree) {
+          return
+        }
+        await refreshWorkspaceGitStatus(worktree)
+      }
+    }
+    const workerCount = Math.min(GIT_STATUS_REFRESH_CONCURRENCY, candidates.length)
+    void Promise.all(Array.from({ length: workerCount }, () => runWorker()))
+
+    return () => {
+      cancelled = true
+    }
+  }, [refreshWorkspaceGitStatus, sourceRows])
+
   const inspectedWorktree =
     rows.find((row) => row.worktreeId === inspectedWorktreeId) ??
     rows.find((row) => row.status === 'ok') ??
@@ -657,16 +1472,16 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
     null
   const maxSize = Math.max(...rows.map((row) => row.sizeBytes), 0)
   const selectedDeletableIds = useMemo(
-    () => getSelectedDeletableWorkspaceIds(rows, selectedIds, isWorktreeDeleting),
-    [isWorktreeDeleting, rows, selectedIds]
+    () => getSelectedDeletableWorkspaceIds(rows, selectedIds, isWorktreeUnavailableForDelete),
+    [isWorktreeUnavailableForDelete, rows, selectedIds]
   )
   const selectedDeletableIdSet = useMemo(
     () => new Set(selectedDeletableIds),
     [selectedDeletableIds]
   )
   const visibleDeletableIds = useMemo(
-    () => getVisibleDeletableWorkspaceIds(rows, isWorktreeDeleting),
-    [isWorktreeDeleting, rows]
+    () => getVisibleDeletableWorkspaceIds(rows, isWorktreeUnavailableForDelete),
+    [isWorktreeUnavailableForDelete, rows]
   )
   const allVisibleSelected =
     visibleDeletableIds.length > 0 && visibleDeletableIds.every((id) => selectedIds.has(id))
@@ -823,6 +1638,69 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
     deleteWorktrees(selectedDeletableIds)
   }
 
+  const runPackageManagerCacheCleanup = useCallback(
+    (
+      target: WorkspacePackageManagerCacheTarget,
+      action: WorkspacePackageManagerCacheCleanupAction
+    ): void => {
+      setCacheCleanupStateByTargetId((current) => ({
+        ...current,
+        [target.id]: {
+          runningActionId: action.id,
+          error: null,
+          lastOutput: current[target.id]?.lastOutput ?? null
+        }
+      }))
+      void window.api.workspaceSpace
+        .cleanupPackageManagerCache({
+          targetId: target.id,
+          actionId: action.id,
+          packageManager: target.packageManager,
+          connectionId: target.connectionId,
+          cwd: target.cwd
+        })
+        .then((result) => {
+          if (!result.ok) {
+            setCacheCleanupStateByTargetId((current) => ({
+              ...current,
+              [target.id]: {
+                runningActionId: null,
+                error: result.error,
+                lastOutput: current[target.id]?.lastOutput ?? null
+              }
+            }))
+            toast.error('Cache cleanup failed', { description: result.error })
+            return
+          }
+          const copy = getPackageManagerCleanupSuccessCopy(result)
+          setCacheCleanupStateByTargetId((current) => ({
+            ...current,
+            [target.id]: {
+              runningActionId: null,
+              error: null,
+              lastOutput: copy.output
+            }
+          }))
+          toast.success('Cache cleanup completed', {
+            description: copy.toastDescription
+          })
+        })
+        .catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error)
+          setCacheCleanupStateByTargetId((current) => ({
+            ...current,
+            [target.id]: {
+              runningActionId: null,
+              error: message,
+              lastOutput: current[target.id]?.lastOutput ?? null
+            }
+          }))
+          toast.error('Cache cleanup failed', { description: message })
+        })
+    },
+    []
+  )
+
   return (
     <div className="space-y-5">
       <div className="grid overflow-hidden rounded-lg border border-border/65 bg-background/35 md:grid-cols-4 md:divide-x md:divide-border/60">
@@ -909,6 +1787,12 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
           ))}
         </div>
       ) : null}
+
+      <PackageManagerCacheSection
+        targets={packageManagerCaches}
+        stateByTargetId={cacheCleanupStateByTargetId}
+        onRun={runPackageManagerCacheCleanup}
+      />
 
       {hasRows || isInitialScan ? (
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.6fr)]">
@@ -1013,7 +1897,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
       {hasRows || isInitialScan ? (
         <div className="overflow-x-auto rounded-lg border border-border/70 bg-background/30">
           <div className="min-w-[46rem]">
-            <div className="grid grid-cols-[1.75rem_minmax(0,1.35fr)_minmax(9rem,0.65fr)_8rem_6rem] gap-3 border-b border-border/60 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            <div className="grid grid-cols-[1.75rem_minmax(0,1.25fr)_minmax(9rem,0.55fr)_8rem_9.5rem] gap-3 border-b border-border/60 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
               <div className="flex items-center">
                 <CheckButton
                   checked={visibleSelectionState}
@@ -1071,9 +1955,34 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
                     maxSize={maxSize}
                     selected={selectedIds.has(worktree.worktreeId)}
                     inspected={inspectedWorktree?.worktreeId === worktree.worktreeId}
+                    decisionDetails={
+                      decisionDetailsByWorktreeId.get(worktree.worktreeId) ??
+                      getWorkspaceDecisionDetails(worktree, {
+                        worktreeMap,
+                        tabsByWorktree,
+                        ptyIdsByTabId,
+                        agentStatusByPaneKey,
+                        migrationUnsupportedByPtyId,
+                        runtimePaneTitlesByTabId,
+                        retainedAgentsByPaneKey,
+                        openFiles,
+                        editorDrafts,
+                        browserTabsByWorktree,
+                        gitStatusByWorktree,
+                        remoteStatusesByWorktree,
+                        hostedReviewCache,
+                        issueCache,
+                        linearIssueCache,
+                        settings,
+                        activeWorktreeId,
+                        now: Date.now()
+                      })
+                    }
+                    gitRefreshState={gitRefreshStateByWorktreeId[worktree.worktreeId]}
                     deleteState={deleteStateByWorktreeId[worktree.worktreeId]}
                     onToggleSelected={() => toggleSelection(worktree.worktreeId)}
                     onInspect={() => setInspectedWorktreeId(worktree.worktreeId)}
+                    onOpenWorkspace={() => activateAndRevealWorktree(worktree.worktreeId)}
                     onDelete={() => deleteWorktrees([worktree.worktreeId])}
                     onForceDelete={() => forceDeleteWorktree(worktree)}
                   />

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import type { WorkspaceSpaceWorktree } from '../../../../shared/workspace-space-types'
 import {
+  countWorkspaceSpaceActiveAgents,
   filterWorkspaceSpaceRows,
   getSelectedDeletableWorkspaceIds,
   getVisibleDeletableWorkspaceIds,
+  getWorkspaceSpaceGitStatusRefreshCandidates,
+  isWorkspaceSpaceRowReadyToDelete,
   sortWorkspaceSpaceRows
 } from './workspace-space-presentation'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 
 function row(overrides: Partial<WorkspaceSpaceWorktree>): WorkspaceSpaceWorktree {
   return {
@@ -30,6 +34,35 @@ function row(overrides: Partial<WorkspaceSpaceWorktree>): WorkspaceSpaceWorktree
     topLevelItems: [],
     omittedTopLevelItemCount: 0,
     omittedTopLevelSizeBytes: 0,
+    ...overrides
+  }
+}
+
+function ready(
+  overrides: Partial<NonNullable<Parameters<typeof isWorkspaceSpaceRowReadyToDelete>[1]>> = {}
+) {
+  return {
+    isActive: false,
+    changedFileCount: 0,
+    dirtyEditorBufferCount: 0,
+    activeAgentCount: 0,
+    liveTerminalCount: 0,
+    browserTabCount: 0,
+    reviewLabel: null,
+    issueLabel: null,
+    linearIssueLabel: null,
+    ...overrides
+  }
+}
+
+function activeAgent(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: '',
+    updatedAt: 1_000,
+    stateStartedAt: 1_000,
+    paneKey: 'tab-1:00000000-0000-4000-8000-000000000001',
+    stateHistory: [],
     ...overrides
   }
 }
@@ -89,5 +122,102 @@ describe('workspace space presentation helpers', () => {
     expect(
       getSelectedDeletableWorkspaceIds(rows, new Set(['idle', 'deleting']), isDeleting)
     ).toEqual(['idle'])
+  })
+
+  it('treats open browser tabs as active workspace usage for deletion readiness', () => {
+    const workspace = row({ worktreeId: 'with-browser', canDelete: true, status: 'ok' })
+
+    expect(isWorkspaceSpaceRowReadyToDelete(workspace, ready())).toBe(true)
+    expect(isWorkspaceSpaceRowReadyToDelete(workspace, ready({ browserTabCount: 1 }))).toBe(false)
+  })
+
+  it('counts hookless title-derived running agents as active workspace usage', () => {
+    const count = countWorkspaceSpaceActiveAgents({
+      worktreeId: 'wt',
+      tabs: [{ id: 'tab-1', title: 'Codex working' }],
+      agentStatusByPaneKey: {},
+      migrationUnsupportedByPtyId: {},
+      runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      now: 1_000
+    })
+
+    expect(count).toBe(1)
+  })
+
+  it('does not count title-derived agents when the terminal has no live pty', () => {
+    const count = countWorkspaceSpaceActiveAgents({
+      worktreeId: 'wt',
+      tabs: [{ id: 'tab-1', title: 'Codex working' }],
+      agentStatusByPaneKey: {},
+      migrationUnsupportedByPtyId: {},
+      runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: {},
+      now: 1_000
+    })
+
+    expect(count).toBe(0)
+  })
+
+  it('counts fresh explicit active agents and ignores stale active entries', () => {
+    expect(
+      countWorkspaceSpaceActiveAgents({
+        worktreeId: 'wt',
+        tabs: [{ id: 'tab-1', title: 'Terminal' }],
+        agentStatusByPaneKey: {
+          [activeAgent().paneKey]: activeAgent()
+        },
+        migrationUnsupportedByPtyId: {},
+        runtimePaneTitlesByTabId: {},
+        ptyIdsByTabId: {},
+        now: 1_000
+      })
+    ).toBe(1)
+
+    expect(
+      countWorkspaceSpaceActiveAgents({
+        worktreeId: 'wt',
+        tabs: [{ id: 'tab-1', title: 'Terminal' }],
+        agentStatusByPaneKey: {
+          [activeAgent().paneKey]: activeAgent({ updatedAt: 1_000 })
+        },
+        migrationUnsupportedByPtyId: {},
+        runtimePaneTitlesByTabId: {},
+        ptyIdsByTabId: {},
+        now: 60 * 60 * 1_000
+      })
+    ).toBe(0)
+  })
+
+  it('counts migration-unsupported agent entries by worktree id', () => {
+    const count = countWorkspaceSpaceActiveAgents({
+      worktreeId: 'wt',
+      tabs: [],
+      agentStatusByPaneKey: {},
+      migrationUnsupportedByPtyId: {
+        'pty-1': {
+          ptyId: 'pty-1',
+          worktreeId: 'wt',
+          reason: 'legacy-numeric-pane-key',
+          source: 'local',
+          updatedAt: 1_000
+        }
+      },
+      runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: {},
+      now: 1_000
+    })
+
+    expect(count).toBe(1)
+  })
+
+  it('returns every refreshable git-status row without a first-page cap', () => {
+    const rows = Array.from({ length: 60 }, (_, index) =>
+      row({ worktreeId: `wt-${index}`, isMainWorktree: false, canDelete: true, status: 'ok' })
+    )
+
+    expect(
+      getWorkspaceSpaceGitStatusRefreshCandidates(rows).map((item) => item.worktreeId)
+    ).toEqual(rows.map((item) => item.worktreeId))
   })
 })

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.ts
@@ -1,7 +1,132 @@
+import { detectAgentStatusFromTitle, isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry,
+  type MigrationUnsupportedPtyEntry
+} from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
 import type { WorkspaceSpaceWorktree } from '../../../../shared/workspace-space-types'
 
 export type WorkspaceSpaceSortKey = 'size' | 'name' | 'repo' | 'activity'
 export type WorkspaceSpaceSortDirection = 'asc' | 'desc'
+
+export type WorkspaceSpaceDeleteReadiness = {
+  isActive: boolean
+  changedFileCount: number | null
+  dirtyEditorBufferCount: number
+  activeAgentCount: number
+  liveTerminalCount: number
+  browserTabCount: number
+  reviewLabel: string | null
+  issueLabel: string | null
+  linearIssueLabel: string | null
+}
+
+export type WorkspaceSpaceAgentActivityInputs = {
+  worktreeId: string
+  tabs: readonly Pick<TerminalTab, 'id' | 'title'>[]
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  migrationUnsupportedByPtyId: Record<string, MigrationUnsupportedPtyEntry>
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  ptyIdsByTabId: Record<string, string[]>
+  now: number
+}
+
+function getPaneKeyTabId(paneKey: string): string | null {
+  const parsed = parsePaneKey(paneKey)
+  if (parsed) {
+    return parsed.tabId
+  }
+
+  // Why: older hydrated snapshots can still carry `tabId:numericPaneId`.
+  // Delete readiness only needs tab ownership, so preserve the conservative
+  // "workspace is in use" signal instead of treating the row as deletable.
+  const separatorIndex = paneKey.indexOf(':')
+  if (
+    separatorIndex <= 0 ||
+    separatorIndex !== paneKey.lastIndexOf(':') ||
+    separatorIndex === paneKey.length - 1
+  ) {
+    return null
+  }
+  return paneKey.slice(0, separatorIndex)
+}
+
+function isActiveAgentState(entry: Pick<AgentStatusEntry, 'state'>): boolean {
+  return entry.state === 'working' || entry.state === 'blocked' || entry.state === 'waiting'
+}
+
+function countTitleActiveAgentsForTab(
+  tab: Pick<TerminalTab, 'id' | 'title'>,
+  runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
+  ptyIdsByTabId: Record<string, string[]>
+): number {
+  if (!tabHasLivePty(ptyIdsByTabId, tab.id)) {
+    return 0
+  }
+
+  const paneTitles = runtimePaneTitlesByTabId[tab.id]
+  if (paneTitles && Object.keys(paneTitles).length > 0) {
+    return Object.values(paneTitles).filter((title) => {
+      const status = detectAgentStatusFromTitle(title)
+      return status === 'working' || status === 'permission'
+    }).length
+  }
+
+  const status = detectAgentStatusFromTitle(tab.title)
+  return status === 'working' || status === 'permission' ? 1 : 0
+}
+
+export function countWorkspaceSpaceActiveAgents({
+  worktreeId,
+  tabs,
+  agentStatusByPaneKey,
+  migrationUnsupportedByPtyId,
+  runtimePaneTitlesByTabId,
+  ptyIdsByTabId,
+  now
+}: WorkspaceSpaceAgentActivityInputs): number {
+  const tabIds = new Set(tabs.map((tab) => tab.id))
+  const tabsWithActiveHook = new Set<string>()
+  let count = 0
+
+  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
+    if (!isActiveAgentState(entry)) {
+      continue
+    }
+    if (!isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+      continue
+    }
+    const tabId = getPaneKeyTabId(entry.paneKey || paneKey)
+    if (!tabId || !tabIds.has(tabId)) {
+      continue
+    }
+    tabsWithActiveHook.add(tabId)
+    count += 1
+  }
+
+  for (const entry of Object.values(migrationUnsupportedByPtyId)) {
+    const tabId = entry.tabId ?? (entry.paneKey ? getPaneKeyTabId(entry.paneKey) : null)
+    if (entry.worktreeId !== worktreeId && (!tabId || !tabIds.has(tabId))) {
+      continue
+    }
+    if (tabId) {
+      tabsWithActiveHook.add(tabId)
+    }
+    count += 1
+  }
+
+  for (const tab of tabs) {
+    if (tabsWithActiveHook.has(tab.id)) {
+      continue
+    }
+    count += countTitleActiveAgentsForTab(tab, runtimePaneTitlesByTabId, ptyIdsByTabId)
+  }
+
+  return count
+}
 
 export function getWorkspaceSpaceSearchText(worktree: WorkspaceSpaceWorktree): string {
   return [
@@ -66,6 +191,35 @@ export function filterWorkspaceSpaceRows(
     }
     return getWorkspaceSpaceSearchText(row).includes(normalizedQuery)
   })
+}
+
+export function isWorkspaceSpaceRowReadyToDelete(
+  worktree: WorkspaceSpaceWorktree,
+  readiness: WorkspaceSpaceDeleteReadiness | undefined
+): boolean {
+  return (
+    worktree.canDelete &&
+    worktree.status === 'ok' &&
+    !worktree.isMainWorktree &&
+    readiness !== undefined &&
+    !readiness.isActive &&
+    readiness.changedFileCount === 0 &&
+    readiness.dirtyEditorBufferCount === 0 &&
+    readiness.activeAgentCount === 0 &&
+    readiness.liveTerminalCount === 0 &&
+    readiness.browserTabCount === 0 &&
+    !readiness.reviewLabel &&
+    !readiness.issueLabel &&
+    !readiness.linearIssueLabel
+  )
+}
+
+export function getWorkspaceSpaceGitStatusRefreshCandidates(
+  rows: readonly WorkspaceSpaceWorktree[]
+): WorkspaceSpaceWorktree[] {
+  return rows.filter(
+    (worktree) => worktree.canDelete && worktree.status === 'ok' && !worktree.isMainWorktree
+  )
 }
 
 export function getSelectedDeletableWorkspaceIds(

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1079,6 +1079,18 @@ describe('createEditorSlice editor drafts', () => {
 })
 
 describe('createEditorSlice conflict status reconciliation', () => {
+  it('records clean git status checks with an explicit empty entry list', () => {
+    const store = createEditorStore()
+
+    store.getState().setGitStatus('wt-clean', {
+      conflictOperation: 'unknown',
+      entries: []
+    })
+
+    expect(store.getState().gitStatusByWorktree).toHaveProperty('wt-clean')
+    expect(store.getState().gitStatusByWorktree['wt-clean']).toEqual([])
+  })
+
   it('clears ignored path cache when status refresh omits ignored paths', () => {
     const store = createEditorStore()
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -2491,6 +2491,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   // 'session' for Resolved locally) and for all Resolved locally lifecycle.
   setGitStatus: (worktreeId, status) =>
     set((s) => {
+      const hadStatusEntry = Object.prototype.hasOwnProperty.call(s.gitStatusByWorktree, worktreeId)
       const prevEntries = s.gitStatusByWorktree[worktreeId] ?? []
       const prevOperation = s.gitConflictOperationByWorktree[worktreeId] ?? 'unknown'
       const currentTracked = { ...s.trackedConflictPathsByWorktree[worktreeId] }
@@ -2549,7 +2550,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       }
 
       const nextOpenFiles = reconcileOpenFilesForStatus(s.openFiles, worktreeId, nextEntries)
-      const statusUnchanged = areGitStatusEntriesEqual(prevEntries, nextEntries)
+      const statusUnchanged = hadStatusEntry && areGitStatusEntriesEqual(prevEntries, nextEntries)
       const trackedUnchanged = areTrackedConflictMapsEqual(
         s.trackedConflictPathsByWorktree[worktreeId] ?? {},
         currentTracked

--- a/src/renderer/src/store/slices/workspace-space.test.ts
+++ b/src/renderer/src/store/slices/workspace-space.test.ts
@@ -1,0 +1,170 @@
+import { create } from 'zustand'
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceSpaceAnalysis } from '../../../../shared/workspace-space-types'
+import type { AppState } from '../types'
+import { createWorkspaceSpaceSlice } from './workspace-space'
+
+function createWorkspaceSpaceTestStore() {
+  return create<AppState>()(
+    (...a) =>
+      ({
+        ...createWorkspaceSpaceSlice(...a)
+      }) as unknown as AppState
+  )
+}
+
+function makeAnalysis(): WorkspaceSpaceAnalysis {
+  return {
+    scannedAt: 1,
+    totalSizeBytes: 300,
+    reclaimableBytes: 300,
+    worktreeCount: 2,
+    scannedWorktreeCount: 2,
+    unavailableWorktreeCount: 0,
+    packageManagerCaches: [
+      {
+        id: 'local:pnpm:%2Frepo%2Fmain',
+        packageManager: 'pnpm',
+        connectionId: null,
+        isRemote: false,
+        targetLabel: 'pnpm on this computer',
+        cwd: '/repo/main',
+        cachePath: null,
+        detectedWorktreeCount: 2,
+        detectedWorktrees: [
+          { worktreeId: 'repo-1::/repo/main', lockfiles: ['pnpm-lock.yaml'] },
+          { worktreeId: 'repo-1::/repo/feature', lockfiles: ['pnpm-lock.yaml'] }
+        ],
+        detectedLockfiles: ['pnpm-lock.yaml'],
+        cliAvailable: true,
+        unavailableReason: null,
+        cleanupActions: []
+      },
+      {
+        id: 'local:npm:%2Frepo%2Ffeature',
+        packageManager: 'npm',
+        connectionId: null,
+        isRemote: false,
+        targetLabel: 'npm on this computer',
+        cwd: '/repo/feature',
+        cachePath: null,
+        detectedWorktreeCount: 1,
+        detectedWorktrees: [
+          { worktreeId: 'repo-1::/repo/feature', lockfiles: ['package-lock.json'] }
+        ],
+        detectedLockfiles: ['package-lock.json'],
+        cliAvailable: true,
+        unavailableReason: null,
+        cleanupActions: []
+      }
+    ],
+    repos: [
+      {
+        repoId: 'repo-1',
+        displayName: 'orca',
+        path: '/repo/main',
+        isRemote: false,
+        worktreeCount: 2,
+        scannedWorktreeCount: 2,
+        unavailableWorktreeCount: 0,
+        totalSizeBytes: 300,
+        reclaimableBytes: 300,
+        error: null
+      }
+    ],
+    worktrees: [
+      {
+        worktreeId: 'repo-1::/repo/main',
+        repoId: 'repo-1',
+        repoDisplayName: 'orca',
+        repoPath: '/repo/main',
+        displayName: 'main',
+        path: '/repo/main',
+        branch: 'refs/heads/main',
+        isMainWorktree: true,
+        isRemote: false,
+        isSparse: false,
+        status: 'ok',
+        error: null,
+        sizeBytes: 100,
+        reclaimableBytes: 0,
+        canDelete: false,
+        lastActivityAt: 0,
+        scannedAt: 1,
+        skippedEntryCount: 0,
+        topLevelItems: [],
+        omittedTopLevelItemCount: 0,
+        omittedTopLevelSizeBytes: 0
+      },
+      {
+        worktreeId: 'repo-1::/repo/feature',
+        repoId: 'repo-1',
+        repoDisplayName: 'orca',
+        repoPath: '/repo/main',
+        displayName: 'feature',
+        path: '/repo/feature',
+        branch: 'refs/heads/feature',
+        isMainWorktree: false,
+        isRemote: false,
+        isSparse: false,
+        status: 'ok',
+        error: null,
+        sizeBytes: 200,
+        reclaimableBytes: 200,
+        canDelete: true,
+        lastActivityAt: 0,
+        scannedAt: 1,
+        skippedEntryCount: 0,
+        topLevelItems: [],
+        omittedTopLevelItemCount: 0,
+        omittedTopLevelSizeBytes: 0
+      }
+    ]
+  }
+}
+
+describe('workspace space slice', () => {
+  it('removes stale package-manager cache detections when workspaces are removed', () => {
+    const store = createWorkspaceSpaceTestStore()
+    store.setState({ workspaceSpaceAnalysis: makeAnalysis() })
+
+    store.getState().removeWorkspaceSpaceWorktrees(['repo-1::/repo/feature'])
+
+    const analysis = store.getState().workspaceSpaceAnalysis
+    expect(analysis?.worktreeCount).toBe(1)
+    expect(analysis?.packageManagerCaches).toEqual([
+      expect.objectContaining({
+        id: 'local:pnpm:%2Frepo%2Fmain',
+        cwd: '/repo/main',
+        detectedWorktreeCount: 1,
+        detectedWorktrees: [{ worktreeId: 'repo-1::/repo/main', lockfiles: ['pnpm-lock.yaml'] }],
+        detectedLockfiles: ['pnpm-lock.yaml']
+      })
+    ])
+  })
+
+  it('moves a package-manager cleanup target to a surviving cwd', () => {
+    const store = createWorkspaceSpaceTestStore()
+    store.setState({ workspaceSpaceAnalysis: makeAnalysis() })
+
+    store.getState().removeWorkspaceSpaceWorktrees(['repo-1::/repo/main'])
+
+    const analysis = store.getState().workspaceSpaceAnalysis
+    expect(analysis?.packageManagerCaches).toEqual([
+      expect.objectContaining({
+        id: 'local:pnpm:%2Frepo%2Ffeature',
+        cwd: '/repo/feature',
+        detectedWorktreeCount: 1,
+        detectedWorktrees: [{ worktreeId: 'repo-1::/repo/feature', lockfiles: ['pnpm-lock.yaml'] }]
+      }),
+      expect.objectContaining({
+        id: 'local:npm:%2Frepo%2Ffeature',
+        cwd: '/repo/feature',
+        detectedWorktreeCount: 1,
+        detectedWorktrees: [
+          { worktreeId: 'repo-1::/repo/feature', lockfiles: ['package-lock.json'] }
+        ]
+      })
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/workspace-space.ts
+++ b/src/renderer/src/store/slices/workspace-space.ts
@@ -1,8 +1,10 @@
 import type { StateCreator } from 'zustand'
 import type {
   WorkspaceSpaceAnalysis,
+  WorkspacePackageManagerCacheTarget,
   WorkspaceSpaceScanProgress
 } from '../../../../shared/workspace-space-types'
+import { createPackageManagerCacheTargetId } from '../../../../shared/package-manager-cache-cleanup'
 import type { AppState } from '../types'
 
 let inFlightScan: Promise<WorkspaceSpaceAnalysis> | null = null
@@ -30,6 +32,9 @@ function removeDeletedWorktreesFromAnalysis(
     repoRows.push(worktree)
     rowsByRepoId.set(worktree.repoId, repoRows)
   }
+  const worktreePathById = new Map(
+    worktrees.map((worktree) => [worktree.worktreeId, worktree.path])
+  )
   const repos = analysis.repos.map((repo) => {
     const repoRows = rowsByRepoId.get(repo.repoId) ?? []
     return {
@@ -41,6 +46,34 @@ function removeDeletedWorktreesFromAnalysis(
       reclaimableBytes: repoRows.reduce((sum, row) => sum + row.reclaimableBytes, 0)
     }
   })
+  const packageManagerCaches = analysis.packageManagerCaches.flatMap((target) => {
+    const detectedWorktrees = target.detectedWorktrees.filter(
+      (worktree) => !deletedSet.has(worktree.worktreeId)
+    )
+    if (detectedWorktrees.length === 0) {
+      return []
+    }
+    const survivingCwds = detectedWorktrees
+      .map((worktree) => worktreePathById.get(worktree.worktreeId))
+      .filter((path): path is string => typeof path === 'string' && path.length > 0)
+    const cwd = survivingCwds.includes(target.cwd) ? target.cwd : survivingCwds[0]
+    if (!cwd) {
+      return []
+    }
+    const detectedLockfiles = [
+      ...new Set(detectedWorktrees.flatMap((worktree) => worktree.lockfiles))
+    ].sort((a, b) => a.localeCompare(b))
+    return [
+      {
+        ...target,
+        id: createPackageManagerCacheTargetId(target.connectionId, target.packageManager, cwd),
+        cwd,
+        detectedWorktreeCount: detectedWorktrees.length,
+        detectedWorktrees,
+        detectedLockfiles
+      } satisfies WorkspacePackageManagerCacheTarget
+    ]
+  })
 
   return {
     ...analysis,
@@ -51,6 +84,7 @@ function removeDeletedWorktreesFromAnalysis(
     unavailableWorktreeCount:
       worktrees.filter((row) => row.status !== 'ok').length +
       repos.filter((repo) => repo.error !== null).length,
+    packageManagerCaches,
     repos,
     worktrees
   }

--- a/src/shared/package-manager-cache-cleanup.test.ts
+++ b/src/shared/package-manager-cache-cleanup.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  detectPackageManagersFromFilenames,
+  getPackageManagerCacheCleanupAction,
+  getPackageManagerCacheCleanupActions,
+  getPackageManagerCacheSafetyCopy
+} from './package-manager-cache-cleanup'
+
+describe('package manager cache cleanup metadata', () => {
+  it('detects package managers from top-level lockfiles', () => {
+    const detected = detectPackageManagersFromFilenames([
+      'package.json',
+      'pnpm-lock.yaml',
+      'package-lock.json',
+      'bun.lockb',
+      'src'
+    ])
+
+    expect(detected.get('pnpm')).toEqual(['pnpm-lock.yaml'])
+    expect(detected.get('npm')).toEqual(['package-lock.json'])
+    expect(detected.get('bun')).toEqual(['bun.lockb'])
+    expect(detected.has('yarn')).toBe(false)
+  })
+
+  it('uses conservative commands for safe defaults and explicit aggressive cleanup', () => {
+    expect(getPackageManagerCacheCleanupAction('pnpm', 'pnpm-store-prune')).toMatchObject({
+      binary: 'pnpm',
+      args: ['store', 'prune'],
+      safety: 'safe'
+    })
+    expect(getPackageManagerCacheCleanupAction('npm', 'npm-cache-verify')).toMatchObject({
+      binary: 'npm',
+      args: ['cache', 'verify'],
+      safety: 'safe'
+    })
+    expect(getPackageManagerCacheCleanupAction('npm', 'npm-cache-clean-force')).toMatchObject({
+      binary: 'npm',
+      args: ['cache', 'clean', '--force'],
+      safety: 'aggressive'
+    })
+    expect(getPackageManagerCacheCleanupActions('yarn')[0]).toMatchObject({
+      binary: 'yarn',
+      args: ['cache', 'clean'],
+      safety: 'aggressive'
+    })
+    expect(getPackageManagerCacheCleanupActions('bun')[0]).toMatchObject({
+      binary: 'bun',
+      args: ['pm', 'cache', 'rm'],
+      safety: 'aggressive'
+    })
+  })
+
+  it('keeps safety copy explicit', () => {
+    expect(getPackageManagerCacheSafetyCopy('safe')).toBe('Safe default')
+    expect(getPackageManagerCacheSafetyCopy('aggressive')).toBe('Aggressive')
+  })
+})

--- a/src/shared/package-manager-cache-cleanup.ts
+++ b/src/shared/package-manager-cache-cleanup.ts
@@ -1,0 +1,159 @@
+import type {
+  WorkspacePackageManager,
+  WorkspacePackageManagerCacheCleanupAction,
+  WorkspacePackageManagerCacheCleanupSafety
+} from './workspace-space-types'
+
+type PackageManagerCacheDefinition = {
+  packageManager: WorkspacePackageManager
+  lockfiles: readonly string[]
+  actions: readonly Omit<WorkspacePackageManagerCacheCleanupAction, 'packageManager' | 'command'>[]
+}
+
+const DEFINITIONS: readonly PackageManagerCacheDefinition[] = [
+  {
+    packageManager: 'pnpm',
+    lockfiles: ['pnpm-lock.yaml'],
+    actions: [
+      {
+        id: 'pnpm-store-prune',
+        safety: 'safe',
+        binary: 'pnpm',
+        args: ['store', 'prune'],
+        label: 'Prune pnpm store',
+        description:
+          'Removes unreferenced packages from the pnpm store without editing projects or lockfiles.'
+      }
+    ]
+  },
+  {
+    packageManager: 'npm',
+    lockfiles: ['package-lock.json', 'npm-shrinkwrap.json'],
+    actions: [
+      {
+        id: 'npm-cache-verify',
+        safety: 'safe',
+        binary: 'npm',
+        args: ['cache', 'verify'],
+        label: 'Verify npm cache',
+        description: 'Verifies cache integrity and garbage-collects unneeded npm cache data.'
+      },
+      {
+        id: 'npm-cache-clean-force',
+        safety: 'aggressive',
+        binary: 'npm',
+        args: ['cache', 'clean', '--force'],
+        label: 'Clean npm cache',
+        description: 'Deletes npm cache data. Future installs may need to download packages again.'
+      }
+    ]
+  },
+  {
+    packageManager: 'yarn',
+    lockfiles: ['yarn.lock'],
+    actions: [
+      {
+        id: 'yarn-cache-clean',
+        safety: 'aggressive',
+        binary: 'yarn',
+        args: ['cache', 'clean'],
+        label: 'Clean Yarn cache',
+        description:
+          'Removes Yarn shared cache files. Future installs may need to download packages again.'
+      }
+    ]
+  },
+  {
+    packageManager: 'bun',
+    lockfiles: ['bun.lock', 'bun.lockb'],
+    actions: [
+      {
+        id: 'bun-pm-cache-rm',
+        safety: 'aggressive',
+        binary: 'bun',
+        args: ['pm', 'cache', 'rm'],
+        label: 'Clean Bun cache',
+        description:
+          'Removes Bun global module cache data. Future installs may need to download packages again.'
+      }
+    ]
+  }
+]
+
+const DEFINITIONS_BY_MANAGER = new Map(
+  DEFINITIONS.map((definition) => [definition.packageManager, definition])
+)
+
+export function formatPackageManagerCacheCommand(binary: string, args: readonly string[]): string {
+  return [binary, ...args].join(' ')
+}
+
+export function createPackageManagerCacheTargetId(
+  connectionId: string | null,
+  packageManager: WorkspacePackageManager,
+  cwd: string
+): string {
+  return `${connectionId ? `ssh:${encodeURIComponent(connectionId)}` : 'local'}:${packageManager}:${encodeURIComponent(cwd)}`
+}
+
+export function getPackageManagerLabel(packageManager: WorkspacePackageManager): string {
+  switch (packageManager) {
+    case 'npm':
+      return 'npm'
+    case 'pnpm':
+      return 'pnpm'
+    case 'yarn':
+      return 'Yarn'
+    case 'bun':
+      return 'Bun'
+  }
+}
+
+export function getPackageManagerCacheCleanupActions(
+  packageManager: WorkspacePackageManager
+): WorkspacePackageManagerCacheCleanupAction[] {
+  const definition = DEFINITIONS_BY_MANAGER.get(packageManager)
+  if (!definition) {
+    return []
+  }
+  return definition.actions.map((action) => ({
+    ...action,
+    packageManager,
+    command: formatPackageManagerCacheCommand(action.binary, action.args)
+  }))
+}
+
+export function getPackageManagerCacheCleanupAction(
+  packageManager: WorkspacePackageManager,
+  actionId: string
+): WorkspacePackageManagerCacheCleanupAction | null {
+  return (
+    getPackageManagerCacheCleanupActions(packageManager).find((action) => action.id === actionId) ??
+    null
+  )
+}
+
+export function getPackageManagerCacheSafetyCopy(
+  safety: WorkspacePackageManagerCacheCleanupSafety
+): string {
+  switch (safety) {
+    case 'safe':
+      return 'Safe default'
+    case 'aggressive':
+      return 'Aggressive'
+  }
+}
+
+export function detectPackageManagersFromFilenames(
+  filenames: readonly string[]
+): Map<WorkspacePackageManager, string[]> {
+  const names = new Set(filenames)
+  const detected = new Map<WorkspacePackageManager, string[]>()
+  for (const definition of DEFINITIONS) {
+    const lockfiles = definition.lockfiles.filter((lockfile) => names.has(lockfile))
+    if (lockfiles.length > 0) {
+      detected.set(definition.packageManager, lockfiles)
+    }
+  }
+  return detected
+}

--- a/src/shared/workspace-space-types.ts
+++ b/src/shared/workspace-space-types.ts
@@ -51,6 +51,63 @@ export type WorkspaceSpaceRepoSummary = {
   error: string | null
 }
 
+export type WorkspacePackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
+
+export type WorkspacePackageManagerCacheCleanupSafety = 'safe' | 'aggressive'
+
+export type WorkspacePackageManagerCacheCleanupAction = {
+  id: string
+  packageManager: WorkspacePackageManager
+  safety: WorkspacePackageManagerCacheCleanupSafety
+  binary: string
+  args: string[]
+  command: string
+  label: string
+  description: string
+}
+
+export type WorkspacePackageManagerCacheTargetWorktree = {
+  worktreeId: string
+  lockfiles: string[]
+}
+
+export type WorkspacePackageManagerCacheTarget = {
+  id: string
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  isRemote: boolean
+  targetLabel: string
+  cwd: string
+  cachePath: string | null
+  detectedWorktreeCount: number
+  detectedWorktrees: WorkspacePackageManagerCacheTargetWorktree[]
+  detectedLockfiles: string[]
+  cliAvailable: boolean
+  unavailableReason: string | null
+  cleanupActions: WorkspacePackageManagerCacheCleanupAction[]
+}
+
+export type WorkspacePackageManagerCacheCleanupRequest = {
+  targetId: string
+  actionId: string
+  packageManager: WorkspacePackageManager
+  connectionId: string | null
+  cwd: string
+}
+
+export type WorkspacePackageManagerCacheCleanupResult =
+  | {
+      ok: true
+      action: WorkspacePackageManagerCacheCleanupAction
+      stdout: string
+      stderr: string
+      cachePath: string | null
+      cacheSizeBeforeBytes: number | null
+      cacheSizeAfterBytes: number | null
+      reclaimedBytes: number | null
+    }
+  | { ok: false; error: string }
+
 export type WorkspaceSpaceAnalysis = {
   scannedAt: number
   totalSizeBytes: number
@@ -58,6 +115,7 @@ export type WorkspaceSpaceAnalysis = {
   worktreeCount: number
   scannedWorktreeCount: number
   unavailableWorktreeCount: number
+  packageManagerCaches: WorkspacePackageManagerCacheTarget[]
   repos: WorkspaceSpaceRepoSummary[]
   worktrees: WorkspaceSpaceWorktree[]
 }

--- a/tests/e2e/workspace-space-git-status.spec.ts
+++ b/tests/e2e/workspace-space-git-status.spec.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from 'child_process'
+import { mkdtempSync, realpathSync, rmSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { test, expect } from './helpers/orca-app'
+
+test.describe('Workspace Space git status checks', () => {
+  test('checks every scanned deletable row, including rows after the first 50', async ({
+    orcaPage,
+    testRepoPath
+  }) => {
+    const worktreeParent = mkdtempSync(path.join(os.tmpdir(), 'orca-space-git-status-'))
+    const worktreePaths = Array.from({ length: 60 }, (_, index) =>
+      path.join(worktreeParent, `worktree-${index}`)
+    )
+
+    try {
+      for (const worktreePath of worktreePaths) {
+        execFileSync('git', ['worktree', 'add', '--detach', worktreePath, 'HEAD'], {
+          cwd: testRepoPath,
+          stdio: 'pipe'
+        })
+      }
+      const registeredWorktreePaths = worktreePaths.map((worktreePath) =>
+        realpathSync(worktreePath)
+      )
+
+      await orcaPage.evaluate(
+        async ({ testRepoPath, worktreePaths }) => {
+          const store = window.__store
+          if (!store) {
+            throw new Error('Expected e2e store to be exposed')
+          }
+
+          const initialState = store.getState()
+          const repo = initialState.repos.find((item) => item.path === testRepoPath)
+          if (!repo) {
+            throw new Error('Expected test repo to be loaded')
+          }
+          await initialState.fetchWorktrees(repo.id)
+          await window.api.git.status({ worktreePath: worktreePaths[0] })
+
+          const state = store.getState()
+          const expectedPaths = new Set(worktreePaths)
+          const worktrees = (state.worktreesByRepo[repo.id] ?? []).filter((worktree) =>
+            expectedPaths.has(worktree.path)
+          )
+          if (worktrees.length !== worktreePaths.length) {
+            throw new Error(
+              `Expected ${worktreePaths.length} registered worktrees, got ${
+                worktrees.length
+              } from ${(state.worktreesByRepo[repo.id] ?? []).length}: ${(
+                state.worktreesByRepo[repo.id] ?? []
+              )
+                .slice(0, 5)
+                .map((worktree) => worktree.path)
+                .join(', ')}`
+            )
+          }
+          const rows = worktrees.map((worktree, index) => ({
+            worktreeId: worktree.id,
+            repoId: repo.id,
+            repoDisplayName: repo.displayName,
+            repoPath: testRepoPath,
+            displayName: worktree.displayName,
+            path: worktree.path,
+            branch: worktree.branch,
+            isMainWorktree: false,
+            isRemote: false,
+            isSparse: worktree.isSparse,
+            canDelete: true,
+            lastActivityAt: worktree.lastActivityAt,
+            status: 'ok' as const,
+            error: null,
+            scannedAt: Date.now(),
+            sizeBytes: 1000 + index,
+            reclaimableBytes: 1000 + index,
+            skippedEntryCount: 0,
+            topLevelItems: [],
+            omittedTopLevelItemCount: 0,
+            omittedTopLevelSizeBytes: 0
+          }))
+
+          store.setState({
+            gitStatusByWorktree: {},
+            workspaceSpaceAnalysis: {
+              scannedAt: Date.now(),
+              totalSizeBytes: rows.reduce((sum, row) => sum + row.sizeBytes, 0),
+              reclaimableBytes: rows.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+              worktreeCount: rows.length,
+              scannedWorktreeCount: rows.length,
+              unavailableWorktreeCount: 0,
+              packageManagerCaches: [],
+              repos: [
+                {
+                  repoId: repo.id,
+                  displayName: repo.displayName,
+                  path: repo.path,
+                  isRemote: false,
+                  worktreeCount: rows.length,
+                  scannedWorktreeCount: rows.length,
+                  unavailableWorktreeCount: 0,
+                  totalSizeBytes: rows.reduce((sum, row) => sum + row.sizeBytes, 0),
+                  reclaimableBytes: rows.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+                  error: null
+                }
+              ],
+              worktrees: rows
+            }
+          })
+          store.getState().openSpacePage()
+        },
+        { testRepoPath, worktreePaths: registeredWorktreePaths }
+      )
+
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(() => {
+              const state = window.__store?.getState()
+              if (!state?.workspaceSpaceAnalysis) {
+                return 60
+              }
+              return state.workspaceSpaceAnalysis.worktrees.filter(
+                (row) => state.gitStatusByWorktree[row.worktreeId] === undefined
+              ).length
+            }),
+          { timeout: 30_000 }
+        )
+        .toBe(0)
+
+      await expect(orcaPage.getByText('Keep: git not checked')).toHaveCount(0)
+    } finally {
+      for (const worktreePath of worktreePaths) {
+        try {
+          execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
+            cwd: testRepoPath,
+            stdio: 'pipe'
+          })
+        } catch {
+          // Best effort cleanup; the fixture removes the source repo after the test.
+        }
+      }
+      rmSync(worktreeParent, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
- Fix workspace space cache and git status cleanup checks

- Treat browser tabs as workspace delete blockers

- Move deletion readiness into shared presentation logic so tests cover it
- Preserve explicit empty git status entries for clean worktrees

- Add package manager cache cleanup to space manager

- Detect npm, pnpm, Yarn, and Bun caches from lockfiles during scans
- Add explicit cleanup IPC for safe and aggressive cache actions
- Support local, SSH, and Windows command execution paths safely
- Tighten workspace deletion decisions with git, editor, agent, and terminal state
