### PR TITLE
Add Cmd+J create action

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -29,6 +29,12 @@ import {
   type MatchRange,
   type PaletteSearchResult
 } from '@/lib/worktree-palette-search'
+import {
+  CREATE_WORKTREE_ITEM_ID,
+  createWorktreePaletteRequestGuard,
+  getNextWorktreePaletteSelection,
+  getWorktreePaletteCreateActionState
+} from '@/lib/worktree-palette-create-action'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import {
   isBlankBrowserUrl,
@@ -185,6 +191,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const skipRestoreFocusRef = useRef(false)
   const prevQueryRef = useRef('')
   const listRef = useRef<HTMLDivElement>(null)
+  const createLookupGuard = useMemo(() => createWorktreePaletteRequestGuard(), [])
+  const preserveCreateLookupOnCloseRef = useRef(false)
 
   const repoMap = useMemo(() => new Map(repos.map((r) => [r.id, r])), [repos])
   const canCreateWorktree = useMemo(() => repos.some((repo) => isGitRepoKind(repo)), [repos])
@@ -473,9 +481,17 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [listEntries]
   )
 
-  const createWorktreeName = deferredQuery.trim()
-  const showCreateAction =
-    canCreateWorktree && createWorktreeName.length > 0 && worktreeItems.length === 0
+  const selectableItemIds = useMemo(() => selectableItems.map((item) => item.id), [selectableItems])
+
+  const { createWorktreeName, showCreateAction } = useMemo(
+    () =>
+      getWorktreePaletteCreateActionState({
+        canCreateWorktree,
+        query: deferredQuery,
+        selectableItemIds
+      }),
+    [canCreateWorktree, deferredQuery, selectableItemIds]
+  )
 
   const isLoading = repos.length > 0 && Object.keys(worktreesByRepo).length === 0
   // Why: empty-state / "has any worktrees?" uses the full visible list
@@ -487,6 +503,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
   useEffect(() => {
     if (visible && !wasVisibleRef.current) {
+      createLookupGuard.invalidate()
       previousWorktreeIdRef.current = activeWorktreeId
       previousActiveTabTypeRef.current = activeTabType
       previousBrowserPageIdRef.current =
@@ -510,8 +527,25 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       setSelectedItemId('')
     }
 
+    if (!visible && wasVisibleRef.current) {
+      if (preserveCreateLookupOnCloseRef.current) {
+        // Why: create intentionally closes the palette before GH resolves;
+        // reopening still invalidates the pending lookup above.
+        preserveCreateLookupOnCloseRef.current = false
+      } else {
+        createLookupGuard.invalidate()
+      }
+    }
+
     wasVisibleRef.current = visible
-  }, [activeBrowserTabId, activeTabType, activeWorktreeId, browserTabsByWorktree, visible])
+  }, [
+    activeBrowserTabId,
+    activeTabType,
+    activeWorktreeId,
+    browserTabsByWorktree,
+    createLookupGuard,
+    visible
+  ])
 
   useEffect(() => {
     if (!visible) {
@@ -520,34 +554,22 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     const queryChanged = deferredQuery !== prevQueryRef.current
     prevQueryRef.current = deferredQuery
 
-    const firstSelectableId = showCreateAction ? '__create_worktree__' : null
-
+    const nextSelectedItemId = getNextWorktreePaletteSelection({
+      currentSelectedItemId: selectedItemId,
+      queryChanged,
+      selectableItemIds,
+      showCreateAction
+    })
     if (queryChanged) {
-      if (selectableItems.length > 0) {
-        setSelectedItemId(selectableItems[0].id)
-      } else {
-        setSelectedItemId(firstSelectableId ?? '')
-      }
+      setSelectedItemId(nextSelectedItemId)
       listRef.current?.scrollTo(0, 0)
       return
     }
 
-    if (selectableItems.length === 0) {
-      setSelectedItemId(firstSelectableId ?? '')
-      return
+    if (nextSelectedItemId !== selectedItemId) {
+      setSelectedItemId(nextSelectedItemId)
     }
-
-    if (selectedItemId === '__create_worktree__' && showCreateAction) {
-      return
-    }
-
-    if (
-      !selectableItems.some((item) => item.id === selectedItemId) &&
-      selectedItemId !== firstSelectableId
-    ) {
-      setSelectedItemId(firstSelectableId ?? selectableItems[0].id)
-    }
-  }, [deferredQuery, selectedItemId, showCreateAction, visible, selectableItems])
+  }, [deferredQuery, selectedItemId, showCreateAction, visible, selectableItemIds])
 
   const focusFallbackSurface = useCallback(() => {
     requestAnimationFrame(() => {
@@ -709,6 +731,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       // Why: awaiting inside the user gesture would leave the palette open
       // indefinitely on slow networks. Close immediately and populate the
       // composer once the lookup returns.
+      const lookupToken = createLookupGuard.start()
+      preserveCreateLookupOnCloseRef.current = true
       closeModal()
       void window.api.gh
         .workItemByOwnerRepo({
@@ -720,6 +744,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
           type: ghLink.type
         })
         .then((item) => {
+          if (!createLookupGuard.isCurrent(lookupToken)) {
+            return
+          }
           const data: Record<string, unknown> = { initialRepoId: repoForLookup.id }
           if (item) {
             const linkedWorkItem: LinkedWorkItemSummary = {
@@ -739,6 +766,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
           )
         })
         .catch(() => {
+          if (!createLookupGuard.isCurrent(lookupToken)) {
+            return
+          }
           queueMicrotask(() =>
             openModal('new-workspace-composer', {
               initialRepoId: repoForLookup.id,
@@ -770,10 +800,15 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         return
       }
 
+      const lookupToken = createLookupGuard.start()
+      preserveCreateLookupOnCloseRef.current = true
       closeModal()
       void window.api.gh
         .workItem({ repoPath: repoForLookup.path, repoId: repoForLookup.id, number: ghNumber })
         .then((item) => {
+          if (!createLookupGuard.isCurrent(lookupToken)) {
+            return
+          }
           const data: Record<string, unknown> = { initialRepoId: repoForLookup.id }
           if (item) {
             const linkedWorkItem: LinkedWorkItemSummary = {
@@ -792,6 +827,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
           )
         })
         .catch(() => {
+          if (!createLookupGuard.isCurrent(lookupToken)) {
+            return
+          }
           queueMicrotask(() =>
             openModal('new-workspace-composer', {
               initialRepoId: repoForLookup.id,
@@ -805,7 +843,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
 
     // Case 3: plain name — open composer prefilled.
     openComposer(trimmed ? { prefilledName: trimmed } : {})
-  }, [allWorktrees, closeModal, createWorktreeName, openModal, repoMap])
+  }, [allWorktrees, closeModal, createLookupGuard, createWorktreeName, openModal, repoMap])
 
   const handleCloseAutoFocus = useCallback((e: Event) => {
     e.preventDefault()
@@ -1115,9 +1153,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
               // auto-select it before our effect promotes the first real match
               // when the query only matches browser pages.
               <CommandItem
-                value="__create_worktree__"
+                value={CREATE_WORKTREE_ITEM_ID}
                 onSelect={handleCreateWorktree}
-                className="group mx-0.5 mt-1 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-1.5 text-left outline-none transition-[background-color,border-color,box-shadow] data-[selected=true]:border-border data-[selected=true]:bg-neutral-100 data-[selected=true]:text-foreground dark:data-[selected=true]:bg-neutral-800"
+                className="group mx-0.5 mt-1 flex cursor-pointer items-center gap-3 rounded-lg border border-transparent px-3 py-1.5 text-left outline-none transition-[background-color,border-color,box-shadow] data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground"
               >
                 <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-dashed border-border/60 bg-muted/25 text-muted-foreground/70">
                   <Plus size={13} aria-hidden="true" />

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CREATE_WORKTREE_ITEM_ID,
+  createWorktreePaletteRequestGuard,
+  getNextWorktreePaletteSelection,
+  getWorktreePaletteCreateActionState
+} from './worktree-palette-create-action'
+
+describe('worktree-palette-create-action', () => {
+  it('shows create for typed queries with workspace matches but selects the first real row', () => {
+    const state = getWorktreePaletteCreateActionState({
+      canCreateWorktree: true,
+      query: 'feature',
+      selectableItemIds: ['worktree:one']
+    })
+
+    expect(state).toEqual({
+      createWorktreeName: 'feature',
+      showCreateAction: true,
+      shouldDefaultToCreate: false
+    })
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: '',
+        queryChanged: true,
+        selectableItemIds: ['worktree:one'],
+        showCreateAction: state.showCreateAction
+      })
+    ).toBe('worktree:one')
+  })
+
+  it('shows create for typed queries with browser-only matches but selects the browser row', () => {
+    const state = getWorktreePaletteCreateActionState({
+      canCreateWorktree: true,
+      query: 'localhost',
+      selectableItemIds: ['browser-page:one']
+    })
+
+    expect(state.showCreateAction).toBe(true)
+    expect(state.shouldDefaultToCreate).toBe(false)
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: '',
+        queryChanged: true,
+        selectableItemIds: ['browser-page:one'],
+        showCreateAction: state.showCreateAction
+      })
+    ).toBe('browser-page:one')
+  })
+
+  it('defaults to create for typed queries with no real matches', () => {
+    const state = getWorktreePaletteCreateActionState({
+      canCreateWorktree: true,
+      query: 'new-workspace',
+      selectableItemIds: []
+    })
+
+    expect(state.showCreateAction).toBe(true)
+    expect(state.shouldDefaultToCreate).toBe(true)
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: '',
+        queryChanged: true,
+        selectableItemIds: [],
+        showCreateAction: state.showCreateAction
+      })
+    ).toBe(CREATE_WORKTREE_ITEM_ID)
+  })
+
+  it('moves selection back to the first real row when the query changes after manual create selection', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: CREATE_WORKTREE_ITEM_ID,
+        queryChanged: true,
+        selectableItemIds: ['worktree:match'],
+        showCreateAction: true
+      })
+    ).toBe('worktree:match')
+  })
+
+  it('preserves manual create selection during non-query churn while create remains visible', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: CREATE_WORKTREE_ITEM_ID,
+        queryChanged: false,
+        selectableItemIds: ['worktree:match'],
+        showCreateAction: true
+      })
+    ).toBe(CREATE_WORKTREE_ITEM_ID)
+  })
+
+  it('hides create when no git repos are available', () => {
+    expect(
+      getWorktreePaletteCreateActionState({
+        canCreateWorktree: false,
+        query: 'new-workspace',
+        selectableItemIds: []
+      }).showCreateAction
+    ).toBe(false)
+  })
+
+  it('hides create for an empty query', () => {
+    expect(
+      getWorktreePaletteCreateActionState({
+        canCreateWorktree: true,
+        query: '   ',
+        selectableItemIds: []
+      }).showCreateAction
+    ).toBe(false)
+  })
+
+  it('falls back deterministically when the selected row disappears', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: 'worktree:deleted',
+        queryChanged: false,
+        selectableItemIds: ['browser-page:first', 'worktree:second'],
+        showCreateAction: true
+      })
+    ).toBe('browser-page:first')
+  })
+
+  it('invalidates stale async create lookups', () => {
+    const guard = createWorktreePaletteRequestGuard()
+    const first = guard.start()
+
+    expect(guard.isCurrent(first)).toBe(true)
+    guard.invalidate()
+    expect(guard.isCurrent(first)).toBe(false)
+
+    const second = guard.start()
+    expect(guard.isCurrent(first)).toBe(false)
+    expect(guard.isCurrent(second)).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/worktree-palette-create-action.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.ts
@@ -1,0 +1,74 @@
+export const CREATE_WORKTREE_ITEM_ID = '__create_worktree__'
+
+export type WorktreePaletteCreateActionState = {
+  createWorktreeName: string
+  showCreateAction: boolean
+  shouldDefaultToCreate: boolean
+}
+
+export function getWorktreePaletteCreateActionState({
+  canCreateWorktree,
+  query,
+  selectableItemIds
+}: {
+  canCreateWorktree: boolean
+  query: string
+  selectableItemIds: readonly string[]
+}): WorktreePaletteCreateActionState {
+  const createWorktreeName = query.trim()
+  const showCreateAction = canCreateWorktree && createWorktreeName.length > 0
+  return {
+    createWorktreeName,
+    showCreateAction,
+    shouldDefaultToCreate: showCreateAction && selectableItemIds.length === 0
+  }
+}
+
+export function getNextWorktreePaletteSelection({
+  currentSelectedItemId,
+  queryChanged,
+  selectableItemIds,
+  showCreateAction
+}: {
+  currentSelectedItemId: string
+  queryChanged: boolean
+  selectableItemIds: readonly string[]
+  showCreateAction: boolean
+}): string {
+  const firstSelectableId = selectableItemIds[0] ?? null
+
+  if (queryChanged) {
+    return firstSelectableId ?? (showCreateAction ? CREATE_WORKTREE_ITEM_ID : '')
+  }
+
+  if (currentSelectedItemId === CREATE_WORKTREE_ITEM_ID && showCreateAction) {
+    return currentSelectedItemId
+  }
+
+  if (selectableItemIds.includes(currentSelectedItemId)) {
+    return currentSelectedItemId
+  }
+
+  return firstSelectableId ?? (showCreateAction ? CREATE_WORKTREE_ITEM_ID : '')
+}
+
+export type WorktreePaletteRequestGuard = {
+  start: () => number
+  invalidate: () => void
+  isCurrent: (token: number) => boolean
+}
+
+export function createWorktreePaletteRequestGuard(): WorktreePaletteRequestGuard {
+  let currentToken = 0
+
+  return {
+    start: () => {
+      currentToken += 1
+      return currentToken
+    },
+    invalidate: () => {
+      currentToken += 1
+    },
+    isCurrent: (token: number) => token === currentToken
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the Cmd+J worktree create action described in `docs/cmd-j-create-action.md`.
- Keeps matching worktree results as the active default while exposing a create row for typed queries.
- Adds focused coverage for partial matches, no-match selection, empty-query hiding, and existing-result priority.

## Validation
- Electron validation passed in the running build.
- PASS typed partial workspace match: create row visible, first real result selected.
- PASS typed no-match query: create row visible and selected.
- PASS query cleared: create row disappears.
- PASS adjacent existing-result smoke: existing real result remains active default while create row is present.

## Notes
- Local validation screenshots and report are intentionally uncommitted under `validation-screenshots/`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
