### PR TITLE
Improve worktree visibility dialog copy

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -132,6 +132,10 @@ import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
 import { getRepositoryBadgeColorSectionId } from '@/components/settings/repository-settings-targets'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
+import {
+  effectiveExternalWorktreeVisibility,
+  isLegacyRepoForExternalWorktreeVisibility
+} from '../../../../shared/worktree-ownership'
 
 // How long to wait after a sortEpoch bump before actually re-sorting.
 // Prevents jarring position shifts when background events (AI starting work,
@@ -207,6 +211,14 @@ function stopNestedWorktreeCardBubble(event: React.SyntheticEvent<HTMLElement>):
 
 function getWorktreeOptionId(worktreeId: string): string {
   return `worktree-list-option-${encodeURIComponent(worktreeId)}`
+}
+
+function getWorktreeVisibilityMenuLabel(repo: Repo): string {
+  const visibility = effectiveExternalWorktreeVisibility(
+    repo,
+    isLegacyRepoForExternalWorktreeVisibility(repo)
+  )
+  return visibility === 'show' ? 'Hide non-Orca worktrees' : 'Import Worktrees'
 }
 
 const LINEAGE_INDENT = 18
@@ -1990,7 +2002,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               }}
                             >
                               <Eye className="size-3.5" />
-                              Import Worktrees
+                              {getWorktreeVisibilityMenuLabel(row.repo)}
                             </DropdownMenuItem>
                           ) : null}
                           <DropdownMenuSeparator />

--- a/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Import } from 'lucide-react'
+import { Eye, EyeOff } from 'lucide-react'
 import { useAppStore } from '@/store'
 import {
   Dialog,
@@ -41,12 +41,8 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
           (worktree) => !worktree.selectedCheckout && worktree.ownership !== 'orca-managed'
         ).length
       : 0
-  const hiddenWorktreeLabel = `${hiddenCount} non-Orca ${
-    hiddenCount === 1 ? 'worktree' : 'worktrees'
-  }`
-  const importedWorktreeLabel = `${otherCount} non-Orca ${
-    otherCount === 1 ? 'worktree' : 'worktrees'
-  }`
+  const hiddenWorktreeLabel = `${hiddenCount} ${hiddenCount === 1 ? 'worktree' : 'worktrees'}`
+  const shownWorktreeLabel = `${otherCount} ${otherCount === 1 ? 'worktree' : 'worktrees'}`
 
   const handleToggle = useCallback(async () => {
     if (!repoId) {
@@ -65,23 +61,21 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
     <Dialog open onOpenChange={(open) => !open && closeModal()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Import Worktrees</DialogTitle>
+          <DialogTitle>Non-Orca worktrees</DialogTitle>
           <DialogDescription>{repo.displayName}</DialogDescription>
         </DialogHeader>
 
         <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/30 p-3">
           <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
-            <Import className="size-4" />
+            {showOther ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
           </div>
           <div className="min-w-0 flex-1">
             <div className="text-sm font-medium">
-              {showOther
-                ? 'Imported non-Orca worktrees into sidebar'
-                : 'Import non-Orca worktrees into sidebar'}
+              {showOther ? 'Shown in sidebar' : 'Hidden from sidebar'}
             </div>
             <div className="text-xs text-muted-foreground">
               {showOther
-                ? `${importedWorktreeLabel} imported`
+                ? `${shownWorktreeLabel} currently shown`
                 : `${hiddenWorktreeLabel} available to import`}
             </div>
           </div>
@@ -90,7 +84,7 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
             variant={showOther ? 'secondary' : 'outline'}
             onClick={handleToggle}
           >
-            {showOther ? 'Remove' : 'Import'}
+            {showOther ? 'Hide' : 'Import'}
           </Button>
         </div>
       </DialogContent>

--- a/src/renderer/src/lib/agent-ready-wait.test.ts
+++ b/src/renderer/src/lib/agent-ready-wait.test.ts
@@ -35,7 +35,7 @@ describe('waitForAgentReady', () => {
       hasChildProcesses: false
     })
 
-    await expect(waitForAgentReady('tab-1', 'claude', { timeoutMs: 1 })).resolves.toEqual({
+    await expect(waitForAgentReady('tab-1', 'claude', { timeoutMs: 100 })).resolves.toEqual({
       ready: true,
       reason: 'foreground-match'
     })


### PR DESCRIPTION
## Summary
- Update the worktree visibility dialog to describe shown vs hidden non-Orca worktrees
- Change the sidebar menu label to hide external worktrees when they are currently shown

## Test Plan
- pnpm typecheck