### PR TITLE
Pause low-priority polls while hidden

### DIFF
--- a/src/renderer/src/components/github/github-rate-limit-display.tsx
+++ b/src/renderer/src/components/github/github-rate-limit-display.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Gauge, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import type { GetRateLimitResult, GitHubRateLimitSnapshot } from '../../../../shared/types'
@@ -96,20 +97,10 @@ export function useGitHubRateLimitSnapshot(options?: { autoRefresh?: boolean }):
     if (!autoRefresh) {
       return
     }
-    const fetchIfVisible = (): void => {
-      if (document.visibilityState === 'visible' && document.hasFocus()) {
-        void refresh(false)
-      }
-    }
-    void refresh(false)
-    const handle = window.setInterval(fetchIfVisible, REFRESH_INTERVAL_MS)
-    window.addEventListener('focus', fetchIfVisible)
-    document.addEventListener('visibilitychange', fetchIfVisible)
-    return () => {
-      window.clearInterval(handle)
-      window.removeEventListener('focus', fetchIfVisible)
-      document.removeEventListener('visibilitychange', fetchIfVisible)
-    }
+    return installWindowVisibilityInterval({
+      run: () => void refresh(false),
+      intervalMs: REFRESH_INTERVAL_MS
+    })
   }, [autoRefresh, refresh])
 
   return { snapshot, hasError, isFetching, refresh }

--- a/src/renderer/src/components/ports/WorkspacePortScanner.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.tsx
@@ -6,6 +6,7 @@ import {
   scanWorkspacePortsForTarget,
   workspacePortRuntimeTargetKey
 } from '@/lib/workspace-port-actions'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 
 const WORKSPACE_PORT_SCAN_INTERVAL_MS = 5_000
@@ -71,42 +72,21 @@ export function WorkspacePortScanner(): null {
   }, [hasWorktrees, runtimeTarget, scanKey, setWorkspacePortScan, setWorkspacePortScanRefreshing])
 
   useEffect(() => {
-    let cancelled = false
-    let timeout: ReturnType<typeof setTimeout> | null = null
     generationRef.current += 1
     setWorkspacePortScan(null)
 
-    const run = async (): Promise<void> => {
-      try {
-        if (document.visibilityState === 'visible') {
-          await refresh()
-        }
-      } finally {
-        if (!cancelled) {
-          timeout = setTimeout(() => void run(), WORKSPACE_PORT_SCAN_INTERVAL_MS)
-        }
-      }
-    }
-
-    void run()
-
-    const refreshWhenVisible = (): void => {
-      if (document.visibilityState === 'visible' && document.hasFocus()) {
-        void refresh()
-      }
-    }
-    window.addEventListener('focus', refreshWhenVisible)
-    document.addEventListener('visibilitychange', refreshWhenVisible)
+    // Why: workspace port scans can cross runtime IPC or shell out remotely.
+    // Keep the timer stopped while no UI can display the result; visibility
+    // changes run one immediate refresh on return.
+    const stopVisibleInterval = installWindowVisibilityInterval({
+      run: () => void refresh(),
+      intervalMs: WORKSPACE_PORT_SCAN_INTERVAL_MS
+    })
 
     return () => {
-      cancelled = true
       generationRef.current += 1
       inFlightRef.current = null
-      if (timeout) {
-        clearTimeout(timeout)
-      }
-      window.removeEventListener('focus', refreshWhenVisible)
-      document.removeEventListener('visibilitychange', refreshWhenVisible)
+      stopVisibleInterval()
     }
   }, [refresh, setWorkspacePortScan])
 

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -31,6 +31,7 @@ import {
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { useAppStore } from '../../store'
 import { useWorktreeMap } from '../../store/selectors'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
@@ -798,23 +799,13 @@ export function ResourceUsageStatusSegment({
       setSessionsError(false)
       return
     }
-    const refreshIfVisible = (): void => {
-      if (document.visibilityState === 'visible' && document.hasFocus()) {
-        void refreshSessions()
-      }
-    }
-    void refreshSessions()
     // Why: the closed-popover badge is informational. Polling daemon sessions
     // while the whole window is hidden keeps IPC and daemon list calls hot for
-    // no visible UI; focus/visibility refreshes catch the badge up immediately.
-    const interval = setInterval(refreshIfVisible, SESSIONS_POLL_MS)
-    window.addEventListener('focus', refreshIfVisible)
-    document.addEventListener('visibilitychange', refreshIfVisible)
-    return () => {
-      clearInterval(interval)
-      window.removeEventListener('focus', refreshIfVisible)
-      document.removeEventListener('visibilitychange', refreshIfVisible)
-    }
+    // no visible UI; visibility refreshes catch the badge up immediately.
+    return installWindowVisibilityInterval({
+      run: () => void refreshSessions(),
+      intervalMs: SESSIONS_POLL_MS
+    })
   }, [runtimeEnvironmentActive, refreshSessions])
 
   const repoDisplayNameById = useMemo(() => {

--- a/src/renderer/src/lib/window-visibility-interval.test.ts
+++ b/src/renderer/src/lib/window-visibility-interval.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installWindowVisibilityInterval } from './window-visibility-interval'
+
+describe('installWindowVisibilityInterval', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('runs intervals only while the document is visible', () => {
+    let visibilityState: DocumentVisibilityState = 'hidden'
+    const documentListeners = new Map<string, () => void>()
+    const clearIntervalMock = vi.fn()
+    const setIntervalMock = vi.fn(() => 1 as unknown as ReturnType<typeof setInterval>)
+    const run = vi.fn()
+
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+    vi.stubGlobal('document', {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener: vi.fn((event: string, listener: () => void) => {
+        documentListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn()
+    })
+
+    const cleanup = installWindowVisibilityInterval({
+      run,
+      intervalMs: 3000,
+      setIntervalFn: setIntervalMock,
+      clearIntervalFn: clearIntervalMock
+    })
+
+    expect(run).not.toHaveBeenCalled()
+    expect(setIntervalMock).not.toHaveBeenCalled()
+
+    visibilityState = 'visible'
+    documentListeners.get('visibilitychange')?.()
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(setIntervalMock).toHaveBeenCalledTimes(1)
+
+    visibilityState = 'hidden'
+    documentListeners.get('visibilitychange')?.()
+    expect(clearIntervalMock).toHaveBeenCalledWith(1)
+
+    visibilityState = 'visible'
+    documentListeners.get('visibilitychange')?.()
+    expect(run).toHaveBeenCalledTimes(2)
+    expect(setIntervalMock).toHaveBeenCalledTimes(2)
+
+    cleanup()
+    expect(document.removeEventListener).toHaveBeenCalledWith(
+      'visibilitychange',
+      documentListeners.get('visibilitychange')
+    )
+  })
+
+  it('starts while visible even when the window is not focused', () => {
+    const run = vi.fn()
+    const setIntervalMock = vi.fn(() => 1 as unknown as ReturnType<typeof setInterval>)
+
+    vi.stubGlobal('window', {
+      hasFocus: vi.fn(() => false)
+    })
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+
+    const cleanup = installWindowVisibilityInterval({
+      run,
+      intervalMs: 3000,
+      setIntervalFn: setIntervalMock
+    })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(setIntervalMock).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+})

--- a/src/renderer/src/lib/window-visibility-interval.ts
+++ b/src/renderer/src/lib/window-visibility-interval.ts
@@ -1,0 +1,60 @@
+export type WindowVisibilityIntervalTimer = ReturnType<typeof setInterval>
+
+export function isWindowVisible(): boolean {
+  return (
+    typeof document === 'undefined' ||
+    typeof document.visibilityState === 'undefined' ||
+    document.visibilityState === 'visible'
+  )
+}
+
+export function installWindowVisibilityInterval(args: {
+  run: () => void
+  intervalMs: number
+  setIntervalFn?: (callback: () => void, intervalMs: number) => WindowVisibilityIntervalTimer
+  clearIntervalFn?: (handle: WindowVisibilityIntervalTimer) => void
+}): () => void {
+  const setIntervalFn =
+    args.setIntervalFn ??
+    ((callback: () => void, intervalMs: number): WindowVisibilityIntervalTimer =>
+      setInterval(callback, intervalMs))
+  const clearIntervalFn =
+    args.clearIntervalFn ?? ((handle: WindowVisibilityIntervalTimer): void => clearInterval(handle))
+  let intervalId: WindowVisibilityIntervalTimer | null = null
+
+  const stop = (): void => {
+    if (!intervalId) {
+      return
+    }
+    clearIntervalFn(intervalId)
+    intervalId = null
+  }
+  const start = (): void => {
+    if (intervalId || !isWindowVisible()) {
+      return
+    }
+    args.run()
+    // Why: many callers shell out or cross IPC. Keep their interval alive only
+    // while Orca can present the refreshed data, but still refresh a visible
+    // unfocused window so status UI does not go stale on a second display.
+    intervalId = setIntervalFn(args.run, args.intervalMs)
+  }
+  const reconcile = (): void => {
+    if (isWindowVisible()) {
+      start()
+    } else {
+      stop()
+    }
+  }
+
+  start()
+  if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', reconcile)
+  }
+  return () => {
+    stop()
+    if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
+      document.removeEventListener('visibilitychange', reconcile)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared visible-window interval helper that stops timers while the document is hidden
- keep visible-but-unfocused windows refreshing so status UI on another display does not go stale
- move GitHub rate-limit, workspace port scan, and resource session badge polling onto the helper

## UX / regression risk
- Low after focused helper tests, full tests, typecheck, and e2e build.
- Hidden windows stop low-priority polling and refresh immediately when visible again.
- Visible but unfocused windows continue refreshing.
- This PR intentionally does not change Source Control, Checks, PR/check-status polling, WorktreeCard PR/issue refresh, Git providers, SSH transport, or terminal PTY transport.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/window-visibility-interval.test.ts
- pnpm exec oxlint src/renderer/src/lib/window-visibility-interval.ts src/renderer/src/lib/window-visibility-interval.test.ts src/renderer/src/components/github/github-rate-limit-display.tsx src/renderer/src/components/ports/WorkspacePortScanner.tsx src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm typecheck
- pnpm test
- pnpm exec electron-vite build --mode e2e
- git diff --check
- sensitive reference scan
