### PR TITLE
Fix PR refresh coordinator test arguments

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -342,6 +342,7 @@ describe('pr-refresh-coordinator', () => {
       '/repo',
       'feature/test',
       null,
+      null,
       null
     )
     expect(getPRForBranchOutcomeMock).toHaveBeenNthCalledWith(
@@ -349,7 +350,8 @@ describe('pr-refresh-coordinator', () => {
       '/repo',
       'feature/test',
       null,
-      'ssh-1'
+      'ssh-1',
+      null
     )
   })
 


### PR DESCRIPTION
## Summary
- Update PR refresh coordinator expectations to include the fallback PR number argument passed to getPRForBranchOutcome.

## Tests
- pnpm vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts

## Note
- Full `pnpm test -- src/main/github/pr-refresh-coordinator.test.ts` currently runs the broader suite and fails in unrelated `src/main/runtime/orchestration-cli-subprocess.test.ts` because the subprocess exits with 1 instead of 0.