### PR TITLE
Respect disabled settings for mobile notifications

### DIFF
--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -247,6 +247,31 @@ describe('registerNotificationHandlers', () => {
     expect(notificationCtorMock).not.toHaveBeenCalled()
   })
 
+  it('does not dispatch mobile notifications when notifications are disabled in settings', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: false,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: true
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'disabled'
+    })
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+    expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
   it('suppresses active-worktree notifications while Orca is focused', () => {
     getAllWindowsMock.mockReturnValue([
       {
@@ -733,6 +758,56 @@ describe('registerNotificationHandlers', () => {
       delivered: false,
       reason: 'source-disabled'
     })
+  })
+
+  it('does not dispatch mobile notifications when the specific source toggle is off', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: false,
+            terminalBell: true,
+            suppressWhenFocused: true
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'source-disabled'
+    })
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+    expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch mobile terminal-bell notifications when terminal bell is off', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: false,
+            suppressWhenFocused: true
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'terminal-bell', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'source-disabled'
+    })
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+    expect(notificationCtorMock).not.toHaveBeenCalled()
   })
 
   it('deduplicates repeated notifications for the same worktree', () => {

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -105,11 +105,21 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       _event,
       args: NotificationDispatchRequest
     ): NotificationDispatchResult | Promise<NotificationDispatchResult> => {
-      // Why: mobile push is independent of desktop notification guards.
-      // The user's phone should receive the notification even when the desktop
-      // window is focused (suppressWhenFocused), Electron notifications aren't
-      // supported, or the desktop is in cooldown. The mobile client decides
-      // independently whether to show based on its own app state.
+      const settings = store.getSettings().notifications
+      if (!settings.enabled) {
+        return { delivered: false, reason: 'disabled' }
+      }
+
+      if (
+        (args.source === 'agent-task-complete' && !settings.agentTaskComplete) ||
+        (args.source === 'terminal-bell' && !settings.terminalBell)
+      ) {
+        return { delivered: false, reason: 'source-disabled' }
+      }
+
+      // Why: global/source notification switches are user intent across every
+      // notification surface; desktop-only guards below should not suppress
+      // mobile clients that decide visibility from their own app state.
       if (runtime) {
         const opts = buildNotificationOptions(args)
         runtime.dispatchMobileNotification({
@@ -122,18 +132,6 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
 
       if (!Notification.isSupported()) {
         return { delivered: false, reason: 'not-supported' }
-      }
-
-      const settings = store.getSettings().notifications
-      if (!settings.enabled) {
-        return { delivered: false, reason: 'disabled' }
-      }
-
-      if (
-        (args.source === 'agent-task-complete' && !settings.agentTaskComplete) ||
-        (args.source === 'terminal-bell' && !settings.terminalBell)
-      ) {
-        return { delivered: false, reason: 'source-disabled' }
       }
 
       const browserWindow =


### PR DESCRIPTION
## Summary
- gate notification dispatch before mobile fan-out when global notifications are disabled
- respect source-specific settings for agent-complete and terminal-bell mobile notifications
- add regression coverage for disabled global/source settings

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/notifications.test.ts
- pnpm exec oxlint src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts
- pnpm run typecheck:node
- git diff --check

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.