### PR TITLE
[codex] fix: disable Gemini PreToolUse hook install

### DIFF
--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type * as osModule from 'os'
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: getPathMock
+  }
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof osModule>()
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import { GeminiHookService } from './hook-service'
+
+describe('GeminiHookService', () => {
+  let homeDir: string
+  let userDataDir: string
+
+  beforeAll(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'orca-gemini-home-'))
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-gemini-userdata-'))
+    homedirMock.mockReturnValue(homeDir)
+    getPathMock.mockImplementation((name: string) => {
+      if (name === 'userData') {
+        return userDataDir
+      }
+      throw new Error(`unexpected getPath(${name})`)
+    })
+  })
+
+  afterAll(() => {
+    rmSync(homeDir, { recursive: true, force: true })
+    rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  it('removes stale PreToolUse hooks when reinstalling managed Gemini hooks', () => {
+    const configDir = join(homeDir, '.gemini')
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            BeforeAgent: [
+              {
+                hooks: [{ type: 'command', command: 'echo user-before-agent' }]
+              }
+            ],
+            PreToolUse: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command:
+                      "if [ -x '/Users/ramzi/.orca/agent-hooks/gemini-hook.sh' ]; then /bin/sh '/Users/ramzi/.orca/agent-hooks/gemini-hook.sh'; fi"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        null,
+        2
+      )
+    )
+
+    const service = new GeminiHookService()
+    const status = service.install()
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf8'))
+
+    expect(status.state).toBe('installed')
+    expect(Object.keys(config.hooks).sort()).toEqual(['AfterAgent', 'AfterTool', 'BeforeAgent'])
+    expect(config.hooks.PreToolUse).toBeUndefined()
+    expect(config.hooks.BeforeAgent).toHaveLength(2)
+    expect(config.hooks.BeforeAgent[0].hooks[0].command).toBe('echo user-before-agent')
+    expect(config.hooks.BeforeAgent[1].hooks[0].command).toContain('agent-hooks/gemini-hook.sh')
+    expect(config.hooks.AfterAgent[0].hooks[0].command).toContain('agent-hooks/gemini-hook.sh')
+    expect(config.hooks.AfterTool[0].hooks[0].command).toContain('agent-hooks/gemini-hook.sh')
+  })
+})

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -17,12 +17,12 @@ import {
 // (approvals flow through inline UI), so Orca cannot surface a waiting state
 // for Gemini — that is an upstream limitation, not an Orca bug.
 //
-// PreToolUse surfaces the current tool name + input preview (e.g.
-// `read_file: src/foo.ts`) so long-running tool calls aren't a silent gap
-// between BeforeAgent and AfterAgent. PostToolUse is intentionally omitted —
-// AfterTool already signals "back to working" and the tool name from
-// PreToolUse is what we show; PostToolUse would be a redundant fire.
-const GEMINI_EVENTS = ['BeforeAgent', 'AfterAgent', 'AfterTool', 'PreToolUse'] as const
+// Gemini's PreToolUse hook is not safe to install here: some CLI environments
+// reject the forwarded hook payload outright, which blocks tool execution
+// instead of merely enriching the dashboard. Keep the integration to the
+// turn-safe lifecycle events until Gemini exposes a stable pre-tool hook
+// contract Orca can consume without interfering with the agent.
+const GEMINI_EVENTS = ['BeforeAgent', 'AfterAgent', 'AfterTool'] as const
 
 function getConfigPath(): string {
   return join(homedir(), '.gemini', 'settings.json')
@@ -166,6 +166,27 @@ export class GeminiHookService {
     // Electron userData path (dev vs. prod). Without this, repeated installs
     // accumulate duplicate hook entries pointing at defunct scripts.
     const isManagedCommand = createManagedCommandMatcher(getManagedScriptFileName())
+
+    const managedEvents = new Set<string>(GEMINI_EVENTS)
+
+    // Why: when Orca stops subscribing to an event, install() must sweep the
+    // old managed entry out of any leftover event bucket. Otherwise a stale
+    // hook such as PreToolUse survives forever in ~/.gemini/settings.json and
+    // continues firing even though the current build no longer wants it.
+    for (const [eventName, definitions] of Object.entries(nextHooks)) {
+      if (managedEvents.has(eventName)) {
+        continue
+      }
+      if (!Array.isArray(definitions)) {
+        continue
+      }
+      const cleaned = removeManagedCommands(definitions, isManagedCommand)
+      if (cleaned.length === 0) {
+        delete nextHooks[eventName]
+      } else {
+        nextHooks[eventName] = cleaned
+      }
+    }
 
     for (const eventName of GEMINI_EVENTS) {
       const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []


### PR DESCRIPTION
## Summary
- stop installing the Gemini `PreToolUse` managed hook from Orca
- sweep stale managed Gemini hook entries from removed event buckets during reinstall
- add a regression test that proves reinstall removes an existing `PreToolUse` hook from `~/.gemini/settings.json`

## Root Cause
Orca was auto-installing a managed Gemini `PreToolUse` hook into `~/.gemini/settings.json`. In some Gemini CLI environments that hook payload is rejected during tool dispatch, which turns a dashboard status integration into a tool-execution blocker. Reinstall also left stale `PreToolUse` entries behind because the Gemini installer only updated currently subscribed events and never cleaned removed ones.

## Impact
- Gemini sessions keep the dashboard-safe lifecycle hooks (`BeforeAgent`, `AfterAgent`, `AfterTool`)
- Orca no longer injects the problematic `PreToolUse` hook for Gemini
- existing stale managed `PreToolUse` entries are removed on reinstall instead of persisting forever

## Validation
- `pnpm test src/main/gemini/hook-service.test.ts`
- `pnpm typecheck:node`
