### PR TITLE
Use play icon for quick commands context menu

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -8,8 +8,8 @@ import {
   PanelsTopLeft,
   PanelRightClose,
   Pencil,
+  Play,
   Plus,
-  SquareTerminal,
   X
 } from 'lucide-react'
 import {
@@ -141,7 +141,7 @@ export default function TerminalContextMenu({
         </DropdownMenuItem>
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
-            <SquareTerminal />
+            <Play fill="currentColor" strokeWidth={0} />
             Quick Commands
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-60">


### PR DESCRIPTION
## Summary
- replace the terminal context menu Quick Commands icon with the filled lucide Play icon
- align the menu with the tab bar quick commands button and settings navigation

## Verification
- pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
- pnpm run typecheck:web
- npx electron-vite build --mode e2e
- launched an e2e Electron instance, opened the terminal context menu, and captured proof at artifacts/quick-commands-context-menu-play-button.png

Note: screenshot evidence was kept out of git per repo policy.

Made with [Orca](https://github.com/stablyai/orca) 🐋
