### PR TITLE
Use MonitorUp icon for Open in Orca action

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '@/components/ui/hover-card'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { CircleDot, ExternalLink, GitMerge, PanelRightOpen, Pencil, StickyNote } from 'lucide-react'
+import { CircleDot, ExternalLink, GitMerge, MonitorUp, Pencil, StickyNote } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import CommentMarkdown from './CommentMarkdown'
@@ -305,7 +305,7 @@ export function WorktreeCardDetailsHover({
                         label="Open in Orca"
                         onClick={dismissAndRun(onOpenGitHubIssueInOrca)}
                       >
-                        <PanelRightOpen className="size-3" />
+                        <MonitorUp className="size-3" />
                       </MetadataActionIcon>
                     )}
                     {issue.url && (
@@ -349,7 +349,7 @@ export function WorktreeCardDetailsHover({
                         label="Open in Orca"
                         onClick={dismissAndRun(onOpenLinearIssueInOrca)}
                       >
-                        <PanelRightOpen className="size-3" />
+                        <MonitorUp className="size-3" />
                       </MetadataActionIcon>
                     )}
                     {linearIssue.url && (
@@ -393,7 +393,7 @@ export function WorktreeCardDetailsHover({
                         label="Open in Orca"
                         onClick={dismissAndRun(onOpenReviewInOrca)}
                       >
-                        <PanelRightOpen className="size-3" />
+                        <MonitorUp className="size-3" />
                       </MetadataActionIcon>
                     )}
                     {review.url && (


### PR DESCRIPTION
## Summary
- Swap `PanelRightOpen` for `MonitorUp` on the "Open in Orca" action button in `WorktreeCardMeta` hover card
- Fixes brightness/density mismatch with the adjacent `ExternalLink` ("View on GitHub/Linear") icon — `PanelRightOpen` rendered visibly fainter at `size-3` due to its thinner outline

## Test plan
- [ ] Hover a workspace card with a linked GitHub issue, Linear issue, and PR — confirm the "Open in Orca" icon now reads at the same visual weight as the external-link icon next to it

Made with [Orca](https://github.com/stablyai/orca) 🐋
