### PR TITLE
Fix SSH PTY routing after restoring multiple workspaces

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1191,6 +1191,66 @@ describe('registerPtyHandlers', () => {
         expect(store.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'remote-pty', 'expired')
       })
 
+      it('marks a scoped SSH session expired using the raw relay lease id', async () => {
+        const scopedPtyId = 'ssh:ssh-1@@remote-pty'
+        const sshSpawn = vi.fn(async () => {
+          throw new Error('SSH_SESSION_EXPIRED: remote-pty')
+        })
+        const store = {
+          markSshRemotePtyLease: vi.fn()
+        }
+        registerSshPtyProvider('ssh-1', {
+          spawn: sshSpawn,
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown: vi.fn(),
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses: vi.fn(async () => []),
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        setPtyOwnership(scopedPtyId, 'ssh-1')
+        handlers.clear()
+        registerPtyHandlers(
+          mainWindow as never,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          store as never
+        )
+
+        try {
+          await expect(
+            handlers.get('pty:spawn')!(null, {
+              cols: 80,
+              rows: 24,
+              env: {},
+              connectionId: 'ssh-1',
+              sessionId: scopedPtyId
+            })
+          ).rejects.toThrow('SSH_SESSION_EXPIRED: remote-pty')
+        } finally {
+          deletePtyOwnership(scopedPtyId)
+        }
+
+        expect(store.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'remote-pty', 'expired')
+        expect(openCodeClearPtyMock).toHaveBeenCalledWith(scopedPtyId)
+        expect(piClearPtyMock).toHaveBeenCalledWith(scopedPtyId)
+      })
+
       it('does not tombstone an SSH lease when explicit kill shutdown fails transiently', async () => {
         const store = {
           markSshRemotePtyLease: vi.fn()
@@ -1593,6 +1653,85 @@ describe('registerPtyHandlers', () => {
 
     await handlers.get('pty:kill')!(null, { id: 'remote-pty' })
     expect(sshShutdown).toHaveBeenCalledWith('remote-pty', {
+      immediate: true,
+      keepHistory: false
+    })
+  })
+
+  it('lists duplicate SSH relay session ids as distinct app sessions', async () => {
+    registerPtyHandlers(mainWindow as never)
+    const shutdownA = vi.fn(async () => undefined)
+    const shutdownB = vi.fn(async () => undefined)
+    registerSshPtyProvider('ssh-a', {
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: shutdownA,
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [
+        { id: 'ssh:ssh-a@@pty-1', cwd: '/repo-a', title: 'ssh-a' }
+      ]),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerSshPtyProvider('ssh-b', {
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: shutdownB,
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [
+        { id: 'ssh:ssh-b@@pty-1', cwd: '/repo-b', title: 'ssh-b' }
+      ]),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+
+    const sessions = (await handlers.get('pty:listSessions')!(null, undefined)) as {
+      id: string
+      cwd: string
+      title: string
+    }[]
+
+    expect(sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'ssh:ssh-a@@pty-1', cwd: '/repo-a' }),
+        expect.objectContaining({ id: 'ssh:ssh-b@@pty-1', cwd: '/repo-b' })
+      ])
+    )
+
+    await handlers.get('pty:kill')!(null, { id: 'ssh:ssh-a@@pty-1' })
+    await handlers.get('pty:kill')!(null, { id: 'ssh:ssh-b@@pty-1' })
+
+    expect(shutdownA).toHaveBeenCalledWith('ssh:ssh-a@@pty-1', {
+      immediate: true,
+      keepHistory: false
+    })
+    expect(shutdownB).toHaveBeenCalledWith('ssh:ssh-b@@pty-1', {
       immediate: true,
       keepHistory: false
     })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -17,6 +17,7 @@ import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import { SSH_SESSION_EXPIRED_ERROR, isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
+import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
 import { mintPtySessionId, isSafePtySessionId } from '../daemon/pty-session-id'
 import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -181,6 +182,14 @@ function getProviderForPty(ptyId: string): IPtyProvider {
   return getProvider(connectionId)
 }
 
+function getAppPtyId(connectionId: string | null | undefined, ptyId: string): string {
+  return connectionId ? toAppSshPtyId(connectionId, ptyId) : ptyId
+}
+
+function getRelayPtyId(connectionId: string | null | undefined, ptyId: string): string {
+  return connectionId ? toRelaySshPtyId(connectionId, ptyId) : ptyId
+}
+
 function tryGetProviderForPty(ptyId: string): IPtyProvider | undefined {
   try {
     return getProviderForPty(ptyId)
@@ -216,7 +225,7 @@ function finishPtyShutdown(
 ): void {
   clearProviderPtyState(id)
   if (connectionId) {
-    store?.markSshRemotePtyLease(connectionId, id, 'terminated')
+    store?.markSshRemotePtyLease(connectionId, getRelayPtyId(connectionId, id), 'terminated')
   }
   ptyOwnership.delete(id)
   markClaudePtyExited(id)
@@ -1164,6 +1173,14 @@ export function registerPtyHandlers(
       const isMintedSessionId = args.sessionId === undefined && isDaemonHostSpawn
       const effectiveSessionId =
         args.sessionId ?? (isDaemonHostSpawn ? mintPtySessionId(args.worktreeId) : undefined)
+      const effectiveSessionAppId =
+        effectiveSessionId !== undefined
+          ? getAppPtyId(args.connectionId, effectiveSessionId)
+          : undefined
+      const effectiveSessionRelayId =
+        effectiveSessionId !== undefined
+          ? getRelayPtyId(args.connectionId, effectiveSessionId)
+          : undefined
       // Why: the renderer sets pane env for SSH too. Only forward it to the
       // remote when the relay hook path is enabled; otherwise a newer relay
       // could emit statuses this Orca build is not prepared to route.
@@ -1319,7 +1336,10 @@ export function registerPtyHandlers(
         // Why: daemon PTYs can emit prompt/startup bytes before spawn()
         // resolves. Runtime headless snapshots need the real pane geometry
         // for those early bytes; otherwise they default to 80x24 and wrap TUIs.
-        ptySizes.set(effectiveSessionId, { cols: args.cols, rows: args.rows })
+        ptySizes.set(effectiveSessionAppId ?? effectiveSessionId, {
+          cols: args.cols,
+          rows: args.rows
+        })
       }
       if (process.platform === 'win32' && !args.connectionId) {
         // Why: the renderer only models PowerShell as one shell family. Thread
@@ -1339,21 +1359,23 @@ export function registerPtyHandlers(
       } catch (err) {
         const rawMessage = err instanceof Error ? err.message : String(err)
         const spawnError = normalizeNodePtySpawnError(err)
-        if (effectiveSessionId !== undefined) {
-          ptySizes.delete(effectiveSessionId)
+        if (effectiveSessionAppId !== undefined) {
+          ptySizes.delete(effectiveSessionAppId)
         }
         if (
           args.connectionId &&
-          effectiveSessionId !== undefined &&
+          effectiveSessionRelayId !== undefined &&
           (spawnError.message.includes(SSH_SESSION_EXPIRED_ERROR) ||
             rawMessage.includes(SSH_SESSION_EXPIRED_ERROR))
         ) {
           // Why: expired remote reattach means the relay has already dropped
           // the backing PTY. Clear the durable lease so later session writes
           // cannot restore the stale pane binding.
-          clearProviderPtyState(effectiveSessionId)
-          deletePtyOwnership(effectiveSessionId)
-          store?.markSshRemotePtyLease(args.connectionId, effectiveSessionId, 'expired')
+          if (effectiveSessionAppId !== undefined) {
+            clearProviderPtyState(effectiveSessionAppId)
+            deletePtyOwnership(effectiveSessionAppId)
+          }
+          store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
         }
         // Why: when buildPtyHostEnv materialized a Pi overlay for this id
         // but provider.spawn failed, the overlay would leak.
@@ -1392,13 +1414,14 @@ export function registerPtyHandlers(
         }
       }
       ptyOwnership.set(result.id, args.connectionId ?? null)
+      const relayResultId = getRelayPtyId(args.connectionId, result.id)
       if (store && args.connectionId) {
         // Why: remote PTYs live in the SSH relay grace window after Orca
         // detaches. Persist their IDs immediately so reconnect can reattach
         // instead of treating the tab as a fresh shell.
         store.upsertSshRemotePtyLease({
           targetId: args.connectionId,
-          ptyId: result.id,
+          ptyId: relayResultId,
           ...(typeof args.worktreeId === 'string' ? { worktreeId: args.worktreeId } : {}),
           ...(typeof args.tabId === 'string' ? { tabId: args.tabId } : {}),
           ...(validatedLeafId ? { leafId: validatedLeafId } : {}),
@@ -1442,7 +1465,7 @@ export function registerPtyHandlers(
             deletePtyOwnership(result.id)
           }
           if (!result.isReattach && args.connectionId && store) {
-            store.removeSshRemotePtyLease(args.connectionId, result.id)
+            store.removeSshRemotePtyLease(args.connectionId, relayResultId)
           }
           throw new Error(createTerminalSessionStateSaveFailureMessage())
         }

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -159,7 +159,12 @@ vi.mock('../ssh/ssh-port-forward', () => ({
 
 import { registerSshHandlers } from './ssh'
 import type { SshTarget } from '../../shared/ssh-types'
-import { getSshPtyProvider, getPtyIdsForConnection } from './pty'
+import {
+  clearProviderPtyState,
+  deletePtyOwnership,
+  getSshPtyProvider,
+  getPtyIdsForConnection
+} from './pty'
 
 describe('SSH IPC handlers', () => {
   const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
@@ -219,6 +224,8 @@ describe('SSH IPC handlers', () => {
     mockPortForwardManager.dispose.mockReset()
     vi.mocked(getSshPtyProvider).mockReset()
     vi.mocked(getPtyIdsForConnection).mockReset().mockReturnValue([])
+    vi.mocked(clearProviderPtyState).mockReset()
+    vi.mocked(deletePtyOwnership).mockReset()
 
     registerSshHandlers(mockStore as never, () => mockWindow as never)
   })
@@ -481,6 +488,48 @@ describe('SSH IPC handlers', () => {
     expect(mockConnectionManager.disconnect).not.toHaveBeenCalledWith('ssh-1')
   })
 
+  it('ssh:terminateSessions cleans scoped live PTYs while tombstoning raw leases', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    mockStore.getSshRemotePtyLeases.mockReturnValue([
+      { targetId: 'ssh-1', ptyId: 'pty-lease', state: 'detached' }
+    ])
+    vi.mocked(getSshPtyProvider).mockReturnValue(mockPtyProvider as never)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['ssh:ssh-1@@pty-live'])
+    mockPtyProvider.shutdown.mockResolvedValue(undefined)
+
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+    await handlers.get('ssh:terminateSessions')!(null, { targetId: 'ssh-1' })
+
+    expect(mockPtyProvider.shutdown).toHaveBeenCalledWith('ssh:ssh-1@@pty-live', {
+      immediate: true,
+      keepHistory: false
+    })
+    expect(mockPtyProvider.shutdown).toHaveBeenCalledWith('ssh:ssh-1@@pty-lease', {
+      immediate: true,
+      keepHistory: false
+    })
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:ssh-1@@pty-live')
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:ssh-1@@pty-lease')
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:ssh-1@@pty-live')
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:ssh-1@@pty-lease')
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'pty-live', 'terminated')
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'pty-lease', 'terminated')
+  })
+
   it('ssh:terminateSessions ignores expired leases when disconnected', async () => {
     mockStore.getSshRemotePtyLeases.mockReturnValue([
       { targetId: 'ssh-1', ptyId: 'pty-expired', state: 'expired' }
@@ -524,6 +573,33 @@ describe('SSH IPC handlers', () => {
       'pty-expired',
       'expired'
     )
+    expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
+  })
+
+  it('ssh:resetRelay clears scoped live PTYs while expiring raw leases', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const conn = {}
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue(conn)
+    mockConnectionManager.getConnection.mockReturnValue(undefined)
+    mockStore.getSshRemotePtyLeases.mockReturnValue([
+      { targetId: 'ssh-1', ptyId: 'pty-lease', state: 'detached' }
+    ])
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['ssh:ssh-1@@pty-live'])
+
+    await handlers.get('ssh:resetRelay')!(null, { targetId: 'ssh-1' })
+
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'pty-lease', 'expired')
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:ssh-1@@pty-live')
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:ssh-1@@pty-lease')
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:ssh-1@@pty-live')
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:ssh-1@@pty-lease')
     expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
   })
 

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -19,6 +19,7 @@ import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isAuthError } from '../ssh/ssh-connection-utils'
 import { forceStopRelayForTarget } from '../ssh/ssh-relay-reset'
 import { isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
+import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
 import { registerSshBrowseHandler } from './ssh-browse'
 import { requestCredential, registerCredentialHandler } from './ssh-passphrase'
 import {
@@ -664,15 +665,17 @@ export function registerSshHandlers(
     const shutdownFailures: string[] = []
     for (const [index, result] of shutdownResults.entries()) {
       const ptyId = ptyIds[index]
+      const appPtyId = toAppSshPtyId(args.targetId, ptyId)
+      const relayPtyId = toRelaySshPtyId(args.targetId, ptyId)
       if (result.status !== 'fulfilled' && !isSshPtyNotFoundError(result.reason)) {
         shutdownFailures.push(
           `${ptyId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
         )
         continue
       }
-      clearProviderPtyState(ptyId)
-      deletePtyOwnership(ptyId)
-      store.markSshRemotePtyLease(args.targetId, ptyId, 'terminated')
+      clearProviderPtyState(appPtyId)
+      deletePtyOwnership(appPtyId)
+      store.markSshRemotePtyLease(args.targetId, relayPtyId, 'terminated')
     }
     if (shutdownFailures.length > 0) {
       // Why: a failed relay shutdown can leave the remote process alive in the
@@ -727,8 +730,9 @@ export function registerSshHandlers(
       // handle owned by that relay is stale even if the reset command failed
       // after the remote process accepted SIGTERM.
       for (const ptyId of ptyIds) {
-        clearProviderPtyState(ptyId)
-        deletePtyOwnership(ptyId)
+        const appPtyId = toAppSshPtyId(targetId, ptyId)
+        clearProviderPtyState(appPtyId)
+        deletePtyOwnership(appPtyId)
       }
       // Why: reset's connect() can trip onCredentialRequest, which adds to
       // credentialRequestedForTarget. Without this delete, a later doConnect

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -650,7 +650,22 @@ export function registerSshHandlers(
       .getSshRemotePtyLeases(args.targetId)
       .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
       .map((lease) => lease.ptyId)
-    const ptyIds = Array.from(new Set([...getPtyIdsForConnection(args.targetId), ...leasedIds]))
+    const ptyIdsByRelayId = new Map<string, string>()
+    for (const ptyId of getPtyIdsForConnection(args.targetId)) {
+      const relayPtyId = toRelaySshPtyId(args.targetId, ptyId)
+      ptyIdsByRelayId.set(relayPtyId, toAppSshPtyId(args.targetId, ptyId))
+    }
+    for (const ptyId of leasedIds) {
+      const relayPtyId = toRelaySshPtyId(args.targetId, ptyId)
+      ptyIdsByRelayId.set(
+        relayPtyId,
+        ptyIdsByRelayId.get(relayPtyId) ?? toAppSshPtyId(args.targetId, ptyId)
+      )
+    }
+    const ptyIds = Array.from(ptyIdsByRelayId, ([relayPtyId, appPtyId]) => ({
+      relayPtyId,
+      appPtyId
+    }))
 
     if (ptyIds.length > 0 && !provider) {
       throw new Error(
@@ -659,17 +674,17 @@ export function registerSshHandlers(
     }
     const shutdownResults = provider
       ? await Promise.allSettled(
-          ptyIds.map((ptyId) => provider.shutdown(ptyId, { immediate: true, keepHistory: false }))
+          ptyIds.map(({ appPtyId }) =>
+            provider.shutdown(appPtyId, { immediate: true, keepHistory: false })
+          )
         )
       : []
     const shutdownFailures: string[] = []
     for (const [index, result] of shutdownResults.entries()) {
-      const ptyId = ptyIds[index]
-      const appPtyId = toAppSshPtyId(args.targetId, ptyId)
-      const relayPtyId = toRelaySshPtyId(args.targetId, ptyId)
+      const { appPtyId, relayPtyId } = ptyIds[index]
       if (result.status !== 'fulfilled' && !isSshPtyNotFoundError(result.reason)) {
         shutdownFailures.push(
-          `${ptyId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
+          `${relayPtyId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
         )
         continue
       }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3913,6 +3913,52 @@ describe('Store', () => {
     expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
   })
 
+  it('matches scoped SSH workspace bindings against raw relay leases', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'ssh:ssh-1@@remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty' }
+        }
+      }
+    })
+
+    store.removeSshRemotePtyLeases('ssh-1')
+
+    const session = store.getWorkspaceSession()
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
+  })
+
   it('clears workspace bindings before removing contextless SSH remote PTY leases', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3959,6 +3959,100 @@ describe('Store', () => {
     expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
   })
 
+  it('stores scoped SSH remote PTY leases as raw relay ids', async () => {
+    const store = await createStore()
+
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'ssh:ssh-1@@remote-pty',
+      state: 'attached'
+    })
+
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({
+        targetId: 'ssh-1',
+        ptyId: 'remote-pty',
+        state: 'attached'
+      })
+    ])
+  })
+
+  it('rejects mismatched scoped SSH remote PTY lease ids on write paths', async () => {
+    const store = await createStore()
+
+    expect(() =>
+      store.upsertSshRemotePtyLease({
+        targetId: 'ssh-1',
+        ptyId: 'ssh:ssh-2@@remote-pty',
+        state: 'attached'
+      })
+    ).toThrow('belongs to SSH connection "ssh-2"')
+  })
+
+  it('updates SSH remote PTY leases when callers pass scoped app ids', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      state: 'attached'
+    })
+
+    store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'terminated')
+
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({
+        ptyId: 'remote-pty',
+        state: 'terminated'
+      })
+    ])
+  })
+
+  it('removes SSH remote PTY leases when callers pass scoped app ids', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'detached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab1',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab1',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: 'ssh:ssh-1@@remote-pty'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        tab1: {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty' }
+        }
+      }
+    })
+
+    store.removeSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty')
+
+    const session = store.getWorkspaceSession()
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
+    expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
+    expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
+  })
+
   it('clears workspace bindings before removing contextless SSH remote PTY leases', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -63,6 +63,7 @@ import {
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
+import { toRelaySshPtyId } from './providers/ssh-pty-id'
 import {
   isTerminalLeafId,
   makePaneKey,
@@ -2581,6 +2582,14 @@ export class Store {
     return !leases?.some((lease) => lease.state === 'terminated' || lease.state === 'expired')
   }
 
+  private getRelayPtyIdForSshLeaseBinding(targetId: string, ptyId: string): string {
+    try {
+      return toRelaySshPtyId(targetId, ptyId)
+    } catch {
+      return ptyId
+    }
+  }
+
   private sshRemotePtyLeaseMatchesBinding(
     lease: SshRemotePtyLease,
     binding: {
@@ -2591,7 +2600,8 @@ export class Store {
       leafId?: string
     }
   ): boolean {
-    if (lease.ptyId !== binding.ptyId) {
+    const bindingPtyId = this.getRelayPtyIdForSshLeaseBinding(lease.targetId, binding.ptyId)
+    if (lease.ptyId !== bindingPtyId) {
       return false
     }
     // Why: remote PTY ids are scoped to a relay target. Workspace PTY bindings
@@ -2635,7 +2645,8 @@ export class Store {
       leafId?: string
     }
   ): boolean {
-    if (lease.targetId !== binding.targetId || lease.ptyId !== binding.ptyId) {
+    const bindingPtyId = this.getRelayPtyIdForSshLeaseBinding(binding.targetId, binding.ptyId)
+    if (lease.targetId !== binding.targetId || lease.ptyId !== bindingPtyId) {
       return false
     }
     // Why: target removal is destructive. Legacy/contextless leases should

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2582,12 +2582,16 @@ export class Store {
     return !leases?.some((lease) => lease.state === 'terminated' || lease.state === 'expired')
   }
 
-  private getRelayPtyIdForSshLeaseBinding(targetId: string, ptyId: string): string {
+  private getRelayPtyIdForSshLeaseComparison(targetId: string, ptyId: string): string {
     try {
       return toRelaySshPtyId(targetId, ptyId)
     } catch {
       return ptyId
     }
+  }
+
+  private getRelayPtyIdForSshLeaseStorage(targetId: string, ptyId: string): string {
+    return toRelaySshPtyId(targetId, ptyId)
   }
 
   private sshRemotePtyLeaseMatchesBinding(
@@ -2600,7 +2604,7 @@ export class Store {
       leafId?: string
     }
   ): boolean {
-    const bindingPtyId = this.getRelayPtyIdForSshLeaseBinding(lease.targetId, binding.ptyId)
+    const bindingPtyId = this.getRelayPtyIdForSshLeaseComparison(lease.targetId, binding.ptyId)
     if (lease.ptyId !== bindingPtyId) {
       return false
     }
@@ -2645,7 +2649,7 @@ export class Store {
       leafId?: string
     }
   ): boolean {
-    const bindingPtyId = this.getRelayPtyIdForSshLeaseBinding(binding.targetId, binding.ptyId)
+    const bindingPtyId = this.getRelayPtyIdForSshLeaseComparison(binding.targetId, binding.ptyId)
     if (lease.targetId !== binding.targetId || lease.ptyId !== bindingPtyId) {
       return false
     }
@@ -2825,6 +2829,12 @@ export class Store {
     if (normalizedLease.leafId !== undefined && !isTerminalLeafId(normalizedLease.leafId)) {
       delete normalizedLease.leafId
     }
+    // Why: app-facing SSH PTY ids are globally scoped; durable relay leases
+    // stay target-local so reconnect can call relay pty.attach with raw ids.
+    normalizedLease.ptyId = this.getRelayPtyIdForSshLeaseStorage(
+      normalizedLease.targetId,
+      normalizedLease.ptyId
+    )
     const now = Date.now()
     const existingIndex = this.state.sshRemotePtyLeases.findIndex(
       (entry) =>
@@ -2871,8 +2881,9 @@ export class Store {
   }
 
   markSshRemotePtyLease(targetId: string, ptyId: string, state: SshRemotePtyLease['state']): void {
+    const relayPtyId = this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId)
     const lease = this.state.sshRemotePtyLeases?.find(
-      (entry) => entry.targetId === targetId && entry.ptyId === ptyId
+      (entry) => entry.targetId === targetId && entry.ptyId === relayPtyId
     )
     if (!lease || lease.state === state) {
       return
@@ -2889,13 +2900,14 @@ export class Store {
   }
 
   removeSshRemotePtyLease(targetId: string, ptyId: string): void {
+    const relayPtyId = this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId)
     const leases = (this.state.sshRemotePtyLeases ?? []).filter(
-      (lease) => lease.targetId === targetId && lease.ptyId === ptyId
+      (lease) => lease.targetId === targetId && lease.ptyId === relayPtyId
     )
     const before = this.state.sshRemotePtyLeases?.length ?? 0
     this.clearSshRemotePtyBindingsForLeases(targetId, leases)
     this.state.sshRemotePtyLeases = (this.state.sshRemotePtyLeases ?? []).filter(
-      (lease) => lease.targetId !== targetId || lease.ptyId !== ptyId
+      (lease) => lease.targetId !== targetId || lease.ptyId !== relayPtyId
     )
     if (this.state.sshRemotePtyLeases.length !== before) {
       this.flush()

--- a/src/main/providers/provider-dispatch.test.ts
+++ b/src/main/providers/provider-dispatch.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { handleMock, removeHandlerMock, removeAllListenersMock } = vi.hoisted(() => ({
+const { handleMock, onMock, removeHandlerMock, removeAllListenersMock } = vi.hoisted(() => ({
   handleMock: vi.fn(),
+  onMock: vi.fn(),
   removeHandlerMock: vi.fn(),
   removeAllListenersMock: vi.fn()
 }))
@@ -13,7 +14,7 @@ vi.mock('electron', () => ({
   },
   ipcMain: {
     handle: handleMock,
-    on: vi.fn(),
+    on: onMock,
     removeHandler: removeHandlerMock,
     removeAllListeners: removeAllListenersMock
   }
@@ -50,7 +51,13 @@ vi.mock('../pi/titlebar-extension-service', () => ({
   piTitlebarExtensionService: { buildPtyEnv: () => ({}), clearPty: vi.fn() }
 }))
 
-import { registerPtyHandlers, registerSshPtyProvider, unregisterSshPtyProvider } from '../ipc/pty'
+import {
+  deletePtyOwnership,
+  registerPtyHandlers,
+  registerSshPtyProvider,
+  setPtyOwnership,
+  unregisterSshPtyProvider
+} from '../ipc/pty'
 import type { IPtyProvider } from './types'
 
 describe('PTY provider dispatch', () => {
@@ -63,10 +70,39 @@ describe('PTY provider dispatch', () => {
   function setup(): void {
     handlers.clear()
     handleMock.mockReset()
+    onMock.mockReset()
     handleMock.mockImplementation((channel: string, handler: (...a: unknown[]) => unknown) => {
       handlers.set(channel, handler)
     })
+    onMock.mockImplementation((channel: string, handler: (...a: unknown[]) => unknown) => {
+      handlers.set(channel, handler)
+    })
     registerPtyHandlers(mainWindow as never)
+  }
+
+  function createMockProvider(id: string): IPtyProvider {
+    return {
+      spawn: vi.fn().mockResolvedValue({ id }),
+      attach: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      listProcesses: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn(),
+      onData: vi.fn().mockReturnValue(() => {}),
+      onReplay: vi.fn().mockReturnValue(() => {}),
+      onExit: vi.fn().mockReturnValue(() => {})
+    }
   }
 
   it('routes to local provider when connectionId is null', async () => {
@@ -90,28 +126,7 @@ describe('PTY provider dispatch', () => {
 
   it('routes to SSH provider when connectionId is set', async () => {
     setup()
-    const mockSshProvider: IPtyProvider = {
-      spawn: vi.fn().mockResolvedValue({ id: 'ssh-pty-1' }),
-      attach: vi.fn(),
-      write: vi.fn(),
-      resize: vi.fn(),
-      shutdown: vi.fn(),
-      sendSignal: vi.fn(),
-      getCwd: vi.fn(),
-      getInitialCwd: vi.fn(),
-      clearBuffer: vi.fn(),
-      acknowledgeDataEvent: vi.fn(),
-      hasChildProcesses: vi.fn(),
-      getForegroundProcess: vi.fn(),
-      serialize: vi.fn(),
-      revive: vi.fn(),
-      listProcesses: vi.fn(),
-      getDefaultShell: vi.fn(),
-      getProfiles: vi.fn(),
-      onData: vi.fn().mockReturnValue(() => {}),
-      onReplay: vi.fn().mockReturnValue(() => {}),
-      onExit: vi.fn().mockReturnValue(() => {})
-    }
+    const mockSshProvider = createMockProvider('ssh-pty-1')
 
     registerSshPtyProvider('conn-123', mockSshProvider)
 
@@ -145,28 +160,7 @@ describe('PTY provider dispatch', () => {
 
   it('unregisterSshPtyProvider removes the provider', async () => {
     setup()
-    const mockProvider: IPtyProvider = {
-      spawn: vi.fn().mockResolvedValue({ id: 'ssh-pty-2' }),
-      attach: vi.fn(),
-      write: vi.fn(),
-      resize: vi.fn(),
-      shutdown: vi.fn(),
-      sendSignal: vi.fn(),
-      getCwd: vi.fn(),
-      getInitialCwd: vi.fn(),
-      clearBuffer: vi.fn(),
-      acknowledgeDataEvent: vi.fn(),
-      hasChildProcesses: vi.fn(),
-      getForegroundProcess: vi.fn(),
-      serialize: vi.fn(),
-      revive: vi.fn(),
-      listProcesses: vi.fn(),
-      getDefaultShell: vi.fn(),
-      getProfiles: vi.fn(),
-      onData: vi.fn().mockReturnValue(() => {}),
-      onReplay: vi.fn().mockReturnValue(() => {}),
-      onExit: vi.fn().mockReturnValue(() => {})
-    }
+    const mockProvider = createMockProvider('ssh-pty-2')
 
     registerSshPtyProvider('conn-456', mockProvider)
     unregisterSshPtyProvider('conn-456')
@@ -178,5 +172,31 @@ describe('PTY provider dispatch', () => {
         connectionId: 'conn-456'
       })
     ).rejects.toThrow('No PTY provider for connection "conn-456"')
+  })
+
+  it('keeps same relay PTY ids distinct across SSH targets', () => {
+    setup()
+    const providerA = createMockProvider('ssh:conn-a@@pty-1')
+    const providerB = createMockProvider('ssh:conn-b@@pty-1')
+    registerSshPtyProvider('conn-a', providerA)
+    registerSshPtyProvider('conn-b', providerB)
+    setPtyOwnership('ssh:conn-a@@pty-1', 'conn-a')
+    setPtyOwnership('ssh:conn-b@@pty-1', 'conn-b')
+
+    try {
+      const write = handlers.get('pty:write') as (event: unknown, args: unknown) => void
+      write(null, { id: 'ssh:conn-a@@pty-1', data: 'a' })
+      write(null, { id: 'ssh:conn-b@@pty-1', data: 'b' })
+
+      expect(providerA.write).toHaveBeenCalledWith('ssh:conn-a@@pty-1', 'a')
+      expect(providerB.write).toHaveBeenCalledWith('ssh:conn-b@@pty-1', 'b')
+      expect(providerA.write).not.toHaveBeenCalledWith('ssh:conn-b@@pty-1', expect.anything())
+      expect(providerB.write).not.toHaveBeenCalledWith('ssh:conn-a@@pty-1', expect.anything())
+    } finally {
+      deletePtyOwnership('ssh:conn-a@@pty-1')
+      deletePtyOwnership('ssh:conn-b@@pty-1')
+      unregisterSshPtyProvider('conn-a')
+      unregisterSshPtyProvider('conn-b')
+    }
   })
 })

--- a/src/main/providers/ssh-pty-id.ts
+++ b/src/main/providers/ssh-pty-id.ts
@@ -1,0 +1,54 @@
+const SSH_PTY_ID_PREFIX = 'ssh:'
+const SSH_PTY_ID_SEPARATOR = '@@'
+
+// Why: SSH relays allocate target-local ids like "pty-1"; app-wide routing
+// needs the target id embedded so two relays cannot collide after restore.
+export type ParsedSshPtyId = {
+  connectionId: string
+  relayPtyId: string
+}
+
+export function parseAppSshPtyId(ptyId: string): ParsedSshPtyId | null {
+  if (!ptyId.startsWith(SSH_PTY_ID_PREFIX)) {
+    return null
+  }
+  const separatorIndex = ptyId.indexOf(SSH_PTY_ID_SEPARATOR, SSH_PTY_ID_PREFIX.length)
+  if (separatorIndex === -1) {
+    return null
+  }
+  const encodedConnectionId = ptyId.slice(SSH_PTY_ID_PREFIX.length, separatorIndex)
+  const relayPtyId = ptyId.slice(separatorIndex + SSH_PTY_ID_SEPARATOR.length)
+  if (!encodedConnectionId || !relayPtyId) {
+    return null
+  }
+  try {
+    return {
+      connectionId: decodeURIComponent(encodedConnectionId),
+      relayPtyId
+    }
+  } catch {
+    return null
+  }
+}
+
+export function toAppSshPtyId(connectionId: string, relayPtyId: string): string {
+  const parsed = parseAppSshPtyId(relayPtyId)
+  if (parsed) {
+    if (parsed.connectionId !== connectionId) {
+      throw new Error(`PTY ${relayPtyId} belongs to SSH connection "${parsed.connectionId}"`)
+    }
+    return relayPtyId
+  }
+  return `${SSH_PTY_ID_PREFIX}${encodeURIComponent(connectionId)}${SSH_PTY_ID_SEPARATOR}${relayPtyId}`
+}
+
+export function toRelaySshPtyId(connectionId: string, ptyId: string): string {
+  const parsed = parseAppSshPtyId(ptyId)
+  if (!parsed) {
+    return ptyId
+  }
+  if (parsed.connectionId !== connectionId) {
+    throw new Error(`PTY ${ptyId} belongs to SSH connection "${parsed.connectionId}"`)
+  }
+  return parsed.relayPtyId
+}

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -22,6 +22,7 @@ function createMockMux(): MockMultiplexer {
 describe('SshPtyProvider', () => {
   let mux: MockMultiplexer
   let provider: SshPtyProvider
+  const scopedPty1 = 'ssh:conn-1@@pty-1'
 
   beforeEach(() => {
     mux = createMockMux()
@@ -44,7 +45,7 @@ describe('SshPtyProvider', () => {
         cwd: undefined,
         env: undefined
       })
-      expect(result).toEqual({ id: 'pty-1' })
+      expect(result).toEqual({ id: scopedPty1 })
     })
 
     it('passes cwd and env through', async () => {
@@ -77,7 +78,29 @@ describe('SshPtyProvider', () => {
         suppressReplayNotification: true
       })
       expect(result).toEqual({
+        id: 'ssh:conn-1@@pty-old',
+        isReattach: true,
+        replay: 'buffered-output'
+      })
+    })
+
+    it('reattaches scoped app ids using raw relay ids', async () => {
+      mux.request.mockResolvedValue({ replay: 'buffered-output' })
+
+      const result = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'ssh:conn-1@@pty-old'
+      })
+
+      expect(mux.request).toHaveBeenCalledWith('pty.attach', {
         id: 'pty-old',
+        cols: 80,
+        rows: 24,
+        suppressReplayNotification: true
+      })
+      expect(result).toEqual({
+        id: 'ssh:conn-1@@pty-old',
         isReattach: true,
         replay: 'buffered-output'
       })
@@ -111,12 +134,12 @@ describe('SshPtyProvider', () => {
   })
 
   it('attach sends pty.attach request', async () => {
-    await provider.attach('pty-1')
+    await provider.attach(scopedPty1)
     expect(mux.request).toHaveBeenCalledWith('pty.attach', { id: 'pty-1' })
   })
 
   it('write sends pty.data notification', () => {
-    provider.write('pty-1', 'hello')
+    provider.write(scopedPty1, 'hello')
     expect(mux.notify).toHaveBeenCalledWith('pty.data', { id: 'pty-1', data: 'hello' })
   })
 
@@ -180,7 +203,7 @@ describe('SshPtyProvider', () => {
     const processes = [{ id: 'pty-1', cwd: '/home', title: 'zsh' }]
     mux.request.mockResolvedValue(processes)
     const result = await provider.listProcesses()
-    expect(result).toEqual(processes)
+    expect(result).toEqual([{ id: scopedPty1, cwd: '/home', title: 'zsh' }])
   })
 
   it('getDefaultShell returns shell path', async () => {
@@ -198,7 +221,7 @@ describe('SshPtyProvider', () => {
       const notifHandler = mux.onNotification.mock.calls[0][0]
       notifHandler('pty.data', { id: 'pty-1', data: 'output' })
 
-      expect(handler).toHaveBeenCalledWith({ id: 'pty-1', data: 'output' })
+      expect(handler).toHaveBeenCalledWith({ id: scopedPty1, data: 'output' })
     })
 
     it('forwards pty.replay notifications to replay listeners', () => {
@@ -208,7 +231,7 @@ describe('SshPtyProvider', () => {
       const notifHandler = mux.onNotification.mock.calls[0][0]
       notifHandler('pty.replay', { id: 'pty-1', data: 'buffered output' })
 
-      expect(handler).toHaveBeenCalledWith({ id: 'pty-1', data: 'buffered output' })
+      expect(handler).toHaveBeenCalledWith({ id: scopedPty1, data: 'buffered output' })
     })
 
     it('forwards pty.exit notifications to exit listeners', () => {
@@ -218,7 +241,7 @@ describe('SshPtyProvider', () => {
       const notifHandler = mux.onNotification.mock.calls[0][0]
       notifHandler('pty.exit', { id: 'pty-1', code: 0 })
 
-      expect(handler).toHaveBeenCalledWith({ id: 'pty-1', code: 0 })
+      expect(handler).toHaveBeenCalledWith({ id: scopedPty1, code: 0 })
     })
 
     it('allows unsubscribing from events', () => {
@@ -243,6 +266,21 @@ describe('SshPtyProvider', () => {
 
       expect(handler1).toHaveBeenCalled()
       expect(handler2).toHaveBeenCalled()
+    })
+
+    it('namespaces identical relay ids from different SSH connections', () => {
+      const otherMux = createMockMux()
+      const otherProvider = new SshPtyProvider('conn-2', otherMux as never)
+      const firstHandler = vi.fn()
+      const secondHandler = vi.fn()
+      provider.onData(firstHandler)
+      otherProvider.onData(secondHandler)
+
+      mux.onNotification.mock.calls[0][0]('pty.data', { id: 'pty-1', data: 'first' })
+      otherMux.onNotification.mock.calls[0][0]('pty.data', { id: 'pty-1', data: 'second' })
+
+      expect(firstHandler).toHaveBeenCalledWith({ id: scopedPty1, data: 'first' })
+      expect(secondHandler).toHaveBeenCalledWith({ id: 'ssh:conn-2@@pty-1', data: 'second' })
     })
   })
 })

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -144,12 +144,12 @@ describe('SshPtyProvider', () => {
   })
 
   it('resize sends pty.resize notification', () => {
-    provider.resize('pty-1', 120, 40)
+    provider.resize(scopedPty1, 120, 40)
     expect(mux.notify).toHaveBeenCalledWith('pty.resize', { id: 'pty-1', cols: 120, rows: 40 })
   })
 
   it('shutdown sends pty.shutdown request', async () => {
-    await provider.shutdown('pty-1', { immediate: true })
+    await provider.shutdown(scopedPty1, { immediate: true })
     expect(mux.request).toHaveBeenCalledWith('pty.shutdown', {
       id: 'pty-1',
       immediate: true,
@@ -158,7 +158,7 @@ describe('SshPtyProvider', () => {
   })
 
   it('shutdown forwards keepHistory: true over the relay', async () => {
-    await provider.shutdown('pty-1', { immediate: true, keepHistory: true })
+    await provider.shutdown(scopedPty1, { immediate: true, keepHistory: true })
     expect(mux.request).toHaveBeenCalledWith('pty.shutdown', {
       id: 'pty-1',
       immediate: true,
@@ -167,36 +167,54 @@ describe('SshPtyProvider', () => {
   })
 
   it('sendSignal sends pty.sendSignal request', async () => {
-    await provider.sendSignal('pty-1', 'SIGINT')
+    await provider.sendSignal(scopedPty1, 'SIGINT')
     expect(mux.request).toHaveBeenCalledWith('pty.sendSignal', { id: 'pty-1', signal: 'SIGINT' })
   })
 
   it('getCwd sends pty.getCwd request', async () => {
     mux.request.mockResolvedValue('/home/user/project')
-    const cwd = await provider.getCwd('pty-1')
+    const cwd = await provider.getCwd(scopedPty1)
     expect(cwd).toBe('/home/user/project')
+    expect(mux.request).toHaveBeenCalledWith('pty.getCwd', { id: 'pty-1' })
   })
 
   it('clearBuffer sends pty.clearBuffer request', async () => {
-    await provider.clearBuffer('pty-1')
+    await provider.clearBuffer(scopedPty1)
     expect(mux.request).toHaveBeenCalledWith('pty.clearBuffer', { id: 'pty-1' })
   })
 
   it('acknowledgeDataEvent sends pty.ackData notification', () => {
-    provider.acknowledgeDataEvent('pty-1', 1024)
+    provider.acknowledgeDataEvent(scopedPty1, 1024)
     expect(mux.notify).toHaveBeenCalledWith('pty.ackData', { id: 'pty-1', charCount: 1024 })
   })
 
   it('hasChildProcesses sends request and returns result', async () => {
     mux.request.mockResolvedValue(true)
-    const result = await provider.hasChildProcesses('pty-1')
+    const result = await provider.hasChildProcesses(scopedPty1)
     expect(result).toBe(true)
+    expect(mux.request).toHaveBeenCalledWith('pty.hasChildProcesses', { id: 'pty-1' })
   })
 
   it('getForegroundProcess returns process name', async () => {
     mux.request.mockResolvedValue('node')
-    const result = await provider.getForegroundProcess('pty-1')
+    const result = await provider.getForegroundProcess(scopedPty1)
     expect(result).toBe('node')
+    expect(mux.request).toHaveBeenCalledWith('pty.getForegroundProcess', { id: 'pty-1' })
+  })
+
+  it('serializes scoped app ids using raw relay ids', async () => {
+    mux.request.mockResolvedValue('serialized')
+
+    const result = await provider.serialize([scopedPty1])
+
+    expect(result).toBe('serialized')
+    expect(mux.request).toHaveBeenCalledWith('pty.serialize', { ids: ['pty-1'] })
+  })
+
+  it('rejects scoped ids owned by another SSH connection', async () => {
+    await expect(provider.shutdown('ssh:conn-2@@pty-1', { immediate: true })).rejects.toThrow(
+      'belongs to SSH connection "conn-2"'
+    )
   })
 
   it('listProcesses returns process list', async () => {

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -1,5 +1,6 @@
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from './types'
+import { toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
 
 type DataCallback = (payload: { id: string; data: string }) => void
 type ReplayCallback = (payload: { id: string; data: string }) => void
@@ -37,19 +38,19 @@ export class SshPtyProvider implements IPtyProvider {
       switch (method) {
         case 'pty.data':
           for (const cb of this.dataListeners) {
-            cb({ id: params.id as string, data: params.data as string })
+            cb({ id: this.toAppPtyId(params.id as string), data: params.data as string })
           }
           break
 
         case 'pty.replay':
           for (const cb of this.replayListeners) {
-            cb({ id: params.id as string, data: params.data as string })
+            cb({ id: this.toAppPtyId(params.id as string), data: params.data as string })
           }
           break
 
         case 'pty.exit':
           for (const cb of this.exitListeners) {
-            cb({ id: params.id as string, code: params.code as number })
+            cb({ id: this.toAppPtyId(params.id as string), code: params.code as number })
           }
           break
       }
@@ -70,17 +71,26 @@ export class SshPtyProvider implements IPtyProvider {
     return this.connectionId
   }
 
+  private toRelayPtyId(id: string): string {
+    return toRelaySshPtyId(this.connectionId, id)
+  }
+
+  private toAppPtyId(id: string): string {
+    return toAppSshPtyId(this.connectionId, id)
+  }
+
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
     // Why: when sessionId is present, the caller is requesting reattach to an
     // existing relay PTY (persisted across app restart). pty.attach replays
     // the buffered output the relay kept alive during the grace window.
     if (opts.sessionId) {
+      const relaySessionId = this.toRelayPtyId(opts.sessionId)
       console.warn(
         `[ssh-pty] spawn() called with sessionId=${opts.sessionId}, attempting pty.attach`
       )
       try {
         const attachResult = (await this.mux.request('pty.attach', {
-          id: opts.sessionId,
+          id: relaySessionId,
           cols: opts.cols,
           rows: opts.rows,
           suppressReplayNotification: true
@@ -89,7 +99,7 @@ export class SshPtyProvider implements IPtyProvider {
           `[ssh-pty] pty.attach succeeded for ${opts.sessionId}, replay=${!!attachResult.replay}`
         )
         return {
-          id: opts.sessionId,
+          id: this.toAppPtyId(relaySessionId),
           isReattach: true,
           ...(attachResult.replay ? { replay: attachResult.replay } : {})
         }
@@ -99,7 +109,7 @@ export class SshPtyProvider implements IPtyProvider {
         // binding before replacing the dead relay PTY in the same pane.
         console.warn(`[ssh-pty] pty.attach FAILED for ${opts.sessionId}:`, err)
         if (isSshPtyNotFoundError(err)) {
-          throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${opts.sessionId}`)
+          throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}`)
         }
         throw err
       }
@@ -113,64 +123,67 @@ export class SshPtyProvider implements IPtyProvider {
     })
     return {
       ...(result as PtySpawnResult),
+      id: this.toAppPtyId((result as PtySpawnResult).id),
       ...(opts.sessionId ? { sessionExpired: true } : {})
     }
   }
 
   async attach(id: string): Promise<void> {
-    await this.mux.request('pty.attach', { id })
+    await this.mux.request('pty.attach', { id: this.toRelayPtyId(id) })
   }
 
   write(id: string, data: string): void {
-    this.mux.notify('pty.data', { id, data })
+    this.mux.notify('pty.data', { id: this.toRelayPtyId(id), data })
   }
 
   resize(id: string, cols: number, rows: number): void {
-    this.mux.notify('pty.resize', { id, cols, rows })
+    this.mux.notify('pty.resize', { id: this.toRelayPtyId(id), cols, rows })
   }
 
   async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
     await this.mux.request('pty.shutdown', {
-      id,
+      id: this.toRelayPtyId(id),
       immediate: opts.immediate ?? false,
       keepHistory: opts.keepHistory ?? false
     })
   }
 
   async sendSignal(id: string, signal: string): Promise<void> {
-    await this.mux.request('pty.sendSignal', { id, signal })
+    await this.mux.request('pty.sendSignal', { id: this.toRelayPtyId(id), signal })
   }
 
   async getCwd(id: string): Promise<string> {
-    const result = await this.mux.request('pty.getCwd', { id })
+    const result = await this.mux.request('pty.getCwd', { id: this.toRelayPtyId(id) })
     return result as string
   }
 
   async getInitialCwd(id: string): Promise<string> {
-    const result = await this.mux.request('pty.getInitialCwd', { id })
+    const result = await this.mux.request('pty.getInitialCwd', { id: this.toRelayPtyId(id) })
     return result as string
   }
 
   async clearBuffer(id: string): Promise<void> {
-    await this.mux.request('pty.clearBuffer', { id })
+    await this.mux.request('pty.clearBuffer', { id: this.toRelayPtyId(id) })
   }
 
   acknowledgeDataEvent(id: string, charCount: number): void {
-    this.mux.notify('pty.ackData', { id, charCount })
+    this.mux.notify('pty.ackData', { id: this.toRelayPtyId(id), charCount })
   }
 
   async hasChildProcesses(id: string): Promise<boolean> {
-    const result = await this.mux.request('pty.hasChildProcesses', { id })
+    const result = await this.mux.request('pty.hasChildProcesses', { id: this.toRelayPtyId(id) })
     return result as boolean
   }
 
   async getForegroundProcess(id: string): Promise<string | null> {
-    const result = await this.mux.request('pty.getForegroundProcess', { id })
+    const result = await this.mux.request('pty.getForegroundProcess', { id: this.toRelayPtyId(id) })
     return result as string | null
   }
 
   async serialize(ids: string[]): Promise<string> {
-    const result = await this.mux.request('pty.serialize', { ids })
+    const result = await this.mux.request('pty.serialize', {
+      ids: ids.map((id) => this.toRelayPtyId(id))
+    })
     return result as string
   }
 
@@ -180,7 +193,10 @@ export class SshPtyProvider implements IPtyProvider {
 
   async listProcesses(): Promise<{ id: string; cwd: string; title: string }[]> {
     const result = await this.mux.request('pty.listProcesses')
-    return result as { id: string; cwd: string; title: string }[]
+    return (result as { id: string; cwd: string; title: string }[]).map((session) => ({
+      ...session,
+      id: this.toAppPtyId(session.id)
+    }))
   }
 
   async getDefaultShell(): Promise<string> {

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -45,6 +45,8 @@ export type PtySpawnOptions = {
 }
 
 export type PtySpawnResult = {
+  /** App-facing PTY id. Remote providers must return globally routable ids,
+   *  not relay-local handles, because renderer/runtime IPC routes by this key. */
   id: string
   /** OS-level pid of the shell process, when available at spawn time.
    *  Why: the memory collector needs this to walk each PTY's process

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../../shared/agent-hook-relay'
 import { agentHookServer, _internals as agentHookInternals } from '../agent-hooks/server'
 import { getSshPtyProvider } from '../ipc/pty'
+import { toAppSshPtyId } from '../providers/ssh-pty-id'
 
 vi.mock('./ssh-relay-deploy', () => ({
   deployAndLaunchRelay: vi.fn()
@@ -230,7 +231,7 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
       }
     })
 
-    expect(spawn.id).toBe('remote-pty-1')
+    expect(spawn.id).toBe(toAppSshPtyId('conn-fake', 'remote-pty-1'))
     expect(relay.ptySpawnRequests).toHaveLength(1)
     expect(relay.ptySpawnRequests[0]).toMatchObject({
       cwd: '/home/orca/project',

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -290,14 +290,14 @@ describe('SshRelaySession', () => {
       attach: mockAttach,
       dispose: vi.fn()
     } as unknown as ReturnType<typeof getSshPtyProvider>)
-    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['ssh:target-1@@pty-1'])
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
 
     await session.establish(mockConn)
 
     expect(mockAttach).toHaveBeenCalledWith('pty-1')
-    expect(setPtyOwnership).toHaveBeenCalledWith('pty-1', 'target-1')
+    expect(setPtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-1', 'target-1')
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-1', 'attached')
   })
 
@@ -321,7 +321,7 @@ describe('SshRelaySession', () => {
 
     expect(mockAttach).toHaveBeenCalledWith('pty-live')
     expect(mockAttach).not.toHaveBeenCalledWith('pty-expired')
-    expect(setPtyOwnership).toHaveBeenCalledWith('pty-live', 'target-1')
+    expect(setPtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-live', 'target-1')
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-live', 'attached')
   })
 
@@ -411,10 +411,10 @@ describe('SshRelaySession', () => {
 
     expect(mockAttach).toHaveBeenCalledWith('pty-stale')
     expect(mockAttach).toHaveBeenCalledWith('pty-live')
-    expect(clearProviderPtyState).toHaveBeenCalledWith('pty-stale')
-    expect(deletePtyOwnership).toHaveBeenCalledWith('pty-stale')
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:target-1@@pty-stale')
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-stale')
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
-      id: 'pty-stale',
+      id: 'ssh:target-1@@pty-stale',
       code: -1
     })
   })

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -14,6 +14,7 @@ import { isRelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import type { RelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
 import { SshPtyProvider, isSshPtyNotFoundError } from '../providers/ssh-pty-provider'
+import { toAppSshPtyId, toRelaySshPtyId } from '../providers/ssh-pty-id'
 import { SshFilesystemProvider } from '../providers/ssh-filesystem-provider'
 import { SshGitProvider } from '../providers/ssh-git-provider'
 import { agentHookServer } from '../agent-hooks/server'
@@ -754,9 +755,10 @@ export class SshRelaySession {
       }
     })
     ptyProvider.onExit((payload) => {
+      const relayPtyId = toRelaySshPtyId(this.targetId, payload.id)
       clearProviderPtyState(payload.id)
       deletePtyOwnership(payload.id)
-      this.store.markSshRemotePtyLease(this.targetId, payload.id, 'terminated')
+      this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'terminated')
       this.runtime?.onPtyExit(payload.id, payload.code)
       const win = getWin()
       if (win && !win.isDestroyed()) {
@@ -772,7 +774,14 @@ export class SshRelaySession {
       .map((lease) => lease.ptyId)
     // Why: after app restart, ptyOwnership is empty but durable SSH leases
     // still describe remote PTYs that survived in the relay grace window.
-    const ptyIds = Array.from(new Set([...getPtyIdsForConnection(this.targetId), ...leasedPtyIds]))
+    const ptyIds = Array.from(
+      new Set([
+        ...getPtyIdsForConnection(this.targetId).map((ptyId) =>
+          toRelaySshPtyId(this.targetId, ptyId)
+        ),
+        ...leasedPtyIds
+      ])
+    )
     const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
     if (!ptyProvider) {
       return
@@ -786,7 +795,8 @@ export class SshRelaySession {
         if (!shouldContinue()) {
           return
         }
-        setPtyOwnership(ptyId, this.targetId)
+        const appPtyId = toAppSshPtyId(this.targetId, ptyId)
+        setPtyOwnership(appPtyId, this.targetId)
         this.store.markSshRemotePtyLease(this.targetId, ptyId, 'attached')
       } catch (err) {
         if (!isSshPtyNotFoundError(err)) {
@@ -797,15 +807,16 @@ export class SshRelaySession {
             err instanceof Error ? err.message : String(err)
           }`
         )
-        clearProviderPtyState(ptyId)
-        deletePtyOwnership(ptyId)
+        const appPtyId = toAppSshPtyId(this.targetId, ptyId)
+        clearProviderPtyState(appPtyId)
+        deletePtyOwnership(appPtyId)
         this.store.markSshRemotePtyLease(this.targetId, ptyId, 'expired')
         // Why: if the new relay cannot reattach this id, the remote backing
         // process is gone. Tell the renderer so it clears stale pane bindings
         // instead of keeping a cursor-only terminal.
         const win = this.getMainWindow()
         if (win && !win.isDestroyed()) {
-          win.webContents.send('pty:exit', { id: ptyId, code: -1 })
+          win.webContents.send('pty:exit', { id: appPtyId, code: -1 })
         }
       }
     }


### PR DESCRIPTION
﻿## Summary
- Fixes #2528 by making app-facing SSH PTY IDs include the SSH target/connection id, while keeping the relay protocol's target-local PTY IDs unchanged.
- Normalizes scoped app IDs back to raw relay IDs when updating persisted SSH remote PTY leases.
- Updates restore, provider dispatch, persistence, and SSH IPC tests to cover duplicate relay PTY IDs across SSH targets.

## Root Cause
Each SSH relay allocates PTY IDs locally, so two different SSH targets can both produce `pty-1`. The main process and renderer used those raw IDs as app-global keys for ownership and terminal routing, so after restoring multiple SSH workspaces the last reattached `pty-1` could steal ownership and route IO to the wrong target.

## Reproduction
Reproduced on Windows using two saved SSH workspace targets pointed at a local WSL sshd. Before the fix, after app restart both restored terminal tabs accepted commands, but the second tab routed to the first repo:

```text
BEFORE_A ... /repo-a
BEFORE_B ... /repo-b
AFTER_A  ... /repo-a
AFTER_B  ... /repo-a
```

## Verification
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-pty-provider.test.ts src/main/providers/provider-dispatch.test.ts src/main/ssh/ssh-relay-session.test.ts src/main/ipc/ssh.test.ts src/main/persistence.test.ts -t "SshPtyProvider|PTY provider dispatch|SshRelaySession|SSH IPC handlers|SSH remote PTY leases|scoped SSH workspace bindings|clears workspace bindings before removing SSH remote PTY leases"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts -t "SSH"`
- `pnpm run build:relay`
- `npx electron-vite build --mode e2e`
- Local Windows + WSL SSH restore verification passed after fix:

```text
__ISSUE_2528_BEFORE_A_1779394483761__:/home/jinwoo/orca-issue-2528/repo-a
__ISSUE_2528_BEFORE_B_1779394485625__:/home/jinwoo/orca-issue-2528/repo-b
__ISSUE_2528_AFTER_A_1779394521324__:/home/jinwoo/orca-issue-2528/repo-a
__ISSUE_2528_AFTER_B_1779394521586__:/home/jinwoo/orca-issue-2528/repo-b
```

Fixes #2528
