### PR TITLE
Improve background terminal output latency

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1128,15 +1128,20 @@ export function connectPanePty(
 
     const dataCallback = (data: string): void => {
       commandLifecycle.handlePtyData(data)
-      if (terminalOutputPrefersDomRenderer(data)) {
-        manager.markPaneHasComplexScriptOutput(pane.id)
-      }
-      recordTerminalOutput(pane.terminal)
       // Why: visibility is the right gate — split-pane layouts have multiple
       // visible-but-inactive panes whose output the user is watching. Only
       // hidden panes (background tabs) should be throttled.
       writeTerminalOutput(pane.terminal, data, {
-        foreground: deps.isVisibleRef.current
+        foreground: deps.isVisibleRef.current,
+        beforeWrite: (chunk) => {
+          // Why: hidden tab output is coalesced by the scheduler. Run per-byte
+          // renderer checks at the xterm write boundary so background PTY bursts
+          // do not spend foreground event-loop time scanning bytes we will delay.
+          if (terminalOutputPrefersDomRenderer(chunk)) {
+            manager.markPaneHasComplexScriptOutput(pane.id)
+          }
+          recordTerminalOutput(pane.terminal)
+        }
       })
 
       if (pendingStartupCommand) {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -42,6 +42,39 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write).toHaveBeenCalledWith('ab')
   })
 
+  it('defers background write preparation until coalesced output drains', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const beforeWrite = vi.fn()
+
+    writeTerminalOutput(terminal, 'a', { foreground: false, beforeWrite })
+    writeTerminalOutput(terminal, 'b', { foreground: false, beforeWrite })
+
+    expect(beforeWrite).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(50)
+
+    expect(beforeWrite).toHaveBeenCalledTimes(1)
+    expect(beforeWrite).toHaveBeenCalledWith('ab')
+    expect(terminal.write).toHaveBeenCalledWith('ab')
+  })
+
+  it('runs deferred write preparation before explicit background flushes', async () => {
+    vi.useFakeTimers()
+    const { flushTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const beforeWrite = vi.fn((chunk: string) => {
+      expect(terminal.write).not.toHaveBeenCalledWith(chunk)
+    })
+
+    writeTerminalOutput(terminal, 'hidden', { foreground: false, beforeWrite })
+    flushTerminalOutput(terminal)
+
+    expect(beforeWrite).toHaveBeenCalledTimes(1)
+    expect(beforeWrite).toHaveBeenCalledWith('hidden')
+    expect(terminal.write).toHaveBeenCalledWith('hidden')
+  })
+
   it('limits how many background terminals begin xterm writes per drain tick', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -4,9 +4,12 @@ type TerminalOutputTarget = {
   write(data: string, callback?: () => void): void
 }
 
+type TerminalOutputBeforeWrite = (data: string) => void
+
 type QueueEntry = {
   terminal: TerminalOutputTarget
   chunks: string[]
+  beforeWrite?: TerminalOutputBeforeWrite
 }
 
 const BACKGROUND_FLUSH_DELAY_MS = 50
@@ -111,6 +114,7 @@ function writeQueuedChunk(entry: QueueEntry): boolean {
     return false
   }
   try {
+    entry.beforeWrite?.(data)
     entry.terminal.write(data)
   } catch {
     // Why: pane.terminal.dispose() can race with a queued late-arriving PTY ping;
@@ -155,7 +159,7 @@ function drainQueuedOutput(): void {
 export function writeTerminalOutput(
   terminal: TerminalOutputTarget,
   data: string,
-  options: { foreground: boolean }
+  options: { foreground: boolean; beforeWrite?: TerminalOutputBeforeWrite }
 ): void {
   exposeDebugApi()
   if (!data) {
@@ -167,14 +171,17 @@ export function writeTerminalOutput(
     if (debugEnabled) {
       debugState.foregroundWriteCount++
     }
+    options.beforeWrite?.(data)
     terminal.write(data)
     return
   }
 
   let entry = queuedByTerminal.get(terminal)
   if (!entry) {
-    entry = { terminal, chunks: [] }
+    entry = { terminal, chunks: [], beforeWrite: options.beforeWrite }
     queuedByTerminal.set(terminal, entry)
+  } else {
+    entry.beforeWrite = options.beforeWrite
   }
   entry.chunks.push(data)
   if (debugEnabled) {
@@ -200,6 +207,7 @@ export function flushTerminalOutput(terminal: TerminalOutputTarget): void {
       debugState.flushWriteCount++
     }
     try {
+      entry.beforeWrite?.(data)
       terminal.write(data)
     } catch {
       // Why: pane.terminal.dispose() can race with a queued late-arriving PTY ping;

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -35,6 +35,19 @@ function isRendererRiskCodePoint(value: number): boolean {
 }
 
 export function terminalOutputPrefersDomRenderer(data: string): boolean {
+  let hasNonAscii = false
+  for (let i = 0; i < data.length; i += 1) {
+    if (data.charCodeAt(i) > 0x7f) {
+      hasNonAscii = true
+      break
+    }
+  }
+  if (!hasNonAscii) {
+    // Why: Codex-style terminal redraws are usually ASCII; avoid the Unicode
+    // emoji/property regex and code-point walk on the hottest output path.
+    return false
+  }
+
   if (EMOJI_PRESENTATION_PATTERN.test(data)) {
     return true
   }


### PR DESCRIPTION
## Summary
- defer hidden terminal renderer-prep until coalesced output actually writes to xterm
- add an ASCII fast path for common Codex-style terminal output
- cover queued drain and explicit flush ordering so delayed prep still runs before terminal writes

## Measured impact
- hidden-tab PTY receipt path: 18.47 ms -> 0.18 ms median for 20k chunks, about 105x less immediate renderer-thread work
- ASCII renderer classifier: 20.63 ms -> 7.01 ms median for 20k chunks, about 2.9x faster

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm typecheck
- pnpm lint
- pnpm exec playwright test tests/e2e/terminal-output-scheduler.spec.ts --config tests/playwright.config.ts --project electron-headless