### PR TITLE
Update mobile 0.0.9 release links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Control your agents from your phone.
 </p>
 
 - **iOS:** [Download from App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.8)
+- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.9)
 
 ---
 

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -42,7 +42,7 @@ export const PLATFORM_COPY: Record<
   android: {
     description: 'Scan with your Android camera to download the latest APK from GitHub Releases.',
     ctaLabel: 'Download APK',
-    url: 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.8'
+    url: 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.9'
   }
 }
 

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../../store'
 import { MobilePane, MOBILE_PANE_SEARCH_ENTRIES } from './MobilePane'
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
-const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.8'
+const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.9'
 
 const MOBILE_ENABLE_SEARCH_ENTRY: SettingsSearchEntry = {
   title: 'Mobile',


### PR DESCRIPTION
## Summary
- Point Android download links at the published mobile-v0.0.9 release

## Verification
- gh release view mobile-v0.0.9 --repo stablyai/orca --json tagName,url,isPrerelease,assets,publishedAt,name
- rg -n "mobile-v0\.0\.8|0\.0\.8|releases/tag/mobile-v" README.md src docs mobile 2>/dev/null

Made with [Orca](https://github.com/stablyai/orca) 🐋
