### PR TITLE
Stabilize droid hook notification E2E

### DIFF
--- a/tests/e2e/droid-notification.spec.ts
+++ b/tests/e2e/droid-notification.spec.ts
@@ -155,6 +155,13 @@ test.describe('Droid notifications', () => {
     await installMainProcessNotificationDispatchSpy(electronApp)
     const endpoint = await readHookEndpoint(electronApp)
 
+    // Why: the synthetic hook bypasses the shell startup path; wait for a
+    // responsive PTY so the notification liveness gate can observe the turn.
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const readyMarker = `__CODEX_HOOK_NOTIFY_READY_${Date.now()}__`
+    await sendToTerminal(orcaPage, ptyId, `printf '${readyMarker}\\n'\r`)
+    await waitForTerminalOutput(orcaPage, readyMarker)
+
     const { paneKey, worktreeId } = await getActivePaneDescriptor(orcaPage)
     const prompt = `codex-hook-notify-${Date.now()}`
     await emitCodexHookStatus(endpoint, {


### PR DESCRIPTION
## Summary
- wait for the active terminal PTY to be registered and responsive before sending the synthetic Codex hook in the inactive-worktree notification E2E
- avoids racing the renderer notification liveness gate on slower Linux CI

## Verification
- pnpm exec electron-vite build --mode e2e
- SKIP_BUILD=1 npx playwright test --config tests/playwright.config.ts --project electron-headless --grep "Codex hook completion dispatches while its worktree is inactive" --repeat-each=10 tests/e2e/droid-notification.spec.ts
- SKIP_BUILD=1 pnpm run test:e2e --shard=1/5
- pnpm run lint
- pnpm run typecheck:web
- git diff --check