### PR TITLE
Fix Droid notification routing flakes

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2197,7 +2197,74 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
-  it('buffers ready push events until the pane leaf resolves in renderer layout', async () => {
+  it('applies ready push events for an unmounted inactive terminal tab', async () => {
+    const setAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Inactive Tab' }]
+      },
+      terminalLayoutsByTabId: {}
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'done',
+      prompt: 'inactive prompt',
+      agentType: 'codex',
+      lastAssistantMessage: 'inactive completion',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatus).toHaveBeenCalledWith(
+      FUTURE_PANE_KEY,
+      expect.objectContaining({
+        state: 'done',
+        prompt: 'inactive prompt',
+        agentType: 'codex',
+        lastAssistantMessage: 'inactive completion'
+      }),
+      'Inactive Tab',
+      { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 }
+    )
+  })
+
+  it('buffers ready push events until a mounted tab contains the pane leaf', async () => {
     const setAgentStatus = vi.fn()
     const track = vi.fn()
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
@@ -2212,7 +2279,13 @@ describe('useIpcEvents agent status snapshot integration', () => {
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
       },
-      terminalLayoutsByTabId: {}
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: STALE_LEAF_ID },
+          activeLeafId: STALE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
     })
 
     stubReactSyncEffect()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2215,24 +2215,6 @@ function resolvePaneKey(
   }
   const { tabId, leafId } = parsed
   const layout = store.terminalLayoutsByTabId?.[tabId]
-  const leafExists = collectLeafIdsInOrder(layout?.root).includes(leafId)
-  if (!leafExists) {
-    return {
-      exists: false,
-      title: undefined,
-      repoConnectionId: null,
-      repoConnectionResolved: false,
-      owningWorktreeId: undefined
-    }
-  }
-  // Why: replay can remint numeric pane ids, so status title recovery must use
-  // persisted leaf-keyed titles when crossing from hook state into tab state.
-  const rawPaneTitle = layout?.titlesByLeafId?.[leafId]
-  // Why: treat an empty-string paneTitle as "no title" so the tab-level
-  // fallback still fires. `paneTitle ?? tabTitle` alone would short-circuit on
-  // '' and also erase any previously-cached terminalTitle in the store
-  // (`terminalTitle ?? existing?.terminalTitle` resolves to '').
-  const paneTitle = rawPaneTitle && rawPaneTitle.length > 0 ? rawPaneTitle : undefined
   let exists = false
   let tabTitle: string | undefined
   let owningWorktreeId: string | undefined
@@ -2263,6 +2245,33 @@ function resolvePaneKey(
       repoConnectionId = repo?.connectionId ?? null
     }
   }
+  if (!exists) {
+    return {
+      exists: false,
+      title: undefined,
+      repoConnectionId,
+      repoConnectionResolved,
+      owningWorktreeId
+    }
+  }
+  const leafExists = layout ? collectLeafIdsInOrder(layout.root).includes(leafId) : true
+  if (!leafExists) {
+    return {
+      exists: false,
+      title: undefined,
+      repoConnectionId,
+      repoConnectionResolved,
+      owningWorktreeId
+    }
+  }
+  // Why: inactive worktrees can have a durable tab and live PTY while their
+  // terminal layout is temporarily unmounted. Hook state must still land there.
+  const rawPaneTitle = layout?.titlesByLeafId?.[leafId]
+  // Why: treat an empty-string paneTitle as "no title" so the tab-level
+  // fallback still fires. `paneTitle ?? tabTitle` alone would short-circuit on
+  // '' and also erase any previously-cached terminalTitle in the store
+  // (`terminalTitle ?? existing?.terminalTitle` resolves to '').
+  const paneTitle = rawPaneTitle && rawPaneTitle.length > 0 ? rawPaneTitle : undefined
   return {
     exists,
     title: paneTitle ?? tabTitle,

--- a/tests/e2e/droid-notification.spec.ts
+++ b/tests/e2e/droid-notification.spec.ts
@@ -227,7 +227,20 @@ test.describe('Droid notifications', () => {
     await waitForTerminalOutput(orcaPage, marker)
 
     await emitOscTitle(orcaPage, ptyId, 'Codex working')
+    await expect
+      .poll(async () => (await getRendererTitleLog(orcaPage)).includes('Codex working'), {
+        timeout: 10_000,
+        message: 'Codex working title did not reach the renderer before completion'
+      })
+      .toBe(true)
+
     await emitOscTitle(orcaPage, ptyId, 'Codex done')
+    await expect
+      .poll(async () => (await getRendererTitleLog(orcaPage)).includes('Codex done'), {
+        timeout: 10_000,
+        message: 'Codex done title did not reach the renderer'
+      })
+      .toBe(true)
 
     await expect
       .poll(


### PR DESCRIPTION
## Summary
- route agent hook status for inactive terminal tabs by durable tab ownership when the mounted layout is temporarily absent
- keep mounted-layout leaf validation for closed panes
- wait for observable Droid/Codex title transitions before asserting completion notifications

## Validation
- pnpm run lint
- pnpm run typecheck
- pnpm test -- src/renderer/src/hooks/useIpcEvents.test.ts tests/e2e/droid-notification.spec.ts (full Vitest run: 875 files, 9230 tests)
- npx electron-vite build --mode e2e
- SKIP_BUILD=1 npx stably test --config tests/playwright.config.ts --project=electron-headless tests/e2e/droid-notification.spec.ts --repeat-each=20
- SKIP_BUILD=1 npx stably test --config tests/playwright.config.ts --project=electron-headless --shard=1/5