### PR TITLE
Preserve floating terminal focus while dragging

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -603,6 +603,56 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
   })
 
+  it('preserves terminal focus when dragging the titlebar from inside the floating panel', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    const activeElement = { closest: vi.fn().mockReturnValue(panelElement) }
+    const titlebarTarget = { closest: vi.fn().mockReturnValue(null) }
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(titlebarTarget, HTMLElement.prototype)
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+    vi.stubGlobal('document', { activeElement })
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture: vi.fn() },
+      pointerId: 1,
+      target: titlebarTarget
+    })
+
+    expect(panelElement.focus).not.toHaveBeenCalled()
+  })
+
+  it('focuses the floating panel for titlebar shortcuts when focus starts outside it', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    const activeElement = { closest: vi.fn().mockReturnValue(null) }
+    const titlebarTarget = { closest: vi.fn().mockReturnValue(null) }
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(titlebarTarget, HTMLElement.prototype)
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+    vi.stubGlobal('document', { activeElement })
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture: vi.fn() },
+      pointerId: 1,
+      target: titlebarTarget
+    })
+
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
   it('minimizes the empty floating workspace on Cmd+W after landing focus', async () => {
     const onOpenChange = vi.fn()
     const element = await renderPanel(true, onOpenChange)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -642,6 +642,15 @@ export function FloatingTerminalPanel({
   }, [activeGroup, closeFloatingItems])
 
   const focusPanelForShortcuts = useCallback(() => {
+    const active = document.activeElement
+    if (
+      active instanceof HTMLElement &&
+      active.closest('[data-floating-terminal-panel]') !== null
+    ) {
+      // Why: dragging the titlebar while xterm/editor already has focus should
+      // not steal the typing target just to keep panel shortcuts scoped.
+      return
+    }
     panelRef.current?.focus({ preventScroll: true })
   }, [])
 


### PR DESCRIPTION
## Summary
- Stacked on #2504.
- Preserve the existing typing focus when the floating terminal titlebar is dragged while focus is already inside the floating panel.
- Still focus the floating panel for titlebar shortcuts when focus starts outside the panel.
- Include the WorktreeCard PR display test harness fixes from #2504: mock the native-context-menu export and wrap SSR renders in TooltipProvider.
- Add focused panel tests for both focus-preserving and focus-acquiring titlebar drag cases.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx