### PR TITLE
Fix terminal startup command echo race

### DIFF
--- a/src/main/daemon/post-ready-flush-gate.test.ts
+++ b/src/main/daemon/post-ready-flush-gate.test.ts
@@ -6,6 +6,7 @@ import {
 } from './post-ready-flush-gate'
 
 describe('PostReadyFlushGate', () => {
+  const EARLY_ECHO_RACE_WINDOW_MS = 50
   let onFlush: ReturnType<typeof vi.fn<() => void>>
   let gate: PostReadyFlushGate
 
@@ -31,6 +32,17 @@ describe('PostReadyFlushGate', () => {
     expect(onFlush).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps input queued through the early prompt echo race window', () => {
+    gate.arm()
+    gate.notifyData()
+
+    vi.advanceTimersByTime(EARLY_ECHO_RACE_WINDOW_MS)
+    expect(onFlush).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS - EARLY_ECHO_RACE_WINDOW_MS)
     expect(onFlush).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/daemon/post-ready-flush-gate.ts
+++ b/src/main/daemon/post-ready-flush-gate.ts
@@ -18,8 +18,8 @@
  * which solves the same race on the non-daemon path.
  */
 
-export const POST_READY_FLUSH_DELAY_MS = 30
-export const POST_READY_FLUSH_FALLBACK_MS = 50
+export const POST_READY_FLUSH_DELAY_MS = 100
+export const POST_READY_FLUSH_FALLBACK_MS = 150
 
 export class PostReadyFlushGate {
   private awaitingPromptDraw = false

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Session } from './session'
+import { POST_READY_FLUSH_DELAY_MS } from './post-ready-flush-gate'
 import type { SessionState, ShellReadyState } from './types'
 
 // Stub the subprocess — Session talks to it via an interface, not child_process directly.
@@ -196,7 +197,7 @@ describe('Session', () => {
       expect(subprocess.written).toEqual([])
 
       subprocess.simulateData('\r\nuser@host $ ')
-      vi.advanceTimersByTime(30)
+      vi.advanceTimersByTime(POST_READY_FLUSH_DELAY_MS)
       expect(subprocess.written).toEqual(['first\n', 'second\n'])
     })
 

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TerminalHost } from './terminal-host'
+import { POST_READY_FLUSH_DELAY_MS } from './post-ready-flush-gate'
 import type { SubprocessHandle } from './session'
 
 function createMockSubprocess(): SubprocessHandle {
@@ -157,7 +158,7 @@ describe('TerminalHost', () => {
       expect(lastSubprocess.write).not.toHaveBeenCalled()
 
       lastSubprocess._onDataCb?.('\r\nuser@host $ ')
-      await new Promise((r) => setTimeout(r, 40))
+      await new Promise((r) => setTimeout(r, POST_READY_FLUSH_DELAY_MS + 10))
       expect(lastSubprocess.write).toHaveBeenCalledWith('echo hello\n')
     })
   })

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -8,7 +8,10 @@ import { join } from 'path'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import type * as pty from 'node-pty'
 import type * as LocalPtyShellReadyModule from './local-pty-shell-ready'
-import { writeStartupCommandWhenShellReady } from './local-pty-shell-ready'
+import {
+  POST_READY_STARTUP_WRITE_FALLBACK_MS,
+  writeStartupCommandWhenShellReady
+} from './local-pty-shell-ready'
 
 const { getUserDataPathMock } = vi.hoisted(() => ({
   getUserDataPathMock: vi.fn<() => string>()
@@ -93,9 +96,8 @@ describe('writeStartupCommandWhenShellReady', () => {
     writeStartupCommandWhenShellReady(ready, proc, 'claude', () => {})
 
     await ready
-    // flush path waits for a post-ready data chunk (prompt draw) then 30ms,
-    // or falls back after 50ms if no data arrives.
-    vi.advanceTimersByTime(50)
+    // No prompt data arrived after the marker, so the fallback path flushes.
+    vi.advanceTimersByTime(POST_READY_STARTUP_WRITE_FALLBACK_MS)
     await Promise.resolve()
 
     expect(proc._writes).toEqual(['claude\n'])
@@ -108,7 +110,7 @@ describe('writeStartupCommandWhenShellReady', () => {
     writeStartupCommandWhenShellReady(ready, proc, 'claude', () => {})
 
     await ready
-    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(POST_READY_STARTUP_WRITE_FALLBACK_MS)
     await Promise.resolve()
 
     expect(proc._writes).toEqual(['claude\r'])
@@ -121,7 +123,7 @@ describe('writeStartupCommandWhenShellReady', () => {
     writeStartupCommandWhenShellReady(ready, proc, 'claude\n', () => {})
 
     await ready
-    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(POST_READY_STARTUP_WRITE_FALLBACK_MS)
     await Promise.resolve()
 
     expect(proc._writes).toEqual(['claude\n'])

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -28,6 +28,8 @@ function quotePosixSingle(value: string): string {
 }
 
 const STARTUP_COMMAND_READY_MAX_WAIT_MS = 1500
+export const POST_READY_STARTUP_WRITE_DELAY_MS = 100
+export const POST_READY_STARTUP_WRITE_FALLBACK_MS = 150
 const SHELL_READY_MARKER = '\x1b]777;orca-shell-ready'
 const SHELL_READY_MARKER_ESCAPED = '\\033]777;orca-shell-ready\\007'
 
@@ -506,7 +508,7 @@ export function writeStartupCommandWhenShellReady(
     // data is the shell drawing its prompt, which means the shell is about to
     // (or has already) switched to raw mode. A brief follow-up delay covers the
     // gap between the last prompt write() and the tcsetattr() that enables raw
-    // mode. The 50ms fallback timeout handles the case where the prompt data
+    // mode. The fallback timeout handles the case where the prompt data
     // arrived in the same chunk as the ready marker (no subsequent onData).
     postReadyDataDisposable = proc.onData(() => {
       postReadyDataDisposable?.dispose()
@@ -514,14 +516,14 @@ export function writeStartupCommandWhenShellReady(
       if (postReadyTimer !== null) {
         clearTimeout(postReadyTimer)
       }
-      postReadyTimer = setTimeout(flush, 30)
+      postReadyTimer = setTimeout(flush, POST_READY_STARTUP_WRITE_DELAY_MS)
     })
     postReadyTimer = setTimeout(() => {
       postReadyDataDisposable?.dispose()
       postReadyDataDisposable = null
       postReadyTimer = null
       flush()
-    }, 50)
+    }, POST_READY_STARTUP_WRITE_FALLBACK_MS)
   })
   onExit(cleanup)
 }


### PR DESCRIPTION
## Summary
- increase the post-shell-ready startup command delay for daemon and local PTY paths
- add a regression guard for the early prompt echo race window
- keep timing tests tied to exported constants instead of duplicated literals

## Repro
Before the patch, running:

```sh
orca terminal create --command "echo ORCA_ECHO_REPRO"
```

executed the command correctly, but rendered the typed line with the first character duplicated at the prompt, e.g. `eecho ORCA_ECHO_REPRO`. The same race made `claude` appear as `cclaude`/`tclaude` when launched through `orca terminal create --command`.

## Verification
- `pnpm exec vitest run src/main/daemon/post-ready-flush-gate.test.ts src/main/daemon/session.test.ts src/main/providers/local-pty-shell-ready.test.ts`
- `pnpm run typecheck:node`

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.