### PR TITLE
Remove create PR success toast

### DIFF
--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -142,12 +142,6 @@ export function CreatePullRequestDialog({
         worktreePath
       })
       if (result.ok) {
-        toast.success(`Pull request #${result.number} created`, {
-          action: {
-            label: 'Open on GitHub',
-            onClick: () => window.api.shell.openUrl(result.url)
-          }
-        })
         await onCreated(result)
         onOpenChange(false)
         return

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -2293,12 +2293,6 @@ function SourceControlInner(): React.JSX.Element {
       })
 
       if (result.ok) {
-        toast.success(`Pull request #${result.number} created`, {
-          action: {
-            label: 'Open on GitHub',
-            onClick: () => window.api.shell.openUrl(result.url)
-          }
-        })
         await handlePullRequestCreated(result)
         return
       }


### PR DESCRIPTION
## Summary
- remove the success toast shown after a new pull request is created from source control create flows
- keep existing-review and error/warning toasts intact

## Tests
- pnpm run typecheck:web
- pnpm lint