### PR TITLE
Coalesce Source Control branch compare

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -107,6 +107,7 @@ import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { DiffNotesSendMenu } from '@/components/editor/DiffNotesSendMenu'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import {
   notifyEditorExternalFileChange,
   requestEditorSaveQuiesce
@@ -142,7 +143,6 @@ import type {
   GitConflictKind,
   GitConflictOperation,
   GitStatusEntry,
-  GitUpstreamStatus,
   GlobalSettings,
   SourceControlViewMode,
   TuiAgent
@@ -160,6 +160,9 @@ import { hasExpandedCommitFailureDetails, summarizeCommitFailure } from './commi
 
 export type SourceControlScope = 'all' | 'uncommitted'
 type RemoteActionError = { kind: RemoteOpKind; message: string }
+
+const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
+const EMPTY_BRANCH_CHANGE_ENTRIES: GitBranchChangeEntry[] = []
 
 // Why: directional signifiers ahead of each primary action label. Commit
 // (✓) is affirmative; Push (↑) points in the direction data flows; Sync
@@ -764,11 +767,27 @@ function SourceControlInner(): React.JSX.Element {
   const worktreeMap = useWorktreeMap()
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
-  const gitStatusByWorktree = useAppStore((s) => s.gitStatusByWorktree)
-  const gitConflictOperationByWorktree = useAppStore((s) => s.gitConflictOperationByWorktree)
-  const gitBranchChangesByWorktree = useAppStore((s) => s.gitBranchChangesByWorktree)
-  const gitBranchCompareSummaryByWorktree = useAppStore((s) => s.gitBranchCompareSummaryByWorktree)
-  const remoteStatusesByWorktree = useAppStore((s) => s.remoteStatusesByWorktree)
+  const entries = useAppStore((s) =>
+    activeWorktreeId
+      ? (s.gitStatusByWorktree[activeWorktreeId] ?? EMPTY_GIT_STATUS_ENTRIES)
+      : EMPTY_GIT_STATUS_ENTRIES
+  )
+  const branchEntries = useAppStore((s) =>
+    activeWorktreeId
+      ? (s.gitBranchChangesByWorktree[activeWorktreeId] ?? EMPTY_BRANCH_CHANGE_ENTRIES)
+      : EMPTY_BRANCH_CHANGE_ENTRIES
+  )
+  const branchSummary = useAppStore((s) =>
+    activeWorktreeId ? (s.gitBranchCompareSummaryByWorktree[activeWorktreeId] ?? null) : null
+  )
+  const conflictOperation = useAppStore((s) =>
+    activeWorktreeId ? (s.gitConflictOperationByWorktree[activeWorktreeId] ?? 'unknown') : 'unknown'
+  )
+  // Why: leave undefined until fetchUpstreamStatus resolves for this worktree.
+  // A synthetic "no upstream" flashes "Publish Branch" during worktree switches.
+  const remoteStatus = useAppStore((s) =>
+    activeWorktreeId ? s.remoteStatusesByWorktree[activeWorktreeId] : undefined
+  )
   const isRemoteOperationActive = useAppStore((s) => s.isRemoteOperationActive)
   const inFlightRemoteOpKind = useAppStore((s) => s.inFlightRemoteOpKind)
   const settings = useAppStore((s) => s.settings)
@@ -1035,27 +1054,6 @@ function SourceControlInner(): React.JSX.Element {
     activePullRequestGenerationRecordCandidate.context.branch === branchName
       ? activePullRequestGenerationRecordCandidate
       : null
-  const entries = useMemo(
-    () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
-    [activeWorktreeId, gitStatusByWorktree]
-  )
-  const branchEntries = useMemo(
-    () => (activeWorktreeId ? (gitBranchChangesByWorktree[activeWorktreeId] ?? []) : []),
-    [activeWorktreeId, gitBranchChangesByWorktree]
-  )
-  const branchSummary = activeWorktreeId
-    ? (gitBranchCompareSummaryByWorktree[activeWorktreeId] ?? null)
-    : null
-  const conflictOperation = activeWorktreeId
-    ? (gitConflictOperationByWorktree[activeWorktreeId] ?? 'unknown')
-    : 'unknown'
-  // Why: leave undefined until fetchUpstreamStatus resolves for this worktree.
-  // Substituting a synthetic { hasUpstream: false } flashes "Publish Branch"
-  // on every worktree switch — resolvePrimaryAction treats it as an
-  // unpublished branch until the real status lands a moment later.
-  const remoteStatus: GitUpstreamStatus | undefined = activeWorktreeId
-    ? remoteStatusesByWorktree[activeWorktreeId]
-    : undefined
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
   // Why: gate polling on both the active tab AND the sidebar being open.
   // The sidebar now stays mounted when closed (for performance), so without
@@ -2810,7 +2808,12 @@ function SourceControlInner(): React.JSX.Element {
     refreshActiveGitStatusAfterMutation
   ])
 
-  const refreshBranchCompare = useCallback(async () => {
+  const branchCompareInFlightRef = useRef(false)
+  const branchCompareRerunRef = useRef(false)
+  const branchCompareRunPromiseRef = useRef<Promise<void> | null>(null)
+  const refreshBranchCompareRef = useRef<() => Promise<void>>(async () => {})
+
+  const runBranchCompare = useCallback(async () => {
     if (!activeWorktreeId || !worktreePath || !effectiveBaseRef || isFolder) {
       return
     }
@@ -2876,7 +2879,38 @@ function SourceControlInner(): React.JSX.Element {
     worktreePath
   ])
 
-  const refreshBranchCompareRef = useRef(refreshBranchCompare)
+  const refreshBranchCompare = useCallback(async () => {
+    if (branchCompareInFlightRef.current) {
+      branchCompareRerunRef.current = true
+      return branchCompareRunPromiseRef.current ?? undefined
+    }
+
+    branchCompareInFlightRef.current = true
+    const runPromise = (async (): Promise<void> => {
+      // Why: branch compare shells out to git on a timer and can exceed the
+      // 5s poll interval on large repos. Keep one compare chain in flight and
+      // collapse skipped ticks into one trailing refresh instead of stacking
+      // subprocesses while preserving the await contract for direct callers.
+      try {
+        await runBranchCompare()
+      } finally {
+        branchCompareInFlightRef.current = false
+        if (branchCompareRerunRef.current) {
+          branchCompareRerunRef.current = false
+          await refreshBranchCompareRef.current()
+        }
+      }
+    })()
+    branchCompareRunPromiseRef.current = runPromise
+    try {
+      await runPromise
+    } finally {
+      if (branchCompareRunPromiseRef.current === runPromise) {
+        branchCompareRunPromiseRef.current = null
+      }
+    }
+  }, [runBranchCompare])
+
   refreshBranchCompareRef.current = refreshBranchCompare
 
   const refreshGitHistory = useCallback(async (): Promise<void> => {
@@ -2938,21 +2972,13 @@ function SourceControlInner(): React.JSX.Element {
       return
     }
 
-    void refreshBranchCompareRef.current()
-    const refreshIfFocused = (): void => {
-      if (document.hasFocus()) {
-        void refreshBranchCompareRef.current()
-      }
-    }
     // Why: branch compare shells out to git every tick. The panel only needs
-    // background freshness while Orca is focused; on focus we refresh
-    // immediately so hidden-window time does not burn subprocess work.
-    const intervalId = window.setInterval(refreshIfFocused, BRANCH_REFRESH_INTERVAL_MS)
-    window.addEventListener('focus', refreshIfFocused)
-    return () => {
-      window.clearInterval(intervalId)
-      window.removeEventListener('focus', refreshIfFocused)
-    }
+    // background freshness while Orca is visible; hidden-window time should not
+    // burn subprocess work or timer wakeups.
+    return installWindowVisibilityInterval({
+      run: () => void refreshBranchCompareRef.current(),
+      intervalMs: BRANCH_REFRESH_INTERVAL_MS
+    })
   }, [activeWorktreeId, effectiveBaseRef, isBranchVisible, isFolder, worktreePath])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- narrow Source Control subscriptions to the active worktree git/branch/upstream slices
- coalesce overlapping branch-compare polls so slow git compares do not stack subprocesses
- run branch compare through the visible-window interval helper so visible-but-unfocused panels stay fresh while hidden windows pause

## UX / regression risk
- Moderate but contained to the Source Control panel branch-compare surface.
- Existing visible-panel guard remains in place; hidden windows pause and visible panels refresh immediately through the shared helper.
- ChecksPanel, PR status polling, hosted review refresh, terminal transport, SSH transport, and provider IPC paths are not changed.

## Verification
- pnpm exec oxlint src/renderer/src/components/right-sidebar/SourceControl.tsx
- pnpm typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControl.commit-drafts.test.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/lib/window-visibility-interval.test.ts
- pnpm test
- pnpm exec electron-vite build --mode e2e
- git diff --check
- sensitive reference scan