### PR TITLE
Default workspace list to repo grouping

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -322,12 +322,12 @@ export default function HostScreen() {
   const [lastKnownWorktrees, setLastKnownWorktrees] = useState<Worktree[]>(initialCache ?? [])
   const [search, setSearch] = useState('')
   const [showSearch, setShowSearch] = useState(false)
-  const [sortMode, setSortMode] = useState<SortMode>('smart')
+  const [sortMode, setSortMode] = useState<SortMode>('recent')
   const [filters, setFilters] = useState<FilterState>({
     activeOnly: false,
     selectedRepos: new Set()
   })
-  const [groupMode, setGroupMode] = useState<GroupMode>('none')
+  const [groupMode, setGroupMode] = useState<GroupMode>('repo')
 
   // Modals
   const [showSortPicker, setShowSortPicker] = useState(false)

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -32,15 +32,15 @@ export type HostPreferences = {
 }
 
 const DEFAULT_PREFS: HostPreferences = {
-  sortMode: 'smart',
+  sortMode: 'recent',
   filterMode: 'all',
-  groupMode: 'none',
+  groupMode: 'repo',
   collapsedGroups: [],
   selectedRepos: []
 }
-const SORT_MODES = new Set(['smart', 'recent', 'name'])
+const SORT_MODES = new Set(['smart', 'recent', 'name', 'repo'])
 const FILTER_MODES = new Set(['all', 'active'])
-const GROUP_MODES = new Set(['none', 'repo', 'prStatus'])
+const GROUP_MODES = new Set(['none', 'workspaceStatus', 'repo', 'prStatus'])
 
 function stringArray(value: unknown): string[] {
   return Array.isArray(value)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -257,7 +257,7 @@ describe('Store', () => {
     const store = await createStore()
     const ui = store.getUI()
     expect(ui.sidebarWidth).toBe(280)
-    expect(ui.groupBy).toBe('workspace-status')
+    expect(ui.groupBy).toBe('repo')
     expect(ui.lastActiveRepoId).toBeNull()
     expect(ui.dismissedUpdateVersion).toBeNull()
     expect(ui.lastUpdateCheckAt).toBeNull()
@@ -1650,7 +1650,7 @@ describe('Store', () => {
     store.updateUI({ sidebarWidth: 400 })
     const ui = store.getUI()
     expect(ui.sidebarWidth).toBe(400)
-    expect(ui.groupBy).toBe('workspace-status') // default preserved
+    expect(ui.groupBy).toBe('repo') // default preserved
     expect(ui.dismissedUpdateVersion).toBeNull()
   })
 

--- a/src/renderer/src/components/mobile/slides/WorktreeListSlide.tsx
+++ b/src/renderer/src/components/mobile/slides/WorktreeListSlide.tsx
@@ -33,12 +33,12 @@ export function WorktreeListSlide({ tapping }: { tapping: boolean }): React.JSX.
             Filter
           </button>
           <button type="button" className="mp-wl-button">
-            <SmartIcon />
-            Smart
+            <SortIcon />
+            Recent
           </button>
           <button type="button" className="mp-wl-button">
             <GroupIcon />
-            Group
+            Repo
           </button>
           <span className="mp-wl-spacer" />
           <span className="mp-wl-icon">
@@ -218,7 +218,7 @@ function FilterIcon(): React.JSX.Element {
   )
 }
 
-function SmartIcon(): React.JSX.Element {
+function SortIcon(): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
       <line x1="21" y1="4" x2="14" y2="4" />

--- a/src/renderer/src/lib/startup-ui-hydration.test.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.test.ts
@@ -52,7 +52,7 @@ describe('startup UI hydration fallback', () => {
 
     expect(hydratePersistedUI).toHaveBeenCalledTimes(1)
     expect(hydratePersistedUI.mock.calls[0][0].sidebarWidth).toBe(280)
-    expect(hydratePersistedUI.mock.calls[0][0].groupBy).toBe('workspace-status')
+    expect(hydratePersistedUI.mock.calls[0][0].groupBy).toBe('repo')
     expect(hydratePersistedUI.mock.calls[0][0].sortBy).toBe('name')
     expect(hydratePersistedUI.mock.calls[0][0].hideSleepingWorkspaces).toBe(false)
     expect(hydratePersistedUI.mock.calls[0][0].showSleepingWorkspaces).toBe(true)

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -36,7 +36,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     lastActiveWorktreeId: null,
     sidebarWidth: 280,
     rightSidebarWidth: 350,
-    groupBy: 'workspace-status',
+    groupBy: 'repo',
     sortBy: 'name',
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -943,7 +943,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       return { setupScriptPromptDismissedRepoIds: next }
     }),
 
-  groupBy: 'workspace-status',
+  groupBy: 'repo',
   // Why: group keys are mode-specific (e.g. repo id vs PR status), so
   // collapsed state from one mode is meaningless in another. Clearing
   // also prevents unbounded accumulation of stale keys across mode switches.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -350,7 +350,7 @@ export function getDefaultUIState(): PersistedUIState {
     lastActiveWorktreeId: null,
     sidebarWidth: 280,
     rightSidebarWidth: 350,
-    groupBy: 'workspace-status',
+    groupBy: 'repo',
     sortBy: 'recent',
     showActiveOnly: false,
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,


### PR DESCRIPTION
## Summary
- default new desktop workspace lists to repo grouping while keeping recent sort
- align startup fallback and tests with the repo grouping default
- align mobile first-run workspace preferences and mobile promo chip to recent + repo, while preserving the Smart sort label
- allow mobile persisted preferences for the existing Repo sort and Status grouping options

## Tests
- [x] pnpm run typecheck
- [x] pnpm run lint
- [x] git diff --check origin/main...HEAD
- [x] pnpm vitest run --config config/vitest.config.ts src/main/persistence.test.ts src/renderer/src/lib/startup-ui-hydration.test.ts
- [x] pnpm --dir mobile install --frozen-lockfile
- [x] pnpm --dir mobile lint
- [x] pnpm --dir mobile test
- [x] pnpm --dir mobile exec tsc --noEmit
- [x] Direct mobile preference check: fresh host defaults to sortMode=recent and groupMode=repo; persisted repo sort and workspaceStatus grouping are accepted; invalid values sanitize back to the new defaults.
- [x] Electron PR worktree validation: launched brennanb2025/default-workspace-group-sort from /Users/thebr/orca/workspaces/orca/default-workspace-group-sort, verified window.api.app.getIdentity(), started with a temporary fresh userData profile, added only demo-project, and observed the rendered sidebar grouped under demo-project 65.
- [x] Console/app logs inspected: no console errors; only the existing React Grab outdated dev warning was present.

## Notes
- No SSH, runtime RPC, agent/provider/auth, or git-provider flow changed in this diff, so no live remote/provider run was required.

Made with [Orca](https://github.com/stablyai/orca) 🐋
