### PR TITLE
Add onboarding tour retention telemetry

### DIFF
--- a/src/main/ipc/telemetry.test.ts
+++ b/src/main/ipc/telemetry.test.ts
@@ -221,9 +221,10 @@ describe('telemetry IPC handlers', () => {
     registerWith({ installId: 'x', existedBeforeTelemetryRelease: false, optedIn: true })
     getOnboardingCohortAtEmitMock.mockReturnValue({ cohort: 'fresh_install' })
     const handler = handlers.get('telemetry:track')!
-    handler({}, 'onboarding_step_viewed', { step: 1 })
+    handler({}, 'onboarding_step_viewed', { step: 1, value_kind: 'agent' })
     expect(trackMock).toHaveBeenCalledWith('onboarding_step_viewed', {
       step: 1,
+      value_kind: 'agent',
       cohort: 'fresh_install'
     })
   })

--- a/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
@@ -11,6 +11,7 @@ import { getAgentsSteps, type AgentsStepId } from '../../../../shared/agents-orc
 import { getWorkbenchSteps, type WorkbenchStepId } from '../../../../shared/workbench-steps'
 import { getReviewSteps, type ReviewStepId } from '../../../../shared/review-steps'
 import type { FeatureWallOpenSourceTelemetry } from '../../../../shared/telemetry-events'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
 import { track } from '@/lib/telemetry'
 import { useAppStore } from '@/store'
 import { usePrefersReducedMotion } from './feature-wall-modal-helpers'
@@ -32,7 +33,7 @@ const IS_MAC_PLATFORM = typeof navigator !== 'undefined' && navigator.userAgent.
 type FeatureWallTourSurfaceProps = {
   isOpen: boolean
   source: FeatureWallOpenSourceTelemetry
-  onDone: () => void | Promise<void>
+  onDone: (markSuccessfulExit?: () => void) => boolean | void | Promise<boolean | void>
   className?: string
   panelClassName?: string
   doneLabel?: string
@@ -40,6 +41,7 @@ type FeatureWallTourSurfaceProps = {
   enableKeyboardShortcut?: boolean
   compactRail?: boolean
   detachedFooter?: boolean
+  onTourDepthSummaryChange?: (summary: FeatureWallTourDepthSummary) => void
 }
 
 export function FeatureWallTourSurface({
@@ -52,7 +54,8 @@ export function FeatureWallTourSurface({
   footerText = 'Reopen any time from Help > Explore Orca.',
   enableKeyboardShortcut = true,
   compactRail = false,
-  detachedFooter = false
+  detachedFooter = false,
+  onTourDepthSummaryChange
 }: FeatureWallTourSurfaceProps): JSX.Element | null {
   const settings = useAppStore((s) => s.settings)
   const updateSettings = useAppStore((s) => s.updateSettings)
@@ -64,7 +67,6 @@ export function FeatureWallTourSurface({
     DEFAULT_FEATURE_WALL_WORKFLOW_ID
   )
   const railRefs = useRef<(HTMLButtonElement | null)[]>([])
-  useFeatureWallTourTelemetry(isOpen, source)
 
   const selectedIndex = useMemo(
     () =>
@@ -96,8 +98,14 @@ export function FeatureWallTourSurface({
     taskSourcePresentation.hasConnectedTaskSource,
     taskSourcePresentation.isCheckingTaskSources,
     orchestrationSkillInstalled,
-    browserUseSkillInstalled
+    browserUseSkillInstalled,
+    { onTourDepthSummaryChange }
   )
+  const { markExitAction } = useFeatureWallTourTelemetry({
+    isOpen,
+    source,
+    getDepthSummary: completion.getTourDepthSummary
+  })
 
   useEffect(() => {
     if (!agentsSteps.some((s) => s.id === agentsStepId)) {
@@ -295,7 +303,21 @@ export function FeatureWallTourSurface({
       }
     }
     if (isLastWorkflow) {
-      void onDone()
+      const exitAction = source === 'onboarding' ? 'onboarding_continue' : 'done'
+      let markedSuccessfulExit = false
+      const markSuccessfulExit = (): void => {
+        if (markedSuccessfulExit) {
+          return
+        }
+        markedSuccessfulExit = true
+        markExitAction(exitAction)
+      }
+      const doneResult = onDone(markSuccessfulExit)
+      if (doneResult instanceof Promise) {
+        void doneResult.then((result) => result !== false && markSuccessfulExit())
+      } else if (doneResult !== false) {
+        markSuccessfulExit()
+      }
       return
     }
     const nextWorkflow = FEATURE_WALL_WORKFLOWS[selectedIndex + 1]
@@ -310,6 +332,7 @@ export function FeatureWallTourSurface({
     completion,
     handleSelect,
     isLastWorkflow,
+    markExitAction,
     markWorkflowVisited,
     onDone,
     reviewStepId,
@@ -317,6 +340,7 @@ export function FeatureWallTourSurface({
     reviewSteps,
     selected.id,
     selectedIndex,
+    source,
     workbenchStepId,
     workbenchStepIndex,
     workbenchSteps

--- a/src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
@@ -3,6 +3,7 @@ import type { FeatureWallWorkflowId } from '../../../../shared/feature-wall-work
 import type { AgentsStepId } from '../../../../shared/agents-orchestration-steps'
 import type { WorkbenchStepId } from '../../../../shared/workbench-steps'
 import type { ReviewStepId } from '../../../../shared/review-steps'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
 import {
   getCommitMessageAgentCapability,
   isCustomAgentId,
@@ -17,6 +18,7 @@ import {
 } from './feature-wall-completion-progress'
 import { hasFeatureWallUsageTracking } from './feature-wall-usage-tracking'
 import { usePersistedFeatureWallCompletion } from './use-persisted-feature-wall-completion'
+import { useFeatureWallSessionDepth } from './use-feature-wall-session-depth'
 
 export type FeatureWallCompletionState = {
   workflowDone: Record<FeatureWallWorkflowId, boolean>
@@ -28,6 +30,7 @@ export type FeatureWallCompletionState = {
   markWorkbenchStepVisited: (id: WorkbenchStepId) => void
   markReviewStepVisited: (id: ReviewStepId) => void
   refreshUsageAccountState: () => Promise<void>
+  getTourDepthSummary: () => FeatureWallTourDepthSummary
 }
 
 export function useFeatureWallCompletion(
@@ -35,8 +38,10 @@ export function useFeatureWallCompletion(
   hasConnectedTaskSource: boolean,
   isCheckingTaskSources: boolean,
   orchestrationSkillInstalled: boolean,
-  browserUseSkillInstalled: boolean
+  browserUseSkillInstalled: boolean,
+  options: { onTourDepthSummaryChange?: (summary: FeatureWallTourDepthSummary) => void } = {}
 ): FeatureWallCompletionState {
+  const { onTourDepthSummaryChange } = options
   const settings = useAppStore((s) => s.settings)
   const preflightStatus = useAppStore((s) => s.preflightStatus)
   const rateLimits = useAppStore((s) => s.rateLimits)
@@ -94,9 +99,20 @@ export function useFeatureWallCompletion(
     setHasUsageAccount(await readUsageAccountState())
   }, [readUsageAccountState])
 
-  // Pull current account state once when the modal opens, then refresh on
-  // window focus — keeps the checkmark current after a sign-in flow that
-  // happens outside the modal.
+  const sessionDepth = useFeatureWallSessionDepth({
+    isOpen,
+    hasConnectedTaskSource,
+    isCheckingTaskSources,
+    hasUsageAccount,
+    orchestrationSkillInstalled,
+    browserUseSkillInstalled,
+    githubConfigured,
+    aiCommitPrConfigured,
+    onTourDepthSummaryChange
+  })
+
+  // Pull current account state once when the modal opens, then refresh on focus
+  // after a sign-in flow that happens outside the modal.
   useEffect(() => {
     if (isOpen) {
       void fetchRateLimits()
@@ -231,15 +247,53 @@ export function useFeatureWallCompletion(
     ]
   )
 
+  const {
+    markWorkflowVisitedForSession: markSessionWorkflowVisited,
+    markAgentStepVisitedForSession: markSessionAgentStepVisited,
+    markWorkbenchStepVisitedForSession: markSessionWorkbenchStepVisited,
+    markReviewStepVisitedForSession: markSessionReviewStepVisited,
+    getTourDepthSummary
+  } = sessionDepth
+
+  const markWorkflowVisitedForSession = useCallback(
+    (id: FeatureWallWorkflowId): void => {
+      markWorkflowVisited(id)
+      markSessionWorkflowVisited(id)
+    },
+    [markSessionWorkflowVisited, markWorkflowVisited]
+  )
+  const markAgentStepVisitedForSession = useCallback(
+    (id: AgentsStepId): void => {
+      markAgentStepVisited(id)
+      markSessionAgentStepVisited(id)
+    },
+    [markAgentStepVisited, markSessionAgentStepVisited]
+  )
+  const markWorkbenchStepVisitedForSession = useCallback(
+    (id: WorkbenchStepId): void => {
+      markWorkbenchStepVisited(id)
+      markSessionWorkbenchStepVisited(id)
+    },
+    [markSessionWorkbenchStepVisited, markWorkbenchStepVisited]
+  )
+  const markReviewStepVisitedForSession = useCallback(
+    (id: ReviewStepId): void => {
+      markReviewStepVisited(id)
+      markSessionReviewStepVisited(id)
+    },
+    [markReviewStepVisited, markSessionReviewStepVisited]
+  )
+
   return {
     workflowDone,
     agentStepDone,
     workbenchStepDone,
     reviewStepDone,
-    markWorkflowVisited,
-    markAgentStepVisited,
-    markWorkbenchStepVisited,
-    markReviewStepVisited,
-    refreshUsageAccountState
+    markWorkflowVisited: markWorkflowVisitedForSession,
+    markAgentStepVisited: markAgentStepVisitedForSession,
+    markWorkbenchStepVisited: markWorkbenchStepVisitedForSession,
+    markReviewStepVisited: markReviewStepVisitedForSession,
+    refreshUsageAccountState,
+    getTourDepthSummary
   }
 }

--- a/src/renderer/src/components/feature-wall/use-feature-wall-session-depth.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-session-depth.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { AgentsStepId } from '../../../../shared/agents-orchestration-steps'
+import type { FeatureWallWorkflowId } from '../../../../shared/feature-wall-workflows'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
+import { buildFeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
+import type { ReviewStepId } from '../../../../shared/review-steps'
+import type { WorkbenchStepId } from '../../../../shared/workbench-steps'
+import { getFeatureWallCompletionProgress } from './feature-wall-completion-progress'
+
+type FeatureWallSessionDepthInput = {
+  isOpen: boolean
+  hasConnectedTaskSource: boolean
+  isCheckingTaskSources: boolean
+  hasUsageAccount: boolean
+  orchestrationSkillInstalled: boolean
+  browserUseSkillInstalled: boolean
+  githubConfigured: boolean
+  aiCommitPrConfigured: boolean
+  onTourDepthSummaryChange?: (summary: FeatureWallTourDepthSummary) => void
+}
+
+export type FeatureWallSessionDepthTracker = {
+  markWorkflowVisitedForSession: (id: FeatureWallWorkflowId) => void
+  markAgentStepVisitedForSession: (id: AgentsStepId) => void
+  markWorkbenchStepVisitedForSession: (id: WorkbenchStepId) => void
+  markReviewStepVisitedForSession: (id: ReviewStepId) => void
+  getTourDepthSummary: () => FeatureWallTourDepthSummary
+}
+
+export function useFeatureWallSessionDepth(
+  input: FeatureWallSessionDepthInput
+): FeatureWallSessionDepthTracker {
+  const {
+    isOpen,
+    hasConnectedTaskSource,
+    isCheckingTaskSources,
+    hasUsageAccount,
+    orchestrationSkillInstalled,
+    browserUseSkillInstalled,
+    githubConfigured,
+    aiCommitPrConfigured,
+    onTourDepthSummaryChange
+  } = input
+  const sessionDepthRef = useRef<{
+    visitedWorkflows: Set<FeatureWallWorkflowId>
+    visitedAgentSteps: Set<AgentsStepId>
+    visitedWorkbenchSteps: Set<WorkbenchStepId>
+    visitedReviewSteps: Set<ReviewStepId>
+    lastGroupId: FeatureWallWorkflowId | null
+  }>({
+    visitedWorkflows: new Set(),
+    visitedAgentSteps: new Set(),
+    visitedWorkbenchSteps: new Set(),
+    visitedReviewSteps: new Set(),
+    lastGroupId: null
+  })
+
+  const getTourDepthSummary = useCallback((): FeatureWallTourDepthSummary => {
+    const session = sessionDepthRef.current
+    const progress = getFeatureWallCompletionProgress({
+      visitedWorkflows: session.visitedWorkflows,
+      visitedAgentSteps: session.visitedAgentSteps,
+      visitedWorkbenchSteps: session.visitedWorkbenchSteps,
+      visitedReviewSteps: session.visitedReviewSteps,
+      hasConnectedTaskSource,
+      isCheckingTaskSources,
+      hasUsageAccount,
+      orchestrationSkillInstalled,
+      browserUseSkillInstalled,
+      githubConfigured,
+      aiCommitPrConfigured
+    })
+    return buildFeatureWallTourDepthSummary({
+      ...progress,
+      visitedWorkflows: session.visitedWorkflows,
+      visitedAgentSteps: session.visitedAgentSteps,
+      visitedWorkbenchSteps: session.visitedWorkbenchSteps,
+      visitedReviewSteps: session.visitedReviewSteps,
+      lastGroupId: session.lastGroupId
+    })
+  }, [
+    aiCommitPrConfigured,
+    browserUseSkillInstalled,
+    githubConfigured,
+    hasConnectedTaskSource,
+    hasUsageAccount,
+    isCheckingTaskSources,
+    orchestrationSkillInstalled
+  ])
+
+  const publishTourDepthSummary = useCallback((): void => {
+    onTourDepthSummaryChange?.(getTourDepthSummary())
+  }, [getTourDepthSummary, onTourDepthSummaryChange])
+
+  const wasOpenRef = useRef(false)
+  useEffect(() => {
+    const openedNow = isOpen && !wasOpenRef.current
+    wasOpenRef.current = isOpen
+    if (!openedNow) {
+      return
+    }
+    // Why: depth telemetry is per explicit tour session; persisted completion
+    // can color the UI but must not leak into current-session depth fields.
+    sessionDepthRef.current = {
+      visitedWorkflows: new Set(),
+      visitedAgentSteps: new Set(),
+      visitedWorkbenchSteps: new Set(),
+      visitedReviewSteps: new Set(),
+      lastGroupId: null
+    }
+    publishTourDepthSummary()
+  }, [isOpen, publishTourDepthSummary])
+
+  useEffect(() => {
+    if (isOpen) {
+      publishTourDepthSummary()
+    }
+  }, [isOpen, publishTourDepthSummary])
+
+  const markWorkflowVisitedForSession = useCallback(
+    (id: FeatureWallWorkflowId): void => {
+      const session = sessionDepthRef.current
+      session.lastGroupId = id
+      session.visitedWorkflows.add(id)
+      publishTourDepthSummary()
+    },
+    [publishTourDepthSummary]
+  )
+  const markAgentStepVisitedForSession = useCallback(
+    (id: AgentsStepId): void => {
+      sessionDepthRef.current.visitedAgentSteps.add(id)
+      publishTourDepthSummary()
+    },
+    [publishTourDepthSummary]
+  )
+  const markWorkbenchStepVisitedForSession = useCallback(
+    (id: WorkbenchStepId): void => {
+      sessionDepthRef.current.visitedWorkbenchSteps.add(id)
+      publishTourDepthSummary()
+    },
+    [publishTourDepthSummary]
+  )
+  const markReviewStepVisitedForSession = useCallback(
+    (id: ReviewStepId): void => {
+      sessionDepthRef.current.visitedReviewSteps.add(id)
+      publishTourDepthSummary()
+    },
+    [publishTourDepthSummary]
+  )
+
+  return {
+    markWorkflowVisitedForSession,
+    markAgentStepVisitedForSession,
+    markWorkbenchStepVisitedForSession,
+    markReviewStepVisitedForSession,
+    getTourDepthSummary
+  }
+}

--- a/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildFeatureWallClosedTelemetry,
+  createFeatureWallTourTelemetryState,
+  markFeatureWallTourExitAction,
+  openFeatureWallTourTelemetrySession
+} from './use-feature-wall-tour-telemetry'
+
+describe('feature wall tour close telemetry session', () => {
+  it('emits one close summary for one explicit open', () => {
+    const state = createFeatureWallTourTelemetryState()
+    const opened = openFeatureWallTourTelemetrySession(state, 100)
+    markFeatureWallTourExitAction(state, 'done')
+
+    expect(opened).toBe(true)
+    expect(
+      buildFeatureWallClosedTelemetry(state, 350, 'help_menu', {
+        furthest_step: 'agents_usage',
+        last_group_id: 'agents-orchestration',
+        visited_workflow_count: 3,
+        visited_substep_count: 2,
+        completed_workflow_count: 1,
+        completed_substep_count: 1
+      })
+    ).toEqual({
+      dwell_ms: 250,
+      source: 'help_menu',
+      exit_action: 'done',
+      furthest_step: 'agents_usage',
+      last_group_id: 'agents-orchestration',
+      visited_workflow_count: 3,
+      visited_substep_count: 2,
+      completed_workflow_count: 1,
+      completed_substep_count: 1
+    })
+    expect(
+      buildFeatureWallClosedTelemetry(state, 375, 'help_menu', {
+        visited_workflow_count: 0,
+        visited_substep_count: 0,
+        completed_workflow_count: 0,
+        completed_substep_count: 0
+      })
+    ).toBeNull()
+  })
+
+  it('ignores duplicate opens until the current session closes', () => {
+    const state = createFeatureWallTourTelemetryState()
+
+    expect(openFeatureWallTourTelemetrySession(state, 100)).toBe(true)
+    expect(openFeatureWallTourTelemetrySession(state, 150)).toBe(false)
+    expect(
+      buildFeatureWallClosedTelemetry(state, 200, 'onboarding', {
+        visited_workflow_count: 1,
+        visited_substep_count: 0,
+        completed_workflow_count: 1,
+        completed_substep_count: 0
+      })
+    ).toMatchObject({ dwell_ms: 100, source: 'onboarding' })
+  })
+})

--- a/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
@@ -1,32 +1,106 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { FEATURE_WALL_MAX_DWELL_MS } from '../../../../shared/feature-wall-telemetry'
-import type { FeatureWallOpenSourceTelemetry } from '../../../../shared/telemetry-events'
+import type { FeatureWallExitAction } from '../../../../shared/feature-wall-tour-depth'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
+import type {
+  EventProps,
+  FeatureWallOpenSourceTelemetry
+} from '../../../../shared/telemetry-events'
 import { track } from '@/lib/telemetry'
 
-export function useFeatureWallTourTelemetry(
-  isOpen: boolean,
-  source: FeatureWallOpenSourceTelemetry
-): void {
-  const telemetryRef = useRef<{ open: boolean; openedAtMs: number }>({
+export type FeatureWallTourTelemetryState = {
+  open: boolean
+  openedAtMs: number
+  exitAction: FeatureWallExitAction
+}
+
+export function createFeatureWallTourTelemetryState(): FeatureWallTourTelemetryState {
+  return {
     open: false,
-    openedAtMs: 0
-  })
+    openedAtMs: 0,
+    exitAction: 'dismissed'
+  }
+}
+
+export function openFeatureWallTourTelemetrySession(
+  state: FeatureWallTourTelemetryState,
+  nowMs: number
+): boolean {
+  if (state.open) {
+    return false
+  }
+  state.open = true
+  state.openedAtMs = nowMs
+  state.exitAction = 'dismissed'
+  return true
+}
+
+export function buildFeatureWallClosedTelemetry(
+  state: FeatureWallTourTelemetryState,
+  nowMs: number,
+  source: FeatureWallOpenSourceTelemetry,
+  depthSummary: FeatureWallTourDepthSummary
+): EventProps<'feature_wall_closed'> | null {
+  if (!state.open) {
+    return null
+  }
+  const dwellMs = Math.min(
+    FEATURE_WALL_MAX_DWELL_MS,
+    Math.max(0, Math.round(nowMs - state.openedAtMs))
+  )
+  state.open = false
+  return {
+    dwell_ms: dwellMs,
+    source,
+    exit_action: state.exitAction,
+    ...(depthSummary.furthest_step ? { furthest_step: depthSummary.furthest_step } : {}),
+    ...(depthSummary.last_group_id ? { last_group_id: depthSummary.last_group_id } : {}),
+    visited_workflow_count: depthSummary.visited_workflow_count,
+    visited_substep_count: depthSummary.visited_substep_count,
+    completed_workflow_count: depthSummary.completed_workflow_count,
+    completed_substep_count: depthSummary.completed_substep_count
+  }
+}
+
+export function markFeatureWallTourExitAction(
+  state: FeatureWallTourTelemetryState,
+  exitAction: FeatureWallExitAction
+): void {
+  state.exitAction = exitAction
+}
+
+export function useFeatureWallTourTelemetry(args: {
+  isOpen: boolean
+  source: FeatureWallOpenSourceTelemetry
+  getDepthSummary: () => FeatureWallTourDepthSummary
+}): { markExitAction: (exitAction: FeatureWallExitAction) => void } {
+  const { isOpen, source, getDepthSummary } = args
+  const telemetryRef = useRef<FeatureWallTourTelemetryState>(createFeatureWallTourTelemetryState())
+  const sourceRef = useRef(source)
+  const getDepthSummaryRef = useRef(getDepthSummary)
+  useEffect(() => {
+    sourceRef.current = source
+    getDepthSummaryRef.current = getDepthSummary
+  }, [getDepthSummary, source])
 
   const emitCloseTelemetry = useCallback(() => {
-    if (!telemetryRef.current.open) {
-      return
-    }
-    const dwellMs = Math.min(
-      FEATURE_WALL_MAX_DWELL_MS,
-      Math.max(0, Math.round(performance.now() - telemetryRef.current.openedAtMs))
+    const payload = buildFeatureWallClosedTelemetry(
+      telemetryRef.current,
+      performance.now(),
+      sourceRef.current,
+      getDepthSummaryRef.current()
     )
-    track('feature_wall_closed', { dwell_ms: dwellMs })
-    telemetryRef.current.open = false
+    if (payload) {
+      track('feature_wall_closed', payload)
+    }
+  }, [])
+
+  const markExitAction = useCallback((exitAction: FeatureWallExitAction): void => {
+    markFeatureWallTourExitAction(telemetryRef.current, exitAction)
   }, [])
 
   useEffect(() => {
-    if (isOpen && !telemetryRef.current.open) {
-      telemetryRef.current = { open: true, openedAtMs: performance.now() }
+    if (isOpen && openFeatureWallTourTelemetrySession(telemetryRef.current, performance.now())) {
       track('feature_wall_opened', { source })
       return
     }
@@ -38,4 +112,6 @@ export function useFeatureWallTourTelemetry(
   useEffect(() => {
     return () => emitCloseTelemetry()
   }, [emitCloseTelemetry])
+
+  return { markExitAction }
 }

--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -263,6 +263,7 @@ export default function OnboardingFlow({
               busyLabel={busyLabel}
               onStartTour={flow.startTour}
               onCompleteTour={flow.completeTour}
+              onTourDepthSummaryChange={flow.recordTourDepthSummary}
             />
           )}
           {currentStep.id === 'repo' && (

--- a/src/renderer/src/components/onboarding/OnboardingTourStep.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingTourStep.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react'
 import { flushSync } from 'react-dom'
 import { ArrowRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
 import { FeatureTourPreview } from '../feature-wall/FeatureTourPreview'
 import { FeatureWallTourSurface } from '../feature-wall/FeatureWallTourSurface'
 import { usePrefersReducedMotion } from '../feature-wall/feature-wall-modal-helpers'
@@ -10,7 +11,8 @@ type OnboardingTourStepProps = {
   tourStarted: boolean
   busyLabel: string | null
   onStartTour: () => void
-  onCompleteTour: () => void | Promise<void>
+  onCompleteTour: (markSuccessfulExit?: () => void) => boolean | void | Promise<boolean | void>
+  onTourDepthSummaryChange: (summary: FeatureWallTourDepthSummary) => void
 }
 
 type ViewTransition = {
@@ -25,7 +27,8 @@ export function OnboardingTourStep({
   tourStarted,
   busyLabel,
   onStartTour,
-  onCompleteTour
+  onCompleteTour,
+  onTourDepthSummaryChange
 }: OnboardingTourStepProps): JSX.Element {
   const prefersReducedMotion = usePrefersReducedMotion()
 
@@ -70,6 +73,7 @@ export function OnboardingTourStep({
         footerText={null}
         compactRail
         detachedFooter
+        onTourDepthSummaryChange={onTourDepthSummaryChange}
         className="h-full max-h-[790px] min-h-0"
         panelClassName="rounded-xl border border-border bg-card"
       />

--- a/src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createOnboardingTourOutcomeTracker,
+  markOnboardingTourIntroReached,
+  markOnboardingTourStarted,
+  recordOnboardingTourDepthSummary,
+  resolveOnboardingTourOutcome,
+  resolvePendingOnboardingTourOutcome
+} from './onboarding-tour-outcome-tracker'
+
+const depthSummary = {
+  furthest_step: 'review_ship',
+  last_group_id: 'review',
+  visited_workflow_count: 5,
+  visited_substep_count: 9,
+  completed_workflow_count: 4,
+  completed_substep_count: 7
+} as const
+
+describe('onboarding tour outcome tracker', () => {
+  it('emits one skipped outcome for one intro skip', () => {
+    const tracker = createOnboardingTourOutcomeTracker()
+    markOnboardingTourIntroReached(tracker, 100)
+
+    expect(resolveOnboardingTourOutcome(tracker, 'skipped_intro', 250, 'button')).toEqual({
+      outcome: 'skipped_intro',
+      intro_duration_ms: 150,
+      advanced_via: 'button'
+    })
+    expect(resolveOnboardingTourOutcome(tracker, 'skipped_intro', 260, 'button')).toBeNull()
+  })
+
+  it('emits one completed outcome with inline tour depth', () => {
+    const tracker = createOnboardingTourOutcomeTracker()
+    markOnboardingTourIntroReached(tracker, 100)
+    markOnboardingTourStarted(tracker, 175)
+    recordOnboardingTourDepthSummary(tracker, depthSummary)
+
+    expect(resolveOnboardingTourOutcome(tracker, 'completed_inline', 575, 'button')).toEqual({
+      outcome: 'completed_inline',
+      intro_duration_ms: 75,
+      tour_dwell_ms: 400,
+      furthest_step: 'review_ship',
+      visited_workflow_count: 5,
+      visited_substep_count: 9,
+      completed_workflow_count: 4,
+      completed_substep_count: 7,
+      advanced_via: 'button'
+    })
+    expect(resolvePendingOnboardingTourOutcome(tracker, 600)).toBeNull()
+  })
+
+  it('does not resolve a back or step jump partial before session resolution', () => {
+    const tracker = createOnboardingTourOutcomeTracker()
+    markOnboardingTourIntroReached(tracker, 100)
+    markOnboardingTourStarted(tracker, 125)
+
+    expect(tracker.startedInline).toBe(true)
+    recordOnboardingTourDepthSummary(tracker, {
+      visited_workflow_count: 1,
+      visited_substep_count: 0,
+      completed_workflow_count: 1,
+      completed_substep_count: 0
+    })
+    expect(resolveOnboardingTourOutcome(tracker, 'completed_inline', 225, 'button')).toMatchObject({
+      outcome: 'completed_inline'
+    })
+    expect(resolvePendingOnboardingTourOutcome(tracker, 250)).toBeNull()
+  })
+
+  it('classifies a started tour as partial even if the final action is skip', () => {
+    const tracker = createOnboardingTourOutcomeTracker()
+    markOnboardingTourIntroReached(tracker, 100)
+    markOnboardingTourStarted(tracker, 150)
+    recordOnboardingTourDepthSummary(tracker, {
+      furthest_step: 'tasks',
+      last_group_id: 'tasks',
+      visited_workflow_count: 2,
+      visited_substep_count: 0,
+      completed_workflow_count: 1,
+      completed_substep_count: 0
+    })
+
+    expect(resolveOnboardingTourOutcome(tracker, 'skipped_intro', 400, 'button')).toEqual({
+      outcome: 'started_partial',
+      intro_duration_ms: 50,
+      tour_dwell_ms: 250,
+      furthest_step: 'tasks',
+      visited_workflow_count: 2,
+      visited_substep_count: 0,
+      completed_workflow_count: 1,
+      completed_substep_count: 0,
+      advanced_via: 'button'
+    })
+  })
+
+  it('emits at most one pending partial on session close or unmount', () => {
+    const tracker = createOnboardingTourOutcomeTracker()
+    markOnboardingTourIntroReached(tracker, 100)
+    markOnboardingTourStarted(tracker, 150)
+    recordOnboardingTourDepthSummary(tracker, {
+      furthest_step: 'workbench_editor',
+      last_group_id: 'workbench',
+      visited_workflow_count: 1,
+      visited_substep_count: 2,
+      completed_workflow_count: 0,
+      completed_substep_count: 2
+    })
+
+    expect(resolvePendingOnboardingTourOutcome(tracker, 450)).toEqual({
+      outcome: 'started_partial',
+      intro_duration_ms: 50,
+      tour_dwell_ms: 300,
+      furthest_step: 'workbench_editor',
+      visited_workflow_count: 1,
+      visited_substep_count: 2,
+      completed_workflow_count: 0,
+      completed_substep_count: 2
+    })
+    expect(resolvePendingOnboardingTourOutcome(tracker, 475)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.ts
+++ b/src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.ts
@@ -1,0 +1,122 @@
+import { FEATURE_WALL_MAX_DWELL_MS } from '../../../../shared/feature-wall-telemetry'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
+import type { EventProps } from '../../../../shared/telemetry-events'
+
+type OnboardingTourOutcome = EventProps<'onboarding_tour_outcome'>['outcome']
+type OnboardingTourOutcomePayload = EventProps<'onboarding_tour_outcome'>
+
+export type OnboardingTourOutcomeTracker = {
+  reachedIntro: boolean
+  startedInline: boolean
+  completedInline: boolean
+  emitted: boolean
+  introStartedAtMs: number | null
+  introDurationMs: number | null
+  tourStartedAtMs: number | null
+  latestDepthSummary: FeatureWallTourDepthSummary | null
+}
+
+export function createOnboardingTourOutcomeTracker(): OnboardingTourOutcomeTracker {
+  return {
+    reachedIntro: false,
+    startedInline: false,
+    completedInline: false,
+    emitted: false,
+    introStartedAtMs: null,
+    introDurationMs: null,
+    tourStartedAtMs: null,
+    latestDepthSummary: null
+  }
+}
+
+function boundedDurationMs(startedAtMs: number | null, nowMs: number): number | undefined {
+  if (startedAtMs === null) {
+    return undefined
+  }
+  return Math.min(FEATURE_WALL_MAX_DWELL_MS, Math.max(0, Math.round(nowMs - startedAtMs)))
+}
+
+export function markOnboardingTourIntroReached(
+  tracker: OnboardingTourOutcomeTracker,
+  nowMs: number
+): void {
+  if (tracker.reachedIntro) {
+    return
+  }
+  tracker.reachedIntro = true
+  tracker.introStartedAtMs = nowMs
+}
+
+export function markOnboardingTourStarted(
+  tracker: OnboardingTourOutcomeTracker,
+  nowMs: number
+): void {
+  if (!tracker.reachedIntro) {
+    markOnboardingTourIntroReached(tracker, nowMs)
+  }
+  tracker.startedInline = true
+  tracker.introDurationMs = boundedDurationMs(tracker.introStartedAtMs, nowMs) ?? 0
+  tracker.tourStartedAtMs = nowMs
+}
+
+export function recordOnboardingTourDepthSummary(
+  tracker: OnboardingTourOutcomeTracker,
+  summary: FeatureWallTourDepthSummary
+): void {
+  tracker.latestDepthSummary = summary
+}
+
+export function resolveOnboardingTourOutcome(
+  tracker: OnboardingTourOutcomeTracker,
+  outcome: OnboardingTourOutcome,
+  nowMs: number,
+  advancedVia?: NonNullable<OnboardingTourOutcomePayload['advanced_via']>
+): OnboardingTourOutcomePayload | null {
+  if (!tracker.reachedIntro || tracker.emitted) {
+    return null
+  }
+  const resolvedOutcome =
+    tracker.completedInline || outcome === 'completed_inline'
+      ? 'completed_inline'
+      : tracker.startedInline
+        ? 'started_partial'
+        : outcome
+  const introDurationMs =
+    tracker.introDurationMs ?? boundedDurationMs(tracker.introStartedAtMs, nowMs)
+  const depthSummary = resolvedOutcome === 'skipped_intro' ? null : tracker.latestDepthSummary
+  const tourDwellMs =
+    resolvedOutcome === 'skipped_intro'
+      ? undefined
+      : boundedDurationMs(tracker.tourStartedAtMs, nowMs)
+
+  tracker.emitted = true
+  if (resolvedOutcome === 'completed_inline') {
+    tracker.completedInline = true
+  }
+
+  return {
+    outcome: resolvedOutcome,
+    ...(introDurationMs !== undefined ? { intro_duration_ms: introDurationMs } : {}),
+    ...(tourDwellMs !== undefined ? { tour_dwell_ms: tourDwellMs } : {}),
+    ...(depthSummary
+      ? {
+          ...(depthSummary.furthest_step ? { furthest_step: depthSummary.furthest_step } : {}),
+          visited_workflow_count: depthSummary.visited_workflow_count,
+          visited_substep_count: depthSummary.visited_substep_count,
+          completed_workflow_count: depthSummary.completed_workflow_count,
+          completed_substep_count: depthSummary.completed_substep_count
+        }
+      : {}),
+    ...(advancedVia ? { advanced_via: advancedVia } : {})
+  }
+}
+
+export function resolvePendingOnboardingTourOutcome(
+  tracker: OnboardingTourOutcomeTracker,
+  nowMs: number
+): OnboardingTourOutcomePayload | null {
+  if (!tracker.startedInline || tracker.completedInline) {
+    return null
+  }
+  return resolveOnboardingTourOutcome(tracker, 'started_partial', nowMs)
+}

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -8,6 +8,7 @@ import { applyDocumentTheme } from '@/lib/document-theme'
 import { track } from '@/lib/telemetry'
 import { buildAgentPickedPayload } from './agent-picked-payload'
 import { ONBOARDING_FINAL_STEP } from '../../../../shared/constants'
+import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type { EventProps } from '../../../../shared/telemetry-events'
 import type { GlobalSettings, OnboardingState, Repo, TuiAgent } from '../../../../shared/types'
@@ -19,6 +20,14 @@ import {
   type OnboardingFeatureSetupSelection
 } from './onboarding-feature-setup'
 import { STEPS, type StepNumber } from './use-onboarding-flow-types'
+import {
+  createOnboardingTourOutcomeTracker,
+  markOnboardingTourIntroReached,
+  markOnboardingTourStarted,
+  recordOnboardingTourDepthSummary,
+  resolveOnboardingTourOutcome,
+  resolvePendingOnboardingTourOutcome
+} from './onboarding-tour-outcome-tracker'
 import { persistStep, useCloseWith, usePersistCurrentStep } from './use-onboarding-flow-persistence'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { buildOnboardingFolderAgentStartup } from '@/lib/onboarding-folder-agent-startup'
@@ -105,6 +114,7 @@ export function useOnboardingFlow(
   const [tourStarted, setTourStarted] = useState(false)
   const [busyLabel, setBusyLabel] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const tourOutcomeTrackerRef = useRef(createOnboardingTourOutcomeTracker())
 
   // Why: settings load async; the lazy useState initializers above run before
   // settings hydrates. Re-sync once when settings transitions to non-null,
@@ -269,12 +279,53 @@ export function useOnboardingFlow(
   const stepStartedAtRef = useRef<number>(Date.now())
   useEffect(() => {
     stepStartedAtRef.current = Date.now()
-    track('onboarding_step_viewed', { step: currentStep.stepNumber })
-  }, [currentStep.stepNumber])
+    track('onboarding_step_viewed', {
+      step: currentStep.stepNumber,
+      value_kind: currentStep.valueKind
+    })
+    if (currentStep.id === 'tour') {
+      markOnboardingTourIntroReached(tourOutcomeTrackerRef.current, stepStartedAtRef.current)
+    }
+  }, [currentStep.id, currentStep.stepNumber, currentStep.valueKind])
 
   const consumeStepDurationMs = useCallback((): number => {
     return Math.max(0, Date.now() - stepStartedAtRef.current)
   }, [])
+
+  const emitTourOutcome = useCallback(
+    (
+      outcome: EventProps<'onboarding_tour_outcome'>['outcome'],
+      advancedVia?: NonNullable<EventProps<'onboarding_tour_outcome'>['advanced_via']>
+    ): void => {
+      const payload = resolveOnboardingTourOutcome(
+        tourOutcomeTrackerRef.current,
+        outcome,
+        Date.now(),
+        advancedVia
+      )
+      if (payload) {
+        track('onboarding_tour_outcome', payload)
+      }
+    },
+    []
+  )
+
+  const emitPendingTourOutcome = useCallback((): void => {
+    const payload = resolvePendingOnboardingTourOutcome(tourOutcomeTrackerRef.current, Date.now())
+    if (payload) {
+      track('onboarding_tour_outcome', payload)
+    }
+  }, [])
+
+  const recordTourDepthSummary = useCallback((summary: FeatureWallTourDepthSummary): void => {
+    recordOnboardingTourDepthSummary(tourOutcomeTrackerRef.current, summary)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      emitPendingTourOutcome()
+    }
+  }, [emitPendingTourOutcome])
 
   const trackTaskSourcesSnapshot = useCallback(
     (
@@ -346,6 +397,7 @@ export function useOnboardingFlow(
       if (!closed) {
         return
       }
+      emitPendingTourOutcome()
       // Why: the repo step has no keyboard-vs-button advance — Cmd+Enter
       // routes to `openFolder()` which collapses both into the path-clicked
       // path. Emit `duration_ms` only; `advanced_via` is intentionally absent
@@ -363,7 +415,15 @@ export function useOnboardingFlow(
         })
       }
     },
-    [closeWith, consumeStepDurationMs, fetchRepos, fetchWorktrees, openModal, settings]
+    [
+      closeWith,
+      consumeStepDurationMs,
+      emitPendingTourOutcome,
+      fetchRepos,
+      fetchWorktrees,
+      openModal,
+      settings
+    ]
   )
 
   const persistCurrentStep = usePersistCurrentStep({
@@ -607,6 +667,7 @@ export function useOnboardingFlow(
       // because Orca needs a project before the app has a useful first state.
       track('onboarding_step_skipped', {
         step: currentStep.stepNumber,
+        value_kind: currentStep.valueKind,
         duration_ms: durationMs,
         advanced_via: 'button'
       })
@@ -625,6 +686,7 @@ export function useOnboardingFlow(
     consumeStepDurationMs,
     currentStep.id,
     currentStep.stepNumber,
+    currentStep.valueKind,
     onOnboardingChange,
     selectedAgent,
     settings,
@@ -637,47 +699,56 @@ export function useOnboardingFlow(
       return
     }
     setError(null)
+    markOnboardingTourStarted(tourOutcomeTrackerRef.current, Date.now())
     setTourStarted(true)
   }, [busyLabel])
 
-  const completeTour = useCallback(async () => {
-    if (busyLabel || currentStep.id !== 'tour') {
-      return
-    }
-    setError(null)
-    const repoStepIndex = STEPS.findIndex((step) => step.id === 'repo')
-    const repoStep = STEPS[repoStepIndex]
-    if (!repoStep) {
-      return
-    }
-    const durationMs = consumeStepDurationMs()
-    setBusyLabel('Saving…')
-    try {
-      const nextState = await persistStep(repoStep.stepNumber - 1)
-      onOnboardingChange(nextState)
-      track('onboarding_step_completed', {
-        step: currentStep.stepNumber,
-        value_kind: currentStep.valueKind,
-        duration_ms: durationMs,
-        advanced_via: 'button'
-      })
-      setTourStarted(false)
-      setStepIndex(repoStepIndex)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      setError(message)
-      toast.error('Could not continue to project setup', { description: message })
-    } finally {
-      setBusyLabel(null)
-    }
-  }, [
-    busyLabel,
-    consumeStepDurationMs,
-    currentStep.id,
-    currentStep.stepNumber,
-    currentStep.valueKind,
-    onOnboardingChange
-  ])
+  const completeTour = useCallback(
+    async (markSuccessfulExit?: () => void): Promise<boolean> => {
+      if (busyLabel || currentStep.id !== 'tour') {
+        return false
+      }
+      setError(null)
+      const repoStepIndex = STEPS.findIndex((step) => step.id === 'repo')
+      const repoStep = STEPS[repoStepIndex]
+      if (!repoStep) {
+        return false
+      }
+      const durationMs = consumeStepDurationMs()
+      setBusyLabel('Saving…')
+      try {
+        const nextState = await persistStep(repoStep.stepNumber - 1)
+        onOnboardingChange(nextState)
+        track('onboarding_step_completed', {
+          step: currentStep.stepNumber,
+          value_kind: currentStep.valueKind,
+          duration_ms: durationMs,
+          advanced_via: 'button'
+        })
+        emitTourOutcome('completed_inline', 'button')
+        markSuccessfulExit?.()
+        setTourStarted(false)
+        setStepIndex(repoStepIndex)
+        return true
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        setError(message)
+        toast.error('Could not continue to project setup', { description: message })
+        return false
+      } finally {
+        setBusyLabel(null)
+      }
+    },
+    [
+      busyLabel,
+      consumeStepDurationMs,
+      emitTourOutcome,
+      currentStep.id,
+      currentStep.stepNumber,
+      currentStep.valueKind,
+      onOnboardingChange
+    ]
+  )
 
   const skipTourToRepo = useCallback(async () => {
     if (busyLabel || currentStep.id !== 'tour') {
@@ -696,9 +767,11 @@ export function useOnboardingFlow(
       onOnboardingChange(nextState)
       track('onboarding_step_skipped', {
         step: currentStep.stepNumber,
+        value_kind: currentStep.valueKind,
         duration_ms: durationMs,
         advanced_via: 'button'
       })
+      emitTourOutcome('skipped_intro', 'button')
       setTourStarted(false)
       setStepIndex(repoStepIndex)
     } catch (err) {
@@ -708,7 +781,15 @@ export function useOnboardingFlow(
     } finally {
       setBusyLabel(null)
     }
-  }, [busyLabel, consumeStepDurationMs, currentStep.id, currentStep.stepNumber, onOnboardingChange])
+  }, [
+    busyLabel,
+    consumeStepDurationMs,
+    currentStep.id,
+    currentStep.stepNumber,
+    currentStep.valueKind,
+    emitTourOutcome,
+    onOnboardingChange
+  ])
 
   const skipAgentSetup = useCallback(async () => {
     if (busyLabel || currentStep.id !== 'agentSetup') {
@@ -723,6 +804,7 @@ export function useOnboardingFlow(
       onOnboardingChange(nextState)
       track('onboarding_step_skipped', {
         step: currentStep.stepNumber,
+        value_kind: currentStep.valueKind,
         duration_ms: durationMs,
         advanced_via: 'button'
       })
@@ -734,7 +816,14 @@ export function useOnboardingFlow(
       setError(message)
       toast.error('Could not skip agent setup', { description: message })
     }
-  }, [busyLabel, consumeStepDurationMs, currentStep.id, currentStep.stepNumber, onOnboardingChange])
+  }, [
+    busyLabel,
+    consumeStepDurationMs,
+    currentStep.id,
+    currentStep.stepNumber,
+    currentStep.valueKind,
+    onOnboardingChange
+  ])
 
   const openSshSettings = useCallback(async () => {
     if (busyLabel || currentStep.id !== 'repo') {
@@ -808,6 +897,7 @@ export function useOnboardingFlow(
     startTour,
     completeTour,
     skipTourToRepo,
+    recordTourDepthSummary,
     back,
     jumpToStep,
     openFolder,

--- a/src/shared/feature-wall-tour-depth.test.ts
+++ b/src/shared/feature-wall-tour-depth.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentsStepId } from './agents-orchestration-steps'
+import type { FeatureWallWorkflowId } from './feature-wall-workflows'
+import type { ReviewStepId } from './review-steps'
+import type { WorkbenchStepId } from './workbench-steps'
+import {
+  buildFeatureWallTourDepthSummary,
+  getFeatureWallTourDepthStep
+} from './feature-wall-tour-depth'
+
+describe('feature wall tour depth summary', () => {
+  it('maps workflow and nested steps to canonical depth values', () => {
+    expect(getFeatureWallTourDepthStep({ workflowId: 'workspaces' })).toBe('workspaces')
+    expect(
+      getFeatureWallTourDepthStep({
+        workflowId: 'agents-orchestration',
+        agentStepId: 'usage'
+      })
+    ).toBe('agents_usage')
+    expect(
+      getFeatureWallTourDepthStep({ workflowId: 'workbench', workbenchStepId: 'browser' })
+    ).toBe('workbench_browser')
+    expect(getFeatureWallTourDepthStep({ workflowId: 'review', reviewStepId: 'ship' })).toBe(
+      'review_ship'
+    )
+  })
+
+  it('builds session-local counts and furthest step from visited sets', () => {
+    expect(
+      buildFeatureWallTourDepthSummary({
+        visitedWorkflows: new Set<FeatureWallWorkflowId>(['workspaces', 'workbench']),
+        visitedAgentSteps: new Set<AgentsStepId>(),
+        visitedWorkbenchSteps: new Set<WorkbenchStepId>(['terminal', 'editor']),
+        visitedReviewSteps: new Set<ReviewStepId>(),
+        workflowDone: {
+          workspaces: true,
+          tasks: false,
+          'agents-orchestration': false,
+          workbench: false,
+          review: false
+        },
+        agentStepDone: {
+          statuses: false,
+          usage: false,
+          orchestration: false
+        },
+        workbenchStepDone: {
+          terminal: true,
+          editor: true,
+          browser: false
+        },
+        reviewStepDone: {
+          notes: false,
+          'pr-view': false,
+          ship: false
+        },
+        lastGroupId: 'workbench'
+      })
+    ).toEqual({
+      furthest_step: 'workbench_editor',
+      last_group_id: 'workbench',
+      visited_workflow_count: 2,
+      visited_substep_count: 2,
+      completed_workflow_count: 1,
+      completed_substep_count: 2
+    })
+  })
+})

--- a/src/shared/feature-wall-tour-depth.ts
+++ b/src/shared/feature-wall-tour-depth.ts
@@ -1,0 +1,127 @@
+import type { AgentsStepId } from './agents-orchestration-steps'
+import type { FeatureWallWorkflowId } from './feature-wall-workflows'
+import type { ReviewStepId } from './review-steps'
+import type { WorkbenchStepId } from './workbench-steps'
+
+export const FEATURE_WALL_TOUR_DEPTH_STEPS = [
+  'workspaces',
+  'tasks',
+  'agents_statuses',
+  'agents_usage',
+  'agents_orchestration',
+  'workbench_terminal',
+  'workbench_editor',
+  'workbench_browser',
+  'review_notes',
+  'review_pr_view',
+  'review_ship'
+] as const
+
+export type FeatureWallTourDepthStep = (typeof FEATURE_WALL_TOUR_DEPTH_STEPS)[number]
+
+export const FEATURE_WALL_EXIT_ACTIONS = ['done', 'dismissed', 'onboarding_continue'] as const
+
+export type FeatureWallExitAction = (typeof FEATURE_WALL_EXIT_ACTIONS)[number]
+
+export type FeatureWallTourDepthSummary = {
+  furthest_step?: FeatureWallTourDepthStep
+  last_group_id?: FeatureWallWorkflowId
+  visited_workflow_count: number
+  visited_substep_count: number
+  completed_workflow_count: number
+  completed_substep_count: number
+}
+
+export type FeatureWallTourDepthInput = {
+  visitedWorkflows: ReadonlySet<FeatureWallWorkflowId>
+  visitedAgentSteps: ReadonlySet<AgentsStepId>
+  visitedWorkbenchSteps: ReadonlySet<WorkbenchStepId>
+  visitedReviewSteps: ReadonlySet<ReviewStepId>
+  workflowDone: Record<FeatureWallWorkflowId, boolean>
+  agentStepDone: Record<AgentsStepId, boolean>
+  workbenchStepDone: Record<WorkbenchStepId, boolean>
+  reviewStepDone: Record<ReviewStepId, boolean>
+  lastGroupId: FeatureWallWorkflowId | null
+}
+
+const DEPTH_STEP_RANK = new Map<FeatureWallTourDepthStep, number>(
+  FEATURE_WALL_TOUR_DEPTH_STEPS.map((step, index) => [step, index])
+)
+
+const AGENT_DEPTH_STEP: Record<AgentsStepId, FeatureWallTourDepthStep> = {
+  statuses: 'agents_statuses',
+  usage: 'agents_usage',
+  orchestration: 'agents_orchestration'
+}
+
+const WORKBENCH_DEPTH_STEP: Record<WorkbenchStepId, FeatureWallTourDepthStep> = {
+  terminal: 'workbench_terminal',
+  editor: 'workbench_editor',
+  browser: 'workbench_browser'
+}
+
+const REVIEW_DEPTH_STEP: Record<ReviewStepId, FeatureWallTourDepthStep> = {
+  notes: 'review_notes',
+  'pr-view': 'review_pr_view',
+  ship: 'review_ship'
+}
+
+function getFurthestDepthStep(
+  steps: Iterable<FeatureWallTourDepthStep>
+): FeatureWallTourDepthStep | undefined {
+  let furthest: FeatureWallTourDepthStep | undefined
+  let furthestRank = -1
+  for (const step of steps) {
+    const rank = DEPTH_STEP_RANK.get(step) ?? -1
+    if (rank > furthestRank) {
+      furthest = step
+      furthestRank = rank
+    }
+  }
+  return furthest
+}
+
+export function getFeatureWallTourDepthStep(input: {
+  workflowId: FeatureWallWorkflowId
+  agentStepId?: AgentsStepId
+  workbenchStepId?: WorkbenchStepId
+  reviewStepId?: ReviewStepId
+}): FeatureWallTourDepthStep {
+  if (input.workflowId === 'agents-orchestration') {
+    return AGENT_DEPTH_STEP[input.agentStepId ?? 'statuses']
+  }
+  if (input.workflowId === 'workbench') {
+    return WORKBENCH_DEPTH_STEP[input.workbenchStepId ?? 'terminal']
+  }
+  if (input.workflowId === 'review') {
+    return REVIEW_DEPTH_STEP[input.reviewStepId ?? 'notes']
+  }
+  return input.workflowId
+}
+
+export function buildFeatureWallTourDepthSummary(
+  input: FeatureWallTourDepthInput
+): FeatureWallTourDepthSummary {
+  const visitedDepthSteps = [
+    ...(input.visitedWorkflows.has('workspaces') ? (['workspaces'] as const) : []),
+    ...(input.visitedWorkflows.has('tasks') ? (['tasks'] as const) : []),
+    ...[...input.visitedAgentSteps].map((step) => AGENT_DEPTH_STEP[step]),
+    ...[...input.visitedWorkbenchSteps].map((step) => WORKBENCH_DEPTH_STEP[step]),
+    ...[...input.visitedReviewSteps].map((step) => REVIEW_DEPTH_STEP[step])
+  ]
+  const furthestStep = getFurthestDepthStep(visitedDepthSteps)
+  return {
+    ...(furthestStep ? { furthest_step: furthestStep } : {}),
+    ...(input.lastGroupId ? { last_group_id: input.lastGroupId } : {}),
+    visited_workflow_count: input.visitedWorkflows.size,
+    visited_substep_count:
+      input.visitedAgentSteps.size +
+      input.visitedWorkbenchSteps.size +
+      input.visitedReviewSteps.size,
+    completed_workflow_count: Object.values(input.workflowDone).filter(Boolean).length,
+    completed_substep_count:
+      Object.values(input.agentStepDone).filter(Boolean).length +
+      Object.values(input.workbenchStepDone).filter(Boolean).length +
+      Object.values(input.reviewStepDone).filter(Boolean).length
+  }
+}

--- a/src/shared/onboarding-tour-telemetry-events.test.ts
+++ b/src/shared/onboarding-tour-telemetry-events.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { eventSchemas } from './telemetry-events'
+
+describe('onboarding tour telemetry schemas', () => {
+  it('accepts semantic value_kind on viewed and skipped steps', () => {
+    expect(
+      eventSchemas.onboarding_step_viewed.safeParse({
+        step: 6,
+        value_kind: 'tour'
+      }).success
+    ).toBe(true)
+    expect(
+      eventSchemas.onboarding_step_skipped.safeParse({
+        step: 6,
+        value_kind: 'tour',
+        duration_ms: 1200,
+        advanced_via: 'button'
+      }).success
+    ).toBe(true)
+  })
+
+  it('rejects invalid semantic value_kind on viewed and skipped steps', () => {
+    expect(
+      eventSchemas.onboarding_step_viewed.safeParse({
+        step: 6,
+        value_kind: 'tour_intro'
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.onboarding_step_skipped.safeParse({
+        step: 6,
+        value_kind: 'tour_intro'
+      }).success
+    ).toBe(false)
+  })
+
+  it('accepts the onboarding tour outcome summary payload', () => {
+    expect(
+      eventSchemas.onboarding_tour_outcome.safeParse({
+        outcome: 'completed_inline',
+        intro_duration_ms: 500,
+        tour_dwell_ms: 2500,
+        furthest_step: 'review_ship',
+        visited_workflow_count: 5,
+        visited_substep_count: 9,
+        completed_workflow_count: 4,
+        completed_substep_count: 7,
+        advanced_via: 'button'
+      }).success
+    ).toBe(true)
+  })
+
+  it('rejects invalid tour outcome fields and extra raw payload', () => {
+    expect(
+      eventSchemas.onboarding_tour_outcome.safeParse({
+        outcome: 'finished',
+        intro_duration_ms: 500
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.onboarding_tour_outcome.safeParse({
+        outcome: 'started_partial',
+        visited_workflow_count: 6
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.onboarding_tour_outcome.safeParse({
+        outcome: 'started_partial',
+        command: 'npm test'
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.onboarding_tour_outcome.safeParse({
+        outcome: 'skipped_intro',
+        tour_dwell_ms: 2500
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -15,6 +15,7 @@
 
 import { z } from 'zod'
 import { FEATURE_WALL_MAX_DWELL_MS } from './feature-wall-telemetry'
+import { FEATURE_WALL_EXIT_ACTIONS, FEATURE_WALL_TOUR_DEPTH_STEPS } from './feature-wall-tour-depth'
 import { SETUP_SCRIPT_IMPORT_PROVIDERS } from './setup-script-import-providers'
 import { WORKSPACE_SOURCE_VALUES, type WorkspaceSource } from './workspace-source'
 
@@ -180,6 +181,12 @@ export const featureWallWorkflowIdSchema = z.enum([
 ])
 export type FeatureWallWorkflowIdTelemetry = z.infer<typeof featureWallWorkflowIdSchema>
 
+export const featureWallTourDepthStepSchema = z.enum(FEATURE_WALL_TOUR_DEPTH_STEPS)
+export type FeatureWallTourDepthStepTelemetry = z.infer<typeof featureWallTourDepthStepSchema>
+
+export const featureWallExitActionSchema = z.enum(FEATURE_WALL_EXIT_ACTIONS)
+export type FeatureWallExitActionTelemetry = z.infer<typeof featureWallExitActionSchema>
+
 // `env_var` is deliberately absent — env-var and CI paths override consent at
 // runtime only (see consent.ts); they never mutate `optedIn` and therefore
 // never fire a `telemetry_opted_in/out` event. If a future path explicitly
@@ -290,7 +297,15 @@ const featureWallOpenedSchema = z
   .strict()
 const featureWallClosedSchema = z
   .object({
-    dwell_ms: z.number().int().min(0).max(FEATURE_WALL_MAX_DWELL_MS)
+    dwell_ms: z.number().int().min(0).max(FEATURE_WALL_MAX_DWELL_MS),
+    source: featureWallOpenSourceSchema.optional(),
+    exit_action: featureWallExitActionSchema.optional(),
+    furthest_step: featureWallTourDepthStepSchema.optional(),
+    last_group_id: featureWallWorkflowIdSchema.optional(),
+    visited_workflow_count: z.number().int().min(0).max(5).optional(),
+    visited_substep_count: z.number().int().min(0).max(9).optional(),
+    completed_workflow_count: z.number().int().min(0).max(5).optional(),
+    completed_substep_count: z.number().int().min(0).max(9).optional()
   })
   .strict()
 const featureWallTileFocusedSchema = z
@@ -475,6 +490,7 @@ const onboardingValueKindSchema = z.enum([
   'tour',
   'repo'
 ])
+const onboardingTourOutcomeSchema = z.enum(['skipped_intro', 'started_partial', 'completed_inline'])
 const onboardingTaskSourcesGithubStatusSchema = z.enum([
   'connected',
   'not_authenticated',
@@ -571,7 +587,11 @@ const onboardingStartedSchema = z
   .object({ resumed_from_step: onboardingStepSchema.optional(), cohort: cohortSchema })
   .strict()
 const onboardingStepViewedSchema = z
-  .object({ step: onboardingStepSchema, cohort: cohortSchema })
+  .object({
+    step: onboardingStepSchema,
+    value_kind: onboardingValueKindSchema,
+    cohort: cohortSchema
+  })
   .strict()
 const onboardingStepCompletedSchema = z
   .object({
@@ -585,11 +605,62 @@ const onboardingStepCompletedSchema = z
 const onboardingStepSkippedSchema = z
   .object({
     step: onboardingStepSchema,
+    value_kind: onboardingValueKindSchema,
     duration_ms: z.number().int().nonnegative().optional(),
     advanced_via: advancedViaSchema,
     cohort: cohortSchema
   })
   .strict()
+type OnboardingTourOutcomeTelemetry = {
+  outcome: z.infer<typeof onboardingTourOutcomeSchema>
+  tour_dwell_ms?: number
+  furthest_step?: z.infer<typeof featureWallTourDepthStepSchema>
+  visited_workflow_count?: number
+  visited_substep_count?: number
+  completed_workflow_count?: number
+  completed_substep_count?: number
+}
+
+function validateOnboardingTourOutcome(
+  props: OnboardingTourOutcomeTelemetry,
+  ctx: z.RefinementCtx
+): void {
+  if (props.outcome !== 'skipped_intro') {
+    return
+  }
+  for (const key of [
+    'tour_dwell_ms',
+    'furthest_step',
+    'visited_workflow_count',
+    'visited_substep_count',
+    'completed_workflow_count',
+    'completed_substep_count'
+  ] as const) {
+    if (props[key] !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: [key],
+        message: `${key} is only valid after the inline tour starts`
+      })
+    }
+  }
+}
+
+const onboardingTourOutcomeEventSchema = z
+  .object({
+    outcome: onboardingTourOutcomeSchema,
+    intro_duration_ms: z.number().int().min(0).max(FEATURE_WALL_MAX_DWELL_MS).optional(),
+    tour_dwell_ms: z.number().int().min(0).max(FEATURE_WALL_MAX_DWELL_MS).optional(),
+    furthest_step: featureWallTourDepthStepSchema.optional(),
+    visited_workflow_count: z.number().int().min(0).max(5).optional(),
+    visited_substep_count: z.number().int().min(0).max(9).optional(),
+    completed_workflow_count: z.number().int().min(0).max(5).optional(),
+    completed_substep_count: z.number().int().min(0).max(9).optional(),
+    advanced_via: advancedViaSchema,
+    cohort: cohortSchema
+  })
+  .strict()
+  .superRefine(validateOnboardingTourOutcome)
 const onboardingStep4PathClickedSchema = z
   .object({ path: onboardingPathSchema, cohort: cohortSchema })
   .strict()
@@ -853,6 +924,7 @@ export const eventSchemas = {
   onboarding_step_viewed: onboardingStepViewedSchema,
   onboarding_step_completed: onboardingStepCompletedSchema,
   onboarding_step_skipped: onboardingStepSkippedSchema,
+  onboarding_tour_outcome: onboardingTourOutcomeEventSchema,
   onboarding_step4_path_clicked: onboardingStep4PathClickedSchema,
   onboarding_step4_path_failed: onboardingStep4PathFailedSchema,
   onboarding_task_sources_snapshot: onboardingTaskSourcesSnapshotSchema,
@@ -963,6 +1035,7 @@ type _OnboardingCohortRoster =
   | 'onboarding_step_viewed'
   | 'onboarding_step_completed'
   | 'onboarding_step_skipped'
+  | 'onboarding_tour_outcome'
   | 'onboarding_step4_path_clicked'
   | 'onboarding_step4_path_failed'
   | 'onboarding_task_sources_snapshot'

--- a/src/shared/telemetry-feature-wall-events.test.ts
+++ b/src/shared/telemetry-feature-wall-events.test.ts
@@ -9,6 +9,22 @@ describe('feature wall schemas', () => {
     expect(eventSchemas.feature_wall_closed.safeParse({ dwell_ms: 1200 }).success).toBe(true)
   })
 
+  it('accepts the close depth summary payload', () => {
+    expect(
+      eventSchemas.feature_wall_closed.safeParse({
+        dwell_ms: 1200,
+        source: 'onboarding',
+        exit_action: 'onboarding_continue',
+        furthest_step: 'review_ship',
+        last_group_id: 'review',
+        visited_workflow_count: 5,
+        visited_substep_count: 9,
+        completed_workflow_count: 4,
+        completed_substep_count: 7
+      }).success
+    ).toBe(true)
+  })
+
   it('rejects stale or invalid source variants', () => {
     expect(eventSchemas.feature_wall_opened.safeParse({}).success).toBe(false)
     expect(eventSchemas.feature_wall_opened.safeParse({ surface: 'help_tour' }).success).toBe(false)
@@ -17,6 +33,29 @@ describe('feature wall schemas', () => {
 
   it('rejects out-of-range dwell time', () => {
     expect(eventSchemas.feature_wall_closed.safeParse({ dwell_ms: -1 }).success).toBe(false)
+  })
+
+  it('rejects invalid close depth fields', () => {
+    expect(
+      eventSchemas.feature_wall_closed.safeParse({
+        dwell_ms: 1200,
+        source: 'help_menu',
+        exit_action: 'left',
+        furthest_step: 'review_raw_url'
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.feature_wall_closed.safeParse({
+        dwell_ms: 1200,
+        visited_workflow_count: 6
+      }).success
+    ).toBe(false)
+    expect(
+      eventSchemas.feature_wall_closed.safeParse({
+        dwell_ms: 1200,
+        repo_path: '/Users/alice/project'
+      }).success
+    ).toBe(false)
   })
 
   it('accepts only known tile ids for tile focus telemetry', () => {


### PR DESCRIPTION
## Summary

Adds low-cardinality onboarding tour telemetry so retention dashboards can compare users who skip, partially start, or complete the inline Explore Orca tour. The implementation also records tour open/close source, dwell, exit action, and coarse depth summaries for onboarding and Help-surface tour sessions.

## Telemetry Availability Handoff

This change adds the source-code paths for onboarding tour and feature-wall tour telemetry. Dashboard work should not use PR merge time as the retention lower bound.

For PostHog dashboard work, set the cohort lower bound to `tour_telemetry_ready_at`: the first released build or first valid PostHog timestamp where all required signals are present, especially `onboarding_tour_outcome` plus `feature_wall_closed` with `source`, `exit_action`, and depth fields. D1/D3/D7 retention tiles should only include cohorts old enough to mature from that readiness timestamp.

This metadata intentionally lives in the PR note, not in telemetry payloads.

## Screenshots

No visual change.

## Tests

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/shared/feature-wall-tour-depth.test.ts src/shared/onboarding-tour-telemetry-events.test.ts src/shared/telemetry-feature-wall-events.test.ts src/renderer/src/components/onboarding/onboarding-tour-outcome-tracker.test.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts src/main/ipc/telemetry.test.ts`
- [x] Launched Electron from `/Users/thebr/orca/workspaces/orca/onboarding-tour-telemetry` on CDP port 9336 and verified `window.api.app.getIdentity()` returned branch `brennanb2025/onboarding-tour-telemetry` and the matching worktree root.
- [x] In `demo-project`, reopened onboarding at the tour step, clicked the real `Skip the tour` control, and verified the UI advanced to `Point Orca at some code` with persisted onboarding `lastCompletedStep: 6`.
- [x] In `demo-project`, clicked `Take the tour`, advanced through the inline workflow tour using the real `Continue` control / shortcut, and verified the UI advanced to repo setup with persisted onboarding `lastCompletedStep: 6`.
- [x] Re-ran Electron with a temporary local main-process telemetry dry-run logger that validates payloads at the `telemetry:track` IPC boundary and logs instead of sending telemetry.
- [x] Verified dry-run console logs for skip, completed-inline, and help-menu close paths emitted the expected `onboarding_*` and `feature_wall_*` events with validator `ok: true`; removed the local dry-run patch and confirmed no temp diff remained.
- [x] Native Help > Explore Orca menu click was exercised in the verified dev instance; it opened the `Get to know Orca` modal with `source: 'help_menu'`, emitted `feature_wall_opened`, initial selection/focus telemetry, and emitted `feature_wall_closed` with validator `ok: true` after the real `Close` button was clicked.
- [x] Checked the Electron console: 0 errors. Existing warning observed: `xterm.js: task queue exceeded allotted deadline by 34ms`.

## AI Review Report

Reviewed with the telemetry product gate and a code-review pass focused on cohort correctness, emission cardinality, and dashboard usefulness. The review flagged and fixed: started-then-skip incorrectly resolving to `skipped_intro`, onboarding continue being marked before async persistence succeeded, and a hook dependency lint issue.

Cross-platform compatibility checked for touched behavior: keyboard shortcuts use the existing Mac vs Ctrl platform check, no new filesystem path assumptions were added, and no provider-specific source-control behavior was touched.

## Security Audit

Telemetry payloads are schema-validated with strict low-cardinality enums, bounded counts, and bounded dwell durations. The PR does not add prompts, command strings, file paths, repo names, URLs, hostnames, raw errors, tokens, secrets, dependencies, or new IPC channels. Onboarding cohort injection remains main-side at the existing `telemetry:track` boundary.

## Notes

This is observational cohort telemetry only; it does not hide/show the tour or create an A/B test. The local design/reference doc is intentionally not included in this PR.
