### PR TITLE
perf: Gate runtime sync key builds by inputs

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -76,6 +76,7 @@ import {
   usePrimarySelectionPaste
 } from './hooks/usePrimarySelectionPaste'
 import {
+  canSkipRuntimeMobileSessionSyncKeyBuild,
   getRuntimeMobileSessionSyncKey,
   runtimeMobileSessionSyncKeysEqual,
   scheduleRuntimeGraphSync,
@@ -772,24 +773,7 @@ function App(): React.JSX.Element {
       // by reference. Mirrors every field used by
       // getRuntimeMobileSessionSyncKey so this gate covers every "could the
       // key have changed?" case.
-      if (
-        state.tabsByWorktree === previousState.tabsByWorktree &&
-        state.groupsByWorktree === previousState.groupsByWorktree &&
-        state.activeGroupIdByWorktree === previousState.activeGroupIdByWorktree &&
-        state.layoutByWorktree === previousState.layoutByWorktree &&
-        state.unifiedTabsByWorktree === previousState.unifiedTabsByWorktree &&
-        state.tabBarOrderByWorktree === previousState.tabBarOrderByWorktree &&
-        state.activeFileId === previousState.activeFileId &&
-        state.activeFileIdByWorktree === previousState.activeFileIdByWorktree &&
-        state.browserTabsByWorktree === previousState.browserTabsByWorktree &&
-        state.browserPagesByWorkspace === previousState.browserPagesByWorkspace &&
-        state.activeBrowserTabIdByWorktree === previousState.activeBrowserTabIdByWorktree &&
-        state.openFiles === previousState.openFiles &&
-        state.editorDrafts === previousState.editorDrafts &&
-        state.activeTabId === previousState.activeTabId &&
-        state.terminalLayoutsByTabId === previousState.terminalLayoutsByTabId &&
-        state.runtimePaneTitlesByTabId === previousState.runtimePaneTitlesByTabId
-      ) {
+      if (canSkipRuntimeMobileSessionSyncKeyBuild(state, previousState)) {
         return
       }
       const nextKey = getRuntimeMobileSessionSyncKey(state, previousState, previousKey)

--- a/src/renderer/src/runtime/sync-runtime-graph.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.test.ts
@@ -2,9 +2,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildMobileSessionTabSnapshots,
+  canSkipRuntimeMobileSessionSyncKeyBuild,
   getRuntimeMobileSessionSyncKey,
   runtimeMobileSessionSyncKeysEqual
 } from './sync-runtime-graph'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import type { AppState } from '../store/types'
 
 function makeState(overrides: Partial<AppState> = {}): AppState {
@@ -24,6 +26,8 @@ function makeState(overrides: Partial<AppState> = {}): AppState {
     openFiles: [],
     editorDrafts: {},
     activeTabId: null,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
     ...overrides
   } as AppState
 }
@@ -31,12 +35,13 @@ function makeState(overrides: Partial<AppState> = {}): AppState {
 // Why: the comparator at `runtimeMobileSessionSyncKeysEqual` checks
 // `terminalLayoutsByTabId`, `runtimePaneTitlesByTabId`, `groupsByWorktree`,
 // `activeGroupIdByWorktree`, `unifiedTabsByWorktree`, `tabBarOrderByWorktree`,
-// and `activeFileIdByWorktree` by reference, and checks `activeTabId` by scalar
-// equality. `makeState`'s defaults allocate fresh `{}` for each map, so two
-// unrelated `makeState({...})` calls trivially diverge. Tests that want to
-// isolate a single field must share every other reference-checked map between
-// the two states; this factory produces one `Partial<AppState>` whose fields
-// can be spread into both `makeState` calls.
+// `activeFileIdByWorktree`, `openFiles`, and `editorDrafts` by reference, and
+// checks `activeTabId` by scalar equality. `makeState`'s defaults allocate
+// fresh `{}`/`[]` for each collection, so two unrelated `makeState({...})`
+// calls trivially diverge. Tests that want to isolate a single field must
+// share every other reference-checked collection between the two states; this
+// factory produces one `Partial<AppState>` whose fields can be spread into both
+// `makeState` calls.
 function makeSharedOverrides(): Partial<AppState> {
   return {
     tabsByWorktree: {},
@@ -49,7 +54,25 @@ function makeSharedOverrides(): Partial<AppState> {
     activeFileIdByWorktree: {},
     activeBrowserTabIdByWorktree: {},
     browserTabsByWorktree: {},
-    browserPagesByWorkspace: {}
+    browserPagesByWorkspace: {},
+    openFiles: [],
+    editorDrafts: {},
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0
+  }
+}
+
+function makeAgentStatusEntry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: 'fix parity',
+    updatedAt: 1_700_000_000_000,
+    stateStartedAt: 1_699_999_999_000,
+    agentType: 'codex',
+    paneKey: 'term-1:11111111-1111-4111-8111-111111111111',
+    terminalTitle: 'codex [working]',
+    stateHistory: [],
+    ...overrides
   }
 }
 
@@ -240,33 +263,131 @@ describe('getRuntimeMobileSessionSyncKey', () => {
     expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(false)
   })
 
-  it('changes when explicit agent status changes', () => {
+  it('changes when explicit agent status epoch changes', () => {
     const sharedOverrides = makeSharedOverrides()
     const before = getRuntimeMobileSessionSyncKey(
       makeState({
         ...sharedOverrides,
-        agentStatusByPaneKey: {}
+        agentStatusByPaneKey: {},
+        agentStatusEpoch: 0
+      })
+    )
+    const after = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: {},
+        agentStatusEpoch: 1
+      })
+    )
+
+    expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(false)
+  })
+
+  it('changes for same-state agent detail updates with the same epoch', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const paneKey = 'term-1:11111111-1111-4111-8111-111111111111'
+    const beforeAgentStatusByPaneKey = {
+      [paneKey]: makeAgentStatusEntry({ paneKey, prompt: 'fix parity' })
+    }
+    const afterAgentStatusByPaneKey = {
+      [paneKey]: makeAgentStatusEntry({ paneKey, prompt: 'continue parity' })
+    }
+
+    const before = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: beforeAgentStatusByPaneKey,
+        agentStatusEpoch: 1
+      })
+    )
+    const after = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: afterAgentStatusByPaneKey,
+        agentStatusEpoch: 1
+      })
+    )
+
+    expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(false)
+  })
+
+  it('coalesces timestamp-only agent heartbeats inside the same freshness bucket', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const paneKey = 'term-1:11111111-1111-4111-8111-111111111111'
+    const before = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: {
+          [paneKey]: makeAgentStatusEntry({ paneKey, updatedAt: 30_000_000 })
+        },
+        agentStatusEpoch: 1
       })
     )
     const after = getRuntimeMobileSessionSyncKey(
       makeState({
         ...sharedOverrides,
         agentStatusByPaneKey: {
-          'term-1:11111111-1111-4111-8111-111111111111': {
-            state: 'working',
-            prompt: 'fix parity',
-            updatedAt: 1_700_000_000_000,
-            stateStartedAt: 1_699_999_999_000,
-            agentType: 'codex',
-            paneKey: 'term-1:11111111-1111-4111-8111-111111111111',
-            terminalTitle: 'codex [working]',
-            stateHistory: []
-          }
-        }
+          [paneKey]: makeAgentStatusEntry({ paneKey, updatedAt: 30_001_000 })
+        },
+        agentStatusEpoch: 1
+      })
+    )
+
+    expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(true)
+  })
+
+  it('changes for timestamp-only agent heartbeats in a later freshness bucket', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const paneKey = 'term-1:11111111-1111-4111-8111-111111111111'
+    const before = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: {
+          [paneKey]: makeAgentStatusEntry({ paneKey, updatedAt: 30_000_000 })
+        },
+        agentStatusEpoch: 1
+      })
+    )
+    const after = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: {
+          [paneKey]: makeAgentStatusEntry({ paneKey, updatedAt: 30_030_000 })
+        },
+        agentStatusEpoch: 1
       })
     )
 
     expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(false)
+  })
+
+  it('does not skip the App subscriber gate for same-epoch agent detail updates', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const paneKey = 'term-1:11111111-1111-4111-8111-111111111111'
+    const before = makeState({
+      ...sharedOverrides,
+      agentStatusByPaneKey: {
+        [paneKey]: makeAgentStatusEntry({ paneKey, prompt: 'fix parity' })
+      },
+      agentStatusEpoch: 1
+    })
+    const after = makeState({
+      ...sharedOverrides,
+      agentStatusByPaneKey: {
+        [paneKey]: makeAgentStatusEntry({ paneKey, prompt: 'continue parity' })
+      },
+      agentStatusEpoch: 1
+    })
+
+    expect(canSkipRuntimeMobileSessionSyncKeyBuild(after, before)).toBe(false)
+  })
+
+  it('skips the App subscriber gate when sync inputs keep the same references', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const before = makeState(sharedOverrides)
+    const after = makeState(sharedOverrides)
+
+    expect(canSkipRuntimeMobileSessionSyncKeyBuild(after, before)).toBe(true)
   })
 })
 

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -69,8 +69,9 @@ const NO_TRANSPORT_GRACE_MS = 10_000
 const EMPTY_ACTIVE_BROWSER_TAB_ID_BY_WORKTREE: AppState['activeBrowserTabIdByWorktree'] = {}
 const EMPTY_BROWSER_TABS_BY_WORKTREE: AppState['browserTabsByWorktree'] = {}
 const EMPTY_BROWSER_PAGES_BY_WORKSPACE: AppState['browserPagesByWorkspace'] = {}
-const EMPTY_AGENT_STATUS_BY_PANE_KEY: AppState['agentStatusByPaneKey'] = {}
 const EMPTY_LAYOUT_BY_WORKTREE: AppState['layoutByWorktree'] = {}
+const EMPTY_AGENT_STATUS_BY_PANE_KEY: AppState['agentStatusByPaneKey'] = {}
+const AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS = 30_000
 let syncScheduled = false
 let syncInFlight = false
 let syncPendingAfterFlight = false
@@ -179,7 +180,8 @@ export type RuntimeMobileSessionSyncKey = {
   activeFileIdByWorktree: AppState['activeFileIdByWorktree']
   activeTabId: AppState['activeTabId']
   activeBrowserTabIdByWorktree: AppState['activeBrowserTabIdByWorktree']
-  agentStatusByPaneKey: AppState['agentStatusByPaneKey']
+  agentStatusEpoch: number
+  agentStatusProjection: string
   // Why: these projections still need value-level inspection because the
   // underlying references churn even when the mobile-relevant shape is
   // unchanged (`tabsByWorktree` reallocates on every OSC title frame).
@@ -190,6 +192,32 @@ export type RuntimeMobileSessionSyncKey = {
   editorDraftsProjection: string
 }
 
+export function canSkipRuntimeMobileSessionSyncKeyBuild(
+  state: AppState,
+  previousState: AppState
+): boolean {
+  return (
+    state.tabsByWorktree === previousState.tabsByWorktree &&
+    state.groupsByWorktree === previousState.groupsByWorktree &&
+    state.activeGroupIdByWorktree === previousState.activeGroupIdByWorktree &&
+    state.layoutByWorktree === previousState.layoutByWorktree &&
+    state.unifiedTabsByWorktree === previousState.unifiedTabsByWorktree &&
+    state.tabBarOrderByWorktree === previousState.tabBarOrderByWorktree &&
+    state.activeFileId === previousState.activeFileId &&
+    state.activeFileIdByWorktree === previousState.activeFileIdByWorktree &&
+    state.browserTabsByWorktree === previousState.browserTabsByWorktree &&
+    state.browserPagesByWorkspace === previousState.browserPagesByWorkspace &&
+    state.activeBrowserTabIdByWorktree === previousState.activeBrowserTabIdByWorktree &&
+    state.openFiles === previousState.openFiles &&
+    state.editorDrafts === previousState.editorDrafts &&
+    state.activeTabId === previousState.activeTabId &&
+    state.terminalLayoutsByTabId === previousState.terminalLayoutsByTabId &&
+    state.runtimePaneTitlesByTabId === previousState.runtimePaneTitlesByTabId &&
+    state.agentStatusEpoch === previousState.agentStatusEpoch &&
+    state.agentStatusByPaneKey === previousState.agentStatusByPaneKey
+  )
+}
+
 export function getRuntimeMobileSessionSyncKey(
   state: AppState,
   previousState?: AppState,
@@ -198,12 +226,16 @@ export function getRuntimeMobileSessionSyncKey(
   const canReusePrevious = previousState !== undefined && previousKey !== undefined
   const browserTabsByWorktree = getBrowserTabsByWorktree(state)
   const browserPagesByWorkspace = getBrowserPagesByWorkspace(state)
+  const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_AGENT_STATUS_BY_PANE_KEY
   const previousBrowserTabsByWorktree = previousState
     ? getBrowserTabsByWorktree(previousState)
     : EMPTY_BROWSER_TABS_BY_WORKTREE
   const previousBrowserPagesByWorkspace = previousState
     ? getBrowserPagesByWorkspace(previousState)
     : EMPTY_BROWSER_PAGES_BY_WORKSPACE
+  const previousAgentStatusByPaneKey = previousState
+    ? (previousState.agentStatusByPaneKey ?? EMPTY_AGENT_STATUS_BY_PANE_KEY)
+    : EMPTY_AGENT_STATUS_BY_PANE_KEY
 
   return {
     terminalLayoutsByTabId: state.terminalLayoutsByTabId,
@@ -218,9 +250,14 @@ export function getRuntimeMobileSessionSyncKey(
     activeTabId: state.activeTabId,
     activeBrowserTabIdByWorktree:
       state.activeBrowserTabIdByWorktree ?? EMPTY_ACTIVE_BROWSER_TAB_ID_BY_WORKTREE,
-    // Why: explicit hook status is published with terminal surfaces so paired
-    // web can render the same per-worktree agent rows before a PTY is opened.
-    agentStatusByPaneKey: state.agentStatusByPaneKey ?? EMPTY_AGENT_STATUS_BY_PANE_KEY,
+    // Why: paired web/mobile snapshots include full agentStatus details. The
+    // epoch covers sort/retention/freshness transitions; the projection covers
+    // prompt/tool details without publishing every timestamp-only heartbeat.
+    agentStatusEpoch: state.agentStatusEpoch ?? 0,
+    agentStatusProjection:
+      canReusePrevious && agentStatusByPaneKey === previousAgentStatusByPaneKey
+        ? previousKey.agentStatusProjection
+        : buildRuntimeMobileAgentStatusProjection(agentStatusByPaneKey),
     // Why: background agent title ticks can change runtimePaneTitlesByTabId
     // many times per second while the user types elsewhere. Reuse unchanged
     // projections so those ticks do not rescan all tabs, files, and drafts.
@@ -351,6 +388,35 @@ function buildRuntimeMobileEditorDraftsProjection(editorDrafts: AppState['editor
   )
 }
 
+function buildRuntimeMobileAgentStatusProjection(
+  agentStatusByPaneKey: AppState['agentStatusByPaneKey']
+): string {
+  return JSON.stringify(
+    Object.entries(agentStatusByPaneKey)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([paneKey, entry]) => ({
+        paneKey,
+        entryPaneKey: entry.paneKey,
+        state: entry.state,
+        prompt: entry.prompt,
+        updatedAtBucket: Math.floor(entry.updatedAt / AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS),
+        stateStartedAt: entry.stateStartedAt,
+        agentType: entry.agentType ?? null,
+        terminalTitle: entry.terminalTitle ?? null,
+        stateHistory: entry.stateHistory.map((history) => ({
+          state: history.state,
+          prompt: history.prompt,
+          startedAt: history.startedAt,
+          interrupted: history.interrupted ?? null
+        })),
+        toolName: entry.toolName ?? null,
+        toolInput: entry.toolInput ?? null,
+        lastAssistantMessage: entry.lastAssistantMessage ?? null,
+        interrupted: entry.interrupted ?? null
+      }))
+  )
+}
+
 export function runtimeMobileSessionSyncKeysEqual(
   a: RuntimeMobileSessionSyncKey,
   b: RuntimeMobileSessionSyncKey
@@ -367,7 +433,8 @@ export function runtimeMobileSessionSyncKeysEqual(
     a.activeFileIdByWorktree === b.activeFileIdByWorktree &&
     a.activeTabId === b.activeTabId &&
     a.activeBrowserTabIdByWorktree === b.activeBrowserTabIdByWorktree &&
-    a.agentStatusByPaneKey === b.agentStatusByPaneKey &&
+    a.agentStatusEpoch === b.agentStatusEpoch &&
+    a.agentStatusProjection === b.agentStatusProjection &&
     a.tabsProjection === b.tabsProjection &&
     a.openFilesProjection === b.openFilesProjection &&
     a.browserProjection === b.browserProjection &&


### PR DESCRIPTION
## Summary
- move App's runtime mobile session sync skip check into the sync-runtime-graph module
- include agent status epoch/detail projection in the sync key so paired clients get prompt/tool updates
- coalesce timestamp-only agent heartbeats into a 30s freshness bucket to avoid runtime graph sync churn

## UX / regression risk
- Contained to paired web/mobile session sync scheduling.
- Does not change terminal layout handling, tab create/close IPC, browser streaming, SSH transport, provider IPC, Source Control, ChecksPanel, or PR status polling.
- Prompt/tool/status detail updates publish immediately; timestamp-only freshness updates publish at most once per 30s bucket.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/sync-runtime-graph.test.ts
- pnpm exec oxlint src/renderer/src/runtime/sync-runtime-graph.ts src/renderer/src/runtime/sync-runtime-graph.test.ts src/renderer/src/App.tsx
- pnpm typecheck
- pnpm test
- pnpm exec electron-vite build --mode e2e
- git diff --check origin/main...HEAD
- sensitive reference scan