### PR TITLE
Make worktree force delete idempotent

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2611,6 +2611,81 @@ describe('registerWorktreeHandlers', () => {
     expect(store.removeWorktreeMeta).not.toHaveBeenCalled()
   })
 
+  it('treats forced deletion of an already-missing unregistered worktree as cleanup', async () => {
+    mockKnownFeatureWorktree('/workspace/real-feature')
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/already-deleted-wt',
+      force: true
+    })
+
+    expect(killAllProcessesForWorktreeMock).not.toHaveBeenCalled()
+    expect(runHookMock).not.toHaveBeenCalled()
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+    expect(runtimeStub.clearOptimisticReconcileToken).toHaveBeenCalledWith(
+      'repo-1::/workspace/already-deleted-wt'
+    )
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith('repo-1::/workspace/already-deleted-wt')
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(
+      'repo-1::/workspace/already-deleted-wt'
+    )
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+      repoId: 'repo-1'
+    })
+  })
+
+  it('coalesces concurrent deletes for the same worktree id', async () => {
+    mockKnownFeatureWorktree()
+    deleteWorktreeHistoryDirMock.mockClear()
+    let removalStarted!: () => void
+    let finishRemoval!: () => void
+    const started = new Promise<void>((resolve) => {
+      removalStarted = resolve
+    })
+    removeWorktreeMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          removalStarted()
+          finishRemoval = resolve
+        })
+    )
+
+    const first = handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt',
+      force: true
+    }) as Promise<void>
+    const second = handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt',
+      force: true
+    }) as Promise<void>
+
+    await started
+    await Promise.resolve()
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1)
+
+    finishRemoval()
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    expect(store.removeWorktreeMeta).toHaveBeenCalledTimes(1)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledTimes(1)
+    expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('still rejects forced unregistered delete paths that exist on disk', async () => {
+    mockKnownFeatureWorktree('/workspace/real-feature')
+
+    await expect(
+      handlers['worktrees:remove'](null, {
+        worktreeId: `repo-1::${process.cwd()}`,
+        force: true
+      })
+    ).rejects.toThrow('Refusing to delete unregistered worktree path')
+
+    expect(killAllProcessesForWorktreeMock).not.toHaveBeenCalled()
+    expect(runHookMock).not.toHaveBeenCalled()
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+    expect(store.removeWorktreeMeta).not.toHaveBeenCalled()
+  })
+
   it('rejects the main worktree before teardown, hooks, or git removal', async () => {
     mockKnownFeatureWorktree()
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2670,6 +2670,38 @@ describe('registerWorktreeHandlers', () => {
     expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects concurrent deletes for the same worktree id with different options', async () => {
+    mockKnownFeatureWorktree()
+    let removalStarted!: () => void
+    let finishRemoval!: () => void
+    const started = new Promise<void>((resolve) => {
+      removalStarted = resolve
+    })
+    removeWorktreeMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          removalStarted()
+          finishRemoval = resolve
+        })
+    )
+
+    const first = handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt'
+    }) as Promise<void>
+
+    await started
+    await expect(
+      handlers['worktrees:remove'](null, {
+        worktreeId: 'repo-1::/workspace/feature-wt',
+        force: true
+      })
+    ).rejects.toThrow('Worktree deletion already in progress')
+
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1)
+    finishRemoval()
+    await expect(first).resolves.toBeUndefined()
+  })
+
   it('still rejects forced unregistered delete paths that exist on disk', async () => {
     mockKnownFeatureWorktree('/workspace/real-feature')
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -105,6 +105,17 @@ async function isAlreadyRemovedWorktreePath(repo: Repo, worktreePath: string): P
   return isWorktreePathMissing(worktreePath, (path) => fsProvider.stat(path))
 }
 
+function getWorktreeRemovalOptionsKey(args: { force?: boolean; skipArchive?: boolean }): string {
+  const forceKey = args.force === true ? 'force' : 'normal'
+  const archiveKey = args.skipArchive === true ? 'skip-archive' : 'run-archive'
+  return `${forceKey}:${archiveKey}`
+}
+
+type WorktreeRemovalInFlight = {
+  optionsKey: string
+  promise: Promise<void>
+}
+
 const loggedUnavailableSshGitProviders = new Set<string>()
 const loggedWorktreeListFailures = new Set<string>()
 const loggedMalformedWorktreeMetaKeys = new Set<string>()
@@ -522,14 +533,18 @@ export function registerWorktreeHandlers(
     }
   )
 
-  const worktreeRemovalsInFlight = new Map<string, Promise<void>>()
+  const worktreeRemovalsInFlight = new Map<string, WorktreeRemovalInFlight>()
 
   ipcMain.handle(
     'worktrees:remove',
     async (_event, args: { worktreeId: string; force?: boolean; skipArchive?: boolean }) => {
+      const optionsKey = getWorktreeRemovalOptionsKey(args)
       const inFlightRemoval = worktreeRemovalsInFlight.get(args.worktreeId)
       if (inFlightRemoval) {
-        return inFlightRemoval
+        if (inFlightRemoval.optionsKey === optionsKey) {
+          return inFlightRemoval.promise
+        }
+        throw new Error(`Worktree deletion already in progress: ${args.worktreeId}`)
       }
 
       // Why: stale toast actions, double-clicks, and Space/sidebar races can
@@ -718,11 +733,11 @@ export function registerWorktreeHandlers(
 
         notifyWorktreesChanged(mainWindow, repoId)
       })()
-      worktreeRemovalsInFlight.set(args.worktreeId, removal)
+      worktreeRemovalsInFlight.set(args.worktreeId, { optionsKey, promise: removal })
       try {
         await removal
       } finally {
-        if (worktreeRemovalsInFlight.get(args.worktreeId) === removal) {
+        if (worktreeRemovalsInFlight.get(args.worktreeId)?.promise === removal) {
           worktreeRemovalsInFlight.delete(args.worktreeId)
         }
       }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -69,7 +69,8 @@ import { workspaceSourceSchema, type WorkspaceSource } from '../../shared/teleme
 import { classifyWorkspaceCreateError } from './workspace-create-error-classifier'
 import {
   canSafelyRemoveOrphanedWorktreeDirectory,
-  getRegisteredDeletableWorktree
+  findRegisteredDeletableWorktree,
+  isWorktreePathMissing
 } from '../worktree-removal-safety'
 
 // Why: worktrees discovered on disk (not created via Orca's UI) have no
@@ -90,6 +91,18 @@ function resolveWorktreeMetaWithDiscoveryStamp(store: Store, worktreeId: string)
     return existing
   }
   return store.setWorktreeMeta(worktreeId, { lastActivityAt: Date.now() })
+}
+
+async function isAlreadyRemovedWorktreePath(repo: Repo, worktreePath: string): Promise<boolean> {
+  if (!repo.connectionId) {
+    return isWorktreePathMissing(worktreePath)
+  }
+
+  const fsProvider = getSshFilesystemProvider(repo.connectionId)
+  if (!fsProvider) {
+    return false
+  }
+  return isWorktreePathMissing(worktreePath, (path) => fsProvider.stat(path))
 }
 
 const loggedUnavailableSshGitProviders = new Set<string>()
@@ -509,128 +522,81 @@ export function registerWorktreeHandlers(
     }
   )
 
+  const worktreeRemovalsInFlight = new Map<string, Promise<void>>()
+
   ipcMain.handle(
     'worktrees:remove',
     async (_event, args: { worktreeId: string; force?: boolean; skipArchive?: boolean }) => {
-      const { repoId, worktreePath } = parseWorktreeId(args.worktreeId)
-      const repo = store.getRepo(repoId)
-      if (!repo) {
-        throw new Error(`Repo not found: ${repoId}`)
-      }
-      if (isFolderRepo(repo)) {
-        throw new Error('Folder mode does not support deleting worktrees.')
+      const inFlightRemoval = worktreeRemovalsInFlight.get(args.worktreeId)
+      if (inFlightRemoval) {
+        return inFlightRemoval
       }
 
-      // Why: the renderer-supplied worktreeId contains a filesystem path.
-      // Re-derive the canonical path from git before any destructive action.
-      const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
-      const registeredWorktrees = repo.connectionId
-        ? await provider!.listWorktrees(repo.path)
-        : await listGitWorktrees(repo.path)
-      const canonicalWorktreePath = getRegisteredDeletableWorktree(
-        repo.path,
-        worktreePath,
-        registeredWorktrees
-      ).path
-      const removedMeta = store.getWorktreeMeta(args.worktreeId)
-      const removedPushTarget = removedMeta?.pushTarget
-      const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+      // Why: stale toast actions, double-clicks, and Space/sidebar races can
+      // target the same worktree concurrently. Share the destructive backend
+      // operation so only one path touches Git and the filesystem.
+      const removal = (async (): Promise<void> => {
+        const { repoId, worktreePath } = parseWorktreeId(args.worktreeId)
+        const repo = store.getRepo(repoId)
+        if (!repo) {
+          throw new Error(`Repo not found: ${repoId}`)
+        }
+        if (isFolderRepo(repo)) {
+          throw new Error('Folder mode does not support deleting worktrees.')
+        }
 
-      if (repo.connectionId) {
-        await (deleteBranch
-          ? provider!.removeWorktree(canonicalWorktreePath, args.force)
-          : provider!.removeWorktree(canonicalWorktreePath, args.force, { deleteBranch }))
-        await cleanupUnusedWorktreePushTargetRemoteSsh(
-          provider!,
+        // Why: the renderer-supplied worktreeId contains a filesystem path.
+        // Re-derive the canonical path from git before any destructive action.
+        const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
+        const registeredWorktrees = repo.connectionId
+          ? await provider!.listWorktrees(repo.path)
+          : await listGitWorktrees(repo.path)
+        const removedMeta = store.getWorktreeMeta(args.worktreeId)
+        const removedPushTarget = removedMeta?.pushTarget
+        const registeredWorktree = findRegisteredDeletableWorktree(
           repo.path,
-          args.worktreeId,
-          removedPushTarget,
-          store
+          worktreePath,
+          registeredWorktrees
         )
-        runtime.clearOptimisticReconcileToken(args.worktreeId)
-        store.removeWorktreeMeta(args.worktreeId)
-        deleteWorktreeHistoryDir(args.worktreeId)
-        notifyWorktreesChanged(mainWindow, repoId)
-        return
-      }
-
-      // Run archive hook before removal
-      const hooks = getEffectiveHooks(repo)
-      if (hooks?.scripts.archive && !args.skipArchive) {
-        const result = await runHook('archive', canonicalWorktreePath, repo)
-        if (!result.success) {
-          console.error(`[hooks] archive hook failed for ${canonicalWorktreePath}:`, result.output)
-        }
-      }
-
-      // Why: `git worktree remove` (non-force) refuses to delete a worktree
-      // that has untracked files, and a symlink pointing into the primary
-      // checkout looks untracked to git. Unlink the user-configured symlinks
-      // first so the normal delete path keeps working — otherwise every
-      // deletion would require the Force Delete toast once the feature is on.
-      if (repo.symlinkPaths && repo.symlinkPaths.length > 0) {
-        await removeWorktreeSymlinks(canonicalWorktreePath, repo.symlinkPaths)
-      }
-
-      let shouldTearDownPtys = true
-      try {
-        await assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false)
-      } catch (error) {
-        if (!isOrphanCompatiblePreflightError(error)) {
-          throw new Error(
-            formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-          )
-        }
-        // Why: orphan cleanup does not need live shells to be killed first,
-        // and preflight did not prove the worktree is cleanly removable.
-        shouldTearDownPtys = false
-      }
-
-      if (shouldTearDownPtys) {
-        // Why: once preflight proves normal deletion is clean, kill PTYs before
-        // git-level removal so shells cannot keep the directory busy.
-        await killAllProcessesForWorktree(args.worktreeId, {
-          runtime,
-          localProvider: getLocalPtyProvider()
-        })
-          .then((r) => {
-            const total = r.runtimeStopped + r.providerStopped + r.registryStopped
-            if (total > 0) {
-              console.info(
-                `[worktree-teardown] ${args.worktreeId} killed runtime=${r.runtimeStopped} provider=${r.providerStopped} registry=${r.registryStopped}`
+        if (!registeredWorktree) {
+          if (args.force && (await isAlreadyRemovedWorktreePath(repo, worktreePath))) {
+            // Why: Force-delete can be retried from stale UI after a prior delete
+            // already removed the directory and Git registration. Treat that as
+            // successful cleanup, but do not delete any unregistered existing path.
+            if (repo.connectionId) {
+              await cleanupUnusedWorktreePushTargetRemoteSsh(
+                provider!,
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store
               )
+            } else {
+              await cleanupUnusedWorktreePushTargetRemote(
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store
+              )
+              invalidateAuthorizedRootsCache()
             }
-          })
-          .catch((err) => {
-            console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
-          })
-      }
-
-      try {
-        await (deleteBranch
-          ? removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false)
-          : removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false, {
-              deleteBranch
-            }))
-      } catch (error) {
-        // If git no longer tracks this worktree, clean up the directory and metadata
-        if (isOrphanedWorktreeError(error)) {
-          console.warn(
-            `[worktrees] Orphaned worktree detected at ${canonicalWorktreePath}, cleaning up`
-          )
-          if (await canSafelyRemoveOrphanedWorktreeDirectory(canonicalWorktreePath, repo.path)) {
-            await rm(canonicalWorktreePath, { recursive: true, force: true }).catch(() => {})
-          } else {
-            console.warn(
-              `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
-            )
+            runtime.clearOptimisticReconcileToken(args.worktreeId)
+            store.removeWorktreeMeta(args.worktreeId)
+            deleteWorktreeHistoryDir(args.worktreeId)
+            notifyWorktreesChanged(mainWindow, repoId)
+            return
           }
-          // Why: `git worktree remove` failed, so git's internal worktree tracking
-          // (`.git/worktrees/<name>`) is still intact. Without pruning, `git worktree
-          // list` continues to show the stale entry and the branch it had checked out
-          // remains locked — other worktrees cannot check it out.
-          await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
-          await cleanupUnusedWorktreePushTargetRemote(
+          throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
+        }
+        const canonicalWorktreePath = registeredWorktree.path
+        const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+
+        if (repo.connectionId) {
+          await (deleteBranch
+            ? provider!.removeWorktree(canonicalWorktreePath, args.force)
+            : provider!.removeWorktree(canonicalWorktreePath, args.force, { deleteBranch }))
+          await cleanupUnusedWorktreePushTargetRemoteSsh(
+            provider!,
             repo.path,
             args.worktreeId,
             removedPushTarget,
@@ -639,26 +605,127 @@ export function registerWorktreeHandlers(
           runtime.clearOptimisticReconcileToken(args.worktreeId)
           store.removeWorktreeMeta(args.worktreeId)
           deleteWorktreeHistoryDir(args.worktreeId)
-          invalidateAuthorizedRootsCache()
           notifyWorktreesChanged(mainWindow, repoId)
           return
         }
-        throw new Error(
-          formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-        )
-      }
-      await cleanupUnusedWorktreePushTargetRemote(
-        repo.path,
-        args.worktreeId,
-        removedPushTarget,
-        store
-      )
-      runtime.clearOptimisticReconcileToken(args.worktreeId)
-      store.removeWorktreeMeta(args.worktreeId)
-      deleteWorktreeHistoryDir(args.worktreeId)
-      invalidateAuthorizedRootsCache()
 
-      notifyWorktreesChanged(mainWindow, repoId)
+        // Run archive hook before removal
+        const hooks = getEffectiveHooks(repo)
+        if (hooks?.scripts.archive && !args.skipArchive) {
+          const result = await runHook('archive', canonicalWorktreePath, repo)
+          if (!result.success) {
+            console.error(
+              `[hooks] archive hook failed for ${canonicalWorktreePath}:`,
+              result.output
+            )
+          }
+        }
+
+        // Why: `git worktree remove` (non-force) refuses to delete a worktree
+        // that has untracked files, and a symlink pointing into the primary
+        // checkout looks untracked to git. Unlink the user-configured symlinks
+        // first so the normal delete path keeps working — otherwise every
+        // deletion would require the Force Delete toast once the feature is on.
+        if (repo.symlinkPaths && repo.symlinkPaths.length > 0) {
+          await removeWorktreeSymlinks(canonicalWorktreePath, repo.symlinkPaths)
+        }
+
+        let shouldTearDownPtys = true
+        try {
+          await assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false)
+        } catch (error) {
+          if (!isOrphanCompatiblePreflightError(error)) {
+            throw new Error(
+              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+            )
+          }
+          // Why: orphan cleanup does not need live shells to be killed first,
+          // and preflight did not prove the worktree is cleanly removable.
+          shouldTearDownPtys = false
+        }
+
+        if (shouldTearDownPtys) {
+          // Why: once preflight proves normal deletion is clean, kill PTYs before
+          // git-level removal so shells cannot keep the directory busy.
+          await killAllProcessesForWorktree(args.worktreeId, {
+            runtime,
+            localProvider: getLocalPtyProvider()
+          })
+            .then((r) => {
+              const total = r.runtimeStopped + r.providerStopped + r.registryStopped
+              if (total > 0) {
+                console.info(
+                  `[worktree-teardown] ${args.worktreeId} killed runtime=${r.runtimeStopped} provider=${r.providerStopped} registry=${r.registryStopped}`
+                )
+              }
+            })
+            .catch((err) => {
+              console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
+            })
+        }
+
+        try {
+          await (deleteBranch
+            ? removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false)
+            : removeWorktree(repo.path, canonicalWorktreePath, args.force ?? false, {
+                deleteBranch
+              }))
+        } catch (error) {
+          // If git no longer tracks this worktree, clean up the directory and metadata
+          if (isOrphanedWorktreeError(error)) {
+            console.warn(
+              `[worktrees] Orphaned worktree detected at ${canonicalWorktreePath}, cleaning up`
+            )
+            if (await canSafelyRemoveOrphanedWorktreeDirectory(canonicalWorktreePath, repo.path)) {
+              await rm(canonicalWorktreePath, { recursive: true, force: true }).catch(() => {})
+            } else {
+              console.warn(
+                `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
+              )
+            }
+            // Why: `git worktree remove` failed, so git's internal worktree tracking
+            // (`.git/worktrees/<name>`) is still intact. Without pruning, `git worktree
+            // list` continues to show the stale entry and the branch it had checked out
+            // remains locked — other worktrees cannot check it out.
+            await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
+            await cleanupUnusedWorktreePushTargetRemote(
+              repo.path,
+              args.worktreeId,
+              removedPushTarget,
+              store
+            )
+            runtime.clearOptimisticReconcileToken(args.worktreeId)
+            store.removeWorktreeMeta(args.worktreeId)
+            deleteWorktreeHistoryDir(args.worktreeId)
+            invalidateAuthorizedRootsCache()
+            notifyWorktreesChanged(mainWindow, repoId)
+            return
+          }
+          throw new Error(
+            formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+          )
+        }
+        await cleanupUnusedWorktreePushTargetRemote(
+          repo.path,
+          args.worktreeId,
+          removedPushTarget,
+          store
+        )
+        runtime.clearOptimisticReconcileToken(args.worktreeId)
+        store.removeWorktreeMeta(args.worktreeId)
+        deleteWorktreeHistoryDir(args.worktreeId)
+        invalidateAuthorizedRootsCache()
+
+        notifyWorktreesChanged(mainWindow, repoId)
+      })()
+      worktreeRemovalsInFlight.set(args.worktreeId, removal)
+      try {
+        await removal
+      } finally {
+        if (worktreeRemovalsInFlight.get(args.worktreeId) === removal) {
+          worktreeRemovalsInFlight.delete(args.worktreeId)
+        }
+      }
     }
   )
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7661,6 +7661,27 @@ describe('OrcaRuntimeService', () => {
     await expect(Promise.all([first, second])).resolves.toEqual([{}, {}])
   })
 
+  it('rejects concurrent runtime worktree removals for the same id with different options', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const removeStarted = deferred<void>()
+    const finishRemoval = deferred<void>()
+    vi.mocked(removeWorktree).mockImplementation(async () => {
+      removeStarted.resolve()
+      await finishRemoval.promise
+    })
+
+    const first = runtime.removeManagedWorktree(TEST_WORKTREE_ID)
+
+    await removeStarted.promise
+    await expect(runtime.removeManagedWorktree(TEST_WORKTREE_ID, true)).rejects.toThrow(
+      'Worktree deletion already in progress'
+    )
+
+    expect(removeWorktree).toHaveBeenCalledTimes(1)
+    finishRemoval.resolve()
+    await expect(first).resolves.toEqual({})
+  })
+
   it('treats forced runtime deletion of an already-missing unregistered worktree as cleanup', async () => {
     const parentDir = await mkdtemp(join(tmpdir(), 'orca-runtime-remove-'))
     const missingWorktreePath = join(parentDir, 'already-deleted')
@@ -7671,17 +7692,7 @@ describe('OrcaRuntimeService', () => {
     runtime.setNotifier(notifier as never)
 
     try {
-      vi.mocked(listWorktrees).mockResolvedValueOnce([
-        {
-          path: missingWorktreePath,
-          head: 'abc',
-          branch: 'feature/already-deleted',
-          isBare: false,
-          isMainWorktree: false
-        }
-      ])
-      await runtime.showManagedWorktree(worktreeId)
-      vi.mocked(listWorktrees).mockResolvedValueOnce([])
+      vi.mocked(listWorktrees).mockResolvedValue([])
 
       await expect(runtime.removeManagedWorktree(worktreeId, true)).resolves.toEqual({})
 
@@ -7701,17 +7712,7 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     try {
-      vi.mocked(listWorktrees).mockResolvedValueOnce([
-        {
-          path: existingWorktreePath,
-          head: 'abc',
-          branch: 'feature/still-present',
-          isBare: false,
-          isMainWorktree: false
-        }
-      ])
-      await runtime.showManagedWorktree(worktreeId)
-      vi.mocked(listWorktrees).mockResolvedValueOnce([])
+      vi.mocked(listWorktrees).mockResolvedValue([])
 
       await expect(runtime.removeManagedWorktree(worktreeId, true)).rejects.toThrow(
         'Refusing to delete unregistered worktree path'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2,6 +2,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { EventEmitter } from 'events'
 import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import type { WorktreeLineage, WorktreeMeta } from '../../shared/types'
 import {
   addWorktree,
@@ -499,6 +501,26 @@ function deferred<T>(): {
     reject = rej
   })
   return { promise, resolve, reject }
+}
+
+function createStaleRuntimeWorktreeStore(worktreeId: string) {
+  const metaById: Record<string, WorktreeMeta> = {
+    [worktreeId]: makeWorktreeMeta()
+  }
+  const removeWorktreeMeta = vi.fn((id: string) => {
+    delete metaById[id]
+  })
+  const runtimeStore = {
+    ...store,
+    getAllWorktreeMeta: () => metaById,
+    getWorktreeMeta: (id: string) => metaById[id],
+    setWorktreeMeta: (id: string, meta: Partial<WorktreeMeta>) => {
+      metaById[id] = { ...(metaById[id] ?? makeWorktreeMeta()), ...meta }
+      return metaById[id]
+    },
+    removeWorktreeMeta
+  }
+  return { runtimeStore, removeWorktreeMeta }
 }
 
 const store = {
@@ -7617,6 +7639,89 @@ describe('OrcaRuntimeService', () => {
     expect(result.warning).toBe(
       `orca.yaml archive hook skipped for ${TEST_WORKTREE_PATH}; pass --run-hooks to run it.`
     )
+  })
+
+  it('coalesces concurrent runtime worktree removals for the same worktree id', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const removeStarted = deferred<void>()
+    const finishRemoval = deferred<void>()
+    vi.mocked(removeWorktree).mockImplementation(async () => {
+      removeStarted.resolve()
+      await finishRemoval.promise
+    })
+
+    const first = runtime.removeManagedWorktree(TEST_WORKTREE_ID, true)
+    const second = runtime.removeManagedWorktree(TEST_WORKTREE_ID, true)
+
+    await removeStarted.promise
+    await Promise.resolve()
+    expect(removeWorktree).toHaveBeenCalledTimes(1)
+
+    finishRemoval.resolve()
+    await expect(Promise.all([first, second])).resolves.toEqual([{}, {}])
+  })
+
+  it('treats forced runtime deletion of an already-missing unregistered worktree as cleanup', async () => {
+    const parentDir = await mkdtemp(join(tmpdir(), 'orca-runtime-remove-'))
+    const missingWorktreePath = join(parentDir, 'already-deleted')
+    const worktreeId = `${TEST_REPO_ID}::${missingWorktreePath}`
+    const { runtimeStore, removeWorktreeMeta } = createStaleRuntimeWorktreeStore(worktreeId)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const notifier = { worktreesChanged: vi.fn() }
+    runtime.setNotifier(notifier as never)
+
+    try {
+      vi.mocked(listWorktrees).mockResolvedValueOnce([
+        {
+          path: missingWorktreePath,
+          head: 'abc',
+          branch: 'feature/already-deleted',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+      await runtime.showManagedWorktree(worktreeId)
+      vi.mocked(listWorktrees).mockResolvedValueOnce([])
+
+      await expect(runtime.removeManagedWorktree(worktreeId, true)).resolves.toEqual({})
+
+      expect(removeWorktree).not.toHaveBeenCalled()
+      expect(removeWorktreeMeta).toHaveBeenCalledWith(worktreeId)
+      expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
+      expect(notifier.worktreesChanged).toHaveBeenCalledWith(TEST_REPO_ID)
+    } finally {
+      await rm(parentDir, { recursive: true, force: true })
+    }
+  })
+
+  it('still rejects forced runtime unregistered delete paths that exist on disk', async () => {
+    const existingWorktreePath = await mkdtemp(join(tmpdir(), 'orca-runtime-remove-existing-'))
+    const worktreeId = `${TEST_REPO_ID}::${existingWorktreePath}`
+    const { runtimeStore, removeWorktreeMeta } = createStaleRuntimeWorktreeStore(worktreeId)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    try {
+      vi.mocked(listWorktrees).mockResolvedValueOnce([
+        {
+          path: existingWorktreePath,
+          head: 'abc',
+          branch: 'feature/still-present',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+      await runtime.showManagedWorktree(worktreeId)
+      vi.mocked(listWorktrees).mockResolvedValueOnce([])
+
+      await expect(runtime.removeManagedWorktree(worktreeId, true)).rejects.toThrow(
+        'Refusing to delete unregistered worktree path'
+      )
+
+      expect(removeWorktree).not.toHaveBeenCalled()
+      expect(removeWorktreeMeta).not.toHaveBeenCalled()
+    } finally {
+      await rm(existingWorktreePath, { recursive: true, force: true })
+    }
   })
 
   it('rejects CLI worktree removal when the target contains another registered worktree', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -325,7 +325,8 @@ import {
 } from '../ipc/worktree-logic'
 import {
   canSafelyRemoveOrphanedWorktreeDirectory,
-  getRegisteredDeletableWorktree
+  findRegisteredDeletableWorktree,
+  isWorktreePathMissing
 } from '../worktree-removal-safety'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 import { HeadlessEmulator } from '../daemon/headless-emulator'
@@ -653,6 +654,18 @@ function omitUndefinedProperties<T extends Record<string, unknown>>(value: T): P
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined)
   ) as Partial<T>
+}
+
+async function isRuntimeWorktreePathMissing(repo: Repo, worktreePath: string): Promise<boolean> {
+  if (!repo.connectionId) {
+    return isWorktreePathMissing(worktreePath)
+  }
+
+  const fsProvider = getSshFilesystemProvider(repo.connectionId)
+  if (!fsProvider) {
+    return false
+  }
+  return isWorktreePathMissing(worktreePath, (path) => fsProvider.stat(path))
 }
 
 async function resolveCreateBranchName(
@@ -1083,6 +1096,7 @@ export class OrcaRuntimeService {
   // canonical key is resolved at most once per repo+remote in the process.
   private canonicalFetchKeyCache = new Map<string, string>()
   private optimisticReconcileTokens = new Map<string, string>()
+  private removeManagedWorktreeInFlight = new Map<string, Promise<{ warning?: string }>>()
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
@@ -7951,144 +7965,192 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
+    const store = this.store
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const repo = this.store.getRepo(worktree.repoId)
-    if (!repo) {
-      throw new Error('repo_not_found')
+    const inFlightRemoval = this.removeManagedWorktreeInFlight.get(worktree.id)
+    if (inFlightRemoval) {
+      return inFlightRemoval
     }
-    if (isFolderRepo(repo)) {
-      throw new Error('Folder mode does not support deleting worktrees.')
-    }
-    const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
-    const registeredWorktrees = repo.connectionId
-      ? await provider!.listWorktrees(repo.path)
-      : await listWorktrees(repo.path)
-    const canonicalWorktreePath = getRegisteredDeletableWorktree(
-      repo.path,
-      worktree.path,
-      registeredWorktrees
-    ).path
-    const deleteBranch = this.store.getWorktreeMeta(worktree.id)?.preserveBranchOnDelete !== true
-    if (repo.connectionId) {
-      await (deleteBranch
-        ? provider!.removeWorktree(canonicalWorktreePath, force)
-        : provider!.removeWorktree(canonicalWorktreePath, force, { deleteBranch }))
-      await cleanupUnusedWorktreePushTargetRemoteSsh(
-        provider!,
+
+    // Why: runtime callers can race the same workspace through CLI/mobile
+    // retries. Share one destructive Git/filesystem operation per worktree ID.
+    const removal = (async (): Promise<{ warning?: string }> => {
+      const repo = store.getRepo(worktree.repoId)
+      if (!repo) {
+        throw new Error('repo_not_found')
+      }
+      if (isFolderRepo(repo)) {
+        throw new Error('Folder mode does not support deleting worktrees.')
+      }
+      const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
+      const registeredWorktrees = repo.connectionId
+        ? await provider!.listWorktrees(repo.path)
+        : await listWorktrees(repo.path)
+      const removedMeta = store.getWorktreeMeta(worktree.id)
+      const registeredWorktree = findRegisteredDeletableWorktree(
         repo.path,
-        worktree.id,
-        worktree.pushTarget,
-        this.store
+        worktree.path,
+        registeredWorktrees
       )
-      this.clearOptimisticReconcileToken(worktree.id)
-      this.store.removeWorktreeMeta(worktree.id)
-      this.invalidateResolvedWorktreeCache()
-      invalidateAuthorizedRootsCache()
-      this.notifier?.worktreesChanged(repo.id)
-      return {}
-    }
-
-    const hooks = getEffectiveHooks(repo)
-    let warning: string | undefined
-    if (hooks?.scripts.archive && runHooks) {
-      const result = await runHook('archive', canonicalWorktreePath, repo)
-      if (!result.success) {
-        console.error(`[hooks] archive hook failed for ${canonicalWorktreePath}:`, result.output)
-      }
-    } else if (hooks?.scripts.archive) {
-      // Runtime RPC calls have no renderer trust prompt, so hooks require explicit CLI opt-in.
-      warning = `orca.yaml archive hook skipped for ${canonicalWorktreePath}; pass --run-hooks to run it.`
-      console.warn(`[hooks] ${warning}`)
-    }
-
-    let shouldTearDownPtys = true
-    try {
-      await assertWorktreeCleanForRemoval(canonicalWorktreePath, force)
-    } catch (error) {
-      if (!isOrphanCompatiblePreflightError(error)) {
-        throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
-      }
-      // Why: orphan cleanup does not need live shells to be killed first,
-      // and preflight did not prove the worktree is cleanly removable.
-      shouldTearDownPtys = false
-    }
-
-    const localProvider = this.getLocalProvider()
-    if (localProvider && shouldTearDownPtys) {
-      // Why: once preflight proves normal deletion is clean, kill PTYs before
-      // git-level removal so shells cannot keep the directory busy. This also
-      // closes the headless-CLI leak for confirmed-removable worktrees.
-      await killAllProcessesForWorktree(worktree.id, {
-        runtime: this,
-        localProvider
-      })
-        .then((r) => {
-          const total = r.runtimeStopped + r.providerStopped + r.registryStopped
-          if (total > 0) {
-            // Why (design §4.4 observability): breadcrumb lets ops
-            // distinguish a renderer-state-induced leak (diff-path purge
-            // non-empty) from a backend-induced one (nothing to kill but
-            // memory still pinned). Emit only when the sweep actually did
-            // work so steady-state logs stay quiet.
-            console.info(
-              `[worktree-teardown] ${worktree.id} killed runtime=${r.runtimeStopped} provider=${r.providerStopped} registry=${r.registryStopped}`
-            )
-          }
-        })
-        .catch((err) => {
-          console.warn(`[worktree-teardown] failed for ${worktree.id}:`, err)
-        })
-    }
-
-    try {
-      await (deleteBranch
-        ? removeWorktree(repo.path, canonicalWorktreePath, force)
-        : removeWorktree(repo.path, canonicalWorktreePath, force, { deleteBranch }))
-    } catch (error) {
-      if (isOrphanedWorktreeError(error)) {
-        if (await canSafelyRemoveOrphanedWorktreeDirectory(canonicalWorktreePath, repo.path)) {
-          await rm(canonicalWorktreePath, { recursive: true, force: true }).catch(() => {})
-        } else {
-          console.warn(
-            `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
-          )
+      if (!registeredWorktree) {
+        if (force && (await isRuntimeWorktreePathMissing(repo, worktree.path))) {
+          // Why: runtime clients can retry a force delete after another surface
+          // already removed the worktree. Finish Orca cleanup without touching
+          // any unregistered path that still exists.
+          await (repo.connectionId
+            ? cleanupUnusedWorktreePushTargetRemoteSsh(
+                provider!,
+                repo.path,
+                worktree.id,
+                worktree.pushTarget,
+                store
+              )
+            : cleanupUnusedWorktreePushTargetRemote(
+                repo.path,
+                worktree.id,
+                worktree.pushTarget,
+                store
+              ))
+          this.clearOptimisticReconcileToken(worktree.id)
+          store.removeWorktreeMeta(worktree.id)
+          this.invalidateResolvedWorktreeCache()
+          invalidateAuthorizedRootsCache()
+          this.notifier?.worktreesChanged(repo.id)
+          return {}
         }
-        // Why: `git worktree remove` failed, so git's internal worktree tracking
-        // (`.git/worktrees/<name>`) is still intact. Without pruning, `git worktree
-        // list` continues to show the stale entry and the branch it had checked out
-        // remains locked — other worktrees cannot check it out.
-        await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
-        await cleanupUnusedWorktreePushTargetRemote(
+        throw new Error(`Refusing to delete unregistered worktree path: ${worktree.path}`)
+      }
+      const canonicalWorktreePath = registeredWorktree.path
+      const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+      if (repo.connectionId) {
+        await (deleteBranch
+          ? provider!.removeWorktree(canonicalWorktreePath, force)
+          : provider!.removeWorktree(canonicalWorktreePath, force, { deleteBranch }))
+        await cleanupUnusedWorktreePushTargetRemoteSsh(
+          provider!,
           repo.path,
           worktree.id,
           worktree.pushTarget,
-          this.store
+          store
         )
         this.clearOptimisticReconcileToken(worktree.id)
-        this.store.removeWorktreeMeta(worktree.id)
+        store.removeWorktreeMeta(worktree.id)
         this.invalidateResolvedWorktreeCache()
         invalidateAuthorizedRootsCache()
         this.notifier?.worktreesChanged(repo.id)
-        return {
-          ...(warning ? { warning } : {})
-        }
+        return {}
       }
-      throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
-    }
 
-    await cleanupUnusedWorktreePushTargetRemote(
-      repo.path,
-      worktree.id,
-      worktree.pushTarget,
-      this.store
-    )
-    this.clearOptimisticReconcileToken(worktree.id)
-    this.store.removeWorktreeMeta(worktree.id)
-    this.invalidateResolvedWorktreeCache()
-    invalidateAuthorizedRootsCache()
-    this.notifier?.worktreesChanged(repo.id)
-    return {
-      ...(warning ? { warning } : {})
+      const hooks = getEffectiveHooks(repo)
+      let warning: string | undefined
+      if (hooks?.scripts.archive && runHooks) {
+        const result = await runHook('archive', canonicalWorktreePath, repo)
+        if (!result.success) {
+          console.error(`[hooks] archive hook failed for ${canonicalWorktreePath}:`, result.output)
+        }
+      } else if (hooks?.scripts.archive) {
+        // Runtime RPC calls have no renderer trust prompt, so hooks require explicit CLI opt-in.
+        warning = `orca.yaml archive hook skipped for ${canonicalWorktreePath}; pass --run-hooks to run it.`
+        console.warn(`[hooks] ${warning}`)
+      }
+
+      let shouldTearDownPtys = true
+      try {
+        await assertWorktreeCleanForRemoval(canonicalWorktreePath, force)
+      } catch (error) {
+        if (!isOrphanCompatiblePreflightError(error)) {
+          throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
+        }
+        // Why: orphan cleanup does not need live shells to be killed first,
+        // and preflight did not prove the worktree is cleanly removable.
+        shouldTearDownPtys = false
+      }
+
+      const localProvider = this.getLocalProvider()
+      if (localProvider && shouldTearDownPtys) {
+        // Why: once preflight proves normal deletion is clean, kill PTYs before
+        // git-level removal so shells cannot keep the directory busy. This also
+        // closes the headless-CLI leak for confirmed-removable worktrees.
+        await killAllProcessesForWorktree(worktree.id, {
+          runtime: this,
+          localProvider
+        })
+          .then((r) => {
+            const total = r.runtimeStopped + r.providerStopped + r.registryStopped
+            if (total > 0) {
+              // Why (design §4.4 observability): breadcrumb lets ops
+              // distinguish a renderer-state-induced leak (diff-path purge
+              // non-empty) from a backend-induced one (nothing to kill but
+              // memory still pinned). Emit only when the sweep actually did
+              // work so steady-state logs stay quiet.
+              console.info(
+                `[worktree-teardown] ${worktree.id} killed runtime=${r.runtimeStopped} provider=${r.providerStopped} registry=${r.registryStopped}`
+              )
+            }
+          })
+          .catch((err) => {
+            console.warn(`[worktree-teardown] failed for ${worktree.id}:`, err)
+          })
+      }
+
+      try {
+        await (deleteBranch
+          ? removeWorktree(repo.path, canonicalWorktreePath, force)
+          : removeWorktree(repo.path, canonicalWorktreePath, force, { deleteBranch }))
+      } catch (error) {
+        if (isOrphanedWorktreeError(error)) {
+          if (await canSafelyRemoveOrphanedWorktreeDirectory(canonicalWorktreePath, repo.path)) {
+            await rm(canonicalWorktreePath, { recursive: true, force: true }).catch(() => {})
+          } else {
+            console.warn(
+              `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
+            )
+          }
+          // Why: `git worktree remove` failed, so git's internal worktree tracking
+          // (`.git/worktrees/<name>`) is still intact. Without pruning, `git worktree
+          // list` continues to show the stale entry and the branch it had checked out
+          // remains locked — other worktrees cannot check it out.
+          await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
+          await cleanupUnusedWorktreePushTargetRemote(
+            repo.path,
+            worktree.id,
+            worktree.pushTarget,
+            store
+          )
+          this.clearOptimisticReconcileToken(worktree.id)
+          store.removeWorktreeMeta(worktree.id)
+          this.invalidateResolvedWorktreeCache()
+          invalidateAuthorizedRootsCache()
+          this.notifier?.worktreesChanged(repo.id)
+          return {
+            ...(warning ? { warning } : {})
+          }
+        }
+        throw new Error(formatWorktreeRemovalError(error, canonicalWorktreePath, force))
+      }
+
+      await cleanupUnusedWorktreePushTargetRemote(
+        repo.path,
+        worktree.id,
+        worktree.pushTarget,
+        store
+      )
+      this.clearOptimisticReconcileToken(worktree.id)
+      store.removeWorktreeMeta(worktree.id)
+      this.invalidateResolvedWorktreeCache()
+      invalidateAuthorizedRootsCache()
+      this.notifier?.worktreesChanged(repo.id)
+      return {
+        ...(warning ? { warning } : {})
+      }
+    })()
+    this.removeManagedWorktreeInFlight.set(worktree.id, removal)
+    try {
+      return await removal
+    } finally {
+      if (this.removeManagedWorktreeInFlight.get(worktree.id) === removal) {
+        this.removeManagedWorktreeInFlight.delete(worktree.id)
+      }
     }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -668,6 +668,35 @@ async function isRuntimeWorktreePathMissing(repo: Repo, worktreePath: string): P
   return isWorktreePathMissing(worktreePath, (path) => fsProvider.stat(path))
 }
 
+type RuntimeWorktreeRemovalTarget = {
+  id: string
+  repoId: string
+  path: string
+  pushTarget?: GitPushTarget
+}
+
+type RuntimeWorktreeRemovalInFlight = {
+  optionsKey: string
+  promise: Promise<{ warning?: string }>
+}
+
+function getRuntimeWorktreeRemovalOptionsKey(force: boolean, runHooks: boolean): string {
+  return `${force ? 'force' : 'normal'}:${runHooks ? 'run-hooks' : 'skip-hooks'}`
+}
+
+function parseExactWorktreeIdSelector(selector: string): RuntimeWorktreeRemovalTarget | null {
+  const worktreeId = selector.startsWith('id:') ? selector.slice(3) : selector
+  const parsed = splitWorktreeId(worktreeId)
+  if (!parsed || !parsed.repoId || !parsed.worktreePath) {
+    return null
+  }
+  return {
+    id: worktreeId,
+    repoId: parsed.repoId,
+    path: parsed.worktreePath
+  }
+}
+
 async function resolveCreateBranchName(
   repoPath: string,
   branchNameOverride: string | undefined,
@@ -1096,7 +1125,7 @@ export class OrcaRuntimeService {
   // canonical key is resolved at most once per repo+remote in the process.
   private canonicalFetchKeyCache = new Map<string, string>()
   private optimisticReconcileTokens = new Map<string, string>()
-  private removeManagedWorktreeInFlight = new Map<string, Promise<{ warning?: string }>>()
+  private removeManagedWorktreeInFlight = new Map<string, RuntimeWorktreeRemovalInFlight>()
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
@@ -7957,6 +7986,36 @@ export class OrcaRuntimeService {
     return getDefaultRemote(repoPath)
   }
 
+  private async resolveWorktreeRemovalTarget(
+    worktreeSelector: string,
+    force: boolean
+  ): Promise<RuntimeWorktreeRemovalTarget> {
+    try {
+      const worktree = await this.resolveWorktreeSelector(worktreeSelector)
+      const removalTarget = {
+        id: worktree.id,
+        repoId: worktree.repoId,
+        path: worktree.path
+      }
+      return worktree.pushTarget
+        ? { ...removalTarget, pushTarget: worktree.pushTarget }
+        : removalTarget
+    } catch (error) {
+      if (!force || !(error instanceof Error) || error.message !== 'selector_not_found') {
+        throw error
+      }
+      const removalTarget = parseExactWorktreeIdSelector(worktreeSelector)
+      const meta = removalTarget ? this.store?.getWorktreeMeta(removalTarget.id) : undefined
+      if (!removalTarget || !meta) {
+        throw error
+      }
+      // Why: force-delete retries can arrive after Git no longer lists the
+      // worktree. Only exact IDs with persisted Orca metadata are accepted here
+      // so branch/path selectors cannot resolve to an arbitrary missing path.
+      return meta.pushTarget ? { ...removalTarget, pushTarget: meta.pushTarget } : removalTarget
+    }
+  }
+
   async removeManagedWorktree(
     worktreeSelector: string,
     force = false,
@@ -7966,16 +8025,20 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const store = this.store
-    const worktree = await this.resolveWorktreeSelector(worktreeSelector)
-    const inFlightRemoval = this.removeManagedWorktreeInFlight.get(worktree.id)
+    const removalTarget = await this.resolveWorktreeRemovalTarget(worktreeSelector, force)
+    const optionsKey = getRuntimeWorktreeRemovalOptionsKey(force, runHooks)
+    const inFlightRemoval = this.removeManagedWorktreeInFlight.get(removalTarget.id)
     if (inFlightRemoval) {
-      return inFlightRemoval
+      if (inFlightRemoval.optionsKey === optionsKey) {
+        return inFlightRemoval.promise
+      }
+      throw new Error(`Worktree deletion already in progress: ${removalTarget.id}`)
     }
 
     // Why: runtime callers can race the same workspace through CLI/mobile
     // retries. Share one destructive Git/filesystem operation per worktree ID.
     const removal = (async (): Promise<{ warning?: string }> => {
-      const repo = store.getRepo(worktree.repoId)
+      const repo = store.getRepo(removalTarget.repoId)
       if (!repo) {
         throw new Error('repo_not_found')
       }
@@ -7986,14 +8049,15 @@ export class OrcaRuntimeService {
       const registeredWorktrees = repo.connectionId
         ? await provider!.listWorktrees(repo.path)
         : await listWorktrees(repo.path)
-      const removedMeta = store.getWorktreeMeta(worktree.id)
+      const removedMeta = store.getWorktreeMeta(removalTarget.id)
+      const removedPushTarget = removedMeta?.pushTarget ?? removalTarget.pushTarget
       const registeredWorktree = findRegisteredDeletableWorktree(
         repo.path,
-        worktree.path,
+        removalTarget.path,
         registeredWorktrees
       )
       if (!registeredWorktree) {
-        if (force && (await isRuntimeWorktreePathMissing(repo, worktree.path))) {
+        if (force && (await isRuntimeWorktreePathMissing(repo, removalTarget.path))) {
           // Why: runtime clients can retry a force delete after another surface
           // already removed the worktree. Finish Orca cleanup without touching
           // any unregistered path that still exists.
@@ -8001,24 +8065,24 @@ export class OrcaRuntimeService {
             ? cleanupUnusedWorktreePushTargetRemoteSsh(
                 provider!,
                 repo.path,
-                worktree.id,
-                worktree.pushTarget,
+                removalTarget.id,
+                removedPushTarget,
                 store
               )
             : cleanupUnusedWorktreePushTargetRemote(
                 repo.path,
-                worktree.id,
-                worktree.pushTarget,
+                removalTarget.id,
+                removedPushTarget,
                 store
               ))
-          this.clearOptimisticReconcileToken(worktree.id)
-          store.removeWorktreeMeta(worktree.id)
+          this.clearOptimisticReconcileToken(removalTarget.id)
+          store.removeWorktreeMeta(removalTarget.id)
           this.invalidateResolvedWorktreeCache()
           invalidateAuthorizedRootsCache()
           this.notifier?.worktreesChanged(repo.id)
           return {}
         }
-        throw new Error(`Refusing to delete unregistered worktree path: ${worktree.path}`)
+        throw new Error(`Refusing to delete unregistered worktree path: ${removalTarget.path}`)
       }
       const canonicalWorktreePath = registeredWorktree.path
       const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
@@ -8029,12 +8093,12 @@ export class OrcaRuntimeService {
         await cleanupUnusedWorktreePushTargetRemoteSsh(
           provider!,
           repo.path,
-          worktree.id,
-          worktree.pushTarget,
+          removalTarget.id,
+          removedPushTarget,
           store
         )
-        this.clearOptimisticReconcileToken(worktree.id)
-        store.removeWorktreeMeta(worktree.id)
+        this.clearOptimisticReconcileToken(removalTarget.id)
+        store.removeWorktreeMeta(removalTarget.id)
         this.invalidateResolvedWorktreeCache()
         invalidateAuthorizedRootsCache()
         this.notifier?.worktreesChanged(repo.id)
@@ -8071,7 +8135,7 @@ export class OrcaRuntimeService {
         // Why: once preflight proves normal deletion is clean, kill PTYs before
         // git-level removal so shells cannot keep the directory busy. This also
         // closes the headless-CLI leak for confirmed-removable worktrees.
-        await killAllProcessesForWorktree(worktree.id, {
+        await killAllProcessesForWorktree(removalTarget.id, {
           runtime: this,
           localProvider
         })
@@ -8084,12 +8148,12 @@ export class OrcaRuntimeService {
               // memory still pinned). Emit only when the sweep actually did
               // work so steady-state logs stay quiet.
               console.info(
-                `[worktree-teardown] ${worktree.id} killed runtime=${r.runtimeStopped} provider=${r.providerStopped} registry=${r.registryStopped}`
+                `[worktree-teardown] ${removalTarget.id} killed runtime=${r.runtimeStopped} provider=${r.providerStopped} registry=${r.registryStopped}`
               )
             }
           })
           .catch((err) => {
-            console.warn(`[worktree-teardown] failed for ${worktree.id}:`, err)
+            console.warn(`[worktree-teardown] failed for ${removalTarget.id}:`, err)
           })
       }
 
@@ -8113,12 +8177,12 @@ export class OrcaRuntimeService {
           await gitExecFileAsync(['worktree', 'prune'], { cwd: repo.path }).catch(() => {})
           await cleanupUnusedWorktreePushTargetRemote(
             repo.path,
-            worktree.id,
-            worktree.pushTarget,
+            removalTarget.id,
+            removedPushTarget,
             store
           )
-          this.clearOptimisticReconcileToken(worktree.id)
-          store.removeWorktreeMeta(worktree.id)
+          this.clearOptimisticReconcileToken(removalTarget.id)
+          store.removeWorktreeMeta(removalTarget.id)
           this.invalidateResolvedWorktreeCache()
           invalidateAuthorizedRootsCache()
           this.notifier?.worktreesChanged(repo.id)
@@ -8131,12 +8195,12 @@ export class OrcaRuntimeService {
 
       await cleanupUnusedWorktreePushTargetRemote(
         repo.path,
-        worktree.id,
-        worktree.pushTarget,
+        removalTarget.id,
+        removedPushTarget,
         store
       )
-      this.clearOptimisticReconcileToken(worktree.id)
-      store.removeWorktreeMeta(worktree.id)
+      this.clearOptimisticReconcileToken(removalTarget.id)
+      store.removeWorktreeMeta(removalTarget.id)
       this.invalidateResolvedWorktreeCache()
       invalidateAuthorizedRootsCache()
       this.notifier?.worktreesChanged(repo.id)
@@ -8144,12 +8208,12 @@ export class OrcaRuntimeService {
         ...(warning ? { warning } : {})
       }
     })()
-    this.removeManagedWorktreeInFlight.set(worktree.id, removal)
+    this.removeManagedWorktreeInFlight.set(removalTarget.id, { optionsKey, promise: removal })
     try {
       return await removal
     } finally {
-      if (this.removeManagedWorktreeInFlight.get(worktree.id) === removal) {
-        this.removeManagedWorktreeInFlight.delete(worktree.id)
+      if (this.removeManagedWorktreeInFlight.get(removalTarget.id)?.promise === removal) {
+        this.removeManagedWorktreeInFlight.delete(removalTarget.id)
       }
     }
   }

--- a/src/main/worktree-removal-safety.test.ts
+++ b/src/main/worktree-removal-safety.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { GitWorktreeInfo } from '../shared/types'
-import { getRegisteredDeletableWorktree } from './worktree-removal-safety'
+import { getRegisteredDeletableWorktree, isWorktreePathMissing } from './worktree-removal-safety'
 
 function makeGitWorktree(path: string, isMainWorktree = false): GitWorktreeInfo {
   return {
@@ -33,5 +33,29 @@ describe('getRegisteredDeletableWorktree', () => {
         makeGitWorktree('/workspaces/parent-copy')
       ])
     ).toMatchObject({ path: '/workspaces/parent' })
+  })
+})
+
+describe('isWorktreePathMissing', () => {
+  it('recognizes missing-path errors from local and remote stat providers', async () => {
+    await expect(
+      isWorktreePathMissing('/missing', async () => {
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      })
+    ).resolves.toBe(true)
+
+    await expect(
+      isWorktreePathMissing('/missing', () => Promise.reject({ code: 'ENOTDIR' }))
+    ).resolves.toBe(true)
+  })
+
+  it('does not classify existing paths or unrelated stat failures as missing', async () => {
+    await expect(isWorktreePathMissing('/exists', async () => ({}))).resolves.toBe(false)
+
+    await expect(
+      isWorktreePathMissing('/unknown', async () => {
+        throw new Error('permission denied')
+      })
+    ).resolves.toBe(false)
   })
 })

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -52,9 +52,21 @@ export function getRegisteredDeletableWorktree(
   requestedWorktreePath: string,
   worktrees: readonly GitWorktreeInfo[]
 ): GitWorktreeInfo {
-  const worktree = worktrees.find((item) => areWorktreePathsEqual(item.path, requestedWorktreePath))
+  const worktree = findRegisteredDeletableWorktree(repoPath, requestedWorktreePath, worktrees)
   if (!worktree) {
     throw new Error(`Refusing to delete unregistered worktree path: ${requestedWorktreePath}`)
+  }
+  return worktree
+}
+
+export function findRegisteredDeletableWorktree(
+  repoPath: string,
+  requestedWorktreePath: string,
+  worktrees: readonly GitWorktreeInfo[]
+): GitWorktreeInfo | null {
+  const worktree = worktrees.find((item) => areWorktreePathsEqual(item.path, requestedWorktreePath))
+  if (!worktree) {
+    return null
   }
   if (worktree.isMainWorktree || isDangerousWorktreeRemovalPath(worktree.path, repoPath)) {
     throw new Error(`Refusing to delete protected worktree path: ${worktree.path}`)
@@ -96,5 +108,39 @@ export async function canSafelyRemoveOrphanedWorktreeDirectory(
     return gitEntry.isFile() || gitEntry.isDirectory() || gitEntry.isSymbolicLink()
   } catch {
     return false
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code =
+    error && typeof error === 'object' && 'code' in error
+      ? String((error as NodeJS.ErrnoException).code)
+      : undefined
+  if (code === 'ENOENT' || code === 'ENOTDIR') {
+    return true
+  }
+
+  let message = ''
+  if (error instanceof Error) {
+    message = error.message
+  } else if (error && typeof error === 'object' && 'message' in error) {
+    message = String((error as { message: unknown }).message)
+  } else if (typeof error === 'string') {
+    message = error
+  }
+  return /\b(ENOENT|ENOTDIR)\b|no such file or directory|cannot find (?:the )?(?:file|path)|(?:file|path) not found/i.test(
+    message
+  )
+}
+
+export async function isWorktreePathMissing(
+  worktreePath: string,
+  statPath: (path: string) => Promise<unknown> = lstat
+): Promise<boolean> {
+  try {
+    await statPath(worktreePath)
+    return false
+  } catch (error) {
+    return isMissingPathError(error)
   }
 }


### PR DESCRIPTION
## Summary
- Treat forced deletion of already-missing, unregistered worktree paths as successful metadata cleanup
- Keep force-delete safety for unregistered paths that still exist, protected paths, and nested registered worktrees
- Coalesce duplicate delete requests per worktree ID across renderer IPC and runtime callers

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts src/main/git/remove-worktree.test.ts`
- [x] Launched the PR worktree Electron app and verified `window.api.app.getIdentity()` reported `brennankbenson/delete-workspace-force-issue` at `/Users/thebr/orca/workspaces/orca/delete-workspace-force-issue`.
- [x] In `demo-project`, created `orca-validation-ui-*`, deleted it through the visible Delete workspace button and confirmation dialog, then verified sidebar removal, Git worktree removal, and folder removal.
- [x] In `demo-project`, called local runtime `worktree.rm` concurrently with normal and force options for `orca-validation-runtime-*`; verified one removal succeeded and the mismatched concurrent request returned `Worktree deletion already in progress`, with no remaining worktree, branch, folder, or UI card.
- [x] In `demo-project`, simulated already-missing worktrees by removing `orca-validation-*-missing-*` with Git first, then verified forced desktop IPC and local runtime cleanup accepted exact IDs and removed stale Orca state without touching unrelated paths.
- [x] In `demo-project`, recreated an ordinary directory at a stale worktree path and verified forced local runtime cleanup rejected it with `Refusing to delete unregistered worktree path` while leaving the directory intact.
- [x] Launched an isolated PR Electron app with `ORCA_DEV_USER_DATA_PATH=/tmp/orca-ssh-delete-1779484372/orca-user-data`, connected to a throwaway Linux Docker target over SSH (`node:20-bookworm`, Node 20, Git 2.39), deployed the relay, and registered `/work/demo-project` cloned from a local demo-project git bundle.
- [x] Over SSH, created `orca-validation-ssh-ui-*`, deleted it through the visible Delete workspace button and confirmation dialog, then verified the remote Git worktree, folder, branch, and sidebar card were removed.
- [x] Over SSH, called runtime `worktree.rm` concurrently with normal and force options for `orca-validation-ssh-runtime-race-*`; verified one removal succeeded and the racing request returned `Worktree deletion already in progress`, with no remaining remote worktree, branch, or folder.
- [x] Over SSH, simulated already-missing worktrees by removing `orca-validation-ssh-*-missing-*` with remote Git first, then verified forced desktop IPC and runtime cleanup accepted exact IDs and removed stale Orca state without touching unrelated paths.
- [x] Over SSH, recreated an ordinary directory at a stale worktree path and verified forced runtime cleanup rejected it with `Refusing to delete unregistered worktree path` while leaving the directory intact.
- [x] Inspected Playwright console and Electron app logs; no related errors. Observed expected worktree purge warnings for the validation deletes.
- [x] Cleanup verified: no `orca-validation-*` Git worktrees, folders, or branches remain locally; no `orca-validation-ssh-*` Git worktrees, folders, or branches remained in the throwaway SSH clone before the container was removed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
