### PR TITLE
Detect installed agent skills in settings

### DIFF
--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -54,5 +54,44 @@ describe('skill discovery', () => {
 
     expect(roots.map((root) => root.path)).not.toContain('/remote/repo/.claude/skills')
     expect(roots.map((root) => root.path)).toContain('/workspace/current/.claude/skills')
+  })
+
+  it('discovers skill packages through symlinked skill directories', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const realSkill = join(root, 'central-skills', 'orca-cli')
+    const linkedSkill = join(home, '.agents', 'skills', 'orca-cli')
+    await mkdir(realSkill, { recursive: true })
+    await mkdir(join(home, '.agents', 'skills'), { recursive: true })
+    await writeFile(join(realSkill, 'SKILL.md'), '# Orca CLI\n\nUse the Orca CLI.')
+    await symlink(realSkill, linkedSkill, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: join(root, 'missing-cwd')
+    })
+
+    const skill = result.skills.find((entry) => entry.name === 'Orca CLI')
+    expect(skill?.sourceKind).toBe('home')
+    expect(skill?.directoryPath).toBe(linkedSkill)
+  })
+
+  it('does not loop through recursive symlinked skill directories', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const skillRoot = join(home, '.agents', 'skills')
+    await mkdir(skillRoot, { recursive: true })
+    await symlink(
+      skillRoot,
+      join(skillRoot, 'loop'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const result = await discoverSkills({
+      homeDir: home,
+      cwd: join(root, 'missing-cwd')
+    })
+
+    expect(result.skills).toEqual([])
   })
 })

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { Dirent } from 'node:fs'
-import { open, readdir, stat } from 'node:fs/promises'
+import { open, readdir, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, join, relative, sep } from 'node:path'
 import type { Repo } from '../../shared/types'
@@ -67,10 +67,22 @@ function sourceLabelForSkill(root: SkillScanRoot, sourceKind: SkillSourceKind): 
 
 async function findSkillFiles(rootPath: string, maxDepth: number): Promise<string[]> {
   const out: string[] = []
+  const visitedDirectoryPaths = new Set<string>()
   async function visit(dirPath: string): Promise<void> {
     if (!isWithinDepth(rootPath, dirPath, maxDepth)) {
       return
     }
+    let resolvedDirPath: string
+    try {
+      resolvedDirPath = await realpath(dirPath)
+    } catch {
+      return
+    }
+    if (visitedDirectoryPaths.has(resolvedDirPath)) {
+      return
+    }
+    visitedDirectoryPaths.add(resolvedDirPath)
+
     let entries: Dirent[]
     try {
       entries = await readdir(dirPath, { withFileTypes: true })
@@ -79,12 +91,36 @@ async function findSkillFiles(rootPath: string, maxDepth: number): Promise<strin
     }
     for (const entry of entries) {
       const entryPath = join(dirPath, entry.name)
-      if (entry.isFile() && entry.name === SKILL_FILE_NAME) {
-        out.push(entryPath)
+      if (entry.name === SKILL_FILE_NAME) {
+        if (entry.isFile()) {
+          out.push(entryPath)
+          continue
+        }
+        if (entry.isSymbolicLink()) {
+          try {
+            if ((await stat(entryPath)).isFile()) {
+              out.push(entryPath)
+            }
+          } catch {
+            // Broken links are not valid skill files.
+          }
+        }
         continue
       }
       if (entry.isDirectory()) {
         await visit(entryPath)
+        continue
+      }
+      if (entry.isSymbolicLink()) {
+        // Why: users commonly symlink agent skill dirs across providers; follow
+        // directory links but guard by realpath so recursive links cannot loop.
+        try {
+          if ((await stat(entryPath)).isDirectory()) {
+            await visit(entryPath)
+          }
+        } catch {
+          // Broken links are not valid skill directories.
+        }
       }
     }
   }
@@ -94,10 +130,22 @@ async function findSkillFiles(rootPath: string, maxDepth: number): Promise<strin
 
 async function countFiles(dirPath: string): Promise<number> {
   let count = 0
+  const visitedDirectoryPaths = new Set<string>()
   async function visit(currentPath: string): Promise<void> {
     if (count >= MAX_SKILL_FILES) {
       return
     }
+    let resolvedPath: string
+    try {
+      resolvedPath = await realpath(currentPath)
+    } catch {
+      return
+    }
+    if (visitedDirectoryPaths.has(resolvedPath)) {
+      return
+    }
+    visitedDirectoryPaths.add(resolvedPath)
+
     let entries: Dirent[]
     try {
       entries = await readdir(currentPath, { withFileTypes: true })
@@ -113,6 +161,14 @@ async function countFiles(dirPath: string): Promise<number> {
         count += 1
       } else if (entry.isDirectory()) {
         await visit(entryPath)
+      } else if (entry.isSymbolicLink()) {
+        try {
+          if ((await stat(entryPath)).isFile()) {
+            count += 1
+          }
+        } catch {
+          // Broken links do not contribute to the skill package file count.
+        }
       }
     }
   }

--- a/src/renderer/src/components/AgentSkillInstalledIndicator.tsx
+++ b/src/renderer/src/components/AgentSkillInstalledIndicator.tsx
@@ -14,11 +14,11 @@ export function AgentSkillInstalledIndicator({
     <span
       aria-label="Skill installed"
       className={cn(
-        'inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-muted-foreground',
+        'inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300',
         className
       )}
     >
-      <Check className="size-3.5 text-foreground" aria-hidden />
+      <Check className="size-3.5" aria-hidden />
       {showLabel ? <span>Installed</span> : <span className="sr-only">Installed</span>}
     </span>
   )

--- a/src/renderer/src/components/AgentSkillInstalledIndicator.tsx
+++ b/src/renderer/src/components/AgentSkillInstalledIndicator.tsx
@@ -1,0 +1,25 @@
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type AgentSkillInstalledIndicatorProps = {
+  className?: string
+  showLabel?: boolean
+}
+
+export function AgentSkillInstalledIndicator({
+  className,
+  showLabel = true
+}: AgentSkillInstalledIndicatorProps): React.JSX.Element {
+  return (
+    <span
+      aria-label="Skill installed"
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium text-muted-foreground',
+        className
+      )}
+    >
+      <Check className="size-3.5 text-foreground" aria-hidden />
+      {showLabel ? <span>Installed</span> : <span className="sr-only">Installed</span>}
+    </span>
+  )
+}

--- a/src/renderer/src/components/integration-status-pill.tsx
+++ b/src/renderer/src/components/integration-status-pill.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils'
+
+export type IntegrationStatusTone = 'connected' | 'attention' | 'neutral'
+
+const TONE_CLASSES: Record<IntegrationStatusTone, { pill: string; dot: string }> = {
+  connected: {
+    pill: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+    dot: 'bg-emerald-500'
+  },
+  attention: {
+    pill: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+    dot: 'bg-amber-500'
+  },
+  neutral: {
+    pill: 'border-border bg-background text-muted-foreground',
+    dot: 'bg-muted-foreground'
+  }
+}
+
+export function IntegrationStatusPill({
+  tone,
+  children
+}: {
+  tone: IntegrationStatusTone
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium',
+        TONE_CLASSES[tone].pill
+      )}
+    >
+      <span className={cn('size-1.5 rounded-full', TONE_CLASSES[tone].dot)} />
+      {children}
+    </span>
+  )
+}

--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
-import { cn } from '@/lib/utils'
+import { IntegrationStatusPill } from '@/components/integration-status-pill'
 import { OnboardingInlineCommandTerminal } from './OnboardingInlineCommandTerminal'
 
 type GitHubSetupState = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
@@ -27,43 +27,6 @@ function getGitHubSetupState(
     return 'not-installed'
   }
   return status.gh.authenticated ? 'connected' : 'not-authenticated'
-}
-
-type StatusTone = 'connected' | 'attention' | 'neutral'
-
-const statusToneClassNames: Record<StatusTone, { pill: string; dot: string }> = {
-  connected: {
-    pill: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
-    dot: 'bg-emerald-500'
-  },
-  attention: {
-    pill: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300',
-    dot: 'bg-amber-500'
-  },
-  neutral: {
-    pill: 'border-border bg-background text-muted-foreground',
-    dot: 'bg-muted-foreground'
-  }
-}
-
-function StatusPill({
-  tone,
-  children
-}: {
-  tone: StatusTone
-  children: React.ReactNode
-}): React.JSX.Element {
-  return (
-    <span
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium',
-        statusToneClassNames[tone].pill
-      )}
-    >
-      <span className={cn('size-1.5 rounded-full', statusToneClassNames[tone].dot)} />
-      {children}
-    </span>
-  )
 }
 
 function GitHubRow(): React.JSX.Element {
@@ -86,13 +49,13 @@ function GitHubRow(): React.JSX.Element {
           <div className="flex items-center gap-2">
             <h3 className="text-[15px] font-semibold leading-tight text-foreground">GitHub</h3>
             {state === 'connected' ? (
-              <StatusPill tone="connected">Connected</StatusPill>
+              <IntegrationStatusPill tone="connected">Connected</IntegrationStatusPill>
             ) : state === 'not-installed' ? (
-              <StatusPill tone="attention">CLI not installed</StatusPill>
+              <IntegrationStatusPill tone="attention">CLI not installed</IntegrationStatusPill>
             ) : state === 'not-authenticated' ? (
-              <StatusPill tone="attention">Sign in needed</StatusPill>
+              <IntegrationStatusPill tone="attention">Sign in needed</IntegrationStatusPill>
             ) : (
-              <StatusPill tone="neutral">Checking…</StatusPill>
+              <IntegrationStatusPill tone="neutral">Checking…</IntegrationStatusPill>
             )}
           </div>
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
@@ -189,7 +152,9 @@ function LinearRow(): React.JSX.Element {
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h3 className="text-[15px] font-semibold leading-tight text-foreground">Linear</h3>
-              {linearStatus.connected ? <StatusPill tone="connected">Connected</StatusPill> : null}
+              {linearStatus.connected ? (
+                <IntegrationStatusPill tone="connected">Connected</IntegrationStatusPill>
+              ) : null}
             </div>
             <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
               {linearStatus.connected
@@ -334,7 +299,7 @@ export function IntegrationsStep(): React.JSX.Element {
               Issues, sprints, and assignees.
             </span>
           </div>
-          <StatusPill tone="neutral">Coming soon</StatusPill>
+          <IntegrationStatusPill tone="neutral">Coming soon</IntegrationStatusPill>
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -6,7 +6,7 @@ import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { useAppStore } from '@/store'
 
 const ONBOARDING_INLINE_TERMINAL_WORKTREE_ID = 'onboarding-inline-terminal'
-const AUTO_INSERT_DELAY_MS = 700
+const AUTO_INSERT_DELAY_MS = 250
 const READY_RETRY_MS = 100
 const READY_MAX_ATTEMPTS = 50
 
@@ -15,6 +15,7 @@ type OnboardingInlineCommandTerminalProps = {
   title: string
   description: string
   ariaLabel: string
+  worktreeId?: string
   onOpened?: () => void
   onInteracted?: (method: 'keyboard' | 'pointer', event?: KeyboardEvent<HTMLElement>) => void
 }
@@ -24,6 +25,7 @@ export function OnboardingInlineCommandTerminal({
   title,
   description,
   ariaLabel,
+  worktreeId = ONBOARDING_INLINE_TERMINAL_WORKTREE_ID,
   onOpened,
   onInteracted
 }: OnboardingInlineCommandTerminalProps): React.JSX.Element {
@@ -56,13 +58,13 @@ export function OnboardingInlineCommandTerminal({
   }, [])
 
   useEffect(() => {
-    const tab = createTab(ONBOARDING_INLINE_TERMINAL_WORKTREE_ID, undefined, undefined, {
+    const tab = createTab(worktreeId, undefined, undefined, {
       activate: false
     })
-    setActiveTabForWorktree(ONBOARDING_INLINE_TERMINAL_WORKTREE_ID, tab.id)
+    setActiveTabForWorktree(worktreeId, tab.id)
     setTabCustomTitle(tab.id, title)
     setTabId(tab.id)
-  }, [createTab, setActiveTabForWorktree, setTabCustomTitle, title])
+  }, [createTab, setActiveTabForWorktree, setTabCustomTitle, title, worktreeId])
 
   useEffect(() => {
     if (prefersReducedMotion) {
@@ -129,7 +131,9 @@ export function OnboardingInlineCommandTerminal({
       if (canceled) {
         return
       }
-      if (findTerminalTabElement(tabId)?.querySelector('[data-pty-id]')) {
+      const terminalElement = findTerminalTabElement(tabId)
+      const hasPty = Boolean(terminalElement?.querySelector('[data-pty-id]'))
+      if (terminalReadyForCommand(terminalElement) || (hasPty && attempt >= READY_MAX_ATTEMPTS)) {
         insertionTimer = window.setTimeout(() => {
           if (!canceled) {
             autoInsertedRef.current = command
@@ -182,7 +186,7 @@ export function OnboardingInlineCommandTerminal({
           {cwd && tabId ? (
             <TerminalPane
               tabId={tabId}
-              worktreeId={ONBOARDING_INLINE_TERMINAL_WORKTREE_ID}
+              worktreeId={worktreeId}
               cwd={cwd}
               isActive
               isVisible
@@ -208,4 +212,14 @@ function findTerminalTabElement(tabId: string): HTMLElement | null {
     }
   }
   return null
+}
+
+function terminalReadyForCommand(element: HTMLElement | null): boolean {
+  if (!element?.querySelector('[data-pty-id]')) {
+    return false
+  }
+  // Why: pasting before the login shell renders a prompt can double-echo the
+  // draft command. Visible terminal text is the least intrusive readiness signal.
+  const renderedText = element.querySelector('.xterm-rows')?.textContent?.trim() ?? ''
+  return renderedText.length > 0
 }

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -64,7 +64,12 @@ export function OnboardingInlineCommandTerminal({
     setActiveTabForWorktree(worktreeId, tab.id)
     setTabCustomTitle(tab.id, title)
     setTabId(tab.id)
-  }, [createTab, setActiveTabForWorktree, setTabCustomTitle, title, worktreeId])
+    return () => {
+      // Why: inline setup panels can disappear after detection succeeds; close
+      // the backing tab so installer shells do not keep running invisibly.
+      closeTab(tab.id)
+    }
+  }, [closeTab, createTab, setActiveTabForWorktree, setTabCustomTitle, title, worktreeId])
 
   useEffect(() => {
     if (prefersReducedMotion) {

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -8,7 +8,7 @@ import { useAppStore } from '@/store'
 const ONBOARDING_INLINE_TERMINAL_WORKTREE_ID = 'onboarding-inline-terminal'
 const AUTO_INSERT_DELAY_MS = 250
 const READY_RETRY_MS = 100
-const READY_MAX_ATTEMPTS = 50
+const PTY_TEXT_FALLBACK_MS = 750
 
 type OnboardingInlineCommandTerminalProps = {
   command: string
@@ -121,40 +121,62 @@ export function OnboardingInlineCommandTerminal({
   }, [command, tabId])
 
   useEffect(() => {
-    if (!tabId || autoInsertedRef.current === command) {
+    if (!tabId || !cwd || autoInsertedRef.current === command) {
       return
     }
     let canceled = false
     let insertionTimer: number | null = null
+    let retryTimer: number | null = null
+    let ptyFirstSeenAt: number | null = null
 
-    const waitForTerminal = (attempt: number): void => {
+    const scheduleInsert = (): void => {
+      if (insertionTimer !== null) {
+        return
+      }
+      insertionTimer = window.setTimeout(() => {
+        if (!canceled) {
+          autoInsertedRef.current = command
+          insertCommand()
+        }
+      }, AUTO_INSERT_DELAY_MS)
+    }
+
+    const waitForTerminal = (): void => {
       if (canceled) {
         return
       }
       const terminalElement = findTerminalTabElement(tabId)
       const hasPty = Boolean(terminalElement?.querySelector('[data-pty-id]'))
-      if (terminalReadyForCommand(terminalElement) || (hasPty && attempt >= READY_MAX_ATTEMPTS)) {
-        insertionTimer = window.setTimeout(() => {
-          if (!canceled) {
-            autoInsertedRef.current = command
-            insertCommand()
-          }
-        }, AUTO_INSERT_DELAY_MS)
+      if (terminalReadyForCommand(terminalElement)) {
+        scheduleInsert()
         return
       }
-      if (attempt < READY_MAX_ATTEMPTS) {
-        window.setTimeout(() => waitForTerminal(attempt + 1), READY_RETRY_MS)
+      if (hasPty) {
+        ptyFirstSeenAt ??= Date.now()
+        // Why: GPU/canvas terminal renderers may not expose visible prompt text
+        // in .xterm-rows. Once the PTY has settled briefly, paste the draft
+        // instead of waiting on a DOM signal that may never arrive.
+        if (Date.now() - ptyFirstSeenAt >= PTY_TEXT_FALLBACK_MS) {
+          scheduleInsert()
+          return
+        }
+      } else {
+        ptyFirstSeenAt = null
       }
+      retryTimer = window.setTimeout(waitForTerminal, READY_RETRY_MS)
     }
 
-    waitForTerminal(0)
+    waitForTerminal()
     return () => {
       canceled = true
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer)
+      }
       if (insertionTimer !== null) {
         window.clearTimeout(insertionTimer)
       }
     }
-  }, [command, insertCommand, tabId])
+  }, [command, cwd, insertCommand, tabId])
 
   // Why: grid 0fr → 1fr animates to the child's natural height without a
   // hardcoded max-height, so we don't leave dead space if the terminal

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -10,7 +10,6 @@ type AgentSkillSetupPanelVariant = 'card' | 'inline'
 type AgentSkillSetupPanelProps = {
   title: string
   detectedDescription: string
-  markedDescription: string
   missingDescription: string
   command: string
   terminalTitle: string
@@ -18,7 +17,6 @@ type AgentSkillSetupPanelProps = {
   terminalWorktreeId: string
   installed: boolean
   detected: boolean
-  markedInstalled?: boolean
   loading: boolean
   error: string | null
   installDisabled?: boolean
@@ -27,13 +25,11 @@ type AgentSkillSetupPanelProps = {
   variant?: AgentSkillSetupPanelVariant
   className?: string
   onRecheck: () => void | Promise<void>
-  onToggleMarkedInstalled?: () => void
 }
 
 export function AgentSkillSetupPanel({
   title,
   detectedDescription,
-  markedDescription,
   missingDescription,
   command,
   terminalTitle,
@@ -41,7 +37,6 @@ export function AgentSkillSetupPanel({
   terminalWorktreeId,
   installed,
   detected,
-  markedInstalled = false,
   loading,
   error,
   installDisabled = false,
@@ -49,8 +44,7 @@ export function AgentSkillSetupPanel({
   icon,
   variant = 'card',
   className,
-  onRecheck,
-  onToggleMarkedInstalled
+  onRecheck
 }: AgentSkillSetupPanelProps): React.JSX.Element {
   const [terminalOpen, setTerminalOpen] = useState(false)
 
@@ -60,11 +54,7 @@ export function AgentSkillSetupPanel({
     }
   }, [installed])
 
-  const body = detected
-    ? detectedDescription
-    : markedInstalled
-      ? markedDescription
-      : missingDescription
+  const body = detected ? detectedDescription : missingDescription
 
   return (
     <div
@@ -93,15 +83,6 @@ export function AgentSkillSetupPanel({
           </div>
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">{body}</p>
           {error ? <p className="mt-1 text-[12px] text-destructive">{error}</p> : null}
-          {!detected && !loading && onToggleMarkedInstalled ? (
-            <button
-              type="button"
-              className="mt-1 text-[12px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:hover:text-muted-foreground"
-              onClick={onToggleMarkedInstalled}
-            >
-              {markedInstalled ? 'Undo manual installed marker' : 'Mark installed'}
-            </button>
-          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {!installed ? (
@@ -134,7 +115,7 @@ export function AgentSkillSetupPanel({
             command={command}
             title={terminalTitle}
             ariaLabel={terminalAriaLabel}
-            description="Press Enter to run the installer. If you already installed this skill, skip this terminal and use Re-check instead."
+            description="Press Enter to run the installer. If you already installed this skill, skip this terminal and click Re-check instead."
           />
         </div>
       ) : null}

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Terminal } from 'lucide-react'
+import { IntegrationStatusPill } from '../integration-status-pill'
+import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
+import { Button } from '../ui/button'
+import { cn } from '@/lib/utils'
+
+type AgentSkillSetupPanelVariant = 'card' | 'inline'
+
+type AgentSkillSetupPanelProps = {
+  title: string
+  detectedDescription: string
+  markedDescription: string
+  missingDescription: string
+  command: string
+  terminalTitle: string
+  terminalAriaLabel: string
+  terminalWorktreeId: string
+  installed: boolean
+  detected: boolean
+  markedInstalled?: boolean
+  loading: boolean
+  error: string | null
+  installDisabled?: boolean
+  leading?: ReactNode
+  icon?: ReactNode
+  variant?: AgentSkillSetupPanelVariant
+  className?: string
+  onRecheck: () => void | Promise<void>
+  onToggleMarkedInstalled?: () => void
+}
+
+export function AgentSkillSetupPanel({
+  title,
+  detectedDescription,
+  markedDescription,
+  missingDescription,
+  command,
+  terminalTitle,
+  terminalAriaLabel,
+  terminalWorktreeId,
+  installed,
+  detected,
+  markedInstalled = false,
+  loading,
+  error,
+  installDisabled = false,
+  leading,
+  icon,
+  variant = 'card',
+  className,
+  onRecheck,
+  onToggleMarkedInstalled
+}: AgentSkillSetupPanelProps): React.JSX.Element {
+  const [terminalOpen, setTerminalOpen] = useState(false)
+
+  useEffect(() => {
+    if (installed) {
+      setTerminalOpen(false)
+    }
+  }, [installed])
+
+  const body = detected
+    ? detectedDescription
+    : markedInstalled
+      ? markedDescription
+      : missingDescription
+
+  return (
+    <div
+      className={cn(
+        variant === 'card' ? 'rounded-xl border border-border bg-muted/20' : null,
+        className
+      )}
+    >
+      <div className={cn('flex items-start gap-4', variant === 'card' ? 'p-5' : null)}>
+        {leading}
+        {icon ? (
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-foreground">
+            {icon}
+          </div>
+        ) : null}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-[15px] font-semibold leading-tight text-foreground">{title}</h3>
+            {loading && !installed ? (
+              <IntegrationStatusPill tone="neutral">Checking...</IntegrationStatusPill>
+            ) : installed ? (
+              <IntegrationStatusPill tone="connected">Installed</IntegrationStatusPill>
+            ) : (
+              <IntegrationStatusPill tone="attention">Not installed</IntegrationStatusPill>
+            )}
+          </div>
+          <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">{body}</p>
+          {error ? <p className="mt-1 text-[12px] text-destructive">{error}</p> : null}
+          {!detected && !loading && onToggleMarkedInstalled ? (
+            <button
+              type="button"
+              className="mt-1 text-[12px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:hover:text-muted-foreground"
+              onClick={onToggleMarkedInstalled}
+            >
+              {markedInstalled ? 'Undo manual installed marker' : 'Mark installed'}
+            </button>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {!installed ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setTerminalOpen(true)}
+              disabled={terminalOpen || installDisabled}
+            >
+              <Terminal className="size-3.5" />
+              Install
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void onRecheck()}
+            disabled={loading}
+          >
+            Re-check
+          </Button>
+        </div>
+      </div>
+      {!installed && terminalOpen ? (
+        <div className={cn(variant === 'card' ? 'px-5 pb-5' : 'mt-3')}>
+          <OnboardingInlineCommandTerminal
+            worktreeId={terminalWorktreeId}
+            command={command}
+            title={terminalTitle}
+            ariaLabel={terminalAriaLabel}
+            description="Press Enter to run the installer. If you already installed this skill, skip this terminal and use Re-check instead."
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -10,7 +10,10 @@ import {
   BROWSER_USE_ENABLED_STORAGE_KEY,
   BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY
 } from '@/lib/browser-use-setup-state'
-import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import {
@@ -97,8 +100,14 @@ export function BrowserUseSetup({
   const cliEnabled = cliStatus?.state === 'installed'
   const cliSupported = cliStatus?.supported ?? false
 
-  const { installed: skillDetected } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
-    enabled: browserUseEnabled
+  const {
+    installed: skillDetected,
+    loading: skillLoading,
+    error: skillError,
+    refresh: refreshSkill
+  } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
+    enabled: browserUseEnabled,
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
 
   // Why: discovery can fail for unusual setups, so keep the manual marker as a
@@ -122,15 +131,6 @@ export function BrowserUseSetup({
       toast.error(error instanceof Error ? error.message : 'Failed to register `orca` in PATH.')
     } finally {
       setCliBusy(false)
-    }
-  }
-
-  const handleCopySkillCommand = async (): Promise<void> => {
-    try {
-      await window.api.ui.writeClipboardText(ORCA_CLI_SKILL_INSTALL_COMMAND)
-      toast.success('Copied install command. Run it on this computer.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy command.')
     }
   }
 
@@ -320,8 +320,10 @@ export function BrowserUseSetup({
             skillInstalled={skillInstalled}
             skillDetected={skillDetected}
             skillMarkedInstalled={skillMarkedInstalled}
+            skillLoading={skillLoading}
+            skillError={skillError}
             disabled={!cliEnabled}
-            onCopy={() => void handleCopySkillCommand()}
+            onRecheck={refreshSkill}
             onToggleInstalled={() => markSkillInstalled(!skillMarkedInstalled)}
           />
         </SearchableSetting>

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -6,10 +6,7 @@ import {
   ORCA_CLI_SKILL_INSTALL_COMMAND,
   ORCA_CLI_SKILL_NAME
 } from '@/lib/agent-feature-install-commands'
-import {
-  BROWSER_USE_ENABLED_STORAGE_KEY,
-  BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY
-} from '@/lib/browser-use-setup-state'
+import { BROWSER_USE_ENABLED_STORAGE_KEY } from '@/lib/browser-use-setup-state'
 import {
   GLOBAL_AGENT_SKILL_SOURCE_KINDS,
   useInstalledAgentSkill
@@ -110,17 +107,6 @@ export function BrowserUseSetup({
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
 
-  // Why: discovery can fail for unusual setups, so keep the manual marker as a
-  // fallback instead of making this guided flow depend only on auto-detection.
-  const [skillMarkedInstalled, setSkillMarkedInstalled] = useState<boolean>(() => {
-    return localStorage.getItem(BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY) === '1'
-  })
-
-  const markSkillInstalled = (value: boolean): void => {
-    setSkillMarkedInstalled(value)
-    localStorage.setItem(BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
-  }
-
   const handleEnableCli = async (): Promise<void> => {
     setCliBusy(true)
     try {
@@ -168,9 +154,7 @@ export function BrowserUseSetup({
   const showStep1 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[0]])
   const showStep2 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[1]])
   const showStep3 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[2]])
-  const skillInstalled = skillDetected || skillMarkedInstalled
-
-  const completedCount = [cliEnabled, skillInstalled, cookiesImported].filter(Boolean).length
+  const completedCount = [cliEnabled, skillDetected, cookiesImported].filter(Boolean).length
 
   const sourceLabel = defaultProfile?.source
     ? `${BROWSER_FAMILY_LABELS[defaultProfile.source.browserFamily] ?? defaultProfile.source.browserFamily}${defaultProfile.source.profileName ? ` (${defaultProfile.source.profileName})` : ''}`
@@ -317,14 +301,11 @@ export function BrowserUseSetup({
         >
           <BrowserUseSkillStep
             command={ORCA_CLI_SKILL_INSTALL_COMMAND}
-            skillInstalled={skillInstalled}
             skillDetected={skillDetected}
-            skillMarkedInstalled={skillMarkedInstalled}
             skillLoading={skillLoading}
             skillError={skillError}
             disabled={!cliEnabled}
             onRecheck={refreshSkill}
-            onToggleInstalled={() => markSkillInstalled(!skillMarkedInstalled)}
           />
         </SearchableSetting>
       ) : null}
@@ -335,7 +316,7 @@ export function BrowserUseSetup({
           description="Import cookies from Chrome, Edge, or other browsers so agents can reuse your logins."
           keywords={BROWSER_USE_PANE_SEARCH_ENTRIES[2].keywords}
           className={`rounded-xl border border-border/60 bg-card/50 p-4 ${
-            cliEnabled && skillInstalled ? '' : 'opacity-60'
+            cliEnabled && skillDetected ? '' : 'opacity-60'
           }`}
         >
           <div className="flex items-start gap-3">

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -2,11 +2,15 @@ import { useEffect, useState } from 'react'
 import { Import, Loader2, MousePointerClick } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
-import { ORCA_CLI_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
+import {
+  ORCA_CLI_SKILL_INSTALL_COMMAND,
+  ORCA_CLI_SKILL_NAME
+} from '@/lib/agent-feature-install-commands'
 import {
   BROWSER_USE_ENABLED_STORAGE_KEY,
   BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY
 } from '@/lib/browser-use-setup-state'
+import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import {
@@ -93,16 +97,18 @@ export function BrowserUseSetup({
   const cliEnabled = cliStatus?.state === 'installed'
   const cliSupported = cliStatus?.supported ?? false
 
-  // Why: the skill install step is a copy-and-run command that happens in the
-  // user's terminal. We cannot detect completion from the app, so we let the
-  // user mark it done explicitly after copying — this avoids falsely implying
-  // progress and keeps the guided flow honest.
-  const [skillInstalled, setSkillInstalled] = useState<boolean>(() => {
+  const { installed: skillDetected } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
+    enabled: browserUseEnabled
+  })
+
+  // Why: discovery can fail for unusual setups, so keep the manual marker as a
+  // fallback instead of making this guided flow depend only on auto-detection.
+  const [skillMarkedInstalled, setSkillMarkedInstalled] = useState<boolean>(() => {
     return localStorage.getItem(BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY) === '1'
   })
 
   const markSkillInstalled = (value: boolean): void => {
-    setSkillInstalled(value)
+    setSkillMarkedInstalled(value)
     localStorage.setItem(BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
   }
 
@@ -162,6 +168,7 @@ export function BrowserUseSetup({
   const showStep1 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[0]])
   const showStep2 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[1]])
   const showStep3 = matchesSettingsSearch(searchQuery, [BROWSER_USE_PANE_SEARCH_ENTRIES[2]])
+  const skillInstalled = skillDetected || skillMarkedInstalled
 
   const completedCount = [cliEnabled, skillInstalled, cookiesImported].filter(Boolean).length
 
@@ -311,9 +318,11 @@ export function BrowserUseSetup({
           <BrowserUseSkillStep
             command={ORCA_CLI_SKILL_INSTALL_COMMAND}
             skillInstalled={skillInstalled}
+            skillDetected={skillDetected}
+            skillMarkedInstalled={skillMarkedInstalled}
             disabled={!cliEnabled}
             onCopy={() => void handleCopySkillCommand()}
-            onToggleInstalled={() => markSkillInstalled(!skillInstalled)}
+            onToggleInstalled={() => markSkillInstalled(!skillMarkedInstalled)}
           />
         </SearchableSetting>
       ) : null}

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
@@ -3,47 +3,38 @@ import { StepBadge } from './BrowserUseStepBadge'
 
 type Props = {
   command: string
-  skillInstalled: boolean
   skillDetected: boolean
-  skillMarkedInstalled: boolean
   skillLoading: boolean
   skillError: string | null
   disabled?: boolean
   onRecheck: () => void | Promise<void>
-  onToggleInstalled: () => void
 }
 
 export function BrowserUseSkillStep({
   command,
-  skillInstalled,
   skillDetected,
-  skillMarkedInstalled,
   skillLoading,
   skillError,
   disabled = false,
-  onRecheck,
-  onToggleInstalled
+  onRecheck
 }: Props): React.JSX.Element {
   return (
     <AgentSkillSetupPanel
       variant="inline"
       title="Browser Use skill"
       detectedDescription="Detected on this machine. Agents can drive Orca's browser."
-      markedDescription="Marked as installed on this machine."
-      missingDescription="Agents need this skill before they can drive Orca's browser. If you already installed it, use Re-check instead of running the installer again."
+      missingDescription="Agents need this skill before they can drive Orca's browser. If you already installed it, click Re-check instead of running the installer again."
       command={command}
       terminalTitle="Browser Use setup"
       terminalAriaLabel="Browser Use skill install terminal"
       terminalWorktreeId="settings-browser-use-skill-terminal"
-      installed={skillInstalled}
+      installed={skillDetected}
       detected={skillDetected}
-      markedInstalled={skillMarkedInstalled}
       loading={skillLoading}
       error={skillError}
       installDisabled={disabled}
-      leading={<StepBadge index={2} state={skillInstalled ? 'done' : 'pending'} />}
+      leading={<StepBadge index={2} state={skillDetected ? 'done' : 'pending'} />}
       onRecheck={onRecheck}
-      onToggleMarkedInstalled={onToggleInstalled}
     />
   )
 }

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
@@ -1,4 +1,5 @@
 import { Copy } from 'lucide-react'
+import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { StepBadge } from './BrowserUseStepBadge'
@@ -6,6 +7,8 @@ import { StepBadge } from './BrowserUseStepBadge'
 type Props = {
   command: string
   skillInstalled: boolean
+  skillDetected: boolean
+  skillMarkedInstalled: boolean
   disabled?: boolean
   onCopy: () => void
   onToggleInstalled: () => void
@@ -14,6 +17,8 @@ type Props = {
 export function BrowserUseSkillStep({
   command,
   skillInstalled,
+  skillDetected,
+  skillMarkedInstalled,
   disabled = false,
   onCopy,
   onToggleInstalled
@@ -50,21 +55,26 @@ export function BrowserUseSkillStep({
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
+          {skillInstalled ? <AgentSkillInstalledIndicator /> : null}
         </div>
         <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
           <span>
-            {skillInstalled
-              ? 'Marked as installed on this machine.'
-              : "Check off once you've run it on this computer."}
+            {skillDetected
+              ? 'Detected as installed on this machine.'
+              : skillMarkedInstalled
+                ? 'Marked as installed on this machine.'
+                : "Check off once you've run it on this computer."}
           </span>
-          <button
-            type="button"
-            className="underline-offset-2 hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:hover:text-muted-foreground"
-            onClick={onToggleInstalled}
-            disabled={disabled}
-          >
-            {skillInstalled ? 'Undo' : 'I ran it'}
-          </button>
+          {!skillDetected ? (
+            <button
+              type="button"
+              className="underline-offset-2 hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:hover:text-muted-foreground"
+              onClick={onToggleInstalled}
+              disabled={disabled}
+            >
+              {skillMarkedInstalled ? 'Undo' : 'I ran it'}
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.tsx
@@ -1,7 +1,4 @@
-import { Copy } from 'lucide-react'
-import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
-import { Button } from '../ui/button'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { StepBadge } from './BrowserUseStepBadge'
 
 type Props = {
@@ -9,8 +6,10 @@ type Props = {
   skillInstalled: boolean
   skillDetected: boolean
   skillMarkedInstalled: boolean
+  skillLoading: boolean
+  skillError: string | null
   disabled?: boolean
-  onCopy: () => void
+  onRecheck: () => void | Promise<void>
   onToggleInstalled: () => void
 }
 
@@ -19,64 +18,32 @@ export function BrowserUseSkillStep({
   skillInstalled,
   skillDetected,
   skillMarkedInstalled,
+  skillLoading,
+  skillError,
   disabled = false,
-  onCopy,
+  onRecheck,
   onToggleInstalled
 }: Props): React.JSX.Element {
   return (
-    <div className="flex items-start gap-3">
-      <StepBadge index={2} state={skillInstalled ? 'done' : 'pending'} />
-      <div className="min-w-0 flex-1 space-y-2">
-        <div className="space-y-1">
-          <p className="text-sm font-medium">Install Browser Use Skill</p>
-          <p className="text-xs text-muted-foreground">
-            Run this once on your computer so Claude Code, Codex, and other agents learn to drive
-            Orca&apos;s browser.
-          </p>
-        </div>
-        <div className="flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
-          <code className="flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
-            {command}
-          </code>
-          <TooltipProvider delayDuration={250}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={onCopy}
-                  aria-label="Copy skill install command"
-                >
-                  <Copy className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                Copy
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          {skillInstalled ? <AgentSkillInstalledIndicator /> : null}
-        </div>
-        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-          <span>
-            {skillDetected
-              ? 'Detected as installed on this machine.'
-              : skillMarkedInstalled
-                ? 'Marked as installed on this machine.'
-                : "Check off once you've run it on this computer."}
-          </span>
-          {!skillDetected ? (
-            <button
-              type="button"
-              className="underline-offset-2 hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:no-underline disabled:hover:text-muted-foreground"
-              onClick={onToggleInstalled}
-              disabled={disabled}
-            >
-              {skillMarkedInstalled ? 'Undo' : 'I ran it'}
-            </button>
-          ) : null}
-        </div>
-      </div>
-    </div>
+    <AgentSkillSetupPanel
+      variant="inline"
+      title="Browser Use skill"
+      detectedDescription="Detected on this machine. Agents can drive Orca's browser."
+      markedDescription="Marked as installed on this machine."
+      missingDescription="Agents need this skill before they can drive Orca's browser. If you already installed it, use Re-check instead of running the installer again."
+      command={command}
+      terminalTitle="Browser Use setup"
+      terminalAriaLabel="Browser Use skill install terminal"
+      terminalWorktreeId="settings-browser-use-skill-terminal"
+      installed={skillInstalled}
+      detected={skillDetected}
+      markedInstalled={skillMarkedInstalled}
+      loading={skillLoading}
+      error={skillError}
+      installDisabled={disabled}
+      leading={<StepBadge index={2} state={skillInstalled ? 'done' : 'pending'} />}
+      onRecheck={onRecheck}
+      onToggleMarkedInstalled={onToggleInstalled}
+    />
   )
 }

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
-import { Copy, FolderOpen, RefreshCw } from 'lucide-react'
+import { FolderOpen, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
 import {
   ORCA_CLI_SKILL_INSTALL_COMMAND,
   ORCA_CLI_SKILL_NAME
 } from '@/lib/agent-feature-install-commands'
-import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
-import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -19,7 +21,10 @@ import {
 } from '../ui/dialog'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { WslCliRegistration } from './WslCliRegistration'
+
+const CLI_SKILL_INSTALLED_STORAGE_KEY = 'orca.cli.skillInstalled'
 
 type CliSectionProps = {
   currentPlatform: string
@@ -53,7 +58,18 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
-  const { installed: cliSkillInstalled } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME)
+  const [cliSkillMarkedInstalled, setCliSkillMarkedInstalled] = useState<boolean>(
+    () => localStorage.getItem(CLI_SKILL_INSTALLED_STORAGE_KEY) === '1'
+  )
+  const {
+    installed: cliSkillDetected,
+    loading: cliSkillLoading,
+    error: cliSkillError,
+    refresh: refreshCliSkill
+  } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
+  const cliSkillInstalled = cliSkillDetected || cliSkillMarkedInstalled
 
   const refreshStatus = async (): Promise<void> => {
     setLoading(true)
@@ -105,13 +121,9 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
     }
   }
 
-  const handleCopySkillInstallCommand = async (command: string): Promise<void> => {
-    try {
-      await window.api.ui.writeClipboardText(command)
-      toast.success('Copied skill install command.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy install command.')
-    }
+  const markCliSkillInstalled = (value: boolean): void => {
+    setCliSkillMarkedInstalled(value)
+    localStorage.setItem(CLI_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
   }
 
   return (
@@ -220,36 +232,25 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
               </p>
             </div>
 
-            <div className="mt-3 space-y-3">
-              <div className="space-y-1">
-                <p className="text-xs text-muted-foreground">CLI skill</p>
-                <div className="inline-flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
-                  <code className="overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
-                    {ORCA_CLI_SKILL_INSTALL_COMMAND}
-                  </code>
-                  <TooltipProvider delayDuration={250}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          onClick={() =>
-                            void handleCopySkillInstallCommand(ORCA_CLI_SKILL_INSTALL_COMMAND)
-                          }
-                          aria-label="Copy CLI skill install command"
-                        >
-                          <Copy className="size-3.5" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={6}>
-                        Copy
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                  {cliSkillInstalled ? <AgentSkillInstalledIndicator /> : null}
-                </div>
-              </div>
-            </div>
+            <AgentSkillSetupPanel
+              className="mt-3"
+              variant="inline"
+              title="CLI skill"
+              detectedDescription="Detected on this machine. Agents know how to use Orca and report status."
+              markedDescription="Marked as installed on this machine."
+              missingDescription="Agents need this skill before they can use Orca and report status. If you already installed it, use Re-check instead of running the installer again."
+              command={ORCA_CLI_SKILL_INSTALL_COMMAND}
+              terminalTitle="CLI skill setup"
+              terminalAriaLabel="CLI skill install terminal"
+              terminalWorktreeId="settings-cli-skill-terminal"
+              installed={cliSkillInstalled}
+              detected={cliSkillDetected}
+              markedInstalled={cliSkillMarkedInstalled}
+              loading={cliSkillLoading}
+              error={cliSkillError}
+              onRecheck={refreshCliSkill}
+              onToggleMarkedInstalled={() => markCliSkillInstalled(!cliSkillMarkedInstalled)}
+            />
           </div>
         ) : null}
       </div>

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react'
 import { Copy, FolderOpen, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
-import { ORCA_CLI_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
+import {
+  ORCA_CLI_SKILL_INSTALL_COMMAND,
+  ORCA_CLI_SKILL_NAME
+} from '@/lib/agent-feature-install-commands'
+import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
+import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -48,6 +53,7 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  const { installed: cliSkillInstalled } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME)
 
   const refreshStatus = async (): Promise<void> => {
     setLoading(true)
@@ -240,6 +246,7 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
+                  {cliSkillInstalled ? <AgentSkillInstalledIndicator /> : null}
                 </div>
               </div>
             </div>

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -24,8 +24,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { WslCliRegistration } from './WslCliRegistration'
 
-const CLI_SKILL_INSTALLED_STORAGE_KEY = 'orca.cli.skillInstalled'
-
 type CliSectionProps = {
   currentPlatform: string
 }
@@ -58,9 +56,6 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
-  const [cliSkillMarkedInstalled, setCliSkillMarkedInstalled] = useState<boolean>(
-    () => localStorage.getItem(CLI_SKILL_INSTALLED_STORAGE_KEY) === '1'
-  )
   const {
     installed: cliSkillDetected,
     loading: cliSkillLoading,
@@ -69,7 +64,6 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
   } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
-  const cliSkillInstalled = cliSkillDetected || cliSkillMarkedInstalled
 
   const refreshStatus = async (): Promise<void> => {
     setLoading(true)
@@ -119,11 +113,6 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
     } finally {
       setBusyAction(null)
     }
-  }
-
-  const markCliSkillInstalled = (value: boolean): void => {
-    setCliSkillMarkedInstalled(value)
-    localStorage.setItem(CLI_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
   }
 
   return (
@@ -237,19 +226,16 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
               variant="inline"
               title="CLI skill"
               detectedDescription="Detected on this machine. Agents know how to use Orca and report status."
-              markedDescription="Marked as installed on this machine."
-              missingDescription="Agents need this skill before they can use Orca and report status. If you already installed it, use Re-check instead of running the installer again."
+              missingDescription="Agents need this skill before they can use Orca and report status. If you already installed it, click Re-check instead of running the installer again."
               command={ORCA_CLI_SKILL_INSTALL_COMMAND}
               terminalTitle="CLI skill setup"
               terminalAriaLabel="CLI skill install terminal"
               terminalWorktreeId="settings-cli-skill-terminal"
-              installed={cliSkillInstalled}
+              installed={cliSkillDetected}
               detected={cliSkillDetected}
-              markedInstalled={cliSkillMarkedInstalled}
               loading={cliSkillLoading}
               error={cliSkillError}
               onRecheck={refreshCliSkill}
-              onToggleMarkedInstalled={() => markCliSkillInstalled(!cliSkillMarkedInstalled)}
             />
           </div>
         ) : null}

--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -25,8 +25,6 @@ import { Button } from '../ui/button'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import type { SettingsSearchEntry } from './settings-search'
 
-const COMPUTER_USE_SKILL_INSTALLED_STORAGE_KEY = 'orca.computerUse.skillInstalled'
-
 export const COMPUTER_USE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Computer Use',
@@ -89,9 +87,6 @@ export function ComputerUsePane(): React.JSX.Element {
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<ComputerUsePermissionId | null>(null)
   const [helperUnavailableReason, setHelperUnavailableReason] = useState<string | null>(null)
-  const [computerUseSkillMarkedInstalled, setComputerUseSkillMarkedInstalled] = useState<boolean>(
-    () => localStorage.getItem(COMPUTER_USE_SKILL_INSTALLED_STORAGE_KEY) === '1'
-  )
   const {
     installed: computerUseSkillDetected,
     loading: computerUseSkillLoading,
@@ -100,7 +95,6 @@ export function ComputerUsePane(): React.JSX.Element {
   } = useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME, {
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
-  const computerUseSkillInstalled = computerUseSkillDetected || computerUseSkillMarkedInstalled
 
   const stateById = useMemo(
     () => new Map(states.map((state) => [state.id, state.status] as const)),
@@ -153,11 +147,6 @@ export function ComputerUsePane(): React.JSX.Element {
     } finally {
       setPendingId(null)
     }
-  }
-
-  const markComputerUseSkillInstalled = (value: boolean): void => {
-    setComputerUseSkillMarkedInstalled(value)
-    localStorage.setItem(COMPUTER_USE_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
   }
 
   const isMac = platform === null || platform === 'darwin'
@@ -236,22 +225,17 @@ export function ComputerUsePane(): React.JSX.Element {
       <AgentSkillSetupPanel
         title="Computer Use skill"
         detectedDescription="Detected on this machine. Agents can use Orca's computer controls."
-        markedDescription="Marked as installed on this machine."
-        missingDescription="Agents need this skill before they can use Orca's computer controls. If you already installed it, use Re-check instead of running the installer again."
+        missingDescription="Agents need this skill before they can use Orca's computer controls. If you already installed it, click Re-check instead of running the installer again."
         command={COMPUTER_USE_SKILL_INSTALL_COMMAND}
         terminalTitle="Computer Use setup"
         terminalAriaLabel="Computer Use skill install terminal"
         terminalWorktreeId="settings-computer-use-skill-terminal"
-        installed={computerUseSkillInstalled}
+        installed={computerUseSkillDetected}
         detected={computerUseSkillDetected}
-        markedInstalled={computerUseSkillMarkedInstalled}
         loading={computerUseSkillLoading}
         error={computerUseSkillError}
         icon={<MonitorCog className="size-5" />}
         onRecheck={refreshComputerUseSkill}
-        onToggleMarkedInstalled={() =>
-          markComputerUseSkillInstalled(!computerUseSkillMarkedInstalled)
-        }
       />
     </div>
   )

--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { Accessibility, Camera, Copy, ExternalLink, RefreshCw, ShieldCheck } from 'lucide-react'
+import {
+  Accessibility,
+  Camera,
+  ExternalLink,
+  MonitorCog,
+  RefreshCw,
+  ShieldCheck
+} from 'lucide-react'
 import { toast } from 'sonner'
 import type {
   ComputerUsePermissionId,
@@ -10,11 +17,15 @@ import {
   COMPUTER_USE_SKILL_INSTALL_COMMAND,
   COMPUTER_USE_SKILL_NAME
 } from '@/lib/agent-feature-install-commands'
-import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
-import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
 import { Button } from '../ui/button'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import type { SettingsSearchEntry } from './settings-search'
+
+const COMPUTER_USE_SKILL_INSTALLED_STORAGE_KEY = 'orca.computerUse.skillInstalled'
 
 export const COMPUTER_USE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
@@ -78,7 +89,18 @@ export function ComputerUsePane(): React.JSX.Element {
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<ComputerUsePermissionId | null>(null)
   const [helperUnavailableReason, setHelperUnavailableReason] = useState<string | null>(null)
-  const { installed: computerUseSkillInstalled } = useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME)
+  const [computerUseSkillMarkedInstalled, setComputerUseSkillMarkedInstalled] = useState<boolean>(
+    () => localStorage.getItem(COMPUTER_USE_SKILL_INSTALLED_STORAGE_KEY) === '1'
+  )
+  const {
+    installed: computerUseSkillDetected,
+    loading: computerUseSkillLoading,
+    error: computerUseSkillError,
+    refresh: refreshComputerUseSkill
+  } = useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME, {
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
+  const computerUseSkillInstalled = computerUseSkillDetected || computerUseSkillMarkedInstalled
 
   const stateById = useMemo(
     () => new Map(states.map((state) => [state.id, state.status] as const)),
@@ -133,13 +155,9 @@ export function ComputerUsePane(): React.JSX.Element {
     }
   }
 
-  const copySkillInstallCommand = async (): Promise<void> => {
-    try {
-      await window.api.ui.writeClipboardText(COMPUTER_USE_SKILL_INSTALL_COMMAND)
-      toast.success('Copied skill install command.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy install command.')
-    }
+  const markComputerUseSkillInstalled = (value: boolean): void => {
+    setComputerUseSkillMarkedInstalled(value)
+    localStorage.setItem(COMPUTER_USE_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
   }
 
   const isMac = platform === null || platform === 'darwin'
@@ -215,37 +233,26 @@ export function ComputerUsePane(): React.JSX.Element {
         </>
       ) : null}
 
-      <div className="space-y-2 rounded-lg border border-border/60 px-4 py-3">
-        <div className="space-y-1">
-          <p className="text-sm font-medium">Install Computer Use Skill</p>
-          <p className="text-xs text-muted-foreground">
-            Run this once on your computer so agents know how to use Orca&apos;s computer controls.
-          </p>
-        </div>
-        <div className="flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
-          <code className="flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
-            {COMPUTER_USE_SKILL_INSTALL_COMMAND}
-          </code>
-          <TooltipProvider delayDuration={250}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => void copySkillInstallCommand()}
-                  aria-label="Copy Computer Use skill install command"
-                >
-                  <Copy className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                Copy
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          {computerUseSkillInstalled ? <AgentSkillInstalledIndicator /> : null}
-        </div>
-      </div>
+      <AgentSkillSetupPanel
+        title="Computer Use skill"
+        detectedDescription="Detected on this machine. Agents can use Orca's computer controls."
+        markedDescription="Marked as installed on this machine."
+        missingDescription="Agents need this skill before they can use Orca's computer controls. If you already installed it, use Re-check instead of running the installer again."
+        command={COMPUTER_USE_SKILL_INSTALL_COMMAND}
+        terminalTitle="Computer Use setup"
+        terminalAriaLabel="Computer Use skill install terminal"
+        terminalWorktreeId="settings-computer-use-skill-terminal"
+        installed={computerUseSkillInstalled}
+        detected={computerUseSkillDetected}
+        markedInstalled={computerUseSkillMarkedInstalled}
+        loading={computerUseSkillLoading}
+        error={computerUseSkillError}
+        icon={<MonitorCog className="size-5" />}
+        onRecheck={refreshComputerUseSkill}
+        onToggleMarkedInstalled={() =>
+          markComputerUseSkillInstalled(!computerUseSkillMarkedInstalled)
+        }
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -6,7 +6,12 @@ import type {
   ComputerUsePermissionState,
   ComputerUsePermissionStatus
 } from '../../../../shared/computer-use-permissions-types'
-import { COMPUTER_USE_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
+import {
+  COMPUTER_USE_SKILL_INSTALL_COMMAND,
+  COMPUTER_USE_SKILL_NAME
+} from '@/lib/agent-feature-install-commands'
+import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
+import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import type { SettingsSearchEntry } from './settings-search'
@@ -73,6 +78,7 @@ export function ComputerUsePane(): React.JSX.Element {
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<ComputerUsePermissionId | null>(null)
   const [helperUnavailableReason, setHelperUnavailableReason] = useState<string | null>(null)
+  const { installed: computerUseSkillInstalled } = useInstalledAgentSkill(COMPUTER_USE_SKILL_NAME)
 
   const stateById = useMemo(
     () => new Map(states.map((state) => [state.id, state.status] as const)),
@@ -237,6 +243,7 @@ export function ComputerUsePane(): React.JSX.Element {
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
+          {computerUseSkillInstalled ? <AgentSkillInstalledIndicator /> : null}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -9,10 +9,8 @@ import {
 } from '@/hooks/useInstalledAgentSkills'
 import {
   ORCHESTRATION_ENABLED_STORAGE_KEY,
-  ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY,
   ORCHESTRATION_SETUP_STATE_EVENT,
   isOrchestrationSetupEnabled,
-  isOrchestrationSkillMarkedInstalled,
   notifyOrchestrationSetupStateChanged
 } from '@/lib/orchestration-setup-state'
 import { SearchableSetting } from './SearchableSetting'
@@ -29,9 +27,6 @@ export function OrchestrationPane(): React.JSX.Element {
     return isOrchestrationSetupEnabled()
   })
 
-  const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState<boolean>(() => {
-    return isOrchestrationSkillMarkedInstalled()
-  })
   const {
     installed: orchestrationSkillDetected,
     loading: orchestrationSkillLoading,
@@ -41,12 +36,10 @@ export function OrchestrationPane(): React.JSX.Element {
     enabled: orchestrationEnabled,
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
-  const orchestrationSkillReady = orchestrationSkillDetected || orchestrationSkillInstalled
 
   useEffect(() => {
     const syncSetupState = (): void => {
       setOrchestrationEnabled(isOrchestrationSetupEnabled())
-      setOrchestrationSkillInstalled(isOrchestrationSkillMarkedInstalled())
     }
     window.addEventListener(ORCHESTRATION_SETUP_STATE_EVENT, syncSetupState)
     return () => {
@@ -57,12 +50,6 @@ export function OrchestrationPane(): React.JSX.Element {
   const toggleOrchestration = (value: boolean): void => {
     setOrchestrationEnabled(value)
     localStorage.setItem(ORCHESTRATION_ENABLED_STORAGE_KEY, value ? '1' : '0')
-    notifyOrchestrationSetupStateChanged()
-  }
-
-  const markOrchestrationSkillInstalled = (value: boolean): void => {
-    setOrchestrationSkillInstalled(value)
-    localStorage.setItem(ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY, value ? '1' : '0')
     notifyOrchestrationSetupStateChanged()
   }
 
@@ -109,22 +96,17 @@ export function OrchestrationPane(): React.JSX.Element {
         <AgentSkillSetupPanel
           title="Orchestration skill"
           detectedDescription="Detected on this machine. Agents can use inter-agent orchestration."
-          markedDescription="Marked as installed on this machine."
-          missingDescription="Agents need this skill before they can use inter-agent orchestration. If you already installed it, use Re-check instead of running the installer again."
+          missingDescription="Agents need this skill before they can use inter-agent orchestration. If you already installed it, click Re-check instead of running the installer again."
           command={ORCHESTRATION_SKILL_INSTALL_COMMAND}
           terminalTitle="Orchestration setup"
           terminalAriaLabel="Orchestration skill install terminal"
           terminalWorktreeId="settings-orchestration-skill-terminal"
-          installed={orchestrationSkillReady}
+          installed={orchestrationSkillDetected}
           detected={orchestrationSkillDetected}
-          markedInstalled={orchestrationSkillInstalled}
           loading={orchestrationSkillLoading}
           error={orchestrationSkillError}
           icon={<Workflow className="size-5" />}
           onRecheck={handleRecheckOrchestrationSkill}
-          onToggleMarkedInstalled={() =>
-            markOrchestrationSkillInstalled(!orchestrationSkillInstalled)
-          }
         />
       ) : null}
     </SearchableSetting>

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from 'react'
-import { Copy } from 'lucide-react'
-import { toast } from 'sonner'
-import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
-import { Button } from '../ui/button'
+import { Workflow } from 'lucide-react'
 import { Label } from '../ui/label'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
-import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
 import {
   ORCHESTRATION_ENABLED_STORAGE_KEY,
   ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY,
@@ -20,6 +19,7 @@ import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { useAppStore } from '../../store'
 import { ORCHESTRATION_PANE_SEARCH_ENTRIES } from './orchestration-search'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 
 export function OrchestrationPane(): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
@@ -32,10 +32,15 @@ export function OrchestrationPane(): React.JSX.Element {
   const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState<boolean>(() => {
     return isOrchestrationSkillMarkedInstalled()
   })
-  const { installed: orchestrationSkillDetected } = useInstalledAgentSkill(
-    ORCHESTRATION_SKILL_NAME,
-    { enabled: orchestrationEnabled }
-  )
+  const {
+    installed: orchestrationSkillDetected,
+    loading: orchestrationSkillLoading,
+    error: orchestrationSkillError,
+    refresh: refreshOrchestrationSkill
+  } = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
+    enabled: orchestrationEnabled,
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
   const orchestrationSkillReady = orchestrationSkillDetected || orchestrationSkillInstalled
 
   useEffect(() => {
@@ -61,13 +66,8 @@ export function OrchestrationPane(): React.JSX.Element {
     notifyOrchestrationSetupStateChanged()
   }
 
-  const handleCopyOrchestrationCommand = async (): Promise<void> => {
-    try {
-      await window.api.ui.writeClipboardText(ORCHESTRATION_SKILL_INSTALL_COMMAND)
-      toast.success('Copied install command. Run it on this computer.')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy command.')
-    }
+  const handleRecheckOrchestrationSkill = async (): Promise<void> => {
+    await refreshOrchestrationSkill()
   }
 
   if (!showOrchestration) {
@@ -106,55 +106,26 @@ export function OrchestrationPane(): React.JSX.Element {
       </div>
 
       {orchestrationEnabled ? (
-        <div className="space-y-3 rounded-xl border border-border/60 bg-card/50 p-4">
-          <div className="space-y-1">
-            <p className="text-sm font-medium">Install Orchestration Skill</p>
-            <p className="text-xs text-muted-foreground">
-              Run this once on your computer so agents learn to use inter-agent orchestration.
-            </p>
-          </div>
-          <div className="flex max-w-full items-center gap-2 rounded-lg border border-border/60 bg-background/60 px-3 py-2">
-            <code className="flex-1 overflow-x-auto whitespace-nowrap text-[11px] text-muted-foreground">
-              {ORCHESTRATION_SKILL_INSTALL_COMMAND}
-            </code>
-            <TooltipProvider delayDuration={250}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() => void handleCopyOrchestrationCommand()}
-                    aria-label="Copy orchestration skill install command"
-                  >
-                    <Copy className="size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  Copy
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            {orchestrationSkillReady ? <AgentSkillInstalledIndicator /> : null}
-          </div>
-          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-            <span>
-              {orchestrationSkillDetected
-                ? 'Detected as installed on this machine.'
-                : orchestrationSkillInstalled
-                  ? 'Marked as installed on this machine.'
-                  : "Check off once you've run it on this computer."}
-            </span>
-            {!orchestrationSkillDetected ? (
-              <button
-                type="button"
-                className="underline-offset-2 hover:text-foreground hover:underline"
-                onClick={() => markOrchestrationSkillInstalled(!orchestrationSkillInstalled)}
-              >
-                {orchestrationSkillInstalled ? 'Undo' : 'I ran it'}
-              </button>
-            ) : null}
-          </div>
-        </div>
+        <AgentSkillSetupPanel
+          title="Orchestration skill"
+          detectedDescription="Detected on this machine. Agents can use inter-agent orchestration."
+          markedDescription="Marked as installed on this machine."
+          missingDescription="Agents need this skill before they can use inter-agent orchestration. If you already installed it, use Re-check instead of running the installer again."
+          command={ORCHESTRATION_SKILL_INSTALL_COMMAND}
+          terminalTitle="Orchestration setup"
+          terminalAriaLabel="Orchestration skill install terminal"
+          terminalWorktreeId="settings-orchestration-skill-terminal"
+          installed={orchestrationSkillReady}
+          detected={orchestrationSkillDetected}
+          markedInstalled={orchestrationSkillInstalled}
+          loading={orchestrationSkillLoading}
+          error={orchestrationSkillError}
+          icon={<Workflow className="size-5" />}
+          onRecheck={handleRecheckOrchestrationSkill}
+          onToggleMarkedInstalled={() =>
+            markOrchestrationSkillInstalled(!orchestrationSkillInstalled)
+          }
+        />
       ) : null}
     </SearchableSetting>
   )

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react'
 import { Copy } from 'lucide-react'
 import { toast } from 'sonner'
+import { AgentSkillInstalledIndicator } from '../AgentSkillInstalledIndicator'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
+import { useInstalledAgentSkill } from '@/hooks/useInstalledAgentSkills'
 import {
   ORCHESTRATION_ENABLED_STORAGE_KEY,
   ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY,
@@ -29,6 +32,11 @@ export function OrchestrationPane(): React.JSX.Element {
   const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState<boolean>(() => {
     return isOrchestrationSkillMarkedInstalled()
   })
+  const { installed: orchestrationSkillDetected } = useInstalledAgentSkill(
+    ORCHESTRATION_SKILL_NAME,
+    { enabled: orchestrationEnabled }
+  )
+  const orchestrationSkillReady = orchestrationSkillDetected || orchestrationSkillInstalled
 
   useEffect(() => {
     const syncSetupState = (): void => {
@@ -126,20 +134,25 @@ export function OrchestrationPane(): React.JSX.Element {
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
+            {orchestrationSkillReady ? <AgentSkillInstalledIndicator /> : null}
           </div>
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
             <span>
-              {orchestrationSkillInstalled
-                ? 'Marked as installed on this machine.'
-                : "Check off once you've run it on this computer."}
+              {orchestrationSkillDetected
+                ? 'Detected as installed on this machine.'
+                : orchestrationSkillInstalled
+                  ? 'Marked as installed on this machine.'
+                  : "Check off once you've run it on this computer."}
             </span>
-            <button
-              type="button"
-              className="underline-offset-2 hover:text-foreground hover:underline"
-              onClick={() => markOrchestrationSkillInstalled(!orchestrationSkillInstalled)}
-            >
-              {orchestrationSkillInstalled ? 'Undo' : 'I ran it'}
-            </button>
+            {!orchestrationSkillDetected ? (
+              <button
+                type="button"
+                className="underline-offset-2 hover:text-foreground hover:underline"
+                onClick={() => markOrchestrationSkillInstalled(!orchestrationSkillInstalled)}
+              >
+                {orchestrationSkillInstalled ? 'Undo' : 'I ran it'}
+              </button>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { DiscoveredSkill } from '../../../shared/skills'
+import { hasInstalledAgentSkill } from './useInstalledAgentSkills'
+
+function skill(overrides: Partial<DiscoveredSkill>): DiscoveredSkill {
+  return {
+    id: 'skill-1',
+    name: 'Example Skill',
+    description: null,
+    providers: ['agent-skills'],
+    sourceKind: 'home',
+    sourceLabel: 'Agent skills home',
+    rootPath: '/Users/test/.agents/skills',
+    directoryPath: '/Users/test/.agents/skills/example-skill',
+    skillFilePath: '/Users/test/.agents/skills/example-skill/SKILL.md',
+    installed: true,
+    fileCount: 1,
+    updatedAt: null,
+    ...overrides
+  }
+}
+
+describe('hasInstalledAgentSkill', () => {
+  it('matches installed skills by summarized name', () => {
+    expect(hasInstalledAgentSkill([skill({ name: 'orca-cli' })], 'orca-cli')).toBe(true)
+  })
+
+  it('matches installed skills by directory name when frontmatter has a display name', () => {
+    expect(
+      hasInstalledAgentSkill(
+        [
+          skill({
+            name: 'Orca CLI',
+            directoryPath: 'C:\\Users\\test\\.agents\\skills\\orca-cli'
+          })
+        ],
+        'orca-cli'
+      )
+    ).toBe(true)
+  })
+
+  it('ignores non-installed discovery entries', () => {
+    expect(
+      hasInstalledAgentSkill([skill({ name: 'orca-cli', installed: false })], 'orca-cli')
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from 'vitest'
-import type { DiscoveredSkill } from '../../../shared/skills'
-import { GLOBAL_AGENT_SKILL_SOURCE_KINDS, hasInstalledAgentSkill } from './useInstalledAgentSkills'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../shared/skills'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  _installedAgentSkillDiscoveryInternalsForTests,
+  hasInstalledAgentSkill
+} from './useInstalledAgentSkills'
+
+afterEach(() => {
+  _installedAgentSkillDiscoveryInternalsForTests.reset()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 function skill(overrides: Partial<DiscoveredSkill>): DiscoveredSkill {
   return {
@@ -18,6 +28,28 @@ function skill(overrides: Partial<DiscoveredSkill>): DiscoveredSkill {
     updatedAt: null,
     ...overrides
   }
+}
+
+function discoveryResult(skills: DiscoveredSkill[] = []): SkillDiscoveryResult {
+  return {
+    skills,
+    sources: [],
+    scannedAt: Date.now()
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
 }
 
 describe('hasInstalledAgentSkill', () => {
@@ -79,5 +111,35 @@ describe('hasInstalledAgentSkill', () => {
         sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
       })
     ).toBe(true)
+  })
+})
+
+describe('discoverInstalledAgentSkills', () => {
+  it('starts a fresh scan when a forced refresh arrives during a background scan', async () => {
+    const firstScan = deferred<SkillDiscoveryResult>()
+    const secondScan = deferred<SkillDiscoveryResult>()
+    const discover = vi.fn<() => Promise<SkillDiscoveryResult>>()
+    discover.mockReturnValueOnce(firstScan.promise)
+    discover.mockReturnValueOnce(secondScan.promise)
+    vi.stubGlobal('window', {
+      api: { skills: { discover } }
+    })
+
+    const backgroundRefresh =
+      _installedAgentSkillDiscoveryInternalsForTests.discoverInstalledAgentSkills(false)
+    const forcedRefresh =
+      _installedAgentSkillDiscoveryInternalsForTests.discoverInstalledAgentSkills(true)
+
+    expect(discover).toHaveBeenCalledTimes(1)
+
+    const staleResult = discoveryResult([])
+    firstScan.resolve(staleResult)
+    await expect(backgroundRefresh).resolves.toBe(staleResult)
+
+    expect(discover).toHaveBeenCalledTimes(2)
+
+    const freshResult = discoveryResult([skill({ name: 'orca-cli' })])
+    secondScan.resolve(freshResult)
+    await expect(forcedRefresh).resolves.toBe(freshResult)
   })
 })

--- a/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { DiscoveredSkill } from '../../../shared/skills'
-import { hasInstalledAgentSkill } from './useInstalledAgentSkills'
+import { GLOBAL_AGENT_SKILL_SOURCE_KINDS, hasInstalledAgentSkill } from './useInstalledAgentSkills'
 
 function skill(overrides: Partial<DiscoveredSkill>): DiscoveredSkill {
   return {
@@ -43,5 +43,41 @@ describe('hasInstalledAgentSkill', () => {
     expect(
       hasInstalledAgentSkill([skill({ name: 'orca-cli', installed: false })], 'orca-cli')
     ).toBe(false)
+  })
+
+  it('does not count repo or plugin skills when matching global installs', () => {
+    expect(
+      hasInstalledAgentSkill(
+        [
+          skill({
+            name: 'orca-cli',
+            sourceKind: 'repo',
+            sourceLabel: 'Repo test .agents',
+            rootPath: '/repo/.agents/skills',
+            directoryPath: '/repo/.agents/skills/orca-cli',
+            skillFilePath: '/repo/.agents/skills/orca-cli/SKILL.md'
+          }),
+          skill({
+            id: 'skill-2',
+            name: 'orca-cli',
+            sourceKind: 'plugin',
+            sourceLabel: 'Codex plugin cache',
+            rootPath: '/Users/test/.codex/plugins/cache',
+            directoryPath: '/Users/test/.codex/plugins/cache/vendor/orca-cli',
+            skillFilePath: '/Users/test/.codex/plugins/cache/vendor/orca-cli/SKILL.md'
+          })
+        ],
+        'orca-cli',
+        { sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS }
+      )
+    ).toBe(false)
+  })
+
+  it('counts home skills when matching global installs', () => {
+    expect(
+      hasInstalledAgentSkill([skill({ name: 'orca-cli' })], 'orca-cli', {
+        sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+      })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../shared/skills'
+
+const INSTALLED_AGENT_SKILLS_CHANGED_EVENT = 'orca:installed-agent-skills-changed'
+
+let cachedDiscovery: SkillDiscoveryResult | null = null
+let pendingDiscovery: Promise<SkillDiscoveryResult> | null = null
+
+function normalizeSkillName(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function basenameFromPath(pathValue: string): string {
+  return pathValue.split(/[\\/]/).filter(Boolean).at(-1) ?? pathValue
+}
+
+export function hasInstalledAgentSkill(
+  skills: readonly DiscoveredSkill[],
+  skillName: string
+): boolean {
+  const expected = normalizeSkillName(skillName)
+  return skills.some((skill) => {
+    if (!skill.installed) {
+      return false
+    }
+    return (
+      normalizeSkillName(skill.name) === expected ||
+      normalizeSkillName(basenameFromPath(skill.directoryPath)) === expected
+    )
+  })
+}
+
+export function notifyInstalledAgentSkillsChanged(): void {
+  cachedDiscovery = null
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(INSTALLED_AGENT_SKILLS_CHANGED_EVENT))
+  }
+}
+
+async function discoverInstalledAgentSkills(force: boolean): Promise<SkillDiscoveryResult> {
+  if (pendingDiscovery) {
+    return pendingDiscovery
+  }
+  if (!force && cachedDiscovery) {
+    return cachedDiscovery
+  }
+
+  pendingDiscovery = window.api.skills.discover()
+  try {
+    cachedDiscovery = await pendingDiscovery
+    return cachedDiscovery
+  } finally {
+    pendingDiscovery = null
+  }
+}
+
+export function useInstalledAgentSkill(
+  skillName: string,
+  options: { enabled?: boolean } = {}
+): {
+  installed: boolean
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+} {
+  const { enabled = true } = options
+  const [result, setResult] = useState<SkillDiscoveryResult | null>(cachedDiscovery)
+  const [loading, setLoading] = useState(enabled && !cachedDiscovery)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(
+    async (force = true): Promise<void> => {
+      if (!enabled) {
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      try {
+        const next = await discoverInstalledAgentSkills(force)
+        setResult(next)
+        setError(null)
+      } catch (refreshError) {
+        setError(
+          refreshError instanceof Error ? refreshError.message : 'Could not scan installed skills.'
+        )
+      } finally {
+        setLoading(false)
+      }
+    },
+    [enabled]
+  )
+
+  useEffect(() => {
+    void refresh(false)
+  }, [refresh])
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    const refreshFromExternalChange = (): void => {
+      void refresh(true)
+    }
+    // Why: skill install commands run outside React state, often in a terminal.
+    // Refresh on focus and explicit install events so completion is detected.
+    window.addEventListener('focus', refreshFromExternalChange)
+    window.addEventListener(INSTALLED_AGENT_SKILLS_CHANGED_EVENT, refreshFromExternalChange)
+    return () => {
+      window.removeEventListener('focus', refreshFromExternalChange)
+      window.removeEventListener(INSTALLED_AGENT_SKILLS_CHANGED_EVENT, refreshFromExternalChange)
+    }
+  }, [enabled, refresh])
+
+  const installed = useMemo(
+    () => (enabled && result ? hasInstalledAgentSkill(result.skills, skillName) : false),
+    [enabled, result, skillName]
+  )
+
+  const forceRefresh = useCallback(() => refresh(true), [refresh])
+
+  return {
+    installed,
+    loading,
+    error,
+    refresh: forceRefresh
+  }
+}

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -17,6 +17,7 @@ type InstalledAgentSkillMatchOptions = {
 
 let cachedDiscovery: SkillDiscoveryResult | null = null
 let pendingDiscovery: Promise<SkillDiscoveryResult> | null = null
+let pendingDiscoverySatisfiesForcedRefresh = false
 
 function normalizeSkillName(value: string): string {
   return value.trim().toLowerCase()
@@ -53,20 +54,54 @@ export function notifyInstalledAgentSkillsChanged(): void {
   }
 }
 
+function startInstalledAgentSkillDiscovery(force: boolean): Promise<SkillDiscoveryResult> {
+  const discovery = window.api.skills
+    .discover()
+    .then((result) => {
+      cachedDiscovery = result
+      return result
+    })
+    .finally(() => {
+      if (pendingDiscovery === discovery) {
+        pendingDiscovery = null
+        pendingDiscoverySatisfiesForcedRefresh = false
+      }
+    })
+  pendingDiscovery = discovery
+  pendingDiscoverySatisfiesForcedRefresh = force
+  return discovery
+}
+
 async function discoverInstalledAgentSkills(force: boolean): Promise<SkillDiscoveryResult> {
-  if (pendingDiscovery) {
-    return pendingDiscovery
-  }
   if (!force && cachedDiscovery) {
     return cachedDiscovery
   }
 
-  pendingDiscovery = window.api.skills.discover()
-  try {
-    cachedDiscovery = await pendingDiscovery
-    return cachedDiscovery
-  } finally {
+  const inFlightDiscovery = pendingDiscovery
+  if (inFlightDiscovery) {
+    if (!force || pendingDiscoverySatisfiesForcedRefresh) {
+      return inFlightDiscovery
+    }
+    try {
+      await inFlightDiscovery
+    } catch {
+      // Why: an explicit re-check should still read current disk state even if
+      // the older background scan failed.
+    }
+    if (pendingDiscovery && pendingDiscovery !== inFlightDiscovery) {
+      return pendingDiscovery
+    }
+  }
+
+  return startInstalledAgentSkillDiscovery(force)
+}
+
+export const _installedAgentSkillDiscoveryInternalsForTests = {
+  discoverInstalledAgentSkills,
+  reset(): void {
+    cachedDiscovery = null
     pendingDiscovery = null
+    pendingDiscoverySatisfiesForcedRefresh = false
   }
 }
 

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -1,7 +1,19 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../shared/skills'
+import type { DiscoveredSkill, SkillDiscoveryResult, SkillSourceKind } from '../../../shared/skills'
 
 const INSTALLED_AGENT_SKILLS_CHANGED_EVENT = 'orca:installed-agent-skills-changed'
+export const GLOBAL_AGENT_SKILL_SOURCE_KINDS = [
+  'home'
+] as const satisfies readonly SkillSourceKind[]
+
+type InstalledAgentSkillOptions = {
+  enabled?: boolean
+  sourceKinds?: readonly SkillSourceKind[]
+}
+
+type InstalledAgentSkillMatchOptions = {
+  sourceKinds?: readonly SkillSourceKind[]
+}
 
 let cachedDiscovery: SkillDiscoveryResult | null = null
 let pendingDiscovery: Promise<SkillDiscoveryResult> | null = null
@@ -16,11 +28,15 @@ function basenameFromPath(pathValue: string): string {
 
 export function hasInstalledAgentSkill(
   skills: readonly DiscoveredSkill[],
-  skillName: string
+  skillName: string,
+  options: InstalledAgentSkillMatchOptions = {}
 ): boolean {
   const expected = normalizeSkillName(skillName)
   return skills.some((skill) => {
     if (!skill.installed) {
+      return false
+    }
+    if (options.sourceKinds && !options.sourceKinds.includes(skill.sourceKind)) {
       return false
     }
     return (
@@ -56,14 +72,14 @@ async function discoverInstalledAgentSkills(force: boolean): Promise<SkillDiscov
 
 export function useInstalledAgentSkill(
   skillName: string,
-  options: { enabled?: boolean } = {}
+  options: InstalledAgentSkillOptions = {}
 ): {
   installed: boolean
   loading: boolean
   error: string | null
   refresh: () => Promise<void>
 } {
-  const { enabled = true } = options
+  const { enabled = true, sourceKinds } = options
   const [result, setResult] = useState<SkillDiscoveryResult | null>(cachedDiscovery)
   const [loading, setLoading] = useState(enabled && !cachedDiscovery)
   const [error, setError] = useState<string | null>(null)
@@ -112,8 +128,9 @@ export function useInstalledAgentSkill(
   }, [enabled, refresh])
 
   const installed = useMemo(
-    () => (enabled && result ? hasInstalledAgentSkill(result.skills, skillName) : false),
-    [enabled, result, skillName]
+    () =>
+      enabled && result ? hasInstalledAgentSkill(result.skills, skillName, { sourceKinds }) : false,
+    [enabled, result, skillName, sourceKinds]
   )
 
   const forceRefresh = useCallback(() => refresh(true), [refresh])

--- a/src/renderer/src/lib/browser-use-setup-state.ts
+++ b/src/renderer/src/lib/browser-use-setup-state.ts
@@ -1,2 +1,1 @@
 export const BROWSER_USE_ENABLED_STORAGE_KEY = 'orca.browserUse.enabled'
-export const BROWSER_USE_SKILL_INSTALLED_STORAGE_KEY = 'orca.browserUse.skillInstalled'

--- a/src/renderer/src/lib/orchestration-setup-state.ts
+++ b/src/renderer/src/lib/orchestration-setup-state.ts
@@ -1,18 +1,13 @@
 export const ORCHESTRATION_SETUP_STATE_EVENT = 'orca:orchestration-setup-state'
 export const ORCHESTRATION_ENABLED_STORAGE_KEY = 'orca.orchestration.enabled'
-export const ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY = 'orca.orchestration.skillInstalled'
 export const ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY = 'orca.orchestration.setupDismissed'
 
 export function isOrchestrationSetupEnabled(): boolean {
   return localStorage.getItem(ORCHESTRATION_ENABLED_STORAGE_KEY) === '1'
 }
 
-export function isOrchestrationSkillMarkedInstalled(): boolean {
-  return localStorage.getItem(ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY) === '1'
-}
-
 export function hasOrchestrationSetupMarker(): boolean {
-  return isOrchestrationSetupEnabled() || isOrchestrationSkillMarkedInstalled()
+  return isOrchestrationSetupEnabled()
 }
 
 export function isOrchestrationSetupDismissed(): boolean {

--- a/tests/e2e/settings-skill-detection.spec.ts
+++ b/tests/e2e/settings-skill-detection.spec.ts
@@ -1,0 +1,125 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+import type {
+  DiscoveredSkill,
+  SkillDiscoveryResult,
+  SkillSourceKind
+} from '../../src/shared/skills'
+import {
+  ORCHESTRATION_ENABLED_STORAGE_KEY,
+  ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY
+} from '../../src/renderer/src/lib/orchestration-setup-state'
+
+type MockSkillDiscoveryGlobal = typeof globalThis & {
+  __orcaSettingsSkillDiscoveryResult?: SkillDiscoveryResult
+}
+
+function makeSkill(sourceKind: SkillSourceKind, directoryPath: string): DiscoveredSkill {
+  return {
+    id: `${sourceKind}-orca-cli`,
+    name: 'orchestration',
+    description: null,
+    providers: ['agent-skills'],
+    sourceKind,
+    sourceLabel: sourceKind,
+    rootPath: directoryPath.replace(/[\\/]orchestration$/, ''),
+    directoryPath,
+    skillFilePath: `${directoryPath}/SKILL.md`,
+    installed: true,
+    fileCount: 1,
+    updatedAt: null
+  }
+}
+
+function discoveryResult(skills: DiscoveredSkill[]): SkillDiscoveryResult {
+  return {
+    skills,
+    sources: [],
+    scannedAt: Date.now()
+  }
+}
+
+async function installMockSkillDiscovery(
+  app: ElectronApplication,
+  result: SkillDiscoveryResult
+): Promise<void> {
+  await app.evaluate((electron, initialResult) => {
+    const global = globalThis as MockSkillDiscoveryGlobal
+    global.__orcaSettingsSkillDiscoveryResult = initialResult
+    electron.ipcMain.removeHandler('skills:discover')
+    electron.ipcMain.handle('skills:discover', () => {
+      const latest = (globalThis as MockSkillDiscoveryGlobal).__orcaSettingsSkillDiscoveryResult
+      if (!latest) {
+        throw new Error('Missing mocked skill discovery result')
+      }
+      return latest
+    })
+  }, result)
+}
+
+async function setMockSkillDiscovery(
+  app: ElectronApplication,
+  result: SkillDiscoveryResult
+): Promise<void> {
+  await app.evaluate((_, nextResult) => {
+    ;(globalThis as MockSkillDiscoveryGlobal).__orcaSettingsSkillDiscoveryResult = nextResult
+  }, result)
+}
+
+async function openOrchestrationSettings(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ enabledKey, installedKey }) => {
+      localStorage.removeItem(enabledKey)
+      localStorage.removeItem(installedKey)
+      const state = window.__store!.getState()
+      state.setSettingsSearchQuery('orchestration')
+      state.openSettingsPage()
+    },
+    {
+      enabledKey: ORCHESTRATION_ENABLED_STORAGE_KEY,
+      installedKey: ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY
+    }
+  )
+  await expect(page.getByPlaceholder('Search settings')).toBeVisible({ timeout: 10_000 })
+  await expect(
+    page
+      .locator('[data-settings-section="orchestration"]')
+      .getByRole('heading', { name: 'Orchestration', exact: true })
+  ).toBeInViewport({ timeout: 10_000 })
+}
+
+test.describe('Settings skill detection', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+  })
+
+  test('shows installed only for global orchestration skill installs', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    await installMockSkillDiscovery(
+      electronApp,
+      discoveryResult([
+        makeSkill('repo', '/workspace/.agents/skills/orchestration'),
+        makeSkill('plugin', '/Users/test/.codex/plugins/cache/vendor/orchestration')
+      ])
+    )
+
+    await openOrchestrationSettings(orcaPage)
+    const section = orcaPage.locator('[data-settings-section="orchestration"]')
+    await section.getByRole('switch').click()
+
+    await expect(section.getByText('Not installed', { exact: true })).toBeVisible()
+    await expect(section.getByText('Agents need this skill', { exact: false })).toBeVisible()
+
+    await setMockSkillDiscovery(
+      electronApp,
+      discoveryResult([makeSkill('home', '/Users/test/.agents/skills/orchestration')])
+    )
+    await section.getByRole('button', { name: 'Re-check' }).click()
+
+    await expect(section.getByText('Installed', { exact: true })).toBeVisible()
+    await expect(section.getByText('Detected on this machine', { exact: false })).toBeVisible()
+  })
+})

--- a/tests/e2e/settings-skill-detection.spec.ts
+++ b/tests/e2e/settings-skill-detection.spec.ts
@@ -6,10 +6,7 @@ import type {
   SkillDiscoveryResult,
   SkillSourceKind
 } from '../../src/shared/skills'
-import {
-  ORCHESTRATION_ENABLED_STORAGE_KEY,
-  ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY
-} from '../../src/renderer/src/lib/orchestration-setup-state'
+import { ORCHESTRATION_ENABLED_STORAGE_KEY } from '../../src/renderer/src/lib/orchestration-setup-state'
 
 type MockSkillDiscoveryGlobal = typeof globalThis & {
   __orcaSettingsSkillDiscoveryResult?: SkillDiscoveryResult
@@ -69,16 +66,14 @@ async function setMockSkillDiscovery(
 
 async function openOrchestrationSettings(page: Page): Promise<void> {
   await page.evaluate(
-    ({ enabledKey, installedKey }) => {
+    ({ enabledKey }) => {
       localStorage.removeItem(enabledKey)
-      localStorage.removeItem(installedKey)
       const state = window.__store!.getState()
       state.setSettingsSearchQuery('orchestration')
       state.openSettingsPage()
     },
     {
-      enabledKey: ORCHESTRATION_ENABLED_STORAGE_KEY,
-      installedKey: ORCHESTRATION_SKILL_INSTALLED_STORAGE_KEY
+      enabledKey: ORCHESTRATION_ENABLED_STORAGE_KEY
     }
   )
   await expect(page.getByPlaceholder('Search settings')).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
## Summary
- Detect globally installed Orca agent skills through the existing skills discovery API.
- Show an installed indicator in Browser Use, Orchestration, Computer Use, and CLI skill setup surfaces.
- Keep manual "I ran it" fallback state for flows where discovery cannot prove installation.

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/useInstalledAgentSkills.test.ts`
- `git diff --check` and `git diff --cached --check`
- Electron validation against this worktree on `demo-project`: verified `window.api.app.getIdentity()` for `brennankbenson/settings-skill-installed-detection`, confirmed `window.api.skills.discover()` finds `orca-cli`, `computer-use`, and `orchestration` in `~/.agents/skills`, and verified the Browser Use, Orchestration, and Computer Use settings panes render the installed indicator and detected copy.

## Notes
- The CLI settings skill row is hidden in this dev launch because `window.api.cli.getInstallStatus()` returns `unsupportedReason: "launch_mode_unavailable"`; the same shared hook and indicator path is covered by the other settings panes.
