### PR TITLE
Add workspace jump actions for port lists

### DIFF
--- a/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.test.tsx
@@ -25,6 +25,7 @@ import { getLocalWorkspacePortSections } from './PortsPanel'
 import {
   killWorkspacePortForTarget,
   openWorkspacePortInBrowser,
+  refreshWorkspacePortScanAfterStop,
   scanWorkspacePortsForTarget
 } from '@/lib/workspace-port-actions'
 
@@ -63,12 +64,14 @@ const localScan = vi.fn()
 const localKill = vi.fn()
 const runtimeCall = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
+const openUrl = vi.fn()
 
 beforeEach(() => {
   localScan.mockReset()
   localKill.mockReset()
   runtimeCall.mockReset()
   runtimeEnvironmentCall.mockReset()
+  openUrl.mockReset()
   activateAndRevealWorktreeMock.mockReset()
   clearRuntimeCompatibilityCacheForTests()
   vi.stubGlobal('window', {
@@ -82,6 +85,9 @@ beforeEach(() => {
       },
       runtimeEnvironments: {
         call: runtimeEnvironmentCall
+      },
+      shell: {
+        openUrl
       }
     }
   })
@@ -249,6 +255,83 @@ describe('PortsPanel runtime routing', () => {
       {
         activate: true
       }
+    )
+    expect(setRemoteBrowserPageHandle).toHaveBeenCalledWith('local-page-1', {
+      environmentId: 'env-1',
+      remotePageId: 'remote-browser-page-1'
+    })
+  })
+
+  it('opens workspace ports in the system browser when link routing is off', async () => {
+    const createBrowserTab = vi.fn()
+    const setRemoteBrowserPageHandle = vi.fn()
+    openUrl.mockResolvedValueOnce(undefined)
+
+    await expect(
+      openWorkspacePortInBrowser({
+        port: workspacePort,
+        runtimeTarget: { kind: 'local' },
+        createBrowserTab: createBrowserTab as never,
+        setRemoteBrowserPageHandle: setRemoteBrowserPageHandle as never,
+        openInOrcaBrowser: false
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect(openUrl).toHaveBeenCalledWith('http://127.0.0.1:63468')
+    expect(createBrowserTab).not.toHaveBeenCalled()
+    expect(activateAndRevealWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('returns post-stop refresh failures without throwing', async () => {
+    const setWorkspacePortScan = vi.fn()
+    const setWorkspacePortScanRefreshing = vi.fn()
+    localScan.mockRejectedValueOnce(new Error('scan failed'))
+
+    await expect(
+      refreshWorkspacePortScanAfterStop({
+        runtimeTarget: { kind: 'local' },
+        setWorkspacePortScan: setWorkspacePortScan as never,
+        setWorkspacePortScanRefreshing: setWorkspacePortScanRefreshing as never
+      })
+    ).resolves.toEqual({ ok: false, reason: 'scan failed' })
+
+    expect(setWorkspacePortScan).not.toHaveBeenCalled()
+    expect(setWorkspacePortScanRefreshing).toHaveBeenNthCalledWith(1, true)
+    expect(setWorkspacePortScanRefreshing).toHaveBeenNthCalledWith(2, false)
+  })
+
+  it('keeps remote workspace ports in the server-side browser when link routing is off', async () => {
+    runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) =>
+      Promise.resolve({
+        id: method,
+        ok: true,
+        result:
+          method === 'status.get' ? compatibleStatus : { browserPageId: 'remote-browser-page-1' },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    const createBrowserTab = vi.fn(() => ({ activePageId: 'local-page-1' }))
+    const setRemoteBrowserPageHandle = vi.fn()
+
+    await expect(
+      openWorkspacePortInBrowser({
+        port: workspacePort,
+        runtimeTarget: { kind: 'environment', environmentId: 'env-1' },
+        createBrowserTab: createBrowserTab as never,
+        setRemoteBrowserPageHandle: setRemoteBrowserPageHandle as never,
+        openInOrcaBrowser: false
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect(openUrl).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
+      'status.get',
+      'browser.tabCreate'
+    ])
+    expect(createBrowserTab).toHaveBeenCalledWith(
+      'repo::/workspace/app',
+      'http://127.0.0.1:63468',
+      { activate: true }
     )
     expect(setRemoteBrowserPageHandle).toHaveBeenCalledWith('local-page-1', {
       environmentId: 'env-1',

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -22,7 +22,9 @@ import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   killWorkspacePortForTarget,
   openWorkspacePortInBrowser,
+  refreshWorkspacePortScanAfterStop,
   scanWorkspacePortsForTarget,
+  shouldOpenWorkspacePortInOrcaBrowser,
   workspacePortRuntimeTargetKey
 } from '@/lib/workspace-port-actions'
 import {
@@ -213,9 +215,18 @@ function LocalWorkspacePortsPanel({ isVisible }: { isVisible: boolean }): React.
         return
       }
       toast.success(`Stopped process on :${port.port}`)
-      await refresh()
+      const refreshResult = await refreshWorkspacePortScanAfterStop({
+        runtimeTarget,
+        setWorkspacePortScan,
+        setWorkspacePortScanRefreshing
+      })
+      if (!refreshResult.ok) {
+        toast.error('Failed to refresh ports', {
+          description: refreshResult.reason
+        })
+      }
     },
-    [activeRepo, refresh, runtimeTarget]
+    [activeRepo, runtimeTarget, setWorkspacePortScan, setWorkspacePortScanRefreshing]
   )
 
   const handleOpenPortInBrowser = useCallback(
@@ -225,13 +236,14 @@ function LocalWorkspacePortsPanel({ isVisible }: { isVisible: boolean }): React.
         activeWorktreeId: activeWorktree?.id,
         runtimeTarget,
         createBrowserTab,
-        setRemoteBrowserPageHandle
+        setRemoteBrowserPageHandle,
+        openInOrcaBrowser: shouldOpenWorkspacePortInOrcaBrowser(settings)
       })
       if (!result.ok) {
         toast.error('Failed to open browser', { description: result.reason })
       }
     },
-    [activeWorktree?.id, createBrowserTab, runtimeTarget, setRemoteBrowserPageHandle]
+    [activeWorktree?.id, createBrowserTab, runtimeTarget, setRemoteBrowserPageHandle, settings]
   )
 
   const { activePorts, otherWorkspacePorts, externalPorts } = useMemo(
@@ -361,7 +373,7 @@ function LocalPortSection({
     <div className="px-3 pt-2">
       <button
         type="button"
-        className="flex items-center gap-1 w-full text-left mb-1 text-muted-foreground hover:text-foreground transition-colors"
+        className="sticky top-0 z-10 mb-1 flex w-full items-center gap-1 border-b border-border/40 bg-background py-1 text-left text-muted-foreground transition-colors hover:text-foreground"
         onClick={onToggle}
         aria-expanded={!collapsed}
         aria-controls={`local-port-section-${id}`}
@@ -497,13 +509,13 @@ function LocalPortRow({
                   size="icon-xs"
                   className="text-muted-foreground hover:text-foreground"
                   onClick={handleOpenBrowserButtonClick}
-                  aria-label="Open in Orca Browser"
+                  aria-label="Open in Browser"
                 >
                   <ExternalLink size={13} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="top" sideOffset={4}>
-                Open in Orca Browser
+                Open in Browser
               </TooltipContent>
             </Tooltip>
             <Tooltip>
@@ -551,7 +563,7 @@ function LocalPortRow({
         >{`:${port.port}`}</ContextMenuLabel>
         <ContextMenuItem className={LOCAL_PORT_MENU_ITEM_CLASS} onSelect={handleOpenBrowser}>
           <ExternalLink size={13} />
-          Open in Orca Browser
+          Open in Browser
         </ContextMenuItem>
         <ContextMenuItem className={LOCAL_PORT_MENU_ITEM_CLASS} onSelect={handleCopy}>
           <Copy size={13} />
@@ -634,6 +646,7 @@ function LocalPortDetailsDialog({
 }
 
 function SshPortsPanel(): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
   const portForwardsByConnection = useAppStore((s) => s.portForwardsByConnection)
   const detectedPortsByConnection = useAppStore((s) => s.detectedPortsByConnection)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
@@ -697,15 +710,20 @@ function SshPortsPanel(): React.JSX.Element {
 
   const handleOpenForwardInBrowser = useCallback(
     (entry: PortForwardEntry) => {
+      const url = browserUrlForPortForwardEntry(entry)
+      if (!shouldOpenWorkspacePortInOrcaBrowser(settings)) {
+        void window.api.shell.openUrl(url)
+        return
+      }
       if (!activeWorktree?.id) {
         toast.error('No workspace selected for the browser.')
         return
       }
-      createBrowserTab(activeWorktree.id, browserUrlForPortForwardEntry(entry), {
+      createBrowserTab(activeWorktree.id, url, {
         activate: true
       })
     },
-    [activeWorktree?.id, createBrowserTab]
+    [activeWorktree?.id, createBrowserTab, settings]
   )
 
   const handleDialogClose = useCallback(() => {
@@ -935,9 +953,7 @@ function ForwardedPortRow({
           className="p-1 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
           onClick={handleOpenBrowserButtonClick}
           title={
-            advertisedBrowserUrl
-              ? `Open ${advertisedBrowserUrl} in Orca Browser`
-              : 'Open in Orca Browser'
+            advertisedBrowserUrl ? `Open ${advertisedBrowserUrl} in Browser` : 'Open in Browser'
           }
         >
           <ExternalLink size={13} />

--- a/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
-import { Plug, Copy, ExternalLink, Trash2 } from 'lucide-react'
+import { Plug, Copy, ExternalLink, FolderOpen, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
@@ -9,10 +9,11 @@ import { SelectedTextCopyMenu } from '@/components/SelectedTextCopyMenu'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   canStopWorkspacePort,
+  goToWorkspacePortOwner,
   killWorkspacePortForTarget,
   openWorkspacePortInBrowser,
-  scanWorkspacePortsForTarget,
-  workspacePortRuntimeTargetKey
+  refreshWorkspacePortScanAfterStop,
+  shouldOpenWorkspacePortInOrcaBrowser
 } from '@/lib/workspace-port-actions'
 import { addressForPort } from '@/lib/workspace-port-urls'
 import type { WorkspacePort } from '../../../../shared/workspace-ports'
@@ -99,14 +100,15 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
         port,
         runtimeTarget,
         createBrowserTab,
-        setRemoteBrowserPageHandle
+        setRemoteBrowserPageHandle,
+        openInOrcaBrowser: shouldOpenWorkspacePortInOrcaBrowser(settings)
       }).then((result) => {
         if (!result.ok) {
           toast.error('Failed to open browser', { description: result.reason })
         }
       })
     },
-    [createBrowserTab, port, runtimeTarget, setRemoteBrowserPageHandle]
+    [createBrowserTab, port, runtimeTarget, setRemoteBrowserPageHandle, settings]
   )
 
   const handleCopy = useCallback(
@@ -136,15 +138,15 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
           return
         }
         toast.success(`Stopped process on ${port.port}`)
-        setWorkspacePortScanRefreshing(true)
-        try {
-          const scan = await scanWorkspacePortsForTarget(runtimeTarget)
-          setWorkspacePortScan({
-            key: `${workspacePortRuntimeTargetKey(runtimeTarget)}:all`,
-            result: scan
+        const refreshResult = await refreshWorkspacePortScanAfterStop({
+          runtimeTarget,
+          setWorkspacePortScan,
+          setWorkspacePortScanRefreshing
+        })
+        if (!refreshResult.ok) {
+          toast.error('Failed to refresh ports', {
+            description: refreshResult.reason
           })
-        } finally {
-          setWorkspacePortScanRefreshing(false)
         }
       }
       void run()
@@ -153,17 +155,17 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
   )
 
   return (
-    <div className="group/port grid min-w-0 grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-2 rounded-md px-1.5 py-1 hover:bg-accent/50">
+    <div className="group/port grid min-w-0 grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-1.5 rounded-md px-1.5 py-1 hover:bg-accent/50">
       <span className="select-text font-mono text-[12px] font-semibold tabular-nums text-foreground">
         {port.port}
       </span>
       <div className="relative flex h-5 min-w-0 items-center">
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className="flex min-w-0 select-text items-baseline gap-1.5 overflow-hidden pr-14 text-[11px] text-muted-foreground">
+            <span className="flex min-w-0 select-text items-baseline gap-1 overflow-hidden pr-[3.75rem] text-[11px] text-muted-foreground">
               <span className="min-w-0 flex-1 truncate">{processLabel}</span>
               <span className="shrink-0 text-muted-foreground/45">-</span>
-              <span className="min-w-10 max-w-20 shrink-0 truncate text-right text-muted-foreground/70">
+              <span className="min-w-0 flex-[1.1] truncate text-muted-foreground/70">
                 {address}
               </span>
             </span>
@@ -177,7 +179,7 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
           </TooltipContent>
         </Tooltip>
         <div className="absolute inset-y-0 right-0 flex items-center gap-0.5 rounded-md border border-border/40 bg-popover/95 px-0.5 opacity-0 shadow-xs transition-opacity group-hover/port:opacity-100 group-focus-within/port:opacity-100">
-          <PortAction label="Open in Orca Browser" onClick={handleOpen}>
+          <PortAction label="Open in Browser" onClick={handleOpen}>
             <ExternalLink className="size-3" />
           </PortAction>
           <PortAction label={`Copy ${address}`} onClick={handleCopy}>
@@ -195,6 +197,17 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
 export function WorktreeCardPortsDetails({
   ports
 }: WorktreeCardPortsProps): React.JSX.Element | null {
+  const handleGoToWorktree = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      const ownerPort = ports[0]
+      if (!ownerPort || !goToWorkspacePortOwner(ownerPort)) {
+        toast.error('Workspace unavailable')
+      }
+    },
+    [ports]
+  )
+
   if (ports.length === 0) {
     return null
   }
@@ -204,9 +217,12 @@ export function WorktreeCardPortsDetails({
       <div className="flex items-center gap-1.5 px-1 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
         <Plug className="size-3" />
         <span>Live Ports</span>
-        <span className="ml-auto font-normal tabular-nums text-muted-foreground/70">
-          {ports.length}
-        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <PortAction label="Go to Worktree" onClick={handleGoToWorktree}>
+            <FolderOpen className="size-3" />
+          </PortAction>
+          <span className="font-normal tabular-nums text-muted-foreground/70">{ports.length}</span>
+        </div>
       </div>
       <div className="space-y-0.5">
         {ports.map((port) => (

--- a/src/renderer/src/components/status-bar/PortsStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/PortsStatusSegment.tsx
@@ -5,6 +5,7 @@ import {
   ChevronRight,
   Copy,
   ExternalLink,
+  FolderOpen,
   LoaderCircle,
   Trash2
 } from 'lucide-react'
@@ -17,9 +18,12 @@ import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   addressForPort,
   canStopWorkspacePort,
+  goToWorkspacePortOwner,
   killWorkspacePortForTarget,
   openWorkspacePortInBrowser,
+  refreshWorkspacePortScanAfterStop,
   scanWorkspacePortsForTarget,
+  shouldOpenWorkspacePortInOrcaBrowser,
   workspacePortRuntimeTargetKey
 } from '@/lib/workspace-port-actions'
 import {
@@ -96,7 +100,8 @@ function PortRow({
   const setWorkspacePortScanRefreshing = useAppStore((s) => s.setWorkspacePortScanRefreshing)
   const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
   const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
-  const canOpen = port.kind === 'workspace' || Boolean(activeWorktreeId)
+  const openInOrcaBrowser = shouldOpenWorkspacePortInOrcaBrowser(settings)
+  const canOpen = !openInOrcaBrowser || port.kind === 'workspace' || Boolean(activeWorktreeId)
   const canStop = canStopWorkspacePort(port)
 
   const handleOpen = useCallback(
@@ -107,14 +112,22 @@ function PortRow({
         activeWorktreeId,
         runtimeTarget,
         createBrowserTab,
-        setRemoteBrowserPageHandle
+        setRemoteBrowserPageHandle,
+        openInOrcaBrowser
       }).then((result) => {
         if (!result.ok) {
           toast.error('Failed to open browser', { description: result.reason })
         }
       })
     },
-    [activeWorktreeId, createBrowserTab, port, runtimeTarget, setRemoteBrowserPageHandle]
+    [
+      activeWorktreeId,
+      createBrowserTab,
+      openInOrcaBrowser,
+      port,
+      runtimeTarget,
+      setRemoteBrowserPageHandle
+    ]
   )
 
   const handleCopy = useCallback(
@@ -144,15 +157,15 @@ function PortRow({
           return
         }
         toast.success(`Stopped process on ${port.port}`)
-        setWorkspacePortScanRefreshing(true)
-        try {
-          const scan = await scanWorkspacePortsForTarget(runtimeTarget)
-          setWorkspacePortScan({
-            key: `${workspacePortRuntimeTargetKey(runtimeTarget)}:all`,
-            result: scan
+        const refreshResult = await refreshWorkspacePortScanAfterStop({
+          runtimeTarget,
+          setWorkspacePortScan,
+          setWorkspacePortScanRefreshing
+        })
+        if (!refreshResult.ok) {
+          toast.error('Failed to refresh ports', {
+            description: refreshResult.reason
           })
-        } finally {
-          setWorkspacePortScanRefreshing(false)
         }
       }
       void run()
@@ -178,7 +191,7 @@ function PortRow({
             </TooltipContent>
           </Tooltip>
           <div className="absolute inset-y-0 right-0 flex items-center gap-0.5 rounded-md border border-border/40 bg-popover/95 px-0.5 opacity-0 shadow-xs transition-opacity group-hover/port:opacity-100 group-focus-within/port:opacity-100">
-            <PortAction label="Open in Orca Browser" onClick={handleOpen} disabled={!canOpen}>
+            <PortAction label="Open in Browser" onClick={handleOpen} disabled={!canOpen}>
               <ExternalLink className="size-3" />
             </PortAction>
             <PortAction label={`Copy ${addressForPort(port)}`} onClick={handleCopy}>
@@ -204,15 +217,35 @@ function WorkspaceGroupRows({
   group: WorkspacePortGroup
   activeWorktreeId: string | null
 }): React.JSX.Element {
+  const handleGoToWorkspace = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      const ownerPort = group.ports[0]
+      if (!ownerPort || !goToWorkspacePortOwner(ownerPort)) {
+        toast.error('Workspace unavailable')
+      }
+    },
+    [group.ports]
+  )
+
   return (
     <section className="border-t border-border/40 first:border-t-0">
-      <div className="flex items-center justify-between gap-2 px-3 py-2">
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-border/40 bg-popover px-3 py-2">
         <span className="min-w-0 truncate text-[12px] font-medium text-foreground">
           {group.displayName}
         </span>
-        <span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
-          {group.ports.length}
-        </span>
+        <div className="flex shrink-0 items-center gap-1">
+          <PortAction
+            label="Go to Worktree"
+            onClick={handleGoToWorkspace}
+            disabled={group.ports.length === 0}
+          >
+            <FolderOpen className="size-3" />
+          </PortAction>
+          <span className="font-mono text-[10px] text-muted-foreground/70">
+            {group.ports.length}
+          </span>
+        </div>
       </div>
       <div className="px-1 pb-1">
         {group.ports.map((port) => (
@@ -344,7 +377,7 @@ export function PortsStatusSegment({ iconOnly }: PortsStatusSegmentProps): React
               <section className="border-t border-border/60">
                 <button
                   type="button"
-                  className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.05em] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-b border-border/40 bg-popover px-3 py-2 text-left text-[11px] font-medium uppercase tracking-[0.05em] text-muted-foreground hover:bg-accent/50 hover:text-foreground"
                   aria-expanded={externalOpen}
                   onClick={() => setExternalOpen((value) => !value)}
                 >

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -14,6 +14,8 @@ import { browserUrlForPort } from './workspace-port-urls'
 
 export { addressForPort } from './workspace-port-urls'
 
+const WORKSPACE_PORT_STOP_SETTLE_MS = 500
+
 export function canStopWorkspacePort(
   port: WorkspacePort
 ): port is WorkspacePort & { kind: 'workspace'; pid: number } {
@@ -24,6 +26,29 @@ type BrowserTabCreator = ReturnType<typeof useAppStore.getState>['createBrowserT
 type RemoteBrowserPageHandleSetter = ReturnType<
   typeof useAppStore.getState
 >['setRemoteBrowserPageHandle']
+type WorkspacePortScanSetter = ReturnType<typeof useAppStore.getState>['setWorkspacePortScan']
+type WorkspacePortScanRefreshingSetter = ReturnType<
+  typeof useAppStore.getState
+>['setWorkspacePortScanRefreshing']
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms))
+}
+
+export function shouldOpenWorkspacePortInOrcaBrowser(
+  settings: { openLinksInApp?: boolean } | null | undefined
+): boolean {
+  return settings?.openLinksInApp !== false
+}
+
+export function workspacePortOwnerWorktreeId(port: WorkspacePort): string | null {
+  return port.kind === 'workspace' ? port.owner.worktreeId : null
+}
+
+export function goToWorkspacePortOwner(port: WorkspacePort): boolean {
+  const worktreeId = workspacePortOwnerWorktreeId(port)
+  return Boolean(worktreeId && activateAndRevealWorktree(worktreeId))
+}
 
 export async function openWorkspacePortInBrowser(args: {
   port: WorkspacePort
@@ -31,13 +56,24 @@ export async function openWorkspacePortInBrowser(args: {
   runtimeTarget: RuntimeClientTarget
   createBrowserTab: BrowserTabCreator
   setRemoteBrowserPageHandle: RemoteBrowserPageHandleSetter
+  openInOrcaBrowser?: boolean
 }): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const url = browserUrlForPort(args.port)
+  if (args.openInOrcaBrowser === false && args.runtimeTarget.kind === 'local') {
+    try {
+      await window.api.shell.openUrl(url)
+      return { ok: true }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return { ok: false, reason: message || 'Failed to open system browser.' }
+    }
+  }
+
   const worktreeId =
     args.port.kind === 'workspace' ? args.port.owner.worktreeId : args.activeWorktreeId
   if (!worktreeId) {
     return { ok: false, reason: 'No workspace selected for the browser.' }
   }
-  const url = browserUrlForPort(args.port)
   activateAndRevealWorktree(worktreeId)
   if (args.runtimeTarget.kind === 'environment') {
     try {
@@ -63,6 +99,55 @@ export async function openWorkspacePortInBrowser(args: {
   }
   args.createBrowserTab(worktreeId, url, { activate: true })
   return { ok: true }
+}
+
+export async function refreshWorkspacePortScanState(args: {
+  runtimeTarget: RuntimeClientTarget
+  setWorkspacePortScan: WorkspacePortScanSetter
+  setWorkspacePortScanRefreshing: WorkspacePortScanRefreshingSetter
+}): Promise<WorkspacePortScanResult> {
+  args.setWorkspacePortScanRefreshing(true)
+  try {
+    const scan = await scanWorkspacePortsForTarget(args.runtimeTarget)
+    args.setWorkspacePortScan({
+      key: `${workspacePortRuntimeTargetKey(args.runtimeTarget)}:all`,
+      result: scan
+    })
+    return scan
+  } finally {
+    args.setWorkspacePortScanRefreshing(false)
+  }
+}
+
+export async function refreshWorkspacePortScanAfterStop(args: {
+  runtimeTarget: RuntimeClientTarget
+  setWorkspacePortScan: WorkspacePortScanSetter
+  setWorkspacePortScanRefreshing: WorkspacePortScanRefreshingSetter
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  args.setWorkspacePortScanRefreshing(true)
+  try {
+    const firstScan = await scanWorkspacePortsForTarget(args.runtimeTarget)
+    args.setWorkspacePortScan({
+      key: `${workspacePortRuntimeTargetKey(args.runtimeTarget)}:all`,
+      result: firstScan
+    })
+
+    // Why: stopping sends SIGTERM, and the listener can remain visible for a
+    // short window. A settled re-scan keeps worktree cards from showing a stale
+    // port row after the process actually exits.
+    await delay(WORKSPACE_PORT_STOP_SETTLE_MS)
+    const settledScan = await scanWorkspacePortsForTarget(args.runtimeTarget)
+    args.setWorkspacePortScan({
+      key: `${workspacePortRuntimeTargetKey(args.runtimeTarget)}:all`,
+      result: settledScan
+    })
+    return { ok: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, reason: message || 'Workspace port scan failed.' }
+  } finally {
+    args.setWorkspacePortScanRefreshing(false)
+  }
 }
 
 export function workspacePortRuntimeTargetKey(target: RuntimeClientTarget): string {


### PR DESCRIPTION
## Summary
- add workspace jump actions for workspace-owned ports
- respect external-browser preference for local port opens while keeping remote runtime ports in the remote browser
- refresh port scans after stopping processes without surfacing stale rows or unhandled refresh failures

## Verification
- pnpm typecheck
- pnpm test -- src/renderer/src/components/right-sidebar/PortsPanel.test.tsx