### PR TITLE
fix: gate hidden hydration by pty id

### DIFF
--- a/src/renderer/src/components/terminal-pane/hidden-terminal-output-state.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-terminal-output-state.ts
@@ -204,8 +204,12 @@ export function cancelHiddenTerminalHydration(
   state.needsHydration = state.chunks.length > 0
 }
 
-export function isHiddenTerminalHydrating(terminal: TerminalOutputTarget): boolean {
-  return hiddenStateByTerminal.get(terminal)?.hydrating === true
+export function isHiddenTerminalHydratingForPty(
+  terminal: TerminalOutputTarget,
+  ptyId: string
+): boolean {
+  const state = hiddenStateByTerminal.get(terminal)
+  return state?.ptyId === ptyId && state.hydrating === true
 }
 
 export function clearHiddenTerminalOutput(terminal: TerminalOutputTarget): void {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2318,6 +2318,71 @@ describe('connectPanePty', () => {
     expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(1)
   })
 
+  it('writes visible PTY bytes after a rebind while stale hydration is in flight', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { getTerminalOutputEpoch } = await import('@/lib/pane-manager/pane-scroll')
+    const { consumeHiddenTerminalHydration, queueHiddenTerminalOutput } =
+      await import('./hidden-terminal-output-state')
+    let currentPtyId = 'pty-old'
+    const transport = createMockTransport(currentPtyId)
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return currentPtyId
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    queueHiddenTerminalOutput(pane.terminal, 'pty-old', 'hidden-before-reveal')
+    consumeHiddenTerminalHydration(pane.terminal)
+    const deps = createDeps({
+      isVisibleRef: { current: true }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+
+    expect(capturedDataCallback.current).not.toBeNull()
+    currentPtyId = 'pty-new'
+    capturedDataCallback.current?.('new-pty-output\r\n')
+
+    expect(pane.terminal.write).toHaveBeenCalledWith('new-pty-output\r\n', expect.any(Function))
+    expect(getTerminalOutputEpoch(pane.terminal as never)).toBe(1)
+  })
+
+  it('writes visible replay bytes after a rebind while stale hydration is in flight', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { consumeHiddenTerminalHydration, queueHiddenTerminalOutput } =
+      await import('./hidden-terminal-output-state')
+    let currentPtyId = 'pty-old'
+    const transport = createMockTransport(currentPtyId)
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    const capturedReplayCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedReplayCallback.current = callbacks.onReplayData ?? null
+      return currentPtyId
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    queueHiddenTerminalOutput(pane.terminal, 'pty-old', 'hidden-before-reveal')
+    consumeHiddenTerminalHydration(pane.terminal)
+    const deps = createDeps({
+      isVisibleRef: { current: true }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+
+    expect(capturedReplayCallback.current).not.toBeNull()
+    currentPtyId = 'pty-new'
+    capturedReplayCallback.current?.('new-replay-output')
+
+    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
+    expect(pane.terminal.write).toHaveBeenCalledWith('new-replay-output', expect.any(Function))
+  })
+
   it('writes visible split-pane PTY bytes immediately even when the tab is not active', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -52,7 +52,7 @@ import {
 import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
 import {
   clearHiddenTerminalOutput,
-  isHiddenTerminalHydrating,
+  isHiddenTerminalHydratingForPty,
   queueHiddenTerminalOutput
 } from './hidden-terminal-output-state'
 
@@ -1228,6 +1228,13 @@ export function connectPanePty(
       pendingSpawnByPaneKey.set(pendingSpawnKey, trackedPromise)
     }
 
+    const shouldQueueOutputForPty = (ptyId: string): boolean => {
+      // Why: hidden hydration belongs to a specific PTY lease. If a visible
+      // pane rebinds while an old snapshot is in flight, new PTY bytes must
+      // paint immediately; no later visibility effect will drain that queue.
+      return !deps.isVisibleRef.current || isHiddenTerminalHydratingForPty(pane.terminal, ptyId)
+    }
+
     // The replay path uses the guard so xterm auto-replies to embedded query
     // sequences don't leak into the shell. xterm.write() buffers internally
     // regardless of DOM visibility and the guard stays engaged via the
@@ -1239,19 +1246,17 @@ export function connectPanePty(
       if (!data) {
         return
       }
-      if (!deps.isVisibleRef.current || isHiddenTerminalHydrating(pane.terminal)) {
-        const ptyId = transport.getPtyId()
-        if (ptyId) {
-          if (options.replaceHiddenQueue) {
-            clearHiddenTerminalOutput(pane.terminal)
-          }
-          if (terminalOutputPrefersDomRenderer(data)) {
-            manager.markPaneHasComplexScriptOutput(pane.id)
-          }
-          recordTerminalOutput(pane.terminal)
-          queueHiddenTerminalOutput(pane.terminal, ptyId, data)
-          return
+      const ptyId = transport.getPtyId()
+      if (ptyId && shouldQueueOutputForPty(ptyId)) {
+        if (options.replaceHiddenQueue) {
+          clearHiddenTerminalOutput(pane.terminal)
         }
+        if (terminalOutputPrefersDomRenderer(data)) {
+          manager.markPaneHasComplexScriptOutput(pane.id)
+        }
+        recordTerminalOutput(pane.terminal)
+        queueHiddenTerminalOutput(pane.terminal, ptyId, data)
+        return
       }
       // Why: drain any queued background bytes BEFORE the replay paint, so the
       // scheduler's deferred drain cannot land older bytes on top of the replay.
@@ -1273,16 +1278,14 @@ export function connectPanePty(
 
     const dataCallback = (data: string): void => {
       commandLifecycle.handlePtyData(data)
-      if (!deps.isVisibleRef.current || isHiddenTerminalHydrating(pane.terminal)) {
-        const ptyId = transport.getPtyId()
-        if (ptyId) {
-          if (terminalOutputPrefersDomRenderer(data)) {
-            manager.markPaneHasComplexScriptOutput(pane.id)
-          }
-          recordTerminalOutput(pane.terminal)
-          queueHiddenTerminalOutput(pane.terminal, ptyId, data)
-          return
+      const ptyId = transport.getPtyId()
+      if (ptyId && shouldQueueOutputForPty(ptyId)) {
+        if (terminalOutputPrefersDomRenderer(data)) {
+          manager.markPaneHasComplexScriptOutput(pane.id)
         }
+        recordTerminalOutput(pane.terminal)
+        queueHiddenTerminalOutput(pane.terminal, ptyId, data)
+        return
       }
       // Why: visibility is the right gate — split-pane layouts have multiple
       // visible-but-inactive panes whose output the user is watching. Only


### PR DESCRIPTION
## Summary
- make hidden terminal hydration checks PTY-specific
- let visible output from a newly rebound PTY paint immediately while stale hydration resolves
- cover live data and replay data rebind races

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
- pnpm typecheck
- pnpm lint