### PR TITLE
Fix Linux package icon sizes

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -182,9 +182,9 @@ module.exports = {
     // Why: Ubuntu 26 ships GNOME Orca as the `orca` package and /usr/bin/orca.
     // The Linux installer should not claim those system package/file names.
     executableName: 'orca-ide',
-    // Why: pin the Linux app icon source so AppImage/deb icon payloads stay
-    // deterministic if electron-builder defaults or resource discovery change.
-    icon: 'resources/build/icon.png',
+    // Why: the icns source lets electron-builder emit standard hicolor PNG
+    // sizes; a single 1024px PNG is ignored by some Linux docks/launchers.
+    icon: 'resources/build/icon.icns',
     extraResources: [
       relayExtraResource,
       {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,0 +1,11 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const electronBuilderConfig = require('../electron-builder.config.cjs')
+
+describe('electron-builder config', () => {
+  it('uses the multi-size icon source for Linux packages', () => {
+    expect(electronBuilderConfig.linux.icon).toBe('resources/build/icon.icns')
+  })
+})


### PR DESCRIPTION
## Summary
- Use the macOS `.icns` app icon as the Linux electron-builder icon source so Linux packages get the standard hicolor PNG size set.
- Add a focused config regression test to keep Linux packaging on the multi-size icon source.

Fixes #2523.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/electron-builder-config.test.mjs`
- `node_modules/.pnpm/app-builder-bin@5.0.0-alpha.12/node_modules/app-builder-bin/mac/app-builder_arm64 icon --format set --root resources/build --root . --out /tmp/orca-icon-set-test --input resources/build/icon.icns` emitted `16, 32, 48, 64, 128, 256, 512`.
- `pnpm exec electron-builder --config config/electron-builder.config.cjs --linux deb --x64 --config.npmRebuild=false`
- Extracted `dist/orca-ide_1.4.16_amd64.deb` and confirmed `usr/share/applications/orca-ide.desktop` has `Icon=orca-ide`.
- Confirmed package includes `usr/share/icons/hicolor/{16x16,32x32,48x48,64x64,128x128,256x256,512x512}/apps/orca-ide.png`.

## Notes
- Full `pnpm run build:linux` on macOS reached electron-builder but failed cross-compiling native modules for `@parcel/watcher`; the metadata-only deb packaging above disables native rebuild to inspect the icon payload from macOS. A Linux release build should still run the normal rebuild path.

Made with [Orca](https://github.com/stablyai/orca) 🐋
