### PR TITLE
Enable primary selection paste by default on Linux

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -82,6 +82,16 @@ async function createStore() {
   return new Store()
 }
 
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const originalPlatform = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return await fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  }
+}
+
 function dataFile(): string {
   return join(testState.dir, 'orca-data.json')
 }
@@ -783,6 +793,63 @@ describe('Store', () => {
     const store = await createStore()
     expect(store.getSettings().floatingTerminalEnabled).toBe(false)
     expect(store.getSettings().floatingTerminalDefaultedForAllUsers).toBe(true)
+  })
+
+  it('migrates the legacy Linux primary-selection default to enabled', async () => {
+    await withPlatform('linux', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: { primarySelectionMiddleClickPaste: false },
+        ui: {},
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+
+      const store = await createStore()
+      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(true)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForLinux).toBe(true)
+    })
+  })
+
+  it('preserves a post-migration Linux primary-selection opt-out', async () => {
+    await withPlatform('linux', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: {
+          primarySelectionMiddleClickPaste: false,
+          primarySelectionMiddleClickPasteDefaultedForLinux: true
+        },
+        ui: {},
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+
+      const store = await createStore()
+      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(false)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForLinux).toBe(true)
+    })
+  })
+
+  it('keeps the primary-selection default disabled on non-Linux profiles', async () => {
+    await withPlatform('darwin', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: { primarySelectionMiddleClickPaste: false },
+        ui: {},
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+
+      const store = await createStore()
+      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(false)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForLinux).toBe(false)
+    })
   })
 
   it('seeds trusted floating workspace directories from legacy explicit cwd values', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1370,6 +1370,13 @@ export class Store {
           visibleTaskProviders: parsed.settings?.visibleTaskProviders,
           defaultTaskSource: parsed.settings?.defaultTaskSource
         })
+        const primarySelectionDefaultedForLinux =
+          parsed.settings?.primarySelectionMiddleClickPasteDefaultedForLinux === true
+        const migratePrimarySelectionLinuxDefault =
+          process.platform === 'linux' && !primarySelectionDefaultedForLinux
+        if (migratePrimarySelectionLinuxDefault) {
+          this.loadNeedsSave = true
+        }
         result = {
           ...defaults,
           ...parsed,
@@ -1381,6 +1388,15 @@ export class Store {
             // the old persisted flag forward once so enabled users don't lose it.
             experimentalPet:
               parsed.settings?.experimentalPet ?? readLegacySidekickFlag(parsed) ?? false,
+            // Why: early primary-selection builds saved Linux's old disabled
+            // default. Flip those profiles once so the platform default matches
+            // terminal/editor convention; the guard preserves future opt-outs.
+            primarySelectionMiddleClickPaste: migratePrimarySelectionLinuxDefault
+              ? true
+              : (parsed.settings?.primarySelectionMiddleClickPaste ??
+                defaults.settings.primarySelectionMiddleClickPaste),
+            primarySelectionMiddleClickPasteDefaultedForLinux:
+              primarySelectionDefaultedForLinux || migratePrimarySelectionLinuxDefault,
             experimentalActivity: migratedExperimentalActivity,
             experimentalActivityDefaultedOffForAllUsers: true,
             terminalMacOptionAsAlt: migratedOptionAsAlt,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -159,6 +159,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorMinimapEnabled: false,
     markdownReviewToolsEnabled: true,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),
+    primarySelectionMiddleClickPasteDefaultedForLinux: getDefaultPrimarySelectionMiddleClickPaste(),
     terminalFontSize: 14,
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1528,6 +1528,9 @@ export type GlobalSettings = {
    *  normal system clipboard; Linux enables it by default, other platforms
    *  leave middle-click semantics unchanged unless the user opts in. */
   primarySelectionMiddleClickPaste?: boolean
+  /** One-shot migration guard for turning the Linux default on for profiles
+   *  that persisted the earlier off-by-default value. */
+  primarySelectionMiddleClickPasteDefaultedForLinux?: boolean
   terminalFontSize: number
   terminalFontFamily: string
   terminalFontWeight: number


### PR DESCRIPTION
## Summary
- keep primary-selection middle-click paste default-on for Linux and opt-in elsewhere
- add a one-shot Linux migration for profiles that persisted the earlier disabled default
- cover migration, opt-out preservation, and non-Linux behavior in persistence tests

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/shared/constants.test.ts src/main/persistence.test.ts src/main/ghostty/mapper.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm run typecheck:cli
- pnpm run lint