### PR TITLE
Allow custom shortcut for equalizing panes

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -81,9 +81,11 @@ export default function TerminalContextMenu({
   const pasteShortcut = useShortcutLabel('terminal.paste')
   const splitRightShortcut = useShortcutLabel('terminal.splitRight')
   const splitDownShortcut = useShortcutLabel('terminal.splitDown')
+  const equalizeShortcut = useShortcutLabel('terminal.equalizePaneSizes')
   const expandShortcut = useShortcutLabel('terminal.expandPane')
   const closeShortcut = useShortcutLabel('terminal.closePane')
   const hasQuickCommands = repoQuickCommands.length > 0 || globalQuickCommands.length > 0
+  const showEqualizeShortcut = equalizeShortcut !== 'Unassigned'
 
   return (
     <DropdownMenu
@@ -213,6 +215,9 @@ export default function TerminalContextMenu({
           <DropdownMenuItem onSelect={onEqualizePaneSizes}>
             <PanelsTopLeft />
             Equalize Pane Sizes
+            {showEqualizeShortcut ? (
+              <DropdownMenuShortcut>{equalizeShortcut}</DropdownMenuShortcut>
+            ) : null}
           </DropdownMenuItem>
         )}
         {canExpandPane && (

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -306,6 +306,20 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
+      if (action.type === 'equalizePaneSizes') {
+        // Consume the chord first so a user-assigned terminal shortcut can't fall
+        // through to app-level zoom when an expanded pane blocks the equalize.
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        if (expandedPaneIdRef.current !== null) {
+          return
+        }
+        manager.equalizePaneSizes()
+        const paneToFocus = manager.getActivePane() ?? manager.getPanes()[0]
+        paneToFocus?.terminal.focus()
+        return
+      }
+
       // Cmd+Shift+Enter expands/collapses the active pane to full terminal area.
       if (action.type === 'toggleExpandActivePane') {
         const panes = manager.getPanes()

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -189,6 +189,22 @@ describe('resolveTerminalShortcutAction', () => {
     ).toBeNull()
   })
 
+  it('resolves equalize pane sizes only when users assign it', () => {
+    expect(
+      resolveTerminalShortcutAction(event({ key: '=', code: 'Equal', metaKey: true }), true)
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: '=', code: 'Equal', metaKey: true }),
+        true,
+        'false',
+        0,
+        false,
+        { 'terminal.equalizePaneSizes': ['Mod+Equal'] }
+      )
+    ).toEqual({ type: 'equalizePaneSizes' })
+  })
+
   it('lets Ctrl+D pass through as EOF on non-Mac, requires Shift for split (#586)', () => {
     // Ctrl+D without Shift on Windows/Linux must NOT trigger split — it's EOF
     expect(

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -33,6 +33,7 @@ export type TerminalShortcutAction =
   | { type: 'toggleSearch' }
   | { type: 'clearActivePane' }
   | { type: 'focusPane'; direction: 'next' | 'previous' }
+  | { type: 'equalizePaneSizes' }
   | { type: 'toggleExpandActivePane' }
   | { type: 'closeActivePane' }
   | { type: 'splitActivePane'; direction: 'vertical' | 'horizontal' }
@@ -66,6 +67,10 @@ export function resolveTerminalShortcutAction(
 
     if (keybindingMatchesAction('terminal.focusNextPane', event, platform, keybindings)) {
       return { type: 'focusPane', direction: 'next' }
+    }
+
+    if (keybindingMatchesAction('terminal.equalizePaneSizes', event, platform, keybindings)) {
+      return { type: 'equalizePaneSizes' }
     }
 
     if (keybindingMatchesAction('terminal.expandPane', event, platform, keybindings)) {

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -118,6 +118,25 @@ describe('keybindings', () => {
     })
   })
 
+  it('keeps equalize pane sizes unassigned until users customize it', () => {
+    expect(getEffectiveKeybindingsForAction('terminal.equalizePaneSizes', 'darwin')).toEqual([])
+    expect(
+      keybindingMatchesAction(
+        'terminal.equalizePaneSizes',
+        { key: '=', code: 'Equal', control: false, meta: true, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'terminal.equalizePaneSizes',
+        { key: '=', code: 'Equal', control: false, meta: true, alt: false, shift: false },
+        'darwin',
+        { 'terminal.equalizePaneSizes': ['Mod+Equal'] }
+      )
+    ).toBe(true)
+  })
+
   it('reports customized renderer conflicts with native menu accelerators', () => {
     expect(findKeybindingConflicts('darwin')).toEqual([])
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -79,6 +79,7 @@ export type KeybindingActionId =
   | 'terminal.clear'
   | 'terminal.focusNextPane'
   | 'terminal.focusPreviousPane'
+  | 'terminal.equalizePaneSizes'
   | 'terminal.expandPane'
   | 'terminal.closePane'
   | 'terminal.splitRight'
@@ -632,6 +633,14 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'terminal',
     searchKeywords: ['shortcut', 'pane', 'focus', 'previous'],
     defaultBindings: platformBindings(['Mod+BracketLeft'])
+  },
+  {
+    id: 'terminal.equalizePaneSizes',
+    title: 'Equalize pane sizes',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: ['shortcut', 'pane', 'split', 'equalize', 'resize', 'balance', 'size'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'terminal.expandPane',


### PR DESCRIPTION
## Summary
- Adds an unassigned `terminal.equalizePaneSizes` shortcut action so users can bind Equalize Pane Sizes themselves.
- Routes the assigned shortcut through the existing terminal shortcut policy and pane manager action.
- Shows the shortcut in the terminal pane context menu only after a user assigns one.

Refs #1848

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts`
- `pnpm run typecheck`
- `pnpm lint`
- `git diff --check`