### PR TITLE
Align Add command tab bar button

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TerminalQuickCommand } from '../../../../shared/types'
+
+type QuickCommandButtonState = {
+  settings: {
+    terminalQuickCommands: TerminalQuickCommand[]
+  }
+  recentQuickCommandIdByGroup: Record<string, string>
+  updateSettings: (settings: unknown) => Promise<void>
+  repos: { id: string }[]
+}
+
+const useAppStoreMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: QuickCommandButtonState) => unknown) => useAppStoreMock(selector)
+}))
+
+vi.mock('@/components/confirmation-dialog', () => ({
+  useConfirmationDialog: () => async () => false
+}))
+
+vi.mock('@/components/ui/tooltip', () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>
+  return {
+    Tooltip: Passthrough,
+    TooltipTrigger: Passthrough,
+    TooltipContent: () => null
+  }
+})
+
+vi.mock('@/components/terminal-quick-commands/TerminalQuickCommandDialog', () => ({
+  createTerminalQuickCommandDraft: (scope: unknown) => ({
+    id: 'draft-command',
+    label: '',
+    command: '',
+    scope
+  }),
+  TerminalQuickCommandDialog: () => null
+}))
+
+describe('TabBarQuickCommandsButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useAppStoreMock.mockImplementation((selector: (state: QuickCommandButtonState) => unknown) =>
+      selector({
+        settings: {
+          terminalQuickCommands: []
+        },
+        repos: [{ id: 'repo-1' }],
+        recentQuickCommandIdByGroup: {},
+        updateSettings: async () => {}
+      })
+    )
+  })
+
+  it('renders the empty add-command trigger as a compact centered button', async () => {
+    const { TabBarQuickCommandsButton } = await import('./TabBarQuickCommandsButton')
+    const html = renderToStaticMarkup(
+      <TabBarQuickCommandsButton worktreeId="repo-1" groupId="group-1" />
+    )
+    expect(html).toContain('Add command')
+
+    const trigger = html.match(/<button[^>]+aria-label="Add quick command"[^>]*>.*?<\/button>/)
+    expect(trigger).not.toBeNull()
+    const triggerHtml = trigger?.[0] ?? ''
+    expect(triggerHtml).toContain('data-size="xs"')
+    expect(triggerHtml).toContain('h-7')
+    expect(triggerHtml).toContain('items-center')
+    expect(triggerHtml).toContain('leading-none')
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   createTerminalQuickCommandDraft,
@@ -144,20 +145,22 @@ export function TabBarQuickCommandsButton({
       <>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="xs"
               onClick={() =>
                 setEditor({
                   mode: 'add',
                   command: createTerminalQuickCommandDraft({ type: 'repo', repoId })
                 })
               }
-              className="my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="my-auto h-7 gap-1 px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground"
               aria-label="Add quick command"
             >
               <Plus className="size-3.5" />
-              <span className="text-[12px] font-medium">Add command</span>
-            </button>
+              <span className="font-medium leading-none">Add command</span>
+            </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom" sideOffset={6}>
             Save a quick command for this repo


### PR DESCRIPTION
## Summary
- Switched the empty quick-command tab bar trigger to the shared Button primitive while preserving the 28px tab bar height.
- Added a focused render test for the compact Add command trigger classes.

## Tests
- GITHUB_TOKEN=dummy pnpm run lint
- GITHUB_TOKEN=dummy pnpm run typecheck:web
- GITHUB_TOKEN=dummy pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.test.tsx
- ORCA_ADD_COMMAND_EVIDENCE_PATH=/tmp/orca-add-command-button.png GITHUB_TOKEN=dummy npx stably test --config=tests/playwright.config.ts --project=electron-headless tests/e2e/tab-bar-quick-command-evidence.spec.ts (temporary evidence spec, removed before commit)

## Electron Evidence
- Screenshot: /tmp/orca-add-command-button.png
- Metrics: buttonHeight=28, labelHeight=12, centerDelta=0, dataSize=xs, labelLineHeight=12px