### PR TITLE
fix: resolve JIS keyboard bracket and backslash shortcut mapping

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-lines -- Why: shared keybinding tests cover the central
+ * registry, parser, matcher, and conflict detector together so shortcut
+ * semantics cannot drift across app surfaces. */
 import { describe, expect, it } from 'vitest'
 import {
   findKeybindingConflicts,
@@ -233,60 +236,130 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
-  it('correctly matches BracketLeft and BracketRight on JIS keyboards', () => {
-    // On a JIS keyboard, the `[` key has code 'BracketRight' and key '{' when shifted.
-    const jisLeftBracketShifted = {
-      key: '{',
+  it('matches logical bracket shortcuts on JIS keyboards without changing code fallback', () => {
+    const jisLeftBracket = {
+      key: '[',
       code: 'BracketRight',
       control: false,
       meta: true,
       alt: false,
-      shift: true
+      shift: false
     }
-
-    // On a JIS keyboard, the `]` key has code 'Backslash' and key '}' when shifted.
-    const jisRightBracketShifted = {
-      key: '}',
+    const jisRightBracket = {
+      key: ']',
       code: 'Backslash',
       control: false,
       meta: true,
       alt: false,
-      shift: true
+      shift: false
     }
+    const jisLeftBracketShifted = { ...jisLeftBracket, key: '{', shift: true }
+    const jisRightBracketShifted = { ...jisRightBracket, key: '}', shift: true }
 
-    // Mod+Shift+BracketLeft should match JIS `[` key (which produces '{')
     expect(
       keybindingMatchesAction('tab.previousSameType', jisLeftBracketShifted, 'darwin', {
         'tab.previousSameType': ['Mod+Shift+BracketLeft']
       })
     ).toBe(true)
-
-    // Mod+Shift+BracketLeft should NOT match JIS `]` key (which produces '}')
     expect(
       keybindingMatchesAction('tab.previousSameType', jisRightBracketShifted, 'darwin', {
         'tab.previousSameType': ['Mod+Shift+BracketLeft']
       })
     ).toBe(false)
-
-    // Mod+Shift+BracketRight should match JIS `]` key (which produces '}')
     expect(
       keybindingMatchesAction('tab.nextSameType', jisRightBracketShifted, 'darwin', {
         'tab.nextSameType': ['Mod+Shift+BracketRight']
       })
     ).toBe(true)
-
-    // Mod+Shift+BracketRight should NOT match JIS `[` key (which produces '{')
     expect(
       keybindingMatchesAction('tab.nextSameType', jisLeftBracketShifted, 'darwin', {
         'tab.nextSameType': ['Mod+Shift+BracketRight']
       })
     ).toBe(false)
 
-    // Ensure JIS `]` key doesn't accidentally trigger a Backslash shortcut
+    expect(keybindingMatchesAction('terminal.focusPreviousPane', jisLeftBracket, 'darwin')).toBe(
+      true
+    )
+    expect(keybindingMatchesAction('terminal.focusNextPane', jisLeftBracket, 'darwin')).toBe(false)
+    expect(keybindingMatchesAction('terminal.focusNextPane', jisRightBracket, 'darwin')).toBe(true)
+
+    expect(
+      keybindingMatchesAction('tab.previousAllTypes', { ...jisLeftBracket, alt: true }, 'darwin')
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction('tab.nextAllTypes', { ...jisRightBracket, alt: true }, 'darwin')
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        { ...jisLeftBracket, control: true, meta: false, alt: true },
+        'linux'
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        { ...jisLeftBracket, control: true, meta: false, alt: true },
+        'linux'
+      )
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'tab.nextAllTypes',
+        { ...jisRightBracket, control: true, meta: false, alt: true },
+        'linux'
+      )
+    ).toBe(true)
+
     expect(
       keybindingMatchesAction('terminal.splitRight', jisRightBracketShifted, 'darwin', {
         'terminal.splitRight': ['Mod+Shift+Backslash']
       })
     ).toBe(false)
+
+    expect(
+      keybindingMatchesAction(
+        'tab.nextSameType',
+        {
+          key: 'Dead',
+          code: 'BracketRight',
+          control: false,
+          meta: true,
+          alt: false,
+          shift: true
+        },
+        'darwin',
+        { 'tab.nextSameType': ['Mod+Shift+BracketRight'] }
+      )
+    ).toBe(true)
+
+    expect(
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        {
+          key: '[',
+          code: 'Digit8',
+          control: true,
+          meta: false,
+          alt: true,
+          shift: false
+        },
+        'linux'
+      )
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'tab.previousAllTypes',
+        {
+          key: 'Dead',
+          code: 'BracketLeft',
+          control: true,
+          meta: false,
+          alt: true,
+          shift: false
+        },
+        'linux'
+      )
+    ).toBe(true)
   })
 })

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -232,4 +232,61 @@ describe('keybindings', () => {
       )
     ).toBe(true)
   })
+
+  it('correctly matches BracketLeft and BracketRight on JIS keyboards', () => {
+    // On a JIS keyboard, the `[` key has code 'BracketRight' and key '{' when shifted.
+    const jisLeftBracketShifted = {
+      key: '{',
+      code: 'BracketRight',
+      control: false,
+      meta: true,
+      alt: false,
+      shift: true
+    }
+
+    // On a JIS keyboard, the `]` key has code 'Backslash' and key '}' when shifted.
+    const jisRightBracketShifted = {
+      key: '}',
+      code: 'Backslash',
+      control: false,
+      meta: true,
+      alt: false,
+      shift: true
+    }
+
+    // Mod+Shift+BracketLeft should match JIS `[` key (which produces '{')
+    expect(
+      keybindingMatchesAction('tab.previousSameType', jisLeftBracketShifted, 'darwin', {
+        'tab.previousSameType': ['Mod+Shift+BracketLeft']
+      })
+    ).toBe(true)
+
+    // Mod+Shift+BracketLeft should NOT match JIS `]` key (which produces '}')
+    expect(
+      keybindingMatchesAction('tab.previousSameType', jisRightBracketShifted, 'darwin', {
+        'tab.previousSameType': ['Mod+Shift+BracketLeft']
+      })
+    ).toBe(false)
+
+    // Mod+Shift+BracketRight should match JIS `]` key (which produces '}')
+    expect(
+      keybindingMatchesAction('tab.nextSameType', jisRightBracketShifted, 'darwin', {
+        'tab.nextSameType': ['Mod+Shift+BracketRight']
+      })
+    ).toBe(true)
+
+    // Mod+Shift+BracketRight should NOT match JIS `[` key (which produces '{')
+    expect(
+      keybindingMatchesAction('tab.nextSameType', jisLeftBracketShifted, 'darwin', {
+        'tab.nextSameType': ['Mod+Shift+BracketRight']
+      })
+    ).toBe(false)
+
+    // Ensure JIS `]` key doesn't accidentally trigger a Backslash shortcut
+    expect(
+      keybindingMatchesAction('terminal.splitRight', jisRightBracketShifted, 'darwin', {
+        'terminal.splitRight': ['Mod+Shift+Backslash']
+      })
+    ).toBe(false)
+  })
 })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1160,7 +1160,60 @@ function letterKeyMatches(input: KeybindingInput, letter: string): boolean {
   return input.code === `Key${letter.toUpperCase()}`
 }
 
-function keyMatches(parsedKey: string, input: KeybindingInput): boolean {
+function semanticPunctuationKey(input: KeybindingInput): string | null {
+  switch (input.key) {
+    case '[':
+    case '{':
+      return 'BracketLeft'
+    case ']':
+    case '}':
+      return 'BracketRight'
+    case '\\':
+    case '|':
+      return 'Backslash'
+    default:
+      return null
+  }
+}
+
+function physicalPunctuationKey(input: KeybindingInput): string | null {
+  switch (input.code) {
+    case 'BracketLeft':
+    case 'BracketRight':
+    case 'Backslash':
+      return input.code
+    default:
+      return null
+  }
+}
+
+function shouldUseSemanticPunctuation(
+  parsed: ParsedKeybinding,
+  input: KeybindingInput,
+  platform: NodeJS.Platform
+): boolean {
+  // Why: Windows/Linux often expose AltGr as Ctrl+Alt. Do not turn ordinary
+  // international text input into Mod+Alt app shortcuts.
+  if (
+    getKeybindingPlatform(platform) !== 'darwin' &&
+    parsed.mod &&
+    parsed.alt &&
+    hasModifier(input, 'control') &&
+    hasModifier(input, 'alt') &&
+    !hasModifier(input, 'meta') &&
+    physicalPunctuationKey(input) === null
+  ) {
+    return false
+  }
+  return true
+}
+
+function keyMatches(
+  parsedKey: string,
+  input: KeybindingInput,
+  parsed: ParsedKeybinding,
+  platform: NodeJS.Platform
+): boolean {
   if (parsedKey.length === 1 && parsedKey >= 'A' && parsedKey <= 'Z') {
     return letterKeyMatches(input, parsedKey)
   }
@@ -1172,15 +1225,16 @@ function keyMatches(parsedKey: string, input: KeybindingInput): boolean {
   const code = input.code ?? ''
   switch (parsedKey) {
     case 'BracketLeft':
-      if (key === ']' || key === '}') {
-        return false
-      }
-      return code === 'BracketLeft' || key === '[' || key === '{'
     case 'BracketRight':
-      if (key === '[' || key === '{') {
-        return false
+    case 'Backslash': {
+      // Why: shortcut labels name logical punctuation, but international
+      // layouts can report the same character from different physical codes.
+      const semanticKey = semanticPunctuationKey(input)
+      if (semanticKey !== null && shouldUseSemanticPunctuation(parsed, input, platform)) {
+        return semanticKey === parsedKey
       }
-      return code === 'BracketRight' || key === ']' || key === '}'
+      return code === parsedKey
+    }
     case 'Minus':
       // Why: shifted "_" is terminal undo/readline input. Users who want it
       // as zoom-out can bind it explicitly instead of having the default steal it.
@@ -1197,11 +1251,6 @@ function keyMatches(parsedKey: string, input: KeybindingInput): boolean {
       return code === 'NumpadSubtract' || key === 'Subtract'
     case 'Enter':
       return key === 'Enter' && (code === 'Enter' || code === 'NumpadEnter' || code === '')
-    case 'Backslash':
-      if (key === ']' || key === '}') {
-        return false
-      }
-      return code === 'Backslash' || key === '\\' || key === '|'
     default:
       return key === parsedKey || code === parsedKey
   }
@@ -1216,7 +1265,9 @@ export function keybindingMatchesInput(
   if (!parsed) {
     return false
   }
-  return modifierStateMatches(parsed, input, platform) && keyMatches(parsed.key, input)
+  return (
+    modifierStateMatches(parsed, input, platform) && keyMatches(parsed.key, input, parsed, platform)
+  )
 }
 
 export function keybindingMatchesAction(

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1172,9 +1172,15 @@ function keyMatches(parsedKey: string, input: KeybindingInput): boolean {
   const code = input.code ?? ''
   switch (parsedKey) {
     case 'BracketLeft':
-      return code === 'BracketLeft'
+      if (key === ']' || key === '}') {
+        return false
+      }
+      return code === 'BracketLeft' || key === '[' || key === '{'
     case 'BracketRight':
-      return code === 'BracketRight'
+      if (key === '[' || key === '{') {
+        return false
+      }
+      return code === 'BracketRight' || key === ']' || key === '}'
     case 'Minus':
       // Why: shifted "_" is terminal undo/readline input. Users who want it
       // as zoom-out can bind it explicitly instead of having the default steal it.
@@ -1191,6 +1197,11 @@ function keyMatches(parsedKey: string, input: KeybindingInput): boolean {
       return code === 'NumpadSubtract' || key === 'Subtract'
     case 'Enter':
       return key === 'Enter' && (code === 'Enter' || code === 'NumpadEnter' || code === '')
+    case 'Backslash':
+      if (key === ']' || key === '}') {
+        return false
+      }
+      return code === 'Backslash' || key === '\\' || key === '|'
     default:
       return key === parsedKey || code === parsedKey
   }


### PR DESCRIPTION
> [!NOTE]
> Please note that since English is not my native language, the text below was generated using AI translation.
> If there is anything you don't understand, please let me know and I will clarify.

## Summary

Fixes an issue where bracket shortcuts (`Cmd+Shift+[` and `Cmd+Shift+]`) do not work correctly on JIS (Japanese) keyboard layouts, specifically when attempting to switch tabs or split panes.

**Problem:**
On a JIS keyboard, the physical keys for `[` and `]` emit different `KeyboardEvent.code` values compared to a US QWERTY layout:
- `[` emits `BracketRight`
- `]` emits `Backslash`

Because the keybinding matcher in `src/shared/keybindings.ts` relied strictly on `event.code` to resolve `BracketLeft`, `BracketRight`, and `Backslash`, JIS users pressing `Cmd+Shift+[` were triggering the `BracketRight` action (Next Tab), and pressing `Cmd+Shift+]` was triggering `Backslash` (which resulted in a no-op or unintended behavior).

**Solution:**
Updated the keybinding resolution logic in `src/shared/keybindings.ts` to also evaluate the `event.key` property when dealing with brackets and backslashes. By checking the actual character inputted (`[`, `{`, `]`, `}`, `\`, `|`), we can reliably determine the user's intent across international keyboard layouts, while still falling back to `event.code` for physical position mapping.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Added dedicated unit tests in `src/shared/keybindings.test.ts` to verify JIS shifted key combinations correctly map to the expected bracket actions and do not falsely trigger backslash/opposite brackets.

## AI Review Report

The AI agent reviewed the keyboard shortcut matching logic. The main risk checked was ensuring that fallback checks on the `event.key` property would not inadvertently break US/UK layouts or create cross-platform conflicts.
- Verified that adding `event.key` checks strictly scopes to characters outputted by those specific keys.
- Added explicit exclusionary checks (e.g. `if (key === ']' || key === '}') { return false }` inside `BracketLeft`) to ensure that if a JIS layout emits `BracketRight` for the `[` key, it doesn't accidentally trigger both shortcuts simultaneously.
- Full local build, typecheck, and unit tests have verified the safety of this change.

## Security Audit

No security implications. This PR only modifies local keyboard event matching logic in the shared layer. No IPC boundary changes, no command execution, and no dependency changes.

## Notes

- Platform Specifics: This specifically resolves a friction point for Japanese macOS/Windows users using JIS keyboards, but the fallback logic also improves shortcut resilience for other international ISO layouts (like German QWERTZ or French AZERTY) that rely on `AltGr` combinations to type brackets.