### PR TITLE
fix(gitlab): restore cwd fallback in listMergeRequests when project r…

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -282,14 +282,57 @@ describe('gitlab client — MR operations', () => {
       expect(result.items[0].isCrossRepository).toBe(true)
     })
 
-    it('returns a not_found envelope when project ref is unresolved', async () => {
+    it('falls back to glab mr list when project ref is unresolved', async () => {
       resolveIssueSourceMock.mockResolvedValueOnce({
         source: null,
         fellBack: false
       })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            id: 300,
+            iid: 3,
+            title: 'fallback mr',
+            state: 'opened',
+            web_url: 'https://gitlab.com/-/merge_requests/3',
+            updated_at: '2026-05-05',
+            source_project_id: 5,
+            target_project_id: 5
+          }
+        ])
+      })
       const result = await listMergeRequests('/repo', 'opened')
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].title).toBe('fallback mr')
+      expect(glabApiWithHeadersMock).not.toHaveBeenCalled()
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+        [
+          'mr',
+          'list',
+          '--output',
+          'json',
+          '--per-page',
+          '20',
+          '--page',
+          '1',
+          '--order',
+          'updated_at',
+          '--sort',
+          'desc'
+        ],
+        { cwd: '/repo' }
+      )
+    })
+
+    it('classifies fallback errors into the result envelope', async () => {
+      resolveIssueSourceMock.mockResolvedValueOnce({
+        source: null,
+        fellBack: false
+      })
+      glabExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 403 Forbidden'))
+      const result = await listMergeRequests('/repo', 'opened')
+      expect(result.error?.type).toBe('permission_denied')
       expect(result.items).toEqual([])
-      expect(result.error?.type).toBe('not_found')
       expect(glabApiWithHeadersMock).not.toHaveBeenCalled()
     })
 

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -336,6 +336,26 @@ describe('gitlab client — MR operations', () => {
       expect(glabApiWithHeadersMock).not.toHaveBeenCalled()
     })
 
+    it('does not run the cwd fallback for unresolved SSH repos', async () => {
+      resolveIssueSourceMock.mockResolvedValueOnce({
+        source: null,
+        fellBack: false
+      })
+      const result = await listMergeRequests(
+        '/remote/repo',
+        'opened',
+        1,
+        20,
+        undefined,
+        undefined,
+        'conn-1'
+      )
+      expect(result.error?.type).toBe('not_found')
+      expect(result.items).toEqual([])
+      expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+      expect(glabApiWithHeadersMock).not.toHaveBeenCalled()
+    })
+
     it('classifies API errors into the result envelope', async () => {
       glabApiWithHeadersMock.mockRejectedValueOnce(new Error('HTTP 403 Forbidden'))
       const result = await listMergeRequests('/repo', 'opened')

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -180,6 +180,19 @@ export async function getMergeRequestForBranch(
   }
 }
 
+function mrListStateFlags(state: MRListState): string[] {
+  switch (state) {
+    case 'opened':
+      return []
+    case 'merged':
+      return ['--merged']
+    case 'closed':
+      return ['--closed']
+    case 'all':
+      return ['--all']
+  }
+}
+
 /**
  * List merge requests for a project. Uses glab CLI pagination because
  * it handles self-hosted auth and project selection consistently.
@@ -205,16 +218,53 @@ export async function listMergeRequests(
     connectionId
   )
   if (!projectRef) {
-    return {
-      items: [],
-      page,
-      perPage,
-      totalCount: 0,
-      totalPages: 0,
-      error: {
-        type: 'not_found',
-        message: 'No GitLab project found for this repository.'
+    // Why: fallback — let glab infer project from cwd, same as listIssues.
+    // Used when the repo's remote host is not in getGlabKnownHosts()
+    // (e.g. a fresh self-hosted instance), but glab itself can still
+    // resolve it from the local git config.
+    const stateFlag = mrListStateFlags(state)
+    await acquire()
+    try {
+      const { stdout } = await glabExecFileAsync(
+        [
+          'mr',
+          'list',
+          '--output',
+          'json',
+          '--per-page',
+          String(perPage),
+          '--page',
+          String(page),
+          '--order',
+          'updated_at',
+          '--sort',
+          'desc',
+          ...stateFlag
+        ],
+        glabRepoExecOptions(repoPath, connectionId)
+      )
+      const data = JSON.parse(stdout) as Parameters<typeof mapMRToWorkItem>[0][]
+      return {
+        items: data.map((d) => mapMRToWorkItem(d, 'unknown')),
+        page,
+        perPage,
+        // Why: the CLI doesn't return x-total headers, so totals are
+        // approximate. For the Tasks UI this is acceptable.
+        totalCount: data.length,
+        totalPages: data.length < perPage ? page : page + 1
       }
+    } catch (err) {
+      const stderr = err instanceof Error ? err.message : String(err)
+      return {
+        items: [],
+        page,
+        perPage,
+        totalCount: 0,
+        totalPages: 0,
+        error: classifyListIssuesError(stderr)
+      }
+    } finally {
+      release()
     }
   }
   // Why: 'all' is exposed as the picker filter but GitLab's API expects

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -218,6 +218,21 @@ export async function listMergeRequests(
     connectionId
   )
   if (!projectRef) {
+    if (connectionId) {
+      // Why: SSH-backed repos have no local cwd for glab to infer from.
+      // Running cwd-less could resolve an unrelated local project instead.
+      return {
+        items: [],
+        page,
+        perPage,
+        totalCount: 0,
+        totalPages: 0,
+        error: {
+          type: 'not_found',
+          message: 'No GitLab project found for this repository.'
+        }
+      }
+    }
     // Why: fallback — let glab infer project from cwd, same as listIssues.
     // Used when the repo's remote host is not in getGlabKnownHosts()
     // (e.g. a fresh self-hosted instance), but glab itself can still


### PR DESCRIPTION
## Summary

Restores the `glab mr list` cwd fallback in `listMergeRequests` so the GitLab MR tab in Tasks works again for repositories whose remote host is not yet listed in `glab auth status`.

A prior refactor (mobile Tasks parity, #b1973657) switched `listMergeRequests` from `glab mr list` to `glab api -i` (direct REST). In that change the fallback that lets `glab` infer the project from the repo's cwd was lost. When `resolveIssueSource` returned `null` (common for self-hosted instances or before `glab auth status` lists the host), the function immediately returned a `not_found` error envelope, leaving the MR list empty.

`listIssues` kept its fallback, which is why the Issues tab still worked. `listTodos` is user-scoped and unaffected.

The fix restores the `glab mr list --output json` fallback path when no `projectRef` is resolved, matching the behavior of `listIssues` and the pre-regression MR list.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — change is limited to main-process Node code; no renderer or native module changes
- [x] Added/updated high-quality tests: replaced the stale `not_found` test with two new cases covering (a) successful fallback and (b) fallback error classification

## AI Review Report

The AI agent reviewed the change for:
- **Cross-platform compatibility**: The fallback reuses `glabRepoExecOptions`, which already handles Windows/WSL cwd routing. No new platform-specific code was introduced.
- **IPC safety**: No new IPC channels; the existing `gitlab:listMRs` handler now receives populated results instead of an empty `not_found` envelope.
- **Command execution safety**: The fallback uses the same `glabExecFileAsync` runner with existing acquire/release concurrency limits. No shell interpolation is added.
- **Regression risk**: The change only affects the `!projectRef` branch; the primary `glab api -i` path is untouched.

## Security Audit

- **Input handling**: No new user input surfaces. The fallback uses the same `repoPath` (already validated by the IPC handler) and `state` enum values.
- **Command execution**: `glab mr list` flags are hardcoded; no user-controlled strings are concatenated.
- **Auth / secrets**: Still flows through the existing `glabExecFileAsync` runner, which respects the user's `glab` auth config.
- No follow-up needed.

## Notes

No platform-specific behavior changes. The fix is a pure restoration of the previous fallback path.