### PR TITLE
Fix OpenCode TUI wheel-scroll redraw bursts

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -47,6 +47,7 @@ import {
   type AgentInterruptInputIntent
 } from '../../../../shared/agent-interrupt-intent'
 import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import { createTerminalWheelInputBatcher } from './terminal-wheel-input-batcher'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -850,6 +851,26 @@ export function connectPanePty(
     : createIpcPtyTransport(transportOptions)
   const hasExistingPaneTransport = deps.paneTransportsRef.current.size > 0
   deps.paneTransportsRef.current.set(pane.id, transport)
+  const canSendTerminalInput = (): boolean => {
+    if (disposed || isPaneReplaying(deps.replayingPanesRef, pane.id)) {
+      return false
+    }
+    const currentPtyId = transport.getPtyId()
+    return (
+      !isCodexPaneStale({
+        tabId: deps.tabId,
+        worktreeId: deps.worktreeId,
+        panePtyId: currentPtyId
+      }) && !(currentPtyId && isPtyLocked(currentPtyId))
+    )
+  }
+  const wheelInputBatcher = createTerminalWheelInputBatcher({
+    terminal: pane.terminal,
+    sendInput: (data) => transport.sendInput(data),
+    // Why: wheel batches flush after a timer; replay/stale/mobile-lock state can
+    // change after the original onData guard accepted the first wheel report.
+    canSend: canSendTerminalInput
+  })
 
   const onDataDisposable = pane.terminal.onData((data) => {
     // Why: xterm auto-replies to embedded query sequences (DA1, DECRQM,
@@ -860,6 +881,7 @@ export function connectPanePty(
     // engage the guard via replayIntoTerminal; here we drop everything
     // xterm emits while the guard is active. See replay-guard.ts.
     if (isPaneReplaying(deps.replayingPanesRef, pane.id)) {
+      wheelInputBatcher.discard()
       return
     }
     const currentPtyId = transport.getPtyId()
@@ -876,6 +898,7 @@ export function connectPanePty(
         panePtyId: currentPtyId
       })
     ) {
+      wheelInputBatcher.discard()
       clearPendingTerminalInputIntent()
       return
     }
@@ -887,6 +910,7 @@ export function connectPanePty(
     // The pty:write IPC has a defense-in-depth twin. See
     // docs/mobile-presence-lock.md.
     if (currentPtyId && isPtyLocked(currentPtyId)) {
+      wheelInputBatcher.discard()
       clearPendingTerminalInputIntent()
       return
     }
@@ -902,6 +926,11 @@ export function connectPanePty(
       // normal cursor visibility when commands intentionally produce no echo.
       suppressTerminalCursorUntilOutputSettles(pane.terminal)
     }
+    if (wheelInputBatcher.enqueueIfWheelInput(data)) {
+      clearPendingTerminalInputIntent()
+      return
+    }
+    wheelInputBatcher.flush()
     const intent = pendingTerminalInputIntent
     // Why: real xterm can deliver the terminal byte even when our DOM keydown
     // listener missed the press. Exact Ctrl+C/Escape bytes are still safe to
@@ -1787,6 +1816,7 @@ export function connectPanePty(
       if (terminalKeyTargetSupportsEvents) {
         terminalKeyTarget.removeEventListener('keydown', onTerminalKeyDown, { capture: true })
       }
+      wheelInputBatcher.discard()
       clearPendingTerminalInputIntent()
       pendingTerminalInputWrite = null
       interruptInference.dispose()

--- a/src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createTerminalWheelInputBatcher,
+  isTerminalWheelInput
+} from './terminal-wheel-input-batcher'
+import { holdForegroundTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-scheduler'
+
+vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
+  holdForegroundTerminalOutput: vi.fn()
+}))
+
+describe('isTerminalWheelInput', () => {
+  it('recognizes SGR wheel reports', () => {
+    expect(isTerminalWheelInput('\x1b[<64;10;20M')).toBe(true)
+    expect(isTerminalWheelInput('\x1b[<65;10;20M\x1b[<64;10;20M')).toBe(true)
+  })
+
+  it('recognizes default-encoded wheel reports', () => {
+    const report = `\x1b[M${String.fromCharCode(64 + 32)}!!`
+
+    expect(isTerminalWheelInput(report)).toBe(true)
+  })
+
+  it('rejects mouse moves, releases, mixed input, and malformed reports', () => {
+    expect(isTerminalWheelInput('\x1b[<35;10;20M')).toBe(false)
+    expect(isTerminalWheelInput('\x1b[<64;10;20m')).toBe(false)
+    expect(isTerminalWheelInput('\x1b[<64;10;20Mabc')).toBe(false)
+    expect(isTerminalWheelInput('a')).toBe(false)
+  })
+})
+
+describe('createTerminalWheelInputBatcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(holdForegroundTerminalOutput).mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('batches wheel input until the burst goes idle', () => {
+    const terminal = {}
+    const sendInput = vi.fn(() => true)
+    const batcher = createTerminalWheelInputBatcher({
+      terminal: terminal as never,
+      sendInput
+    })
+
+    expect(batcher.enqueueIfWheelInput('\x1b[<64;10;20M')).toBe(true)
+    expect(batcher.enqueueIfWheelInput('\x1b[<65;10;20M')).toBe(true)
+    expect(sendInput).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(139)
+    expect(sendInput).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(sendInput).toHaveBeenCalledTimes(1)
+    expect(sendInput).toHaveBeenCalledWith('\x1b[<64;10;20M\x1b[<65;10;20M')
+    expect(holdForegroundTerminalOutput).toHaveBeenCalledWith(terminal, {
+      idleMs: 96,
+      maxMs: 2000
+    })
+  })
+
+  it('flushes at the maximum batch time during continuous wheel input', () => {
+    const sendInput = vi.fn(() => true)
+    const batcher = createTerminalWheelInputBatcher({
+      terminal: {} as never,
+      sendInput
+    })
+
+    for (let i = 0; i < 11; i++) {
+      expect(batcher.enqueueIfWheelInput('\x1b[<64;10;20M')).toBe(true)
+      if (i < 10) {
+        vi.advanceTimersByTime(139)
+      }
+    }
+
+    vi.advanceTimersByTime(109)
+    expect(sendInput).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(sendInput).toHaveBeenCalledTimes(1)
+    expect(sendInput).toHaveBeenCalledWith('\x1b[<64;10;20M'.repeat(11))
+  })
+
+  it('does not claim non-wheel input', () => {
+    const sendInput = vi.fn(() => true)
+    const batcher = createTerminalWheelInputBatcher({
+      terminal: {} as never,
+      sendInput
+    })
+
+    expect(batcher.enqueueIfWheelInput('\x03')).toBe(false)
+    expect(sendInput).not.toHaveBeenCalled()
+  })
+
+  it('drops delayed wheel input when the live send guard fails before flush', () => {
+    let canSend = true
+    const sendInput = vi.fn(() => true)
+    const batcher = createTerminalWheelInputBatcher({
+      terminal: {} as never,
+      sendInput,
+      canSend: () => canSend
+    })
+
+    expect(batcher.enqueueIfWheelInput('\x1b[<64;10;20M')).toBe(true)
+    canSend = false
+    vi.advanceTimersByTime(140)
+
+    expect(sendInput).not.toHaveBeenCalled()
+    expect(holdForegroundTerminalOutput).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes and discards pending input on demand', () => {
+    const sendInput = vi.fn(() => true)
+    const batcher = createTerminalWheelInputBatcher({
+      terminal: {} as never,
+      sendInput
+    })
+
+    batcher.enqueueIfWheelInput('\x1b[<64;10;20M')
+    batcher.flush()
+    expect(sendInput).toHaveBeenCalledWith('\x1b[<64;10;20M')
+
+    batcher.enqueueIfWheelInput('\x1b[<65;10;20M')
+    batcher.discard()
+    vi.advanceTimersByTime(1500)
+    expect(sendInput).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.ts
@@ -1,0 +1,154 @@
+import type { Terminal } from '@xterm/xterm'
+import { holdForegroundTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-scheduler'
+
+// Why: trusted wheel events arrive far enough apart that a 32-80ms debounce
+// still interleaves TUI redraws; 140ms keeps a gesture together while keeping a
+// lone wheel notch below normal human reaction latency.
+const WHEEL_INPUT_BATCH_IDLE_MS = 140
+const WHEEL_INPUT_BATCH_MAX_MS = 1500
+const WHEEL_OUTPUT_HOLD_IDLE_MS = 96
+const WHEEL_OUTPUT_HOLD_MAX_MS = 2000
+const SGR_MOUSE_PREFIX = '\x1b[<'
+const DEFAULT_MOUSE_PREFIX = '\x1b[M'
+
+type TerminalWheelInputBatcherOptions = {
+  terminal: Terminal
+  sendInput: (data: string) => boolean
+  canSend?: () => boolean
+}
+
+export type TerminalWheelInputBatcher = {
+  enqueueIfWheelInput: (data: string) => boolean
+  flush: () => void
+  discard: () => void
+}
+
+function isWheelButtonCode(code: number): boolean {
+  return (code & 64) === 64
+}
+
+function consumeSgrMouseReport(
+  data: string,
+  index: number
+): { nextIndex: number; code: number } | null {
+  if (!data.startsWith(SGR_MOUSE_PREFIX, index)) {
+    return null
+  }
+  const finalIndex = data.indexOf('M', index + SGR_MOUSE_PREFIX.length)
+  if (finalIndex === -1) {
+    return null
+  }
+  const report = data.slice(index + SGR_MOUSE_PREFIX.length, finalIndex)
+  const [codeText, colText, rowText] = report.split(';')
+  if (!codeText || !colText || !rowText) {
+    return null
+  }
+  const code = Number(codeText)
+  const col = Number(colText)
+  const row = Number(rowText)
+  if (!Number.isInteger(code) || !Number.isInteger(col) || !Number.isInteger(row)) {
+    return null
+  }
+  return { nextIndex: finalIndex + 1, code }
+}
+
+function consumeDefaultMouseReport(
+  data: string,
+  index: number
+): { nextIndex: number; code: number } | null {
+  if (!data.startsWith(DEFAULT_MOUSE_PREFIX, index) || index + 6 > data.length) {
+    return null
+  }
+  return {
+    nextIndex: index + 6,
+    code: data.charCodeAt(index + 3) - 32
+  }
+}
+
+export function isTerminalWheelInput(data: string): boolean {
+  if (!data) {
+    return false
+  }
+
+  let index = 0
+  while (index < data.length) {
+    const report = consumeSgrMouseReport(data, index) ?? consumeDefaultMouseReport(data, index)
+    if (!report || !isWheelButtonCode(report.code)) {
+      return false
+    }
+    index = report.nextIndex
+  }
+  return true
+}
+
+export function createTerminalWheelInputBatcher({
+  terminal,
+  sendInput,
+  canSend = () => true
+}: TerminalWheelInputBatcherOptions): TerminalWheelInputBatcher {
+  let idleTimer: ReturnType<typeof setTimeout> | null = null
+  let maxTimer: ReturnType<typeof setTimeout> | null = null
+  const pendingInput: string[] = []
+
+  const clearTimers = (): void => {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer)
+      idleTimer = null
+    }
+    if (maxTimer !== null) {
+      clearTimeout(maxTimer)
+      maxTimer = null
+    }
+  }
+
+  const holdOutput = (): void => {
+    holdForegroundTerminalOutput(terminal, {
+      idleMs: WHEEL_OUTPUT_HOLD_IDLE_MS,
+      maxMs: WHEEL_OUTPUT_HOLD_MAX_MS
+    })
+  }
+
+  const flush = (): void => {
+    clearTimers()
+    if (pendingInput.length === 0) {
+      return
+    }
+    const data = pendingInput.join('')
+    pendingInput.length = 0
+    if (!canSend()) {
+      return
+    }
+    // Why: flushing a wheel batch usually causes a full-screen TUI repaint.
+    // Keep the output side held briefly so xterm doesn't parse that repaint
+    // in the middle of the next native wheel event.
+    holdOutput()
+    sendInput(data)
+  }
+
+  const scheduleFlush = (): void => {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer)
+    }
+    idleTimer = setTimeout(flush, WHEEL_INPUT_BATCH_IDLE_MS)
+    if (maxTimer === null) {
+      maxTimer = setTimeout(flush, WHEEL_INPUT_BATCH_MAX_MS)
+    }
+  }
+
+  return {
+    enqueueIfWheelInput: (data: string): boolean => {
+      if (!isTerminalWheelInput(data)) {
+        return false
+      }
+      pendingInput.push(data)
+      holdOutput()
+      scheduleFlush()
+      return true
+    },
+    flush,
+    discard: () => {
+      clearTimers()
+      pendingInput.length = 0
+    }
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-foreground-output-hold.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-foreground-output-hold.ts
@@ -1,0 +1,168 @@
+import type { ForegroundTerminalOutputTarget } from './pane-terminal-foreground-render-settle'
+
+export type TerminalOutputBeforeWrite = (data: string) => void
+
+export type ForegroundOutputHoldOptions = {
+  idleMs: number
+  maxMs: number
+}
+
+type TerminalOutputTarget = ForegroundTerminalOutputTarget
+
+type ForegroundHoldEntry = {
+  terminal: TerminalOutputTarget
+  chunks: string[]
+  beforeWrite?: TerminalOutputBeforeWrite
+  holdUntil: number
+  idleTimer: ReturnType<typeof setTimeout> | null
+  maxTimer: ReturnType<typeof setTimeout> | null
+}
+
+type WriteForegroundOutput = (
+  terminal: TerminalOutputTarget,
+  data: string,
+  beforeWrite?: TerminalOutputBeforeWrite
+) => void
+
+const foregroundHoldByTerminal = new Map<TerminalOutputTarget, ForegroundHoldEntry>()
+
+function nowMs(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now()
+  }
+  return Date.now()
+}
+
+function clearForegroundHoldTimers(entry: ForegroundHoldEntry): void {
+  if (entry.idleTimer !== null) {
+    clearTimeout(entry.idleTimer)
+    entry.idleTimer = null
+  }
+  if (entry.maxTimer !== null) {
+    clearTimeout(entry.maxTimer)
+    entry.maxTimer = null
+  }
+}
+
+function takeAllQueuedOutput(entry: ForegroundHoldEntry): string {
+  const data = entry.chunks.join('')
+  entry.chunks.length = 0
+  return data
+}
+
+function flushForegroundHoldEntry(
+  entry: ForegroundHoldEntry,
+  writeForegroundOutput: WriteForegroundOutput
+): void {
+  clearForegroundHoldTimers(entry)
+  foregroundHoldByTerminal.delete(entry.terminal)
+
+  const data = takeAllQueuedOutput(entry)
+  if (!data) {
+    return
+  }
+  writeForegroundOutput(entry.terminal, data, entry.beforeWrite)
+}
+
+function scheduleForegroundHoldFlush(
+  entry: ForegroundHoldEntry,
+  writeForegroundOutput: WriteForegroundOutput
+): void {
+  if (entry.idleTimer !== null) {
+    clearTimeout(entry.idleTimer)
+  }
+
+  const delayMs = Math.max(0, entry.holdUntil - nowMs())
+  entry.idleTimer = setTimeout(
+    () => flushForegroundHoldEntry(entry, writeForegroundOutput),
+    delayMs
+  )
+}
+
+function getActiveForegroundHoldEntry(
+  terminal: TerminalOutputTarget,
+  writeForegroundOutput: WriteForegroundOutput,
+  atMs = nowMs()
+): ForegroundHoldEntry | null {
+  const entry = foregroundHoldByTerminal.get(terminal)
+  if (!entry) {
+    return null
+  }
+  if (atMs <= entry.holdUntil) {
+    return entry
+  }
+  flushForegroundHoldEntry(entry, writeForegroundOutput)
+  return null
+}
+
+export function queueForegroundOutputIfHeld(
+  terminal: TerminalOutputTarget,
+  data: string,
+  beforeWrite: TerminalOutputBeforeWrite | undefined,
+  writeForegroundOutput: WriteForegroundOutput
+): boolean {
+  const entry = getActiveForegroundHoldEntry(terminal, writeForegroundOutput)
+  if (!entry) {
+    return false
+  }
+  entry.beforeWrite = beforeWrite
+  entry.chunks.push(data)
+  scheduleForegroundHoldFlush(entry, writeForegroundOutput)
+  return true
+}
+
+export function holdForegroundTerminalOutput(
+  terminal: TerminalOutputTarget,
+  options: ForegroundOutputHoldOptions,
+  writeForegroundOutput?: WriteForegroundOutput
+): void {
+  const atMs = nowMs()
+  const idleMs = Math.max(0, options.idleMs)
+  const maxMs = Math.max(idleMs, options.maxMs)
+  const existing = foregroundHoldByTerminal.get(terminal)
+  const entry =
+    existing && atMs <= existing.holdUntil
+      ? existing
+      : {
+          terminal,
+          chunks: [],
+          holdUntil: atMs,
+          idleTimer: null,
+          maxTimer: null
+        }
+
+  if (existing && existing !== entry && writeForegroundOutput) {
+    flushForegroundHoldEntry(existing, writeForegroundOutput)
+  }
+
+  entry.holdUntil = atMs + idleMs
+  foregroundHoldByTerminal.set(terminal, entry)
+
+  if (writeForegroundOutput) {
+    scheduleForegroundHoldFlush(entry, writeForegroundOutput)
+  }
+
+  if (entry.maxTimer === null && writeForegroundOutput) {
+    // Why: TUI wheel bursts should coalesce enough output for input to keep up,
+    // but continuous scrolling must still repaint periodically.
+    entry.maxTimer = setTimeout(() => flushForegroundHoldEntry(entry, writeForegroundOutput), maxMs)
+  }
+}
+
+export function flushHeldForegroundOutput(
+  terminal: TerminalOutputTarget,
+  writeForegroundOutput: WriteForegroundOutput
+): void {
+  const heldEntry = foregroundHoldByTerminal.get(terminal)
+  if (heldEntry) {
+    flushForegroundHoldEntry(heldEntry, writeForegroundOutput)
+  }
+}
+
+export function discardHeldForegroundOutput(terminal: TerminalOutputTarget): void {
+  const heldEntry = foregroundHoldByTerminal.get(terminal)
+  if (heldEntry) {
+    clearForegroundHoldTimers(heldEntry)
+    foregroundHoldByTerminal.delete(terminal)
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -233,6 +233,96 @@ describe('pane terminal output scheduler', () => {
     expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['old', 'new'])
   })
 
+  it('holds foreground output until a TUI wheel burst goes idle', async () => {
+    vi.useFakeTimers()
+    const { holdForegroundTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+    const beforeWrite = vi.fn()
+
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'a', { foreground: true, beforeWrite })
+    writeTerminalOutput(terminal, 'b', { foreground: true, beforeWrite })
+
+    expect(beforeWrite).not.toHaveBeenCalled()
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(79)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(beforeWrite).toHaveBeenCalledTimes(1)
+    expect(beforeWrite).toHaveBeenCalledWith('ab')
+    expect(terminal.write).toHaveBeenCalledWith('ab', expect.any(Function))
+  })
+
+  it('extends the foreground hold while TUI wheel events continue', async () => {
+    vi.useFakeTimers()
+    const { holdForegroundTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'a', { foreground: true })
+
+    vi.advanceTimersByTime(70)
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'b', { foreground: true })
+
+    vi.advanceTimersByTime(79)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['ab'])
+  })
+
+  it('flushes held foreground output at the maximum hold time during continuous wheel input', async () => {
+    vi.useFakeTimers()
+    const { holdForegroundTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'a', { foreground: true })
+
+    for (const chunk of ['b', 'c', 'd', 'e']) {
+      vi.advanceTimersByTime(70)
+      holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+      writeTerminalOutput(terminal, chunk, { foreground: true })
+    }
+
+    vi.advanceTimersByTime(19)
+    expect(terminal.write).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['abcde'])
+  })
+
+  it('flushes held foreground output before explicit terminal snapshots', async () => {
+    vi.useFakeTimers()
+    const { flushTerminalOutput, holdForegroundTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'held', { foreground: true })
+    flushTerminalOutput(terminal)
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['held'])
+  })
+
+  it('keeps held foreground output before later background output', async () => {
+    vi.useFakeTimers()
+    const { holdForegroundTerminalOutput, writeTerminalOutput } = await loadScheduler()
+    const terminal = createTerminal()
+
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'foreground', { foreground: true })
+    writeTerminalOutput(terminal, 'background', { foreground: false })
+
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['foreground'])
+
+    vi.advanceTimersByTime(50)
+    expect(terminal.write.mock.calls.map(([data]) => data)).toEqual(['foreground', 'background'])
+  })
+
   it('discards queued output for disposed terminals', async () => {
     vi.useFakeTimers()
     const { discardTerminalOutput, writeTerminalOutput } = await loadScheduler()
@@ -264,5 +354,19 @@ describe('pane terminal output scheduler', () => {
     // Advancing further must not rediscover the dead entry.
     vi.advanceTimersByTime(100)
     expect(throwing.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('discards held foreground output for disposed terminals', async () => {
+    vi.useFakeTimers()
+    const { discardTerminalOutput, holdForegroundTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+
+    holdForegroundTerminalOutput(terminal, { idleMs: 80, maxMs: 300 })
+    writeTerminalOutput(terminal, 'stale', { foreground: true })
+    discardTerminalOutput(terminal)
+    vi.advanceTimersByTime(300)
+
+    expect(terminal.write).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -5,10 +5,16 @@ import {
   writeForegroundTerminalChunk,
   type ForegroundTerminalOutputTarget
 } from './pane-terminal-foreground-render-settle'
+import {
+  discardHeldForegroundOutput,
+  flushHeldForegroundOutput,
+  holdForegroundTerminalOutput as holdForegroundTerminalOutputForWriter,
+  queueForegroundOutputIfHeld,
+  type ForegroundOutputHoldOptions,
+  type TerminalOutputBeforeWrite
+} from './pane-terminal-foreground-output-hold'
 
 type TerminalOutputTarget = ForegroundTerminalOutputTarget
-
-type TerminalOutputBeforeWrite = (data: string) => void
 
 type QueueEntry = {
   terminal: TerminalOutputTarget
@@ -160,45 +166,27 @@ function drainQueuedOutput(): void {
   }
 }
 
-export function writeTerminalOutput(
+function writeForegroundOutput(
   terminal: TerminalOutputTarget,
   data: string,
-  options: { foreground: boolean; beforeWrite?: TerminalOutputBeforeWrite }
+  beforeWrite?: TerminalOutputBeforeWrite
 ): void {
-  exposeDebugApi()
-  if (!data) {
-    return
-  }
-
-  if (options.foreground) {
-    flushTerminalOutput(terminal)
-    if (debugEnabled) {
-      debugState.foregroundWriteCount++
-    }
-    options.beforeWrite?.(data)
-    writeForegroundTerminalChunk(terminal, data)
-    return
-  }
-
-  let entry = queuedByTerminal.get(terminal)
-  if (!entry) {
-    entry = { terminal, chunks: [], beforeWrite: options.beforeWrite }
-    queuedByTerminal.set(terminal, entry)
-  } else {
-    entry.beforeWrite = options.beforeWrite
-  }
-  entry.chunks.push(data)
   if (debugEnabled) {
-    debugState.backgroundEnqueueCount++
+    debugState.foregroundWriteCount++
   }
-  // Why: non-focused panes can produce output continuously. Letting every
-  // pane call xterm.write immediately schedules one xterm WriteBuffer timer
-  // per pane, which starves the focused terminal on the shared renderer thread.
-  scheduleDrain(BACKGROUND_FLUSH_DELAY_MS)
+  beforeWrite?.(data)
+  writeForegroundTerminalChunk(terminal, data)
 }
 
-export function flushTerminalOutput(terminal: TerminalOutputTarget): void {
+export function holdForegroundTerminalOutput(
+  terminal: TerminalOutputTarget,
+  options: ForegroundOutputHoldOptions
+): void {
   exposeDebugApi()
+  holdForegroundTerminalOutputForWriter(terminal, options, writeForegroundOutput)
+}
+
+function flushQueuedBackgroundOutput(terminal: TerminalOutputTarget): void {
   const entry = queuedByTerminal.get(terminal)
   if (!entry) {
     return
@@ -221,6 +209,49 @@ export function flushTerminalOutput(terminal: TerminalOutputTarget): void {
     }
     data = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
   }
+}
+
+export function writeTerminalOutput(
+  terminal: TerminalOutputTarget,
+  data: string,
+  options: { foreground: boolean; beforeWrite?: TerminalOutputBeforeWrite }
+): void {
+  exposeDebugApi()
+  if (!data) {
+    return
+  }
+
+  if (options.foreground) {
+    flushQueuedBackgroundOutput(terminal)
+    if (queueForegroundOutputIfHeld(terminal, data, options.beforeWrite, writeForegroundOutput)) {
+      return
+    }
+    writeForegroundOutput(terminal, data, options.beforeWrite)
+    return
+  }
+
+  flushHeldForegroundOutput(terminal, writeForegroundOutput)
+  let entry = queuedByTerminal.get(terminal)
+  if (!entry) {
+    entry = { terminal, chunks: [], beforeWrite: options.beforeWrite }
+    queuedByTerminal.set(terminal, entry)
+  } else {
+    entry.beforeWrite = options.beforeWrite
+  }
+  entry.chunks.push(data)
+  if (debugEnabled) {
+    debugState.backgroundEnqueueCount++
+  }
+  // Why: non-focused panes can produce output continuously. Letting every
+  // pane call xterm.write immediately schedules one xterm WriteBuffer timer
+  // per pane, which starves the focused terminal on the shared renderer thread.
+  scheduleDrain(BACKGROUND_FLUSH_DELAY_MS)
+}
+
+export function flushTerminalOutput(terminal: TerminalOutputTarget): void {
+  exposeDebugApi()
+  flushHeldForegroundOutput(terminal, writeForegroundOutput)
+  flushQueuedBackgroundOutput(terminal)
 }
 
 export function waitForTerminalOutputParsed(terminal: TerminalOutputTarget): Promise<void> {
@@ -251,6 +282,7 @@ export function waitForTerminalOutputParsed(terminal: TerminalOutputTarget): Pro
 export function discardTerminalOutput(terminal: TerminalOutputTarget): void {
   exposeDebugApi()
   queuedByTerminal.delete(terminal)
+  discardHeldForegroundOutput(terminal)
   discardForegroundRenderSettle(terminal)
 }
 


### PR DESCRIPTION
## Summary
- Batches exact xterm-generated TUI wheel mouse reports before forwarding them to the PTY.
- Adds a short foreground-output hold so full-screen TUI redraws coalesce instead of parsing between every native wheel notch.
- Flushes any pending wheel batch before non-wheel terminal input to preserve byte order.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.ts src/renderer/src/components/terminal-pane/terminal-wheel-input-batcher.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts src/renderer/src/lib/pane-manager/pane-terminal-foreground-output-hold.ts`
- Electron OpenCode long-session repro, 160 trusted wheel events: ~56-63s before, 5.6s after; terminal writes ~1,000 before, 21 after; no long tasks observed.