### PR TITLE
Add settings notification sound selector

### DIFF
--- a/src/renderer/src/components/notification-sound-options.ts
+++ b/src/renderer/src/components/notification-sound-options.ts
@@ -1,0 +1,92 @@
+import {
+  Activity,
+  AudioWaveform,
+  Bell,
+  CircleDot,
+  FileAudio,
+  Keyboard,
+  MousePointer2,
+  Radio,
+  Radar,
+  Volume1,
+  Zap,
+  type LucideIcon
+} from 'lucide-react'
+import { basename } from '@/lib/path'
+import type { GlobalSettings } from '../../../shared/types'
+
+export type NotificationSoundOption = {
+  id: GlobalSettings['notifications']['customSoundId']
+  title: string
+  icon: LucideIcon
+}
+
+export const BUILT_IN_NOTIFICATION_SOUND_OPTIONS: readonly NotificationSoundOption[] = [
+  {
+    id: 'system',
+    title: 'System Default',
+    icon: Bell
+  },
+  {
+    id: 'two-tone',
+    title: 'Two Tone',
+    icon: AudioWaveform
+  },
+  {
+    id: 'bong',
+    title: 'Bong',
+    icon: CircleDot
+  },
+  {
+    id: 'thump',
+    title: 'Thump',
+    icon: Volume1
+  },
+  {
+    id: 'blip',
+    title: 'Blip',
+    icon: Zap
+  },
+  {
+    id: 'sonar',
+    title: 'Sonar',
+    icon: Radar
+  },
+  {
+    id: 'blop',
+    title: 'Blop',
+    icon: Activity
+  },
+  {
+    id: 'ding',
+    title: 'Ding',
+    icon: Radio
+  },
+  {
+    id: 'clack',
+    title: 'Clack',
+    icon: Keyboard
+  },
+  {
+    id: 'beep',
+    title: 'Beep',
+    icon: MousePointer2
+  }
+]
+
+export function getNotificationSoundOptions(
+  customPath: string | null | undefined
+): readonly NotificationSoundOption[] {
+  if (!customPath) {
+    return BUILT_IN_NOTIFICATION_SOUND_OPTIONS
+  }
+
+  return [
+    ...BUILT_IN_NOTIFICATION_SOUND_OPTIONS,
+    {
+      id: 'custom',
+      title: basename(customPath),
+      icon: FileAudio
+    }
+  ]
+}

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -1,34 +1,14 @@
 /* eslint-disable max-lines -- Why: this onboarding step owns the full notification setup surface, including macOS guidance, sound choices, upload, and volume controls. */
 import { useEffect, useRef, useState } from 'react'
-import type { LucideIcon } from 'lucide-react'
-import {
-  Activity,
-  AudioWaveform,
-  Bell,
-  BellRing,
-  Check,
-  ChevronDown,
-  CircleDot,
-  FileAudio,
-  Keyboard,
-  MousePointer2,
-  Radio,
-  Radar,
-  Settings,
-  Upload,
-  Volume1,
-  Volume2,
-  X,
-  Zap
-} from 'lucide-react'
+import { BellRing, Check, ChevronDown, FileAudio, Settings, Upload, Volume2, X } from 'lucide-react'
 import { toast } from 'sonner'
 import type { GlobalSettings, NotificationPermissionStatusResult } from '../../../../shared/types'
 import { cn } from '@/lib/utils'
-import { basename } from '@/lib/path'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Slider } from '@/components/ui/slider'
 import { sendNotificationSettingsTestNotification } from '@/components/settings/NotificationsPane'
+import { getNotificationSoundOptions } from '@/components/notification-sound-options'
 import logo from '../../../../../resources/logo.svg'
 
 export type NotificationDraft = {
@@ -41,65 +21,6 @@ type NotificationStepProps = {
   settings: GlobalSettings | null
   updateSettings: (updates: Partial<GlobalSettings>) => Promise<void> | void
 }
-
-type NotificationSoundOption = {
-  id: GlobalSettings['notifications']['customSoundId']
-  title: string
-  icon: LucideIcon
-}
-
-const SOUND_OPTIONS: readonly NotificationSoundOption[] = [
-  {
-    id: 'system',
-    title: 'System Default',
-    icon: Bell
-  },
-  {
-    id: 'two-tone',
-    title: 'Two Tone',
-    icon: AudioWaveform
-  },
-  {
-    id: 'bong',
-    title: 'Bong',
-    icon: CircleDot
-  },
-  {
-    id: 'thump',
-    title: 'Thump',
-    icon: Volume1
-  },
-  {
-    id: 'blip',
-    title: 'Blip',
-    icon: Zap
-  },
-  {
-    id: 'sonar',
-    title: 'Sonar',
-    icon: Radar
-  },
-  {
-    id: 'blop',
-    title: 'Blop',
-    icon: Activity
-  },
-  {
-    id: 'ding',
-    title: 'Ding',
-    icon: Radio
-  },
-  {
-    id: 'clack',
-    title: 'Clack',
-    icon: Keyboard
-  },
-  {
-    id: 'beep',
-    title: 'Beep',
-    icon: MousePointer2
-  }
-]
 
 export function NotificationStep({
   settings,
@@ -215,16 +136,7 @@ export function NotificationStep({
 
   const customPath = notificationSettings.customSoundPath
   const selectedSoundId = notificationSettings.customSoundId
-  const soundOptions = customPath
-    ? [
-        ...SOUND_OPTIONS,
-        {
-          id: 'custom' as const,
-          title: basename(customPath),
-          icon: FileAudio
-        }
-      ]
-    : SOUND_OPTIONS
+  const soundOptions = getNotificationSoundOptions(customPath)
   const canAdjustVolume = selectedSoundId !== 'system'
   const isMac = permissionStatus?.platform === 'darwin'
 

--- a/src/renderer/src/components/settings/NotificationsPane.test.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
 import type { GlobalSettings, NotificationDispatchRequest } from '../../../../shared/types'
-import { sendNotificationSettingsTestNotification } from './NotificationsPane'
+import { getNotificationSoundOptions } from '@/components/notification-sound-options'
+import { NotificationsPane, sendNotificationSettingsTestNotification } from './NotificationsPane'
 
 const { toastError, toastMessage, toastSuccess } = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -39,6 +41,17 @@ describe('NotificationsPane', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('renders built-in notification sound choices in settings', () => {
+    const html = renderToStaticMarkup(
+      <NotificationsPane settings={createSettings()} updateSettings={vi.fn()} />
+    )
+
+    expect(html).toContain('Notification Sound')
+    expect(getNotificationSoundOptions(null).map((option) => option.title)).toEqual(
+      expect.arrayContaining(['System Default', 'Two Tone', 'Bong', 'Ding'])
+    )
   })
 
   it('uses native main-process delivery even when renderer permission is stale denied on macOS', async () => {

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: notification settings keeps delivery toggles, system test feedback, and sound selection on one settings merge path. */
 import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { GlobalSettings } from '../../../../shared/types'
@@ -5,9 +6,17 @@ import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
 import { Slider } from '../ui/slider'
-import { BellRing, Bot, FileAudio, Siren, Volume2, X } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue
+} from '../ui/select'
+import { BellRing, Bot, FileAudio, Siren, Upload, Volume2 } from 'lucide-react'
 import type { SettingsSearchEntry } from './settings-search'
-import { basename } from '@/lib/path'
+import { getNotificationSoundOptions } from '@/components/notification-sound-options'
 
 export const NOTIFICATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
@@ -31,14 +40,26 @@ export const NOTIFICATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     keywords: ['notifications', 'focused', 'suppress', 'filtering']
   },
   {
-    title: 'Custom Sound',
+    title: 'Notification Sound',
     description:
-      'Choose one local audio file (MP3, WAV, OGG, M4A, AAC, or FLAC) for all delivered desktop notifications.',
-    keywords: ['notifications', 'sound', 'audio', 'mp3', 'wav', 'ogg', 'm4a', 'aac', 'flac']
+      'Choose the built-in, system, or local audio file Orca plays for desktop notifications.',
+    keywords: [
+      'notifications',
+      'sound',
+      'audio',
+      'mp3',
+      'wav',
+      'ogg',
+      'm4a',
+      'aac',
+      'flac',
+      'ding',
+      'bong'
+    ]
   },
   {
     title: 'Notification Volume',
-    description: 'Playback volume for the custom notification sound.',
+    description: 'Playback volume for non-system notification sounds.',
     keywords: ['notifications', 'sound', 'volume', 'loudness']
   },
   {
@@ -50,7 +71,19 @@ export const NOTIFICATIONS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 
 type NotificationsPaneProps = {
   settings: GlobalSettings
-  updateSettings: (updates: Partial<GlobalSettings>) => void
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}
+
+const CHOOSE_CUSTOM_SOUND_VALUE = 'choose-custom-file'
+
+type NotificationSoundSelectValue =
+  | GlobalSettings['notifications']['customSoundId']
+  | typeof CHOOSE_CUSTOM_SOUND_VALUE
+
+function isNotificationSoundId(
+  value: NotificationSoundSelectValue
+): value is GlobalSettings['notifications']['customSoundId'] {
+  return value !== CHOOSE_CUSTOM_SOUND_VALUE
 }
 
 type SystemNotificationSettingsCopy = {
@@ -161,11 +194,17 @@ export function NotificationsPane({
   const notificationSettingsRef = useRef(notificationSettings)
   const [isPickingSound, setIsPickingSound] = useState(false)
 
-  const updateNotificationSettings = (updates: Partial<GlobalSettings['notifications']>): void => {
-    updateSettings({
+  const updateNotificationSettings = async (
+    updates: Partial<GlobalSettings['notifications']>
+  ): Promise<void> => {
+    const nextNotifications = {
+      ...notificationSettingsRef.current,
+      ...updates
+    }
+    notificationSettingsRef.current = nextNotifications
+    await updateSettings({
       notifications: {
-        ...notificationSettingsRef.current,
-        ...updates
+        ...nextNotifications
       }
     })
   }
@@ -181,7 +220,7 @@ export function NotificationsPane({
 
   const handleVolumeCommit = (value: number): void => {
     if (notificationSettingsRef.current.customSoundVolume !== value) {
-      updateNotificationSettings({ customSoundVolume: value })
+      void updateNotificationSettings({ customSoundVolume: value })
     }
   }
 
@@ -189,19 +228,45 @@ export function NotificationsPane({
     await sendNotificationSettingsTestNotification(notificationSettings, volumeDraft)
   }
 
-  const handleChooseSound = async (): Promise<void> => {
+  const previewSound = async (
+    customSoundId: GlobalSettings['notifications']['customSoundId']
+  ): Promise<void> => {
+    if (customSoundId === 'system') {
+      return
+    }
+    const result = await window.api.notifications.playSound({
+      force: true,
+      volume: volumeDraft
+    })
+    if (!result.played) {
+      toast.error('Notification sound could not be played')
+    }
+  }
+
+  const handleChooseCustomSound = async (): Promise<void> => {
     setIsPickingSound(true)
     try {
       const soundPath = await window.api.shell.pickAudio()
       if (soundPath) {
-        updateNotificationSettings({ customSoundId: 'custom', customSoundPath: soundPath })
+        await updateNotificationSettings({ customSoundId: 'custom', customSoundPath: soundPath })
+        await previewSound('custom')
       }
     } finally {
       setIsPickingSound(false)
     }
   }
 
-  const selectedSoundPath = notificationSettings.customSoundPath
+  const handleSoundSelect = async (value: NotificationSoundSelectValue): Promise<void> => {
+    if (!isNotificationSoundId(value)) {
+      await handleChooseCustomSound()
+      return
+    }
+    await updateNotificationSettings({ customSoundId: value })
+    await previewSound(value)
+  }
+
+  const selectedSoundId = notificationSettings.customSoundId
+  const soundOptions = getNotificationSoundOptions(notificationSettings.customSoundPath)
 
   return (
     <div className="space-y-1">
@@ -209,7 +274,7 @@ export function NotificationsPane({
         label="Enable Notifications"
         description="Native system notifications for background events."
         checked={notificationSettings.enabled}
-        onToggle={() => updateNotificationSettings({ enabled: !notificationSettings.enabled })}
+        onToggle={() => void updateNotificationSettings({ enabled: !notificationSettings.enabled })}
       />
 
       <Separator />
@@ -221,7 +286,7 @@ export function NotificationsPane({
         checked={notificationSettings.agentTaskComplete}
         disabled={!notificationSettings.enabled}
         onToggle={() =>
-          updateNotificationSettings({
+          void updateNotificationSettings({
             agentTaskComplete: !notificationSettings.agentTaskComplete
           })
         }
@@ -234,7 +299,7 @@ export function NotificationsPane({
         checked={notificationSettings.terminalBell}
         disabled={!notificationSettings.enabled}
         onToggle={() =>
-          updateNotificationSettings({
+          void updateNotificationSettings({
             terminalBell: !notificationSettings.terminalBell
           })
         }
@@ -246,57 +311,48 @@ export function NotificationsPane({
         <div className="space-y-0.5">
           <div className="flex items-center gap-2">
             <FileAudio className="size-4" />
-            <Label>Custom Sound</Label>
+            <Label>Notification Sound</Label>
           </div>
           <p className="text-xs text-muted-foreground">
-            One local audio file for all delivered desktop notifications.
-          </p>
-          <p className="text-[11px] text-muted-foreground/80">
-            Supported formats: MP3, WAV, OGG, M4A, AAC, FLAC.
+            Choose the alert Orca plays when a desktop notification is delivered.
           </p>
         </div>
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <div
-            className="min-h-8 min-w-0 flex-1 rounded-md border border-border/50 bg-muted/35 px-2.5 py-1.5"
-            title={selectedSoundPath ?? undefined}
+        <Select
+          value={selectedSoundId}
+          disabled={!notificationSettings.enabled || isPickingSound}
+          onValueChange={(value) => void handleSoundSelect(value as NotificationSoundSelectValue)}
+        >
+          <SelectTrigger className="w-full max-w-[360px]" size="sm">
+            <SelectValue placeholder="Choose notification sound" />
+          </SelectTrigger>
+          <SelectContent align="start" className="w-[--radix-select-trigger-width]">
+            {soundOptions.map((option) => {
+              const OptionIcon = option.icon
+              return (
+                <SelectItem key={option.id} value={option.id}>
+                  <OptionIcon className="size-4" />
+                  <span className="truncate">{option.title}</span>
+                </SelectItem>
+              )
+            })}
+            <SelectSeparator />
+            <SelectItem value={CHOOSE_CUSTOM_SOUND_VALUE}>
+              <Upload className="size-4" />
+              <span>
+                {notificationSettings.customSoundPath ? 'Change Custom File' : 'Choose Custom File'}
+              </span>
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        {notificationSettings.customSoundPath ? (
+          <p
+            className="truncate font-mono text-[11px] text-muted-foreground"
+            title={notificationSettings.customSoundPath}
           >
-            {selectedSoundPath ? (
-              <div className="min-w-0">
-                <div className="truncate text-xs font-medium">{basename(selectedSoundPath)}</div>
-                <div className="truncate font-mono text-[11px] text-muted-foreground">
-                  {selectedSoundPath}
-                </div>
-              </div>
-            ) : (
-              <div className="text-xs text-muted-foreground">System notification sound</div>
-            )}
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={!notificationSettings.enabled || isPickingSound}
-            onClick={() => void handleChooseSound()}
-            className="gap-2"
-          >
-            <FileAudio className="size-3.5" />
-            {selectedSoundPath ? 'Change' : 'Choose'}
-          </Button>
-          {selectedSoundPath ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={!notificationSettings.enabled}
-              onClick={() => updateNotificationSettings({ customSoundId: 'system' })}
-              className="gap-2"
-            >
-              <X className="size-3.5" />
-              Clear
-            </Button>
-          ) : null}
-        </div>
-        {notificationSettings.customSoundId !== 'system' ? (
+            Custom: {notificationSettings.customSoundPath}
+          </p>
+        ) : null}
+        {selectedSoundId !== 'system' ? (
           <div className="flex items-center gap-3 pt-1">
             <Volume2 className="size-4 text-muted-foreground" />
             <Slider
@@ -325,7 +381,7 @@ export function NotificationsPane({
         checked={notificationSettings.suppressWhenFocused}
         disabled={!notificationSettings.enabled}
         onToggle={() =>
-          updateNotificationSettings({
+          void updateNotificationSettings({
             suppressWhenFocused: !notificationSettings.suppressWhenFocused
           })
         }


### PR DESCRIPTION
## Summary
- Share notification sound metadata between onboarding and Settings
- Add a compact notification sound dropdown to Settings with System Default, built-in sounds, existing custom files, and a Change/Choose Custom File action
- Keep the volume slider visible only for non-system sounds and preview non-system sounds when selected

## Validation
- `pnpm run typecheck`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/NotificationsPane.test.tsx src/renderer/src/components/onboarding/NotificationStep.test.tsx`
- Electron CDP Settings validation: opened Settings → Notifications, verified the compact dropdown lists System Default, built-ins, existing custom file, and Change Custom File; selected Ding and confirmed `customSoundId: "ding"`; selected System Default and confirmed the volume bar hides

## Evidence
- Settings sound selector screenshot captured locally at `/tmp/orca-settings-notification-sound-select-compact.png`
