### PR TITLE
Quiet workspace port background refresh

### DIFF
--- a/src/renderer/src/components/ports/WorkspacePortScanner.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.tsx
@@ -9,7 +9,7 @@ import {
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 
-const WORKSPACE_PORT_SCAN_INTERVAL_MS = 5_000
+const WORKSPACE_PORT_SCAN_INTERVAL_MS = 30_000
 
 function makeUnavailableScan(reason: string): WorkspacePortScanResult {
   return {
@@ -42,7 +42,6 @@ export function WorkspacePortScanner(): null {
     }
 
     const generation = generationRef.current
-    setWorkspacePortScanRefreshing(true)
     const promise = scanWorkspacePortsForTarget(runtimeTarget)
       .then((result) => {
         if (generation === generationRef.current) {
@@ -62,9 +61,6 @@ export function WorkspacePortScanner(): null {
       .finally(() => {
         if (inFlightRef.current === promise) {
           inFlightRef.current = null
-        }
-        if (generation === generationRef.current) {
-          setWorkspacePortScanRefreshing(false)
         }
       })
     inFlightRef.current = promise

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -190,7 +190,7 @@ function LocalWorkspacePortsPanel({ isVisible }: { isVisible: boolean }): React.
     return promise
   }, [activeRepo, runtimeTarget, scanKey, setWorkspacePortScan, setWorkspacePortScanRefreshing])
 
-  // Why: WorkspacePortScanner already owns the 5s all-worktree poll. The
+  // Why: WorkspacePortScanner already owns the 30s all-worktree poll. The
   // panel scopes that shared result instead of starting a second scan loop.
   const displayScan = scan?.key === scanKey && isVisible ? scan.result : null
 

--- a/src/renderer/src/components/status-bar/PortsStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/PortsStatusSegment.tsx
@@ -224,19 +224,50 @@ function WorkspaceGroupRows({
 }
 
 export function PortsStatusSegment({ iconOnly }: PortsStatusSegmentProps): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
   const scan = useAppStore((s) => s.workspacePortScan?.result ?? null)
   const refreshing = useAppStore((s) => s.workspacePortScanRefreshing)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const setWorkspacePortScan = useAppStore((s) => s.setWorkspacePortScan)
   const [open, setOpen] = useState(false)
   const [externalOpen, setExternalOpen] = useState(false)
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const scanKey = `${workspacePortRuntimeTargetKey(runtimeTarget)}:all`
 
   const workspaceGroups = useMemo(() => getWorkspacePortGroups(scan), [scan])
   const externalPorts = useMemo(() => getExternalWorkspacePorts(scan), [scan])
   const workspacePortCount = workspaceGroups.reduce((count, group) => count + group.ports.length, 0)
   const totalCount = workspacePortCount + externalPorts.length
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (!nextOpen) {
+        return
+      }
+      // Why: the 30s background poll is intentionally quiet; opening the
+      // popover should still collapse that stale window without flashing icons.
+      void scanWorkspacePortsForTarget(runtimeTarget)
+        .then((result) => {
+          setWorkspacePortScan({ key: scanKey, result })
+        })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          setWorkspacePortScan({
+            key: scanKey,
+            result: {
+              platform: 'unknown',
+              scannedAt: Date.now(),
+              ports: [],
+              unavailableReason: message || 'Workspace port scan failed.'
+            }
+          })
+        })
+    },
+    [runtimeTarget, scanKey, setWorkspacePortScan]
+  )
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <Tooltip delayDuration={150}>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>


### PR DESCRIPTION
## Summary
- slow the workspace ports background scan from 5s to 30s
- keep automatic background scans from toggling the status-bar refresh spinner
- silently refresh ports when opening the Ports status popover

## Validation
- pnpm exec oxlint src/renderer/src/components/ports/WorkspacePortScanner.tsx src/renderer/src/components/right-sidebar/PortsPanel.tsx src/renderer/src/components/status-bar/PortsStatusSegment.tsx
- pnpm run typecheck:web
- verified in a dev Electron instance that opening the Ports status popover updates the scan timestamp while `workspacePortScanRefreshing` remains false

Made with [Orca](https://github.com/stablyai/orca) 🐋
