### PR TITLE
Cancel native middle-click paste on tab mouseup

### DIFF
--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -19,6 +19,7 @@ import {
   getDropIndicatorClasses,
   type DropIndicator
 } from './drop-indicator'
+import { preventMiddleButtonDefault } from './middle-button-default-guard'
 
 function formatBrowserTabUrlLabel(url: string): string {
   if (url === ORCA_BROWSER_BLANK_URL || url === 'about:blank') {
@@ -141,6 +142,7 @@ export default function BrowserTab({
               e.preventDefault()
             }
           }}
+          onMouseUp={preventMiddleButtonDefault}
           onAuxClick={(e) => {
             if (e.button === 1) {
               e.preventDefault()

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -28,6 +28,7 @@ import { useAppStore } from '@/store'
 import { STATUS_COLORS, STATUS_LABELS } from '../right-sidebar/status-display'
 import type { GitFileStatus } from '../../../../shared/types'
 import type { OpenFile } from '../../store/slices/editor'
+import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from './SortableTab'
 import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import {
@@ -231,6 +232,7 @@ export default function EditorFileTab({
               e.preventDefault()
             }
           }}
+          onMouseUp={preventMiddleButtonDefault}
           onAuxClick={(e) => {
             if (e.button === 1) {
               e.preventDefault()

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -19,6 +19,7 @@ import {
   getDropIndicatorClasses,
   type DropIndicator
 } from './drop-indicator'
+import { preventMiddleButtonDefault } from './middle-button-default-guard'
 
 type SortableTabProps = {
   tab: TerminalTab
@@ -231,6 +232,7 @@ export default function SortableTab({
               e.preventDefault()
             }
           }}
+          onMouseUp={preventMiddleButtonDefault}
           onAuxClick={(e) => {
             if (isEditing) {
               return

--- a/src/renderer/src/components/tab-bar/middle-button-default-guard.test.ts
+++ b/src/renderer/src/components/tab-bar/middle-button-default-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MouseEvent as ReactMouseEvent } from 'react'
+import { preventMiddleButtonDefault } from './middle-button-default-guard'
+
+function buildEvent(button: number): ReactMouseEvent {
+  return {
+    button,
+    preventDefault: vi.fn()
+  } as unknown as ReactMouseEvent
+}
+
+describe('preventMiddleButtonDefault', () => {
+  it('cancels the default mouseup for middle-button (button === 1)', () => {
+    const event = buildEvent(1)
+    preventMiddleButtonDefault(event)
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cancel the default mouseup for the left button (button === 0)', () => {
+    const event = buildEvent(0)
+    preventMiddleButtonDefault(event)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('does not cancel the default mouseup for the right button (button === 2)', () => {
+    const event = buildEvent(2)
+    preventMiddleButtonDefault(event)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-bar/middle-button-default-guard.ts
+++ b/src/renderer/src/components/tab-bar/middle-button-default-guard.ts
@@ -1,0 +1,9 @@
+import type { MouseEvent as ReactMouseEvent } from 'react'
+
+export function preventMiddleButtonDefault(event: ReactMouseEvent): void {
+  if (event.button === 1) {
+    // Why: Chromium's Linux primary-selection paste is gated on mouseup;
+    // mousedown/auxclick cancellation alone still lets it reach the next terminal.
+    event.preventDefault()
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2346.

On Linux with primary-selection paste enabled (the default), middle-clicking a tab to close it produced an unwanted primary-selection paste into whichever terminal became active after the close. Repro is in the linked issue.

The existing \`onMouseDown\` \`preventDefault\` on each tab blocks Chromium's middle-button auto-scroll but is **not** sufficient to block the native paste pipeline — that one is gated on \`mouseup\`. After the tab unmounts via \`onAuxClick\` → \`onClose\`, focus moves to xterm's hidden \`<textarea>\` on the newly active terminal, and the native paste lands there.

This applies on both X11 and Wayland sessions (the issue author confirmed Hyprland with \`wp_primary_selection_unstable_v1\`).

## Fix

Adopt the same option-(a) approach from the issue's analysis:

- Add a small named helper \`preventMiddleButtonDefault\` in \`src/renderer/src/components/tab-bar/middle-button-default-guard.ts\`.
- Wire it as \`onMouseUp\` on \`SortableTab\`, \`BrowserTab\`, and \`EditorFileTab\` — the three tab surfaces that close on middle-click.
- Mirrors the cancel already performed by \`usePrimarySelectionPaste\`'s \`enabled=false\` branch for non-tab surfaces.

The change is **tab-local and surgical**: only the three components that already close on \`auxclick\` get the new \`onMouseUp\`. No global event listeners are added or modified.

## No platform branching

\`event.preventDefault()\` on a \`mouseup\` event is harmless on macOS and Windows — there is no native primary-selection paste pipeline to cancel there. Avoiding a platform check keeps the surfaces consistent and follows the project's cross-platform guidance (no \`navigator.userAgent\` sniffing for a behavior that's a no-op off Linux).

## Tests

\`src/renderer/src/components/tab-bar/middle-button-default-guard.test.ts\` pins the contract:

- Middle button (\`button === 1\`) → \`preventDefault\` is called.
- Left button (\`button === 0\`) → \`preventDefault\` is not called.
- Right button (\`button === 2\`) → \`preventDefault\` is not called.

(Project convention is to extract logic into named functions and unit-test those — no React rendering in tests. See \`QuickLaunchButton.test.ts\` for the same pattern.)

## No visual change

This is pure event-handler behavior; the rendered tab markup is unchanged.

## Manual verification

Manual repro requires a Linux session with primary-selection paste enabled, which I do not have available locally. The fix follows the issue author's analysis precisely and matches the working pattern in the existing \`enabled=false\` branch of \`usePrimarySelectionPaste\`. **Linux verification by a reviewer / the issue author would be appreciated** before merge.

## Cross-platform / security review

- **Cross-platform:** \`preventDefault\` on \`mouseup\` for \`button === 1\` is a no-op on macOS/Windows (no native primary-selection paste pipeline). Behavior is unchanged there.
- **SSH use case:** Tab handlers run in the renderer regardless of where the underlying PTY lives, so the fix applies uniformly.
- **Security:** Strictly stops a spurious paste of *the user's own* primary-selection text into the wrong terminal. No new surfaces exposed, no new code paths in privileged processes.

## CI checks run locally

- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` — 8910 passed, 10 skipped. One pre-existing macOS-only flake in \`src/main/startup/run-electron-vite-dev.test.ts\` (\"preserves relative Electron framework symlinks in the copied mac dev app\") timed out at the 5000ms limit; unrelated to this renderer-only change and the test passes intermittently.
- [x] \`pnpm build\`