### PR TITLE
Keep Kanban open for toast actions

### DIFF
--- a/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.test.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { isWorkspaceBoardKeepOpenTarget } from './use-workspace-kanban-outside-dismiss'
+
+class FakeNode {
+  parentElement: FakeElement | null = null
+}
+
+class FakeElement extends FakeNode {
+  private readonly attributes: ReadonlySet<string>
+
+  constructor(attributes: readonly string[] = [], parentElement: FakeElement | null = null) {
+    super()
+    this.attributes = new Set(attributes)
+    this.parentElement = parentElement
+  }
+
+  closest(selector: string): FakeElement | null {
+    if (this.matches(selector)) {
+      return this
+    }
+    return this.parentElement?.closest(selector) ?? null
+  }
+
+  private matches(selector: string): boolean {
+    return selector
+      .split(',')
+      .map((part) => part.trim())
+      .some((part) => this.attributes.has(part))
+  }
+}
+
+describe('workspace kanban outside dismiss keep-open targets', () => {
+  beforeEach(() => {
+    vi.stubGlobal('Node', FakeNode)
+    vi.stubGlobal('Element', FakeElement)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the board open when a Sonner toast action is clicked', () => {
+    const toast = new FakeElement(['[data-sonner-toast]'])
+    const action = new FakeElement([], toast)
+
+    expect(isWorkspaceBoardKeepOpenTarget(action as unknown as EventTarget)).toBe(true)
+  })
+
+  it('does not keep the board open for generic outside content', () => {
+    const target = new FakeElement()
+
+    expect(isWorkspaceBoardKeepOpenTarget(target as unknown as EventTarget)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts
@@ -11,6 +11,7 @@ const WORKSPACE_BOARD_KEEP_OPEN_SELECTOR = [
   '[data-slot="popover-content"]',
   '[data-slot="dialog-content"]',
   '[data-slot="dialog-overlay"]',
+  '[data-sonner-toast]',
   '[role="dialog"][data-state="open"]',
   '[role="alertdialog"][data-state="open"]',
   '[role="menu"][data-state="open"]'


### PR DESCRIPTION
## Summary
- extend the Workspace Kanban keep-open target predicate to include Sonner toast surfaces
- preserve Kanban while users click app-owned notification actions such as Force Delete
- add regression coverage for nested toast action targets and generic outside targets

## Design / Review Notes
- scoped the design to the shared `isWorkspaceBoardKeepOpenTarget` predicate so document pointerdown handling, Radix `onInteractOutside`, and selection clearing share the same rule
- no SSH or platform-specific behavior changes; this is renderer DOM event targeting only

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.test.ts src/renderer/src/components/sidebar/workspace-kanban-area-selection.test.ts src/renderer/src/components/sidebar/worktree-multi-selection.test.ts
- pnpm typecheck
- pnpm oxlint src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.ts src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.test.ts
- Electron smoke: opened Workspace Kanban, inserted a Sonner-shaped toast action outside the board, clicked it, and verified the action fired while Kanban stayed open