### PR TITLE
Quiet expected SSH GitHub task skips

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -25,7 +25,10 @@ import {
   normalizeHostedReviewHeadRef
 } from '../../shared/hosted-review-refs'
 import { parseTaskQuery, type ParsedTaskQuery } from '../../shared/task-query'
-import { sortWorkItemsByUpdatedAt } from '../../shared/work-items'
+import {
+  GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE,
+  sortWorkItemsByUpdatedAt
+} from '../../shared/work-items'
 import { mkdtemp, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -792,7 +795,7 @@ function assertSshRepoHasResolvedGitHubSource(args: {
   }
   // Why: SSH repo paths are remote-only, so gh cannot use cwd to infer repo
   // context. Without a resolved owner/repo, running gh would query local state.
-  throw new Error('GitHub work items require a GitHub remote for SSH repositories')
+  throw new Error(GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE)
 }
 
 async function listRecentWorkItems(

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -8,6 +8,7 @@ import { createHostedReviewSlice } from './hosted-review'
 import type { AppState } from '../types'
 import type { GitHubWorkItem, PRInfo } from '../../../../shared/types'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+import { GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE } from '../../../../shared/work-items'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
@@ -2189,6 +2190,84 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       repoId: 'repo-id',
       number: 7
     })
+  })
+
+  it('quietly skips SSH repos without a resolved GitHub remote in cross-repo fetches', async () => {
+    const store = createTestStore()
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const item = {
+      type: 'pr',
+      number: 7,
+      title: 'Server PR',
+      url: 'https://example.test/7',
+      updatedAt: '2026-05-21T00:00:00Z'
+    } as GitHubWorkItem
+
+    mockApi.gh.listWorkItems
+      .mockRejectedValueOnce(new Error(GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE))
+      .mockResolvedValueOnce({
+        items: [item],
+        sources: { issues: { owner: 'up', repo: 'r' }, prs: { owner: 'up', repo: 'r' } }
+      })
+
+    try {
+      const result = await store.getState().fetchWorkItemsAcrossRepos(
+        [
+          { repoId: 'ssh-repo', path: '/server/ssh-repo' },
+          { repoId: 'github-repo', path: '/server/github-repo' }
+        ],
+        24,
+        100,
+        ''
+      )
+
+      expect(result.failedCount).toBe(0)
+      expect(result.items).toEqual([{ ...item, repoId: 'github-repo' }])
+      expect(consoleWarn).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+    } finally {
+      consoleWarn.mockRestore()
+      consoleError.mockRestore()
+    }
+  })
+
+  it('quietly skips SSH repos without a resolved GitHub remote in next-page fetches', async () => {
+    const store = createTestStore()
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const item = {
+      type: 'issue',
+      number: 8,
+      title: 'Server issue',
+      url: 'https://example.test/8',
+      updatedAt: '2026-05-21T00:00:00Z'
+    } as GitHubWorkItem
+
+    mockApi.gh.listWorkItems
+      .mockRejectedValueOnce(new Error(GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE))
+      .mockResolvedValueOnce({
+        items: [item],
+        sources: { issues: { owner: 'up', repo: 'r' }, prs: { owner: 'up', repo: 'r' } }
+      })
+
+    try {
+      const result = await store.getState().fetchWorkItemsNextPage(
+        [
+          { repoId: 'ssh-repo', path: '/server/ssh-repo' },
+          { repoId: 'github-repo', path: '/server/github-repo' }
+        ],
+        24,
+        100,
+        '',
+        '2026-05-21T00:00:00Z'
+      )
+
+      expect(result.failedCount).toBe(0)
+      expect(result.items).toEqual([{ ...item, repoId: 'github-repo' }])
+      expect(consoleWarn).not.toHaveBeenCalled()
+    } finally {
+      consoleWarn.mockRestore()
+    }
   })
 
   it('routes project table fetches through the active runtime environment', async () => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -27,7 +27,11 @@ import type {
   GitHubProjectTable,
   GitHubProjectViewError
 } from '../../../../shared/github-project-types'
-import { sortWorkItemsByUpdatedAt, PER_REPO_FETCH_LIMIT } from '../../../../shared/work-items'
+import {
+  isGitHubWorkItemsSshRemoteRequiredError,
+  sortWorkItemsByUpdatedAt,
+  PER_REPO_FETCH_LIMIT
+} from '../../../../shared/work-items'
 import { deriveCheckStatusFromChecks, syncPRChecksStatus } from './github-checks'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
 import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
@@ -1561,7 +1565,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       } catch (err) {
         // Why: surface the error to the caller; keep stale cache entry so the
         // UI can continue to render something useful while the user retries.
-        console.error('Failed to fetch GitHub work items:', err)
+        if (!isGitHubWorkItemsSshRemoteRequiredError(err)) {
+          console.error('Failed to fetch GitHub work items:', err)
+        }
         throw err
       } finally {
         releaseWorkItemSlot()
@@ -1590,6 +1596,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           // nothing at all to contribute.
           // Why: must use perRepoLimit (not displayLimit) so the cache key
           // matches what fetchWorkItems wrote.
+          if (isGitHubWorkItemsSshRemoteRequiredError(err)) {
+            return [] as GitHubWorkItem[]
+          }
           const key = workItemsCacheKey(r.repoId, perRepoLimit, query)
           const cached = get().workItemsCache[key]?.data
           if (cached) {
@@ -1634,6 +1643,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           }
           return envelope.items.map((item): GitHubWorkItem => ({ ...item, repoId: r.repoId }))
         } catch (err) {
+          if (isGitHubWorkItemsSshRemoteRequiredError(err)) {
+            return [] as GitHubWorkItem[]
+          }
           console.warn(`[workItems] next page ${r.repoId} failed:`, err)
           failedCount += 1
           return [] as GitHubWorkItem[]

--- a/src/shared/work-items.ts
+++ b/src/shared/work-items.ts
@@ -7,6 +7,25 @@ export const PER_REPO_FETCH_LIMIT = 36
 // fetch limit so changing the display cap doesn't invalidate cache keys.
 export const CROSS_REPO_DISPLAY_LIMIT = 100
 
+export const GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE =
+  'GitHub work items require a GitHub remote for SSH repositories'
+
+export function isGitHubWorkItemsSshRemoteRequiredError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' &&
+          error !== null &&
+          'message' in error &&
+          typeof error.message === 'string'
+        ? error.message
+        : typeof error === 'string'
+          ? error
+          : ''
+
+  return message.includes(GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE)
+}
+
 // Why: generic over the item shape because main-process callers emit items
 // without repoId (stamped by the renderer after IPC), while renderer callers
 // carry the full GitHubWorkItem. Both share only the updatedAt field needed


### PR DESCRIPTION
## Summary
- share the expected SSH-without-GitHub-remote work-item error message between main and renderer
- skip that expected case in desktop cross-repo Tasks fetches without warning or failed-repo count
- cover initial and paginated cross-repo fetches with regression tests

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/github.test.ts
- pnpm typecheck:tsc
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
