### PR TITLE
Compact terminal shortcut notification

### DIFF
--- a/src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
+++ b/src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
@@ -41,16 +41,21 @@ describe('showTerminalShortcutCaptureNotification', () => {
     vi.clearAllMocks()
   })
 
-  it('keeps the shortcut capture warning visible until dismissed', () => {
+  it('keeps the shortcut capture warning visible long enough to act on', () => {
     showTerminalShortcutCaptureNotification({
       actionId: 'tab.close',
       platform: 'darwin'
     })
 
     expect(toast.message).toHaveBeenCalledWith(
-      'Orca handled a terminal shortcut',
+      'Terminal shortcut handled',
       expect.objectContaining({
-        duration: Infinity,
+        className: expect.stringContaining('!py-2'),
+        classNames: expect.objectContaining({
+          title: expect.stringContaining('truncate'),
+          description: expect.stringContaining('truncate')
+        }),
+        duration: 20_000,
         dismissible: true,
         action: expect.objectContaining({ label: 'Open Shortcuts' })
       })

--- a/src/renderer/src/lib/terminal-shortcut-capture-notification.tsx
+++ b/src/renderer/src/lib/terminal-shortcut-capture-notification.tsx
@@ -11,6 +11,7 @@ import {
 import { useAppStore } from '../store'
 
 const STORAGE_PREFIX = 'orca.terminalShortcutCapturedNotice.'
+const NOTICE_DURATION_MS = 20_000
 
 function hasShownNotice(actionId: KeybindingActionId): boolean {
   try {
@@ -60,12 +61,21 @@ export function showTerminalShortcutCaptureNotification({
     getEffectiveKeybindingsForAction(actionId, platform, keybindings),
     platform
   )
-  toast.message('Orca handled a terminal shortcut', {
-    description: `${definition.title} (${bindingLabel}) can be changed in Keyboard Shortcuts.`,
+  // Why: this toast stays up longer than normal, so keep it compact while still
+  // exposing the captured shortcut and the edit path.
+  toast.message('Terminal shortcut handled', {
+    description: `${definition.title} (${bindingLabel})`,
     // Why: this is the user's one-time rebind path for a captured shortcut; it
-    // should stay visible until they act on or dismiss it.
-    duration: Infinity,
+    // needs enough reading time without becoming persistent chrome.
+    duration: NOTICE_DURATION_MS,
     dismissible: true,
+    className: '!w-[420px] !max-w-[calc(100vw-2rem)] !gap-2 !py-2 !pl-3 !pr-2',
+    classNames: {
+      content: 'min-w-0 flex-1 !gap-0.5',
+      title: 'truncate !leading-5',
+      description: 'truncate !leading-4',
+      actionButton: '!h-7 !shrink-0 !rounded-md !px-2.5'
+    },
     icon: <Keyboard className="size-4 text-muted-foreground" />,
     action: {
       label: 'Open Shortcuts',


### PR DESCRIPTION
## Summary
- shorten and compact the terminal shortcut capture toast
- make it auto-dismiss after 20 seconds instead of staying indefinitely
- keep the Open Shortcuts action available while the toast is visible

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
- pnpm exec oxfmt --check src/renderer/src/lib/terminal-shortcut-capture-notification.tsx src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
- git diff --check -- src/renderer/src/lib/terminal-shortcut-capture-notification.tsx src/renderer/src/lib/terminal-shortcut-capture-notification.test.tsx
- Electron dev build via CDP: toast rendered at 420x56, was visible after ~0.5s, and was gone after a 21.5s wait
