### PR TITLE
Narrow Codex restart stale input checks

### DIFF
--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -1,6 +1,22 @@
 import { RefreshCw } from 'lucide-react'
-import { useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../store'
+
+const EMPTY_TABS: { id: string }[] = []
+
+export function collectStalePtyIdsForTabs({
+  tabs,
+  ptyIdsByTabId,
+  codexRestartNoticeByPtyId
+}: {
+  tabs: { id: string }[]
+  ptyIdsByTabId: Record<string, string[]>
+  codexRestartNoticeByPtyId: Record<string, unknown>
+}): string[] {
+  return tabs.flatMap((tab) =>
+    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) => Boolean(codexRestartNoticeByPtyId[ptyId]))
+  )
+}
 
 export function collectStaleWorktreePtyIds({
   tabsByWorktree,
@@ -13,9 +29,11 @@ export function collectStaleWorktreePtyIds({
   codexRestartNoticeByPtyId: Record<string, unknown>
   worktreeId: string
 }): string[] {
-  return (tabsByWorktree[worktreeId] ?? []).flatMap((tab) =>
-    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) => Boolean(codexRestartNoticeByPtyId[ptyId]))
-  )
+  return collectStalePtyIdsForTabs({
+    tabs: tabsByWorktree[worktreeId] ?? EMPTY_TABS,
+    ptyIdsByTabId,
+    codexRestartNoticeByPtyId
+  })
 }
 
 export function dismissStaleWorktreePtyIds(
@@ -35,22 +53,17 @@ export default function CodexRestartChip({
 }: {
   worktreeId: string
 }): React.JSX.Element | null {
-  const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const ptyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
-  const codexRestartNoticeByPtyId = useAppStore((s) => s.codexRestartNoticeByPtyId)
+  const staleWorktreePtyIds = useAppStore(
+    useShallow((s) =>
+      collectStalePtyIdsForTabs({
+        tabs: s.tabsByWorktree[worktreeId] ?? EMPTY_TABS,
+        ptyIdsByTabId: s.ptyIdsByTabId,
+        codexRestartNoticeByPtyId: s.codexRestartNoticeByPtyId
+      })
+    )
+  )
   const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
   const clearCodexRestartNotice = useAppStore((s) => s.clearCodexRestartNotice)
-
-  const staleWorktreePtyIds = useMemo(
-    () =>
-      collectStaleWorktreePtyIds({
-        tabsByWorktree,
-        ptyIdsByTabId,
-        codexRestartNoticeByPtyId,
-        worktreeId
-      }),
-    [codexRestartNoticeByPtyId, ptyIdsByTabId, tabsByWorktree, worktreeId]
-  )
 
   if (staleWorktreePtyIds.length === 0) {
     return null

--- a/src/renderer/src/components/codex-restart-chip.test.ts
+++ b/src/renderer/src/components/codex-restart-chip.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { collectStaleWorktreePtyIds, dismissStaleWorktreePtyIds } from './CodexRestartChip'
+import {
+  collectStalePtyIdsForTabs,
+  collectStaleWorktreePtyIds,
+  dismissStaleWorktreePtyIds
+} from './CodexRestartChip'
 
 describe('CodexRestartChip helpers', () => {
   it('collects all stale PTY ids for tabs in a worktree', () => {
@@ -37,6 +41,22 @@ describe('CodexRestartChip helpers', () => {
         worktreeId: 'wt1'
       })
     ).toEqual([])
+  })
+
+  it('collects from one worktree tab slice without scanning the whole tab map', () => {
+    expect(
+      collectStalePtyIdsForTabs({
+        tabs: [{ id: 'tab-1' }],
+        ptyIdsByTabId: {
+          'tab-1': ['pty-1'],
+          'tab-2': ['pty-2']
+        },
+        codexRestartNoticeByPtyId: {
+          'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b' },
+          'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+        }
+      })
+    ).toEqual(['pty-1'])
   })
 
   it('dismisses every stale PTY notice in the worktree prompt', () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1251,6 +1251,133 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).toHaveBeenCalledWith('a')
   })
 
+  it('does not enumerate every worktree tab for ordinary input without Codex restart notices', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: new Proxy(
+        {
+          'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }],
+          'wt-2': [{ id: 'tab-2', ptyId: 'pty-other' }]
+        },
+        {
+          ownKeys() {
+            throw new Error('tabsByWorktree should not be enumerated')
+          }
+        }
+      ),
+      codexRestartNoticeByPtyId: {}
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('uses the current worktree tab for Codex stale fallback without enumerating all worktrees', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport(null)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: new Proxy(
+        {
+          'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }],
+          'wt-2': [{ id: 'tab-2', ptyId: 'pty-other' }]
+        },
+        {
+          ownKeys() {
+            throw new Error('tabsByWorktree should not be enumerated')
+          }
+        }
+      ),
+      codexRestartNoticeByPtyId: {
+        'pty-other': { previousAccountLabel: 'A', nextAccountLabel: 'B' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('blocks stale Codex fallback input from the current worktree tab without enumerating all worktrees', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport(null)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: new Proxy(
+        {
+          'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }],
+          'wt-2': [{ id: 'tab-2', ptyId: 'pty-other' }]
+        },
+        {
+          ownKeys() {
+            throw new Error('tabsByWorktree should not be enumerated')
+          }
+        }
+      ),
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).not.toHaveBeenCalled()
+  })
+
   it('blocks input to stale Codex panes until they restart', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -53,6 +53,11 @@ const PTY_CONNECT_DIAG_LIMIT = 200
 const AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS = 250
 const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1000
 const AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS = 10_000
+let codexRestartNoticePresenceSource: Record<
+  string,
+  { previousAccountLabel: string; nextAccountLabel: string }
+> | null = null
+let codexRestartNoticePresence = false
 
 function isAgentTaskCompleteNotificationEnabled(): boolean {
   const notifications = useAppStore.getState().settings?.notifications
@@ -95,6 +100,16 @@ function isSshSessionExpiredError(err: unknown): boolean {
 
 function isRemoteRuntimePtyId(ptyId: string | null | undefined): boolean {
   return typeof ptyId === 'string' && ptyId.startsWith(REMOTE_PTY_ID_PREFIX)
+}
+
+function hasCodexRestartNotices(
+  noticesByPtyId: Record<string, { previousAccountLabel: string; nextAccountLabel: string }>
+): boolean {
+  if (codexRestartNoticePresenceSource !== noticesByPtyId) {
+    codexRestartNoticePresenceSource = noticesByPtyId
+    codexRestartNoticePresence = Object.keys(noticesByPtyId).length > 0
+  }
+  return codexRestartNoticePresence
 }
 
 function sshPromptConnectOutcomeForStatus(
@@ -145,15 +160,21 @@ async function waitForSshConnection(connectionId: string): Promise<SshConnectRes
   return promise
 }
 
-function isCodexPaneStale(args: { tabId: string; panePtyId: string | null }): boolean {
+function isCodexPaneStale(args: {
+  tabId: string
+  worktreeId: string
+  panePtyId: string | null
+}): boolean {
   const state = useAppStore.getState()
   const { codexRestartNoticeByPtyId } = state
+  if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
+    return false
+  }
   if (args.panePtyId && codexRestartNoticeByPtyId[args.panePtyId]) {
     return true
   }
 
-  const tabs = Object.values(state.tabsByWorktree ?? {}).flat()
-  const tab = tabs.find((entry) => entry.id === args.tabId)
+  const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
   if (tab?.ptyId && codexRestartNoticeByPtyId[tab.ptyId]) {
     return true
   }
@@ -685,8 +706,10 @@ export function connectPanePty(
       AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS
     )
   }
-  agentTaskCompleteSettingsUnsubscribe = useAppStore.subscribe(() => {
-    syncAgentTaskCompleteNotificationEnabled()
+  agentTaskCompleteSettingsUnsubscribe = useAppStore.subscribe((state, previousState) => {
+    if (state.settings?.notifications !== previousState?.settings?.notifications) {
+      syncAgentTaskCompleteNotificationEnabled()
+    }
   })
 
   // ─── Agent task-complete: OS notification, not tab attention ──────────
@@ -838,7 +861,13 @@ export function connectPanePty(
     // still says the pane is stale. Fall back to the tab's persisted PTY ID so
     // the block still holds during reconnect races before the live transport has
     // updated its local PTY binding.
-    if (isCodexPaneStale({ tabId: deps.tabId, panePtyId: currentPtyId })) {
+    if (
+      isCodexPaneStale({
+        tabId: deps.tabId,
+        worktreeId: deps.worktreeId,
+        panePtyId: currentPtyId
+      })
+    ) {
       clearPendingTerminalInputIntent()
       return
     }


### PR DESCRIPTION
## Summary
- narrow Codex restart chip state reads to the current worktree tab slice
- skip broad terminal tab enumeration on ordinary input when there are no Codex restart notices
- keep stale-Codex input blocking for both live PTY ids and reconnect-race fallback tab PTY ids
- avoid re-syncing terminal completion notification settings on unrelated store updates

## UX / regression risk
- Low: ordinary terminal input remains immediate and is covered by the typing latency e2e.
- Stale Codex panes still block input before bytes reach the transport.
- No Git, PR, check-status, source-control, SSH connection, or PTY transport selection cadence changes.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/codex-restart-chip.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm exec oxlint src/renderer/src/components/CodexRestartChip.tsx src/renderer/src/components/codex-restart-chip.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json --pretty false
- pnpm typecheck
- pnpm test
- pnpm exec electron-vite build --mode e2e
- SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-typing-latency.spec.ts --config tests/playwright.config.ts --project=electron-headless
- git diff --check
- sensitive external-source reference scan