### PR TITLE
Show terminal pane expand state in header

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -5,7 +5,6 @@ import { createPortal } from 'react-dom'
 import { toast } from 'sonner'
 import {
   BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
-  TOGGLE_TERMINAL_PANE_EXPAND_EVENT,
   type BackgroundMountTerminalWorktreeDetail
 } from '@/constants/terminal'
 import { useAppStore } from '../store'
@@ -38,6 +37,10 @@ import type { TabGroupLayoutNode } from '../../../shared/types'
 import BrowserPane from './browser-pane/BrowserPane'
 import { destroyPersistentWebview } from './browser-pane/webview-registry'
 import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
+import {
+  toggleActiveTerminalPaneExpand,
+  toggleTerminalPaneExpand
+} from './terminal/terminal-tab-actions'
 import TerminalPaneOverlayLayer from './terminal-pane/TerminalPaneOverlayLayer'
 import {
   collectBrowserWebviewIds,
@@ -1052,16 +1055,13 @@ function Terminal(): React.JSX.Element | null {
 
   const handleTogglePaneExpand = useCallback(
     (tabId: string) => {
-      setActiveTab(tabId)
-      requestAnimationFrame(() => {
-        window.dispatchEvent(
-          new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
-            detail: { tabId }
-          })
-        )
-      })
+      if (tabId === activeTabId) {
+        toggleActiveTerminalPaneExpand(tabId)
+        return
+      }
+      toggleTerminalPaneExpand(tabId)
     },
-    [setActiveTab]
+    [activeTabId]
   )
 
   const handleActivateBrowserTab = useCallback(

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -19,7 +19,10 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { useTerminalSaveDialog } from '@/components/terminal/useTerminalSaveDialog'
-import { toggleTerminalPaneExpand } from '@/components/terminal/terminal-tab-actions'
+import {
+  toggleActiveTerminalPaneExpand,
+  toggleTerminalPaneExpand
+} from '@/components/terminal/terminal-tab-actions'
 import { appendUniqueOpenFileIds } from '@/components/terminal/unsaved-close-queue'
 import { getConnectionId } from '@/lib/connection-context'
 import { createUntitledMarkdownFile } from '@/lib/create-untitled-markdown'
@@ -162,6 +165,16 @@ export function FloatingTerminalPanel({
     [activeGroup, groupTabs]
   )
   const activeTerminalId = activeTab?.contentType === 'terminal' ? activeTab.entityId : null
+  const handleTogglePaneExpand = useCallback(
+    (terminalId: string): void => {
+      if (terminalId === activeTerminalId) {
+        toggleActiveTerminalPaneExpand(terminalId)
+        return
+      }
+      toggleTerminalPaneExpand(terminalId)
+    },
+    [activeTerminalId]
+  )
   const activeBrowserId = activeTab?.contentType === 'browser' ? activeTab.entityId : null
   const activeEditorUnifiedId =
     activeTab && activeTab.contentType !== 'terminal' && activeTab.contentType !== 'browser'
@@ -855,7 +868,7 @@ export function FloatingTerminalPanel({
               onOpenFileTab={openFloatingMarkdownTab}
               onSetCustomTitle={setTabCustomTitle}
               onSetTabColor={setTabColor}
-              onTogglePaneExpand={toggleTerminalPaneExpand}
+              onTogglePaneExpand={handleTogglePaneExpand}
               editorFiles={editorItems}
               browserTabs={browserItems}
               activeFileId={activeEditorUnifiedId}

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -19,6 +19,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { useTerminalSaveDialog } from '@/components/terminal/useTerminalSaveDialog'
+import { toggleTerminalPaneExpand } from '@/components/terminal/terminal-tab-actions'
 import { appendUniqueOpenFileIds } from '@/components/terminal/unsaved-close-queue'
 import { getConnectionId } from '@/lib/connection-context'
 import { createUntitledMarkdownFile } from '@/lib/create-untitled-markdown'
@@ -105,7 +106,6 @@ export function FloatingTerminalPanel({
   const setActiveTab = useAppStore((s) => s.setActiveTab)
   const setTabCustomTitle = useAppStore((s) => s.setTabCustomTitle)
   const setTabColor = useAppStore((s) => s.setTabColor)
-  const setTabPaneExpanded = useAppStore((s) => s.setTabPaneExpanded)
   const pinFile = useAppStore((s) => s.pinFile)
   const openFile = useAppStore((s) => s.openFile)
   const browserDefaultUrl = useAppStore((s) => s.browserDefaultUrl)
@@ -855,9 +855,7 @@ export function FloatingTerminalPanel({
               onOpenFileTab={openFloatingMarkdownTab}
               onSetCustomTitle={setTabCustomTitle}
               onSetTabColor={setTabColor}
-              onTogglePaneExpand={(tabId) =>
-                setTabPaneExpanded(tabId, expandedPaneByTabId[tabId] !== true)
-              }
+              onTogglePaneExpand={toggleTerminalPaneExpand}
               editorFiles={editorItems}
               browserTabs={browserItems}
               activeFileId={activeEditorUnifiedId}

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -341,6 +341,7 @@ export default function SortableTab({
                 e.stopPropagation()
                 onToggleExpand(tab.id)
               }}
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
               title="Collapse pane"
               aria-label="Collapse pane"
             >

--- a/src/renderer/src/components/tab-group/TabGroupPanel.pane-state.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.pane-state.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   pinFile: vi.fn(),
   setTabColor: vi.fn(),
   setTabCustomTitle: vi.fn(),
+  toggleActiveTerminalPaneExpand: vi.fn(),
   toggleTerminalPaneExpand: vi.fn()
 }))
 
@@ -37,6 +38,7 @@ vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
   return {
     ...actual,
+    useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
     useMemo: (factory: () => unknown) => factory()
   }
 })
@@ -71,6 +73,7 @@ vi.mock('../tab-bar/TabBarQuickCommandsButton', () => ({
 }))
 
 vi.mock('../terminal/terminal-tab-actions', () => ({
+  toggleActiveTerminalPaneExpand: mocks.toggleActiveTerminalPaneExpand,
   toggleTerminalPaneExpand: mocks.toggleTerminalPaneExpand
 }))
 
@@ -225,6 +228,7 @@ describe('TabGroupPanel pane expand state affordance', () => {
     expect(button).not.toBeNull()
     expect(button?.props['aria-pressed']).toBe(false)
     expect(button?.props['data-pane-expand-state']).toBe('normal')
+    expect(button?.props.style).toMatchObject({ WebkitAppRegion: 'no-drag' })
   })
 
   it('renders a highlighted collapse affordance when the pane is expanded', async () => {
@@ -241,9 +245,14 @@ describe('TabGroupPanel pane expand state affordance', () => {
     const element = await renderPanel()
     const stopPropagation = vi.fn()
     const button = findButtonByLabel(element, 'Expand pane')
-    if (!button || typeof button.props.onClick !== 'function') {
+    if (
+      !button ||
+      typeof button.props.onClick !== 'function' ||
+      typeof button.props.onPointerDown !== 'function'
+    ) {
       throw new Error('expand pane button not found')
     }
+    button.props.onPointerDown({ stopPropagation })
     button.props.onClick({ stopPropagation })
 
     const tabBar = findChildByTypeName(element, 'TabBar')
@@ -252,8 +261,9 @@ describe('TabGroupPanel pane expand state affordance', () => {
     }
     tabBar.props.onTogglePaneExpand('terminal-1')
 
-    expect(stopPropagation).toHaveBeenCalledTimes(1)
-    expect(mocks.toggleTerminalPaneExpand).toHaveBeenNthCalledWith(1, 'terminal-1')
-    expect(mocks.toggleTerminalPaneExpand).toHaveBeenNthCalledWith(2, 'terminal-1')
+    expect(stopPropagation).toHaveBeenCalledTimes(2)
+    expect(mocks.toggleActiveTerminalPaneExpand).toHaveBeenNthCalledWith(1, 'terminal-1')
+    expect(mocks.toggleActiveTerminalPaneExpand).toHaveBeenNthCalledWith(2, 'terminal-1')
+    expect(mocks.toggleTerminalPaneExpand).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tab-group/TabGroupPanel.pane-state.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.pane-state.test.tsx
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  activateBrowser: vi.fn(),
+  activateEditor: vi.fn(),
+  activateTerminal: vi.fn(),
+  closeAllEditorTabsInGroup: vi.fn(),
+  closeGroup: vi.fn(),
+  closeItem: vi.fn(),
+  closeOthers: vi.fn(),
+  closeToRight: vi.fn(),
+  createSplitGroup: vi.fn(),
+  duplicateBrowserTab: vi.fn(),
+  focusGroup: vi.fn(),
+  newBrowserTab: vi.fn(),
+  newFileTab: vi.fn(),
+  newTerminalTab: vi.fn(),
+  newTerminalWithShell: vi.fn(),
+  pinFile: vi.fn(),
+  setTabColor: vi.fn(),
+  setTabCustomTitle: vi.fn(),
+  toggleTerminalPaneExpand: vi.fn()
+}))
+
+const modelBox = vi.hoisted(() => ({
+  model: null as ReturnType<typeof makeModel> | null
+}))
+
+const storeBox = vi.hoisted(() => ({
+  state: {
+    rightSidebarOpen: true,
+    sidebarOpen: true
+  }
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    useMemo: (factory: () => unknown) => factory()
+  }
+})
+
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn() })
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof storeBox.state) => unknown) => selector(storeBox.state)
+}))
+
+vi.mock('./useTabGroupWorkspaceModel', () => ({
+  useTabGroupWorkspaceModel: () => {
+    if (!modelBox.model) {
+      throw new Error('model was not initialized')
+    }
+    return modelBox.model
+  }
+}))
+
+vi.mock('../tab-bar/TabBar', () => ({
+  default: function TabBar() {
+    return null
+  }
+}))
+
+vi.mock('../tab-bar/TabBarQuickCommandsButton', () => ({
+  TabBarQuickCommandsButton: function TabBarQuickCommandsButton() {
+    return null
+  }
+}))
+
+vi.mock('../terminal/terminal-tab-actions', () => ({
+  toggleTerminalPaneExpand: mocks.toggleTerminalPaneExpand
+}))
+
+vi.mock('./TabGroupDropOverlay', () => ({
+  default: function TabGroupDropOverlay() {
+    return null
+  }
+}))
+
+type ComponentProps = {
+  children?: unknown
+  [key: string]: unknown
+}
+
+type ReactElementLike = {
+  type: unknown
+  props: ComponentProps
+}
+
+function makeModel({
+  canExpand = true,
+  expanded = false
+}: {
+  canExpand?: boolean
+  expanded?: boolean
+} = {}) {
+  const terminalTab = {
+    id: 'terminal-1',
+    unifiedTabId: 'unified-terminal-1',
+    ptyId: 'pty-1',
+    worktreeId: 'wt-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  const activeTab = {
+    id: 'unified-terminal-1',
+    entityId: 'terminal-1',
+    groupId: 'group-1',
+    worktreeId: 'wt-1',
+    contentType: 'terminal' as const,
+    label: 'Terminal 1',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  return {
+    group: {
+      id: 'group-1',
+      worktreeId: 'wt-1',
+      activeTabId: activeTab.id,
+      tabOrder: [activeTab.id]
+    },
+    activeTab,
+    browserItems: [],
+    editorItems: [],
+    terminalTabs: [terminalTab],
+    tabBarOrder: [terminalTab.id],
+    groupTabs: [activeTab],
+    expandedPaneByTabId: expanded ? { 'terminal-1': true } : {},
+    canExpandPaneByTabId: canExpand ? { 'terminal-1': true } : {},
+    commands: {
+      activateBrowser: mocks.activateBrowser,
+      activateEditor: mocks.activateEditor,
+      activateTerminal: mocks.activateTerminal,
+      closeAllEditorTabsInGroup: mocks.closeAllEditorTabsInGroup,
+      closeGroup: mocks.closeGroup,
+      closeItem: mocks.closeItem,
+      closeOthers: mocks.closeOthers,
+      closeToRight: mocks.closeToRight,
+      createSplitGroup: mocks.createSplitGroup,
+      duplicateBrowserTab: mocks.duplicateBrowserTab,
+      focusGroup: mocks.focusGroup,
+      newBrowserTab: mocks.newBrowserTab,
+      newFileTab: mocks.newFileTab,
+      newTerminalTab: mocks.newTerminalTab,
+      newTerminalWithShell: mocks.newTerminalWithShell,
+      pinFile: mocks.pinFile,
+      setTabColor: mocks.setTabColor,
+      setTabCustomTitle: mocks.setTabCustomTitle
+    }
+  }
+}
+
+function visit(node: unknown, cb: (element: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      visit(child, cb)
+    }
+    return
+  }
+  if (typeof node !== 'object' || !('props' in node)) {
+    return
+  }
+  const element = node as ReactElementLike
+  cb(element)
+  visit(element.props.children, cb)
+}
+
+function findButtonByLabel(node: unknown, label: string): ReactElementLike | null {
+  let found: ReactElementLike | null = null
+  visit(node, (element) => {
+    if (element.type === 'button' && element.props['aria-label'] === label) {
+      found = element
+    }
+  })
+  return found
+}
+
+function findChildByTypeName(node: unknown, typeName: string): ReactElementLike | null {
+  let found: ReactElementLike | null = null
+  visit(node, (element) => {
+    const type = element.type as { name?: string } | string | undefined
+    const name = typeof type === 'string' ? type : type?.name
+    if (name === typeName) {
+      found = element
+    }
+  })
+  return found
+}
+
+async function renderPanel(): Promise<unknown> {
+  const tabGroupPanelModule = await import('./TabGroupPanel')
+  return tabGroupPanelModule.default({
+    groupId: 'group-1',
+    worktreeId: 'wt-1',
+    isFocused: true,
+    hasSplitGroups: true,
+    touchesRightEdge: false,
+    touchesLeftEdge: false,
+    reserveClosedExplorerToggleSpace: false,
+    reserveCollapsedSidebarHeaderSpace: false
+  })
+}
+
+describe('TabGroupPanel pane expand state affordance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    modelBox.model = makeModel()
+  })
+
+  it('renders a normal-state expand affordance for expandable terminal panes', async () => {
+    const element = await renderPanel()
+    const button = findButtonByLabel(element, 'Expand pane')
+    expect(button).not.toBeNull()
+    expect(button?.props['aria-pressed']).toBe(false)
+    expect(button?.props['data-pane-expand-state']).toBe('normal')
+  })
+
+  it('renders a highlighted collapse affordance when the pane is expanded', async () => {
+    modelBox.model = makeModel({ expanded: true })
+    const element = await renderPanel()
+    const button = findButtonByLabel(element, 'Collapse pane')
+    expect(button).not.toBeNull()
+    expect(button?.props['aria-pressed']).toBe(true)
+    expect(button?.props['data-pane-expand-state']).toBe('expanded')
+    expect(button?.props.className).toContain('bg-accent')
+  })
+
+  it('dispatches the terminal-pane expand toggle from header and tab-bar controls', async () => {
+    const element = await renderPanel()
+    const stopPropagation = vi.fn()
+    const button = findButtonByLabel(element, 'Expand pane')
+    if (!button || typeof button.props.onClick !== 'function') {
+      throw new Error('expand pane button not found')
+    }
+    button.props.onClick({ stopPropagation })
+
+    const tabBar = findChildByTypeName(element, 'TabBar')
+    if (!tabBar || typeof tabBar.props.onTogglePaneExpand !== 'function') {
+      throw new Error('tab bar expand handler not found')
+    }
+    tabBar.props.onTogglePaneExpand('terminal-1')
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+    expect(mocks.toggleTerminalPaneExpand).toHaveBeenNthCalledWith(1, 'terminal-1')
+    expect(mocks.toggleTerminalPaneExpand).toHaveBeenNthCalledWith(2, 'terminal-1')
+  })
+})

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense, useCallback, useMemo } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import { Columns2, Ellipsis, Maximize2, Minimize2, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
@@ -14,7 +14,10 @@ import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import TabGroupDropOverlay from './TabGroupDropOverlay'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
-import { toggleTerminalPaneExpand } from '../terminal/terminal-tab-actions'
+import {
+  toggleActiveTerminalPaneExpand,
+  toggleTerminalPaneExpand
+} from '../terminal/terminal-tab-actions'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   getTabPaneBodyDroppableId,
@@ -85,6 +88,16 @@ export default function TabGroupPanel({
     activeTerminalTabId !== null && model.canExpandPaneByTabId[activeTerminalTabId] === true
   const activeTerminalExpanded =
     activeTerminalTabId !== null && model.expandedPaneByTabId[activeTerminalTabId] === true
+  const handleTogglePaneExpand = useCallback(
+    (terminalId: string): void => {
+      if (terminalId === activeTerminalTabId) {
+        toggleActiveTerminalPaneExpand(terminalId)
+        return
+      }
+      toggleTerminalPaneExpand(terminalId)
+    },
+    [activeTerminalTabId]
+  )
 
   const tabBar = (
     <TabBar
@@ -123,7 +136,7 @@ export default function TabGroupPanel({
       onNewFileTab={commands.newFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}
       onSetTabColor={commands.setTabColor}
-      onTogglePaneExpand={toggleTerminalPaneExpand}
+      onTogglePaneExpand={handleTogglePaneExpand}
       editorFiles={editorItems}
       browserTabs={browserItems}
       activeFileId={
@@ -272,7 +285,7 @@ export default function TabGroupPanel({
                     }}
                     onClick={(event) => {
                       event.stopPropagation()
-                      toggleTerminalPaneExpand(activeTerminalTabId)
+                      handleTogglePaneExpand(activeTerminalTabId)
                     }}
                     className={paneExpandButtonClassName}
                   >

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useMemo } from 'react'
 import { useDroppable } from '@dnd-kit/core'
-import { Columns2, Ellipsis, Rows2, X } from 'lucide-react'
+import { Columns2, Ellipsis, Maximize2, Minimize2, Rows2, X } from 'lucide-react'
 import { useAppStore } from '../../store'
 import {
   DropdownMenu,
@@ -14,6 +14,8 @@ import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import TabGroupDropOverlay from './TabGroupDropOverlay'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
+import { toggleTerminalPaneExpand } from '../terminal/terminal-tab-actions'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   getTabPaneBodyDroppableId,
   type HoveredTabInsertion,
@@ -78,6 +80,11 @@ export default function TabGroupPanel({
     () => ({ anchorName: bodyAnchorName }) as React.CSSProperties,
     [bodyAnchorName]
   )
+  const activeTerminalTabId = activeTab?.contentType === 'terminal' ? activeTab.entityId : null
+  const activeTerminalCanExpand =
+    activeTerminalTabId !== null && model.canExpandPaneByTabId[activeTerminalTabId] === true
+  const activeTerminalExpanded =
+    activeTerminalTabId !== null && model.expandedPaneByTabId[activeTerminalTabId] === true
 
   const tabBar = (
     <TabBar
@@ -116,7 +123,7 @@ export default function TabGroupPanel({
       onNewFileTab={commands.newFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}
       onSetTabColor={commands.setTabColor}
-      onTogglePaneExpand={() => {}}
+      onTogglePaneExpand={toggleTerminalPaneExpand}
       editorFiles={editorItems}
       browserTabs={browserItems}
       activeFileId={
@@ -161,8 +168,15 @@ export default function TabGroupPanel({
     />
   )
 
-  const menuButtonClassName =
-    'flex h-7 w-7 -translate-y-0.5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+  const actionIconButtonBaseClassName =
+    'flex h-7 w-7 -translate-y-0.5 shrink-0 items-center justify-center rounded-md hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+  const menuButtonClassName = `${actionIconButtonBaseClassName} text-muted-foreground hover:bg-accent/50`
+  const paneExpandButtonLabel = activeTerminalExpanded ? 'Collapse pane' : 'Expand pane'
+  const paneExpandButtonClassName = `${actionIconButtonBaseClassName} ${
+    activeTerminalExpanded
+      ? 'bg-accent text-foreground hover:bg-accent'
+      : 'text-muted-foreground hover:bg-accent/50'
+  }`
   // Why: focused-only — the QC split-button and Pane Actions ellipsis both
   // appear together so the action cluster never reflows when focus shifts
   // between groups. Unfocused groups collapse the cluster fully (no
@@ -242,6 +256,38 @@ export default function TabGroupPanel({
             className={actionChromeClassName}
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
+            {/* Why: split-terminal expansion is pane state, so it needs a
+                persistent header affordance instead of hiding only inside the tab. */}
+            {isFocused && activeTerminalCanExpand && activeTerminalTabId !== null ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={paneExpandButtonLabel}
+                    aria-pressed={activeTerminalExpanded}
+                    data-pane-expand-state={activeTerminalExpanded ? 'expanded' : 'normal'}
+                    style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+                    onPointerDown={(event) => {
+                      event.stopPropagation()
+                    }}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      toggleTerminalPaneExpand(activeTerminalTabId)
+                    }}
+                    className={paneExpandButtonClassName}
+                  >
+                    {activeTerminalExpanded ? (
+                      <Minimize2 className="size-4" />
+                    ) : (
+                      <Maximize2 className="size-4" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  {paneExpandButtonLabel}
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
             {isFocused ? (
               <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
             ) : null}

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -113,6 +113,7 @@ function resetStore(): void {
   storeBox.state = {
     activeWorktreeId: 'wt-1',
     browserTabsByWorktree: {},
+    canExpandPaneByTabId: {},
     expandedPaneByTabId: {},
     groupsByWorktree: {
       'wt-1': [

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -57,7 +57,8 @@ export function useTabGroupWorkspaceModel({
       terminalTabs: state.tabsByWorktree[worktreeId] ?? EMPTY_TERMINAL_TABS,
       openFiles: state.openFiles,
       browserTabs: state.browserTabsByWorktree[worktreeId] ?? EMPTY_BROWSER_TABS,
-      expandedPaneByTabId: state.expandedPaneByTabId
+      expandedPaneByTabId: state.expandedPaneByTabId,
+      canExpandPaneByTabId: state.canExpandPaneByTabId
     }))
   )
 
@@ -496,6 +497,7 @@ export function useTabGroupWorkspaceModel({
     tabBarOrder,
     groupTabs,
     expandedPaneByTabId: worktreeState.expandedPaneByTabId,
+    canExpandPaneByTabId: worktreeState.canExpandPaneByTabId,
     commands: {
       focusGroup: () => {
         focusGroup(worktreeId, groupId)

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -996,6 +996,7 @@ export default function TerminalPane({
     paneTransportsRef,
     isActiveRef,
     isVisibleRef,
+    expandedPaneIdRef,
     toggleExpandPane
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-pane-expand-toggle-registry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-expand-toggle-registry.ts
@@ -1,0 +1,19 @@
+type TerminalPaneExpandToggleHandler = () => boolean
+
+const handlersByTabId = new Map<string, TerminalPaneExpandToggleHandler>()
+
+export function registerTerminalPaneExpandToggleHandler(
+  tabId: string,
+  handler: TerminalPaneExpandToggleHandler
+): () => void {
+  handlersByTabId.set(tabId, handler)
+  return () => {
+    if (handlersByTabId.get(tabId) === handler) {
+      handlersByTabId.delete(tabId)
+    }
+  }
+}
+
+export function requestRegisteredTerminalPaneExpandToggle(tabId: string): boolean {
+  return handlersByTabId.get(tabId)?.() === true
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.pane-toggle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.pane-toggle.test.ts
@@ -1,0 +1,169 @@
+import type * as ReactModule from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
+import { useTerminalPaneGlobalEffects } from './use-terminal-pane-global-effects'
+import { requestRegisteredTerminalPaneExpandToggle } from './terminal-pane-expand-toggle-registry'
+
+const mocks = vi.hoisted(() => ({
+  captureScrollState: vi.fn(),
+  fitAndFocusPanes: vi.fn(),
+  fitPanes: vi.fn(),
+  flushTerminalOutput: vi.fn(),
+  getTerminalOutputEpoch: vi.fn(() => 0),
+  handleTerminalFileDrop: vi.fn(),
+  restoreScrollState: vi.fn(),
+  restoreScrollStateAfterLayout: vi.fn()
+}))
+
+const reactRefState = vi.hoisted(() => ({
+  slots: [] as { current: unknown }[],
+  index: 0
+}))
+
+function beginHookRender(): void {
+  reactRefState.index = 0
+}
+
+function resetHookRefs(): void {
+  reactRefState.slots = []
+  reactRefState.index = 0
+}
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactModule>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
+    useEffect: (effect: () => void | (() => void)) => {
+      effect()
+    },
+    useRef: <T>(value: T) => {
+      const index = reactRefState.index
+      reactRefState.index += 1
+      if (!reactRefState.slots[index]) {
+        reactRefState.slots[index] = { current: value }
+      }
+      return reactRefState.slots[index] as { current: T }
+    }
+  }
+})
+
+vi.mock('./pane-helpers', () => ({
+  fitAndFocusPanes: mocks.fitAndFocusPanes,
+  fitPanes: mocks.fitPanes
+}))
+
+vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
+  flushTerminalOutput: mocks.flushTerminalOutput
+}))
+
+vi.mock('@/lib/pane-manager/pane-scroll', () => ({
+  captureScrollState: mocks.captureScrollState,
+  getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
+  restoreScrollState: mocks.restoreScrollState,
+  restoreScrollStateAfterLayout: mocks.restoreScrollStateAfterLayout
+}))
+
+vi.mock('./terminal-drop-handler', () => ({
+  handleTerminalFileDrop: mocks.handleTerminalFileDrop
+}))
+
+class MockResizeObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+}
+
+describe('useTerminalPaneGlobalEffects pane expand events', () => {
+  beforeEach(() => {
+    resetHookRefs()
+    vi.clearAllMocks()
+    ;(globalThis as unknown as { window: unknown }).window = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      api: {
+        ui: {
+          onFileDrop: vi.fn(() => vi.fn())
+        }
+      }
+    }
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver
+  })
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window
+    delete (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver
+  })
+
+  it('collapses the currently expanded pane for chrome-originated toggle events', () => {
+    const toggleExpandPane = vi.fn()
+    const manager = {
+      getPanes: vi.fn(() => [
+        { id: 1, terminal: { name: 'terminal-a' } },
+        { id: 2, terminal: { name: 'terminal-b' } }
+      ]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      paneCount: 2,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      expandedPaneIdRef: { current: 2 },
+      toggleExpandPane
+    })
+
+    const listenerEntry = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([eventName]) => eventName === TOGGLE_TERMINAL_PANE_EXPAND_EVENT)
+    if (!listenerEntry || typeof listenerEntry[1] !== 'function') {
+      throw new Error('toggle expand listener not registered')
+    }
+    listenerEntry[1](
+      new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, { detail: { tabId: 'tab-1' } })
+    )
+
+    expect(toggleExpandPane).toHaveBeenCalledWith(2)
+  })
+
+  it('handles registered chrome toggle requests without waiting for the window event path', () => {
+    const toggleExpandPane = vi.fn()
+    const manager = {
+      getPanes: vi.fn(() => [
+        { id: 1, terminal: { name: 'terminal-a' } },
+        { id: 2, terminal: { name: 'terminal-b' } }
+      ]),
+      resumeRendering: vi.fn(),
+      suspendRendering: vi.fn(),
+      getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
+    }
+
+    beginHookRender()
+    useTerminalPaneGlobalEffects({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      isActive: true,
+      isVisible: true,
+      paneCount: 2,
+      managerRef: { current: manager as never },
+      containerRef: { current: null },
+      paneTransportsRef: { current: new Map() },
+      isActiveRef: { current: false },
+      isVisibleRef: { current: false },
+      expandedPaneIdRef: { current: 2 },
+      toggleExpandPane
+    })
+
+    expect(requestRegisteredTerminalPaneExpandToggle('tab-1')).toBe(true)
+    expect(toggleExpandPane).toHaveBeenCalledWith(2)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -18,6 +18,7 @@ import { restoreScrollStateAfterLayout } from '@/lib/pane-manager/pane-scroll'
 import { useTerminalScrollVisibilityMemory } from './use-terminal-scroll-visibility-memory'
 import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
 import { pasteTerminalText } from './terminal-bracketed-paste'
+import { registerTerminalPaneExpandToggleHandler } from './terminal-pane-expand-toggle-registry'
 
 type UseTerminalPaneGlobalEffectsArgs = {
   tabId: string
@@ -31,6 +32,7 @@ type UseTerminalPaneGlobalEffectsArgs = {
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   isActiveRef: React.RefObject<boolean>
   isVisibleRef: React.RefObject<boolean>
+  expandedPaneIdRef?: React.RefObject<number | null>
   toggleExpandPane: (paneId: number) => void
 }
 
@@ -46,6 +48,7 @@ export function useTerminalPaneGlobalEffects({
   paneTransportsRef,
   isActiveRef,
   isVisibleRef,
+  expandedPaneIdRef,
   toggleExpandPane
 }: UseTerminalPaneGlobalEffectsArgs): void {
   const worktreeIdRef = useRef(worktreeId)
@@ -126,27 +129,45 @@ export function useTerminalPaneGlobalEffects({
   }, [isActive, isVisible])
 
   useEffect(() => {
+    const togglePaneForChrome = (): boolean => {
+      const manager = managerRef.current
+      if (!manager) {
+        return false
+      }
+      const panes = manager.getPanes()
+      if (panes.length < 2) {
+        return false
+      }
+      const expandedPaneId = expandedPaneIdRef?.current ?? null
+      // Why: chrome buttons are outside xterm focus; collapse the pane that is
+      // visibly expanded even if manager focus has drifted to a hidden sibling.
+      let pane = manager.getActivePane() ?? panes[0]
+      if (expandedPaneId !== null) {
+        pane = panes.find((candidate) => candidate.id === expandedPaneId) ?? pane
+      }
+      if (!pane) {
+        return false
+      }
+      toggleExpandPane(pane.id)
+      return true
+    }
+
     const onToggleExpand = (event: Event): void => {
       const detail = (event as CustomEvent<{ tabId?: string }>).detail
       if (!detail?.tabId || detail.tabId !== tabId) {
         return
       }
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      const panes = manager.getPanes()
-      if (panes.length < 2) {
-        return
-      }
-      const pane = manager.getActivePane() ?? panes[0]
-      if (!pane) {
-        return
-      }
-      toggleExpandPane(pane.id)
+      togglePaneForChrome()
     }
+    const unregisterToggleHandler = registerTerminalPaneExpandToggleHandler(
+      tabId,
+      togglePaneForChrome
+    )
     window.addEventListener(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, onToggleExpand)
-    return () => window.removeEventListener(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, onToggleExpand)
+    return () => {
+      unregisterToggleHandler()
+      window.removeEventListener(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, onToggleExpand)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabId])
 

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from '@/store'
 import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { reconcileTabOrder } from '../tab-bar/reconcile-order'
+import { requestRegisteredTerminalPaneExpandToggle } from '../terminal-pane/terminal-pane-expand-toggle-registry'
 import {
   activateWebRuntimeSessionTab,
   closeWebRuntimeSessionTab,
@@ -196,13 +197,27 @@ export function activateEditorFile(fileId: string): void {
   s.setActiveTabType('editor')
 }
 
+function dispatchTerminalPaneExpandToggle(tabId: string): void {
+  window.dispatchEvent(
+    new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
+      detail: { tabId }
+    })
+  )
+}
+
+export function requestTerminalPaneExpandToggle(tabId: string): void {
+  if (!requestRegisteredTerminalPaneExpandToggle(tabId)) {
+    dispatchTerminalPaneExpandToggle(tabId)
+  }
+}
+
+export function toggleActiveTerminalPaneExpand(tabId: string): void {
+  requestTerminalPaneExpandToggle(tabId)
+}
+
 export function toggleTerminalPaneExpand(tabId: string): void {
   useAppStore.getState().setActiveTab(tabId)
   requestAnimationFrame(() => {
-    window.dispatchEvent(
-      new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
-        detail: { tabId }
-      })
-    )
+    requestTerminalPaneExpandToggle(tabId)
   })
 }


### PR DESCRIPTION
## Summary
- Add a focused tab-group header affordance for split terminal pane expand state: Maximize for normal, highlighted Minimize for expanded.
- Wire split tab group and floating terminal tab collapse controls through the existing terminal pane expand event instead of no-op/store-only updates.
- Expose can-expand pane state in the tab-group model and cover the render/click wiring with focused tests.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/TabGroupPanel.pane-state.test.tsx src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts`
- `pnpm run lint`
- `pnpm run typecheck:web`

## Electron
- Not run: a clean Electron dev launch in this worker does not have a preconfigured workspace with a split terminal pane; the state-dependent UI and event wiring are verified with focused component tests.