### PR TITLE
Fix terminal read review edge cases

### DIFF
--- a/skills/orca-cli/SKILL.md
+++ b/skills/orca-cli/SKILL.md
@@ -197,7 +197,7 @@ Use selectors to discover terminals, then use the returned handle for repeated l
 orca terminal list --worktree id:<worktreeId> --json
 orca terminal show --terminal <handle> --json
 orca terminal read --terminal <handle> --json
-orca terminal read --terminal <handle> --cursor <nextCursor> --limit 1000 --json
+orca terminal read --terminal <handle> --cursor <oldestCursor> --limit 1000 --json
 orca terminal send --terminal <handle> --text "continue" --enter --json
 orca terminal wait --terminal <handle> --for exit --timeout-ms 5000 --json
 orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 30000 --json
@@ -216,7 +216,7 @@ orca terminal read --json
 
 Why: `--terminal` is optional for most commands. When omitted, Orca auto-resolves to the active terminal in the current worktree (same as browser commands target the active tab). Use explicit `--terminal <handle>` when operating on a specific pane.
 
-Why: long terminal transcripts should be read with cursors. Save `nextCursor` from a JSON read, then call `terminal read --cursor <nextCursor> --limit <n>` to page forward. Cursor reads default to the retained transcript size; `--limit` can request a smaller page. If `limited` is true, keep reading with the returned `nextCursor`. If `truncated` is true, older output has already fallen out of the retained buffer; use `oldestCursor` as the earliest available cursor.
+Why: long terminal transcripts should be read with cursors. After a limited tail preview without an input cursor, page retained transcript from `oldestCursor`; in that case `nextCursor` already equals `latestCursor` and would skip omitted output. After a cursor read, if `limited` remains true and `nextCursor !== latestCursor`, continue with the returned `nextCursor`. Cursor reads default to the retained transcript size; `--limit` can request a smaller page. If `truncated` is true, older output has already fallen out of the retained buffer; use `oldestCursor` as the earliest available cursor.
 
 Why: terminal handles are runtime-scoped and may go stale after reloads. If Orca returns `terminal_handle_stale`, reacquire a fresh handle with `terminal list`.
 
@@ -241,7 +241,7 @@ Why: `--direction horizontal` splits the pane **left and right** (new pane appea
 - Orca only injects `ORCA_WORKTREE_PATH`-style variables for some setup-hook flows, so they are not a general detection contract for agents.
 - Use `terminal list` to reacquire handles after Orca reloads.
 - Use `terminal read` before `terminal send` unless the next input is obvious.
-- For long agent responses, use `terminal read --json` with `nextCursor`, `--cursor`, and `--limit` instead of relying on the default human preview. Continue paging while `limited` is true; treat `truncated` as a signal that the requested cursor was older than the retained output.
+- For long agent responses, use `terminal read --json` with `oldestCursor`, `nextCursor`, `--cursor`, and `--limit` instead of relying on the default human preview. After a limited tail preview, start at `oldestCursor`; after a cursor read, continue with `nextCursor` only while `limited` is true and `nextCursor !== latestCursor`. Treat `truncated` as a signal that the requested cursor was older than the retained output.
 - Use `terminal wait --terminal <handle> --for exit` only when the task actually depends on process completion.
 - Use `terminal wait --terminal <handle> --for tui-idle` to wait for an agent CLI (Claude Code, Gemini, Codex, etc.) to finish its current task. This detects the working→idle OSC title transition. Always pass `--timeout-ms` as a safety net — unsupported CLIs will hang until timeout.
 - Use `terminal create` to spin up new terminal tabs programmatically, optionally with a `--command` for startup (e.g. `--command "claude"` to launch Claude Code) and `--title` for labeling. In local Orca sessions, `--command "codex"` is routed through Orca's visible terminal path automatically so Codex does not start as a headless/background PTY. After creating a `--command` terminal, use `terminal wait --for tui-idle` to wait for the agent to boot before dispatching.
@@ -625,7 +625,7 @@ When `orca tab create` opens a new tab, it is automatically set as the active ta
 - `terminal wait` supports `--for exit` (wait for process exit) and `--for tui-idle` (wait for a recognized agent CLI like Claude Code, Gemini, or Codex to finish its current task, detected via OSC title transitions). `tui-idle` defaults to a 5-minute timeout if `--timeout-ms` is not specified. Real coding tasks routinely take 15-60 minutes — always pass `--timeout-ms` explicitly.
 - Orca is the source of truth for worktree/terminal state; do not duplicate that state with manual assumptions.
 - The public `orca` command is the interface users experience. Agents should validate and use that surface, not repo-local implementation entrypoints.
-- The 120-line terminal output buffer (`terminal read`) is for status monitoring, not result extraction.
+- The default bounded `terminal read` preview is for status monitoring. For retained transcript extraction, use `terminal read --json` with `oldestCursor`/`nextCursor`, `--cursor`, and `--limit`.
 
 ## References
 

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -91,7 +91,7 @@ describe('formatWorktreeList', () => {
 })
 
 describe('formatTerminalRead', () => {
-  it('prints cursor metadata and limit warnings when the runtime returns them', () => {
+  it('warns limited cursor reads to continue with the next cursor', () => {
     const output = formatTerminalRead({
       terminal: {
         handle: 'term_1',
@@ -109,7 +109,52 @@ describe('formatTerminalRead', () => {
     expect(output).toContain('cursor: 50')
     expect(output).toContain('oldest cursor: 0')
     expect(output).toContain('latest cursor: 150')
-    expect(output).toContain('warning: output limited; read again with the returned cursor')
+    expect(output).toContain('warning: output limited; continue with --cursor 50')
+  })
+
+  it('warns limited tail previews to page retained output from the oldest cursor', () => {
+    const output = formatTerminalRead({
+      terminal: {
+        handle: 'term_1',
+        status: 'running',
+        tail: ['line 100'],
+        truncated: false,
+        limited: true,
+        oldestCursor: '0',
+        nextCursor: '150',
+        latestCursor: '150',
+        returnedLineCount: 1
+      }
+    })
+
+    expect(output).toContain('cursor: 150')
+    expect(output).toContain('oldest cursor: 0')
+    expect(output).toContain('latest cursor: 150')
+    expect(output).toContain(
+      'warning: output limited; page retained output with --cursor 0 --limit <count>'
+    )
+  })
+
+  it('uses a generic limited warning when only partial output is retained', () => {
+    const output = formatTerminalRead({
+      terminal: {
+        handle: 'term_1',
+        status: 'running',
+        tail: [],
+        truncated: false,
+        limited: true,
+        oldestCursor: '150',
+        nextCursor: '150',
+        latestCursor: '150',
+        returnedLineCount: 0
+      }
+    })
+
+    expect(output).toContain('cursor: 150')
+    expect(output).toContain('oldest cursor: 150')
+    expect(output).toContain('latest cursor: 150')
+    expect(output).toContain('warning: output limited')
+    expect(output).not.toContain('page retained output')
   })
 
   it('keeps older runtime read responses readable', () => {

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -178,6 +178,7 @@ export function formatTerminalRead(result: { terminal: RuntimeTerminalRead }): s
     typeof terminal.oldestCursor === 'string' ? [`oldest cursor: ${terminal.oldestCursor}`] : []
   const latestCursor =
     typeof terminal.latestCursor === 'string' ? [`latest cursor: ${terminal.latestCursor}`] : []
+  const limitedWarning = formatTerminalReadLimitedWarning(terminal)
   const header = [
     `handle: ${terminal.handle}`,
     `status: ${terminal.status}`,
@@ -185,9 +186,31 @@ export function formatTerminalRead(result: { terminal: RuntimeTerminalRead }): s
     ...oldestCursor,
     ...latestCursor,
     ...(terminal.truncated ? ['warning: older output is no longer retained'] : []),
-    ...(terminal.limited ? ['warning: output limited; read again with the returned cursor'] : [])
+    ...(limitedWarning ? [limitedWarning] : [])
   ]
   return [...header, '', ...terminal.tail].join('\n')
+}
+
+function formatTerminalReadLimitedWarning(terminal: RuntimeTerminalRead): string | null {
+  if (!terminal.limited) {
+    return null
+  }
+  if (
+    typeof terminal.nextCursor === 'string' &&
+    typeof terminal.latestCursor === 'string' &&
+    terminal.nextCursor !== terminal.latestCursor
+  ) {
+    return `warning: output limited; continue with --cursor ${terminal.nextCursor}`
+  }
+  if (
+    typeof terminal.oldestCursor === 'string' &&
+    typeof terminal.latestCursor === 'string' &&
+    terminal.oldestCursor !== terminal.latestCursor
+  ) {
+    // A tail preview's next cursor is already latest, so oldestCursor is the retained history entry point.
+    return `warning: output limited; page retained output with --cursor ${terminal.oldestCursor} --limit <count>`
+  }
+  return 'warning: output limited'
 }
 
 export function formatTerminalSend(result: { send: RuntimeTerminalSend }): string {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1985,6 +1985,172 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('drops retained PTY transcript memory when a background terminal exits', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+    runtime.onPtyData(
+      'pty-bg',
+      `${Array.from({ length: 20 }, (_, i) => `line-${i}`).join('\n')}`,
+      100
+    )
+    await expect(runtime.readTerminal(handle)).resolves.toMatchObject({
+      status: 'running',
+      tail: expect.arrayContaining(['line-0'])
+    })
+
+    runtime.onPtyExit('pty-bg', 0)
+
+    const pty = (
+      runtime as unknown as {
+        ptysById: Map<
+          string,
+          {
+            tailBuffer: string[]
+            tailPartialLine: string
+            tailLinesTotal: number
+            tailTruncated: boolean
+          }
+        >
+      }
+    ).ptysById.get('pty-bg')
+    expect(pty).toMatchObject({
+      tailBuffer: [],
+      tailPartialLine: '',
+      tailLinesTotal: 0,
+      tailTruncated: false
+    })
+    await expect(runtime.readTerminal(handle)).resolves.toMatchObject({
+      status: 'exited',
+      tail: []
+    })
+  })
+
+  it('keeps retained PTY transcript memory when controller refresh omits a record', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => []
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty('daemon-pty-1', TEST_WORKTREE_ID)
+    runtime.onPtyData('daemon-pty-1', 'still live\npartial', 100)
+
+    await runtime.listTerminals()
+
+    const pty = (
+      runtime as unknown as {
+        ptysById: Map<
+          string,
+          {
+            connected: boolean
+            tailBuffer: string[]
+            tailPartialLine: string
+            tailLinesTotal: number
+          }
+        >
+      }
+    ).ptysById.get('daemon-pty-1')
+    expect(pty).toMatchObject({
+      connected: false,
+      tailBuffer: ['still live'],
+      tailPartialLine: 'partial',
+      tailLinesTotal: 1
+    })
+  })
+
+  it('keeps retained PTY transcript memory when controller refresh fails', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => {
+        throw new Error('controller unavailable')
+      }
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.registerPty('daemon-pty-1', TEST_WORKTREE_ID)
+    runtime.onPtyData('daemon-pty-1', 'still live\npartial', 100)
+
+    await runtime.listTerminals()
+
+    const pty = (
+      runtime as unknown as {
+        ptysById: Map<
+          string,
+          {
+            connected: boolean
+            tailBuffer: string[]
+            tailPartialLine: string
+            tailLinesTotal: number
+          }
+        >
+      }
+    ).ptysById.get('daemon-pty-1')
+    expect(pty).toMatchObject({
+      connected: true,
+      tailBuffer: ['still live'],
+      tailPartialLine: 'partial',
+      tailLinesTotal: 1
+    })
+  })
+
+  it('keeps retained PTY transcript memory when controller refresh times out', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null,
+        listProcesses: () => new Promise(() => {})
+      })
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      runtime.registerPty('daemon-pty-1', TEST_WORKTREE_ID)
+      runtime.onPtyData('daemon-pty-1', 'still live\npartial', 100)
+
+      const terminals = runtime.listTerminals()
+      await vi.advanceTimersByTimeAsync(3_000)
+      await terminals
+
+      const pty = (
+        runtime as unknown as {
+          ptysById: Map<
+            string,
+            {
+              connected: boolean
+              tailBuffer: string[]
+              tailPartialLine: string
+              tailLinesTotal: number
+            }
+          >
+        }
+      ).ptysById.get('daemon-pty-1')
+      expect(pty).toMatchObject({
+        connected: true,
+        tailBuffer: ['still live'],
+        tailPartialLine: 'partial',
+        tailLinesTotal: 1
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle for adopted background PTY handles from the renderer title', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
@@ -2737,6 +2903,11 @@ describe('OrcaRuntimeService', () => {
     expect(firstPage.limited).toBe(true)
     expect(firstPage.truncated).toBe(false)
 
+    const fractionalPage = await runtime.readTerminal(terminal.handle, { cursor: 0, limit: 0.5 })
+    expect(fractionalPage.tail).toEqual(['line-0'])
+    expect(fractionalPage.nextCursor).toBe('1')
+    expect(fractionalPage.limited).toBe(true)
+
     const secondPage = await runtime.readTerminal(terminal.handle, {
       cursor: Number(firstPage.nextCursor),
       limit: 200
@@ -2768,6 +2939,44 @@ describe('OrcaRuntimeService', () => {
     expect(futureCursorRead.tail).toEqual([])
     expect(futureCursorRead.nextCursor).toBe('2250')
     expect(futureCursorRead.limited).toBe(false)
+  })
+
+  it('bounds preview reads by characters for long partial terminal output', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Claude',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const longPartialLine = `${'x'.repeat(40_000)}tail-marker`
+    runtime.onPtyData('pty-1', longPartialLine, 100)
+
+    const preview = await runtime.readTerminal(terminal.handle)
+    expect(preview.tail).toHaveLength(1)
+    expect(preview.tail[0]).toHaveLength(32 * 1024)
+    expect(preview.tail[0].endsWith('tail-marker')).toBe(true)
+    expect(preview.limited).toBe(true)
+    expect(preview.truncated).toBe(true)
+    expect(preview.nextCursor).toBe('0')
   })
 
   it('delivers pending orchestration messages to an already-idle agent', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2989,6 +2989,7 @@ export class OrcaRuntimeService {
       pty.connected = false
       pty.lastExitCode = exitCode
       this.resolvePtyExitWaiters(pty, ptyId)
+      this.pruneDisconnectedPtyTranscript(pty)
     }
 
     for (const leaf of this.leaves.values()) {
@@ -8436,11 +8437,15 @@ export class OrcaRuntimeService {
     if (!this.ptyController?.listProcesses) {
       return
     }
-    const sessions = await withTimeout(
+    const sessionsResult = await withTimeoutResult(
       this.ptyController.listProcesses(),
-      PTY_CONTROLLER_LIST_TIMEOUT_MS,
-      []
+      PTY_CONTROLLER_LIST_TIMEOUT_MS
     )
+    if (!sessionsResult.ok) {
+      // Why: a transient controller failure is not evidence that retained PTYs exited.
+      return
+    }
+    const sessions = sessionsResult.value
     const livePtyIds = new Set(sessions.map((session) => session.id))
     for (const session of sessions) {
       const worktreeId =
@@ -8455,6 +8460,18 @@ export class OrcaRuntimeService {
         pty.connected = false
       }
     }
+  }
+
+  private pruneDisconnectedPtyTranscript(pty: RuntimePtyWorktreeRecord): void {
+    if (pty.connected) {
+      return
+    }
+    // Why: disconnected PTY records can stay addressable for status/exit reads,
+    // but their retained transcripts must not accumulate after the process dies.
+    pty.tailBuffer = []
+    pty.tailPartialLine = ''
+    pty.tailTruncated = false
+    pty.tailLinesTotal = 0
   }
 
   private leafExistsForPty(ptyId: string): boolean {
@@ -10098,6 +10115,7 @@ const MAX_TAIL_LINES = 2000
 const MAX_TAIL_CHARS = 256 * 1024
 const DEFAULT_TERMINAL_READ_LIMIT = 120
 const MAX_TERMINAL_READ_LIMIT = 2000
+const MAX_TERMINAL_PREVIEW_CHARS = 32 * 1024
 const MAX_PREVIEW_LINES = 6
 const MAX_PREVIEW_CHARS = 300
 const WORKTREE_STATUS_PRIORITY: Record<RuntimeWorktreeStatus, number> = {
@@ -10137,6 +10155,24 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Pr
     promise.then(
       (value) => resolve(value),
       () => resolve(fallback)
+    )
+  }).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  })
+}
+
+function withTimeoutResult<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<{ ok: true; value: T } | { ok: false }> {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  return new Promise<{ ok: true; value: T } | { ok: false }>((resolve) => {
+    timeout = setTimeout(() => resolve({ ok: false }), timeoutMs)
+    promise.then(
+      (value) => resolve({ ok: true, value }),
+      () => resolve({ ok: false })
     )
   }).finally(() => {
     if (timeout) {
@@ -10219,7 +10255,32 @@ function terminalReadLimit(limit: number | undefined, defaultLimit: number): num
   if (typeof limit !== 'number' || !Number.isFinite(limit) || limit <= 0) {
     return defaultLimit
   }
-  return Math.min(Math.floor(limit), MAX_TERMINAL_READ_LIMIT)
+  return Math.min(Math.max(1, Math.floor(limit)), MAX_TERMINAL_READ_LIMIT)
+}
+
+function trimTerminalPreviewToCharacterBudget(
+  lines: string[],
+  characterBudget: number
+): { tail: string[]; limited: boolean; omittedLineCount: number; slicedFirstLine: boolean } {
+  let totalCharacters = lines.reduce((sum, line) => sum + line.length, 0)
+  if (totalCharacters <= characterBudget) {
+    return { tail: lines, limited: false, omittedLineCount: 0, slicedFirstLine: false }
+  }
+
+  const tail = [...lines]
+  let omittedLineCount = 0
+  while (tail.length > 0 && totalCharacters - tail[0].length >= characterBudget) {
+    totalCharacters -= tail.shift()!.length
+    omittedLineCount += 1
+  }
+
+  let slicedFirstLine = false
+  if (tail.length > 0 && totalCharacters > characterBudget) {
+    tail[0] = tail[0].slice(totalCharacters - characterBudget)
+    slicedFirstLine = true
+  }
+
+  return { tail, limited: true, omittedLineCount, slicedFirstLine }
 }
 
 function readTerminalTail(args: {
@@ -10276,17 +10337,30 @@ function readTerminalTail(args: {
   // through cursor reads plus --limit.
   const limit = terminalReadLimit(args.limit, DEFAULT_TERMINAL_READ_LIMIT)
   const allLines = buildTailLines(args.completedLines, args.partialLine)
-  const tail = allLines.slice(-limit)
+  const lineBoundedTail = allLines.slice(-limit)
+  const charBoundedTail = trimTerminalPreviewToCharacterBudget(
+    lineBoundedTail,
+    MAX_TERMINAL_PREVIEW_CHARS
+  )
+  const lineBoundedStartIndex = Math.max(0, allLines.length - lineBoundedTail.length)
+  const charBoundedStartIndex = lineBoundedStartIndex + charBoundedTail.omittedLineCount
+  const hasPageableOmittedCompletedLines =
+    Math.min(args.completedLineCount, charBoundedStartIndex) > 0 ||
+    (charBoundedTail.slicedFirstLine && charBoundedStartIndex < args.completedLineCount)
+  // Why: a long unterminated partial line can exceed the preview character
+  // budget, but cursor reads only page completed lines, so the trimmed bytes
+  // cannot be recovered by asking for nextCursor again.
+  const truncatedByNonPageablePartial = charBoundedTail.limited && !hasPageableOmittedCompletedLines
   return {
     handle: args.handle,
     status: args.status,
-    tail,
-    truncated: args.bufferTruncated,
-    limited: tail.length < allLines.length,
+    tail: charBoundedTail.tail,
+    truncated: args.bufferTruncated || truncatedByNonPageablePartial,
+    limited: lineBoundedTail.length < allLines.length || charBoundedTail.limited,
     oldestCursor: String(oldestCursor),
     nextCursor: String(latestCursor),
     latestCursor: String(latestCursor),
-    returnedLineCount: tail.length
+    returnedLineCount: charBoundedTail.tail.length
   }
 }
 

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -167,6 +167,12 @@ function appendPendingMultiplexOutput(stream: TerminalMultiplexStream, data: str
   }
 }
 
+function isTerminalReadPayloadIncomplete(read: { truncated: boolean; limited?: boolean }): boolean {
+  // Why: uncursored terminal reads are bounded previews; limited previews are
+  // incomplete stream payloads even when the retained buffer was not truncated.
+  return read.truncated || read.limited === true
+}
+
 function sendSnapshotFrames(
   sendFrame: (opcode: TerminalStreamOpcode, payload?: Uint8Array<ArrayBufferLike>) => void,
   options: SnapshotFrameOptions
@@ -914,7 +920,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             rows: serialized?.rows ?? size?.rows,
             displayMode,
             seq,
-            truncated: read.truncated
+            truncated: serialized ? read.truncated : isTerminalReadPayloadIncomplete(read)
           })
           sendSnapshotFrames((opcode, payload) => sendFrame(request.streamId, opcode, payload), {
             kind: 'scrollback',
@@ -922,7 +928,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             rows: serialized?.rows ?? size?.rows ?? 24,
             displayMode,
             seq,
-            truncated: read.truncated,
+            truncated: serialized ? read.truncated : isTerminalReadPayloadIncomplete(read),
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
             data: serialized?.data ?? (read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : '')
           })
@@ -1011,7 +1017,12 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
 
       if (!leaf?.ptyId) {
         const read = await runtime.readTerminal(params.terminal)
-        emit({ type: 'subscribed', streamId: null, lines: read.tail, truncated: read.truncated })
+        emit({
+          type: 'subscribed',
+          streamId: null,
+          lines: read.tail,
+          truncated: isTerminalReadPayloadIncomplete(read)
+        })
         emit({ type: 'end' })
         return
       }
@@ -1031,7 +1042,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         emit({
           type: 'scrollback',
           lines: read.tail,
-          truncated: read.truncated,
+          truncated: isTerminalReadPayloadIncomplete(read),
           serialized: serialized?.data,
           cols: serialized?.cols ?? size?.cols,
           rows: serialized?.rows ?? size?.rows,
@@ -1218,7 +1229,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           type: 'subscribed',
           streamId,
           lines: read.tail,
-          truncated: read.truncated,
+          truncated: isTerminalReadPayloadIncomplete(read),
           cols: serialized?.cols ?? size?.cols,
           rows: serialized?.rows ?? size?.rows,
           displayMode,
@@ -1230,7 +1241,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           rows: serialized?.rows ?? size?.rows ?? 24,
           displayMode,
           seq,
-          truncated: read.truncated,
+          truncated: serialized ? read.truncated : isTerminalReadPayloadIncomplete(read),
           truncatedByByteBudget: serialized?.truncatedByByteBudget,
           data: serialized?.data ?? ''
         })

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -192,6 +192,102 @@ describe('terminal multiplex RPC', () => {
     }
   })
 
+  it('marks multiplex fallback snapshots truncated when the uncursored read is limited', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const handlers = new Map<
+      number,
+      (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+    >()
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi
+        .fn()
+        .mockResolvedValue({ tail: ['line 120'], truncated: false, limited: true }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue(null),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 120, rows: 40 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+      getTerminalFitOverride: vi.fn().mockReturnValue(null),
+      getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        const cleanup = cleanups.get(id)
+        cleanups.delete(id)
+        cleanup?.()
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true })
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.multiplex', {}),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-multiplex-limited',
+        sendBinary: (bytes) => binaryFrames.push(bytes),
+        registerBinaryStreamHandler: (streamId, handler) => {
+          handlers.set(streamId, handler)
+          return () => handlers.delete(streamId)
+        }
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    handlers.get(0)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Subscribe,
+          streamId: 0,
+          seq: 1,
+          payload: encodeTerminalStreamJson({
+            streamId: 11,
+            terminal: 'terminal-1',
+            client: { id: 'desktop-1', type: 'desktop' }
+          })
+        })
+      )!
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    const subscribed = messages
+      .map((msg) => JSON.parse(msg).result)
+      .find((result) => result?.type === 'subscribed')
+    expect(subscribed).toMatchObject({
+      type: 'subscribed',
+      streamId: 11,
+      truncated: true
+    })
+
+    const decodedFrames = binaryFrames.map((frame) => decodeTerminalStreamFrame(frame))
+    const snapshotStart = decodedFrames.find(
+      (frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart && frame.streamId === 11
+    )
+    expect(snapshotStart && decodeTerminalStreamJson(snapshotStart.payload)).toMatchObject({
+      truncated: true
+    })
+    const snapshotData = decodedFrames
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotChunk)
+      .map((frame) => (frame ? decodeTerminalStreamText(frame.payload) : ''))
+      .join('')
+    expect(snapshotData).toBe('line 120\r\n')
+
+    runtime.cleanupSubscription('terminal-multiplex:conn-multiplex-limited')
+    await dispatchPromise
+  })
+
   it('drops desktop multiplex input while a mobile client owns the terminal floor', async () => {
     const messages: string[] = []
     const handlers = new Map<

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
 import {
   TerminalStreamOpcode,
   decodeTerminalStreamFrame,
+  decodeTerminalStreamJson,
   decodeTerminalStreamText
 } from '../../../shared/terminal-stream-protocol'
 
@@ -22,6 +23,208 @@ function makeRequest(method: string, params?: unknown): RpcRequest {
 }
 
 describe('terminal subscribe buffering', () => {
+  it('marks scrollback-only subscribed previews truncated when the uncursored read is limited', async () => {
+    const messages: string[] = []
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: null }),
+      readTerminal: vi
+        .fn()
+        .mockResolvedValue({ tail: ['line 120'], truncated: false, limited: true })
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    await dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', { terminal: 'terminal-1' }),
+      (msg) => messages.push(msg)
+    )
+
+    expect(messages.map((msg) => JSON.parse(msg).result)).toEqual([
+      {
+        type: 'subscribed',
+        streamId: null,
+        lines: ['line 120'],
+        truncated: true
+      },
+      { type: 'end' }
+    ])
+  })
+
+  it('marks legacy scrollback previews truncated when the uncursored read is limited', async () => {
+    const messages: string[] = []
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi
+        .fn()
+        .mockResolvedValue({ tail: ['line 120'], truncated: false, limited: true }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue(null),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        cleanups.get(id)?.()
+        cleanups.delete(id)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', {
+        terminal: 'terminal-1',
+        client: { id: 'desktop-1', type: 'desktop' }
+      }),
+      (msg) => messages.push(msg)
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'scrollback')).toBe(true)
+    )
+    const scrollback = messages
+      .map((msg) => JSON.parse(msg).result)
+      .find((result) => result?.type === 'scrollback')
+    expect(scrollback).toMatchObject({
+      type: 'scrollback',
+      lines: ['line 120'],
+      truncated: true
+    })
+
+    runtime.cleanupSubscription('terminal-1:desktop-1')
+    await dispatchPromise
+  })
+
+  it('marks binary subscribed previews truncated when the uncursored read is limited', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi
+        .fn()
+        .mockResolvedValue({ tail: ['line 120'], truncated: false, limited: true }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue(null),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        cleanups.get(id)?.()
+        cleanups.delete(id)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateMobileViewport: vi.fn().mockResolvedValue(false)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', {
+        terminal: 'terminal-1',
+        client: { id: 'desktop-1', type: 'desktop' },
+        capabilities: { terminalBinaryStream: 1 }
+      }),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-binary-limited',
+        sendBinary: (bytes) => binaryFrames.push(bytes)
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    const subscribed = messages
+      .map((msg) => JSON.parse(msg).result)
+      .find((result) => result?.type === 'subscribed')
+    expect(subscribed).toMatchObject({
+      type: 'subscribed',
+      lines: ['line 120'],
+      truncated: true
+    })
+    const snapshotStart = binaryFrames
+      .map((frame) => decodeTerminalStreamFrame(frame))
+      .find((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart)
+    expect(snapshotStart && decodeTerminalStreamJson(snapshotStart.payload)).toMatchObject({
+      truncated: true
+    })
+
+    runtime.cleanupSubscription('terminal-1:desktop-1')
+    await dispatchPromise
+  })
+
+  it('does not mark binary snapshot frames truncated from a limited read when serialized data is available', async () => {
+    const messages: string[] = []
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const cleanups = new Map<string, () => void>()
+    const runtime = stubRuntime({
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      readTerminal: vi
+        .fn()
+        .mockResolvedValue({ tail: ['line 120'], truncated: false, limited: true }),
+      serializeTerminalBuffer: vi.fn().mockResolvedValue({
+        data: 'serialized snapshot\r\n',
+        cols: 100,
+        rows: 30
+      }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        cleanups.get(id)?.()
+        cleanups.delete(id)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+      sendTerminal: vi.fn().mockResolvedValue({ accepted: true }),
+      updateMobileViewport: vi.fn().mockResolvedValue(false)
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', {
+        terminal: 'terminal-1',
+        client: { id: 'desktop-1', type: 'desktop' },
+        capabilities: { terminalBinaryStream: 1 }
+      }),
+      (msg) => messages.push(msg),
+      {
+        connectionId: 'conn-binary-serialized-limited',
+        sendBinary: (bytes) => binaryFrames.push(bytes)
+      }
+    )
+
+    await vi.waitFor(() =>
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(true)
+    )
+    const snapshotStart = binaryFrames
+      .map((frame) => decodeTerminalStreamFrame(frame))
+      .find((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart)
+    expect(snapshotStart && decodeTerminalStreamJson(snapshotStart.payload)).toMatchObject({
+      cols: 100,
+      rows: 30,
+      truncated: false,
+      truncatedByByteBudget: false
+    })
+
+    runtime.cleanupSubscription('terminal-1:desktop-1')
+    await dispatchPromise
+  })
+
   it('bounds legacy binary output queued while the initial snapshot is serializing', async () => {
     vi.useFakeTimers()
     try {


### PR DESCRIPTION
## Summary
- fix auto-review findings from #2553 around terminal read pagination and incomplete-output signaling
- keep disconnected PTY transcript pruning to explicit exit while preserving SSH/partial-refresh safety
- add preview character budgeting, safer limited-output CLI warnings, and streaming/multiplex truncation metadata coverage
- update the repo-shipped orca-cli skill guidance for cursor pagination

## Validation
- `pnpm test src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts src/cli/index.test.ts src/cli/format.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build:cli`

## Auto-review-fix
- Ran 4 review iterations with parallel review/validation/fix agents.
- Exit reason: max iterations reached after final fixes; all final fixes have focused tests/typecheck/lint/build passing.

Made with [Orca](https://github.com/stablyai/orca) 🐋
