### PR TITLE
Keep PR generation scoped when switching worktrees

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
@@ -27,6 +27,7 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     commitError: null as string | null,
     remoteActionError: null as string | null,
     isCommitting: inputs.isCommitting,
+    showComposer: true,
     aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,
@@ -149,5 +150,20 @@ describe('CommitArea AI generation', () => {
     })
     expect(markup).toContain('Commit')
     expect(markup).toContain('aria-label="Generate commit message with AI"')
+  })
+
+  it('can hide only the composer while keeping the split action surface visible', () => {
+    const markup = renderCommitArea({
+      ...baseProps({ hasMessage: false, stagedCount: 0 }),
+      commitMessage: '',
+      aiEnabled: true,
+      aiAgentConfigured: true,
+      showComposer: false
+    })
+
+    expect(markup).not.toContain('aria-label="Commit message"')
+    expect(markup).not.toContain('aria-label="Generate commit message with AI"')
+    expect(markup).toContain('Nothing to commit')
+    expect(markup).toContain('aria-label="More commit and remote actions"')
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.pr-generation-records.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.pr-generation-records.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import {
+  arePullRequestGenerationFieldsEqual,
+  createRunningPullRequestGenerationRecord,
+  getPullRequestGenerationRecordKey,
+  getPullRequestGenerationWorktreeKey,
+  resolvePullRequestGenerationCancel,
+  resolvePullRequestGenerationSuccess,
+  shouldApplyPullRequestGenerationResult,
+  shouldHydratePullRequestGenerationResult,
+  type PullRequestGenerationRecord
+} from './SourceControl'
+
+const seed = {
+  base: 'main',
+  title: 'feat: add worktree-safe generation',
+  body: 'Body',
+  draft: false
+}
+
+function runningRecord(overrides: Partial<PullRequestGenerationRecord> = {}) {
+  return {
+    context: {
+      worktreeId: 'wt-a',
+      worktreePath: '/repo/a',
+      connectionId: 'conn-a',
+      requestId: 3,
+      repoId: 'repo-1',
+      branch: 'feature-a'
+    },
+    seed,
+    status: 'running' as const,
+    result: null,
+    error: null,
+    hydrated: false,
+    ...overrides
+  }
+}
+
+describe('SourceControl pull request generation records', () => {
+  it('keys PR generation by worktree id and falls back to path', () => {
+    expect(getPullRequestGenerationWorktreeKey('wt-a', '/repo/a')).toBe('wt-a')
+    expect(getPullRequestGenerationWorktreeKey(null, '/repo/a')).toBe('/repo/a')
+    expect(getPullRequestGenerationWorktreeKey(null, '')).toBeNull()
+    expect(
+      getPullRequestGenerationRecordKey({
+        worktreeId: 'wt-a',
+        worktreePath: '/repo/a',
+        repoId: 'repo-1',
+        branch: 'feature-a'
+      })
+    ).not.toBe(
+      getPullRequestGenerationRecordKey({
+        worktreeId: 'wt-a',
+        worktreePath: '/repo/a',
+        repoId: 'repo-1',
+        branch: 'feature-b'
+      })
+    )
+  })
+
+  it('applies generated PR fields only to the original running request with unchanged seed', () => {
+    expect(
+      shouldApplyPullRequestGenerationResult({
+        record: runningRecord(),
+        requestId: 3,
+        currentFields: seed
+      })
+    ).toBe(true)
+
+    expect(
+      shouldApplyPullRequestGenerationResult({
+        record: runningRecord(),
+        requestId: 4,
+        currentFields: seed
+      })
+    ).toBe(false)
+
+    expect(
+      shouldApplyPullRequestGenerationResult({
+        record: runningRecord(),
+        requestId: 3,
+        currentFields: { ...seed, base: 'release' }
+      })
+    ).toBe(false)
+  })
+
+  it('treats draft changes as stale PR generation input', () => {
+    expect(arePullRequestGenerationFieldsEqual(seed, { ...seed, draft: true })).toBe(false)
+  })
+
+  it('rehydrates a completed result only when the seed still matches', () => {
+    const record = runningRecord({
+      status: 'succeeded',
+      result: { ...seed, title: 'Generated title' }
+    })
+
+    expect(
+      shouldHydratePullRequestGenerationResult({
+        record,
+        currentFields: seed
+      })
+    ).toBe(true)
+
+    expect(
+      shouldHydratePullRequestGenerationResult({
+        record,
+        currentFields: { ...seed, body: 'Edited body' }
+      })
+    ).toBe(false)
+
+    expect(
+      shouldHydratePullRequestGenerationResult({
+        record: { ...record, hydrated: true },
+        currentFields: seed
+      })
+    ).toBe(false)
+  })
+
+  it('keeps a switched-away PR generation owned by the original worktree', () => {
+    const worktreeA = createRunningPullRequestGenerationRecord(
+      {
+        worktreeId: 'wt-a',
+        worktreePath: '/repo/a',
+        connectionId: 'conn-a',
+        requestId: 1,
+        repoId: 'repo-1',
+        branch: 'feature-a'
+      },
+      seed
+    )
+    const records: Record<string, PullRequestGenerationRecord> = {
+      'wt-a': worktreeA
+    }
+
+    // Switching to B and pressing stop must not manufacture or cancel A's record.
+    const canceledB = resolvePullRequestGenerationCancel(records['wt-b'])
+    expect(canceledB).toBeNull()
+    expect(records['wt-a'].status).toBe('running')
+
+    const generated = {
+      base: 'main',
+      title: 'Generated PR title',
+      body: 'Generated body',
+      draft: false
+    }
+    const completedA = resolvePullRequestGenerationSuccess({
+      record: records['wt-a'],
+      requestId: 1,
+      currentFields: seed,
+      result: generated
+    })
+
+    expect(completedA).toMatchObject({
+      status: 'succeeded',
+      result: generated,
+      hydrated: false
+    })
+    expect(
+      shouldHydratePullRequestGenerationResult({
+        record: completedA,
+        currentFields: seed
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -116,9 +116,11 @@ import {
   bulkStageRuntimeGitPaths,
   bulkUnstageRuntimeGitPaths,
   cancelRuntimeGenerateCommitMessage,
+  cancelRuntimeGeneratePullRequestFields,
   commitRuntimeGit,
   discardRuntimeGitPath,
   generateRuntimeCommitMessage,
+  generateRuntimePullRequestFields,
   getRuntimeGitBranchCompare,
   getRuntimeGitCommitCompare,
   getRuntimeGitHistory,
@@ -210,6 +212,35 @@ function createDefaultCollapsedSections(): Set<string> {
 // (tests and other components) instead of going through this module.
 
 type CommitDraftsByWorktree = Record<string, string>
+
+export type PullRequestGenerationFields = {
+  base: string
+  title: string
+  body: string
+  draft: boolean
+}
+
+export type PullRequestGenerationContext = {
+  worktreeId: string | null
+  worktreePath: string
+  connectionId?: string
+  requestId: number
+  repoId: string
+  branch: string
+}
+
+export type PullRequestGenerationStatus = 'idle' | 'running' | 'canceled' | 'failed' | 'succeeded'
+
+export type PullRequestGenerationRecord = {
+  context: PullRequestGenerationContext
+  seed: PullRequestGenerationFields
+  status: PullRequestGenerationStatus
+  result: PullRequestGenerationFields | null
+  error: string | null
+  hydrated: boolean
+}
+
+type PullRequestGenerationRecords = Record<string, PullRequestGenerationRecord>
 
 export function normalizeSourceControlViewMode(value: unknown): SourceControlViewMode {
   return value === 'tree' || value === 'list' ? value : 'list'
@@ -308,6 +339,13 @@ type PendingDiffCommentsClear =
   | { kind: 'all'; worktreeId: string }
   | { kind: 'file'; worktreeId: string; filePath: string }
 
+type HostedReviewCreationState = {
+  repoId: string
+  worktreeId: string
+  branch: string
+  data: HostedReviewCreationEligibility
+}
+
 export function readCommitDraftForWorktree(
   drafts: CommitDraftsByWorktree,
   worktreeId: string | null | undefined
@@ -321,6 +359,160 @@ export function writeCommitDraftForWorktree(
   value: string
 ): CommitDraftsByWorktree {
   return { ...drafts, [worktreeId]: value }
+}
+
+export function getPullRequestGenerationWorktreeKey(
+  worktreeId: string | null | undefined,
+  worktreePath: string | null | undefined
+): string | null {
+  if (worktreeId) {
+    return worktreeId
+  }
+  return worktreePath?.trim() ? worktreePath : null
+}
+
+export function getPullRequestGenerationRecordKey({
+  worktreeId,
+  worktreePath,
+  repoId,
+  branch
+}: {
+  worktreeId: string | null | undefined
+  worktreePath: string | null | undefined
+  repoId: string | null | undefined
+  branch: string | null | undefined
+}): string | null {
+  const worktreeKey = getPullRequestGenerationWorktreeKey(worktreeId, worktreePath)
+  if (!worktreeKey || !repoId || !branch) {
+    return null
+  }
+  return JSON.stringify([repoId, worktreeKey, branch])
+}
+
+export function arePullRequestGenerationFieldsEqual(
+  left: PullRequestGenerationFields,
+  right: PullRequestGenerationFields
+): boolean {
+  return (
+    left.base === right.base &&
+    left.title === right.title &&
+    left.body === right.body &&
+    left.draft === right.draft
+  )
+}
+
+export function shouldApplyPullRequestGenerationResult({
+  record,
+  requestId,
+  currentFields
+}: {
+  record: PullRequestGenerationRecord | null | undefined
+  requestId: number
+  currentFields: PullRequestGenerationFields
+}): boolean {
+  return (
+    record?.context.requestId === requestId &&
+    record.status === 'running' &&
+    arePullRequestGenerationFieldsEqual(record.seed, currentFields)
+  )
+}
+
+export function shouldHydratePullRequestGenerationResult({
+  record,
+  currentFields
+}: {
+  record: PullRequestGenerationRecord | null | undefined
+  currentFields: PullRequestGenerationFields
+}): boolean {
+  return (
+    record?.status === 'succeeded' &&
+    record.result !== null &&
+    !record.hydrated &&
+    arePullRequestGenerationFieldsEqual(record.seed, currentFields)
+  )
+}
+
+export function createRunningPullRequestGenerationRecord(
+  context: PullRequestGenerationContext,
+  seed: PullRequestGenerationFields
+): PullRequestGenerationRecord {
+  return {
+    context,
+    seed,
+    status: 'running',
+    result: null,
+    error: null,
+    hydrated: false
+  }
+}
+
+export function resolvePullRequestGenerationSuccess({
+  record,
+  requestId,
+  currentFields,
+  result
+}: {
+  record: PullRequestGenerationRecord | null | undefined
+  requestId: number
+  currentFields: PullRequestGenerationFields
+  result: PullRequestGenerationFields
+}): PullRequestGenerationRecord | null {
+  if (!record || record.context.requestId !== requestId || record.status !== 'running') {
+    return null
+  }
+  if (!shouldApplyPullRequestGenerationResult({ record, requestId, currentFields })) {
+    return {
+      ...record,
+      status: 'failed',
+      result: null,
+      error: 'Fields changed while generating. Run generate again for a fresh draft.',
+      hydrated: false
+    }
+  }
+  return {
+    ...record,
+    status: 'succeeded',
+    result,
+    error: null,
+    hydrated: false
+  }
+}
+
+export function resolvePullRequestGenerationFailure({
+  record,
+  requestId,
+  error,
+  canceled = false
+}: {
+  record: PullRequestGenerationRecord | null | undefined
+  requestId: number
+  error: string | null
+  canceled?: boolean
+}): PullRequestGenerationRecord | null {
+  if (!record || record.context.requestId !== requestId || record.status !== 'running') {
+    return null
+  }
+  return {
+    ...record,
+    status: canceled ? 'canceled' : 'failed',
+    result: null,
+    error: canceled ? null : error,
+    hydrated: false
+  }
+}
+
+export function resolvePullRequestGenerationCancel(
+  record: PullRequestGenerationRecord | null | undefined
+): PullRequestGenerationRecord | null {
+  if (!record || record.status !== 'running') {
+    return null
+  }
+  return {
+    ...record,
+    status: 'canceled',
+    error: null,
+    hydrated: false
+  }
 }
 
 const CONFLICT_KIND_LABELS: Record<GitConflictKind, string> = {
@@ -791,8 +983,8 @@ function SourceControlInner(): React.JSX.Element {
   const [generateErrors, setGenerateErrors] = useState<Record<string, string | null>>({})
   const isGenerating = generateInFlightByWorktree[activeWorktreeId ?? ''] ?? false
   const generateError = generateErrors[activeWorktreeId ?? ''] ?? null
-  const [hostedReviewCreation, setHostedReviewCreation] =
-    useState<HostedReviewCreationEligibility | null>(null)
+  const [hostedReviewCreationState, setHostedReviewCreationState] =
+    useState<HostedReviewCreationState | null>(null)
   const createPrInFlightRef = useRef<Record<string, boolean>>({})
   const [createPrInFlightByWorktree, setCreatePrInFlightByWorktree] = useState<
     Record<string, boolean>
@@ -800,6 +992,10 @@ function SourceControlInner(): React.JSX.Element {
   const [createPrErrors, setCreatePrErrors] = useState<Record<string, string | null>>({})
   const isCreatingPr = createPrInFlightByWorktree[activeWorktreeId ?? ''] ?? false
   const createPrError = createPrErrors[activeWorktreeId ?? ''] ?? null
+  const prGenerationRequestSeqRef = useRef(0)
+  const prGenerationInFlightRef = useRef<Record<string, boolean>>({})
+  const prFieldsByGenerationKeyRef = useRef<Record<string, PullRequestGenerationFields>>({})
+  const [prGenerationRecords, setPrGenerationRecords] = useState<PullRequestGenerationRecords>({})
   const commitMessageAi = useAppStore((s) => s.settings?.commitMessageAi)
   const effectiveCommitMessageAgentId = useMemo(
     () => resolveCommitMessageAgentChoice(commitMessageAi?.agentId, settings?.defaultTuiAgent),
@@ -820,6 +1016,23 @@ function SourceControlInner(): React.JSX.Element {
 
   const isFolder = activeRepo ? isFolderRepo(activeRepo) : false
   const worktreePath = activeWorktree?.path ?? null
+  const branchName = activeWorktree?.branch.replace(/^refs\/heads\//, '') ?? 'HEAD'
+  const activePullRequestGenerationKey = getPullRequestGenerationRecordKey({
+    worktreeId: activeWorktreeId,
+    worktreePath,
+    repoId: activeRepo?.id,
+    branch: branchName
+  })
+  const activePullRequestGenerationRecordCandidate = activePullRequestGenerationKey
+    ? (prGenerationRecords[activePullRequestGenerationKey] ?? null)
+    : null
+  const activePullRequestGenerationRecord =
+    activePullRequestGenerationRecordCandidate &&
+    activePullRequestGenerationRecordCandidate.context.repoId === activeRepo?.id &&
+    activePullRequestGenerationRecordCandidate.context.worktreeId === activeWorktreeId &&
+    activePullRequestGenerationRecordCandidate.context.branch === branchName
+      ? activePullRequestGenerationRecordCandidate
+      : null
   const entries = useMemo(
     () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
     [activeWorktreeId, gitStatusByWorktree]
@@ -883,6 +1096,31 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [refreshActiveGitStatus])
 
+  const refreshGitStatusAfterPullRequestGeneration = useCallback(
+    async (context: PullRequestGenerationContext): Promise<void> => {
+      if (!context.worktreeId || isFolder) {
+        return
+      }
+      try {
+        await refreshGitStatusForWorktree({
+          settings: useAppStore.getState().settings,
+          worktreeId: context.worktreeId,
+          worktreePath: context.worktreePath,
+          connectionId: context.connectionId,
+          deps: {
+            setGitStatus,
+            updateWorktreeGitIdentity,
+            setUpstreamStatus,
+            fetchUpstreamStatus
+          }
+        })
+      } catch (error) {
+        console.warn('[SourceControl] post-generation git status refresh failed', error)
+      }
+    },
+    [fetchUpstreamStatus, isFolder, setGitStatus, setUpstreamStatus, updateWorktreeGitIdentity]
+  )
+
   useEffect(() => {
     if (!activeRepo || isFolder) {
       return
@@ -923,7 +1161,13 @@ function SourceControlInner(): React.JSX.Element {
   const effectiveBaseRef = activeRepo?.worktreeBaseRef ?? defaultBaseRef
   const hasUncommittedEntries = entries.length > 0
 
-  const branchName = activeWorktree?.branch.replace(/^refs\/heads\//, '') ?? 'HEAD'
+  const hostedReviewCreation =
+    hostedReviewCreationState &&
+    activeRepo?.id === hostedReviewCreationState.repoId &&
+    activeWorktreeId === hostedReviewCreationState.worktreeId &&
+    branchName === hostedReviewCreationState.branch
+      ? hostedReviewCreationState.data
+      : null
   const hostedReviewCacheKey =
     activeRepo && branchName
       ? getHostedReviewCacheKey(activeRepo.path, branchName, settings, activeRepo.id)
@@ -1586,6 +1830,170 @@ function SourceControlInner(): React.JSX.Element {
     await refreshActiveGitStatusAfterMutation()
   }, [refreshActiveGitStatusAfterMutation])
 
+  const handleGeneratePullRequestFieldsForActive = useCallback(
+    async (fields: PullRequestGenerationFields): Promise<void> => {
+      if (!activeRepo || !activePullRequestGenerationKey || !worktreePath || !branchName) {
+        return
+      }
+      if (prGenerationInFlightRef.current[activePullRequestGenerationKey]) {
+        return
+      }
+      const requestId = prGenerationRequestSeqRef.current + 1
+      prGenerationRequestSeqRef.current = requestId
+      const generationKey = activePullRequestGenerationKey
+      const context: PullRequestGenerationContext = {
+        worktreeId: activeWorktreeId,
+        worktreePath,
+        connectionId: getConnectionId(activeWorktreeId) ?? undefined,
+        requestId,
+        repoId: activeRepo.id,
+        branch: branchName
+      }
+      const seed = { ...fields }
+      prGenerationInFlightRef.current[generationKey] = true
+      prFieldsByGenerationKeyRef.current[generationKey] = seed
+      setPrGenerationRecords((prev) => ({
+        ...prev,
+        [generationKey]: createRunningPullRequestGenerationRecord(context, seed)
+      }))
+
+      try {
+        const result = await generateRuntimePullRequestFields(
+          {
+            settings: useAppStore.getState().settings,
+            worktreeId: context.worktreeId,
+            worktreePath: context.worktreePath,
+            connectionId: context.connectionId
+          },
+          {
+            base: stripBaseRef(seed.base.trim()),
+            title: seed.title,
+            body: seed.body,
+            draft: seed.draft
+          }
+        )
+        if (result.branchChangedByPreparation) {
+          await refreshGitStatusAfterPullRequestGeneration(context)
+        }
+        setPrGenerationRecords((prev) => {
+          const record = prev[generationKey]
+          if (!result.success) {
+            const nextRecord = resolvePullRequestGenerationFailure({
+              record,
+              requestId,
+              canceled: result.canceled,
+              error: result.canceled ? null : result.error
+            })
+            if (!nextRecord) {
+              return prev
+            }
+            return {
+              ...prev,
+              [generationKey]: nextRecord
+            }
+          }
+          if (!record) {
+            return prev
+          }
+          const currentFields = prFieldsByGenerationKeyRef.current[generationKey] ?? record.seed
+          const nextRecord = resolvePullRequestGenerationSuccess({
+            record,
+            requestId,
+            currentFields,
+            result: {
+              base: stripBaseRef(result.fields.base),
+              title: result.fields.title,
+              body: result.fields.body,
+              draft: result.fields.draft
+            }
+          })
+          if (!nextRecord) {
+            return prev
+          }
+          return {
+            ...prev,
+            [generationKey]: nextRecord
+          }
+        })
+      } catch (error) {
+        setPrGenerationRecords((prev) => {
+          const record = prev[generationKey]
+          const nextRecord = resolvePullRequestGenerationFailure({
+            record,
+            requestId,
+            error:
+              error instanceof Error ? error.message : 'Failed to generate pull request details'
+          })
+          if (!nextRecord) {
+            return prev
+          }
+          return {
+            ...prev,
+            [generationKey]: nextRecord
+          }
+        })
+      } finally {
+        prGenerationInFlightRef.current[generationKey] = false
+      }
+    },
+    [
+      activePullRequestGenerationKey,
+      activeRepo,
+      activeWorktreeId,
+      branchName,
+      refreshGitStatusAfterPullRequestGeneration,
+      worktreePath
+    ]
+  )
+
+  const handleCancelGeneratePullRequestFieldsForActive = useCallback((): void => {
+    if (!activePullRequestGenerationKey) {
+      return
+    }
+    const record = prGenerationRecords[activePullRequestGenerationKey]
+    if (!record || record.status !== 'running') {
+      return
+    }
+    const generationKey = activePullRequestGenerationKey
+    setPrGenerationRecords((prev) => {
+      const current = prev[generationKey]
+      if (!current || current.context.requestId !== record.context.requestId) {
+        return prev
+      }
+      const nextRecord = resolvePullRequestGenerationCancel(current)
+      if (!nextRecord) {
+        return prev
+      }
+      return {
+        ...prev,
+        [generationKey]: nextRecord
+      }
+    })
+    void cancelRuntimeGeneratePullRequestFields({
+      settings: useAppStore.getState().settings,
+      worktreeId: record.context.worktreeId,
+      worktreePath: record.context.worktreePath,
+      connectionId: record.context.connectionId
+    }).catch((error) => {
+      setPrGenerationRecords((prev) => {
+        const current = prev[generationKey]
+        if (!current || current.context.requestId !== record.context.requestId) {
+          return prev
+        }
+        return {
+          ...prev,
+          [generationKey]: {
+            ...current,
+            status: 'failed',
+            error:
+              error instanceof Error ? error.message : 'Failed to stop pull request generation',
+            hydrated: false
+          }
+        }
+      })
+    })
+  }, [activePullRequestGenerationKey, prGenerationRecords])
+
   const {
     aiGenerationEnabled: prAiGenerationEnabled,
     base: prBase,
@@ -1616,12 +2024,108 @@ function SourceControlInner(): React.JSX.Element {
     eligibility: hostedReviewCreation,
     settings,
     submitting: isCreatingPr,
-    onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration
+    onBranchChangedByGeneration: handleBranchChangedByPullRequestGeneration,
+    generation: {
+      generating: activePullRequestGenerationRecord?.status === 'running',
+      generateError: activePullRequestGenerationRecord?.error ?? null,
+      onGenerate: (fields) => {
+        void handleGeneratePullRequestFieldsForActive(fields)
+      },
+      onCancelGenerate: handleCancelGeneratePullRequestFieldsForActive
+    }
   })
 
   useEffect(() => {
-    if (!isBranchVisible || !activeRepo || isFolder || !branchName) {
-      setHostedReviewCreation(null)
+    if (!activePullRequestGenerationKey) {
+      return
+    }
+    if (
+      activePullRequestGenerationRecord?.status === 'succeeded' &&
+      !activePullRequestGenerationRecord.hydrated
+    ) {
+      return
+    }
+    prFieldsByGenerationKeyRef.current[activePullRequestGenerationKey] = {
+      base: prBase,
+      title: prTitle,
+      body: prBody,
+      draft: prDraft
+    }
+  }, [
+    activePullRequestGenerationKey,
+    activePullRequestGenerationRecord,
+    prBase,
+    prBody,
+    prDraft,
+    prTitle
+  ])
+
+  useEffect(() => {
+    if (
+      !activePullRequestGenerationKey ||
+      !activePullRequestGenerationRecord ||
+      activePullRequestGenerationRecord.status !== 'succeeded' ||
+      !activePullRequestGenerationRecord.result ||
+      activePullRequestGenerationRecord.hydrated
+    ) {
+      return
+    }
+    const currentFields = prFieldsByGenerationKeyRef.current[activePullRequestGenerationKey] ?? {
+      base: prBase,
+      title: prTitle,
+      body: prBody,
+      draft: prDraft
+    }
+    if (
+      !shouldHydratePullRequestGenerationResult({
+        record: activePullRequestGenerationRecord,
+        currentFields
+      })
+    ) {
+      setPrGenerationRecords((prev) => ({
+        ...prev,
+        [activePullRequestGenerationKey]: {
+          ...activePullRequestGenerationRecord,
+          status: 'failed',
+          error: 'Fields changed while generating. Run generate again for a fresh draft.',
+          hydrated: false
+        }
+      }))
+      return
+    }
+    const result = activePullRequestGenerationRecord.result
+    setPrBase(result.base)
+    setPrBaseQuery('')
+    setPrBaseResults([])
+    setPrTitle(result.title)
+    setPrBody(result.body)
+    setPrDraft(result.draft)
+    prFieldsByGenerationKeyRef.current[activePullRequestGenerationKey] = result
+    setPrGenerationRecords((prev) => ({
+      ...prev,
+      [activePullRequestGenerationKey]: {
+        ...activePullRequestGenerationRecord,
+        hydrated: true
+      }
+    }))
+  }, [
+    activePullRequestGenerationKey,
+    activePullRequestGenerationRecord,
+    prBase,
+    prBody,
+    prDraft,
+    prTitle,
+    setPrBase,
+    setPrBaseQuery,
+    setPrBaseResults,
+    setPrBody,
+    setPrDraft,
+    setPrTitle
+  ])
+
+  useEffect(() => {
+    if (!isBranchVisible || !activeRepo || isFolder || !branchName || !activeWorktreeId) {
+      setHostedReviewCreationState(null)
       return
     }
     // Why: skip refetches while the user's PR flow is mid-flight. AI generation
@@ -1648,13 +2152,18 @@ function SourceControlInner(): React.JSX.Element {
     })
       .then((result) => {
         if (!stale) {
-          setHostedReviewCreation(result)
+          setHostedReviewCreationState({
+            repoId: activeRepo.id,
+            worktreeId: activeWorktreeId,
+            branch: branchName,
+            data: result
+          })
         }
       })
       .catch((error) => {
         console.warn('[SourceControl] hosted review creation eligibility failed', error)
         if (!stale) {
-          setHostedReviewCreation(null)
+          setHostedReviewCreationState(null)
         }
       })
     return () => {
@@ -1675,6 +2184,7 @@ function SourceControlInner(): React.JSX.Element {
     remoteStatus?.ahead,
     remoteStatus?.behind,
     remoteStatus?.hasUpstream,
+    activeWorktreeId,
     worktreePath
   ])
 
@@ -3195,6 +3705,7 @@ function SourceControlInner(): React.JSX.Element {
                 commitError={commitError}
                 remoteActionError={remoteActionError?.message ?? null}
                 isCommitting={isCommitting}
+                showComposer={!(scope === 'all' && showGenericEmptyState)}
                 aiEnabled={commitMessageAi?.enabled === true}
                 aiAgentConfigured={
                   commitMessageAi?.enabled === true &&
@@ -3985,6 +4496,7 @@ type CommitAreaProps = {
   remoteActionError: string | null
   isCommitting: boolean
   isCreatingPr?: boolean
+  showComposer?: boolean
   aiEnabled: boolean
   aiAgentConfigured: boolean
   isGenerating: boolean
@@ -4009,6 +4521,7 @@ export function CommitArea({
   remoteActionError,
   isCommitting,
   isCreatingPr = false,
+  showComposer = true,
   aiEnabled,
   aiAgentConfigured,
   isGenerating,
@@ -4106,7 +4619,7 @@ export function CommitArea({
   // Why: only render the Generate button when the user has opted into the
   // feature. Mounting a perma-disabled button would leak space and add noise
   // for users who never plan to use AI commit messages.
-  const showGenerate = aiEnabled
+  const showGenerate = showComposer && aiEnabled
   let generateDisabledReason: string | undefined
   if (isGenerating) {
     generateDisabledReason = 'Generating commit message…'
@@ -4129,63 +4642,65 @@ export function CommitArea({
 
   return (
     <div className="px-3 pb-2">
-      <div className="relative">
-        <textarea
-          rows={rows}
-          value={commitMessage}
-          onChange={(e) => onCommitMessageChange(e.target.value)}
-          placeholder="Message"
-          aria-label="Commit message"
-          aria-describedby={describedBy || undefined}
-          // Why: reserve right padding so typed text does not slide under the
-          // absolute-positioned Generate icon in the top-right corner.
-          className={`mt-0.5 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring ${
-            showGenerate ? 'pr-7' : ''
-          }`}
-        />
-        {showGenerate &&
-          (isGenerating ? (
-            // Why: while generating the icon doubles as the cancel affordance.
-            // Default state shows the spinning RefreshCw; on hover/focus we
-            // swap to a Square ("stop") with a destructive tint so the user
-            // sees that clicking will abort the run. Group/group-hover toggles
-            // keep this stateless on the React side.
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => onCancelGenerate()}
-                  title="Stop generating"
-                  aria-label="Stop generating commit message"
-                  className="group absolute right-1.5 top-1.5 inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/40"
-                >
-                  <RefreshCw className="size-3.5 animate-spin group-hover:hidden group-focus-visible:hidden" />
-                  <Square className="hidden size-3.5 fill-current group-hover:block group-focus-visible:block" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="left" sideOffset={6}>
-                Generating commit message. Click to stop.
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <button
-              type="button"
-              disabled={isGenerateDisabled}
-              onClick={() => onGenerate()}
-              title={generateDisabledReason ?? 'Generate commit message with AI'}
-              aria-label="Generate commit message with AI"
-              className="absolute right-1.5 top-1.5 inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-            >
-              <Sparkles className="size-3.5" />
-            </button>
-          ))}
-      </div>
+      {showComposer ? (
+        <div className="relative">
+          <textarea
+            rows={rows}
+            value={commitMessage}
+            onChange={(e) => onCommitMessageChange(e.target.value)}
+            placeholder="Message"
+            aria-label="Commit message"
+            aria-describedby={describedBy || undefined}
+            // Why: reserve right padding so typed text does not slide under the
+            // absolute-positioned Generate icon in the top-right corner.
+            className={`mt-0.5 w-full resize-none rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring ${
+              showGenerate ? 'pr-7' : ''
+            }`}
+          />
+          {showGenerate &&
+            (isGenerating ? (
+              // Why: while generating the icon doubles as the cancel affordance.
+              // Default state shows the spinning RefreshCw; on hover/focus we
+              // swap to a Square ("stop") with a destructive tint so the user
+              // sees that clicking will abort the run. Group/group-hover toggles
+              // keep this stateless on the React side.
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => onCancelGenerate()}
+                    title="Stop generating"
+                    aria-label="Stop generating commit message"
+                    className="group absolute right-1.5 top-1.5 inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/40"
+                  >
+                    <RefreshCw className="size-3.5 animate-spin group-hover:hidden group-focus-visible:hidden" />
+                    <Square className="hidden size-3.5 fill-current group-hover:block group-focus-visible:block" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="left" sideOffset={6}>
+                  Generating commit message. Click to stop.
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <button
+                type="button"
+                disabled={isGenerateDisabled}
+                onClick={() => onGenerate()}
+                title={generateDisabledReason ?? 'Generate commit message with AI'}
+                aria-label="Generate commit message with AI"
+                className="absolute right-1.5 top-1.5 inline-flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              >
+                <Sparkles className="size-3.5" />
+              </button>
+            ))}
+        </div>
+      ) : null}
       {/* Why: primary + chevron sit together as a visual split button so the
           edit → commit → push loop stays in a single vertical band. The
           chevron exposes the full action surface (fetch, pull, sync,
           publish, compound commits) without forcing morphing labels to
           carry every possible intent. */}
-      <div className="mt-1 flex items-stretch">
+      <div className={cn(showComposer ? 'mt-1 flex items-stretch' : 'flex items-stretch')}>
         {/* Why: match the "Squash and merge" button in PRActions
             (size="xs", px-3 text-[11px]) so the sidebar has a consistent
             action-button shape across Source Control and Checks. The primary

--- a/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
+++ b/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
@@ -5,7 +5,8 @@ import { getConnectionId } from '@/lib/connection-context'
 import { useAppStore, type AppState } from '@/store'
 import {
   cancelRuntimeGeneratePullRequestFields,
-  generateRuntimePullRequestFields
+  generateRuntimePullRequestFields,
+  type RuntimeGitContext
 } from '@/runtime/runtime-git-client'
 import {
   getRuntimeRepoBaseRefDefault,
@@ -28,6 +29,12 @@ type UseCreatePullRequestDialogFieldsOptions = {
   settings: AppState['settings']
   submitting: boolean
   onBranchChangedByGeneration?: () => Promise<void>
+  generation?: {
+    generating: boolean
+    generateError: string | null
+    onGenerate: (fields: { base: string; title: string; body: string; draft: boolean }) => void
+    onCancelGenerate: () => void
+  }
 }
 
 type GenerationSeed = {
@@ -36,6 +43,7 @@ type GenerationSeed = {
   title: string
   body: string
   draft: boolean
+  context: RuntimeGitContext
 }
 
 export function stripBaseRef(ref: string): string {
@@ -51,7 +59,8 @@ export function useCreatePullRequestDialogFields({
   eligibility,
   settings,
   submitting,
-  onBranchChangedByGeneration
+  onBranchChangedByGeneration,
+  generation
 }: UseCreatePullRequestDialogFieldsOptions) {
   const commitMessageAi = settings?.commitMessageAi
   const effectiveCommitMessageAgentId = resolveCommitMessageAgentChoice(
@@ -77,6 +86,7 @@ export function useCreatePullRequestDialogFields({
   const [baseSearchError, setBaseSearchError] = useState<string | null>(null)
   const [generating, setGenerating] = useState(false)
   const [generateError, setGenerateError] = useState<string | null>(null)
+  const hasExternalGeneration = Boolean(generation)
 
   useEffect(() => {
     latestFieldsRef.current = { base, title, body, draft }
@@ -84,27 +94,26 @@ export function useCreatePullRequestDialogFields({
 
   useEffect(() => {
     if (!open) {
-      generationRequestIdRef.current += 1
-      if (generateInFlightRef.current && worktreePath) {
-        const connectionId = getConnectionId(worktreeId) ?? undefined
-        void cancelRuntimeGeneratePullRequestFields({
-          settings,
-          worktreeId,
-          worktreePath,
-          connectionId
-        })
+      if (!hasExternalGeneration) {
+        generationRequestIdRef.current += 1
+        if (generateInFlightRef.current) {
+          const requestContext = generationSeedRef.current?.context
+          if (requestContext?.worktreePath) {
+            void cancelRuntimeGeneratePullRequestFields(requestContext)
+          }
+        }
+        generateInFlightRef.current = false
+        generationSeedRef.current = null
+        initializedFromEligibilityRef.current = null
+        setGenerating(false)
+        setGenerateError(null)
       }
-      generateInFlightRef.current = false
-      generationSeedRef.current = null
-      initializedFromEligibilityRef.current = null
-      setGenerating(false)
-      setGenerateError(null)
       return
     }
     if (!eligibility) {
       return
     }
-    const initializationKey = `${repoId}:${branch}`
+    const initializationKey = `${repoId}:${worktreeId ?? worktreePath}:${branch}`
     if (initializedFromEligibilityRef.current === initializationKey) {
       return
     }
@@ -120,7 +129,10 @@ export function useCreatePullRequestDialogFields({
     setBaseResults([])
     setBaseSearchError(null)
     setGenerateError(null)
-  }, [branch, eligibility, open, repoId, settings, worktreeId, worktreePath])
+  }, [branch, eligibility, hasExternalGeneration, open, repoId, worktreeId, worktreePath])
+
+  const effectiveGenerating = generation?.generating ?? generating
+  const effectiveGenerateError = generation?.generateError ?? generateError
 
   useEffect(() => {
     if (!open || base) {
@@ -183,35 +195,37 @@ export function useCreatePullRequestDialogFields({
   } else if (!base.trim()) {
     generateDisabledReason = 'Choose a base branch before generating.'
   }
-  const generateDisabled = !generating && Boolean(generateDisabledReason)
+  const generateDisabled = !effectiveGenerating && Boolean(generateDisabledReason)
 
   const handleGenerate = useCallback(async (): Promise<void> => {
-    if (!worktreePath || !base.trim() || generateInFlightRef.current || generateDisabled) {
+    if (!worktreePath || !base.trim() || effectiveGenerating || generateDisabled) {
+      return
+    }
+    if (generation) {
+      generation.onGenerate({ base, title, body, draft })
       return
     }
     const requestId = generationRequestIdRef.current + 1
     generationRequestIdRef.current = requestId
-    const seed = { requestId, base, title, body, draft }
+    const connectionId = getConnectionId(worktreeId) ?? undefined
+    const requestContext = {
+      settings: useAppStore.getState().settings,
+      worktreeId,
+      worktreePath,
+      connectionId
+    }
+    const seed = { requestId, base, title, body, draft, context: requestContext }
     generationSeedRef.current = seed
     generateInFlightRef.current = true
     setGenerating(true)
     setGenerateError(null)
     try {
-      const connectionId = getConnectionId(worktreeId) ?? undefined
-      const result = await generateRuntimePullRequestFields(
-        {
-          settings: useAppStore.getState().settings,
-          worktreeId,
-          worktreePath,
-          connectionId
-        },
-        {
-          base: stripBaseRef(base.trim()),
-          title,
-          body,
-          draft
-        }
-      )
+      const result = await generateRuntimePullRequestFields(requestContext, {
+        base: stripBaseRef(base.trim()),
+        title,
+        body,
+        draft
+      })
       if (result.branchChangedByPreparation) {
         await onBranchChangedByGeneration?.()
       }
@@ -266,6 +280,8 @@ export function useCreatePullRequestDialogFields({
     base,
     body,
     draft,
+    effectiveGenerating,
+    generation,
     generateDisabled,
     onBranchChangedByGeneration,
     title,
@@ -274,7 +290,12 @@ export function useCreatePullRequestDialogFields({
   ])
 
   const handleCancelGenerate = useCallback((): void => {
-    if (!worktreePath || !generateInFlightRef.current) {
+    if (generation) {
+      generation.onCancelGenerate()
+      return
+    }
+    const requestContext = generationSeedRef.current?.context
+    if (!requestContext?.worktreePath || !generateInFlightRef.current) {
       return
     }
     generationRequestIdRef.current += 1
@@ -282,14 +303,8 @@ export function useCreatePullRequestDialogFields({
     generationSeedRef.current = null
     setGenerating(false)
     setGenerateError(null)
-    const connectionId = getConnectionId(worktreeId) ?? undefined
-    void cancelRuntimeGeneratePullRequestFields({
-      settings: useAppStore.getState().settings,
-      worktreeId,
-      worktreePath,
-      connectionId
-    })
-  }, [worktreeId, worktreePath])
+    void cancelRuntimeGeneratePullRequestFields(requestContext)
+  }, [generation])
 
   return {
     aiGenerationEnabled: commitMessageAi?.enabled === true,
@@ -306,8 +321,8 @@ export function useCreatePullRequestDialogFields({
     baseResults,
     setBaseResults,
     baseSearchError,
-    generating,
-    generateError,
+    generating: effectiveGenerating,
+    generateError: effectiveGenerateError,
     generateDisabled,
     generateDisabledReason,
     handleGenerate,

--- a/tests/e2e/helpers/source-control-ai-generation.ts
+++ b/tests/e2e/helpers/source-control-ai-generation.ts
@@ -1,0 +1,246 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+import { execFileSync } from 'child_process'
+import { writeFileSync } from 'fs'
+import path from 'path'
+export async function openSourceControl(page: Page, worktreeId: string): Promise<void> {
+  await page.evaluate((targetWorktreeId) => {
+    const state = window.__store?.getState()
+    state?.setActiveWorktree(targetWorktreeId)
+    state?.setRightSidebarOpen(true)
+    state?.setRightSidebarTab('source-control')
+  }, worktreeId)
+  await expect
+    .poll(
+      () =>
+        page.evaluate((targetWorktreeId) => {
+          const state = window.__store?.getState()
+          return (
+            state?.activeWorktreeId === targetWorktreeId &&
+            state.rightSidebarOpen &&
+            state.rightSidebarTab === 'source-control'
+          )
+        }, worktreeId),
+      { timeout: 5_000 }
+    )
+    .toBe(true)
+}
+export async function seedCreatePrComposer(page: Page): Promise<{
+  primaryWorktreeId: string
+  prWorktreeId: string
+  prWorktreePath: string
+  primaryBranch: string
+}> {
+  return page.evaluate(async () => {
+    const store =
+      window.__store ??
+      (() => {
+        throw new Error('window.__store is not available')
+      })()
+
+    const state = store.getState()
+    const worktrees = Object.values(state.worktreesByRepo).flat()
+    const primaryWorktree = worktrees.find((entry) =>
+      entry.branch.replace(/^refs\/heads\//, '').match(/^(main|master)$/)
+    )
+    const prWorktree = worktrees.find(
+      (entry) => entry.branch.replace(/^refs\/heads\//, '') === 'e2e-secondary'
+    )
+    if (!primaryWorktree || !prWorktree) {
+      throw new Error('E2E fixture did not expose the expected main + secondary worktrees')
+    }
+    const repo =
+      state.repos.find((entry) => entry.id === prWorktree.repoId) ??
+      (() => {
+        throw new Error('PR worktree repo not found')
+      })()
+
+    const branch = prWorktree.branch.replace(/^refs\/heads\//, '')
+    const primaryBranch = primaryWorktree.branch.replace(/^refs\/heads\//, '')
+    const eligibility = {
+      provider: 'github' as const,
+      review: null,
+      canCreate: true,
+      blockedReason: null,
+      nextAction: null,
+      defaultBaseRef: primaryBranch,
+      head: branch,
+      title: 'Seed PR title',
+      body: 'Seed PR body'
+    }
+
+    store.setState((current) => ({
+      repos: current.repos.map((candidate) =>
+        candidate.id === repo.id ? { ...candidate, worktreeBaseRef: primaryBranch } : candidate
+      ),
+      gitStatusByWorktree: {
+        ...current.gitStatusByWorktree,
+        [primaryWorktree.id]: [],
+        [prWorktree.id]: []
+      },
+      remoteStatusesByWorktree: {
+        ...current.remoteStatusesByWorktree,
+        [prWorktree.id]: {
+          hasUpstream: true,
+          upstreamName: `origin/${branch}`,
+          ahead: 0,
+          behind: 0
+        }
+      },
+      getHostedReviewCreationEligibility: async (args) =>
+        args.branch === branch ? eligibility : { ...eligibility, canCreate: false },
+      fetchHostedReviewForBranch: async () => null,
+      fetchPRForBranch: async () => null,
+      fetchUpstreamStatus: async () => undefined,
+      setUpstreamStatus: () => undefined
+    }))
+
+    return {
+      primaryWorktreeId: primaryWorktree.id,
+      prWorktreeId: prWorktree.id,
+      prWorktreePath: prWorktree.path,
+      primaryBranch
+    }
+  })
+}
+
+export async function seedCommitMessageComposer(page: Page): Promise<{
+  primaryWorktreeId: string
+  commitWorktreeId: string
+  commitWorktreePath: string
+}> {
+  return page.evaluate(async () => {
+    const store =
+      window.__store ??
+      (() => {
+        throw new Error('window.__store is not available')
+      })()
+
+    const state = store.getState()
+    const worktrees = Object.values(state.worktreesByRepo).flat()
+    const primaryWorktree = worktrees.find((entry) =>
+      entry.branch.replace(/^refs\/heads\//, '').match(/^(main|master)$/)
+    )
+    const commitWorktree = worktrees.find(
+      (entry) => entry.branch.replace(/^refs\/heads\//, '') === 'e2e-secondary'
+    )
+    if (!primaryWorktree || !commitWorktree) {
+      throw new Error('E2E fixture did not expose the expected main + secondary worktrees')
+    }
+    const primaryBranch = primaryWorktree.branch.replace(/^refs\/heads\//, '')
+
+    store.setState((current) => ({
+      gitStatusByWorktree: {
+        ...current.gitStatusByWorktree,
+        [primaryWorktree.id]: [],
+        [commitWorktree.id]: [
+          {
+            path: 'e2e-commit-message-generation.txt',
+            status: 'added' as const,
+            area: 'staged' as const
+          }
+        ]
+      },
+      remoteStatusesByWorktree: {
+        ...current.remoteStatusesByWorktree,
+        [primaryWorktree.id]: {
+          hasUpstream: true,
+          upstreamName: primaryBranch,
+          ahead: 0,
+          behind: 0
+        },
+        [commitWorktree.id]: {
+          hasUpstream: false,
+          ahead: 0,
+          behind: 0
+        }
+      },
+      gitBranchCompareSummaryByWorktree: {
+        ...current.gitBranchCompareSummaryByWorktree,
+        [primaryWorktree.id]: {
+          baseRef: primaryBranch,
+          baseOid: null,
+          compareRef: primaryBranch,
+          headOid: null,
+          mergeBase: null,
+          changedFiles: 0,
+          commitsAhead: 0,
+          status: 'ready' as const
+        }
+      },
+      gitBranchCompareEntriesByWorktree: {
+        ...current.gitBranchCompareEntriesByWorktree,
+        [primaryWorktree.id]: []
+      }
+    }))
+
+    return {
+      primaryWorktreeId: primaryWorktree.id,
+      commitWorktreeId: commitWorktree.id,
+      commitWorktreePath: commitWorktree.path
+    }
+  })
+}
+
+export async function seedCleanBranchEmptyState(page: Page): Promise<string> {
+  return page.evaluate(async () => {
+    const store =
+      window.__store ??
+      (() => {
+        throw new Error('window.__store is not available')
+      })()
+
+    const state = store.getState()
+    const primaryWorktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.branch.replace(/^refs\/heads\//, '').match(/^(main|master)$/))
+    if (!primaryWorktree) {
+      throw new Error('Primary worktree not found')
+    }
+
+    const primaryBranch = primaryWorktree.branch.replace(/^refs\/heads\//, '')
+    store.setState((current) => ({
+      gitStatusByWorktree: { ...current.gitStatusByWorktree, [primaryWorktree.id]: [] },
+      remoteStatusesByWorktree: {
+        ...current.remoteStatusesByWorktree,
+        [primaryWorktree.id]: {
+          hasUpstream: true,
+          upstreamName: primaryBranch,
+          ahead: 0,
+          behind: 0
+        }
+      },
+      gitBranchCompareSummaryByWorktree: {
+        ...current.gitBranchCompareSummaryByWorktree,
+        [primaryWorktree.id]: {
+          baseRef: primaryBranch,
+          baseOid: null,
+          compareRef: primaryBranch,
+          headOid: null,
+          mergeBase: null,
+          changedFiles: 0,
+          commitsAhead: 0,
+          status: 'ready' as const
+        }
+      },
+      gitBranchCompareEntriesByWorktree: {
+        ...current.gitBranchCompareEntriesByWorktree,
+        [primaryWorktree.id]: []
+      }
+    }))
+    return primaryWorktree.id
+  })
+}
+
+export function createBranchCommit(worktreePath: string): void {
+  const changedFile = path.join(worktreePath, 'e2e-pr-generation-change.txt')
+  writeFileSync(changedFile, `PR generation worktree switch validation ${Date.now()}\n`)
+  execFileSync('git', ['add', 'e2e-pr-generation-change.txt'], { cwd: worktreePath })
+  execFileSync('git', ['commit', '-m', 'E2E PR generation change'], { cwd: worktreePath })
+}
+
+export function createStagedCommitMessageChange(worktreePath: string): void {
+  const changedFile = path.join(worktreePath, 'e2e-commit-message-generation.txt')
+  writeFileSync(changedFile, `Commit message worktree switch validation ${Date.now()}\n`)
+  execFileSync('git', ['add', 'e2e-commit-message-generation.txt'], { cwd: worktreePath })
+}

--- a/tests/e2e/helpers/source-control-ai-generators.ts
+++ b/tests/e2e/helpers/source-control-ai-generators.ts
@@ -1,0 +1,74 @@
+import type { Page } from '@stablyai/playwright-test'
+import { writeFileSync } from 'fs'
+
+async function setCustomGenerator(page: Page, scriptPath: string): Promise<void> {
+  await page.evaluate(async (scriptPath) => {
+    const store =
+      window.__store ??
+      (() => {
+        throw new Error('window.__store is not available')
+      })()
+    const currentSettings = store.getState().settings
+    if (!currentSettings) {
+      throw new Error('Settings were not loaded')
+    }
+    await store.getState().updateSettings({
+      activeRuntimeEnvironmentId: null,
+      commitMessageAi: {
+        ...currentSettings.commitMessageAi,
+        enabled: true,
+        agentId: 'custom' as const,
+        selectedModelByAgent: {},
+        selectedThinkingByModel: {},
+        customPrompt: '',
+        customAgentCommand: `node ${JSON.stringify(scriptPath)}`
+      }
+    })
+  }, scriptPath)
+}
+
+export async function installDelayedPrGenerator(
+  page: Page,
+  generatorScriptPath: string,
+  callLogPath: string,
+  base: string
+): Promise<void> {
+  writeFileSync(
+    generatorScriptPath,
+    [
+      "const fs = require('fs')",
+      `fs.appendFileSync(${JSON.stringify(callLogPath)}, 'start\\n')`,
+      'setTimeout(() => {',
+      '  console.log(JSON.stringify({',
+      `    base: ${JSON.stringify(base)},`,
+      "    title: 'Generated PR title after switch',",
+      "    body: 'Generated PR body after switch',",
+      '    draft: false',
+      '  }))',
+      `  fs.appendFileSync(${JSON.stringify(callLogPath)}, 'finish\\n')`,
+      '}, 1500)'
+    ].join('\n')
+  )
+  await setCustomGenerator(page, generatorScriptPath)
+}
+
+export async function installDelayedCommitMessageGenerator(
+  page: Page,
+  generatorScriptPath: string,
+  callLogPath: string
+): Promise<void> {
+  writeFileSync(
+    generatorScriptPath,
+    [
+      "const fs = require('fs')",
+      `fs.appendFileSync(${JSON.stringify(callLogPath)}, 'start\\n')`,
+      'setTimeout(() => {',
+      "  console.log('Generated commit message after switch')",
+      "  console.log('')",
+      "  console.log('Generated from staged e2e-commit-message-generation.txt after switching worktrees')",
+      `  fs.appendFileSync(${JSON.stringify(callLogPath)}, 'finish\\n')`,
+      '}, 1500)'
+    ].join('\n')
+  )
+  await setCustomGenerator(page, generatorScriptPath)
+}

--- a/tests/e2e/source-control-pr-generation-switch.spec.ts
+++ b/tests/e2e/source-control-pr-generation-switch.spec.ts
@@ -1,0 +1,276 @@
+import type { TestInfo } from '@stablyai/playwright-test'
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
+import path from 'path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  createBranchCommit,
+  createStagedCommitMessageChange,
+  openSourceControl,
+  seedCleanBranchEmptyState,
+  seedCommitMessageComposer,
+  seedCreatePrComposer
+} from './helpers/source-control-ai-generation'
+import {
+  installDelayedCommitMessageGenerator,
+  installDelayedPrGenerator
+} from './helpers/source-control-ai-generators'
+
+function readLog(pathname: string): string {
+  try {
+    return readFileSync(pathname, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+async function writeEvidence(
+  testInfo: TestInfo,
+  screenshotDir: string,
+  filename: string,
+  evidence: unknown
+): Promise<void> {
+  const evidencePath = path.join(screenshotDir, filename)
+  writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`)
+  await testInfo.attach(filename, {
+    path: evidencePath,
+    contentType: 'application/json'
+  })
+}
+
+test.describe('Source Control AI PR generation worktree switching', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  test('keeps pending PR generation attached to its original worktree', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const { primaryWorktreeId, prWorktreeId, prWorktreePath, primaryBranch } =
+      await seedCreatePrComposer(orcaPage)
+    createBranchCommit(prWorktreePath)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `pr-generation-switch-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+    const generatorScriptPath = path.join(screenshotDir, 'delayed-pr-generator.cjs')
+    const callLogPath = path.join(screenshotDir, 'delayed-pr-generator.log')
+    await installDelayedPrGenerator(orcaPage, generatorScriptPath, callLogPath, primaryBranch)
+
+    await openSourceControl(orcaPage, prWorktreeId)
+    const generate = orcaPage.getByRole('button', {
+      name: 'Generate pull request details with AI'
+    })
+    await expect(generate).toBeVisible({ timeout: 10_000 })
+    await expect(generate).toBeEnabled()
+    await generate.click()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating pull request details' })
+    ).toBeVisible()
+    await expect
+      .poll(() => {
+        return readLog(callLogPath)
+      })
+      .toContain('start')
+    const pendingEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        rightSidebarTab: state?.rightSidebarTab
+      }
+    })
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-pr-generation-pending-on-a.png')
+    })
+
+    await openSourceControl(orcaPage, primaryWorktreeId)
+    await expect(orcaPage.getByText('Generated PR title after switch')).toHaveCount(0)
+    const switchedEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        visibleGeneratedTitle: document.body.textContent?.includes(
+          'Generated PR title after switch'
+        )
+      }
+    })
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '02-switched-to-b-no-generated-fields.png')
+    })
+
+    await expect
+      .poll(() => readFileSync(callLogPath, 'utf8'), { timeout: 10_000 })
+      .toContain('finish')
+    await openSourceControl(orcaPage, prWorktreeId)
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request title' })).toHaveValue(
+      'Generated PR title after switch',
+      { timeout: 10_000 }
+    )
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request description' })).toHaveValue(
+      'Generated PR body after switch'
+    )
+    const finalEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        title: (document.querySelector('[aria-label="Pull request title"]') as HTMLInputElement)
+          ?.value,
+        body: (
+          document.querySelector('[aria-label="Pull request description"]') as HTMLTextAreaElement
+        )?.value
+      }
+    })
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '03-returned-to-a-generated-fields.png')
+    })
+    await writeEvidence(testInfo, screenshotDir, 'pr-generation-evidence.json', {
+      expectedOriginalWorktreeId: prWorktreeId,
+      expectedOtherWorktreeId: primaryWorktreeId,
+      generatorLog: readLog(callLogPath),
+      pending: pendingEvidence,
+      switchedAway: switchedEvidence,
+      returned: finalEvidence
+    })
+  })
+
+  test('keeps pending commit message generation attached to its original worktree', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const { primaryWorktreeId, commitWorktreeId, commitWorktreePath } =
+      await seedCommitMessageComposer(orcaPage)
+    createStagedCommitMessageChange(commitWorktreePath)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `commit-message-generation-switch-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+    const generatorScriptPath = path.join(screenshotDir, 'delayed-commit-generator.cjs')
+    const callLogPath = path.join(screenshotDir, 'delayed-commit-generator.log')
+    await installDelayedCommitMessageGenerator(orcaPage, generatorScriptPath, callLogPath)
+
+    await openSourceControl(orcaPage, commitWorktreeId)
+    await expect(orcaPage.getByText('e2e-commit-message-generation.txt')).toBeVisible({
+      timeout: 10_000
+    })
+    const generate = orcaPage.getByRole('button', {
+      name: 'Generate commit message with AI'
+    })
+    await expect(generate).toBeVisible({ timeout: 10_000 })
+    await expect(generate).toBeEnabled()
+    await generate.click()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating commit message' })
+    ).toBeVisible()
+    await expect
+      .poll(() => {
+        return readLog(callLogPath)
+      })
+      .toContain('start')
+    const pendingEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        commitMessage: (
+          document.querySelector('[aria-label="Commit message"]') as HTMLTextAreaElement
+        )?.value
+      }
+    })
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-commit-message-generation-pending-on-a.png')
+    })
+
+    await openSourceControl(orcaPage, primaryWorktreeId)
+    await expect(orcaPage.getByText('Generated commit message after switch')).toHaveCount(0)
+    await expect(
+      orcaPage.getByRole('button', { name: 'Stop generating commit message' })
+    ).toHaveCount(0)
+    const switchedEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        visibleGeneratedMessage: document.body.textContent?.includes(
+          'Generated commit message after switch'
+        )
+      }
+    })
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '02-switched-to-b-no-generated-commit-message.png')
+    })
+
+    await expect
+      .poll(() => readFileSync(callLogPath, 'utf8'), { timeout: 10_000 })
+      .toContain('finish')
+    await openSourceControl(orcaPage, commitWorktreeId)
+    await expect(orcaPage.getByRole('textbox', { name: 'Commit message' })).toHaveValue(
+      'Generated commit message after switch\n\nGenerated from staged e2e-commit-message-generation.txt after switching worktrees',
+      { timeout: 10_000 }
+    )
+    const finalEvidence = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      return {
+        activeWorktreeId: state?.activeWorktreeId,
+        commitMessage: (
+          document.querySelector('[aria-label="Commit message"]') as HTMLTextAreaElement
+        )?.value
+      }
+    })
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '03-returned-to-a-generated-commit-message.png')
+    })
+    await writeEvidence(testInfo, screenshotDir, 'commit-message-generation-evidence.json', {
+      expectedOriginalWorktreeId: commitWorktreeId,
+      expectedOtherWorktreeId: primaryWorktreeId,
+      generatorLog: readLog(callLogPath),
+      pending: pendingEvidence,
+      switchedAway: switchedEvidence,
+      returned: finalEvidence
+    })
+  })
+
+  test('hides the commit AI composer on a clean branch empty state', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const primaryWorktreeId = await seedCleanBranchEmptyState(orcaPage)
+
+    const screenshotDir = path.join(
+      process.cwd(),
+      'validation-screenshots',
+      `clean-empty-state-${Date.now()}`
+    )
+    mkdirSync(screenshotDir, { recursive: true })
+    await testInfo.attach('validation-screenshot-dir', {
+      body: screenshotDir,
+      contentType: 'text/plain'
+    })
+
+    await openSourceControl(orcaPage, primaryWorktreeId)
+    await expect(orcaPage.getByText('No changes on this branch')).toBeVisible({ timeout: 10_000 })
+    await expect(orcaPage.getByRole('textbox', { name: 'Commit message' })).toHaveCount(0)
+    await expect(
+      orcaPage.getByRole('button', { name: 'Generate commit message with AI' })
+    ).toHaveCount(0)
+    await expect(
+      orcaPage.getByRole('button', { name: /Commit|Push|Pull|Sync|Publish Branch/ }).first()
+    ).toBeVisible()
+    await orcaPage.screenshot({
+      path: path.join(screenshotDir, '01-clean-branch-no-commit-ai-composer.png')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- scope in-flight PR generation records to repo, worktree, and branch so switching does not hydrate the wrong composer
- preserve local PR dialog cancellation/cleanup while Source Control keeps worktree-owned generation alive
- add unit and e2e coverage for PR/commit AI generation during worktree switches and clean empty-state composer behavior

## Tests
- pnpm typecheck
- pnpm test -- src/renderer/src/components/right-sidebar/SourceControl.pr-generation-records.test.ts src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx