### PR TITLE
Fix unified workspace options regression

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1296,6 +1296,65 @@ describe('createMainWindow', () => {
     expect(webContents.send).not.toHaveBeenCalledWith('ui:toggleLeftSidebar')
   })
 
+  it('lets the shortcut recorder capture app shortcuts before main interception', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const setFocusedListener = vi
+      .mocked(ipcMain.on)
+      .mock.calls.find(([channel]) => channel === 'ui:setShortcutRecorderFocused')?.[1]
+    expect(setFocusedListener).toBeTypeOf('function')
+    setFocusedListener?.({ sender: webContents } as never, true)
+
+    const preventDefault = vi.fn()
+    const isDarwin = process.platform === 'darwin'
+    windowHandlers['before-input-event'](
+      { preventDefault } as never,
+      {
+        type: 'keyDown',
+        code: 'KeyB',
+        key: 'b',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: false
+      } as never
+    )
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:toggleLeftSidebar')
+  })
+
   it('skips Cmd+B interception when floating terminal input is focused', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -508,6 +508,7 @@ export function createMainWindow(
   let markdownEditorFocused = false
   let terminalInputFocused = false
   let floatingTerminalInputFocused = false
+  let shortcutRecorderFocused = false
 
   const markdownFocusChannel = 'ui:setMarkdownEditorFocused'
   // Why: coerce to strict boolean and verify the sender. A renderer bug or
@@ -543,6 +544,16 @@ export function createMainWindow(
     floatingTerminalInputFocused = focused === true
   }
   ipcMain.on(floatingTerminalInputFocusChannel, onFloatingTerminalInputFocused)
+  const shortcutRecorderFocusChannel = 'ui:setShortcutRecorderFocused'
+  // Why: the Settings recorder must receive existing app shortcuts so users can
+  // rebind them; before-input-event would otherwise consume the key first.
+  const onShortcutRecorderFocused = (event: Electron.IpcMainEvent, focused: unknown): void => {
+    if (event.sender !== mainWindow.webContents) {
+      return
+    }
+    shortcutRecorderFocused = focused === true
+  }
+  ipcMain.on(shortcutRecorderFocusChannel, onShortcutRecorderFocused)
 
   const onMainContextMenu = (_event: Electron.Event, params: Electron.ContextMenuParams): void => {
     const template = buildEditableContextMenuTemplate(params, mainWindow.webContents)
@@ -567,6 +578,9 @@ export function createMainWindow(
   }
   const resetFloatingTerminalInputFocus = (): void => {
     floatingTerminalInputFocused = false
+  }
+  const resetShortcutRecorderFocus = (): void => {
+    shortcutRecorderFocused = false
   }
   let rendererProcessGone = false
   let rendererRecoveryTimer: ReturnType<typeof setTimeout> | null = null
@@ -609,6 +623,7 @@ export function createMainWindow(
     resetMarkdownEditorFocus()
     resetTerminalInputFocus()
     resetFloatingTerminalInputFocus()
+    resetShortcutRecorderFocus()
     if (opts?.shouldRecordRendererCrash?.(details, rendererWebContentsId) !== false) {
       opts?.onRendererProcessGone?.(details, rendererWebContentsId)
     }
@@ -619,12 +634,14 @@ export function createMainWindow(
     resetMarkdownEditorFocus()
     resetTerminalInputFocus()
     resetFloatingTerminalInputFocus()
+    resetShortcutRecorderFocus()
   })
   mainWindow.webContents.on('did-start-navigation', (_e, _url, _isInPlace, isMainFrame) => {
     if (isMainFrame) {
       resetMarkdownEditorFocus()
       resetTerminalInputFocus()
       resetFloatingTerminalInputFocus()
+      resetShortcutRecorderFocus()
     }
   })
   mainWindow.webContents.on('did-finish-load', () => {
@@ -634,6 +651,10 @@ export function createMainWindow(
 
   let ctrlTabSwitching = false
   mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (shortcutRecorderFocused) {
+      return
+    }
+
     if (input.type === 'keyDown' && is.dev && input.code === 'F12') {
       event.preventDefault()
       if (mainWindow.webContents.isDevToolsOpened()) {
@@ -988,6 +1009,7 @@ export function createMainWindow(
     markdownEditorFocused = false
     terminalInputFocused = false
     floatingTerminalInputFocused = false
+    shortcutRecorderFocused = false
     clearRendererRecoveryTimer()
     ipcMain.removeListener(trafficLightChannel, onSyncTrafficLights)
     ipcMain.removeListener(minimizeChannel, onMinimize)
@@ -1000,6 +1022,7 @@ export function createMainWindow(
     ipcMain.removeListener(markdownFocusChannel, onMarkdownEditorFocused)
     ipcMain.removeListener(terminalInputFocusChannel, onTerminalInputFocused)
     ipcMain.removeListener(floatingTerminalInputFocusChannel, onFloatingTerminalInputFocused)
+    ipcMain.removeListener(shortcutRecorderFocusChannel, onShortcutRecorderFocused)
     // Why: on updater-triggered shutdown, BrowserWindow can emit `closed`
     // after its webContents has already been destroyed. The destroyed
     // webContents owns its listeners, so do not touch `mainWindow.webContents`

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1861,6 +1861,7 @@ export type PreloadApi = {
     setMarkdownEditorFocused: (focused: boolean) => void
     setTerminalInputFocused: (focused: boolean) => void
     setFloatingTerminalInputFocused: (focused: boolean) => void
+    setShortcutRecorderFocused: (focused: boolean) => void
     onRichMarkdownContextCommand: (
       callback: (payload: RichMarkdownContextMenuCommandPayload) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2692,6 +2692,9 @@ const api = {
     setFloatingTerminalInputFocused: (focused: boolean): void => {
       ipcRenderer.send('ui:setFloatingTerminalInputFocused', focused)
     },
+    setShortcutRecorderFocused: (focused: boolean): void => {
+      ipcRenderer.send('ui:setShortcutRecorderFocused', focused)
+    },
     onRichMarkdownContextCommand: (
       callback: (payload: RichMarkdownContextMenuCommandPayload) => void
     ): (() => void) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1021,6 +1021,14 @@ function App(): React.JSX.Element {
       if (e.defaultPrevented) {
         return
       }
+      // Why: the Settings recorder intentionally captures existing app
+      // shortcuts, so global handlers must not fire while its button has focus.
+      if (
+        e.target instanceof Element &&
+        e.target.closest('[data-shortcut-recorder-active]') !== null
+      ) {
+        return
+      }
       const context = getKeybindingContext(e.target)
 
       // Note: some app-level shortcuts are also intercepted via

--- a/src/renderer/src/components/settings/ShortcutBindingRow.tsx
+++ b/src/renderer/src/components/settings/ShortcutBindingRow.tsx
@@ -82,6 +82,8 @@ export function ShortcutBindingRow({
     if (recording) {
       recordButtonRef.current?.focus()
     }
+    window.api.ui.setShortcutRecorderFocused(recording)
+    return () => window.api.ui.setShortcutRecorderFocused(false)
   }, [recording])
 
   const statusMessage = error ?? (warnings.length > 0 ? warnings.join(' ') : '')
@@ -171,6 +173,8 @@ export function ShortcutBindingRow({
         size="sm"
         aria-invalid={Boolean(error)}
         aria-pressed={recording}
+        data-shortcut-recorder=""
+        data-shortcut-recorder-active={recording ? '' : undefined}
         onClick={() => {
           if (recording) {
             return

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,49 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { Kanban, Plus, SlidersHorizontal } from 'lucide-react'
+import { Kanban, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  DropdownMenuCheckboxItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem
-} from '@/components/ui/dropdown-menu'
-import type { WorktreeCardProperty } from '../../../../shared/types'
-import SidebarFilter from './SidebarFilter'
+import SidebarWorkspaceOptionsMenu from './SidebarWorkspaceOptionsMenu'
 import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
-
-const GROUP_BY_OPTIONS = [
-  { id: 'none', label: 'None' },
-  { id: 'workspace-status', label: 'Status' },
-  { id: 'pr-status', label: 'PR' },
-  { id: 'repo', label: 'Repo' }
-] as const
-
-const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
-  // Why: toggles the inline "Agent activity" list rendered below each
-  // workspace card body (see WorktreeCard -> WorktreeCardAgents). Off hides
-  // the list; there is no alternate surface.
-  { id: 'inline-agents', label: 'Agent activity' }
-]
-
-const SORT_OPTIONS = [
-  { id: 'name', label: 'Name', description: null },
-  {
-    id: 'smart',
-    label: 'Smart',
-    description: 'Agents that need attention, then most recent activity.'
-  },
-  { id: 'recent', label: 'Recent', description: null },
-  { id: 'repo', label: 'Repo', description: null }
-] as const
 
 const SidebarHeader = React.memo(function SidebarHeader() {
   const newWorktreeShortcutLabel = useShortcutLabel('workspace.create')
@@ -52,13 +15,6 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
   const canCreateWorktree = repos.some((repo) => isGitRepoKind(repo))
-
-  const worktreeCardProperties = useAppStore((s) => s.worktreeCardProperties)
-  const toggleWorktreeCardProperty = useAppStore((s) => s.toggleWorktreeCardProperty)
-  const sortBy = useAppStore((s) => s.sortBy)
-  const setSortBy = useAppStore((s) => s.setSortBy)
-  const groupBy = useAppStore((s) => s.groupBy)
-  const setGroupBy = useAppStore((s) => s.setGroupBy)
 
   const handleWorkspaceBoardOpenChange = useCallback((open: boolean) => {
     setWorkspaceBoardOpen(open)
@@ -115,105 +71,10 @@ const SidebarHeader = React.memo(function SidebarHeader() {
           </span>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
-          <SidebarFilter preserveWorkspaceBoardOpen onMenuOpenChange={setWorkspaceBoardMenuOpen} />
-          <DropdownMenu modal={false} onOpenChange={setWorkspaceBoardMenuOpen}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground"
-                    aria-label="View options"
-                    data-workspace-board-preserve-open=""
-                  >
-                    <SlidersHorizontal className="size-3.5" strokeWidth={2.25} />
-                  </Button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                View options
-              </TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent
-              side="right"
-              align="start"
-              sideOffset={8}
-              className="w-56 pb-2"
-              data-workspace-board-preserve-open=""
-            >
-              <DropdownMenuLabel>Group by</DropdownMenuLabel>
-              <div className="px-2 pt-0.5 pb-1">
-                <ToggleGroup
-                  type="single"
-                  value={groupBy}
-                  onValueChange={(v) => {
-                    if (v) {
-                      setGroupBy(v as typeof groupBy)
-                    }
-                  }}
-                  variant="outline"
-                  size="sm"
-                  className="h-6 w-full justify-start"
-                >
-                  {GROUP_BY_OPTIONS.map((opt) => (
-                    <ToggleGroupItem
-                      key={opt.id}
-                      value={opt.id}
-                      className="h-6 px-2 text-[10px] data-[state=on]:bg-foreground/10 data-[state=on]:font-semibold data-[state=on]:text-foreground"
-                    >
-                      {opt.label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              </div>
-
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={sortBy}
-                onValueChange={(v) => setSortBy(v as typeof sortBy)}
-              >
-                {SORT_OPTIONS.map((opt) => {
-                  const radioItem = (
-                    <DropdownMenuRadioItem
-                      key={opt.id}
-                      value={opt.id}
-                      // Keep the menu open so people can compare sort modes and
-                      // toggle card properties without reopening the same panel.
-                      onSelect={(e) => e.preventDefault()}
-                    >
-                      {opt.label}
-                    </DropdownMenuRadioItem>
-                  )
-                  if (!opt.description) {
-                    return radioItem
-                  }
-                  return (
-                    <Tooltip key={opt.id}>
-                      <TooltipTrigger asChild>{radioItem}</TooltipTrigger>
-                      <TooltipContent side="right" sideOffset={6}>
-                        {opt.description}
-                      </TooltipContent>
-                    </Tooltip>
-                  )
-                })}
-              </DropdownMenuRadioGroup>
-
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>Show properties</DropdownMenuLabel>
-              {PROPERTY_OPTIONS.map((opt) => (
-                <DropdownMenuCheckboxItem
-                  key={opt.id}
-                  checked={worktreeCardProperties.includes(opt.id)}
-                  onCheckedChange={() => toggleWorktreeCardProperty(opt.id)}
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  {opt.label}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <SidebarWorkspaceOptionsMenu
+            preserveWorkspaceBoardOpen
+            onMenuOpenChange={setWorkspaceBoardMenuOpen}
+          />
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1209,6 +1209,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     setMarkdownEditorFocused: () => {},
     setTerminalInputFocused: () => {},
     setFloatingTerminalInputFocused: () => {},
+    setShortcutRecorderFocused: () => {},
     onRichMarkdownContextCommand: () => noopUnsubscribe,
     onFullscreenChanged: () => noopUnsubscribe,
     minimize: () => {},


### PR DESCRIPTION
## Summary
- Restore the sidebar header to the single unified Workspace options button instead of separate Edit filters and View options controls.
- Keep the Settings shortcut recorder from being preempted by main-process and renderer app shortcut routing, so existing app shortcuts can be captured for rebinding.
- Add regression coverage for the main-process shortcut interception case.

## PR #2581 audit
- Reviewed the #2581 merge commit, file list, and current post-merge state for keybinding registry/config IPC, main-window shortcut interception, renderer/global shortcut routing, terminal/browser/editor shortcut paths, Settings shortcut UI, web preload adapter, and the sidebar conflict area.
- Found and fixed two current regressions: the revived split sidebar controls, and the shortcut recorder losing to app shortcut interception.
- I did not find additional current regressions in the reviewed #2581 paths. A few risky #2581 shortcut-routing areas had already been changed by later follow-up PRs, especially #2610.

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts src/shared/keybindings.test.ts src/main/keybindings/keybinding-file.test.ts src/main/ipc/keybindings.test.ts src/main/menu/register-app-menu.test.ts src/shared/window-shortcut-policy.test.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/main/browser/browser-manager.test.ts src/main/browser/browser-manager-grab.test.ts
- pnpm run typecheck:web
- pnpm run typecheck:node
- pnpm exec oxlint src/main/window/createMainWindow.test.ts src/main/window/createMainWindow.ts src/preload/api-types.ts src/preload/index.ts src/renderer/src/App.tsx src/renderer/src/components/settings/ShortcutBindingRow.tsx src/renderer/src/components/sidebar/SidebarHeader.tsx src/renderer/src/web/web-preload-api.ts
- git diff --check
- Electron visual verification on this worktree via CDP: saw one Workspace options button, no Edit filters or View options buttons, and verified the unified menu contains grouping, sort, filters, properties, and project controls. Also verified the Shortcuts recorder enters the focused Press keys state and cancels cleanly.