### PR TITLE
fix: avoid duplicate reveal hydration output

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3380,5 +3380,57 @@ describe('registerPtyHandlers', () => {
         {}
       )
     })
+
+    it('flushes pending renderer PTY batches around headless serialization', async () => {
+      vi.useFakeTimers()
+      try {
+        const mockProc = createMockProc()
+        spawnMock.mockReturnValue(mockProc.proc)
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyData: vi.fn(),
+          onPtyExit: vi.fn(),
+          preAllocateHandleForPty: vi.fn(),
+          serializeHeadlessTerminalBufferForRenderer: vi.fn(async () => {
+            mockProc.emitData('during-serialize')
+            return {
+              data: 'headless',
+              cols: 100,
+              rows: 30
+            }
+          })
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const spawnResult = (await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: '/tmp'
+        })) as { id: string }
+        mainWindow.webContents.send.mockClear()
+        mockProc.emitData('before-serialize')
+
+        await handlers.get('pty:serializeHeadlessBuffer')!(null, { id: spawnResult.id })
+
+        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+          id: spawnResult.id,
+          data: 'before-serialize'
+        })
+        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+          id: spawnResult.id,
+          data: 'during-serialize'
+        })
+        expect(runtime.serializeHeadlessTerminalBufferForRenderer).toHaveBeenCalledWith(
+          spawnResult.id,
+          {}
+        )
+        mainWindow.webContents.send.mockClear()
+        vi.advanceTimersByTime(8)
+        expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -687,6 +687,18 @@ export function registerPtyHandlers(
     flushTimer = null
   }
 
+  const flushPendingDataForPty = (id: string): void => {
+    const data = pendingData.get(id)
+    if (!data) {
+      return
+    }
+    pendingData.delete(id)
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('pty:data', { id, data })
+    }
+    clearFlushTimerIfIdle()
+  }
+
   // Why: extracted so the "Restart daemon" flow can rebind against the fresh
   // adapter after replaceDaemonProvider runs. Both the startup registration
   // and the post-restart rebind go through the same code path — no risk of
@@ -1835,7 +1847,14 @@ export function registerPtyHandlers(
       ) {
         opts.scrollbackRows = Math.floor(args.scrollbackRows)
       }
-      return runtime.serializeHeadlessTerminalBufferForRenderer(args.id, opts)
+      // Why: hidden-pane reveal uses the headless snapshot as the authoritative
+      // paint. Flush any ≤8ms main-process PTY batch before and after the
+      // snapshot so renderer-side hydration can drop its duplicate fallback
+      // queue without losing bytes that already reached the headless model.
+      flushPendingDataForPty(args.id)
+      const snapshot = await runtime.serializeHeadlessTerminalBufferForRenderer(args.id, opts)
+      flushPendingDataForPty(args.id)
+      return snapshot
     }
   )
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -267,7 +267,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(terminal.write).not.toHaveBeenCalledWith('fallback-hidden-output', expect.any(Function))
   })
 
-  it('keeps reveal-time output queued until the headless hydration completes', async () => {
+  it('does not duplicate reveal-time output when the headless snapshot succeeds', async () => {
     const terminal = {
       name: 'terminal-a',
       options: { scrollback: 1000 },
@@ -311,13 +311,75 @@ describe('useTerminalPaneGlobalEffects', () => {
     })
     queueHiddenTerminalOutput(terminal, 'pty-1', 'arrived-during-hydration')
 
-    resolveSnapshot({ data: 'headless-current-output', cols: 120, rows: 40 })
+    resolveSnapshot({
+      data: 'headless-current-output arrived-during-hydration',
+      cols: 120,
+      rows: 40
+    })
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(terminal.write).toHaveBeenCalledWith('headless-current-output', expect.any(Function))
-    expect(terminal.write).toHaveBeenCalledWith('arrived-during-hydration', expect.any(Function))
+    expect(terminal.write).toHaveBeenCalledWith(
+      'headless-current-output arrived-during-hydration',
+      expect.any(Function)
+    )
+    expect(terminal.write).not.toHaveBeenCalledWith(
+      'arrived-during-hydration',
+      expect.any(Function)
+    )
     expect(terminal.write).not.toHaveBeenCalledWith('fallback-hidden-output', expect.any(Function))
+  })
+
+  it('replays reveal-time output when the headless snapshot is unavailable', async () => {
+    const terminal = {
+      name: 'terminal-a',
+      options: { scrollback: 1000 },
+      write: vi.fn((_data: string, callback?: () => void) => callback?.())
+    }
+    const pane = { id: 1, terminal }
+    const transport = { getPtyId: vi.fn(() => 'pty-1') }
+    const manager = {
+      getPanes: vi.fn(() => [pane]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      fitAllPanes: vi.fn(),
+      getActivePane: vi.fn(() => null),
+      setActivePane: vi.fn()
+    }
+    let resolveSnapshot!: (snapshot: { data: string; cols: number; rows: number } | null) => void
+    const snapshotPromise = new Promise<{ data: string; cols: number; rows: number } | null>(
+      (resolve) => {
+        resolveSnapshot = resolve
+      }
+    )
+    window.api.pty.serializeHeadlessBuffer = vi.fn(
+      () => snapshotPromise
+    ) as typeof window.api.pty.serializeHeadlessBuffer
+    queueHiddenTerminalOutput(terminal, 'pty-1', 'fallback-hidden-output')
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      paneCount: 1,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map([[1, transport]]) as never },
+      replayingPanesRef: { current: new Map<number, number>() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      toggleExpandPane: vi.fn()
+    })
+    queueHiddenTerminalOutput(terminal, 'pty-1', 'arrived-during-hydration')
+
+    resolveSnapshot(null)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(terminal.write).toHaveBeenCalledWith('fallback-hidden-output', expect.any(Function))
+    expect(terminal.write).toHaveBeenCalledWith('arrived-during-hydration', expect.any(Function))
   })
 
   it('does not let stale hydration clear output queued for a rebound PTY', async () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -122,10 +122,10 @@ export function useTerminalPaneGlobalEffects({
             // guard, so terminal query replies do not leak into the shell.
             replayIntoTerminal(pane, replayingPanesRef, '\x1b[2J\x1b[3J\x1b[H')
             replayIntoTerminal(pane, replayingPanesRef, snapshot.data)
-            const queuedDuringHydration = markHiddenTerminalHydrated(pane.terminal, hydration)
-            if (queuedDuringHydration) {
-              replayIntoTerminal(pane, replayingPanesRef, queuedDuringHydration)
-            }
+            // Why: the main serializer flushes pending PTY batches around the
+            // headless snapshot. Any renderer bytes queued during this window
+            // are already represented in the authoritative snapshot.
+            markHiddenTerminalHydrated(pane.terminal, hydration)
             return
           }
           if (hydration.fallbackData) {


### PR DESCRIPTION
## Summary
- flush the requested PTY pending renderer batch before and after headless serialization
- treat successful headless hydration as authoritative so queued reveal bytes are not replayed twice
- keep fallback replay when no headless snapshot is available

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/ipc/pty.test.ts
- pnpm typecheck
- pnpm lint