### PR TITLE
Fix Antigravity tool calls blocked by Orca hook

### DIFF
--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -236,7 +236,8 @@ describe('remote hook service installers', () => {
       expect(command).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
       expect(command).toContain(`ORCA_ANTIGRAVITY_EVENT='${eventName}'`)
     }
-    for (const eventName of ['PreToolUse', 'PostToolUse']) {
+    expect(antigravityConfig['orca-status'].PreToolUse).toBeUndefined()
+    for (const eventName of ['PostToolUse']) {
       const definition = antigravityConfig['orca-status'][eventName]?.[0]
       const command = definition?.hooks?.[0]?.command
       expect(definition?.matcher).toBe('*')
@@ -283,6 +284,55 @@ describe('remote hook service installers', () => {
       expect(command).toMatch(/^if \[ -x /)
     }
     expect(grokConfig.hooks.PreToolUse?.[0]?.matcher).toBe('*')
+  })
+
+  it('removes stale remote Antigravity PreToolUse hooks while installing SSH hooks', async () => {
+    const { sftp, fs } = createFakeSftp()
+    fs.files.set(
+      '/home/dev/.gemini/config/hooks.json',
+      `${JSON.stringify(
+        {
+          'orca-status': {
+            PreToolUse: [
+              {
+                matcher: '*',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: '/tmp/old/agent-hooks/antigravity-hook.sh'
+                  }
+                ]
+              }
+            ],
+            PostToolUse: [
+              {
+                matcher: '*',
+                hooks: [
+                  {
+                    type: 'command',
+                    command: 'echo user-authored'
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        null,
+        2
+      )}\n`
+    )
+
+    await new AntigravityHookService().installRemote(sftp, '/home/dev')
+
+    const config = JSON.parse(fs.files.get('/home/dev/.gemini/config/hooks.json')!) as {
+      'orca-status': Record<string, { hooks?: { command: string }[] }[]>
+    }
+    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    const postToolCommands = config['orca-status'].PostToolUse.flatMap((definition) =>
+      (definition.hooks ?? []).map((hook) => hook.command)
+    )
+    expect(postToolCommands).toContain('echo user-authored')
+    expect(postToolCommands.some((command) => command.includes('antigravity-hook.sh'))).toBe(true)
   })
 
   it('installs remote Copilot hooks under the user-level hooks directory', async () => {

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -46,9 +46,9 @@ describe('AntigravityHookService', () => {
       >
     }
     expect(Object.keys(config['orca-status']).sort()).toEqual(
-      ['PostInvocation', 'PostToolUse', 'PreInvocation', 'PreToolUse', 'Stop'].sort()
+      ['PostInvocation', 'PostToolUse', 'PreInvocation', 'Stop'].sort()
     )
-    expect(config['orca-status'].PreToolUse[0].matcher).toBe('*')
+    expect(config['orca-status'].PreToolUse).toBeUndefined()
     expect(config['orca-status'].PostToolUse[0].matcher).toBe('*')
     expect(config['orca-status'].PreInvocation[0].command).toContain('antigravity-hook')
     expect(config['orca-status'].PreInvocation[0].command).toContain(
@@ -130,7 +130,8 @@ describe('AntigravityHookService', () => {
       'orca-status': Record<string, { command?: string; hooks?: { command: string }[] }[]>
     }
     expect(config['orca-status'].OldEvent).toBeUndefined()
-    const commands = config['orca-status'].PreToolUse.flatMap((definition) =>
+    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    const commands = config['orca-status'].PostToolUse.flatMap((definition) =>
       (definition.hooks ?? []).map((hook) => hook.command)
     )
     expect(commands).toHaveLength(1)

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -25,7 +25,8 @@ const ANTIGRAVITY_EVENTS = [
   { eventName: 'PreInvocation', schema: 'direct' },
   { eventName: 'PostInvocation', schema: 'direct' },
   { eventName: 'Stop', schema: 'direct' },
-  { eventName: 'PreToolUse', schema: 'tool' },
+  // Why: Antigravity requires PreToolUse hooks to make permission decisions.
+  // Orca's hook is observational, so installing there can block user tools.
   { eventName: 'PostToolUse', schema: 'tool' }
 ] as const
 


### PR DESCRIPTION
## Summary
- stop installing Orca's observational Antigravity hook on PreToolUse, which Antigravity treats as a permission gate
- keep Antigravity status hooks on invocation/post-tool/stop events
- add local and SSH remote installer coverage that stale managed PreToolUse entries are removed

Fixes #2426

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/antigravity/hook-service.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/antigravity/hook-service.ts src/main/antigravity/hook-service.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts