### PR TITLE
Fix sidebar worktree cache when sidebar is hidden

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2809,6 +2809,9 @@ const WorktreeList = React.memo(function WorktreeList({
   // new numbering but the shortcut cache still points at the previous order.
   useLayoutEffect(() => {
     setVisibleWorktreeIds(renderedWorktreeIds)
+    // Why: collapsed/full-page sidebar states unmount the list. Clear the
+    // rendered-order cache so shortcuts fall back to the live store snapshot.
+    return () => setVisibleWorktreeIds([])
   }, [renderedWorktreeIds])
 
   const handleCreateForRepo = useCallback(

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -64,26 +64,32 @@ function Sidebar({
         ref={containerRef}
         className="relative min-h-0 flex-shrink-0 bg-sidebar flex flex-col overflow-hidden scrollbar-sleek-parent"
       >
-        {/* Fixed controls */}
-        <SidebarNav />
-        <SidebarHeader />
+        {sidebarOpen && (
+          <>
+            {/* Fixed controls */}
+            <SidebarNav />
+            <SidebarHeader />
 
-        <WorktreeList
-          scrollOffsetRef={worktreeScrollOffsetRef}
-          scrollAnchorRef={worktreeScrollAnchorRef}
-        />
+            <WorktreeList
+              scrollOffsetRef={worktreeScrollOffsetRef}
+              scrollAnchorRef={worktreeScrollAnchorRef}
+            />
 
-        <SetupScriptPromptCard />
+            <SetupScriptPromptCard />
 
-        {/* Fixed bottom toolbar */}
-        <SidebarToolbar />
+            {/* Fixed bottom toolbar */}
+            <SidebarToolbar />
+          </>
+        )}
 
         {/* Resize handle */}
-        <div
-          data-sidebar-resize-handle=""
-          className="absolute top-0 right-0 z-10 h-full w-px cursor-col-resize transition-colors hover:bg-ring/20 active:bg-ring/30"
-          onMouseDown={onResizeStart}
-        />
+        {sidebarOpen && (
+          <div
+            data-sidebar-resize-handle=""
+            className="absolute top-0 right-0 z-10 h-full w-px cursor-col-resize transition-colors hover:bg-ring/20 active:bg-ring/30"
+            onMouseDown={onResizeStart}
+          />
+        )}
       </div>
 
       {/* Dialog (rendered outside sidebar to avoid clipping) */}


### PR DESCRIPTION
## Summary
- Unmount sidebar contents when the sidebar is closed so hidden controls/lists do not remain rendered
- Clear the visible worktree shortcut cache when the worktree list unmounts so shortcuts fall back to the live store order

## Verification
- pnpm typecheck
- review-and-submit round 1: no issues found