### PR TITLE
Respect disabled terminal bell settings

### DIFF
--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -39,9 +39,9 @@ export function createBellDetector(): BellDetector {
   ): BellDetectionResult => {
     const stripBells = options.stripBells === true
     let containsBell = false
-    let strippedSegments: string[] | null = null
-    let stripSegmentStart = 0
-    let strippedAny = false
+    let outputSegments: string[] | null = null
+    let outputSegmentStart = 0
+    let outputChanged = false
 
     for (let i = 0; i < data.length; i += 1) {
       const char = data[i]
@@ -49,12 +49,24 @@ export function createBellDetector(): BellDetector {
         if (!stripBells) {
           return
         }
-        strippedAny = true
-        strippedSegments ??= []
-        if (stripSegmentStart < i) {
-          strippedSegments.push(data.slice(stripSegmentStart, i))
+        outputChanged = true
+        outputSegments ??= []
+        if (outputSegmentStart < i) {
+          outputSegments.push(data.slice(outputSegmentStart, i))
         }
-        stripSegmentStart = i + 1
+        outputSegmentStart = i + 1
+      }
+      const replaceCurrentChar = (replacement: string): void => {
+        if (!stripBells) {
+          return
+        }
+        outputChanged = true
+        outputSegments ??= []
+        if (outputSegmentStart < i) {
+          outputSegments.push(data.slice(outputSegmentStart, i))
+        }
+        outputSegments.push(replacement)
+        outputSegmentStart = i + 1
       }
 
       if (inOsc) {
@@ -77,6 +89,11 @@ export function createBellDetector(): BellDetector {
 
         if (char === '\x07') {
           inOsc = false
+          // Why: BEL can legally terminate OSC sequences, but it is still a
+          // raw BEL byte at the terminal write boundary. When audible bells
+          // are disabled, use the equivalent ST terminator so titles/status
+          // parse without any BEL byte reaching xterm/Electron.
+          replaceCurrentChar('\x1b\\')
           continue
         }
 
@@ -123,15 +140,20 @@ export function createBellDetector(): BellDetector {
       }
     }
 
-    if (stripBells && strippedAny) {
-      if (stripSegmentStart < data.length) {
-        strippedSegments?.push(data.slice(stripSegmentStart))
+    if (stripBells && outputChanged) {
+      const segments: string[] = outputSegments ?? []
+      if (outputSegmentStart < data.length) {
+        segments.push(data.slice(outputSegmentStart))
+      }
+      return {
+        containsBell,
+        data: segments.join('')
       }
     }
 
     return {
       containsBell,
-      data: stripBells && strippedAny ? (strippedSegments ?? []).join('') : data
+      data
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -17,8 +17,14 @@
  * that ended mid-escape does not leak into the next stream.
  */
 export type BellDetector = {
+  processChunk(data: string, options?: { stripBells?: boolean }): BellDetectionResult
   chunkContainsBell(data: string): boolean
   reset(): void
+}
+
+export type BellDetectionResult = {
+  containsBell: boolean
+  data: string
 }
 
 export function createBellDetector(): BellDetector {
@@ -26,70 +32,107 @@ export function createBellDetector(): BellDetector {
   let inOsc = false
   let pendingOscEscape = false
 
-  return {
-    chunkContainsBell(data: string): boolean {
-      for (let i = 0; i < data.length; i += 1) {
-        const char = data[i]
+  const processChunk = (
+    data: string,
+    options: { stripBells?: boolean } = {}
+  ): BellDetectionResult => {
+    const stripBells = options.stripBells === true
+    let containsBell = false
+    let strippedData = ''
+    let strippedAny = false
 
-        if (inOsc) {
-          if (char === '\x18' || char === '\x1a') {
-            // ECMA-48 escape-cancel codes — abort the in-progress OSC string
-            // so a malformed/truncated OSC does not swallow the next BEL.
-            inOsc = false
-            pendingOscEscape = false
-            continue
-          }
+    for (let i = 0; i < data.length; i += 1) {
+      const char = data[i]
+      const append = (): void => {
+        if (stripBells) {
+          strippedData += char
+        }
+      }
 
-          if (pendingOscEscape) {
-            pendingOscEscape = char === '\x1b'
-            if (char === '\\') {
-              inOsc = false
-              pendingOscEscape = false
-            }
-            continue
-          }
+      if (inOsc) {
+        if (char === '\x18' || char === '\x1a') {
+          // ECMA-48 escape-cancel codes — abort the in-progress OSC string
+          // so a malformed/truncated OSC does not swallow the next BEL.
+          inOsc = false
+          pendingOscEscape = false
+          append()
+          continue
+        }
 
-          if (char === '\x07') {
-            inOsc = false
-            continue
-          }
-
+        if (pendingOscEscape) {
           pendingOscEscape = char === '\x1b'
-          continue
-        }
-
-        if (pendingEscape) {
-          if (char === '\x18' || char === '\x1a') {
-            // ECMA-48 escape-cancel codes also abort a pending ESC.
-            pendingEscape = false
-            continue
-          }
-          pendingEscape = false
-          if (char === ']') {
-            inOsc = true
+          if (char === '\\') {
+            inOsc = false
             pendingOscEscape = false
-          } else if (char === '\x1b') {
-            pendingEscape = true
-          } else if (char === '\x07') {
-            // A bare ESC is not a valid introducer for any sequence that
-            // consumes a following BEL. Treat the BEL as a real terminal
-            // bell rather than silently swallowing it with the orphan ESC.
-            return true
           }
-          continue
-        }
-
-        if (char === '\x1b') {
-          pendingEscape = true
+          append()
           continue
         }
 
         if (char === '\x07') {
-          return true
+          inOsc = false
+          append()
+          continue
         }
+
+        pendingOscEscape = char === '\x1b'
+        append()
+        continue
       }
 
-      return false
+      if (pendingEscape) {
+        if (char === '\x18' || char === '\x1a') {
+          // ECMA-48 escape-cancel codes also abort a pending ESC.
+          pendingEscape = false
+          append()
+          continue
+        }
+        pendingEscape = false
+        if (char === ']') {
+          inOsc = true
+          pendingOscEscape = false
+        } else if (char === '\x1b') {
+          pendingEscape = true
+        } else if (char === '\x07') {
+          // A bare ESC is not a valid introducer for any sequence that
+          // consumes a following BEL. Treat the BEL as a real terminal
+          // bell rather than silently swallowing it with the orphan ESC.
+          containsBell = true
+          if (stripBells) {
+            strippedAny = true
+            continue
+          }
+        }
+        append()
+        continue
+      }
+
+      if (char === '\x1b') {
+        pendingEscape = true
+        append()
+        continue
+      }
+
+      if (char === '\x07') {
+        containsBell = true
+        if (stripBells) {
+          strippedAny = true
+          continue
+        }
+      }
+      append()
+    }
+
+    return {
+      containsBell,
+      data: stripBells && strippedAny ? strippedData : data
+    }
+  }
+
+  return {
+    processChunk,
+    chunkContainsBell(data: string): boolean {
+      return processChunk(data).containsBell
     },
     reset(): void {
       pendingEscape = false

--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -19,6 +19,7 @@
 export type BellDetector = {
   processChunk(data: string, options?: { stripBells?: boolean }): BellDetectionResult
   chunkContainsBell(data: string): boolean
+  hasPendingEscapeSequence(): boolean
   reset(): void
 }
 
@@ -133,6 +134,9 @@ export function createBellDetector(): BellDetector {
     processChunk,
     chunkContainsBell(data: string): boolean {
       return processChunk(data).containsBell
+    },
+    hasPendingEscapeSequence(): boolean {
+      return pendingEscape || inOsc || pendingOscEscape
     },
     reset(): void {
       pendingEscape = false

--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -39,15 +39,22 @@ export function createBellDetector(): BellDetector {
   ): BellDetectionResult => {
     const stripBells = options.stripBells === true
     let containsBell = false
-    let strippedData = ''
+    let strippedSegments: string[] | null = null
+    let stripSegmentStart = 0
     let strippedAny = false
 
     for (let i = 0; i < data.length; i += 1) {
       const char = data[i]
-      const append = (): void => {
-        if (stripBells) {
-          strippedData += char
+      const stripCurrentChar = (): void => {
+        if (!stripBells) {
+          return
         }
+        strippedAny = true
+        strippedSegments ??= []
+        if (stripSegmentStart < i) {
+          strippedSegments.push(data.slice(stripSegmentStart, i))
+        }
+        stripSegmentStart = i + 1
       }
 
       if (inOsc) {
@@ -56,7 +63,6 @@ export function createBellDetector(): BellDetector {
           // so a malformed/truncated OSC does not swallow the next BEL.
           inOsc = false
           pendingOscEscape = false
-          append()
           continue
         }
 
@@ -66,18 +72,15 @@ export function createBellDetector(): BellDetector {
             inOsc = false
             pendingOscEscape = false
           }
-          append()
           continue
         }
 
         if (char === '\x07') {
           inOsc = false
-          append()
           continue
         }
 
         pendingOscEscape = char === '\x1b'
-        append()
         continue
       }
 
@@ -85,7 +88,6 @@ export function createBellDetector(): BellDetector {
         if (char === '\x18' || char === '\x1a') {
           // ECMA-48 escape-cancel codes also abort a pending ESC.
           pendingEscape = false
-          append()
           continue
         }
         pendingEscape = false
@@ -100,33 +102,36 @@ export function createBellDetector(): BellDetector {
           // bell rather than silently swallowing it with the orphan ESC.
           containsBell = true
           if (stripBells) {
-            strippedAny = true
+            stripCurrentChar()
             continue
           }
         }
-        append()
         continue
       }
 
       if (char === '\x1b') {
         pendingEscape = true
-        append()
         continue
       }
 
       if (char === '\x07') {
         containsBell = true
         if (stripBells) {
-          strippedAny = true
+          stripCurrentChar()
           continue
         }
       }
-      append()
+    }
+
+    if (stripBells && strippedAny) {
+      if (stripSegmentStart < data.length) {
+        strippedSegments?.push(data.slice(stripSegmentStart))
+      }
     }
 
     return {
       containsBell,
-      data: stripBells && strippedAny ? strippedData : data
+      data: stripBells && strippedAny ? (strippedSegments ?? []).join('') : data
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2372,11 +2372,10 @@ describe('connectPanePty', () => {
 
   // Why: BEL (0x07) is the attention signal. connectPanePty wires an
   // onBell handler that raises the worktree unread dot, the tab-level
-  // bell indicator, and an OS notification. Under the ghostty
-  // show-until-interact model, the unread flags clear when the user
-  // actually interacts with the pane — keystroke via xterm onData or
-  // pointerdown on the container (see TerminalPane.tsx). This test
-  // locks in the mark wiring; separate tests below cover the clear path.
+  // bell indicator, and an OS notification. The unread flags clear when the
+  // user actually interacts with the pane — keystroke via xterm onData or
+  // pointerdown on the container (see TerminalPane.tsx). This test locks in
+  // the mark wiring; separate tests below cover the clear path.
   it('wires onBell to raise worktree unread, tab unread, and OS notification', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -71,6 +71,7 @@ type StoreState = {
 
 type ConnectCallbacks = {
   onData?: (data: string) => void
+  onReplayData?: (data: string) => void
   onError?: (msg: string) => void
 }
 
@@ -1959,6 +1960,114 @@ describe('connectPanePty', () => {
     // the daemon does not redeliver the cold-restore payload on the next
     // reattach.
     expect(window.api.pty.ackColdRestore).toHaveBeenCalledWith('tab-pty')
+  })
+
+  it('strips audible BELs from reattach replay while preserving OSC terminators', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return {
+          id: sessionId,
+          replay: 'before\x1b]0;Replay title\x07\x07after'
+        }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'before\x1b]0;Replay title\x07after',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      'before\x1b]0;Replay title\x07\x07after',
+      expect.any(Function)
+    )
+  })
+
+  it('strips audible BELs from relay replay callbacks before writing into xterm', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(
+      async ({ callbacks }: { callbacks?: ConnectCallbacks }) => {
+        callbacks?.onReplayData?.('before\x1b]0;Relay title\x07\x07after')
+        return 'pty-1'
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: null }]
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'before\x1b]0;Relay title\x07after',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      'before\x1b]0;Relay title\x07\x07after',
+      expect.any(Function)
+    )
+  })
+
+  it('cancels incomplete OSC replay before live terminal output resumes', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(
+      async ({ callbacks }: { callbacks?: ConnectCallbacks }) => {
+        callbacks?.onReplayData?.('\x1b]0;unterminated replay title')
+        capturedDataCallback.current = callbacks?.onData ?? null
+        return 'pty-1'
+      }
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: null }]
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+    capturedDataCallback.current?.('\x07live output')
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b]0;unterminated replay title\x18',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith('\x07live output')
   })
 
   // Regression for foreground input lag with many background terminals:

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2299,6 +2299,59 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('passes a terminal bell silencing predicate based on notification settings', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const shouldSilenceTerminalBell = createdTransportOptions[0]?.shouldSilenceTerminalBell as
+      | (() => boolean)
+      | undefined
+    if (!shouldSilenceTerminalBell) {
+      throw new Error('Expected shouldSilenceTerminalBell to be registered')
+    }
+
+    expect(shouldSilenceTerminalBell()).toBe(true)
+
+    const enabledNotifications = {
+      enabled: true,
+      agentTaskComplete: true,
+      terminalBell: true,
+      suppressWhenFocused: true,
+      customSoundPath: null
+    }
+    mockStoreState.settings = {
+      ...mockStoreState.settings,
+      notifications: enabledNotifications
+    }
+    expect(shouldSilenceTerminalBell()).toBe(false)
+
+    mockStoreState.settings = {
+      ...mockStoreState.settings,
+      notifications: {
+        ...enabledNotifications,
+        terminalBell: false
+      }
+    }
+    expect(shouldSilenceTerminalBell()).toBe(true)
+
+    mockStoreState.settings = {
+      ...mockStoreState.settings,
+      notifications: {
+        ...enabledNotifications,
+        enabled: false,
+        terminalBell: true
+      }
+    }
+    expect(shouldSilenceTerminalBell()).toBe(true)
+  })
+
   it('lets concurrent agent-complete notifications win over terminal bell notifications', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { useNotificationDispatch } = await vi.importActual<typeof UseNotificationDispatchModule>(

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1962,7 +1962,7 @@ describe('connectPanePty', () => {
     expect(window.api.pty.ackColdRestore).toHaveBeenCalledWith('tab-pty')
   })
 
-  it('strips audible BELs from reattach replay while preserving OSC terminators', async () => {
+  it('strips audible BELs from reattach replay while preserving OSC termination', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -1993,7 +1993,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(20)
 
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      'before\x1b]0;Replay title\x07after',
+      'before\x1b]0;Replay title\x1b\\after',
       expect.any(Function)
     )
     expect(pane.terminal.write).not.toHaveBeenCalledWith(
@@ -2027,7 +2027,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(20)
 
     expect(pane.terminal.write).toHaveBeenCalledWith(
-      'before\x1b]0;Relay title\x07after',
+      'before\x1b]0;Relay title\x1b\\after',
       expect.any(Function)
     )
     expect(pane.terminal.write).not.toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -59,6 +59,11 @@ function isAgentTaskCompleteNotificationEnabled(): boolean {
   return notifications?.enabled !== false && notifications?.agentTaskComplete !== false
 }
 
+function shouldSilenceTerminalBell(): boolean {
+  const notifications = useAppStore.getState().settings?.notifications
+  return notifications?.enabled !== true || notifications.terminalBell !== true
+}
+
 function hasAgentNotificationDetail(entry: AgentStatusEntry | undefined): boolean {
   return Boolean(
     entry &&
@@ -794,6 +799,7 @@ export function connectPanePty(
     onTitleChange,
     onPtySpawn,
     onBell,
+    shouldSilenceTerminalBell,
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1118,7 +1118,8 @@ export function connectPanePty(
     const replayBellDetector = createBellDetector()
     const writeReplayData = (data: string): void => {
       // Why: replay bytes are historical output. They must not play a fresh
-      // local bell, but OSC terminator BELs still need to reach xterm intact.
+      // local bell. OSC BEL terminators are rewritten to ST so xterm still
+      // closes the OSC sequence without seeing any raw BEL byte.
       let replayData = replayBellDetector.processChunk(data, { stripBells: true }).data
       if (replayBellDetector.hasPendingEscapeSequence()) {
         // Why: replay buffers can be truncated mid-OSC. Cancel the historical

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -45,6 +45,7 @@ import {
   type AgentInterruptInputIntent
 } from '../../../../shared/agent-interrupt-intent'
 import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import { createBellDetector } from './bell-detector'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -1114,14 +1115,24 @@ export function connectPanePty(
     // sequences don't leak into the shell. xterm.write() buffers internally
     // regardless of DOM visibility and the guard stays engaged via the
     // write-completion callback until xterm finishes parsing.
+    const replayBellDetector = createBellDetector()
     const writeReplayData = (data: string): void => {
+      // Why: replay bytes are historical output. They must not play a fresh
+      // local bell, but OSC terminator BELs still need to reach xterm intact.
+      let replayData = replayBellDetector.processChunk(data, { stripBells: true }).data
+      if (replayBellDetector.hasPendingEscapeSequence()) {
+        // Why: replay buffers can be truncated mid-OSC. Cancel the historical
+        // sequence now so live BEL filtering cannot strand xterm inside it.
+        replayData += '\x18'
+        replayBellDetector.reset()
+      }
       // Why: drain any queued background bytes BEFORE the replay paint, so the
       // scheduler's deferred drain cannot land older bytes on top of the replay.
       flushTerminalOutput(pane.terminal)
-      if (terminalOutputPrefersDomRenderer(data)) {
+      if (terminalOutputPrefersDomRenderer(replayData)) {
         manager.markPaneHasComplexScriptOutput(pane.id)
       }
-      replayIntoTerminal(pane, deps.replayingPanesRef, data)
+      replayIntoTerminal(pane, deps.replayingPanesRef, replayData)
     }
 
     const replayDataCallback = (data: string): void => {

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -305,6 +305,8 @@ export type IpcPtyTransportOptions = {
   onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   onBell?: () => void
+  /** Return true when bare BEL bytes should not reach xterm for audible playback. */
+  shouldSilenceTerminalBell?: () => boolean
   onAgentBecameIdle?: (title: string) => void
   onAgentBecameWorking?: () => void
   onAgentExited?: () => void

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -157,7 +157,7 @@ describe('createIpcPtyTransport', () => {
     expect(onBell).toHaveBeenCalledTimes(1)
   })
 
-  it('strips audible BELs before terminal output when terminal bells are silenced', async () => {
+  it('strips audible BELs before terminal output while preserving UI bell attention', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const onBell = vi.fn()
     const onTitleChange = vi.fn()
@@ -174,6 +174,7 @@ describe('createIpcPtyTransport', () => {
 
     expect(onDataCallback).toHaveBeenCalledWith(']0;Claude done')
     expect(onTitleChange).toHaveBeenCalledWith('Claude done', 'Claude done')
+    // Why: muting audible terminal output must not mute Orca's UI bell state.
     expect(onBell).toHaveBeenCalledTimes(1)
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -157,6 +157,86 @@ describe('createIpcPtyTransport', () => {
     expect(onBell).toHaveBeenCalledTimes(1)
   })
 
+  it('strips audible BELs before terminal output when terminal bells are silenced', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onBell = vi.fn()
+    const onTitleChange = vi.fn()
+    const onDataCallback = vi.fn()
+
+    const transport = createIpcPtyTransport({
+      onBell,
+      onTitleChange,
+      shouldSilenceTerminalBell: () => true
+    })
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+
+    onData?.({ id: 'pty-1', data: ']0;Claude done' })
+
+    expect(onDataCallback).toHaveBeenCalledWith(']0;Claude done')
+    expect(onTitleChange).toHaveBeenCalledWith('Claude done', 'Claude done')
+    expect(onBell).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips audible BELs when the OSC terminator and bell arrive in a later chunk', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onBell = vi.fn()
+    const onTitleChange = vi.fn()
+    const onDataCallback = vi.fn()
+
+    const transport = createIpcPtyTransport({
+      onBell,
+      onTitleChange,
+      shouldSilenceTerminalBell: () => true
+    })
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+
+    onData?.({ id: 'pty-1', data: ']0;Claude done' })
+    onData?.({ id: 'pty-1', data: '' })
+
+    expect(onDataCallback).toHaveBeenNthCalledWith(1, ']0;Claude done')
+    expect(onDataCallback).toHaveBeenNthCalledWith(2, '')
+    expect(onTitleChange).not.toHaveBeenCalled()
+    expect(onBell).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps audible BELs in terminal output when terminal bells are enabled', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onBell = vi.fn()
+    const onDataCallback = vi.fn()
+
+    const transport = createIpcPtyTransport({
+      onBell,
+      shouldSilenceTerminalBell: () => false
+    })
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+
+    onData?.({ id: 'pty-1', data: 'ready' })
+
+    expect(onDataCallback).toHaveBeenCalledWith('ready')
+    expect(onBell).toHaveBeenCalledTimes(1)
+  })
+
+  it('strips replayed BELs before terminal output even when terminal bells are enabled', async () => {
+    const { createIpcPtyTransport, registerEagerPtyBuffer } = await import('./pty-transport')
+    const onReplayData = vi.fn()
+    const onBell = vi.fn()
+
+    registerEagerPtyBuffer('pty-restored', vi.fn())
+    onData?.({ id: 'pty-restored', data: 'old output' })
+
+    const transport = createIpcPtyTransport({
+      onBell,
+      shouldSilenceTerminalBell: () => false
+    })
+    transport.attach({
+      existingPtyId: 'pty-restored',
+      callbacks: { onReplayData }
+    })
+
+    expect(onReplayData).toHaveBeenCalledWith('old output')
+    expect(onBell).not.toHaveBeenCalled()
+  })
+
   it('routes eager-buffered bytes through onReplayData so the renderer can engage the replay guard', async () => {
     const { createIpcPtyTransport, registerEagerPtyBuffer } = await import('./pty-transport')
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -172,10 +172,31 @@ describe('createIpcPtyTransport', () => {
 
     onData?.({ id: 'pty-1', data: ']0;Claude done' })
 
-    expect(onDataCallback).toHaveBeenCalledWith(']0;Claude done')
+    expect(onDataCallback).toHaveBeenCalledWith(']0;Claude done\\')
     expect(onTitleChange).toHaveBeenCalledWith('Claude done', 'Claude done')
     // Why: muting audible terminal output must not mute Orca's UI bell state.
     expect(onBell).toHaveBeenCalledTimes(1)
+  })
+
+  it('converts OSC BEL terminators to ST when terminal bells are silenced', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onBell = vi.fn()
+    const onTitleChange = vi.fn()
+    const onDataCallback = vi.fn()
+
+    const transport = createIpcPtyTransport({
+      onBell,
+      onTitleChange,
+      shouldSilenceTerminalBell: () => true
+    })
+    await transport.connect({ url: '', callbacks: { onData: onDataCallback } })
+
+    onData?.({ id: 'pty-1', data: ']133;C]0;Codex done' })
+
+    expect(onDataCallback).toHaveBeenCalledWith(']133;C\\]0;Codex done\\')
+    expect(onDataCallback.mock.calls[0]?.[0]).not.toContain('')
+    expect(onTitleChange).toHaveBeenCalledWith('Codex done', 'Codex done')
+    expect(onBell).not.toHaveBeenCalled()
   })
 
   it('strips audible BELs when the OSC terminator and bell arrive in a later chunk', async () => {
@@ -195,7 +216,7 @@ describe('createIpcPtyTransport', () => {
     onData?.({ id: 'pty-1', data: '' })
 
     expect(onDataCallback).toHaveBeenNthCalledWith(1, ']0;Claude done')
-    expect(onDataCallback).toHaveBeenNthCalledWith(2, '')
+    expect(onDataCallback).toHaveBeenNthCalledWith(2, '\\')
     expect(onTitleChange).not.toHaveBeenCalled()
     expect(onBell).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -50,6 +50,7 @@ type PtyOutputProcessorOptions = Pick<
   IpcPtyTransportOptions,
   | 'onTitleChange'
   | 'onBell'
+  | 'shouldSilenceTerminalBell'
   | 'onAgentBecameIdle'
   | 'onAgentBecameWorking'
   | 'onAgentExited'
@@ -64,6 +65,7 @@ type ProcessPtyOutputOptions = {
 export function createPtyOutputProcessor({
   onTitleChange,
   onBell,
+  shouldSilenceTerminalBell,
   onAgentBecameIdle,
   onAgentBecameWorking,
   onAgentExited,
@@ -141,10 +143,18 @@ export function createPtyOutputProcessor({
         onAgentStatus(payload)
       }
     }
+    const bellResult = bellDetector.processChunk(data, {
+      // Why: a raw BEL can make xterm/Electron play a local ding before the
+      // native notification path sees user settings. Strip only audible BELs;
+      // OSC title terminators stay in the stream so title parsing remains intact.
+      stripBells: suppressAttentionEvents || shouldSilenceTerminalBell?.() === true
+    })
+    const terminalData = bellResult.data
+
     if (options.replayingBufferedData && callbacks.onReplayData) {
-      callbacks.onReplayData(data)
+      callbacks.onReplayData(terminalData)
     } else {
-      callbacks.onData?.(data)
+      callbacks.onData?.(terminalData)
     }
     if (onTitleChange) {
       // Why: feed EVERY OSC title in the chunk through the observer, not just
@@ -155,7 +165,7 @@ export function createPtyOutputProcessor({
       // dropped, so the worktree card never observed the working state.
       // Processing titles in order preserves the working→idle transition
       // that detectAgentStatusFromTitle and agentTracker both key off.
-      const titles = extractAllOscTitles(data)
+      const titles = extractAllOscTitles(terminalData)
       if (titles.length > 0) {
         clearStaleTitleTimer()
         for (const title of titles) {
@@ -179,7 +189,7 @@ export function createPtyOutputProcessor({
     // `\e]0;title\a`) is correctly ignored — only true terminal bells raise
     // attention. suppressAttentionEvents gates this during eager-buffer replay
     // so historical BELs do not produce fresh alerts on cold reattach.
-    if (onBell && bellDetector.chunkContainsBell(data) && !suppressAttentionEvents) {
+    if (onBell && bellResult.containsBell && !suppressAttentionEvents) {
       onBell()
     }
   }
@@ -213,6 +223,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     onTitleChange,
     onPtySpawn,
     onBell,
+    shouldSilenceTerminalBell,
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
@@ -230,6 +241,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   const outputProcessor = createPtyOutputProcessor({
     onTitleChange,
     onBell,
+    shouldSilenceTerminalBell,
     onAgentBecameIdle: (title) => {
       if (!suppressAttentionEvents) {
         onAgentBecameIdle?.(title)

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -78,10 +78,10 @@ export function createPtyOutputProcessor({
   ) => void
   clearAccumulatedState: () => void
   clearStaleTitleTimer: () => void
-  resetBellDetector: () => void
+  resetReplayState: () => void
 } {
   const bellDetector = createBellDetector()
-  const processAgentStatusChunk = createAgentStatusOscProcessor()
+  let processAgentStatusChunk = createAgentStatusOscProcessor()
   let lastEmittedTitle: string | null = null
   let staleTitleTimer: ReturnType<typeof setTimeout> | null = null
   const agentTracker =
@@ -197,6 +197,14 @@ export function createPtyOutputProcessor({
   function clearAccumulatedState(): void {
     clearStaleTitleTimer()
     agentTracker?.reset()
+    processAgentStatusChunk = createAgentStatusOscProcessor()
+    bellDetector.reset()
+  }
+
+  function resetReplayState(): void {
+    // Why: replay buffers are historical bytes. Parser state from a truncated
+    // replay sequence must not carry into the following live PTY stream.
+    processAgentStatusChunk = createAgentStatusOscProcessor()
     bellDetector.reset()
   }
 
@@ -204,7 +212,7 @@ export function createPtyOutputProcessor({
     processData,
     clearAccumulatedState,
     clearStaleTitleTimer,
-    resetBellDetector: () => bellDetector.reset()
+    resetReplayState
   }
 }
 
@@ -462,13 +470,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             // that was never live in this app instance. Cancel it so the replay has
             // no lingering side effects.
             outputProcessor.clearStaleTitleTimer()
-            // Why: eager-buffered bytes may end mid-OSC (truncated/partial session
-            // data), leaving bellDetector with inOsc = true. Without resetting, the
-            // next real BEL in live data would be silently classified as an OSC
-            // terminator and dropped. BEL is the sole attention signal per the PR
-            // design, so this reset guards the attention pipeline against a silent
-            // regression driven by replay state leaking into the live stream.
-            outputProcessor.resetBellDetector()
+            outputProcessor.resetReplayState()
           }
         }
         bufferHandle.dispose()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -146,7 +146,8 @@ export function createPtyOutputProcessor({
     const bellResult = bellDetector.processChunk(data, {
       // Why: BEL is terminal attention, not visible output. When audible bells
       // are disabled, keep bare BELs out of the terminal so this path cannot
-      // bypass Orca's sound policy. OSC terminators stay intact for titles.
+      // bypass Orca's sound policy. OSC BEL terminators are converted to ST
+      // so title/status parsing still works without writing any BEL byte.
       stripBells: suppressAttentionEvents || shouldSilenceTerminalBell?.() === true
     })
     const terminalData = bellResult.data

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -144,9 +144,9 @@ export function createPtyOutputProcessor({
       }
     }
     const bellResult = bellDetector.processChunk(data, {
-      // Why: a raw BEL can make xterm/Electron play a local ding before the
-      // native notification path sees user settings. Strip only audible BELs;
-      // OSC title terminators stay in the stream so title parsing remains intact.
+      // Why: BEL is terminal attention, not visible output. When audible bells
+      // are disabled, keep bare BELs out of the terminal so this path cannot
+      // bypass Orca's sound policy. OSC terminators stay intact for titles.
       stripBells: suppressAttentionEvents || shouldSilenceTerminalBell?.() === true
     })
     const terminalData = bellResult.data

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -907,6 +907,28 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onConnect).toHaveBeenCalled()
   })
 
+  it('resets replay parser state after an incomplete remote snapshot', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onReplayData = vi.fn()
+    const onData = vi.fn()
+    const onBell = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      onBell,
+      shouldSilenceTerminalBell: () => true
+    })
+
+    await transport.connect({ url: '', callbacks: { onReplayData, onData } })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const { streamId } = latestSubscribePayload()
+    emitSnapshot(streamId, '\x1b]0;unterminated remote title')
+    emitOutput(streamId, '\x07live output')
+
+    expect(onReplayData).toHaveBeenCalledWith('\x1b]0;unterminated remote title')
+    expect(onData).toHaveBeenCalledWith('live output')
+    expect(onBell).toHaveBeenCalledTimes(1)
+  })
+
   it('bounds oversized binary snapshots without closing the live stream', async () => {
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const onReplayData = vi.fn()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -525,6 +525,28 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onBell).toHaveBeenCalledTimes(1)
   })
 
+  it('strips audible BELs from remote data when terminal bells are silenced', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onData = vi.fn()
+    const onTitleChange = vi.fn()
+    const onBell = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      onTitleChange,
+      onBell,
+      shouldSilenceTerminalBell: () => true
+    })
+
+    await transport.connect({ url: '', callbacks: { onData } })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const { streamId } = latestSubscribePayload()
+    emitOutput(streamId, 'before\x1b]0;Remote done\x07\x07after')
+
+    expect(onData).toHaveBeenCalledWith('before\x1b]0;Remote done\x07after')
+    expect(onTitleChange).toHaveBeenCalledWith('Remote done', 'Remote done')
+    expect(onBell).toHaveBeenCalledTimes(1)
+  })
+
   it('processes binary remote data chunks through the terminal parser', async () => {
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const onData = vi.fn()
@@ -851,7 +873,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       'before\x1b]9999;{"state":"working","prompt":"old","agentType":"codex"}\x07after\x1b]0;Remote title\x07\x07'
     )
 
-    expect(onReplayData).toHaveBeenCalledWith('beforeafter\x1b]0;Remote title\x07\x07')
+    expect(onReplayData).toHaveBeenCalledWith('beforeafter\x1b]0;Remote title\x07')
     expect(onTitleChange).toHaveBeenCalledWith('Remote title', 'Remote title')
     expect(onAgentStatus).not.toHaveBeenCalled()
     expect(onBell).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -542,7 +542,7 @@ describe('createRemoteRuntimePtyTransport', () => {
     const { streamId } = latestSubscribePayload()
     emitOutput(streamId, 'before\x1b]0;Remote done\x07\x07after')
 
-    expect(onData).toHaveBeenCalledWith('before\x1b]0;Remote done\x07after')
+    expect(onData).toHaveBeenCalledWith('before\x1b]0;Remote done\x1b\\after')
     expect(onTitleChange).toHaveBeenCalledWith('Remote done', 'Remote done')
     expect(onBell).toHaveBeenCalledTimes(1)
   })
@@ -873,7 +873,7 @@ describe('createRemoteRuntimePtyTransport', () => {
       'before\x1b]9999;{"state":"working","prompt":"old","agentType":"codex"}\x07after\x1b]0;Remote title\x07\x07'
     )
 
-    expect(onReplayData).toHaveBeenCalledWith('beforeafter\x1b]0;Remote title\x07')
+    expect(onReplayData).toHaveBeenCalledWith('beforeafter\x1b]0;Remote title\x1b\\')
     expect(onTitleChange).toHaveBeenCalledWith('Remote title', 'Remote title')
     expect(onAgentStatus).not.toHaveBeenCalled()
     expect(onBell).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -310,11 +310,15 @@ export function createRemoteRuntimePtyTransport(
       callbacks: {
         onData: (data) => outputProcessor.processData(data, storedCallbacks),
         onSnapshot: (data) => {
-          if (data) {
-            outputProcessor.processData(data, storedCallbacks, {
-              replayingBufferedData: true,
-              suppressAttentionEvents: true
-            })
+          try {
+            if (data) {
+              outputProcessor.processData(data, storedCallbacks, {
+                replayingBufferedData: true,
+                suppressAttentionEvents: true
+              })
+            }
+          } finally {
+            outputProcessor.resetReplayState()
           }
         },
         onSubscribed: () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -55,6 +55,7 @@ export function createRemoteRuntimePtyTransport(
     onPtySpawn,
     onTitleChange,
     onBell,
+    shouldSilenceTerminalBell,
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,
@@ -76,6 +77,7 @@ export function createRemoteRuntimePtyTransport(
   const outputProcessor = createPtyOutputProcessor({
     onTitleChange,
     onBell,
+    shouldSilenceTerminalBell,
     onAgentBecameIdle,
     onAgentBecameWorking,
     onAgentExited,


### PR DESCRIPTION
## Summary
- strip audible bare BEL bytes from live and replayed PTY output when terminal bell notifications are disabled
- rewrite OSC BEL terminators to ST while muted so title/status parsing still works without writing any raw BEL byte to xterm/Electron
- preserve UI bell/unread indicators for live bare BELs; only the audible terminal byte is suppressed
- avoid hot-path stripped-output allocation until terminal output actually needs rewriting
- keep replay output self-contained by canceling incomplete historical escape/OSC sequences before live bytes resume
- reset replay parser state after eager-buffer and remote runtime snapshot replays so truncated historical output cannot affect live BEL detection

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check origin/main...HEAD` and working tree
- [x] Focused terminal-pane vitest suite: 3 files, 121 tests
- [x] Electron dev app launched from this worktree; identity verified via CDP as `Orca: brennankbenson/turn-notifs-off`
- [x] Direct notification IPC guard with notifications disabled: `terminal-bell` and `agent-task-complete` both returned `{ delivered: false, reason: "disabled" }`
- [x] Focused shell BEL test with notifications disabled: terminal-write probe saw 0 BEL bytes, xterm fired 0 bell events, and the source tab/worktree unread state still flipped true
- [x] Inactive-workspace shell BEL test with notifications disabled: raw PTY stream contained BEL bytes, terminal-write probe saw 0 BEL bytes, xterm fired 0 bell events, and the inactive source tab/worktree unread state still flipped true
- [x] Real agent TUI completion in an inactive workspace with notifications disabled: prompt completed with `OK`; raw PTY stream contained 32 BEL bytes, all terminal writes contained 0 BEL bytes, xterm fired 0 bell events, and the agent process was cleaned up