### PR TITLE
Fix test notification cooldown

### DIFF
--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -704,6 +704,25 @@ describe('registerNotificationHandlers', () => {
     expect(notificationShowMock).toHaveBeenCalledTimes(1)
   })
 
+  it('does not cooldown explicit test notifications', () => {
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: false
+        }
+      })
+    } as never)
+
+    const handler = getDispatchHandler()
+
+    expect(handler({}, { source: 'test' })).toEqual({ delivered: true })
+    expect(handler({}, { source: 'test' })).toEqual({ delivered: true })
+    expect(notificationShowMock).toHaveBeenCalledTimes(2)
+  })
+
   it('loads allowed custom sound files for preload playback', async () => {
     const soundPath = join(tempDir, 'sound.ogg')
     writeFileSync(soundPath, Buffer.from([1, 2, 3]))

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -111,21 +111,25 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         return { delivered: false, reason: 'suppressed-focus' }
       }
 
-      // Dedupe by worktree, not by source — an agent finishing and a terminal bell
-      // often fire within the same data chunk so only the first one should surface.
-      const dedupeKey = args.worktreeId ?? args.worktreeLabel ?? 'global'
-      const now = Date.now()
-      const lastSentAt = recentNotifications.get(dedupeKey) ?? 0
-      if (now - lastSentAt < NOTIFICATION_COOLDOWN_MS) {
-        return { delivered: false, reason: 'cooldown' }
-      }
-      recentNotifications.set(dedupeKey, now)
+      // Why: the Settings test button is an explicit user action, often
+      // clicked repeatedly while tuning sounds, so it must bypass burst dedupe.
+      if (args.source !== 'test') {
+        // Dedupe by worktree, not by source — an agent finishing and a terminal bell
+        // often fire within the same data chunk so only the first one should surface.
+        const dedupeKey = args.worktreeId ?? args.worktreeLabel ?? 'global'
+        const now = Date.now()
+        const lastSentAt = recentNotifications.get(dedupeKey) ?? 0
+        if (now - lastSentAt < NOTIFICATION_COOLDOWN_MS) {
+          return { delivered: false, reason: 'cooldown' }
+        }
+        recentNotifications.set(dedupeKey, now)
 
-      // Evict stale entries so the map doesn't grow unbounded.
-      if (recentNotifications.size > 50) {
-        for (const [key, ts] of recentNotifications) {
-          if (now - ts >= NOTIFICATION_COOLDOWN_MS) {
-            recentNotifications.delete(key)
+        // Evict stale entries so the map doesn't grow unbounded.
+        if (recentNotifications.size > 50) {
+          for (const [key, ts] of recentNotifications) {
+            if (now - ts >= NOTIFICATION_COOLDOWN_MS) {
+              recentNotifications.delete(key)
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- bypass the notification burst cooldown for explicit Settings test notifications
- keep dedupe/cooldown behavior for real background notifications
- add regression coverage for repeated test notification clicks

## Tests
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/notifications.test.ts src/renderer/src/components/settings/NotificationsPane.test.tsx
- pnpm run typecheck
- pnpm run lint
- git diff --check