### PR TITLE
Polish Cmd+J supporting-text chip and port label

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -989,8 +989,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                             </span>
                           </div>
                           {entry.match.supportingText && (
-                            <div className="mt-1.5 flex min-w-0 items-start gap-2 text-[12px] leading-5 text-muted-foreground/88">
-                              <span className="shrink-0 rounded-full border border-border/45 bg-background/45 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/75">
+                            <div className="mt-1.5 flex min-w-0 items-center gap-2 text-[12px] leading-5 text-muted-foreground/88">
+                              <span className="inline-flex h-[18px] shrink-0 items-center rounded border border-border bg-foreground/[0.04] px-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                                 {entry.match.supportingText.label}
                               </span>
                               <span className="truncate">

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -212,8 +212,8 @@ describe('worktree-palette-search', () => {
     expect(results[0].matchedField).toBe('port')
     expect(results[0].supportingText).toEqual({
       label: 'Port',
-      text: ':3000 vite',
-      matchRange: { start: 1, end: 5 }
+      text: '3000 · vite',
+      matchRange: { start: 0, end: 4 }
     })
   })
 })

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -188,15 +188,15 @@ export function searchWorktrees(
       const portText = String(port.port)
       const portIndex = portText.indexOf(numericQuery)
       if (portIndex !== -1) {
-        const label = `:${portText}${port.processName ? ` ${port.processName}` : ''}`
+        const label = port.processName ? `${portText} · ${port.processName}` : portText
         results.push(
           makeResult(worktree.id, 'port', {
             supportingText: {
               label: 'Port',
               text: label,
               matchRange: {
-                start: 1 + portIndex,
-                end: 1 + portIndex + numericQuery.length
+                start: portIndex,
+                end: portIndex + numericQuery.length
               }
             }
           })


### PR DESCRIPTION
## Summary
- The supporting-text chip (Port / Comment / PR / Issue) in the worktree jump palette rendered as a faintly-bordered, stretched capsule that sat above the text baseline and was nearly invisible on unselected rows.
- Switched the chip to a fixed-height rounded shape with a stronger border, vertically centered the row, and dropped the orphan colon from the port label so the line reads `PORT 62082 · node` instead of `PORT :62082 node`.

## Changes
- `WorktreeJumpPalette.tsx` — supporting-text row is now `items-center`; chip is `inline-flex h-[18px] items-center rounded border-border bg-foreground/[0.04] px-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground`. No more rounded-full capsule, faint border, or vertical misalignment.
- `worktree-palette-search.ts` — port label is now `\`${portText} · ${processName}\`` (or just `portText`); leading colon dropped, match-range offsets re-anchored.
- `worktree-palette-search.test.ts` — updated expectation to match the new format.

## Test plan
- [x] `vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-palette-search.test.ts` passes (8/8)
- [x] `npm run typecheck:web` clean
- [ ] Manual: Cmd+J, type a port number, confirm `PORT 62082 · node` renders with chip aligned to the text baseline on both selected and unselected rows
- [ ] Manual: Cmd+J, type a comment / PR / issue substring, confirm chip alignment + visibility looks right across all four label types

Made with [Orca](https://github.com/stablyai/orca) 🐋
