### PR TITLE
Restore SSH port forwarding UI

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -342,6 +342,7 @@ describe('pr-refresh-coordinator', () => {
       '/repo',
       'feature/test',
       null,
+      null,
       null
     )
     expect(getPRForBranchOutcomeMock).toHaveBeenNthCalledWith(
@@ -349,7 +350,8 @@ describe('pr-refresh-coordinator', () => {
       '/repo',
       'feature/test',
       null,
-      'ssh-1'
+      'ssh-1',
+      null
     )
   })
 

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -19,6 +19,8 @@ export type ActivityBarItem = {
   shortcut: string
   /** When true, hidden for non-git (folder-mode) repos. */
   gitOnly?: boolean
+  /** When true, shown only for worktrees that belong to an SSH repo. */
+  sshOnly?: boolean
 }
 
 const STATUS_DOT_COLOR: Record<CheckStatus, string> = {

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Cable, Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
+import { Plug, Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
@@ -74,7 +74,7 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
   },
   {
     id: 'ports',
-    icon: Cable,
+    icon: Plug,
     title: 'Ports',
     shortcut: '',
     sshOnly: true

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
+import { Cable, Files, Search, GitBranch, ListChecks, PanelRight } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { cn } from '@/lib/utils'
@@ -19,6 +19,7 @@ import FileExplorer from './FileExplorer'
 import SourceControl from './SourceControl'
 import SearchPanel from './Search'
 import ChecksPanel from './ChecksPanel'
+import PortsPanel from './PortsPanel'
 import { getTopActivityBarLayout } from './activity-bar-overflow'
 import {
   ActivityBarButton,
@@ -26,6 +27,7 @@ import {
   type ActivityBarItem
 } from './activity-bar-buttons'
 import { getActiveChecksStatus } from './active-checks-status'
+import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
 
 const MIN_WIDTH = 220
 // Why: long file names (e.g. construction drawing sheets, multi-part document
@@ -69,6 +71,13 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
     title: 'Checks',
     shortcut: `${isMac ? '\u21E7' : 'Shift+'}${mod}K`,
     gitOnly: true
+  },
+  {
+    id: 'ports',
+    icon: Cable,
+    title: 'Ports',
+    shortcut: '',
+    sshOnly: true
   }
 ]
 
@@ -88,16 +97,11 @@ function RightSidebarInner(): React.JSX.Element {
   // Hide those tabs so the activity bar only shows relevant actions.
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const isFolder = activeRepo ? isFolderRepo(activeRepo) : false
+  const isSshRepo = Boolean(activeRepo?.connectionId)
 
   const visibleItems = useMemo(
-    () =>
-      ACTIVITY_ITEMS.filter((item) => {
-        if (item.gitOnly && isFolder) {
-          return false
-        }
-        return true
-      }),
-    [isFolder]
+    () => getVisibleRightSidebarActivityItems(ACTIVITY_ITEMS, { isFolder, isSshRepo }),
+    [isFolder, isSshRepo]
   )
 
   // If the active tab is hidden (e.g. switched from a git repo to a folder),
@@ -137,6 +141,12 @@ function RightSidebarInner(): React.JSX.Element {
         {effectiveTab === 'search' && <SearchPanel />}
         {effectiveTab === 'source-control' && <SourceControl />}
         {effectiveTab === 'checks' && <ChecksPanel />}
+        {/* Why: SSH port forwarding still depends on the raw ports.detect data,
+            which the workspace-scoped status bar popover intentionally does not
+            expose. Keep this panel reachable only for SSH worktrees. */}
+        {effectiveTab === 'ports' && (
+          <PortsPanel isVisible={rightSidebarOpen && effectiveTab === 'ports'} />
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { Files } from 'lucide-react'
+import type { ActivityBarItem } from './activity-bar-buttons'
+import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-visibility'
+
+const items: ActivityBarItem[] = [
+  { id: 'explorer', icon: Files, title: 'Explorer', shortcut: '' },
+  { id: 'source-control', icon: Files, title: 'Source Control', shortcut: '', gitOnly: true },
+  { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true }
+]
+
+describe('getVisibleRightSidebarActivityItems', () => {
+  it('shows ports only for SSH repos', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, { isFolder: false, isSshRepo: false }).map(
+        (item) => item.id
+      )
+    ).toEqual(['explorer', 'source-control'])
+
+    expect(
+      getVisibleRightSidebarActivityItems(items, { isFolder: false, isSshRepo: true }).map(
+        (item) => item.id
+      )
+    ).toEqual(['explorer', 'source-control', 'ports'])
+  })
+
+  it('still hides git-only tabs for folder repos', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, { isFolder: true, isSshRepo: true }).map(
+        (item) => item.id
+      )
+    ).toEqual(['explorer', 'ports'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
@@ -1,0 +1,22 @@
+import type { ActivityBarItem } from './activity-bar-buttons'
+
+export function getVisibleRightSidebarActivityItems(
+  items: ActivityBarItem[],
+  {
+    isFolder,
+    isSshRepo
+  }: {
+    isFolder: boolean
+    isSshRepo: boolean
+  }
+): ActivityBarItem[] {
+  return items.filter((item) => {
+    if (item.gitOnly && isFolder) {
+      return false
+    }
+    if (item.sshOnly && !isSshRepo) {
+      return false
+    }
+    return true
+  })
+}


### PR DESCRIPTION
## Summary
- restore the right-sidebar Ports tab for SSH-backed worktrees only
- re-mount the existing SSH port forwarding panel so manual forwards and raw detected remote ports are reachable again
- add a focused activity visibility test for SSH-only and git-only sidebar tabs

Fixes #2536

## Verification
- pnpm test src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts src/renderer/src/components/right-sidebar/activity-bar-overflow.test.ts src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
- pnpm run typecheck
- pnpm run lint
- Electron UI check: injected temporary SSH repo state, confirmed the right-sidebar Ports tab rendered forwarded and detected sections, and confirmed Add opens the Forward a Port dialog

## Notes
- Real SSH VM forwarding was not exercised; the UI surface was verified with in-memory SSH state.

Made with [Orca](https://github.com/stablyai/orca)

Made with [Orca](https://github.com/stablyai/orca) 🐋
