### PR TITLE
Default primary selection paste on macOS

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -873,6 +873,9 @@ describe('Store', () => {
       const store = await createStore()
       expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(true)
       expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForLinux).toBe(true)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForTerminalDefaults).toBe(
+        true
+      )
     })
   })
 
@@ -894,10 +897,13 @@ describe('Store', () => {
       const store = await createStore()
       expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(false)
       expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForLinux).toBe(true)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForTerminalDefaults).toBe(
+        true
+      )
     })
   })
 
-  it('keeps the primary-selection default disabled on non-Linux profiles', async () => {
+  it('migrates the legacy macOS primary-selection default to enabled', async () => {
     await withPlatform('darwin', async () => {
       writeDataFile({
         schemaVersion: 1,
@@ -910,8 +916,54 @@ describe('Store', () => {
       })
 
       const store = await createStore()
-      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(false)
+      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(true)
       expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForLinux).toBe(false)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForTerminalDefaults).toBe(
+        true
+      )
+    })
+  })
+
+  it('preserves a post-migration macOS primary-selection opt-out', async () => {
+    await withPlatform('darwin', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: {
+          primarySelectionMiddleClickPaste: false,
+          primarySelectionMiddleClickPasteDefaultedForTerminalDefaults: true
+        },
+        ui: {},
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+
+      const store = await createStore()
+      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(false)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForTerminalDefaults).toBe(
+        true
+      )
+    })
+  })
+
+  it('keeps the primary-selection default disabled on Windows profiles', async () => {
+    await withPlatform('win32', async () => {
+      writeDataFile({
+        schemaVersion: 1,
+        repos: [],
+        worktreeMeta: {},
+        settings: { primarySelectionMiddleClickPaste: false },
+        ui: {},
+        githubCache: { pr: {}, issue: {} },
+        workspaceSession: {}
+      })
+
+      const store = await createStore()
+      expect(store.getSettings().primarySelectionMiddleClickPaste).toBe(false)
+      expect(store.getSettings().primarySelectionMiddleClickPasteDefaultedForTerminalDefaults).toBe(
+        false
+      )
     })
   })
 

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1399,9 +1399,18 @@ export class Store {
         })
         const primarySelectionDefaultedForLinux =
           parsed.settings?.primarySelectionMiddleClickPasteDefaultedForLinux === true
-        const migratePrimarySelectionLinuxDefault =
-          process.platform === 'linux' && !primarySelectionDefaultedForLinux
-        if (migratePrimarySelectionLinuxDefault) {
+        const primarySelectionDefaultedForTerminalDefaults =
+          parsed.settings?.primarySelectionMiddleClickPasteDefaultedForTerminalDefaults === true
+        const primarySelectionPlatformDefaultEnabled =
+          defaults.settings.primarySelectionMiddleClickPaste === true
+        const primarySelectionAlreadyDefaultedForPlatform =
+          primarySelectionDefaultedForTerminalDefaults ||
+          (process.platform === 'linux' && primarySelectionDefaultedForLinux)
+        const migratePrimarySelectionPlatformDefault =
+          primarySelectionPlatformDefaultEnabled && !primarySelectionAlreadyDefaultedForPlatform
+        const stampPrimarySelectionTerminalDefaults =
+          primarySelectionPlatformDefaultEnabled && !primarySelectionDefaultedForTerminalDefaults
+        if (migratePrimarySelectionPlatformDefault || stampPrimarySelectionTerminalDefaults) {
           this.loadNeedsSave = true
         }
         result = {
@@ -1415,15 +1424,18 @@ export class Store {
             // the old persisted flag forward once so enabled users don't lose it.
             experimentalPet:
               parsed.settings?.experimentalPet ?? readLegacySidekickFlag(parsed) ?? false,
-            // Why: early primary-selection builds saved Linux's old disabled
-            // default. Flip those profiles once so the platform default matches
-            // terminal/editor convention; the guard preserves future opt-outs.
-            primarySelectionMiddleClickPaste: migratePrimarySelectionLinuxDefault
+            // Why: early primary-selection builds saved the disabled default.
+            // Flip Linux/macOS profiles once so terminal-style defaults match
+            // platform convention; the guards preserve future opt-outs.
+            primarySelectionMiddleClickPaste: migratePrimarySelectionPlatformDefault
               ? true
               : (parsed.settings?.primarySelectionMiddleClickPaste ??
                 defaults.settings.primarySelectionMiddleClickPaste),
             primarySelectionMiddleClickPasteDefaultedForLinux:
-              primarySelectionDefaultedForLinux || migratePrimarySelectionLinuxDefault,
+              primarySelectionDefaultedForLinux ||
+              (process.platform === 'linux' && migratePrimarySelectionPlatformDefault),
+            primarySelectionMiddleClickPasteDefaultedForTerminalDefaults:
+              primarySelectionDefaultedForTerminalDefaults || stampPrimarySelectionTerminalDefaults,
             experimentalActivity: migratedExperimentalActivity,
             experimentalActivityDefaultedOffForAllUsers: true,
             terminalMacOptionAsAlt: migratedOptionAsAlt,

--- a/src/renderer/src/components/settings/InputPane.tsx
+++ b/src/renderer/src/components/settings/InputPane.tsx
@@ -2,13 +2,13 @@ import type { GlobalSettings } from '../../../../shared/types'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
 import type { SettingsSearchEntry } from './settings-search'
-import { isLinuxUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { isDefaultPrimarySelectionMiddleClickPasteUserAgent } from '@/hooks/usePrimarySelectionPaste'
 
 export const INPUT_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Middle-click Paste from Selection',
     description:
-      'On Linux, selected text uses the system selection clipboard. Other platforms use a private buffer when enabled.',
+      'Enabled by default on Linux and macOS. Linux uses the system selection clipboard; other platforms use a private buffer.',
     keywords: [
       'input',
       'editing',
@@ -19,7 +19,8 @@ export const INPUT_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'paste',
       'clipboard',
       'x11',
-      'linux'
+      'linux',
+      'macos'
     ]
   }
 ]
@@ -30,13 +31,15 @@ type InputPaneProps = {
 }
 
 export function InputPane({ settings, updateSettings }: InputPaneProps): React.JSX.Element {
-  const enabled = settings.primarySelectionMiddleClickPaste ?? isLinuxUserAgent()
+  const enabled =
+    settings.primarySelectionMiddleClickPaste ??
+    isDefaultPrimarySelectionMiddleClickPasteUserAgent()
 
   return (
     <section className="space-y-4">
       <SearchableSetting
         title="Middle-click Paste from Selection"
-        description="On Linux, selected text uses the system selection clipboard. Other platforms use a private buffer when enabled."
+        description="Enabled by default on Linux and macOS. Linux uses the system selection clipboard; other platforms use a private buffer."
         keywords={[
           'input',
           'editing',
@@ -47,15 +50,16 @@ export function InputPane({ settings, updateSettings }: InputPaneProps): React.J
           'paste',
           'clipboard',
           'x11',
-          'linux'
+          'linux',
+          'macos'
         ]}
         className="flex items-center justify-between gap-4 px-1 py-2"
       >
         <div className="space-y-0.5">
           <Label>Middle-click Paste from Selection</Label>
           <p className="text-xs text-muted-foreground">
-            On Linux, use the system selection clipboard. On other platforms, use a private buffer
-            when this is enabled.
+            Enabled by default on Linux and macOS. Linux uses the system selection clipboard; other
+            platforms use a private buffer.
           </p>
         </div>
         <button

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.ts
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { isLinuxUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { isLinuxUserAgent, isMacUserAgent } from '@/components/terminal-pane/pane-helpers'
 import {
   readPrimarySelectionText,
   setPrimarySelectionEnabled,
@@ -16,7 +16,13 @@ export function resolvePrimarySelectionMiddleClickPaste(
   setting: boolean | undefined,
   userAgent: string = typeof navigator === 'undefined' ? '' : navigator.userAgent
 ): boolean {
-  return setting ?? isLinuxUserAgent(userAgent)
+  return setting ?? isDefaultPrimarySelectionMiddleClickPasteUserAgent(userAgent)
+}
+
+export function isDefaultPrimarySelectionMiddleClickPasteUserAgent(
+  userAgent: string = typeof navigator === 'undefined' ? '' : navigator.userAgent
+): boolean {
+  return isLinuxUserAgent(userAgent) || isMacUserAgent(userAgent)
 }
 
 function captureCurrentSelection(): void {

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -28,8 +28,11 @@ describe('getDefaultPrimarySelectionMiddleClickPaste', () => {
     expect(getDefaultPrimarySelectionMiddleClickPaste('linux')).toBe(true)
   })
 
-  it('leaves primary selection paste opt-in on macOS and Windows', () => {
-    expect(getDefaultPrimarySelectionMiddleClickPaste('darwin')).toBe(false)
+  it('enables primary selection paste on macOS by default', () => {
+    expect(getDefaultPrimarySelectionMiddleClickPaste('darwin')).toBe(true)
+  })
+
+  it('leaves primary selection paste opt-in on Windows', () => {
     expect(getDefaultPrimarySelectionMiddleClickPaste('win32')).toBe(false)
   })
 })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -72,7 +72,8 @@ function defaultTerminalFontFamily(): string {
 
 export const getDefaultPrimarySelectionMiddleClickPaste = (
   platform = typeof process !== 'undefined' ? process.platform : ''
-): boolean => platform === 'linux'
+): boolean => platform === 'linux' || platform === 'darwin'
+
 /**
  * Why: ProseMirror builds an in-memory tree for the entire document, so large
  * markdown files cause noticeable typing lag in the rich editor. Files above
@@ -161,7 +162,10 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorMinimapEnabled: false,
     markdownReviewToolsEnabled: true,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),
-    primarySelectionMiddleClickPasteDefaultedForLinux: getDefaultPrimarySelectionMiddleClickPaste(),
+    primarySelectionMiddleClickPasteDefaultedForLinux:
+      typeof process !== 'undefined' && process.platform === 'linux',
+    primarySelectionMiddleClickPasteDefaultedForTerminalDefaults:
+      getDefaultPrimarySelectionMiddleClickPaste(),
     terminalFontSize: 14,
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1527,13 +1527,16 @@ export type GlobalSettings = {
   editorMinimapEnabled: boolean
   /** Whether local markdown review note controls and the review panel are shown. */
   markdownReviewToolsEnabled: boolean
-  /** Why: mirrors X11 primary-selection muscle memory without mutating the
-   *  normal system clipboard; Linux enables it by default, other platforms
-   *  leave middle-click semantics unchanged unless the user opts in. */
+  /** Why: mirrors terminal selection-paste muscle memory without mutating the
+   *  normal system clipboard; Linux and macOS enable it by default, Windows
+   *  leaves middle-click semantics unchanged unless the user opts in. */
   primarySelectionMiddleClickPaste?: boolean
   /** One-shot migration guard for turning the Linux default on for profiles
    *  that persisted the earlier off-by-default value. */
   primarySelectionMiddleClickPasteDefaultedForLinux?: boolean
+  /** One-shot migration guard for widening the terminal-style default to
+   *  Linux/macOS while preserving later explicit opt-outs. */
+  primarySelectionMiddleClickPasteDefaultedForTerminalDefaults?: boolean
   terminalFontSize: number
   terminalFontFamily: string
   terminalFontWeight: number


### PR DESCRIPTION
## Summary
- default primary-selection middle-click paste on for macOS as well as Linux
- keep Windows opt-in because the single Orca toggle also enables copy-on-select capture
- add a migration guard for the widened platform default while preserving previous Linux and macOS opt-outs

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/shared/constants.test.ts src/main/persistence.test.ts src/main/ghostty/mapper.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm run typecheck:cli
- pnpm run lint