### PR TITLE
Fix E2E worktree fixture visibility

### DIFF
--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -209,6 +209,21 @@ export function useOnboardingFlow(
   useEffect(() => {
     persistedThemeRef.current = settings?.theme ?? 'dark'
   }, [settings?.theme])
+  const themeStepEntryThemeRef = useRef<GlobalSettings['theme'] | null>(null)
+  const themeStepEntryCapturedRef = useRef(false)
+  useEffect(() => {
+    if (currentStep.id !== 'theme') {
+      themeStepEntryCapturedRef.current = false
+      return
+    }
+    if (!settings || themeStepEntryCapturedRef.current) {
+      return
+    }
+    // Why: theme tile clicks persist immediately for normal progression, but
+    // "Skip to project setup" should keep the preference the user arrived with.
+    themeStepEntryCapturedRef.current = true
+    themeStepEntryThemeRef.current = settings.theme
+  }, [currentStep.id, settings])
 
   // Apply preview when local theme changes.
   useEffect(() => {
@@ -569,11 +584,15 @@ export function useOnboardingFlow(
       return
     }
     const durationMs = consumeStepDurationMs()
-    // Why: theme step previews on the document without persisting. On skip,
-    // revert to the saved theme before advancing so the preview doesn't leak.
-    if (currentStep.id === 'theme' && settings) {
-      setTheme(settings.theme)
-      applyDocumentTheme(settings.theme)
+    // Why: theme tiles save immediately for a stable preview, but skip still
+    // means "do not keep this step's choice."
+    if (currentStep.id === 'theme') {
+      const themeBeforePreview = themeStepEntryThemeRef.current ?? settings?.theme
+      if (themeBeforePreview) {
+        setTheme(themeBeforePreview)
+        applyDocumentTheme(themeBeforePreview)
+        await updateSettings({ theme: themeBeforePreview })
+      }
     }
     // Why: the repo step seeds folder terminals from saved settings. Preserve
     // the visible agent choice when optional preferences are skipped.

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -15,6 +15,7 @@
 
 import {
   test as base,
+  expect as playwrightExpect,
   _electron as electron,
   type Page,
   type ElectronApplication,
@@ -264,14 +265,22 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     }, repoPath)
 
     // Fetch repos in the renderer store so it picks up the new repo
-    await page.evaluate(async () => {
+    await page.evaluate(async (repoPath) => {
       const store = window.__store
       if (!store) {
         return
       }
 
       await store.getState().fetchRepos()
-    })
+      const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
+      if (!repo) {
+        throw new Error(`Expected e2e repo to be loaded: ${repoPath}`)
+      }
+      // Why: the fixture deliberately creates external Git worktrees. New
+      // repos hide those by default after the visibility rollout, so opt this
+      // disposable repo into showing them before specs assert on worktree state.
+      await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
+    }, repoPath)
 
     // Wait for the repo to appear and fetch its worktrees
     await page.evaluate(async () => {
@@ -285,6 +294,31 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
         await store.getState().fetchWorktrees(repo.id)
       }
     })
+
+    // Why: parallel specs mutate real git worktrees in the shared fixture repo.
+    // A first scan can briefly return no rows while git holds a worktree lock,
+    // so poll the public fetch path until the seeded primary + secondary load.
+    await playwrightExpect
+      .poll(
+        () =>
+          page.evaluate(async (repoPath) => {
+            const store = window.__store
+            if (!store) {
+              return 0
+            }
+            const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
+            if (!repo) {
+              return 0
+            }
+            await store.getState().fetchWorktrees(repo.id)
+            return store.getState().worktreesByRepo[repo.id]?.length ?? 0
+          }, repoPath),
+        {
+          timeout: 30_000,
+          message: 'seeded e2e worktrees did not load'
+        }
+      )
+      .toBeGreaterThanOrEqual(2)
 
     // Wait for workspaceSessionReady to become true
     await page.waitForFunction(

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -118,16 +118,24 @@ export async function attachRepoAndOpenTerminal(page: Page, repoPath: string): P
     await store.getState().fetchRepos()
   })
 
-  await page.evaluate(async () => {
+  const repoId = await page.evaluate(async (repoPath) => {
     const store = window.__store
     if (!store) {
-      return
+      return null
     }
-    const repos = store.getState().repos
-    for (const repo of repos) {
-      await store.getState().fetchWorktrees(repo.id)
+    const repo = store.getState().repos.find((candidate) => candidate.path === repoPath)
+    if (!repo) {
+      return null
     }
-  })
+    // Why: this restart fixture uses the global e2e repo, whose seeded Git
+    // worktree is external to Orca's workspace root after the visibility rollout.
+    await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
+    return repo.id
+  }, repoPath)
+
+  if (!repoId) {
+    throw new Error(`attachRepoAndOpenTerminal: expected e2e repo to be loaded: ${repoPath}`)
+  }
 
   await page.waitForFunction(
     () => window.__store?.getState().workspaceSessionReady === true,
@@ -145,13 +153,14 @@ export async function attachRepoAndOpenTerminal(page: Page, repoPath: string): P
   await expect
     .poll(
       async () =>
-        page.evaluate(() => {
+        page.evaluate(async (repoId) => {
           const store = window.__store
           if (!store) {
             return false
           }
-          return Object.values(store.getState().worktreesByRepo).flat().length > 0
-        }),
+          await store.getState().fetchWorktrees(repoId)
+          return (store.getState().worktreesByRepo[repoId]?.length ?? 0) > 0
+        }, repoId),
       {
         timeout: 15_000,
         message: 'attachRepoAndOpenTerminal: seeded worktree never surfaced in the store'

--- a/tests/e2e/terminal-codex-lag-stress.spec.ts
+++ b/tests/e2e/terminal-codex-lag-stress.spec.ts
@@ -97,11 +97,14 @@ process.stdin.on('data', (chunk) => {
 `
 }
 
+// Why: shard-level load can let the first ready line scroll out before
+// Playwright polls, so the marker stays in repeated output too.
 function backgroundCodexScript(runId: string, intervalMs: number, payloadChars: number): string {
   return `
 const id = process.argv[2] ?? 'bg'
+const readyMarker = 'BG_READY_${runId}_' + id
 let seq = 0
-process.stdout.write('BG_READY_${runId}_' + id + '\\n')
+process.stdout.write(readyMarker + '\\n')
 const emit = () => {
   seq += 1
   const spinner = ['|','/','-','\\\\'][seq % 4]
@@ -116,7 +119,7 @@ const emit = () => {
   }
   process.stdout.write('\\x1b]0;' + spinner + ' Codex ' + id + ' ' + seq + '\\x07')
   process.stdout.write('\\x1b]9999;' + JSON.stringify(payload) + '\\x07')
-  process.stdout.write('\\r\\x1b[2K' + spinner + ' codex ' + id + ' thinking ' + seq + ' ' + 'x'.repeat(${payloadChars}) + '\\n')
+  process.stdout.write('\\r\\x1b[2K' + spinner + ' codex ' + id + ' thinking ' + seq + ' ' + readyMarker + ' ' + 'x'.repeat(${payloadChars}) + '\\n')
 }
 setTimeout(() => setInterval(emit, ${intervalMs}), 250)
 `
@@ -131,7 +134,8 @@ function realCodexBackgroundScript(
 import { spawn } from 'node:child_process'
 
 const id = process.argv[2] ?? 'bg'
-process.stdout.write('BG_READY_${runId}_' + id + '\\n')
+const readyMarker = 'BG_READY_${runId}_' + id
+process.stdout.write(readyMarker + '\\n')
 
 let seq = 0
 const emit = () => {
@@ -147,7 +151,7 @@ const emit = () => {
   }
   process.stdout.write('\\x1b]0;' + spinner + ' Real Codex ' + id + ' ' + seq + '\\x07')
   process.stdout.write('\\x1b]9999;' + JSON.stringify(payload) + '\\x07')
-  process.stdout.write('\\r\\x1b[2K' + spinner + ' real codex ' + id + ' active ' + seq + ' ' + 'x'.repeat(${payloadChars}) + '\\n')
+  process.stdout.write('\\r\\x1b[2K' + spinner + ' real codex ' + id + ' active ' + seq + ' ' + readyMarker + ' ' + 'x'.repeat(${payloadChars}) + '\\n')
 }
 const heartbeat = setInterval(emit, ${intervalMs})
 


### PR DESCRIPTION
## Summary
- opt E2E fixture repos into external worktree visibility after the 2026-05-23 rollout
- poll worktree scans in shared and restart fixtures so seeded worktrees are loaded deterministically
- restore onboarding theme when skipping from the theme step
- keep the terminal lag stress readiness marker visible under shard-level output load

## Verification
- pnpm typecheck
- pnpm lint
- pnpm exec oxfmt --check src/renderer/src/components/onboarding/use-onboarding-flow.ts tests/e2e/helpers/orca-app.ts tests/e2e/helpers/orca-restart.ts tests/e2e/terminal-codex-lag-stress.spec.ts
- CI=true SKIP_BUILD=1 pnpm run test:e2e --shard=1/5
- CI=true SKIP_BUILD=1 pnpm run test:e2e --shard=2/5
- CI=true SKIP_BUILD=1 pnpm run test:e2e --shard=3/5
- CI=true SKIP_BUILD=1 pnpm run test:e2e --shard=4/5
- CI=true SKIP_BUILD=1 pnpm run test:e2e --shard=5/5