### PR TITLE
Fix stale headless reveal snapshots

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2194,6 +2194,40 @@ describe('OrcaRuntimeService', () => {
     expect(writes).toEqual(['continue', '\r'])
   })
 
+  it('includes headless writes appended while a renderer snapshot is awaiting prior writes', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const firstWrite = deferred<void>()
+    let appendedWriteParsed = false
+    const state = {
+      emulator: {
+        isAlternateScreen: false,
+        getSnapshot: vi.fn(() => ({
+          rehydrateSequences: '',
+          snapshotAnsi: appendedWriteParsed ? 'before-after' : 'before',
+          cols: 80,
+          rows: 24
+        }))
+      },
+      writeChain: firstWrite.promise
+    }
+    const runtimeInternals = runtime as unknown as {
+      headlessTerminals: Map<string, typeof state>
+    }
+    runtimeInternals.headlessTerminals.set('pty-1', state)
+
+    const snapshotPromise = runtime.serializeHeadlessTerminalBufferForRenderer('pty-1')
+    state.writeChain = state.writeChain.then(() => {
+      appendedWriteParsed = true
+    })
+    firstWrite.resolve()
+
+    await expect(snapshotPromise).resolves.toEqual({
+      data: 'before-after',
+      cols: 80,
+      rows: 24
+    })
+  })
+
   it('creates visible terminal sessions without asking the renderer to focus a tab', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
     const createTerminal = vi.fn()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -578,6 +578,7 @@ const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const DRAFT_PASTE_READY_TIMEOUT_MS = 8000
+const HEADLESS_RENDERER_SNAPSHOT_STABLE_WRITE_ATTEMPTS = 8
 const RECENT_PTY_OUTPUT_LIMIT = 4096
 
 type RuntimeNotifier = {
@@ -2319,7 +2320,10 @@ export class OrcaRuntimeService {
     ptyId: string,
     opts: { scrollbackRows?: number } = {}
   ): Promise<{ data: string; cols: number; rows: number } | null> {
-    return this.serializeHeadlessTerminalBuffer(ptyId, opts)
+    return this.serializeHeadlessTerminalBuffer(ptyId, {
+      ...opts,
+      requireStableWrites: true
+    })
   }
 
   async clearTerminalBuffer(handle: string): Promise<{ handle: string; cleared: boolean }> {
@@ -2543,13 +2547,15 @@ export class OrcaRuntimeService {
 
   private async serializeHeadlessTerminalBuffer(
     ptyId: string,
-    opts: { scrollbackRows?: number } = {}
+    opts: { scrollbackRows?: number; requireStableWrites?: boolean } = {}
   ): Promise<{ data: string; cols: number; rows: number } | null> {
     const state = this.headlessTerminals.get(ptyId)
     if (!state) {
       return null
     }
-    await state.writeChain
+    if (!(await this.waitForHeadlessWritesBeforeSnapshot(state, opts.requireStableWrites))) {
+      return null
+    }
     // Why: when an alternate-screen TUI (Claude Code, vim, etc.) is currently
     // active, the visible content is the alt-screen snapshot — replaying any
     // normal-buffer scrollback before it can duplicate shell prompts and
@@ -2562,6 +2568,30 @@ export class OrcaRuntimeService {
     const snapshot = state.emulator.getSnapshot({ scrollbackRows })
     const data = snapshot.rehydrateSequences + snapshot.snapshotAnsi
     return data.length > 0 ? { data, cols: snapshot.cols, rows: snapshot.rows } : null
+  }
+
+  private async waitForHeadlessWritesBeforeSnapshot(
+    state: RuntimeHeadlessTerminal,
+    requireStableWrites = false
+  ): Promise<boolean> {
+    let observed = state.writeChain
+    await observed
+    if (!requireStableWrites || state.writeChain === observed) {
+      return true
+    }
+
+    for (let attempt = 0; attempt < HEADLESS_RENDERER_SNAPSHOT_STABLE_WRITE_ATTEMPTS; attempt++) {
+      observed = state.writeChain
+      await observed
+      if (state.writeChain === observed) {
+        return true
+      }
+    }
+
+    // Why: renderer reveal drops its fallback queue on a successful snapshot.
+    // If output keeps appending while we wait, prefer the renderer fallback
+    // replay over returning a stale "authoritative" headless snapshot.
+    return false
   }
 
   private disposeHeadlessTerminal(ptyId: string): void {


### PR DESCRIPTION
## Summary
- wait for headless writes appended while renderer reveal snapshots are awaiting earlier writes
- return null for an unstable renderer reveal snapshot so the renderer fallback queue replays instead of dropping bytes
- add a deterministic runtime test for the promise-ordering race

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check