### PR TITLE
test: fix hidden terminal CI fallout

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.ghostty.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.ghostty.test.ts
@@ -80,10 +80,26 @@ vi.mock('../ui/toggle-group', () => ({
 }))
 
 vi.mock('./SettingsFormControls', () => ({
+  SettingsRow: function SettingsRow({ children }: { children?: unknown }) {
+    return children
+  },
   NumberField: function NumberField() {
     return null
   },
   FontAutocomplete: function FontAutocomplete() {
+    return null
+  },
+  SettingsSegmentedControl: function SettingsSegmentedControl({
+    options
+  }: {
+    options?: readonly { label: string }[]
+  }) {
+    return options?.map((option) => option.label) ?? null
+  },
+  SettingsSubsectionHeader: function SettingsSubsectionHeader() {
+    return null
+  },
+  SettingsSwitchRow: function SettingsSwitchRow() {
     return null
   }
 }))

--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -80,10 +80,34 @@ vi.mock('../ui/toggle-group', () => ({
 }))
 
 vi.mock('./SettingsFormControls', () => ({
+  SettingsRow: function SettingsRow({
+    description,
+    control,
+    children
+  }: {
+    description?: unknown
+    control?: unknown
+    children?: unknown
+  }) {
+    return [description, control, children]
+  },
   NumberField: function NumberField() {
     return null
   },
   FontAutocomplete: function FontAutocomplete() {
+    return null
+  },
+  SettingsSegmentedControl: function SettingsSegmentedControl({
+    options
+  }: {
+    options?: readonly { label: string }[]
+  }) {
+    return options?.map((option) => option.label) ?? null
+  },
+  SettingsSubsectionHeader: function SettingsSubsectionHeader() {
+    return null
+  },
+  SettingsSwitchRow: function SettingsSwitchRow() {
     return null
   }
 }))
@@ -140,6 +164,15 @@ type ReactElementLike = {
   props: Record<string, unknown>
 }
 
+function getPropNodes(el: ReactElementLike): unknown[] {
+  const nodes = [el.props?.children, el.props?.description, el.props?.control]
+  const options = el.props?.options
+  if (Array.isArray(options)) {
+    nodes.push(options.map((option) => (option as { label?: unknown }).label))
+  }
+  return nodes
+}
+
 function collectText(node: unknown): string {
   if (node == null) {
     return ''
@@ -154,7 +187,7 @@ function collectText(node: unknown): string {
     return node.map(collectText).join('')
   }
   const el = node as ReactElementLike
-  return collectText(el.props?.children)
+  return getPropNodes(el).map(collectText).join('')
 }
 
 function findAnchorByText(node: unknown, text: string): ReactElementLike | null {
@@ -178,7 +211,13 @@ function findAnchorByText(node: unknown, text: string): ReactElementLike | null 
   if (typeName === 'a' && collectText(el.props.children).includes(text)) {
     return el
   }
-  return findAnchorByText(el.props?.children, text)
+  for (const child of getPropNodes(el)) {
+    const found = findAnchorByText(child, text)
+    if (found) {
+      return found
+    }
+  }
+  return null
 }
 
 describe('TerminalPane PowerShell version setting', () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -515,11 +515,13 @@ describe('createRemoteRuntimePtyTransport', () => {
       'before\x1b]9999;{"state":"working","prompt":"ship it","agentType":"codex"}\x07after\x1b]0;. Claude working\x07\x07'
     )
 
-    expect(onAgentStatus).toHaveBeenCalledWith({
-      state: 'working',
-      prompt: 'ship it',
-      agentType: 'codex'
-    })
+    await vi.waitFor(() =>
+      expect(onAgentStatus).toHaveBeenCalledWith({
+        state: 'working',
+        prompt: 'ship it',
+        agentType: 'codex'
+      })
+    )
     expect(onData).toHaveBeenCalledWith('beforeafter\x1b]0;. Claude working\x07\x07')
     expect(onTitleChange).toHaveBeenCalledWith('. Claude working', '. Claude working')
     expect(onBell).toHaveBeenCalledTimes(1)
@@ -546,11 +548,13 @@ describe('createRemoteRuntimePtyTransport', () => {
       'before\x1b]9999;{"state":"working","prompt":"ship it","agentType":"codex"}\x07after'
     )
 
-    expect(onAgentStatus).toHaveBeenCalledWith({
-      state: 'working',
-      prompt: 'ship it',
-      agentType: 'codex'
-    })
+    await vi.waitFor(() =>
+      expect(onAgentStatus).toHaveBeenCalledWith({
+        state: 'working',
+        prompt: 'ship it',
+        agentType: 'codex'
+      })
+    )
     expect(onData).toHaveBeenCalledWith('beforeafter')
   })
 
@@ -852,7 +856,9 @@ describe('createRemoteRuntimePtyTransport', () => {
     )
 
     expect(onReplayData).toHaveBeenCalledWith('beforeafter\x1b]0;Remote title\x07\x07')
-    expect(onTitleChange).toHaveBeenCalledWith('Remote title', 'Remote title')
+    await vi.waitFor(() =>
+      expect(onTitleChange).toHaveBeenCalledWith('Remote title', 'Remote title')
+    )
     expect(onAgentStatus).not.toHaveBeenCalled()
     expect(onBell).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- update TerminalPane settings test mocks for the refactored settings controls
- wait for deferred PTY parser side effects in remote runtime transport tests

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/TerminalPane.ghostty.test.ts src/renderer/src/components/settings/TerminalPane.pwsh.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
- pnpm typecheck
- pnpm lint

Fixes CI fallout from #2682.