### PR TITLE
Improve onboarding step indicator contrast

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -163,7 +163,7 @@ export default function OnboardingFlow({
                           ? 'w-10 bg-foreground'
                           : isDone
                             ? 'w-6 bg-muted-foreground/70 hover:bg-foreground/80'
-                            : 'w-6 bg-muted hover:bg-muted-foreground/60'
+                            : 'w-6 bg-muted-foreground/25 hover:bg-muted-foreground/45'
                       )}
                       aria-label={`Go to onboarding step ${step.stepNumber}: ${stepCopy[step.id].title}`}
                       aria-current={isActive ? 'step' : undefined}


### PR DESCRIPTION
## Summary
- Increase contrast for upcoming onboarding step indicator bars in light mode
- Keep the completed/current state styling unchanged

## Validation
- `pnpm run typecheck`
- Electron CDP validation on `onboard-ux @ nwparker/onboarding-indicator-contrast`
- Opened onboarding in light mode and visually confirmed upcoming bars are visible against the white background

## Evidence
- Screenshot captured locally at `/tmp/orca-onboarding-indicator-light.png`
