### PR TITLE
Fix lineage child count order below agents

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -1,0 +1,253 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree, WorktreeLineage } from '../../../../shared/types'
+
+const mockStore = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => {
+  const useAppStore = ((selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mockStore.state)) as ((
+    selector: (state: Record<string, unknown>) => unknown
+  ) => unknown) & {
+    getState: () => Record<string, unknown>
+  }
+  useAppStore.getState = () => mockStore.state
+  return { useAppStore }
+})
+
+vi.mock('@tanstack/react-virtual', () => ({
+  defaultRangeExtractor: ({ startIndex, endIndex }: { startIndex: number; endIndex: number }) =>
+    Array.from({ length: endIndex - startIndex + 1 }, (_, index) => startIndex + index),
+  measureElement: () => 32,
+  useVirtualizer: ({ count }: { count: number }) => ({
+    elementsCache: new Map(),
+    getTotalSize: () => count * 80,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 80
+      })),
+    measureElement: vi.fn(),
+    scrollToIndex: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/useVirtualizedScrollAnchor', () => ({
+  VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT: 'orca:test-record-scroll-anchor',
+  useVirtualizedScrollAnchor: vi.fn()
+}))
+
+vi.mock('./repo-header-drag', () => ({
+  useRepoHeaderDrag: () => ({
+    state: { draggingRepoId: null, dropIndicatorY: null },
+    onHandlePointerDown: vi.fn()
+  })
+}))
+
+vi.mock('./WorktreeCard', () => ({
+  default: ({
+    worktree,
+    lineageChildren
+  }: {
+    worktree: Worktree
+    lineageChildren?: React.ReactNode
+  }) =>
+    React.createElement(
+      'section',
+      { 'data-worktree-card-id': worktree.id },
+      React.createElement('h2', null, worktree.displayName),
+      lineageChildren
+    )
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: ({ worktreeId }: { worktreeId: string }) =>
+    React.createElement(
+      'div',
+      { role: 'group', 'aria-label': 'Agents', 'data-agent-worktree-id': worktreeId },
+      'Review fixture prompt'
+    )
+}))
+
+vi.mock('./WorktreeActivityStatusIndicator', () => ({
+  WorktreeActivityStatusIndicator: () => React.createElement('span', { 'data-status-dot': true })
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'orca:test-close-context-menus',
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR: 'data-orca-context-menu-scope'
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  TooltipContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('span', null, children),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children)
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children)
+}))
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/tmp/lineage-order',
+    displayName: 'lineage-order',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(args: {
+  id: string
+  displayName: string
+  branch: string
+  sortOrder: number
+  instanceId: string
+}): Worktree {
+  return {
+    id: args.id,
+    instanceId: args.instanceId,
+    repoId: 'repo-1',
+    path: `/tmp/lineage-order/${args.id}`,
+    displayName: args.displayName,
+    branch: args.branch,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: args.sortOrder,
+    lastActivityAt: args.sortOrder
+  }
+}
+
+function makeLineage(worktree: Worktree, parent: Worktree): WorktreeLineage {
+  return {
+    worktreeId: worktree.id,
+    worktreeInstanceId: worktree.instanceId!,
+    parentWorktreeId: parent.id,
+    parentWorktreeInstanceId: parent.instanceId!,
+    origin: 'orchestration',
+    capture: { source: 'orchestration-context', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+function setLineageFixtureState(): void {
+  const repo = makeRepo()
+  const parent = makeWorktree({
+    id: 'parent',
+    instanceId: 'parent-instance',
+    displayName: 'lineage parent',
+    branch: 'parent-branch',
+    sortOrder: 30
+  })
+  const child = makeWorktree({
+    id: 'child',
+    instanceId: 'child-instance',
+    displayName: 'lineage child with agent',
+    branch: 'child-branch',
+    sortOrder: 20
+  })
+  const grandchild = makeWorktree({
+    id: 'grandchild',
+    instanceId: 'grandchild-instance',
+    displayName: 'lineage grandchild',
+    branch: 'grandchild-branch',
+    sortOrder: 10
+  })
+
+  mockStore.state = {
+    activeModal: '',
+    activeView: 'terminal',
+    activeWorktreeId: null,
+    agentStatusByPaneKey: {},
+    browserTabsByWorktree: {},
+    clearPendingRevealWorktreeId: vi.fn(),
+    collapsedGroups: new Set<string>(),
+    filterRepoIds: [],
+    groupBy: 'none',
+    hideDefaultBranchWorkspace: false,
+    issueCache: {},
+    migrationUnsupportedByPtyId: {},
+    openModal: vi.fn(),
+    pendingRevealWorktree: null,
+    prCache: {},
+    prVisibleRefreshGeneration: 0,
+    ptyIdsByTabId: {},
+    reorderRepos: vi.fn(),
+    reportVisibleGitHubPRRefreshCandidates: vi.fn(),
+    repos: [repo],
+    runtimePaneTitlesByTabId: {},
+    setFilterRepoIds: vi.fn(),
+    setHideDefaultBranchWorkspace: vi.fn(),
+    setShowSleepingWorkspaces: vi.fn(),
+    setSortBy: vi.fn(),
+    settings: null,
+    showSleepingWorkspaces: true,
+    sortBy: 'manual',
+    sortEpoch: 0,
+    sshConnectedGeneration: 0,
+    sshConnectionStates: new Map(),
+    sshTargetLabels: new Map(),
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    toggleCollapsedGroup: vi.fn(),
+    updateWorktreeMeta: vi.fn(),
+    updateWorktreesMeta: vi.fn(),
+    workspaceStatuses: [],
+    worktreeCardProperties: ['status', 'inline-agents'],
+    worktreeLineageById: {
+      [child.id]: makeLineage(child, parent),
+      [grandchild.id]: makeLineage(grandchild, child)
+    },
+    worktreesByRepo: {
+      [repo.id]: [parent, child, grandchild]
+    }
+  }
+}
+
+describe('WorktreeList lineage child card renderer', () => {
+  it('renders nested inline agent rows before the nested child-count toggle', async () => {
+    setLineageFixtureState()
+    const { default: WorktreeList } = await import('./WorktreeList')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(WorktreeList, {
+        scrollOffsetRef: { current: 0 },
+        scrollAnchorRef: { current: null }
+      })
+    )
+
+    const childStart = markup.indexOf('lineage child with agent')
+    const agentRowIndex = markup.indexOf('Review fixture prompt', childStart)
+    const childToggleIndex = markup.indexOf('1 child', childStart)
+
+    expect(childStart).toBeGreaterThan(-1)
+    expect(agentRowIndex).toBeGreaterThan(childStart)
+    expect(childToggleIndex).toBeGreaterThan(childStart)
+    expect(agentRowIndex).toBeLessThan(childToggleIndex)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2098,6 +2098,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                             {child.worktree.comment}
                           </div>
                         ) : null}
+                        {showInlineAgentCards ? (
+                          // Why: nested lineage children use this lightweight
+                          // renderer instead of WorktreeCard, so their inline
+                          // agent rows must be mounted here explicitly.
+                          <WorktreeCardAgents
+                            worktreeId={child.worktree.id}
+                            className="mt-1 divide-y-0"
+                          />
+                        ) : null}
                         {child.lineageChildCount > 0 && lineageToggleGroupKey ? (
                           <div className="mt-1.5 flex min-w-0 justify-start">
                             <Tooltip>
@@ -2139,15 +2148,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               </TooltipContent>
                             </Tooltip>
                           </div>
-                        ) : null}
-                        {showInlineAgentCards ? (
-                          // Why: nested lineage children use this lightweight
-                          // renderer instead of WorktreeCard, so their inline
-                          // agent rows must be mounted here explicitly.
-                          <WorktreeCardAgents
-                            worktreeId={child.worktree.id}
-                            className="mt-1 divide-y-0"
-                          />
                         ) : null}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Move the nested lineage child-card inline agent rows above the `n children` lineage toggle.
- Add a focused `WorktreeList` render regression that builds parent -> child -> grandchild lineage and asserts the nested agent row precedes the nested `1 child` toggle.

## Design
Design doc: `docs/lineage-child-agent-status-order.md` (local pipeline artifact; ignored by repo policy for design/planning docs).

Design-review outcome: `auto-design-review-fix` completed clean after 3 review iterations. It kept the scope narrow to the nested `renderLineageChildCard` path because top-level `WorktreeCard` already had the correct order.

## Implementation
Changed `src/renderer/src/components/sidebar/WorktreeList.tsx` to mount `WorktreeCardAgents` before the nested lineage child-count toggle. No changes to lineage grouping, agent-row derivation, collapse behavior, SSH reconnect lookup, or label copy.

Deviation from design: none.

## Completeness Verification
Initial completeness review found the first regression was only source-order based. I replaced it with a DOM/server-rendered `WorktreeList` test. The rerun completed clean with no findings.

## Code Review
Round 1 ran two independent `review-code` reviewers in parallel. Both returned clean with only residual live UI/SSH validation gaps noted; no second round was needed.

## Brennan Test Changes
Verdict: land.

Live Electron validation:
- Launched Electron from this exact PR worktree and verified identity matched branch `brennankbenson/child-indicator-agent-status-child-swapped` and this workspace root.
- Used isolated temp app state plus real `demo-project`.
- Created disposable parent -> child -> grandchild lineage.
- Verified nested child card rendered `Lineage proof agent row` above the `1 child` toggle.
- DOM/bounds proof: agent group was before the toggle in DOM and visually above it (`agentTop=353`, `toggleTop=413`).
- Clicked the nested child `1 child` toggle; it collapsed the grandchild, changed to `Show 1 child workspace`, and the agent row remained above the toggle.
- No console errors observed. Dev-only React Grab version warnings and expected cleanup warnings only.
- Cleanup removed disposable worktrees, closed Playwright, stopped Electron, and removed isolated temp user data.

Screenshot proof captured locally, not committed per repo policy:
`/Users/thebr/orca/workspaces/orca/child-indicator-agent-status-child-swapped/.playwright-cli/lineage-child-agent-status-order-current.png`

## Checks
- `pnpm run typecheck` passed
- `pnpm run lint` passed
- `git diff --check` passed
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/WorktreeCard.lineage.test.tsx src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts` passed: 4 files, 48 tests
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts` passed
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts` passed

## Residual Risk
- Live SSH reconnect-dialog scenario was not exercised. The branch changes renderer ordering only and leaves the existing SSH lookup/click path unchanged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
