### PR TITLE
Add Orca Mobile marketing + pairing flow

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -199,6 +199,7 @@ const ActivityPrototypePage = lazy(() => import('./components/activity/ActivityP
 const Settings = lazy(() => import('./components/settings/Settings'))
 const SkillsPage = lazy(() => import('./components/skills/SkillsPage'))
 const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/WorkspaceSpacePage'))
+const MobilePage = lazy(() => import('./components/mobile/MobilePage'))
 const QuickOpen = lazy(() => import('./components/QuickOpen'))
 const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'))
 const NewWorkspaceComposerModal = lazy(() => import('./components/NewWorkspaceComposerModal'))
@@ -1007,7 +1008,8 @@ function App(): React.JSX.Element {
     activeView !== 'activity' &&
     activeView !== 'automations' &&
     activeView !== 'space' &&
-    activeView !== 'skills'
+    activeView !== 'skills' &&
+    activeView !== 'mobile'
 
   const handleToggleExpand = (): void => {
     if (!effectiveActiveTabId) {
@@ -1044,7 +1046,8 @@ function App(): React.JSX.Element {
         activeView !== 'activity' &&
         activeView !== 'automations' &&
         activeView !== 'space' &&
-        activeView !== 'skills'
+        activeView !== 'skills' &&
+        activeView !== 'mobile'
 
       const openSearchSidebar = (query: string | null): void => {
         if (query && activeWorktreeId) {
@@ -1476,7 +1479,8 @@ function App(): React.JSX.Element {
         activeView === 'activity' ||
         activeView === 'automations' ||
         activeView === 'space' ||
-        activeView === 'skills') &&
+        activeView === 'skills' ||
+        activeView === 'mobile') &&
       rightSidebarOpen
     ) {
       // Why: hide the right sidebar immediately when entering full-page
@@ -1662,6 +1666,7 @@ function App(): React.JSX.Element {
                       {activeView === 'automations' ? <AutomationsPage /> : null}
                       {activeView === 'activity' ? <ActivityPrototypePage /> : null}
                       {activeView === 'space' ? <WorkspaceSpacePage /> : null}
+                      {activeView === 'mobile' ? <MobilePage /> : null}
                       {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
                     </Suspense>
                   </div>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5,6 +5,7 @@
 @import './rich-markdown-editor.css';
 @import './markdown-preview.css';
 @import './terminal.css';
+@import './mobile-page.css';
 
 @font-face {
   font-family: 'Geist';

--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -64,7 +64,13 @@
       rgba(59, 130, 246, 0.06) 35%,
       transparent 60%
     ),
-    radial-gradient(circle, rgba(255, 255, 255, 0.06) 1px, transparent 1.2px);
+    /* Why: theme-aware so dots are visible in light mode too — hardcoded
+       white dots disappear on the light background. */
+    radial-gradient(
+        circle,
+        color-mix(in srgb, var(--foreground) 8%, transparent) 1px,
+        transparent 1.2px
+      );
   background-size:
     200% 200%,
     200% 200%,

--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -1,0 +1,1490 @@
+/* Why: ported from mobile/orca-mobile-sidebar-mock-v3.html. The mock is the
+   1:1 design spec for the in-app Mobile page; styles are scoped under
+   .mobile-page-root so they don't leak into the rest of the app shell. */
+
+.mobile-page-root {
+  /* Real mobile-app tokens (from mobile/src/theme/mobile-theme.ts) — used
+     inside .mp-device-screen so simulated screens match the app exactly. */
+  --m-bg-base: #111111;
+  --m-bg-panel: #1a1a1a;
+  --m-bg-raised: #242424;
+  --m-border: #2a2a2a;
+  --m-text-primary: #e0e0e0;
+  --m-text-secondary: #888888;
+  --m-text-muted: #555555;
+  --m-accent-blue: #3b82f6;
+  --m-status-green: #22c55e;
+  --m-status-amber: #f59e0b;
+  --m-status-red: #ef4444;
+  --m-mono: 'Menlo', 'SF Mono', monospace;
+
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  color: var(--foreground);
+}
+
+/* ── Hero ────────────────────────────────────────────────────────── */
+
+.mobile-page-root .mp-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 660px) minmax(0, 470px);
+  justify-content: center;
+  align-items: center;
+  gap: clamp(40px, 4.5vw, 70px);
+  padding: clamp(44px, 5.5vw, 72px) clamp(36px, 4.5vw, 64px);
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.mobile-page-root .mp-hero::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 0;
+  width: 1200px;
+  height: 1000px;
+  background: radial-gradient(
+    ellipse at top right,
+    rgba(99, 102, 241, 0.65) 0%,
+    rgba(99, 102, 241, 0.32) 25%,
+    rgba(99, 102, 241, 0.12) 50%,
+    transparent 75%
+  );
+  filter: blur(40px);
+  opacity: 1;
+  content: '';
+  pointer-events: none;
+}
+
+.mobile-page-root .mp-hero::after {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 0;
+  width: 900px;
+  height: 800px;
+  background: radial-gradient(
+    ellipse at bottom left,
+    rgba(59, 130, 246, 0.45) 0%,
+    rgba(59, 130, 246, 0.18) 35%,
+    transparent 70%
+  );
+  filter: blur(50px);
+  opacity: 1;
+  content: '';
+  pointer-events: none;
+}
+
+.mobile-page-root .mp-hero-copy {
+  position: relative;
+  z-index: 1;
+  max-width: 660px;
+}
+
+.mobile-page-root .mp-eyebrow-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 22px;
+}
+
+.mobile-page-root .mp-eyebrow {
+  color: var(--muted-foreground);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mobile-page-root .mp-h1 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: clamp(46px, 5vw, 72px);
+  font-weight: 650;
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+}
+
+.mobile-page-root .mp-lead {
+  max-width: 580px;
+  margin: 24px 0 38px;
+  color: var(--muted-foreground);
+  font-size: 20px;
+  font-weight: 450;
+  line-height: 1.55;
+}
+
+.mobile-page-root .mp-cta-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 28px;
+}
+
+.mobile-page-root .mp-primary-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 54px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  padding: 0 28px;
+  font-size: 17px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.mobile-page-root .mp-primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px -12px color-mix(in srgb, var(--foreground) 40%, transparent);
+}
+
+.mobile-page-root .mp-primary-action svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Step flow ─────────────────────────────────────────────────────── */
+
+.mobile-page-root .mp-flow-header {
+  margin-bottom: 24px;
+}
+
+.mobile-page-root .mp-flow-step-head {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.mobile-page-root .mp-step-num {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-step-title {
+  font-size: 18px;
+  font-weight: 650;
+  color: var(--foreground);
+}
+
+.mobile-page-root .mp-flow-viewport {
+  position: relative;
+  min-height: 360px;
+}
+
+.mobile-page-root .mp-flow-screen {
+  position: absolute;
+  inset: 0;
+  transform: translateX(40px);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform 280ms cubic-bezier(0.32, 0.72, 0.24, 1),
+    opacity 200ms ease;
+}
+
+.mobile-page-root .mp-flow-screen.is-active {
+  position: relative;
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.mobile-page-root .mp-flow-screen.is-past {
+  transform: translateX(-40px);
+  opacity: 0;
+}
+
+.mobile-page-root .mp-flow-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 24px;
+}
+
+.mobile-page-root .mp-flow-back,
+.mobile-page-root .mp-flow-continue {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 140ms ease,
+    color 140ms ease,
+    opacity 140ms ease;
+}
+
+.mobile-page-root .mp-flow-back svg,
+.mobile-page-root .mp-flow-continue svg {
+  width: 13px;
+  height: 13px;
+}
+
+.mobile-page-root .mp-flow-back {
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+}
+
+.mobile-page-root .mp-flow-back:hover {
+  background: color-mix(in srgb, var(--foreground) 10%, transparent);
+}
+
+.mobile-page-root .mp-flow-continue {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.mobile-page-root .mp-flow-continue.is-hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.mobile-page-root .mp-step-body {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.mobile-page-root .mp-platform-toggle {
+  display: inline-flex;
+  margin: 12px 0;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+}
+
+.mobile-page-root .mp-platform-toggle button {
+  border: 0;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mobile-page-root .mp-platform-toggle button.is-active {
+  background: var(--foreground);
+  color: var(--background);
+}
+
+.mobile-page-root .mp-install-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 4px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--foreground) 3%, transparent);
+  color: var(--foreground);
+  font-size: 13px;
+}
+
+.mobile-page-root .mp-install-row > div:first-child {
+  flex: 1;
+}
+
+.mobile-page-root .mp-small-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.mobile-page-root .mp-ghost-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.mobile-page-root .mp-ghost-action:hover {
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+
+.mobile-page-root .mp-ghost-action svg {
+  width: 12px;
+  height: 12px;
+}
+
+.mobile-page-root .mp-qr {
+  display: grid;
+  place-items: center;
+  padding: 8px;
+  border-radius: 12px;
+  background: #fafafa;
+}
+
+.mobile-page-root .mp-qr img {
+  display: block;
+  width: 116px;
+  height: 116px;
+}
+
+/* Pairing settings card */
+.mobile-page-root .mp-pair-settings {
+  margin-top: 12px;
+  background: var(--m-bg-panel);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.mobile-page-root .mp-pair-settings + .mp-pair-settings {
+  margin-top: 12px;
+}
+
+.mobile-page-root .mp-pair-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  color: var(--m-text-primary);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.mobile-page-root .mp-pair-row .mp-pair-icon {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  color: var(--m-text-secondary);
+  flex-shrink: 0;
+}
+
+.mobile-page-root .mp-pair-row .mp-pair-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mobile-page-root .mp-pair-row .mp-pair-label {
+  flex: 1;
+  color: var(--m-text-primary);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.mobile-page-root .mp-pair-row .mp-pair-value {
+  color: var(--m-text-muted);
+  font-family: var(--m-mono);
+  font-size: 12px;
+}
+
+.mobile-page-root .mp-pair-row.mp-pair-row-qr {
+  align-items: flex-start;
+}
+
+.mobile-page-root .mp-pair-row.mp-pair-row-qr .mp-pair-label {
+  padding-top: 4px;
+}
+
+.mobile-page-root .mp-pair-separator {
+  height: 1px;
+  background: var(--m-border);
+  margin: 0 14px;
+}
+
+.mobile-page-root .mp-pair-action-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 14px;
+  background: transparent;
+  border: 0;
+  color: var(--m-text-primary);
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mobile-page-root .mp-pair-action-row:hover {
+  background: var(--m-bg-raised);
+}
+
+.mobile-page-root .mp-pair-action-row .mp-pair-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mobile-page-root .mp-pair-action-row .mp-pair-label {
+  flex: 1;
+}
+
+.mobile-page-root .mp-pair-action-row .mp-pair-meta {
+  color: var(--m-text-muted);
+  font-size: 12px;
+}
+
+.mobile-page-root .mp-pair-action-row:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+/* ── Phone stage ────────────────────────────────────────────────── */
+
+.mobile-page-root .mp-stage {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  min-height: 830px;
+}
+
+.mobile-page-root .mp-phone-frame {
+  position: relative;
+  width: min(100%, 470px);
+  aspect-ratio: 9 / 19.5;
+  border-radius: 48px;
+  background: #0a0a0a;
+  padding: 7px;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--foreground) 14%, transparent),
+    0 50px 100px -30px rgba(0, 0, 0, 0.7);
+}
+
+.mobile-page-root .mp-phone-screen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 41px;
+  background: var(--m-bg-base);
+}
+
+.mobile-page-root .mp-screen-slide {
+  position: absolute;
+  inset: 0;
+  transform: translateX(100%);
+  transition: transform 320ms cubic-bezier(0.32, 0.72, 0.24, 1);
+  pointer-events: none;
+  will-change: transform;
+}
+
+.mobile-page-root .mp-screen-slide.is-active {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.mobile-page-root .mp-screen-slide.is-past {
+  transform: translateX(-22%);
+}
+
+.mobile-page-root .mp-screen-slide.is-reset {
+  transition: none;
+}
+
+@keyframes mp-tap-pulse {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 0 transparent;
+  }
+  20%,
+  70% {
+    box-shadow: inset 0 0 0 200px var(--m-bg-raised);
+  }
+}
+
+.mobile-page-root .is-tapping {
+  animation: mp-tap-pulse 280ms ease-out;
+}
+
+/* ── Simulated mobile-app screens (real tokens) ─────────────────── */
+
+.mobile-page-root .mp-device-screen {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  background: var(--m-bg-base);
+  color: var(--m-text-primary);
+  font-family:
+    'Geist',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  font-size: 13px;
+  /* Why: phone-frame grew 50% but slide content uses fixed px tokens; zoom
+     scales children in layout space so they fill the bigger frame proportionally. */
+  zoom: 1.35;
+}
+
+.mobile-page-root .mp-wl-chrome,
+.mobile-page-root .mp-session-chrome {
+  padding-top: 18px;
+}
+
+/* Top bar */
+.mobile-page-root .mp-app-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 26px 11px 12px;
+}
+
+.mobile-page-root .mp-app-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mobile-page-root .mp-app-brand .mp-orca-logo {
+  width: 28px;
+  height: 18px;
+  color: var(--m-text-primary);
+}
+
+.mobile-page-root .mp-app-brand-name {
+  color: var(--m-text-primary);
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.mobile-page-root .mp-icon-button {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border: 0;
+  border-radius: 18px;
+  background: transparent;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-icon-button svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-scroll-region {
+  flex: 1;
+  overflow: hidden;
+  padding: 0 11px;
+}
+
+.mobile-page-root .mp-greeting {
+  padding: 6px 4px 10px;
+}
+
+.mobile-page-root .mp-greeting-title {
+  color: var(--m-text-primary);
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.mobile-page-root .mp-stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.mobile-page-root .mp-stat-card {
+  border: 1px solid var(--m-border);
+  border-radius: 10px;
+  background: rgba(26, 26, 26, 0.6);
+  padding: 8px 10px;
+}
+
+.mobile-page-root .mp-stat-value {
+  color: var(--m-text-primary);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.mobile-page-root .mp-stat-label {
+  margin-top: 1px;
+  color: var(--m-text-muted);
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.mobile-page-root .mp-section-label {
+  margin: 0 0 6px;
+  padding-left: 4px;
+  color: var(--m-text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* Host card */
+.mobile-page-root .mp-host-card {
+  display: flex;
+  align-items: center;
+  min-height: 60px;
+  padding: 10px 12px;
+  gap: 12px;
+  border: 1px solid var(--m-border);
+  border-radius: 14px;
+  background: var(--m-bg-panel);
+}
+
+.mobile-page-root .mp-host-card + .mp-host-card {
+  margin-top: 6px;
+}
+
+.mobile-page-root .mp-host-icon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 11px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-primary);
+}
+
+.mobile-page-root .mp-host-icon svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-host-icon.is-dim {
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-host-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.mobile-page-root .mp-host-name {
+  color: var(--m-text-primary);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+.mobile-page-root .mp-host-name.is-dim {
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-host-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  color: var(--m-text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.mobile-page-root .mp-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.mobile-page-root .mp-status-dot.is-green {
+  background: var(--m-status-green);
+}
+
+.mobile-page-root .mp-status-dot.is-amber {
+  background: var(--m-status-amber);
+}
+
+.mobile-page-root .mp-status-dot.is-muted {
+  background: var(--m-text-muted);
+}
+
+.mobile-page-root .mp-chevron-right {
+  color: var(--m-text-muted);
+}
+
+.mobile-page-root .mp-chevron-right svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+}
+
+/* Resume card */
+.mobile-page-root .mp-resume-card {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  gap: 12px;
+  border: 1px solid var(--m-border);
+  border-radius: 14px;
+  background: var(--m-bg-panel);
+}
+
+.mobile-page-root .mp-resume-icon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 11px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-resume-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-resume-title {
+  color: var(--m-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-resume-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  color: var(--m-text-secondary);
+  font-size: 11px;
+}
+
+.mobile-page-root .mp-repo-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+/* Quick actions */
+.mobile-page-root .mp-quick-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.mobile-page-root .mp-quick-action {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--m-border);
+  border-radius: 14px;
+  background: var(--m-bg-panel);
+}
+
+.mobile-page-root .mp-quick-action-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-quick-action-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-quick-action-label {
+  color: var(--m-text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Tasks home card */
+.mobile-page-root .mp-task-home-card {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  gap: 12px;
+  border: 1px solid var(--m-border);
+  border-radius: 14px;
+  background: var(--m-bg-panel);
+}
+
+.mobile-page-root .mp-task-home-icon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 11px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-task-home-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-task-home-title {
+  color: var(--m-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-task-home-subtitle {
+  margin-top: 2px;
+  color: var(--m-text-secondary);
+  font-size: 11px;
+}
+
+.mobile-page-root .mp-task-home-providers {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 8px;
+}
+
+.mobile-page-root .mp-task-home-provider-button {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 6px;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-task-home-provider-button svg {
+  width: 22px;
+  height: 22px;
+  stroke-width: 1.75;
+}
+
+/* Account usage */
+.mobile-page-root .mp-accounts-card {
+  background: var(--m-bg-panel);
+  border: 1px solid var(--m-border);
+  border-radius: 14px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mobile-page-root .mp-accounts-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mobile-page-root .mp-accounts-icon {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: 9px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-primary);
+}
+
+.mobile-page-root .mp-accounts-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.mobile-page-root .mp-accounts-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mobile-page-root .mp-accounts-email {
+  color: var(--m-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-accounts-bars {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.mobile-page-root .mp-usage-bar {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mobile-page-root .mp-usage-bar-label {
+  color: var(--m-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 16px;
+}
+
+.mobile-page-root .mp-usage-bar-track {
+  flex: 1;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--m-bg-raised);
+  overflow: hidden;
+}
+
+.mobile-page-root .mp-usage-bar-fill {
+  height: 100%;
+  background: var(--m-text-secondary);
+  border-radius: inherit;
+}
+
+/* ── Worktree-list screen ───────────────────────────────────────── */
+
+.mobile-page-root .mp-wl-chrome {
+  background: var(--m-bg-panel);
+  border-bottom: 1px solid var(--m-border);
+}
+
+.mobile-page-root .mp-wl-statusrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 16px 0;
+  min-height: 34px;
+}
+
+.mobile-page-root .mp-wl-back {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  margin-right: 4px;
+  color: var(--m-text-primary);
+}
+
+.mobile-page-root .mp-wl-back svg {
+  width: 22px;
+  height: 22px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-wl-host {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.mobile-page-root .mp-wl-host-name {
+  color: var(--m-text-primary);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-wl-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--m-border);
+}
+
+.mobile-page-root .mp-wl-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border: 1px solid var(--m-border);
+  border-radius: 12px;
+  color: var(--m-text-secondary);
+  font-size: 12px;
+}
+
+.mobile-page-root .mp-wl-chip svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-wl-button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  color: var(--m-text-secondary);
+  font-size: 12px;
+}
+
+.mobile-page-root .mp-wl-button svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-wl-spacer {
+  flex: 1;
+}
+
+.mobile-page-root .mp-wl-icon {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-wl-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-wl-section {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 16px 4px;
+  color: var(--m-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mobile-page-root .mp-wl-section svg {
+  width: 12px;
+  height: 12px;
+  stroke-width: 2;
+}
+
+.mobile-page-root .mp-wl-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.mobile-page-root .mp-wl-row {
+  display: flex;
+  align-items: flex-start;
+  padding: 10px 16px;
+  gap: 8px;
+}
+
+.mobile-page-root .mp-wl-sep {
+  height: 1px;
+  margin-left: 40px;
+  margin-right: 16px;
+  background: var(--m-border);
+}
+
+.mobile-page-root .mp-wl-indicator {
+  display: grid;
+  width: 20px;
+  place-items: center;
+  padding-top: 6px;
+}
+
+.mobile-page-root .mp-wl-spinner {
+  width: 8px;
+  height: 8px;
+  border-radius: 4px;
+  border: 2px solid #eab308;
+  border-top-color: transparent;
+  animation: mp-wl-spin 1s linear infinite;
+}
+
+.mobile-page-root .mp-wl-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 4px;
+}
+
+.mobile-page-root .mp-wl-dot.is-green {
+  background: #10b981;
+}
+
+.mobile-page-root .mp-wl-dot.is-muted {
+  background: rgba(115, 115, 115, 0.4);
+}
+
+.mobile-page-root .mp-wl-dot.is-red {
+  background: #ef4444;
+}
+
+@keyframes mp-wl-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.mobile-page-root .mp-wl-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.mobile-page-root .mp-wl-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mobile-page-root .mp-wl-name {
+  color: var(--m-text-primary);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-wl-pr {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-secondary);
+  font-size: 10px;
+}
+
+.mobile-page-root .mp-wl-pr svg {
+  width: 10px;
+  height: 10px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-wl-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  color: var(--m-text-secondary);
+  font-size: 11px;
+}
+
+.mobile-page-root .mp-wl-meta-row .mp-repo-dot {
+  width: 6px;
+  height: 6px;
+}
+
+.mobile-page-root .mp-wl-branch {
+  color: var(--m-text-muted);
+  font-family: var(--m-mono);
+}
+
+.mobile-page-root .mp-wl-preview {
+  margin-top: 2px;
+  color: var(--m-text-muted);
+  font-family: var(--m-mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mobile-page-root .mp-wl-tcount {
+  min-width: 16px;
+  padding-top: 3px;
+  color: var(--m-text-muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+/* ── Session / terminal screen ─────────────────────────────────── */
+
+.mobile-page-root .mp-session-chrome {
+  background: var(--m-bg-panel);
+  border-bottom: 1px solid var(--m-border);
+}
+
+.mobile-page-root .mp-session-topbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px 8px;
+  min-height: 48px;
+}
+
+.mobile-page-root .mp-session-back {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-session-back svg {
+  width: 22px;
+  height: 22px;
+  stroke-width: 2.2;
+}
+
+.mobile-page-root .mp-session-title-block {
+  flex: 1;
+  min-width: 0;
+}
+
+.mobile-page-root .mp-session-title {
+  color: var(--m-text-primary);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.mobile-page-root .mp-session-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  color: var(--m-text-secondary);
+  font-size: 12px;
+}
+
+.mobile-page-root .mp-session-iconbtn {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-session-iconbtn svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 2.1;
+}
+
+.mobile-page-root .mp-session-tabbar {
+  display: flex;
+  align-items: stretch;
+  border-top: 1px solid var(--m-border);
+  height: 36px;
+}
+
+.mobile-page-root .mp-session-tab {
+  max-width: 128px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 12px;
+  border-bottom: 2px solid transparent;
+  color: var(--m-text-secondary);
+  font-size: 13px;
+}
+
+.mobile-page-root .mp-session-tab.is-active {
+  border-bottom-color: var(--m-accent-blue);
+  color: var(--m-text-primary);
+}
+
+.mobile-page-root .mp-session-tab svg {
+  width: 13px;
+  height: 13px;
+  stroke-width: 2.1;
+}
+
+.mobile-page-root .mp-session-tab-add {
+  width: 40px;
+  display: grid;
+  place-items: center;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-session-tab-add svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2.2;
+}
+
+/* Tokyonight terminal */
+.mobile-page-root .mp-terminal {
+  flex: 1;
+  background: #1a1b26;
+  color: #c0caf5;
+  font-family: var(--m-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  padding: 12px 14px;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.mobile-page-root .mp-term-line {
+  display: block;
+}
+
+.mobile-page-root .mp-term-prompt {
+  color: #7aa2f7;
+}
+.mobile-page-root .mp-term-cmd {
+  color: #c0caf5;
+}
+.mobile-page-root .mp-term-comment {
+  color: #565f89;
+}
+.mobile-page-root .mp-term-warn {
+  color: #e0af68;
+}
+.mobile-page-root .mp-term-ok {
+  color: #9ece6a;
+}
+.mobile-page-root .mp-term-tool {
+  color: #bb9af7;
+}
+.mobile-page-root .mp-term-mid {
+  color: #a9b1d6;
+}
+.mobile-page-root .mp-term-dim {
+  color: #565f89;
+}
+
+.mobile-page-root .mp-term-cursor {
+  display: inline-block;
+  width: 7px;
+  height: 13px;
+  background: #c0caf5;
+  vertical-align: text-bottom;
+  animation: mp-term-blink 1s steps(2, start) infinite;
+}
+
+@keyframes mp-term-blink {
+  to {
+    background: transparent;
+  }
+}
+
+/* Accessory + input bar */
+.mobile-page-root .mp-accessory-bar {
+  background: var(--m-bg-panel);
+  border-top: 1px solid var(--m-border);
+  overflow: hidden;
+}
+
+.mobile-page-root .mp-accessory-content {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.mobile-page-root .mp-accessory-content::-webkit-scrollbar {
+  display: none;
+}
+
+.mobile-page-root .mp-accessory-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: 36px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-secondary);
+  font-size: 12px;
+  font-family: var(--m-mono);
+}
+
+.mobile-page-root .mp-accessory-key.is-icon {
+  padding: 4px 8px;
+}
+
+.mobile-page-root .mp-accessory-key.is-icon svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 1.75;
+}
+
+.mobile-page-root .mp-accessory-key.is-add {
+  background: transparent;
+  color: var(--m-text-secondary);
+}
+
+.mobile-page-root .mp-input-bar {
+  display: flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-top: 1px solid var(--m-border);
+  background: var(--m-bg-panel);
+  gap: 8px;
+}
+
+.mobile-page-root .mp-text-input {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-muted);
+  font-family: var(--m-mono);
+  font-size: 14px;
+}
+
+.mobile-page-root .mp-round-button {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 17px;
+  background: var(--m-bg-raised);
+  color: var(--m-text-secondary);
+  flex: 0 0 auto;
+}
+
+.mobile-page-root .mp-round-button svg {
+  width: 17px;
+  height: 17px;
+  stroke-width: 2.4;
+}
+
+/* Reduced motion: pin to home, no slide transitions */
+@media (prefers-reduced-motion: reduce) {
+  .mobile-page-root .mp-screen-slide {
+    transition: none;
+  }
+}
+
+/* Narrow viewport: stack the hero so the phone falls below the copy */
+@media (max-width: 920px) {
+  .mobile-page-root .mp-hero {
+    grid-template-columns: 1fr;
+    padding: 56px 32px 48px;
+  }
+}

--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -85,6 +85,18 @@
   position: relative;
   z-index: 1;
   max-width: 660px;
+  display: flex;
+  flex-direction: column;
+  /* Why: min-height (rather than fixed height) keeps the intro/flow
+     screens at a uniform 420px box for centering, while letting the
+     paired view grow when the device list needs more room. */
+  min-height: 420px;
+}
+
+.mobile-page-root .mp-hero-copy > * {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .mobile-page-root .mp-eyebrow-row {
@@ -120,39 +132,131 @@
   line-height: 1.55;
 }
 
+.mobile-page-root .mp-paired-list {
+  list-style: none;
+  margin: 18px 0 0;
+  /* Why: right padding reserves space for the scrollbar so it doesn't
+     sit on top of the row's right edge when the list overflows. */
+  padding: 0 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 452px;
+  /* Why: cap so 4 rows fit fully and the 5th onward scrolls. Rows render
+     at ~64px each plus 8px gap, so 4 × 64 + 3 × 8 ≈ 280px. */
+  max-height: 288px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.mobile-page-root .mp-paired-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--foreground) 2%, transparent);
+}
+
+.mobile-page-root .mp-paired-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+}
+
+.mobile-page-root .mp-paired-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.mobile-page-root .mp-paired-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.mobile-page-root .mp-paired-name {
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-page-root .mp-paired-meta {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.mobile-page-root .mp-paired-revoke {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.mobile-page-root .mp-paired-revoke:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--destructive, oklch(0.6 0.2 25)) 12%, transparent);
+  color: var(--destructive, oklch(0.6 0.2 25));
+}
+
+.mobile-page-root .mp-paired-revoke[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.mobile-page-root .mp-paired-revoke svg {
+  width: 14px;
+  height: 14px;
+}
+
 .mobile-page-root .mp-cta-row {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 14px;
-  margin-bottom: 28px;
+  margin-top: auto;
+  padding-top: 16px;
 }
 
 .mobile-page-root .mp-primary-action {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  height: 54px;
+  gap: 8px;
+  height: 40px;
   border: 0;
   border-radius: 999px;
   background: var(--primary);
   color: var(--primary-foreground);
-  padding: 0 28px;
-  font-size: 17px;
+  padding: 0 18px;
+  font-size: 13px;
   font-weight: 600;
+  line-height: 1;
   cursor: pointer;
   transition:
-    transform 140ms ease,
-    box-shadow 140ms ease;
-}
-
-.mobile-page-root .mp-primary-action:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 30px -12px color-mix(in srgb, var(--foreground) 40%, transparent);
+    background 140ms ease,
+    color 140ms ease;
 }
 
 .mobile-page-root .mp-primary-action svg {
-  width: 14px;
-  height: 14px;
+  width: 13px;
+  height: 13px;
 }
 
 /* Step flow ─────────────────────────────────────────────────────── */
@@ -189,7 +293,6 @@
 
 .mobile-page-root .mp-flow-viewport {
   position: relative;
-  min-height: 360px;
 }
 
 .mobile-page-root .mp-flow-screen {
@@ -219,11 +322,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 24px;
+  margin-top: auto;
+  padding-top: 16px;
 }
 
-.mobile-page-root .mp-flow-back,
 .mobile-page-root .mp-flow-continue {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -233,31 +337,44 @@
   border-radius: 999px;
   font-size: 13px;
   font-weight: 600;
+  line-height: 1;
   cursor: pointer;
+  background: var(--primary);
+  color: var(--primary-foreground);
   transition:
     background 140ms ease,
     color 140ms ease,
     opacity 140ms ease;
 }
 
-.mobile-page-root .mp-flow-back svg,
 .mobile-page-root .mp-flow-continue svg {
   width: 13px;
   height: 13px;
 }
 
 .mobile-page-root .mp-flow-back {
-  background: color-mix(in srgb, var(--foreground) 6%, transparent);
-  color: var(--foreground);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  transition: color 140ms ease;
 }
 
 .mobile-page-root .mp-flow-back:hover {
-  background: color-mix(in srgb, var(--foreground) 10%, transparent);
+  color: var(--foreground);
 }
 
-.mobile-page-root .mp-flow-continue {
-  background: var(--primary);
-  color: var(--primary-foreground);
+.mobile-page-root .mp-flow-back svg {
+  width: 12px;
+  height: 12px;
 }
 
 .mobile-page-root .mp-flow-continue.is-hidden {
@@ -355,6 +472,201 @@
   display: block;
   width: 116px;
   height: 116px;
+}
+
+.mobile-page-root .mp-qr-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.mobile-page-root .mp-link-under {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  transition: color 140ms ease;
+}
+
+.mobile-page-root .mp-link-under:hover:not([disabled]) {
+  color: var(--foreground);
+}
+
+.mobile-page-root .mp-link-under[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Step 1 (Get the app) — borderless layout, page-1 typography */
+.mobile-page-root .mp-step2-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 32px;
+  align-items: start;
+}
+
+/* Why: align the QR's top with the body copy ("Scan the QR…") instead
+   of the eyebrow row above it. The eyebrow row is ~22px tall + 22px
+   margin-bottom, and the h2 is ~38px line-height with no top margin —
+   so push the QR down by roughly that combined height. */
+.mobile-page-root .mp-step2-layout > .mp-qr,
+.mobile-page-root .mp-step2-layout > .mp-qr-stack {
+  margin-top: 88px;
+}
+
+.mobile-page-root .mp-step2-copy {
+  min-width: 0;
+}
+
+.mobile-page-root .mp-h2 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: clamp(28px, 3vw, 38px);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+}
+
+.mobile-page-root .mp-lead-sm {
+  max-width: 420px;
+  margin: 14px 0 22px;
+  color: var(--muted-foreground);
+  font-size: 15px;
+  font-weight: 450;
+  line-height: 1.55;
+}
+
+.mobile-page-root .mp-tab-toggle {
+  display: inline-flex;
+  gap: 18px;
+  margin: 2px 0 22px;
+}
+
+.mobile-page-root .mp-tab-toggle button {
+  border: 0;
+  background: transparent;
+  padding: 0 0 6px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border-bottom: 1.5px solid transparent;
+  transition:
+    color 140ms ease,
+    border-color 140ms ease;
+}
+
+.mobile-page-root .mp-tab-toggle button.is-active {
+  color: var(--foreground);
+  border-bottom-color: var(--foreground);
+}
+
+.mobile-page-root .mp-inline-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.mobile-page-root .mp-text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0.85;
+  transition: opacity 140ms ease;
+}
+
+.mobile-page-root .mp-text-link:hover {
+  opacity: 1;
+}
+
+.mobile-page-root .mp-text-link svg {
+  width: 13px;
+  height: 13px;
+}
+
+.mobile-page-root .mp-text-link[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.mobile-page-root .mp-network-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 18px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.mobile-page-root .mp-network-label {
+  color: var(--muted-foreground);
+  font-weight: 600;
+}
+
+.mobile-page-root .mp-network-select {
+  min-width: 220px;
+  max-width: 280px;
+}
+
+.mobile-page-root .mp-network-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.mobile-page-root .mp-network-refresh:hover:not([disabled]) {
+  background-color: color-mix(in srgb, var(--foreground) 6%, transparent);
+  color: var(--foreground);
+}
+
+.mobile-page-root .mp-network-refresh[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mobile-page-root .mp-network-refresh svg {
+  width: 14px;
+  height: 14px;
+}
+
+.mobile-page-root .mp-network-refresh.is-spinning svg {
+  animation: mp-network-refresh-spin 900ms linear infinite;
+}
+
+@keyframes mp-network-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.mobile-page-root .mp-action-divider {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  opacity: 0.6;
 }
 
 /* Pairing settings card */

--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -311,13 +311,16 @@
   color: var(--foreground);
 }
 
+/* Why: stack both step screens in the same grid cell so the viewport
+   sizes to the tallest child. This keeps the back button at the same
+   Y on Step 1 and Step 2 even though Step 2 has more rows of content. */
 .mobile-page-root .mp-flow-viewport {
-  position: relative;
+  display: grid;
+  grid-template-areas: 'stack';
 }
 
 .mobile-page-root .mp-flow-screen {
-  position: absolute;
-  inset: 0;
+  grid-area: stack;
   transform: translateX(40px);
   opacity: 0;
   pointer-events: none;
@@ -327,7 +330,6 @@
 }
 
 .mobile-page-root .mp-flow-screen.is-active {
-  position: relative;
   transform: translateX(0);
   opacity: 1;
   pointer-events: auto;
@@ -344,6 +346,10 @@
   justify-content: space-between;
   margin-top: auto;
   padding-top: 16px;
+  /* Why: keep row height stable across steps so the back button doesn't jump
+     vertically when the right side switches between a 40px Continue button
+     and a placeholder span. */
+  min-height: calc(40px + 16px);
 }
 
 .mobile-page-root .mp-flow-continue {

--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -2,6 +2,13 @@
    1:1 design spec for the in-app Mobile page; styles are scoped under
    .mobile-page-root so they don't leak into the rest of the app shell. */
 
+.mobile-page-root .mp-close-button {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 2;
+}
+
 .mobile-page-root {
   /* Real mobile-app tokens (from mobile/src/theme/mobile-theme.ts) — used
      inside .mp-device-screen so simulated screens match the app exactly. */
@@ -40,45 +47,58 @@
   height: 100%;
   overflow: auto;
   scrollbar-width: thin;
+  /* Why: layer four large soft radial blobs across the whole hero so the
+     blue/indigo glow fills the dead space the corner-pinned blobs used to
+     leave empty. Each blob is animated below for slow drift. */
+  background-color: transparent;
+  background-image:
+    radial-gradient(
+      ellipse 40% 35% at 90% 10%,
+      rgba(99, 102, 241, 0.28) 0%,
+      rgba(99, 102, 241, 0.08) 30%,
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 38% 32% at 10% 95%,
+      rgba(59, 130, 246, 0.22) 0%,
+      rgba(59, 130, 246, 0.06) 35%,
+      transparent 60%
+    ),
+    radial-gradient(circle, rgba(255, 255, 255, 0.06) 1px, transparent 1.2px);
+  background-size:
+    200% 200%,
+    200% 200%,
+    5px 5px;
+  background-position:
+    90% 10%,
+    10% 95%,
+    0 0;
+  background-repeat: no-repeat, no-repeat, repeat;
+  /* Why: animating background-position drifts the four blobs slowly across
+     the hero. The dot grid (last layer) stays fixed at 0 0. */
+  animation: mp-hero-bg-drift 32s ease-in-out infinite alternate;
+  will-change: background-position;
 }
 
-.mobile-page-root .mp-hero::before {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 0;
-  width: 1200px;
-  height: 1000px;
-  background: radial-gradient(
-    ellipse at top right,
-    rgba(99, 102, 241, 0.65) 0%,
-    rgba(99, 102, 241, 0.32) 25%,
-    rgba(99, 102, 241, 0.12) 50%,
-    transparent 75%
-  );
-  filter: blur(40px);
-  opacity: 1;
-  content: '';
-  pointer-events: none;
+@keyframes mp-hero-bg-drift {
+  0% {
+    background-position:
+      90% 10%,
+      10% 95%,
+      0 0;
+  }
+  100% {
+    background-position:
+      75% 25%,
+      25% 80%,
+      0 0;
+  }
 }
 
-.mobile-page-root .mp-hero::after {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  z-index: 0;
-  width: 900px;
-  height: 800px;
-  background: radial-gradient(
-    ellipse at bottom left,
-    rgba(59, 130, 246, 0.45) 0%,
-    rgba(59, 130, 246, 0.18) 35%,
-    transparent 70%
-  );
-  filter: blur(50px);
-  opacity: 1;
-  content: '';
-  pointer-events: none;
+@media (prefers-reduced-motion: reduce) {
+  .mobile-page-root .mp-hero {
+    animation: none;
+  }
 }
 
 .mobile-page-root .mp-hero-copy {
@@ -799,6 +819,11 @@
   overflow: hidden;
   border-radius: 41px;
   background: var(--m-bg-base);
+  /* Why: Chromium occasionally fails to clip transformed children to a
+     rounded-corner overflow:hidden ancestor. Forcing a paint containment
+     boundary guarantees the off-screen slide can't leak past the bezel. */
+  contain: paint;
+  isolation: isolate;
 }
 
 .mobile-page-root .mp-screen-slide {

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -1,0 +1,267 @@
+import { cn } from '../../lib/utils'
+
+export type Platform = 'ios' | 'android'
+export type StepIndex = 0 | 1
+
+const STEP_TITLES = ['Get the app', 'Pair this Mac'] as const
+
+export function HeroIntro({ onStart }: { onStart: () => void }): React.JSX.Element {
+  return (
+    <div>
+      <div className="mp-eyebrow-row">
+        <span className="mp-eyebrow">Orca Mobile</span>
+      </div>
+      <h1 className="mp-h1">Your workspaces, in your pocket.</h1>
+      <p className="mp-lead">
+        Control Orca from your phone. Check on agents, review changes, and kick off tasks while
+        you&apos;re away from your desk.
+      </p>
+      <div className="mp-cta-row">
+        <button type="button" className="mp-primary-action" onClick={onStart}>
+          Get started
+          <ArrowRightIcon />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+type HeroFlowProps = {
+  stepIdx: StepIndex
+  platform: Platform
+  onPlatformChange: (next: Platform) => void
+  installQrUrl: string | null
+  installCopy: { description: string; ctaLabel: string; url: string }
+  onOpenInstallUrl: () => void
+  onCopyInstallUrl: () => void
+  pairQrDataUrl: string | null
+  pairEndpoint: string | null
+  pairingUrl: string | null
+  pairLoading: boolean
+  onRegeneratePairing: () => void
+  onBack: () => void
+  onContinue: () => void
+}
+
+export function HeroFlow({
+  stepIdx,
+  platform,
+  onPlatformChange,
+  installQrUrl,
+  installCopy,
+  onOpenInstallUrl,
+  onCopyInstallUrl,
+  pairQrDataUrl,
+  pairEndpoint,
+  pairingUrl,
+  pairLoading,
+  onRegeneratePairing,
+  onBack,
+  onContinue
+}: HeroFlowProps): React.JSX.Element {
+  const isLast = stepIdx === 1
+
+  return (
+    <div>
+      <div className="mp-flow-header">
+        <div className="mp-flow-step-head">
+          <div className="mp-step-num">{stepIdx + 1}</div>
+          <div className="mp-step-title">{STEP_TITLES[stepIdx]}</div>
+        </div>
+      </div>
+
+      <div className="mp-flow-viewport">
+        <div className={cn('mp-flow-screen', stepIdx === 0 ? 'is-active' : 'is-past')}>
+          <div className="mp-step-body">
+            <div className="mp-platform-toggle" role="tablist" aria-label="Phone platform">
+              <button
+                type="button"
+                className={cn(platform === 'ios' && 'is-active')}
+                onClick={() => onPlatformChange('ios')}
+              >
+                iOS
+              </button>
+              <button
+                type="button"
+                className={cn(platform === 'android' && 'is-active')}
+                onClick={() => onPlatformChange('android')}
+              >
+                Android
+              </button>
+            </div>
+
+            <div className="mp-install-row">
+              <div>
+                <div>{installCopy.description}</div>
+                <div className="mp-small-actions">
+                  <button type="button" className="mp-ghost-action" onClick={onOpenInstallUrl}>
+                    {installCopy.ctaLabel}
+                  </button>
+                  <button type="button" className="mp-ghost-action" onClick={onCopyInstallUrl}>
+                    <CopyIcon />
+                    Copy link
+                  </button>
+                </div>
+              </div>
+              <div className="mp-qr" aria-label="Install QR code">
+                {installQrUrl ? <img src={installQrUrl} alt="Install QR" /> : null}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={cn('mp-flow-screen', stepIdx === 1 && 'is-active')}>
+          <div className="mp-step-body">
+            From the phone, hit <strong>Pair Desktop</strong> and scan the QR below.
+            <div className="mp-pair-settings" role="group" aria-label="Pairing details">
+              <div className="mp-pair-row">
+                <span className="mp-pair-icon" aria-hidden>
+                  <ServerIcon />
+                </span>
+                <span className="mp-pair-label">Endpoint</span>
+                <span className="mp-pair-value">
+                  {pairEndpoint ?? (pairLoading ? 'Generating…' : 'Not generated yet')}
+                </span>
+              </div>
+              <div className="mp-pair-separator" />
+              <div className="mp-pair-row mp-pair-row-qr">
+                <span className="mp-pair-icon" aria-hidden>
+                  <QrIcon />
+                </span>
+                <span className="mp-pair-label">Pairing QR</span>
+                <div className="mp-qr" aria-label="Pairing QR code">
+                  {pairQrDataUrl ? <img src={pairQrDataUrl} alt="Pairing QR" /> : null}
+                </div>
+              </div>
+              {pairingUrl ? (
+                <>
+                  <div className="mp-pair-separator" />
+                  <div className="mp-pair-row">
+                    <span className="mp-pair-icon" aria-hidden>
+                      <LinkIcon />
+                    </span>
+                    <span className="mp-pair-label">Pairing URL</span>
+                    <span
+                      className="mp-pair-value"
+                      style={{
+                        maxWidth: 220,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap'
+                      }}
+                    >
+                      {pairingUrl}
+                    </span>
+                  </div>
+                </>
+              ) : null}
+            </div>
+            <div className="mp-pair-settings">
+              <button
+                type="button"
+                className="mp-pair-action-row"
+                onClick={onRegeneratePairing}
+                disabled={pairLoading}
+              >
+                <span className="mp-pair-icon" aria-hidden>
+                  <RotateIcon />
+                </span>
+                <span className="mp-pair-label">
+                  {pairLoading
+                    ? 'Generating…'
+                    : pairQrDataUrl
+                      ? 'Regenerate pairing code'
+                      : 'Generate pairing code'}
+                </span>
+                <span className="mp-pair-meta">Rotates each tap</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mp-flow-actions">
+        <button type="button" className="mp-flow-back" onClick={onBack}>
+          <ArrowLeftIcon />
+          Back
+        </button>
+        <button
+          type="button"
+          className={cn('mp-flow-continue', isLast && 'is-hidden')}
+          onClick={onContinue}
+          aria-hidden={isLast}
+        >
+          Continue
+          <ArrowRightIcon />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ArrowRightIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4">
+      <path d="M5 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </svg>
+  )
+}
+
+function ArrowLeftIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function CopyIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  )
+}
+
+function ServerIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  )
+}
+
+function QrIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <path d="M14 14h3v3" />
+      <path d="M21 14v3" />
+      <path d="M14 21h3" />
+    </svg>
+  )
+}
+
+function RotateIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+      <path d="M21 12a9 9 0 1 1-3-6.7" />
+      <path d="M21 4v5h-5" />
+    </svg>
+  )
+}
+
+function LinkIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+      <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1 1" />
+      <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1-1" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -169,10 +169,11 @@ export function HeroFlow({
               <p className="mp-lead-sm">
                 Scan the QR with your phone or open the install link to grab Orca Mobile.
               </p>
-              <div className="mp-tab-toggle" role="tablist" aria-label="Phone platform">
+              <div className="mp-tab-toggle">
                 <button
                   type="button"
                   className={cn(platform === 'ios' && 'is-active')}
+                  aria-pressed={platform === 'ios'}
                   onClick={() => onPlatformChange('ios')}
                 >
                   iOS
@@ -180,6 +181,7 @@ export function HeroFlow({
                 <button
                   type="button"
                   className={cn(platform === 'android' && 'is-active')}
+                  aria-pressed={platform === 'android'}
                   onClick={() => onPlatformChange('android')}
                 >
                   Android
@@ -261,8 +263,16 @@ export function HeroFlow({
               </div>
             </div>
             <div className="mp-qr-stack">
-              <div className="mp-qr" aria-label="Pairing QR code">
-                {pairQrDataUrl ? <img src={pairQrDataUrl} alt="Pairing QR" /> : null}
+              <div
+                className="mp-qr"
+                aria-label="Pairing QR code"
+                aria-busy={pairLoading && !pairQrDataUrl}
+              >
+                {pairQrDataUrl ? (
+                  <img src={pairQrDataUrl} alt="Pairing QR" />
+                ) : pairLoading ? (
+                  <span className="mp-qr-loading">Generating…</span>
+                ) : null}
               </div>
               <button
                 type="button"

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -1,9 +1,28 @@
 import { cn } from '../../lib/utils'
+import type { MobileNetworkInterface } from '../settings/mobile-network-interface-selection'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 
 export type Platform = 'ios' | 'android'
 export type StepIndex = 0 | 1
 
-const STEP_TITLES = ['Get the app', 'Pair this Mac'] as const
+export type PairedDevice = {
+  deviceId: string
+  name: string
+  pairedAt: number
+  lastSeenAt: number
+}
+
+// Why: header copy needs to refer to the *user's* device by its native name.
+function getDeviceLabel(): string {
+  const ua = navigator.userAgent
+  if (ua.includes('Mac')) {
+    return 'Mac'
+  }
+  if (ua.includes('Windows')) {
+    return 'PC'
+  }
+  return 'computer'
+}
 
 export function HeroIntro({ onStart }: { onStart: () => void }): React.JSX.Element {
   return (
@@ -26,6 +45,69 @@ export function HeroIntro({ onStart }: { onStart: () => void }): React.JSX.Eleme
   )
 }
 
+type HeroPairedProps = {
+  devices: readonly PairedDevice[]
+  onPairAnother: () => void
+  onRevoke: (deviceId: string) => void
+  revokingDeviceIds: readonly string[]
+}
+
+export function HeroPaired({
+  devices,
+  onPairAnother,
+  onRevoke,
+  revokingDeviceIds
+}: HeroPairedProps): React.JSX.Element {
+  return (
+    <div>
+      <div className="mp-eyebrow-row">
+        <span className="mp-eyebrow">Orca Mobile</span>
+      </div>
+      <h1 className="mp-h1">
+        {devices.length === 1 ? 'Your phone is paired.' : 'Your phones are paired.'}
+      </h1>
+      <p className="mp-lead-sm">
+        Open Orca Mobile to pick up where you left off, or pair another device.
+      </p>
+      <ul className="mp-paired-list">
+        {devices.map((device) => {
+          const revoking = revokingDeviceIds.includes(device.deviceId)
+          return (
+            <li key={device.deviceId} className="mp-paired-row">
+              <div className="mp-paired-icon">
+                <PhoneSmallIcon />
+              </div>
+              <div className="mp-paired-main">
+                <div className="mp-paired-name">{device.name}</div>
+                <div className="mp-paired-meta">
+                  Paired {new Date(device.pairedAt).toLocaleDateString()}
+                </div>
+              </div>
+              <button
+                type="button"
+                className="mp-paired-revoke"
+                onClick={() => onRevoke(device.deviceId)}
+                disabled={revoking}
+                aria-label={`Revoke ${device.name}`}
+                title="Revoke device"
+              >
+                <TrashIcon />
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+      <div className="mp-flow-actions">
+        <button type="button" className="mp-flow-back" onClick={onPairAnother}>
+          <ArrowLeftIcon />
+          Pair another device
+        </button>
+        <span />
+      </div>
+    </div>
+  )
+}
+
 type HeroFlowProps = {
   stepIdx: StepIndex
   platform: Platform
@@ -35,12 +117,18 @@ type HeroFlowProps = {
   onOpenInstallUrl: () => void
   onCopyInstallUrl: () => void
   pairQrDataUrl: string | null
-  pairEndpoint: string | null
   pairingUrl: string | null
   pairLoading: boolean
   onRegeneratePairing: () => void
+  onCopyPairingCode: () => void
+  networkInterfaces: readonly MobileNetworkInterface[]
+  selectedAddress: string | undefined
+  onSelectedAddressChange: (address: string) => void
+  onRefreshNetworkInterfaces: () => void
+  refreshingNetworkInterfaces: boolean
   onBack: () => void
   onContinue: () => void
+  onDone?: () => void
 }
 
 export function HeroFlow({
@@ -52,128 +140,137 @@ export function HeroFlow({
   onOpenInstallUrl,
   onCopyInstallUrl,
   pairQrDataUrl,
-  pairEndpoint,
   pairingUrl,
   pairLoading,
   onRegeneratePairing,
+  onCopyPairingCode,
+  networkInterfaces,
+  selectedAddress,
+  onSelectedAddressChange,
+  onRefreshNetworkInterfaces,
+  refreshingNetworkInterfaces,
   onBack,
-  onContinue
+  onContinue,
+  onDone
 }: HeroFlowProps): React.JSX.Element {
   const isLast = stepIdx === 1
 
   return (
     <div>
-      <div className="mp-flow-header">
-        <div className="mp-flow-step-head">
-          <div className="mp-step-num">{stepIdx + 1}</div>
-          <div className="mp-step-title">{STEP_TITLES[stepIdx]}</div>
-        </div>
-      </div>
-
       <div className="mp-flow-viewport">
         <div className={cn('mp-flow-screen', stepIdx === 0 ? 'is-active' : 'is-past')}>
-          <div className="mp-step-body">
-            <div className="mp-platform-toggle" role="tablist" aria-label="Phone platform">
-              <button
-                type="button"
-                className={cn(platform === 'ios' && 'is-active')}
-                onClick={() => onPlatformChange('ios')}
-              >
-                iOS
-              </button>
-              <button
-                type="button"
-                className={cn(platform === 'android' && 'is-active')}
-                onClick={() => onPlatformChange('android')}
-              >
-                Android
-              </button>
+          <div className="mp-step2-layout">
+            <div className="mp-step2-copy">
+              <div className="mp-eyebrow-row">
+                <div className="mp-step-num">{stepIdx + 1}</div>
+                <span className="mp-eyebrow">Step 1 of 2</span>
+              </div>
+              <h2 className="mp-h2">Get the app.</h2>
+              <p className="mp-lead-sm">
+                Scan the QR with your phone or open the install link to grab Orca Mobile.
+              </p>
+              <div className="mp-tab-toggle" role="tablist" aria-label="Phone platform">
+                <button
+                  type="button"
+                  className={cn(platform === 'ios' && 'is-active')}
+                  onClick={() => onPlatformChange('ios')}
+                >
+                  iOS
+                </button>
+                <button
+                  type="button"
+                  className={cn(platform === 'android' && 'is-active')}
+                  onClick={() => onPlatformChange('android')}
+                >
+                  Android
+                </button>
+              </div>
+              <div className="mp-inline-actions">
+                <button type="button" className="mp-ghost-action" onClick={onOpenInstallUrl}>
+                  {installCopy.ctaLabel}
+                </button>
+                <button type="button" className="mp-text-link" onClick={onCopyInstallUrl}>
+                  <CopyIcon />
+                  Copy install link
+                </button>
+              </div>
             </div>
-
-            <div className="mp-install-row">
-              <div>
-                <div>{installCopy.description}</div>
-                <div className="mp-small-actions">
-                  <button type="button" className="mp-ghost-action" onClick={onOpenInstallUrl}>
-                    {installCopy.ctaLabel}
-                  </button>
-                  <button type="button" className="mp-ghost-action" onClick={onCopyInstallUrl}>
-                    <CopyIcon />
-                    Copy link
-                  </button>
-                </div>
-              </div>
-              <div className="mp-qr" aria-label="Install QR code">
-                {installQrUrl ? <img src={installQrUrl} alt="Install QR" /> : null}
-              </div>
+            <div className="mp-qr" aria-label="Install QR code">
+              {installQrUrl ? <img src={installQrUrl} alt="Install QR" /> : null}
             </div>
           </div>
         </div>
 
         <div className={cn('mp-flow-screen', stepIdx === 1 && 'is-active')}>
-          <div className="mp-step-body">
-            From the phone, hit <strong>Pair Desktop</strong> and scan the QR below.
-            <div className="mp-pair-settings" role="group" aria-label="Pairing details">
-              <div className="mp-pair-row">
-                <span className="mp-pair-icon" aria-hidden>
-                  <ServerIcon />
-                </span>
-                <span className="mp-pair-label">Endpoint</span>
-                <span className="mp-pair-value">
-                  {pairEndpoint ?? (pairLoading ? 'Generating…' : 'Not generated yet')}
-                </span>
+          <div className="mp-step2-layout">
+            <div className="mp-step2-copy">
+              <div className="mp-eyebrow-row">
+                <div className="mp-step-num">2</div>
+                <span className="mp-eyebrow">Step 2 of 2</span>
               </div>
-              <div className="mp-pair-separator" />
-              <div className="mp-pair-row mp-pair-row-qr">
-                <span className="mp-pair-icon" aria-hidden>
-                  <QrIcon />
-                </span>
-                <span className="mp-pair-label">Pairing QR</span>
-                <div className="mp-qr" aria-label="Pairing QR code">
-                  {pairQrDataUrl ? <img src={pairQrDataUrl} alt="Pairing QR" /> : null}
-                </div>
+              <h2 className="mp-h2">Pair this {getDeviceLabel()}.</h2>
+              <p className="mp-lead-sm">
+                Open Orca Mobile, tap <strong>Pair Desktop</strong>, and scan the code.
+              </p>
+
+              <div className="mp-network-row">
+                <span className="mp-network-label">Network</span>
+                <Select
+                  value={selectedAddress ?? ''}
+                  onValueChange={onSelectedAddressChange}
+                  disabled={networkInterfaces.length === 0}
+                >
+                  <SelectTrigger
+                    size="sm"
+                    className="mp-network-select"
+                    aria-label="Network interface to advertise"
+                  >
+                    <SelectValue placeholder="No interfaces found" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {networkInterfaces.map((iface) => (
+                      <SelectItem key={`${iface.name}-${iface.address}`} value={iface.address}>
+                        {iface.address} ({iface.name})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <button
+                  type="button"
+                  className={cn('mp-network-refresh', refreshingNetworkInterfaces && 'is-spinning')}
+                  onClick={onRefreshNetworkInterfaces}
+                  disabled={refreshingNetworkInterfaces}
+                  aria-label="Refresh network interfaces"
+                  title="Refresh network interfaces"
+                >
+                  <RefreshIcon />
+                </button>
               </div>
-              {pairingUrl ? (
-                <>
-                  <div className="mp-pair-separator" />
-                  <div className="mp-pair-row">
-                    <span className="mp-pair-icon" aria-hidden>
-                      <LinkIcon />
-                    </span>
-                    <span className="mp-pair-label">Pairing URL</span>
-                    <span
-                      className="mp-pair-value"
-                      style={{
-                        maxWidth: 220,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap'
-                      }}
-                    >
-                      {pairingUrl}
-                    </span>
-                  </div>
-                </>
-              ) : null}
+
+              <div className="mp-inline-actions">
+                <span className="mp-action-divider">Can&apos;t scan?</span>
+                <button
+                  type="button"
+                  className="mp-text-link"
+                  onClick={onCopyPairingCode}
+                  disabled={!pairingUrl || pairLoading}
+                >
+                  <CopyIcon />
+                  Copy pairing code
+                </button>
+              </div>
             </div>
-            <div className="mp-pair-settings">
+            <div className="mp-qr-stack">
+              <div className="mp-qr" aria-label="Pairing QR code">
+                {pairQrDataUrl ? <img src={pairQrDataUrl} alt="Pairing QR" /> : null}
+              </div>
               <button
                 type="button"
-                className="mp-pair-action-row"
+                className="mp-link-under"
                 onClick={onRegeneratePairing}
                 disabled={pairLoading}
               >
-                <span className="mp-pair-icon" aria-hidden>
-                  <RotateIcon />
-                </span>
-                <span className="mp-pair-label">
-                  {pairLoading
-                    ? 'Generating…'
-                    : pairQrDataUrl
-                      ? 'Regenerate pairing code'
-                      : 'Generate pairing code'}
-                </span>
-                <span className="mp-pair-meta">Rotates each tap</span>
+                {pairLoading ? 'Generating…' : pairQrDataUrl ? 'Regenerate code' : 'Generate code'}
               </button>
             </div>
           </div>
@@ -185,15 +282,21 @@ export function HeroFlow({
           <ArrowLeftIcon />
           Back
         </button>
-        <button
-          type="button"
-          className={cn('mp-flow-continue', isLast && 'is-hidden')}
-          onClick={onContinue}
-          aria-hidden={isLast}
-        >
-          Continue
-          <ArrowRightIcon />
-        </button>
+        {isLast ? (
+          onDone ? (
+            <button type="button" className="mp-primary-action" onClick={onDone}>
+              Done
+              <ArrowRightIcon />
+            </button>
+          ) : (
+            <span />
+          )
+        ) : (
+          <button type="button" className="mp-flow-continue" onClick={onContinue}>
+            Continue
+            <ArrowRightIcon />
+          </button>
+        )}
       </div>
     </div>
   )
@@ -225,43 +328,32 @@ function CopyIcon(): React.JSX.Element {
   )
 }
 
-function ServerIcon(): React.JSX.Element {
+function PhoneSmallIcon(): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
-      <rect x="2" y="3" width="20" height="14" rx="2" />
-      <line x1="8" y1="21" x2="16" y2="21" />
-      <line x1="12" y1="17" x2="12" y2="21" />
+      <rect x="6" y="3" width="12" height="18" rx="2.5" />
+      <line x1="11" y1="18" x2="13" y2="18" />
     </svg>
   )
 }
 
-function QrIcon(): React.JSX.Element {
+function TrashIcon(): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
-      <rect x="3" y="3" width="7" height="7" rx="1" />
-      <rect x="14" y="3" width="7" height="7" rx="1" />
-      <rect x="3" y="14" width="7" height="7" rx="1" />
-      <path d="M14 14h3v3" />
-      <path d="M21 14v3" />
-      <path d="M14 21h3" />
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="M19 6 18 20a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
     </svg>
   )
 }
 
-function RotateIcon(): React.JSX.Element {
+function RefreshIcon(): React.JSX.Element {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M21 12a9 9 0 1 1-3-6.7" />
       <path d="M21 4v5h-5" />
-    </svg>
-  )
-}
-
-function LinkIcon(): React.JSX.Element {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
-      <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1 1" />
-      <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1-1" />
+      <path d="M3 12a9 9 0 0 0 15 6.7" />
+      <path d="M3 20v-5h5" />
     </svg>
   )
 }

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -65,6 +65,10 @@ export default function MobilePage(): React.JSX.Element {
   const [revokingDeviceIds, setRevokingDeviceIds] = useState<string[]>([])
   const [deviceCountAtPairStart, setDeviceCountAtPairStart] = useState<number | null>(null)
   const hasGeneratedRef = useRef(false)
+  // Tracks the previous stage so we can set the paired-view baseline exactly
+  // once on entry into 'paired', avoiding a polling-stop race when devices
+  // change while already in paired view.
+  const lastStageRef = useRef<FlowStage | null>(null)
   const closeMobilePage = useAppStore((s) => s.closeMobilePage)
 
   const loadDevices = useCallback(async (): Promise<PairedDevice[]> => {
@@ -72,7 +76,10 @@ export default function MobilePage(): React.JSX.Element {
       const result = await window.api.mobile.listDevices()
       setDevices(result.devices)
       return result.devices
-    } catch {
+    } catch (err) {
+      // Log so a transient IPC failure (which routes the user to 'intro') is
+      // observable; keep returning [] so callers' behavior is unchanged.
+      console.error('mobile.listDevices failed', err)
       return []
     }
   }, [])
@@ -95,7 +102,19 @@ export default function MobilePage(): React.JSX.Element {
 
   const revokeDevice = useCallback(
     async (deviceId: string) => {
-      setRevokingDeviceIds((prev) => [...prev, deviceId])
+      // Dedupe rapid double-clicks: if a revoke for this id is already in
+      // flight, bail before issuing a second IPC call.
+      let alreadyRevoking = false
+      setRevokingDeviceIds((prev) => {
+        if (prev.includes(deviceId)) {
+          alreadyRevoking = true
+          return prev
+        }
+        return [...prev, deviceId]
+      })
+      if (alreadyRevoking) {
+        return
+      }
       try {
         await window.api.mobile.revokeDevice({ deviceId })
         const remaining = await loadDevices()
@@ -118,6 +137,9 @@ export default function MobilePage(): React.JSX.Element {
     if (stage !== 'flow') {
       return
     }
+    // Clear the previous QR synchronously so the user never sees a stale
+    // platform's image while the new one is rendering.
+    setInstallQrUrl(null)
     let cancelled = false
     void (async () => {
       try {
@@ -166,13 +188,20 @@ export default function MobilePage(): React.JSX.Element {
     try {
       const result = await window.api.mobile.listNetworkInterfaces()
       setNetworkInterfaces(result.interfaces)
-      setSelectedAddress((current) => selectRefreshedNetworkAddress(current, result.interfaces))
+      // Resolve the new address before committing it so we can detect a real
+      // change and remint the QR — otherwise the QR keeps encoding the stale
+      // endpoint after a network refresh swaps the active interface.
+      const newAddress = selectRefreshedNetworkAddress(selectedAddress, result.interfaces)
+      setSelectedAddress(newAddress)
+      if (newAddress !== selectedAddress && hasGeneratedRef.current) {
+        void generatePairing(true, newAddress)
+      }
     } catch {
       // Network list is non-critical; the QR will still mint with default routing.
     } finally {
       setRefreshingNetworkInterfaces(false)
     }
-  }, [])
+  }, [selectedAddress, generatePairing])
 
   useEffect(() => {
     if (stage !== 'flow') {
@@ -197,7 +226,8 @@ export default function MobilePage(): React.JSX.Element {
     try {
       await window.api.ui.writeClipboardText(pairingUrl)
       toast.success('Pairing code copied')
-    } catch {
+    } catch (err) {
+      console.error('writeClipboardText failed', err)
       toast.error('Failed to copy pairing code')
     }
   }, [pairingUrl])
@@ -238,18 +268,29 @@ export default function MobilePage(): React.JSX.Element {
     }
   }, [stage, devices.length, deviceCountAtPairStart])
 
-  // Why: re-baseline the polling counter whenever the paired view is shown
-  // so any subsequent pair (including ones initiated from a different
-  // surface) triggers a refresh.
+  // Why: set the paired-view polling baseline exactly once on entry into
+  // 'paired'. Re-baselining on every devices.length change opened a small
+  // window where polling stopped then resumed; capturing the count once on
+  // transition lets newly added devices flow through naturally.
   useEffect(() => {
-    if (stage === 'paired') {
+    if (stage === 'paired' && lastStageRef.current !== 'paired') {
       setDeviceCountAtPairStart(devices.length)
     }
-  }, [stage, devices.length])
+    lastStageRef.current = stage
+    // devices.length is intentionally excluded: we want to capture the count
+    // only at the moment of the stage transition, not re-run on every change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stage])
 
   const enterFlow = (): void => {
     setStepIdx(0)
     setDeviceCountAtPairStart(devices.length)
+    // Force the auto-generate effect to mint a fresh pairing token on next
+    // entry into Step 2, and clear stale QR state so we never flash an
+    // expired code from a previous session.
+    hasGeneratedRef.current = false
+    setPairQrDataUrl(null)
+    setPairingUrl(null)
     setStage('flow')
   }
 
@@ -258,6 +299,10 @@ export default function MobilePage(): React.JSX.Element {
   const pairAnotherDevice = (): void => {
     setStepIdx(1)
     setDeviceCountAtPairStart(devices.length)
+    // Same reset as enterFlow — re-entering must mint a fresh pairing offer.
+    hasGeneratedRef.current = false
+    setPairQrDataUrl(null)
+    setPairingUrl(null)
     setStage('flow')
   }
 
@@ -283,7 +328,8 @@ export default function MobilePage(): React.JSX.Element {
     try {
       await window.api.ui.writeClipboardText(PLATFORM_COPY[platform].url)
       toast.success('Install link copied')
-    } catch {
+    } catch (err) {
+      console.error('writeClipboardText failed', err)
       toast.error('Failed to copy link')
     }
   }
@@ -311,8 +357,10 @@ export default function MobilePage(): React.JSX.Element {
       event.preventDefault()
       closeMobilePage()
     }
-    window.addEventListener('keydown', onKeyDown, { capture: true })
-    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+    // Why: bubble phase (no capture) so Radix popovers/selects get a chance
+    // to consume Escape first; the defaultPrevented check below then skips.
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [closeMobilePage])
 
   return (

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -2,9 +2,21 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import QRCodeBrowser from 'qrcode/lib/browser'
 import { toast } from 'sonner'
 import { PhoneCarousel } from './PhoneCarousel'
-import { HeroFlow, HeroIntro, type Platform, type StepIndex } from './MobileHero'
+import {
+  HeroFlow,
+  HeroIntro,
+  HeroPaired,
+  type PairedDevice,
+  type Platform,
+  type StepIndex
+} from './MobileHero'
+import {
+  selectRefreshedNetworkAddress,
+  type MobileNetworkInterface
+} from '../settings/mobile-network-interface-selection'
+import { useMobilePairingDevicePolling } from '../settings/mobile-pairing-device-polling'
 
-type FlowStage = 'intro' | 'flow'
+type FlowStage = 'intro' | 'paired' | 'flow'
 
 async function renderQrDataUrl(text: string): Promise<string> {
   return QRCodeBrowser.toDataURL(text, {
@@ -31,17 +43,69 @@ export const PLATFORM_COPY: Record<
 }
 
 export default function MobilePage(): React.JSX.Element {
-  const [stage, setStage] = useState<FlowStage>('intro')
+  // Why: stage starts unresolved so we don't flash the intro before we know
+  // whether any devices are already paired.
+  const [stage, setStage] = useState<FlowStage | null>(null)
   const [stepIdx, setStepIdx] = useState<StepIndex>(0)
 
   const [platform, setPlatform] = useState<Platform>('ios')
   const [installQrUrl, setInstallQrUrl] = useState<string | null>(null)
 
   const [pairQrDataUrl, setPairQrDataUrl] = useState<string | null>(null)
-  const [pairEndpoint, setPairEndpoint] = useState<string | null>(null)
   const [pairingUrl, setPairingUrl] = useState<string | null>(null)
   const [pairLoading, setPairLoading] = useState(false)
+  const [networkInterfaces, setNetworkInterfaces] = useState<MobileNetworkInterface[]>([])
+  const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined)
+  const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
+  const [devices, setDevices] = useState<PairedDevice[]>([])
+  const [revokingDeviceIds, setRevokingDeviceIds] = useState<string[]>([])
+  const [deviceCountAtPairStart, setDeviceCountAtPairStart] = useState<number | null>(null)
   const hasGeneratedRef = useRef(false)
+
+  const loadDevices = useCallback(async (): Promise<PairedDevice[]> => {
+    try {
+      const result = await window.api.mobile.listDevices()
+      setDevices(result.devices)
+      return result.devices
+    } catch {
+      return []
+    }
+  }, [])
+
+  // Why: pick the initial stage based on whether any devices are already
+  // paired so returning users don't see the marketing intro every time.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      const initialDevices = await loadDevices()
+      if (cancelled) {
+        return
+      }
+      setStage(initialDevices.length > 0 ? 'paired' : 'intro')
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [loadDevices])
+
+  const revokeDevice = useCallback(
+    async (deviceId: string) => {
+      setRevokingDeviceIds((prev) => [...prev, deviceId])
+      try {
+        await window.api.mobile.revokeDevice({ deviceId })
+        const remaining = await loadDevices()
+        toast.success('Device revoked')
+        if (remaining.length === 0) {
+          setStage('intro')
+        }
+      } catch {
+        toast.error('Failed to revoke device')
+      } finally {
+        setRevokingDeviceIds((prev) => prev.filter((id) => id !== deviceId))
+      }
+    },
+    [loadDevices]
+  )
 
   // Why: render install QRs lazily — only after the user enters the flow,
   // and re-render whenever the platform changes.
@@ -67,24 +131,71 @@ export default function MobilePage(): React.JSX.Element {
     }
   }, [platform, stage])
 
-  const generatePairing = useCallback(async (rotate: boolean) => {
-    setPairLoading(true)
-    try {
-      const result = await window.api.mobile.getPairingQR(rotate ? { rotate: true } : {})
-      if (result.available) {
-        setPairQrDataUrl(result.qrDataUrl)
-        setPairEndpoint(result.endpoint)
-        setPairingUrl(result.pairingUrl)
-        hasGeneratedRef.current = true
-      } else {
-        toast.error('WebSocket transport is not running')
+  const generatePairing = useCallback(
+    async (rotate: boolean, addressOverride?: string) => {
+      setPairLoading(true)
+      try {
+        const address = addressOverride ?? selectedAddress
+        const result = await window.api.mobile.getPairingQR({
+          ...(address ? { address } : {}),
+          ...(rotate ? { rotate: true } : {})
+        })
+        if (result.available) {
+          setPairQrDataUrl(result.qrDataUrl)
+          setPairingUrl(result.pairingUrl)
+          hasGeneratedRef.current = true
+        } else {
+          toast.error('WebSocket transport is not running')
+        }
+      } catch {
+        toast.error('Failed to generate pairing code')
+      } finally {
+        setPairLoading(false)
       }
+    },
+    [selectedAddress]
+  )
+
+  const loadNetworkInterfaces = useCallback(async () => {
+    setRefreshingNetworkInterfaces(true)
+    try {
+      const result = await window.api.mobile.listNetworkInterfaces()
+      setNetworkInterfaces(result.interfaces)
+      setSelectedAddress((current) => selectRefreshedNetworkAddress(current, result.interfaces))
     } catch {
-      toast.error('Failed to generate pairing code')
+      // Network list is non-critical; the QR will still mint with default routing.
     } finally {
-      setPairLoading(false)
+      setRefreshingNetworkInterfaces(false)
     }
   }, [])
+
+  useEffect(() => {
+    if (stage !== 'flow') {
+      return
+    }
+    void loadNetworkInterfaces()
+  }, [stage, loadNetworkInterfaces])
+
+  const handleAddressChange = useCallback(
+    (address: string) => {
+      setSelectedAddress(address)
+      // Switching network must remint so the QR encodes the new endpoint.
+      void generatePairing(true, address)
+    },
+    [generatePairing]
+  )
+
+  const copyPairingCode = useCallback(async () => {
+    if (!pairingUrl) {
+      return
+    }
+    try {
+      await window.api.ui.writeClipboardText(pairingUrl)
+      toast.success('Pairing code copied')
+    } catch {
+      toast.error('Failed to copy pairing code')
+    }
+  }, [pairingUrl])
 
   // Why: when Step 2 first becomes visible, mint a pairing offer so the
   // user sees a real QR immediately. Subsequent visits keep the existing
@@ -96,8 +207,52 @@ export default function MobilePage(): React.JSX.Element {
     void generatePairing(false)
   }, [stage, stepIdx, generatePairing])
 
+  // Why: poll for new pairings while the user is on Step 2 so we can
+  // auto-transition to the paired summary the moment their phone connects.
+  const polledLoadDevices = useCallback(async () => {
+    await loadDevices()
+  }, [loadDevices])
+
+  // Why: poll for new pairings on Step 2 (waiting for the first pair) and
+  // also on the paired view (so additional phones that finish pairing while
+  // the user is reading the list show up without a manual refresh).
+  useMobilePairingDevicePolling({
+    deviceCountAtQr:
+      (stage === 'flow' && stepIdx === 1) || stage === 'paired' ? deviceCountAtPairStart : null,
+    currentDeviceCount: devices.length,
+    loadDevices: polledLoadDevices
+  })
+
+  useEffect(() => {
+    if (
+      stage === 'flow' &&
+      deviceCountAtPairStart !== null &&
+      devices.length > deviceCountAtPairStart
+    ) {
+      setStage('paired')
+    }
+  }, [stage, devices.length, deviceCountAtPairStart])
+
+  // Why: re-baseline the polling counter whenever the paired view is shown
+  // so any subsequent pair (including ones initiated from a different
+  // surface) triggers a refresh.
+  useEffect(() => {
+    if (stage === 'paired') {
+      setDeviceCountAtPairStart(devices.length)
+    }
+  }, [stage, devices.length])
+
   const enterFlow = (): void => {
     setStepIdx(0)
+    setDeviceCountAtPairStart(devices.length)
+    setStage('flow')
+  }
+
+  // Why: from the paired summary, "Pair another device" jumps straight to
+  // Step 2 since the app is presumably already installed on the user's phone.
+  const pairAnotherDevice = (): void => {
+    setStepIdx(1)
+    setDeviceCountAtPairStart(devices.length)
     setStage('flow')
   }
 
@@ -132,8 +287,15 @@ export default function MobilePage(): React.JSX.Element {
     <div className="mobile-page-root">
       <section className="mp-hero">
         <div className="mp-hero-copy">
-          {stage === 'intro' ? (
+          {stage === null ? null : stage === 'intro' ? (
             <HeroIntro onStart={enterFlow} />
+          ) : stage === 'paired' ? (
+            <HeroPaired
+              devices={devices}
+              onPairAnother={pairAnotherDevice}
+              onRevoke={(id) => void revokeDevice(id)}
+              revokingDeviceIds={revokingDeviceIds}
+            />
           ) : (
             <HeroFlow
               stepIdx={stepIdx}
@@ -144,12 +306,18 @@ export default function MobilePage(): React.JSX.Element {
               onOpenInstallUrl={openInstallUrl}
               onCopyInstallUrl={() => void copyInstallUrl()}
               pairQrDataUrl={pairQrDataUrl}
-              pairEndpoint={pairEndpoint}
               pairingUrl={pairingUrl}
               pairLoading={pairLoading}
               onRegeneratePairing={() => void generatePairing(true)}
+              onCopyPairingCode={() => void copyPairingCode()}
+              networkInterfaces={networkInterfaces}
+              selectedAddress={selectedAddress}
+              onSelectedAddressChange={handleAddressChange}
+              onRefreshNetworkInterfaces={() => void loadNetworkInterfaces()}
+              refreshingNetworkInterfaces={refreshingNetworkInterfaces}
               onBack={handleBack}
               onContinue={handleContinue}
+              onDone={devices.length > 0 ? () => setStage('paired') : undefined}
             />
           )}
         </div>

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import QRCodeBrowser from 'qrcode/lib/browser'
 import { toast } from 'sonner'
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '@/store'
 import { PhoneCarousel } from './PhoneCarousel'
 import {
   HeroFlow,
@@ -61,6 +65,7 @@ export default function MobilePage(): React.JSX.Element {
   const [revokingDeviceIds, setRevokingDeviceIds] = useState<string[]>([])
   const [deviceCountAtPairStart, setDeviceCountAtPairStart] = useState<number | null>(null)
   const hasGeneratedRef = useRef(false)
+  const closeMobilePage = useAppStore((s) => s.closeMobilePage)
 
   const loadDevices = useCallback(async (): Promise<PairedDevice[]> => {
     try {
@@ -283,8 +288,53 @@ export default function MobilePage(): React.JSX.Element {
     }
   }
 
+  // Why: mirror Automations/Tasks — Esc first exits field focus, then closes the page.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key !== 'Escape' || event.defaultPrevented) {
+        return
+      }
+      const target = event.target
+      if (!(target instanceof HTMLElement)) {
+        return
+      }
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.isContentEditable
+      ) {
+        event.preventDefault()
+        target.blur()
+        return
+      }
+      event.preventDefault()
+      closeMobilePage()
+    }
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
+  }, [closeMobilePage])
+
   return (
     <div className="mobile-page-root">
+      <div className="mp-close-button">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 rounded-full"
+              onClick={closeMobilePage}
+              aria-label="Close Orca Mobile"
+            >
+              <X className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            Close · Esc
+          </TooltipContent>
+        </Tooltip>
+      </div>
       <section className="mp-hero">
         <div className="mp-hero-copy">
           {stage === null ? null : stage === 'intro' ? (

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import QRCodeBrowser from 'qrcode/lib/browser'
+import { toast } from 'sonner'
+import { PhoneCarousel } from './PhoneCarousel'
+import { HeroFlow, HeroIntro, type Platform, type StepIndex } from './MobileHero'
+
+type FlowStage = 'intro' | 'flow'
+
+async function renderQrDataUrl(text: string): Promise<string> {
+  return QRCodeBrowser.toDataURL(text, {
+    errorCorrectionLevel: 'M',
+    margin: 2,
+    width: 232
+  })
+}
+
+export const PLATFORM_COPY: Record<
+  Platform,
+  { description: string; ctaLabel: string; url: string }
+> = {
+  ios: {
+    description: 'Scan with your iPhone camera to open the App Store.',
+    ctaLabel: 'Open App Store',
+    url: 'https://apps.apple.com/app/orca-ide/id6766130217'
+  },
+  android: {
+    description: 'Scan with your Android camera to download the latest APK from GitHub Releases.',
+    ctaLabel: 'Download APK',
+    url: 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.8'
+  }
+}
+
+export default function MobilePage(): React.JSX.Element {
+  const [stage, setStage] = useState<FlowStage>('intro')
+  const [stepIdx, setStepIdx] = useState<StepIndex>(0)
+
+  const [platform, setPlatform] = useState<Platform>('ios')
+  const [installQrUrl, setInstallQrUrl] = useState<string | null>(null)
+
+  const [pairQrDataUrl, setPairQrDataUrl] = useState<string | null>(null)
+  const [pairEndpoint, setPairEndpoint] = useState<string | null>(null)
+  const [pairingUrl, setPairingUrl] = useState<string | null>(null)
+  const [pairLoading, setPairLoading] = useState(false)
+  const hasGeneratedRef = useRef(false)
+
+  // Why: render install QRs lazily — only after the user enters the flow,
+  // and re-render whenever the platform changes.
+  useEffect(() => {
+    if (stage !== 'flow') {
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const dataUrl = await renderQrDataUrl(PLATFORM_COPY[platform].url)
+        if (!cancelled) {
+          setInstallQrUrl(dataUrl)
+        }
+      } catch {
+        if (!cancelled) {
+          setInstallQrUrl(null)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [platform, stage])
+
+  const generatePairing = useCallback(async (rotate: boolean) => {
+    setPairLoading(true)
+    try {
+      const result = await window.api.mobile.getPairingQR(rotate ? { rotate: true } : {})
+      if (result.available) {
+        setPairQrDataUrl(result.qrDataUrl)
+        setPairEndpoint(result.endpoint)
+        setPairingUrl(result.pairingUrl)
+        hasGeneratedRef.current = true
+      } else {
+        toast.error('WebSocket transport is not running')
+      }
+    } catch {
+      toast.error('Failed to generate pairing code')
+    } finally {
+      setPairLoading(false)
+    }
+  }, [])
+
+  // Why: when Step 2 first becomes visible, mint a pairing offer so the
+  // user sees a real QR immediately. Subsequent visits keep the existing
+  // token unless they hit Regenerate.
+  useEffect(() => {
+    if (stage !== 'flow' || stepIdx !== 1 || hasGeneratedRef.current) {
+      return
+    }
+    void generatePairing(false)
+  }, [stage, stepIdx, generatePairing])
+
+  const enterFlow = (): void => {
+    setStepIdx(0)
+    setStage('flow')
+  }
+
+  const handleBack = (): void => {
+    if (stepIdx === 1) {
+      setStepIdx(0)
+    } else {
+      setStage('intro')
+    }
+  }
+
+  const handleContinue = (): void => {
+    if (stepIdx === 0) {
+      setStepIdx(1)
+    }
+  }
+
+  const openInstallUrl = (): void => {
+    void window.api.shell.openUrl(PLATFORM_COPY[platform].url)
+  }
+
+  const copyInstallUrl = async (): Promise<void> => {
+    try {
+      await window.api.ui.writeClipboardText(PLATFORM_COPY[platform].url)
+      toast.success('Install link copied')
+    } catch {
+      toast.error('Failed to copy link')
+    }
+  }
+
+  return (
+    <div className="mobile-page-root">
+      <section className="mp-hero">
+        <div className="mp-hero-copy">
+          {stage === 'intro' ? (
+            <HeroIntro onStart={enterFlow} />
+          ) : (
+            <HeroFlow
+              stepIdx={stepIdx}
+              platform={platform}
+              onPlatformChange={setPlatform}
+              installQrUrl={installQrUrl}
+              installCopy={PLATFORM_COPY[platform]}
+              onOpenInstallUrl={openInstallUrl}
+              onCopyInstallUrl={() => void copyInstallUrl()}
+              pairQrDataUrl={pairQrDataUrl}
+              pairEndpoint={pairEndpoint}
+              pairingUrl={pairingUrl}
+              pairLoading={pairLoading}
+              onRegeneratePairing={() => void generatePairing(true)}
+              onBack={handleBack}
+              onContinue={handleContinue}
+            />
+          )}
+        </div>
+
+        <div className="mp-stage" aria-label="Phone preview">
+          <PhoneCarousel />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/renderer/src/components/mobile/PhoneCarousel.tsx
+++ b/src/renderer/src/components/mobile/PhoneCarousel.tsx
@@ -4,7 +4,7 @@ import { HomeSlide } from './slides/HomeSlide'
 import { WorktreeListSlide } from './slides/WorktreeListSlide'
 import { TerminalSlide } from './slides/TerminalSlide'
 
-const DWELL_MS = 3000
+const DWELL_MS = 4500
 const TAP_BEFORE_PUSH_MS = 240
 const SLIDE_TRANSITION_MS = 320
 

--- a/src/renderer/src/components/mobile/PhoneCarousel.tsx
+++ b/src/renderer/src/components/mobile/PhoneCarousel.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '../../lib/utils'
+import { HomeSlide } from './slides/HomeSlide'
+import { WorktreeListSlide } from './slides/WorktreeListSlide'
+import { TerminalSlide } from './slides/TerminalSlide'
+
+const DWELL_MS = 3000
+const TAP_BEFORE_PUSH_MS = 240
+const SLIDE_TRANSITION_MS = 320
+
+type Phase = 'normal' | 'reset'
+
+export function PhoneCarousel(): React.JSX.Element {
+  const [activeIdx, setActiveIdx] = useState(0)
+  const [phase, setPhase] = useState<Phase>('normal')
+  const [tappingSlide, setTappingSlide] = useState<number | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduce) {
+      return
+    }
+
+    let cancelled = false
+    let dwellTimer: ReturnType<typeof setTimeout> | null = null
+    let tapTimer: ReturnType<typeof setTimeout> | null = null
+    let resetTimer: ReturnType<typeof setTimeout> | null = null
+
+    const schedule = (idx: number): void => {
+      dwellTimer = setTimeout(() => {
+        if (cancelled) {
+          return
+        }
+        // Pulse the tap target on the current slide, then advance.
+        if (idx < 2) {
+          setTappingSlide(idx)
+          tapTimer = setTimeout(() => {
+            if (cancelled) {
+              return
+            }
+            setTappingSlide(null)
+          }, 320)
+          setTimeout(() => {
+            if (cancelled) {
+              return
+            }
+            const next = idx + 1
+            setActiveIdx(next)
+            schedule(next)
+          }, TAP_BEFORE_PUSH_MS)
+        } else {
+          // Hard cut back to home — snap with no transition, then re-enable.
+          setPhase('reset')
+          setActiveIdx(0)
+          resetTimer = setTimeout(() => {
+            if (cancelled) {
+              return
+            }
+            setPhase('normal')
+            schedule(0)
+          }, 30)
+        }
+      }, DWELL_MS)
+    }
+
+    schedule(0)
+
+    const onVisibility = (): void => {
+      if (document.hidden && dwellTimer) {
+        clearTimeout(dwellTimer)
+        dwellTimer = null
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      cancelled = true
+      if (dwellTimer) {
+        clearTimeout(dwellTimer)
+      }
+      if (tapTimer) {
+        clearTimeout(tapTimer)
+      }
+      if (resetTimer) {
+        clearTimeout(resetTimer)
+      }
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [])
+
+  // Why: while the slide reset is in progress we want all slides to snap
+  // back to their off-stage positions with no transition; the next render
+  // tick removes is-reset so the subsequent push animates again.
+  useEffect(() => {
+    if (phase !== 'reset') {
+      return
+    }
+    const id = requestAnimationFrame(() => {
+      // force layout so the no-transition state takes effect before
+      // transitions are re-enabled
+      void containerRef.current?.offsetHeight
+    })
+    return () => cancelAnimationFrame(id)
+  }, [phase])
+
+  const slideClass = (idx: number): string =>
+    cn(
+      'mp-screen-slide',
+      phase === 'reset' && 'is-reset',
+      idx === activeIdx && 'is-active',
+      idx < activeIdx && 'is-past'
+    )
+
+  return (
+    <div className="mp-phone-frame">
+      <div className="mp-phone-screen" ref={containerRef}>
+        <div className={slideClass(0)} role="img" aria-label="Orca Mobile home screen">
+          <HomeSlide tapping={tappingSlide === 0} />
+        </div>
+        <div className={slideClass(1)} role="img" aria-label="Worktree list">
+          <WorktreeListSlide tapping={tappingSlide === 1} />
+        </div>
+        <div className={slideClass(2)} role="img" aria-label="Terminal session">
+          <TerminalSlide />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Re-export for convenience so consumers can import slide-transition
+// timing in tests.
+export const _slideTimings = {
+  DWELL_MS,
+  TAP_BEFORE_PUSH_MS,
+  SLIDE_TRANSITION_MS
+}

--- a/src/renderer/src/components/mobile/PhoneCarousel.tsx
+++ b/src/renderer/src/components/mobile/PhoneCarousel.tsx
@@ -6,7 +6,6 @@ import { TerminalSlide } from './slides/TerminalSlide'
 
 const DWELL_MS = 4500
 const TAP_BEFORE_PUSH_MS = 240
-const SLIDE_TRANSITION_MS = 320
 
 type Phase = 'normal' | 'reset'
 
@@ -28,6 +27,7 @@ export function PhoneCarousel(): React.JSX.Element {
     let cancelled = false
     let dwellTimer: ReturnType<typeof setTimeout> | null = null
     let tapTimer: ReturnType<typeof setTimeout> | null = null
+    let advanceTimer: ReturnType<typeof setTimeout> | null = null
     let resetTimer: ReturnType<typeof setTimeout> | null = null
 
     const schedule = (idx: number): void => {
@@ -44,7 +44,7 @@ export function PhoneCarousel(): React.JSX.Element {
             }
             setTappingSlide(null)
           }, 320)
-          setTimeout(() => {
+          advanceTimer = setTimeout(() => {
             if (cancelled) {
               return
             }
@@ -69,14 +69,6 @@ export function PhoneCarousel(): React.JSX.Element {
 
     schedule(0)
 
-    const onVisibility = (): void => {
-      if (document.hidden && dwellTimer) {
-        clearTimeout(dwellTimer)
-        dwellTimer = null
-      }
-    }
-    document.addEventListener('visibilitychange', onVisibility)
-
     return () => {
       cancelled = true
       if (dwellTimer) {
@@ -85,10 +77,12 @@ export function PhoneCarousel(): React.JSX.Element {
       if (tapTimer) {
         clearTimeout(tapTimer)
       }
+      if (advanceTimer) {
+        clearTimeout(advanceTimer)
+      }
       if (resetTimer) {
         clearTimeout(resetTimer)
       }
-      document.removeEventListener('visibilitychange', onVisibility)
     }
   }, [])
 
@@ -130,12 +124,4 @@ export function PhoneCarousel(): React.JSX.Element {
       </div>
     </div>
   )
-}
-
-// Re-export for convenience so consumers can import slide-transition
-// timing in tests.
-export const _slideTimings = {
-  DWELL_MS,
-  TAP_BEFORE_PUSH_MS,
-  SLIDE_TRANSITION_MS
 }

--- a/src/renderer/src/components/mobile/slides/HomeSlide.tsx
+++ b/src/renderer/src/components/mobile/slides/HomeSlide.tsx
@@ -85,11 +85,14 @@ export function HomeSlide({ tapping }: { tapping: boolean }): React.JSX.Element 
           </div>
           <div className="mp-host-main">
             <div className="mp-task-home-title">Tasks</div>
-            <div className="mp-task-home-subtitle">GitHub</div>
+            <div className="mp-task-home-subtitle">GitHub · Linear</div>
           </div>
-          <div className="mp-task-home-providers" aria-label="GitHub">
+          <div className="mp-task-home-providers" aria-label="GitHub and Linear">
             <div className="mp-task-home-provider-button">
               <GithubIcon />
+            </div>
+            <div className="mp-task-home-provider-button">
+              <LinearIcon />
             </div>
           </div>
           <div className="mp-chevron-right">
@@ -245,6 +248,14 @@ function GithubIcon(): React.JSX.Element {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
       <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
       <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  )
+}
+
+function LinearIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 100 100" fill="currentColor" aria-hidden>
+      <path d="M1.225 61.523c-.187-.738.708-1.235 1.246-.697l36.703 36.703c.538.538.041 1.433-.697 1.246C20.6 94.16 5.84 79.4 1.225 61.523ZM.002 46.811a.997.997 0 0 0 .291.749l52.147 52.147a.998.998 0 0 0 .749.291 50.328 50.328 0 0 0 9.235-1.119c.667-.149.904-.972.422-1.454L1.575 37.154c-.482-.482-1.305-.245-1.454.422A50.328 50.328 0 0 0 .002 46.81Zm4.528-18.34a.998.998 0 0 0 .195 1.144l64.66 64.66a.998.998 0 0 0 1.144.195 50.45 50.45 0 0 0 5.913-3.46.999.999 0 0 0 .14-1.518L9.51 22.418a.999.999 0 0 0-1.518.14 50.45 50.45 0 0 0-3.46 5.913Zm10.435-13.075a.999.999 0 0 0 .002 1.41l68.226 68.226a.999.999 0 0 0 1.41.002c19.292-19.477 19.234-50.97-.176-70.378-19.410-19.410-50.901-19.468-70.378-.176-1.061 1.044.916 1.916.916 1.916Z" />
     </svg>
   )
 }

--- a/src/renderer/src/components/mobile/slides/HomeSlide.tsx
+++ b/src/renderer/src/components/mobile/slides/HomeSlide.tsx
@@ -1,0 +1,273 @@
+import { ClaudeIcon, OpenAIIcon } from '../../status-bar/icons'
+import { cn } from '../../../lib/utils'
+
+export function HomeSlide({ tapping }: { tapping: boolean }): React.JSX.Element {
+  return (
+    <div className="mp-device-screen">
+      <div className="mp-app-topbar">
+        <div className="mp-app-brand">
+          <OrcaLogo />
+          <span className="mp-app-brand-name">Orca</span>
+        </div>
+        <button type="button" className="mp-icon-button" aria-label="Settings">
+          <SettingsIcon />
+        </button>
+      </div>
+
+      <div className="mp-scroll-region">
+        <div className="mp-greeting">
+          <div className="mp-greeting-title">Welcome back</div>
+        </div>
+
+        <div className="mp-stat-row">
+          <Stat value="1,284" label="Agents spawned" />
+          <Stat value="142h" label="Agent time" />
+          <Stat value="96" label="PRs created" />
+        </div>
+
+        <div className="mp-section-label">Desktops</div>
+        <div className={cn('mp-host-card', tapping && 'is-tapping')}>
+          <div className="mp-host-icon">
+            <DesktopIcon />
+          </div>
+          <div className="mp-host-main">
+            <div className="mp-host-name">MacBook Pro</div>
+            <div className="mp-host-meta">
+              <span className="mp-status-dot is-green" />
+              <span>Connected · 40 worktrees · 5 active</span>
+            </div>
+          </div>
+          <div className="mp-chevron-right">
+            <ChevronIcon />
+          </div>
+        </div>
+        <div className="mp-host-card">
+          <div className="mp-host-icon is-dim">
+            <DesktopIcon />
+          </div>
+          <div className="mp-host-main">
+            <div className="mp-host-name is-dim">M1 Mini · home</div>
+            <div className="mp-host-meta">
+              <span className="mp-status-dot is-muted" />
+              <span>Disconnected</span>
+            </div>
+          </div>
+          <div className="mp-chevron-right">
+            <ChevronIcon />
+          </div>
+        </div>
+
+        <div className="mp-section-label" style={{ marginTop: 14 }}>
+          Resume
+        </div>
+        <div className="mp-resume-card">
+          <div className="mp-resume-icon">
+            <ResumeIcon />
+          </div>
+          <div className="mp-host-main">
+            <div className="mp-resume-title">feat/mobile-page</div>
+            <div className="mp-resume-sub">
+              <span className="mp-repo-dot" style={{ background: '#3b82f6' }} />
+              <span>orca&nbsp;&nbsp;·&nbsp;&nbsp;feat/mobile-page</span>
+            </div>
+          </div>
+          <div className="mp-chevron-right">
+            <ChevronIcon />
+          </div>
+        </div>
+
+        <div className="mp-section-label" style={{ marginTop: 10 }}>
+          Tasks
+        </div>
+        <div className="mp-task-home-card">
+          <div className="mp-task-home-icon">
+            <ListTodoIcon />
+          </div>
+          <div className="mp-host-main">
+            <div className="mp-task-home-title">Tasks</div>
+            <div className="mp-task-home-subtitle">GitHub</div>
+          </div>
+          <div className="mp-task-home-providers" aria-label="GitHub">
+            <div className="mp-task-home-provider-button">
+              <GithubIcon />
+            </div>
+          </div>
+          <div className="mp-chevron-right">
+            <ChevronIcon />
+          </div>
+        </div>
+
+        <div className="mp-section-label" style={{ marginTop: 14 }}>
+          Quick Actions
+        </div>
+        <div className="mp-quick-actions">
+          <div className="mp-quick-action">
+            <div className="mp-quick-action-icon">
+              <QrSmallIcon />
+            </div>
+            <div className="mp-quick-action-label">Pair Desktop</div>
+          </div>
+          <div className="mp-quick-action">
+            <div className="mp-quick-action-icon">
+              <PlusIcon />
+            </div>
+            <div className="mp-quick-action-label">New Workspace</div>
+          </div>
+        </div>
+
+        <div className="mp-section-label" style={{ marginTop: 14 }}>
+          Account usage
+        </div>
+        <div className="mp-accounts-card">
+          <AccountRow
+            icon={<ClaudeIcon size={18} />}
+            email="claude@stably.ai"
+            sessionPct={42}
+            weekPct={18}
+          />
+          <AccountRow
+            icon={<OpenAIIcon size={18} />}
+            email="codex@stably.ai"
+            sessionPct={67}
+            weekPct={31}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Stat({ value, label }: { value: string; label: string }): React.JSX.Element {
+  return (
+    <div className="mp-stat-card">
+      <div className="mp-stat-value">{value}</div>
+      <div className="mp-stat-label">{label}</div>
+    </div>
+  )
+}
+
+function AccountRow({
+  icon,
+  email,
+  sessionPct,
+  weekPct
+}: {
+  icon: React.ReactNode
+  email: string
+  sessionPct: number
+  weekPct: number
+}): React.JSX.Element {
+  return (
+    <div className="mp-accounts-row">
+      <div className="mp-accounts-icon">{icon}</div>
+      <div className="mp-accounts-info">
+        <div className="mp-accounts-email">{email}</div>
+        <div className="mp-accounts-bars">
+          <UsageBar label="5h" pct={sessionPct} />
+          <UsageBar label="7d" pct={weekPct} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function UsageBar({ label, pct }: { label: string; pct: number }): React.JSX.Element {
+  return (
+    <div className="mp-usage-bar">
+      <div className="mp-usage-bar-label">{label}</div>
+      <div className="mp-usage-bar-track">
+        <div className="mp-usage-bar-fill" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  )
+}
+
+function OrcaLogo(): React.JSX.Element {
+  return (
+    <svg className="mp-orca-logo" viewBox="0 0 318.60232 202.66667" fill="currentColor" aria-hidden>
+      <g transform="translate(-6.6666669,-70.666669)">
+        <path d="m 177.81311,248.33334 c 23.82304,-41.29793 40.54045,-66.84626 49.51207,-75.66667 6.81685,-6.70196 10.07373,-8.7374 20.07265,-12.54475 34.57822,-13.16655 61.04674,-26.78733 72.37222,-37.24295 9.62924,-8.88966 9.34286,-9.01142 -23.43671,-9.964 -35.71756,-1.03796 -43.72989,0.42119 -62.17546,11.323 -16.72118,9.88265 -34.20103,30.11225 -42.74704,49.47157 -2.57353,5.82985 -14.81294,44.3056 -27.96399,87.90747 -2.86036,9.48343 -3.02466,11.71633 -0.86213,11.71633 0.44382,0 7.29659,-11.25 15.22839,-25 z m -65.14644,-8.32267 C 120,239.3326 130.5,237.50979 136,235.95998 c 5.5,-1.5498 12.25,-3.13783 15,-3.52895 2.75,-0.39111 5,-0.95485 5,-1.25275 0,-0.29789 2.15135,-7.58487 4.78078,-16.19328 8.49209,-27.80201 12.21334,-40.41629 21.13747,-71.65166 4.81891,-16.86667 11.23502,-39.185 14.25802,-49.596301 5.12803,-17.66103 5.74763,-23.07037 2.64253,-23.07037 -1.84887,0 -4.07048,6.908293 -16.72243,52.000001 -21.78975,77.65896 -20.80806,74.74393 -26.84794,79.72251 -7.5925,6.25838 -25.03916,14.82524 -36.10856,17.73044 -17.0947,4.48656 -33.410599,3.86724 -53.116765,-2.01622 -18.569242,-5.54403 -23.142662,-5.80284 -33.639754,-1.9037 -5.875424,2.18242 -9.864152,5.04363 -16.716684,11.99127 -4.95,5.0187 -9.0000001,10.02884 -9.0000001,11.13364 0,1.75174 5.9276921,2.00299 46.3333351,1.96383 25.483334,-0.0247 52.333338,-0.59969 59.666668,-1.27777 z M 252.69513,104.63708 c 12.18267,-3.48651 15.77304,-7.895503 9.63821,-11.835773 -10.19296,-6.546726 -36.19849,-1.77301 -41.19436,7.561863 -1.2556,2.3461 -0.98698,3.2037 1.68353,5.375 2.69471,2.19098 4.59991,2.47691 12.53928,1.88189 5.14899,-0.3859 12.94899,-1.72824 17.33334,-2.98298 z" />
+      </g>
+    </svg>
+  )
+}
+
+function SettingsIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
+    </svg>
+  )
+}
+
+function DesktopIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8" />
+      <path d="M12 17v4" />
+    </svg>
+  )
+}
+
+function ChevronIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  )
+}
+
+function ResumeIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="m4 17 6-6-6-6" />
+      <path d="M12 19h8" />
+    </svg>
+  )
+}
+
+function ListTodoIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="3" y="5" width="6" height="6" rx="1" />
+      <path d="m3 17 2 2 4-4" />
+      <path d="M13 6h8" />
+      <path d="M13 12h8" />
+      <path d="M13 18h8" />
+    </svg>
+  )
+}
+
+function GithubIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  )
+}
+
+function QrSmallIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="3" height="3" />
+      <rect x="18" y="14" width="3" height="3" />
+      <rect x="14" y="18" width="3" height="3" />
+      <rect x="18" y="18" width="3" height="3" />
+    </svg>
+  )
+}
+
+function PlusIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M5 12h14" />
+      <path d="M12 5v14" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/mobile/slides/TerminalSlide.tsx
+++ b/src/renderer/src/components/mobile/slides/TerminalSlide.tsx
@@ -1,0 +1,210 @@
+export function TerminalSlide(): React.JSX.Element {
+  return (
+    <div className="mp-device-screen">
+      <div className="mp-session-chrome">
+        <div className="mp-session-topbar">
+          <button type="button" className="mp-session-back" aria-label="Back">
+            <ChevronLeftIcon />
+          </button>
+          <div className="mp-session-title-block">
+            <div className="mp-session-title">feat/mobile-page</div>
+            <div className="mp-session-meta-row">
+              <span className="mp-status-dot is-green" />
+              <span>2 terminals · claude active</span>
+            </div>
+          </div>
+          <button type="button" className="mp-session-iconbtn" aria-label="Source control">
+            <BranchIcon />
+          </button>
+          <button type="button" className="mp-session-iconbtn" aria-label="Files">
+            <FolderIcon />
+          </button>
+        </div>
+
+        <div className="mp-session-tabbar">
+          <div className="mp-session-tab is-active">claude</div>
+          <div className="mp-session-tab">
+            <span>shell</span>
+          </div>
+          <div className="mp-session-tab">
+            <FileIcon />
+            <span>PLAN.md</span>
+          </div>
+          <div className="mp-session-tab-add">
+            <PlusIcon />
+          </div>
+        </div>
+      </div>
+
+      <div className="mp-terminal">
+        <span className="mp-term-line">
+          <span className="mp-term-prompt">dev@mac</span>{' '}
+          <span className="mp-term-dim">orca/feat-mobile-page</span>{' '}
+          <span className="mp-term-prompt">$</span> <span className="mp-term-cmd">claude</span>
+        </span>
+        <span className="mp-term-line" />
+        <span className="mp-term-line">
+          <span className="mp-term-tool">●</span> <span className="mp-term-mid">Read</span>{' '}
+          <span className="mp-term-dim">mobile/orca-mobile-sidebar-mock-v3.html</span>
+        </span>
+        <span className="mp-term-line">
+          {'  '}
+          <span className="mp-term-comment">⎿ Read 2103 lines</span>
+        </span>
+        <span className="mp-term-line" />
+        <span className="mp-term-line">
+          <span className="mp-term-tool">●</span> <span className="mp-term-mid">Edit</span>{' '}
+          <span className="mp-term-dim">mobile/orca-mobile-sidebar-mock-v3.html</span>
+        </span>
+        <span className="mp-term-line">
+          {'  '}
+          <span className="mp-term-comment">⎿ Replaced pair-scan slide with terminal session</span>
+        </span>
+        <span className="mp-term-line" />
+        <span className="mp-term-line">
+          <span className="mp-term-tool">●</span> <span className="mp-term-mid">Bash</span>{' '}
+          <span className="mp-term-dim">pnpm test --filter mobile</span>
+        </span>
+        <span className="mp-term-line">
+          {'  '}
+          <span className="mp-term-comment">⎿ </span>
+          <span className="mp-term-ok">PASS</span>
+          <span className="mp-term-comment"> src/transport/host-store.test.ts</span>
+        </span>
+        <span className="mp-term-line">
+          {'     '}
+          <span className="mp-term-ok">PASS</span>
+          <span className="mp-term-comment"> src/cache/worktree-cache.test.ts</span>
+        </span>
+        <span className="mp-term-line">
+          {'     '}
+          <span className="mp-term-warn">●</span>
+          <span className="mp-term-comment"> 14 passed, 1 skipped (1.8s)</span>
+        </span>
+        <span className="mp-term-line" />
+        <span className="mp-term-line">
+          <span className="mp-term-mid">
+            I&apos;ve replaced the pair-scan slide with a high-fidelity
+          </span>
+        </span>
+        <span className="mp-term-line">
+          <span className="mp-term-mid">
+            terminal screen. Tokyonight palette, Menlo, real claude
+          </span>
+        </span>
+        <span className="mp-term-line">
+          <span className="mp-term-mid">tool-call formatting. Want me to add the diff next?</span>
+        </span>
+        <span className="mp-term-line" />
+        <span className="mp-term-line">
+          <span className="mp-term-prompt">›</span> <span className="mp-term-cursor" />
+        </span>
+      </div>
+
+      <div className="mp-accessory-bar">
+        <div className="mp-accessory-content">
+          <div className="mp-accessory-key is-icon" aria-label="Switch to phone mode">
+            <PhoneIcon />
+          </div>
+          <div className="mp-accessory-key">Paste</div>
+          <div className="mp-accessory-key">Esc</div>
+          <div className="mp-accessory-key">Tab</div>
+          <div className="mp-accessory-key">⌫</div>
+          <div className="mp-accessory-key">↑</div>
+          <div className="mp-accessory-key">↓</div>
+          <div className="mp-accessory-key">←</div>
+          <div className="mp-accessory-key">→</div>
+          <div className="mp-accessory-key">Ctrl+C</div>
+          <div className="mp-accessory-key">Ctrl+L</div>
+          <div className="mp-accessory-key is-icon is-add" aria-label="Add custom shortcut">
+            <PlusIcon />
+          </div>
+        </div>
+      </div>
+
+      <div className="mp-input-bar">
+        <div className="mp-text-input">Type a command…</div>
+        <div className="mp-round-button" aria-label="Voice dictation">
+          <MicIcon />
+        </div>
+        <div className="mp-round-button" aria-label="Send">
+          <ArrowUpIcon />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ChevronLeftIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function BranchIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <circle cx="6" cy="3" r="2.5" />
+      <circle cx="6" cy="21" r="2.5" />
+      <circle cx="18" cy="12" r="2.5" />
+      <path d="M6 5.5v13" />
+      <path d="M18 9.5a6 6 0 0 0-6-6" />
+    </svg>
+  )
+}
+
+function FolderIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M4 4h6l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Z" />
+    </svg>
+  )
+}
+
+function FileIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
+      <path d="M14 2v6h6" />
+    </svg>
+  )
+}
+
+function PlusIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M5 12h14" />
+      <path d="M12 5v14" />
+    </svg>
+  )
+}
+
+function PhoneIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
+      <path d="M12 18h.01" />
+    </svg>
+  )
+}
+
+function MicIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <rect x="9" y="2" width="6" height="12" rx="3" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+    </svg>
+  )
+}
+
+function ArrowUpIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M12 19V5" />
+      <path d="m5 12 7-7 7 7" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/mobile/slides/WorktreeListSlide.tsx
+++ b/src/renderer/src/components/mobile/slides/WorktreeListSlide.tsx
@@ -1,0 +1,301 @@
+import { cn } from '../../../lib/utils'
+
+type Indicator = 'spinner' | 'green' | 'muted' | 'red'
+
+type WorktreeRowProps = {
+  indicator: Indicator
+  name: string
+  pr?: string
+  repoColor: string
+  repo: string
+  branch: string
+  preview?: string
+  tcount?: number
+  tapping?: boolean
+}
+
+export function WorktreeListSlide({ tapping }: { tapping: boolean }): React.JSX.Element {
+  return (
+    <div className="mp-device-screen">
+      <div className="mp-wl-chrome">
+        <div className="mp-wl-statusrow">
+          <button type="button" className="mp-wl-back" aria-label="Back">
+            <ChevronLeftIcon />
+          </button>
+          <div className="mp-wl-host">
+            <span className="mp-status-dot is-green" />
+            <span className="mp-wl-host-name">MacBook Pro</span>
+          </div>
+        </div>
+        <div className="mp-wl-toolbar">
+          <button type="button" className="mp-wl-chip">
+            <FilterIcon />
+            Filter
+          </button>
+          <button type="button" className="mp-wl-button">
+            <SmartIcon />
+            Smart
+          </button>
+          <button type="button" className="mp-wl-button">
+            <GroupIcon />
+            Group
+          </button>
+          <span className="mp-wl-spacer" />
+          <span className="mp-wl-icon">
+            <UserCircleIcon />
+          </span>
+          <span className="mp-wl-icon">
+            <PlusIcon />
+          </span>
+          <span className="mp-wl-icon">
+            <SearchIcon />
+          </span>
+        </div>
+      </div>
+
+      <div className="mp-wl-section">
+        <CaretIcon />
+        <PinIcon />
+        <span style={{ marginLeft: 4 }}>Pinned</span>
+        <span style={{ marginLeft: 4, color: 'var(--m-text-muted)' }}>3</span>
+      </div>
+
+      <div className="mp-wl-list">
+        <WorktreeRow
+          indicator="spinner"
+          name="feat/mobile-page"
+          pr="#2491"
+          repoColor="#3b82f6"
+          repo="orca"
+          branch="feat/mobile-page"
+          preview="claude · refactoring v3 mock to use real screens…"
+          tcount={2}
+          tapping={tapping}
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="green"
+          name="runtime/web-pairing"
+          pr="#2487"
+          repoColor="#22c55e"
+          repo="orca"
+          branch="feat/web-pairing"
+          preview="$ pnpm test --filter web-runtime"
+          tcount={1}
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="red"
+          name="infra/notifier"
+          repoColor="#f97316"
+          repo="orca"
+          branch="main"
+          preview="awaiting permission · sudo apt install"
+          tcount={1}
+        />
+      </div>
+
+      <div className="mp-wl-section">
+        <CaretIcon />
+        <span>Active</span>
+        <span style={{ marginLeft: 4, color: 'var(--m-text-muted)' }}>37</span>
+      </div>
+      <div className="mp-wl-list">
+        <WorktreeRow
+          indicator="green"
+          name="docs/styleguide-update"
+          repoColor="#8b5cf6"
+          repo="orca"
+          branch="feat/styleguide"
+          preview="$ pnpm lint"
+          tcount={1}
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="muted"
+          name="feat/runtime-perf"
+          repoColor="#3b82f6"
+          repo="orca"
+          branch="feat/runtime-perf"
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="spinner"
+          name="fix/notifier-cooldown"
+          pr="#2483"
+          repoColor="#f97316"
+          repo="orca"
+          branch="feat/notifier-cooldown"
+          preview="claude · investigating macOS notification queue…"
+          tcount={1}
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="muted"
+          name="chore/deps-bump"
+          repoColor="#22c55e"
+          repo="orca"
+          branch="feat/deps-bump"
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="green"
+          name="experiment/ssh-multiplex"
+          repoColor="#3b82f6"
+          repo="orca"
+          branch="feat/ssh-mux"
+          preview="$ ssh -O check orca-relay"
+          tcount={2}
+        />
+        <div className="mp-wl-sep" />
+        <WorktreeRow
+          indicator="muted"
+          name="refactor/host-store"
+          repoColor="#8b5cf6"
+          repo="orca"
+          branch="feat/host-store"
+        />
+      </div>
+    </div>
+  )
+}
+
+function WorktreeRow({
+  indicator,
+  name,
+  pr,
+  repoColor,
+  repo,
+  branch,
+  preview,
+  tcount,
+  tapping
+}: WorktreeRowProps): React.JSX.Element {
+  return (
+    <div className={cn('mp-wl-row', tapping && 'is-tapping')}>
+      <div className="mp-wl-indicator">
+        {indicator === 'spinner' ? (
+          <div className="mp-wl-spinner" />
+        ) : (
+          <div className={cn('mp-wl-dot', `is-${indicator}`)} />
+        )}
+      </div>
+      <div className="mp-wl-main">
+        <div className="mp-wl-name-row">
+          <div className="mp-wl-name">{name}</div>
+          {pr ? (
+            <div className="mp-wl-pr">
+              <PrIcon />
+              {pr}
+            </div>
+          ) : null}
+        </div>
+        <div className="mp-wl-meta-row">
+          <span className="mp-repo-dot" style={{ background: repoColor }} />
+          <span>{repo}</span>
+          <span className="mp-wl-branch">{branch}</span>
+        </div>
+        {preview ? <div className="mp-wl-preview">{preview}</div> : null}
+      </div>
+      {tcount !== undefined ? <div className="mp-wl-tcount">{tcount}</div> : null}
+    </div>
+  )
+}
+
+function ChevronLeftIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function FilterIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+    </svg>
+  )
+}
+
+function SmartIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <line x1="21" y1="4" x2="14" y2="4" />
+      <line x1="10" y1="4" x2="3" y2="4" />
+      <line x1="21" y1="12" x2="12" y2="12" />
+      <line x1="8" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="20" x2="16" y2="20" />
+      <line x1="12" y1="20" x2="3" y2="20" />
+      <line x1="14" y1="2" x2="14" y2="6" />
+      <line x1="8" y1="10" x2="8" y2="14" />
+      <line x1="16" y1="18" x2="16" y2="22" />
+    </svg>
+  )
+}
+
+function GroupIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.91a1 1 0 0 0 0-1.83Z" />
+      <path d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12" />
+      <path d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17" />
+    </svg>
+  )
+}
+
+function UserCircleIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M18 20a6 6 0 0 0-12 0" />
+      <circle cx="12" cy="10" r="4" />
+    </svg>
+  )
+}
+
+function PlusIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="M5 12h14" />
+      <path d="M12 5v14" />
+    </svg>
+  )
+}
+
+function SearchIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  )
+}
+
+function CaretIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  )
+}
+
+function PinIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" style={{ marginLeft: 2 }}>
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1Z" />
+    </svg>
+  )
+}
+
+function PrIcon(): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <circle cx="6" cy="6" r="3" />
+      <path d="M6 9v12" />
+      <circle cx="18" cy="18" r="3" />
+      <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -580,8 +580,7 @@ function Settings(): React.JSX.Element {
               description: 'Control terminals and agents from your phone.',
               icon: Smartphone,
               searchEntries: MOBILE_SETTINGS_PANE_SEARCH_ENTRIES,
-              group: 'remote',
-              badge: 'Beta'
+              group: 'remote'
             },
             {
               id: 'computer-use' as const,

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../../shared/task-providers'
 import { useActivityUnreadCount } from '@/components/activity/useActivityUnreadCount'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { useMobileSidebarOnboardingBadge } from './mobile-sidebar-onboarding-badge'
 
 export function shouldShowAgentsButton(
   settings: Pick<GlobalSettings, 'experimentalActivity'> | null | undefined
@@ -119,6 +120,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const activityActive = activeView === 'activity'
   const mobileActive = activeView === 'mobile'
   const activityUnreadCount = useActivityUnreadCount(showAgentsButton, 'sidebar-badge')
+  const mobileOnboardingBadge = useMobileSidebarOnboardingBadge()
 
   return (
     <div className="flex flex-col gap-0.5 px-2 pt-2 pb-1">
@@ -246,7 +248,10 @@ const SidebarNav = React.memo(function SidebarNav() {
       ) : null}
       <button
         type="button"
-        onClick={openMobilePage}
+        onClick={() => {
+          mobileOnboardingBadge.dismiss()
+          openMobilePage()
+        }}
         aria-current={mobileActive ? 'page' : undefined}
         className={cn(
           'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
@@ -260,6 +265,11 @@ const SidebarNav = React.memo(function SidebarNav() {
           strokeWidth={mobileActive ? 2.25 : 1.75}
         />
         <span className="flex-1">Orca Mobile</span>
+        {mobileOnboardingBadge.visible ? (
+          <span className="rounded-full bg-primary px-1.5 py-px text-[10px] font-semibold text-primary-foreground">
+            New
+          </span>
+        ) : null}
       </button>
       <button
         type="button"

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Bell, CalendarClock, Github, Gitlab, List, Search } from 'lucide-react'
+import { Bell, CalendarClock, Github, Gitlab, List, Search, Smartphone } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useRepoMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
@@ -26,6 +26,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const openTaskPage = useAppStore((s) => s.openTaskPage)
   const openAutomationsPage = useAppStore((s) => s.openAutomationsPage)
   const openActivityPage = useAppStore((s) => s.openActivityPage)
+  const openMobilePage = useAppStore((s) => s.openMobilePage)
   const openModal = useAppStore((s) => s.openModal)
   const activeView = useAppStore((s) => s.activeView)
   const repos = useAppStore((s) => s.repos)
@@ -116,6 +117,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const tasksActive = activeView === 'tasks'
   const automationsActive = activeView === 'automations'
   const activityActive = activeView === 'activity'
+  const mobileActive = activeView === 'mobile'
   const activityUnreadCount = useActivityUnreadCount(showAgentsButton, 'sidebar-badge')
 
   return (
@@ -242,6 +244,23 @@ const SidebarNav = React.memo(function SidebarNav() {
           ) : null}
         </button>
       ) : null}
+      <button
+        type="button"
+        onClick={openMobilePage}
+        aria-current={mobileActive ? 'page' : undefined}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium tracking-tight transition-colors',
+          mobileActive
+            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+            : 'text-sidebar-foreground/60 hover:bg-sidebar-foreground/8'
+        )}
+      >
+        <Smartphone
+          className={cn('size-4 shrink-0', !mobileActive && 'text-sidebar-foreground/30')}
+          strokeWidth={mobileActive ? 2.25 : 1.75}
+        />
+        <span className="flex-1">Orca Mobile</span>
+      </button>
       <button
         type="button"
         onClick={() => openModal('worktree-palette')}

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -9,8 +9,7 @@ import {
   HardDrive,
   MessageSquareText,
   School,
-  Settings,
-  Smartphone
+  Settings
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -253,7 +252,6 @@ function FeedbackDialog({
 const SidebarToolbar = React.memo(function SidebarToolbar() {
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
-  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const openSkillsPage = useAppStore((s) => s.openSkillsPage)
   const openSpacePage = useAppStore((s) => s.openSpacePage)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
@@ -266,11 +264,6 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
     }
     lastShowOnboardingAtRef.current = now
     void showOnboardingFromRenderer()
-  }
-
-  const openMobileSettings = (): void => {
-    openSettingsTarget({ pane: 'mobile', repoId: null })
-    openSettingsPage()
   }
 
   return (
@@ -313,10 +306,6 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
               </TooltipContent>
             </Tooltip>
             <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-44">
-              <DropdownMenuItem onSelect={openMobileSettings}>
-                <Smartphone className="size-3.5" />
-                Orca Mobile
-              </DropdownMenuItem>
               <DropdownMenuItem onSelect={openSkillsPage}>
                 <BookOpen className="size-3.5" />
                 Skills

--- a/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.ts
+++ b/src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const DISMISS_KEY = 'orca.mobile.sidebar-onboarding-dismissed'
+
+function readDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(DISMISS_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+// Why: surface a one-time "Try it" badge on the Orca Mobile sidebar entry
+// for users who haven't paired any device. Clicking the row dismisses it
+// permanently, mirroring the once-and-done feel of an inbox unread dot.
+export function useMobileSidebarOnboardingBadge(): {
+  visible: boolean
+  dismiss: () => void
+} {
+  const [dismissed, setDismissed] = useState<boolean>(() => readDismissed())
+  const [hasPairedDevice, setHasPairedDevice] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    if (dismissed) {
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await window.api.mobile.listDevices()
+        if (!cancelled) {
+          setHasPairedDevice(result.devices.length > 0)
+        }
+      } catch {
+        if (!cancelled) {
+          setHasPairedDevice(false)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [dismissed])
+
+  const dismiss = useCallback(() => {
+    if (dismissed) {
+      return
+    }
+    try {
+      window.localStorage.setItem(DISMISS_KEY, '1')
+    } catch {
+      // Best-effort; if storage is unavailable the badge will reappear next mount.
+    }
+    setDismissed(true)
+  }, [dismissed])
+
+  return {
+    visible: !dismissed && hasPairedDevice === false,
+    dismiss
+  }
+}

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -3,7 +3,15 @@
  * based on current view, tab type, and focused element.
  */
 export function resolveZoomTarget(args: {
-  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space' | 'skills'
+  activeView:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'mobile'
   activeTabType: 'terminal' | 'editor' | 'browser'
   activeElement: unknown
 }): 'terminal' | 'editor' | 'ui' {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -23,6 +23,10 @@ function createTerminal(args: {
   }
   return {
     buffer: { active },
+    // Why: restoreScrollStateNow guards on terminal.element to avoid calling
+    // scroll APIs after WebGL teardown. Stub a truthy element so these tests
+    // exercise the live restore path.
+    element: {} as HTMLElement,
     registerMarker: vi.fn((cursorYOffset: number) =>
       createMarker(active.baseY + active.cursorY + cursorYOffset)
     ),
@@ -98,6 +102,38 @@ describe('scroll state', () => {
 
     expect(terminal.scrollToLine).toHaveBeenCalledWith(42)
     expect(terminal.buffer.active.viewportY).toBe(42)
+  })
+
+  it('skips restore when the terminal element is gone (post WebGL teardown)', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 100 })
+    ;(terminal as unknown as { element: HTMLElement | undefined }).element = undefined
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 100,
+      baseY: 100
+    }
+
+    restoreScrollState(terminal, state)
+
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled()
+    expect(terminal.scrollToLine).not.toHaveBeenCalled()
+  })
+
+  it('swallows xterm dimensions errors thrown after a mid-flight WebGL suspend', () => {
+    const terminal = createTerminal({ viewportY: 50, baseY: 100 })
+    ;(terminal.scrollToBottom as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'dimensions')")
+    })
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 100,
+      baseY: 100
+    }
+
+    expect(() => restoreScrollState(terminal, state)).not.toThrow()
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1)
   })
 
   it('uses the visible line marker when resize reflow changes numeric line positions', () => {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -136,6 +136,22 @@ describe('scroll state', () => {
     expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1)
   })
 
+  it('swallows xterm dimensions errors from scrollToLine on the not-at-bottom branch', () => {
+    const terminal = createTerminal({ viewportY: 10, baseY: 100 })
+    ;(terminal.scrollToLine as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'dimensions')")
+    })
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 42,
+      baseY: 100
+    }
+
+    expect(() => restoreScrollState(terminal, state)).not.toThrow()
+    expect(terminal.scrollToLine).toHaveBeenCalledTimes(1)
+  })
+
   it('uses the visible line marker when resize reflow changes numeric line positions', () => {
     const terminal = createTerminal({ viewportY: 10, baseY: 300 })
     const marker = createMarker(160)

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -115,13 +115,20 @@ export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollS
 }
 
 function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
+  if (!terminal.element) {
+    return
+  }
   const buf = terminal.buffer.active
   if (state.bufferType === 'alternate' || buf.type !== state.bufferType) {
     return
   }
 
+  // Why: WebGL suspend disposes xterm's render service while leaving
+  // terminal.element attached, so scrollToBottom/scrollToLine/scrollLines all
+  // throw "cannot read dimensions" until the pane re-attaches. Swallow that
+  // window quietly — the next visibility flip re-fits and re-restores.
   if (state.wasAtBottom) {
-    terminal.scrollToBottom()
+    safeScrollCall(() => terminal.scrollToBottom())
     forceViewportScrollbarSync(terminal)
     return
   }
@@ -136,8 +143,16 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
   // reflow settles; keep the marker alive so each call consults the live
   // line. Callers (restoreScrollState, the timeout in
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
-  terminal.scrollToLine(targetLine)
+  safeScrollCall(() => terminal.scrollToLine(targetLine))
   forceViewportScrollbarSync(terminal)
+}
+
+function safeScrollCall(fn: () => void): void {
+  try {
+    fn()
+  } catch {
+    /* xterm render service torn down — re-fit on next visibility flip restores it */
+  }
 }
 
 function releaseScrollStateMarker(state: ScrollState): void {
@@ -155,10 +170,10 @@ function forceViewportScrollbarSync(terminal: Terminal): void {
     return
   }
   if (buf.viewportY > 0) {
-    terminal.scrollLines(-1)
-    terminal.scrollLines(1)
+    safeScrollCall(() => terminal.scrollLines(-1))
+    safeScrollCall(() => terminal.scrollLines(1))
   } else if (buf.viewportY < buf.baseY) {
-    terminal.scrollLines(1)
-    terminal.scrollLines(-1)
+    safeScrollCall(() => terminal.scrollLines(1))
+    safeScrollCall(() => terminal.scrollLines(-1))
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -128,8 +128,9 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
   // throw "cannot read dimensions" until the pane re-attaches. Swallow that
   // window quietly — the next visibility flip re-fits and re-restores.
   if (state.wasAtBottom) {
-    safeScrollCall(() => terminal.scrollToBottom())
-    forceViewportScrollbarSync(terminal)
+    if (safeScrollCall(() => terminal.scrollToBottom())) {
+      forceViewportScrollbarSync(terminal)
+    }
     return
   }
 
@@ -143,15 +144,23 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
   // reflow settles; keep the marker alive so each call consults the live
   // line. Callers (restoreScrollState, the timeout in
   // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
-  safeScrollCall(() => terminal.scrollToLine(targetLine))
-  forceViewportScrollbarSync(terminal)
+  if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
+    forceViewportScrollbarSync(terminal)
+  }
 }
 
-function safeScrollCall(fn: () => void): void {
+function safeScrollCall(fn: () => void): boolean {
   try {
     fn()
-  } catch {
-    /* xterm render service torn down — re-fit on next visibility flip restores it */
+    return true
+  } catch (err) {
+    // Why: xterm's renderer can null out internal dimensions during WebGL
+    // teardown, throwing "Cannot read properties of undefined (reading
+    // 'dimensions')". Tolerate that; surface anything else.
+    if (err instanceof TypeError && /dimensions/.test(err.message)) {
+      return false
+    }
+    throw err
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -42,6 +42,7 @@ function createPane({
   const terminal = {
     cols: terminalCols,
     rows: terminalRows,
+    element: {} as HTMLElement,
     resize: vi.fn((cols: number, rows: number) => {
       terminal.cols = cols
       terminal.rows = rows

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -277,13 +277,71 @@ export type UISlice = {
   acknowledgedAgentsByPaneKey: Record<string, number>
   acknowledgeAgents: (paneKeys: string[]) => void
   unacknowledgeAgents: (paneKeys: string[]) => void
-  activeView: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space' | 'skills'
-  previousViewBeforeTasks: 'terminal' | 'settings' | 'activity' | 'automations' | 'space' | 'skills'
-  previousViewBeforeSettings: 'terminal' | 'tasks' | 'activity' | 'automations' | 'space' | 'skills'
-  previousViewBeforeActivity: 'terminal' | 'settings' | 'tasks' | 'automations' | 'space' | 'skills'
-  previousViewBeforeAutomations: 'terminal' | 'settings' | 'tasks' | 'activity' | 'space' | 'skills'
-  previousViewBeforeSpace: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'skills'
-  previousViewBeforeSkills: 'terminal' | 'settings' | 'tasks' | 'activity' | 'automations' | 'space'
+  activeView:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'mobile'
+  previousViewBeforeTasks:
+    | 'terminal'
+    | 'settings'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'mobile'
+  previousViewBeforeSettings:
+    | 'terminal'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'mobile'
+  previousViewBeforeActivity:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'automations'
+    | 'space'
+    | 'skills'
+    | 'mobile'
+  previousViewBeforeAutomations:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'space'
+    | 'skills'
+    | 'mobile'
+  previousViewBeforeSpace:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'skills'
+    | 'mobile'
+  previousViewBeforeSkills:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'mobile'
+  previousViewBeforeMobile:
+    | 'terminal'
+    | 'settings'
+    | 'tasks'
+    | 'activity'
+    | 'automations'
+    | 'space'
+    | 'skills'
   setActiveView: (view: UISlice['activeView']) => void
   taskPageData: {
     preselectedRepoId?: string
@@ -332,6 +390,8 @@ export type UISlice = {
   closeSpacePage: () => void
   openSkillsPage: () => void
   closeSkillsPage: () => void
+  openMobilePage: () => void
+  closeMobilePage: () => void
   setNewWorkspaceDraft: (draft: NonNullable<UISlice['newWorkspaceDraft']>) => void
   clearNewWorkspaceDraft: () => void
   openSettingsPage: () => void
@@ -546,6 +606,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   previousViewBeforeAutomations: 'terminal',
   previousViewBeforeSpace: 'terminal',
   previousViewBeforeSkills: 'terminal',
+  previousViewBeforeMobile: 'terminal',
   setActiveView: (view) => set({ activeView: view }),
   taskPageData: {},
   taskResumeState: undefined,
@@ -753,6 +814,16 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   closeSkillsPage: () =>
     set((state) => ({
       activeView: state.previousViewBeforeSkills
+    })),
+  openMobilePage: () =>
+    set((state) => ({
+      activeView: 'mobile',
+      previousViewBeforeMobile:
+        state.activeView === 'mobile' ? state.previousViewBeforeMobile : state.activeView
+    })),
+  closeMobilePage: () =>
+    set((state) => ({
+      activeView: state.previousViewBeforeMobile
     })),
   setNewWorkspaceDraft: (draft) => set({ newWorkspaceDraft: draft }),
   clearNewWorkspaceDraft: () => set({ newWorkspaceDraft: null }),


### PR DESCRIPTION
## Summary
- Add an in-app Orca Mobile marketing page with a hero pitch and a phone-frame carousel cycling through Home, Worktrees, and Terminal mocks.
- Wire a multi-stage pairing wizard (intro → "Get the app" → "Pair this Mac/PC" → paired summary) that polls for new devices on Step 2 and on the paired list, auto-advancing as phones connect and supporting per-device revoke.
- Surface a one-time "New" badge on the sidebar's Orca Mobile entry for users with zero paired devices; clicking the row dismisses it permanently via localStorage.

## Test plan
- [ ] Cold start with no paired devices lands on the intro hero and shows the sidebar "New" badge; clicking the row hides the badge and the badge stays gone after reload.
- [ ] Walk Get started → Step 1 → Step 2 → scan with Orca Mobile; verify the page auto-transitions to the paired summary.
- [ ] Pair a 2nd phone while sitting on the paired list; verify it appears without manual reload.
- [ ] Pair 5+ devices; verify the list scrolls after 4 rows without pushing the action row off-screen.
- [ ] Revoke each device down to zero; verify the page returns to the intro and the badge stays dismissed.
- [ ] On Step 2 with a device already paired, verify the white "Done" button appears and returns to the paired summary.
- [ ] Verify the "Pair this {Mac/PC/computer}" header reflects the host platform.
- [ ] Verify hero gradient renders (top-right indigo, bottom-left blue).

Made with [Orca](https://github.com/stablyai/orca) 🐋
