### PR TITLE
Fix agent quick-launch watchdog

### DIFF
--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
@@ -2,66 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { shouldShowLaunchWatchdogTimeout } from './QuickLaunchButton'
 
 describe('shouldShowLaunchWatchdogTimeout', () => {
-  it('lets the paste timeout own ready-but-not-pasteable notes launches', () => {
+  it('does not report slow agent readiness once a PTY exists', () => {
     expect(
       shouldShowLaunchWatchdogTimeout({
-        launchSource: 'notes_send',
-        prompt: 'Fix the race in Source Control.',
-        pasteDraftAfterLaunch: true,
         hasPty: true
       })
     ).toBe(false)
   })
 
-  it('lets the paste timeout own ready-but-not-pasteable conflict-resolution launches', () => {
+  it('reports launches where no PTY appeared', () => {
     expect(
       shouldShowLaunchWatchdogTimeout({
-        launchSource: 'conflict_resolution',
-        prompt: 'Resolve the current rebase conflicts.',
-        pasteDraftAfterLaunch: true,
-        hasPty: true
-      })
-    ).toBe(false)
-  })
-
-  it('still reports notes launches where no PTY appeared', () => {
-    expect(
-      shouldShowLaunchWatchdogTimeout({
-        launchSource: 'notes_send',
-        prompt: 'Fix the race in Source Control.',
-        pasteDraftAfterLaunch: true,
         hasPty: false
-      })
-    ).toBe(true)
-  })
-
-  it('keeps the launch watchdog for notes launches without paste fallback', () => {
-    expect(
-      shouldShowLaunchWatchdogTimeout({
-        launchSource: 'notes_send',
-        prompt: 'Start with this prompt.',
-        pasteDraftAfterLaunch: false,
-        hasPty: true
-      })
-    ).toBe(true)
-  })
-
-  it('keeps the launch watchdog for empty notes prompts and non-notes launch sources', () => {
-    expect(
-      shouldShowLaunchWatchdogTimeout({
-        launchSource: 'notes_send',
-        prompt: '   \n\t',
-        pasteDraftAfterLaunch: true,
-        hasPty: true
-      })
-    ).toBe(true)
-
-    expect(
-      shouldShowLaunchWatchdogTimeout({
-        launchSource: 'tab_bar_quick_launch',
-        prompt: 'Start with this prompt.',
-        pasteDraftAfterLaunch: true,
-        hasPty: true
       })
     ).toBe(true)
   })

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -6,7 +6,6 @@ import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
 import { useAppStore } from '@/store'
 import { useDetectedAgents } from '@/hooks/useDetectedAgents'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
-import { waitForAgentReady } from '@/lib/agent-ready-wait'
 import type { TuiAgent } from '../../../../shared/types'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 
@@ -50,27 +49,42 @@ function orderAgents(
   return [defaultAgent, ...inCatalogOrder.filter((id) => id !== defaultAgent)]
 }
 
-export function shouldShowLaunchWatchdogTimeout({
-  launchSource,
-  prompt,
-  pasteDraftAfterLaunch,
-  hasPty
-}: {
-  launchSource?: LaunchSource
-  prompt?: string
-  pasteDraftAfterLaunch: boolean
-  hasPty: boolean
-}): boolean {
-  return !(
-    (launchSource === 'notes_send' || launchSource === 'conflict_resolution') &&
-    (prompt?.trim().length ?? 0) > 0 &&
-    pasteDraftAfterLaunch &&
-    hasPty
-  )
+export function shouldShowLaunchWatchdogTimeout({ hasPty }: { hasPty: boolean }): boolean {
+  return !hasPty
 }
 
 function getLaunchWatchdogTimeoutMessage(label: string): string {
-  return `Couldn't launch ${label} — the terminal is still open.`
+  return `Couldn't launch ${label} — the terminal did not start.`
+}
+
+function getTerminalLaunchState(tabId: string): { stillOpen: boolean; hasPty: boolean } {
+  const state = useAppStore.getState()
+  const hasPtyBinding = (state.ptyIdsByTabId[tabId]?.length ?? 0) > 0
+  let stillOpen = false
+  let tabPtyId: string | null = null
+
+  for (const tabs of Object.values(state.tabsByWorktree)) {
+    const tab = tabs.find((t) => t.id === tabId)
+    if (tab) {
+      stillOpen = true
+      tabPtyId = tab.ptyId
+      break
+    }
+  }
+
+  return { stillOpen, hasPty: hasPtyBinding || tabPtyId !== null }
+}
+
+async function waitForTerminalPty(tabId: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const launchState = getTerminalLaunchState(tabId)
+    if (launchState.hasPty) {
+      return true
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 100))
+  }
+  return getTerminalLaunchState(tabId).hasPty
 }
 
 function QuickLaunchAgentMenuItemsInner({
@@ -124,36 +138,21 @@ function QuickLaunchAgentMenuItemsInner({
       }
       onFocusTerminal(result.tabId)
 
-      // Why: the watchdog guards against "queued startup command never ran" —
-      // e.g. shell failed to spawn. Suppress the toast if the tab has been
-      // closed or the worktree has been navigated away from before the
-      // deadline (see §States: Launch failure handling). Bracketed-paste
-      // failures have their own toast in launch-agent-in-new-tab.ts.
-      void waitForAgentReady(result.tabId, result.startupPlan.expectedProcess, {
-        timeoutMs: 5000
-      }).then((ready) => {
-        if (ready.ready) {
+      // Why: launch success means the terminal session exists. Agent readiness
+      // can lag behind on slow machines, and prompt paste flows already own
+      // their own readiness timeout once a PTY exists.
+      void waitForTerminalPty(result.tabId, 5000).then((hasPty) => {
+        if (hasPty) {
           return
         }
-        const state = useAppStore.getState()
-        const stillOpen = Object.values(state.tabsByWorktree).some((tabs) =>
-          tabs.some((t) => t.id === result.tabId)
-        )
-        if (!stillOpen) {
+        const launchState = getTerminalLaunchState(result.tabId)
+        if (!launchState.stillOpen) {
           return
         }
-        if (state.activeWorktreeId !== worktreeId) {
+        if (useAppStore.getState().activeWorktreeId !== worktreeId) {
           return
         }
-        const hasPty = (state.ptyIdsByTabId[result.tabId]?.length ?? 0) > 0
-        if (
-          !shouldShowLaunchWatchdogTimeout({
-            launchSource,
-            prompt,
-            pasteDraftAfterLaunch: result.pasteDraftAfterLaunch,
-            hasPty
-          })
-        ) {
+        if (!shouldShowLaunchWatchdogTimeout({ hasPty: launchState.hasPty })) {
           return
         }
         toast.message(getLaunchWatchdogTimeoutMessage(label))


### PR DESCRIPTION
## Summary
- Treat quick-launch as successful once the terminal PTY exists, so slow agent readiness does not show a launch failure toast.
- Keep the launch watchdog for cases where no terminal PTY starts.
- Update the watchdog unit test around PTY presence.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts`
- [x] Launched this PR worktree in Electron via CDP on port 9333 and verified app identity for `brennanb2025/Couldn-t-launch-Codex-the-terminal-is-still-open`.
- [x] In `demo-project`, clicked New tab -> Codex; verified a new terminal tab appeared with a PTY binding, Codex rendered, and no launch-failure toast appeared after the watchdog interval.
- [x] In `demo-project`, added a temporary review note, clicked Source Control Notes -> Send notes to a new agent -> Codex; verified the notes-send launch created a PTY-backed Codex tab, marked the note sent, and showed no launch or paste timeout toast after the watchdog interval.
- [x] Inspected app logs for relevant launch/watchdog failures; only unrelated pre-existing repo-path and remote-fetch warnings appeared.
- [x] Cleaned up the temporary note and the two validation Codex tabs; PR worktree is clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
