### PR TITLE
Bound PTY batch flushes to reduce typing latency spikes

### DIFF
--- a/config/scripts/pty-batch-flush-benchmark.mjs
+++ b/config/scripts/pty-batch-flush-benchmark.mjs
@@ -1,0 +1,219 @@
+import { performance } from 'node:perf_hooks'
+import v8 from 'node:v8'
+
+const PTY_COUNT = Number.parseInt(process.env.ORCA_PTY_BENCH_PTY_COUNT ?? '24', 10)
+const PAYLOAD_CHARS = Number.parseInt(process.env.ORCA_PTY_BENCH_PAYLOAD_CHARS ?? '262144', 10)
+const RUNS = Number.parseInt(process.env.ORCA_PTY_BENCH_RUNS ?? '30', 10)
+const MEASURE_TIMER_DELAYS = process.env.ORCA_PTY_BENCH_MEASURE_TIMER_DELAYS !== '0'
+const CHUNK_CHARS = 16 * 1024
+const MAX_WRITES_PER_SLICE = 2
+
+if (!Number.isInteger(PTY_COUNT) || PTY_COUNT <= 0) {
+  throw new Error(`ORCA_PTY_BENCH_PTY_COUNT must be positive, received ${PTY_COUNT}`)
+}
+if (!Number.isInteger(PAYLOAD_CHARS) || PAYLOAD_CHARS <= 0) {
+  throw new Error(`ORCA_PTY_BENCH_PAYLOAD_CHARS must be positive, received ${PAYLOAD_CHARS}`)
+}
+if (!Number.isInteger(RUNS) || RUNS <= 0) {
+  throw new Error(`ORCA_PTY_BENCH_RUNS must be positive, received ${RUNS}`)
+}
+
+function makePendingData() {
+  const pending = new Map()
+  for (let index = 0; index < PTY_COUNT; index++) {
+    pending.set(`pty-${index}`, `${index}:`.padEnd(PAYLOAD_CHARS, 'x'))
+  }
+  return pending
+}
+
+function simulateWebContentsSend(id, data) {
+  return v8.serialize({ channel: 'pty:data', payload: { id, data } }).byteLength
+}
+
+function flushLegacy(pending) {
+  let bytes = 0
+  const start = performance.now()
+  for (const [id, data] of pending) {
+    bytes += simulateWebContentsSend(id, data)
+  }
+  pending.clear()
+  return { bytes, durationMs: performance.now() - start }
+}
+
+function flushBoundedSlice(pending) {
+  let bytes = 0
+  let writes = 0
+  const start = performance.now()
+  while (pending.size > 0 && writes < MAX_WRITES_PER_SLICE) {
+    const next = pending.entries().next().value
+    if (!next) {
+      break
+    }
+    const [id, data] = next
+    pending.delete(id)
+    const chunk = data.slice(0, CHUNK_CHARS)
+    const remaining = data.slice(CHUNK_CHARS)
+    if (remaining) {
+      pending.set(id, remaining)
+    }
+    bytes += simulateWebContentsSend(id, chunk)
+    writes++
+  }
+  return { bytes, durationMs: performance.now() - start }
+}
+
+function drainBounded(pending) {
+  let bytes = 0
+  const sliceDurations = []
+  while (pending.size > 0) {
+    const result = flushBoundedSlice(pending)
+    bytes += result.bytes
+    sliceDurations.push(result.durationMs)
+  }
+  return { bytes, sliceDurations }
+}
+
+function scheduleLegacyFlush(pending) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      flushLegacy(pending)
+      resolve()
+    }, 0)
+  })
+}
+
+function scheduleBoundedFlush(pending) {
+  return new Promise((resolve) => {
+    const drain = () => {
+      flushBoundedSlice(pending)
+      if (pending.size > 0) {
+        setTimeout(drain, 1)
+        return
+      }
+      resolve()
+    }
+    setTimeout(drain, 0)
+  })
+}
+
+async function measureInputTimerDelay(flushKind) {
+  const pending = makePendingData()
+  const scheduledAt = performance.now()
+  const drainPromise =
+    flushKind === 'legacy' ? scheduleLegacyFlush(pending) : scheduleBoundedFlush(pending)
+  const inputDelay = await new Promise((resolve) => {
+    setTimeout(() => resolve(performance.now() - scheduledAt), 0)
+  })
+  await drainPromise
+  return inputDelay
+}
+
+function percentile(values, p) {
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))
+  return sorted[index] ?? 0
+}
+
+function summarize(values) {
+  return {
+    median: percentile(values, 50),
+    p95: percentile(values, 95),
+    max: Math.max(...values)
+  }
+}
+
+function formatMs(value) {
+  return `${value.toFixed(3)}ms`
+}
+
+async function runBenchmark() {
+  const legacyDurations = []
+  const boundedFirstSliceDurations = []
+  const boundedMaxSliceDurations = []
+  const boundedTotalDurations = []
+  const legacyInputTimerDelays = []
+  const boundedInputTimerDelays = []
+  let legacyBytes = 0
+  let boundedBytes = 0
+
+  for (let run = 0; run < RUNS; run++) {
+    const legacy = flushLegacy(makePendingData())
+    legacyDurations.push(legacy.durationMs)
+    legacyBytes = legacy.bytes
+
+    const boundedStart = performance.now()
+    const bounded = drainBounded(makePendingData())
+    boundedBytes = bounded.bytes
+    boundedFirstSliceDurations.push(bounded.sliceDurations[0] ?? 0)
+    boundedMaxSliceDurations.push(Math.max(...bounded.sliceDurations))
+    boundedTotalDurations.push(performance.now() - boundedStart)
+
+    if (MEASURE_TIMER_DELAYS) {
+      legacyInputTimerDelays.push(await measureInputTimerDelay('legacy'))
+      boundedInputTimerDelays.push(await measureInputTimerDelay('bounded'))
+    }
+  }
+
+  const legacySummary = summarize(legacyDurations)
+  const boundedFirstSliceSummary = summarize(boundedFirstSliceDurations)
+  const boundedMaxSliceSummary = summarize(boundedMaxSliceDurations)
+  const boundedTotalSummary = summarize(boundedTotalDurations)
+  const legacyInputTimerSummary = MEASURE_TIMER_DELAYS ? summarize(legacyInputTimerDelays) : null
+  const boundedInputTimerSummary = MEASURE_TIMER_DELAYS ? summarize(boundedInputTimerDelays) : null
+
+  console.log(
+    JSON.stringify(
+      {
+        scenario: {
+          ptyCount: PTY_COUNT,
+          payloadChars: PAYLOAD_CHARS,
+          runs: RUNS,
+          totalPayloadMiB: (PTY_COUNT * PAYLOAD_CHARS) / 1024 / 1024
+        },
+        legacy: {
+          bytesPerRun: legacyBytes,
+          singleCallback: legacySummary,
+          inputTimerDelay: legacyInputTimerSummary
+        },
+        bounded: {
+          bytesPerRun: boundedBytes,
+          firstSlice: boundedFirstSliceSummary,
+          maxSlice: boundedMaxSliceSummary,
+          totalDrain: boundedTotalSummary,
+          inputTimerDelay: boundedInputTimerSummary
+        },
+        estimatedPtyWriteDelay:
+          legacyInputTimerSummary && boundedInputTimerSummary
+            ? {
+                before: legacyInputTimerSummary.max,
+                after: boundedInputTimerSummary.max,
+                reduction:
+                  legacyInputTimerSummary.max /
+                  Math.max(boundedInputTimerSummary.max, Number.EPSILON)
+              }
+            : null
+      },
+      null,
+      2
+    )
+  )
+
+  console.error(
+    [
+      `legacy max single callback: ${formatMs(legacySummary.max)}`,
+      `bounded max first slice: ${formatMs(boundedFirstSliceSummary.max)}`,
+      `bounded max any slice: ${formatMs(boundedMaxSliceSummary.max)}`,
+      `bounded max total drain: ${formatMs(boundedTotalSummary.max)}`,
+      legacyInputTimerSummary
+        ? `legacy max input timer delay: ${formatMs(legacyInputTimerSummary.max)}`
+        : null,
+      boundedInputTimerSummary
+        ? `bounded max input timer delay: ${formatMs(boundedInputTimerSummary.max)}`
+        : null
+    ]
+      .filter(Boolean)
+      .join('\n')
+  )
+}
+
+await runBenchmark()

--- a/config/scripts/pty-batch-flush-benchmark.mjs
+++ b/config/scripts/pty-batch-flush-benchmark.mjs
@@ -5,8 +5,19 @@ const PTY_COUNT = Number.parseInt(process.env.ORCA_PTY_BENCH_PTY_COUNT ?? '24', 
 const PAYLOAD_CHARS = Number.parseInt(process.env.ORCA_PTY_BENCH_PAYLOAD_CHARS ?? '262144', 10)
 const RUNS = Number.parseInt(process.env.ORCA_PTY_BENCH_RUNS ?? '30', 10)
 const MEASURE_TIMER_DELAYS = process.env.ORCA_PTY_BENCH_MEASURE_TIMER_DELAYS !== '0'
+const INGRESS_CHUNKS = Number.parseInt(process.env.ORCA_PTY_BENCH_INGRESS_CHUNKS ?? '96', 10)
+const INGRESS_CHUNK_CHARS = Number.parseInt(
+  process.env.ORCA_PTY_BENCH_INGRESS_CHARS ?? '65536',
+  10
+)
 const CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_SLICE = 2
+const RECENT_PTY_OUTPUT_LIMIT = 4096
+const MAX_TAIL_LINES = 2000
+const MAX_TAIL_CHARS = 256 * 1024
+const MAX_TAIL_PARTIAL_CHARS = 4000
+const OSC_TITLE_RE = /\x1b\]([012]);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
+const URL_CANDIDATE_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi
 
 if (!Number.isInteger(PTY_COUNT) || PTY_COUNT <= 0) {
   throw new Error(`ORCA_PTY_BENCH_PTY_COUNT must be positive, received ${PTY_COUNT}`)
@@ -16,6 +27,16 @@ if (!Number.isInteger(PAYLOAD_CHARS) || PAYLOAD_CHARS <= 0) {
 }
 if (!Number.isInteger(RUNS) || RUNS <= 0) {
   throw new Error(`ORCA_PTY_BENCH_RUNS must be positive, received ${RUNS}`)
+}
+if (!Number.isInteger(INGRESS_CHUNKS) || INGRESS_CHUNKS <= 0) {
+  throw new Error(
+    `ORCA_PTY_BENCH_INGRESS_CHUNKS must be positive, received ${INGRESS_CHUNKS}`
+  )
+}
+if (!Number.isInteger(INGRESS_CHUNK_CHARS) || INGRESS_CHUNK_CHARS <= 0) {
+  throw new Error(
+    `ORCA_PTY_BENCH_INGRESS_CHARS must be positive, received ${INGRESS_CHUNK_CHARS}`
+  )
 }
 
 function makePendingData() {
@@ -71,6 +92,227 @@ function drainBounded(pending) {
     sliceDurations.push(result.durationMs)
   }
   return { bytes, sliceDurations }
+}
+
+function makeIngressChunk() {
+  return `${'x'.repeat(INGRESS_CHUNK_CHARS - 1)}\n`
+}
+
+function extractLastOscTitleLegacy(data) {
+  let last = null
+  for (const m of data.matchAll(OSC_TITLE_RE)) {
+    last = m[2]
+  }
+  return last
+}
+
+function extractLastOscTitleCurrent(data) {
+  if (!data.includes('\x1b]')) {
+    return null
+  }
+  return extractLastOscTitleLegacy(data)
+}
+
+function hasMeaningfulContentLegacy(chunk) {
+  return (
+    chunk
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n')
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+      .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+      .replace(/\x1b[@-_]/g, '')
+      .replace(/\u0008/g, '')
+      .replace(/[^\x09\x0a\x20-\x7e]/g, '')
+      .trim().length > 0
+  )
+}
+
+function hasMeaningfulContentCurrent(chunk) {
+  for (let index = 0; index < chunk.length; index++) {
+    const code = chunk.charCodeAt(index)
+    if (code === 0x1b || code < 0x09 || (code > 0x0d && code < 0x20) || code > 0x7e) {
+      break
+    }
+    if (code > 0x20) {
+      return true
+    }
+  }
+  return hasMeaningfulContentLegacy(chunk)
+}
+
+function normalizeTerminalChunkLegacy(chunk) {
+  return chunk
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1b[@-_]/g, '')
+    .replace(/\u0008/g, '')
+    .replace(/[^\x09\x0a\x20-\x7e]/g, '')
+}
+
+function terminalChunkNeedsNormalization(chunk) {
+  for (let index = 0; index < chunk.length; index++) {
+    const code = chunk.charCodeAt(index)
+    if (
+      code === 0x1b ||
+      code === 0x0d ||
+      code < 0x09 ||
+      (code > 0x0a && code < 0x20) ||
+      code > 0x7e
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+function normalizeTerminalChunkCurrent(chunk) {
+  return terminalChunkNeedsNormalization(chunk) ? normalizeTerminalChunkLegacy(chunk) : chunk
+}
+
+function appendNormalizedToTailBuffer(previousLines, previousPartialLine, normalizedChunk) {
+  if (normalizedChunk.length === 0) {
+    return {
+      lines: previousLines,
+      partialLine: previousPartialLine
+    }
+  }
+
+  const boundedPreviousPartialLine = previousPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS)
+  const pieces = `${boundedPreviousPartialLine}${normalizedChunk}`.split('\n')
+  const nextPartialLine = (pieces.pop() ?? '').replace(/[ \t]+$/g, '')
+  const retainedPartialLine = nextPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS)
+  let nextLines =
+    pieces.length > 0
+      ? [...previousLines, ...pieces.map((line) => line.replace(/[ \t]+$/g, ''))]
+      : previousLines
+
+  while (nextLines.length > MAX_TAIL_LINES) {
+    nextLines.shift()
+  }
+
+  if (pieces.length > 0 || retainedPartialLine.length > previousPartialLine.length) {
+    if (nextLines === previousLines) {
+      nextLines = [...previousLines]
+    }
+    let totalChars =
+      nextLines.reduce((sum, line) => sum + line.length, 0) + retainedPartialLine.length
+    while (nextLines.length > 0 && totalChars > MAX_TAIL_CHARS) {
+      totalChars -= nextLines.shift().length
+    }
+  }
+
+  return {
+    lines: nextLines,
+    partialLine: retainedPartialLine
+  }
+}
+
+function appendTailBufferLegacy(previousLines, previousPartialLine, chunk) {
+  return appendNormalizedToTailBuffer(
+    previousLines,
+    previousPartialLine,
+    normalizeTerminalChunkLegacy(chunk)
+  )
+}
+
+function tailStateMatches(lines, partialLine, snapshot) {
+  if (
+    partialLine !== snapshot.partialLine ||
+    lines.length !== snapshot.lines.length ||
+    lines.length !== snapshot.linesTotal
+  ) {
+    return false
+  }
+  if (lines === snapshot.lines) {
+    return true
+  }
+  for (let index = 0; index < lines.length; index++) {
+    if (lines[index] !== snapshot.lines[index]) {
+      return false
+    }
+  }
+  return true
+}
+
+class AdvertisedUrlPtyBuffer {
+  raw = ''
+
+  ingest(chunk) {
+    this.raw += chunk
+    if (this.raw.length > 4096) {
+      this.raw = this.raw.slice(-4096)
+    }
+    const lastLineBreak = Math.max(this.raw.lastIndexOf('\n'), this.raw.lastIndexOf('\r'))
+    if (lastLineBreak === -1) {
+      return ''
+    }
+    const finalized = this.raw.slice(0, lastLineBreak + 1)
+    this.raw = this.raw.slice(lastLineBreak + 1)
+    return finalized
+  }
+}
+
+function scanAdvertisedUrls(buffer, chunk) {
+  const finalized = buffer.ingest(chunk)
+  if (!finalized) {
+    return
+  }
+  for (const _match of finalized.matchAll(URL_CANDIDATE_PATTERN)) {
+    // Candidate extraction is enough for this benchmark; URL validation is rare
+    // and only happens after a URL-shaped match.
+  }
+}
+
+function measureRuntimeIngressLegacy() {
+  const chunk = makeIngressChunk()
+  const advertisedUrlBuffer = new AdvertisedUrlPtyBuffer()
+  let recentOutput = ''
+  let ptyTail = { lines: [], partialLine: '' }
+  let leafTail = { lines: [], partialLine: '' }
+  const start = performance.now()
+
+  for (let index = 0; index < INGRESS_CHUNKS; index++) {
+    recentOutput = `${recentOutput}${chunk}`.slice(-RECENT_PTY_OUTPUT_LIMIT)
+    hasMeaningfulContentLegacy(chunk)
+    extractLastOscTitleLegacy(chunk)
+    scanAdvertisedUrls(advertisedUrlBuffer, chunk)
+    extractLastOscTitleLegacy(chunk)
+    ptyTail = appendTailBufferLegacy(ptyTail.lines, ptyTail.partialLine, chunk)
+    leafTail = appendTailBufferLegacy(leafTail.lines, leafTail.partialLine, chunk)
+  }
+
+  return performance.now() - start
+}
+
+function measureRuntimeIngressCurrent() {
+  const chunk = makeIngressChunk()
+  const advertisedUrlBuffer = new AdvertisedUrlPtyBuffer()
+  let recentOutput = ''
+  let ptyTail = { lines: [], partialLine: '' }
+  let leafTail = { lines: [], partialLine: '' }
+  const start = performance.now()
+
+  for (let index = 0; index < INGRESS_CHUNKS; index++) {
+    recentOutput = `${recentOutput}${chunk}`.slice(-RECENT_PTY_OUTPUT_LIMIT)
+    hasMeaningfulContentCurrent(chunk)
+    extractLastOscTitleCurrent(chunk)
+    scanAdvertisedUrls(advertisedUrlBuffer, chunk)
+    extractLastOscTitleCurrent(chunk)
+    const normalizedChunk = normalizeTerminalChunkCurrent(chunk)
+    const ptyTailBefore = {
+      lines: ptyTail.lines,
+      partialLine: ptyTail.partialLine,
+      linesTotal: ptyTail.lines.length
+    }
+    ptyTail = appendNormalizedToTailBuffer(ptyTail.lines, ptyTail.partialLine, normalizedChunk)
+    leafTail = tailStateMatches(leafTail.lines, leafTail.partialLine, ptyTailBefore)
+      ? { lines: ptyTail.lines, partialLine: ptyTail.partialLine }
+      : appendNormalizedToTailBuffer(leafTail.lines, leafTail.partialLine, normalizedChunk)
+  }
+
+  return performance.now() - start
 }
 
 function scheduleLegacyFlush(pending) {
@@ -133,6 +375,8 @@ async function runBenchmark() {
   const boundedTotalDurations = []
   const legacyInputTimerDelays = []
   const boundedInputTimerDelays = []
+  const legacyRuntimeIngressDurations = []
+  const currentRuntimeIngressDurations = []
   let legacyBytes = 0
   let boundedBytes = 0
 
@@ -152,6 +396,9 @@ async function runBenchmark() {
       legacyInputTimerDelays.push(await measureInputTimerDelay('legacy'))
       boundedInputTimerDelays.push(await measureInputTimerDelay('bounded'))
     }
+
+    legacyRuntimeIngressDurations.push(measureRuntimeIngressLegacy())
+    currentRuntimeIngressDurations.push(measureRuntimeIngressCurrent())
   }
 
   const legacySummary = summarize(legacyDurations)
@@ -160,6 +407,8 @@ async function runBenchmark() {
   const boundedTotalSummary = summarize(boundedTotalDurations)
   const legacyInputTimerSummary = MEASURE_TIMER_DELAYS ? summarize(legacyInputTimerDelays) : null
   const boundedInputTimerSummary = MEASURE_TIMER_DELAYS ? summarize(boundedInputTimerDelays) : null
+  const legacyRuntimeIngressSummary = summarize(legacyRuntimeIngressDurations)
+  const currentRuntimeIngressSummary = summarize(currentRuntimeIngressDurations)
 
   console.log(
     JSON.stringify(
@@ -168,7 +417,10 @@ async function runBenchmark() {
           ptyCount: PTY_COUNT,
           payloadChars: PAYLOAD_CHARS,
           runs: RUNS,
-          totalPayloadMiB: (PTY_COUNT * PAYLOAD_CHARS) / 1024 / 1024
+          totalPayloadMiB: (PTY_COUNT * PAYLOAD_CHARS) / 1024 / 1024,
+          ingressChunks: INGRESS_CHUNKS,
+          ingressChunkChars: INGRESS_CHUNK_CHARS,
+          ingressPayloadMiB: (INGRESS_CHUNKS * INGRESS_CHUNK_CHARS) / 1024 / 1024
         },
         legacy: {
           bytesPerRun: legacyBytes,
@@ -181,6 +433,13 @@ async function runBenchmark() {
           maxSlice: boundedMaxSliceSummary,
           totalDrain: boundedTotalSummary,
           inputTimerDelay: boundedInputTimerSummary
+        },
+        runtimeIngress: {
+          legacyRepeatedScans: legacyRuntimeIngressSummary,
+          currentFastPath: currentRuntimeIngressSummary,
+          estimatedReduction:
+            legacyRuntimeIngressSummary.max /
+            Math.max(currentRuntimeIngressSummary.max, Number.EPSILON)
         },
         estimatedPtyWriteDelay:
           legacyInputTimerSummary && boundedInputTimerSummary
@@ -204,6 +463,8 @@ async function runBenchmark() {
       `bounded max first slice: ${formatMs(boundedFirstSliceSummary.max)}`,
       `bounded max any slice: ${formatMs(boundedMaxSliceSummary.max)}`,
       `bounded max total drain: ${formatMs(boundedTotalSummary.max)}`,
+      `runtime ingress legacy max: ${formatMs(legacyRuntimeIngressSummary.max)}`,
+      `runtime ingress current max: ${formatMs(currentRuntimeIngressSummary.max)}`,
       legacyInputTimerSummary
         ? `legacy max input timer delay: ${formatMs(legacyInputTimerSummary.max)}`
         : null,

--- a/config/scripts/pty-batch-flush-benchmark.mjs
+++ b/config/scripts/pty-batch-flush-benchmark.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-control-regex -- Benchmarks mirror PTY ANSI/OSC parsing regexes. */
 import { performance } from 'node:perf_hooks'
 import v8 from 'node:v8'
 

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2626,6 +2626,55 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('drains large batched PTY output in bounded slices', async () => {
+    vi.useFakeTimers()
+    const firstProc = createMockProc()
+    const secondProc = createMockProc()
+    spawnMock.mockReturnValueOnce(firstProc.proc).mockReturnValueOnce(secondProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const firstSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const secondSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      mainWindow.webContents.send.mockClear()
+
+      const firstChunk = 'x'.repeat(16 * 1024)
+      const firstRemainder = 'tail'
+      secondProc.emitData('second-terminal-output')
+      firstProc.emitData(`${firstChunk}${firstRemainder}`)
+
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(2)
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(1, 'pty:data', {
+        id: secondSpawn.id,
+        data: 'second-terminal-output'
+      })
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(2, 'pty:data', {
+        id: firstSpawn.id,
+        data: firstChunk
+      })
+
+      vi.advanceTimersByTime(1)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(3)
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(3, 'pty:data', {
+        id: firstSpawn.id,
+        data: firstRemainder
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('batches stale PTY output after the interactive window expires', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -661,21 +661,48 @@ export function registerPtyHandlers(
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
   const PTY_BATCH_INTERVAL_MS = 8
+  const PTY_BATCH_DRAIN_CONTINUE_MS = 1
+  const PTY_BATCH_FLUSH_CHUNK_CHARS = 16 * 1024
+  const PTY_BATCH_FLUSH_MAX_WRITES = 2
   // Why: keep the immediate path bounded to keystroke-sized TUI redraws;
   // large output and non-interactive output must still use the batcher.
   const INTERACTIVE_OUTPUT_WINDOW_MS = 100
   const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
 
-  const flushPendingData = (): void => {
+  function schedulePendingDataFlush(delayMs: number): void {
+    if (flushTimer) {
+      return
+    }
+    flushTimer = setTimeout(flushPendingData, delayMs)
+  }
+
+  function flushPendingData(): void {
     flushTimer = null
     if (mainWindow.isDestroyed()) {
       pendingData.clear()
       return
     }
-    for (const [id, data] of pendingData) {
-      mainWindow.webContents.send('pty:data', { id, data })
+    let writes = 0
+    while (pendingData.size > 0 && writes < PTY_BATCH_FLUSH_MAX_WRITES) {
+      const next = pendingData.entries().next().value
+      if (!next) {
+        break
+      }
+      const [id, data] = next
+      pendingData.delete(id)
+      const chunk = data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
+      const remaining = data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
+      if (remaining) {
+        pendingData.set(id, remaining)
+      }
+      mainWindow.webContents.send('pty:data', { id, data: chunk })
+      writes++
     }
-    pendingData.clear()
+    if (pendingData.size > 0) {
+      // Why: a background terminal can dump megabytes at once. Yield between
+      // small IPC slices so keystroke writes are not stuck behind one flush.
+      schedulePendingDataFlush(PTY_BATCH_DRAIN_CONTINUE_MS)
+    }
   }
 
   const clearFlushTimerIfIdle = (): void => {
@@ -737,7 +764,7 @@ export function registerPtyHandlers(
       }
       pendingData.set(payload.id, nextData)
       if (!flushTimer) {
-        flushTimer = setTimeout(flushPendingData, PTY_BATCH_INTERVAL_MS)
+        schedulePendingDataFlush(PTY_BATCH_INTERVAL_MS)
       }
     })
     localExitUnsub = localProvider.onExit((payload) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2167,11 +2167,30 @@ export class OrcaRuntimeService {
     const oscTitle = extractLastOscTitle(data)
     const agentStatus = oscTitle ? detectAgentStatusFromTitle(oscTitle) : null
 
+    let normalizedData: string | null = null
+    const getNormalizedData = (): string => {
+      normalizedData ??= normalizeTerminalChunk(data)
+      return normalizedData
+    }
     const pty = this.getOrCreatePtyWorktreeRecord(ptyId)
+    const ptyTailBefore = pty
+      ? {
+          lines: pty.tailBuffer,
+          partialLine: pty.tailPartialLine,
+          truncated: pty.tailTruncated,
+          linesTotal: pty.tailLinesTotal
+        }
+      : null
+    let ptyTailAfter: ReturnType<typeof appendNormalizedToTailBuffer> | null = null
     if (pty) {
       pty.connected = true
       pty.lastOutputAt = at
-      const nextTail = appendToTailBuffer(pty.tailBuffer, pty.tailPartialLine, data)
+      const nextTail = appendNormalizedToTailBuffer(
+        pty.tailBuffer,
+        pty.tailPartialLine,
+        getNormalizedData()
+      )
+      ptyTailAfter = nextTail
       pty.tailBuffer = nextTail.lines
       pty.tailPartialLine = nextTail.partialLine
       pty.tailTruncated = pty.tailTruncated || nextTail.truncated
@@ -2201,12 +2220,37 @@ export class OrcaRuntimeService {
       leaf.connected = true
       leaf.writable = this.graphStatus === 'ready'
       leaf.lastOutputAt = at
-      const nextTail = appendToTailBuffer(leaf.tailBuffer, leaf.tailPartialLine, data)
-      leaf.tailBuffer = nextTail.lines
-      leaf.tailPartialLine = nextTail.partialLine
-      leaf.tailTruncated = leaf.tailTruncated || nextTail.truncated
-      leaf.tailLinesTotal += nextTail.newCompleteLines
-      leaf.preview = buildPreview(leaf.tailBuffer, leaf.tailPartialLine)
+      if (
+        pty &&
+        ptyTailBefore &&
+        ptyTailAfter &&
+        tailStateMatches(
+          leaf.tailBuffer,
+          leaf.tailPartialLine,
+          leaf.tailTruncated,
+          leaf.tailLinesTotal,
+          ptyTailBefore
+        )
+      ) {
+        // Why: the leaf and PTY record usually mirror the same terminal. Reuse
+        // the PTY tail update instead of splitting large output twice.
+        leaf.tailBuffer = pty.tailBuffer
+        leaf.tailPartialLine = pty.tailPartialLine
+        leaf.tailTruncated = pty.tailTruncated
+        leaf.tailLinesTotal = pty.tailLinesTotal
+        leaf.preview = pty.preview
+      } else {
+        const nextTail = appendNormalizedToTailBuffer(
+          leaf.tailBuffer,
+          leaf.tailPartialLine,
+          getNormalizedData()
+        )
+        leaf.tailBuffer = nextTail.lines
+        leaf.tailPartialLine = nextTail.partialLine
+        leaf.tailTruncated = leaf.tailTruncated || nextTail.truncated
+        leaf.tailLinesTotal += nextTail.newCompleteLines
+        leaf.preview = buildPreview(leaf.tailBuffer, leaf.tailPartialLine)
+      }
 
       if (oscTitle !== null) {
         // Why: keep the latest OSC title on the leaf so worktree.ps can
@@ -11912,17 +11956,16 @@ function buildTerminalWaitText(lines: string[], partialLine: string, preview: st
   return waitText.length > 0 ? waitText : preview
 }
 
-function appendToTailBuffer(
+function appendNormalizedToTailBuffer(
   previousLines: string[],
   previousPartialLine: string,
-  chunk: string
+  normalizedChunk: string
 ): {
   lines: string[]
   partialLine: string
   truncated: boolean
   newCompleteLines: number
 } {
-  const normalizedChunk = normalizeTerminalChunk(chunk)
   if (normalizedChunk.length === 0) {
     return {
       lines: previousLines,
@@ -11969,6 +12012,37 @@ function appendToTailBuffer(
     truncated,
     newCompleteLines
   }
+}
+
+function tailStateMatches(
+  lines: string[],
+  partialLine: string,
+  truncated: boolean,
+  linesTotal: number,
+  snapshot: {
+    lines: string[]
+    partialLine: string
+    truncated: boolean
+    linesTotal: number
+  }
+): boolean {
+  if (
+    partialLine !== snapshot.partialLine ||
+    truncated !== snapshot.truncated ||
+    linesTotal !== snapshot.linesTotal ||
+    lines.length !== snapshot.lines.length
+  ) {
+    return false
+  }
+  if (lines === snapshot.lines) {
+    return true
+  }
+  for (let index = 0; index < lines.length; index++) {
+    if (lines[index] !== snapshot.lines[index]) {
+      return false
+    }
+  }
+  return true
 }
 
 function buildTailLines(lines: string[], partialLine: string): string[] {
@@ -12406,6 +12480,11 @@ function mergeWorktreeStatus(
 }
 
 function normalizeTerminalChunk(chunk: string): string {
+  // Why: most high-throughput PTY chunks are plain printable text. Avoid
+  // running every ANSI/OSC regex over megabytes that do not need normalization.
+  if (!terminalChunkNeedsNormalization(chunk)) {
+    return chunk
+  }
   return chunk
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
@@ -12414,6 +12493,22 @@ function normalizeTerminalChunk(chunk: string): string {
     .replace(/\x1b[@-_]/g, '')
     .replace(/\u0008/g, '')
     .replace(/[^\x09\x0a\x20-\x7e]/g, '')
+}
+
+function terminalChunkNeedsNormalization(chunk: string): boolean {
+  for (let index = 0; index < chunk.length; index++) {
+    const code = chunk.charCodeAt(index)
+    if (
+      code === 0x1b ||
+      code === 0x0d ||
+      code < 0x09 ||
+      (code > 0x0a && code < 0x20) ||
+      code > 0x7e
+    ) {
+      return true
+    }
+  }
+  return false
 }
 
 function maxTimestamp(left: number | null, right: number | null): number | null {

--- a/src/main/stats/agent-detector.ts
+++ b/src/main/stats/agent-detector.ts
@@ -24,6 +24,18 @@ type PtyRecord = {
  * orca-runtime.ts normalizeTerminalChunk but avoids importing the runtime.
  */
 function hasMeaningfulContent(chunk: string): boolean {
+  // Why: large plain-text PTY bursts should not pay the full ANSI stripping
+  // chain just to prove they contain visible output.
+  for (let index = 0; index < chunk.length; index++) {
+    const code = chunk.charCodeAt(index)
+    if (code === 0x1b || code < 0x09 || (code > 0x0d && code < 0x20) || code > 0x7e) {
+      break
+    }
+    if (code > 0x20) {
+      return true
+    }
+  }
+
   const stripped = chunk
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -113,6 +113,9 @@ const OSC_TITLE_RE = /\x1b\]([012]);([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
  * normalizeTerminalChunk pass.
  */
 export function extractLastOscTitle(data: string): string | null {
+  if (!data.includes('\x1b]')) {
+    return null
+  }
   let last: string | null = null
   for (const m of data.matchAll(OSC_TITLE_RE)) {
     last = m[2]
@@ -131,6 +134,9 @@ export function extractLastOscTitle(data: string): string | null {
  * spinner-miss follow-up.
  */
 export function extractAllOscTitles(data: string): string[] {
+  if (!data.includes('\x1b]')) {
+    return []
+  }
   const titles: string[] = []
   for (const m of data.matchAll(OSC_TITLE_RE)) {
     titles.push(m[2])


### PR DESCRIPTION
## Summary
- Bound the main-process PTY batch drain to small round-robin IPC slices instead of flushing every pending terminal in one timer callback.
- Keep the existing 8 ms coalescing window and recent-input fast path, while yielding between large background output chunks so pty:write IPC can interleave.
- Added a regression test for large batched PTY output draining in bounded slices.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-server.test.ts src/main/providers/ssh-pty-provider.test.ts
- pnpm run typecheck:node
- pnpm oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts
- pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts