### PR TITLE
Defer Codex restart status scans

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -11,7 +11,7 @@ import {
   RefreshCw,
   Server
 } from 'lucide-react'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   DropdownMenu,
@@ -41,6 +41,7 @@ import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy
 import { PetStatusSegment } from './PetStatusSegment'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { FloatingTerminalIconContextMenu } from '@/components/floating-terminal/FloatingTerminalIconContextMenu'
+import { summarizeCodexRestartStatus } from './codex-restart-status-summary'
 
 type StatusBarProps = {
   floatingTerminalOpen: boolean
@@ -54,6 +55,57 @@ function getCodexAccountLabel(
     return 'System default'
   }
   return state.accounts.find((account) => account.id === accountId)?.email ?? 'Codex account'
+}
+
+function CodexRestartStatusPrompt(): React.JSX.Element | null {
+  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const codexRestartNoticeByPtyId = useAppStore((s) => s.codexRestartNoticeByPtyId)
+  const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
+
+  const staleCodexStatus = useMemo(
+    () =>
+      summarizeCodexRestartStatus({
+        tabsByWorktree,
+        ptyIdsByTabId,
+        codexRestartNoticeByPtyId
+      }),
+    [codexRestartNoticeByPtyId, ptyIdsByTabId, tabsByWorktree]
+  )
+
+  if (staleCodexStatus.staleTabCount === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <div className="px-2 py-2">
+        <div className="text-[11px] text-muted-foreground">
+          {/* Why: stale restart notices are tracked per PTY session, but the
+          bulk restart action operates per PTY-backed pane restart. Show
+          both counts so split panes do not make the number look wrong. */}
+          {staleCodexStatus.staleSessionCount === 1
+            ? '1 Codex session is still on the old account'
+            : `${staleCodexStatus.staleSessionCount} Codex sessions are still on the old account.`}
+          {staleCodexStatus.staleWorktreeCount > 1 ? (
+            <span className="mt-0.5 block">
+              Visible sessions restart now. Others restart when their worktree becomes active.
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => queueCodexPaneRestarts(staleCodexStatus.stalePtyIds)}
+          className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-border/70 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent/60"
+        >
+          {staleCodexStatus.staleSessionCount === 1
+            ? 'Restart Session'
+            : `Restart ${staleCodexStatus.staleSessionCount} Sessions`}
+        </button>
+      </div>
+    </>
+  )
 }
 
 function ClaudeSwitcherMenu({
@@ -432,10 +484,6 @@ function CodexSwitcherMenu({
   const fetchSettings = useAppStore((s) => s.fetchSettings)
   const fetchInactiveCodexAccountUsage = useAppStore((s) => s.fetchInactiveCodexAccountUsage)
   const inactiveCodexAccounts = useAppStore((s) => s.rateLimits.inactiveCodexAccounts)
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const codexRestartNoticeByPtyId = useAppStore((s) => s.codexRestartNoticeByPtyId)
-  const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
   const codexAccountSyncKey = useAppStore((s) => {
     const settings = s.settings
     if (!settings) {
@@ -517,17 +565,6 @@ function CodexSwitcherMenu({
           : account.email
       }))
   ]
-  const staleCodexPtyIds = Object.keys(codexRestartNoticeByPtyId)
-  const staleCodexTabIds = Object.keys(ptyIdsByTabId).filter((tabId) =>
-    (ptyIdsByTabId[tabId] ?? []).some((ptyId) => Boolean(codexRestartNoticeByPtyId[ptyId]))
-  )
-  const staleCodexWorktreeCount = new Set(
-    Object.entries(tabsByWorktree).flatMap(([worktreeId, tabs]) =>
-      tabs.some((tab) => staleCodexTabIds.includes(tab.id)) ? [worktreeId] : []
-    )
-  ).size
-  const staleCodexSessionCount = staleCodexPtyIds.length
-  const staleCodexTabCount = staleCodexTabIds.length
 
   return (
     <ProviderDetailsMenu
@@ -598,35 +635,7 @@ function CodexSwitcherMenu({
           </div>
         </div>
       ) : null}
-      {staleCodexTabCount > 0 ? (
-        <>
-          <DropdownMenuSeparator />
-          <div className="px-2 py-2">
-            <div className="text-[11px] text-muted-foreground">
-              {/* Why: stale restart notices are tracked per PTY session, but the
-              bulk restart action operates per PTY-backed pane restart. Show
-              both counts so split panes do not make the number look wrong. */}
-              {staleCodexSessionCount === 1
-                ? '1 Codex session is still on the old account'
-                : `${staleCodexSessionCount} Codex sessions are still on the old account.`}
-              {staleCodexWorktreeCount > 1 ? (
-                <span className="mt-0.5 block">
-                  Visible sessions restart now. Others restart when their worktree becomes active.
-                </span>
-              ) : null}
-            </div>
-            <button
-              type="button"
-              onClick={() => queueCodexPaneRestarts(staleCodexPtyIds)}
-              className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-border/70 px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent/60"
-            >
-              {staleCodexSessionCount === 1
-                ? 'Restart Session'
-                : `Restart ${staleCodexSessionCount} Sessions`}
-            </button>
-          </div>
-        </>
-      ) : null}
+      {open ? <CodexRestartStatusPrompt /> : null}
       <DropdownMenuSeparator />
       <DropdownMenuItem
         onSelect={() => {

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeCodexRestartStatus } from './codex-restart-status-summary'
+
+describe('summarizeCodexRestartStatus', () => {
+  it('does not scan tab maps when there are no stale Codex restart notices', () => {
+    const throwingTabsByWorktree = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error('tabsByWorktree should not be scanned')
+        }
+      }
+    ) as Record<string, { id: string }[]>
+    const throwingPtyIdsByTabId = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error('ptyIdsByTabId should not be scanned')
+        }
+      }
+    ) as Record<string, string[]>
+
+    expect(
+      summarizeCodexRestartStatus({
+        tabsByWorktree: throwingTabsByWorktree,
+        ptyIdsByTabId: throwingPtyIdsByTabId,
+        codexRestartNoticeByPtyId: {}
+      })
+    ).toEqual({
+      stalePtyIds: [],
+      staleSessionCount: 0,
+      staleTabCount: 0,
+      staleWorktreeCount: 0
+    })
+  })
+
+  it('counts stale Codex sessions, tabs, and worktrees', () => {
+    expect(
+      summarizeCodexRestartStatus({
+        tabsByWorktree: {
+          wt1: [{ id: 'tab-1' }, { id: 'tab-2' }],
+          wt2: [{ id: 'tab-3' }]
+        },
+        ptyIdsByTabId: {
+          'tab-1': ['pty-1', 'pty-2'],
+          'tab-2': ['pty-3'],
+          'tab-3': ['pty-4']
+        },
+        codexRestartNoticeByPtyId: {
+          'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b' },
+          'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' },
+          'pty-4': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+        }
+      })
+    ).toEqual({
+      stalePtyIds: ['pty-1', 'pty-2', 'pty-4'],
+      staleSessionCount: 3,
+      staleTabCount: 2,
+      staleWorktreeCount: 2
+    })
+  })
+})

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
@@ -1,0 +1,54 @@
+type TabLookup = Record<string, { id: string }[]>
+
+export type CodexRestartStatusSummaryInput = {
+  tabsByWorktree: TabLookup
+  ptyIdsByTabId: Record<string, string[]>
+  codexRestartNoticeByPtyId: Record<string, unknown>
+}
+
+export type CodexRestartStatusSummary = {
+  stalePtyIds: string[]
+  staleSessionCount: number
+  staleTabCount: number
+  staleWorktreeCount: number
+}
+
+const EMPTY_CODEX_RESTART_STATUS_SUMMARY: CodexRestartStatusSummary = {
+  stalePtyIds: [],
+  staleSessionCount: 0,
+  staleTabCount: 0,
+  staleWorktreeCount: 0
+}
+
+export function summarizeCodexRestartStatus({
+  tabsByWorktree,
+  ptyIdsByTabId,
+  codexRestartNoticeByPtyId
+}: CodexRestartStatusSummaryInput): CodexRestartStatusSummary {
+  const stalePtyIds = Object.keys(codexRestartNoticeByPtyId)
+  if (stalePtyIds.length === 0) {
+    return EMPTY_CODEX_RESTART_STATUS_SUMMARY
+  }
+
+  const stalePtyIdSet = new Set(stalePtyIds)
+  const staleTabIds = new Set<string>()
+  for (const [tabId, ptyIds] of Object.entries(ptyIdsByTabId)) {
+    if (ptyIds.some((ptyId) => stalePtyIdSet.has(ptyId))) {
+      staleTabIds.add(tabId)
+    }
+  }
+
+  const staleWorktreeIds = new Set<string>()
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    if (tabs.some((tab) => staleTabIds.has(tab.id))) {
+      staleWorktreeIds.add(worktreeId)
+    }
+  }
+
+  return {
+    stalePtyIds,
+    staleSessionCount: stalePtyIds.length,
+    staleTabCount: staleTabIds.size,
+    staleWorktreeCount: staleWorktreeIds.size
+  }
+}


### PR DESCRIPTION
## Summary
- move Codex stale-restart tab/worktree scans out of the closed status-bar switcher
- compute restart counts only while the Codex account menu prompt is mounted
- add a deterministic no-scan regression test for the zero-notice path

## Measurement / verification
- New test proves zero stale notices do not enumerate accumulated tab/worktree maps
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts src/renderer/src/components/status-bar/resource-session-navigation.test.ts src/renderer/src/components/codex-restart-chip.test.ts
- pnpm typecheck
- pnpm lint
- pnpm test