### PR TITLE
Stop auto-populating create PR fields

### DIFF
--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -358,23 +358,13 @@ describe('getHostedReviewCreationEligibility', () => {
       blockedReason: null,
       nextAction: null,
       defaultBaseRef: 'origin/main',
-      head: 'feature/create-pr',
-      title: 'Feature title',
-      body: 'Feature title'
+      head: 'feature/create-pr'
     })
   })
 
-  it('resolves remote eligibility through SSH repo metadata', async () => {
+  it('resolves remote eligibility through SSH repo metadata without generating PR copy', async () => {
     const remoteGit = {
-      exec: vi.fn(async (args: string[]) => {
-        if (args[0] === 'log' && args.includes('--pretty=%s')) {
-          return { stdout: 'Remote title\n', stderr: '' }
-        }
-        if (args[0] === 'log') {
-          return { stdout: '- Remote title\n', stderr: '' }
-        }
-        return { stdout: '', stderr: '' }
-      })
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' }))
     }
     getSshGitProviderMock.mockReturnValue(remoteGit)
 
@@ -392,8 +382,7 @@ describe('getHostedReviewCreationEligibility', () => {
     ).resolves.toMatchObject({
       provider: 'github',
       canCreate: true,
-      title: 'Remote title',
-      body: '- Remote title'
+      head: 'feature/create-pr'
     })
 
     expect(getProjectSlugMock).toHaveBeenCalledWith('/remote/repo', 'ssh-1')
@@ -401,7 +390,7 @@ describe('getHostedReviewCreationEligibility', () => {
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
       expect.objectContaining({ repoPath: '/remote/repo', connectionId: 'ssh-1' })
     )
-    expect(remoteGit.exec).toHaveBeenCalledWith(['log', '-1', '--pretty=%s'], '/remote/repo')
+    expect(remoteGit.exec).not.toHaveBeenCalled()
   })
 
   it('offers push as the next action for authenticated branches with local-only commits', async () => {

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -34,15 +34,6 @@ function stripRefPrefix(ref: string): string {
   return normalizeHostedReviewHeadRef(ref)
 }
 
-function branchToTitle(branch: string): string {
-  const lastSegment = branch.split('/').filter(Boolean).at(-1) ?? branch
-  return lastSegment
-    .replace(/[-_]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase())
-}
-
 async function detectHostedReviewProvider(
   repoPath: string,
   connectionId?: string | null
@@ -98,44 +89,6 @@ async function runGitForHostedReview(
     return provider.exec(args, repoPath)
   }
   return gitExecFileAsync(args, { cwd: repoPath })
-}
-
-async function getLatestCommitSubject(
-  repoPath: string,
-  connectionId?: string | null
-): Promise<string | null> {
-  try {
-    const { stdout } = await runGitForHostedReview(
-      repoPath,
-      ['log', '-1', '--pretty=%s'],
-      connectionId
-    )
-    const subject = stdout.trim()
-    return subject || null
-  } catch {
-    return null
-  }
-}
-
-async function getCommitSummaryBody(
-  repoPath: string,
-  base: string | null,
-  connectionId?: string | null
-): Promise<string | null> {
-  if (!base) {
-    return null
-  }
-  try {
-    const { stdout } = await runGitForHostedReview(
-      repoPath,
-      ['log', '--pretty=format:- %s', '--max-count=20', `${base}..HEAD`],
-      connectionId
-    )
-    const body = stdout.trim()
-    return body || null
-  } catch {
-    return null
-  }
 }
 
 async function getDefaultBaseRef(
@@ -340,16 +293,11 @@ export async function getHostedReviewCreationEligibility(
     connectionId: args.connectionId ?? null
   })
 
-  const title =
-    (await getLatestCommitSubject(args.repoPath, args.connectionId)) ?? branchToTitle(branch)
-  const body = await getCommitSummaryBody(args.repoPath, defaultBaseRef ?? null, args.connectionId)
   const baseResult = {
     provider,
     review: review ? { number: review.number, url: review.url } : null,
     defaultBaseRef,
-    head: branch || null,
-    title,
-    body
+    head: branch || null
   }
 
   if (!branch || branch === 'HEAD') {

--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -306,6 +306,7 @@ export function CreatePullRequestDialog({
               id="create-pr-title"
               value={title}
               onChange={(event) => setTitle(event.target.value)}
+              placeholder="Title"
               aria-invalid={!title.trim()}
             />
           </div>
@@ -317,18 +318,19 @@ export function CreatePullRequestDialog({
               value={body}
               onChange={(event) => setBody(event.target.value)}
               rows={6}
+              placeholder="Description (optional)"
               className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
             />
           </div>
 
-          <label className="flex items-center gap-2 text-sm text-foreground">
+          <label className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
             <input
               type="checkbox"
               checked={draft}
               onChange={(event) => setDraft(event.target.checked)}
-              className="size-4 rounded border-border accent-primary"
+              className="size-4 shrink-0 rounded border-border accent-primary"
             />
-            Draft
+            <span className="min-w-0 flex-1 truncate">Create as draft</span>
           </label>
 
           {stripBaseRef(base).toLowerCase() === stripBaseRef(branch).toLowerCase() ? (

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4475,22 +4475,25 @@ function PullRequestComposer({
               aria-hidden="true"
             />
           </div>
-          <label
-            className={cn(
-              'inline-flex shrink-0 items-center gap-1.5 text-[11px]',
-              fieldsLocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer text-foreground'
-            )}
-          >
-            <input
-              type="checkbox"
-              checked={draft}
-              disabled={fieldsLocked}
-              onChange={(event) => setDraft(event.target.checked)}
-              className="size-3.5 rounded border-border accent-primary"
-            />
-            Draft
-          </label>
         </div>
+
+        <label
+          className={cn(
+            'flex h-7 items-center gap-2 rounded-md border border-border bg-background px-2 text-xs text-foreground transition-colors',
+            fieldsLocked
+              ? 'cursor-not-allowed opacity-60'
+              : 'cursor-pointer hover:bg-accent hover:text-accent-foreground'
+          )}
+        >
+          <input
+            type="checkbox"
+            checked={draft}
+            disabled={fieldsLocked}
+            onChange={(event) => setDraft(event.target.checked)}
+            className="size-3.5 shrink-0 rounded border-border accent-primary"
+          />
+          <span className="min-w-0 flex-1 truncate">Create as draft</span>
+        </label>
 
         {baseResults.length > 0 ? (
           <div className="max-h-28 overflow-auto rounded-md border border-border p-1 scrollbar-sleek">

--- a/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
+++ b/src/renderer/src/components/right-sidebar/useCreatePullRequestDialogFields.ts
@@ -122,8 +122,10 @@ export function useCreatePullRequestDialogFields({
     initializedFromEligibilityRef.current = initializationKey
     const initialBase = eligibility.defaultBaseRef ?? ''
     setBase(stripBaseRef(initialBase))
-    setTitle(eligibility.title ?? '')
-    setBody(eligibility.body ?? '')
+    // Why: PR reviewer-facing copy should be explicit or AI-generated on
+    // request; commit-subject summaries were too noisy as automatic defaults.
+    setTitle('')
+    setBody('')
     setDraft(false)
     setBaseQuery('')
     setBaseResults([])

--- a/tests/e2e/helpers/source-control-ai-generation.ts
+++ b/tests/e2e/helpers/source-control-ai-generation.ts
@@ -64,9 +64,7 @@ export async function seedCreatePrComposer(page: Page): Promise<{
       blockedReason: null,
       nextAction: null,
       defaultBaseRef: primaryBranch,
-      head: branch,
-      title: 'Seed PR title',
-      body: 'Seed PR body'
+      head: branch
     }
 
     store.setState((current) => ({

--- a/tests/e2e/source-control-create-pr.spec.ts
+++ b/tests/e2e/source-control-create-pr.spec.ts
@@ -110,9 +110,7 @@ async function seedCreatePREligibleBranch(
       blockedReason: null,
       nextAction: null,
       defaultBaseRef: 'origin/main',
-      head: branch,
-      title: 'Create PR from E2E',
-      body: '- Initial commit for E2E'
+      head: branch
     }
 
     ;(window as unknown as { __createPRPayloads: CreatePRPayload[] }).__createPRPayloads = []
@@ -187,16 +185,19 @@ test.describe('Source Control create pull request', () => {
 
     const createButton = orcaPage.getByRole('button', { name: 'Create PR' })
     await expect(createButton).toBeVisible({ timeout: 10_000 })
-    await expect(createButton).toBeEnabled()
-    await expect(orcaPage.getByRole('textbox', { name: 'Pull request title' })).toHaveValue(
-      'Create PR from E2E'
-    )
+    await expect(createButton).toBeDisabled()
+    const titleInput = orcaPage.getByRole('textbox', { name: 'Pull request title' })
+    const descriptionInput = orcaPage.getByRole('textbox', {
+      name: 'Pull request description'
+    })
+    await expect(titleInput).toHaveValue('')
     await expect(orcaPage.getByRole('textbox', { name: 'Pull request base branch' })).toHaveValue(
       'main'
     )
-    await expect(orcaPage.getByRole('textbox', { name: 'Pull request description' })).toHaveValue(
-      '- Initial commit for E2E'
-    )
+    await expect(descriptionInput).toHaveValue('')
+    await titleInput.fill('Create PR from E2E')
+    await descriptionInput.fill('- Initial commit for E2E')
+    await expect(createButton).toBeEnabled()
     await createButton.click()
 
     await expect


### PR DESCRIPTION
## Summary
- Stop seeding Create PR title and description from commit subjects
- Keep the base branch default, but require explicit or generated reviewer-facing copy
- Improve the draft control to a full-width `Create as draft` checkbox row

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/source-control/hosted-review-creation.test.ts`
- [x] `pnpm test:e2e -- tests/e2e/source-control-create-pr.spec.ts`
- [x] Electron/CDP validation from `/Users/thebr/orca/workspaces/orca/Create-PR-auto-populate`; verified `window.api.app.getIdentity()` matched `brennanb2025/Create-PR-auto-populate`.
- [x] Used demo-project for the live app workflow: verified the real eligibility path returns no auto-generated title/body, opened the Create PR composer with empty title/description and base `main`, filled title/body, toggled `Create as draft`, clicked `Create draft PR`, and captured the dry-run payload with `draft: true` and the demo-project worktree path.
- [x] Inspected console/app logs for relevant failures; only warning was expected from the fake dry-run PR number not existing after the captured submit.

Made with [Orca](https://github.com/stablyai/orca) 🐋
