### PR TITLE
Keep git history graph sticky

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -178,6 +178,8 @@ export function GitHistoryPanel({
     return null
   }
 
+  const expandedBodyClassName = 'h-64 max-h-[33vh] overflow-y-auto scrollbar-sleek'
+
   return (
     <div>
       <div className="pl-1 pr-3 pt-3 pb-1">
@@ -237,19 +239,28 @@ export function GitHistoryPanel({
         </div>
       </div>
       {!collapsed && state.status === 'error' && !result && (
-        <div className="px-6 py-2 text-[11px] text-destructive">{state.error}</div>
+        <div className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-destructive')}>
+          {state.error}
+        </div>
       )}
       {!collapsed && state.status === 'loading' && !result && (
-        <div className="flex items-center gap-2 px-6 py-2 text-[11px] text-muted-foreground">
+        <div
+          className={cn(
+            expandedBodyClassName,
+            'flex items-start gap-2 px-6 py-2 text-[11px] text-muted-foreground'
+          )}
+        >
           <RefreshCw className="size-3 animate-spin" />
           <span>Loading graph...</span>
         </div>
       )}
       {!collapsed && result && viewModels.length === 0 && (
-        <div className="px-6 py-2 text-[11px] text-muted-foreground">No commits yet</div>
+        <div className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-muted-foreground')}>
+          No commits yet
+        </div>
       )}
       {!collapsed && viewModels.length > 0 && (
-        <div className="max-h-[33vh] overflow-y-auto scrollbar-sleek">
+        <div className={expandedBodyClassName}>
           {viewModels.map((viewModel) => (
             <GitHistoryRow
               key={`${viewModel.kind}:${viewModel.historyItem.id}`}

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -19,6 +19,14 @@ export type GitHistoryPanelState =
 const DEFAULT_GIT_HISTORY_PANEL_HEIGHT = 256
 const MIN_GIT_HISTORY_PANEL_HEIGHT = 96
 const MAX_GIT_HISTORY_PANEL_HEIGHT = 520
+const MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT = '33vh'
+
+type GitHistoryResizeSession = {
+  startY: number
+  startHeight: number
+  previousCursor: string
+  previousUserSelect: string
+}
 
 function clampGitHistoryPanelHeight(height: number): number {
   return Math.min(MAX_GIT_HISTORY_PANEL_HEIGHT, Math.max(MIN_GIT_HISTORY_PANEL_HEIGHT, height))
@@ -77,29 +85,14 @@ function GitHistoryRow({
   const visibleRefs = refs.slice(0, 2)
   const hiddenRefs = refs.slice(2)
   const rowTooltip = item.message || item.subject
-
-  return (
-    <button
-      type="button"
-      className={cn(
-        'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_4.5rem_3.25rem_3.75rem] grid-rows-[auto_auto] items-start gap-x-1.5 px-3 py-1 text-left text-xs transition-colors',
-        canOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
-        !canOpenCommit && 'cursor-default',
-        isBoundaryNode && 'text-muted-foreground'
-      )}
-      title={rowTooltip}
-      aria-disabled={!canOpenCommit}
-      aria-label={
-        canOpenCommit ? `Open commit ${item.displayId ?? item.id}: ${item.subject}` : item.subject
-      }
-      data-testid="git-history-row"
-      tabIndex={canOpenCommit ? undefined : -1}
-      onClick={() => {
-        if (canOpenCommit) {
-          onOpenCommit?.(item)
-        }
-      }}
-    >
+  const rowClassName = cn(
+    'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_4.5rem_3.25rem_3.75rem] grid-rows-[auto_auto] items-start gap-x-1.5 px-3 py-1 text-left text-xs transition-colors',
+    canOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
+    !canOpenCommit && 'cursor-default',
+    isBoundaryNode && 'text-muted-foreground'
+  )
+  const rowContent = (
+    <>
       <div className="row-span-2">
         <GitHistoryGraphSvg viewModel={viewModel} />
       </div>
@@ -162,6 +155,29 @@ function GitHistoryRow({
           </div>
         )}
       </div>
+    </>
+  )
+
+  if (!canOpenCommit) {
+    return (
+      <div className={rowClassName} title={rowTooltip} data-testid="git-history-row">
+        {rowContent}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={rowClassName}
+      title={rowTooltip}
+      aria-label={`Open commit ${item.displayId ?? item.id}: ${item.subject}`}
+      data-testid="git-history-row"
+      onClick={() => {
+        onOpenCommit?.(item)
+      }}
+    >
+      {rowContent}
     </button>
   )
 }
@@ -199,15 +215,16 @@ export function GitHistoryPanel({
   const loading = state.status === 'loading' || state.status === 'refreshing'
   const count = result?.items.length ?? 0
   const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
-  const resizeSessionRef = useRef<{ startY: number; startHeight: number } | null>(null)
+  const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
 
   const stopResize = useCallback((): void => {
-    if (!resizeSessionRef.current) {
+    const session = resizeSessionRef.current
+    if (!session) {
       return
     }
     resizeSessionRef.current = null
-    document.body.style.cursor = ''
-    document.body.style.userSelect = ''
+    document.body.style.cursor = session.previousCursor
+    document.body.style.userSelect = session.previousUserSelect
   }, [])
 
   const handleResizePointerMove = useCallback((event: PointerEvent): void => {
@@ -228,6 +245,7 @@ export function GitHistoryPanel({
       window.removeEventListener('pointerup', stopResize)
       window.removeEventListener('pointercancel', stopResize)
       window.removeEventListener('blur', stopResize)
+      stopResize()
     }
   }, [handleResizePointerMove, stopResize])
 
@@ -237,7 +255,12 @@ export function GitHistoryPanel({
         return
       }
       event.preventDefault()
-      resizeSessionRef.current = { startY: event.clientY, startHeight: panelHeight }
+      resizeSessionRef.current = {
+        startY: event.clientY,
+        startHeight: panelHeight,
+        previousCursor: document.body.style.cursor,
+        previousUserSelect: document.body.style.userSelect
+      }
       document.body.style.cursor = 'row-resize'
       document.body.style.userSelect = 'none'
       event.currentTarget.setPointerCapture(event.pointerId)
@@ -263,7 +286,9 @@ export function GitHistoryPanel({
   }, [])
 
   const expandedBodyClassName = 'overflow-y-auto scrollbar-sleek'
-  const expandedBodyStyle = { height: panelHeight }
+  const expandedBodyStyle = {
+    height: `min(${panelHeight}px, ${MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT})`
+  }
 
   return (
     <div className="relative">

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown, CircleHelp, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -15,6 +15,14 @@ export type GitHistoryPanelState =
   | { status: 'idle' | 'loading'; result?: GitHistoryResult; error?: string }
   | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: string }
   | { status: 'error'; result?: GitHistoryResult; error: string }
+
+const DEFAULT_GIT_HISTORY_PANEL_HEIGHT = 256
+const MIN_GIT_HISTORY_PANEL_HEIGHT = 96
+const MAX_GIT_HISTORY_PANEL_HEIGHT = 520
+
+function clampGitHistoryPanelHeight(height: number): number {
+  return Math.min(MAX_GIT_HISTORY_PANEL_HEIGHT, Math.max(MIN_GIT_HISTORY_PANEL_HEIGHT, height))
+}
 
 function formatHistoryTimestamp(timestamp: number | undefined): string {
   if (!timestamp) {
@@ -74,41 +82,63 @@ function GitHistoryRow({
     <button
       type="button"
       className={cn(
-        'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-stretch gap-1.5 px-3 py-1 text-left text-xs transition-colors disabled:cursor-default disabled:opacity-100',
+        'grid min-h-[34px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_4.5rem_3.25rem_3.75rem] grid-rows-[auto_auto] items-start gap-x-1.5 px-3 py-1 text-left text-xs transition-colors',
         canOpenCommit && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
+        !canOpenCommit && 'cursor-default',
         isBoundaryNode && 'text-muted-foreground'
       )}
       title={rowTooltip}
+      aria-disabled={!canOpenCommit}
+      aria-label={
+        canOpenCommit ? `Open commit ${item.displayId ?? item.id}: ${item.subject}` : item.subject
+      }
       data-testid="git-history-row"
-      disabled={!canOpenCommit}
+      tabIndex={canOpenCommit ? undefined : -1}
       onClick={() => {
         if (canOpenCommit) {
           onOpenCommit?.(item)
         }
       }}
     >
-      <GitHistoryGraphSvg viewModel={viewModel} />
-      <div className="flex min-w-0 flex-col justify-center overflow-hidden">
-        <div className="flex min-w-0 items-baseline gap-1.5">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="min-w-0 flex-1 truncate text-foreground" title={rowTooltip}>
-                {item.subject}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
-              {rowTooltip}
-            </TooltipContent>
-          </Tooltip>
-          {item.author && (
-            <span className="max-w-[5.5rem] shrink truncate text-[11px] text-muted-foreground">
+      <div className="row-span-2">
+        <GitHistoryGraphSvg viewModel={viewModel} />
+      </div>
+      <div className="min-w-0 overflow-hidden">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="block min-w-0 truncate text-foreground" title={rowTooltip}>
+              {item.subject}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6} className="max-w-96 whitespace-pre-wrap">
+            {rowTooltip}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      {item.author ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground"
+              title={item.author}
+            >
               {item.author}
             </span>
-          )}
-          {timestamp && (
-            <span className="shrink-0 text-[11px] text-muted-foreground">{timestamp}</span>
-          )}
-        </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all">
+            {item.author}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground" />
+      )}
+      <span className="min-w-0 truncate text-right text-[11px] leading-4 text-muted-foreground">
+        {timestamp}
+      </span>
+      <span className="min-w-0 truncate text-right font-mono text-[10px] leading-4 text-muted-foreground">
+        {!isBoundaryNode ? item.displayId : ''}
+      </span>
+      <div className="col-span-4 col-start-2 min-w-0 overflow-hidden">
         {refs.length > 0 && (
           <div className="mt-0.5 flex h-3.5 min-w-0 items-center gap-1 overflow-hidden">
             {visibleRefs.map((ref) => (
@@ -132,11 +162,6 @@ function GitHistoryRow({
           </div>
         )}
       </div>
-      {item.displayId && !isBoundaryNode && (
-        <span className="mt-0.5 shrink-0 font-mono text-[10px] leading-none text-muted-foreground">
-          {item.displayId}
-        </span>
-      )}
     </button>
   )
 }
@@ -173,28 +198,102 @@ export function GitHistoryPanel({
 
   const loading = state.status === 'loading' || state.status === 'refreshing'
   const count = result?.items.length ?? 0
+  const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
+  const resizeSessionRef = useRef<{ startY: number; startHeight: number } | null>(null)
 
-  if (!result && state.status === 'idle') {
-    return null
-  }
+  const stopResize = useCallback((): void => {
+    if (!resizeSessionRef.current) {
+      return
+    }
+    resizeSessionRef.current = null
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }, [])
 
-  const expandedBodyClassName = 'h-64 max-h-[33vh] overflow-y-auto scrollbar-sleek'
+  const handleResizePointerMove = useCallback((event: PointerEvent): void => {
+    const session = resizeSessionRef.current
+    if (!session) {
+      return
+    }
+    setPanelHeight(clampGitHistoryPanelHeight(session.startHeight + session.startY - event.clientY))
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('pointermove', handleResizePointerMove)
+    window.addEventListener('pointerup', stopResize)
+    window.addEventListener('pointercancel', stopResize)
+    window.addEventListener('blur', stopResize)
+    return () => {
+      window.removeEventListener('pointermove', handleResizePointerMove)
+      window.removeEventListener('pointerup', stopResize)
+      window.removeEventListener('pointercancel', stopResize)
+      window.removeEventListener('blur', stopResize)
+    }
+  }, [handleResizePointerMove, stopResize])
+
+  const startResize = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>): void => {
+      if (collapsed) {
+        return
+      }
+      event.preventDefault()
+      resizeSessionRef.current = { startY: event.clientY, startHeight: panelHeight }
+      document.body.style.cursor = 'row-resize'
+      document.body.style.userSelect = 'none'
+      event.currentTarget.setPointerCapture(event.pointerId)
+    },
+    [collapsed, panelHeight]
+  )
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const step = event.shiftKey ? 32 : 16
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setPanelHeight((height) => clampGitHistoryPanelHeight(height + step))
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setPanelHeight((height) => clampGitHistoryPanelHeight(height - step))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setPanelHeight(MIN_GIT_HISTORY_PANEL_HEIGHT)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setPanelHeight(MAX_GIT_HISTORY_PANEL_HEIGHT)
+    }
+  }, [])
+
+  const expandedBodyClassName = 'overflow-y-auto scrollbar-sleek'
+  const expandedBodyStyle = { height: panelHeight }
 
   return (
-    <div>
-      <div className="pl-1 pr-3 pt-3 pb-1">
-        <div className="group/history flex items-center rounded-md pr-1 hover:bg-accent hover:text-accent-foreground">
+    <div className="relative">
+      {!collapsed && (
+        <div
+          role="separator"
+          aria-label="Resize graph"
+          aria-orientation="horizontal"
+          aria-valuemin={MIN_GIT_HISTORY_PANEL_HEIGHT}
+          aria-valuemax={MAX_GIT_HISTORY_PANEL_HEIGHT}
+          aria-valuenow={panelHeight}
+          tabIndex={0}
+          className="absolute inset-x-0 -top-1 z-10 h-2 cursor-row-resize outline-none focus-visible:bg-ring/30"
+          onPointerDown={startResize}
+          onKeyDown={handleResizeKeyDown}
+        />
+      )}
+      <div className="h-7 pl-1 pr-3">
+        <div className="flex h-full items-stretch rounded-md pr-1">
           <button
             type="button"
-            className="flex min-w-0 flex-1 items-center gap-1 px-0.5 py-0.5 text-left text-xs font-semibold uppercase tracking-wider text-foreground/70 group-hover/history:text-accent-foreground"
+            className="flex min-w-0 flex-1 items-center gap-1 px-0.5 text-left text-[11px] font-semibold uppercase tracking-wider text-foreground/70"
             onClick={onToggle}
           >
             <ChevronDown
-              className={cn('size-3.5 shrink-0 transition-transform', collapsed && '-rotate-90')}
+              className={cn('size-3 shrink-0 transition-transform', collapsed && '-rotate-90')}
             />
             <span>Graph</span>
-            <span className="text-[11px] font-medium tabular-nums">{count}</span>
-            {result?.hasMore && <span className="text-[11px] font-medium">+</span>}
+            {result && <span className="text-[10px] font-medium tabular-nums">{count}</span>}
+            {result?.hasMore && <span className="text-[10px] font-medium">+</span>}
           </button>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -202,7 +301,7 @@ export function GitHistoryPanel({
                 type="button"
                 variant="ghost"
                 size="icon-xs"
-                className="h-auto w-auto p-0.5 text-muted-foreground hover:text-foreground"
+                className="my-auto h-auto w-auto p-0.5 text-muted-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent [&_svg]:size-3"
                 aria-label="What are graph refs?"
                 onClick={(event) => {
                   event.stopPropagation()
@@ -222,9 +321,13 @@ export function GitHistoryPanel({
                 type="button"
                 variant="ghost"
                 size="icon-xs"
-                className="h-auto w-auto p-0.5 text-muted-foreground hover:text-foreground"
+                className="my-auto h-auto w-auto p-0.5 text-muted-foreground hover:bg-transparent hover:text-muted-foreground dark:hover:bg-transparent [&_svg]:size-3"
                 onClick={(event) => {
                   event.stopPropagation()
+                  if (collapsed) {
+                    onToggle()
+                    return
+                  }
                   onRefresh()
                 }}
                 aria-label="Refresh graph"
@@ -239,28 +342,35 @@ export function GitHistoryPanel({
         </div>
       </div>
       {!collapsed && state.status === 'error' && !result && (
-        <div className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-destructive')}>
+        <div
+          className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-destructive')}
+          style={expandedBodyStyle}
+        >
           {state.error}
         </div>
       )}
-      {!collapsed && state.status === 'loading' && !result && (
+      {!collapsed && (state.status === 'idle' || state.status === 'loading') && !result && (
         <div
           className={cn(
             expandedBodyClassName,
             'flex items-start gap-2 px-6 py-2 text-[11px] text-muted-foreground'
           )}
+          style={expandedBodyStyle}
         >
           <RefreshCw className="size-3 animate-spin" />
           <span>Loading graph...</span>
         </div>
       )}
       {!collapsed && result && viewModels.length === 0 && (
-        <div className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-muted-foreground')}>
+        <div
+          className={cn(expandedBodyClassName, 'px-6 py-2 text-[11px] text-muted-foreground')}
+          style={expandedBodyStyle}
+        >
           No commits yet
         </div>
       )}
       {!collapsed && viewModels.length > 0 && (
-        <div className={expandedBodyClassName}>
+        <div className={expandedBodyClassName} style={expandedBodyStyle}>
           {viewModels.map((viewModel) => (
             <GitHistoryRow
               key={`${viewModel.kind}:${viewModel.historyItem.id}`}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -205,7 +205,7 @@ const SOURCE_CONTROL_TREE_INDENT_PX = 12
 const SOURCE_CONTROL_TREE_DIRECTORY_PADDING_PX = 8
 const SOURCE_CONTROL_TREE_FILE_PADDING_PX = 20
 const EMPTY_GIT_HISTORY_STATE: GitHistoryPanelState = { status: 'idle' }
-const DEFAULT_COLLAPSED_SECTIONS = ['history'] as const
+const DEFAULT_COLLAPSED_SECTIONS = [] as const
 
 function createDefaultCollapsedSections(): Set<string> {
   return new Set(DEFAULT_COLLAPSED_SECTIONS)
@@ -4071,9 +4071,9 @@ function SourceControlInner(): React.JSX.Element {
 
           {scope === 'all' && !normalizedFilter && (
             // Why: the graph is reference context for the whole panel, so when
-            // file sections are short it should occupy the bottom instead of
-            // crowding the commit controls.
-            <div className="mt-auto">
+            // file sections are short it should occupy the bottom, and when the
+            // pane scrolls it should remain docked as branch context.
+            <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
               <GitHistoryPanel
                 state={gitHistoryState}
                 collapsed={collapsedSections.has('history')}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -205,7 +205,7 @@ const SOURCE_CONTROL_TREE_INDENT_PX = 12
 const SOURCE_CONTROL_TREE_DIRECTORY_PADDING_PX = 8
 const SOURCE_CONTROL_TREE_FILE_PADDING_PX = 20
 const EMPTY_GIT_HISTORY_STATE: GitHistoryPanelState = { status: 'idle' }
-const DEFAULT_COLLAPSED_SECTIONS = [] as const
+const DEFAULT_COLLAPSED_SECTIONS = ['history'] as const
 
 function createDefaultCollapsedSections(): Set<string> {
   return new Set(DEFAULT_COLLAPSED_SECTIONS)
@@ -1034,6 +1034,7 @@ function SourceControlInner(): React.JSX.Element {
   const gitHistoryState = activeWorktreeId
     ? (gitHistoryByWorktree[activeWorktreeId] ?? EMPTY_GIT_HISTORY_STATE)
     : EMPTY_GIT_HISTORY_STATE
+  const isGitHistoryExpanded = !collapsedSections.has('history')
 
   const isFolder = activeRepo ? isFolderRepo(activeRepo) : false
   const worktreePath = activeWorktree?.path ?? null
@@ -2914,7 +2915,13 @@ function SourceControlInner(): React.JSX.Element {
   refreshBranchCompareRef.current = refreshBranchCompare
 
   const refreshGitHistory = useCallback(async (): Promise<void> => {
-    if (!activeWorktreeId || !worktreePath || isFolder || !isBranchVisible) {
+    if (
+      !activeWorktreeId ||
+      !worktreePath ||
+      isFolder ||
+      !isBranchVisible ||
+      !isGitHistoryExpanded
+    ) {
       return
     }
 
@@ -2962,7 +2969,14 @@ function SourceControlInner(): React.JSX.Element {
         }
       })
     }
-  }, [activeWorktreeId, effectiveBaseRef, isBranchVisible, isFolder, worktreePath])
+  }, [
+    activeWorktreeId,
+    effectiveBaseRef,
+    isBranchVisible,
+    isFolder,
+    isGitHistoryExpanded,
+    worktreePath
+  ])
 
   const refreshGitHistoryRef = useRef(refreshGitHistory)
   refreshGitHistoryRef.current = refreshGitHistory
@@ -2982,14 +2996,20 @@ function SourceControlInner(): React.JSX.Element {
   }, [activeWorktreeId, effectiveBaseRef, isBranchVisible, isFolder, worktreePath])
 
   useEffect(() => {
-    // Why: history shells out to git, but unlike branch compare it only needs
-    // visible-load and mutation refreshes. Avoid polling so long sessions don't
-    // spawn git processes for a decorative graph.
-    if (!isBranchVisible) {
+    // Why: history shells out to git. Defer the first load until the user
+    // expands Graph so source control stays cheap for large/remote repos.
+    if (!isBranchVisible || !isGitHistoryExpanded) {
       return
     }
     void refreshGitHistoryRef.current()
-  }, [activeWorktreeId, effectiveBaseRef, isBranchVisible, isFolder, worktreePath])
+  }, [
+    activeWorktreeId,
+    effectiveBaseRef,
+    isBranchVisible,
+    isFolder,
+    isGitHistoryExpanded,
+    worktreePath
+  ])
 
   useEffect(() => {
     // Why: gate on isBranchVisible so we don't spawn git processes while the
@@ -3650,7 +3670,7 @@ function SourceControlInner(): React.JSX.Element {
         </div>
 
         <div
-          className="relative flex flex-1 flex-col overflow-auto scrollbar-sleek py-1"
+          className="relative flex flex-1 flex-col overflow-auto scrollbar-sleek pt-1"
           style={{ paddingBottom: selectedKeys.size > 0 ? 50 : undefined }}
         >
           {unresolvedConflictReviewEntries.length > 0 && (
@@ -4069,20 +4089,24 @@ function SourceControlInner(): React.JSX.Element {
             </div>
           )}
 
-          {scope === 'all' && !normalizedFilter && (
-            // Why: the graph is reference context for the whole panel, so when
-            // file sections are short it should occupy the bottom, and when the
-            // pane scrolls it should remain docked as branch context.
-            <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
-              <GitHistoryPanel
-                state={gitHistoryState}
-                collapsed={collapsedSections.has('history')}
-                onToggle={() => toggleSection('history')}
-                onRefresh={() => void refreshGitHistory()}
-                onOpenCommit={(item) => void openHistoryCommitDiff(item)}
-              />
-            </div>
-          )}
+          {scope === 'all' &&
+            !normalizedFilter &&
+            activeWorktreeId &&
+            worktreePath &&
+            !isFolder && (
+              // Why: the graph is reference context for the whole panel, so when
+              // file sections are short it should occupy the bottom, and when the
+              // pane scrolls it should remain docked as branch context.
+              <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
+                <GitHistoryPanel
+                  state={gitHistoryState}
+                  collapsed={collapsedSections.has('history')}
+                  onToggle={() => toggleSection('history')}
+                  onRefresh={() => void refreshGitHistory()}
+                  onOpenCommit={(item) => void openHistoryCommitDiff(item)}
+                />
+              </div>
+            )}
         </div>
 
         {selectedKeys.size > 0 && (

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1273,6 +1273,8 @@ function SourceControlInner(): React.JSX.Element {
   }, [entries])
 
   const normalizedFilter = filterQuery.toLowerCase()
+  const isGitHistoryVisible =
+    scope === 'all' && !normalizedFilter && Boolean(activeWorktreeId && worktreePath && !isFolder)
 
   const filteredGrouped = useMemo(() => {
     if (!normalizedFilter) {
@@ -2920,7 +2922,8 @@ function SourceControlInner(): React.JSX.Element {
       !worktreePath ||
       isFolder ||
       !isBranchVisible ||
-      !isGitHistoryExpanded
+      !isGitHistoryExpanded ||
+      !isGitHistoryVisible
     ) {
       return
     }
@@ -2975,6 +2978,7 @@ function SourceControlInner(): React.JSX.Element {
     isBranchVisible,
     isFolder,
     isGitHistoryExpanded,
+    isGitHistoryVisible,
     worktreePath
   ])
 
@@ -2998,7 +3002,7 @@ function SourceControlInner(): React.JSX.Element {
   useEffect(() => {
     // Why: history shells out to git. Defer the first load until the user
     // expands Graph so source control stays cheap for large/remote repos.
-    if (!isBranchVisible || !isGitHistoryExpanded) {
+    if (!isBranchVisible || !isGitHistoryExpanded || !isGitHistoryVisible) {
       return
     }
     void refreshGitHistoryRef.current()
@@ -3008,6 +3012,7 @@ function SourceControlInner(): React.JSX.Element {
     isBranchVisible,
     isFolder,
     isGitHistoryExpanded,
+    isGitHistoryVisible,
     worktreePath
   ])
 
@@ -4089,24 +4094,20 @@ function SourceControlInner(): React.JSX.Element {
             </div>
           )}
 
-          {scope === 'all' &&
-            !normalizedFilter &&
-            activeWorktreeId &&
-            worktreePath &&
-            !isFolder && (
-              // Why: the graph is reference context for the whole panel, so when
-              // file sections are short it should occupy the bottom, and when the
-              // pane scrolls it should remain docked as branch context.
-              <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
-                <GitHistoryPanel
-                  state={gitHistoryState}
-                  collapsed={collapsedSections.has('history')}
-                  onToggle={() => toggleSection('history')}
-                  onRefresh={() => void refreshGitHistory()}
-                  onOpenCommit={(item) => void openHistoryCommitDiff(item)}
-                />
-              </div>
-            )}
+          {isGitHistoryVisible && (
+            // Why: the graph is reference context for the whole panel, so when
+            // file sections are short it should occupy the bottom, and when the
+            // pane scrolls it should remain docked as branch context.
+            <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
+              <GitHistoryPanel
+                state={gitHistoryState}
+                collapsed={collapsedSections.has('history')}
+                onToggle={() => toggleSection('history')}
+                onRefresh={() => void refreshGitHistory()}
+                onOpenCommit={(item) => void openHistoryCommitDiff(item)}
+              />
+            </div>
+          )}
         </div>
 
         {selectedKeys.size > 0 && (


### PR DESCRIPTION
## Summary
- keep the git history graph docked at the bottom of Source Control
- cap the expanded graph body to a viewport-relative height
- avoid git history refresh work while the graph is hidden

## Testing
- git diff --check
- commit hook: oxlint, oxfmt