### PR TITLE
Fix blank automation run terminals

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -189,6 +189,30 @@ describe('createIpcPtyTransport', () => {
     expect(onDataCallback).not.toHaveBeenCalledWith(bufferedPayload)
   })
 
+  it('clears before replaying eager-buffered output so hidden automation terminals do not open blank', async () => {
+    const { createIpcPtyTransport, registerEagerPtyBuffer } = await import('./pty-transport')
+
+    const bufferedPayload = '\x1b[?1049hAutomation agent is running'
+    registerEagerPtyBuffer('pty-automation', vi.fn())
+    onData?.({
+      id: 'pty-automation',
+      data: bufferedPayload
+    })
+
+    const transport = createIpcPtyTransport()
+    const onReplayData = vi.fn()
+
+    transport.attach({
+      existingPtyId: 'pty-automation',
+      callbacks: {
+        onReplayData
+      }
+    })
+
+    const clear = '\x1b[2J\x1b[3J\x1b[H'
+    expect(onReplayData.mock.calls.map(([data]) => data)).toEqual([clear, bufferedPayload])
+  })
+
   it('routes the attach-time clear sequence through onReplayData for non-alternate-screen sessions', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -418,6 +418,19 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       registerPtyDataHandler(id)
       registerPtyExitHandler(id)
 
+      // Why: hidden automation PTYs may have already rendered their TUI into
+      // the eager buffer. Clear stale pane contents before replaying that
+      // buffer; clearing afterward erases the only visible frame and opens a
+      // blank terminal until the TUI happens to repaint.
+      if (!options.isAlternateScreen) {
+        const clear = '\x1b[2J\x1b[3J\x1b[H'
+        if (storedCallbacks.onReplayData) {
+          storedCallbacks.onReplayData(clear)
+        } else {
+          storedCallbacks.onData?.(clear)
+        }
+      }
+
       // Why: replay buffered data through the real handler so title/bell/agent
       // tracking (including OSC 9999 agent status) processes the output —
       // otherwise restored tabs keep a default title.
@@ -460,21 +473,6 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           }
         }
         bufferHandle.dispose()
-      }
-
-      // Why: clear the display before writing the snapshot so restored
-      // content doesn't layer on top of stale output. Skip the clear for
-      // alternate-screen sessions — the snapshot already fills the screen
-      // and clearing would erase it.
-      // Why onReplayData: treat this clear as replay-path too so any data
-      // that immediately follows from the renderer sits under the same guard.
-      if (!options.isAlternateScreen) {
-        const clear = '\x1b[2J\x1b[3J\x1b[H'
-        if (storedCallbacks.onReplayData) {
-          storedCallbacks.onReplayData(clear)
-        } else {
-          storedCallbacks.onData?.(clear)
-        }
       }
 
       if (options.cols && options.rows) {


### PR DESCRIPTION
## Summary
- Fix hidden automation PTY attach so stale pane contents clear before replaying eager-buffered output
- Add a regression test for automation-style eager-buffer replay ordering

Fixes #2513

## Repro and Verification
- Reproduced the pre-fix blank terminal visually on detached parent commit `a140313d4` using the real pre-fix `createIpcPtyTransport.attach()` path: eager-buffered marker output was written, then the attach-time clear sequence erased it, leaving the xterm surface blank. Captured write order: `[marker, clear]`; visible text: empty.
- Verified the same visual harness on fixed branch `jinwoo0825/bug-automations-blank-terminal`: attach wrote `[clear, marker]`, and the marker remained visible in the xterm surface.
- Reproduced the attach-order failure with a failing regression test before the fix: eager-buffered TUI output replayed, then the clear-screen sequence erased it.
- Verified focused tests pass:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/components/terminal-pane/pty-dispatcher-pi-routing.test.ts`
- Verified in the Electron dev app using a harmless TUI-like automation command: Automations -> Runs -> View run rendered `AUTOMATION_REPRO_VISIBLE` instead of a blank terminal.
- Verified the fixed branch with a real Codex automation session: Automations -> Runs -> View run rendered the Codex TUI and `AUTOMATION_REAL_CODEX_VISIBLE`.

## Notes
- Follow-up pre-fix live checks with real Codex did not reproduce a fully blank canvas on this machine; one completed run showed the Codex TUI, and one launched/running run opened to a shell prompt instead of the buffered Codex TUI. The visual transport harness and regression test reproduce the exact clear-after-replay failure this patch fixes.
- Local Node is now `v24.15.0`, matching the repo engine.

Made with [Orca](https://github.com/stablyai/orca)
