### PR TITLE
Stabilize worktree lineage E2E seed

### DIFF
--- a/tests/e2e/worktree-lineage-state.ts
+++ b/tests/e2e/worktree-lineage-state.ts
@@ -17,6 +17,12 @@ export async function seedLineageScenario(page: Page): Promise<LineageScenario> 
     state.setSidebarOpen(true)
     state.setGroupBy('none')
     state.setSortBy('recent')
+    // Why: these specs assert lineage structure, not the user's persisted
+    // sidebar filters. Make the seeded child render even when it has no live PTY.
+    state.setShowActiveOnly(false)
+    state.setShowSleepingWorkspaces(true)
+    state.setHideDefaultBranchWorkspace(false)
+    state.setFilterRepoIds([])
 
     const worktrees = Object.values(state.worktreesByRepo)
       .flat()


### PR DESCRIPTION
## Summary
- reset sidebar filter state in the worktree lineage E2E seeding helper
- make the seeded child workspace visible even when sleeping workspaces are hidden by persisted/default UI state

## Verification
- pnpm run lint
- pnpm run typecheck:web
- SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e -- tests/e2e/worktree-lineage.spec.ts tests/e2e/droid-notification.spec.ts
- SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 npx playwright test --config tests/playwright.config.ts --project electron-headless --grep "Codex hook completion dispatches while its worktree is inactive" --repeat-each=20 tests/e2e/droid-notification.spec.ts
- SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e --shard=5/5
- SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e --shard=1/5

Failed release run investigated: https://github.com/stablyai/orca/actions/runs/26212988315/job/77128602308