### PR TITLE
Fix tab-bar collapse for expanded terminal pane

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -116,7 +116,7 @@ export default function TabGroupPanel({
       onNewFileTab={commands.newFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}
       onSetTabColor={commands.setTabColor}
-      onTogglePaneExpand={() => {}}
+      onTogglePaneExpand={commands.toggleTerminalPaneExpand}
       editorFiles={editorItems}
       browserTabs={browserItems}
       activeFileId={

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 
 const mocks = vi.hoisted(() => ({
   activateTab: vi.fn(),
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   createEmptySplitGroup: vi.fn(),
   createTab: vi.fn(),
   destroyWorkspaceWebviews: vi.fn(),
+  dispatchEvent: vi.fn(),
   dropUnifiedTab: vi.fn(),
   focusGroup: vi.fn(),
   focusTerminalTabSurface: vi.fn(),
@@ -155,6 +157,17 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     resetStore()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('window', {
+      dispatchEvent: mocks.dispatchEvent
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('returns keyboard focus to xterm after a terminal tab is activated', async () => {
@@ -168,5 +181,20 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-1')
     expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1')
+  })
+
+  it('toggles pane expansion from the split-group tab bar collapse button', async () => {
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.toggleTerminalPaneExpand('terminal-1')
+
+    expect(mocks.focusGroup).toHaveBeenCalledWith('wt-1', 'group-1')
+    expect(mocks.activateTab).toHaveBeenCalledWith('unified-terminal-1')
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
+    const event = mocks.dispatchEvent.mock.calls[0]?.[0] as CustomEvent<{ tabId: string }>
+    expect(event.type).toBe(TOGGLE_TERMINAL_PANE_EXPAND_EVENT)
+    expect(event.detail).toEqual({ tabId: 'terminal-1' })
   })
 })

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -19,6 +19,7 @@ import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import { destroyWorkspaceWebviews } from '../../store/slices/browser-webview-cleanup'
 import { requestEditorFileClose } from '../editor/editor-autosave'
 import { focusTerminalTabSurface } from '../../lib/focus-terminal-tab-surface'
+import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import {
   activateWebRuntimeSessionTab,
   closeWebRuntimeSessionTab,
@@ -312,6 +313,28 @@ export function useTabGroupWorkspaceModel({
       focusTerminalTabSurface(terminalId)
     },
     [activateTab, focusGroup, groupId, groupTabs, setActiveTab, setActiveTabType, worktreeId]
+  )
+
+  const toggleTerminalPaneExpand = useCallback(
+    (terminalId: string) => {
+      const item = groupTabs.find(
+        (candidate) => candidate.entityId === terminalId && candidate.contentType === 'terminal'
+      )
+      if (!item) {
+        return
+      }
+      // Why: the tab-bar collapse icon stops pointer propagation, so it does
+      // not run the normal tab activation handler before toggling pane layout.
+      activateTerminal(terminalId)
+      requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
+            detail: { tabId: terminalId }
+          })
+        )
+      })
+    },
+    [activateTerminal, groupTabs]
   )
 
   const activateEditor = useCallback(
@@ -614,7 +637,8 @@ export function useTabGroupWorkspaceModel({
       },
       pinFile,
       setTabColor,
-      setTabCustomTitle
+      setTabCustomTitle,
+      toggleTerminalPaneExpand
     }
   }
 }


### PR DESCRIPTION
## Summary
- wire split-group tab-bar expand/collapse button to the terminal pane toggle command
- activate the owning terminal/group before dispatching the existing pane expand event
- add regression coverage for the split-group tab-bar collapse path

## Review
- local review found no in-scope correctness, type-safety, security, or performance issues

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts src/renderer/src/components/tab-group/TabGroupPanel.tsx src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
- git diff --check
- Electron/CDP: split terminal, expanded pane, clicked actual tab-bar Collapse pane button, verified two panes restored and expanded state cleared

CI intentionally not waited on per request.