### PR TITLE
Fix terminal pane scroll restoration after resize

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -86,6 +86,13 @@ export type ScrollState = {
   wasAtBottom: boolean
   viewportY: number
   baseY: number
+  viewportAnchor?: {
+    charOffset: number
+    logicalPrefix?: string
+    segment: string
+    segmentOffset: number
+    logicalText?: string
+  }
   firstVisibleLineMarker?: IMarker
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-scroll-viewport-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll-viewport-anchor.test.ts
@@ -1,0 +1,146 @@
+import type { Terminal } from '@xterm/xterm'
+import { describe, expect, it, vi } from 'vitest'
+import type { ScrollState } from './pane-manager-types'
+import { captureScrollState, restoreScrollState } from './pane-scroll'
+
+function createTerminal(args: {
+  viewportY: number
+  baseY: number
+  cols: number
+  cursorY?: number
+  lines: ReturnType<typeof createBufferLine>[]
+}): Terminal {
+  const active = {
+    type: 'normal',
+    viewportY: args.viewportY,
+    baseY: args.baseY,
+    cursorY: args.cursorY ?? 5,
+    length: args.lines.length,
+    getLine: vi.fn((lineY: number) => args.lines[lineY])
+  }
+  return {
+    buffer: { active },
+    cols: args.cols,
+    rows: 24,
+    element: {} as HTMLElement,
+    registerMarker: vi.fn(),
+    scrollToLine: vi.fn((line: number) => {
+      active.viewportY = line
+    }),
+    scrollLines: vi.fn((delta: number) => {
+      active.viewportY = Math.max(0, Math.min(active.baseY, active.viewportY + delta))
+    })
+  } as unknown as Terminal
+}
+
+function createBufferLine(
+  text: string,
+  isWrapped = false
+): {
+  isWrapped: boolean
+  translateToString: ReturnType<typeof vi.fn>
+} {
+  return {
+    isWrapped,
+    translateToString: vi.fn((trimRight?: boolean) => (trimRight ? text.trimEnd() : text))
+  }
+}
+
+describe('scroll viewport anchors', () => {
+  it('restores by content anchor when resize reflow moves the visible line', () => {
+    const beforeResize = createTerminal({
+      viewportY: 2,
+      baseY: 4,
+      cursorY: 4,
+      cols: 10,
+      lines: [
+        createBufferLine('prompt'),
+        createBufferLine('ABCDEFGHIJ'),
+        createBufferLine('KLMNOPQRST', true),
+        createBufferLine('UVWXYZ', true),
+        createBufferLine('tail')
+      ]
+    })
+    const state = captureScrollState(beforeResize)
+    const afterResize = createTerminal({
+      viewportY: 0,
+      baseY: 7,
+      cols: 5,
+      lines: [
+        createBufferLine('prompt'),
+        createBufferLine('ABCDE'),
+        createBufferLine('FGHIJ', true),
+        createBufferLine('KLMNO', true),
+        createBufferLine('PQRST', true),
+        createBufferLine('UVWXY', true),
+        createBufferLine('Z', true),
+        createBufferLine('tail')
+      ]
+    })
+
+    restoreScrollState(afterResize, state)
+
+    expect(afterResize.scrollToLine).toHaveBeenCalledWith(3)
+    expect(afterResize.buffer.active.viewportY).toBe(3)
+  })
+
+  it('restores long logical lines using the captured visible segment', () => {
+    const longText = `${'A'.repeat(21_000)}VISIBLE_ANCHOR_TEXT${'B'.repeat(1_000)}`
+    const beforeResize = createTerminal({
+      viewportY: 21,
+      baseY: 25,
+      cursorY: 25,
+      cols: 1000,
+      lines: Array.from({ length: 23 }, (_, index) =>
+        createBufferLine(longText.slice(index * 1000, (index + 1) * 1000), index > 0)
+      )
+    })
+    const state = captureScrollState(beforeResize)
+    const afterResize = createTerminal({
+      viewportY: 0,
+      baseY: 50,
+      cols: 500,
+      lines: Array.from({ length: 45 }, (_, index) =>
+        createBufferLine(longText.slice(index * 500, (index + 1) * 500), index > 0)
+      )
+    })
+
+    restoreScrollState(afterResize, state)
+
+    expect(afterResize.scrollToLine).toHaveBeenCalledWith(42)
+    expect(afterResize.buffer.active.viewportY).toBe(42)
+  })
+
+  it('prefers a logical-line prefix over a repeated visible segment', () => {
+    const terminal = createTerminal({
+      viewportY: 0,
+      baseY: 20,
+      cols: 5,
+      lines: [
+        createBufferLine('repeat'),
+        createBufferLine('KLMNO', true),
+        createBufferLine('UNIQUE-LINE-042'),
+        createBufferLine('ABCDE', true),
+        createBufferLine('KLMNO', true),
+        createBufferLine('tail')
+      ]
+    })
+    const state: ScrollState = {
+      bufferType: 'normal',
+      wasAtBottom: false,
+      viewportY: 10,
+      baseY: 10,
+      viewportAnchor: {
+        charOffset: 10,
+        logicalPrefix: 'UNIQUE-LINE-042',
+        segment: 'KLMNO',
+        segmentOffset: 0
+      }
+    }
+
+    restoreScrollState(terminal, state)
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(4)
+    expect(terminal.buffer.active.viewportY).toBe(4)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-scroll-viewport-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll-viewport-anchor.ts
@@ -1,0 +1,212 @@
+import type { Terminal } from '@xterm/xterm'
+import type { ScrollState } from './pane-manager-types'
+
+const MAX_FULL_ANCHOR_TEXT_LENGTH = 20_000
+const ANCHOR_CONTEXT_BEFORE = 80
+const ANCHOR_CONTEXT_AFTER = 240
+const ANCHOR_PREFIX_LENGTH = 240
+const ANCHOR_SEARCH_RADIUS_LINES = 1500
+
+type SearchRange = { start: number; end: number }
+
+export function captureViewportAnchor(
+  terminal: Terminal
+): ScrollState['viewportAnchor'] | undefined {
+  const buf = terminal.buffer.active
+  if (typeof buf.getLine !== 'function') {
+    return undefined
+  }
+  const viewportY = buf.viewportY
+  const startY = findLogicalLineStart(buf, viewportY)
+  const logicalText = readLogicalLineText(buf, startY)
+  if (!logicalText) {
+    return undefined
+  }
+
+  const cols = Math.max(terminal.cols, 1)
+  const charOffset = Math.min(Math.max(0, viewportY - startY) * cols, logicalText.length)
+  const segmentStart = Math.max(0, charOffset - ANCHOR_CONTEXT_BEFORE)
+  const segmentEnd = Math.min(logicalText.length, charOffset + ANCHOR_CONTEXT_AFTER)
+  const segment = logicalText.slice(segmentStart, segmentEnd).trim()
+  if (!segment) {
+    return undefined
+  }
+
+  return {
+    charOffset,
+    logicalPrefix: logicalText.slice(0, ANCHOR_PREFIX_LENGTH).trim(),
+    segment,
+    segmentOffset: charOffset - segmentStart,
+    logicalText: logicalText.length <= MAX_FULL_ANCHOR_TEXT_LENGTH ? logicalText : undefined
+  }
+}
+
+export function resolveViewportAnchorLine(terminal: Terminal, state: ScrollState): number | null {
+  const anchor = state.viewportAnchor
+  if (!anchor) {
+    return null
+  }
+  const buf = terminal.buffer.active
+  if (typeof buf.getLine !== 'function') {
+    return null
+  }
+  const length = getBufferLength(buf, terminal.rows)
+  const ranges = getAnchorSearchRanges(state, buf, length)
+
+  for (const range of ranges) {
+    const line = searchViewportAnchorRange(buf, terminal, anchor, range, false)
+    if (line !== null) {
+      return line
+    }
+  }
+
+  for (const range of ranges) {
+    const line = searchViewportAnchorRange(buf, terminal, anchor, range, true)
+    if (line !== null) {
+      return line
+    }
+  }
+
+  return null
+}
+
+function getAnchorSearchRanges(
+  state: ScrollState,
+  buf: Terminal['buffer']['active'],
+  length: number
+): SearchRange[] {
+  const ranges: SearchRange[] = []
+  const estimate =
+    state.baseY > 0 && buf.baseY > 0
+      ? Math.round((state.viewportY / state.baseY) * buf.baseY)
+      : state.viewportY
+  const focused = clampSearchRange(
+    estimate - ANCHOR_SEARCH_RADIUS_LINES,
+    estimate + ANCHOR_SEARCH_RADIUS_LINES,
+    length
+  )
+  if (focused) {
+    ranges.push(focused)
+  }
+  const full = clampSearchRange(0, length - 1, length)
+  if (full && (!focused || focused.start !== full.start || focused.end !== full.end)) {
+    ranges.push(full)
+  }
+  return ranges
+}
+
+function clampSearchRange(start: number, end: number, length: number): SearchRange | null {
+  const clampedStart = Math.max(0, Math.min(start, length - 1))
+  const clampedEnd = Math.max(0, Math.min(end, length - 1))
+  if (clampedStart > clampedEnd) {
+    return null
+  }
+  return { start: clampedStart, end: clampedEnd }
+}
+
+function searchViewportAnchorRange(
+  buf: Terminal['buffer']['active'],
+  terminal: Terminal,
+  anchor: NonNullable<ScrollState['viewportAnchor']>,
+  range: SearchRange,
+  allowSegmentFallback: boolean
+): number | null {
+  let segmentFallbackLine: number | null = null
+
+  for (let lineY = range.start; lineY <= range.end; lineY++) {
+    const line = buf.getLine(lineY)
+    if (!line || (lineY > 0 && line.isWrapped)) {
+      continue
+    }
+
+    const logicalText = readLogicalLineText(buf, lineY)
+    if (!logicalText) {
+      continue
+    }
+
+    if (anchor.logicalText && logicalText === anchor.logicalText) {
+      return resolveDisplayLineForCharOffset(
+        buf,
+        lineY,
+        anchor.charOffset,
+        terminal.cols,
+        terminal.rows
+      )
+    }
+
+    if (anchor.logicalPrefix && logicalText.startsWith(anchor.logicalPrefix)) {
+      return resolveDisplayLineForCharOffset(
+        buf,
+        lineY,
+        anchor.charOffset,
+        terminal.cols,
+        terminal.rows
+      )
+    }
+
+    if (allowSegmentFallback) {
+      const segmentIndex = logicalText.indexOf(anchor.segment)
+      if (segmentIndex >= 0 && segmentFallbackLine === null) {
+        segmentFallbackLine = resolveDisplayLineForCharOffset(
+          buf,
+          lineY,
+          segmentIndex + anchor.segmentOffset,
+          terminal.cols,
+          terminal.rows
+        )
+      }
+    }
+  }
+
+  return segmentFallbackLine
+}
+
+function findLogicalLineStart(buf: Terminal['buffer']['active'], lineY: number): number {
+  let startY = lineY
+  while (startY > 0 && buf.getLine(startY)?.isWrapped) {
+    startY--
+  }
+  return startY
+}
+
+function readLogicalLineText(buf: Terminal['buffer']['active'], startY: number): string {
+  const length = getBufferLength(buf)
+  let text = ''
+  for (let lineY = startY; lineY < length; lineY++) {
+    const line = buf.getLine(lineY)
+    if (!line || (lineY > startY && !line.isWrapped)) {
+      break
+    }
+    text += line.translateToString(false)
+  }
+  return text.trimEnd()
+}
+
+function resolveDisplayLineForCharOffset(
+  buf: Terminal['buffer']['active'],
+  startY: number,
+  charOffset: number,
+  cols: number,
+  rows: number
+): number {
+  const endY = findLogicalLineEnd(buf, startY, rows)
+  const targetY = startY + Math.floor(Math.max(0, charOffset) / Math.max(cols, 1))
+  return Math.min(targetY, endY, buf.baseY)
+}
+
+function findLogicalLineEnd(buf: Terminal['buffer']['active'], startY: number, rows = 0): number {
+  const length = getBufferLength(buf, rows)
+  let endY = startY
+  for (let lineY = startY + 1; lineY < length; lineY++) {
+    const line = buf.getLine(lineY)
+    if (!line?.isWrapped) {
+      break
+    }
+    endY = lineY
+  }
+  return endY
+}
+
+function getBufferLength(buf: Terminal['buffer']['active'], fallbackRows = 0): number {
+  return typeof buf.length === 'number' ? buf.length : buf.baseY + fallbackRows
+}

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -23,6 +23,8 @@ function createTerminal(args: {
   }
   return {
     buffer: { active },
+    cols: 80,
+    rows: 24,
     // Why: restoreScrollStateNow guards on terminal.element to avoid calling
     // scroll APIs after WebGL teardown. Stub a truthy element so these tests
     // exercise the live restore path.

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -1,5 +1,6 @@
 import type { Terminal } from '@xterm/xterm'
 import type { ScrollState } from './pane-manager-types'
+import { captureViewportAnchor, resolveViewportAnchorLine } from './pane-scroll-viewport-anchor'
 
 const terminalOutputEpochs = new WeakMap<Terminal, number>()
 const deferredScrollRestores = new WeakMap<
@@ -47,8 +48,13 @@ export function captureScrollState(terminal: Terminal): ScrollState {
     wasAtBottom,
     viewportY,
     baseY: buf.baseY,
-    // Why: xterm markers track the same buffer line through resize reflow;
-    // a numeric viewport line alone can point at different content afterward.
+    // Why: xterm markers stay tied to numeric buffer rows during width
+    // reflow. A content anchor lets restore find the same logical line after
+    // split panes change cols and the row number no longer points at it.
+    viewportAnchor:
+      !wasAtBottom && buf.type === 'normal' ? captureViewportAnchor(terminal) : undefined,
+    // Why: markers are still a useful fallback for non-reflowing changes
+    // and scrollback trim, but content anchors win when cols change.
     firstVisibleLineMarker:
       !wasAtBottom && buf.type === 'normal'
         ? terminal.registerMarker?.(viewportY - (buf.baseY + buf.cursorY))
@@ -138,7 +144,11 @@ function restoreScrollStateNow(terminal: Terminal, state: ScrollState): void {
     state.firstVisibleLineMarker && !state.firstVisibleLineMarker.isDisposed
       ? state.firstVisibleLineMarker.line
       : -1
-  const targetLine = Math.min(markerLine >= 0 ? markerLine : state.viewportY, buf.baseY)
+  const anchorLine = resolveViewportAnchorLine(terminal, state)
+  const targetLine = Math.min(
+    anchorLine ?? (markerLine >= 0 ? markerLine : state.viewportY),
+    buf.baseY
+  )
   state.viewportY = targetLine
   // Why: deferred rAF/timeout restores re-invoke this function after xterm
   // reflow settles; keep the marker alive so each call consults the live


### PR DESCRIPTION
## Summary
- capture a content-based viewport anchor for non-bottom terminal scroll state
- resolve that anchor after pane width changes before falling back to markers or numeric viewport lines
- split anchor logic and focused tests into dedicated files to satisfy lint max-lines

## Verification
- pnpm lint
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-scroll.test.ts src/renderer/src/lib/pane-manager/pane-scroll-viewport-anchor.test.ts
- pnpm run typecheck:web

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.