### PR TITLE
Restore repo folder colors in workspace sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -100,6 +100,7 @@ import {
   setSidebarPointerDragDocumentStyles,
   updateSidebarDragPreviewPosition
 } from './worktree-sidebar-pointer-drag-dom'
+import { resolveRepoGroupHeaderColor } from './repo-header-color'
 import {
   areWorktreeSelectionsEqual,
   getWorktreeSelectionIntent,
@@ -1729,6 +1730,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   ? getWorkspaceStatusFromGroupKey(row.key, workspaceStatuses)
                   : null
               const isPinnedHeader = row.key === PINNED_GROUP_KEY
+              const repoHeaderColor = resolveRepoGroupHeaderColor({
+                groupBy,
+                headerKey: row.key,
+                badgeColor: row.repo?.badgeColor
+              })
               const createState = row.repo
                 ? getRepoHeaderCreateState({
                     repo: row.repo,
@@ -1822,8 +1828,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         }
                         className={cn(
                           'flex size-4 shrink-0 items-center justify-center rounded-[4px]',
-                          row.repo ? 'text-muted-foreground' : row.tone
+                          repoHeaderColor ? 'text-muted-foreground' : row.tone
                         )}
+                        style={repoHeaderColor ? { color: repoHeaderColor } : undefined}
                       >
                         <row.icon className={row.repo ? 'size-3.5' : 'size-3'} />
                       </div>

--- a/src/renderer/src/components/sidebar/repo-header-color.test.ts
+++ b/src/renderer/src/components/sidebar/repo-header-color.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_REPO_BADGE_COLOR, REPO_COLORS } from '../../../../shared/constants'
+import { resolveRepoGroupHeaderColor, resolveRepoHeaderColor } from './repo-header-color'
+
+describe('resolveRepoHeaderColor', () => {
+  it('returns a canonical palette color', () => {
+    expect(resolveRepoHeaderColor(REPO_COLORS[3])).toBe(REPO_COLORS[3])
+  })
+
+  it('keeps the default repo badge color gray', () => {
+    expect(resolveRepoHeaderColor(DEFAULT_REPO_BADGE_COLOR)).toBe(DEFAULT_REPO_BADGE_COLOR)
+  })
+
+  it.each([undefined, null, ''])('falls back for missing or empty input: %s', (badgeColor) => {
+    expect(resolveRepoHeaderColor(badgeColor)).toBe(DEFAULT_REPO_BADGE_COLOR)
+  })
+
+  it('normalizes whitespace and casing to the canonical palette value', () => {
+    expect(resolveRepoHeaderColor(`  ${REPO_COLORS[4].toUpperCase()}  `)).toBe(REPO_COLORS[4])
+  })
+
+  it('falls back for out-of-palette colors', () => {
+    expect(resolveRepoHeaderColor('#123456')).toBe(DEFAULT_REPO_BADGE_COLOR)
+  })
+})
+
+describe('resolveRepoGroupHeaderColor', () => {
+  it('returns the repo color for repo group headers', () => {
+    expect(
+      resolveRepoGroupHeaderColor({
+        groupBy: 'repo',
+        headerKey: 'repo:repo-1',
+        badgeColor: REPO_COLORS[5]
+      })
+    ).toBe(REPO_COLORS[5])
+  })
+
+  it('falls back to gray for unknown repo group headers', () => {
+    expect(
+      resolveRepoGroupHeaderColor({
+        groupBy: 'repo',
+        headerKey: 'repo:missing-repo',
+        badgeColor: undefined
+      })
+    ).toBe(DEFAULT_REPO_BADGE_COLOR)
+  })
+
+  it('does not color pinned headers while grouped by repo', () => {
+    expect(
+      resolveRepoGroupHeaderColor({
+        groupBy: 'repo',
+        headerKey: 'pinned',
+        badgeColor: undefined
+      })
+    ).toBeUndefined()
+  })
+
+  it('does not color repo-looking keys in other grouping modes', () => {
+    expect(
+      resolveRepoGroupHeaderColor({
+        groupBy: 'workspace-status',
+        headerKey: 'repo:repo-1',
+        badgeColor: REPO_COLORS[2]
+      })
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/repo-header-color.ts
+++ b/src/renderer/src/components/sidebar/repo-header-color.ts
@@ -1,0 +1,29 @@
+import { DEFAULT_REPO_BADGE_COLOR, REPO_COLORS } from '../../../../shared/constants'
+
+const REPO_GROUP_HEADER_KEY_PREFIX = 'repo:'
+
+export function resolveRepoHeaderColor(badgeColor: string | null | undefined): string {
+  const normalizedBadgeColor = badgeColor?.trim().toLowerCase()
+  if (!normalizedBadgeColor) {
+    return DEFAULT_REPO_BADGE_COLOR
+  }
+
+  // Why: persisted repo colors are rendered as inline CSS here, so only the
+  // documented palette should reach the sidebar.
+  return (
+    REPO_COLORS.find((repoColor) => repoColor === normalizedBadgeColor) ?? DEFAULT_REPO_BADGE_COLOR
+  )
+}
+
+export function resolveRepoGroupHeaderColor(args: {
+  groupBy: string
+  headerKey: string
+  badgeColor: string | null | undefined
+}): string | undefined {
+  // Why: pinned headers can appear while grouped by repo, but only repo:* headers
+  // represent a repo folder whose user-authored badge color should be shown.
+  if (args.groupBy !== 'repo' || !args.headerKey.startsWith(REPO_GROUP_HEADER_KEY_PREFIX)) {
+    return undefined
+  }
+  return resolveRepoHeaderColor(args.badgeColor)
+}

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -668,4 +668,15 @@ describe('WorktreeList header styles', () => {
 
     expect(source).toContain('[&_path]:cursor-pointer')
   })
+
+  it('resolves repo header color from repo group headers only', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)),
+      'utf8'
+    )
+
+    expect(source).toContain('resolveRepoGroupHeaderColor({')
+    expect(source).toContain('headerKey: row.key')
+    expect(source).toContain('style={repoHeaderColor ? { color: repoHeaderColor } : undefined}')
+  })
 })


### PR DESCRIPTION
## Summary

- Restores saved repo badge colors on workspace sidebar repo-folder headers.
- Resolves repo header colors through the documented `REPO_COLORS` palette, falling back to default gray for missing, empty, or malformed persisted values.
- Keeps pinned, workspace-status, PR-status, and other non-repo headers on their existing token-based colors.

## Brennan YOLO Lite Evidence

- Design doc: `docs/readd-repo-folder-colors-design.md` (local pipeline artifact)
- Design review: `auto-design-review-fix` completed clean after iteration 2; reviewers found no remaining design issues.
- Implementation: added `repo-header-color.ts`, wired `WorktreeList.tsx` repo headers to `resolveRepoGroupHeaderColor`, and added focused coverage. No deviations from the reviewed design.
- Completeness verification: first pass caught pinned headers receiving fallback repo color; fixed by gating on `repo:*` header keys. Second pass confirmed complete.
- Code review loop: round 1 ran two independent `review-code` reviewers; both returned no issues.
- Brennan test changes: result `land`.

## Validation

Static checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/repo-header-color.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts` — 53 tests passed
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/sidebar/repo-header-color.ts src/renderer/src/components/sidebar/repo-header-color.test.ts src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-list-groups.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

Product validation:

- Launched the exact worktree in Electron and verified identity: `/Users/thebr/orca/workspaces/orca/readd-repo-colors`, branch `brennankbenson/readd-repo-colors`.
- Used `demo-project` as the target.
- Switched workspace sidebar grouping to Repo through the Workspace options UI and filtered to `demo-project`.
- Verified custom repo color `#ef4444` persisted and the repo folder icon rendered `rgb(239, 68, 68)`.
- Verified default gray `#737373` persisted and rendered `rgb(115, 115, 115)`.
- Verified the pinned header exception: pinned header had no inline repo color and stayed token-colored while the repo header stayed red.

Local evidence artifacts (not committed):

- `.context/readd-repo-colors-demo-custom.png`
- `.context/readd-repo-colors-demo-default-gray.png`
- `.context/readd-repo-colors-pinned-header.png`

## Notes

- No persistence migration is needed; existing repos already carry `badgeColor`.
- No SSH/runtime/provider behavior changed. SSH repos use the same `Repo.badgeColor` render path.
- Remaining risk: WorktreeList render coverage is source-level rather than a DOM unit test, but the Electron product validation directly inspected the rendered sidebar behavior.

Made with [Orca](https://github.com/stablyai/orca) 🐋
