### PR TITLE
Add boring backlog write scheduler for hidden terminals

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -97,6 +97,27 @@ describe('pane terminal output scheduler', () => {
     expect(terminals[2].write).toHaveBeenCalledWith('pane-2')
   })
 
+  it('uses a bounded catch-up budget when hidden output builds a backlog', async () => {
+    vi.useFakeTimers()
+    const { writeTerminalOutput } = await loadScheduler()
+    const terminals = [createTerminal(), createTerminal(), createTerminal()]
+    const largeChunk = 'x'.repeat(80 * 1024)
+
+    terminals.forEach((terminal) => {
+      writeTerminalOutput(terminal, largeChunk, { foreground: false })
+    })
+
+    vi.advanceTimersByTime(100)
+    expect(terminals[0].write).toHaveBeenCalledTimes(1)
+    expect(terminals[1].write).toHaveBeenCalledTimes(1)
+    expect(terminals[2].write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(50)
+    expect(terminals[0].write).toHaveBeenCalledTimes(2)
+    expect(terminals[1].write).toHaveBeenCalledTimes(1)
+    expect(terminals[2].write).toHaveBeenCalledTimes(1)
+  })
+
   it('rotates terminals with remaining backlog behind untouched queued terminals', async () => {
     vi.useFakeTimers()
     const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -9,23 +9,26 @@ type TerminalOutputBeforeWrite = (data: string) => void
 type QueueEntry = {
   terminal: TerminalOutputTarget
   chunks: string[]
+  queuedChars: number
   beforeWrite?: TerminalOutputBeforeWrite
 }
 
 const BACKGROUND_FLUSH_DELAY_MS = 100
 const BACKGROUND_DRAIN_INTERVAL_MS = 50
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
-const MAX_WRITES_PER_DRAIN = 1
+const BASE_WRITES_PER_DRAIN = 1
+const CATCH_UP_WRITES_PER_DRAIN = 2
+const CATCH_UP_BACKLOG_CHARS = 128 * 1024
 const PARSE_SETTLE_TIMEOUT_MS = 250
 
 const queuedByTerminal = new Map<TerminalOutputTarget, QueueEntry>()
 let drainTimer: ReturnType<typeof setTimeout> | null = null
+let totalQueuedChars = 0
 const debugEnabled = e2eConfig.exposeStore
 
 // Why no lossy queue cap: dropping raw terminal bytes can corrupt parser state
-// (half an escape sequence, missed mode reset, wrong scrollback). A pathological
-// background producer can still consume memory/CPU; preserving terminal
-// correctness means that case needs adaptive/backpressure work, not truncation.
+// (half an escape sequence, missed mode reset, wrong scrollback). When hidden
+// agents build a real backlog, use a bounded catch-up budget instead.
 
 type TerminalOutputSchedulerDebugSnapshot = {
   backgroundEnqueueCount: number
@@ -34,6 +37,8 @@ type TerminalOutputSchedulerDebugSnapshot = {
   flushWriteCount: number
   scheduledDrainCount: number
   drainWrites: number[]
+  queuedChars: number
+  maxQueuedChars: number
 }
 
 type TerminalOutputSchedulerDebugApi = {
@@ -47,7 +52,9 @@ const debugState: TerminalOutputSchedulerDebugSnapshot = {
   backgroundWriteCount: 0,
   flushWriteCount: 0,
   scheduledDrainCount: 0,
-  drainWrites: []
+  drainWrites: [],
+  queuedChars: 0,
+  maxQueuedChars: 0
 }
 
 function resetDebugState(): void {
@@ -57,6 +64,16 @@ function resetDebugState(): void {
   debugState.flushWriteCount = 0
   debugState.scheduledDrainCount = 0
   debugState.drainWrites = []
+  debugState.queuedChars = totalQueuedChars
+  debugState.maxQueuedChars = totalQueuedChars
+}
+
+function recordQueuedChars(): void {
+  if (!debugEnabled) {
+    return
+  }
+  debugState.queuedChars = totalQueuedChars
+  debugState.maxQueuedChars = Math.max(debugState.maxQueuedChars, totalQueuedChars)
 }
 
 function exposeDebugApi(): void {
@@ -87,6 +104,12 @@ function scheduleDrain(delayMs: number): void {
   drainTimer = setTimeout(drainQueuedOutput, delayMs)
 }
 
+function maxWritesForCurrentBacklog(): number {
+  return totalQueuedChars >= CATCH_UP_BACKLOG_CHARS
+    ? CATCH_UP_WRITES_PER_DRAIN
+    : BASE_WRITES_PER_DRAIN
+}
+
 function takeQueuedChunk(entry: QueueEntry, limit: number): string {
   let remaining = limit
   let data = ''
@@ -105,7 +128,17 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): string {
     remaining = 0
   }
 
+  entry.queuedChars -= data.length
+  totalQueuedChars -= data.length
+  recordQueuedChars()
   return data
+}
+
+function dropQueuedEntry(entry: QueueEntry): void {
+  totalQueuedChars -= entry.queuedChars
+  entry.queuedChars = 0
+  entry.chunks.length = 0
+  recordQueuedChars()
 }
 
 function writeQueuedChunk(entry: QueueEntry): boolean {
@@ -120,7 +153,7 @@ function writeQueuedChunk(entry: QueueEntry): boolean {
     // Why: pane.terminal.dispose() can race with a queued late-arriving PTY ping;
     // a write to a disposed terminal throws. Drop the entry rather than crashing
     // the scheduler for other panes still draining.
-    entry.chunks.length = 0
+    dropQueuedEntry(entry)
     return false
   }
   return true
@@ -129,8 +162,9 @@ function writeQueuedChunk(entry: QueueEntry): boolean {
 function drainQueuedOutput(): void {
   drainTimer = null
   let writes = 0
+  const maxWrites = maxWritesForCurrentBacklog()
 
-  while (queuedByTerminal.size > 0 && writes < MAX_WRITES_PER_DRAIN) {
+  while (queuedByTerminal.size > 0 && writes < maxWrites) {
     const entry = queuedByTerminal.values().next().value
     if (!entry) {
       break
@@ -178,12 +212,15 @@ export function writeTerminalOutput(
 
   let entry = queuedByTerminal.get(terminal)
   if (!entry) {
-    entry = { terminal, chunks: [], beforeWrite: options.beforeWrite }
+    entry = { terminal, chunks: [], queuedChars: 0, beforeWrite: options.beforeWrite }
     queuedByTerminal.set(terminal, entry)
   } else {
     entry.beforeWrite = options.beforeWrite
   }
   entry.chunks.push(data)
+  entry.queuedChars += data.length
+  totalQueuedChars += data.length
+  recordQueuedChars()
   if (debugEnabled) {
     debugState.backgroundEnqueueCount++
   }
@@ -213,6 +250,7 @@ export function flushTerminalOutput(terminal: TerminalOutputTarget): void {
       // Why: pane.terminal.dispose() can race with a queued late-arriving PTY ping;
       // a write to a disposed terminal throws. Drop the entry rather than crashing
       // the scheduler for other panes still draining.
+      dropQueuedEntry(entry)
       return
     }
     data = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
@@ -246,7 +284,12 @@ export function waitForTerminalOutputParsed(terminal: TerminalOutputTarget): Pro
 
 export function discardTerminalOutput(terminal: TerminalOutputTarget): void {
   exposeDebugApi()
+  const entry = queuedByTerminal.get(terminal)
+  if (!entry) {
+    return
+  }
   queuedByTerminal.delete(terminal)
+  dropQueuedEntry(entry)
 }
 
 exposeDebugApi()

--- a/tests/e2e/terminal-codex-lag-stress.spec.ts
+++ b/tests/e2e/terminal-codex-lag-stress.spec.ts
@@ -68,6 +68,8 @@ type TerminalOutputSchedulerDebugSnapshot = {
   flushWriteCount: number
   scheduledDrainCount: number
   drainWrites: number[]
+  queuedChars: number
+  maxQueuedChars: number
 }
 
 type StressWorktree = {
@@ -118,7 +120,9 @@ const emit = () => {
   process.stdout.write('\\x1b]9999;' + JSON.stringify(payload) + '\\x07')
   process.stdout.write('\\r\\x1b[2K' + spinner + ' codex ' + id + ' thinking ' + seq + ' ' + 'x'.repeat(${payloadChars}) + '\\n')
 }
-setTimeout(() => setInterval(emit, ${intervalMs}), 250)
+// Why: keep the ready marker in the terminal tail long enough for Playwright
+// to observe it before high-volume background output starts.
+setTimeout(() => setInterval(emit, ${intervalMs}), 1500)
 `
 }
 
@@ -149,7 +153,18 @@ const emit = () => {
   process.stdout.write('\\x1b]9999;' + JSON.stringify(payload) + '\\x07')
   process.stdout.write('\\r\\x1b[2K' + spinner + ' real codex ' + id + ' active ' + seq + ' ' + 'x'.repeat(${payloadChars}) + '\\n')
 }
-const heartbeat = setInterval(emit, ${intervalMs})
+// Why: keep the ready marker in the terminal tail long enough for Playwright
+// to observe it before high-volume background output starts.
+let heartbeat = null
+const heartbeatDelay = setTimeout(() => {
+  heartbeat = setInterval(emit, ${intervalMs})
+}, 1500)
+const clearHeartbeat = () => {
+  clearTimeout(heartbeatDelay)
+  if (heartbeat !== null) {
+    clearInterval(heartbeat)
+  }
+}
 
 const progressPrefix = 'ORCA_REAL_CODEX_PROGRESS_${runId}_' + id
 const progressProgram =
@@ -173,13 +188,13 @@ const child = spawn(
 )
 
 child.on('error', (error) => {
-  clearInterval(heartbeat)
+  clearHeartbeat()
   console.error('BG_CODEX_ERROR_${runId}_' + id + ' ' + error.message)
   process.exit(1)
 })
 
 child.on('exit', (code, signal) => {
-  clearInterval(heartbeat)
+  clearHeartbeat()
   process.stdout.write(
     'BG_CODEX_EXIT_${runId}_' + id + ' ' + (code === null ? signal : code) + '\\n'
   )

--- a/tests/e2e/terminal-output-scheduler.spec.ts
+++ b/tests/e2e/terminal-output-scheduler.spec.ts
@@ -24,6 +24,8 @@ type SchedulerDebugSnapshot = {
   flushWriteCount: number
   scheduledDrainCount: number
   drainWrites: number[]
+  queuedChars: number
+  maxQueuedChars: number
 }
 
 type SchedulerDebugWindow = Window & {


### PR DESCRIPTION
## Summary

- Adds an adaptive hidden-terminal backlog drain: hidden terminals still use the gentle one-write drain by default, then move to a bounded two-write catch-up budget once queued output reaches 128KB.
- Tracks queued hidden-terminal bytes in the e2e-only scheduler debug snapshot so stress runs can show whether the backlog path was actually exercised.
- Hardens the terminal Codex lag stress benchmark ready marker so high-volume background output cannot evict the setup marker before Playwright observes it.

## Why this shape

This keeps the primary scheduler boring and local: no settings migration, no experimental toggle surface, and no dropped terminal bytes. Foreground/visible terminals still write immediately. Hidden terminals only get extra budget after real backlog pressure appears.

## Evidence

Focused unit tests:

```sh
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
# 2 files passed, 84 tests passed
```

Cheap gates on the rebased commit:

```sh
pnpm typecheck
pnpm lint
```

Direct scheduler e2e:

```sh
pnpm exec playwright test tests/e2e/terminal-output-scheduler.spec.ts --config tests/playwright.config.ts --project electron-headless
# 1 passed
```

Default terminal lag stress:

```sh
pnpm exec playwright test tests/e2e/terminal-codex-lag-stress.spec.ts --config tests/playwright.config.ts --project electron-headless
```

Result:

```text
worktrees=36 backgroundTerminals=4 backgroundMode=synthetic backgroundIntervalMs=10 backgroundPayloadChars=220 median=4.9ms worst=17.0ms worstRafGap=19.5ms worstLongTask=0.0ms scheduler={"backgroundEnqueueCount":63,"foregroundWriteCount":32,"backgroundWriteCount":4,"flushWriteCount":0,"scheduledDrainCount":4,"drainWrites":[1,1,1,1],"queuedChars":7640,"maxQueuedChars":10932}
```

Heavy backlog stress, exercising catch-up:

```sh
ORCA_E2E_CODEX_LAG_WORKTREES=72 ORCA_E2E_CODEX_LAG_BACKGROUND_TERMINALS=6 ORCA_E2E_CODEX_LAG_BACKGROUND_INTERVAL_MS=5 ORCA_E2E_CODEX_LAG_BACKGROUND_PAYLOAD_CHARS=500 pnpm exec playwright test tests/e2e/terminal-codex-lag-stress.spec.ts --config tests/playwright.config.ts --project electron-headless
```

Result:

```text
worktrees=72 backgroundTerminals=6 backgroundMode=synthetic backgroundIntervalMs=5 backgroundPayloadChars=500 median=3.2ms worst=11.1ms worstRafGap=17.7ms worstLongTask=0.0ms scheduler={"backgroundEnqueueCount":62,"foregroundWriteCount":32,"backgroundWriteCount":3,"flushWriteCount":0,"scheduledDrainCount":2,"drainWrites":[1,2],"queuedChars":142774,"maxQueuedChars":150058}
```

The heavy run proves the catch-up budget activated (`drainWrites` includes `2`) while foreground typing latency stayed low.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.
