### PR TITLE
fix: preserve hidden output across PTY rebinding

### DIFF
--- a/src/renderer/src/components/terminal-pane/hidden-terminal-output-state.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-terminal-output-state.ts
@@ -215,4 +215,18 @@ export function clearHiddenTerminalOutput(terminal: TerminalOutputTarget): void 
   }
 }
 
+export function clearHiddenTerminalOutputForPty(
+  terminal: TerminalOutputTarget,
+  ptyId: string
+): void {
+  exposeDebugApi()
+  const state = hiddenStateByTerminal.get(terminal)
+  if (state?.ptyId !== ptyId) {
+    return
+  }
+  if (hiddenStateByTerminal.delete(terminal) && debugEnabled) {
+    debugState.clearedCount++
+  }
+}
+
 exposeDebugApi()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -320,6 +320,74 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(terminal.write).not.toHaveBeenCalledWith('fallback-hidden-output', expect.any(Function))
   })
 
+  it('does not let stale hydration clear output queued for a rebound PTY', async () => {
+    const terminal = {
+      name: 'terminal-a',
+      options: { scrollback: 1000 },
+      write: vi.fn((_data: string, callback?: () => void) => callback?.())
+    }
+    const pane = { id: 1, terminal }
+    let currentPtyId = 'pty-1'
+    const transport = { getPtyId: vi.fn(() => currentPtyId) }
+    const manager = {
+      getPanes: vi.fn(() => [pane]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    let resolveSnapshot!: (snapshot: { data: string; cols: number; rows: number } | null) => void
+    const snapshotPromise = new Promise<{ data: string; cols: number; rows: number } | null>(
+      (resolve) => {
+        resolveSnapshot = resolve
+      }
+    )
+    window.api.pty.serializeHeadlessBuffer = vi.fn((id: string) => {
+      if (id === 'pty-1') {
+        return snapshotPromise
+      }
+      return Promise.resolve(null)
+    }) as typeof window.api.pty.serializeHeadlessBuffer
+    const baseArgs = {
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      paneCount: 1,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, transport]]) as never },
+      replayingPanesRef: { current: new Map<number, number>() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      toggleExpandPane: vi.fn()
+    }
+    queueHiddenTerminalOutput(terminal, 'pty-1', 'old-output')
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects(baseArgs)
+
+    currentPtyId = 'pty-2'
+    queueHiddenTerminalOutput(terminal, 'pty-2', 'new-output')
+    resolveSnapshot({ data: 'stale-headless-output', cols: 120, rows: 40 })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(terminal.write).not.toHaveBeenCalledWith('stale-headless-output', expect.any(Function))
+    terminal.write.mockClear()
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects(baseArgs)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(window.api.pty.serializeHeadlessBuffer).toHaveBeenCalledWith('pty-2', {
+      scrollbackRows: 1000
+    })
+    expect(terminal.write).toHaveBeenCalledWith('new-output', expect.any(Function))
+  })
+
   it('restores from the pre-hide scroll state when hidden layout changes the viewport', () => {
     const terminalA = { name: 'terminal-a' }
     const manager = {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -23,7 +23,7 @@ import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
 import { replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
 import {
   cancelHiddenTerminalHydration,
-  clearHiddenTerminalOutput,
+  clearHiddenTerminalOutputForPty,
   consumeHiddenTerminalHydration,
   markHiddenTerminalFallbackReplayed,
   markHiddenTerminalHydrated
@@ -90,7 +90,7 @@ export function useTerminalPaneGlobalEffects({
       }
       const transport = paneTransportsRef.current.get(pane.id)
       if (transport?.getPtyId() !== hydration.ptyId) {
-        clearHiddenTerminalOutput(pane.terminal)
+        clearHiddenTerminalOutputForPty(pane.terminal, hydration.ptyId)
         return
       }
       const scrollbackRows =
@@ -105,7 +105,7 @@ export function useTerminalPaneGlobalEffects({
             return
           }
           if (transport.getPtyId() !== hydration.ptyId) {
-            clearHiddenTerminalOutput(pane.terminal)
+            clearHiddenTerminalOutputForPty(pane.terminal, hydration.ptyId)
             return
           }
           if (snapshot?.data) {
@@ -139,7 +139,7 @@ export function useTerminalPaneGlobalEffects({
             return
           }
           if (transport.getPtyId() !== hydration.ptyId) {
-            clearHiddenTerminalOutput(pane.terminal)
+            clearHiddenTerminalOutputForPty(pane.terminal, hydration.ptyId)
             return
           }
           if (hydration.fallbackData) {


### PR DESCRIPTION
## Summary
- keep stale hidden-terminal hydration cleanup scoped to the PTY it consumed
- prevent an old async headless snapshot from deleting hidden output queued for a newly rebound PTY
- add a regression test for the rebinding race

## Correctness / perf review
The hidden-output perf path intentionally avoids painting background PTY output. The remaining race was correctness-focused: old hydration cleanup could drop new queued output after a pane rebound to a different PTY. The fix avoids extra work and keeps cleanup O(1) by checking the queued state identity before deleting.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/ipc/pty.test.ts
- pnpm typecheck
- pnpm lint