### PR TITLE
Add Tailscale DNS hint for agent failures

### DIFF
--- a/src/main/network/macos-tailscale-dns-diagnostic.test.ts
+++ b/src/main/network/macos-tailscale-dns-diagnostic.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseMacTailscaleDnsDiagnostic,
+  withMacTailscaleDnsHintForDiagnostic
+} from './macos-tailscale-dns-diagnostic'
+
+const MAGIC_DNS_ONLY_SCUTIL = `
+DNS configuration
+
+resolver #1
+  nameserver[0] : 100.100.100.100
+  flags    : Request A records
+  reach    : 0x00000002 (Reachable)
+  order    : 5000
+
+DNS configuration (for scoped queries)
+
+resolver #1
+  nameserver[0] : 192.168.1.1
+  if_index : 14 (en0)
+`
+
+describe('parseMacTailscaleDnsDiagnostic', () => {
+  it('detects Tailscale MagicDNS as the only global resolver', () => {
+    const diagnostic = parseMacTailscaleDnsDiagnostic(MAGIC_DNS_ONLY_SCUTIL)
+
+    expect(diagnostic).toEqual({ globalNameservers: ['100.100.100.100'] })
+  })
+
+  it('ignores configurations with non-Tailscale global resolvers', () => {
+    const diagnostic = parseMacTailscaleDnsDiagnostic(`
+DNS configuration
+
+resolver #1
+  nameserver[0] : 100.100.100.100
+  nameserver[1] : 1.1.1.1
+  order    : 5000
+`)
+
+    expect(diagnostic).toBeNull()
+  })
+
+  it('does not treat scoped-only Tailscale resolvers as the global failure shape', () => {
+    const diagnostic = parseMacTailscaleDnsDiagnostic(`
+DNS configuration
+
+resolver #1
+  nameserver[0] : 192.168.1.1
+  order    : 5000
+
+DNS configuration (for scoped queries)
+
+resolver #1
+  nameserver[0] : 100.100.100.100
+  if_index : 19 (utun7)
+`)
+
+    expect(diagnostic).toBeNull()
+  })
+})
+
+describe('withMacTailscaleDnsHintForDiagnostic', () => {
+  it('adds a Tailscale DNS hint for the Codex lookup failure from the issue', () => {
+    const diagnostic = parseMacTailscaleDnsDiagnostic(MAGIC_DNS_ONLY_SCUTIL)
+    const result = withMacTailscaleDnsHintForDiagnostic(
+      'Codex failed. Check the agent CLI configuration and try again.',
+      'stream disconnected before completion: failed to lookup address information: nodename nor servname provided, or not known',
+      diagnostic
+    )
+
+    expect(result).toContain('Tailscale MagicDNS (100.100.100.100)')
+    expect(result).toContain('add an upstream DNS server')
+  })
+
+  it('leaves unrelated failures unchanged even under MagicDNS-only DNS', () => {
+    const diagnostic = parseMacTailscaleDnsDiagnostic(MAGIC_DNS_ONLY_SCUTIL)
+    const message = 'Codex failed. Check the agent CLI configuration and try again.'
+
+    expect(withMacTailscaleDnsHintForDiagnostic(message, 'permission denied', diagnostic)).toBe(
+      message
+    )
+  })
+})

--- a/src/main/network/macos-tailscale-dns-diagnostic.ts
+++ b/src/main/network/macos-tailscale-dns-diagnostic.ts
@@ -1,0 +1,93 @@
+import { execFileSync } from 'node:child_process'
+
+const TAILSCALE_MAGIC_DNS = '100.100.100.100'
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+type DnsDiagnostic = {
+  globalNameservers: string[]
+}
+
+type CacheEntry = {
+  expiresAt: number
+  diagnostic: DnsDiagnostic | null
+}
+
+let cache: CacheEntry | null = null
+
+const NETWORK_LOOKUP_FAILURE_RE =
+  /\b(?:ENOTFOUND|EAI_AGAIN|ESERVFAIL|ERR_NAME_NOT_RESOLVED)\b|lookup address|nodename nor servname|name resolution|dns|websocket|connection refused/i
+
+function globalDnsSection(scutilOutput: string): string {
+  const scopedStart = scutilOutput.indexOf('\nDNS configuration (for scoped queries)')
+  return scopedStart >= 0 ? scutilOutput.slice(0, scopedStart) : scutilOutput
+}
+
+export function parseMacTailscaleDnsDiagnostic(scutilOutput: string): DnsDiagnostic | null {
+  const globalSection = globalDnsSection(scutilOutput)
+  const nameservers = [
+    ...new Set(
+      Array.from(globalSection.matchAll(/nameserver\[\d+\]\s*:\s*([^\s]+)/g), (match) =>
+        match[1].trim()
+      )
+    )
+  ]
+
+  if (nameservers.length === 0) {
+    return null
+  }
+  if (!nameservers.every((nameserver) => nameserver === TAILSCALE_MAGIC_DNS)) {
+    return null
+  }
+
+  return { globalNameservers: nameservers }
+}
+
+function readMacTailscaleDnsDiagnostic(now = Date.now()): DnsDiagnostic | null {
+  if (process.platform !== 'darwin') {
+    return null
+  }
+  if (cache && cache.expiresAt > now) {
+    return cache.diagnostic
+  }
+
+  let diagnostic: DnsDiagnostic | null = null
+  try {
+    const output = execFileSync('scutil', ['--dns'], {
+      encoding: 'utf8',
+      timeout: 1500,
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    diagnostic = parseMacTailscaleDnsDiagnostic(output)
+  } catch {
+    diagnostic = null
+  }
+
+  cache = { diagnostic, expiresAt: now + CACHE_TTL_MS }
+  return diagnostic
+}
+
+export function withMacTailscaleDnsHintForDiagnostic(
+  message: string,
+  detail: string | null | undefined,
+  diagnostic: DnsDiagnostic | null
+): string {
+  const probeText = `${message}\n${detail ?? ''}`
+  if (!NETWORK_LOOKUP_FAILURE_RE.test(probeText)) {
+    return message
+  }
+  if (!diagnostic) {
+    return message
+  }
+
+  // Why: Claude/Codex own the failing API transports, so Orca can only point
+  // users at the macOS resolver configuration that makes those transports fail.
+  return `${message} macOS is using Tailscale MagicDNS (100.100.100.100) as the only global DNS resolver; add an upstream DNS server to the active network service or configure Tailscale global nameservers, then retry.`
+}
+
+export function withMacTailscaleDnsHint(message: string, detail?: string | null): string {
+  return withMacTailscaleDnsHintForDiagnostic(message, detail, readMacTailscaleDnsDiagnostic())
+}
+
+export function __resetMacTailscaleDnsDiagnosticCacheForTests(): void {
+  cache = null
+}

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -18,6 +18,7 @@ import {
   resolveOwnedClaudeManagedAuthPath
 } from '../claude-accounts/managed-auth-path'
 import { createOAuthUsageError, OAuthUsageError } from './claude-oauth-usage-error'
+import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -318,7 +319,7 @@ export async function fetchClaudeRateLimits(options?: {
           session: null,
           weekly: null,
           updatedAt: Date.now(),
-          error: err.message,
+          error: withMacTailscaleDnsHint(err.message),
           status: 'error'
         }
       }
@@ -340,7 +341,7 @@ export async function fetchClaudeRateLimits(options?: {
         session: null,
         weekly: null,
         updatedAt: Date.now(),
-        error: message,
+        error: withMacTailscaleDnsHint(message),
         status: 'error'
       }
     }

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -1,7 +1,11 @@
+/* eslint-disable max-lines -- Why: Claude PTY usage scraping keeps prompt
+driving, parser, timers, and teardown in one state machine; splitting it would
+make the lifecycle harder to audit. */
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { applyClaudeEnvPatch } from '../claude-accounts/environment'
+import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 
 const PTY_TIMEOUT_MS = 25_000
 const MAX_OUTPUT_LENGTH = 100_000 // 100KB buffer limit
@@ -218,10 +222,12 @@ export async function fetchViaPty(options?: {
             session: null,
             weekly: null,
             updatedAt: Date.now(),
-            error:
+            error: withMacTailscaleDnsHint(
               CLAUDE_21_USAGE_TABS_RE.test(clean) || CLAUDE_21_SESSION_STATS_RE.test(clean)
                 ? describeClaudeUsageFailure(clean)
                 : 'PTY timeout — /usage panel did not render',
+              clean
+            ),
             status: 'error'
           })
         }
@@ -268,7 +274,7 @@ export async function fetchViaPty(options?: {
           session: null,
           weekly: null,
           updatedAt: Date.now(),
-          error: describeClaudeUsageFailure(clean),
+          error: withMacTailscaleDnsHint(describeClaudeUsageFailure(clean), clean),
           status: 'error'
         })
       } else {
@@ -369,7 +375,10 @@ export async function fetchViaPty(options?: {
           session,
           weekly,
           updatedAt: Date.now(),
-          error: session || weekly ? null : 'CLI exited before /usage rendered',
+          error:
+            session || weekly
+              ? null
+              : withMacTailscaleDnsHint('CLI exited before /usage rendered', clean),
           status: session || weekly ? 'ok' : 'error'
         })
       }

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -4,10 +4,12 @@ differences and ensure account-scoped env handling stays identical. */
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { spawn } from 'node:child_process'
 import { resolveCodexCommand } from '../codex-cli/command'
+import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
 
 const RPC_TIMEOUT_MS = 10_000
 const PTY_TIMEOUT_MS = 15_000
+const MAX_DIAGNOSTIC_OUTPUT_LENGTH = 100_000
 
 export type FetchCodexRateLimitsOptions = {
   codexHomePath?: string | null
@@ -88,6 +90,7 @@ function mapRpcWindow(
 async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<ProviderRateLimits> {
   return new Promise<ProviderRateLimits>((resolve) => {
     let buffer = ''
+    let stderr = ''
     let resolved = false
     let rpcId = 0
 
@@ -196,7 +199,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
                 session: null,
                 weekly: null,
                 updatedAt: Date.now(),
-                error: msg.error.message,
+                error: withMacTailscaleDnsHint(msg.error.message, stderr),
                 status: 'error'
               })
               return
@@ -222,6 +225,14 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
     })
 
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString()
+      // Why: this background poll only needs recent failure context for hints.
+      if (stderr.length > MAX_DIAGNOSTIC_OUTPUT_LENGTH) {
+        stderr = stderr.slice(-MAX_DIAGNOSTIC_OUTPUT_LENGTH)
+      }
+    })
+
     child.on('error', (err) => {
       if (!resolved) {
         resolved = true
@@ -237,7 +248,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
             ? isBareCommand
               ? 'Codex CLI not found'
               : 'Codex CLI found but could not run — Node.js may not be in your PATH'
-            : err.message,
+            : withMacTailscaleDnsHint(err.message, stderr),
           status: isEnoent && isBareCommand ? 'unavailable' : 'error'
         })
       }
@@ -252,7 +263,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
           session: null,
           weekly: null,
           updatedAt: Date.now(),
-          error: 'RPC process exited unexpectedly',
+          error: withMacTailscaleDnsHint('RPC process exited unexpectedly', stderr),
           status: 'error'
         })
       }
@@ -354,7 +365,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
           session: null,
           weekly: null,
           updatedAt: Date.now(),
-          error: 'PTY timeout',
+          error: withMacTailscaleDnsHint('PTY timeout', output),
           status: 'error'
         })
       }
@@ -390,7 +401,10 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
             session,
             weekly,
             updatedAt: Date.now(),
-            error: session || weekly ? null : 'Failed to parse CLI output',
+            error:
+              session || weekly
+                ? null
+                : withMacTailscaleDnsHint('Failed to parse CLI output', clean),
             status: session || weekly ? 'ok' : 'error'
           })
         }, 500)
@@ -413,7 +427,10 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
           session,
           weekly,
           updatedAt: Date.now(),
-          error: session || weekly ? null : 'CLI exited before status was available',
+          error:
+            session || weekly
+              ? null
+              : withMacTailscaleDnsHint('CLI exited before status was available', clean),
           status: session || weekly ? 'ok' : 'error'
         })
       }
@@ -454,7 +471,7 @@ export async function fetchCodexRateLimits(
       session: null,
       weekly: null,
       updatedAt: Date.now(),
-      error: isNotInstalled ? 'Codex CLI not found' : message,
+      error: isNotInstalled ? 'Codex CLI not found' : withMacTailscaleDnsHint(message),
       status: isNotInstalled ? 'unavailable' : 'error'
     }
   }

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -40,6 +40,7 @@ import {
   UnsafeWindowsBatchArgumentsError,
   WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR
 } from '../win32-utils'
+import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 
 const GENERATION_TIMEOUT_MS = 60_000
 const MAX_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024
@@ -197,8 +198,15 @@ function sanitizeAgentFailureDetail(detail: string | null): string | null {
   return trimmed.length > 240 ? `${trimmed.slice(0, 240).trimEnd()}...` : trimmed
 }
 
-function userFacingAgentFailure(label: string): string {
-  return `${label} failed. Check the agent CLI configuration and try again.`
+function userFacingAgentFailure(
+  label: string,
+  detail?: string | null,
+  options?: { includeLocalMacDnsHint?: boolean }
+): string {
+  const message = `${label} failed. Check the agent CLI configuration and try again.`
+  return options?.includeLocalMacDnsHint === false
+    ? message
+    : withMacTailscaleDnsHint(message, detail)
 }
 
 function userFacingUnsafeWindowsBatchArgs(label: string): string {
@@ -241,7 +249,10 @@ function finalizeModelDiscoveryOutput(
     })
     return {
       success: false,
-      error: `${spec.label} model discovery failed. Check the agent CLI configuration and try again.`
+      error: withMacTailscaleDnsHint(
+        `${spec.label} model discovery failed. Check the agent CLI configuration and try again.`,
+        safeDetail
+      )
     }
   }
   let models = spec.modelDiscovery?.parse(stdout) ?? []
@@ -619,8 +630,9 @@ function finalizeFromAgentOutput(args: {
   label: string
   emptyResultName: string
   finalize: (result: InternalTextGenerationResult) => void
+  includeLocalMacDnsHint?: boolean
 }): void {
-  const { code, stdout, stderr, label, emptyResultName, finalize } = args
+  const { code, stdout, stderr, label, emptyResultName, finalize, includeLocalMacDnsHint } = args
   if (code !== 0) {
     const safeDetail = sanitizeAgentFailureDetail(extractAgentErrorMessage(stdout, stderr))
     console.error('[commit-message] Generator failed:', {
@@ -630,7 +642,10 @@ function finalizeFromAgentOutput(args: {
       stdout,
       stderr
     })
-    finalize({ success: false, error: userFacingAgentFailure(label) })
+    finalize({
+      success: false,
+      error: userFacingAgentFailure(label, safeDetail, { includeLocalMacDnsHint })
+    })
     return
   }
   const cleaned = cleanGeneratedCommitMessage(stdout)
@@ -644,7 +659,10 @@ function finalizeFromAgentOutput(args: {
         stdout,
         stderr
       })
-      finalize({ success: false, error: userFacingAgentFailure(label) })
+      finalize({
+        success: false,
+        error: userFacingAgentFailure(label, safeDetail, { includeLocalMacDnsHint })
+      })
       return
     }
     finalize({ success: false, error: `${label} returned an empty ${emptyResultName}.` })
@@ -709,7 +727,9 @@ async function runRemotePlan(
       stderr: result.stderr,
       label,
       emptyResultName,
-      finalize: resolve
+      finalize: resolve,
+      // Why: remote agent output reflects the SSH target, not this Mac's DNS.
+      includeLocalMacDnsHint: false
     })
   })
 }


### PR DESCRIPTION
## Summary
- Detect macOS configurations where Tailscale MagicDNS (100.100.100.100) is the only global resolver
- Add a targeted DNS hint to Claude/Codex rate-limit and AI text-generation failures when stderr/output looks like DNS or websocket lookup trouble
- Cover MagicDNS-only parsing and the Codex lookup error from #2687 with focused tests

## Notes
This does not force Claude/Codex API transports to use a different resolver. Orca does not own those third-party websocket transports, so this PR surfaces the actionable system DNS remediation when the reported failure shape appears.

Refs #2687

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/main/network/macos-tailscale-dns-diagnostic.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/network/macos-tailscale-dns-diagnostic.ts src/main/network/macos-tailscale-dns-diagnostic.test.ts src/main/rate-limits/codex-fetcher.ts src/main/rate-limits/claude-pty.ts src/main/rate-limits/claude-fetcher.ts src/main/text-generation/commit-message-text-generation.ts
- git diff --check