### PR TITLE
Improve live ports hovercard behavior

### DIFF
--- a/src/renderer/src/components/sidebar/SelectedTextCopyMenu.tsx
+++ b/src/renderer/src/components/sidebar/SelectedTextCopyMenu.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+import { Copy } from 'lucide-react'
+
+type SelectedTextCopyMenuProps = {
+  children: React.ReactNode
+  className?: string
+}
+
+type MenuState = {
+  x: number
+  y: number
+  text: string
+}
+
+const MENU_WIDTH = 144
+const MENU_HEIGHT = 36
+const MENU_MARGIN = 8
+
+function getSelectionTextInside(container: HTMLElement): string {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) {
+    return ''
+  }
+
+  const anchorNode = selection.anchorNode
+  const focusNode = selection.focusNode
+  if (!anchorNode || !focusNode) {
+    return ''
+  }
+
+  if (!container.contains(anchorNode) || !container.contains(focusNode)) {
+    return ''
+  }
+
+  return selection.toString().trim()
+}
+
+export function SelectedTextCopyMenu({
+  children,
+  className
+}: SelectedTextCopyMenuProps): React.JSX.Element {
+  const [menu, setMenu] = React.useState<MenuState | null>(null)
+
+  React.useEffect(() => {
+    if (!menu) {
+      return
+    }
+
+    const close = (): void => setMenu(null)
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        close()
+      }
+    }
+
+    window.addEventListener('pointerdown', close)
+    window.addEventListener('keydown', handleKeyDown, true)
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('resize', close)
+    return () => {
+      window.removeEventListener('pointerdown', close)
+      window.removeEventListener('keydown', handleKeyDown, true)
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('resize', close)
+    }
+  }, [menu])
+
+  const handleContextMenu = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const selectedText = getSelectionTextInside(event.currentTarget)
+    if (!selectedText) {
+      return
+    }
+
+    // Why: allowing the event through reopens the workspace card menu. Render
+    // this through a body portal so transformed hovercards cannot offset it.
+    event.preventDefault()
+    event.stopPropagation()
+    event.nativeEvent.stopImmediatePropagation()
+    setMenu({
+      text: selectedText,
+      x: Math.max(
+        MENU_MARGIN,
+        Math.min(event.clientX, window.innerWidth - MENU_WIDTH - MENU_MARGIN)
+      ),
+      y: Math.max(
+        MENU_MARGIN,
+        Math.min(event.clientY, window.innerHeight - MENU_HEIGHT - MENU_MARGIN)
+      )
+    })
+  }, [])
+
+  const handleCopy = React.useCallback(() => {
+    if (!menu) {
+      return
+    }
+    void window.api.ui.writeClipboardText(menu.text)
+    setMenu(null)
+  }, [menu])
+
+  return (
+    <div className={className} onContextMenuCapture={handleContextMenu}>
+      {children}
+      {menu &&
+        createPortal(
+          <div
+            className="fixed z-[100] min-w-36 rounded-[11px] border border-black/14 bg-popover p-1 text-popover-foreground shadow-[0_16px_36px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.14)] dark:border-white/14 dark:shadow-[0_20px_44px_rgba(0,0,0,0.42),inset_0_1px_0_rgba(255,255,255,0.04)]"
+            style={{ left: menu.x, top: menu.y }}
+            onPointerDown={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-1 text-left text-[12px] font-[450] leading-5 outline-hidden hover:bg-accent focus:bg-accent"
+              onClick={handleCopy}
+            >
+              <Copy className="size-3.5 text-muted-foreground" />
+              Copy
+            </button>
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -38,7 +38,7 @@ import {
   hasWorktreeCardDetails,
   type WorktreeCardIssueDisplay
 } from './WorktreeCardMeta'
-import { WorktreeCardPorts } from './WorktreeCardPorts'
+import { WorktreeCardPortsDetails, WorktreeCardPortsTrigger } from './WorktreeCardPorts'
 import { writeWorkspaceDragData } from './workspace-status'
 import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
@@ -470,6 +470,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     review: metaReview,
     comment: metaComment
   })
+  const hasPorts = workspacePorts.length > 0
 
   const cardBody = (
     <div
@@ -671,44 +672,39 @@ const WorktreeCard = React.memo(function WorktreeCard({
           </div>
 
           <div className="ml-auto flex shrink-0 items-center gap-1 pr-1.5">
-            {hasDetails ? (
-              <WorktreeCardDetailsHover
-                issue={metaIssue}
-                linearIssue={metaLinearIssue}
-                review={metaReview}
-                comment={metaComment}
-                onEditIssue={handleEditIssue}
-                onEditComment={handleEditComment}
-                onOpenGitHubIssueInOrca={
-                  metaIssue && 'url' in metaIssue && metaIssue.url
-                    ? handleOpenGitHubIssueInOrca
-                    : undefined
-                }
-                onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
-                onOpenReviewInOrca={
-                  metaReview?.url && metaReview.provider === 'github'
-                    ? handleOpenReviewInOrca
-                    : undefined
-                }
-              >
-                <WorktreeCardMetaBadges
-                  issue={metaIssue}
-                  linearIssue={metaLinearIssue}
-                  review={metaReview}
-                  comment={metaComment}
-                  className="ml-0 pr-0"
-                />
-              </WorktreeCardDetailsHover>
-            ) : (
-              <WorktreeCardMetaBadges
-                issue={metaIssue}
-                linearIssue={metaLinearIssue}
-                review={metaReview}
-                comment={metaComment}
-                className="ml-0 pr-0"
-              />
-            )}
-            <WorktreeCardPorts ports={workspacePorts} />
+            <WorktreeCardDetailsHover
+              issue={metaIssue}
+              linearIssue={metaLinearIssue}
+              review={metaReview}
+              comment={metaComment}
+              detailsAfter={hasPorts ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null}
+              onEditIssue={handleEditIssue}
+              onEditComment={handleEditComment}
+              onOpenGitHubIssueInOrca={
+                metaIssue && 'url' in metaIssue && metaIssue.url
+                  ? handleOpenGitHubIssueInOrca
+                  : undefined
+              }
+              onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
+              onOpenReviewInOrca={
+                metaReview?.url && metaReview.provider === 'github'
+                  ? handleOpenReviewInOrca
+                  : undefined
+              }
+            >
+              <div className="flex shrink-0 items-center gap-1">
+                {hasPorts && <WorktreeCardPortsTrigger ports={workspacePorts} />}
+                {hasDetails && (
+                  <WorktreeCardMetaBadges
+                    issue={metaIssue}
+                    linearIssue={metaLinearIssue}
+                    review={metaReview}
+                    comment={metaComment}
+                    className="ml-0 pr-0"
+                  />
+                )}
+              </div>
+            </WorktreeCardDetailsHover>
           </div>
         </div>
 

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -11,6 +11,8 @@ import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import CommentMarkdown from './CommentMarkdown'
 import { PullRequestIcon } from './WorktreeCardHelpers'
+import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from './WorktreeContextMenu'
+import { SelectedTextCopyMenu } from './SelectedTextCopyMenu'
 import {
   IssueStateBadge,
   LinearStateBadge,
@@ -50,6 +52,7 @@ type WorktreeCardMetaBadgesRootProps = WorktreeCardMetaBadgesProps &
 
 type WorktreeCardDetailsHoverProps = WorktreeCardMetaBadgesProps & {
   children: React.ReactElement
+  detailsAfter?: React.ReactNode
   onEditIssue: (event: React.MouseEvent) => void
   onEditComment: (event: React.MouseEvent) => void
   onOpenGitHubIssueInOrca?: (event: React.MouseEvent) => void
@@ -259,6 +262,7 @@ export function WorktreeCardDetailsHover({
   review,
   comment,
   children,
+  detailsAfter,
   onEditIssue,
   onEditComment,
   onOpenGitHubIssueInOrca,
@@ -274,7 +278,7 @@ export function WorktreeCardDetailsHover({
     []
   )
 
-  if (!hasWorktreeCardDetails({ issue, linearIssue, review, comment })) {
+  if (!hasWorktreeCardDetails({ issue, linearIssue, review, comment }) && !detailsAfter) {
     return children
   }
 
@@ -290,9 +294,11 @@ export function WorktreeCardDetailsHover({
         align="start"
         sideOffset={8}
         className="w-80 max-h-[28rem] overflow-y-auto p-3 text-xs scrollbar-sleek"
+        {...{ [WORKTREE_NATIVE_CONTEXT_MENU_ATTR]: '' }}
         onClick={(event) => event.stopPropagation()}
+        onDoubleClick={(event) => event.stopPropagation()}
       >
-        <div className="space-y-3">
+        <SelectedTextCopyMenu className="space-y-3">
           {issue && (
             <section className="space-y-1.5">
               <DetailHeader
@@ -437,7 +443,9 @@ export function WorktreeCardDetailsHover({
               </div>
             </section>
           )}
-        </div>
+
+          {detailsAfter}
+        </SelectedTextCopyMenu>
       </HoverCardContent>
     </HoverCard>
   )

--- a/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
@@ -15,17 +15,40 @@ import {
   workspacePortRuntimeTargetKey
 } from '@/lib/workspace-port-actions'
 import type { WorkspacePort } from '../../../../shared/workspace-ports'
+import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from './WorktreeContextMenu'
+import { SelectedTextCopyMenu } from './SelectedTextCopyMenu'
 
 type WorktreeCardPortsProps = {
   ports: WorkspacePort[]
 }
 
+export function WorktreeCardPortsTrigger({
+  ports
+}: WorktreeCardPortsProps): React.JSX.Element | null {
+  if (ports.length === 0) {
+    return null
+  }
+
+  return (
+    <button
+      type="button"
+      className="inline-flex size-3.5 shrink-0 items-center justify-center rounded text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+      aria-label={`${ports.length} live ${ports.length === 1 ? 'port' : 'ports'}`}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <Cable className="size-3.5" />
+    </button>
+  )
+}
+
 function PortAction({
   label,
+  disabled = false,
   onClick,
   children
 }: {
   label: string
+  disabled?: boolean
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   children: React.ReactNode
 }): React.JSX.Element {
@@ -36,7 +59,8 @@ function PortAction({
           type="button"
           variant="ghost"
           size="icon-xs"
-          className="size-6 text-muted-foreground hover:text-foreground"
+          disabled={disabled}
+          className="size-5 text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:text-muted-foreground/35"
           aria-label={label}
           onClick={onClick}
         >
@@ -81,7 +105,7 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation()
       void window.api.ui.writeClipboardText(addressForPort(port))
-      toast.success(`Copied :${port.port}`)
+      toast.success(`Copied ${port.port}`)
     },
     [port]
   )
@@ -102,7 +126,7 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
           toast.error(result.reason)
           return
         }
-        toast.success(`Stopped process on :${port.port}`)
+        toast.success(`Stopped process on ${port.port}`)
         setWorkspacePortScanRefreshing(true)
         try {
           const scan = await scanWorkspacePortsForTarget(runtimeTarget)
@@ -120,27 +144,59 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
   )
 
   return (
-    <div className="flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1 hover:bg-accent/50">
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        <span className="shrink-0 font-mono text-[12px] font-semibold text-foreground">
-          :{port.port}
-        </span>
-        <span className="truncate text-[11px] text-muted-foreground">{processLabel}</span>
-      </div>
-      <div className="flex shrink-0 items-center gap-0.5">
-        <PortAction label="Open in Orca Browser" onClick={handleOpen}>
-          <ExternalLink className="size-3" />
-        </PortAction>
-        <PortAction label={`Copy ${addressForPort(port)}`} onClick={handleCopy}>
-          <Copy className="size-3" />
-        </PortAction>
-        {canStop && (
-          <PortAction label="Stop Process" onClick={handleStop}>
+    <div className="group/port grid min-w-0 grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-2 rounded-md px-1.5 py-1 hover:bg-accent/50">
+      <span className="select-text font-mono text-[12px] font-semibold tabular-nums text-foreground">
+        {port.port}
+      </span>
+      <div className="relative flex h-5 min-w-0 items-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="block min-w-0 select-text truncate text-[11px] text-muted-foreground">
+              {processLabel}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {processLabel}
+          </TooltipContent>
+        </Tooltip>
+        <div className="absolute inset-y-0 right-0 flex items-center gap-0.5 rounded-md border border-border/40 bg-popover/95 px-0.5 opacity-0 shadow-xs transition-opacity group-hover/port:opacity-100 group-focus-within/port:opacity-100">
+          <PortAction label="Open in Orca Browser" onClick={handleOpen}>
+            <ExternalLink className="size-3" />
+          </PortAction>
+          <PortAction label={`Copy ${addressForPort(port)}`} onClick={handleCopy}>
+            <Copy className="size-3" />
+          </PortAction>
+          <PortAction label="Stop Process" disabled={!canStop} onClick={handleStop}>
             <Trash2 className="size-3" />
           </PortAction>
-        )}
+        </div>
       </div>
     </div>
+  )
+}
+
+export function WorktreeCardPortsDetails({
+  ports
+}: WorktreeCardPortsProps): React.JSX.Element | null {
+  if (ports.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="space-y-1.5">
+      <div className="flex items-center gap-1.5 px-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+        <Cable className="size-3" />
+        <span>Live Ports</span>
+        <span className="ml-auto font-normal tabular-nums text-muted-foreground/70">
+          {ports.length}
+        </span>
+      </div>
+      <div className="space-y-0.5">
+        {ports.map((port) => (
+          <WorktreePortRow key={port.id} port={port} />
+        ))}
+      </div>
+    </section>
   )
 }
 
@@ -152,34 +208,20 @@ export function WorktreeCardPorts({ ports }: WorktreeCardPortsProps): React.JSX.
   return (
     <HoverCard openDelay={250} closeDelay={120}>
       <HoverCardTrigger asChild>
-        <button
-          type="button"
-          className="inline-flex size-3.5 shrink-0 items-center justify-center rounded text-muted-foreground/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
-          aria-label={`${ports.length} live ${ports.length === 1 ? 'port' : 'ports'}`}
-          onClick={(event) => event.stopPropagation()}
-        >
-          <Cable className="size-3.5" />
-        </button>
+        <WorktreeCardPortsTrigger ports={ports} />
       </HoverCardTrigger>
       <HoverCardContent
         side="right"
         align="start"
         sideOffset={8}
-        className="w-72 p-2 text-xs"
+        className="w-56 select-text p-2 text-xs"
+        {...{ [WORKTREE_NATIVE_CONTEXT_MENU_ATTR]: '' }}
         onClick={(event) => event.stopPropagation()}
+        onDoubleClick={(event) => event.stopPropagation()}
       >
-        <div className="mb-1.5 flex items-center gap-1.5 px-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-          <Cable className="size-3" />
-          <span>Live Ports</span>
-          <span className="ml-auto font-normal tabular-nums text-muted-foreground/70">
-            {ports.length}
-          </span>
-        </div>
-        <div className="space-y-0.5">
-          {ports.map((port) => (
-            <WorktreePortRow key={port.id} port={port} />
-          ))}
-        </div>
+        <SelectedTextCopyMenu>
+          <WorktreeCardPortsDetails ports={ports} />
+        </SelectedTextCopyMenu>
       </HoverCardContent>
     </HoverCard>
   )

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -1,9 +1,40 @@
 import { describe, expect, it } from 'vitest'
 import {
   hasSleepableWorkspaceActivity,
+  shouldUseNativeContextMenu,
   shouldIgnoreNestedWorktreeContextMenuScope,
   shouldSuppressContextMenuFollowUpClick
 } from './WorktreeContextMenu'
+
+describe('shouldUseNativeContextMenu', () => {
+  it('uses the browser context menu for marked hovercard content', () => {
+    const target = {
+      closest: (selector: string) =>
+        selector === '[data-worktree-native-context-menu]' ? ({} as Element) : null
+    } as unknown as EventTarget
+
+    expect(shouldUseNativeContextMenu(target)).toBe(true)
+  })
+
+  it('uses the browser context menu for text nodes inside marked content', () => {
+    const target = {
+      parentElement: {
+        closest: (selector: string) =>
+          selector === '[data-worktree-native-context-menu]' ? ({} as Element) : null
+      }
+    } as unknown as EventTarget
+
+    expect(shouldUseNativeContextMenu(target)).toBe(true)
+  })
+
+  it('keeps the worktree context menu for unmarked targets', () => {
+    const target = {
+      closest: () => null
+    } as unknown as EventTarget
+
+    expect(shouldUseNativeContextMenu(target)).toBe(false)
+  })
+})
 
 describe('shouldIgnoreNestedWorktreeContextMenuScope', () => {
   it('allows the context menu scope that owns the event target', () => {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -51,7 +51,20 @@ type Props = {
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 const WORKTREE_CONTEXT_MENU_SCOPE_ATTR = 'data-worktree-context-menu-scope'
+const WORKTREE_NATIVE_CONTEXT_MENU_ATTR = 'data-worktree-native-context-menu'
 const CONTEXT_MENU_CLICK_SUPPRESSION_MS = 500
+
+function shouldUseNativeContextMenu(target: EventTarget | null): boolean {
+  const maybeElement = target as {
+    closest?: (selector: string) => Element | null
+    parentElement?: { closest?: (selector: string) => Element | null }
+  } | null
+  const nativeContextMenuSelector = `[${WORKTREE_NATIVE_CONTEXT_MENU_ATTR}]`
+  return (
+    (maybeElement?.closest?.(nativeContextMenuSelector) ??
+      maybeElement?.parentElement?.closest?.(nativeContextMenuSelector)) != null
+  )
+}
 
 function shouldIgnoreNestedWorktreeContextMenuScope(
   currentTarget: EventTarget,
@@ -391,6 +404,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
       className="relative"
       {...{ [WORKTREE_CONTEXT_MENU_SCOPE_ATTR]: 'worktree' }}
       onContextMenuCapture={(event) => {
+        if (shouldUseNativeContextMenu(event.target)) {
+          return
+        }
         if (shouldIgnoreNestedWorktreeContextMenuScope(event.currentTarget, event.target)) {
           return
         }
@@ -563,7 +579,9 @@ export default WorktreeContextMenu
 export {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
+  WORKTREE_NATIVE_CONTEXT_MENU_ATTR,
   hasSleepableWorkspaceActivity,
+  shouldUseNativeContextMenu,
   shouldSuppressContextMenuFollowUpClick,
   shouldIgnoreNestedWorktreeContextMenuScope
 }


### PR DESCRIPTION
## Summary
- Combine live ports with the workspace metadata hovercard so hovering any icon in the cluster opens one shared card.
- Tighten live port row layout, action reveal, and selectable text behavior.
- Add selected-text copy handling inside the hovercard without triggering the workspace context menu.

## Validation
- pnpm run typecheck:web
- pnpm run typecheck:node
- pnpm run typecheck:cli
- pnpm lint
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
- Electron smoke test: selected live port text, right-clicked, copied, and verified clipboard contents.