### PR TITLE
Remove persistent notification settings shortcut

### DIFF
--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import type { GlobalSettings, NotificationPermissionStatusResult } from '../../../../shared/types'
+import type { GlobalSettings } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
 import { Slider } from '../ui/slider'
-import { BellRing, Bot, ExternalLink, FileAudio, Siren, Volume2, X } from 'lucide-react'
+import { BellRing, Bot, FileAudio, Siren, Volume2, X } from 'lucide-react'
 import type { SettingsSearchEntry } from './settings-search'
 import { basename } from '@/lib/path'
 
@@ -54,7 +54,6 @@ type NotificationsPaneProps = {
 }
 
 type SystemNotificationSettingsCopy = {
-  buttonLabel: string
   failureTitle: string
   failureDescription: string
 }
@@ -64,7 +63,6 @@ function getSystemNotificationSettingsCopy(
 ): SystemNotificationSettingsCopy | null {
   if (platform === 'darwin') {
     return {
-      buttonLabel: 'macOS Settings',
       failureTitle: 'macOS did not show the notification',
       failureDescription: 'Enable Allow notifications for Orca in System Settings.'
     }
@@ -72,7 +70,6 @@ function getSystemNotificationSettingsCopy(
 
   if (platform === 'win32') {
     return {
-      buttonLabel: 'Windows Settings',
       failureTitle: 'Windows did not show the notification',
       failureDescription: 'Enable notifications for Orca in Windows Settings.'
     }
@@ -162,8 +159,6 @@ export function NotificationsPane({
   const notificationSettings = settings.notifications
   const notificationSettingsRef = useRef(notificationSettings)
   const [isPickingSound, setIsPickingSound] = useState(false)
-  const [permissionStatus, setPermissionStatus] =
-    useState<NotificationPermissionStatusResult | null>(null)
 
   const updateNotificationSettings = (updates: Partial<GlobalSettings['notifications']>): void => {
     updateSettings({
@@ -183,25 +178,6 @@ export function NotificationsPane({
     setVolumeDraft(notificationSettings.customSoundVolume)
   }, [notificationSettings])
 
-  useEffect(() => {
-    let cancelled = false
-    void window.api.notifications
-      .getPermissionStatus()
-      .then((status) => {
-        if (!cancelled) {
-          setPermissionStatus(status)
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setPermissionStatus(null)
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
   const handleVolumeCommit = (value: number): void => {
     if (notificationSettingsRef.current.customSoundVolume !== value) {
       updateNotificationSettings({ customSoundVolume: value })
@@ -210,10 +186,6 @@ export function NotificationsPane({
 
   const handleSendTestNotification = async (): Promise<void> => {
     await sendNotificationSettingsTestNotification(notificationSettings, volumeDraft)
-  }
-
-  const handleOpenSystemSettings = async (): Promise<void> => {
-    await window.api.notifications.openSystemSettings()
   }
 
   const handleChooseSound = async (): Promise<void> => {
@@ -229,9 +201,6 @@ export function NotificationsPane({
   }
 
   const selectedSoundPath = notificationSettings.customSoundPath
-  const systemSettingsCopy = permissionStatus
-    ? getSystemNotificationSettingsCopy(permissionStatus.platform)
-    : null
 
   return (
     <div className="space-y-1">
@@ -372,18 +341,6 @@ export function NotificationsPane({
           <BellRing className="size-3.5" />
           Send Test Notification
         </Button>
-        {systemSettingsCopy ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={!notificationSettings.enabled}
-            onClick={() => void handleOpenSystemSettings()}
-            className="gap-2"
-          >
-            <ExternalLink className="size-3.5" />
-            {systemSettingsCopy.buttonLabel}
-          </Button>
-        ) : null}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Remove the always-visible system notification settings shortcut from the Notifications pane.
- Keep the contextual Open Settings action in notification test recovery toasts.

## Notes
- Electron 42 adds the macOS UNNotification backend and notification history APIs, but it still does not expose a built-in app notification authorization query. Electron's docs still recommend native/userland notification-state helpers for ahead-of-time detection.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/NotificationsPane.test.tsx src/main/ipc/notifications.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- Manual Electron verification on `nwparker/remove-persistent-notification-settings`:
  - Opened Settings > Notifications.
  - Verified the persistent `macOS Settings` button is gone.
  - Clicked Send Test Notification and verified the toast still contains `Open Settings`.
