### PR TITLE
fix: preserve hidden terminal output state

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -71,6 +71,7 @@ type StoreState = {
 
 type ConnectCallbacks = {
   onData?: (data: string) => void
+  onReplayData?: (data: string) => void
   onError?: (msg: string) => void
 }
 
@@ -2144,6 +2145,46 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).not.toHaveBeenCalledWith('replay-payload', expect.any(Function))
   })
 
+  it('does not paint hidden reattach snapshots into xterm', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { consumeHiddenTerminalHydration } = await import('./hidden-terminal-output-state')
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return {
+          id: sessionId,
+          snapshot: 'snapshot-payload',
+          replay: 'replay-payload'
+        }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
+      }
+    } as StoreState
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false },
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('snapshot-payload', expect.any(Function))
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('replay-payload', expect.any(Function))
+    expect(consumeHiddenTerminalHydration(pane.terminal)?.fallbackData).toBe(
+      `\x1b[2J\x1b[3J\x1b[Hsnapshot-payload${POST_REPLAY_REATTACH_RESET}`
+    )
+  })
+
   it('paints only relay replay when reattach result has replay and coldRestore but no snapshot', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
@@ -2188,6 +2229,7 @@ describe('connectPanePty', () => {
   // state is restored from the runtime headless model when the pane is shown.
   it('does not write non-visible PTY bytes into xterm', async () => {
     const { connectPanePty } = await import('./pty-connection')
+    const { getTerminalOutputEpoch } = await import('@/lib/pane-manager/pane-scroll')
     const transport = createMockTransport('pty-id')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
@@ -2206,13 +2248,48 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(capturedDataCallback.current).not.toBeNull()
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(0)
     capturedDataCallback.current?.('hello\r\n')
 
     expect(pane.terminal.write).not.toHaveBeenCalledWith('hello\r\n')
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(1)
+  })
+
+  it('does not write non-visible replay bytes into xterm', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { getTerminalOutputEpoch } = await import('@/lib/pane-manager/pane-scroll')
+    const { consumeHiddenTerminalHydration } = await import('./hidden-terminal-output-state')
+    const transport = createMockTransport('pty-id')
+    const capturedReplayCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    expect(capturedReplayCallback.current).not.toBeNull()
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(0)
+    capturedReplayCallback.current?.('restored-output')
+
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('restored-output', expect.any(Function))
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(2)
+    expect(consumeHiddenTerminalHydration(pane.terminal)?.fallbackData).toBe(
+      '\x1b[2J\x1b[3J\x1b[Hrestored-output'
+    )
   })
 
   it('keeps visible PTY bytes off xterm while hidden hydration is in flight', async () => {
     const { connectPanePty } = await import('./pty-connection')
+    const { getTerminalOutputEpoch } = await import('@/lib/pane-manager/pane-scroll')
     const { consumeHiddenTerminalHydration, queueHiddenTerminalOutput } =
       await import('./hidden-terminal-output-state')
     const transport = createMockTransport('pty-id')
@@ -2234,9 +2311,11 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(6)
 
     expect(capturedDataCallback.current).not.toBeNull()
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(0)
     capturedDataCallback.current?.('arrived-during-hydration\r\n')
 
     expect(pane.terminal.write).not.toHaveBeenCalledWith('arrived-during-hydration\r\n')
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(1)
   })
 
   it('writes visible split-pane PTY bytes immediately even when the tab is not active', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1232,7 +1232,27 @@ export function connectPanePty(
     // sequences don't leak into the shell. xterm.write() buffers internally
     // regardless of DOM visibility and the guard stays engaged via the
     // write-completion callback until xterm finishes parsing.
-    const writeReplayData = (data: string): void => {
+    const writeReplayData = (
+      data: string,
+      options: { replaceHiddenQueue?: boolean } = {}
+    ): void => {
+      if (!data) {
+        return
+      }
+      if (!deps.isVisibleRef.current || isHiddenTerminalHydrating(pane.terminal)) {
+        const ptyId = transport.getPtyId()
+        if (ptyId) {
+          if (options.replaceHiddenQueue) {
+            clearHiddenTerminalOutput(pane.terminal)
+          }
+          if (terminalOutputPrefersDomRenderer(data)) {
+            manager.markPaneHasComplexScriptOutput(pane.id)
+          }
+          recordTerminalOutput(pane.terminal)
+          queueHiddenTerminalOutput(pane.terminal, ptyId, data)
+          return
+        }
+      }
       // Why: drain any queued background bytes BEFORE the replay paint, so the
       // scheduler's deferred drain cannot land older bytes on top of the replay.
       flushTerminalOutput(pane.terminal)
@@ -1247,7 +1267,7 @@ export function connectPanePty(
       // Relay replay buffer holds the last 100 KB of output, which may
       // overlap with content already rendered in xterm before the
       // disconnect. Clear first to prevent duplication on SSH reconnect.
-      writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+      writeReplayData('\x1b[2J\x1b[3J\x1b[H', { replaceHiddenQueue: true })
       writeReplayData(data)
     }
 
@@ -1259,6 +1279,7 @@ export function connectPanePty(
           if (terminalOutputPrefersDomRenderer(data)) {
             manager.markPaneHasComplexScriptOutput(pane.id)
           }
+          recordTerminalOutput(pane.terminal)
           queueHiddenTerminalOutput(pane.terminal, ptyId, data)
           return
         }
@@ -1357,7 +1378,7 @@ export function connectPanePty(
       // the daemon and relay are by definition tracking the same session
       // and only the freshest source belongs on screen.
       if (connectResult?.snapshot) {
-        writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+        writeReplayData('\x1b[2J\x1b[3J\x1b[H', { replaceHiddenQueue: true })
         writeReplayData(connectResult.snapshot)
         // Snapshot reattach keeps a live session, so avoid the broader mode
         // reset. We only drop stale cursor/focus state that should not leak
@@ -1375,7 +1396,7 @@ export function connectPanePty(
         // already hold pre-disconnect content; clear first to avoid
         // duplication. The reattach reset prevents stale cursor/focus mode
         // bits in the replayed data from leaking into the restored terminal.
-        writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+        writeReplayData('\x1b[2J\x1b[3J\x1b[H', { replaceHiddenQueue: true })
         writeReplayData(connectResult.replay)
         writeReplayData(POST_REPLAY_REATTACH_RESET)
         if (connectResult.coldRestore) {
@@ -1391,7 +1412,7 @@ export function connectPanePty(
         // may contain query sequences the previous agent CLI emitted;
         // writing them through xterm.write would trigger auto-replies that
         // land in the new shell's stdin. See replay-guard.ts.
-        writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+        writeReplayData('\x1b[2J\x1b[3J\x1b[H', { replaceHiddenQueue: true })
         writeReplayData(connectResult.coldRestore.scrollback)
         writeReplayData('\r\n\x1b[2m--- session restored ---\x1b[0m\r\n\r\n')
         // Cold-restore means the daemon lost the session and spawned a


### PR DESCRIPTION
## Summary
- record terminal output epochs when hidden bytes are queued instead of painted
- keep hidden replay/snapshot/cold-restore bytes out of xterm until reveal
- preserve fallback hydration for runtimes without an authoritative headless snapshot

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/main/ipc/pty.test.ts
- pnpm typecheck
- pnpm lint