### PR TITLE
Use home cwd for floating terminals

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -327,7 +327,7 @@ export function setupGuestShortcutForwarding(args: {
     if (input.code === 'KeyB' && input.shift) {
       renderer.send('ui:newBrowserTab')
     } else if (input.code === 'KeyT' && !input.shift) {
-      // Why: Cmd/Ctrl+T always opens a new terminal in the central pane,
+      // Why: Cmd/Ctrl+T opens a terminal in the user's active terminal surface
       // even when focus is inside a browser guest. Cmd/Ctrl+Shift+B is the
       // dedicated shortcut for new browser tabs.
       renderer.send('ui:newTerminalTab')

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -14,6 +14,7 @@ import { isWslAvailable } from '../wsl'
 import { setUnreadDockBadgeCount } from '../dock/unread-badge'
 import { authorizeExternalPath } from './filesystem-auth'
 import {
+  ensureDefaultFloatingWorkspacePath,
   grantFloatingWorkspaceDirectory,
   resolveFloatingTerminalCwd
 } from './floating-workspace-directory'
@@ -22,11 +23,9 @@ import { isMarkdownDocumentName, markdownDocumentFromFilePath } from './markdown
 const execFileAsync = promisify(execFile)
 
 async function pickFloatingMarkdownDocument(
-  event: IpcMainInvokeEvent,
-  store: Store,
-  args?: FloatingTerminalCwdRequest
+  event: IpcMainInvokeEvent
 ): Promise<MarkdownDocument | null> {
-  const cwd = await resolveFloatingTerminalCwd(store, args)
+  const cwd = await ensureDefaultFloatingWorkspacePath()
   const options = {
     defaultPath: cwd,
     properties: ['openFile'],
@@ -181,9 +180,9 @@ export function registerAppHandlers(store: Store): void {
     resolveFloatingTerminalCwd(store, args)
   )
 
-  ipcMain.handle('app:pickFloatingMarkdownDocument', (event, args?: FloatingTerminalCwdRequest) =>
-    pickFloatingMarkdownDocument(event, store, args)
-  )
+  ipcMain.handle('app:getFloatingMarkdownDirectory', () => ensureDefaultFloatingWorkspacePath())
+
+  ipcMain.handle('app:pickFloatingMarkdownDocument', (event) => pickFloatingMarkdownDocument(event))
 
   ipcMain.handle('app:pickFloatingWorkspaceDirectory', (event) =>
     pickFloatingWorkspaceDirectory(event, store)

--- a/src/main/ipc/floating-workspace-directory.test.ts
+++ b/src/main/ipc/floating-workspace-directory.test.ts
@@ -20,6 +20,7 @@ vi.mock('./filesystem-auth', () => ({
 }))
 
 import {
+  ensureDefaultFloatingWorkspacePath,
   grantFloatingWorkspaceDirectory,
   resolveFloatingTerminalCwd,
   sanitizeFloatingWorkspaceDirectorySetting
@@ -76,6 +77,24 @@ describe('floating workspace directory authorization', () => {
   async function symlinkDirectory(target: string, linkPath: string): Promise<void> {
     await symlink(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir')
   }
+
+  it('defaults terminal cwd to home without authorizing home for markdown writes', async () => {
+    const store = createStore()
+
+    await expect(resolveFloatingTerminalCwd(store as never)).resolves.toBe(homeDir)
+
+    expect(authorizeExternalPathMock).not.toHaveBeenCalledWith(homeDir)
+  })
+
+  it('keeps the app-owned directory for floating markdown notes', async () => {
+    await expect(ensureDefaultFloatingWorkspacePath()).resolves.toBe(
+      path.join(userDataDir, 'floating-workspace')
+    )
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith(
+      path.join(userDataDir, 'floating-workspace')
+    )
+  })
 
   it('persists picker-approved directories and reauthorizes them on resolution', async () => {
     const store = createStore()
@@ -161,6 +180,16 @@ describe('floating workspace directory authorization', () => {
     await expect(
       sanitizeFloatingWorkspaceDirectorySetting(store as never, arbitraryDir)
     ).resolves.toBe('')
+  })
+
+  it('preserves home shorthand as a terminal-only setting', async () => {
+    const store = createStore()
+
+    await expect(sanitizeFloatingWorkspaceDirectorySetting(store as never, '~')).resolves.toBe('~')
+    await expect(resolveFloatingTerminalCwd(store as never, { path: '~' })).resolves.toBe(homeDir)
+    await expect(
+      resolveFloatingTerminalCwd(store as never, { path: '~', requireTrusted: true })
+    ).resolves.toBe(path.join(userDataDir, 'floating-workspace'))
   })
 
   it('still resolves accessible ad hoc terminal directories when trust is not required', async () => {

--- a/src/main/ipc/floating-workspace-directory.ts
+++ b/src/main/ipc/floating-workspace-directory.ts
@@ -82,7 +82,9 @@ export async function resolveFloatingTerminalCwd(
 ): Promise<string> {
   const configuredPath = typeof args?.path === 'string' ? args.path.trim() : ''
   if (!configuredPath) {
-    return ensureDefaultFloatingWorkspacePath()
+    return args?.requireTrusted === true
+      ? ensureDefaultFloatingWorkspacePath()
+      : resolveFloatingWorkspaceInput('~')
   }
 
   const cwd = resolveFloatingWorkspaceInput(configuredPath)
@@ -127,6 +129,9 @@ export async function sanitizeFloatingWorkspaceDirectorySetting(
   const trimmed = dirPath.trim()
   if (!trimmed) {
     return ''
+  }
+  if (trimmed === '~') {
+    return '~'
   }
   const resolvedDir = resolveFloatingWorkspaceInput(trimmed)
   const canonicalDir = await canonicalizeAccessibleDirectory(resolvedDir)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -859,6 +859,44 @@ describe('Store', () => {
     expect(store.getSettings().floatingTerminalTrustedCwds).toEqual([])
   })
 
+  it('restores migrated blank floating terminal cwd settings to home shorthand', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        floatingTerminalCwd: '',
+        floatingTerminalCwdMigratedToAppWorkspace: true
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().floatingTerminalCwd).toBe('~')
+  })
+
+  it('preserves legacy home shorthand as the floating terminal cwd', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        floatingTerminalCwd: '~'
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().floatingTerminalCwd).toBe('~')
+    expect(store.getSettings().floatingTerminalTrustedCwds).toEqual([])
+  })
+
   it('canonicalizes persisted floating workspace trust paths on load', async () => {
     const trustedTarget = join(testState.dir, 'trusted-target')
     const trustedLink = join(testState.dir, 'trusted-link')

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1315,13 +1315,14 @@ export class Store {
           : true
         const floatingTerminalCwdMigrated =
           parsed.settings?.floatingTerminalCwdMigratedToAppWorkspace === true
-        // Why: the old inherited floating cwd was '~', which works for shells
-        // but not for app-managed markdown files. Migrate only once so users
-        // can still explicitly choose '~' after this release.
+        // Why: an earlier migration wrote '' for the default app-owned notes
+        // directory. Floating terminals should still open at home by default;
+        // markdown notes resolve their app-owned directory through a separate IPC.
         const migratedFloatingTerminalCwd = floatingTerminalCwdMigrated
-          ? (parsed.settings?.floatingTerminalCwd ?? defaults.settings.floatingTerminalCwd)
-          : parsed.settings?.floatingTerminalCwd === undefined ||
-              parsed.settings.floatingTerminalCwd === '~'
+          ? !parsed.settings?.floatingTerminalCwd
+            ? defaults.settings.floatingTerminalCwd
+            : parsed.settings.floatingTerminalCwd
+          : parsed.settings?.floatingTerminalCwd === undefined
             ? defaults.settings.floatingTerminalCwd
             : parsed.settings.floatingTerminalCwd
         const normalizedFloatingTerminalTrustedCwds = normalizeFloatingWorkspaceTrustedCwds(

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -560,11 +560,12 @@ export type AppApi = {
   setUnreadDockBadgeCount: (count: number) => Promise<void>
   /** Resolves the launch directory for global Floating Terminal tabs. */
   getFloatingTerminalCwd: (args?: FloatingTerminalCwdRequest) => Promise<string>
+  /** Resolves Orca's app-owned directory for auto-created Floating Workspace
+   *  markdown notes. */
+  getFloatingMarkdownDirectory: () => Promise<string>
   /** Opens a native picker for markdown documents, rooted in the floating
    *  workspace, and authorizes the selected file for editor reads/writes. */
-  pickFloatingMarkdownDocument: (
-    args?: FloatingTerminalCwdRequest
-  ) => Promise<MarkdownDocument | null>
+  pickFloatingMarkdownDocument: () => Promise<MarkdownDocument | null>
   /** Opens a native directory picker and authorizes the selected directory
    *  for Floating Workspace markdown file creation. */
   pickFloatingWorkspaceDirectory: () => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -368,10 +368,10 @@ const api = {
       ipcRenderer.invoke('app:setUnreadDockBadgeCount', count),
     getFloatingTerminalCwd: (args?: FloatingTerminalCwdRequest): Promise<string> =>
       ipcRenderer.invoke('app:getFloatingTerminalCwd', args),
-    pickFloatingMarkdownDocument: (
-      args?: FloatingTerminalCwdRequest
-    ): Promise<MarkdownDocument | null> =>
-      ipcRenderer.invoke('app:pickFloatingMarkdownDocument', args),
+    getFloatingMarkdownDirectory: (): Promise<string> =>
+      ipcRenderer.invoke('app:getFloatingMarkdownDirectory'),
+    pickFloatingMarkdownDocument: (): Promise<MarkdownDocument | null> =>
+      ipcRenderer.invoke('app:pickFloatingMarkdownDocument'),
     pickFloatingWorkspaceDirectory: (): Promise<string | null> =>
       ipcRenderer.invoke('app:pickFloatingWorkspaceDirectory')
   },

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -73,6 +73,10 @@ import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
+import {
+  createFloatingWorkspaceTerminalTab,
+  isFloatingWorkspacePanelVisible
+} from '@/lib/floating-workspace-terminal-actions'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
@@ -1048,6 +1052,10 @@ function Terminal(): React.JSX.Element | null {
       // terminal from anywhere in the central pane.
       if (mod && e.key === 't' && !e.shiftKey && !e.repeat) {
         e.preventDefault()
+        if (isFloatingWorkspacePanelVisible()) {
+          void createFloatingWorkspaceTerminalTab(useAppStore.getState())
+          return
+        }
         handleNewTab()
         return
       }

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -78,6 +78,7 @@ const mocks = vi.hoisted(() => ({
   createWebRuntimeSessionBrowserTab: vi.fn(),
   createWebRuntimeSessionTerminal: vi.fn(),
   focusTerminalTabSurface: vi.fn(),
+  getFloatingMarkdownDirectory: vi.fn(),
   getFloatingTerminalCwd: vi.fn(),
   getInstallStatus: vi.fn(),
   isWebRuntimeSessionActive: vi.fn(),
@@ -475,6 +476,7 @@ describe('FloatingTerminalPanel close behavior', () => {
     mocks.createTab.mockReturnValue(makeTab({ id: 'created-tab' }))
     mocks.createWebRuntimeSessionBrowserTab.mockResolvedValue(false)
     mocks.createWebRuntimeSessionTerminal.mockResolvedValue(false)
+    mocks.getFloatingMarkdownDirectory.mockResolvedValue('/tmp/orca/floating-notes')
     mocks.getFloatingTerminalCwd.mockResolvedValue('/tmp/orca')
     mocks.getInstallStatus.mockResolvedValue({ state: 'installed' })
     mocks.isWebRuntimeSessionActive.mockReturnValue(false)
@@ -483,6 +485,7 @@ describe('FloatingTerminalPanel close behavior', () => {
       addEventListener: vi.fn(),
       api: {
         app: {
+          getFloatingMarkdownDirectory: mocks.getFloatingMarkdownDirectory,
           getFloatingTerminalCwd: mocks.getFloatingTerminalCwd,
           pickFloatingMarkdownDocument: mocks.pickFloatingMarkdownDocument
         },
@@ -557,7 +560,7 @@ describe('FloatingTerminalPanel close behavior', () => {
   it('creates floating markdown files in local filesystem mode', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
     vi.mocked(createUntitledMarkdownFile).mockResolvedValue({
-      filePath: '/tmp/orca/untitled.md',
+      filePath: '/tmp/orca/floating-notes/untitled.md',
       relativePath: 'untitled.md',
       worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
       language: 'markdown',
@@ -574,13 +577,13 @@ describe('FloatingTerminalPanel close behavior', () => {
     await flushAsyncWork()
 
     expect(createUntitledMarkdownFile).toHaveBeenCalledWith(
-      '/tmp/orca',
+      '/tmp/orca/floating-notes',
       FLOATING_TERMINAL_WORKTREE_ID,
       undefined,
       { activeRuntimeEnvironmentId: null }
     )
     expect(mocks.openFile).toHaveBeenCalledWith(
-      expect.objectContaining({ filePath: '/tmp/orca/untitled.md' }),
+      expect.objectContaining({ filePath: '/tmp/orca/floating-notes/untitled.md' }),
       expect.objectContaining({ suppressActiveRuntimeFallback: true })
     )
   })
@@ -599,7 +602,7 @@ describe('FloatingTerminalPanel close behavior', () => {
     ;(tabBar.props.onOpenFileTab as () => void)()
     await flushAsyncWork()
 
-    expect(mocks.pickFloatingMarkdownDocument).toHaveBeenCalledWith({ path: '' })
+    expect(mocks.pickFloatingMarkdownDocument).toHaveBeenCalledWith()
     expect(mocks.openFile).toHaveBeenCalledWith(
       expect.objectContaining({
         filePath: '/tmp/orca/notes.md',

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -106,6 +106,7 @@ export function FloatingTerminalPanel({
   const floatingTerminalCwd = useAppStore((s) => s.settings?.floatingTerminalCwd ?? '')
 
   const [cwd, setCwd] = useState<string | null>(null)
+  const [markdownCwd, setMarkdownCwd] = useState<string | null>(null)
   const [bounds, setBounds] = useState(() => getDefaultFloatingTerminalBounds())
   const [maximized, setMaximized] = useState(false)
   const [orchestrationDialogOpen, setOrchestrationDialogOpen] = useState(false)
@@ -328,11 +329,14 @@ export function FloatingTerminalPanel({
   useEffect(() => {
     void window.api.app
       .getFloatingTerminalCwd({
-        path: floatingTerminalCwd,
-        requireTrusted: true
+        path: floatingTerminalCwd
       })
       .then(setCwd)
   }, [floatingTerminalCwd])
+
+  useEffect(() => {
+    void window.api.app.getFloatingMarkdownDirectory().then(setMarkdownCwd)
+  }, [])
 
   useEffect(() => {
     if (!open || !activeTerminalId) {
@@ -461,13 +465,13 @@ export function FloatingTerminalPanel({
   }, [activeGroup, browserDefaultUrl, createBrowserTab])
 
   const createFloatingMarkdownTab = useCallback(() => {
-    if (!cwd) {
+    if (!markdownCwd) {
       return
     }
     void (async () => {
       try {
         const fileInfo = await createUntitledMarkdownFile(
-          cwd,
+          markdownCwd,
           FLOATING_TERMINAL_WORKTREE_ID,
           getConnectionId(FLOATING_TERMINAL_WORKTREE_ID) ?? undefined,
           LOCAL_RUNTIME_SETTINGS
@@ -481,14 +485,12 @@ export function FloatingTerminalPanel({
         toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
       }
     })()
-  }, [activeGroup, cwd, openFile])
+  }, [activeGroup, markdownCwd, openFile])
 
   const openFloatingMarkdownTab = useCallback(() => {
     void (async () => {
       try {
-        const document = await window.api.app.pickFloatingMarkdownDocument({
-          path: floatingTerminalCwd
-        })
+        const document = await window.api.app.pickFloatingMarkdownDocument()
         if (!document) {
           return
         }
@@ -511,7 +513,7 @@ export function FloatingTerminalPanel({
         toast.error(extractIpcErrorMessage(err, 'Failed to open markdown file.'))
       }
     })()
-  }, [activeGroup, floatingTerminalCwd, openFile])
+  }, [activeGroup, openFile])
 
   const closeFloatingItems = useCallback(
     (visibleIds: string[]) => {

--- a/src/renderer/src/components/settings/FloatingWorkspacePane.test.tsx
+++ b/src/renderer/src/components/settings/FloatingWorkspacePane.test.tsx
@@ -2,18 +2,28 @@ import { describe, expect, it } from 'vitest'
 import { getFloatingWorkspaceDirectoryInputValue } from './FloatingWorkspacePane'
 
 describe('getFloatingWorkspaceDirectoryInputValue', () => {
-  it('shows the resolved app-owned default', () => {
+  it('shows home shorthand for the default terminal directory', () => {
     expect(
       getFloatingWorkspaceDirectoryInputValue({
-        resolvedFloatingWorkspacePath:
-          '/Users/example/Library/Application Support/Orca/floating-workspace'
+        configuredFloatingWorkspacePath: '~',
+        resolvedFloatingWorkspacePath: '/Users/example'
       })
-    ).toBe('/Users/example/Library/Application Support/Orca/floating-workspace')
+    ).toBe('~')
+  })
+
+  it('shows home shorthand for legacy blank terminal directory settings', () => {
+    expect(
+      getFloatingWorkspaceDirectoryInputValue({
+        configuredFloatingWorkspacePath: '',
+        resolvedFloatingWorkspacePath: '/Users/example'
+      })
+    ).toBe('~')
   })
 
   it('shows the main-resolved trusted custom directory', () => {
     expect(
       getFloatingWorkspaceDirectoryInputValue({
+        configuredFloatingWorkspacePath: '/Users/example/notes',
         resolvedFloatingWorkspacePath: '/Users/example/notes'
       })
     ).toBe('/Users/example/notes')

--- a/src/renderer/src/components/settings/FloatingWorkspacePane.tsx
+++ b/src/renderer/src/components/settings/FloatingWorkspacePane.tsx
@@ -16,10 +16,16 @@ type FloatingWorkspacePaneProps = {
 }
 
 export function getFloatingWorkspaceDirectoryInputValue({
+  configuredFloatingWorkspacePath,
   resolvedFloatingWorkspacePath
 }: {
+  configuredFloatingWorkspacePath: string
   resolvedFloatingWorkspacePath: string
 }): string {
+  const configuredPath = configuredFloatingWorkspacePath.trim()
+  if (!configuredPath || configuredPath === '~') {
+    return '~'
+  }
   return resolvedFloatingWorkspacePath
 }
 
@@ -34,8 +40,7 @@ export function FloatingWorkspacePane({
     let cancelled = false
     void window.api.app
       .getFloatingTerminalCwd({
-        path: settings.floatingTerminalCwd,
-        requireTrusted: true
+        path: settings.floatingTerminalCwd
       })
       .then((path) => {
         if (!cancelled) {
@@ -61,6 +66,7 @@ export function FloatingWorkspacePane({
   }
 
   const directoryInputValue = getFloatingWorkspaceDirectoryInputValue({
+    configuredFloatingWorkspacePath: settings.floatingTerminalCwd,
     resolvedFloatingWorkspacePath
   })
 
@@ -116,12 +122,12 @@ export function FloatingWorkspacePane({
         </div>
 
         <div className="space-y-2">
-          <Label>Default Directory</Label>
+          <Label>Terminal Directory</Label>
           <div className="flex max-w-xl gap-2">
             <Input
               value={directoryInputValue}
               readOnly
-              placeholder="Orca floating workspace"
+              placeholder="~"
               className="min-w-0 flex-1"
             />
             <Button
@@ -135,7 +141,8 @@ export function FloatingWorkspacePane({
             </Button>
           </div>
           <p className="text-xs text-muted-foreground">
-            New floating workspace tabs start here. The default is the Orca app-owned workspace.
+            New floating terminal tabs start here. Markdown notes are saved in Orca&apos;s app-owned
+            floating workspace.
           </p>
         </div>
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -69,6 +69,10 @@ import {
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
 import {
+  createFloatingWorkspaceTerminalTab,
+  isFloatingWorkspacePanelVisible
+} from '@/lib/floating-workspace-terminal-actions'
+import {
   observeAgentHookCompletionForNotification,
   resetAgentHookCompletionNotificationCoordinators,
   syncAgentHookCompletionNotificationSettings
@@ -1461,6 +1465,10 @@ export function useIpcEvents(): void {
     unsubs.push(
       window.api.ui.onNewTerminalTab(() => {
         const store = useAppStore.getState()
+        if (isFloatingWorkspacePanelVisible()) {
+          void createFloatingWorkspaceTerminalTab(store)
+          return
+        }
         const worktreeId = store.activeWorktreeId
         if (!worktreeId) {
           return

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { TerminalTab } from '../../../shared/types'
+import {
+  createFloatingWorkspaceTerminalTab,
+  isFloatingWorkspacePanelVisible
+} from './floating-workspace-terminal-actions'
+
+const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
+const focusTerminalTabSurfaceMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock
+}))
+
+vi.mock('./focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: focusTerminalTabSurfaceMock
+}))
+
+function makeTab(id: string): TerminalTab {
+  return {
+    id,
+    ptyId: null,
+    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+describe('isFloatingWorkspacePanelVisible', () => {
+  it('detects the visible floating workspace panel', () => {
+    const doc = {
+      querySelector: vi.fn().mockReturnValue({})
+    }
+
+    expect(isFloatingWorkspacePanelVisible(doc as never)).toBe(true)
+    expect(doc.querySelector).toHaveBeenCalledWith(
+      '[data-floating-terminal-panel][aria-hidden="false"]'
+    )
+  })
+
+  it('returns false when the floating workspace panel is hidden or absent', () => {
+    expect(isFloatingWorkspacePanelVisible({ querySelector: vi.fn().mockReturnValue(null) })).toBe(
+      false
+    )
+  })
+})
+
+describe('createFloatingWorkspaceTerminalTab', () => {
+  beforeEach(() => {
+    createWebRuntimeSessionTerminalMock.mockReset()
+    focusTerminalTabSurfaceMock.mockReset()
+  })
+
+  it('creates and focuses a local floating workspace terminal in the active floating group', async () => {
+    const tab = makeTab('floating-tab-1')
+    const store = {
+      activeGroupIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: 'floating-group' },
+      settings: { activeRuntimeEnvironmentId: null },
+      createTab: vi.fn().mockReturnValue(tab),
+      activateTab: vi.fn()
+    }
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(false)
+
+    await expect(createFloatingWorkspaceTerminalTab(store as never)).resolves.toBe(tab)
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      environmentId: undefined,
+      targetGroupId: 'floating-group',
+      command: undefined,
+      activate: true,
+      selectWorktree: false
+    })
+    expect(store.createTab).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'floating-group',
+      undefined,
+      { activate: false }
+    )
+    expect(store.activateTab).toHaveBeenCalledWith('floating-tab-1')
+    expect(focusTerminalTabSurfaceMock).toHaveBeenCalledWith('floating-tab-1')
+  })
+
+  it('leaves local tabs untouched when the web runtime accepts the floating terminal', async () => {
+    const store = {
+      activeGroupIdByWorktree: {},
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      createTab: vi.fn(),
+      activateTab: vi.fn()
+    }
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(true)
+
+    await expect(createFloatingWorkspaceTerminalTab(store as never, 'pwsh')).resolves.toBeNull()
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+        environmentId: 'env-1',
+        command: 'pwsh',
+        selectWorktree: false
+      })
+    )
+    expect(store.createTab).not.toHaveBeenCalled()
+    expect(store.activateTab).not.toHaveBeenCalled()
+    expect(focusTerminalTabSurfaceMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -1,0 +1,43 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import type { TerminalTab } from '../../../shared/types'
+import type { AppState } from '@/store/types'
+import { createWebRuntimeSessionTerminal } from '@/runtime/web-runtime-session'
+import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
+
+type FloatingWorkspaceTerminalStore = Pick<
+  AppState,
+  'activeGroupIdByWorktree' | 'createTab' | 'activateTab' | 'settings'
+>
+
+export function isFloatingWorkspacePanelVisible(
+  doc: Pick<Document, 'querySelector'> = document
+): boolean {
+  return Boolean(doc.querySelector('[data-floating-terminal-panel][aria-hidden="false"]'))
+}
+
+export async function createFloatingWorkspaceTerminalTab(
+  store: FloatingWorkspaceTerminalStore,
+  shellOverride?: string
+): Promise<TerminalTab | null> {
+  const targetGroupId = store.activeGroupIdByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
+  const runtimeEnvironmentId = store.settings?.activeRuntimeEnvironmentId?.trim()
+  if (
+    await createWebRuntimeSessionTerminal({
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      environmentId: runtimeEnvironmentId,
+      targetGroupId,
+      command: shellOverride,
+      activate: true,
+      selectWorktree: false
+    })
+  ) {
+    return null
+  }
+
+  const tab = store.createTab(FLOATING_TERMINAL_WORKTREE_ID, targetGroupId, shellOverride, {
+    activate: false
+  })
+  store.activateTab(tab.id)
+  focusTerminalTabSurface(tab.id)
+  return tab
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -86,6 +86,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       getKeyboardInputSourceId: () => Promise.resolve(null),
       setUnreadDockBadgeCount: () => Promise.resolve(),
       getFloatingTerminalCwd: () => Promise.resolve(''),
+      getFloatingMarkdownDirectory: () => Promise.resolve(''),
       pickFloatingMarkdownDocument: () => Promise.resolve(null),
       pickFloatingWorkspaceDirectory: () => Promise.resolve(null)
     },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -212,7 +212,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     ctrlTabOrderMode: 'mru',
     floatingTerminalEnabled: true,
     floatingTerminalDefaultedForAllUsers: true,
-    floatingTerminalCwd: '',
+    floatingTerminalCwd: '~',
     floatingTerminalTrustedCwds: [],
     floatingTerminalCwdMigratedToAppWorkspace: true,
     floatingTerminalTriggerLocation: 'floating-button',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1621,14 +1621,14 @@ export type GlobalSettings = {
    *  landed, the floating workspace defaulted off and many profiles persisted
    *  that inherited false. Once migrated, an explicit off choice sticks. */
   floatingTerminalDefaultedForAllUsers?: boolean
-  /** Where new Floating Workspace tabs start. Empty means Orca's app-owned
+  /** Where new Floating Workspace terminal tabs start. Empty or '~' means
+   *  the user's home directory; markdown notes use Orca's app-owned
    *  floating workspace under Electron userData. */
   floatingTerminalCwd: string
   /** Picker-approved Floating Workspace directories that may be reauthorized
    *  across restarts. Renderer-provided text alone must not populate this. */
   floatingTerminalTrustedCwds?: string[]
-  /** One-shot migration from the old implicit '~' default to the app-owned
-   *  floating workspace. Explicit future '~' choices are preserved. */
+  /** One-shot migration marker for legacy floating workspace cwd trust grants. */
   floatingTerminalCwdMigratedToAppWorkspace?: boolean
   /** Where the Floating Workspace toggle is shown. Defaults to the floating
    *  button for discoverability. */


### PR DESCRIPTION
## Summary
- Default Floating Workspace terminal cwd back to home (`~`) while keeping markdown note creation/opening rooted in Orca app-owned floating workspace directory.
- Normalize previously migrated blank floating cwd settings back to `~`.
- Route Cmd/Ctrl+T into the floating workspace when the floating panel is visible, including browser-guest forwarded shortcuts.

## Verification
- `pnpm test src/main/ipc/floating-workspace-directory.test.ts src/main/persistence.test.ts src/renderer/src/components/settings/FloatingWorkspacePane.test.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/lib/floating-workspace-terminal-actions.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `git diff --check`