### PR TITLE
Fix onboarding light theme and add settings sound selector

### DIFF
--- a/src/renderer/src/components/onboarding/ThemeStep.test.ts
+++ b/src/renderer/src/components/onboarding/ThemeStep.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyOnboardingThemeSelection } from './ThemeStep'
+
+describe('applyOnboardingThemeSelection', () => {
+  it('previews and persists the selected theme immediately', () => {
+    const onThemeChange = vi.fn()
+    const updateSettings = vi.fn().mockResolvedValue(undefined)
+
+    applyOnboardingThemeSelection('light', onThemeChange, updateSettings)
+
+    expect(onThemeChange).toHaveBeenCalledWith('light')
+    expect(updateSettings).toHaveBeenCalledWith({ theme: 'light' })
+  })
+})

--- a/src/renderer/src/components/onboarding/ThemeStep.tsx
+++ b/src/renderer/src/components/onboarding/ThemeStep.tsx
@@ -17,6 +17,17 @@ type ThemeStepProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => Promise<void>
 }
 
+export function applyOnboardingThemeSelection(
+  id: GlobalSettings['theme'],
+  onThemeChange: (theme: GlobalSettings['theme']) => void,
+  updateSettings: (updates: Partial<GlobalSettings>) => Promise<void>
+): void {
+  onThemeChange(id)
+  // Why: later onboarding controls also save settings. Persist the theme at
+  // selection time so those unrelated writes cannot reapply the old theme.
+  void updateSettings({ theme: id })
+}
+
 // The two UI-only states (`'idle'`, `'detecting'`) never fire telemetry. The
 // remaining states are exactly `DiscoveryStatusEmitted`, which is the
 // schema-side enum the compile-time guard in
@@ -179,7 +190,7 @@ export function ThemeStep({ theme, onThemeChange, settings, updateSettings }: Th
                   ? 'border-violet-500/60 bg-violet-500/10 ring-2 ring-violet-500/30'
                   : 'border-border bg-muted/30 hover:bg-muted/60'
               )}
-              onClick={() => onThemeChange(id)}
+              onClick={() => applyOnboardingThemeSelection(id, onThemeChange, updateSettings)}
             >
               <div className="relative mb-3 h-24 overflow-hidden rounded-lg border border-border">
                 <ChromePreview variant={id} />


### PR DESCRIPTION
## Summary
- Persist onboarding theme selections immediately when the user clicks System/Dark/Light
- Prevent later onboarding settings writes, like Ghostty import or notification sound selection, from reapplying an older saved theme
- Share notification sound metadata between onboarding and settings
- Add a compact notification sound dropdown to Settings with built-in sounds, custom-file selection, volume for non-system sounds, and test notification support
- Add regression coverage for theme selection and settings sound rendering

## Validation
- `pnpm run typecheck`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/NotificationsPane.test.tsx src/renderer/src/components/onboarding/NotificationStep.test.tsx src/renderer/src/components/onboarding/ThemeStep.test.ts`
- Electron CDP on `onboard-ux @ nwparker/onboarding-theme-preview-fix`: reproduced the light-theme dark flip before the fix, then verified unrelated settings writes no longer flip the root theme
- Electron CDP Settings validation: opened Settings → Notifications, verified the compact sound dropdown lists System Default, built-ins, existing custom file, and Change Custom File; selected Ding and confirmed `customSoundId: "ding"`; selected System Default and confirmed the volume bar hides

## Evidence
- Fixed onboarding notification screenshot captured locally at `/tmp/orca-theme-sound-after-fix.png`
- Settings sound selector screenshot captured locally at `/tmp/orca-settings-notification-sound-select-compact.png`