### PR TITLE
Fix Ctrl+C CSI-u terminal input leak

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -911,7 +911,9 @@ describe('connectPanePty', () => {
     vi.advanceTimersByTime(500)
     await flushAsyncTicks()
 
-    expect(transport.sendInputAccepted).toHaveBeenCalledWith('\x1b[99;5u')
+    expect(transport.sendInputAccepted).toHaveBeenCalledWith('\x03')
+    expect(transport.sendInput).toHaveBeenCalledWith('\x03')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5u')
     expect(window.api.agentStatus.inferInterrupt).toHaveBeenCalledWith({
       paneKey,
       baselineUpdatedAt: 1_000,
@@ -920,6 +922,90 @@ describe('connectPanePty', () => {
       baselineAgentType: 'codex',
       intent: 'ctrl-c'
     })
+  })
+
+  it('drops the matching enhanced Ctrl+C key-up after sending the interrupt byte', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5u')
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5:3u')
+    await flushAsyncTicks()
+
+    expect(transport.sendInputAccepted).toHaveBeenCalledTimes(1)
+    expect(transport.sendInputAccepted).toHaveBeenCalledWith('\x03')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5:3u')
+  })
+
+  it('drops an enhanced Ctrl+C key-up that arrives before the press sequence', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5:3u')
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5u')
+    await flushAsyncTicks()
+
+    expect(transport.sendInputAccepted).toHaveBeenCalledTimes(1)
+    expect(transport.sendInputAccepted).toHaveBeenCalledWith('\x03')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5:3u')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5u')
+  })
+
+  it('normalizes combined enhanced Ctrl+C press and release input to one interrupt byte', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5:3u\x1b[99;5u')
+    await flushAsyncTicks()
+
+    expect(transport.sendInputAccepted).toHaveBeenCalledTimes(1)
+    expect(transport.sendInputAccepted).toHaveBeenCalledWith('\x03')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5:3u\x1b[99;5u')
   })
 
   it('infers interrupt for an explicit working status even if the title is already non-agent', async () => {
@@ -1086,6 +1172,38 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(transport.sendInput).toHaveBeenCalledWith('\x03')
+    expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
+  })
+
+  it('normalizes enhanced Ctrl+C input for transports that cannot acknowledge writes', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    delete transport.sendInputAccepted
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'c', ctrlKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5u')
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b[99;5:3u')
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(transport.sendInput).toHaveBeenCalledTimes(1)
+    expect(transport.sendInput).toHaveBeenCalledWith('\x03')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5u')
+    expect(transport.sendInput).not.toHaveBeenCalledWith('\x1b[99;5:3u')
     expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -64,6 +64,10 @@ const AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS = 250
 const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1000
 const AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS = 10_000
 const HIDDEN_TERMINAL_METADATA_FLUSH_MS = 100
+type CtrlCKeyProtocolInput = {
+  hasPressOrRepeat: boolean
+  hasRelease: boolean
+}
 let codexRestartNoticePresenceSource: Record<
   string,
   { previousAccountLabel: string; nextAccountLabel: string }
@@ -94,6 +98,48 @@ function recordPtyConnectDiagnostic(message: string): void {
   if (diag.length > PTY_CONNECT_DIAG_LIMIT) {
     diag.splice(0, diag.length - PTY_CONNECT_DIAG_LIMIT)
   }
+}
+
+function parseCtrlCKeyProtocolInput(data: string): CtrlCKeyProtocolInput | null {
+  let offset = 0
+  let hasPressOrRepeat = false
+  let hasRelease = false
+
+  while (offset < data.length) {
+    if (!data.startsWith('\x1b[99;5', offset)) {
+      return null
+    }
+    offset += '\x1b[99;5'.length
+    let eventType = '1'
+    if (data[offset] === ':') {
+      const next = data[offset + 1]
+      if (next !== '1' && next !== '2' && next !== '3') {
+        return null
+      }
+      eventType = next
+      offset += 2
+    }
+    if (data[offset] !== 'u') {
+      return null
+    }
+    offset += 1
+    if (eventType === '3') {
+      hasRelease = true
+    } else {
+      hasPressOrRepeat = true
+    }
+  }
+
+  return hasPressOrRepeat || hasRelease ? { hasPressOrRepeat, hasRelease } : null
+}
+
+function normalizeInputForInterruptIntent(intent: AgentInterruptInputIntent, data: string): string {
+  if (intent !== 'ctrl-c') {
+    return data
+  }
+  // Why: Codex enables kitty keyboard release reporting, and xterm then emits
+  // CSI-u for Ctrl+C. Shells echo those bytes if the mode leaks past the TUI.
+  return parseCtrlCKeyProtocolInput(data)?.hasPressOrRepeat ? '\x03' : data
 }
 
 // Why: when multiple panes/tabs need the same deferred SSH connection,
@@ -385,6 +431,10 @@ export function connectPanePty(
   }
   const inferIntentFromExactTerminalInput = (data: string): AgentInterruptInputIntent | null => {
     if (data === '\x03') {
+      return 'ctrl-c'
+    }
+    const ctrlCProtocolInput = parseCtrlCKeyProtocolInput(data)
+    if (ctrlCProtocolInput?.hasPressOrRepeat) {
       return 'ctrl-c'
     }
     if (data === '\x1b') {
@@ -982,6 +1032,12 @@ export function connectPanePty(
       // normal cursor visibility when commands intentionally produce no echo.
       suppressTerminalCursorUntilOutputSettles(pane.terminal)
     }
+    const ctrlCProtocolInput = parseCtrlCKeyProtocolInput(data)
+    if (ctrlCProtocolInput?.hasRelease && !ctrlCProtocolInput.hasPressOrRepeat) {
+      // Why: Ctrl+C key-up reports are protocol bookkeeping; forwarding them
+      // after the press leaks CSI-u text into shells and exited TUIs.
+      return
+    }
     const intent = pendingTerminalInputIntent
     // Why: real xterm can deliver the terminal byte even when our DOM keydown
     // listener missed the press. Exact Ctrl+C/Escape bytes are still safe to
@@ -990,8 +1046,9 @@ export function connectPanePty(
     const acknowledgedIntent = intent ?? inferIntentFromExactTerminalInput(data)
     if (acknowledgedIntent && transport.sendInputAccepted) {
       clearPendingTerminalInputIntent()
+      const inputData = normalizeInputForInterruptIntent(acknowledgedIntent, data)
       const writePromise = transport
-        .sendInputAccepted(data)
+        .sendInputAccepted(inputData)
         .then((accepted) => {
           if (accepted) {
             interruptInference.observeInputIntent(acknowledgedIntent)
@@ -1005,7 +1062,8 @@ export function connectPanePty(
       return
     }
     if (intent) {
-      transport.sendInput(data)
+      const inputData = normalizeInputForInterruptIntent(intent, data)
+      transport.sendInput(inputData)
       clearPendingTerminalInputIntent()
       return
     }


### PR DESCRIPTION
## Summary
- Normalize Ctrl+C CSI-u press/repeat packets to ETX so Codex/agent terminals interrupt instead of echoing protocol text.
- Drop release-only Ctrl+C CSI-u packets before transport writes, including the screenshot-style release-before-press ordering.
- Add focused terminal connection coverage for press, release, combined packets, and transports without write acknowledgements.

## Tests
- `pnpm test src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Evidence
- Electron dev app was driven through CDP with kitty keyboard mode enabled; the terminal buffer showed `^C` after Ctrl+C and no leaked `99;5` CSI-u text.
- A final clean-profile Electron recreation was attempted, but the worker became stuck reconstructing workspace state; the PR is based on the passing final code-level checks plus the earlier live buffer evidence.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.