### PR TITLE
Restore React Grab and workspace card quick actions

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -9,6 +9,9 @@ const openModal = vi.fn()
 const updateWorktreeMeta = vi.fn()
 
 let worktreeCardProperties: WorktreeCardProperty[] = ['status', 'unread']
+let tabsByWorktree: Record<string, { id: string }[]> = {}
+let ptyIdsByTabId: Record<string, string[]> = {}
+let browserTabsByWorktree: Record<string, { id: string }[]> = {}
 
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
@@ -24,6 +27,9 @@ vi.mock('@/store', () => ({
       settings: null,
       sshConnectionStates: new Map(),
       sshTargetLabels: new Map(),
+      browserTabsByWorktree,
+      ptyIdsByTabId,
+      tabsByWorktree,
       updateWorktreeMeta,
       worktreeCardProperties
     })
@@ -98,6 +104,9 @@ describe('WorktreeCard quick actions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     worktreeCardProperties = ['status', 'unread']
+    tabsByWorktree = {}
+    ptyIdsByTabId = {}
+    browserTabsByWorktree = {}
   })
 
   it('marks the unread toggle as a workspace-board-preserving action', async () => {
@@ -109,5 +118,28 @@ describe('WorktreeCard quick actions', () => {
 
     expect(markup).toContain('aria-label="Mark as read"')
     expect(markup).toContain('data-workspace-board-preserve-open=""')
+  })
+
+  it('shows delete as the top-right quick action for an inactive workspace', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('aria-label="Delete workspace"')
+  })
+
+  it('shows sleep as the top-right quick action for a workspace with live activity', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+    const worktree = makeWorktree()
+    tabsByWorktree = { [worktree.id]: [{ id: 'tab-1' }] }
+    ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={worktree} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('aria-label="Sleep workspace"')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -11,8 +11,10 @@ import {
   ChevronDown,
   GitMerge,
   LoaderCircle,
+  Moon,
   Server,
   ServerOff,
+  Trash2,
   Workflow
 } from 'lucide-react'
 import CacheTimer from './CacheTimer'
@@ -42,6 +44,10 @@ import { WorktreeCardPortsDetails, WorktreeCardPortsTrigger } from './WorktreeCa
 import { writeWorkspaceDragData } from './workspace-status'
 import { getWorktreeCardPrDisplay } from './worktree-card-pr-display'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
+import { hasActiveWorkspaceActivity } from '@/lib/worktree-activity-state'
+import { runWorktreeDelete } from './delete-worktree-flow'
+import { runSleepWorktree } from './sleep-worktree-flow'
+import { getWorkspaceQuickActionKind } from './worktree-card-quick-action'
 
 type WorktreeCardProps = {
   worktree: Worktree
@@ -154,6 +160,26 @@ const WorktreeCard = React.memo(function WorktreeCard({
   })
   const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
   const [showDisconnectedDialog, setShowDisconnectedDialog] = useState(false)
+  const [isMacOptionPressed, setIsMacOptionPressed] = useState(false)
+
+  useEffect(() => {
+    const isMac = navigator.userAgent.includes('Mac')
+    if (!isMac) {
+      return
+    }
+    const handleKeyChange = (event: KeyboardEvent): void => {
+      setIsMacOptionPressed(event.altKey)
+    }
+    const handleWindowBlur = (): void => setIsMacOptionPressed(false)
+    window.addEventListener('keydown', handleKeyChange, true)
+    window.addEventListener('keyup', handleKeyChange, true)
+    window.addEventListener('blur', handleWindowBlur)
+    return () => {
+      window.removeEventListener('keydown', handleKeyChange, true)
+      window.removeEventListener('keyup', handleKeyChange, true)
+      window.removeEventListener('blur', handleWindowBlur)
+    }
+  }, [])
 
   // Why: on restart the previously-active worktree is auto-restored without a
   // click, so the dialog never opens. Auto-show it for the active card when SSH
@@ -232,6 +258,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
         }
     : null
   const isDeleting = deleteState?.isDeleting ?? false
+  const hasActiveActivity = useAppStore((s) =>
+    hasActiveWorkspaceActivity(
+      worktree.id,
+      s.tabsByWorktree,
+      s.ptyIdsByTabId,
+      s.browserTabsByWorktree
+    )
+  )
 
   const showPR = cardProps.includes('pr')
   const showIssue = cardProps.includes('issue')
@@ -367,6 +401,30 @@ const WorktreeCard = React.memo(function WorktreeCard({
     },
     [worktree.id, worktree.isUnread, updateWorktreeMeta]
   )
+  const quickActionKind = getWorkspaceQuickActionKind({
+    hasActiveActivity,
+    isDeletable: !worktree.isMainWorktree && !isFolder,
+    isInactive: !hasActiveActivity,
+    isMacOptionPressed
+  })
+  const handleWorkspaceQuickAction = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (quickActionKind === 'sleep') {
+        void runSleepWorktree(worktree.id)
+      } else if (quickActionKind === 'delete') {
+        runWorktreeDelete(worktree.id)
+      }
+    },
+    [quickActionKind, worktree.id]
+  )
+  const quickActionLabel =
+    quickActionKind === 'sleep'
+      ? 'Sleep workspace'
+      : quickActionKind === 'delete'
+        ? 'Delete workspace'
+        : ''
 
   const unreadTooltip = worktree.isUnread ? 'Mark read' : 'Mark unread'
   const childWorkspaceLabel = `${lineageChildCount} child ${
@@ -546,7 +604,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       <div className="flex-1 min-w-0 flex flex-col gap-1.5">
         {/* Header row: Title */}
         <div className="flex items-center justify-between min-w-0 gap-2">
-          <div className="flex items-center gap-1.5 min-w-0">
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
             {repo?.connectionId && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -625,6 +683,38 @@ const WorktreeCard = React.memo(function WorktreeCard({
               </Tooltip>
             )}
           </div>
+
+          {quickActionKind && !isDeleting && (
+            <div className="ml-auto flex shrink-0 items-center justify-center pr-1.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    data-workspace-board-preserve-open=""
+                    onPointerDown={stopQuickActionPointerPropagation}
+                    onClick={handleWorkspaceQuickAction}
+                    className={cn(
+                      'inline-flex size-4 items-center justify-center rounded bg-transparent opacity-0 transition-colors transition-opacity',
+                      'group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
+                      quickActionKind === 'delete'
+                        ? 'text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:bg-transparent focus-visible:text-foreground'
+                        : 'text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:bg-transparent focus-visible:text-foreground'
+                    )}
+                    aria-label={quickActionLabel}
+                  >
+                    {quickActionKind === 'delete' ? (
+                      <Trash2 className="size-3.5" />
+                    ) : (
+                      <Moon className="size-3.5" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {quickActionKind === 'delete' ? 'Delete workspace' : 'Sleep workspace'}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
         </div>
 
         {/* Why: the left metadata lane clips before the right metadata badges,

--- a/src/renderer/src/components/sidebar/worktree-card-quick-action.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-quick-action.ts
@@ -1,0 +1,21 @@
+export type WorktreeCardQuickActionKind = 'sleep' | 'delete' | null
+
+export function getWorkspaceQuickActionKind({
+  hasActiveActivity,
+  isDeletable,
+  isInactive,
+  isMacOptionPressed
+}: {
+  hasActiveActivity: boolean
+  isDeletable: boolean
+  isInactive: boolean
+  isMacOptionPressed: boolean
+}): WorktreeCardQuickActionKind {
+  if (isInactive) {
+    return isDeletable ? 'delete' : null
+  }
+  if (hasActiveActivity) {
+    return isMacOptionPressed && isDeletable ? 'delete' : 'sleep'
+  }
+  return null
+}

--- a/src/renderer/src/lib/react-grab-dev-gate.test.ts
+++ b/src/renderer/src/lib/react-grab-dev-gate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { shouldEnableReactGrab } from './react-grab-dev-gate'
+
+describe('shouldEnableReactGrab', () => {
+  it('enables React Grab by default in dev builds', () => {
+    expect(shouldEnableReactGrab({ dev: true })).toBe(true)
+  })
+
+  it('allows an explicit local opt-out in dev builds', () => {
+    expect(shouldEnableReactGrab({ dev: true, enableFlag: 'false' })).toBe(false)
+  })
+
+  it('stays disabled outside dev builds', () => {
+    expect(shouldEnableReactGrab({ dev: false })).toBe(false)
+    expect(shouldEnableReactGrab({ dev: false, enableFlag: 'true' })).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/react-grab-dev-gate.ts
+++ b/src/renderer/src/lib/react-grab-dev-gate.ts
@@ -1,0 +1,10 @@
+export type ReactGrabDevEnv = {
+  readonly dev: boolean
+  readonly enableFlag?: string
+}
+
+export function shouldEnableReactGrab(env: ReactGrabDevEnv): boolean {
+  // Why: `pn dev` does not set VITE_ENABLE_REACT_GRAB; dev builds should keep
+  // React Grab's Cmd/Ctrl+C shortcut on unless a developer explicitly opts out.
+  return env.dev && env.enableFlag !== 'false'
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -4,8 +4,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import { applyDocumentTheme } from './lib/document-theme'
+import { shouldEnableReactGrab } from './lib/react-grab-dev-gate'
 
-if (import.meta.env.DEV && import.meta.env.VITE_ENABLE_REACT_GRAB === 'true') {
+if (
+  import.meta.env.DEV &&
+  shouldEnableReactGrab({
+    dev: import.meta.env.DEV,
+    enableFlag: import.meta.env.VITE_ENABLE_REACT_GRAB
+  })
+) {
   void import('react-grab').then(({ init }) => init())
   void import('react-grab/styles.css')
 }


### PR DESCRIPTION
## Summary
- restore React Grab in pn dev by default, with an explicit VITE_ENABLE_REACT_GRAB=false opt-out
- add the workspace-card top-right quick action button: live workspaces show Sleep, inactive deletable workspaces show Delete, and Option on macOS flips live workspaces to Delete
- cover the React Grab gate and card quick-action rendering with focused tests

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx src/renderer/src/lib/react-grab-dev-gate.test.ts
- pnpm run typecheck:web