### PR TITLE
perf: Stabilize worktree sidebar activity inputs

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -87,6 +87,10 @@ import {
   sidebarHasActiveFilters
 } from './visible-worktrees'
 import {
+  getVisibleWorktreeBrowserActivityTabs,
+  getVisibleWorktreeTerminalActivityTabs
+} from './visible-worktree-activity-inputs'
+import {
   VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT,
   useVirtualizedScrollAnchor,
   type VirtualizedScrollAnchor
@@ -134,6 +138,18 @@ const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
   // Why: TanStack Virtual owns scroll correction. Native browser anchoring can
   // fight virtual row measurement/remounts and produce visible jumps.
   overflowAnchor: 'none'
+}
+
+const recordKeyCountCache = new WeakMap<Record<string, unknown>, number>()
+
+export function countRecordKeysByReference(record: Record<string, unknown>): number {
+  const cached = recordKeyCountCache.get(record)
+  if (cached !== undefined) {
+    return cached
+  }
+  const count = Object.keys(record).length
+  recordKeyCountCache.set(record, count)
+  return count
 }
 
 export function shouldAdjustWorktreeSidebarMeasuredRowScroll(args: {
@@ -527,6 +543,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const [worktreeDragState, setWorktreeDragState] = useState<WorktreeRowDragState>(
     WORKTREE_ROW_DRAG_INITIAL_STATE
   )
+  const [documentVisibilityRevision, setDocumentVisibilityRevision] = useState(0)
   const worktreeDragSessionRef = useRef<WorktreeDragSession | null>(null)
   const worktreePointerDragRef = useRef<WorktreePointerDrag | null>(null)
   const suppressWorktreeClickUntilRef = useRef(0)
@@ -540,6 +557,20 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
   const prVisibleRefreshGeneration = useAppStore((s) => s.prVisibleRefreshGeneration)
   const settings = useAppStore((s) => s.settings)
+
+  useEffect(
+    () =>
+      installWorktreeVisibleRefreshVisibilityListener(() => {
+        if (document.visibilityState !== 'visible') {
+          // Why: the visible row identity can be unchanged after returning
+          // from a hidden window; reset the key so visible PR/CI rows catch up.
+          lastVisibleRefreshKeyRef.current = '__document_hidden__'
+          return
+        }
+        setDocumentVisibilityRevision((revision) => revision + 1)
+      }),
+    []
+  )
 
   // Drag is only meaningful when repo headers are using manual order. The
   // controller is still constructed for hook order stability when inert.
@@ -901,8 +932,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     settings
   ])
 
-  const prCacheLen = useAppStore((s) => Object.keys(s.prCache).length)
-  const issueCacheLen = useAppStore((s) => Object.keys(s.issueCache).length)
+  const prCacheLen = useAppStore((s) => countRecordKeysByReference(s.prCache))
+  const issueCacheLen = useAppStore((s) => countRecordKeysByReference(s.issueCache))
   const renderRowKeySignature = useMemo(
     () => renderRows.map(getRenderRowKey).join('\n'),
     [renderRows]
@@ -1530,6 +1561,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     reportVisibleGitHubPRRefreshCandidates(visibleWorktreeIds, Date.now())
   }, [
     cardProps,
+    documentVisibilityRevision,
     groupBy,
     renderRows,
     reportVisibleGitHubPRRefreshCandidates,
@@ -2297,6 +2329,11 @@ type WorktreeListProps = {
   scrollAnchorRef: React.MutableRefObject<VirtualizedScrollAnchor>
 }
 
+export function installWorktreeVisibleRefreshVisibilityListener(onChange: () => void): () => void {
+  document.addEventListener('visibilitychange', onChange)
+  return () => document.removeEventListener('visibilitychange', onChange)
+}
+
 const WorktreeList = React.memo(function WorktreeList({
   scrollOffsetRef,
   scrollAnchorRef
@@ -2327,10 +2364,12 @@ const WorktreeList = React.memo(function WorktreeList({
 
   // Read tabsByWorktree when needed for filtering or sorting
   const needsActivityMaps = !showSleepingWorkspaces || sortBy === 'smart'
-  const tabsByWorktree = useAppStore((s) => (needsActivityMaps ? s.tabsByWorktree : null))
+  const tabsByWorktree = useAppStore((s) =>
+    needsActivityMaps ? getVisibleWorktreeTerminalActivityTabs(s.tabsByWorktree) : null
+  )
   const ptyIdsByTabId = useAppStore((s) => (needsActivityMaps ? s.ptyIdsByTabId : null))
   const browserTabsByWorktree = useAppStore((s) =>
-    !showSleepingWorkspaces ? s.browserTabsByWorktree : null
+    !showSleepingWorkspaces ? getVisibleWorktreeBrowserActivityTabs(s.browserTabsByWorktree) : null
   )
 
   const cardProps = useAppStore((s) => s.worktreeCardProperties)

--- a/src/renderer/src/components/sidebar/visible-worktree-activity-inputs.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-activity-inputs.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserWorkspace, TerminalTab } from '../../../../shared/types'
+import {
+  getVisibleWorktreeBrowserActivityTabs,
+  getVisibleWorktreeTerminalActivityTabs
+} from './visible-worktree-activity-inputs'
+
+function terminalTab(id: string, title: string): TerminalTab {
+  return {
+    id,
+    ptyId: id,
+    worktreeId: 'wt-1',
+    title,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function browserTab(id: string, title: string): BrowserWorkspace {
+  return {
+    id,
+    worktreeId: 'wt-1',
+    activePageId: `${id}-page`,
+    pageIds: [`${id}-page`],
+    url: 'https://example.com',
+    title,
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 0
+  }
+}
+
+describe('visible worktree activity inputs', () => {
+  it('preserves terminal activity projection when only tab metadata changes', () => {
+    const first = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'First')]
+    })
+
+    const second = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'Renamed')]
+    })
+
+    expect(second).toBe(first)
+    expect(second['wt-1']).toBe(first['wt-1'])
+  })
+
+  it('updates terminal activity projection when tab ids change', () => {
+    const first = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'First')]
+    })
+
+    const second = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'First'), terminalTab('tab-2', 'Second')]
+    })
+
+    expect(second).not.toBe(first)
+    expect(second['wt-1']?.map((tab) => tab.id)).toEqual(['tab-1', 'tab-2'])
+  })
+
+  it('reuses unchanged terminal worktree arrays when a sibling worktree changes', () => {
+    const first = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'First')],
+      'wt-2': [terminalTab('tab-2', 'Second')]
+    })
+
+    const second = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'Renamed')],
+      'wt-2': [terminalTab('tab-3', 'Third')]
+    })
+
+    expect(second).not.toBe(first)
+    expect(second['wt-1']).toBe(first['wt-1'])
+    expect(second['wt-2']).not.toBe(first['wt-2'])
+    expect(second['wt-2']?.map((tab) => tab.id)).toEqual(['tab-3'])
+  })
+
+  it('drops terminal projections for removed worktrees', () => {
+    const first = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'First')],
+      'wt-2': [terminalTab('tab-2', 'Second')]
+    })
+
+    const second = getVisibleWorktreeTerminalActivityTabs({
+      'wt-1': [terminalTab('tab-1', 'Renamed')]
+    })
+
+    expect(second).not.toBe(first)
+    expect(Object.keys(second)).toEqual(['wt-1'])
+    expect(second['wt-1']).toBe(first['wt-1'])
+  })
+
+  it('preserves browser activity projection when only browser metadata changes', () => {
+    const first = getVisibleWorktreeBrowserActivityTabs({
+      'wt-1': [browserTab('browser-1', 'First')]
+    })
+
+    const second = getVisibleWorktreeBrowserActivityTabs({
+      'wt-1': [browserTab('browser-1', 'Renamed')]
+    })
+
+    expect(second).toBe(first)
+    expect(second['wt-1']).toBe(first['wt-1'])
+  })
+
+  it('updates browser activity projection when browser ids change', () => {
+    const first = getVisibleWorktreeBrowserActivityTabs({
+      'wt-1': [browserTab('browser-1', 'First')]
+    })
+
+    const second = getVisibleWorktreeBrowserActivityTabs({
+      'wt-1': [browserTab('browser-2', 'Second')]
+    })
+
+    expect(second).not.toBe(first)
+    expect(second['wt-1']?.map((tab) => tab.id)).toEqual(['browser-2'])
+  })
+
+  it('drops browser projections for removed worktrees', () => {
+    const first = getVisibleWorktreeBrowserActivityTabs({
+      'wt-1': [browserTab('browser-1', 'First')],
+      'wt-2': [browserTab('browser-2', 'Second')]
+    })
+
+    const second = getVisibleWorktreeBrowserActivityTabs({
+      'wt-1': [browserTab('browser-1', 'Renamed')]
+    })
+
+    expect(second).not.toBe(first)
+    expect(Object.keys(second)).toEqual(['wt-1'])
+    expect(second['wt-1']).toBe(first['wt-1'])
+  })
+})

--- a/src/renderer/src/components/sidebar/visible-worktree-activity-inputs.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-activity-inputs.ts
@@ -1,0 +1,77 @@
+import type { BrowserWorkspace, TerminalTab } from '../../../../shared/types'
+
+type TerminalActivityTab = Pick<TerminalTab, 'id'>
+type BrowserActivityTab = Pick<BrowserWorkspace, 'id'>
+
+function haveSameIds<T extends { id: string }>(
+  previous: readonly T[] | undefined,
+  next: readonly { id: string }[]
+): boolean {
+  if (!previous || previous.length !== next.length) {
+    return false
+  }
+  for (let index = 0; index < next.length; index++) {
+    if (previous[index]?.id !== next[index]?.id) {
+      return false
+    }
+  }
+  return true
+}
+
+function projectIdTabs<T extends { id: string }, U extends { id: string }>(
+  tabsByWorktree: Record<string, readonly T[]>,
+  previousProjection: Record<string, U[]> | null
+): { projection: Record<string, U[]>; unchanged: boolean } {
+  const nextProjection: Record<string, U[]> = {}
+  let unchanged =
+    previousProjection !== null &&
+    Object.keys(previousProjection).length === Object.keys(tabsByWorktree).length
+
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    const previousTabs = previousProjection?.[worktreeId]
+    if (haveSameIds(previousTabs, tabs)) {
+      nextProjection[worktreeId] = previousTabs as U[]
+      continue
+    }
+    unchanged = false
+    nextProjection[worktreeId] = tabs.map((tab) => ({ id: tab.id }) as U)
+  }
+
+  return { projection: nextProjection, unchanged }
+}
+
+let cachedTerminalSource: Record<string, TerminalTab[]> | null = null
+let cachedTerminalProjection: Record<string, TerminalActivityTab[]> | null = null
+
+export function getVisibleWorktreeTerminalActivityTabs(
+  tabsByWorktree: Record<string, TerminalTab[]>
+): Record<string, TerminalActivityTab[]> {
+  if (cachedTerminalSource === tabsByWorktree && cachedTerminalProjection) {
+    return cachedTerminalProjection
+  }
+  const { projection, unchanged } = projectIdTabs(tabsByWorktree, cachedTerminalProjection)
+  cachedTerminalSource = tabsByWorktree
+  if (unchanged && cachedTerminalProjection) {
+    return cachedTerminalProjection
+  }
+  cachedTerminalProjection = projection
+  return projection
+}
+
+let cachedBrowserSource: Record<string, BrowserWorkspace[]> | null = null
+let cachedBrowserProjection: Record<string, BrowserActivityTab[]> | null = null
+
+export function getVisibleWorktreeBrowserActivityTabs(
+  browserTabsByWorktree: Record<string, BrowserWorkspace[]>
+): Record<string, BrowserActivityTab[]> {
+  if (cachedBrowserSource === browserTabsByWorktree && cachedBrowserProjection) {
+    return cachedBrowserProjection
+  }
+  const { projection, unchanged } = projectIdTabs(browserTabsByWorktree, cachedBrowserProjection)
+  cachedBrowserSource = browserTabsByWorktree
+  if (unchanged && cachedBrowserProjection) {
+    return cachedBrowserProjection
+  }
+  cachedBrowserProjection = projection
+  return projection
+}

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -84,7 +84,7 @@ export function computeVisibleWorktreeIds(
   opts: {
     filterRepoIds: string[]
     showSleepingWorkspaces: boolean
-    tabsByWorktree: Record<string, TerminalTab[]> | null
+    tabsByWorktree: Record<string, Pick<TerminalTab, 'id'>[]> | null
     ptyIdsByTabId: Record<string, string[]> | null
     browserTabsByWorktree?: Record<string, { id: string }[]> | null
     // Why required: every caller (WorktreeList, getVisibleWorktreeIds

--- a/src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  countRecordKeysByReference,
   resolvePendingSidebarReveal,
   shouldAdjustWorktreeSidebarMeasuredRowScroll
 } from './WorktreeList'
@@ -15,6 +16,21 @@ const makeHeaderRow = (key: string) =>
   }) as const
 
 describe('shouldAdjustWorktreeSidebarMeasuredRowScroll', () => {
+  it('counts record keys once per object reference', () => {
+    const keysSpy = vi.spyOn(Object, 'keys')
+    const first = { a: 1, b: 2 }
+    const second = { ...first, c: 3 }
+
+    try {
+      expect(countRecordKeysByReference(first)).toBe(2)
+      expect(countRecordKeysByReference(first)).toBe(2)
+      expect(countRecordKeysByReference(second)).toBe(3)
+      expect(keysSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      keysSpy.mockRestore()
+    }
+  })
+
   it('suppresses measured-row scroll correction while TanStack is scrolling', () => {
     expect(
       shouldAdjustWorktreeSidebarMeasuredRowScroll({

--- a/src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installWorktreeVisibleRefreshVisibilityListener } from './WorktreeList'
+
+describe('installWorktreeVisibleRefreshVisibilityListener', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('subscribes to document visibility changes so visible PR refresh can rerun on return', () => {
+    const listeners = new Map<string, () => void>()
+    const onChange = vi.fn()
+    const addEventListener = vi.fn((event: string, listener: () => void) => {
+      listeners.set(event, listener)
+    })
+    const removeEventListener = vi.fn()
+
+    vi.stubGlobal('document', {
+      addEventListener,
+      removeEventListener
+    })
+
+    const cleanup = installWorktreeVisibleRefreshVisibilityListener(onChange)
+
+    expect(addEventListener).toHaveBeenCalledWith('visibilitychange', onChange)
+    listeners.get('visibilitychange')?.()
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    expect(removeEventListener).toHaveBeenCalledWith('visibilitychange', onChange)
+  })
+})


### PR DESCRIPTION
## Summary
- project WorktreeList terminal/browser activity inputs down to stable id-only maps
- cache PR/issue cache key counts by record reference for virtual row remeasurement
- rerun visible PR/CI refresh when the document becomes visible again

## UX / regression risk
- Contained to WorktreeList sidebar filtering/refresh work.
- Does not change Source Control, ChecksPanel, terminal lifecycle, SSH transport, provider IPC, paired runtime IPC, or browser tab state.
- Visible PR/CI cards still refresh on visible-window return; hidden windows do not keep triggering visible-row refresh while hidden.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktree-activity-inputs.test.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/visible-worktree-activity-inputs.ts src/renderer/src/components/sidebar/visible-worktree-activity-inputs.test.ts src/renderer/src/components/sidebar/visible-worktrees.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts src/renderer/src/components/sidebar/worktree-list-visible-refresh.test.ts
- pnpm typecheck
- pnpm test
- pnpm exec electron-vite build --mode e2e
- git diff origin/main...HEAD --check
- Sensitive reference and test-marker scan passed