### PR TITLE
Minimize empty floating terminal with close shortcut

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -56,6 +56,7 @@ import {
   FloatingTerminalToggleButton
 } from './components/floating-terminal/FloatingTerminalPanel'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
+import { shouldMinimizeFloatingWorkspacePanelOnCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
 import { DictationController } from './components/dictation/DictationController'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
@@ -104,6 +105,7 @@ import {
 import type { VirtualizedScrollAnchor } from './hooks/useVirtualizedScrollAnchor'
 import type { RemoteWorkspacePatchResult } from '../../shared/remote-workspace-types'
 import type { OnboardingState } from '../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 import { getFeatureTipsAppOpenDecision } from './components/feature-tips/feature-tip-startup-gate'
 
 const isMac = navigator.userAgent.includes('Mac')
@@ -284,6 +286,9 @@ function App(): React.JSX.Element {
   const worktreeSidebarScrollOffsetRef = useRef(0)
   const worktreeSidebarScrollAnchorRef = useRef<VirtualizedScrollAnchor>(null)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const floatingUnifiedTabCount = useAppStore(
+    (s) => s.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]?.length ?? 0
+  )
   const activeTabId = useAppStore((s) => s.activeTabId)
   const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
   const canExpandPaneByTabId = useAppStore((s) => s.canExpandPaneByTabId)
@@ -1095,6 +1100,24 @@ function App(): React.JSX.Element {
         return
       }
 
+      // Why: after the last floating tab is closed, the empty overlay has no
+      // pane-level handler; Cmd/Ctrl+W should minimize only that landing state.
+      if (
+        !e.altKey &&
+        !e.shiftKey &&
+        e.key.toLowerCase() === 'w' &&
+        shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+          activeView,
+          activeWorktreeId,
+          floatingTerminalOpen,
+          floatingUnifiedTabCount
+        })
+      ) {
+        e.preventDefault()
+        setFloatingTerminalOpenWithFocus(false)
+        return
+      }
+
       // Cmd/Ctrl+B — toggle left sidebar
       if (!e.altKey && !e.shiftKey && e.key.toLowerCase() === 'b') {
         e.preventDefault()
@@ -1153,7 +1176,14 @@ function App(): React.JSX.Element {
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [activeView, activeWorktreeId, actions])
+  }, [
+    activeView,
+    activeWorktreeId,
+    actions,
+    floatingTerminalOpen,
+    floatingUnifiedTabCount,
+    setFloatingTerminalOpenWithFocus
+  ])
 
   useLayoutEffect(() => {
     const controls = titlebarLeftControlsRef.current

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -56,7 +56,10 @@ import {
   FloatingTerminalToggleButton
 } from './components/floating-terminal/FloatingTerminalPanel'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
-import { shouldMinimizeFloatingWorkspacePanelOnCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
+import {
+  isFloatingWorkspacePanelFocused,
+  shouldMinimizeFloatingWorkspacePanelOnCloseShortcut
+} from '@/lib/floating-workspace-terminal-actions'
 import { DictationController } from './components/dictation/DictationController'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
@@ -1097,6 +1100,10 @@ function App(): React.JSX.Element {
       }
 
       if (!mod) {
+        return
+      }
+
+      if (isFloatingWorkspacePanelFocused()) {
         return
       }
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -447,6 +447,19 @@ function findByTypeName(node: unknown, typeName: string): ReactElementLike {
   return found
 }
 
+function findByProp(node: unknown, propName: string): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (entry) => {
+    if (entry.props[propName]) {
+      found = entry
+    }
+  })
+  if (!found) {
+    throw new Error(`${propName} not found`)
+  }
+  return found
+}
+
 function runEffects(): void {
   const effects = hookRuntime.effects.splice(0)
   for (const effect of effects) {
@@ -495,6 +508,8 @@ describe('FloatingTerminalPanel close behavior', () => {
       innerWidth: 1200,
       removeEventListener: vi.fn()
     })
+    vi.stubGlobal('navigator', { userAgent: 'Macintosh' })
+    vi.stubGlobal('HTMLElement', class {})
     vi.stubGlobal('localStorage', { setItem: vi.fn() })
   })
 
@@ -555,6 +570,60 @@ describe('FloatingTerminalPanel close behavior', () => {
     )
     expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('created-tab')
+  })
+
+  it('routes titlebar Cmd+T to the floating workspace', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebarTarget = { closest: vi.fn().mockReturnValue({}) }
+    Object.setPrototypeOf(titlebarTarget, HTMLElement.prototype)
+    const preventDefault = vi.fn()
+
+    ;(panel.props.onKeyDownCapture as (event: unknown) => void)({
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: 't',
+      metaKey: true,
+      preventDefault,
+      repeat: false,
+      shiftKey: false,
+      target: titlebarTarget
+    })
+    await flushAsyncWork()
+
+    expect(preventDefault).toHaveBeenCalledWith()
+    expect(mocks.createTab).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'floating-group',
+      undefined,
+      { activate: false }
+    )
+    expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
+  })
+
+  it('minimizes the empty floating workspace on Cmd+W after landing focus', async () => {
+    const onOpenChange = vi.fn()
+    const element = await renderPanel(true, onOpenChange)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const emptyStateTarget = { closest: vi.fn().mockReturnValue({}) }
+    Object.setPrototypeOf(emptyStateTarget, HTMLElement.prototype)
+
+    ;(panel.props.onKeyDownCapture as (event: unknown) => void)({
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: 'w',
+      metaKey: true,
+      preventDefault: vi.fn(),
+      repeat: false,
+      shiftKey: false,
+      target: emptyStateTarget
+    })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mocks.closeTab).not.toHaveBeenCalled()
   })
 
   it('creates floating markdown files in local filesystem mode', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -74,6 +74,7 @@ type FloatingTerminalPanelProps = {
 
 const FLOATING_TERMINAL_NO_DRAG_SELECTOR =
   'button,input,textarea,select,[role="menuitem"],[data-testid="sortable-tab"],[data-floating-terminal-no-drag]'
+const FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR = '[data-floating-terminal-shortcut-surface]'
 
 function isFloatingTerminalDragTarget(target: EventTarget): boolean {
   return !(target instanceof HTMLElement && target.closest(FLOATING_TERMINAL_NO_DRAG_SELECTOR))
@@ -640,6 +641,66 @@ export function FloatingTerminalPanel({
     )
   }, [activeGroup, closeFloatingItems])
 
+  const focusPanelForShortcuts = useCallback(() => {
+    panelRef.current?.focus({ preventScroll: true })
+  }, [])
+
+  const handleShortcutSurfaceKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!open || event.defaultPrevented || event.repeat) {
+        return
+      }
+      const target = event.target
+      if (
+        !(target instanceof HTMLElement) ||
+        (target !== panelRef.current &&
+          target.closest(FLOATING_TERMINAL_SHORTCUT_SURFACE_SELECTOR) === null)
+      ) {
+        return
+      }
+
+      const isMac = navigator.userAgent.includes('Mac')
+      const mod = isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+      if (!mod || event.altKey) {
+        return
+      }
+
+      const key = event.key.toLowerCase()
+      if (!event.shiftKey && key === 't') {
+        event.preventDefault()
+        createFloatingTerminalTab()
+        return
+      }
+      if (event.shiftKey && key === 'b') {
+        event.preventDefault()
+        createFloatingBrowserTab()
+        return
+      }
+      if (event.shiftKey && key === 'm') {
+        event.preventDefault()
+        createFloatingMarkdownTab()
+        return
+      }
+      if (!event.shiftKey && key === 'w') {
+        event.preventDefault()
+        if (activeTab) {
+          closeFloatingItem(activeTab.id)
+        } else {
+          onOpenChange(false)
+        }
+      }
+    },
+    [
+      activeTab,
+      closeFloatingItem,
+      createFloatingBrowserTab,
+      createFloatingMarkdownTab,
+      createFloatingTerminalTab,
+      onOpenChange,
+      open
+    ]
+  )
+
   const toggleMaximized = useCallback(() => {
     setMaximized((current) => {
       if (current) {
@@ -664,6 +725,9 @@ export function FloatingTerminalPanel({
     if (!isFloatingTerminalDragTarget(target)) {
       return
     }
+    // Why: clicking the draggable titlebar should make the floating workspace
+    // own shortcuts even when the main app is still on Landing.
+    focusPanelForShortcuts()
     dragRef.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -713,6 +777,7 @@ export function FloatingTerminalPanel({
       ref={panelRef}
       data-floating-terminal-panel
       aria-hidden={!open}
+      tabIndex={-1}
       className={`fixed z-50 flex min-h-[280px] min-w-[420px] overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] ${open ? 'opacity-100' : 'invisible pointer-events-none opacity-0'}`}
       style={{
         visibility: open ? 'visible' : 'hidden',
@@ -730,10 +795,12 @@ export function FloatingTerminalPanel({
           clampFloatingTerminalBounds({ ...prev, width: rect.width, height: rect.height })
         )
       }}
+      onKeyDownCapture={handleShortcutSurfaceKeyDown}
     >
       <div className="flex min-h-0 flex-1 flex-col">
         <div
           className="flex h-9 shrink-0 cursor-grab items-center border-b border-border bg-[var(--bg-titlebar,var(--card))] active:cursor-grabbing"
+          data-floating-terminal-shortcut-surface
           onPointerDown={handleDragStart}
           onPointerMove={handleDragMove}
           onPointerUp={handleDragEnd}
@@ -863,6 +930,7 @@ export function FloatingTerminalPanel({
               onOpenMarkdown={openFloatingMarkdownTab}
               onNewBrowser={createFloatingBrowserTab}
               onClose={() => onOpenChange(false)}
+              onFocusPanel={focusPanelForShortcuts}
             />
           ) : null}
         </div>
@@ -958,16 +1026,22 @@ function FloatingTerminalEmptyState({
   onNewMarkdown,
   onOpenMarkdown,
   onNewBrowser,
-  onClose
+  onClose,
+  onFocusPanel
 }: {
   onNewTerminal: () => void
   onNewMarkdown: () => void
   onOpenMarkdown: () => void
   onNewBrowser: () => void
   onClose: () => void
+  onFocusPanel: () => void
 }): React.JSX.Element {
   return (
-    <div className="absolute inset-0 flex items-center justify-center">
+    <div
+      className="absolute inset-0 flex items-center justify-center"
+      data-floating-terminal-shortcut-surface
+      onPointerDown={onFocusPanel}
+    >
       <div className="flex w-[230px] flex-col items-center gap-1.5" data-floating-terminal-no-drag>
         <Button
           type="button"

--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -114,6 +114,10 @@ function makeHostedReview(overrides: Partial<HostedReviewInfo> = {}): HostedRevi
   }
 }
 
+function renderWorktreeCardMarkup(element: ReactNode): string {
+  return renderToStaticMarkup(<>{element}</>)
+}
+
 describe('WorktreeCard linked PR display', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -124,7 +128,7 @@ describe('WorktreeCard linked PR display', () => {
   it('keeps an icon-only linked GH PR badge visible before hosted review details are cached', async () => {
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
-    const markup = renderToStaticMarkup(
+    const markup = renderWorktreeCardMarkup(
       <WorktreeCard worktree={makeWorktree({ linkedPR: 456 })} repo={makeRepo()} isActive={false} />
     )
 
@@ -136,7 +140,7 @@ describe('WorktreeCard linked PR display', () => {
     worktreeCardProperties = ['issue', 'pr', 'comment']
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
-    const markup = renderToStaticMarkup(
+    const markup = renderWorktreeCardMarkup(
       <WorktreeCard
         worktree={makeWorktree({
           linkedIssue: 123,
@@ -170,7 +174,7 @@ describe('WorktreeCard linked PR display', () => {
     }
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
-    const markup = renderToStaticMarkup(
+    const markup = renderWorktreeCardMarkup(
       <WorktreeCard worktree={makeWorktree({ linkedPR: 456 })} repo={makeRepo()} isActive={false} />
     )
 

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -3,6 +3,7 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { TerminalTab } from '../../../shared/types'
 import {
   createFloatingWorkspaceTerminalTab,
+  isFloatingWorkspacePanelFocused,
   isFloatingWorkspacePanelVisible,
   shouldMinimizeFloatingWorkspacePanelOnCloseShortcut
 } from './floating-workspace-terminal-actions'
@@ -47,6 +48,22 @@ describe('isFloatingWorkspacePanelVisible', () => {
     expect(isFloatingWorkspacePanelVisible({ querySelector: vi.fn().mockReturnValue(null) })).toBe(
       false
     )
+  })
+})
+
+describe('isFloatingWorkspacePanelFocused', () => {
+  it('detects focus inside the floating workspace panel', () => {
+    const activeElement = {
+      closest: vi.fn().mockReturnValue({})
+    }
+    vi.stubGlobal('HTMLElement', class {})
+
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+
+    expect(isFloatingWorkspacePanelFocused({ activeElement } as never)).toBe(true)
+    expect(activeElement.closest).toHaveBeenCalledWith('[data-floating-terminal-panel]')
+
+    vi.unstubAllGlobals()
   })
 })
 

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -3,7 +3,8 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { TerminalTab } from '../../../shared/types'
 import {
   createFloatingWorkspaceTerminalTab,
-  isFloatingWorkspacePanelVisible
+  isFloatingWorkspacePanelVisible,
+  shouldMinimizeFloatingWorkspacePanelOnCloseShortcut
 } from './floating-workspace-terminal-actions'
 
 const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
@@ -107,5 +108,45 @@ describe('createFloatingWorkspaceTerminalTab', () => {
     expect(store.createTab).not.toHaveBeenCalled()
     expect(store.activateTab).not.toHaveBeenCalled()
     expect(focusTerminalTabSurfaceMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('shouldMinimizeFloatingWorkspacePanelOnCloseShortcut', () => {
+  const base = {
+    activeView: 'terminal',
+    activeWorktreeId: null,
+    floatingTerminalOpen: true,
+    floatingUnifiedTabCount: 0
+  }
+
+  it('allows Cmd/Ctrl+W to minimize the empty floating panel from landing', () => {
+    expect(shouldMinimizeFloatingWorkspacePanelOnCloseShortcut(base)).toBe(true)
+  })
+
+  it('does not minimize outside the empty floating-panel landing state', () => {
+    expect(
+      shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+        ...base,
+        floatingUnifiedTabCount: 1
+      })
+    ).toBe(false)
+    expect(
+      shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+        ...base,
+        activeWorktreeId: 'worktree-1'
+      })
+    ).toBe(false)
+    expect(
+      shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+        ...base,
+        activeView: 'settings'
+      })
+    ).toBe(false)
+    expect(
+      shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+        ...base,
+        floatingTerminalOpen: false
+      })
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -15,6 +15,13 @@ export function isFloatingWorkspacePanelVisible(
   return Boolean(doc.querySelector('[data-floating-terminal-panel][aria-hidden="false"]'))
 }
 
+export function isFloatingWorkspacePanelFocused(
+  doc: Pick<Document, 'activeElement'> = document
+): boolean {
+  const active = doc.activeElement
+  return active instanceof HTMLElement && active.closest('[data-floating-terminal-panel]') !== null
+}
+
 export function shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
   activeView,
   activeWorktreeId,

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -15,6 +15,25 @@ export function isFloatingWorkspacePanelVisible(
   return Boolean(doc.querySelector('[data-floating-terminal-panel][aria-hidden="false"]'))
 }
 
+export function shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+  activeView,
+  activeWorktreeId,
+  floatingTerminalOpen,
+  floatingUnifiedTabCount
+}: {
+  activeView: string
+  activeWorktreeId: string | null
+  floatingTerminalOpen: boolean
+  floatingUnifiedTabCount: number
+}): boolean {
+  return (
+    floatingTerminalOpen &&
+    floatingUnifiedTabCount === 0 &&
+    activeView === 'terminal' &&
+    activeWorktreeId === null
+  )
+}
+
 export async function createFloatingWorkspaceTerminalTab(
   store: FloatingWorkspaceTerminalStore,
   shellOverride?: string


### PR DESCRIPTION
## Summary
- Minimize the floating terminal panel on Cmd/Ctrl+W only when the app is on Landing, the floating panel is open, and the floating workspace has no tabs.
- Make the floating terminal titlebar and empty landing state focusable shortcut surfaces so focused floating UI handles Cmd/Ctrl+T, Cmd/Ctrl+Shift+B, Cmd/Ctrl+Shift+M, and Cmd/Ctrl+W instead of the Landing/app chrome shortcuts.
- Fix the full-suite WorktreeCard PR display test mock by exporting WORKTREE_NATIVE_CONTEXT_MENU_ATTR.
- Add focused policy and panel tests for the allowed/rejected states.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/floating-workspace-terminal-actions.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/App.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/lib/floating-workspace-terminal-actions.ts src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
- pnpm exec oxfmt --check src/renderer/src/App.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/lib/floating-workspace-terminal-actions.ts src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx

## Notes
- Full local pnpm test passed the CI-failing WorktreeCard file, then hit an unrelated macOS symlink assertion in src/main/startup/run-electron-vite-dev.test.ts.