### PR TITLE
Strip ELECTRON_RUN_AS_NODE from daemon-spawned PTY env

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -214,6 +214,26 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_WORKTREE_ID).toBe('child-worktree')
   })
 
+  it('strips ELECTRON_RUN_AS_NODE inherited from the daemon process', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const previous = process.env.ELECTRON_RUN_AS_NODE
+    process.env.ELECTRON_RUN_AS_NODE = '1'
+
+    try {
+      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ELECTRON_RUN_AS_NODE
+      } else {
+        process.env.ELECTRON_RUN_AS_NODE = previous
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
+  })
+
   it('does not inherit parent agent hook endpoint for development hook env', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -78,6 +78,16 @@ function removeInheritedDevAgentHookEndpoint(
   }
 }
 
+function removeInheritedElectronRunAsNode(env: Record<string, string>): void {
+  // Why: the daemon is forked from main with ELECTRON_RUN_AS_NODE=1 so that
+  // node-pty's posix_spawn helper isn't disturbed by Electron's GPU init.
+  // That flag must not leak into user shells: any child that resolves to the
+  // bundled `electron` binary (e.g. `electron .`, `npx electron`,
+  // electron-builder subprocesses) would then run as plain Node and silently
+  // misbehave.
+  delete env.ELECTRON_RUN_AS_NODE
+}
+
 function formatMissingDaemonPathError(kind: 'helper' | 'cwd', path: string): DaemonProtocolError {
   const detailName = kind === 'helper' ? 'helper' : 'cwd'
   const step = kind === 'helper' ? 'posix_spawn' : 'daemon_cwd'
@@ -181,6 +191,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   // of the terminal that launched `pn dev`; each PTY must opt into its own.
   removeUnspecifiedPaneIdentityEnv(env, opts.env)
   removeInheritedDevAgentHookEndpoint(env, opts.env)
+  removeInheritedElectronRunAsNode(env)
   removeInheritedNoColor(env)
 
   env.LANG ??= 'en_US.UTF-8'


### PR DESCRIPTION
## Summary

Fixes #2414.

The daemon process is forked from main with `ELECTRON_RUN_AS_NODE=1` so that node-pty's `posix_spawn` helper isn't disturbed by Electron's GPU init (`src/main/daemon/daemon-init.ts:142-148`). That flag was leaking through `process.env` into every daemon-backed terminal — and any user shell that resolved to the bundled `electron` binary (`electron .`, `npx electron`, `electron-builder` subprocesses, build scripts that shell out to `electron`) would then run as plain Node with no window, no GPU, and no asar `require` integration, then silently misbehave.

The codebase already strips this flag at other boundaries (`src/cli/runtime/launch.ts:155`, `config/scripts/run-electron-vite-dev.mjs:23`, `tests/e2e/helpers/orca-app.ts`, `tests/e2e/helpers/orca-restart.ts`). The daemon → PTY hop was simply missed.

## Fix

Add a sibling to `removeInheritedDevAgentHookEndpoint` / `removeInheritedNoColor` in `src/main/daemon/pty-subprocess.ts` that unconditionally deletes `ELECTRON_RUN_AS_NODE` from the child shell env, and call it in the same spot as the other env scrubbers.

The in-process `LocalPtyProvider` is unaffected — main is not launched with `ELECTRON_RUN_AS_NODE`, so `process.env.ELECTRON_RUN_AS_NODE` is undefined there. Only the daemon path leaks.

## Test plan

Added a regression test in `src/main/daemon/pty-subprocess.test.ts` that sets `ELECTRON_RUN_AS_NODE=1` on the daemon process env, spawns a PTY, and asserts the child env does not carry it.

Manual repro before the fix:

1. Open any terminal in Orca (daemon-backed is the default).
2. \`env | grep ELECTRON_RUN_AS_NODE\` → \`ELECTRON_RUN_AS_NODE=1\`.
3. \`electron .\` from a project that uses Electron → runs as Node, window never opens.

After the fix, step 2 returns nothing and step 3 launches Electron normally.

CI checks run locally:

- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (8888 passed, 10 skipped)
- [x] \`pnpm build\`

## No visual change

This is a pure env-scrubbing fix in the daemon's PTY spawn path. No UI changes.

## Cross-platform / security review

- **Cross-platform:** The scrub is platform-agnostic — the leak occurs on every OS where the daemon path is used (macOS, Linux, Windows). The fix is a single `delete env.ELECTRON_RUN_AS_NODE` with no platform branching.
- **SSH use case:** Daemon-backed terminals are also used over SSH; the scrub applies uniformly there.
- **Security:** Strictly reduces information leakage from the parent daemon into user shells; cannot expose a previously-hidden surface. No new code paths, no new dependencies.