### PR TITLE
Keep terminal shortcut notice visible

### DIFF
--- a/src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
+++ b/src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { showTerminalShortcutCaptureNotification } from './terminal-shortcut-capture-notification'
+
+const { toastMessage } = vi.hoisted(() => ({
+  toastMessage: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    message: toastMessage
+  }
+}))
+
+function createLocalStorage(): Storage {
+  const values = new Map<string, string>()
+
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value)
+    }
+  }
+}
+
+describe('showTerminalShortcutCaptureNotification', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorage())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('keeps the shortcut capture warning visible until dismissed', () => {
+    showTerminalShortcutCaptureNotification({
+      actionId: 'tab.close',
+      platform: 'darwin'
+    })
+
+    expect(toast.message).toHaveBeenCalledWith(
+      'Orca handled a terminal shortcut',
+      expect.objectContaining({
+        duration: Infinity,
+        dismissible: true,
+        action: expect.objectContaining({ label: 'Open Shortcuts' })
+      })
+    )
+  })
+})

--- a/src/renderer/src/lib/terminal-shortcut-capture-notification.tsx
+++ b/src/renderer/src/lib/terminal-shortcut-capture-notification.tsx
@@ -62,6 +62,10 @@ export function showTerminalShortcutCaptureNotification({
   )
   toast.message('Orca handled a terminal shortcut', {
     description: `${definition.title} (${bindingLabel}) can be changed in Keyboard Shortcuts.`,
+    // Why: this is the user's one-time rebind path for a captured shortcut; it
+    // should stay visible until they act on or dismiss it.
+    duration: Infinity,
+    dismissible: true,
     icon: <Keyboard className="size-4 text-muted-foreground" />,
     action: {
       label: 'Open Shortcuts',


### PR DESCRIPTION
## Summary
- Keep the terminal shortcut capture warning visible until the user dismisses it or opens shortcut settings.
- Add a focused regression test for the sticky, dismissible toast options.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
- pnpm run typecheck
- pnpm lint
- Electron dev build visual check: triggered the terminal shortcut warning with Meta+B and confirmed it was still visible after 7 seconds with Close toast + Open Shortcuts affordances.

## Review
- Local code review found no issues in the changed notification path or test.
