### PR TITLE
Add Notion landing page variants

### DIFF
--- a/docs/notion-landing-page-analysis.md
+++ b/docs/notion-landing-page-analysis.md
@@ -1,0 +1,41 @@
+# Why the "Meet the night shift" Landing Page Works
+
+The "Meet the night shift" screenshot is effective because it sells a clear product transformation in the first viewport: Notion is no longer just a place where teams organize work, but a workspace that can keep work moving after people step away. That promise is specific, easy to remember, and immediately tied to visible product behavior. The duplicated HTML variants in this worktree reinforce the same strategic direction: `index.html` and `notion-home-variant-b.html` are identical Variant B implementations, while `notion-home-variant-a.html` explores a lighter alternate treatment with the same core message, CTA structure, trust strip, and product mockup.
+
+## Conversion Strengths
+
+The page does the most important conversion work quickly. The headline, "Meet the night shift," is short enough to land emotionally, but concrete enough to imply a benefit: work gets handled while the team is offline. The subcopy converts the metaphor into jobs-to-be-done: drafting updates, sorting inboxes, preparing tomorrow's plan, and keeping everything inside the existing workspace. That avoids a vague AI claim and frames the product as useful in daily operating rhythms.
+
+The primary CTA, "Get Notion free," stays visible in the nav and appears again below the hero copy. That repetition is good conversion hygiene because users who are already convinced do not need to hunt. The secondary CTA, "Request a demo," gives higher-intent teams a path without competing too hard with the free signup action. Variant B improves this further by pairing the CTAs with an announcement bar that says "Meet Notion 3.1" and a nav-level product frame, so the page feels like a real launch moment rather than a decorative concept.
+
+## Visual Hierarchy
+
+The first viewport has a disciplined hierarchy: announcement, navigation, eyebrow, headline, explanatory copy, CTAs, product proof. Each layer answers a different question. The announcement says what is new. The eyebrow says what category the feature belongs to. The headline creates memory. The subcopy explains relevance. The CTAs create an action path. The product mockup proves the promise visually.
+
+The screenshot also uses scale well. The headline is the dominant element, but the mockup is large enough to become the second read instead of a background ornament. Floating badges, connector lines, and the central workspace preview pull attention inward. This creates a useful visual loop: the eye starts at "night shift," moves down into the workspace, then scans the surrounding badges for examples of work being handled. Variant A uses a similar stage pattern with simpler badges such as Calendar agent, Inbox triage, Research, AI notes, and Tasks. Variant B makes the story more concrete by showing richer outcomes like Slack digest, PRs reviewed, Tomorrow's plan, Research scout, and a Notion agent on duty at 03:14 AM.
+
+## Trust Building
+
+Trust comes from three sources: recognizable product context, credible specificity, and social proof. The mockup looks like a workspace, not an abstract AI diagram. It includes familiar surfaces such as a sidebar, project rows, status pills, task lists, and document-like cards. The data points are specific enough to feel operational: 14 drafts ready, 128 inbox items triaged, 6 morning briefs, 12 tasks queued, and items marked Done, Running, or Queued. These details make the automation feel bounded and observable.
+
+The customer logo strip strengthens that trust without taking over the page. It appears immediately after the hero stage, so users see a hint of external validation without the page becoming a logo wall. The logos also broaden the perceived audience: the product looks useful for cross-functional teams that need shared context, follow-up, planning, and coordination.
+
+## Product Storytelling
+
+The strongest storytelling move is that the page turns an AI feature into a time-based narrative. "Night shift" implies continuity, relief, and momentum. The user does not have to understand model capabilities, agent architecture, or automation rules before understanding the benefit. The page says: leave work in the workspace, come back to progress.
+
+The product mockup carries that story better than a generic illustration would. In Variant B, the center is a "Night shift" workspace with an agent update timestamp and a queue. Around it are inputs and outputs of modern team work: messages, reviews, calendars, research, and briefs. Variant A tells the same story through a handoff model: "Pick something to hand off" with cards for tomorrow's brief, inbox sorting, and lead research. Together, the duplicated variants show a useful direction: position automation as an extension of the workspace people already use, not as a detached chatbot.
+
+## Interaction Design
+
+The page includes enough interaction to feel usable without distracting from the core conversion path. Dropdown menus in the nav make the product taxonomy feel real. The dismissible announcement bar gives users control. The CTAs open a modal flow, which keeps the signup/demo intent close to the page instead of forcing a context switch. Floating badges are focusable and have tooltips, making the surrounding product proof feel inspectable rather than purely decorative.
+
+Variant B is especially strong because its mockup has page rows, active states, cards, status labels, and a task list that imply real system behavior. Users can infer what the product will do before they click anything. The UI does not need to become a full demo, but it provides enough affordances to feel coherent and operable.
+
+## First-Viewport Composition
+
+The first viewport works because it contains the complete argument without feeling cramped. Brand and navigation establish credibility at the top. The announcement creates launch context. The centered hero copy gives the message room. The CTAs arrive before the visual complexity of the stage. The large app mockup then occupies the lower portion of the viewport, with enough of the logo strip visible afterward to suggest depth below the fold.
+
+That final detail is important. A landing page should not make the first viewport feel like a sealed poster. Here, the hero stage is the main event, but the trust strip starts the next section and encourages scrolling. The duplicated `index.html` and `notion-home-variant-b.html` capture the stronger version of that composition: clearer product outcomes, denser proof, and a more convincing sense that the workspace is actively doing useful work. Variant A is simpler and approachable, but Variant B better connects the campaign idea to visible product value.
+
+Overall, the screenshot is effective because every major element supports the same practical promise: Notion helps teams hand off routine coordination, return to organized progress, and trust the workspace as the place where that work happened.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,662 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Meet the night shift — Notion (Variant B)</title>
+<style>
+  :root {
+    --navy-900: #0b1220;
+    --navy-800: #0f172a;
+    --navy-700: #111c34;
+    --ink: #1f2937;
+    --muted: #94a3b8;
+    --line: rgba(255,255,255,0.08);
+    --blue: #2f6bff;
+    --blue-2: #5b8cff;
+    --soft: #f5f6f8;
+    --paper: #ffffff;
+    --shadow-lg: 0 30px 60px -20px rgba(2,6,23,0.45), 0 12px 24px -10px rgba(2,6,23,0.35);
+    --radius: 14px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #e6ecf5;
+    background: var(--navy-900);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: inherit; text-decoration: none; }
+  button { font: inherit; cursor: pointer; }
+  :focus-visible { outline: 2px solid #9cc0ff; outline-offset: 2px; border-radius: 6px; }
+
+  /* Variant label */
+  .variant-tag {
+    position: fixed; right: 12px; bottom: 12px; z-index: 90;
+    background: #ffffff; color: #0b1220;
+    border-radius: 999px; padding: 6px 10px;
+    font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+    border: 1px solid rgba(0,0,0,0.06);
+  }
+
+  /* Announcement */
+  .announce {
+    background: linear-gradient(90deg, #0a1124 0%, #131e3d 50%, #0a1124 100%);
+    color: #dde6f7;
+    border-bottom: 1px solid var(--line);
+    font-size: 13px;
+    display: flex; align-items: center; justify-content: center; gap: 12px;
+    padding: 10px 16px; position: relative;
+  }
+  .announce strong { color: #fff; font-weight: 600; }
+  .announce a.link { color: #9cc0ff; border-bottom: 1px solid rgba(156,192,255,0.4); padding-bottom: 1px; }
+  .announce .close {
+    position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+    background: transparent; color: #cfd8ee; border: 0; padding: 6px 8px; border-radius: 6px;
+  }
+  .announce .close:hover { background: rgba(255,255,255,0.06); }
+
+  /* Nav */
+  .nav-wrap { position: sticky; top: 0; z-index: 60; background: rgba(11,18,32,0.7); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+  .nav {
+    max-width: 1240px; margin: 0 auto; padding: 14px 24px;
+    display: flex; align-items: center; gap: 22px;
+  }
+  .brand { display: flex; align-items: center; gap: 8px; font-weight: 700; font-size: 18px; color: #fff; }
+  .brand-mark {
+    width: 26px; height: 26px; border-radius: 6px; background: #fff; color: #0b1220;
+    display: grid; place-items: center; font-weight: 900; font-size: 16px;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+  }
+  .nav-links { display: flex; gap: 4px; margin-left: 12px; flex: 1; }
+  .nav-links button {
+    background: transparent; border: 0; color: #cfd8ee; padding: 8px 12px;
+    border-radius: 8px; font-size: 14px; display: inline-flex; align-items: center; gap: 6px;
+  }
+  .nav-links button:hover { background: rgba(255,255,255,0.06); color: #fff; }
+  .nav-links .caret { font-size: 10px; opacity: 0.7; }
+  .nav-actions { display: flex; align-items: center; gap: 6px; }
+  .nav-actions .ghost {
+    background: transparent; border: 0; color: #cfd8ee; padding: 8px 12px; border-radius: 8px; font-size: 14px;
+  }
+  .nav-actions .ghost:hover { background: rgba(255,255,255,0.06); color: #fff; }
+  .nav-actions .primary {
+    background: #fff; color: #0b1220; border: 0; padding: 8px 14px; border-radius: 8px;
+    font-weight: 600; font-size: 14px;
+  }
+  .nav-actions .primary:hover { background: #e8edf6; }
+
+  /* Dropdown */
+  .menu {
+    position: absolute; top: calc(100% + 8px); left: 0; min-width: 220px;
+    background: #11182a; border: 1px solid var(--line); border-radius: 12px; padding: 8px;
+    box-shadow: 0 24px 48px rgba(0,0,0,0.45); display: none; z-index: 70;
+  }
+  .menu[data-open="true"] { display: block; }
+  .menu a, .menu button.item {
+    display: block; width: 100%; text-align: left; padding: 8px 10px; border-radius: 8px;
+    color: #dde6f7; font-size: 14px; background: transparent; border: 0;
+  }
+  .menu a:hover, .menu button.item:hover { background: rgba(255,255,255,0.06); color: #fff; }
+  .nav-item { position: relative; }
+
+  /* Hero */
+  .hero {
+    position: relative; overflow: hidden;
+    background:
+      radial-gradient(800px 380px at 80% -10%, rgba(91,140,255,0.18), transparent 60%),
+      radial-gradient(600px 320px at 10% 10%, rgba(47,107,255,0.12), transparent 60%),
+      linear-gradient(180deg, #0b1220 0%, #0a1224 100%);
+    padding: 56px 24px 24px;
+  }
+  .hero-inner { max-width: 1180px; margin: 0 auto; text-align: center; position: relative; }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    color: #9cc0ff; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+    background: rgba(91,140,255,0.1); border: 1px solid rgba(156,192,255,0.25);
+    padding: 6px 10px; border-radius: 999px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: #9cc0ff; box-shadow: 0 0 12px #9cc0ff; }
+  h1.headline {
+    font-size: clamp(40px, 6vw, 80px);
+    line-height: 1.02; letter-spacing: -0.03em;
+    margin: 18px auto 14px; font-weight: 700; color: #fff; max-width: 16ch;
+  }
+  h1.headline .accent {
+    background: linear-gradient(90deg, #cfdcff 0%, #ffffff 50%, #9cc0ff 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .subcopy {
+    font-size: clamp(15px, 1.4vw, 18px); color: #b8c4dc;
+    max-width: 64ch; margin: 0 auto 24px;
+  }
+  .ctas { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; margin-bottom: 36px; }
+  .btn { border-radius: 10px; padding: 12px 18px; font-size: 14px; font-weight: 600; border: 0; }
+  .btn-primary { background: #fff; color: #0b1220; }
+  .btn-primary:hover { background: #e8edf6; transform: translateY(-1px); }
+  .btn-secondary { background: rgba(255,255,255,0.06); color: #fff; border: 1px solid rgba(255,255,255,0.18); }
+  .btn-secondary:hover { background: rgba(255,255,255,0.1); }
+  .btn:active { transform: translateY(0); }
+
+  /* Stage with mockup + badges + connectors */
+  .stage {
+    position: relative;
+    margin: 0 auto; max-width: 1100px;
+    padding: 40px 0 24px;
+  }
+  .connectors { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+  .connectors path { fill: none; stroke: url(#wire); stroke-width: 2; stroke-linecap: round; }
+  .connectors .dash { stroke-dasharray: 4 6; opacity: 0.55; }
+
+  /* Mockup window */
+  .mockup {
+    position: relative; z-index: 2;
+    background: var(--paper); color: var(--ink);
+    border-radius: 14px; box-shadow: var(--shadow-lg);
+    overflow: hidden; border: 1px solid rgba(0,0,0,0.06);
+    max-width: 880px; margin: 0 auto;
+  }
+  .mock-titlebar {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px; border-bottom: 1px solid #eef0f4; background: #fafbfc;
+  }
+  .traffic { display: flex; gap: 6px; }
+  .traffic span { width: 10px; height: 10px; border-radius: 50%; }
+  .traffic .r { background: #ff5f56; } .traffic .y { background: #ffbd2e; } .traffic .g { background: #27c93f; }
+  .mock-url {
+    flex: 1; background: #fff; border: 1px solid #eaecef; border-radius: 6px;
+    font-size: 12px; color: #6b7280; padding: 5px 10px; text-align: center;
+  }
+  .mock-body { display: grid; grid-template-columns: 200px 1fr; min-height: 360px; }
+  .mock-side {
+    background: #fafbfc; border-right: 1px solid #eef0f4;
+    padding: 14px 12px; font-size: 13px; color: #4b5563;
+  }
+  .mock-side .group { font-size: 11px; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.08em; margin: 14px 6px 6px; }
+  .mock-side .row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 6px 8px; border-radius: 6px; cursor: pointer;
+  }
+  .mock-side .row:hover { background: #eef2f7; }
+  .mock-side .row.active { background: #e8efff; color: #1e3a8a; }
+  .mock-side .ic { width: 16px; text-align: center; }
+
+  .mock-content { padding: 18px 22px; }
+  .mock-h {
+    display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
+  }
+  .mock-emoji { font-size: 22px; }
+  .mock-title { font-size: 22px; font-weight: 700; color: #111827; letter-spacing: -0.01em; }
+  .mock-meta { font-size: 12px; color: #6b7280; margin-bottom: 14px; }
+  .mock-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 14px;
+  }
+  .mock-card {
+    background: #f7f9fc; border: 1px solid #eef0f4; border-radius: 10px; padding: 10px;
+    cursor: pointer; transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  }
+  .mock-card:hover { transform: translateY(-2px); border-color: #c9d6f5; box-shadow: 0 6px 14px rgba(15,23,42,0.06); }
+  .mock-card .label { font-size: 11px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.06em; }
+  .mock-card .value { font-size: 18px; font-weight: 700; color: #111827; margin-top: 4px; }
+  .mock-card .trend { font-size: 11px; color: #16a34a; margin-top: 2px; }
+
+  .mock-list { border: 1px solid #eef0f4; border-radius: 10px; overflow: hidden; }
+  .mock-list .item {
+    display: grid; grid-template-columns: 22px 1fr auto auto; gap: 10px;
+    align-items: center; padding: 9px 12px; font-size: 13px;
+    border-bottom: 1px solid #f1f3f7; cursor: pointer;
+  }
+  .mock-list .item:last-child { border-bottom: 0; }
+  .mock-list .item:hover { background: #f6f9ff; }
+  .mock-list .check {
+    width: 14px; height: 14px; border-radius: 4px; border: 1.5px solid #c7cfdb; display: inline-block;
+  }
+  .mock-list .item[data-done="true"] .check { background: #2f6bff; border-color: #2f6bff; position: relative; }
+  .mock-list .item[data-done="true"] .check::after {
+    content: ""; position: absolute; left: 3px; top: 1px; width: 4px; height: 8px;
+    border-right: 2px solid #fff; border-bottom: 2px solid #fff; transform: rotate(45deg);
+  }
+  .mock-list .item[data-done="true"] .name { color: #9aa3b2; text-decoration: line-through; }
+  .pill { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: #eef2f7; color: #475569; }
+  .pill.blue { background: #e6efff; color: #1d4ed8; }
+  .pill.amber { background: #fff3d6; color: #92400e; }
+  .pill.green { background: #dcfce7; color: #166534; }
+  .avatar { width: 22px; height: 22px; border-radius: 50%; background: linear-gradient(135deg, #94a3b8, #475569); color:#fff; font-size: 10px; display: grid; place-items: center; font-weight: 700; }
+
+  /* Badges */
+  .badge {
+    position: absolute; z-index: 3;
+    background: #fff; color: #0b1220;
+    border: 1px solid rgba(0,0,0,0.05);
+    border-radius: 12px; padding: 8px 12px;
+    font-size: 12px; font-weight: 600;
+    display: inline-flex; align-items: center; gap: 8px;
+    box-shadow: 0 14px 30px -10px rgba(2,6,23,0.45), 0 4px 8px rgba(2,6,23,0.25);
+    transform: translate(-50%, -50%);
+    animation: float 6s ease-in-out infinite;
+    cursor: default;
+  }
+  .badge:hover { transform: translate(-50%, calc(-50% - 3px)); }
+  .badge .ic { width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; font-size: 13px; color: #fff; }
+  .badge .sub { color: #6b7280; font-weight: 500; font-size: 11px; }
+  .badge.dark { background: #0f172a; color: #fff; border-color: rgba(255,255,255,0.08); }
+  .badge.dark .sub { color: #9aa7c2; }
+
+  .b1 { top: 8%; left: 12%; animation-delay: 0s; }
+  .b2 { top: 22%; left: 92%; animation-delay: -1.5s; }
+  .b3 { top: 64%; left: 6%; animation-delay: -2.2s; }
+  .b4 { top: 80%; left: 88%; animation-delay: -3s; }
+  .b5 { top: 92%; left: 38%; animation-delay: -4s; }
+
+  @keyframes float {
+    0%, 100% { transform: translate(-50%, -50%); }
+    50% { transform: translate(-50%, calc(-50% - 6px)); }
+  }
+
+  /* Logo strip */
+  .logos {
+    background: #0a1224; border-top: 1px solid var(--line);
+    padding: 36px 24px;
+  }
+  .logos-inner {
+    max-width: 1180px; margin: 0 auto; text-align: center;
+  }
+  .logos-title { color: #8aa0c6; font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 18px; }
+  .logos-row {
+    display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 36px;
+    color: #c4cee2; opacity: 0.85;
+    font-weight: 700; letter-spacing: 0.02em;
+  }
+  .logo {
+    font-size: 18px; display: inline-flex; align-items: center; gap: 6px;
+    filter: grayscale(1) brightness(1.4); opacity: 0.85;
+  }
+  .logo:hover { opacity: 1; }
+  .logo .glyph { display: inline-grid; place-items: center; width: 22px; height: 22px; }
+
+  /* Modal */
+  .backdrop {
+    position: fixed; inset: 0; background: rgba(2,6,23,0.6); display: none;
+    align-items: center; justify-content: center; z-index: 100;
+  }
+  .backdrop[data-open="true"] { display: flex; }
+  .modal {
+    background: #fff; color: #0b1220; border-radius: 14px;
+    width: min(440px, 92vw); padding: 22px; box-shadow: var(--shadow-lg);
+  }
+  .modal h3 { margin: 0 0 6px; font-size: 18px; }
+  .modal p { margin: 0 0 14px; color: #475569; font-size: 14px; }
+  .modal .field { display: flex; gap: 8px; }
+  .modal input {
+    flex: 1; padding: 10px 12px; border-radius: 8px; border: 1px solid #e5e7eb; font-size: 14px;
+  }
+  .modal input:focus { border-color: #2f6bff; outline: 2px solid #c7d8ff; }
+  .modal .row-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+  .modal .btn-primary { background: #0b1220; color: #fff; }
+  .modal .btn-primary:hover { background: #1f2a44; }
+  .modal .btn-ghost { background: transparent; color: #475569; border: 1px solid #e5e7eb; }
+
+  /* Toast */
+  .toast {
+    position: fixed; left: 50%; bottom: 24px; transform: translate(-50%, 80px);
+    background: #0b1220; color: #fff; padding: 10px 14px; border-radius: 10px;
+    font-size: 13px; box-shadow: 0 16px 40px rgba(0,0,0,0.4); opacity: 0;
+    transition: transform 240ms ease, opacity 240ms ease; z-index: 110; pointer-events: none;
+  }
+  .toast.show { opacity: 1; transform: translate(-50%, 0); }
+
+  /* Responsive */
+  @media (max-width: 880px) {
+    .nav-links { display: none; }
+    .mock-body { grid-template-columns: 1fr; }
+    .mock-side { display: none; }
+    .mock-grid { grid-template-columns: 1fr 1fr; }
+    .badge { font-size: 11px; padding: 6px 10px; }
+    .b1 { top: -2%; left: 22%; }
+    .b2 { top: 8%; left: 82%; }
+    .b3 { top: 62%; left: 12%; }
+    .b4 { top: 86%; left: 80%; }
+    .b5 { top: 100%; left: 50%; }
+  }
+  @media (max-width: 520px) {
+    .hero { padding: 36px 14px 14px; }
+    .ctas { flex-direction: column; align-items: stretch; }
+    .ctas .btn { width: 100%; }
+    .mock-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <div class="variant-tag" aria-label="Variant label">VARIANT B</div>
+
+  <!-- Announcement -->
+  <div class="announce" id="announce" role="region" aria-label="Announcement">
+    <span>✨</span>
+    <span><strong>New:</strong> Meet Notion 3.1 — connected agents that work overnight. <a href="#" class="link">See what's new →</a></span>
+    <button class="close" id="announceClose" aria-label="Dismiss announcement">✕</button>
+  </div>
+
+  <!-- Nav -->
+  <div class="nav-wrap">
+    <nav class="nav" aria-label="Primary">
+      <a href="#" class="brand"><span class="brand-mark">N</span> Notion</a>
+      <div class="nav-links" id="navLinks">
+        <div class="nav-item">
+          <button data-menu="product">Product <span class="caret">▼</span></button>
+          <div class="menu" id="menu-product" role="menu">
+            <a href="#" role="menuitem">Docs</a>
+            <a href="#" role="menuitem">Wiki</a>
+            <a href="#" role="menuitem">Projects</a>
+            <a href="#" role="menuitem">Calendar</a>
+            <a href="#" role="menuitem">AI</a>
+          </div>
+        </div>
+        <div class="nav-item">
+          <button data-menu="solutions">Solutions <span class="caret">▼</span></button>
+          <div class="menu" id="menu-solutions" role="menu">
+            <a href="#" role="menuitem">Engineering</a>
+            <a href="#" role="menuitem">Design</a>
+            <a href="#" role="menuitem">Marketing</a>
+            <a href="#" role="menuitem">Operations</a>
+          </div>
+        </div>
+        <div class="nav-item">
+          <button data-menu="resources">Resources <span class="caret">▼</span></button>
+          <div class="menu" id="menu-resources" role="menu">
+            <a href="#" role="menuitem">Help center</a>
+            <a href="#" role="menuitem">Templates</a>
+            <a href="#" role="menuitem">Guides</a>
+            <a href="#" role="menuitem">Community</a>
+          </div>
+        </div>
+        <div class="nav-item">
+          <button data-menu="pricing">Pricing</button>
+        </div>
+      </div>
+      <div class="nav-actions">
+        <button class="ghost" id="signIn">Sign in</button>
+        <button class="primary" id="getNotionBtn">Get Notion free</button>
+      </div>
+    </nav>
+  </div>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <span class="eyebrow"><span class="dot"></span> Now with overnight agents</span>
+      <h1 class="headline">Meet the <span class="accent">night shift.</span></h1>
+      <p class="subcopy">
+        While your team sleeps, Notion agents draft updates, sort inboxes, and prep tomorrow's plan — all inside the same workspace your docs, projects, and meetings already live in.
+      </p>
+      <div class="ctas">
+        <button class="btn btn-primary" id="ctaPrimary">Get Notion free</button>
+        <button class="btn btn-secondary" id="ctaSecondary">Request a demo →</button>
+      </div>
+
+      <!-- Stage -->
+      <div class="stage" id="stage">
+        <!-- SVG connectors -->
+        <svg class="connectors" viewBox="0 0 1100 640" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="wire" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#6ea0ff" stop-opacity="0.0" />
+              <stop offset="40%" stop-color="#6ea0ff" stop-opacity="0.85" />
+              <stop offset="100%" stop-color="#2f6bff" stop-opacity="0.9" />
+            </linearGradient>
+          </defs>
+          <!-- winding paths from badges into mockup -->
+          <path d="M120,80 C260,40 320,260 540,260" />
+          <path d="M1010,140 C880,180 760,220 620,260" />
+          <path class="dash" d="M80,420 C260,420 360,360 520,360" />
+          <path class="dash" d="M980,520 C820,520 700,420 600,380" />
+          <path d="M420,610 C460,540 520,480 540,420" />
+        </svg>
+
+        <!-- Mockup -->
+        <div class="mockup" role="group" aria-label="Notion workspace preview">
+          <div class="mock-titlebar">
+            <div class="traffic" aria-hidden="true"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+            <div class="mock-url">notion.so / night-shift / overview</div>
+          </div>
+          <div class="mock-body">
+            <aside class="mock-side" aria-label="Sidebar">
+              <div class="group">Workspace</div>
+              <div class="row" data-page="overview"><span class="ic">🏠</span> Overview</div>
+              <div class="row active" data-page="night-shift"><span class="ic">🌙</span> Night shift</div>
+              <div class="row" data-page="inbox"><span class="ic">📥</span> Inbox</div>
+              <div class="row" data-page="projects"><span class="ic">🗂️</span> Projects</div>
+              <div class="row" data-page="calendar"><span class="ic">🗓️</span> Calendar</div>
+              <div class="group">Agents</div>
+              <div class="row" data-page="standup"><span class="ic">🧭</span> Standup writer</div>
+              <div class="row" data-page="triage"><span class="ic">📨</span> Inbox triage</div>
+              <div class="row" data-page="research"><span class="ic">🔎</span> Research scout</div>
+            </aside>
+            <main class="mock-content">
+              <div class="mock-h">
+                <span class="mock-emoji">🌙</span>
+                <span class="mock-title" id="mockTitle">Night shift</span>
+              </div>
+              <div class="mock-meta">Updated by Agent · 3 minutes ago · 12 tasks queued</div>
+
+              <div class="mock-grid">
+                <div class="mock-card" data-card="drafts">
+                  <div class="label">Drafts ready</div>
+                  <div class="value">14</div>
+                  <div class="trend">+4 since midnight</div>
+                </div>
+                <div class="mock-card" data-card="inbox">
+                  <div class="label">Inbox triaged</div>
+                  <div class="value">128</div>
+                  <div class="trend">98% sorted</div>
+                </div>
+                <div class="mock-card" data-card="briefs">
+                  <div class="label">Morning briefs</div>
+                  <div class="value">6</div>
+                  <div class="trend">Due 8:00 AM</div>
+                </div>
+              </div>
+
+              <div class="mock-list" id="taskList" aria-label="Overnight task list">
+                <div class="item" data-done="true">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Summarize yesterday's standup</span>
+                  <span class="pill green">Done</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+                <div class="item" data-done="true">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Draft Q3 roadmap update</span>
+                  <span class="pill blue">Doc</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+                <div class="item" data-done="false">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Flag overdue tickets in Projects</span>
+                  <span class="pill amber">Running</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+                <div class="item" data-done="false">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Compile weekly customer feedback</span>
+                  <span class="pill">Queued</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+
+        <!-- Floating badges -->
+        <div class="badge b1" tabindex="0" data-tip="Slack messages summarized">
+          <span class="ic" style="background:#4a154b">💬</span>
+          <span><div>Slack digest</div><div class="sub">17 threads · 3 actions</div></span>
+        </div>
+        <div class="badge b2 dark" tabindex="0" data-tip="GitHub PRs reviewed">
+          <span class="ic" style="background:#1f2937">🐙</span>
+          <span><div>PRs reviewed</div><div class="sub">9 awaiting you</div></span>
+        </div>
+        <div class="badge b3" tabindex="0" data-tip="Calendar prepared">
+          <span class="ic" style="background:#0b76ff">🗓️</span>
+          <span><div>Tomorrow's plan</div><div class="sub">5 meetings prepped</div></span>
+        </div>
+        <div class="badge b4" tabindex="0" data-tip="Research scout completed">
+          <span class="ic" style="background:#16a34a">🔎</span>
+          <span><div>Research scout</div><div class="sub">12 sources cited</div></span>
+        </div>
+        <div class="badge b5 dark" tabindex="0" data-tip="Notion AI agent">
+          <span class="ic" style="background:linear-gradient(135deg,#5b8cff,#2f6bff)">✨</span>
+          <span><div>Notion agent</div><div class="sub">on duty · 03:14 AM</div></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Logos strip -->
+  <section class="logos">
+    <div class="logos-inner">
+      <div class="logos-title">Trusted by teams at</div>
+      <div class="logos-row" aria-label="Customer logos">
+        <span class="logo"><span class="glyph">◎</span> OpenAI</span>
+        <span class="logo"><span class="glyph">▲</span> Vercel</span>
+        <span class="logo"><span class="glyph">◇</span> Figma</span>
+        <span class="logo"><span class="glyph">●</span> Loom</span>
+        <span class="logo"><span class="glyph">✦</span> Ramp</span>
+        <span class="logo"><span class="glyph">⌬</span> Match</span>
+        <span class="logo"><span class="glyph">◧</span> Toyota</span>
+        <span class="logo"><span class="glyph">◐</span> Headspace</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Modal -->
+  <div class="backdrop" id="backdrop" aria-hidden="true">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <h3 id="modalTitle">Get Notion free</h3>
+      <p>Drop your work email — we'll send a one-click signup link.</p>
+      <div class="field">
+        <input id="emailInput" type="email" placeholder="you@company.com" autocomplete="email" />
+        <button class="btn btn-primary" id="modalSubmit">Continue</button>
+      </div>
+      <div class="row-actions">
+        <button class="btn btn-ghost" id="modalCancel">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="toast" id="toast" role="status" aria-live="polite">Saved</div>
+
+<script>
+  // Announcement close
+  const announce = document.getElementById('announce');
+  document.getElementById('announceClose').addEventListener('click', () => {
+    announce.style.display = 'none';
+  });
+
+  // Dropdown menus
+  const navLinks = document.getElementById('navLinks');
+  const menus = {
+    product: document.getElementById('menu-product'),
+    solutions: document.getElementById('menu-solutions'),
+    resources: document.getElementById('menu-resources'),
+  };
+  function closeAllMenus(except) {
+    Object.entries(menus).forEach(([k, el]) => {
+      if (k !== except) el.dataset.open = 'false';
+    });
+  }
+  navLinks.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-menu]');
+    if (!btn) return;
+    const key = btn.dataset.menu;
+    if (key === 'pricing') { showToast('Pricing coming up'); closeAllMenus(); return; }
+    const m = menus[key];
+    const open = m.dataset.open === 'true';
+    closeAllMenus(open ? null : key);
+    m.dataset.open = open ? 'false' : 'true';
+    e.stopPropagation();
+  });
+  document.addEventListener('click', () => closeAllMenus());
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { closeAllMenus(); closeModal(); } });
+
+  // Toast
+  const toast = document.getElementById('toast');
+  let toastT;
+  function showToast(msg) {
+    toast.textContent = msg;
+    toast.classList.add('show');
+    clearTimeout(toastT);
+    toastT = setTimeout(() => toast.classList.remove('show'), 1800);
+  }
+
+  // Modal
+  const backdrop = document.getElementById('backdrop');
+  const emailInput = document.getElementById('emailInput');
+  function openModal() {
+    backdrop.dataset.open = 'true';
+    backdrop.setAttribute('aria-hidden', 'false');
+    setTimeout(() => emailInput.focus(), 30);
+  }
+  function closeModal() {
+    backdrop.dataset.open = 'false';
+    backdrop.setAttribute('aria-hidden', 'true');
+  }
+  document.getElementById('ctaPrimary').addEventListener('click', openModal);
+  document.getElementById('getNotionBtn').addEventListener('click', openModal);
+  document.getElementById('ctaSecondary').addEventListener('click', () => showToast('Demo request noted ✨'));
+  document.getElementById('signIn').addEventListener('click', () => showToast('Sign-in is just a demo here'));
+  document.getElementById('modalCancel').addEventListener('click', closeModal);
+  backdrop.addEventListener('click', (e) => { if (e.target === backdrop) closeModal(); });
+  document.getElementById('modalSubmit').addEventListener('click', () => {
+    const v = emailInput.value.trim();
+    if (!v || !v.includes('@')) { emailInput.focus(); showToast('Enter a valid email'); return; }
+    closeModal();
+    emailInput.value = '';
+    showToast("You're on the list — check your inbox 📬");
+  });
+
+  // Mockup interactions
+  const mockTitle = document.getElementById('mockTitle');
+  const titles = {
+    overview: 'Overview',
+    'night-shift': 'Night shift',
+    inbox: 'Inbox',
+    projects: 'Projects',
+    calendar: 'Calendar',
+    standup: 'Standup writer',
+    triage: 'Inbox triage',
+    research: 'Research scout',
+  };
+  document.querySelectorAll('.mock-side .row').forEach((row) => {
+    row.addEventListener('click', () => {
+      document.querySelectorAll('.mock-side .row').forEach((r) => r.classList.remove('active'));
+      row.classList.add('active');
+      const k = row.dataset.page;
+      mockTitle.textContent = titles[k] || 'Workspace';
+    });
+  });
+
+  document.querySelectorAll('.mock-card').forEach((c) => {
+    c.addEventListener('click', () => showToast('Opened ' + c.querySelector('.label').textContent.toLowerCase()));
+  });
+
+  document.querySelectorAll('#taskList .item').forEach((item) => {
+    item.addEventListener('click', () => {
+      const done = item.dataset.done === 'true';
+      item.dataset.done = done ? 'false' : 'true';
+      const pill = item.querySelector('.pill');
+      if (!done) { pill.textContent = 'Done'; pill.className = 'pill green'; }
+      else { pill.textContent = 'Queued'; pill.className = 'pill'; }
+    });
+  });
+
+  // Badge tooltips via toast
+  document.querySelectorAll('.badge').forEach((b) => {
+    b.addEventListener('click', () => showToast(b.dataset.tip));
+    b.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); showToast(b.dataset.tip); } });
+  });
+</script>
+</body>
+</html>

--- a/notion-home-variant-a.html
+++ b/notion-home-variant-a.html
@@ -225,7 +225,7 @@
     max-width: 620px;
     margin: 0 auto 26px;
   }
-  .ctas { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+  .ctas { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; max-width: 100%; }
   .btn {
     display: inline-flex;
     align-items: center;
@@ -241,10 +241,17 @@
   .btn-ghost { background: rgba(255,255,255,0.1); color: #fff; border: 1px solid rgba(255,255,255,0.2); }
   .btn-ghost:hover { background: rgba(255,255,255,0.18); }
   .btn:active { transform: translateY(1px); }
+  .reassurance-line,
   .status-line {
-    margin-top: 14px;
     font-size: 13px;
-    color: rgba(255,255,255,0.6);
+    color: rgba(255,255,255,0.74);
+  }
+  .reassurance-line {
+    margin: 10px 0 0;
+    line-height: 1.4;
+  }
+  .status-line {
+    margin-top: 8px;
     min-height: 18px;
   }
 
@@ -490,7 +497,7 @@
     .announce { font-size: 12.5px; padding: 8px 36px 8px 12px; }
     h1.headline { font-size: 44px; }
     .ctas { width: 100%; }
-    .btn { width: 100%; justify-content: center; }
+    .btn { width: 100%; max-width: 100%; justify-content: center; }
   }
 </style>
 </head>
@@ -576,6 +583,7 @@
       <button class="btn btn-primary" id="cta-primary" aria-describedby="status-line">Get Notion free</button>
       <button class="btn btn-ghost" id="cta-secondary" aria-describedby="status-line">Request a demo</button>
     </div>
+    <p class="reassurance-line">No credit card required.</p>
     <div class="status-line" id="status-line" role="status" aria-live="polite"></div>
   </div>
 

--- a/notion-home-variant-a.html
+++ b/notion-home-variant-a.html
@@ -1,0 +1,789 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Notion — Meet the night shift</title>
+<style>
+  :root {
+    --navy-900: #0a1638;
+    --navy-800: #0f1b40;
+    --navy-700: #142554;
+    --ink: #1f1f1f;
+    --muted: #6b7280;
+    --line: rgba(255, 255, 255, 0.12);
+    --blue: #3b82f6;
+    --blue-soft: #60a5fa;
+    --bar-bg: #f3eee5;
+    --bar-ink: #2b2b2b;
+    --white: #ffffff;
+    --shadow: 0 30px 60px rgba(2, 8, 30, 0.45);
+    --radius: 14px;
+    --radius-lg: 22px;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+                 Inter, "Helvetica Neue", Arial, sans-serif;
+    color: var(--white);
+    background: var(--navy-900);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: inherit; text-decoration: none; }
+  button { font: inherit; cursor: pointer; border: 0; background: none; color: inherit; }
+  :focus-visible { outline: 2px solid #ffd54a; outline-offset: 3px; border-radius: 6px; }
+
+  /* Variant label */
+  .variant-tag {
+    position: fixed;
+    left: 12px;
+    bottom: 12px;
+    z-index: 9999;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: rgba(0,0,0,0.65);
+    color: #fff;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(255,255,255,0.18);
+  }
+
+  /* Announcement bar */
+  .announce {
+    background: var(--bar-bg);
+    color: var(--bar-ink);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 8px 44px 8px 16px;
+    font-size: 13.5px;
+    position: relative;
+  }
+  .announce strong { font-weight: 600; }
+  .announce a.link { text-decoration: underline; text-underline-offset: 2px; }
+  .announce .arrow { display: inline-block; transform: translateX(2px); }
+  .announce .close {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    color: #555;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .announce .close:hover { background: rgba(0,0,0,0.06); color: #000; }
+
+  /* Hero shell */
+  .hero {
+    background: radial-gradient(1200px 600px at 50% -200px, #1a2a66 0%, var(--navy-900) 60%);
+    padding-bottom: 60px;
+    overflow: hidden;
+    position: relative;
+  }
+
+  /* Nav */
+  .nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 36px;
+    max-width: 1280px;
+    margin: 0 auto;
+  }
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 700;
+    font-size: 22px;
+    letter-spacing: -0.01em;
+  }
+  .brand-mark {
+    width: 26px;
+    height: 26px;
+    background: #fff;
+    color: #000;
+    border-radius: 5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 900;
+    font-family: Georgia, "Times New Roman", serif;
+    font-size: 18px;
+  }
+  .nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 6px;
+  }
+  .nav .menu-item {
+    position: relative;
+  }
+  .nav .menu-btn {
+    padding: 8px 12px;
+    border-radius: 8px;
+    color: rgba(255,255,255,0.85);
+    font-size: 14.5px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .nav .menu-btn:hover { background: rgba(255,255,255,0.07); color: #fff; }
+  .nav .caret {
+    width: 10px; height: 10px;
+    border-right: 1.6px solid currentColor;
+    border-bottom: 1.6px solid currentColor;
+    transform: rotate(45deg) translate(-2px,-2px);
+    margin-left: 2px;
+    opacity: 0.7;
+  }
+  .dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    min-width: 220px;
+    background: #fff;
+    color: #1f1f1f;
+    border-radius: 12px;
+    box-shadow: 0 16px 40px rgba(0,0,0,0.25);
+    padding: 6px;
+    display: none;
+    z-index: 50;
+  }
+  .dropdown a {
+    display: block;
+    padding: 8px 10px;
+    border-radius: 8px;
+    font-size: 14px;
+  }
+  .dropdown a:hover { background: #f4f4f4; }
+  .menu-item.open .dropdown { display: block; }
+
+  .nav-right { display: flex; align-items: center; gap: 6px; }
+  .nav-right .text-link { padding: 8px 12px; font-size: 14.5px; color: rgba(255,255,255,0.85); border-radius: 8px; }
+  .nav-right .text-link:hover { background: rgba(255,255,255,0.07); color: #fff; }
+  .nav-right .pill {
+    background: #fff;
+    color: #111;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 14px;
+  }
+  .nav-right .pill:hover { background: #eaeaea; }
+
+  /* Hero copy */
+  .hero-copy {
+    text-align: center;
+    max-width: 880px;
+    margin: 26px auto 0;
+    padding: 0 24px;
+  }
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.7);
+    margin-bottom: 18px;
+  }
+  .eyebrow .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: #ffb84a;
+    box-shadow: 0 0 0 4px rgba(255,184,74,0.18);
+  }
+  h1.headline {
+    font-size: clamp(40px, 7vw, 84px);
+    line-height: 1.02;
+    letter-spacing: -0.025em;
+    margin: 0 0 18px;
+    font-weight: 600;
+  }
+  h1.headline .accent {
+    background: linear-gradient(180deg, #cfe0ff 0%, #7da6ff 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .subcopy {
+    font-size: clamp(15px, 1.4vw, 18px);
+    line-height: 1.55;
+    color: rgba(255,255,255,0.78);
+    max-width: 620px;
+    margin: 0 auto 26px;
+  }
+  .ctas { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 20px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 15px;
+    transition: transform 0.06s ease, background 0.15s ease;
+  }
+  .btn-primary { background: #fff; color: #111; }
+  .btn-primary:hover { background: #eaeaea; }
+  .btn-ghost { background: rgba(255,255,255,0.1); color: #fff; border: 1px solid rgba(255,255,255,0.2); }
+  .btn-ghost:hover { background: rgba(255,255,255,0.18); }
+  .btn:active { transform: translateY(1px); }
+  .status-line {
+    margin-top: 14px;
+    font-size: 13px;
+    color: rgba(255,255,255,0.6);
+    min-height: 18px;
+  }
+
+  /* Stage with mockup + path lines + badges */
+  .stage {
+    position: relative;
+    max-width: 1180px;
+    margin: 56px auto 0;
+    padding: 0 24px;
+  }
+  .paths {
+    position: absolute;
+    inset: -40px 0 -10px 0;
+    width: 100%;
+    height: calc(100% + 50px);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .mock {
+    position: relative;
+    z-index: 2;
+    background: #fff;
+    color: var(--ink);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    border: 1px solid rgba(255,255,255,0.06);
+  }
+  .mock-titlebar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: #f6f5f3;
+    border-bottom: 1px solid #ececec;
+  }
+  .traffic { display: inline-flex; gap: 6px; }
+  .traffic span { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+  .traffic .r { background: #ff5f56; }
+  .traffic .y { background: #ffbd2e; }
+  .traffic .g { background: #27c93f; }
+  .crumbs {
+    font-size: 12.5px;
+    color: #6b7280;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .crumbs .sep { color: #c0c0c0; }
+  .mock-body {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    min-height: 360px;
+  }
+  .side {
+    background: #fafaf8;
+    border-right: 1px solid #efefee;
+    padding: 14px 12px;
+    font-size: 13.5px;
+    color: #3a3a3a;
+  }
+  .side .group { margin-bottom: 14px; }
+  .side .group-title {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #9b9b97;
+    padding: 4px 6px;
+  }
+  .side .row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 5px 6px; border-radius: 6px;
+    cursor: pointer;
+  }
+  .side .row:hover { background: #efece4; }
+  .side .row .ic { width: 16px; text-align: center; opacity: 0.85; }
+  .side .row.active { background: #ece8dc; font-weight: 600; }
+
+  .main { padding: 22px 26px 26px; }
+  .h-eyebrow {
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #9b9b97;
+    margin-bottom: 8px;
+  }
+  .h-title {
+    font-size: 26px;
+    font-weight: 700;
+    margin: 0 0 14px;
+    letter-spacing: -0.01em;
+  }
+  .blocks {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
+  .block {
+    background: #f7f6f1;
+    border: 1px solid #ececea;
+    border-radius: 12px;
+    padding: 12px 12px 14px;
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+    cursor: pointer;
+    outline: none;
+  }
+  .block:hover, .block:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 24px rgba(20,20,30,0.08);
+    background: #fff;
+  }
+  .block .emoji { font-size: 20px; }
+  .block .title { font-weight: 600; font-size: 14px; margin-top: 8px; }
+  .block .desc { font-size: 12.5px; color: #6b7280; margin-top: 4px; line-height: 1.4; }
+  .lines {
+    margin-top: 18px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .lines .ln {
+    height: 10px; border-radius: 4px;
+    background: linear-gradient(90deg, #ececea, #f6f5f3);
+  }
+  .lines .ln.s { width: 60%; }
+  .lines .ln.m { width: 80%; }
+
+  /* Floating badges */
+  .badge {
+    position: absolute;
+    z-index: 3;
+    background: rgba(255,255,255,0.96);
+    color: #111;
+    border-radius: 14px;
+    padding: 10px 12px;
+    box-shadow: 0 14px 30px rgba(2,8,30,0.35);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    font-weight: 500;
+    backdrop-filter: blur(6px);
+    transition: transform 0.15s ease;
+  }
+  .badge:hover { transform: translateY(-2px); }
+  .badge .ic {
+    width: 28px; height: 28px; border-radius: 8px;
+    background: #eef2ff; color: #3b82f6;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 16px;
+  }
+  .badge.b1 { top: 10%; left: -6px; }
+  .badge.b2 { top: 38%; left: -30px; }
+  .badge.b3 { top: 12%; right: -6px; }
+  .badge.b4 { bottom: 14%; right: -30px; }
+  .badge.b5 { bottom: -10px; left: 30%; }
+
+  /* Logo strip */
+  .logos {
+    margin: 70px auto 0;
+    max-width: 1200px;
+    padding: 0 24px;
+  }
+  .logos .label {
+    text-align: center;
+    color: rgba(255,255,255,0.55);
+    font-size: 12.5px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 22px;
+  }
+  .logo-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    flex-wrap: wrap;
+    opacity: 0.85;
+  }
+  .logo {
+    color: rgba(255,255,255,0.75);
+    font-weight: 700;
+    font-size: 18px;
+    letter-spacing: 0.01em;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    filter: grayscale(100%);
+    transition: opacity 0.15s ease;
+  }
+  .logo:hover { opacity: 1; color: #fff; }
+
+  /* Modal */
+  .modal-backdrop {
+    position: fixed; inset: 0;
+    background: rgba(2,6,20,0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 24px;
+  }
+  .modal-backdrop.open { display: flex; }
+  .modal {
+    background: #fff;
+    color: #111;
+    border-radius: 16px;
+    width: 100%;
+    max-width: 460px;
+    padding: 24px;
+    box-shadow: 0 30px 80px rgba(0,0,0,0.4);
+  }
+  .modal h2 { margin: 0 0 6px; font-size: 22px; }
+  .modal p { margin: 0 0 16px; color: #4b5563; font-size: 14.5px; line-height: 1.5; }
+  .modal form { display: flex; flex-direction: column; gap: 10px; }
+  .modal input {
+    padding: 11px 12px;
+    border: 1px solid #d6d6d6;
+    border-radius: 10px;
+    font: inherit;
+    font-size: 14px;
+  }
+  .modal input:focus { outline: 2px solid #3b82f6; outline-offset: 1px; border-color: #3b82f6; }
+  .modal-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }
+  .modal .btn-primary, .modal .btn-ghost { color: #111; }
+  .modal .btn-ghost { background: #f1f1f1; border-color: transparent; }
+
+  /* Mobile */
+  @media (max-width: 880px) {
+    .nav ul.primary, .nav-right .text-link { display: none; }
+    .stage { margin-top: 36px; }
+    .mock-body { grid-template-columns: 1fr; }
+    .side {
+      display: none;
+    }
+    .blocks { grid-template-columns: 1fr; }
+    .badge.b2 { left: -10px; }
+    .badge.b4 { right: -10px; }
+    .logo-row { gap: 14px; justify-content: center; }
+  }
+  @media (max-width: 520px) {
+    .badge { display: none; }
+    .nav { padding: 14px 18px; }
+    .announce { font-size: 12.5px; padding: 8px 36px 8px 12px; }
+    h1.headline { font-size: 44px; }
+    .ctas { width: 100%; }
+    .btn { width: 100%; justify-content: center; }
+  }
+</style>
+</head>
+<body>
+
+<div class="variant-tag" aria-hidden="true">Variant A</div>
+
+<!-- Announcement bar -->
+<div class="announce" id="announce" role="region" aria-label="Announcement">
+  <span><strong>New:</strong> Agents are here. Hand off the busywork and let your workspace work for you.
+    <a href="#" class="link">Read the announcement <span class="arrow">→</span></a>
+  </span>
+  <button class="close" id="announce-close" aria-label="Dismiss announcement">✕</button>
+</div>
+
+<!-- Hero -->
+<header class="hero">
+  <nav class="nav" aria-label="Primary">
+    <a class="brand" href="#" aria-label="Notion home">
+      <span class="brand-mark">N</span>
+      <span>Notion</span>
+    </a>
+
+    <ul class="primary" id="primary-menu">
+      <li class="menu-item" data-menu>
+        <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Notion <span class="caret"></span></button>
+        <div class="dropdown" role="menu">
+          <a href="#" role="menuitem">Docs &amp; Wikis</a>
+          <a href="#" role="menuitem">Projects</a>
+          <a href="#" role="menuitem">Calendar</a>
+          <a href="#" role="menuitem">Forms</a>
+        </div>
+      </li>
+      <li class="menu-item" data-menu>
+        <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Mail <span class="caret"></span></button>
+        <div class="dropdown" role="menu">
+          <a href="#" role="menuitem">Inbox triage</a>
+          <a href="#" role="menuitem">Smart replies</a>
+          <a href="#" role="menuitem">Filters</a>
+        </div>
+      </li>
+      <li class="menu-item" data-menu>
+        <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Calendar <span class="caret"></span></button>
+        <div class="dropdown" role="menu">
+          <a href="#" role="menuitem">Scheduling</a>
+          <a href="#" role="menuitem">Availability</a>
+          <a href="#" role="menuitem">Bookings</a>
+        </div>
+      </li>
+      <li class="menu-item" data-menu>
+        <button class="menu-btn" aria-haspopup="true" aria-expanded="false">AI <span class="caret"></span></button>
+        <div class="dropdown" role="menu">
+          <a href="#" role="menuitem">AI Meeting Notes</a>
+          <a href="#" role="menuitem">Research mode</a>
+          <a href="#" role="menuitem">Agents</a>
+        </div>
+      </li>
+      <li class="menu-item"><a class="menu-btn" href="#">Pricing</a></li>
+      <li class="menu-item" data-menu>
+        <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Resources <span class="caret"></span></button>
+        <div class="dropdown" role="menu">
+          <a href="#" role="menuitem">Templates</a>
+          <a href="#" role="menuitem">Help center</a>
+          <a href="#" role="menuitem">Customer stories</a>
+        </div>
+      </li>
+    </ul>
+
+    <div class="nav-right">
+      <a class="text-link" href="#" id="login-link">Log in</a>
+      <a class="pill" href="#" id="get-started-top">Get Notion free</a>
+    </div>
+  </nav>
+
+  <div class="hero-copy">
+    <div class="eyebrow"><span class="dot"></span> Agents now in beta</div>
+    <h1 class="headline">Meet the <span class="accent">night shift.</span></h1>
+    <p class="subcopy">
+      Agents that take work off your plate — drafting docs, organizing projects, and following up
+      while you sleep. Your workspace finally pulls its own weight.
+    </p>
+    <div class="ctas">
+      <button class="btn btn-primary" id="cta-primary" aria-describedby="status-line">Get Notion free</button>
+      <button class="btn btn-ghost" id="cta-secondary" aria-describedby="status-line">Request a demo</button>
+    </div>
+    <div class="status-line" id="status-line" role="status" aria-live="polite"></div>
+  </div>
+
+  <!-- Stage -->
+  <div class="stage" aria-hidden="false">
+    <!-- Winding blue path lines -->
+    <svg class="paths" viewBox="0 0 1200 700" preserveAspectRatio="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="pg" x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stop-color="#7aa6ff" stop-opacity="0"/>
+          <stop offset="40%" stop-color="#7aa6ff" stop-opacity="0.9"/>
+          <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
+        </linearGradient>
+        <linearGradient id="pg2" x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stop-color="#3b82f6" stop-opacity="0"/>
+          <stop offset="50%" stop-color="#9bbcff" stop-opacity="0.8"/>
+          <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
+        </linearGradient>
+      </defs>
+      <path d="M -20,120 C 200,40 280,260 480,200 S 760,40 1000,160 S 1220,360 1240,300"
+            stroke="url(#pg)" stroke-width="2" fill="none" />
+      <path d="M -20,360 C 220,420 320,220 520,300 S 820,520 1040,400 S 1240,260 1260,310"
+            stroke="url(#pg2)" stroke-width="2" fill="none" />
+      <path d="M -20,520 C 200,560 360,420 540,500 S 800,640 1000,560"
+            stroke="url(#pg)" stroke-width="1.5" fill="none" opacity="0.6" />
+    </svg>
+
+    <!-- Floating badges -->
+    <button class="badge b1" aria-label="Open Calendar agent"><span class="ic">📅</span> Calendar agent</button>
+    <button class="badge b2" aria-label="Open Inbox triage"><span class="ic">✉️</span> Inbox triage</button>
+    <button class="badge b3" aria-label="Open Research"><span class="ic">🔍</span> Research</button>
+    <button class="badge b4" aria-label="Open Notes"><span class="ic">📝</span> AI notes</button>
+    <button class="badge b5" aria-label="Open Tasks"><span class="ic">✅</span> Tasks</button>
+
+    <!-- App window mockup -->
+    <div class="mock" role="img" aria-label="Notion app preview">
+      <div class="mock-titlebar">
+        <span class="traffic"><span class="r"></span><span class="y"></span><span class="g"></span></span>
+        <span class="crumbs">Workspace <span class="sep">/</span> Team home <span class="sep">/</span> Tonight's agenda</span>
+      </div>
+      <div class="mock-body">
+        <aside class="side" aria-label="Sidebar">
+          <div class="group">
+            <div class="group-title">Workspace</div>
+            <div class="row active"><span class="ic">🏠</span> Team home</div>
+            <div class="row"><span class="ic">📥</span> Inbox</div>
+            <div class="row"><span class="ic">📅</span> Calendar</div>
+            <div class="row"><span class="ic">🤖</span> Agents</div>
+          </div>
+          <div class="group">
+            <div class="group-title">Projects</div>
+            <div class="row"><span class="ic">🚀</span> Launch plan</div>
+            <div class="row"><span class="ic">🧭</span> Roadmap Q3</div>
+            <div class="row"><span class="ic">📚</span> Research</div>
+          </div>
+        </aside>
+        <section class="main">
+          <div class="h-eyebrow">Tonight · Agents working</div>
+          <h2 class="h-title">Pick something to hand off</h2>
+          <div class="blocks">
+            <button class="block" data-card="brief">
+              <div class="emoji">🌙</div>
+              <div class="title">Draft tomorrow's brief</div>
+              <div class="desc">Pulls from yesterday's notes, calendar, and inbox.</div>
+            </button>
+            <button class="block" data-card="inbox">
+              <div class="emoji">✉️</div>
+              <div class="title">Sort the inbox</div>
+              <div class="desc">Triage, label, and reply where safe.</div>
+            </button>
+            <button class="block" data-card="research">
+              <div class="emoji">🔭</div>
+              <div class="title">Research the lead</div>
+              <div class="desc">Compiles a one-page recap from the web.</div>
+            </button>
+          </div>
+          <div class="lines" aria-hidden="true">
+            <div class="ln m"></div>
+            <div class="ln s"></div>
+            <div class="ln m"></div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+
+  <!-- Logo strip -->
+  <section class="logos" aria-label="Customers">
+    <div class="label">Trusted by teams at</div>
+    <div class="logo-row">
+      <span class="logo">◎ OpenAI</span>
+      <span class="logo">▲ Vercel</span>
+      <span class="logo">◆ Figma</span>
+      <span class="logo">✦ Ramp</span>
+      <span class="logo">⬢ Linear</span>
+      <span class="logo">★ Pixar</span>
+      <span class="logo">◈ Headspace</span>
+    </div>
+  </section>
+</header>
+
+<!-- Demo modal -->
+<div class="modal-backdrop" id="demo-modal" role="dialog" aria-modal="true" aria-labelledby="demo-title">
+  <div class="modal">
+    <h2 id="demo-title">Request a demo</h2>
+    <p>Tell us where to send the invite. We'll follow up within one business day.</p>
+    <form id="demo-form">
+      <input type="text" name="name" placeholder="Full name" required />
+      <input type="email" name="email" placeholder="Work email" required />
+      <input type="text" name="company" placeholder="Company" />
+      <div class="modal-actions">
+        <button type="button" class="btn btn-ghost" id="demo-cancel">Cancel</button>
+        <button type="submit" class="btn btn-primary">Send request</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+(function () {
+  // Announcement dismiss
+  var bar = document.getElementById('announce');
+  document.getElementById('announce-close').addEventListener('click', function () {
+    bar.style.display = 'none';
+  });
+
+  // Dropdowns: click to toggle, click-outside to close, ESC to close
+  var menus = document.querySelectorAll('.menu-item[data-menu]');
+  menus.forEach(function (item) {
+    var btn = item.querySelector('.menu-btn');
+    btn.addEventListener('click', function (e) {
+      e.preventDefault();
+      var wasOpen = item.classList.contains('open');
+      menus.forEach(function (m) {
+        m.classList.remove('open');
+        var b = m.querySelector('.menu-btn');
+        if (b) b.setAttribute('aria-expanded', 'false');
+      });
+      if (!wasOpen) {
+        item.classList.add('open');
+        btn.setAttribute('aria-expanded', 'true');
+      }
+    });
+  });
+  document.addEventListener('click', function (e) {
+    if (!e.target.closest('.menu-item')) {
+      menus.forEach(function (m) {
+        m.classList.remove('open');
+        var b = m.querySelector('.menu-btn');
+        if (b) b.setAttribute('aria-expanded', 'false');
+      });
+    }
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      menus.forEach(function (m) { m.classList.remove('open'); });
+      closeModal();
+    }
+  });
+
+  // Status line for CTAs
+  var status = document.getElementById('status-line');
+  function setStatus(msg) {
+    status.textContent = msg;
+    clearTimeout(setStatus._t);
+    setStatus._t = setTimeout(function () { status.textContent = ''; }, 4000);
+  }
+  document.getElementById('cta-primary').addEventListener('click', function () {
+    setStatus('Spinning up your free workspace…');
+  });
+  document.getElementById('get-started-top').addEventListener('click', function (e) {
+    e.preventDefault();
+    setStatus('Spinning up your free workspace…');
+  });
+  document.getElementById('login-link').addEventListener('click', function (e) {
+    e.preventDefault();
+    setStatus('Redirecting to log in…');
+  });
+
+  // Modal
+  var modal = document.getElementById('demo-modal');
+  function openModal() { modal.classList.add('open'); modal.querySelector('input').focus(); }
+  function closeModal() { modal.classList.remove('open'); }
+  document.getElementById('cta-secondary').addEventListener('click', openModal);
+  document.getElementById('demo-cancel').addEventListener('click', closeModal);
+  modal.addEventListener('click', function (e) { if (e.target === modal) closeModal(); });
+  document.getElementById('demo-form').addEventListener('submit', function (e) {
+    e.preventDefault();
+    closeModal();
+    setStatus('Demo request received — check your inbox.');
+  });
+
+  // App cards
+  document.querySelectorAll('.block').forEach(function (card) {
+    card.addEventListener('click', function () {
+      var kind = card.getAttribute('data-card');
+      var label = card.querySelector('.title').textContent;
+      setStatus('Agent started: ' + label);
+    });
+  });
+
+  // Floating badges
+  document.querySelectorAll('.badge').forEach(function (b) {
+    b.addEventListener('click', function () {
+      setStatus('Opened ' + b.textContent.trim());
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/notion-home-variant-b.html
+++ b/notion-home-variant-b.html
@@ -1,0 +1,662 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Meet the night shift — Notion (Variant B)</title>
+<style>
+  :root {
+    --navy-900: #0b1220;
+    --navy-800: #0f172a;
+    --navy-700: #111c34;
+    --ink: #1f2937;
+    --muted: #94a3b8;
+    --line: rgba(255,255,255,0.08);
+    --blue: #2f6bff;
+    --blue-2: #5b8cff;
+    --soft: #f5f6f8;
+    --paper: #ffffff;
+    --shadow-lg: 0 30px 60px -20px rgba(2,6,23,0.45), 0 12px 24px -10px rgba(2,6,23,0.35);
+    --radius: 14px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #e6ecf5;
+    background: var(--navy-900);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: inherit; text-decoration: none; }
+  button { font: inherit; cursor: pointer; }
+  :focus-visible { outline: 2px solid #9cc0ff; outline-offset: 2px; border-radius: 6px; }
+
+  /* Variant label */
+  .variant-tag {
+    position: fixed; right: 12px; bottom: 12px; z-index: 90;
+    background: #ffffff; color: #0b1220;
+    border-radius: 999px; padding: 6px 10px;
+    font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+    border: 1px solid rgba(0,0,0,0.06);
+  }
+
+  /* Announcement */
+  .announce {
+    background: linear-gradient(90deg, #0a1124 0%, #131e3d 50%, #0a1124 100%);
+    color: #dde6f7;
+    border-bottom: 1px solid var(--line);
+    font-size: 13px;
+    display: flex; align-items: center; justify-content: center; gap: 12px;
+    padding: 10px 16px; position: relative;
+  }
+  .announce strong { color: #fff; font-weight: 600; }
+  .announce a.link { color: #9cc0ff; border-bottom: 1px solid rgba(156,192,255,0.4); padding-bottom: 1px; }
+  .announce .close {
+    position: absolute; right: 10px; top: 50%; transform: translateY(-50%);
+    background: transparent; color: #cfd8ee; border: 0; padding: 6px 8px; border-radius: 6px;
+  }
+  .announce .close:hover { background: rgba(255,255,255,0.06); }
+
+  /* Nav */
+  .nav-wrap { position: sticky; top: 0; z-index: 60; background: rgba(11,18,32,0.7); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); }
+  .nav {
+    max-width: 1240px; margin: 0 auto; padding: 14px 24px;
+    display: flex; align-items: center; gap: 22px;
+  }
+  .brand { display: flex; align-items: center; gap: 8px; font-weight: 700; font-size: 18px; color: #fff; }
+  .brand-mark {
+    width: 26px; height: 26px; border-radius: 6px; background: #fff; color: #0b1220;
+    display: grid; place-items: center; font-weight: 900; font-size: 16px;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+  }
+  .nav-links { display: flex; gap: 4px; margin-left: 12px; flex: 1; }
+  .nav-links button {
+    background: transparent; border: 0; color: #cfd8ee; padding: 8px 12px;
+    border-radius: 8px; font-size: 14px; display: inline-flex; align-items: center; gap: 6px;
+  }
+  .nav-links button:hover { background: rgba(255,255,255,0.06); color: #fff; }
+  .nav-links .caret { font-size: 10px; opacity: 0.7; }
+  .nav-actions { display: flex; align-items: center; gap: 6px; }
+  .nav-actions .ghost {
+    background: transparent; border: 0; color: #cfd8ee; padding: 8px 12px; border-radius: 8px; font-size: 14px;
+  }
+  .nav-actions .ghost:hover { background: rgba(255,255,255,0.06); color: #fff; }
+  .nav-actions .primary {
+    background: #fff; color: #0b1220; border: 0; padding: 8px 14px; border-radius: 8px;
+    font-weight: 600; font-size: 14px;
+  }
+  .nav-actions .primary:hover { background: #e8edf6; }
+
+  /* Dropdown */
+  .menu {
+    position: absolute; top: calc(100% + 8px); left: 0; min-width: 220px;
+    background: #11182a; border: 1px solid var(--line); border-radius: 12px; padding: 8px;
+    box-shadow: 0 24px 48px rgba(0,0,0,0.45); display: none; z-index: 70;
+  }
+  .menu[data-open="true"] { display: block; }
+  .menu a, .menu button.item {
+    display: block; width: 100%; text-align: left; padding: 8px 10px; border-radius: 8px;
+    color: #dde6f7; font-size: 14px; background: transparent; border: 0;
+  }
+  .menu a:hover, .menu button.item:hover { background: rgba(255,255,255,0.06); color: #fff; }
+  .nav-item { position: relative; }
+
+  /* Hero */
+  .hero {
+    position: relative; overflow: hidden;
+    background:
+      radial-gradient(800px 380px at 80% -10%, rgba(91,140,255,0.18), transparent 60%),
+      radial-gradient(600px 320px at 10% 10%, rgba(47,107,255,0.12), transparent 60%),
+      linear-gradient(180deg, #0b1220 0%, #0a1224 100%);
+    padding: 56px 24px 24px;
+  }
+  .hero-inner { max-width: 1180px; margin: 0 auto; text-align: center; position: relative; }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    color: #9cc0ff; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+    background: rgba(91,140,255,0.1); border: 1px solid rgba(156,192,255,0.25);
+    padding: 6px 10px; border-radius: 999px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: #9cc0ff; box-shadow: 0 0 12px #9cc0ff; }
+  h1.headline {
+    font-size: clamp(40px, 6vw, 80px);
+    line-height: 1.02; letter-spacing: -0.03em;
+    margin: 18px auto 14px; font-weight: 700; color: #fff; max-width: 16ch;
+  }
+  h1.headline .accent {
+    background: linear-gradient(90deg, #cfdcff 0%, #ffffff 50%, #9cc0ff 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .subcopy {
+    font-size: clamp(15px, 1.4vw, 18px); color: #b8c4dc;
+    max-width: 64ch; margin: 0 auto 24px;
+  }
+  .ctas { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; margin-bottom: 36px; }
+  .btn { border-radius: 10px; padding: 12px 18px; font-size: 14px; font-weight: 600; border: 0; }
+  .btn-primary { background: #fff; color: #0b1220; }
+  .btn-primary:hover { background: #e8edf6; transform: translateY(-1px); }
+  .btn-secondary { background: rgba(255,255,255,0.06); color: #fff; border: 1px solid rgba(255,255,255,0.18); }
+  .btn-secondary:hover { background: rgba(255,255,255,0.1); }
+  .btn:active { transform: translateY(0); }
+
+  /* Stage with mockup + badges + connectors */
+  .stage {
+    position: relative;
+    margin: 0 auto; max-width: 1100px;
+    padding: 40px 0 24px;
+  }
+  .connectors { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+  .connectors path { fill: none; stroke: url(#wire); stroke-width: 2; stroke-linecap: round; }
+  .connectors .dash { stroke-dasharray: 4 6; opacity: 0.55; }
+
+  /* Mockup window */
+  .mockup {
+    position: relative; z-index: 2;
+    background: var(--paper); color: var(--ink);
+    border-radius: 14px; box-shadow: var(--shadow-lg);
+    overflow: hidden; border: 1px solid rgba(0,0,0,0.06);
+    max-width: 880px; margin: 0 auto;
+  }
+  .mock-titlebar {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px; border-bottom: 1px solid #eef0f4; background: #fafbfc;
+  }
+  .traffic { display: flex; gap: 6px; }
+  .traffic span { width: 10px; height: 10px; border-radius: 50%; }
+  .traffic .r { background: #ff5f56; } .traffic .y { background: #ffbd2e; } .traffic .g { background: #27c93f; }
+  .mock-url {
+    flex: 1; background: #fff; border: 1px solid #eaecef; border-radius: 6px;
+    font-size: 12px; color: #6b7280; padding: 5px 10px; text-align: center;
+  }
+  .mock-body { display: grid; grid-template-columns: 200px 1fr; min-height: 360px; }
+  .mock-side {
+    background: #fafbfc; border-right: 1px solid #eef0f4;
+    padding: 14px 12px; font-size: 13px; color: #4b5563;
+  }
+  .mock-side .group { font-size: 11px; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.08em; margin: 14px 6px 6px; }
+  .mock-side .row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 6px 8px; border-radius: 6px; cursor: pointer;
+  }
+  .mock-side .row:hover { background: #eef2f7; }
+  .mock-side .row.active { background: #e8efff; color: #1e3a8a; }
+  .mock-side .ic { width: 16px; text-align: center; }
+
+  .mock-content { padding: 18px 22px; }
+  .mock-h {
+    display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
+  }
+  .mock-emoji { font-size: 22px; }
+  .mock-title { font-size: 22px; font-weight: 700; color: #111827; letter-spacing: -0.01em; }
+  .mock-meta { font-size: 12px; color: #6b7280; margin-bottom: 14px; }
+  .mock-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 14px;
+  }
+  .mock-card {
+    background: #f7f9fc; border: 1px solid #eef0f4; border-radius: 10px; padding: 10px;
+    cursor: pointer; transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  }
+  .mock-card:hover { transform: translateY(-2px); border-color: #c9d6f5; box-shadow: 0 6px 14px rgba(15,23,42,0.06); }
+  .mock-card .label { font-size: 11px; color: #6b7280; text-transform: uppercase; letter-spacing: 0.06em; }
+  .mock-card .value { font-size: 18px; font-weight: 700; color: #111827; margin-top: 4px; }
+  .mock-card .trend { font-size: 11px; color: #16a34a; margin-top: 2px; }
+
+  .mock-list { border: 1px solid #eef0f4; border-radius: 10px; overflow: hidden; }
+  .mock-list .item {
+    display: grid; grid-template-columns: 22px 1fr auto auto; gap: 10px;
+    align-items: center; padding: 9px 12px; font-size: 13px;
+    border-bottom: 1px solid #f1f3f7; cursor: pointer;
+  }
+  .mock-list .item:last-child { border-bottom: 0; }
+  .mock-list .item:hover { background: #f6f9ff; }
+  .mock-list .check {
+    width: 14px; height: 14px; border-radius: 4px; border: 1.5px solid #c7cfdb; display: inline-block;
+  }
+  .mock-list .item[data-done="true"] .check { background: #2f6bff; border-color: #2f6bff; position: relative; }
+  .mock-list .item[data-done="true"] .check::after {
+    content: ""; position: absolute; left: 3px; top: 1px; width: 4px; height: 8px;
+    border-right: 2px solid #fff; border-bottom: 2px solid #fff; transform: rotate(45deg);
+  }
+  .mock-list .item[data-done="true"] .name { color: #9aa3b2; text-decoration: line-through; }
+  .pill { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: #eef2f7; color: #475569; }
+  .pill.blue { background: #e6efff; color: #1d4ed8; }
+  .pill.amber { background: #fff3d6; color: #92400e; }
+  .pill.green { background: #dcfce7; color: #166534; }
+  .avatar { width: 22px; height: 22px; border-radius: 50%; background: linear-gradient(135deg, #94a3b8, #475569); color:#fff; font-size: 10px; display: grid; place-items: center; font-weight: 700; }
+
+  /* Badges */
+  .badge {
+    position: absolute; z-index: 3;
+    background: #fff; color: #0b1220;
+    border: 1px solid rgba(0,0,0,0.05);
+    border-radius: 12px; padding: 8px 12px;
+    font-size: 12px; font-weight: 600;
+    display: inline-flex; align-items: center; gap: 8px;
+    box-shadow: 0 14px 30px -10px rgba(2,6,23,0.45), 0 4px 8px rgba(2,6,23,0.25);
+    transform: translate(-50%, -50%);
+    animation: float 6s ease-in-out infinite;
+    cursor: default;
+  }
+  .badge:hover { transform: translate(-50%, calc(-50% - 3px)); }
+  .badge .ic { width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; font-size: 13px; color: #fff; }
+  .badge .sub { color: #6b7280; font-weight: 500; font-size: 11px; }
+  .badge.dark { background: #0f172a; color: #fff; border-color: rgba(255,255,255,0.08); }
+  .badge.dark .sub { color: #9aa7c2; }
+
+  .b1 { top: 8%; left: 12%; animation-delay: 0s; }
+  .b2 { top: 22%; left: 92%; animation-delay: -1.5s; }
+  .b3 { top: 64%; left: 6%; animation-delay: -2.2s; }
+  .b4 { top: 80%; left: 88%; animation-delay: -3s; }
+  .b5 { top: 92%; left: 38%; animation-delay: -4s; }
+
+  @keyframes float {
+    0%, 100% { transform: translate(-50%, -50%); }
+    50% { transform: translate(-50%, calc(-50% - 6px)); }
+  }
+
+  /* Logo strip */
+  .logos {
+    background: #0a1224; border-top: 1px solid var(--line);
+    padding: 36px 24px;
+  }
+  .logos-inner {
+    max-width: 1180px; margin: 0 auto; text-align: center;
+  }
+  .logos-title { color: #8aa0c6; font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 18px; }
+  .logos-row {
+    display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 36px;
+    color: #c4cee2; opacity: 0.85;
+    font-weight: 700; letter-spacing: 0.02em;
+  }
+  .logo {
+    font-size: 18px; display: inline-flex; align-items: center; gap: 6px;
+    filter: grayscale(1) brightness(1.4); opacity: 0.85;
+  }
+  .logo:hover { opacity: 1; }
+  .logo .glyph { display: inline-grid; place-items: center; width: 22px; height: 22px; }
+
+  /* Modal */
+  .backdrop {
+    position: fixed; inset: 0; background: rgba(2,6,23,0.6); display: none;
+    align-items: center; justify-content: center; z-index: 100;
+  }
+  .backdrop[data-open="true"] { display: flex; }
+  .modal {
+    background: #fff; color: #0b1220; border-radius: 14px;
+    width: min(440px, 92vw); padding: 22px; box-shadow: var(--shadow-lg);
+  }
+  .modal h3 { margin: 0 0 6px; font-size: 18px; }
+  .modal p { margin: 0 0 14px; color: #475569; font-size: 14px; }
+  .modal .field { display: flex; gap: 8px; }
+  .modal input {
+    flex: 1; padding: 10px 12px; border-radius: 8px; border: 1px solid #e5e7eb; font-size: 14px;
+  }
+  .modal input:focus { border-color: #2f6bff; outline: 2px solid #c7d8ff; }
+  .modal .row-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+  .modal .btn-primary { background: #0b1220; color: #fff; }
+  .modal .btn-primary:hover { background: #1f2a44; }
+  .modal .btn-ghost { background: transparent; color: #475569; border: 1px solid #e5e7eb; }
+
+  /* Toast */
+  .toast {
+    position: fixed; left: 50%; bottom: 24px; transform: translate(-50%, 80px);
+    background: #0b1220; color: #fff; padding: 10px 14px; border-radius: 10px;
+    font-size: 13px; box-shadow: 0 16px 40px rgba(0,0,0,0.4); opacity: 0;
+    transition: transform 240ms ease, opacity 240ms ease; z-index: 110; pointer-events: none;
+  }
+  .toast.show { opacity: 1; transform: translate(-50%, 0); }
+
+  /* Responsive */
+  @media (max-width: 880px) {
+    .nav-links { display: none; }
+    .mock-body { grid-template-columns: 1fr; }
+    .mock-side { display: none; }
+    .mock-grid { grid-template-columns: 1fr 1fr; }
+    .badge { font-size: 11px; padding: 6px 10px; }
+    .b1 { top: -2%; left: 22%; }
+    .b2 { top: 8%; left: 82%; }
+    .b3 { top: 62%; left: 12%; }
+    .b4 { top: 86%; left: 80%; }
+    .b5 { top: 100%; left: 50%; }
+  }
+  @media (max-width: 520px) {
+    .hero { padding: 36px 14px 14px; }
+    .ctas { flex-direction: column; align-items: stretch; }
+    .ctas .btn { width: 100%; }
+    .mock-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+  <div class="variant-tag" aria-label="Variant label">VARIANT B</div>
+
+  <!-- Announcement -->
+  <div class="announce" id="announce" role="region" aria-label="Announcement">
+    <span>✨</span>
+    <span><strong>New:</strong> Meet Notion 3.1 — connected agents that work overnight. <a href="#" class="link">See what's new →</a></span>
+    <button class="close" id="announceClose" aria-label="Dismiss announcement">✕</button>
+  </div>
+
+  <!-- Nav -->
+  <div class="nav-wrap">
+    <nav class="nav" aria-label="Primary">
+      <a href="#" class="brand"><span class="brand-mark">N</span> Notion</a>
+      <div class="nav-links" id="navLinks">
+        <div class="nav-item">
+          <button data-menu="product">Product <span class="caret">▼</span></button>
+          <div class="menu" id="menu-product" role="menu">
+            <a href="#" role="menuitem">Docs</a>
+            <a href="#" role="menuitem">Wiki</a>
+            <a href="#" role="menuitem">Projects</a>
+            <a href="#" role="menuitem">Calendar</a>
+            <a href="#" role="menuitem">AI</a>
+          </div>
+        </div>
+        <div class="nav-item">
+          <button data-menu="solutions">Solutions <span class="caret">▼</span></button>
+          <div class="menu" id="menu-solutions" role="menu">
+            <a href="#" role="menuitem">Engineering</a>
+            <a href="#" role="menuitem">Design</a>
+            <a href="#" role="menuitem">Marketing</a>
+            <a href="#" role="menuitem">Operations</a>
+          </div>
+        </div>
+        <div class="nav-item">
+          <button data-menu="resources">Resources <span class="caret">▼</span></button>
+          <div class="menu" id="menu-resources" role="menu">
+            <a href="#" role="menuitem">Help center</a>
+            <a href="#" role="menuitem">Templates</a>
+            <a href="#" role="menuitem">Guides</a>
+            <a href="#" role="menuitem">Community</a>
+          </div>
+        </div>
+        <div class="nav-item">
+          <button data-menu="pricing">Pricing</button>
+        </div>
+      </div>
+      <div class="nav-actions">
+        <button class="ghost" id="signIn">Sign in</button>
+        <button class="primary" id="getNotionBtn">Get Notion free</button>
+      </div>
+    </nav>
+  </div>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <span class="eyebrow"><span class="dot"></span> Now with overnight agents</span>
+      <h1 class="headline">Meet the <span class="accent">night shift.</span></h1>
+      <p class="subcopy">
+        While your team sleeps, Notion agents draft updates, sort inboxes, and prep tomorrow's plan — all inside the same workspace your docs, projects, and meetings already live in.
+      </p>
+      <div class="ctas">
+        <button class="btn btn-primary" id="ctaPrimary">Get Notion free</button>
+        <button class="btn btn-secondary" id="ctaSecondary">Request a demo →</button>
+      </div>
+
+      <!-- Stage -->
+      <div class="stage" id="stage">
+        <!-- SVG connectors -->
+        <svg class="connectors" viewBox="0 0 1100 640" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="wire" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#6ea0ff" stop-opacity="0.0" />
+              <stop offset="40%" stop-color="#6ea0ff" stop-opacity="0.85" />
+              <stop offset="100%" stop-color="#2f6bff" stop-opacity="0.9" />
+            </linearGradient>
+          </defs>
+          <!-- winding paths from badges into mockup -->
+          <path d="M120,80 C260,40 320,260 540,260" />
+          <path d="M1010,140 C880,180 760,220 620,260" />
+          <path class="dash" d="M80,420 C260,420 360,360 520,360" />
+          <path class="dash" d="M980,520 C820,520 700,420 600,380" />
+          <path d="M420,610 C460,540 520,480 540,420" />
+        </svg>
+
+        <!-- Mockup -->
+        <div class="mockup" role="group" aria-label="Notion workspace preview">
+          <div class="mock-titlebar">
+            <div class="traffic" aria-hidden="true"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+            <div class="mock-url">notion.so / night-shift / overview</div>
+          </div>
+          <div class="mock-body">
+            <aside class="mock-side" aria-label="Sidebar">
+              <div class="group">Workspace</div>
+              <div class="row" data-page="overview"><span class="ic">🏠</span> Overview</div>
+              <div class="row active" data-page="night-shift"><span class="ic">🌙</span> Night shift</div>
+              <div class="row" data-page="inbox"><span class="ic">📥</span> Inbox</div>
+              <div class="row" data-page="projects"><span class="ic">🗂️</span> Projects</div>
+              <div class="row" data-page="calendar"><span class="ic">🗓️</span> Calendar</div>
+              <div class="group">Agents</div>
+              <div class="row" data-page="standup"><span class="ic">🧭</span> Standup writer</div>
+              <div class="row" data-page="triage"><span class="ic">📨</span> Inbox triage</div>
+              <div class="row" data-page="research"><span class="ic">🔎</span> Research scout</div>
+            </aside>
+            <main class="mock-content">
+              <div class="mock-h">
+                <span class="mock-emoji">🌙</span>
+                <span class="mock-title" id="mockTitle">Night shift</span>
+              </div>
+              <div class="mock-meta">Updated by Agent · 3 minutes ago · 12 tasks queued</div>
+
+              <div class="mock-grid">
+                <div class="mock-card" data-card="drafts">
+                  <div class="label">Drafts ready</div>
+                  <div class="value">14</div>
+                  <div class="trend">+4 since midnight</div>
+                </div>
+                <div class="mock-card" data-card="inbox">
+                  <div class="label">Inbox triaged</div>
+                  <div class="value">128</div>
+                  <div class="trend">98% sorted</div>
+                </div>
+                <div class="mock-card" data-card="briefs">
+                  <div class="label">Morning briefs</div>
+                  <div class="value">6</div>
+                  <div class="trend">Due 8:00 AM</div>
+                </div>
+              </div>
+
+              <div class="mock-list" id="taskList" aria-label="Overnight task list">
+                <div class="item" data-done="true">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Summarize yesterday's standup</span>
+                  <span class="pill green">Done</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+                <div class="item" data-done="true">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Draft Q3 roadmap update</span>
+                  <span class="pill blue">Doc</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+                <div class="item" data-done="false">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Flag overdue tickets in Projects</span>
+                  <span class="pill amber">Running</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+                <div class="item" data-done="false">
+                  <span class="check" aria-hidden="true"></span>
+                  <span class="name">Compile weekly customer feedback</span>
+                  <span class="pill">Queued</span>
+                  <span class="avatar" title="Agent">AI</span>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+
+        <!-- Floating badges -->
+        <div class="badge b1" tabindex="0" data-tip="Slack messages summarized">
+          <span class="ic" style="background:#4a154b">💬</span>
+          <span><div>Slack digest</div><div class="sub">17 threads · 3 actions</div></span>
+        </div>
+        <div class="badge b2 dark" tabindex="0" data-tip="GitHub PRs reviewed">
+          <span class="ic" style="background:#1f2937">🐙</span>
+          <span><div>PRs reviewed</div><div class="sub">9 awaiting you</div></span>
+        </div>
+        <div class="badge b3" tabindex="0" data-tip="Calendar prepared">
+          <span class="ic" style="background:#0b76ff">🗓️</span>
+          <span><div>Tomorrow's plan</div><div class="sub">5 meetings prepped</div></span>
+        </div>
+        <div class="badge b4" tabindex="0" data-tip="Research scout completed">
+          <span class="ic" style="background:#16a34a">🔎</span>
+          <span><div>Research scout</div><div class="sub">12 sources cited</div></span>
+        </div>
+        <div class="badge b5 dark" tabindex="0" data-tip="Notion AI agent">
+          <span class="ic" style="background:linear-gradient(135deg,#5b8cff,#2f6bff)">✨</span>
+          <span><div>Notion agent</div><div class="sub">on duty · 03:14 AM</div></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Logos strip -->
+  <section class="logos">
+    <div class="logos-inner">
+      <div class="logos-title">Trusted by teams at</div>
+      <div class="logos-row" aria-label="Customer logos">
+        <span class="logo"><span class="glyph">◎</span> OpenAI</span>
+        <span class="logo"><span class="glyph">▲</span> Vercel</span>
+        <span class="logo"><span class="glyph">◇</span> Figma</span>
+        <span class="logo"><span class="glyph">●</span> Loom</span>
+        <span class="logo"><span class="glyph">✦</span> Ramp</span>
+        <span class="logo"><span class="glyph">⌬</span> Match</span>
+        <span class="logo"><span class="glyph">◧</span> Toyota</span>
+        <span class="logo"><span class="glyph">◐</span> Headspace</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Modal -->
+  <div class="backdrop" id="backdrop" aria-hidden="true">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <h3 id="modalTitle">Get Notion free</h3>
+      <p>Drop your work email — we'll send a one-click signup link.</p>
+      <div class="field">
+        <input id="emailInput" type="email" placeholder="you@company.com" autocomplete="email" />
+        <button class="btn btn-primary" id="modalSubmit">Continue</button>
+      </div>
+      <div class="row-actions">
+        <button class="btn btn-ghost" id="modalCancel">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="toast" id="toast" role="status" aria-live="polite">Saved</div>
+
+<script>
+  // Announcement close
+  const announce = document.getElementById('announce');
+  document.getElementById('announceClose').addEventListener('click', () => {
+    announce.style.display = 'none';
+  });
+
+  // Dropdown menus
+  const navLinks = document.getElementById('navLinks');
+  const menus = {
+    product: document.getElementById('menu-product'),
+    solutions: document.getElementById('menu-solutions'),
+    resources: document.getElementById('menu-resources'),
+  };
+  function closeAllMenus(except) {
+    Object.entries(menus).forEach(([k, el]) => {
+      if (k !== except) el.dataset.open = 'false';
+    });
+  }
+  navLinks.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-menu]');
+    if (!btn) return;
+    const key = btn.dataset.menu;
+    if (key === 'pricing') { showToast('Pricing coming up'); closeAllMenus(); return; }
+    const m = menus[key];
+    const open = m.dataset.open === 'true';
+    closeAllMenus(open ? null : key);
+    m.dataset.open = open ? 'false' : 'true';
+    e.stopPropagation();
+  });
+  document.addEventListener('click', () => closeAllMenus());
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { closeAllMenus(); closeModal(); } });
+
+  // Toast
+  const toast = document.getElementById('toast');
+  let toastT;
+  function showToast(msg) {
+    toast.textContent = msg;
+    toast.classList.add('show');
+    clearTimeout(toastT);
+    toastT = setTimeout(() => toast.classList.remove('show'), 1800);
+  }
+
+  // Modal
+  const backdrop = document.getElementById('backdrop');
+  const emailInput = document.getElementById('emailInput');
+  function openModal() {
+    backdrop.dataset.open = 'true';
+    backdrop.setAttribute('aria-hidden', 'false');
+    setTimeout(() => emailInput.focus(), 30);
+  }
+  function closeModal() {
+    backdrop.dataset.open = 'false';
+    backdrop.setAttribute('aria-hidden', 'true');
+  }
+  document.getElementById('ctaPrimary').addEventListener('click', openModal);
+  document.getElementById('getNotionBtn').addEventListener('click', openModal);
+  document.getElementById('ctaSecondary').addEventListener('click', () => showToast('Demo request noted ✨'));
+  document.getElementById('signIn').addEventListener('click', () => showToast('Sign-in is just a demo here'));
+  document.getElementById('modalCancel').addEventListener('click', closeModal);
+  backdrop.addEventListener('click', (e) => { if (e.target === backdrop) closeModal(); });
+  document.getElementById('modalSubmit').addEventListener('click', () => {
+    const v = emailInput.value.trim();
+    if (!v || !v.includes('@')) { emailInput.focus(); showToast('Enter a valid email'); return; }
+    closeModal();
+    emailInput.value = '';
+    showToast("You're on the list — check your inbox 📬");
+  });
+
+  // Mockup interactions
+  const mockTitle = document.getElementById('mockTitle');
+  const titles = {
+    overview: 'Overview',
+    'night-shift': 'Night shift',
+    inbox: 'Inbox',
+    projects: 'Projects',
+    calendar: 'Calendar',
+    standup: 'Standup writer',
+    triage: 'Inbox triage',
+    research: 'Research scout',
+  };
+  document.querySelectorAll('.mock-side .row').forEach((row) => {
+    row.addEventListener('click', () => {
+      document.querySelectorAll('.mock-side .row').forEach((r) => r.classList.remove('active'));
+      row.classList.add('active');
+      const k = row.dataset.page;
+      mockTitle.textContent = titles[k] || 'Workspace';
+    });
+  });
+
+  document.querySelectorAll('.mock-card').forEach((c) => {
+    c.addEventListener('click', () => showToast('Opened ' + c.querySelector('.label').textContent.toLowerCase()));
+  });
+
+  document.querySelectorAll('#taskList .item').forEach((item) => {
+    item.addEventListener('click', () => {
+      const done = item.dataset.done === 'true';
+      item.dataset.done = done ? 'false' : 'true';
+      const pill = item.querySelector('.pill');
+      if (!done) { pill.textContent = 'Done'; pill.className = 'pill green'; }
+      else { pill.textContent = 'Queued'; pill.className = 'pill'; }
+    });
+  });
+
+  // Badge tooltips via toast
+  document.querySelectorAll('.badge').forEach((b) => {
+    b.addEventListener('click', () => showToast(b.dataset.tip));
+    b.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); showToast(b.dataset.tip); } });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone Notion landing page HTML for the default page and two comparison variants.
- Keep `index.html` intentionally identical to `notion-home-variant-b.html` as the default page.
- Add `docs/notion-landing-page-analysis.md` documenting the landing page direction.

## Files
- `index.html`
- `notion-home-variant-a.html`
- `notion-home-variant-b.html`
- `docs/notion-landing-page-analysis.md`

## Validation
- Validated Variant B/default in Orca browser: announcement dismiss, nav dropdown, CTA modal, and email input.
- Validated Variant A in Orca browser: nav dropdown and demo modal.

## Notes
- HTML is standalone and uses no external assets.