### PR TITLE
Improve terminal attention notifications

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -120,6 +120,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,
     experimentalActivity: true,
+    experimentalTerminalAttention: false,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -107,6 +107,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,
     experimentalActivity: true,
+    experimentalTerminalAttention: false,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -652,7 +652,7 @@ describe('registerNotificationHandlers', () => {
     )
   })
 
-  it('uses rich formatter output for mobile notifications before desktop guards', () => {
+  it('uses rich formatter output for mobile notifications before the native support guard', () => {
     notificationIsSupportedMock.mockReturnValue(false)
     const dispatchMobileNotification = vi.fn()
     registerNotificationHandlers(
@@ -692,6 +692,145 @@ describe('registerNotificationHandlers', () => {
       worktreeId: 'repo::wt1'
     })
     expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch mobile notifications when notifications are disabled', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: false,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'disabled'
+    })
+
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch mobile notifications when the source is disabled', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: false,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'source-disabled'
+    })
+
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch mobile notifications for focused active-worktree notifications', () => {
+    getAllWindowsMock.mockReturnValue([
+      {
+        isDestroyed: () => false,
+        isFocused: () => true
+      } as never
+    ])
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: true
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(
+      handler(
+        {},
+        { source: 'agent-task-complete', worktreeId: 'repo::wt1', isActiveWorktree: true }
+      )
+    ).toEqual({
+      delivered: false,
+      reason: 'suppressed-focus'
+    })
+
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch mobile notifications for cooldown-suppressed bursts', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: true
+    })
+    expect(handler({}, { source: 'terminal-bell', worktreeId: 'repo::wt1' })).toEqual({
+      delivered: false,
+      reason: 'cooldown'
+    })
+
+    expect(dispatchMobileNotification).toHaveBeenCalledTimes(1)
+    expect(dispatchMobileNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete', worktreeId: 'repo::wt1' })
+    )
+  })
+
+  it('does not forward explicit desktop test notifications to mobile clients', () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'test' })).toEqual({ delivered: true })
+
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
   })
 
   it('silences the native notification when a custom sound is configured', () => {

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -157,25 +157,6 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       _event,
       args: NotificationDispatchRequest
     ): NotificationDispatchResult | Promise<NotificationDispatchResult> => {
-      // Why: mobile push is independent of desktop notification guards.
-      // The user's phone should receive the notification even when the desktop
-      // window is focused (suppressWhenFocused), Electron notifications aren't
-      // supported, or the desktop is in cooldown. The mobile client decides
-      // independently whether to show based on its own app state.
-      if (runtime) {
-        const opts = buildNotificationOptions(args)
-        runtime.dispatchMobileNotification({
-          source: args.source,
-          title: opts.title,
-          body: opts.body,
-          worktreeId: args.worktreeId
-        })
-      }
-
-      if (!Notification.isSupported()) {
-        return { delivered: false, reason: 'not-supported' }
-      }
-
       const settings = store.getSettings().notifications
       if (!settings.enabled) {
         return { delivered: false, reason: 'disabled' }
@@ -223,6 +204,23 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       }
 
       const notificationOptions = buildNotificationOptions(args)
+
+      // Why: paired mobile clients should follow the same user-facing
+      // notification gates as desktop delivery, while still working on hosts
+      // where Electron native notifications are unavailable.
+      if (runtime && args.source !== 'test') {
+        runtime.dispatchMobileNotification({
+          source: args.source,
+          title: notificationOptions.title,
+          body: notificationOptions.body,
+          worktreeId: args.worktreeId
+        })
+      }
+
+      if (!Notification.isSupported()) {
+        return { delivered: false, reason: 'not-supported' }
+      }
+
       if (getEffectiveNotificationSoundId(settings) !== 'system') {
         notificationOptions.silent = true
       } else if (process.platform === 'darwin') {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -247,6 +247,7 @@ describe('Store', () => {
     expect(settings.openInApplications).toEqual([])
     expect(settings.experimentalActivity).toBe(false)
     expect(settings.experimentalActivityDefaultedOffForAllUsers).toBe(true)
+    expect(settings.experimentalTerminalAttention).toBe(false)
     expect(settings.floatingTerminalEnabled).toBe(true)
     expect(settings.floatingTerminalDefaultedForAllUsers).toBe(true)
     expect(settings.notifications.customSoundPath).toBeNull()
@@ -750,6 +751,7 @@ describe('Store', () => {
     expect(store.getSettings().visibleTaskProviders).toEqual(['github', 'gitlab', 'linear'])
     expect(store.getSettings().experimentalActivity).toBe(false)
     expect(store.getSettings().experimentalActivityDefaultedOffForAllUsers).toBe(true)
+    expect(store.getSettings().experimentalTerminalAttention).toBe(false)
     expect(store.getSettings().notifications.customSoundPath).toBeNull()
     // repos should be loaded
     expect(store.getRepos()).toHaveLength(1)

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -155,6 +155,22 @@
   animation: pane-focus-rim-flash 1.5s ease-out forwards;
 }
 
+.pane[data-terminal-attention] .xterm-container {
+  box-shadow: none;
+}
+
+.pane[data-terminal-attention] .xterm-container::after {
+  content: '';
+  position: absolute;
+  inset: 0 4px 4px 0;
+  z-index: 5;
+  pointer-events: none;
+  border-radius: 2px;
+  box-shadow:
+    inset 0 0 0 1.5px color-mix(in srgb, var(--terminal-pane-locate) 64%, transparent),
+    inset 0 0 0 3px color-mix(in srgb, var(--terminal-pane-locate) 18%, transparent);
+}
+
 @keyframes pane-focus-rim-flash {
   0% {
     opacity: 1;

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -24,6 +24,9 @@ export function ExperimentalPane({
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const showPet = matchesSettingsSearch(searchQuery, [EXPERIMENTAL_SEARCH_ENTRY.pet])
   const showAgentsView = matchesSettingsSearch(searchQuery, [EXPERIMENTAL_SEARCH_ENTRY.activity])
+  const showTerminalAttention = matchesSettingsSearch(searchQuery, [
+    EXPERIMENTAL_SEARCH_ENTRY.terminalAttention
+  ])
   const showWorktreeSymlinks = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.symlinks
   ])
@@ -101,6 +104,44 @@ export function ExperimentalPane({
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
                   settings.experimentalActivity ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showTerminalAttention ? (
+        <SearchableSetting
+          title="Terminal attention"
+          description="Persistent pane highlight for terminal bell and agent-completion events."
+          keywords={EXPERIMENTAL_SEARCH_ENTRY.terminalAttention.keywords}
+          className="space-y-3 py-2"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>Terminal attention</Label>
+              <p className="text-xs text-muted-foreground">
+                Keeps a pane-level highlight visible after terminal bell or agent-completion events
+                until you interact with that pane. Experimental while we tune the signal.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.experimentalTerminalAttention}
+              onClick={() =>
+                updateSettings({
+                  experimentalTerminalAttention: !settings.experimentalTerminalAttention
+                })
+              }
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                settings.experimentalTerminalAttention ? 'bg-foreground' : 'bg-muted-foreground/30'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+                  settings.experimentalTerminalAttention ? 'translate-x-4' : 'translate-x-0.5'
                 }`}
               />
             </button>

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -32,6 +32,22 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ]
   },
   {
+    title: 'Terminal attention',
+    description: 'Persistent pane highlight for terminal bell and agent-completion events.',
+    keywords: [
+      'experimental',
+      'terminal',
+      'attention',
+      'highlight',
+      'pane',
+      'bell',
+      'notification',
+      'agent',
+      'completion',
+      'unread'
+    ]
+  },
+  {
     title: 'Symlinks on worktrees',
     description:
       'Automatically symlink configured files or folders into newly created worktrees so shared state (envs, caches, installs) stays connected.',
@@ -64,5 +80,6 @@ function findEntry(title: string): SettingsSearchEntry {
 export const EXPERIMENTAL_SEARCH_ENTRY = {
   pet: findEntry('Pet'),
   activity: findEntry('Agents View'),
+  terminalAttention: findEntry('Terminal attention'),
   symlinks: findEntry('Symlinks on worktrees')
 } as const

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -315,8 +315,14 @@ export default function TerminalPane({
   const clearTabPtyId = useAppStore((store) => store.clearTabPtyId)
   const markWorktreeUnread = useAppStore((store) => store.markWorktreeUnread)
   const markTerminalTabUnread = useAppStore((store) => store.markTerminalTabUnread)
+  const markTerminalPaneUnread = useAppStore((store) => store.markTerminalPaneUnread)
   const clearWorktreeUnread = useAppStore((store) => store.clearWorktreeUnread)
   const clearTerminalTabUnread = useAppStore((store) => store.clearTerminalTabUnread)
+  const clearTerminalPaneUnread = useAppStore((store) => store.clearTerminalPaneUnread)
+  const unreadTerminalPanes = useAppStore((store) => store.unreadTerminalPanes)
+  const terminalAttentionEnabled = useAppStore(
+    (store) => store.settings?.experimentalTerminalAttention === true
+  )
   const openSpacePage = useAppStore((store) => store.openSpacePage)
   const refreshWorkspaceSpace = useAppStore((store) => store.refreshWorkspaceSpace)
   const settings = useAppStore((store) => store.settings)
@@ -701,8 +707,10 @@ export default function TerminalPane({
     updateTabPtyId,
     markWorktreeUnread,
     markTerminalTabUnread,
+    markTerminalPaneUnread,
     clearWorktreeUnread,
     clearTerminalTabUnread,
+    clearTerminalPaneUnread,
     dispatchNotification,
     setCacheTimerStartedAt,
     syncPanePtyLayoutBinding,
@@ -904,8 +912,10 @@ export default function TerminalPane({
         updateTabPtyId,
         markWorktreeUnread,
         markTerminalTabUnread,
+        markTerminalPaneUnread,
         clearWorktreeUnread,
         clearTerminalTabUnread,
+        clearTerminalPaneUnread,
         dispatchNotification,
         setCacheTimerStartedAt,
         syncPanePtyLayoutBinding
@@ -921,8 +931,10 @@ export default function TerminalPane({
       dispatchNotification,
       markWorktreeUnread,
       markTerminalTabUnread,
+      markTerminalPaneUnread,
       clearWorktreeUnread,
       clearTerminalTabUnread,
+      clearTerminalPaneUnread,
       onPtyExitRef,
       setCacheTimerStartedAt,
       setRuntimePaneTitle,
@@ -1164,7 +1176,7 @@ export default function TerminalPane({
   }, [isActive, worktreeId, keybindings])
 
   // Why: a click inside the terminal container is a deliberate interaction
-  // with the pane — dismiss the bell indicator for this tab and worktree
+  // with the pane — dismiss the attention indicator for this tab and worktree
   // (ghostty "show until interact" semantics). onData already covers
   // keystrokes; pointerdown covers the mouse path, including right-click
   // and middle-click paste, which also count as engagement with the pane.
@@ -1184,15 +1196,36 @@ export default function TerminalPane({
     if (!container) {
       return
     }
-    const onPointerDown = (): void => {
+    const onPointerDown = (event: PointerEvent): void => {
       clearTerminalTabUnread(tabId)
       clearWorktreeUnread(worktreeId)
+      const paneElement =
+        event.target instanceof Element ? event.target.closest('.pane[data-leaf-id]') : null
+      const leafId = paneElement?.getAttribute('data-leaf-id')
+      if (leafId) {
+        clearTerminalPaneUnread(makePaneKey(tabId, leafId))
+      }
     }
     container.addEventListener('pointerdown', onPointerDown, { capture: true })
     return () => {
       container.removeEventListener('pointerdown', onPointerDown, { capture: true })
     }
-  }, [tabId, worktreeId, clearTerminalTabUnread, clearWorktreeUnread])
+  }, [tabId, worktreeId, clearTerminalTabUnread, clearTerminalPaneUnread, clearWorktreeUnread])
+
+  useLayoutEffect(() => {
+    const manager = managerRef.current
+    if (!manager) {
+      return
+    }
+    for (const pane of manager.getPanes()) {
+      const paneKey = makePaneKey(tabId, pane.leafId)
+      if (terminalAttentionEnabled && unreadTerminalPanes[paneKey]) {
+        pane.container.setAttribute('data-terminal-attention', '')
+      } else {
+        pane.container.removeAttribute('data-terminal-attention')
+      }
+    }
+  }, [tabId, paneCount, terminalAttentionEnabled, unreadTerminalPanes])
 
   // Sync the data-has-title attribute on pane containers when titles change,
   // and reflow terminals so safeFit() sees the correct available height.

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -35,8 +35,10 @@ export type PtyConnectionDeps = {
   updateTabPtyId: (tabId: string, ptyId: string) => void
   markWorktreeUnread: (worktreeId: string) => void
   markTerminalTabUnread: (tabId: string) => void
+  markTerminalPaneUnread: (paneKey: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
   clearTerminalTabUnread: (tabId: string) => void
+  clearTerminalPaneUnread: (paneKey: string) => void
   // Why: the renderer dispatches two notification sources — BEL from the PTY
   // byte stream and agent-task-complete on the working→idle title transition.
   // shared/types.ts keeps a wider NotificationEventSource union because the

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8,6 +8,7 @@ import {
 } from './layout-serialization'
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 
 // Why: the fresh-spawn and reattach paths now chain pre-signal → spawn →
 // register/settle through multiple microtasks. Tests that previously flushed
@@ -31,6 +32,7 @@ type StoreState = {
   activeWorktreeId: string | null
   tabsByWorktree: Record<string, { id: string; ptyId: string | null; title?: string }[]>
   ptyIdsByTabId?: Record<string, string[]>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
   unreadTerminalTabs?: Record<string, true>
   worktreesByRepo: Record<
     string,
@@ -49,6 +51,7 @@ type StoreState = {
   settings: {
     promptCacheTimerEnabled?: boolean
     activeRuntimeEnvironmentId?: string | null
+    experimentalTerminalAttention?: boolean
     notifications?: {
       enabled?: boolean
       agentTaskComplete?: boolean
@@ -73,6 +76,8 @@ type StoreState = {
   setAgentStatus: ReturnType<typeof vi.fn>
   removeAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
+  markTerminalTabUnread: ReturnType<typeof vi.fn>
+  markTerminalPaneUnread: ReturnType<typeof vi.fn>
 }
 
 type ConnectCallbacks = {
@@ -308,8 +313,10 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     updateTabPtyId: vi.fn(),
     markWorktreeUnread: vi.fn(),
     markTerminalTabUnread: vi.fn(),
+    markTerminalPaneUnread: vi.fn(),
     clearWorktreeUnread: vi.fn(),
     clearTerminalTabUnread: vi.fn(),
+    clearTerminalPaneUnread: vi.fn(),
     dispatchNotification: vi.fn(),
     setCacheTimerStartedAt: vi.fn(),
     syncPanePtyLayoutBinding: vi.fn(),
@@ -392,6 +399,14 @@ describe('connectPanePty', () => {
       ptyIdsByTabId: {
         'tab-1': ['tab-pty']
       },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_1 },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_1]: 'tab-pty' }
+        }
+      },
       unreadTerminalTabs: {},
       worktreesByRepo: {
         repo1: [{ id: 'wt-1', repoId: 'repo1', path: '/tmp/wt-1', displayName: 'feat/notis' }]
@@ -399,7 +414,7 @@ describe('connectPanePty', () => {
       repos: [{ id: 'repo1', connectionId: null, displayName: 'orca' }],
       sshConnectionStates: new Map(),
       cacheTimerByKey: {},
-      settings: { promptCacheTimerEnabled: true },
+      settings: { promptCacheTimerEnabled: true, experimentalTerminalAttention: true },
       codexRestartNoticeByPtyId: {},
       deferredSshReconnectTargets: [],
       deferredSshSessionIdsByTabId: {},
@@ -420,7 +435,9 @@ describe('connectPanePty', () => {
         }
       }),
       removeAgentStatus: vi.fn(),
-      dropAgentStatus: vi.fn()
+      dropAgentStatus: vi.fn(),
+      markTerminalTabUnread: vi.fn(),
+      markTerminalPaneUnread: vi.fn()
     } as StoreState
     ;(globalThis as unknown as { window: unknown }).window = {
       api: {
@@ -3257,10 +3274,9 @@ describe('connectPanePty', () => {
 
   // Why: BEL (0x07) is the attention signal. connectPanePty wires an
   // onBell handler that raises the worktree unread dot, the tab-level
-  // bell indicator, and an OS notification. Under the ghostty
-  // show-until-interact model, the unread flags clear when the user
-  // actually interacts with the pane — keystroke via xterm onData or
-  // pointerdown on the container (see TerminalPane.tsx). This test
+  // indicator, the pane marker, and an OS notification. The unread flags
+  // clear when the user actually interacts with the pane — keystroke via
+  // xterm onData or pointerdown on the container (see TerminalPane.tsx). This test
   // locks in the mark wiring; separate tests below cover the clear path.
   it('wires onBell to raise worktree unread, tab unread, and OS notification', async () => {
     const { connectPanePty } = await import('./pty-connection')
@@ -3283,6 +3299,7 @@ describe('connectPanePty', () => {
 
     expect(deps.markWorktreeUnread).toHaveBeenCalledTimes(1)
     expect(deps.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(deps.markTerminalPaneUnread).toHaveBeenCalledWith(makePaneKey('tab-1', LEAF_1))
     expect(deps.dispatchNotification).not.toHaveBeenCalled()
     vi.advanceTimersByTime(250)
     expect(deps.dispatchNotification).toHaveBeenCalledWith(
@@ -3291,6 +3308,33 @@ describe('connectPanePty', () => {
         paneKey: makePaneKey('tab-1', LEAF_1)
       })
     )
+  })
+
+  it('does not raise pane attention on bell when the experimental setting is disabled', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState.settings = {
+      ...mockStoreState.settings,
+      experimentalTerminalAttention: false
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const bellHandler = createdTransportOptions[0]?.onBell as (() => void) | undefined
+    if (!bellHandler) {
+      throw new Error('Expected onBell to be registered')
+    }
+
+    bellHandler()
+
+    expect(deps.markWorktreeUnread).toHaveBeenCalledTimes(1)
+    expect(deps.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(deps.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
   it('lets concurrent agent-complete notifications win over terminal bell notifications', async () => {
@@ -3929,6 +3973,7 @@ describe('connectPanePty', () => {
     ;(onDataHandler as (data: string) => void)('a')
 
     expect(deps.clearTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(deps.clearTerminalPaneUnread).toHaveBeenCalledWith(makePaneKey('tab-1', LEAF_1))
     expect(deps.clearWorktreeUnread).toHaveBeenCalledWith('wt-1')
     expect(transport.sendInput).toHaveBeenCalledWith('a')
   })
@@ -4154,11 +4199,11 @@ describe('connectPanePty', () => {
   })
 
   // Why: the working→idle transition fires an 'agent-task-complete' OS
-  // notification (user-toggleable in Settings). When the user has switched
-  // away, the notification dispatch boundary also raises the workspace unread
-  // bell so the Dock badge and sidebar agree with the system notification.
-  // Double-firing with a concurrent BEL is collapsed by the per-worktree
-  // dedupe in main/ipc/notifications.ts.
+  // notification (user-toggleable in Settings) and raises the same visual
+  // attention marker as BEL so agents that don't emit BEL still leave a
+  // findable terminal highlight. Double-firing with a concurrent BEL is
+  // idempotent in the unread stores and collapsed by the per-worktree dedupe
+  // in main/ipc/notifications.ts.
   //
   // This test deliberately wires the real useNotificationDispatch hook into
   // connectPanePty instead of a vi.fn() stub. A stub would let the producer
@@ -4166,7 +4211,7 @@ describe('connectPanePty', () => {
   // routing through the real hook to window.api.notifications.dispatch means
   // removing the producer breaks the IPC assertion, which is the user-facing
   // contract.
-  it('dispatches agent-task-complete on working→idle and marks a switched-away worktree unread', async () => {
+  it('dispatches agent-task-complete on working→idle and raises tab/worktree unread', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { useNotificationDispatch } = await vi.importActual<typeof UseNotificationDispatchModule>(
       './use-notification-dispatch'
@@ -4220,9 +4265,8 @@ describe('connectPanePty', () => {
     vi.useFakeTimers()
     idleHandler('* Claude done')
 
-    expect(deps.markWorktreeUnread).not.toHaveBeenCalled()
     expect(mockStoreState.markWorktreeUnread).not.toHaveBeenCalled()
-    expect(deps.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockStoreState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(dispatchNotification).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(250)
@@ -4234,6 +4278,8 @@ describe('connectPanePty', () => {
       paneKey
     })
     expect(mockStoreState.markWorktreeUnread).toHaveBeenCalledWith('wt-1')
+    expect(mockStoreState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockStoreState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
     expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'agent-task-complete',

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -705,11 +705,9 @@ export function connectPanePty(
   }
   // ─── Attention signal: BEL ────────────────────────────────────────────
   //
-  // BEL (0x07) is the attention signal. A BEL raises both the tab-level
-  // bell indicator and the worktree-level dot, and fires an OS
-  // notification. The unread flag clears when the user activates the tab
-  // (see activateTab / focusGroup in the terminals slice) — the bell
-  // auto-clears on focus/keystroke.
+  // BEL (0x07) is the attention signal. A BEL raises tab- and worktree-level
+  // indicators, and fires an OS notification. The experimental pane marker
+  // clears when the user interacts with the exact pane.
   //
   // The one case where BEL falsely fires is when a crashed TUI left DEC
   // private mode 1004 (focus event reporting) enabled — pane clicks then
@@ -726,6 +724,9 @@ export function connectPanePty(
     // decision higher up, not a transport-layer guess.
     deps.markWorktreeUnread(deps.worktreeId)
     deps.markTerminalTabUnread(deps.tabId)
+    if (useAppStore.getState().settings?.experimentalTerminalAttention === true) {
+      deps.markTerminalPaneUnread(cacheKey)
+    }
     // Why: agent CLIs often emit BEL in the same completion burst as their
     // working->idle title change. Delay only the OS notification so the richer
     // agent-complete notification can win the main-process worktree cooldown.
@@ -859,21 +860,18 @@ export function connectPanePty(
     }
   })
 
-  // ─── Agent task-complete: OS notification + background workspace unread ─
+  // ─── Agent task-complete: notification-backed attention ───────────────
   //
   // The working→idle title transition drives two independent concerns:
   //   1. The Claude prompt-cache countdown in the sidebar.
   //   2. The "Agent Task Complete" OS notification users toggle in Settings.
   //
-  // We intentionally do NOT raise tab-level unread from here. The shared
-  // notification dispatcher marks switched-away workspaces unread, while BEL
-  // remains the terminal-byte attention source for tab bells and non-agent
-  // long-running tasks. OS notifications are a separate channel: not every
-  // agent CLI reliably emits BEL on completion (Gemini, some Codex flows), and
-  // without this dispatch the Settings toggle would have zero producers.
-  // Double-firing with a concurrent BEL is handled by delaying the BEL OS
-  // notification below; main still keeps a 5 s per-worktree dedupe as the
-  // final guard.
+  // This path raises the same terminal attention marker as BEL through the
+  // shared notification dispatcher. Not every agent CLI reliably emits BEL on
+  // completion (Gemini, some Codex flows), and the highlight needs to remain
+  // findable after the OS banner is gone. Double-firing with a concurrent BEL
+  // is handled by delaying the BEL OS notification below; main still keeps a
+  // 5 s per-worktree dedupe as the final guard.
   const onAgentBecameIdle = (title: string): void => {
     // Why: only start the prompt-cache countdown for Claude agents — other
     // agents have different (or no) prompt-caching semantics and showing a
@@ -1040,10 +1038,10 @@ export function connectPanePty(
       return
     }
     // Why: a real keystroke into the terminal is the unambiguous "user is
-    // here" signal that dismisses the bell (ghostty "show until interact").
-    // Guarded by the replay and codex-stale checks above so synthetic xterm
-    // auto-replies never count as interaction.
+    // here" signal that dismisses attention. Guarded by the replay and
+    // codex-stale checks above so synthetic xterm auto-replies never count.
     deps.clearTerminalTabUnread(deps.tabId)
+    deps.clearTerminalPaneUnread(cacheKey)
     deps.clearWorktreeUnread(deps.worktreeId)
     if (shouldSuppressForegroundCursor) {
       // Why: native Windows ConPTY can leave the old visual cursor painted

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { dispatchTerminalNotification } from './use-notification-dispatch'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 
 type MockState = {
   activeWorktreeId: string | null
   tabsByWorktree: Record<string, { id: string }[]>
   ptyIdsByTabId: Record<string, string[]>
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
   browserTabsByWorktree: Record<string, unknown[]>
   retainedAgentsByPaneKey: Record<string, { worktreeId: string }>
   agentStatusByPaneKey: Record<string, AgentStatusEntry>
@@ -21,11 +23,15 @@ type MockState = {
   >
   repos: { id: string; displayName?: string; connectionId?: string | null }[]
   settings: {
+    experimentalTerminalAttention?: boolean
     notifications?: {
       customSoundPath?: string | null
+      customSoundId?: string | null
     }
   }
   markWorktreeUnread: ReturnType<typeof vi.fn>
+  markTerminalTabUnread: ReturnType<typeof vi.fn>
+  markTerminalPaneUnread: ReturnType<typeof vi.fn>
 }
 
 const playDesktopNotificationSound = vi.hoisted(() => vi.fn())
@@ -56,15 +62,28 @@ function makeAgentStatus(paneKey: string): AgentStatusEntry {
 }
 
 describe('dispatchTerminalNotification', () => {
-  const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+  const liveLeafId = '11111111-1111-4111-8111-111111111111'
+  const staleLeafId = '22222222-2222-4222-8222-222222222222'
+  const paneKey = `tab-1:${liveLeafId}`
+  const stalePaneKey = `tab-1:${staleLeafId}`
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockState = {
       activeWorktreeId: 'wt-secondary',
-      tabsByWorktree: {},
+      tabsByWorktree: {
+        'wt-primary': [{ id: 'tab-1' }]
+      },
       ptyIdsByTabId: {
         'tab-1': ['pty-1']
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: liveLeafId },
+          activeLeafId: liveLeafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [liveLeafId]: 'pty-1' }
+        }
       },
       browserTabsByWorktree: {},
       retainedAgentsByPaneKey: {},
@@ -88,8 +107,10 @@ describe('dispatchTerminalNotification', () => {
         ]
       },
       repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
-      settings: { notifications: { customSoundPath: null } },
-      markWorktreeUnread: vi.fn()
+      settings: { experimentalTerminalAttention: true, notifications: { customSoundPath: null } },
+      markWorktreeUnread: vi.fn(),
+      markTerminalTabUnread: vi.fn(),
+      markTerminalPaneUnread: vi.fn()
     }
     ;(globalThis as unknown as { window: unknown }).window = {
       api: {
@@ -100,7 +121,7 @@ describe('dispatchTerminalNotification', () => {
     }
   })
 
-  it('uses a live pane key when inactive worktree tab membership is not hydrated', () => {
+  it('uses a live pane key when marking inactive worktree attention', () => {
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
@@ -123,9 +144,69 @@ describe('dispatchTerminalNotification', () => {
       })
     )
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
-  it('does not mark the visible worktree unread for agent completion notifications', () => {
+  it('uses a live pane key when inactive worktree tab membership is not hydrated', () => {
+    mockState.tabsByWorktree = {}
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('uses tab liveness when the layout has the leaf but no leaf pty binding yet', () => {
+    mockState.terminalLayoutsByTabId['tab-1'].ptyIdsByLeafId = {}
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        worktreeId: 'wt-primary',
+        paneKey
+      })
+    )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
+    expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('falls back to background-worktree unread when terminal attention is disabled', () => {
+    mockState.settings.experimentalTerminalAttention = false
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('does not mark the visible worktree unread when terminal attention is disabled', () => {
+    mockState.settings.experimentalTerminalAttention = false
     mockState.activeWorktreeId = 'wt-primary'
 
     dispatchTerminalNotification('wt-primary', {
@@ -136,6 +217,40 @@ describe('dispatchTerminalNotification', () => {
 
     expect(window.api.notifications.dispatch).toHaveBeenCalled()
     expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('drops a pane key when its tab is hydrated under another worktree', () => {
+    mockState.tabsByWorktree = {
+      'wt-secondary': [{ id: 'tab-1' }]
+    }
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('does not mark unread for a stale closed pane key when another pty in the tab is live', () => {
+    mockState.agentStatusByPaneKey[stalePaneKey] = makeAgentStatus(stalePaneKey)
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey: stalePaneKey
+    })
+
+    expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
   it('still drops stale notifications when neither worktree nor pane has a live pty', () => {
@@ -148,5 +263,8 @@ describe('dispatchTerminalNotification', () => {
     })
 
     expect(window.api.notifications.dispatch).not.toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -5,6 +5,7 @@ import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalPaneLayoutNode } from '../../../../shared/types'
 
 const AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS = 10_000
 
@@ -42,6 +43,57 @@ function hasLivePtyForNotification(
   // list is between renderer hydration states; the pane-key PTY binding is the
   // live terminal source in that path.
   return hasLivePtyForWorktree(state, worktreeId) || hasLivePtyForPaneKey(state, paneKey)
+}
+
+function layoutContainsLeaf(
+  node: TerminalPaneLayoutNode | null | undefined,
+  leafId: string
+): boolean {
+  if (!node) {
+    return false
+  }
+  if (node.type === 'leaf') {
+    return node.leafId === leafId
+  }
+  return layoutContainsLeaf(node.first, leafId) || layoutContainsLeaf(node.second, leafId)
+}
+
+function isCurrentLivePaneKey(
+  state: ReturnType<typeof useAppStore.getState>,
+  worktreeId: string,
+  paneKey: string
+): boolean {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return false
+  }
+
+  const tabExistsInAnotherWorktree = Object.entries(state.tabsByWorktree).some(
+    ([candidateWorktreeId, tabs]) =>
+      candidateWorktreeId !== worktreeId && tabs.some((tab) => tab.id === parsed.tabId)
+  )
+  if (tabExistsInAnotherWorktree) {
+    return false
+  }
+
+  const livePtyIds = state.ptyIdsByTabId[parsed.tabId] ?? []
+  if (livePtyIds.length === 0) {
+    return false
+  }
+
+  const layout = state.terminalLayoutsByTabId?.[parsed.tabId]
+  if (!layout) {
+    return true
+  }
+
+  if (!layoutContainsLeaf(layout.root, parsed.leafId)) {
+    return false
+  }
+
+  const leafPtyId = layout.ptyIdsByLeafId?.[parsed.leafId]
+  // Why: layout hydration can briefly know the leaf before restoring its PTY
+  // binding; the tab-level live PTY list remains the liveness source then.
+  return leafPtyId === undefined || livePtyIds.includes(leafPtyId)
 }
 
 function getPaneKeyTabId(paneKey: string): string | null {
@@ -158,10 +210,28 @@ export function dispatchTerminalNotification(
     return
   }
 
-  if (event.source === 'agent-task-complete' && state.activeWorktreeId !== worktreeId) {
-    // Why: a task-complete notification for a background workspace must leave
-    // the same durable unread signal that drives the sidebar bell and Dock badge.
-    state.markWorktreeUnread(worktreeId)
+  if (event.source === 'agent-task-complete') {
+    const terminalAttentionEnabled = state.settings?.experimentalTerminalAttention === true
+    let tabId: string | null = null
+    if (event.paneKey) {
+      tabId = getPaneKeyTabId(event.paneKey)
+      // Why: delayed completion hooks from a closed split pane can arrive while
+      // another pane in the tab is still live; stale leaf completions must not
+      // create unread state or OS notifications.
+      if (!tabId || !isCurrentLivePaneKey(state, worktreeId, event.paneKey)) {
+        return
+      }
+    }
+
+    if (terminalAttentionEnabled && tabId && event.paneKey) {
+      state.markWorktreeUnread(worktreeId)
+      state.markTerminalTabUnread(tabId)
+      state.markTerminalPaneUnread(event.paneKey)
+    } else if (state.activeWorktreeId !== worktreeId) {
+      // Why: when pane attention is disabled, agent completion still preserves
+      // the existing background-workspace unread signal for Dock/sidebar state.
+      state.markWorktreeUnread(worktreeId)
+    }
   }
 
   // Why: prefer worktree.repoId over string-parsing the worktreeId. The

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -124,8 +124,10 @@ type UseTerminalPaneLifecycleDeps = {
   updateTabPtyId: (tabId: string, ptyId: string) => void
   markWorktreeUnread: (worktreeId: string) => void
   markTerminalTabUnread: (tabId: string) => void
+  markTerminalPaneUnread: (paneKey: string) => void
   clearWorktreeUnread: (worktreeId: string) => void
   clearTerminalTabUnread: (tabId: string) => void
+  clearTerminalPaneUnread: (paneKey: string) => void
   dispatchNotification: (event: {
     source: 'terminal-bell' | 'agent-task-complete'
     terminalTitle?: string
@@ -269,8 +271,10 @@ export function useTerminalPaneLifecycle({
   updateTabPtyId,
   markWorktreeUnread,
   markTerminalTabUnread,
+  markTerminalPaneUnread,
   clearWorktreeUnread,
   clearTerminalTabUnread,
+  clearTerminalPaneUnread,
   dispatchNotification,
   setCacheTimerStartedAt,
   syncPanePtyLayoutBinding,
@@ -444,8 +448,10 @@ export function useTerminalPaneLifecycle({
       updateTabPtyId,
       markWorktreeUnread,
       markTerminalTabUnread,
+      markTerminalPaneUnread,
       clearWorktreeUnread,
       clearTerminalTabUnread,
+      clearTerminalPaneUnread,
       dispatchNotification,
       setCacheTimerStartedAt,
       syncPanePtyLayoutBinding,
@@ -750,6 +756,18 @@ export function useTerminalPaneLifecycle({
           panePtyBinding.dispose()
           panePtyBindings.delete(paneId)
         }
+        // Why: closing a pane is user-initiated teardown of this row — drop
+        // (not remove) so any retained `done` snapshot for this pane is also
+        // cleared and a same-frame live→gone transition cannot re-snapshot
+        // it via the retention sync. This is pane-keyed state, so it must
+        // clear even if the PTY transport was already removed.
+        const leafId = closedPane?.leafId
+        if (leafId) {
+          const paneKey = makePaneKey(tabId, leafId)
+          useAppStore.getState().setCacheTimerStartedAt(paneKey, null)
+          clearTerminalPaneUnread(paneKey)
+          useAppStore.getState().dropAgentStatus(paneKey)
+        }
         if (transport) {
           const ptyId = suppressIntentionalPaneCloseExit(
             transport,
@@ -761,16 +779,6 @@ export function useTerminalPaneLifecycle({
             // so the last-surviving pane is not mistaken for an exited tab.
             syncPanePtyLayoutBinding(paneId, null)
             clearTabPtyId(tabId, ptyId)
-          }
-          // Why: closing a pane is user-initiated teardown of this row — drop
-          // (not remove) so any retained `done` snapshot for this pane is also
-          // cleared and a same-frame live→gone transition cannot re-snapshot
-          // it via the retention sync.
-          const leafId = closedPane?.leafId
-          if (leafId) {
-            const paneKey = makePaneKey(tabId, leafId)
-            useAppStore.getState().setCacheTimerStartedAt(paneKey, null)
-            useAppStore.getState().dropAgentStatus(paneKey)
           }
           transport.destroy?.()
           paneTransportsRef.current.delete(paneId)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -166,16 +166,16 @@ export type TerminalSlice = {
   /** Live pane titles keyed by tabId then paneId. Unlike the legacy tab title,
    *  this preserves split-pane agent status per pane while TerminalPane is mounted. */
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
-  /** Why: per-tab activity indicators. A tab gets flagged unread when an
-   *  agent in any of its panes transitions working→idle (onAgentBecameIdle
-   *  in pty-connection.ts) while the tab is not currently focused. The flag
-   *  clears when the user activates the tab. This is ephemeral UI state
-   *  only — not persisted across restarts.
-   *
-   *  Note: BEL (0x07) bytes intentionally do NOT flip this flag. See the
-   *  long-form rationale in pty-connection.ts around `onAgentBecameIdle`
-   *  for why BEL is too ambiguous to drive cross-surface attention. */
+  /** Why: per-tab activity indicators. A tab gets flagged unread when terminal
+   *  output requests attention (BEL) or an agent-complete notification is
+   *  dispatched for one of its panes. The flag clears when the user activates
+   *  or interacts with the tab. This is ephemeral UI state only — not
+   *  persisted across restarts. */
   unreadTerminalTabs: Record<string, true>
+  /** Pane-keyed attention marker for split-pane precision. This is narrower
+   *  than unreadTerminalTabs and clears when the user interacts with the exact
+   *  pane that raised attention. */
+  unreadTerminalPanes: Record<string, true>
   suppressedPtyExitIds: Record<string, true>
   pendingCodexPaneRestartIds: Record<string, true>
   codexRestartNoticeByPtyId: Record<
@@ -286,11 +286,13 @@ export type TerminalSlice = {
    *  group within the active worktree. A visible tab is already "seen",
    *  so a flag would never clear naturally. */
   markTerminalTabUnread: (tabId: string) => void
+  markTerminalPaneUnread: (paneKey: string) => void
   /** Clear a tab's unread indicator. Called on user interaction with the
    *  pane (keystroke, click) — matches ghostty's "show until interact"
    *  model where the bell stays visible until the user engages with the
    *  surface that raised it. */
   clearTerminalTabUnread: (tabId: string) => void
+  clearTerminalPaneUnread: (paneKey: string) => void
   setTabCustomTitle: (tabId: string, title: string | null) => void
   setTabColor: (tabId: string, color: string | null) => void
   updateTabPtyId: (tabId: string, ptyId: string) => void
@@ -367,6 +369,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   ptyIdsByTabId: {},
   runtimePaneTitlesByTabId: {},
   unreadTerminalTabs: {},
+  unreadTerminalPanes: {},
   suppressedPtyExitIds: {},
   pendingCodexPaneRestartIds: {},
   codexRestartNoticeByPtyId: {},
@@ -710,6 +713,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
         delete nextUnreadTerminalTabs[tabId]
       }
+      let nextUnreadTerminalPanes = s.unreadTerminalPanes
+      for (const paneKey of Object.keys(s.unreadTerminalPanes)) {
+        if (paneKey.startsWith(`${tabId}:`)) {
+          if (nextUnreadTerminalPanes === s.unreadTerminalPanes) {
+            nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
+          }
+          delete nextUnreadTerminalPanes[paneKey]
+        }
+      }
       const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
       delete nextPendingStartupByTabId[tabId]
       const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
@@ -774,6 +786,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         // of full-state selectors. Mirrors the sibling pattern in tabs.ts.
         ...(nextUnreadTerminalTabs !== s.unreadTerminalTabs
           ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {}),
+        ...(nextUnreadTerminalPanes !== s.unreadTerminalPanes
+          ? { unreadTerminalPanes: nextUnreadTerminalPanes }
           : {}),
         expandedPaneByTabId: nextExpanded,
         canExpandPaneByTabId: nextCanExpand,
@@ -1064,9 +1079,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     if (!ownerTab) {
       return
     }
-    // Why: BEL must fire regardless of focus (ghostty semantics — "show
-    // until interact"). A BEL on the focused tab sets the indicator; real
-    // user interaction with the pane dismisses it. Keystroke/pointerdown
+    // Why: terminal attention must stay visible until interaction ("show
+    // until interact"). A signal on the focused tab still sets the indicator;
+    // real user interaction with the pane dismisses it. Keystroke/pointerdown
     // routes through clearTerminalTabUnread (see pty-connection.ts and
     // TerminalPane.tsx); tab/group activation clears unreadTerminalTabs
     // directly in activateTab/focusGroup as a pre-existing side-effect.
@@ -1078,6 +1093,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     })
   },
 
+  markTerminalPaneUnread: (paneKey) => {
+    set((s) => {
+      if (s.unreadTerminalPanes[paneKey]) {
+        return s
+      }
+      return { unreadTerminalPanes: { ...s.unreadTerminalPanes, [paneKey]: true as const } }
+    })
+  },
+
   clearTerminalTabUnread: (tabId) => {
     set((s) => {
       if (!s.unreadTerminalTabs[tabId]) {
@@ -1086,6 +1110,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const copy = { ...s.unreadTerminalTabs }
       delete copy[tabId]
       return { unreadTerminalTabs: copy }
+    })
+  },
+
+  clearTerminalPaneUnread: (paneKey) => {
+    set((s) => {
+      if (!s.unreadTerminalPanes[paneKey]) {
+        return s
+      }
+      const copy = { ...s.unreadTerminalPanes }
+      delete copy[paneKey]
+      return { unreadTerminalPanes: copy }
     })
   },
 
@@ -1376,6 +1411,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // selectors on unrelated shutdown calls. Mirrors the sibling pattern
       // in tabs.ts.
       let nextUnreadTerminalTabs = s.unreadTerminalTabs
+      let nextUnreadTerminalPanes = s.unreadTerminalPanes
       for (const tab of tabs) {
         if (!keepIdentifiers) {
           delete nextRuntimePaneTitlesByTabId[tab.id]
@@ -1387,6 +1423,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
           }
           delete nextUnreadTerminalTabs[tab.id]
+        }
+        for (const paneKey of Object.keys(nextUnreadTerminalPanes)) {
+          if (paneKey.startsWith(`${tab.id}:`)) {
+            if (nextUnreadTerminalPanes === s.unreadTerminalPanes) {
+              nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
+            }
+            delete nextUnreadTerminalPanes[paneKey]
+          }
         }
         if (!keepIdentifiers) {
           const existingLayout = nextTerminalLayoutsByTabId[tab.id]
@@ -1429,6 +1473,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         // of full-state selectors. Mirrors the sibling pattern in tabs.ts.
         ...(nextUnreadTerminalTabs !== s.unreadTerminalTabs
           ? { unreadTerminalTabs: nextUnreadTerminalTabs }
+          : {}),
+        ...(nextUnreadTerminalPanes !== s.unreadTerminalPanes
+          ? { unreadTerminalPanes: nextUnreadTerminalPanes }
           : {})
       }
     })

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1466,11 +1466,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   },
 
   markWorktreeUnread: (worktreeId) => {
-    // Why: BEL must fire regardless of focus (ghostty semantics — "show
-    // until interact"). Interaction with a pane inside the worktree
-    // dismisses the dot via clearWorktreeUnread. Worktree activation via
-    // setActiveWorktree also clears isUnread as a side-effect; that path
-    // predates this PR and is unaffected here.
+    // Why: terminal attention should remain visible until the user engages
+    // with the worktree. Interaction with a pane inside the worktree dismisses
+    // the dot via clearWorktreeUnread. Worktree activation via setActiveWorktree
+    // also clears isUnread as a side-effect; that path predates this PR and is
+    // unaffected here.
     let shouldPersist = false
     const now = Date.now()
     set((s) => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -273,6 +273,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalPet: false,
     experimentalActivity: false,
     experimentalActivityDefaultedOffForAllUsers: true,
+    experimentalTerminalAttention: false,
     experimentalWorktreeSymlinks: false,
     // Why: local desktop remains the default server until the user explicitly
     // selects a saved runtime environment.

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -237,6 +237,7 @@ export const SETTINGS_CHANGED_WHITELIST = [
   'experimentalMobile',
   'experimentalPet',
   'experimentalActivity',
+  'experimentalTerminalAttention',
   'experimentalWorktreeSymlinks',
   'geminiCliOAuthEnabled'
 ] as const satisfies readonly BooleanGlobalSettingsKey[]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1902,6 +1902,10 @@ export type GlobalSettings = {
   /** One-shot migration guard for defaulting the Agents view off for all
    *  users. Once set, later explicit opt-ins persist normally. */
   experimentalActivityDefaultedOffForAllUsers?: boolean
+  /** Experimental: persistent terminal pane attention ring for terminal bell
+   *  and agent-completion events. Opt-in while the signal/noise balance is
+   *  being tested. */
+  experimentalTerminalAttention: boolean
   /** Experimental: when creating a worktree, automatically symlink a
    *  user-configured set of files/folders from the primary checkout (e.g.
    *  `.env`, `node_modules`) into the new worktree. Opt-in while the


### PR DESCRIPTION
## Summary
- Gate mobile push dispatch behind the same notification settings, focus, cooldown, and explicit-test suppression as desktop notifications.
- Add a default-off Experimental setting for persistent pane-level terminal attention.
- When enabled, terminal bell and valid agent-complete events leave a pane highlight until pane interaction; stale pane completions are ignored before unread state or OS notification dispatch.

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/persistence.test.ts src/main/ipc/notifications.test.ts
- pnpm run typecheck:web
- pnpm run typecheck:node
- git diff --check