### PR TITLE
Prepare mobile 0.0.9

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump Orca Mobile to 0.0.9
- Leave iOS build number and Android versionCode at 1

## Verification
- node -e "const app=require('./mobile/app.json'); console.log(app.expo.version, app.expo.ios?.buildNumber, app.expo.android?.versionCode)"