### PR TITLE
Fix Monaco diff editor disposal crash

### DIFF
--- a/src/renderer/src/lib/monaco-diff-editor-disposal.test.ts
+++ b/src/renderer/src/lib/monaco-diff-editor-disposal.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
+import {
+  guardMonacoDiffEditorDispose,
+  installMonacoDiffEditorDisposalGuard
+} from './monaco-diff-editor-disposal'
+
+function createMockDiffEditor(dispose: () => void): editor.IStandaloneDiffEditor {
+  return { dispose } as unknown as editor.IStandaloneDiffEditor
+}
+
+describe('guardMonacoDiffEditorDispose', () => {
+  it('contains Monaco disposal errors after invoking the real dispose path', () => {
+    const disposeError = new AggregateError(
+      [new Error('inner dispose failed')],
+      'Encountered errors while disposing of store'
+    )
+    const reportError = vi.fn()
+    const originalDispose = vi.fn(() => {
+      throw disposeError
+    })
+    const diffEditor = createMockDiffEditor(originalDispose)
+
+    guardMonacoDiffEditorDispose(diffEditor, reportError)
+
+    expect(() => diffEditor.dispose()).not.toThrow()
+    expect(originalDispose).toHaveBeenCalledTimes(1)
+    expect(reportError).toHaveBeenCalledWith(disposeError)
+  })
+
+  it('does not repeatedly dispose an editor after the guarded disposal has run', () => {
+    const originalDispose = vi.fn()
+    const diffEditor = createMockDiffEditor(originalDispose)
+
+    guardMonacoDiffEditorDispose(diffEditor)
+    diffEditor.dispose()
+    diffEditor.dispose()
+
+    expect(originalDispose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('installMonacoDiffEditorDisposalGuard', () => {
+  it('wraps diff editors created by Monaco and keeps factory installation idempotent', () => {
+    const disposeError = new AggregateError(
+      [new Error('inner dispose failed')],
+      'Encountered errors while disposing of store'
+    )
+    const reportError = vi.fn()
+    const originalDispose = vi.fn(() => {
+      throw disposeError
+    })
+    const createDiffEditor = vi.fn((_element: HTMLElement) => createMockDiffEditor(originalDispose))
+    const monaco = {
+      editor: {
+        createDiffEditor
+      }
+    }
+
+    installMonacoDiffEditorDisposalGuard(monaco, reportError)
+    installMonacoDiffEditorDisposalGuard(monaco, reportError)
+
+    const diffEditor = monaco.editor.createDiffEditor({} as HTMLElement)
+
+    expect(createDiffEditor).toHaveBeenCalledTimes(1)
+    expect(() => diffEditor.dispose()).not.toThrow()
+    expect(originalDispose).toHaveBeenCalledTimes(1)
+    expect(reportError).toHaveBeenCalledWith(disposeError)
+  })
+})

--- a/src/renderer/src/lib/monaco-diff-editor-disposal.ts
+++ b/src/renderer/src/lib/monaco-diff-editor-disposal.ts
@@ -1,0 +1,73 @@
+import type { editor } from 'monaco-editor'
+
+type CreateDiffEditor = (
+  domElement: HTMLElement,
+  options?: editor.IStandaloneDiffEditorConstructionOptions,
+  override?: editor.IEditorOverrideServices
+) => editor.IStandaloneDiffEditor
+
+type MonacoDiffEditorNamespace = {
+  editor: {
+    createDiffEditor: CreateDiffEditor
+  }
+}
+
+type GuardedDiffEditor = editor.IStandaloneDiffEditor & {
+  __orcaDiffEditorDisposeGuardInstalled?: true
+}
+
+type GuardedEditorNamespace = MonacoDiffEditorNamespace['editor'] & {
+  __orcaDiffEditorFactoryGuardInstalled?: true
+}
+
+type DisposeErrorReporter = (error: unknown) => void
+
+function reportMonacoDiffDisposeError(error: unknown): void {
+  console.warn('[monaco] Diff editor disposal threw after teardown was requested', error)
+}
+
+export function guardMonacoDiffEditorDispose(
+  diffEditor: editor.IStandaloneDiffEditor,
+  reportError: DisposeErrorReporter = reportMonacoDiffDisposeError
+): editor.IStandaloneDiffEditor {
+  const guardedDiffEditor = diffEditor as GuardedDiffEditor
+  if (guardedDiffEditor.__orcaDiffEditorDisposeGuardInstalled) {
+    return diffEditor
+  }
+
+  const originalDispose = diffEditor.dispose.bind(diffEditor)
+  let didDispose = false
+
+  guardedDiffEditor.dispose = () => {
+    if (didDispose) {
+      return
+    }
+    didDispose = true
+
+    try {
+      originalDispose()
+    } catch (error) {
+      // Why: Monaco's DisposableStore throws AggregateError after attempting
+      // teardown; letting it escape React cleanup can crash the renderer.
+      reportError(error)
+    }
+  }
+  guardedDiffEditor.__orcaDiffEditorDisposeGuardInstalled = true
+
+  return diffEditor
+}
+
+export function installMonacoDiffEditorDisposalGuard(
+  monaco: MonacoDiffEditorNamespace,
+  reportError?: DisposeErrorReporter
+): void {
+  const editorNamespace = monaco.editor as GuardedEditorNamespace
+  if (editorNamespace.__orcaDiffEditorFactoryGuardInstalled) {
+    return
+  }
+
+  const createDiffEditor = editorNamespace.createDiffEditor.bind(editorNamespace)
+  editorNamespace.createDiffEditor = ((...args: Parameters<CreateDiffEditor>) =>
+    guardMonacoDiffEditorDispose(createDiffEditor(...args), reportError)) as CreateDiffEditor
+  editorNamespace.__orcaDiffEditorFactoryGuardInstalled = true
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -10,6 +10,7 @@ import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
+import { installMonacoDiffEditorDisposalGuard } from './monaco-diff-editor-disposal'
 
 globalThis.MonacoEnvironment = {
   getWorker(_workerId, label) {
@@ -71,6 +72,7 @@ monacoTS.javascriptDefaults.setCompilerOptions({
 registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
+installMonacoDiffEditorDisposalGuard(monaco)
 
 // Configure Monaco to use the locally bundled editor instead of CDN
 loader.config({ monaco })


### PR DESCRIPTION
## Summary
- Guard Monaco diff editors at creation so disposal AggregateError is logged instead of escaping React cleanup.
- Install the guard through `monaco-setup`, covering single-file diffs, combined/virtualized diffs, and hosted review diffs.
- Add regression coverage for caught disposal errors and idempotent factory wrapping.

## Root Cause
The Slack crash log showed `AggregateError: Encountered errors while disposing of store` escaping from Monaco `StandaloneDiffEditor.dispose()` during diff navigation/unmount. `@monaco-editor/react` directly calls the diff editor dispose function in its cleanup path, so any Monaco disposal aggregate becomes an unhandled renderer error even though Monaco has already attempted child teardown. Wrapping the diff editor dispose function lets cleanup run once, reports the disposal failure, and prevents the renderer crash.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/monaco-diff-editor-disposal.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/lib/monaco-diff-editor-disposal.ts src/renderer/src/lib/monaco-diff-editor-disposal.test.ts src/renderer/src/lib/monaco-setup.ts`
- `npx stably test tests/e2e/tab-close-navigation.spec.ts --config=tests/playwright.config.ts --project=electron-headless` (3 passed; Stably reporting skipped because credentials are not configured locally)