### PR TITLE
Add crash report diagnostic log upload

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -835,6 +835,9 @@ jobs:
       # Why ORCA_BUILD_IDENTITY here (not in env at the job level): the
       # value comes from the per-tag classification above and electron-vite
       # reads it from `process.env` during `pnpm build:release` only.
+      # Why ORCA_DIAGNOSTICS_TOKEN_URL here: official builds pin crash
+      # diagnostic uploads to Orca's endpoint at compile time, matching the
+      # telemetry gate's "official binary only" behavior.
       - name: Build app
         run: pnpm build:release
         env:
@@ -842,6 +845,7 @@ jobs:
           # the macOS release runner, leaving v1.4.2-rc.8 as an incomplete draft.
           NODE_OPTIONS: --max-old-space-size=4096
           ORCA_BUILD_IDENTITY: ${{ steps.tag-classify.outputs.identity }}
+          ORCA_DIAGNOSTICS_TOKEN_URL: https://api.onorca.dev/diagnostics/token
           ORCA_POSTHOG_WRITE_KEY: ${{ secrets.ORCA_POSTHOG_WRITE_KEY }}
 
       # Why: macOS signing secrets (CSC_LINK, CSC_KEY_PASSWORD) must NOT be

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -845,7 +845,7 @@ jobs:
           # the macOS release runner, leaving v1.4.2-rc.8 as an incomplete draft.
           NODE_OPTIONS: --max-old-space-size=4096
           ORCA_BUILD_IDENTITY: ${{ steps.tag-classify.outputs.identity }}
-          ORCA_DIAGNOSTICS_TOKEN_URL: https://api.onorca.dev/diagnostics/token
+          ORCA_DIAGNOSTICS_TOKEN_URL: https://www.onorca.dev/diagnostics/token
           ORCA_POSTHOG_WRITE_KEY: ${{ secrets.ORCA_POSTHOG_WRITE_KEY }}
 
       # Why: macOS signing secrets (CSC_LINK, CSC_KEY_PASSWORD) must NOT be

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -125,6 +125,7 @@ branch refs/heads/main
     expect(calls).toEqual(
       expect.arrayContaining(['git worktree remove /repo-feature', 'git branch -d -- feature/test'])
     )
+    expect(calls).not.toContain('git worktree prune')
     expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git branch -d -- feature/test')
   })
 
@@ -146,6 +147,7 @@ branch refs/heads/feature/test
 
     const calls = getGitCalls()
     expect(calls).toContain('git worktree remove /repo-feature')
+    expect(calls).not.toContain('git worktree prune')
     expect(calls).not.toContain('git branch -d -- feature/test')
     expect(calls).not.toContain('git branch -D -- feature/test')
   })
@@ -200,7 +202,6 @@ branch refs/heads/feature/test
     )
     expect(calls.filter((call) => call === 'git branch -d -- feature/test')).toHaveLength(2)
     expect(calls).not.toContain('git branch -D -- feature/test')
-    expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git worktree prune')
   })
 
   it('deletes the branch after prune removes stale sibling worktree entries', async () => {
@@ -228,22 +229,22 @@ branch refs/heads/main
       },
       'git branch -d -- feature/test': {
         error: new Error("cannot delete branch 'feature/test' used by worktree at '/repo-stale'")
+      },
+      'git branch -d -- feature/test#2': {
+        stdout: ''
       }
     })
 
     await removeWorktree('/repo', '/repo-feature')
 
     const calls = getGitCalls()
-    expect(calls).toEqual(
-      expect.arrayContaining([
-        'git worktree remove /repo-feature',
-        'git worktree prune',
-        'git branch -d -- feature/test'
-      ])
-    )
-    expect(calls.lastIndexOf('git branch -d -- feature/test')).toBeGreaterThan(
-      calls.indexOf('git worktree prune')
-    )
+    expect(calls).toEqual([
+      'git worktree list --porcelain -z',
+      'git worktree remove /repo-feature',
+      'git branch -d -- feature/test',
+      'git worktree prune',
+      'git branch -d -- feature/test'
+    ])
   })
 
   it('passes --force before the worktree path when forced removal is requested', async () => {
@@ -300,6 +301,7 @@ branch refs/heads/main
         'git branch -d -- feature/test'
       ])
     )
+    expect(calls).not.toContain('git worktree prune')
   })
 
   it('keeps removal successful when branch cleanup fails', async () => {
@@ -942,10 +944,12 @@ branch refs/heads/main
         'git config --local push.autoSetupRemote true',
         'git sparse-checkout init --cone',
         'git sparse-checkout set -- packages/web',
+        'git config --local --unset-all branch.feature/test.base',
         'git worktree remove --force /repo-feature',
         'git branch -D -- feature/test'
       ])
     )
+    expect(calls).not.toContain('git worktree prune')
     expectGitCallOrder(
       calls,
       'git sparse-checkout set -- packages/web',

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -6,7 +6,6 @@ const {
   handlers,
   listeners,
   clipboardWriteTextMock,
-  dialogShowMessageBoxMock,
   collectDiagnosticBundleMock,
   deleteDiagnosticBundleMock,
   getDiagnosticsStatusMock,
@@ -19,7 +18,6 @@ const {
   handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
   listeners: new Map<string, (_event: unknown, args?: unknown) => void>(),
   clipboardWriteTextMock: vi.fn(),
-  dialogShowMessageBoxMock: vi.fn(),
   collectDiagnosticBundleMock: vi.fn(),
   deleteDiagnosticBundleMock: vi.fn(),
   getDiagnosticsStatusMock: vi.fn(),
@@ -33,7 +31,6 @@ const {
 vi.mock('electron', () => ({
   app: { getVersion: () => '1.2.3-test' },
   clipboard: { writeText: clipboardWriteTextMock },
-  dialog: { showMessageBox: dialogShowMessageBoxMock },
   ipcMain: {
     removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
     handle: vi.fn((channel: string, handler: (_event: unknown, args?: unknown) => unknown) => {
@@ -109,8 +106,6 @@ describe('registerCrashReportingHandlers', () => {
     handlers.clear()
     listeners.clear()
     clipboardWriteTextMock.mockReset()
-    dialogShowMessageBoxMock.mockReset()
-    dialogShowMessageBoxMock.mockResolvedValue({ response: 0 })
     collectDiagnosticBundleMock.mockReset()
     collectDiagnosticBundleMock.mockReturnValue(diagnosticBundle())
     deleteDiagnosticBundleMock.mockReset()
@@ -238,13 +233,6 @@ describe('registerCrashReportingHandlers', () => {
       payload: diagnosticBundle().payload,
       bundleSubmissionId: diagnosticBundle().bundleSubmissionId
     })
-    expect(dialogShowMessageBoxMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        buttons: ['Attach Logs', 'Send Without Logs'],
-        defaultId: 1,
-        message: 'Attach recent redacted diagnostic logs to this crash report?'
-      })
-    )
     expect(markSent).toHaveBeenCalledWith(pending.id)
   })
 
@@ -300,7 +288,7 @@ describe('registerCrashReportingHandlers', () => {
     expect(listRecent).not.toHaveBeenCalled()
   })
 
-  it('requires main-process confirmation before uploading crash logs after Send Report', async () => {
+  it('uploads crash logs by default after Send Report', async () => {
     registerCrashReportingHandlers({
       getById: vi.fn(async () => null),
       dismiss: vi.fn(),
@@ -334,13 +322,6 @@ describe('registerCrashReportingHandlers', () => {
       payload: diagnosticBundle().payload,
       bundleSubmissionId: diagnosticBundle().bundleSubmissionId
     })
-    expect(dialogShowMessageBoxMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        buttons: ['Attach Logs', 'Send Without Logs'],
-        defaultId: 1,
-        cancelId: 1
-      })
-    )
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({
         feedback: expect.stringContaining('ticketabcdefghijklmnop')
@@ -348,8 +329,7 @@ describe('registerCrashReportingHandlers', () => {
     )
   })
 
-  it('submits the crash report without logs when main-process log confirmation is declined', async () => {
-    dialogShowMessageBoxMock.mockResolvedValue({ response: 1 })
+  it('submits the crash report without logs when the user excludes diagnostic logs', async () => {
     registerCrashReportingHandlers({
       getById: vi.fn(async () => null),
       dismiss: vi.fn(),
@@ -362,6 +342,7 @@ describe('registerCrashReportingHandlers', () => {
 
     const result = await handlers.get('crashReports:submit')?.(null, {
       notes: 'manual report',
+      includeDiagnosticLogs: false,
       submitAnonymously: true,
       githubLogin: null,
       githubEmail: null

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -241,6 +241,7 @@ describe('registerCrashReportingHandlers', () => {
     expect(dialogShowMessageBoxMock).toHaveBeenCalledWith(
       expect.objectContaining({
         buttons: ['Attach Logs', 'Send Without Logs'],
+        defaultId: 1,
         message: 'Attach recent redacted diagnostic logs to this crash report?'
       })
     )
@@ -336,6 +337,7 @@ describe('registerCrashReportingHandlers', () => {
     expect(dialogShowMessageBoxMock).toHaveBeenCalledWith(
       expect.objectContaining({
         buttons: ['Attach Logs', 'Send Without Logs'],
+        defaultId: 1,
         cancelId: 1
       })
     )

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -6,6 +6,7 @@ const {
   handlers,
   listeners,
   clipboardWriteTextMock,
+  dialogShowMessageBoxMock,
   collectDiagnosticBundleMock,
   deleteDiagnosticBundleMock,
   getDiagnosticsStatusMock,
@@ -18,6 +19,7 @@ const {
   handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
   listeners: new Map<string, (_event: unknown, args?: unknown) => void>(),
   clipboardWriteTextMock: vi.fn(),
+  dialogShowMessageBoxMock: vi.fn(),
   collectDiagnosticBundleMock: vi.fn(),
   deleteDiagnosticBundleMock: vi.fn(),
   getDiagnosticsStatusMock: vi.fn(),
@@ -31,6 +33,7 @@ const {
 vi.mock('electron', () => ({
   app: { getVersion: () => '1.2.3-test' },
   clipboard: { writeText: clipboardWriteTextMock },
+  dialog: { showMessageBox: dialogShowMessageBoxMock },
   ipcMain: {
     removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
     handle: vi.fn((channel: string, handler: (_event: unknown, args?: unknown) => unknown) => {
@@ -106,6 +109,8 @@ describe('registerCrashReportingHandlers', () => {
     handlers.clear()
     listeners.clear()
     clipboardWriteTextMock.mockReset()
+    dialogShowMessageBoxMock.mockReset()
+    dialogShowMessageBoxMock.mockResolvedValue({ response: 0 })
     collectDiagnosticBundleMock.mockReset()
     collectDiagnosticBundleMock.mockReturnValue(diagnosticBundle())
     deleteDiagnosticBundleMock.mockReset()
@@ -233,6 +238,12 @@ describe('registerCrashReportingHandlers', () => {
       payload: diagnosticBundle().payload,
       bundleSubmissionId: diagnosticBundle().bundleSubmissionId
     })
+    expect(dialogShowMessageBoxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buttons: ['Attach Logs', 'Send Without Logs'],
+        message: 'Attach recent redacted diagnostic logs to this crash report?'
+      })
+    )
     expect(markSent).toHaveBeenCalledWith(pending.id)
   })
 
@@ -288,7 +299,7 @@ describe('registerCrashReportingHandlers', () => {
     expect(listRecent).not.toHaveBeenCalled()
   })
 
-  it('uploads crash logs after Send Report without a second native confirmation', async () => {
+  it('requires main-process confirmation before uploading crash logs after Send Report', async () => {
     registerCrashReportingHandlers({
       getById: vi.fn(async () => null),
       dismiss: vi.fn(),
@@ -322,9 +333,51 @@ describe('registerCrashReportingHandlers', () => {
       payload: diagnosticBundle().payload,
       bundleSubmissionId: diagnosticBundle().bundleSubmissionId
     })
+    expect(dialogShowMessageBoxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buttons: ['Attach Logs', 'Send Without Logs'],
+        cancelId: 1
+      })
+    )
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({
         feedback: expect.stringContaining('ticketabcdefghijklmnop')
+      })
+    )
+  })
+
+  it('submits the crash report without logs when main-process log confirmation is declined', async () => {
+    dialogShowMessageBoxMock.mockResolvedValue({ response: 1 })
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => null),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => []),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:submit')?.(null, {
+      notes: 'manual report',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      report: null,
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: 'diagnostic log upload skipped by user'
+      }
+    })
+    expect(collectDiagnosticBundleMock).not.toHaveBeenCalled()
+    expect(uploadDiagnosticBundleMock).not.toHaveBeenCalled()
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedback: expect.stringContaining('diagnostic log upload skipped by user')
       })
     )
   })

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share one mocked ipcMain registry and store contract. */
+/* oxlint-disable max-lines -- Why: crash-reporting IPC tests share mocked Electron/observability handler setup; splitting would duplicate brittle IPC wiring. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CrashReportRecord } from '../../shared/crash-reporting'
 
@@ -6,18 +6,30 @@ const {
   handlers,
   listeners,
   clipboardWriteTextMock,
+  collectDiagnosticBundleMock,
+  deleteDiagnosticBundleMock,
+  getDiagnosticsStatusMock,
+  recordCrashBreadcrumbMock,
+  resolveDiagnosticOrcaChannelMock,
+  resolveDiagnosticTokenEndpointMock,
   submitFeedbackMock,
-  recordCrashBreadcrumbMock
+  uploadDiagnosticBundleMock
 } = vi.hoisted(() => ({
   handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
   listeners: new Map<string, (_event: unknown, args?: unknown) => void>(),
   clipboardWriteTextMock: vi.fn(),
+  collectDiagnosticBundleMock: vi.fn(),
+  deleteDiagnosticBundleMock: vi.fn(),
+  getDiagnosticsStatusMock: vi.fn(),
+  recordCrashBreadcrumbMock: vi.fn(),
+  resolveDiagnosticOrcaChannelMock: vi.fn(),
+  resolveDiagnosticTokenEndpointMock: vi.fn(),
   submitFeedbackMock: vi.fn(),
-  recordCrashBreadcrumbMock: vi.fn()
+  uploadDiagnosticBundleMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
-  app: { getVersion: () => '1.0.0-test' },
+  app: { getVersion: () => '1.2.3-test' },
   clipboard: { writeText: clipboardWriteTextMock },
   ipcMain: {
     removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
@@ -40,11 +52,32 @@ vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
   recordCrashBreadcrumb: (...args: unknown[]) => recordCrashBreadcrumbMock(...args)
 }))
 
+vi.mock('../observability', () => ({
+  collectDiagnosticBundle: collectDiagnosticBundleMock,
+  deleteDiagnosticBundle: deleteDiagnosticBundleMock,
+  getDiagnosticsStatus: getDiagnosticsStatusMock,
+  uploadDiagnosticBundle: uploadDiagnosticBundleMock
+}))
+
+vi.mock('../observability/diagnostic-upload-endpoint', () => ({
+  resolveDiagnosticOrcaChannel: resolveDiagnosticOrcaChannelMock,
+  resolveDiagnosticTokenEndpoint: resolveDiagnosticTokenEndpointMock
+}))
+
 import {
   _getCrashReportingStateSizesForTests,
   _resetRendererErrorReportDedupeForTests,
   registerCrashReportingHandlers
 } from './crash-reporting'
+
+function diagnosticBundle(): ReturnType<typeof collectDiagnosticBundleMock> {
+  return {
+    bundleSubmissionId: 'bundleabcdefghijklmnop',
+    payload: '{"type":"bundle-header"}\n',
+    bytes: 25,
+    spanCount: 1
+  }
+}
 
 function report(
   status: CrashReportRecord['status'] = 'pending',
@@ -73,9 +106,30 @@ describe('registerCrashReportingHandlers', () => {
     handlers.clear()
     listeners.clear()
     clipboardWriteTextMock.mockReset()
+    collectDiagnosticBundleMock.mockReset()
+    collectDiagnosticBundleMock.mockReturnValue(diagnosticBundle())
+    deleteDiagnosticBundleMock.mockReset()
+    deleteDiagnosticBundleMock.mockResolvedValue(undefined)
+    getDiagnosticsStatusMock.mockReset()
+    getDiagnosticsStatusMock.mockReturnValue({
+      localFileEnabled: true,
+      otlpEnabled: false,
+      bundleEnabled: true,
+      otlpStatus: 'Disabled',
+      traceFilePath: '/tmp/main.trace.ndjson',
+      traceFamilySize: 25
+    })
+    resolveDiagnosticOrcaChannelMock.mockReset()
+    resolveDiagnosticOrcaChannelMock.mockReturnValue('stable')
+    resolveDiagnosticTokenEndpointMock.mockReset()
+    resolveDiagnosticTokenEndpointMock.mockReturnValue(
+      'https://diagnostics.example.com/diagnostics/token'
+    )
     submitFeedbackMock.mockReset()
     recordCrashBreadcrumbMock.mockReset()
     submitFeedbackMock.mockResolvedValue({ ok: true })
+    uploadDiagnosticBundleMock.mockReset()
+    uploadDiagnosticBundleMock.mockResolvedValue({ ticketId: 'ticketabcdefghijklmnop' })
     _resetRendererErrorReportDedupeForTests()
   })
 
@@ -100,6 +154,32 @@ describe('registerCrashReportingHandlers', () => {
     expect(clipboardWriteTextMock).toHaveBeenCalledWith(
       expect.stringContaining('extra [redacted-path]')
     )
+  })
+
+  it('copies an uncaptured crash report when the caller intentionally omits reportId', async () => {
+    const pending = report('pending', 'crash-late-pending')
+    const listRecent = vi.fn(async () => [pending])
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => null),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent,
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:copyLatestDiagnostics')?.(null, {
+      notes: 'after opening /Users/alice/project'
+    })
+
+    expect(result).toEqual({ ok: true })
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith(expect.stringContaining('not captured'))
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith(expect.stringContaining('[redacted-path]'))
+    expect(clipboardWriteTextMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('crash-late-pending')
+    )
+    expect(listRecent).not.toHaveBeenCalled()
   })
 
   it('returns dismissed unsent reports for the manual Help menu entry', async () => {
@@ -142,13 +222,147 @@ describe('registerCrashReportingHandlers', () => {
 
     expect(result).toEqual({ ok: true, report: sent })
     expect(submitFeedbackMock).toHaveBeenCalledWith({
-      feedback: expect.stringContaining('extra [redacted-path]'),
+      feedback: expect.stringContaining('ticketabcdefghijklmnop'),
       submissionType: 'crash',
       submitAnonymously: false,
       githubLogin: 'trusted-user',
       githubEmail: null
     })
+    expect(uploadDiagnosticBundleMock).toHaveBeenCalledWith({
+      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
+      payload: diagnosticBundle().payload,
+      bundleSubmissionId: diagnosticBundle().bundleSubmissionId
+    })
     expect(markSent).toHaveBeenCalledWith(pending.id)
+  })
+
+  it('submits an uncaptured Help menu crash report and uploads the diagnostic bundle', async () => {
+    const pending = report('pending', 'crash-late-pending')
+    const markSent = vi.fn()
+    const listRecent = vi.fn(async () => [pending])
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => null),
+      dismiss: vi.fn(),
+      markSent,
+      markDismissedSent: vi.fn(),
+      listRecent,
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:submit')?.(null, {
+      notes: 'blank window after opening /Users/alice/project',
+      submitAnonymously: false,
+      githubLogin: 'trusted-user',
+      githubEmail: null
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      report: null,
+      diagnosticBundle: {
+        status: 'uploaded',
+        ticketId: 'ticketabcdefghijklmnop',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
+    expect(collectDiagnosticBundleMock).toHaveBeenCalledWith(
+      expect.objectContaining({ lookbackMinutes: 3 * 24 * 60, orcaChannel: 'stable' })
+    )
+    expect(submitFeedbackMock).toHaveBeenCalledWith({
+      feedback: expect.stringContaining('Report ID: not captured'),
+      submissionType: 'crash',
+      submitAnonymously: false,
+      githubLogin: 'trusted-user',
+      githubEmail: null
+    })
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ feedback: expect.stringContaining('ticketabcdefghijklmnop') })
+    )
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ feedback: expect.stringContaining('[redacted-path]') })
+    )
+    expect(markSent).not.toHaveBeenCalled()
+    expect(listRecent).not.toHaveBeenCalled()
+  })
+
+  it('uploads crash logs after Send Report without a second native confirmation', async () => {
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => null),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => []),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:submit')?.(null, {
+      notes: 'manual report',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      report: null,
+      diagnosticBundle: {
+        status: 'uploaded',
+        ticketId: 'ticketabcdefghijklmnop',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
+    expect(uploadDiagnosticBundleMock).toHaveBeenCalledWith({
+      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
+      payload: diagnosticBundle().payload,
+      bundleSubmissionId: diagnosticBundle().bundleSubmissionId
+    })
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedback: expect.stringContaining('ticketabcdefghijklmnop')
+      })
+    )
+  })
+
+  it('still submits an uncaptured crash report when the diagnostic bundle cannot upload', async () => {
+    resolveDiagnosticTokenEndpointMock.mockReturnValue(null)
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => null),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => []),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:submit')?.(null, {
+      notes: 'manual report',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      report: null,
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: 'diagnostic upload endpoint is not configured for this build',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
+    expect(uploadDiagnosticBundleMock).not.toHaveBeenCalled()
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ feedback: expect.stringContaining('Status: not uploaded') })
+    )
   })
 
   it('submits a dismissed startup prompt through feedback and marks it sent', async () => {
@@ -238,7 +452,55 @@ describe('registerCrashReportingHandlers', () => {
       error: 'status 500',
       report: pending
     })
+    expect(deleteDiagnosticBundleMock).toHaveBeenCalledWith({
+      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
+      ticketId: 'ticketabcdefghijklmnop'
+    })
     expect(markSent).not.toHaveBeenCalled()
+  })
+
+  it('returns the uploaded diagnostic ticket if cleanup fails after feedback submission fails', async () => {
+    const pending = report('pending', 'crash-failed-cleanup')
+    submitFeedbackMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      error: 'status 500'
+    })
+    deleteDiagnosticBundleMock.mockRejectedValue(new Error('delete failed'))
+    registerCrashReportingHandlers({
+      getById: vi.fn(async () => pending),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => [pending]),
+      record: vi.fn(),
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const result = await handlers.get('crashReports:submit')?.(null, {
+      reportId: pending.id,
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      error: 'status 500',
+      report: pending,
+      diagnosticBundle: {
+        status: 'uploaded',
+        ticketId: 'ticketabcdefghijklmnop',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
+    expect(deleteDiagnosticBundleMock).toHaveBeenCalledWith({
+      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
+      ticketId: 'ticketabcdefghijklmnop'
+    })
   })
 
   it('bounds submitted report ids by evicting the oldest successful sends', async () => {
@@ -309,7 +571,7 @@ describe('registerCrashReportingHandlers', () => {
         processType: 'react-render',
         reason: 'react-error-boundary',
         exitCode: null,
-        appVersion: '1.0.0-test',
+        appVersion: '1.2.3-test',
         details: expect.objectContaining({
           boundary_id: 'terminal.workbench',
           surface: 'terminal-workbench',

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -7,25 +7,19 @@ const {
   listeners,
   clipboardWriteTextMock,
   collectDiagnosticBundleMock,
-  deleteDiagnosticBundleMock,
   getDiagnosticsStatusMock,
   recordCrashBreadcrumbMock,
   resolveDiagnosticOrcaChannelMock,
-  resolveDiagnosticTokenEndpointMock,
-  submitFeedbackMock,
-  uploadDiagnosticBundleMock
+  submitFeedbackMock
 } = vi.hoisted(() => ({
   handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
   listeners: new Map<string, (_event: unknown, args?: unknown) => void>(),
   clipboardWriteTextMock: vi.fn(),
   collectDiagnosticBundleMock: vi.fn(),
-  deleteDiagnosticBundleMock: vi.fn(),
   getDiagnosticsStatusMock: vi.fn(),
   recordCrashBreadcrumbMock: vi.fn(),
   resolveDiagnosticOrcaChannelMock: vi.fn(),
-  resolveDiagnosticTokenEndpointMock: vi.fn(),
-  submitFeedbackMock: vi.fn(),
-  uploadDiagnosticBundleMock: vi.fn()
+  submitFeedbackMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -54,14 +48,11 @@ vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
 
 vi.mock('../observability', () => ({
   collectDiagnosticBundle: collectDiagnosticBundleMock,
-  deleteDiagnosticBundle: deleteDiagnosticBundleMock,
-  getDiagnosticsStatus: getDiagnosticsStatusMock,
-  uploadDiagnosticBundle: uploadDiagnosticBundleMock
+  getDiagnosticsStatus: getDiagnosticsStatusMock
 }))
 
 vi.mock('../observability/diagnostic-upload-endpoint', () => ({
-  resolveDiagnosticOrcaChannel: resolveDiagnosticOrcaChannelMock,
-  resolveDiagnosticTokenEndpoint: resolveDiagnosticTokenEndpointMock
+  resolveDiagnosticOrcaChannel: resolveDiagnosticOrcaChannelMock
 }))
 
 import {
@@ -108,8 +99,6 @@ describe('registerCrashReportingHandlers', () => {
     clipboardWriteTextMock.mockReset()
     collectDiagnosticBundleMock.mockReset()
     collectDiagnosticBundleMock.mockReturnValue(diagnosticBundle())
-    deleteDiagnosticBundleMock.mockReset()
-    deleteDiagnosticBundleMock.mockResolvedValue(undefined)
     getDiagnosticsStatusMock.mockReset()
     getDiagnosticsStatusMock.mockReturnValue({
       localFileEnabled: true,
@@ -121,15 +110,9 @@ describe('registerCrashReportingHandlers', () => {
     })
     resolveDiagnosticOrcaChannelMock.mockReset()
     resolveDiagnosticOrcaChannelMock.mockReturnValue('stable')
-    resolveDiagnosticTokenEndpointMock.mockReset()
-    resolveDiagnosticTokenEndpointMock.mockReturnValue(
-      'https://diagnostics.example.com/diagnostics/token'
-    )
     submitFeedbackMock.mockReset()
     recordCrashBreadcrumbMock.mockReset()
     submitFeedbackMock.mockResolvedValue({ ok: true })
-    uploadDiagnosticBundleMock.mockReset()
-    uploadDiagnosticBundleMock.mockResolvedValue({ ticketId: 'ticketabcdefghijklmnop' })
     _resetRendererErrorReportDedupeForTests()
   })
 
@@ -224,29 +207,29 @@ describe('registerCrashReportingHandlers', () => {
       ok: true,
       report: sent,
       diagnosticBundle: {
-        status: 'uploaded',
-        ticketId: 'ticketabcdefghijklmnop',
+        status: 'attached',
         bundleSubmissionId: 'bundleabcdefghijklmnop',
         bytes: 25,
         spanCount: 1
       }
     })
     expect(submitFeedbackMock).toHaveBeenCalledWith({
-      feedback: expect.stringContaining('ticketabcdefghijklmnop'),
+      feedback: expect.stringContaining('Status: attached'),
       submissionType: 'crash',
       submitAnonymously: false,
       githubLogin: 'trusted-user',
-      githubEmail: null
-    })
-    expect(uploadDiagnosticBundleMock).toHaveBeenCalledWith({
-      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
-      payload: diagnosticBundle().payload,
-      bundleSubmissionId: diagnosticBundle().bundleSubmissionId
+      githubEmail: null,
+      diagnosticBundle: {
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        content: diagnosticBundle().payload,
+        bytes: 25,
+        spanCount: 1
+      }
     })
     expect(markSent).toHaveBeenCalledWith(pending.id)
   })
 
-  it('submits an uncaptured Help menu crash report and uploads the diagnostic bundle', async () => {
+  it('submits an uncaptured Help menu crash report with an attached diagnostic bundle', async () => {
     const pending = report('pending', 'crash-late-pending')
     const markSent = vi.fn()
     const listRecent = vi.fn(async () => [pending])
@@ -271,8 +254,7 @@ describe('registerCrashReportingHandlers', () => {
       ok: true,
       report: null,
       diagnosticBundle: {
-        status: 'uploaded',
-        ticketId: 'ticketabcdefghijklmnop',
+        status: 'attached',
         bundleSubmissionId: 'bundleabcdefghijklmnop',
         bytes: 25,
         spanCount: 1
@@ -286,10 +268,16 @@ describe('registerCrashReportingHandlers', () => {
       submissionType: 'crash',
       submitAnonymously: false,
       githubLogin: 'trusted-user',
-      githubEmail: null
+      githubEmail: null,
+      diagnosticBundle: {
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        content: diagnosticBundle().payload,
+        bytes: 25,
+        spanCount: 1
+      }
     })
     expect(submitFeedbackMock).toHaveBeenCalledWith(
-      expect.objectContaining({ feedback: expect.stringContaining('ticketabcdefghijklmnop') })
+      expect.objectContaining({ feedback: expect.stringContaining('Status: attached') })
     )
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({ feedback: expect.stringContaining('[redacted-path]') })
@@ -320,21 +308,21 @@ describe('registerCrashReportingHandlers', () => {
       ok: true,
       report: null,
       diagnosticBundle: {
-        status: 'uploaded',
-        ticketId: 'ticketabcdefghijklmnop',
+        status: 'attached',
         bundleSubmissionId: 'bundleabcdefghijklmnop',
         bytes: 25,
         spanCount: 1
       }
     })
-    expect(uploadDiagnosticBundleMock).toHaveBeenCalledWith({
-      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
-      payload: diagnosticBundle().payload,
-      bundleSubmissionId: diagnosticBundle().bundleSubmissionId
-    })
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        feedback: expect.stringContaining('ticketabcdefghijklmnop')
+        feedback: expect.stringContaining('Status: attached'),
+        diagnosticBundle: {
+          bundleSubmissionId: 'bundleabcdefghijklmnop',
+          content: diagnosticBundle().payload,
+          bytes: 25,
+          spanCount: 1
+        }
       })
     )
   })
@@ -367,7 +355,6 @@ describe('registerCrashReportingHandlers', () => {
       }
     })
     expect(collectDiagnosticBundleMock).not.toHaveBeenCalled()
-    expect(uploadDiagnosticBundleMock).not.toHaveBeenCalled()
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({
         feedback: expect.stringContaining('diagnostic log upload skipped by user')
@@ -375,8 +362,10 @@ describe('registerCrashReportingHandlers', () => {
     )
   })
 
-  it('still submits an uncaptured crash report when the diagnostic bundle cannot upload', async () => {
-    resolveDiagnosticTokenEndpointMock.mockReturnValue(null)
+  it('still submits an uncaptured crash report when the diagnostic bundle cannot be collected', async () => {
+    collectDiagnosticBundleMock.mockImplementation(() => {
+      throw new Error('collect failed')
+    })
     registerCrashReportingHandlers({
       getById: vi.fn(async () => null),
       dismiss: vi.fn(),
@@ -399,13 +388,9 @@ describe('registerCrashReportingHandlers', () => {
       report: null,
       diagnosticBundle: {
         status: 'not_uploaded',
-        reason: 'diagnostic upload endpoint is not configured for this build',
-        bundleSubmissionId: 'bundleabcdefghijklmnop',
-        bytes: 25,
-        spanCount: 1
+        reason: 'collect failed'
       }
     })
-    expect(uploadDiagnosticBundleMock).not.toHaveBeenCalled()
     expect(submitFeedbackMock).toHaveBeenCalledWith(
       expect.objectContaining({ feedback: expect.stringContaining('Status: not uploaded') })
     )
@@ -437,8 +422,7 @@ describe('registerCrashReportingHandlers', () => {
       ok: true,
       report: sent,
       diagnosticBundle: {
-        status: 'uploaded',
-        ticketId: 'ticketabcdefghijklmnop',
+        status: 'attached',
         bundleSubmissionId: 'bundleabcdefghijklmnop',
         bytes: 25,
         spanCount: 1
@@ -449,7 +433,13 @@ describe('registerCrashReportingHandlers', () => {
       submissionType: 'crash',
       submitAnonymously: true,
       githubLogin: null,
-      githubEmail: null
+      githubEmail: null,
+      diagnosticBundle: {
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        content: diagnosticBundle().payload,
+        bytes: 25,
+        spanCount: 1
+      }
     })
     expect(markDismissedSent).toHaveBeenCalledWith(dismissed.id)
   })
@@ -508,55 +498,17 @@ describe('registerCrashReportingHandlers', () => {
       error: 'status 500',
       report: pending
     })
-    expect(deleteDiagnosticBundleMock).toHaveBeenCalledWith({
-      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
-      ticketId: 'ticketabcdefghijklmnop'
-    })
+    expect(submitFeedbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        diagnosticBundle: {
+          bundleSubmissionId: 'bundleabcdefghijklmnop',
+          content: diagnosticBundle().payload,
+          bytes: 25,
+          spanCount: 1
+        }
+      })
+    )
     expect(markSent).not.toHaveBeenCalled()
-  })
-
-  it('returns the uploaded diagnostic ticket if cleanup fails after feedback submission fails', async () => {
-    const pending = report('pending', 'crash-failed-cleanup')
-    submitFeedbackMock.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'status 500'
-    })
-    deleteDiagnosticBundleMock.mockRejectedValue(new Error('delete failed'))
-    registerCrashReportingHandlers({
-      getById: vi.fn(async () => pending),
-      dismiss: vi.fn(),
-      markSent: vi.fn(),
-      markDismissedSent: vi.fn(),
-      listRecent: vi.fn(async () => [pending]),
-      record: vi.fn(),
-      formatDiagnosticText: vi.fn()
-    } as never)
-
-    const result = await handlers.get('crashReports:submit')?.(null, {
-      reportId: pending.id,
-      submitAnonymously: true,
-      githubLogin: null,
-      githubEmail: null
-    })
-
-    expect(result).toEqual({
-      ok: false,
-      status: 500,
-      error: 'status 500',
-      report: pending,
-      diagnosticBundle: {
-        status: 'uploaded',
-        ticketId: 'ticketabcdefghijklmnop',
-        bundleSubmissionId: 'bundleabcdefghijklmnop',
-        bytes: 25,
-        spanCount: 1
-      }
-    })
-    expect(deleteDiagnosticBundleMock).toHaveBeenCalledWith({
-      tokenEndpoint: 'https://diagnostics.example.com/diagnostics/token',
-      ticketId: 'ticketabcdefghijklmnop'
-    })
   })
 
   it('bounds submitted report ids by evicting the oldest successful sends', async () => {

--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -220,7 +220,17 @@ describe('registerCrashReportingHandlers', () => {
       githubEmail: null
     })
 
-    expect(result).toEqual({ ok: true, report: sent })
+    expect(result).toEqual({
+      ok: true,
+      report: sent,
+      diagnosticBundle: {
+        status: 'uploaded',
+        ticketId: 'ticketabcdefghijklmnop',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
     expect(submitFeedbackMock).toHaveBeenCalledWith({
       feedback: expect.stringContaining('ticketabcdefghijklmnop'),
       submissionType: 'crash',
@@ -423,7 +433,17 @@ describe('registerCrashReportingHandlers', () => {
       githubEmail: null
     })
 
-    expect(result).toEqual({ ok: true, report: sent })
+    expect(result).toEqual({
+      ok: true,
+      report: sent,
+      diagnosticBundle: {
+        status: 'uploaded',
+        ticketId: 'ticketabcdefghijklmnop',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 25,
+        spanCount: 1
+      }
+    })
     expect(submitFeedbackMock).toHaveBeenCalledWith({
       feedback: expect.stringContaining('sent from startup prompt'),
       submissionType: 'crash',

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -361,10 +361,7 @@ async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticB
         ticketId: result.ticketId,
         bundleSubmissionId: bundle.bundleSubmissionId,
         bytes: bundle.bytes,
-        spanCount: bundle.spanCount,
-        ...(result.blobUrl ? { blobUrl: result.blobUrl } : {}),
-        ...(result.blobDownloadUrl ? { blobDownloadUrl: result.blobDownloadUrl } : {}),
-        ...(result.blobPathname ? { blobPathname: result.blobPathname } : {})
+        spanCount: bundle.spanCount
       },
       tokenEndpoint
     }

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -361,7 +361,10 @@ async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticB
         ticketId: result.ticketId,
         bundleSubmissionId: bundle.bundleSubmissionId,
         bytes: bundle.bytes,
-        spanCount: bundle.spanCount
+        spanCount: bundle.spanCount,
+        ...(result.blobUrl ? { blobUrl: result.blobUrl } : {}),
+        ...(result.blobDownloadUrl ? { blobDownloadUrl: result.blobDownloadUrl } : {}),
+        ...(result.blobPathname ? { blobPathname: result.blobPathname } : {})
       },
       tokenEndpoint
     }

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -323,7 +323,7 @@ async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticB
   const consent = await dialog.showMessageBox({
     type: 'question',
     buttons: ['Attach Logs', 'Send Without Logs'],
-    defaultId: 0,
+    defaultId: 1,
     cancelId: 1,
     title: 'Attach diagnostic logs?',
     message: 'Attach recent redacted diagnostic logs to this crash report?',

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share renderer
    error capture, diagnostic upload, and crash-store submission state. */
 import os from 'node:os'
-import { app, clipboard, ipcMain } from 'electron'
+import { app, clipboard, dialog, ipcMain } from 'electron'
 import {
   type CrashReportBreadcrumbData,
   type CrashReportDiagnosticBundle,
@@ -316,6 +316,37 @@ async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticB
       diagnosticBundle: {
         status: 'not_uploaded',
         reason: status.disabledReason ?? 'diagnostic bundle collection is disabled'
+      }
+    }
+  }
+
+  const consent = await dialog.showMessageBox({
+    type: 'question',
+    buttons: ['Attach Logs', 'Send Without Logs'],
+    defaultId: 0,
+    cancelId: 1,
+    title: 'Attach diagnostic logs?',
+    message: 'Attach recent redacted diagnostic logs to this crash report?',
+    detail:
+      'Orca will upload a capped redacted diagnostic bundle to support and link it in the crash report. Choose Send Without Logs to submit only the crash details.'
+  })
+  if (consent.response !== 0) {
+    return {
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: 'diagnostic log upload skipped by user'
+      }
+    }
+  }
+
+  // Why: the renderer is untrusted; re-check the diagnostics setting after the
+  // main-process consent dialog before collecting or uploading log bytes.
+  const statusAfterConsent = getDiagnosticsStatus()
+  if (!statusAfterConsent.bundleEnabled) {
+    return {
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: statusAfterConsent.disabledReason ?? 'diagnostic bundle collection is disabled'
       }
     }
   }

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share renderer
    error capture, diagnostic upload, and crash-store submission state. */
 import os from 'node:os'
-import { app, clipboard, dialog, ipcMain } from 'electron'
+import { app, clipboard, ipcMain } from 'electron'
 import {
   type CrashReportBreadcrumbData,
   type CrashReportDiagnosticBundle,
@@ -309,6 +309,15 @@ function buildUncapturedCrashReportText(
   )
 }
 
+function skippedCrashDiagnosticBundle(): CrashDiagnosticBundleUpload {
+  return {
+    diagnosticBundle: {
+      status: 'not_uploaded',
+      reason: 'diagnostic log upload skipped by user'
+    }
+  }
+}
+
 async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticBundleUpload> {
   const status = getDiagnosticsStatus()
   if (!status.bundleEnabled) {
@@ -316,37 +325,6 @@ async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticB
       diagnosticBundle: {
         status: 'not_uploaded',
         reason: status.disabledReason ?? 'diagnostic bundle collection is disabled'
-      }
-    }
-  }
-
-  const consent = await dialog.showMessageBox({
-    type: 'question',
-    buttons: ['Attach Logs', 'Send Without Logs'],
-    defaultId: 1,
-    cancelId: 1,
-    title: 'Attach diagnostic logs?',
-    message: 'Attach recent redacted diagnostic logs to this crash report?',
-    detail:
-      'Orca will upload a capped redacted diagnostic bundle to support and link it in the crash report. Choose Send Without Logs to submit only the crash details.'
-  })
-  if (consent.response !== 0) {
-    return {
-      diagnosticBundle: {
-        status: 'not_uploaded',
-        reason: 'diagnostic log upload skipped by user'
-      }
-    }
-  }
-
-  // Why: the renderer is untrusted; re-check the diagnostics setting after the
-  // main-process consent dialog before collecting or uploading log bytes.
-  const statusAfterConsent = getDiagnosticsStatus()
-  if (!statusAfterConsent.bundleEnabled) {
-    return {
-      diagnosticBundle: {
-        status: 'not_uploaded',
-        reason: statusAfterConsent.disabledReason ?? 'diagnostic bundle collection is disabled'
       }
     }
   }
@@ -492,7 +470,10 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
     async (_event, args: CrashReportSubmitArgs): Promise<CrashReportSubmitResult> => {
       const report = await getRequestedCrashReport(store, args)
       if (!report) {
-        const diagnosticUpload = await collectAndUploadCrashDiagnosticBundle()
+        const diagnosticUpload =
+          args.includeDiagnosticLogs === false
+            ? skippedCrashDiagnosticBundle()
+            : await collectAndUploadCrashDiagnosticBundle()
         const diagnosticBundle = diagnosticUpload.diagnosticBundle
         const result = await submitFeedback({
           feedback: buildUncapturedCrashReportText(args.notes, diagnosticBundle),
@@ -532,7 +513,10 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
 
       inFlightSubmissions.add(report.id)
       try {
-        const diagnosticUpload = await collectAndUploadCrashDiagnosticBundle()
+        const diagnosticUpload =
+          args.includeDiagnosticLogs === false
+            ? skippedCrashDiagnosticBundle()
+            : await collectAndUploadCrashDiagnosticBundle()
         const diagnosticBundle = diagnosticUpload.diagnosticBundle
         const result = await submitFeedback({
           feedback: formatCrashReportText(report, args.notes, diagnosticBundle),

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -1,14 +1,17 @@
-/* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share one
-   dedupe/submission state machine and one crash-store contract. */
+/* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share renderer
+   error capture, diagnostic upload, and crash-store submission state. */
 import os from 'node:os'
 import { app, clipboard, ipcMain } from 'electron'
 import {
   type CrashReportBreadcrumbData,
-  formatCrashReportText,
+  type CrashReportDiagnosticBundle,
   type ReactErrorBoundaryReportArgs,
   type ReactErrorBoundaryReportResult,
   type CrashReportSubmitArgs,
-  type CrashReportSubmitResult
+  type CrashReportSubmitResult,
+  formatCrashReportText,
+  formatUncapturedCrashReportText,
+  sanitizeCrashReportString
 } from '../../shared/crash-reporting'
 import { submitFeedback } from './feedback'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
@@ -16,6 +19,16 @@ import {
   getCrashBreadcrumbSnapshot,
   recordCrashBreadcrumb
 } from '../crash-reporting/crash-breadcrumb-store'
+import {
+  collectDiagnosticBundle,
+  deleteDiagnosticBundle,
+  getDiagnosticsStatus,
+  uploadDiagnosticBundle
+} from '../observability'
+import {
+  resolveDiagnosticOrcaChannel,
+  resolveDiagnosticTokenEndpoint
+} from '../observability/diagnostic-upload-endpoint'
 
 const inFlightSubmissions = new Set<string>()
 const submittedReportIds = new Set<string>()
@@ -25,6 +38,7 @@ const RENDERER_ERROR_DEDUPE_MS = 10 * 60 * 1000
 const MAX_RENDERER_ERROR_KEY_AGE_MS = RENDERER_ERROR_DEDUPE_MS * 2
 const MAX_RECENT_RENDERER_ERROR_REPORT_KEYS = 256
 const MAX_SUBMITTED_REPORT_IDS = 256
+const CRASH_REPORT_LOG_LOOKBACK_MINUTES = 3 * 24 * 60
 
 const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surface']>([
   'app-root',
@@ -38,6 +52,11 @@ const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surf
   'overlay',
   'rich-markdown-editor'
 ])
+
+type CrashDiagnosticBundleUpload = {
+  readonly diagnosticBundle: CrashReportDiagnosticBundle
+  readonly tokenEndpoint?: string
+}
 
 function stringField(value: unknown, maxLength: number): string | undefined {
   if (typeof value !== 'string') {
@@ -240,6 +259,18 @@ async function getLatestSendableReport(
   )
 }
 
+async function getRequestedCrashReport(
+  store: CrashReportStore,
+  args?: { reportId?: string }
+): Promise<Awaited<ReturnType<CrashReportStore['getLatestPending']>>> {
+  if (args?.reportId) {
+    return store.getById(args.reportId)
+  }
+  // Why: Help > Report Crash can intentionally submit without a report ID.
+  // Do not replace that uncaptured report with a pending crash that appears later.
+  return args ? null : getLatestPendingReport(store)
+}
+
 function sanitizeRendererBreadcrumbData(value: unknown): CrashReportBreadcrumbData | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined
@@ -253,6 +284,121 @@ function sanitizeRendererBreadcrumbData(value: unknown): CrashReportBreadcrumbDa
     }
   }
   return Object.keys(sanitized).length > 0 ? sanitized : undefined
+}
+
+function formatUnknownError(error: unknown): string {
+  return sanitizeCrashReportString(error instanceof Error ? error.message : String(error))
+}
+
+function buildUncapturedCrashReportText(
+  notes: string | undefined,
+  diagnosticBundle?: CrashReportDiagnosticBundle
+): string {
+  return formatUncapturedCrashReportText(
+    {
+      createdAt: new Date().toISOString(),
+      appVersion: app.getVersion(),
+      platform: os.platform(),
+      osRelease: os.release(),
+      arch: os.arch(),
+      electronVersion: process.versions.electron ?? 'unknown',
+      chromeVersion: process.versions.chrome ?? 'unknown'
+    },
+    notes,
+    diagnosticBundle
+  )
+}
+
+async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticBundleUpload> {
+  const status = getDiagnosticsStatus()
+  if (!status.bundleEnabled) {
+    return {
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: status.disabledReason ?? 'diagnostic bundle collection is disabled'
+      }
+    }
+  }
+
+  let bundle: ReturnType<typeof collectDiagnosticBundle>
+  try {
+    bundle = collectDiagnosticBundle({
+      appVersion: app.getVersion(),
+      platform: os.platform(),
+      arch: os.arch(),
+      osRelease: os.release(),
+      orcaChannel: resolveDiagnosticOrcaChannel(),
+      // Why: Help > Report Crash is often used after relaunch, long after the
+      // default 30 minute support bundle window would miss the failure context.
+      lookbackMinutes: CRASH_REPORT_LOG_LOOKBACK_MINUTES
+    })
+  } catch (error) {
+    return { diagnosticBundle: { status: 'not_uploaded', reason: formatUnknownError(error) } }
+  }
+
+  const tokenEndpoint = resolveDiagnosticTokenEndpoint()
+  if (!tokenEndpoint) {
+    return {
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: 'diagnostic upload endpoint is not configured for this build',
+        bundleSubmissionId: bundle.bundleSubmissionId,
+        bytes: bundle.bytes,
+        spanCount: bundle.spanCount
+      }
+    }
+  }
+
+  try {
+    const result = await uploadDiagnosticBundle({
+      tokenEndpoint,
+      payload: bundle.payload,
+      bundleSubmissionId: bundle.bundleSubmissionId
+    })
+    return {
+      diagnosticBundle: {
+        status: 'uploaded',
+        ticketId: result.ticketId,
+        bundleSubmissionId: bundle.bundleSubmissionId,
+        bytes: bundle.bytes,
+        spanCount: bundle.spanCount
+      },
+      tokenEndpoint
+    }
+  } catch (error) {
+    return {
+      diagnosticBundle: {
+        status: 'not_uploaded',
+        reason: formatUnknownError(error),
+        bundleSubmissionId: bundle.bundleSubmissionId,
+        bytes: bundle.bytes,
+        spanCount: bundle.spanCount
+      }
+    }
+  }
+}
+
+async function deleteUploadedCrashDiagnosticBundle(
+  upload: CrashDiagnosticBundleUpload
+): Promise<boolean> {
+  if (upload.diagnosticBundle.status !== 'uploaded') {
+    return true
+  }
+  if (!upload.tokenEndpoint) {
+    return false
+  }
+  try {
+    await deleteDiagnosticBundle({
+      tokenEndpoint: upload.tokenEndpoint,
+      ticketId: upload.diagnosticBundle.ticketId
+    })
+    return true
+  } catch (error) {
+    // Why: if the feedback post fails after log upload, deleting the orphaned
+    // bundle preserves the user's expectation that one Send creates one report.
+    console.error('[crash-reporting] Failed to delete orphaned diagnostic bundle:', error)
+    return false
+  }
 }
 
 export function registerCrashReportingHandlers(store: CrashReportStore): void {
@@ -289,11 +435,10 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   ipcMain.handle(
     'crashReports:copyLatestDiagnostics',
     async (_event, args?: { reportId?: string; notes?: string }) => {
-      const report = args?.reportId
-        ? await store.getById(args.reportId)
-        : await getLatestPendingReport(store)
+      const report = await getRequestedCrashReport(store, args)
       if (!report) {
-        return { ok: false as const, error: 'No crash report available.' }
+        clipboard.writeText(buildUncapturedCrashReportText(args?.notes))
+        return { ok: true as const }
       }
       clipboard.writeText(formatCrashReportText(report, args?.notes))
       return { ok: true as const }
@@ -314,11 +459,26 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   ipcMain.handle(
     'crashReports:submit',
     async (_event, args: CrashReportSubmitArgs): Promise<CrashReportSubmitResult> => {
-      const report = args.reportId
-        ? await store.getById(args.reportId)
-        : await getLatestPendingReport(store)
+      const report = await getRequestedCrashReport(store, args)
       if (!report) {
-        return { ok: false, status: null, error: 'No crash report available.' }
+        const diagnosticUpload = await collectAndUploadCrashDiagnosticBundle()
+        const diagnosticBundle = diagnosticUpload.diagnosticBundle
+        const result = await submitFeedback({
+          feedback: buildUncapturedCrashReportText(args.notes, diagnosticBundle),
+          submissionType: 'crash',
+          submitAnonymously: args.submitAnonymously,
+          githubLogin: args.githubLogin,
+          githubEmail: args.githubEmail
+        })
+        return result.ok
+          ? { ok: true, report: null, diagnosticBundle }
+          : {
+              ...result,
+              report: null,
+              ...((await deleteUploadedCrashDiagnosticBundle(diagnosticUpload))
+                ? {}
+                : { diagnosticBundle })
+            }
       }
       const canSubmitDismissedReport = Boolean(args.reportId && report.status === 'dismissed')
       if (
@@ -341,15 +501,23 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
 
       inFlightSubmissions.add(report.id)
       try {
+        const diagnosticUpload = await collectAndUploadCrashDiagnosticBundle()
+        const diagnosticBundle = diagnosticUpload.diagnosticBundle
         const result = await submitFeedback({
-          feedback: formatCrashReportText(report, args.notes),
+          feedback: formatCrashReportText(report, args.notes, diagnosticBundle),
           submissionType: 'crash',
           submitAnonymously: args.submitAnonymously,
           githubLogin: args.githubLogin,
           githubEmail: args.githubEmail
         })
         if (!result.ok) {
-          return { ...result, report }
+          return {
+            ...result,
+            report,
+            ...((await deleteUploadedCrashDiagnosticBundle(diagnosticUpload))
+              ? {}
+              : { diagnosticBundle })
+          }
         }
         rememberSubmittedReportId(report.id)
         if (report.status === 'dismissed') {

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -540,21 +540,21 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
             // Why: startup prompts are dismissed before the user can send from
             // the still-open dialog, so successful uploads must update storage.
             const sent = await store.markDismissedSent(report.id)
-            return { ok: true, report: sent ?? { ...report, status: 'sent' } }
+            return { ok: true, report: sent ?? { ...report, status: 'sent' }, diagnosticBundle }
           } catch (error) {
             console.error('[crash-reporting] Failed to mark dismissed crash report sent:', error)
-            return { ok: true, report: { ...report, status: 'sent' } }
+            return { ok: true, report: { ...report, status: 'sent' }, diagnosticBundle }
           }
         }
         try {
           const sent = await store.markSent(report.id)
-          return { ok: true, report: sent ?? { ...report, status: 'sent' } }
+          return { ok: true, report: sent ?? { ...report, status: 'sent' }, diagnosticBundle }
         } catch (error) {
           // Why: the upstream submission already succeeded. A local persistence
           // failure must not present as upload failure or invite duplicate sends
           // during this app session.
           console.error('[crash-reporting] Failed to mark crash report sent:', error)
-          return { ok: true, report: { ...report, status: 'sent' } }
+          return { ok: true, report: { ...report, status: 'sent' }, diagnosticBundle }
         }
       } finally {
         inFlightSubmissions.delete(report.id)

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -19,16 +19,9 @@ import {
   getCrashBreadcrumbSnapshot,
   recordCrashBreadcrumb
 } from '../crash-reporting/crash-breadcrumb-store'
-import {
-  collectDiagnosticBundle,
-  deleteDiagnosticBundle,
-  getDiagnosticsStatus,
-  uploadDiagnosticBundle
-} from '../observability'
-import {
-  resolveDiagnosticOrcaChannel,
-  resolveDiagnosticTokenEndpoint
-} from '../observability/diagnostic-upload-endpoint'
+import { collectDiagnosticBundle, getDiagnosticsStatus } from '../observability'
+import { resolveDiagnosticOrcaChannel } from '../observability/diagnostic-upload-endpoint'
+import type { FeedbackDiagnosticBundleAttachment } from './feedback'
 
 const inFlightSubmissions = new Set<string>()
 const submittedReportIds = new Set<string>()
@@ -53,9 +46,9 @@ const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surf
   'rich-markdown-editor'
 ])
 
-type CrashDiagnosticBundleUpload = {
+type CrashDiagnosticBundleAttachment = {
   readonly diagnosticBundle: CrashReportDiagnosticBundle
-  readonly tokenEndpoint?: string
+  readonly feedbackDiagnosticBundle?: FeedbackDiagnosticBundleAttachment
 }
 
 function stringField(value: unknown, maxLength: number): string | undefined {
@@ -309,7 +302,7 @@ function buildUncapturedCrashReportText(
   )
 }
 
-function skippedCrashDiagnosticBundle(): CrashDiagnosticBundleUpload {
+function skippedCrashDiagnosticBundle(): CrashDiagnosticBundleAttachment {
   return {
     diagnosticBundle: {
       status: 'not_uploaded',
@@ -318,7 +311,7 @@ function skippedCrashDiagnosticBundle(): CrashDiagnosticBundleUpload {
   }
 }
 
-async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticBundleUpload> {
+function collectCrashDiagnosticBundleAttachment(): CrashDiagnosticBundleAttachment {
   const status = getDiagnosticsStatus()
   if (!status.bundleEnabled) {
     return {
@@ -345,68 +338,19 @@ async function collectAndUploadCrashDiagnosticBundle(): Promise<CrashDiagnosticB
     return { diagnosticBundle: { status: 'not_uploaded', reason: formatUnknownError(error) } }
   }
 
-  const tokenEndpoint = resolveDiagnosticTokenEndpoint()
-  if (!tokenEndpoint) {
-    return {
-      diagnosticBundle: {
-        status: 'not_uploaded',
-        reason: 'diagnostic upload endpoint is not configured for this build',
-        bundleSubmissionId: bundle.bundleSubmissionId,
-        bytes: bundle.bytes,
-        spanCount: bundle.spanCount
-      }
+  return {
+    diagnosticBundle: {
+      status: 'attached',
+      bundleSubmissionId: bundle.bundleSubmissionId,
+      bytes: bundle.bytes,
+      spanCount: bundle.spanCount
+    },
+    feedbackDiagnosticBundle: {
+      bundleSubmissionId: bundle.bundleSubmissionId,
+      content: bundle.payload,
+      bytes: bundle.bytes,
+      spanCount: bundle.spanCount
     }
-  }
-
-  try {
-    const result = await uploadDiagnosticBundle({
-      tokenEndpoint,
-      payload: bundle.payload,
-      bundleSubmissionId: bundle.bundleSubmissionId
-    })
-    return {
-      diagnosticBundle: {
-        status: 'uploaded',
-        ticketId: result.ticketId,
-        bundleSubmissionId: bundle.bundleSubmissionId,
-        bytes: bundle.bytes,
-        spanCount: bundle.spanCount
-      },
-      tokenEndpoint
-    }
-  } catch (error) {
-    return {
-      diagnosticBundle: {
-        status: 'not_uploaded',
-        reason: formatUnknownError(error),
-        bundleSubmissionId: bundle.bundleSubmissionId,
-        bytes: bundle.bytes,
-        spanCount: bundle.spanCount
-      }
-    }
-  }
-}
-
-async function deleteUploadedCrashDiagnosticBundle(
-  upload: CrashDiagnosticBundleUpload
-): Promise<boolean> {
-  if (upload.diagnosticBundle.status !== 'uploaded') {
-    return true
-  }
-  if (!upload.tokenEndpoint) {
-    return false
-  }
-  try {
-    await deleteDiagnosticBundle({
-      tokenEndpoint: upload.tokenEndpoint,
-      ticketId: upload.diagnosticBundle.ticketId
-    })
-    return true
-  } catch (error) {
-    // Why: if the feedback post fails after log upload, deleting the orphaned
-    // bundle preserves the user's expectation that one Send creates one report.
-    console.error('[crash-reporting] Failed to delete orphaned diagnostic bundle:', error)
-    return false
   }
 }
 
@@ -473,23 +417,23 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         const diagnosticUpload =
           args.includeDiagnosticLogs === false
             ? skippedCrashDiagnosticBundle()
-            : await collectAndUploadCrashDiagnosticBundle()
+            : collectCrashDiagnosticBundleAttachment()
         const diagnosticBundle = diagnosticUpload.diagnosticBundle
         const result = await submitFeedback({
           feedback: buildUncapturedCrashReportText(args.notes, diagnosticBundle),
           submissionType: 'crash',
           submitAnonymously: args.submitAnonymously,
           githubLogin: args.githubLogin,
-          githubEmail: args.githubEmail
+          githubEmail: args.githubEmail,
+          ...(diagnosticUpload.feedbackDiagnosticBundle
+            ? { diagnosticBundle: diagnosticUpload.feedbackDiagnosticBundle }
+            : {})
         })
         return result.ok
           ? { ok: true, report: null, diagnosticBundle }
           : {
               ...result,
-              report: null,
-              ...((await deleteUploadedCrashDiagnosticBundle(diagnosticUpload))
-                ? {}
-                : { diagnosticBundle })
+              report: null
             }
       }
       const canSubmitDismissedReport = Boolean(args.reportId && report.status === 'dismissed')
@@ -516,22 +460,22 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         const diagnosticUpload =
           args.includeDiagnosticLogs === false
             ? skippedCrashDiagnosticBundle()
-            : await collectAndUploadCrashDiagnosticBundle()
+            : collectCrashDiagnosticBundleAttachment()
         const diagnosticBundle = diagnosticUpload.diagnosticBundle
         const result = await submitFeedback({
           feedback: formatCrashReportText(report, args.notes, diagnosticBundle),
           submissionType: 'crash',
           submitAnonymously: args.submitAnonymously,
           githubLogin: args.githubLogin,
-          githubEmail: args.githubEmail
+          githubEmail: args.githubEmail,
+          ...(diagnosticUpload.feedbackDiagnosticBundle
+            ? { diagnosticBundle: diagnosticUpload.feedbackDiagnosticBundle }
+            : {})
         })
         if (!result.ok) {
           return {
             ...result,
-            report,
-            ...((await deleteUploadedCrashDiagnosticBundle(diagnosticUpload))
-              ? {}
-              : { diagnosticBundle })
+            report
           }
         }
         rememberSubmittedReportId(report.id)

--- a/src/main/ipc/diagnostics.ts
+++ b/src/main/ipc/diagnostics.ts
@@ -36,6 +36,10 @@ import {
 } from '../observability'
 import type { CollectedBundle } from '../observability/bundle'
 import type { UploadBundleResult } from '../observability/diagnostic-bundle-upload'
+import {
+  resolveDiagnosticOrcaChannel,
+  resolveDiagnosticTokenEndpoint
+} from '../observability/diagnostic-upload-endpoint'
 
 export type DiagnosticsBundlePreview = Omit<CollectedBundle, 'payload'>
 
@@ -51,56 +55,6 @@ type PendingBundle = {
 }
 
 const pendingBundles = new Map<string, PendingBundle>()
-
-// Build-time constant for the diagnostic-token endpoint. Substituted by
-// electron-vite at compile time. Local / contributor builds get `null`,
-// at which point the upload path returns a clear "endpoint not configured"
-// error rather than POSTing to a placeholder.
-//
-// The dev escape hatch is `ORCA_DIAGNOSTICS_TOKEN_URL` — set this env var
-// to point at a local server during development. Mirrors the
-// `ORCA_OTLP_TRACES_URL` env-var pattern for OTLP.
-function resolveBuildTokenEndpoint(): string | null {
-  const endpoint =
-    typeof ORCA_DIAGNOSTICS_TOKEN_URL !== 'undefined'
-      ? ORCA_DIAGNOSTICS_TOKEN_URL
-      : ((globalThis as { ORCA_DIAGNOSTICS_TOKEN_URL?: string | null })
-          .ORCA_DIAGNOSTICS_TOKEN_URL ?? null)
-  return typeof endpoint === 'string' && endpoint.length > 0 ? endpoint : null
-}
-
-function resolveBuildIdentity(): 'stable' | 'rc' | null {
-  const ident =
-    typeof ORCA_BUILD_IDENTITY !== 'undefined'
-      ? ORCA_BUILD_IDENTITY
-      : ((globalThis as { ORCA_BUILD_IDENTITY?: 'stable' | 'rc' | null }).ORCA_BUILD_IDENTITY ??
-        null)
-  return ident === 'stable' || ident === 'rc' ? ident : null
-}
-
-function resolveTokenEndpoint(): string | null {
-  const buildEndpoint = resolveBuildTokenEndpoint()
-  // Official builds must stay pinned to the CI-substituted endpoint; the
-  // upload confirmation says "Orca support", so env cannot redirect it.
-  if (resolveBuildIdentity()) {
-    return buildEndpoint
-  }
-  // Env wins only for dev / unofficial builds so contributors can point a
-  // local packaged app at staging without re-running a release pipeline.
-  const fromEnv = process.env.ORCA_DIAGNOSTICS_TOKEN_URL
-  if (fromEnv && fromEnv.length > 0) {
-    return fromEnv
-  }
-  return buildEndpoint
-}
-
-function resolveOrcaChannel(): 'stable' | 'rc' | 'dev' {
-  const ident = resolveBuildIdentity()
-  if (ident === 'stable' || ident === 'rc') {
-    return ident
-  }
-  return 'dev'
-}
 
 function prunePendingBundles(now = Date.now()): void {
   for (const [id, pending] of pendingBundles) {
@@ -307,7 +261,7 @@ export function registerDiagnosticsHandlers(): void {
         platform: osPlatform(),
         arch: osArch(),
         osRelease: osRelease(),
-        orcaChannel: resolveOrcaChannel(),
+        orcaChannel: resolveDiagnosticOrcaChannel(),
         ...(lookbackMinutes !== undefined ? { lookbackMinutes } : {})
       })
       rememberBundle(bundle)
@@ -334,7 +288,7 @@ export function registerDiagnosticsHandlers(): void {
       if (!getDiagnosticsStatus().bundleEnabled) {
         throw new Error('diagnostic bundle collection is disabled')
       }
-      const tokenEndpoint = resolveTokenEndpoint()
+      const tokenEndpoint = resolveDiagnosticTokenEndpoint()
       if (!tokenEndpoint) {
         throw new Error('diagnostic upload endpoint is not configured for this build')
       }
@@ -371,7 +325,7 @@ export function registerDiagnosticsHandlers(): void {
     if (!isTicketId(ticketId)) {
       throw new Error('ticketId has invalid format')
     }
-    const tokenEndpoint = resolveTokenEndpoint()
+    const tokenEndpoint = resolveDiagnosticTokenEndpoint()
     if (!tokenEndpoint) {
       throw new Error('diagnostic upload endpoint is not configured for this build')
     }

--- a/src/main/ipc/feedback.test.ts
+++ b/src/main/ipc/feedback.test.ts
@@ -102,7 +102,7 @@ describe('submitFeedback', () => {
   it('falls back when the primary feedback request stalls', async () => {
     vi.useFakeTimers()
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
-      if (url.includes('api.onorca.dev')) {
+      if (url.includes('www.onorca.dev')) {
         return new Promise((_resolve, reject) => {
           init?.signal?.addEventListener('abort', () => reject(new Error('request aborted')))
         })
@@ -125,7 +125,7 @@ describe('submitFeedback', () => {
   it('does not retry the fallback when the fallback fails after a primary server error', async () => {
     vi.useFakeTimers()
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {
-      if (url.includes('api.onorca.dev')) {
+      if (url.includes('www.onorca.dev')) {
         return Promise.resolve({ ok: false, status: 500 } as Response)
       }
       return new Promise((_resolve, reject) => {
@@ -147,6 +147,18 @@ describe('submitFeedback', () => {
       error: 'fallback aborted'
     })
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('posts to the website API first so crash reports use the snippet-capable route', async () => {
+    await submitFeedback({
+      feedback: '[Crash Report]',
+      submissionType: 'crash',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null
+    } as Parameters<typeof submitFeedback>[0])
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://www.onorca.dev/v1/feedback')
   })
 
   it('forces renderer IPC submissions onto the feedback lane', async () => {

--- a/src/main/ipc/feedback.test.ts
+++ b/src/main/ipc/feedback.test.ts
@@ -99,6 +99,46 @@ describe('submitFeedback', () => {
     })
   })
 
+  it('attaches diagnostic bundles only to crash submissions', async () => {
+    const diagnosticBundle = {
+      bundleSubmissionId: 'bundleabcdefghijklmnop',
+      content: '{"type":"bundle-header"}\n',
+      bytes: 25,
+      spanCount: 1
+    }
+    await submitFeedback({
+      feedback: '[Crash Report]',
+      submissionType: 'crash',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null,
+      diagnosticBundle
+    } as Parameters<typeof submitFeedback>[0])
+    await submitFeedback({
+      feedback: 'normal feedback',
+      submitAnonymously: true,
+      githubLogin: null,
+      githubEmail: null,
+      diagnosticBundle
+    } as Parameters<typeof submitFeedback>[0])
+
+    const crashInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+    const feedbackInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined
+    const crashFormData = crashInit?.body as FormData
+    expect(crashFormData).toBeInstanceOf(FormData)
+    expect(crashInit?.headers).toBeUndefined()
+    expect(crashFormData.get('submissionType')).toBe('crash')
+    expect(crashFormData.get('diagnosticBundleSubmissionId')).toBe(
+      diagnosticBundle.bundleSubmissionId
+    )
+    expect(crashFormData.get('diagnosticBundleBytes')).toBe(String(diagnosticBundle.bytes))
+    expect(crashFormData.get('diagnosticBundleSpanCount')).toBe(String(diagnosticBundle.spanCount))
+    const file = crashFormData.get('diagnosticBundleFile')
+    expect(file).toBeInstanceOf(Blob)
+    await expect((file as Blob).text()).resolves.toBe(diagnosticBundle.content)
+    expect(JSON.parse(String(feedbackInit?.body))).not.toHaveProperty('diagnosticBundle')
+  })
+
   it('falls back when the primary feedback request stalls', async () => {
     vi.useFakeTimers()
     fetchMock.mockImplementation((url: string, init?: RequestInit) => {

--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -6,8 +6,8 @@ import { app, ipcMain, net } from 'electron'
 // endpoint rejects. Electron's net module runs in the main process and is not
 // subject to CORS, so we proxy the submission through IPC. This mirrors the
 // same pattern used by updater-changelog.ts and updater-nudge.ts.
-const FEEDBACK_API_URL = 'https://api.onorca.dev/v1/feedback'
-const FEEDBACK_API_FALLBACK_URL = 'https://www.onorca.dev/v1/feedback'
+const FEEDBACK_API_URL = 'https://www.onorca.dev/v1/feedback'
+const FEEDBACK_API_FALLBACK_URL = 'https://api.onorca.dev/v1/feedback'
 const FEEDBACK_REQUEST_TIMEOUT_MS = 10_000
 
 export type FeedbackSubmissionType = 'feedback' | 'crash'
@@ -114,9 +114,8 @@ export async function submitFeedback(
     if (res.ok) {
       return { ok: true }
     }
-    // Why: DNS for api.onorca.dev can lag behind a deploy. Only fall back on
-    // 404/5xx-style results and network errors — don't mask real 4xx responses
-    // from a healthy host.
+    // Why: keep api.onorca.dev as a compatibility fallback, but prefer the
+    // website API because it owns the Slack file/snippet crash delivery path.
     if (res.status === 404 || res.status >= 500) {
       return submitFallbackFeedback(body)
     }

--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -123,7 +123,7 @@ export async function submitFeedback(
   } catch (error) {
     // Why: falling back on any network-level failure preserves the prior
     // behavior where DNS/connect failures on the primary host transparently
-    // try the website-hosted versioned endpoint.
+    // try the legacy API endpoint.
     return submitFallbackFeedback(body, error)
   }
 }

--- a/src/main/ipc/feedback.ts
+++ b/src/main/ipc/feedback.ts
@@ -9,6 +9,7 @@ import { app, ipcMain, net } from 'electron'
 const FEEDBACK_API_URL = 'https://www.onorca.dev/v1/feedback'
 const FEEDBACK_API_FALLBACK_URL = 'https://api.onorca.dev/v1/feedback'
 const FEEDBACK_REQUEST_TIMEOUT_MS = 10_000
+const DIAGNOSTIC_BUNDLE_CONTENT_TYPE = 'application/x-ndjson'
 
 export type FeedbackSubmissionType = 'feedback' | 'crash'
 
@@ -17,6 +18,13 @@ export type FeedbackSubmitArgs = {
   submitAnonymously?: boolean
   githubLogin: string | null
   githubEmail: string | null
+}
+
+export type FeedbackDiagnosticBundleAttachment = {
+  bundleSubmissionId: string
+  content: string
+  bytes: number
+  spanCount: number
 }
 
 type FeedbackSubmitBody = {
@@ -28,6 +36,7 @@ type FeedbackSubmitBody = {
   platform: NodeJS.Platform
   osRelease: string
   arch: string
+  diagnosticBundle?: FeedbackDiagnosticBundleAttachment
 }
 
 export type FeedbackSubmitResult =
@@ -36,6 +45,7 @@ export type FeedbackSubmitResult =
 
 type InternalFeedbackSubmitArgs = FeedbackSubmitArgs & {
   submissionType?: FeedbackSubmissionType
+  diagnosticBundle?: FeedbackDiagnosticBundleAttachment
 }
 
 // Why: the Slack notification and any follow-up investigation need to know
@@ -57,7 +67,10 @@ function buildSubmitBody(args: InternalFeedbackSubmitArgs): FeedbackSubmitBody {
     appVersion: app.getVersion(),
     platform: process.platform,
     osRelease: os.release(),
-    arch: process.arch
+    arch: process.arch,
+    ...(args.submissionType === 'crash' && args.diagnosticBundle
+      ? { diagnosticBundle: args.diagnosticBundle }
+      : {})
   }
 }
 
@@ -67,14 +80,59 @@ async function postFeedback(url: string, body: FeedbackSubmitBody): Promise<Resp
   // submission flows pending forever.
   const timeout = setTimeout(() => controller.abort(), FEEDBACK_REQUEST_TIMEOUT_MS)
   try {
-    return await net.fetch(url, {
+    const init: RequestInit = {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      ...feedbackRequestBodyInit(body),
       signal: controller.signal
-    })
+    }
+    return await net.fetch(url, init)
   } finally {
     clearTimeout(timeout)
+  }
+}
+
+function feedbackRequestBodyInit(body: FeedbackSubmitBody): Pick<RequestInit, 'body' | 'headers'> {
+  if (!body.diagnosticBundle) {
+    return {
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }
+  }
+
+  const formData = new FormData()
+  appendFeedbackFormField(formData, 'feedback', body.feedback)
+  appendFeedbackFormField(formData, 'submissionType', body.submissionType)
+  appendFeedbackFormField(formData, 'githubLogin', body.githubLogin)
+  appendFeedbackFormField(formData, 'githubEmail', body.githubEmail)
+  appendFeedbackFormField(formData, 'appVersion', body.appVersion)
+  appendFeedbackFormField(formData, 'platform', body.platform)
+  appendFeedbackFormField(formData, 'osRelease', body.osRelease)
+  appendFeedbackFormField(formData, 'arch', body.arch)
+  appendFeedbackFormField(
+    formData,
+    'diagnosticBundleSubmissionId',
+    body.diagnosticBundle.bundleSubmissionId
+  )
+  appendFeedbackFormField(formData, 'diagnosticBundleBytes', String(body.diagnosticBundle.bytes))
+  appendFeedbackFormField(
+    formData,
+    'diagnosticBundleSpanCount',
+    String(body.diagnosticBundle.spanCount)
+  )
+  formData.append(
+    'diagnosticBundleFile',
+    new Blob([body.diagnosticBundle.content], { type: DIAGNOSTIC_BUNDLE_CONTENT_TYPE }),
+    `orca-diagnostics-${body.diagnosticBundle.bundleSubmissionId}.ndjson`
+  )
+
+  // Why: multipart avoids JSON-escaping a near-cap NDJSON bundle over the
+  // backend request limit while still submitting one feedback request.
+  return { body: formData }
+}
+
+function appendFeedbackFormField(formData: FormData, key: string, value: string | null): void {
+  if (value !== null) {
+    formData.append(key, value)
   }
 }
 

--- a/src/main/observability/bundle.test.ts
+++ b/src/main/observability/bundle.test.ts
@@ -490,7 +490,7 @@ describe('uploadBundle and deleteBundle', () => {
     ).rejects.toThrow(/^diagnostic response exceeded size limit$/)
   })
 
-  it('returns diagnostic blob links from successful uploads', async () => {
+  it('returns only the diagnostic ticket from successful uploads', async () => {
     const baseUrl = await listen((req, res) => {
       res.setHeader('content-type', 'application/json')
       if (req.url === '/token') {
@@ -504,14 +504,10 @@ describe('uploadBundle and deleteBundle', () => {
         )
         return
       }
-      const downloadUrl = `${baseUrl}/diagnostics/download/ticketabcdefghijklmnop?token=signed`
       res.statusCode = 201
       res.end(
         JSON.stringify({
-          ticket_id: 'ticketabcdefghijklmnop',
-          blob_url: 'https://blob.vercel-storage.com/diagnostics/ticket.ndjson',
-          blob_download_url: downloadUrl,
-          blob_pathname: 'diagnostics/ticket.ndjson'
+          ticket_id: 'ticketabcdefghijklmnop'
         })
       )
     })
@@ -523,9 +519,7 @@ describe('uploadBundle and deleteBundle', () => {
         bundleSubmissionId: generateBundleSubmissionId()
       })
     ).resolves.toEqual({
-      ticketId: 'ticketabcdefghijklmnop',
-      blobDownloadUrl: `${baseUrl}/diagnostics/download/ticketabcdefghijklmnop?token=signed`,
-      blobPathname: 'diagnostics/ticket.ndjson'
+      ticketId: 'ticketabcdefghijklmnop'
     })
   })
 

--- a/src/main/observability/bundle.test.ts
+++ b/src/main/observability/bundle.test.ts
@@ -490,6 +490,45 @@ describe('uploadBundle and deleteBundle', () => {
     ).rejects.toThrow(/^diagnostic response exceeded size limit$/)
   })
 
+  it('returns diagnostic blob links from successful uploads', async () => {
+    const baseUrl = await listen((req, res) => {
+      res.setHeader('content-type', 'application/json')
+      if (req.url === '/token') {
+        res.end(
+          JSON.stringify({
+            token: 'test-token',
+            expires_at: new Date(Date.now() + 60_000).toISOString(),
+            upload_url: `${baseUrl}/upload`,
+            max_bytes: _internalsForTests.MAX_BUNDLE_BYTES
+          })
+        )
+        return
+      }
+      const downloadUrl = `${baseUrl}/diagnostics/download/ticketabcdefghijklmnop?token=signed`
+      res.statusCode = 201
+      res.end(
+        JSON.stringify({
+          ticket_id: 'ticketabcdefghijklmnop',
+          blob_url: 'https://blob.vercel-storage.com/diagnostics/ticket.ndjson',
+          blob_download_url: downloadUrl,
+          blob_pathname: 'diagnostics/ticket.ndjson'
+        })
+      )
+    })
+
+    await expect(
+      uploadBundle({
+        tokenEndpoint: `${baseUrl}/token`,
+        payload: '{}\n',
+        bundleSubmissionId: generateBundleSubmissionId()
+      })
+    ).resolves.toEqual({
+      ticketId: 'ticketabcdefghijklmnop',
+      blobDownloadUrl: `${baseUrl}/diagnostics/download/ticketabcdefghijklmnop?token=signed`,
+      blobPathname: 'diagnostics/ticket.ndjson'
+    })
+  })
+
   it('posts deletion requests to the diagnostics delete endpoint for a ticket', async () => {
     const ticketId = generateBundleSubmissionId()
     const seen: string[] = []

--- a/src/main/observability/bundle.ts
+++ b/src/main/observability/bundle.ts
@@ -53,7 +53,7 @@ export type CollectedBundle = {
   readonly bundleSubmissionId: string
   /** UTF-8 NDJSON payload — header line + N redacted span lines. */
   readonly payload: string
-  /** Byte length of `payload`. Pre-checked against the 10 MB upload cap. */
+  /** Byte length of `payload`. Pre-checked against the 4 MiB upload cap. */
   readonly bytes: number
   /** Span-line count, for the preview window's "N spans" label. */
   readonly spanCount: number
@@ -179,7 +179,7 @@ export function collectBundle(opts: CollectBundleOptions): CollectedBundle {
         continue
       }
       if (currentBytes + redactedBytes > MAX_BUNDLE_BYTES) {
-        // Hard ceiling at the same 10 MB the upload endpoint enforces (F4).
+        // Hard ceiling at the same 4 MiB the upload endpoint enforces.
         // Check before appending so the preview can be uploaded as-is.
         break outer
       }

--- a/src/main/observability/diagnostic-bundle-limits.ts
+++ b/src/main/observability/diagnostic-bundle-limits.ts
@@ -1,1 +1,1 @@
-export const MAX_BUNDLE_BYTES = 10 * 1024 * 1024 // 10 MB cap enforced before upload
+export const MAX_BUNDLE_BYTES = 4 * 1024 * 1024 // 4 MiB cap enforced before upload

--- a/src/main/observability/diagnostic-bundle-upload.ts
+++ b/src/main/observability/diagnostic-bundle-upload.ts
@@ -42,7 +42,7 @@ type UploadResponse = {
 export async function uploadBundle(opts: UploadBundleOptions): Promise<UploadBundleResult> {
   const bytes = Buffer.byteLength(opts.payload)
   if (bytes > MAX_BUNDLE_BYTES) {
-    throw new Error(`bundle exceeds 10 MB cap (${bytes} bytes)`)
+    throw new Error(`bundle exceeds 4 MiB cap (${bytes} bytes)`)
   }
 
   // (1) Request a token. The token endpoint is rate-limited per IP at the

--- a/src/main/observability/diagnostic-bundle-upload.ts
+++ b/src/main/observability/diagnostic-bundle-upload.ts
@@ -16,6 +16,9 @@ export type UploadBundleOptions = {
 
 export type UploadBundleResult = {
   readonly ticketId: string
+  readonly blobUrl?: string
+  readonly blobDownloadUrl?: string
+  readonly blobPathname?: string
 }
 
 export type DeleteBundleOptions = {
@@ -32,6 +35,44 @@ type TokenResponse = {
 
 type UploadResponse = {
   readonly ticket_id: string
+  readonly blob_url?: unknown
+  readonly blob_download_url?: unknown
+  readonly blob_pathname?: unknown
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]' ||
+    hostname === '::1'
+  )
+}
+
+function optionalTrustedDiagnosticUrl(value: unknown, tokenEndpoint: string): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined
+  }
+  try {
+    const parsed = new URL(value)
+    const token = new URL(tokenEndpoint)
+    if (parsed.host !== token.host) {
+      return undefined
+    }
+    if (token.protocol === 'https:') {
+      return parsed.protocol === 'https:' ? value : undefined
+    }
+    if (token.protocol === 'http:') {
+      return parsed.protocol === 'http:' && isLoopbackHostname(parsed.hostname) ? value : undefined
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 /**
@@ -90,7 +131,18 @@ export async function uploadBundle(opts: UploadBundleOptions): Promise<UploadBun
   if (typeof uploadRes.ticket_id !== 'string' || uploadRes.ticket_id.length === 0) {
     throw new Error('malformed upload response: missing ticket_id')
   }
-  return { ticketId: uploadRes.ticket_id }
+  const blobUrl = optionalTrustedDiagnosticUrl(uploadRes.blob_url, opts.tokenEndpoint)
+  const blobDownloadUrl = optionalTrustedDiagnosticUrl(
+    uploadRes.blob_download_url,
+    opts.tokenEndpoint
+  )
+  const blobPathname = optionalString(uploadRes.blob_pathname)
+  return {
+    ticketId: uploadRes.ticket_id,
+    ...(blobUrl ? { blobUrl } : {}),
+    ...(blobDownloadUrl ? { blobDownloadUrl } : {}),
+    ...(blobPathname ? { blobPathname } : {})
+  }
 }
 
 export async function deleteBundle(opts: DeleteBundleOptions): Promise<void> {

--- a/src/main/observability/diagnostic-bundle-upload.ts
+++ b/src/main/observability/diagnostic-bundle-upload.ts
@@ -16,9 +16,6 @@ export type UploadBundleOptions = {
 
 export type UploadBundleResult = {
   readonly ticketId: string
-  readonly blobUrl?: string
-  readonly blobDownloadUrl?: string
-  readonly blobPathname?: string
 }
 
 export type DeleteBundleOptions = {
@@ -35,44 +32,6 @@ type TokenResponse = {
 
 type UploadResponse = {
   readonly ticket_id: string
-  readonly blob_url?: unknown
-  readonly blob_download_url?: unknown
-  readonly blob_pathname?: unknown
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  return (
-    hostname === 'localhost' ||
-    hostname === '127.0.0.1' ||
-    hostname === '[::1]' ||
-    hostname === '::1'
-  )
-}
-
-function optionalTrustedDiagnosticUrl(value: unknown, tokenEndpoint: string): string | undefined {
-  if (typeof value !== 'string' || value.length === 0) {
-    return undefined
-  }
-  try {
-    const parsed = new URL(value)
-    const token = new URL(tokenEndpoint)
-    if (parsed.host !== token.host) {
-      return undefined
-    }
-    if (token.protocol === 'https:') {
-      return parsed.protocol === 'https:' ? value : undefined
-    }
-    if (token.protocol === 'http:') {
-      return parsed.protocol === 'http:' && isLoopbackHostname(parsed.hostname) ? value : undefined
-    }
-    return undefined
-  } catch {
-    return undefined
-  }
-}
-
-function optionalString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 /**
@@ -131,17 +90,8 @@ export async function uploadBundle(opts: UploadBundleOptions): Promise<UploadBun
   if (typeof uploadRes.ticket_id !== 'string' || uploadRes.ticket_id.length === 0) {
     throw new Error('malformed upload response: missing ticket_id')
   }
-  const blobUrl = optionalTrustedDiagnosticUrl(uploadRes.blob_url, opts.tokenEndpoint)
-  const blobDownloadUrl = optionalTrustedDiagnosticUrl(
-    uploadRes.blob_download_url,
-    opts.tokenEndpoint
-  )
-  const blobPathname = optionalString(uploadRes.blob_pathname)
   return {
-    ticketId: uploadRes.ticket_id,
-    ...(blobUrl ? { blobUrl } : {}),
-    ...(blobDownloadUrl ? { blobDownloadUrl } : {}),
-    ...(blobPathname ? { blobPathname } : {})
+    ticketId: uploadRes.ticket_id
   }
 }
 

--- a/src/main/observability/diagnostic-upload-endpoint.ts
+++ b/src/main/observability/diagnostic-upload-endpoint.ts
@@ -1,0 +1,42 @@
+// Build-time diagnostic upload routing. Kept outside ipc/diagnostics.ts so
+// crash reporting can attach logs through the same pinned endpoint rules.
+
+export function resolveDiagnosticBuildTokenEndpoint(): string | null {
+  const endpoint =
+    typeof ORCA_DIAGNOSTICS_TOKEN_URL !== 'undefined'
+      ? ORCA_DIAGNOSTICS_TOKEN_URL
+      : ((globalThis as { ORCA_DIAGNOSTICS_TOKEN_URL?: string | null })
+          .ORCA_DIAGNOSTICS_TOKEN_URL ?? null)
+  return typeof endpoint === 'string' && endpoint.length > 0 ? endpoint : null
+}
+
+export function resolveDiagnosticBuildIdentity(): 'stable' | 'rc' | null {
+  const ident =
+    typeof ORCA_BUILD_IDENTITY !== 'undefined'
+      ? ORCA_BUILD_IDENTITY
+      : ((globalThis as { ORCA_BUILD_IDENTITY?: 'stable' | 'rc' | null }).ORCA_BUILD_IDENTITY ??
+        null)
+  return ident === 'stable' || ident === 'rc' ? ident : null
+}
+
+export function resolveDiagnosticTokenEndpoint(): string | null {
+  const buildEndpoint = resolveDiagnosticBuildTokenEndpoint()
+  // Official builds must stay pinned to the CI-substituted endpoint; user env
+  // cannot redirect uploads that the UI labels as going to Orca support.
+  if (resolveDiagnosticBuildIdentity()) {
+    return buildEndpoint
+  }
+  const fromEnv = process.env.ORCA_DIAGNOSTICS_TOKEN_URL
+  if (fromEnv && fromEnv.length > 0) {
+    return fromEnv
+  }
+  return buildEndpoint
+}
+
+export function resolveDiagnosticOrcaChannel(): 'stable' | 'rc' | 'dev' {
+  const ident = resolveDiagnosticBuildIdentity()
+  if (ident === 'stable' || ident === 'rc') {
+    return ident
+  }
+  return 'dev'
+}

--- a/src/main/observability/redactor.ts
+++ b/src/main/observability/redactor.ts
@@ -27,7 +27,7 @@
 //
 // Per-attribute length capping is deliberately NOT applied here. The spec
 // argues against it (see §The redactor "No per-attribute length cap"):
-// envelope-level bounds (10 MB × 10 file rotation; 10 MB Mode-3 upload cap)
+// envelope-level bounds (10 MB × 10 file rotation; 4 MiB bundle upload cap)
 // already cover the worst case, and a per-attribute truncation would eat the
 // tail of long stack chains, which is the most diagnostic part. Spans that
 // dump a multi-MB blob into one attribute are a call-site bug to fix at the

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -2,6 +2,7 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } f
 import { AlertTriangle, Clipboard, Send } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -10,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   formatCrashReportText,
@@ -73,6 +75,7 @@ export function CrashReportDialogSurface({
 }: CrashReportDialogSurfaceProps): React.JSX.Element {
   const mountedRef = useMountedRef()
   const [notes, setNotes] = useState('')
+  const [includeDiagnosticLogs, setIncludeDiagnosticLogs] = useState(true)
   const [submitting, setSubmitting] = useState(false)
   const [viewer, setViewer] = useState<GitHubViewer | null>(null)
   // Why: account lookup can resolve after the dialog closes or reopens.
@@ -114,6 +117,7 @@ export function CrashReportDialogSurface({
       clearViewer()
       return
     }
+    setIncludeDiagnosticLogs(true)
     loadViewerForOpenDialog()
   }, [clearViewer, loadViewerForOpenDialog, open])
 
@@ -152,6 +156,7 @@ export function CrashReportDialogSurface({
       const result = await window.api.crashReports.submit({
         ...(report ? { reportId: report.id } : {}),
         notes,
+        includeDiagnosticLogs,
         // Why: crash reporting must degrade to anonymous if gh is unavailable;
         // identity lookup is best-effort and never blocks report creation.
         submitAnonymously: !viewer,
@@ -229,25 +234,25 @@ export function CrashReportDialogSurface({
         <div className="space-y-3">
           {report ? (
             <>
-            <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs">
-              <div className="font-medium text-foreground">{formatSummary(report)}</div>
-              <div className="mt-1 text-muted-foreground">
-                {new Date(report.createdAt).toLocaleString()} · {report.platform} {report.arch} ·
-                {translate('auto.components.crash.report.CrashReportDialog.835037edc9', 'Orca')}{' '}
-                {report.appVersion}
+              <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs">
+                <div className="font-medium text-foreground">{formatSummary(report)}</div>
+                <div className="mt-1 text-muted-foreground">
+                  {new Date(report.createdAt).toLocaleString()} · {report.platform} {report.arch} ·
+                  {translate('auto.components.crash.report.CrashReportDialog.835037edc9', 'Orca')}{' '}
+                  {report.appVersion}
+                </div>
               </div>
-            </div>
-            <div className="space-y-1.5">
-              <div className="text-[11px] font-medium text-muted-foreground">
-                {translate(
-                  'auto.components.crash.report.CrashReportDialog.6d3ebe216a',
-                  'Diagnostic text'
-                )}
+              <div className="space-y-1.5">
+                <div className="text-[11px] font-medium text-muted-foreground">
+                  {translate(
+                    'auto.components.crash.report.CrashReportDialog.6d3ebe216a',
+                    'Diagnostic text'
+                  )}
+                </div>
+                <pre className="max-h-44 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/20 p-3 font-mono text-[11px] leading-5 text-muted-foreground scrollbar-sleek">
+                  {diagnosticText}
+                </pre>
               </div>
-              <pre className="max-h-44 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/20 p-3 font-mono text-[11px] leading-5 text-muted-foreground scrollbar-sleek">
-                {diagnosticText}
-              </pre>
-            </div>
             </>
           ) : (
             <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs text-muted-foreground">
@@ -266,6 +271,23 @@ export function CrashReportDialogSurface({
             placeholder={getNotesPlaceholder(report)}
             className="min-h-24 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           />
+          <div className="flex items-start gap-2 rounded-md border border-border/70 bg-muted/20 p-3">
+            <Checkbox
+              id="crash-report-attach-diagnostics"
+              checked={includeDiagnosticLogs}
+              onCheckedChange={(checked) => setIncludeDiagnosticLogs(checked === true)}
+              disabled={submitting}
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <Label htmlFor="crash-report-attach-diagnostics" className="text-xs">
+                Attach recent diagnostic logs
+              </Label>
+              <div className="text-xs leading-5 text-muted-foreground">
+                Sends a capped redacted log bundle with the report.
+              </div>
+            </div>
+          </div>
         </div>
 
         <DialogFooter className="gap-2">

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -30,18 +30,27 @@ function formatSummary(report: CrashReportRecord): string {
 }
 
 function getDialogTitle(report: CrashReportRecord | null): string {
+  if (!report) {
+    return 'Report a crash'
+  }
   return report && isReactErrorBoundaryReport(report)
     ? 'Orca hit a recoverable UI error'
     : 'Orca closed unexpectedly'
 }
 
 function getDialogDescription(report: CrashReportRecord | null): string {
+  if (!report) {
+    return 'Send a privacy-safe crash report. Recent redacted diagnostic logs are included when available.'
+  }
   return report && isReactErrorBoundaryReport(report)
     ? 'Send a privacy-safe diagnostic report to help us understand the failed UI surface.'
     : 'Send a privacy-safe diagnostic report to help us understand what happened.'
 }
 
 function getNotesPlaceholder(report: CrashReportRecord | null): string {
+  if (!report) {
+    return 'Optional: what happened?'
+  }
   return report && isReactErrorBoundaryReport(report)
     ? 'Optional: what were you doing before this UI error?'
     : 'Optional: what were you doing before Orca closed?'
@@ -110,7 +119,7 @@ export function CrashReportDialogSurface({
 
   const handleCopy = async (): Promise<void> => {
     const result = await window.api.crashReports.copyLatestDiagnostics(
-      report ? { reportId: report.id, notes } : {}
+      report ? { reportId: report.id, notes } : { notes }
     )
     if (!result.ok) {
       toast.error(result.error)
@@ -138,13 +147,10 @@ export function CrashReportDialogSurface({
   }
 
   const handleSubmit = async (): Promise<void> => {
-    if (!report) {
-      return
-    }
     setSubmitting(true)
     try {
       const result = await window.api.crashReports.submit({
-        reportId: report.id,
+        ...(report ? { reportId: report.id } : {}),
         notes,
         // Why: crash reporting must degrade to anonymous if gh is unavailable;
         // identity lookup is best-effort and never blocks report creation.
@@ -153,7 +159,20 @@ export function CrashReportDialogSurface({
         githubEmail: null
       })
       if (!result.ok) {
-        throw new Error(result.error)
+        if (result.diagnosticBundle?.status === 'uploaded') {
+          toast.error(
+            `Failed to send crash report. Diagnostic ticket ${result.diagnosticBundle.ticketId} was uploaded but not linked.`
+          )
+        } else {
+          toast.error(
+            translate(
+              'auto.components.crash.report.CrashReportDialog.56a3dfa283',
+              'Failed to send crash report.'
+            )
+          )
+        }
+        console.error('Failed to submit crash report:', result.error)
+        return
       }
       if (!mountedRef.current) {
         return
@@ -207,8 +226,9 @@ export function CrashReportDialogSurface({
           <DialogDescription className="text-xs">{getDialogDescription(report)}</DialogDescription>
         </DialogHeader>
 
-        {report ? (
-          <div className="space-y-3">
+        <div className="space-y-3">
+          {report ? (
+            <>
             <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs">
               <div className="font-medium text-foreground">{formatSummary(report)}</div>
               <div className="mt-1 text-muted-foreground">
@@ -217,13 +237,6 @@ export function CrashReportDialogSurface({
                 {report.appVersion}
               </div>
             </div>
-            <textarea
-              value={notes}
-              onChange={(event) => setNotes(event.target.value)}
-              rows={4}
-              placeholder={getNotesPlaceholder(report)}
-              className="min-h-24 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            />
             <div className="space-y-1.5">
               <div className="text-[11px] font-medium text-muted-foreground">
                 {translate(
@@ -235,23 +248,28 @@ export function CrashReportDialogSurface({
                 {diagnosticText}
               </pre>
             </div>
-          </div>
-        ) : (
-          <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs text-muted-foreground">
-            {loading
-              ? translate(
-                  'auto.components.crash.report.CrashReportDialog.765591798d',
-                  'Checking for crash reports...'
-                )
-              : translate(
-                  'auto.components.crash.report.CrashReportDialog.b175e90213',
-                  'No crash report is available.'
-                )}
-          </div>
-        )}
+            </>
+          ) : (
+            <div className="rounded-md border border-border/70 bg-muted/30 p-3 text-xs text-muted-foreground">
+              {loading
+                ? translate(
+                    'auto.components.crash.report.CrashReportDialog.765591798d',
+                    'Checking for crash reports...'
+                  )
+                : 'No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.'}
+            </div>
+          )}
+          <textarea
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            rows={4}
+            placeholder={getNotesPlaceholder(report)}
+            className="min-h-24 w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          />
+        </div>
 
         <DialogFooter className="gap-2">
-          <Button type="button" variant="outline" size="sm" onClick={handleCopy} disabled={!report}>
+          <Button type="button" variant="outline" size="sm" onClick={handleCopy} disabled={loading}>
             <Clipboard className="size-3.5" />
             {translate('auto.components.crash.report.CrashReportDialog.50b00dc327', 'Copy Details')}
           </Button>
@@ -264,7 +282,7 @@ export function CrashReportDialogSurface({
           >
             {translate('auto.components.crash.report.CrashReportDialog.88fea8e84e', "Don't Send")}
           </Button>
-          <Button type="button" size="sm" onClick={handleSubmit} disabled={!report || submitting}>
+          <Button type="button" size="sm" onClick={handleSubmit} disabled={loading || submitting}>
             <Send className="size-3.5" />
             {translate('auto.components.crash.report.CrashReportDialog.b4951cd27c', 'Send Report')}
           </Button>

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -166,7 +166,11 @@ export function CrashReportDialogSurface({
       if (!result.ok) {
         if (result.diagnosticBundle?.status === 'uploaded') {
           toast.error(
-            `Failed to send crash report. Diagnostic ticket ${result.diagnosticBundle.ticketId} was uploaded but not linked.`
+            translate(
+              'auto.components.crash.report.CrashReportDialog.b2e36f53a1',
+              'Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.',
+              { value0: result.diagnosticBundle.ticketId }
+            )
           )
         } else {
           toast.error(

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -265,7 +265,10 @@ export function CrashReportDialogSurface({
                     'auto.components.crash.report.CrashReportDialog.765591798d',
                     'Checking for crash reports...'
                   )
-                : 'No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.'}
+                : translate(
+                    'auto.components.crash.report.CrashReportDialog.ead6fc0510',
+                    'No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.'
+                  )}
             </div>
           )}
           <textarea
@@ -285,10 +288,16 @@ export function CrashReportDialogSurface({
             />
             <div className="space-y-1">
               <Label htmlFor="crash-report-attach-diagnostics" className="text-xs">
-                Attach recent diagnostic logs
+                {translate(
+                  'auto.components.crash.report.CrashReportDialog.b082f27490',
+                  'Attach recent diagnostic logs'
+                )}
               </Label>
               <div className="text-xs leading-5 text-muted-foreground">
-                Sends a capped redacted log bundle with the report.
+                {translate(
+                  'auto.components.crash.report.CrashReportDialog.e59f0b9427',
+                  'Sends a capped redacted log bundle with the report.'
+                )}
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -1023,6 +1023,28 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 
+  it('does not crash if the preload focus bridge is stale during dev reload', async () => {
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      api: {
+        app: {
+          getFloatingMarkdownDirectory: mocks.getFloatingMarkdownDirectory,
+          getFloatingTerminalCwd: mocks.getFloatingTerminalCwd,
+          pickFloatingMarkdownDocument: mocks.pickFloatingMarkdownDocument
+        },
+        browser: { notifyActiveTabChanged: vi.fn() },
+        cli: { getInstallStatus: mocks.getInstallStatus },
+        ui: {}
+      },
+      innerWidth: 1200,
+      removeEventListener: vi.fn()
+    })
+
+    await renderPanel(false)
+
+    expect(() => runEffects()).not.toThrow()
+  })
+
   it('minimizes the empty floating workspace from the empty state', async () => {
     const onOpenChange = vi.fn()
     const element = await renderPanel(true, onOpenChange)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -156,6 +156,16 @@ function areFloatingTerminalPanelCommittedBoundsEqual(
   return left !== null && JSON.stringify(left) === JSON.stringify(right)
 }
 
+function setFloatingTerminalInputFocusedInMain(focused: boolean): void {
+  const setInputFocused = window.api.ui.setFloatingTerminalInputFocused
+  // Why: dev reloads can pair a new renderer with an older preload; losing this
+  // shortcut mirror should not take down the whole React tree.
+  if (typeof setInputFocused !== 'function') {
+    return
+  }
+  setInputFocused(focused)
+}
+
 export function FloatingTerminalPanel({
   open,
   onOpenChange,
@@ -913,7 +923,7 @@ export function FloatingTerminalPanel({
   }, [cancelShortcutFocusFrame, focusPanelForShortcuts])
 
   const setFloatingTerminalInputFocused = useCallback((target: EventTarget | null): void => {
-    window.api.ui.setFloatingTerminalInputFocused(isFloatingWorkspaceTerminalInputTarget(target))
+    setFloatingTerminalInputFocusedInMain(isFloatingWorkspaceTerminalInputTarget(target))
   }, [])
 
   const handleShortcutSurfaceKeyDown = useCallback(
@@ -1119,9 +1129,9 @@ export function FloatingTerminalPanel({
 
   useEffect(() => {
     if (!open) {
-      window.api.ui.setFloatingTerminalInputFocused(false)
+      setFloatingTerminalInputFocusedInMain(false)
     }
-    return () => window.api.ui.setFloatingTerminalInputFocused(false)
+    return () => setFloatingTerminalInputFocusedInMain(false)
   }, [open])
 
   useEffect(() => {
@@ -1134,7 +1144,7 @@ export function FloatingTerminalPanel({
       if (!panel || !(event.target instanceof Node) || panel.contains(event.target)) {
         return
       }
-      window.api.ui.setFloatingTerminalInputFocused(false)
+      setFloatingTerminalInputFocusedInMain(false)
       const active = document.activeElement
       if (active instanceof HTMLElement && panel.contains(active)) {
         // Why: regular tab strip items are non-focusable, so clicking them can
@@ -1150,7 +1160,7 @@ export function FloatingTerminalPanel({
       }
       // Why: browser webviews focus out-of-process and do not emit renderer
       // pointerdown events, so release floating ownership on renderer blur too.
-      window.api.ui.setFloatingTerminalInputFocused(false)
+      setFloatingTerminalInputFocusedInMain(false)
       active.blur()
     }
 

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -61,6 +61,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenuContent: () => null,
   DropdownMenuItem: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DropdownMenuSeparator: () => null,
+  DropdownMenuShortcut: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
 }))
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10503,7 +10503,11 @@
             "8e24fe4f75": "Crash report sent.",
             "8b8473c544": "Crash report copied.",
             "b175e90213": "No crash report is available.",
-            "765591798d": "Checking for crash reports..."
+            "765591798d": "Checking for crash reports...",
+            "b2e36f53a1": "Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.",
+            "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
+            "b082f27490": "Attach recent diagnostic logs",
+            "e59f0b9427": "Sends a capped redacted log bundle with the report."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10503,7 +10503,11 @@
             "8e24fe4f75": "Informe de fallo enviado.",
             "8b8473c544": "Se copió el informe de fallos.",
             "b175e90213": "No hay ningún informe de fallo disponible.",
-            "765591798d": "Comprobando informes de fallos..."
+            "765591798d": "Comprobando informes de fallos...",
+            "b2e36f53a1": "Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.",
+            "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
+            "b082f27490": "Attach recent diagnostic logs",
+            "e59f0b9427": "Sends a capped redacted log bundle with the report."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10503,7 +10503,11 @@
             "8e24fe4f75": "クラッシュレポートが送信されました。",
             "8b8473c544": "クラッシュレポートがコピーされました。",
             "b175e90213": "クラッシュレポートはありません。",
-            "765591798d": "クラッシュレポートを確認しています..."
+            "765591798d": "クラッシュレポートを確認しています...",
+            "b2e36f53a1": "Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.",
+            "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
+            "b082f27490": "Attach recent diagnostic logs",
+            "e59f0b9427": "Sends a capped redacted log bundle with the report."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10503,7 +10503,11 @@
             "8e24fe4f75": "크래시 보고서가 전송되었습니다.",
             "8b8473c544": "크래시 보고서가 복사되었습니다.",
             "b175e90213": "크래시 보고서가 없습니다.",
-            "765591798d": "크래시 보고서 확인 중..."
+            "765591798d": "크래시 보고서 확인 중...",
+            "b2e36f53a1": "Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.",
+            "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
+            "b082f27490": "Attach recent diagnostic logs",
+            "e59f0b9427": "Sends a capped redacted log bundle with the report."
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10503,7 +10503,11 @@
             "8e24fe4f75": "已发送错误报告。",
             "8b8473c544": "已复制错误报告。",
             "b175e90213": "没有可用的错误报告。",
-            "765591798d": "正在检查错误报告..."
+            "765591798d": "正在检查错误报告...",
+            "b2e36f53a1": "Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.",
+            "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
+            "b082f27490": "Attach recent diagnostic logs",
+            "e59f0b9427": "Sends a capped redacted log bundle with the report."
           }
         }
       },

--- a/src/shared/crash-reporting-diagnostic-bundle.ts
+++ b/src/shared/crash-reporting-diagnostic-bundle.ts
@@ -1,0 +1,74 @@
+export type CrashReportDiagnosticBundle =
+  | {
+      status: 'uploaded'
+      ticketId: string
+      bundleSubmissionId: string
+      bytes: number
+      spanCount: number
+      blobUrl?: string
+      blobDownloadUrl?: string
+      blobPathname?: string
+    }
+  | {
+      status: 'not_uploaded'
+      reason: string
+      bundleSubmissionId?: string
+      bytes?: number
+      spanCount?: number
+    }
+
+const LOCAL_HTTP_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1'])
+
+function sanitizeCrashReportUrl(value: string, sanitizeString: (value: string) => string): string {
+  try {
+    const parsed = new URL(value)
+    const allowed =
+      parsed.protocol === 'https:' ||
+      (parsed.protocol === 'http:' && LOCAL_HTTP_HOSTNAMES.has(parsed.hostname))
+    return allowed ? value : sanitizeString(value)
+  } catch {
+    return sanitizeString(value)
+  }
+}
+
+export function appendDiagnosticBundleLines(
+  lines: string[],
+  diagnosticBundle: CrashReportDiagnosticBundle | undefined,
+  sanitizeString: (value: string) => string
+): void {
+  if (!diagnosticBundle) {
+    return
+  }
+  lines.push('', 'Diagnostic log:')
+  if (diagnosticBundle.status === 'uploaded') {
+    lines.push(
+      '- Status: uploaded',
+      `- Ticket ID: ${sanitizeString(diagnosticBundle.ticketId)}`,
+      `- Bundle submission ID: ${sanitizeString(diagnosticBundle.bundleSubmissionId)}`,
+      `- Spans: ${diagnosticBundle.spanCount}`,
+      `- Bytes: ${diagnosticBundle.bytes}`
+    )
+    if (diagnosticBundle.blobUrl) {
+      lines.push(`- Blob URL: ${sanitizeCrashReportUrl(diagnosticBundle.blobUrl, sanitizeString)}`)
+    }
+    if (diagnosticBundle.blobDownloadUrl) {
+      lines.push(
+        `- Blob download URL: ${sanitizeCrashReportUrl(diagnosticBundle.blobDownloadUrl, sanitizeString)}`
+      )
+    }
+    if (diagnosticBundle.blobPathname) {
+      lines.push(`- Blob path: ${sanitizeString(diagnosticBundle.blobPathname)}`)
+    }
+    return
+  }
+  lines.push('- Status: not uploaded', `- Reason: ${sanitizeString(diagnosticBundle.reason)}`)
+  if (diagnosticBundle.bundleSubmissionId) {
+    lines.push(`- Bundle submission ID: ${sanitizeString(diagnosticBundle.bundleSubmissionId)}`)
+  }
+  if (typeof diagnosticBundle.spanCount === 'number') {
+    lines.push(`- Spans: ${diagnosticBundle.spanCount}`)
+  }
+  if (typeof diagnosticBundle.bytes === 'number') {
+    lines.push(`- Bytes: ${diagnosticBundle.bytes}`)
+  }
+}

--- a/src/shared/crash-reporting-diagnostic-bundle.ts
+++ b/src/shared/crash-reporting-diagnostic-bundle.ts
@@ -5,9 +5,6 @@ export type CrashReportDiagnosticBundle =
       bundleSubmissionId: string
       bytes: number
       spanCount: number
-      blobUrl?: string
-      blobDownloadUrl?: string
-      blobPathname?: string
     }
   | {
       status: 'not_uploaded'
@@ -16,20 +13,6 @@ export type CrashReportDiagnosticBundle =
       bytes?: number
       spanCount?: number
     }
-
-const LOCAL_HTTP_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1'])
-
-function sanitizeCrashReportUrl(value: string, sanitizeString: (value: string) => string): string {
-  try {
-    const parsed = new URL(value)
-    const allowed =
-      parsed.protocol === 'https:' ||
-      (parsed.protocol === 'http:' && LOCAL_HTTP_HOSTNAMES.has(parsed.hostname))
-    return allowed ? value : sanitizeString(value)
-  } catch {
-    return sanitizeString(value)
-  }
-}
 
 export function appendDiagnosticBundleLines(
   lines: string[],
@@ -48,17 +31,6 @@ export function appendDiagnosticBundleLines(
       `- Spans: ${diagnosticBundle.spanCount}`,
       `- Bytes: ${diagnosticBundle.bytes}`
     )
-    if (diagnosticBundle.blobUrl) {
-      lines.push(`- Blob URL: ${sanitizeCrashReportUrl(diagnosticBundle.blobUrl, sanitizeString)}`)
-    }
-    if (diagnosticBundle.blobDownloadUrl) {
-      lines.push(
-        `- Blob download URL: ${sanitizeCrashReportUrl(diagnosticBundle.blobDownloadUrl, sanitizeString)}`
-      )
-    }
-    if (diagnosticBundle.blobPathname) {
-      lines.push(`- Blob path: ${sanitizeString(diagnosticBundle.blobPathname)}`)
-    }
     return
   }
   lines.push('- Status: not uploaded', `- Reason: ${sanitizeString(diagnosticBundle.reason)}`)

--- a/src/shared/crash-reporting-diagnostic-bundle.ts
+++ b/src/shared/crash-reporting-diagnostic-bundle.ts
@@ -1,5 +1,11 @@
 export type CrashReportDiagnosticBundle =
   | {
+      status: 'attached'
+      bundleSubmissionId: string
+      bytes: number
+      spanCount: number
+    }
+  | {
       status: 'uploaded'
       ticketId: string
       bundleSubmissionId: string
@@ -23,6 +29,15 @@ export function appendDiagnosticBundleLines(
     return
   }
   lines.push('', 'Diagnostic log:')
+  if (diagnosticBundle.status === 'attached') {
+    lines.push(
+      '- Status: attached',
+      `- Bundle submission ID: ${sanitizeString(diagnosticBundle.bundleSubmissionId)}`,
+      `- Spans: ${diagnosticBundle.spanCount}`,
+      `- Bytes: ${diagnosticBundle.bytes}`
+    )
+    return
+  }
   if (diagnosticBundle.status === 'uploaded') {
     lines.push(
       '- Status: uploaded',

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -109,11 +109,7 @@ describe('crash-reporting shared helpers', () => {
       ticketId: 'ticketabcdefghijklmnop',
       bundleSubmissionId: 'bundleabcdefghijklmnop',
       bytes: 1024,
-      spanCount: 12,
-      blobUrl: 'https://blob.vercel-storage.com/diagnostics/ticketabcdefghijklmnop.ndjson',
-      blobDownloadUrl:
-        'https://blob.vercel-storage.com/diagnostics/ticketabcdefghijklmnop.ndjson?download=1',
-      blobPathname: 'diagnostics/ticketabcdefghijklmnop.ndjson'
+      spanCount: 12
     })
 
     expect(text).toContain('[Crash Report]')
@@ -121,9 +117,6 @@ describe('crash-reporting shared helpers', () => {
     expect(text).toContain('agent_state_changed')
     expect(text).toContain('Diagnostic log:')
     expect(text).toContain('ticketabcdefghijklmnop')
-    expect(text).toContain('Blob URL: https://blob.vercel-storage.com')
-    expect(text).toContain('Blob download URL: https://blob.vercel-storage.com')
-    expect(text).toContain('Blob path: diagnostics/ticketabcdefghijklmnop.ndjson')
     expect(text).toContain('User notes:')
     expect(text).toContain('[redacted-path]')
     expect(text).not.toContain('Route:')

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatCrashReportText,
+  formatUncapturedCrashReportText,
   isCrashReportReason,
   sanitizeCrashReportBreadcrumbs,
   sanitizeCrashReportDetails,
@@ -103,11 +104,19 @@ describe('crash-reporting shared helpers', () => {
       ]
     }
 
-    const text = formatCrashReportText(report, 'saw /Users/me/project')
+    const text = formatCrashReportText(report, 'saw /Users/me/project', {
+      status: 'uploaded',
+      ticketId: 'ticketabcdefghijklmnop',
+      bundleSubmissionId: 'bundleabcdefghijklmnop',
+      bytes: 1024,
+      spanCount: 12
+    })
 
     expect(text).toContain('[Crash Report]')
     expect(text).toContain('Recent activity:')
     expect(text).toContain('agent_state_changed')
+    expect(text).toContain('Diagnostic log:')
+    expect(text).toContain('ticketabcdefghijklmnop')
     expect(text).toContain('User notes:')
     expect(text).toContain('[redacted-path]')
     expect(text).not.toContain('Route:')
@@ -139,5 +148,33 @@ describe('crash-reporting shared helpers', () => {
 
     expect(text.length).toBeLessThanOrEqual(64_000)
     expect(text).toContain('[Crash report truncated to fit feedback endpoint limits.]')
+  })
+
+  it('formats uncaptured crash reports so users can still submit from Help', () => {
+    const text = formatUncapturedCrashReportText(
+      {
+        createdAt: '2026-05-16T01:00:00.000Z',
+        appVersion: '1.0.0',
+        platform: 'darwin',
+        osRelease: '25.0.0',
+        arch: 'arm64',
+        electronVersion: '41.0.0',
+        chromeVersion: '141.0.0'
+      },
+      'happened after opening /Users/me/project',
+      {
+        status: 'not_uploaded',
+        reason: 'diagnostic upload endpoint is not configured for this build',
+        bundleSubmissionId: 'bundleabcdefghijklmnop',
+        bytes: 2048,
+        spanCount: 3
+      }
+    )
+
+    expect(text).toContain('Report ID: not captured')
+    expect(text).toContain('Reason: no captured crash report')
+    expect(text).toContain('Diagnostic log:')
+    expect(text).toContain('Status: not uploaded')
+    expect(text).toContain('[redacted-path]')
   })
 })

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -109,7 +109,11 @@ describe('crash-reporting shared helpers', () => {
       ticketId: 'ticketabcdefghijklmnop',
       bundleSubmissionId: 'bundleabcdefghijklmnop',
       bytes: 1024,
-      spanCount: 12
+      spanCount: 12,
+      blobUrl: 'https://blob.vercel-storage.com/diagnostics/ticketabcdefghijklmnop.ndjson',
+      blobDownloadUrl:
+        'https://blob.vercel-storage.com/diagnostics/ticketabcdefghijklmnop.ndjson?download=1',
+      blobPathname: 'diagnostics/ticketabcdefghijklmnop.ndjson'
     })
 
     expect(text).toContain('[Crash Report]')
@@ -117,10 +121,13 @@ describe('crash-reporting shared helpers', () => {
     expect(text).toContain('agent_state_changed')
     expect(text).toContain('Diagnostic log:')
     expect(text).toContain('ticketabcdefghijklmnop')
+    expect(text).toContain('Blob URL: https://blob.vercel-storage.com')
+    expect(text).toContain('Blob download URL: https://blob.vercel-storage.com')
+    expect(text).toContain('Blob path: diagnostics/ticketabcdefghijklmnop.ndjson')
     expect(text).toContain('User notes:')
     expect(text).toContain('[redacted-path]')
     expect(text).not.toContain('Route:')
-    expect(text).not.toContain('URL:')
+    expect(text).not.toContain('\nURL:')
   })
 
   it('caps formatted reports to the crash endpoint limit', () => {

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -117,6 +117,7 @@ describe('crash-reporting shared helpers', () => {
     expect(text).toContain('agent_state_changed')
     expect(text).toContain('Diagnostic log:')
     expect(text).toContain('ticketabcdefghijklmnop')
+    expect(text.indexOf('Diagnostic log:')).toBeLessThan(text.indexOf('Details:'))
     expect(text).toContain('User notes:')
     expect(text).toContain('[redacted-path]')
     expect(text).not.toContain('Route:')

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -92,6 +92,7 @@ export type ReactErrorBoundaryReportResult =
 export type CrashReportSubmitArgs = {
   reportId?: string
   notes?: string
+  includeDiagnosticLogs?: boolean
   submitAnonymously?: boolean
   githubLogin: string | null
   githubEmail: string | null

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -1,3 +1,10 @@
+import {
+  appendDiagnosticBundleLines,
+  type CrashReportDiagnosticBundle
+} from './crash-reporting-diagnostic-bundle'
+
+export type { CrashReportDiagnosticBundle } from './crash-reporting-diagnostic-bundle'
+
 export type CrashReportStatus = 'pending' | 'sent' | 'dismissed'
 export type CrashReportSource = 'renderer' | 'child'
 
@@ -33,22 +40,6 @@ export type CrashReportRecord = {
   details: Record<string, CrashReportDetailValue>
   breadcrumbs?: CrashReportBreadcrumb[]
 }
-
-export type CrashReportDiagnosticBundle =
-  | {
-      status: 'uploaded'
-      ticketId: string
-      bundleSubmissionId: string
-      bytes: number
-      spanCount: number
-    }
-  | {
-      status: 'not_uploaded'
-      reason: string
-      bundleSubmissionId?: string
-      bytes?: number
-      spanCount?: number
-    }
 
 export type UncapturedCrashReportContext = {
   createdAt: string
@@ -137,7 +128,6 @@ const PATH_PATTERNS = [
   /[A-Za-z]:\\(?:(?!\s+(?:\/|[A-Za-z]:\\|\\\\|gh[pousr]_|sk-|(?:token|api[_-]?key|secret|password)=))[^"'`<>\n\r)])+/gi,
   /\\\\[^\\\s"'`<>\n\r)]+\\(?:(?!\s+(?:\/|[A-Za-z]:\\|\\\\|gh[pousr]_|sk-|(?:token|api[_-]?key|secret|password)=))[^"'`<>\n\r)])+/gi
 ]
-
 export function isCrashReportReason(reason: string): boolean {
   return [
     'abnormal-exit',
@@ -265,7 +255,7 @@ export function formatCrashReportText(
     }
   }
 
-  appendDiagnosticBundleLines(lines, diagnosticBundle)
+  appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
 
   const trimmedNotes = notes?.trim()
   if (trimmedNotes) {
@@ -300,7 +290,7 @@ export function formatUncapturedCrashReportText(
     '- report_source: help_menu'
   ]
 
-  appendDiagnosticBundleLines(lines, diagnosticBundle)
+  appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
 
   const trimmedNotes = notes?.trim()
   if (trimmedNotes) {
@@ -308,41 +298,6 @@ export function formatUncapturedCrashReportText(
   }
 
   return truncateFormattedCrashReport(lines.join('\n'))
-}
-
-function appendDiagnosticBundleLines(
-  lines: string[],
-  diagnosticBundle: CrashReportDiagnosticBundle | undefined
-): void {
-  if (!diagnosticBundle) {
-    return
-  }
-  lines.push('', 'Diagnostic log:')
-  if (diagnosticBundle.status === 'uploaded') {
-    lines.push(
-      '- Status: uploaded',
-      `- Ticket ID: ${sanitizeCrashReportString(diagnosticBundle.ticketId)}`,
-      `- Bundle submission ID: ${sanitizeCrashReportString(diagnosticBundle.bundleSubmissionId)}`,
-      `- Spans: ${diagnosticBundle.spanCount}`,
-      `- Bytes: ${diagnosticBundle.bytes}`
-    )
-    return
-  }
-  lines.push(
-    '- Status: not uploaded',
-    `- Reason: ${sanitizeCrashReportString(diagnosticBundle.reason)}`
-  )
-  if (diagnosticBundle.bundleSubmissionId) {
-    lines.push(
-      `- Bundle submission ID: ${sanitizeCrashReportString(diagnosticBundle.bundleSubmissionId)}`
-    )
-  }
-  if (typeof diagnosticBundle.spanCount === 'number') {
-    lines.push(`- Spans: ${diagnosticBundle.spanCount}`)
-  }
-  if (typeof diagnosticBundle.bytes === 'number') {
-    lines.push(`- Bytes: ${diagnosticBundle.bytes}`)
-  }
 }
 
 function truncateFormattedCrashReport(text: string): string {

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -235,6 +235,8 @@ export function formatCrashReportText(
     `Chrome: ${report.chromeVersion}`
   ]
 
+  appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
+
   const details = Object.entries(report.details)
   if (details.length > 0) {
     lines.push('', 'Details:')
@@ -254,8 +256,6 @@ export function formatCrashReportText(
       lines.push(`- ${breadcrumb.createdAt}: ${breadcrumb.name}${suffix}`)
     }
   }
-
-  appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
 
   const trimmedNotes = notes?.trim()
   if (trimmedNotes) {

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -34,6 +34,32 @@ export type CrashReportRecord = {
   breadcrumbs?: CrashReportBreadcrumb[]
 }
 
+export type CrashReportDiagnosticBundle =
+  | {
+      status: 'uploaded'
+      ticketId: string
+      bundleSubmissionId: string
+      bytes: number
+      spanCount: number
+    }
+  | {
+      status: 'not_uploaded'
+      reason: string
+      bundleSubmissionId?: string
+      bytes?: number
+      spanCount?: number
+    }
+
+export type UncapturedCrashReportContext = {
+  createdAt: string
+  appVersion: string
+  platform: NodeJS.Platform
+  osRelease: string
+  arch: string
+  electronVersion: string
+  chromeVersion: string
+}
+
 export type CrashReportCreateInput = Omit<
   CrashReportRecord,
   'id' | 'createdAt' | 'status' | 'details' | 'breadcrumbs'
@@ -81,8 +107,14 @@ export type CrashReportSubmitArgs = {
 }
 
 export type CrashReportSubmitResult =
-  | { ok: true; report: CrashReportRecord }
-  | { ok: false; status: number | null; error: string; report?: CrashReportRecord }
+  | { ok: true; report: CrashReportRecord | null; diagnosticBundle?: CrashReportDiagnosticBundle }
+  | {
+      ok: false
+      status: number | null
+      error: string
+      report?: CrashReportRecord | null
+      diagnosticBundle?: CrashReportDiagnosticBundle
+    }
 
 const MAX_STRING_DETAIL_LENGTH = 240
 const MAX_STACK_DETAIL_LENGTH = 4_000
@@ -192,7 +224,11 @@ export function sanitizeCrashReportBreadcrumbs(
   return sanitized.length > 0 ? sanitized : undefined
 }
 
-export function formatCrashReportText(report: CrashReportRecord, notes?: string): string {
+export function formatCrashReportText(
+  report: CrashReportRecord,
+  notes?: string,
+  diagnosticBundle?: CrashReportDiagnosticBundle
+): string {
   const lines = [
     '[Crash Report]',
     '',
@@ -229,12 +265,84 @@ export function formatCrashReportText(report: CrashReportRecord, notes?: string)
     }
   }
 
+  appendDiagnosticBundleLines(lines, diagnosticBundle)
+
   const trimmedNotes = notes?.trim()
   if (trimmedNotes) {
     lines.push('', 'User notes:', sanitizeCrashReportString(trimmedNotes))
   }
 
   return truncateFormattedCrashReport(lines.join('\n'))
+}
+
+export function formatUncapturedCrashReportText(
+  context: UncapturedCrashReportContext,
+  notes?: string,
+  diagnosticBundle?: CrashReportDiagnosticBundle
+): string {
+  const lines = [
+    '[Crash Report]',
+    '',
+    'Report ID: not captured',
+    `Created: ${context.createdAt}`,
+    'Status: uncaptured',
+    'Source: user-reported',
+    'Process: unknown',
+    'Reason: no captured crash report',
+    'Exit code: unknown',
+    `App version: ${context.appVersion}`,
+    `Platform: ${context.platform} ${context.osRelease} ${context.arch}`,
+    `Electron: ${context.electronVersion}`,
+    `Chrome: ${context.chromeVersion}`,
+    '',
+    'Details:',
+    '- captured_crash_report: false',
+    '- report_source: help_menu'
+  ]
+
+  appendDiagnosticBundleLines(lines, diagnosticBundle)
+
+  const trimmedNotes = notes?.trim()
+  if (trimmedNotes) {
+    lines.push('', 'User notes:', sanitizeCrashReportString(trimmedNotes))
+  }
+
+  return truncateFormattedCrashReport(lines.join('\n'))
+}
+
+function appendDiagnosticBundleLines(
+  lines: string[],
+  diagnosticBundle: CrashReportDiagnosticBundle | undefined
+): void {
+  if (!diagnosticBundle) {
+    return
+  }
+  lines.push('', 'Diagnostic log:')
+  if (diagnosticBundle.status === 'uploaded') {
+    lines.push(
+      '- Status: uploaded',
+      `- Ticket ID: ${sanitizeCrashReportString(diagnosticBundle.ticketId)}`,
+      `- Bundle submission ID: ${sanitizeCrashReportString(diagnosticBundle.bundleSubmissionId)}`,
+      `- Spans: ${diagnosticBundle.spanCount}`,
+      `- Bytes: ${diagnosticBundle.bytes}`
+    )
+    return
+  }
+  lines.push(
+    '- Status: not uploaded',
+    `- Reason: ${sanitizeCrashReportString(diagnosticBundle.reason)}`
+  )
+  if (diagnosticBundle.bundleSubmissionId) {
+    lines.push(
+      `- Bundle submission ID: ${sanitizeCrashReportString(diagnosticBundle.bundleSubmissionId)}`
+    )
+  }
+  if (typeof diagnosticBundle.spanCount === 'number') {
+    lines.push(`- Spans: ${diagnosticBundle.spanCount}`)
+  }
+  if (typeof diagnosticBundle.bytes === 'number') {
+    lines.push(`- Bytes: ${diagnosticBundle.bytes}`)
+  }
 }
 
 function truncateFormattedCrashReport(text: string): string {


### PR DESCRIPTION
## Summary

This PR wires Orca diagnostic logs into crash report submission for both crash-report entry points:

- captured crash reports shown after a real Electron/process crash
- uncaptured manual reports opened from Help > Report Crash

When the user clicks `Send Report`, Orca best-effort collects a recent redacted diagnostic NDJSON bundle when diagnostics are available. The crash report text still sends if diagnostics are disabled or unavailable; in those cases it includes `Diagnostic log: Status: not uploaded` with the reason.

For reports with logs, Orca now sends the crash report and diagnostic NDJSON together to `/v1/feedback` as one multipart request. The marketing backend completes the Slack upload as one message containing two text snippets: the readable crash report and the NDJSON bundle.

Manual Help > Report Crash submissions can intentionally omit `reportId`; they stay uncaptured and no longer fall back to a later pending stored crash report.

This also keeps the floating terminal preload bridge backward-compatible during dev reloads by making the optional focus mirror a no-op when an older preload is present.

## Rollout dependencies

Marketing website PR #137 must be merged and deployed before this PR is merged/released:

https://github.com/stablyai/orca-marketing-website/pull/137

That PR provides the new backend behavior:

- `POST /v1/feedback` accepts multipart crash submissions with `diagnosticBundleFile`
- the crash report text and diagnostic NDJSON are uploaded to Slack together in one `files.completeUploadExternal` call
- existing JSON feedback/crash submissions remain supported
- existing `/diagnostics/token`, `/diagnostics/upload`, and `/diagnostics/delete/:ticketId` remain available for older clients and standalone diagnostic uploads

Production marketing envs needed for diagnostics/Slack:

```bash
ORCA_DIAGNOSTICS_TOKEN_SECRET=<unguessable random secret>
ORCA_CRASHES_SLACK_BOT_TOKEN=xoxb-...
ORCA_CRASHES_SLACK_CHANNEL_ID=C0123456789
```

Official Orca release builds compile in:

```bash
ORCA_DIAGNOSTICS_TOKEN_URL=https://www.onorca.dev/diagnostics/token
```

`ORCA_DIAGNOSTICS_SUPPORT_BASE_URL`, `BLOB_READ_WRITE_TOKEN`, and Vercel Blob storage are not part of this rollout.

## Security / privacy shape

- Diagnostic collection runs only in main, not renderer.
- Crash diagnostic attachments are only sent from the main-process crash lane, not public renderer feedback IPC.
- Diagnostic bundles use the existing redacted NDJSON bundle path and are capped at 4 MiB.
- Multipart transport avoids JSON-escaping large NDJSON bundles over the backend request limit.
- Crash report text includes diagnostic bundle metadata, not Blob/download/support URLs.
- If feedback submission fails, there is no orphaned diagnostics upload to clean up because the crash report and logs are submitted together.

## Validation

- [x] `pnpm test src/main/ipc/crash-reporting.test.ts src/main/ipc/feedback.test.ts`
- [x] `pnpm lint -- src/main/ipc/crash-reporting.ts src/main/ipc/feedback.ts src/shared/crash-reporting-diagnostic-bundle.ts src/main/ipc/crash-reporting.test.ts src/main/ipc/feedback.test.ts src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx src/renderer/src/i18n/locales/en.json src/renderer/src/i18n/locales/es.json src/renderer/src/i18n/locales/ja.json src/renderer/src/i18n/locales/ko.json src/renderer/src/i18n/locales/zh.json`
- [x] `pnpm exec tsc --noEmit --pretty false`
- [x] Prior manual live validation in Electron confirmed a real renderer crash could be captured and submitted to production Slack. The latest change adjusts the transport so the diagnostic NDJSON and crash report land in one Slack message once marketing PR #137 is deployed.

## Risk assessment

Risk: HIGH

This touches crash reporting, diagnostic attachment transport, and support observability. Runtime behavior is intentionally fail-open for crash report text submission and fail-closed for diagnostic attachment collection when local diagnostics are unavailable.