### PR TITLE
Recover terminal renderer after agent status changes

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -238,6 +238,7 @@ function createPane(paneId: number) {
 function createManager(paneCount = 1) {
   return {
     setPaneGpuRendering: vi.fn(),
+    recoverPaneRenderer: vi.fn(),
     markPaneHasComplexScriptOutput: vi.fn(),
     getPanes: vi.fn(() =>
       Array.from({ length: paneCount }, (_, index) => ({

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -63,6 +63,8 @@ const PTY_CONNECT_DIAG_LIMIT = 200
 const AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS = 250
 const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1000
 const AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS = 10_000
+const AGENT_RENDERER_RECOVERY_WORKING_DELAY_MS = 180
+const AGENT_RENDERER_RECOVERY_IDLE_DELAY_MS = 320
 const HIDDEN_TERMINAL_METADATA_FLUSH_MS = 100
 let codexRestartNoticePresenceSource: Record<
   string,
@@ -563,6 +565,23 @@ export function connectPanePty(
     }
   }
 
+  const scheduleAgentRendererRecovery = (
+    state: ParsedAgentStatusPayload['state'] | 'title-working' | 'title-idle'
+  ): void => {
+    if (!deps.isVisibleRef.current) {
+      return
+    }
+    // Why: Slack reports matched silent WebGL glyph-atlas corruption after
+    // agent submit/settle; rebuilding around agent state edges mirrors the
+    // user workaround (navigation/GPU toggle) without touching hidden panes.
+    manager.recoverPaneRenderer(pane.id, {
+      delayMs:
+        state === 'working' || state === 'title-working'
+          ? AGENT_RENDERER_RECOVERY_WORKING_DELAY_MS
+          : AGENT_RENDERER_RECOVERY_IDLE_DELAY_MS
+    })
+  }
+
   const applyAgentStatusNow = (payload: ParsedAgentStatusPayload): void => {
     // Why: capture the store snapshot once so the title lookup and the
     // setAgentStatus call observe the same state. Re-reading getState()
@@ -572,6 +591,14 @@ export function connectPanePty(
     const currentState = useAppStore.getState()
     const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
     currentState.setAgentStatus(cacheKey, payload, title)
+    if (
+      payload.state === 'working' ||
+      payload.state === 'done' ||
+      payload.state === 'waiting' ||
+      payload.state === 'blocked'
+    ) {
+      scheduleAgentRendererRecovery(payload.state)
+    }
     if (syncAgentTaskCompleteNotificationEnabled()) {
       agentCompletionCoordinator.observeHookStatus(payload)
     }
@@ -814,6 +841,7 @@ export function connectPanePty(
   // notification below; main still keeps a 5 s per-worktree dedupe as the
   // final guard.
   const onAgentBecameIdle = (title: string): void => {
+    scheduleAgentRendererRecovery('title-idle')
     // Why: only start the prompt-cache countdown for Claude agents — other
     // agents have different (or no) prompt-caching semantics and showing a
     // timer for them would be misleading.
@@ -833,6 +861,7 @@ export function connectPanePty(
     }
   }
   const onAgentBecameWorking = (): void => {
+    scheduleAgentRendererRecovery('title-working')
     if (syncAgentTaskCompleteNotificationEnabled()) {
       agentCompletionCoordinator.observeTitleWorking()
     }

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -25,6 +25,7 @@ import {
 import { buildDefaultTerminalOptions } from './pane-terminal-options'
 import { ENABLE_WEBGL_RENDERER, attachWebgl, disposeWebgl } from './pane-webgl-renderer'
 import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
+import { cancelPaneRendererRecovery } from './pane-renderer-recovery'
 
 // ---------------------------------------------------------------------------
 // Pane creation, terminal open/close, addon management
@@ -289,6 +290,7 @@ export function disposePane(
   pane: ManagedPaneInternal,
   panes: Map<number, ManagedPaneInternal>
 ): void {
+  cancelPaneRendererRecovery(pane)
   detachPaneFitResizeObserver(pane)
   if (pane.compositionHandler) {
     pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: PaneManager owns the imperative split tree, renderer state, and drag callbacks; splitting it would make lifecycle ordering harder to audit. */
 import type {
   PaneManagerOptions,
   PaneStyleOptions,
@@ -29,6 +30,7 @@ import {
   setPaneGpuRenderingState,
   suspendPaneRendering
 } from './pane-rendering-control'
+import { schedulePaneRendererRecovery } from './pane-renderer-recovery'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { PaneIdentityRegistry } from './pane-identity-registry'
 import { closeManagedPane, splitManagedPane } from './pane-split-close'
@@ -231,6 +233,14 @@ export class PaneManager {
 
   setPaneGpuRendering(paneId: number, enabled: boolean): void {
     setPaneGpuRenderingState(this.panes, paneId, enabled)
+  }
+
+  recoverPaneRenderer(paneId: number, options?: { delayMs?: number }): void {
+    const pane = this.panes.get(paneId)
+    if (!pane) {
+      return
+    }
+    schedulePaneRendererRecovery(pane, options)
   }
 
   setTerminalGpuAcceleration(mode: PaneManagerOptions['terminalGpuAcceleration']): void {

--- a/src/renderer/src/lib/pane-manager/pane-renderer-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-renderer-recovery.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { cancelPaneRendererRecovery, schedulePaneRendererRecovery } from './pane-renderer-recovery'
+
+const webglMock = vi.hoisted(() => ({
+  dispose: vi.fn()
+}))
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn().mockImplementation(function WebglAddon() {
+    return {
+      dispose: webglMock.dispose,
+      onContextLoss: vi.fn()
+    }
+  })
+}))
+
+function createPane(): ManagedPaneInternal {
+  const leafId = '11111111-1111-4111-8111-111111111111' as never
+  return {
+    id: 1,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      cols: 80,
+      rows: 24,
+      element: {} as HTMLElement,
+      loadAddon: vi.fn(),
+      refresh: vi.fn()
+    } as never,
+    container: { dataset: {} } as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'auto',
+    gpuRenderingEnabled: true,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    webglAddon: {
+      dispose: vi.fn()
+    } as never,
+    ligaturesAddon: null,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 80, rows: 23 })),
+      fit: vi.fn()
+    } as never,
+    searchAddon: {} as never,
+    serializeAddon: {} as never,
+    unicode11Addon: {} as never,
+    webLinksAddon: {} as never,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+describe('schedulePaneRendererRecovery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+    })
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    webglMock.dispose.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reattaches active WebGL panes to rebuild the glyph atlas', () => {
+    const pane = createPane()
+    const oldWebglDispose = vi.mocked(pane.webglAddon!.dispose)
+
+    schedulePaneRendererRecovery(pane, { delayMs: 5 })
+    vi.advanceTimersByTime(5)
+
+    expect(oldWebglDispose).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('refreshes DOM-rendered panes without trying to attach WebGL', () => {
+    const pane = createPane()
+    pane.webglAddon = null
+    pane.terminalGpuAcceleration = 'off'
+
+    schedulePaneRendererRecovery(pane, { delayMs: 5 })
+    vi.advanceTimersByTime(5)
+
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('does not recover panes while rendering is suspended', () => {
+    const pane = createPane()
+    const oldWebglDispose = vi.mocked(pane.webglAddon!.dispose)
+    pane.webglAttachmentDeferred = true
+
+    schedulePaneRendererRecovery(pane, { delayMs: 5 })
+    vi.advanceTimersByTime(5)
+
+    expect(oldWebglDispose).not.toHaveBeenCalled()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending recovery for disposed panes', () => {
+    const pane = createPane()
+    const oldWebglDispose = vi.mocked(pane.webglAddon!.dispose)
+
+    schedulePaneRendererRecovery(pane, { delayMs: 5 })
+    cancelPaneRendererRecovery(pane)
+    vi.advanceTimersByTime(5)
+
+    expect(oldWebglDispose).not.toHaveBeenCalled()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-renderer-recovery.ts
+++ b/src/renderer/src/lib/pane-manager/pane-renderer-recovery.ts
@@ -1,0 +1,89 @@
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { safeFit } from './pane-tree-ops'
+import { attachWebgl, disposeWebgl } from './pane-webgl-renderer'
+
+const DEFAULT_RENDERER_RECOVERY_DELAY_MS = 120
+const MIN_RENDERER_RECOVERY_INTERVAL_MS = 1_500
+
+type PendingRendererRecovery = {
+  rafId: number | null
+  timeoutId: ReturnType<typeof setTimeout> | null
+}
+
+const pendingRecoveryByPane = new WeakMap<ManagedPaneInternal, PendingRendererRecovery>()
+const lastRecoveryAtByPane = new WeakMap<ManagedPaneInternal, number>()
+
+function refreshTerminalBuffer(pane: ManagedPaneInternal): void {
+  if (pane.terminal.rows <= 0) {
+    return
+  }
+  pane.terminal.refresh(0, pane.terminal.rows - 1)
+}
+
+function runPaneRendererRecovery(pane: ManagedPaneInternal): void {
+  if (pane.webglAttachmentDeferred || !pane.terminal.element) {
+    return
+  }
+
+  try {
+    if (pane.webglAddon) {
+      // Why: reported corruption matched a stale WebGL glyph atlas; a plain
+      // xterm refresh does not rebuild that atlas, but reattaching WebGL does.
+      disposeWebgl(pane)
+      attachWebgl(pane)
+      safeFit(pane)
+      return
+    }
+    refreshTerminalBuffer(pane)
+  } catch {
+    /* ignore — renderer recovery is best effort */
+  }
+}
+
+export function schedulePaneRendererRecovery(
+  pane: ManagedPaneInternal,
+  options: { delayMs?: number } = {}
+): void {
+  if (pendingRecoveryByPane.has(pane)) {
+    return
+  }
+
+  const now = Date.now()
+  const lastRecoveryAt = lastRecoveryAtByPane.get(pane) ?? 0
+  const throttleDelay = Math.max(0, MIN_RENDERER_RECOVERY_INTERVAL_MS - (now - lastRecoveryAt))
+  const delayMs = Math.max(options.delayMs ?? DEFAULT_RENDERER_RECOVERY_DELAY_MS, throttleDelay)
+  const pending: PendingRendererRecovery = { rafId: null, timeoutId: null }
+  pendingRecoveryByPane.set(pane, pending)
+  pending.timeoutId = setTimeout(() => {
+    pending.timeoutId = null
+    const recover = (): void => {
+      pending.rafId = null
+      pendingRecoveryByPane.delete(pane)
+      if (pane.webglAttachmentDeferred || !pane.terminal.element) {
+        return
+      }
+      lastRecoveryAtByPane.set(pane, Date.now())
+      runPaneRendererRecovery(pane)
+    }
+
+    if (typeof requestAnimationFrame === 'function') {
+      pending.rafId = requestAnimationFrame(recover)
+      return
+    }
+    recover()
+  }, delayMs)
+}
+
+export function cancelPaneRendererRecovery(pane: ManagedPaneInternal): void {
+  const pending = pendingRecoveryByPane.get(pane)
+  if (!pending) {
+    return
+  }
+  if (pending.timeoutId !== null) {
+    clearTimeout(pending.timeoutId)
+  }
+  if (pending.rafId !== null && typeof cancelAnimationFrame === 'function') {
+    cancelAnimationFrame(pending.rafId)
+  }
+  pendingRecoveryByPane.delete(pane)
+}


### PR DESCRIPTION
## Summary
- Add a throttled terminal renderer recovery path that reattaches active WebGL panes, rebuilding the glyph atlas, or refreshes DOM-rendered panes.
- Schedule recovery only around visible agent working/idle/done/waiting/blocked state edges, matching the navigation/GPU-toggle workaround without spending GPU contexts on hidden panes.
- Cancel pending renderer recovery during pane disposal and cover WebGL/DOM/suspended/cancel cases with focused unit tests.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-renderer-recovery.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.test.ts`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `pnpm run test:e2e -- tests/e2e/terminal-cursor-inactive-style.spec.ts`
- Attempted `pnpm run test:e2e -- tests/e2e/terminal-output-scheduler.spec.ts` twice; Electron built/launched both times, but the spec failed before completing its target assertion on existing/flaky tab activation/background scheduler setup (`New Terminal did not become the active tab`, then `Background PTY output did not enter the scheduler queue`).