### PR TITLE
Add animated agent status feature tip

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1330,6 +1330,80 @@
   transform-origin: center;
 }
 
+/* Why: feature-tip source GIFs are storyboard references; the app ships
+   token-driven authored motion that works offline and respects reduced motion. */
+@keyframes feature-tip-agent-row {
+  0%,
+  8% {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  18%,
+  78% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  92%,
+  100% {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+}
+
+@keyframes feature-tip-agent-card-highlight {
+  0%,
+  100% {
+    border-color: var(--sidebar-border);
+  }
+  32%,
+  76% {
+    border-color: color-mix(in srgb, var(--ring) 45%, var(--sidebar-border));
+  }
+}
+
+@keyframes feature-tip-agent-terminal-line {
+  0%,
+  24% {
+    opacity: 0.35;
+    width: 4rem;
+  }
+  52%,
+  76% {
+    opacity: 0.9;
+    width: 7rem;
+  }
+  100% {
+    opacity: 0.55;
+    width: 5rem;
+  }
+}
+
+.feature-tip-agent-row {
+  animation: feature-tip-agent-row 3.8s cubic-bezier(0.32, 0.72, 0, 1) infinite both;
+}
+
+.feature-tip-agent-card-highlight {
+  animation: feature-tip-agent-card-highlight 3.8s ease-in-out infinite;
+}
+
+.feature-tip-agent-terminal-line {
+  animation: feature-tip-agent-terminal-line 3.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-waveform,
+  .feature-tip-agent-row,
+  .feature-tip-agent-card-highlight,
+  .feature-tip-agent-terminal-line {
+    animation: none !important;
+  }
+
+  .feature-tip-agent-row {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
 /* ── Feature wall: agents-orchestration animations ───────────────── */
 
 /* Why: drives the supported-agents marquee on page 1 of the agents tile.

--- a/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
+++ b/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'react'
-import { Mic, Sparkles } from 'lucide-react'
+import { CircleCheck, Mic, Sparkles } from 'lucide-react'
 import type { FeatureTip } from '../../../../shared/feature-tips'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -17,20 +17,116 @@ import { runFeatureTipPrimaryAction } from './feature-tip-primary-action'
 
 const WAVEFORM_BAR_HEIGHTS = [30, 60, 90, 70, 100, 50, 80, 35, 65]
 
-function AgentStatusSidebarVisual({
-  tip
-}: {
-  tip: Extract<FeatureTip, { action: 'open-agent-status-release-notes' }>
-}): JSX.Element {
+const AGENT_STATUS_VISUAL_ROWS = [
+  {
+    agent: 'Codex',
+    state: 'working',
+    promptClassName: 'w-[58px]',
+    detailClassName: 'w-[78px]',
+    animationDelay: '0.1s'
+  },
+  {
+    agent: 'Claude',
+    state: 'done',
+    promptClassName: 'w-[68px]',
+    detailClassName: 'w-[50px]',
+    animationDelay: '0.45s'
+  },
+  {
+    agent: 'Hermes',
+    state: 'idle',
+    promptClassName: 'w-[52px]',
+    detailClassName: 'w-[64px]',
+    animationDelay: '0.8s'
+  }
+] as const
+
+function AgentStatusVisualDot({ state }: { state: 'working' | 'done' | 'idle' }): JSX.Element {
+  if (state === 'working') {
+    return (
+      <span className="inline-flex size-3 shrink-0 items-center justify-center" aria-hidden="true">
+        <span className="size-2 rounded-full border-[1.5px] border-yellow-500 border-t-transparent animate-spin motion-reduce:animate-none" />
+      </span>
+    )
+  }
+
+  if (state === 'done') {
+    return <CircleCheck className="size-3 shrink-0 text-emerald-500" aria-hidden="true" />
+  }
+
   return (
-    <div className="flex aspect-video w-full max-w-sm items-center justify-center overflow-hidden rounded-md border border-border bg-muted/40">
-      <img
-        src={tip.mediaUrl}
-        alt=""
-        className="h-full w-full object-cover"
-        loading="lazy"
-        draggable={false}
-      />
+    <span className="inline-flex size-3 shrink-0 items-center justify-center" aria-hidden="true">
+      <span className="size-1.5 rounded-full bg-neutral-500/40" />
+    </span>
+  )
+}
+
+function AgentStatusSidebarVisual(): JSX.Element {
+  return (
+    <div
+      className="feature-tip-agent-status-visual flex aspect-video w-full max-w-sm overflow-hidden rounded-md border border-border bg-muted/40 text-[10px] text-foreground"
+      aria-hidden="true"
+    >
+      <div className="flex w-[142px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar p-2 text-sidebar-foreground">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="h-2 w-14 rounded-full bg-sidebar-foreground/30" />
+          <span className="size-2 rounded-full bg-sidebar-border" />
+        </div>
+
+        <div className="feature-tip-agent-card-highlight rounded-md border border-sidebar-border bg-card p-2 shadow-xs">
+          <div className="flex items-center gap-1.5">
+            <span className="size-1.5 rounded-full bg-emerald-500" />
+            <span className="h-2 w-20 rounded-full bg-card-foreground/35" />
+          </div>
+          <div className="mt-1 h-1.5 w-16 rounded-full bg-muted-foreground/25" />
+
+          <div className="mt-2 flex flex-col divide-y divide-border/40">
+            {AGENT_STATUS_VISUAL_ROWS.map((row) => (
+              <div
+                key={row.agent}
+                className="feature-tip-agent-row flex items-start gap-1.5 py-1"
+                style={{ animationDelay: row.animationDelay }}
+              >
+                <AgentStatusVisualDot state={row.state} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <span className="shrink-0 text-[10px] leading-none text-card-foreground/80">
+                      {row.agent}
+                    </span>
+                    <span
+                      className={`h-1.5 rounded-full bg-muted-foreground/35 ${row.promptClassName}`}
+                    />
+                  </div>
+                  <div
+                    className={`mt-1 h-1 rounded-full bg-muted-foreground/20 ${row.detailClassName}`}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-2 rounded-md border border-sidebar-border/70 bg-sidebar-accent/40 p-2 opacity-60">
+          <div className="h-2 w-16 rounded-full bg-sidebar-foreground/25" />
+          <div className="mt-1.5 h-1.5 w-10 rounded-full bg-sidebar-foreground/15" />
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col bg-editor-surface p-3">
+        <div className="flex h-5 items-center gap-1 rounded-t-md border border-border bg-card px-2">
+          <span className="size-1.5 rounded-full bg-muted-foreground/30" />
+          <span className="size-1.5 rounded-full bg-muted-foreground/20" />
+          <span className="size-1.5 rounded-full bg-muted-foreground/20" />
+          <span className="ml-2 h-1.5 w-12 rounded-full bg-muted-foreground/20" />
+        </div>
+        <div className="flex flex-1 flex-col gap-1.5 rounded-b-md border-x border-b border-border bg-background p-2">
+          <span className="h-1.5 w-24 rounded-full bg-foreground/20" />
+          <span className="h-1.5 w-16 rounded-full bg-foreground/15" />
+          <span className="feature-tip-agent-terminal-line h-1.5 w-28 rounded-full bg-yellow-500/55" />
+          <span className="h-1.5 w-20 rounded-full bg-foreground/15" />
+          <span className="mt-auto h-1.5 w-14 rounded-full bg-emerald-500/55" />
+        </div>
+      </div>
     </div>
   )
 }
@@ -56,7 +152,7 @@ function FeatureTipVisual({ tip }: { tip: FeatureTip }): JSX.Element {
         </div>
       )
     case 'open-agent-status-release-notes':
-      return <AgentStatusSidebarVisual tip={tip} />
+      return <AgentStatusSidebarVisual />
   }
 }
 

--- a/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
+++ b/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from 'react'
 import { Mic, Sparkles } from 'lucide-react'
-import { getDefaultVoiceSettings } from '../../../../shared/constants'
 import type { FeatureTip } from '../../../../shared/feature-tips'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -14,8 +13,27 @@ import {
 } from '@/components/ui/dialog'
 import { useAppStore } from '@/store'
 import { getFeatureTipForModal } from './feature-tip-modal-state'
+import { runFeatureTipPrimaryAction } from './feature-tip-primary-action'
 
 const WAVEFORM_BAR_HEIGHTS = [30, 60, 90, 70, 100, 50, 80, 35, 65]
+
+function AgentStatusSidebarVisual({
+  tip
+}: {
+  tip: Extract<FeatureTip, { action: 'open-agent-status-release-notes' }>
+}): JSX.Element {
+  return (
+    <div className="flex aspect-video w-full max-w-sm items-center justify-center overflow-hidden rounded-md border border-border bg-muted/40">
+      <img
+        src={tip.mediaUrl}
+        alt=""
+        className="h-full w-full object-cover"
+        loading="lazy"
+        draggable={false}
+      />
+    </div>
+  )
+}
 
 function FeatureTipVisual({ tip }: { tip: FeatureTip }): JSX.Element {
   switch (tip.action) {
@@ -37,6 +55,8 @@ function FeatureTipVisual({ tip }: { tip: FeatureTip }): JSX.Element {
           </div>
         </div>
       )
+    case 'open-agent-status-release-notes':
+      return <AgentStatusSidebarVisual tip={tip} />
   }
 }
 
@@ -80,21 +100,15 @@ export default function FeatureTipsModal(): JSX.Element | null {
       return
     }
 
-    markFeatureTipsSeen([currentTip.id])
-    switch (currentTip.action) {
-      case 'enable-voice': {
-        const voice = settings?.voice ?? getDefaultVoiceSettings()
-        void updateSettings({
-          voice: {
-            ...voice,
-            enabled: true
-          }
-        })
-        closeModal()
-        openSettingsTarget({ pane: 'voice', repoId: null })
-        openSettingsPage()
-      }
-    }
+    runFeatureTipPrimaryAction(currentTip, {
+      closeModal,
+      markFeatureTipsSeen,
+      openSettingsPage,
+      openSettingsTarget,
+      openUrl: (url) => window.api.shell.openUrl(url),
+      settings,
+      updateSettings
+    })
   }
 
   if (!isOpen || !currentTip) {

--- a/src/renderer/src/components/feature-tips/feature-tip-modal-state.test.ts
+++ b/src/renderer/src/components/feature-tips/feature-tip-modal-state.test.ts
@@ -36,7 +36,7 @@ describe('feature tip modal state', () => {
   it('returns no tip when every tip is already seen and no modal tip id is pinned', () => {
     const tip = getFeatureTipForModal({
       modalData: {},
-      seenTipIds: ['voice-dictation'],
+      seenTipIds: ['voice-dictation', 'agent-status-sidebar'],
       settings: makeSettings()
     })
 

--- a/src/renderer/src/components/feature-tips/feature-tip-primary-action.test.ts
+++ b/src/renderer/src/components/feature-tips/feature-tip-primary-action.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FEATURE_TIPS } from '../../../../shared/feature-tips'
+import { runFeatureTipPrimaryAction } from './feature-tip-primary-action'
+
+function createDeps() {
+  return {
+    closeModal: vi.fn(),
+    markFeatureTipsSeen: vi.fn(),
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: vi.fn(),
+    openUrl: vi.fn(),
+    settings: null,
+    updateSettings: vi.fn()
+  }
+}
+
+describe('feature tip primary action', () => {
+  it('opens the agent status release notes and marks the tip seen', () => {
+    const tip = FEATURE_TIPS.find((item) => item.id === 'agent-status-sidebar')
+    expect(tip).toBeDefined()
+    if (!tip) {
+      return
+    }
+
+    const deps = createDeps()
+    runFeatureTipPrimaryAction(tip, deps)
+
+    expect(deps.markFeatureTipsSeen).toHaveBeenCalledWith(['agent-status-sidebar'])
+    expect(deps.closeModal).toHaveBeenCalledOnce()
+    expect(deps.openUrl).toHaveBeenCalledWith('https://onorca.dev/changelog/1-3-41')
+    expect(deps.updateSettings).not.toHaveBeenCalled()
+    expect(deps.openSettingsPage).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/feature-tips/feature-tip-primary-action.ts
+++ b/src/renderer/src/components/feature-tips/feature-tip-primary-action.ts
@@ -1,0 +1,40 @@
+import { getDefaultVoiceSettings } from '../../../../shared/constants'
+import type { FeatureTip, FeatureTipId } from '../../../../shared/feature-tips'
+import type { GlobalSettings } from '../../../../shared/types'
+
+export type FeatureTipPrimaryActionDependencies = {
+  closeModal: () => void
+  markFeatureTipsSeen: (tipIds: FeatureTipId[]) => void
+  openSettingsPage: () => void
+  openSettingsTarget: (target: { pane: 'voice'; repoId: null }) => void
+  openUrl: (url: string) => void | Promise<void>
+  settings: { voice?: GlobalSettings['voice'] } | null | undefined
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}
+
+export function runFeatureTipPrimaryAction(
+  tip: FeatureTip,
+  deps: FeatureTipPrimaryActionDependencies
+): void {
+  deps.markFeatureTipsSeen([tip.id])
+
+  switch (tip.action) {
+    case 'enable-voice': {
+      const voice = deps.settings?.voice ?? getDefaultVoiceSettings()
+      void deps.updateSettings({
+        voice: {
+          ...voice,
+          enabled: true
+        }
+      })
+      deps.closeModal()
+      deps.openSettingsTarget({ pane: 'voice', repoId: null })
+      deps.openSettingsPage()
+      break
+    }
+    case 'open-agent-status-release-notes':
+      deps.closeModal()
+      void deps.openUrl(tip.releaseNotesUrl)
+      break
+  }
+}

--- a/src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts
+++ b/src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts
@@ -68,7 +68,7 @@ describe('feature tip startup gate', () => {
     expect(
       getFeatureTipsAppOpenDecision({
         activeModal: 'none',
-        featureTipsSeenIds: ['voice-dictation'],
+        featureTipsSeenIds: ['voice-dictation', 'agent-status-sidebar'],
         onboarding: existingUserOnboarding,
         persistedUIReady: true,
         promptedThisSession: false,
@@ -78,7 +78,7 @@ describe('feature tip startup gate', () => {
     ).toEqual({ kind: 'skip' })
   })
 
-  it('does not open after voice dictation is already enabled', () => {
+  it('opens the next tip after voice dictation is already enabled', () => {
     expect(
       getFeatureTipsAppOpenDecision({
         activeModal: 'none',
@@ -89,6 +89,6 @@ describe('feature tip startup gate', () => {
         settings: makeSettings(true),
         suppressedByOnboardingThisSession: false
       })
-    ).toEqual({ kind: 'skip' })
+    ).toEqual({ kind: 'open', tipId: 'agent-status-sidebar' })
   })
 })

--- a/src/shared/feature-tips.test.ts
+++ b/src/shared/feature-tips.test.ts
@@ -10,7 +10,7 @@ describe('feature tips', () => {
   it('orders new unseen tips before older unseen tips', () => {
     const tips = getOrderedUnseenFeatureTips({ seenTipIds: new Set<FeatureTipId>() })
 
-    expect(tips.map((tip) => tip.id)).toEqual(['voice-dictation'])
+    expect(tips.map((tip) => tip.id)).toEqual(['voice-dictation', 'agent-status-sidebar'])
   })
 
   it('skips tips the user has already seen', () => {
@@ -18,7 +18,7 @@ describe('feature tips', () => {
       seenTipIds: new Set<FeatureTipId>(['voice-dictation'])
     })
 
-    expect(tips.map((tip) => tip.id)).toEqual([])
+    expect(tips.map((tip) => tip.id)).toEqual(['agent-status-sidebar'])
   })
 
   it('skips tips for features the user has already completed', () => {
@@ -27,7 +27,7 @@ describe('feature tips', () => {
       completedTipIds: getCompletedFeatureTipIds({ voiceDictationEnabled: true })
     })
 
-    expect(tips.map((tip) => tip.id)).toEqual([])
+    expect(tips.map((tip) => tip.id)).toEqual(['agent-status-sidebar'])
   })
 
   it('normalizes persisted tip ids', () => {

--- a/src/shared/feature-tips.ts
+++ b/src/shared/feature-tips.ts
@@ -1,18 +1,27 @@
-export type FeatureTipId = 'voice-dictation'
+export type FeatureTipId = 'voice-dictation' | 'agent-status-sidebar'
 
 export type FeatureTipPriority = 'new' | 'unseen'
 
-export type FeatureTipAction = 'enable-voice'
+export type FeatureTipAction = 'enable-voice' | 'open-agent-status-release-notes'
 
-export type FeatureTip = {
+type FeatureTipBase = {
   id: FeatureTipId
   priority: FeatureTipPriority
   eyebrow: string
   title: string
   description: string
-  action: FeatureTipAction
   ctaLabel: string
 }
+
+export type FeatureTip =
+  | (FeatureTipBase & {
+      action: 'enable-voice'
+    })
+  | (FeatureTipBase & {
+      action: 'open-agent-status-release-notes'
+      mediaUrl: string
+      releaseNotesUrl: string
+    })
 
 export type CompletedFeatureTipState = {
   voiceDictationEnabled: boolean
@@ -28,6 +37,18 @@ export const FEATURE_TIPS = [
       'Speak into any focused pane and Orca will transcribe it. Press the dictation shortcut to start and stop.',
     action: 'enable-voice',
     ctaLabel: 'Set Up Voice'
+  },
+  {
+    id: 'agent-status-sidebar',
+    priority: 'new',
+    eyebrow: 'New in 1.3.41',
+    title: "See every agent's live status in the sidebar",
+    description:
+      'Worktree cards now show each agent inline with a status dot, so you can spot what is working and what is done without opening every terminal.',
+    action: 'open-agent-status-release-notes',
+    ctaLabel: "See What's New",
+    mediaUrl: 'https://onorca.dev/whats-new/agent-statuses.gif',
+    releaseNotesUrl: 'https://onorca.dev/changelog/1-3-41'
   }
 ] as const satisfies readonly FeatureTip[]
 

--- a/src/shared/feature-tips.ts
+++ b/src/shared/feature-tips.ts
@@ -19,7 +19,6 @@ export type FeatureTip =
     })
   | (FeatureTipBase & {
       action: 'open-agent-status-release-notes'
-      mediaUrl: string
       releaseNotesUrl: string
     })
 
@@ -47,7 +46,6 @@ export const FEATURE_TIPS = [
       'Worktree cards now show each agent inline with a status dot, so you can spot what is working and what is done without opening every terminal.',
     action: 'open-agent-status-release-notes',
     ctaLabel: "See What's New",
-    mediaUrl: 'https://onorca.dev/whats-new/agent-statuses.gif',
     releaseNotesUrl: 'https://onorca.dev/changelog/1-3-41'
   }
 ] as const satisfies readonly FeatureTip[]


### PR DESCRIPTION
## Summary
- Adds a concrete in-app feature tip for live agent statuses in the sidebar.
- Uses the reviewed changelog GIF as animation reference only; the app renders a hand-authored Orca-style animation instead of remote marketing media.
- Links the CTA to the matching 1.3.41 release notes.

## Test plan
- [x] pnpm exec vitest run --config config/vitest.config.ts src/shared/feature-tips.test.ts src/renderer/src/components/feature-tips/feature-tip-modal-state.test.ts src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts src/renderer/src/components/feature-tips/feature-tip-primary-action.test.ts
- [x] pnpm run typecheck:web
- [x] pnpm exec oxlint src/shared/feature-tips.ts src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
- [x] pnpm exec oxfmt --check src/renderer/src/assets/main.css src/renderer/src/components/feature-tips/FeatureTipsModal.tsx src/shared/feature-tips.ts
- [x] git diff --check origin/main...HEAD
- [x] Verified the modal in an Orca dev instance for this exact branch and confirmed reduced-motion disables the feature-tip animations.

Closes the loop from closed PR #2597 with a fresh branch based on current main.
Generated after feature-tip candidate review.

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.