### PR TITLE
Refresh ports when advertised URLs change

### DIFF
--- a/src/main/ipc/workspace-ports.test.ts
+++ b/src/main/ipc/workspace-ports.test.ts
@@ -9,6 +9,9 @@ const { handleMock, scanWorkspacePortsMock, processKillMock } = vi.hoisted(() =>
 }))
 
 vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => [])
+  },
   ipcMain: {
     handle: handleMock
   }
@@ -217,6 +220,43 @@ describe('registerWorkspacePortHandlers', () => {
     expect(result).toEqual({ ok: false, reason: 'Invalid process or port.' })
     expect(scanWorkspacePortsMock).not.toHaveBeenCalled()
     expect(processKillMock).not.toHaveBeenCalled()
+  })
+
+  it('notifies renderers when a local worktree advertised URL changes', () => {
+    const store = makeStore()
+    type AdvertisedUrlListener = (event: { worktreeId: string; port: number }) => void
+    let advertisedUrlListener: AdvertisedUrlListener | undefined
+    const send = vi.fn()
+
+    registerWorkspacePortHandlers(store as never, {
+      advertisedUrlEvents: {
+        onDidChange: (listener) => {
+          advertisedUrlListener = listener
+          return () => {}
+        }
+      },
+      getWindows: () =>
+        [
+          {
+            isDestroyed: () => false,
+            webContents: {
+              isDestroyed: () => false,
+              send
+            }
+          }
+        ] as never
+    })
+
+    expect(advertisedUrlListener).toBeTypeOf('function')
+    const emitAdvertisedUrlChanged = advertisedUrlListener as AdvertisedUrlListener
+    emitAdvertisedUrlChanged({ worktreeId: 'local-repo::/workspace/repo', port: 3002 })
+    emitAdvertisedUrlChanged({ worktreeId: 'remote-repo::/remote/repo', port: 3003 })
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('workspacePorts:advertised-url-changed', {
+      worktreeId: 'local-repo::/workspace/repo',
+      port: 3002
+    })
   })
 })
 

--- a/src/main/ipc/workspace-ports.ts
+++ b/src/main/ipc/workspace-ports.ts
@@ -1,6 +1,8 @@
-import { ipcMain } from 'electron'
+import { BrowserWindow, ipcMain } from 'electron'
 import type { Store } from '../persistence'
+import { advertisedUrlWatcher, type AdvertisedUrlWatcher } from '../ports/advertised-url-watcher'
 import type {
+  WorkspacePortAdvertisedUrlChangedEvent,
   WorkspacePortKillRequest,
   WorkspacePortKillResult,
   WorkspacePortScanRequest,
@@ -12,8 +14,26 @@ import {
   scanWorkspacePortProbes
 } from '../ports/workspace-port-ownership'
 
-export function registerWorkspacePortHandlers(store: Store): void {
+type WorkspacePortHandlersOptions = {
+  advertisedUrlEvents?: Pick<AdvertisedUrlWatcher, 'onDidChange'>
+  getWindows?: () => BrowserWindow[]
+}
+
+export function registerWorkspacePortHandlers(
+  store: Store,
+  options: WorkspacePortHandlersOptions = {}
+): void {
   const inFlightScans = new Map<string, Promise<WorkspacePortScanResult>>()
+  const advertisedUrlEvents = options.advertisedUrlEvents ?? advertisedUrlWatcher
+  const getWindows = options.getWindows ?? (() => BrowserWindow.getAllWindows())
+
+  advertisedUrlEvents.onDidChange((event) => {
+    const localWorktrees = getStoreWorkspacePortProbes(store)
+    if (!localWorktrees.some((worktree) => worktree.id === event.worktreeId)) {
+      return
+    }
+    broadcastWorkspacePortAdvertisedUrlChanged(getWindows, event)
+  })
 
   ipcMain.handle(
     'workspacePorts:scan',
@@ -51,6 +71,22 @@ export function registerWorkspacePortHandlers(store: Store): void {
       return killWorkspacePort(worktrees, args)
     }
   )
+}
+
+function broadcastWorkspacePortAdvertisedUrlChanged(
+  getWindows: () => BrowserWindow[],
+  event: WorkspacePortAdvertisedUrlChangedEvent
+): void {
+  for (const window of getWindows()) {
+    if (window.isDestroyed()) {
+      continue
+    }
+    const webContents = window.webContents
+    if (webContents.isDestroyed()) {
+      continue
+    }
+    webContents.send('workspacePorts:advertised-url-changed', event)
+  }
 }
 
 function parseScanRequest(value: unknown): WorkspacePortScanRequest | undefined {

--- a/src/main/ports/advertised-url-watcher-pid-validation.test.ts
+++ b/src/main/ports/advertised-url-watcher-pid-validation.test.ts
@@ -125,6 +125,18 @@ describe('AdvertisedUrlWatcher.lookup PID validation', () => {
     expect(events).toContainEqual({ worktreeId: WORKTREE, port: 3001 })
   })
 
+  it('keeps a startup URL when the previous scan had not seen the listener yet', () => {
+    const watcher = bindFresh()
+
+    watcher.reconcileScan([WORKTREE], [])
+    watcher.ingest(PTY, 'Nautilus: http://localhost:3002/\n')
+    watcher.reconcileScan([WORKTREE], [{ port: 3002, pid: 4242 }])
+
+    const advertised = watcher.lookup(WORKTREE, 3002, 4242)
+    expect(advertised?.origin).toBe('http://localhost:3002')
+    expect(advertised?.validatedListenerPid).toBe(4242)
+  })
+
   it('evicts an unvalidated URL when scanner observes a different PID first', () => {
     const watcher = bindFresh()
 

--- a/src/main/ports/advertised-url-watcher.ts
+++ b/src/main/ports/advertised-url-watcher.ts
@@ -516,6 +516,11 @@ export class AdvertisedUrlWatcher {
       return true
     }
     const baseline = this.validationBaselines.get(key)
+    if (baseline?.kind === 'absent' && current.kind === 'present') {
+      // Why: dev servers can print their URL before the OS listener scan sees
+      // the port. Let that first present scan validate the startup banner.
+      return false
+    }
     return (
       entry.validatedListenerPid === undefined &&
       baseline !== undefined &&

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -230,6 +230,7 @@ import type {
   WorkspaceSpaceScanProgress
 } from '../shared/workspace-space-types'
 import type {
+  WorkspacePortAdvertisedUrlChangedEvent,
   WorkspacePortKillRequest,
   WorkspacePortKillResult,
   WorkspacePortScanRequest,
@@ -715,6 +716,9 @@ export type PreloadApi = {
   workspacePorts: {
     scan: (args: WorkspacePortScanRequest) => Promise<WorkspacePortScanResult>
     kill: (args: WorkspacePortKillRequest) => Promise<WorkspacePortKillResult>
+    onAdvertisedUrlChanged: (
+      callback: (event: WorkspacePortAdvertisedUrlChangedEvent) => void
+    ) => () => void
   }
   pty: {
     spawn: (opts: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -61,6 +61,7 @@ import type {
   WorkspaceSpaceScanProgress
 } from '../shared/workspace-space-types'
 import type {
+  WorkspacePortAdvertisedUrlChangedEvent,
   WorkspacePortKillRequest,
   WorkspacePortKillResult,
   WorkspacePortScanRequest,
@@ -578,7 +579,17 @@ const api = {
     scan: (args: WorkspacePortScanRequest): Promise<WorkspacePortScanResult> =>
       ipcRenderer.invoke('workspacePorts:scan', args),
     kill: (args: WorkspacePortKillRequest): Promise<WorkspacePortKillResult> =>
-      ipcRenderer.invoke('workspacePorts:kill', args)
+      ipcRenderer.invoke('workspacePorts:kill', args),
+    onAdvertisedUrlChanged: (
+      callback: (event: WorkspacePortAdvertisedUrlChangedEvent) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        event: WorkspacePortAdvertisedUrlChangedEvent
+      ): void => callback(event)
+      ipcRenderer.on('workspacePorts:advertised-url-changed', listener)
+      return () => ipcRenderer.removeListener('workspacePorts:advertised-url-changed', listener)
+    }
   },
 
   pty: {

--- a/src/renderer/src/components/ports/WorkspacePortScanner.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.tsx
@@ -6,10 +6,11 @@ import {
   scanWorkspacePortsForTarget,
   workspacePortRuntimeTargetKey
 } from '@/lib/workspace-port-actions'
-import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
+import { installWindowVisibilityInterval, isWindowVisible } from '@/lib/window-visibility-interval'
 import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 
 const WORKSPACE_PORT_SCAN_INTERVAL_MS = 30_000
+const WORKSPACE_PORT_ADVERTISED_URL_SETTLE_MS = 1_000
 
 function makeUnavailableScan(reason: string): WorkspacePortScanResult {
   return {
@@ -85,6 +86,46 @@ export function WorkspacePortScanner(): null {
       stopVisibleInterval()
     }
   }, [refresh, setWorkspacePortScan])
+
+  useEffect(() => {
+    if (runtimeTarget.kind !== 'local') {
+      return
+    }
+
+    let eventSequence = 0
+    let disposed = false
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+    const clearRetryTimer = (): void => {
+      if (!retryTimer) {
+        return
+      }
+      clearTimeout(retryTimer)
+      retryTimer = null
+    }
+
+    const unsubscribe = window.api.workspacePorts.onAdvertisedUrlChanged(() => {
+      eventSequence += 1
+      const sequence = eventSequence
+      clearRetryTimer()
+      if (!isWindowVisible()) {
+        return
+      }
+      void refresh().finally(() => {
+        if (disposed || sequence !== eventSequence || !isWindowVisible()) {
+          return
+        }
+        // Why: some dev servers print their URL just before the listener is
+        // visible to lsof/netstat. One quiet settle scan catches that startup race.
+        retryTimer = setTimeout(() => void refresh(), WORKSPACE_PORT_ADVERTISED_URL_SETTLE_MS)
+      })
+    })
+
+    return () => {
+      disposed = true
+      clearRetryTimer()
+      unsubscribe()
+    }
+  }, [refresh, runtimeTarget])
 
   return null
 }

--- a/src/shared/workspace-ports.ts
+++ b/src/shared/workspace-ports.ts
@@ -49,6 +49,11 @@ export type WorkspacePortScanRequest = {
   repoId?: string
 }
 
+export type WorkspacePortAdvertisedUrlChangedEvent = {
+  worktreeId: string
+  port: number
+}
+
 export type WorkspacePortKillRequest = {
   repoId?: string
   pid: number


### PR DESCRIPTION
## Summary
- emit a local workspace-port event when terminal-advertised URLs change
- silently refresh the shared ports scan on those events, with a short settle retry for dev-server startup races
- preserve startup URL candidates when a previous scan saw the port as absent before it became available

## Validation
- pnpm exec vitest run src/main/ports/advertised-url-watcher-pid-validation.test.ts src/main/ipc/workspace-ports.test.ts
- pnpm run typecheck
- pnpm lint
- live Electron check: spawned a local Orca PTY that printed `http://nautilus.localhost:61318/`; the Ports popover rendered `nautilus.localhost:61318` within a few seconds, with no refresh spinner

Made with [Orca](https://github.com/stablyai/orca) 🐋
