### PR TITLE
Share dashboard relative-time clock

### DIFF
--- a/src/renderer/src/components/dashboard/useNow.test.ts
+++ b/src/renderer/src/components/dashboard/useNow.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSharedNowClock } from './useNow'
+
+describe('createSharedNowClock', () => {
+  it('shares one timer across subscribers and clears it when idle', () => {
+    let now = 1_000
+    const intervalCallbacks: (() => void)[] = []
+    const handle = {} as ReturnType<typeof setInterval>
+    const setIntervalMock = vi.fn((callback: () => void) => {
+      intervalCallbacks.push(callback)
+      return handle
+    })
+    const clearIntervalMock = vi.fn()
+    const first = vi.fn()
+    const second = vi.fn()
+    const clock = createSharedNowClock(30_000, {
+      now: () => now,
+      setInterval: setIntervalMock,
+      clearInterval: clearIntervalMock
+    })
+
+    const unsubscribeFirst = clock.subscribe(first)
+    const unsubscribeSecond = clock.subscribe(second)
+
+    expect(setIntervalMock).toHaveBeenCalledTimes(1)
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+    now = 31_000
+    const intervalCallback = intervalCallbacks[0]
+    if (!intervalCallback) {
+      throw new Error('expected shared clock to schedule an interval')
+    }
+    intervalCallback()
+    expect(clock.getSnapshot()).toBe(31_000)
+    expect(first).toHaveBeenCalledTimes(2)
+    expect(second).toHaveBeenCalledTimes(1)
+
+    unsubscribeFirst()
+    expect(clearIntervalMock).not.toHaveBeenCalled()
+    unsubscribeSecond()
+    expect(clearIntervalMock).toHaveBeenCalledWith(handle)
+  })
+
+  it('refreshes the snapshot when a new subscriber restarts an idle clock', () => {
+    let now = 1_000
+    const handle = {} as ReturnType<typeof setInterval>
+    const setIntervalMock = vi.fn(() => handle)
+    const clearIntervalMock = vi.fn()
+    const first = vi.fn()
+    const second = vi.fn()
+    const clock = createSharedNowClock(30_000, {
+      now: () => now,
+      setInterval: setIntervalMock,
+      clearInterval: clearIntervalMock
+    })
+
+    const unsubscribeFirst = clock.subscribe(first)
+    expect(clock.getSnapshot()).toBe(1_000)
+    unsubscribeFirst()
+
+    now = 61_000
+    clock.subscribe(second)
+
+    expect(clock.getSnapshot()).toBe(61_000)
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(setIntervalMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/components/dashboard/useNow.ts
+++ b/src/renderer/src/components/dashboard/useNow.ts
@@ -1,4 +1,67 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
+
+type ClockDeps = {
+  now: () => number
+  setInterval: (callback: () => void, intervalMs: number) => ReturnType<typeof setInterval>
+  clearInterval: (handle: ReturnType<typeof setInterval>) => void
+}
+
+type SharedNowClock = {
+  getSnapshot: () => number
+  subscribe: (listener: () => void) => () => void
+}
+
+const nowClocks = new Map<number, SharedNowClock>()
+
+export function createSharedNowClock(
+  intervalMs: number,
+  deps: ClockDeps = {
+    now: () => Date.now(),
+    setInterval: (callback, ms) => setInterval(callback, ms),
+    clearInterval: (handle) => clearInterval(handle)
+  }
+): SharedNowClock {
+  let now = deps.now()
+  let timer: ReturnType<typeof setInterval> | null = null
+  const listeners = new Set<() => void>()
+
+  const tick = (): void => {
+    now = deps.now()
+    for (const listener of listeners) {
+      listener()
+    }
+  }
+
+  return {
+    getSnapshot: () => now,
+    subscribe: (listener) => {
+      listeners.add(listener)
+      if (!timer) {
+        // Why: all mounted relative-time labels at the same cadence can share
+        // one timer. Refresh immediately on restart so remounted labels don't
+        // display the stale timestamp left from the previous subscriber set.
+        tick()
+        timer = deps.setInterval(tick, intervalMs)
+      }
+      return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0 && timer) {
+          deps.clearInterval(timer)
+          timer = null
+        }
+      }
+    }
+  }
+}
+
+function getSharedNowClock(intervalMs: number): SharedNowClock {
+  let clock = nowClocks.get(intervalMs)
+  if (!clock) {
+    clock = createSharedNowClock(intervalMs)
+    nowClocks.set(intervalMs, clock)
+  }
+  return clock
+}
 
 // Why: relative timestamps drift once mounted. A 30s tick keeps the "Xm
 // ago" labels honest without burning a render every second.
@@ -9,10 +72,6 @@ import { useEffect, useState } from 'react'
 // which meant N timers firing at staggered mount times for N rows on
 // screen — turning one logical tick into N independent React commits.
 export function useNow(intervalMs: number): number {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), intervalMs)
-    return () => clearInterval(id)
-  }, [intervalMs])
-  return now
+  const clock = getSharedNowClock(intervalMs)
+  return useSyncExternalStore(clock.subscribe, clock.getSnapshot, clock.getSnapshot)
 }


### PR DESCRIPTION
## Summary
- Replace per-row relative-time intervals with one shared clock per cadence.
- Refresh the shared snapshot immediately when the clock restarts after going idle.
- Add coverage for shared timer cleanup and remount freshness.

## Expected gain
- Low-to-medium renderer win on dashboards/sidebar agent rows with many relative-time labels.
- Converts many staggered row timers into one logical tick, reducing React commit pressure.

## Risk
- Low. The behavior is limited to relative timestamp freshness.
- Regression coverage verifies idle cleanup and immediate freshness after remount.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard/useNow.test.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --pretty false
- git diff --check