### PR TITLE
Link worktree metadata to task detail pages

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -19,6 +19,7 @@ import {
   Braces,
   Check,
   ChevronDown,
+  ChevronLeft,
   CircleDashed,
   CircleDot,
   Copy,
@@ -218,6 +219,8 @@ type GitHubItemDialogProps = {
   repoPath: string | null
   repoId?: string | null
   initialTab?: ItemDialogTab
+  variant?: 'sheet' | 'page'
+  backLabel?: string
   /** Called when the user clicks the primary CTA to start work from this item. */
   onUse: (item: GitHubWorkItem) => void
   onReviewRequestsChange?: (
@@ -4872,6 +4875,8 @@ export default function GitHubItemDialog({
   repoPath,
   repoId,
   initialTab,
+  variant = 'sheet',
+  backLabel = 'Back',
   projectOrigin,
   onUse,
   onReviewRequestsChange,
@@ -5248,6 +5253,298 @@ export default function GitHubItemDialog({
     [details?.pullRequestId, detailsCacheKey, repoPath, workItem]
   )
 
+  const content = workItem ? (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex-none border-b border-border/60 bg-card/80 px-4 py-3 shadow-xs backdrop-blur supports-[backdrop-filter]:bg-card/70">
+        <div className="flex items-start gap-3">
+          {variant === 'page' ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              className="-ml-1 mt-0.5 shrink-0 gap-1.5"
+              aria-label={backLabel}
+            >
+              <ChevronLeft className="size-4" />
+              {backLabel}
+            </Button>
+          ) : null}
+          <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground">
+            <Icon className="size-4" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+              <WorkItemStateBadge item={{ ...workItem, state: localState }} />
+              <span className="font-mono">#{workItem.number}</span>
+              <span>{workItem.type === 'pr' ? 'Pull request' : 'Issue'}</span>
+            </div>
+            <h2 className="text-[15px] font-semibold leading-snug text-foreground">
+              {workItem.title}
+            </h2>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+              <span>{workItem.author ?? 'unknown'}</span>
+              <span>updated {formatRelativeTime(workItem.updatedAt)}</span>
+              {workItem.branchName && (
+                <span className="max-w-full truncate rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                  {workItem.branchName}
+                </span>
+              )}
+            </div>
+            {workItem.type === 'issue' && (
+              <WorkItemIssueSourceIndicator url={workItem.url} repoId={effectiveRepoId} />
+            )}
+          </div>
+          <div className="flex shrink-0 items-center justify-end gap-1">
+            {workItem.type === 'pr' && (
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => onUse(workItem)}
+                className="gap-1.5 whitespace-nowrap"
+                aria-label="Start workspace from PR"
+              >
+                Start workspace from PR
+                <ArrowRight className="size-3.5" />
+              </Button>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => void handleCopyWorkItemLink()}
+                  aria-label="Copy GitHub link"
+                >
+                  {linkCopied ? (
+                    <Check className="size-4 text-emerald-500" />
+                  ) : (
+                    <Copy className="size-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {linkCopied ? 'Copied' : 'Copy GitHub link'}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => window.api.shell.openUrl(workItem.url)}
+                  aria-label="Open on GitHub"
+                >
+                  <ExternalLink className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                Open on GitHub
+              </TooltipContent>
+            </Tooltip>
+            {variant === 'sheet' ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={onClose}
+                    aria-label="Close preview"
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  Close · Esc
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {(repoPath || projectOrigin) && (
+        <GHEditSection
+          item={workItem}
+          repoPath={repoPath}
+          repoId={effectiveRepoId}
+          projectOrigin={projectOrigin}
+          localState={localState}
+          localLabels={localLabels}
+          onStateChange={setLocalState}
+          onLabelsChange={setLocalLabels}
+          onMutated={() => {
+            // Why: drop the cached details for this item so the next
+            // open issues a fresh fetch instead of painting pre-edit
+            // state. We invalidate by (repoPath, type, number) match
+            // because a single mutation can affect entries across all
+            // issueSourcePreference values for the same number.
+            if (repoPath) {
+              invalidateWorkItemDetailsCacheByMatch({
+                repoPath,
+                repoId: effectiveRepoId ?? undefined,
+                type: workItem.type,
+                number: workItem.number
+              })
+            }
+          }}
+          assignees={details?.assignees ?? []}
+          onUse={onUse}
+        />
+      )}
+
+      <div className="min-h-0 flex-1">
+        {error ? (
+          <div className="px-4 py-6 text-[12px] text-destructive">{error}</div>
+        ) : (
+          <Tabs
+            value={tab}
+            onValueChange={(value) => setTab(value as ItemDialogTab)}
+            className="flex h-full min-h-0 flex-col gap-0"
+          >
+            <TabsList
+              variant="line"
+              className="mx-4 mt-2 justify-start gap-3 border-b border-border/60 bg-transparent"
+            >
+              <TabsTrigger value="conversation" className="px-2">
+                <MessageSquare className="size-3.5" />
+                Conversation
+              </TabsTrigger>
+              {workItem.type === 'pr' && (
+                <>
+                  <TabsTrigger value="checks" className="px-2">
+                    <ListChecks className="size-3.5" />
+                    Checks
+                    {checks.length > 0 && (
+                      <span className="ml-1 text-[10px] text-muted-foreground">
+                        {checks.length}
+                      </span>
+                    )}
+                  </TabsTrigger>
+                  <TabsTrigger value="files" className="px-2">
+                    <FileText className="size-3.5" />
+                    Files
+                    {files.length > 0 && (
+                      <span className="ml-1 text-[10px] text-muted-foreground">{files.length}</span>
+                    )}
+                  </TabsTrigger>
+                </>
+              )}
+            </TabsList>
+
+            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+              <TabsContent value="conversation" className="mt-0">
+                <ConversationTab
+                  item={displayWorkItem ?? workItem}
+                  repoPath={repoPath}
+                  repoId={effectiveRepoId}
+                  body={body}
+                  comments={comments}
+                  files={files}
+                  headSha={details?.headSha}
+                  baseSha={details?.baseSha}
+                  loading={loading}
+                  detailsLoaded={detailsLoaded}
+                  checks={checks}
+                  participants={details?.participants ?? []}
+                  localState={localState}
+                  onStateChange={setLocalState}
+                  projectOrigin={projectOrigin}
+                  onMutated={() => {
+                    if (repoPath) {
+                      invalidateWorkItemDetailsCacheByMatch({
+                        repoPath,
+                        repoId: effectiveRepoId ?? undefined,
+                        type: workItem.type,
+                        number: workItem.number
+                      })
+                    }
+                  }}
+                  onChecksUpdated={(nextChecks) => {
+                    if (detailsCacheKey) {
+                      patchCachedPRChecks(detailsCacheKey, nextChecks)
+                    }
+                  }}
+                  onBodyUpdated={(nextBody) => {
+                    if (detailsCacheKey) {
+                      patchCachedWorkItemBody(detailsCacheKey, nextBody)
+                    }
+                  }}
+                  onCommentAdded={appendOptimisticComment}
+                  onReviewersRequested={(nextReviewRequests) => {
+                    if (detailsCacheKey) {
+                      patchCachedPRReviewRequests(detailsCacheKey, nextReviewRequests)
+                    }
+                    onReviewRequestsChange?.(
+                      { id: workItem.id, repoId: workItem.repoId },
+                      nextReviewRequests
+                    )
+                  }}
+                />
+              </TabsContent>
+
+              {workItem.type === 'pr' && (
+                <>
+                  <TabsContent value="checks" className="mt-0">
+                    <ChecksTab
+                      item={workItem}
+                      repoPath={repoPath}
+                      repoId={effectiveRepoId}
+                      headSha={details?.headSha}
+                      checks={checks}
+                      loading={loading || !detailsLoaded}
+                      variant="page"
+                      onChecksUpdated={(nextChecks) => {
+                        if (detailsCacheKey) {
+                          patchCachedPRChecks(detailsCacheKey, nextChecks)
+                        }
+                      }}
+                    />
+                  </TabsContent>
+
+                  <TabsContent value="files" className="mt-0">
+                    {loading && files.length === 0 ? (
+                      <div className="flex items-center justify-center py-10">
+                        <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : files.length === 0 ? (
+                      <div className="px-4 py-10 text-center text-[12px] text-muted-foreground">
+                        No files changed.
+                      </div>
+                    ) : (
+                      <PRFilesCombinedDiffViewer
+                        files={files}
+                        comments={comments}
+                        repoPath={repoPath ?? ''}
+                        repoId={effectiveRepoId ?? ''}
+                        prNumber={workItem.number}
+                        prUrl={workItem.url}
+                        headSha={details?.headSha}
+                        baseSha={details?.baseSha}
+                        pendingViewedPaths={pendingViewedPaths}
+                        onCommentAdded={appendOptimisticComment}
+                        onViewedChange={handlePRFileViewedChange}
+                      />
+                    )}
+                  </TabsContent>
+                </>
+              )}
+            </div>
+          </Tabs>
+        )}
+      </div>
+    </div>
+  ) : null
+
+  if (variant === 'page') {
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-md border border-border/50 bg-background shadow-sm">
+        {content}
+      </div>
+    )
+  }
+
   return (
     <Sheet open={workItem !== null} onOpenChange={(open) => !open && onClose()}>
       <SheetContent
@@ -5289,276 +5586,7 @@ export default function GitHubItemDialog({
           </SheetDescription>
         </VisuallyHidden.Root>
 
-        {workItem && (
-          <div className="flex h-full min-h-0 flex-col">
-            <div className="flex-none border-b border-border/60 bg-card/80 px-4 py-3 shadow-xs backdrop-blur supports-[backdrop-filter]:bg-card/70">
-              <div className="flex items-start gap-3">
-                <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground">
-                  <Icon className="size-4" />
-                </div>
-                <div className="min-w-0 flex-1 space-y-1">
-                  <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
-                    <WorkItemStateBadge item={{ ...workItem, state: localState }} />
-                    <span className="font-mono">#{workItem.number}</span>
-                    <span>{workItem.type === 'pr' ? 'Pull request' : 'Issue'}</span>
-                  </div>
-                  <h2 className="text-[15px] font-semibold leading-snug text-foreground">
-                    {workItem.title}
-                  </h2>
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-                    <span>{workItem.author ?? 'unknown'}</span>
-                    <span>updated {formatRelativeTime(workItem.updatedAt)}</span>
-                    {workItem.branchName && (
-                      <span className="max-w-full truncate rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                        {workItem.branchName}
-                      </span>
-                    )}
-                  </div>
-                  {workItem.type === 'issue' && (
-                    <WorkItemIssueSourceIndicator url={workItem.url} repoId={effectiveRepoId} />
-                  )}
-                </div>
-                <div className="flex shrink-0 items-center justify-end gap-1">
-                  {workItem.type === 'pr' && (
-                    <Button
-                      type="button"
-                      size="sm"
-                      onClick={() => onUse(workItem)}
-                      className="gap-1.5 whitespace-nowrap"
-                      aria-label="Start workspace from PR"
-                    >
-                      Start workspace from PR
-                      <ArrowRight className="size-3.5" />
-                    </Button>
-                  )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => void handleCopyWorkItemLink()}
-                        aria-label="Copy GitHub link"
-                      >
-                        {linkCopied ? (
-                          <Check className="size-4 text-emerald-500" />
-                        ) : (
-                          <Copy className="size-4" />
-                        )}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      {linkCopied ? 'Copied' : 'Copy GitHub link'}
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => window.api.shell.openUrl(workItem.url)}
-                        aria-label="Open on GitHub"
-                      >
-                        <ExternalLink className="size-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Open on GitHub
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={onClose}
-                        aria-label="Close preview"
-                      >
-                        <X className="size-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Close · Esc
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              </div>
-            </div>
-
-            {(repoPath || projectOrigin) && (
-              <GHEditSection
-                item={workItem}
-                repoPath={repoPath}
-                repoId={effectiveRepoId}
-                projectOrigin={projectOrigin}
-                localState={localState}
-                localLabels={localLabels}
-                onStateChange={setLocalState}
-                onLabelsChange={setLocalLabels}
-                onMutated={() => {
-                  // Why: drop the cached details for this item so the next
-                  // open issues a fresh fetch instead of painting pre-edit
-                  // state. We invalidate by (repoPath, type, number) match
-                  // because a single mutation can affect entries across all
-                  // issueSourcePreference values for the same number.
-                  if (repoPath) {
-                    invalidateWorkItemDetailsCacheByMatch({
-                      repoPath,
-                      repoId: effectiveRepoId ?? undefined,
-                      type: workItem.type,
-                      number: workItem.number
-                    })
-                  }
-                }}
-                assignees={details?.assignees ?? []}
-                onUse={onUse}
-              />
-            )}
-
-            <div className="min-h-0 flex-1">
-              {error ? (
-                <div className="px-4 py-6 text-[12px] text-destructive">{error}</div>
-              ) : (
-                <Tabs
-                  value={tab}
-                  onValueChange={(value) => setTab(value as ItemDialogTab)}
-                  className="flex h-full min-h-0 flex-col gap-0"
-                >
-                  <TabsList
-                    variant="line"
-                    className="mx-4 mt-2 justify-start gap-3 border-b border-border/60 bg-transparent"
-                  >
-                    <TabsTrigger value="conversation" className="px-2">
-                      <MessageSquare className="size-3.5" />
-                      Conversation
-                    </TabsTrigger>
-                    {workItem.type === 'pr' && (
-                      <>
-                        <TabsTrigger value="checks" className="px-2">
-                          <ListChecks className="size-3.5" />
-                          Checks
-                          {checks.length > 0 && (
-                            <span className="ml-1 text-[10px] text-muted-foreground">
-                              {checks.length}
-                            </span>
-                          )}
-                        </TabsTrigger>
-                        <TabsTrigger value="files" className="px-2">
-                          <FileText className="size-3.5" />
-                          Files
-                          {files.length > 0 && (
-                            <span className="ml-1 text-[10px] text-muted-foreground">
-                              {files.length}
-                            </span>
-                          )}
-                        </TabsTrigger>
-                      </>
-                    )}
-                  </TabsList>
-
-                  <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
-                    <TabsContent value="conversation" className="mt-0">
-                      <ConversationTab
-                        item={displayWorkItem ?? workItem}
-                        repoPath={repoPath}
-                        repoId={effectiveRepoId}
-                        body={body}
-                        comments={comments}
-                        files={files}
-                        headSha={details?.headSha}
-                        baseSha={details?.baseSha}
-                        loading={loading}
-                        detailsLoaded={detailsLoaded}
-                        checks={checks}
-                        participants={details?.participants ?? []}
-                        localState={localState}
-                        onStateChange={setLocalState}
-                        projectOrigin={projectOrigin}
-                        onMutated={() => {
-                          if (repoPath) {
-                            invalidateWorkItemDetailsCacheByMatch({
-                              repoPath,
-                              repoId: effectiveRepoId ?? undefined,
-                              type: workItem.type,
-                              number: workItem.number
-                            })
-                          }
-                        }}
-                        onChecksUpdated={(nextChecks) => {
-                          if (detailsCacheKey) {
-                            patchCachedPRChecks(detailsCacheKey, nextChecks)
-                          }
-                        }}
-                        onBodyUpdated={(nextBody) => {
-                          if (detailsCacheKey) {
-                            patchCachedWorkItemBody(detailsCacheKey, nextBody)
-                          }
-                        }}
-                        onCommentAdded={appendOptimisticComment}
-                        onReviewersRequested={(nextReviewRequests) => {
-                          if (detailsCacheKey) {
-                            patchCachedPRReviewRequests(detailsCacheKey, nextReviewRequests)
-                          }
-                          onReviewRequestsChange?.(
-                            { id: workItem.id, repoId: workItem.repoId },
-                            nextReviewRequests
-                          )
-                        }}
-                      />
-                    </TabsContent>
-
-                    {workItem.type === 'pr' && (
-                      <>
-                        <TabsContent value="checks" className="mt-0">
-                          <ChecksTab
-                            item={workItem}
-                            repoPath={repoPath}
-                            repoId={effectiveRepoId}
-                            headSha={details?.headSha}
-                            checks={checks}
-                            loading={loading || !detailsLoaded}
-                            variant="page"
-                            onChecksUpdated={(nextChecks) => {
-                              if (detailsCacheKey) {
-                                patchCachedPRChecks(detailsCacheKey, nextChecks)
-                              }
-                            }}
-                          />
-                        </TabsContent>
-
-                        <TabsContent value="files" className="mt-0">
-                          {loading && files.length === 0 ? (
-                            <div className="flex items-center justify-center py-10">
-                              <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
-                            </div>
-                          ) : files.length === 0 ? (
-                            <div className="px-4 py-10 text-center text-[12px] text-muted-foreground">
-                              No files changed.
-                            </div>
-                          ) : (
-                            <PRFilesCombinedDiffViewer
-                              files={files}
-                              comments={comments}
-                              repoPath={repoPath ?? ''}
-                              repoId={effectiveRepoId ?? ''}
-                              prNumber={workItem.number}
-                              prUrl={workItem.url}
-                              headSha={details?.headSha}
-                              baseSha={details?.baseSha}
-                              pendingViewedPaths={pendingViewedPaths}
-                              onCommentAdded={appendOptimisticComment}
-                              onViewedChange={handlePRFileViewedChange}
-                            />
-                          )}
-                        </TabsContent>
-                      </>
-                    )}
-                  </div>
-                </Tabs>
-              )}
-            </div>
-          </div>
-        )}
+        {content}
       </SheetContent>
     </Sheet>
   )

--- a/src/renderer/src/components/LinearIssueWorkspace.tsx
+++ b/src/renderer/src/components/LinearIssueWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   ArrowRight,
   Check,
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   Clipboard,
   FolderKanban,
@@ -58,6 +59,8 @@ type LinearIssueWorkspaceProps = {
   onUse: (issue: LinearIssue) => void
   onOpenIssue: (issue: LinearIssue) => void
   onClose: () => void
+  variant?: 'sheet' | 'page'
+  backLabel?: string
 }
 
 async function copyTextToClipboard(text: string, label: string): Promise<void> {
@@ -376,7 +379,9 @@ export default function LinearIssueWorkspace({
   issue,
   onUse,
   onOpenIssue,
-  onClose
+  onClose,
+  variant = 'sheet',
+  backLabel = 'Back'
 }: LinearIssueWorkspaceProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const [fullIssue, setFullIssue] = useState<LinearIssue | null>(null)
@@ -545,6 +550,263 @@ export default function LinearIssueWorkspace({
     ]
   }, [displayed])
 
+  const content = displayed ? (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
+      <header className="flex h-[61px] flex-none items-center justify-between gap-4 border-b border-border/60 px-5">
+        <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
+          {variant === 'page' ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              className="-ml-2 shrink-0 gap-1.5"
+              aria-label={backLabel}
+            >
+              <ChevronLeft className="size-4" />
+              {backLabel}
+            </Button>
+          ) : null}
+          <LinearIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-medium text-foreground">
+            {displayed.workspaceName ?? 'Linear'}
+          </span>
+          <ChevronRight className="size-3.5 shrink-0" />
+          <span className="shrink-0">Issues</span>
+          <ChevronRight className="size-3.5 shrink-0" />
+          <span className="shrink-0 font-mono">{displayed.identifier}</span>
+          <span className="min-w-0 truncate font-medium text-foreground">{displayed.title}</span>
+          {issueLoading ? <LoaderCircle className="size-3.5 shrink-0 animate-spin" /> : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="hidden px-2 text-sm text-muted-foreground md:inline">2 / 17</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => void copyTextToClipboard(displayed.url, 'URL')}
+                aria-label="Copy Linear URL"
+              >
+                <Link className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              Copy URL
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => void copyTextToClipboard(displayed.identifier, 'Identifier')}
+                aria-label="Copy issue identifier"
+              >
+                <Clipboard className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              Copy identifier
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => onUse(displayed)}
+                aria-label="Start workspace from issue"
+              >
+                <ArrowRight className="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              Start workspace
+            </TooltipContent>
+          </Tooltip>
+          {variant === 'sheet' ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onClose}
+                  aria-label="Close Linear issue preview"
+                >
+                  <X className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                Close
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+        <div className="mx-auto grid w-full grid-cols-1 gap-10 px-7 py-10 lg:grid-cols-[minmax(0,1fr)_320px] lg:px-10 xl:px-12">
+          <main className="min-w-0">
+            <h1 className="max-w-[820px] text-[28px] font-semibold leading-tight text-foreground">
+              {displayed.title}
+            </h1>
+
+            <section className="mt-7 max-w-[820px] text-[15px] leading-7 text-foreground">
+              {displayed.description?.trim() ? (
+                <CommentMarkdown
+                  content={displayed.description}
+                  className="text-[15px] leading-7"
+                />
+              ) : (
+                <p className="text-sm italic text-muted-foreground">No description provided.</p>
+              )}
+            </section>
+
+            <LinearIssueSubIssueButton issue={displayed} onOpenIssue={onOpenIssue} />
+
+            <section className="mt-12 border-t border-border/60 pt-9">
+              <div className="mb-8 flex items-center justify-between gap-3">
+                <h2 className="text-xl font-semibold text-foreground">Activity</h2>
+                <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <LinearIssueAvatar
+                    avatarUrl={displayed.assignee?.avatarUrl}
+                    name={displayed.assignee?.displayName}
+                    className="size-6"
+                  />
+                </div>
+              </div>
+
+              <div className="mb-7 flex items-center gap-3 text-sm text-muted-foreground">
+                <LinearIssueAvatar
+                  avatarUrl={displayed.assignee?.avatarUrl}
+                  name={displayed.assignee?.displayName}
+                  className="size-5"
+                />
+                <span>
+                  {displayed.assignee?.displayName ?? 'Someone'} updated the issue ·{' '}
+                  {formatLinearIssueRelativeTime(displayed.updatedAt)}
+                </span>
+              </div>
+
+              {commentsError ? (
+                <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  <span>{commentsError}</span>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    onClick={() => void loadComments(displayed, requestIdRef.current)}
+                    disabled={commentsLoading}
+                    className="gap-1"
+                  >
+                    {commentsLoading ? (
+                      <LoaderCircle className="size-3 animate-spin" />
+                    ) : (
+                      <RefreshCw className="size-3" />
+                    )}
+                    Retry
+                  </Button>
+                </div>
+              ) : null}
+
+              {commentsLoading && comments.length === 0 ? (
+                <div className="mb-5 flex items-center justify-center py-8">
+                  <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : comments.length > 0 ? (
+                <div className="mb-6 flex flex-col gap-5">
+                  {comments.map((comment) => (
+                    <article key={comment.id} className="flex gap-3">
+                      <LinearIssueAvatar
+                        avatarUrl={comment.user?.avatarUrl}
+                        name={comment.user?.displayName}
+                        className="size-7"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-1 flex min-w-0 items-center gap-2 text-sm">
+                          <span className="truncate font-semibold text-foreground">
+                            {comment.user?.displayName ?? 'Unknown'}
+                          </span>
+                          <span className="shrink-0 text-muted-foreground">
+                            {formatLinearIssueRelativeTime(comment.createdAt)}
+                          </span>
+                        </div>
+                        <div className="rounded-lg border border-border/60 bg-card px-4 py-3">
+                          <CommentMarkdown
+                            content={comment.body}
+                            className="text-[14px] leading-7"
+                          />
+                        </div>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : null}
+
+              <LinearIssueCommentFooter
+                issueId={displayed.id}
+                workspaceId={displayed.workspaceId}
+                onCommentAdded={handleCommentAdded}
+                variant="linear-page"
+              />
+            </section>
+          </main>
+
+          <aside className="space-y-3 lg:sticky lg:top-6 lg:self-start">
+            {editState ? (
+              <LinearIssueEditSection
+                issue={displayed}
+                editState={editState}
+                onEditStateChange={handleEditStateChange}
+                layout="properties"
+              />
+            ) : null}
+            <LinearIssueSidebarProjectCard
+              issue={displayed}
+              onProjectChanged={handleProjectChanged}
+            />
+            <section className="rounded-xl border border-border/60 bg-card text-card-foreground shadow-xs">
+              <div className="flex h-10 items-center gap-1 border-b border-border/50 px-4 text-sm font-medium text-muted-foreground">
+                <span>Actions</span>
+                <ChevronDown className="size-3.5" />
+              </div>
+              <div className="space-y-1 p-3">
+                {actionItems.map((item) => {
+                  const Icon = item.icon
+                  return (
+                    <Tooltip key={item.label}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={item.action}
+                          className="flex min-h-9 w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        >
+                          <Icon className="size-4 shrink-0" />
+                          <span className="truncate">{item.label}</span>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="left" sideOffset={6}>
+                        {item.label}
+                      </TooltipContent>
+                    </Tooltip>
+                  )
+                })}
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </div>
+  ) : null
+
+  if (variant === 'page') {
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-md border border-border/50 bg-background shadow-sm">
+        {content}
+      </div>
+    )
+  }
+
   return (
     <Sheet open={issue !== null} onOpenChange={(open) => !open && onClose()}>
       <SheetContent
@@ -564,243 +826,7 @@ export default function LinearIssueWorkspace({
           </SheetDescription>
         </VisuallyHidden.Root>
 
-        {displayed ? (
-          <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
-            <header className="flex h-[61px] flex-none items-center justify-between gap-4 border-b border-border/60 px-5">
-              <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
-                <LinearIcon className="size-4 shrink-0 text-muted-foreground" />
-                <span className="truncate font-medium text-foreground">
-                  {displayed.workspaceName ?? 'Linear'}
-                </span>
-                <ChevronRight className="size-3.5 shrink-0" />
-                <span className="shrink-0">Issues</span>
-                <ChevronRight className="size-3.5 shrink-0" />
-                <span className="shrink-0 font-mono">{displayed.identifier}</span>
-                <span className="min-w-0 truncate font-medium text-foreground">
-                  {displayed.title}
-                </span>
-                {issueLoading ? <LoaderCircle className="size-3.5 shrink-0 animate-spin" /> : null}
-              </div>
-              <div className="flex shrink-0 items-center gap-1">
-                <span className="hidden px-2 text-sm text-muted-foreground md:inline">2 / 17</span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => void copyTextToClipboard(displayed.url, 'URL')}
-                      aria-label="Copy Linear URL"
-                    >
-                      <Link className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    Copy URL
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => void copyTextToClipboard(displayed.identifier, 'Identifier')}
-                      aria-label="Copy issue identifier"
-                    >
-                      <Clipboard className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    Copy identifier
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => onUse(displayed)}
-                      aria-label="Start workspace from issue"
-                    >
-                      <ArrowRight className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    Start workspace
-                  </TooltipContent>
-                </Tooltip>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={onClose}
-                      aria-label="Close Linear issue preview"
-                    >
-                      <X className="size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    Close
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            </header>
-
-            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
-              <div className="mx-auto grid w-full grid-cols-1 gap-10 px-7 py-10 lg:grid-cols-[minmax(0,1fr)_320px] lg:px-10 xl:px-12">
-                <main className="min-w-0">
-                  <h1 className="max-w-[820px] text-[28px] font-semibold leading-tight text-foreground">
-                    {displayed.title}
-                  </h1>
-
-                  <section className="mt-7 max-w-[820px] text-[15px] leading-7 text-foreground">
-                    {displayed.description?.trim() ? (
-                      <CommentMarkdown
-                        content={displayed.description}
-                        className="text-[15px] leading-7"
-                      />
-                    ) : (
-                      <p className="text-sm italic text-muted-foreground">
-                        No description provided.
-                      </p>
-                    )}
-                  </section>
-
-                  <LinearIssueSubIssueButton issue={displayed} onOpenIssue={onOpenIssue} />
-
-                  <section className="mt-12 border-t border-border/60 pt-9">
-                    <div className="mb-8 flex items-center justify-between gap-3">
-                      <h2 className="text-xl font-semibold text-foreground">Activity</h2>
-                      <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                        <LinearIssueAvatar
-                          avatarUrl={displayed.assignee?.avatarUrl}
-                          name={displayed.assignee?.displayName}
-                          className="size-6"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="mb-7 flex items-center gap-3 text-sm text-muted-foreground">
-                      <LinearIssueAvatar
-                        avatarUrl={displayed.assignee?.avatarUrl}
-                        name={displayed.assignee?.displayName}
-                        className="size-5"
-                      />
-                      <span>
-                        {displayed.assignee?.displayName ?? 'Someone'} updated the issue ·{' '}
-                        {formatLinearIssueRelativeTime(displayed.updatedAt)}
-                      </span>
-                    </div>
-
-                    {commentsError ? (
-                      <div className="mb-4 flex items-center justify-between gap-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                        <span>{commentsError}</span>
-                        <Button
-                          variant="outline"
-                          size="xs"
-                          onClick={() => void loadComments(displayed, requestIdRef.current)}
-                          disabled={commentsLoading}
-                          className="gap-1"
-                        >
-                          {commentsLoading ? (
-                            <LoaderCircle className="size-3 animate-spin" />
-                          ) : (
-                            <RefreshCw className="size-3" />
-                          )}
-                          Retry
-                        </Button>
-                      </div>
-                    ) : null}
-
-                    {commentsLoading && comments.length === 0 ? (
-                      <div className="mb-5 flex items-center justify-center py-8">
-                        <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
-                      </div>
-                    ) : comments.length > 0 ? (
-                      <div className="mb-6 flex flex-col gap-5">
-                        {comments.map((comment) => (
-                          <article key={comment.id} className="flex gap-3">
-                            <LinearIssueAvatar
-                              avatarUrl={comment.user?.avatarUrl}
-                              name={comment.user?.displayName}
-                              className="size-7"
-                            />
-                            <div className="min-w-0 flex-1">
-                              <div className="mb-1 flex min-w-0 items-center gap-2 text-sm">
-                                <span className="truncate font-semibold text-foreground">
-                                  {comment.user?.displayName ?? 'Unknown'}
-                                </span>
-                                <span className="shrink-0 text-muted-foreground">
-                                  {formatLinearIssueRelativeTime(comment.createdAt)}
-                                </span>
-                              </div>
-                              <div className="rounded-lg border border-border/60 bg-card px-4 py-3">
-                                <CommentMarkdown
-                                  content={comment.body}
-                                  className="text-[14px] leading-7"
-                                />
-                              </div>
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    <LinearIssueCommentFooter
-                      issueId={displayed.id}
-                      workspaceId={displayed.workspaceId}
-                      onCommentAdded={handleCommentAdded}
-                      variant="linear-page"
-                    />
-                  </section>
-                </main>
-
-                <aside className="space-y-3 lg:sticky lg:top-6 lg:self-start">
-                  {editState ? (
-                    <LinearIssueEditSection
-                      issue={displayed}
-                      editState={editState}
-                      onEditStateChange={handleEditStateChange}
-                      layout="properties"
-                    />
-                  ) : null}
-                  <LinearIssueSidebarProjectCard
-                    issue={displayed}
-                    onProjectChanged={handleProjectChanged}
-                  />
-                  <section className="rounded-xl border border-border/60 bg-card text-card-foreground shadow-xs">
-                    <div className="flex h-10 items-center gap-1 border-b border-border/50 px-4 text-sm font-medium text-muted-foreground">
-                      <span>Actions</span>
-                      <ChevronDown className="size-3.5" />
-                    </div>
-                    <div className="space-y-1 p-3">
-                      {actionItems.map((item) => {
-                        const Icon = item.icon
-                        return (
-                          <Tooltip key={item.label}>
-                            <TooltipTrigger asChild>
-                              <button
-                                type="button"
-                                onClick={item.action}
-                                className="flex min-h-9 w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground transition hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                              >
-                                <Icon className="size-4 shrink-0" />
-                                <span className="truncate">{item.label}</span>
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="left" sideOffset={6}>
-                              {item.label}
-                            </TooltipContent>
-                          </Tooltip>
-                        )
-                      })}
-                    </div>
-                  </section>
-                </aside>
-              </div>
-            </div>
-          </div>
-        ) : null}
+        {content}
       </SheetContent>
     </Sheet>
   )

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1682,6 +1682,7 @@ export default function TaskPage(): React.JSX.Element {
   const taskResumeState = useAppStore((s) => s.taskResumeState)
   const setTaskResumeState = useAppStore((s) => s.setTaskResumeState)
   const pageData = useAppStore((s) => s.taskPageData)
+  const openTaskPage = useAppStore((s) => s.openTaskPage)
   const closeTaskPage = useAppStore((s) => s.closeTaskPage)
   const activeModal = useAppStore((s) => s.activeModal)
   const repos = useAppStore((s) => s.repos)
@@ -1988,6 +1989,7 @@ export default function TaskPage(): React.JSX.Element {
   const dialogWorkItem = dialogWorkItemKey
     ? (cachedDialogWorkItem ?? githubTaskDrawerWorkItem)
     : null
+  const dialogRepoPath = dialogWorkItem ? (repoMap.get(dialogWorkItem.repoId)?.path ?? null) : null
 
   const setDialogWorkItem = useCallback(
     (item: GitHubWorkItem | null, initialTab: ItemDialogTab = 'conversation') => {
@@ -1995,6 +1997,27 @@ export default function TaskPage(): React.JSX.Element {
       setGithubTaskDrawerWorkItem(item)
     },
     [setGithubTaskDrawerWorkItem]
+  )
+
+  useEffect(() => {
+    if (!pageData.openGitHubWorkItem) {
+      setDialogWorkItem(null)
+      return
+    }
+    setGithubMode('items')
+    setDialogWorkItem(pageData.openGitHubWorkItem, pageData.openGitHubInitialTab)
+  }, [pageData.openGitHubInitialTab, pageData.openGitHubWorkItem, setDialogWorkItem])
+
+  const openGitHubDetailPage = useCallback(
+    (item: GitHubWorkItem, initialTab: ItemDialogTab = 'conversation') => {
+      openTaskPage({
+        taskSource: 'github',
+        preselectedRepoId: item.repoId,
+        openGitHubWorkItem: item,
+        openGitHubInitialTab: initialTab
+      })
+    },
+    [openTaskPage]
   )
 
   const patchTaskPageWorkItemRows = useCallback(
@@ -2166,22 +2189,56 @@ export default function TaskPage(): React.JSX.Element {
     []
   )
 
-  const openRelatedLinearIssue = useCallback(
-    (issue: LinearIssue) => {
-      setSelectedLinearIssue(issue, { allowOutsideList: true })
-    },
-    [setSelectedLinearIssue]
-  )
-
-  const closeSelectedLinearIssue = useCallback(() => {
-    setSelectedLinearIssue(null)
-  }, [setSelectedLinearIssue])
-
   const clearSelectedLinearIssue = useCallback(() => {
     setSelectedLinearIssueCanFloat(false)
     setSelectedLinearIssueId(null)
     setSelectedLinearIssueFallback(null)
   }, [])
+
+  useEffect(() => {
+    if (!pageData.openLinearIssue) {
+      clearSelectedLinearIssue()
+      return
+    }
+    setSelectedLinearIssue(pageData.openLinearIssue, { allowOutsideList: true })
+  }, [clearSelectedLinearIssue, pageData.openLinearIssue, setSelectedLinearIssue])
+
+  const openLinearDetailPage = useCallback(
+    (issue: LinearIssue) => {
+      openTaskPage({ taskSource: 'linear', openLinearIssue: issue })
+    },
+    [openTaskPage]
+  )
+
+  const openRelatedLinearIssue = useCallback(
+    (issue: LinearIssue) => {
+      openLinearDetailPage(issue)
+    },
+    [openLinearDetailPage]
+  )
+
+  const closeTaskDetailPage = useCallback(() => {
+    const state = useAppStore.getState()
+    const currentEntry = state.worktreeNavHistory[state.worktreeNavHistoryIndex]
+    if (
+      typeof currentEntry === 'object' &&
+      currentEntry.kind === 'task-detail' &&
+      state.worktreeNavHistoryIndex > 0
+    ) {
+      state.goBackWorktree()
+      return
+    }
+    setDialogWorkItem(null)
+    clearSelectedLinearIssue()
+    useAppStore.setState((s) => ({
+      taskPageData: {
+        ...s.taskPageData,
+        openGitHubWorkItem: undefined,
+        openGitHubInitialTab: undefined,
+        openLinearIssue: undefined
+      }
+    }))
+  }, [clearSelectedLinearIssue, setDialogWorkItem])
 
   // Linear tab state
   const [linearIssues, setLinearIssues] = useState<LinearIssue[]>([])
@@ -3357,7 +3414,7 @@ export default function TaskPage(): React.JSX.Element {
         updatedAt: new Date().toISOString(),
         author: null
       }
-      setDialogWorkItem(stub)
+      openGitHubDetailPage(stub)
       const stubRepoId = newIssueTargetRepo.id
       const fullIssuePromise = target
         ? callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.workItem>>>(
@@ -3387,7 +3444,14 @@ export default function TaskPage(): React.JSX.Element {
     } finally {
       setNewIssueSubmitting(false)
     }
-  }, [newIssueBody, newIssueSubmitting, newIssueTargetRepo, newIssueTitle, setDialogWorkItem])
+  }, [
+    newIssueBody,
+    newIssueSubmitting,
+    newIssueTargetRepo,
+    newIssueTitle,
+    openGitHubDetailPage,
+    setDialogWorkItem
+  ])
 
   const handleCreateNewLinearIssue = useCallback(async (): Promise<void> => {
     if (!newLinearIssueTargetTeam) {
@@ -3427,7 +3491,7 @@ export default function TaskPage(): React.JSX.Element {
       void linearGetIssue(settings, result.id, newLinearIssueTargetTeam.workspaceId)
         .then((full) => {
           if (full) {
-            setSelectedLinearIssue(full)
+            openLinearDetailPage(full)
           }
         })
         .catch(() => {})
@@ -3439,8 +3503,8 @@ export default function TaskPage(): React.JSX.Element {
     newLinearIssueSubmitting,
     newLinearIssueTargetTeam,
     newLinearIssueTitle,
-    settings,
-    setSelectedLinearIssue
+    openLinearDetailPage,
+    settings
   ])
 
   const githubTasksBusy = tasksLoading || tasksRefreshing || tasksFiltering
@@ -3768,7 +3832,7 @@ export default function TaskPage(): React.JSX.Element {
                               disabled={source.disabled}
                               onClick={() => {
                                 taskSourceManuallyChangedRef.current = true
-                                setTaskSource(source.id)
+                                openTaskPage({ taskSource: source.id })
                                 void updateSettings({ defaultTaskSource: source.id }).catch(() => {
                                   toast.error('Failed to save default task source.')
                                 })
@@ -4318,7 +4382,22 @@ export default function TaskPage(): React.JSX.Element {
             </section>
           </div>
 
-          {taskSource === 'github' && githubMode === 'project' ? (
+          {taskSource === 'github' && dialogWorkItem ? (
+            <GitHubItemDialog
+              workItem={dialogWorkItem}
+              initialTab={dialogInitialTab}
+              repoPath={dialogRepoPath}
+              repoId={dialogWorkItem.repoId}
+              variant="page"
+              backLabel="GitHub list"
+              onUse={(item) => {
+                setDialogWorkItem(null)
+                handleUseWorkItem(item)
+              }}
+              onReviewRequestsChange={handleDialogReviewRequestsChange}
+              onClose={closeTaskDetailPage}
+            />
+          ) : taskSource === 'github' && githubMode === 'project' ? (
             <div className="mt-3 flex min-h-0 min-w-0 max-h-full flex-col overflow-hidden rounded-md border border-border/50 bg-muted/50 shadow-sm">
               <ProjectViewWrapper />
             </div>
@@ -4496,11 +4575,11 @@ export default function TaskPage(): React.JSX.Element {
                           key={`${item.repoId}:${item.id}`}
                           role="button"
                           tabIndex={0}
-                          onClick={() => setDialogWorkItem(item)}
+                          onClick={() => openGitHubDetailPage(item)}
                           onKeyDown={(event) => {
                             if (event.key === 'Enter' || event.key === ' ') {
                               event.preventDefault()
-                              setDialogWorkItem(item)
+                              openGitHubDetailPage(item)
                             }
                           }}
                           className={cn(
@@ -4597,7 +4676,7 @@ export default function TaskPage(): React.JSX.Element {
                               <div className="flex min-w-0 items-center">
                                 <PRChecksCell
                                   item={item}
-                                  onOpen={() => setDialogWorkItem(item, 'checks')}
+                                  onOpen={() => openGitHubDetailPage(item, 'checks')}
                                   onLoadChecks={() => ensurePRChecksLoaded(item)}
                                 />
                               </div>
@@ -4864,6 +4943,15 @@ export default function TaskPage(): React.JSX.Element {
                 </div>
               </div>
             </div>
+          ) : taskSource === 'linear' && selectedLinearIssue ? (
+            <LinearIssueWorkspace
+              issue={selectedLinearIssue}
+              variant="page"
+              backLabel="Linear list"
+              onUse={handleUseLinearItem}
+              onOpenIssue={openRelatedLinearIssue}
+              onClose={closeTaskDetailPage}
+            />
           ) : !linearStatusChecked ? (
             <div className="mt-4 flex items-center justify-center py-14">
               <LoaderCircle className="size-5 animate-spin text-muted-foreground" />
@@ -5109,14 +5197,14 @@ export default function TaskPage(): React.JSX.Element {
                                   setLinearBoardDraggingIssueId(null)
                                   setLinearBoardDragOverKey(null)
                                 }}
-                                onClick={() => setSelectedLinearIssue(issue)}
+                                onClick={() => openLinearDetailPage(issue)}
                                 onKeyDown={(e) => {
                                   if (e.target !== e.currentTarget) {
                                     return
                                   }
                                   if (e.key === 'Enter' || e.key === ' ') {
                                     e.preventDefault()
-                                    setSelectedLinearIssue(issue)
+                                    openLinearDetailPage(issue)
                                   }
                                 }}
                                 className={cn(
@@ -5240,7 +5328,7 @@ export default function TaskPage(): React.JSX.Element {
                           aria-current={selected ? 'true' : undefined}
                           data-current={selected ? 'true' : undefined}
                           onClick={() => {
-                            setSelectedLinearIssue(issue)
+                            openLinearDetailPage(issue)
                           }}
                           onKeyDown={(e) => {
                             if (e.target !== e.currentTarget) {
@@ -5248,7 +5336,7 @@ export default function TaskPage(): React.JSX.Element {
                             }
                             if (e.key === 'Enter' || e.key === ' ') {
                               e.preventDefault()
-                              setSelectedLinearIssue(issue)
+                              openLinearDetailPage(issue)
                             }
                           }}
                           className={cn(
@@ -5403,12 +5491,6 @@ export default function TaskPage(): React.JSX.Element {
                   </div>
                 )}
               </div>
-              <LinearIssueWorkspace
-                issue={selectedLinearIssue}
-                onUse={handleUseLinearItem}
-                onOpenIssue={openRelatedLinearIssue}
-                onClose={closeSelectedLinearIssue}
-              />
             </div>
           )}
         </div>
@@ -5693,25 +5775,6 @@ export default function TaskPage(): React.JSX.Element {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      <GitHubItemDialog
-        workItem={dialogWorkItem}
-        initialTab={dialogInitialTab}
-        repoPath={
-          // Why: the dialog is for a single item — resolve its repoPath from the
-          // item's own repoId (set when fan-out merged the list) so it works in
-          // cross-repo mode too. Reusing the memoized repo map avoids an O(n)
-          // scan on every render while the dialog is open.
-          dialogWorkItem ? (repoMap.get(dialogWorkItem.repoId)?.path ?? null) : null
-        }
-        repoId={dialogWorkItem?.repoId ?? null}
-        onUse={(item) => {
-          setDialogWorkItem(null)
-          handleUseWorkItem(item)
-        }}
-        onReviewRequestsChange={handleDialogReviewRequestsChange}
-        onClose={() => setDialogWorkItem(null)}
-      />
 
       <GitLabItemDialog
         item={gitlabDialogItem}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -24,12 +24,19 @@ import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
-import type { Worktree, Repo, IssueInfo, LinearIssue } from '../../../../shared/types'
+import type {
+  GitHubWorkItem,
+  Worktree,
+  Repo,
+  IssueInfo,
+  LinearIssue
+} from '../../../../shared/types'
 import { branchDisplayName, CONFLICT_OPERATION_LABELS, FilledBellIcon } from './WorktreeCardHelpers'
 import {
   WorktreeCardDetailsHover,
   WorktreeCardMetaBadges,
-  hasWorktreeCardDetails
+  hasWorktreeCardDetails,
+  type WorktreeCardIssueDisplay
 } from './WorktreeCardMeta'
 import { WorktreeCardPorts } from './WorktreeCardPorts'
 import { writeWorkspaceDragData } from './workspace-status'
@@ -83,6 +90,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   onLineageToggle
 }: WorktreeCardProps) {
   const openModal = useAppStore((s) => s.openModal)
+  const openTaskPage = useAppStore((s) => s.openTaskPage)
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const fetchHostedReviewForBranch = useAppStore((s) => s.fetchHostedReviewForBranch)
   const settings = useAppStore((s) => s.settings)
@@ -182,7 +190,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       ? issueEntry.data
       : undefined
     : null
-  const issueDisplay =
+  const issueDisplay: WorktreeCardIssueDisplay | null =
     issue ??
     (worktree.linkedIssue
       ? {
@@ -391,6 +399,62 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const metaLinearIssue = showIssue ? linearIssueDisplay : null
   const metaReview = showPR ? prDisplay : null
   const metaComment = showComment ? worktree.comment : null
+  const handleOpenGitHubIssueInOrca = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      const issueUrl = metaIssue && 'url' in metaIssue ? metaIssue.url : undefined
+      if (!repo || !metaIssue || !issueUrl) {
+        return
+      }
+      const item: GitHubWorkItem = {
+        id: issueUrl,
+        type: 'issue',
+        number: metaIssue.number,
+        title: metaIssue.title,
+        state: 'state' in metaIssue ? (metaIssue.state ?? 'open') : 'open',
+        url: issueUrl,
+        labels: 'labels' in metaIssue ? (metaIssue.labels ?? []) : [],
+        updatedAt: new Date().toISOString(),
+        author: null,
+        repoId: repo.id
+      }
+      openTaskPage({ taskSource: 'github', preselectedRepoId: repo.id, openGitHubWorkItem: item })
+    },
+    [metaIssue, openTaskPage, repo]
+  )
+  const handleOpenReviewInOrca = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (!repo || !metaReview?.url || metaReview.provider !== 'github') {
+        return
+      }
+      const item: GitHubWorkItem = {
+        id: metaReview.url,
+        type: 'pr',
+        number: metaReview.number,
+        title: metaReview.title,
+        state: metaReview.state ?? 'open',
+        url: metaReview.url,
+        labels: [],
+        updatedAt: 'updatedAt' in metaReview ? metaReview.updatedAt : new Date().toISOString(),
+        author: null,
+        headSha: 'headSha' in metaReview ? metaReview.headSha : undefined,
+        repoId: repo.id
+      }
+      openTaskPage({ taskSource: 'github', preselectedRepoId: repo.id, openGitHubWorkItem: item })
+    },
+    [metaReview, openTaskPage, repo]
+  )
+  const handleOpenLinearIssueInOrca = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (!linearIssue) {
+        return
+      }
+      openTaskPage({ taskSource: 'linear', openLinearIssue: linearIssue })
+    },
+    [linearIssue, openTaskPage]
+  )
   const hasDetails = hasWorktreeCardDetails({
     issue: metaIssue,
     linearIssue: metaLinearIssue,
@@ -605,6 +669,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 comment={metaComment}
                 onEditIssue={handleEditIssue}
                 onEditComment={handleEditComment}
+                onOpenGitHubIssueInOrca={
+                  metaIssue && 'url' in metaIssue && metaIssue.url
+                    ? handleOpenGitHubIssueInOrca
+                    : undefined
+                }
+                onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
+                onOpenReviewInOrca={
+                  metaReview?.url && metaReview.provider === 'github'
+                    ? handleOpenReviewInOrca
+                    : undefined
+                }
               >
                 <WorktreeCardMetaBadges
                   issue={metaIssue}

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -1,9 +1,12 @@
+/* eslint-disable max-lines -- Why: the card metadata hover keeps compact badge rendering,
+   provider-specific action rows, and markdown note preview together so the sidebar
+   card has one metadata contract. */
 import React from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { CircleDot, ExternalLink, GitMerge, Pencil, StickyNote } from 'lucide-react'
+import { CircleDot, ExternalLink, GitMerge, PanelRightOpen, Pencil, StickyNote } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import CommentMarkdown from './CommentMarkdown'
@@ -49,6 +52,9 @@ type WorktreeCardDetailsHoverProps = WorktreeCardMetaBadgesProps & {
   children: React.ReactElement
   onEditIssue: (event: React.MouseEvent) => void
   onEditComment: (event: React.MouseEvent) => void
+  onOpenGitHubIssueInOrca?: (event: React.MouseEvent) => void
+  onOpenLinearIssueInOrca?: (event: React.MouseEvent) => void
+  onOpenReviewInOrca?: (event: React.MouseEvent) => void
 }
 
 function hasComment(comment: string | null): boolean {
@@ -254,8 +260,20 @@ export function WorktreeCardDetailsHover({
   comment,
   children,
   onEditIssue,
-  onEditComment
+  onEditComment,
+  onOpenGitHubIssueInOrca,
+  onOpenLinearIssueInOrca,
+  onOpenReviewInOrca
 }: WorktreeCardDetailsHoverProps): React.JSX.Element {
+  const [open, setOpen] = React.useState(false)
+  const dismissAndRun = React.useCallback(
+    (handler: ((event: React.MouseEvent) => void) | undefined) => (event: React.MouseEvent) => {
+      setOpen(false)
+      handler?.(event)
+    },
+    []
+  )
+
   if (!hasWorktreeCardDetails({ issue, linearIssue, review, comment })) {
     return children
   }
@@ -265,7 +283,7 @@ export function WorktreeCardDetailsHover({
   const issueLabels = issue?.labels ?? []
 
   return (
-    <HoverCard openDelay={250} closeDelay={120}>
+    <HoverCard open={open} onOpenChange={setOpen} openDelay={250} closeDelay={120}>
       <HoverCardTrigger asChild>{children}</HoverCardTrigger>
       <HoverCardContent
         side="right"
@@ -282,6 +300,14 @@ export function WorktreeCardDetailsHover({
                 label={`Issue #${issue.number}`}
                 actions={
                   <>
+                    {issue.url && onOpenGitHubIssueInOrca && (
+                      <MetadataActionIcon
+                        label="Open in Orca"
+                        onClick={dismissAndRun(onOpenGitHubIssueInOrca)}
+                      >
+                        <PanelRightOpen className="size-3" />
+                      </MetadataActionIcon>
+                    )}
                     {issue.url && (
                       <MetadataActionIcon label="View on GitHub" href={issue.url}>
                         <ExternalLink className="size-3" />
@@ -318,6 +344,14 @@ export function WorktreeCardDetailsHover({
                 label={`Linear ${linearIssue.identifier}`}
                 actions={
                   <>
+                    {linearIssue.url && onOpenLinearIssueInOrca && (
+                      <MetadataActionIcon
+                        label="Open in Orca"
+                        onClick={dismissAndRun(onOpenLinearIssueInOrca)}
+                      >
+                        <PanelRightOpen className="size-3" />
+                      </MetadataActionIcon>
+                    )}
                     {linearIssue.url && (
                       <MetadataActionIcon label="View on Linear" href={linearIssue.url}>
                         <ExternalLink className="size-3" />
@@ -354,6 +388,14 @@ export function WorktreeCardDetailsHover({
                 label={`${reviewLabel} #${review.number}`}
                 actions={
                   <>
+                    {review.url && onOpenReviewInOrca && (
+                      <MetadataActionIcon
+                        label="Open in Orca"
+                        onClick={dismissAndRun(onOpenReviewInOrca)}
+                      >
+                        <PanelRightOpen className="size-3" />
+                      </MetadataActionIcon>
+                    )}
                     {review.url && (
                       <MetadataActionIcon label={`View on ${reviewProvider}`} href={review.url}>
                         <ExternalLink className="size-3" />

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -293,5 +293,46 @@ setWorktreeNavActivator(activateAndRevealWorktree)
 // (not open*Page) so back/forward does not mutate previousViewBefore* or
 // append duplicate history. See navigateToIndex for the replay branch.
 setWorktreeNavViewActivator((entry) => {
-  useAppStore.getState().setActiveView(entry)
+  if (entry === 'automations') {
+    useAppStore.getState().setActiveView(entry)
+    return
+  }
+  if (entry === 'tasks') {
+    useAppStore.setState((state) => ({
+      activeView: 'tasks',
+      githubTaskDrawerWorkItem: null,
+      taskPageData: {
+        ...state.taskPageData,
+        openGitHubWorkItem: undefined,
+        openGitHubInitialTab: undefined,
+        openLinearIssue: undefined
+      }
+    }))
+    return
+  }
+  if (entry.source === 'github') {
+    useAppStore.setState((state) => ({
+      activeView: 'tasks',
+      taskPageData: {
+        ...state.taskPageData,
+        taskSource: 'github',
+        preselectedRepoId: entry.workItem.repoId,
+        openGitHubWorkItem: entry.workItem,
+        openGitHubInitialTab: entry.initialTab,
+        openLinearIssue: undefined
+      }
+    }))
+    return
+  }
+  useAppStore.setState((state) => ({
+    activeView: 'tasks',
+    githubTaskDrawerWorkItem: null,
+    taskPageData: {
+      ...state.taskPageData,
+      taskSource: 'linear',
+      openGitHubWorkItem: undefined,
+      openGitHubInitialTab: undefined,
+      openLinearIssue: entry.issue
+    }
+  }))
 })

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -2,7 +2,7 @@
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultUIState } from '../../../../shared/constants'
-import type { PersistedUIState, Worktree } from '../../../../shared/types'
+import type { GitHubWorkItem, PersistedUIState, Worktree } from '../../../../shared/types'
 import { createUISlice } from './ui'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
 import type { AppState } from '../types'
@@ -28,6 +28,22 @@ function createUIStore(): StoreApi<AppState> {
 
 function makeWorktree(id: string): Worktree {
   return { id } as unknown as Worktree
+}
+
+function makeGitHubWorkItem(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'pr-95',
+    type: 'pr',
+    number: 95,
+    title: 'feat: add file upload command',
+    state: 'open',
+    url: 'https://github.com/acme/repo/pull/95',
+    labels: [],
+    updatedAt: '2026-05-20T00:00:00.000Z',
+    author: 'octocat',
+    repoId: 'repo-1',
+    ...overrides
+  }
 }
 
 function makePersistedUI(overrides: Partial<PersistedUIState> = {}): PersistedUIState {
@@ -569,6 +585,47 @@ describe('createUISlice page navigation history', () => {
     store.getState().openTaskPage()
     expect(store.getState().worktreeNavHistory).toEqual(['a', 'tasks'])
     expect(store.getState().worktreeNavHistoryIndex).toBe(1)
+
+    store.getState().closeTaskPage()
+    expect(store.getState().activeView).toBe('terminal')
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
+  it('rewinds Tasks detail visits on close', () => {
+    const store = createUIStore()
+    const workItem = makeGitHubWorkItem()
+    store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().openTaskPage({ taskSource: 'github', openGitHubWorkItem: workItem })
+    expect(store.getState().worktreeNavHistory).toEqual([
+      'a',
+      'tasks',
+      { kind: 'task-detail', source: 'github', workItem, initialTab: undefined }
+    ])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(2)
+
+    store.getState().closeTaskPage()
+    expect(store.getState().activeView).toBe('terminal')
+    expect(store.getState().taskPageData).toEqual({})
+    expect(store.getState().githubTaskDrawerWorkItem).toBeNull()
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
+  it('skips the whole Tasks detail stack on close', () => {
+    const store = createUIStore()
+    const workItem = makeGitHubWorkItem()
+    store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().openTaskPage({ taskSource: 'github', openGitHubWorkItem: workItem })
+    store.getState().openTaskPage({ taskSource: 'linear' })
+    expect(store.getState().worktreeNavHistory).toEqual([
+      'a',
+      'tasks',
+      { kind: 'task-detail', source: 'github', workItem, initialTab: undefined },
+      'tasks'
+    ])
 
     store.getState().closeTaskPage()
     expect(store.getState().activeView).toBe('terminal')

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1,11 +1,15 @@
 /* eslint-disable max-lines */
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import { findPrevLiveWorktreeHistoryIndex } from './worktree-nav-history'
+import {
+  findPrevLiveNonTaskStackHistoryIndex,
+  findPrevLiveWorktreeHistoryIndex
+} from './worktree-nav-history'
 import type {
   ChangelogData,
   CustomPet,
   GitHubWorkItem,
+  LinearIssue,
   PersistedTrustedOrcaHooks,
   PersistedUIState,
   StatusBarItem,
@@ -283,6 +287,9 @@ export type UISlice = {
     preselectedRepoId?: string
     prefilledName?: string
     taskSource?: TaskProvider
+    openGitHubWorkItem?: GitHubWorkItem
+    openGitHubInitialTab?: 'conversation' | 'checks' | 'files'
+    openLinearIssue?: LinearIssue
   }
   taskResumeState: TaskResumeState | undefined
   setTaskResumeState: (updates: Partial<TaskResumeState>) => void
@@ -547,7 +554,30 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     // the slice's adjacent-entry dedupe drops re-opens. No isNavigatingHistory
     // guard needed — back-to-Tasks routes through setActiveView('tasks') and
     // never re-enters openTaskPage.
-    get().recordViewVisit('tasks')
+    const detailEntry = data.openGitHubWorkItem
+      ? ({
+          kind: 'task-detail',
+          source: 'github',
+          workItem: data.openGitHubWorkItem,
+          initialTab: data.openGitHubInitialTab
+        } as const)
+      : data.openLinearIssue
+        ? ({
+            kind: 'task-detail',
+            source: 'linear',
+            issue: data.openLinearIssue
+          } as const)
+        : null
+    const currentEntry = get().worktreeNavHistory[get().worktreeNavHistoryIndex]
+    const currentIsTaskStack =
+      currentEntry === 'tasks' ||
+      (typeof currentEntry === 'object' && currentEntry.kind === 'task-detail')
+    if (!detailEntry || !currentIsTaskStack) {
+      get().recordViewVisit('tasks')
+    }
+    if (detailEntry) {
+      get().recordViewVisit(detailEntry)
+    }
     set((state) => ({
       activeView: 'tasks',
       previousViewBeforeTasks:
@@ -643,15 +673,21 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       // isNavigatingHistory guard is needed.
       const currentEntry = state.worktreeNavHistory[state.worktreeNavHistoryIndex]
       let nextHistoryIndex = state.worktreeNavHistoryIndex
-      if (currentEntry === 'tasks') {
-        const prev = findPrevLiveWorktreeHistoryIndex(state)
+      if (
+        currentEntry === 'tasks' ||
+        (typeof currentEntry === 'object' && currentEntry.kind === 'task-detail')
+      ) {
+        const prev = findPrevLiveNonTaskStackHistoryIndex(state)
         if (prev !== null) {
           nextHistoryIndex = prev
+        } else if (typeof currentEntry === 'object' && state.worktreeNavHistory[0] === 'tasks') {
+          nextHistoryIndex = 0
         }
       }
       return {
         activeView: state.previousViewBeforeTasks,
         taskPageData: {},
+        githubTaskDrawerWorkItem: null,
         worktreeNavHistoryIndex: nextHistoryIndex
       }
     }),

--- a/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
@@ -1,13 +1,13 @@
 import { createStore, type StoreApi } from 'zustand/vanilla'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { AppState } from '../types'
-import type { Worktree } from '../../../../shared/types'
+import type { GitHubWorkItem, Worktree } from '../../../../shared/types'
 import {
   createWorktreeNavHistorySlice,
   findPrevLiveWorktreeHistoryIndex,
   setWorktreeNavActivator,
   setWorktreeNavViewActivator,
-  type WorktreeNavHistoryViewEntry
+  type WorktreeNavHistorySimpleViewEntry
 } from './worktree-nav-history'
 
 type MinimalState = Pick<
@@ -40,10 +40,26 @@ function createHistoryStore(worktreeIds: string[] = []): StoreApi<MinimalState> 
   })) as unknown as StoreApi<MinimalState>
 }
 
-const viewCases: { entry: WorktreeNavHistoryViewEntry; label: string }[] = [
+const viewCases: { entry: WorktreeNavHistorySimpleViewEntry; label: string }[] = [
   { entry: 'tasks', label: 'Tasks' },
   { entry: 'automations', label: 'Automations' }
 ]
+
+function makeGitHubWorkItem(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'pr-95',
+    type: 'pr',
+    number: 95,
+    title: 'feat: add file upload command',
+    state: 'open',
+    url: 'https://github.com/acme/repo/pull/95',
+    labels: [],
+    updatedAt: '2026-05-20T00:00:00.000Z',
+    author: 'octocat',
+    repoId: 'repo-1',
+    ...overrides
+  }
+}
 
 describe('worktree-nav-history slice: view entries', () => {
   afterEach(() => {
@@ -55,13 +71,13 @@ describe('worktree-nav-history slice: view entries', () => {
     it(`A -> ${label} -> B, back lands on ${label} then A`, () => {
       const store = createHistoryStore(['a', 'b'])
       const activated: string[] = []
-      const viewed: string[] = []
+      const viewed: WorktreeNavHistorySimpleViewEntry[] = []
       setWorktreeNavActivator((id) => {
         activated.push(id as string)
         return { primaryTabId: null }
       })
       setWorktreeNavViewActivator((v) => {
-        viewed.push(v)
+        viewed.push(v as WorktreeNavHistorySimpleViewEntry)
       })
 
       store.getState().recordWorktreeVisit('a')
@@ -93,9 +109,9 @@ describe('worktree-nav-history slice: view entries', () => {
 
     it(`skips a dead worktree when backing to a prior ${label} entry`, () => {
       const store = createHistoryStore([])
-      const viewed: string[] = []
+      const viewed: WorktreeNavHistorySimpleViewEntry[] = []
       setWorktreeNavViewActivator((v) => {
-        viewed.push(v)
+        viewed.push(v as WorktreeNavHistorySimpleViewEntry)
       })
 
       store.setState({
@@ -118,9 +134,9 @@ describe('worktree-nav-history slice: view entries', () => {
       expect(prev).toBe(0)
       store.setState({ worktreeNavHistoryIndex: prev ?? store.getState().worktreeNavHistoryIndex })
 
-      const viewed: string[] = []
+      const viewed: WorktreeNavHistorySimpleViewEntry[] = []
       setWorktreeNavViewActivator((v) => {
-        viewed.push(v)
+        viewed.push(v as WorktreeNavHistorySimpleViewEntry)
       })
 
       store.getState().goForwardWorktree()
@@ -128,4 +144,33 @@ describe('worktree-nav-history slice: view entries', () => {
       expect(store.getState().worktreeNavHistoryIndex).toBe(1)
     })
   }
+
+  it('replays task detail entries through the same back/forward stack', () => {
+    const store = createHistoryStore(['a'])
+    const detail = {
+      kind: 'task-detail',
+      source: 'github',
+      workItem: makeGitHubWorkItem(),
+      initialTab: 'checks'
+    } as const
+    const viewed: unknown[] = []
+    setWorktreeNavViewActivator((v) => {
+      viewed.push(v)
+    })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().recordViewVisit('tasks')
+    store.getState().recordViewVisit(detail)
+
+    expect(store.getState().worktreeNavHistory).toEqual(['a', 'tasks', detail])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(2)
+
+    store.getState().goBackWorktree()
+    expect(viewed).toEqual(['tasks'])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(1)
+
+    store.getState().goForwardWorktree()
+    expect(viewed).toEqual(['tasks', detail])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(2)
+  })
 })

--- a/src/renderer/src/store/slices/worktree-nav-history.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history.ts
@@ -1,6 +1,7 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import { findWorktreeById } from './worktree-helpers'
+import type { GitHubWorkItem, LinearIssue } from '../../../../shared/types'
 
 // Why: cap the per-session history so a long-lived workspace with many
 // worktree jumps cannot grow the array unbounded. 50 is generous enough
@@ -13,7 +14,18 @@ const MAX_HISTORY = 50
 // "worktree"/"WorktreeHistory" prefix for call-site stability — renaming
 // across ~20 sites would churn for no behavior win. View entries are
 // always live (never skipped by findPrev/NextLiveWorktreeHistoryIndex).
-export type WorktreeNavHistoryViewEntry = 'tasks' | 'automations'
+export type WorktreeNavHistorySimpleViewEntry = 'tasks' | 'automations'
+export type WorktreeNavHistoryTaskDetailEntry =
+  | {
+      kind: 'task-detail'
+      source: 'github'
+      workItem: GitHubWorkItem
+      initialTab?: 'conversation' | 'checks' | 'files'
+    }
+  | { kind: 'task-detail'; source: 'linear'; issue: LinearIssue }
+export type WorktreeNavHistoryViewEntry =
+  | WorktreeNavHistorySimpleViewEntry
+  | WorktreeNavHistoryTaskDetailEntry
 export type WorktreeNavHistoryEntry = string | WorktreeNavHistoryViewEntry
 
 export type WorktreeNavHistorySlice = {
@@ -57,8 +69,26 @@ export function setWorktreeNavViewActivator(fn: ViewActivateFn | null): void {
 
 // Why: view entries short-circuit as live unconditionally — findWorktreeById
 // takes a worktree id and would always return undefined for page sentinels.
+function isViewEntry(entry: WorktreeNavHistoryEntry): entry is WorktreeNavHistoryViewEntry {
+  return entry === 'tasks' || entry === 'automations' || typeof entry === 'object'
+}
+
+function isTaskStackEntry(entry: WorktreeNavHistoryEntry): boolean {
+  return entry === 'tasks' || (typeof entry === 'object' && entry.kind === 'task-detail')
+}
+
+function getHistoryEntryKey(entry: WorktreeNavHistoryEntry): string {
+  if (typeof entry === 'string') {
+    return entry === 'tasks' || entry === 'automations' ? `view:${entry}` : `worktree:${entry}`
+  }
+  if (entry.source === 'github') {
+    return `view:task-detail:github:${entry.workItem.repoId}:${entry.workItem.type}:${entry.workItem.number}:${entry.initialTab ?? 'conversation'}`
+  }
+  return `view:task-detail:linear:${entry.issue.workspaceId ?? 'selected'}:${entry.issue.id}`
+}
+
 function isLiveEntry(entry: WorktreeNavHistoryEntry, state: AppState): boolean {
-  if (entry === 'tasks' || entry === 'automations') {
+  if (isViewEntry(entry)) {
     return true
   }
   return findWorktreeById(state.worktreesByRepo, entry) !== undefined
@@ -72,7 +102,8 @@ function appendHistoryEntry(
   // applies only to the current entry so that A -> B -> A remains a valid
   // stack (user left B, returned to A). Same rule covers page re-opens:
   // Tasks data changes and repeated Automations opens collapse to one entry.
-  if (s.worktreeNavHistory[s.worktreeNavHistoryIndex] === entry) {
+  const current = s.worktreeNavHistory[s.worktreeNavHistoryIndex]
+  if (current !== undefined && getHistoryEntryKey(current) === getHistoryEntryKey(entry)) {
     return s
   }
 
@@ -98,6 +129,16 @@ function appendHistoryEntry(
 export function findPrevLiveWorktreeHistoryIndex(state: AppState): number | null {
   for (let i = state.worktreeNavHistoryIndex - 1; i >= 0; i--) {
     if (isLiveEntry(state.worktreeNavHistory[i], state)) {
+      return i
+    }
+  }
+  return null
+}
+
+export function findPrevLiveNonTaskStackHistoryIndex(state: AppState): number | null {
+  for (let i = state.worktreeNavHistoryIndex - 1; i >= 0; i--) {
+    const entry = state.worktreeNavHistory[i]
+    if (!isTaskStackEntry(entry) && isLiveEntry(entry, state)) {
       return i
     }
   }
@@ -179,7 +220,7 @@ function navigateToIndex(
   const prevNavigating = get().isNavigatingHistory
   set({ isNavigatingHistory: true } as Partial<AppState>)
   try {
-    if (targetEntry === 'tasks' || targetEntry === 'automations') {
+    if (isViewEntry(targetEntry)) {
       if (!viewActivator) {
         // Why: a silent no-op would mean the back/forward chord lands on a
         // page history entry and appears broken. See setWorktreeNavActivator


### PR DESCRIPTION
## Summary
- Add in-page GitHub and Linear task detail views backed by task navigation history
- Add sidebar metadata actions to open linked GitHub issues, GitHub reviews, and Linear issues in Orca
- Fix Tasks close/provider switching behavior so stale detail entries are skipped correctly

## Tests
- pnpm typecheck
- pnpm vitest run src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts src/renderer/src/store/slices/worktree-nav-history.test.ts src/renderer/src/store/slices/ui.test.ts