### PR TITLE
Align tab bar action buttons

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -95,6 +95,9 @@ export function TabBarQuickCommandsButton({
 
   const totalVisible = repoCommands.length + globalCommands.length
   const hasAnyCommands = totalVisible > 0
+  // Why: the bordered quick-command chip reads lower than adjacent icon-only
+  // toolbar buttons in the 32px tab row; lift the chip to match optically.
+  const quickCommandToolbarLiftClass = '-translate-y-0.5'
 
   const handleOpenChange = (next: boolean): void => {
     setMenuOpen(next)
@@ -152,7 +155,10 @@ export function TabBarQuickCommandsButton({
                   command: createTerminalQuickCommandDraft({ type: 'repo', repoId })
                 })
               }
-              className="my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className={cn(
+                quickCommandToolbarLiftClass,
+                'flex h-7 shrink-0 items-center gap-1 self-center rounded-md px-1.5 leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+              )}
               aria-label="Add quick command"
             >
               <Plus className="size-3.5" />
@@ -175,10 +181,9 @@ export function TabBarQuickCommandsButton({
     )
   }
 
-  const splitButtonClass =
-    'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
+  const splitButtonClass = `flex h-7 ${quickCommandToolbarLiftClass} shrink-0 items-stretch self-center overflow-hidden rounded-md leading-none text-muted-foreground ring-1 ring-inset ring-border/60`
   const innerButtonBase =
-    'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+    'flex h-full items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
 
   const renderItem = (command: TerminalQuickCommand): React.JSX.Element => (
     <CommandItem

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -162,13 +162,13 @@ export default function TabGroupPanel({
   )
 
   const menuButtonClassName =
-    'my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+    'flex h-7 w-7 -translate-y-0.5 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
   // Why: focused-only — the QC split-button and Pane Actions ellipsis both
   // appear together so the action cluster never reflows when focus shifts
   // between groups. Unfocused groups collapse the cluster fully (no
   // reserved width) since the surrounding tab strip already absorbs the
   // freed space.
-  const actionChromeClassName = `flex shrink-0 items-center gap-0.5 overflow-hidden transition-[opacity] duration-150 ${
+  const actionChromeClassName = `flex h-full shrink-0 items-center gap-0.5 overflow-hidden transition-[opacity] duration-150 ${
     isFocused ? 'ml-1.5 pointer-events-auto opacity-100' : 'pointer-events-none opacity-0 w-0'
   }`
 


### PR DESCRIPTION
## Summary
- adjust quick-command chip and pane actions vertical alignment in the tab row
- keep focused action chrome at full tab-row height so controls align consistently

## Tests
- pnpm typecheck