### PR TITLE
Restore pointer cursor on worktree cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -485,7 +485,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
             ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
             : 'border border-transparent hover:bg-sidebar-accent/40',
         isActiveSurface && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
-        !nativeDragEnabled && !isDeleting && '!cursor-grab',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
         isSshDisconnected && !isDeleting && 'opacity-60'
       )}

--- a/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-pointer-drag-dom.ts
@@ -25,7 +25,8 @@ export function isSidebarPointerDragBlocked(target: EventTarget | null, row: HTM
 }
 
 export function setSidebarPointerDragDocumentStyles(enabled: boolean): void {
-  document.body.style.cursor = enabled ? 'grabbing' : ''
+  // Why: sidebar cards are click-first; the drop line/preview show drag state
+  // without replacing the normal pointer cursor while crossing targets.
   document.body.style.userSelect = enabled ? 'none' : ''
   document.documentElement.toggleAttribute(POINTER_DRAGGING_ATTR, enabled)
 }


### PR DESCRIPTION
## Summary
- remove the forced grab cursor from left-sidebar worktree cards
- keep click as the primary hover affordance while preserving hold-and-drag behavior

## Tests
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.test.ts src/renderer/src/components/sidebar/worktree-drag-units.test.ts