### PR TITLE
Protect AI instruction files from external PR edits

### DIFF
--- a/.github/workflows/protect-ai-instructions.yml
+++ b/.github/workflows/protect-ai-instructions.yml
@@ -1,0 +1,364 @@
+name: Protect AI instruction files
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  reject-external-ai-instruction-changes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Reject external changes to AI instruction files
+        # Why: this workflow is a security boundary; pin the action so a
+        # retargeted tag cannot change the code that evaluates PR metadata.
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const commentMarker = '<!-- orca-ai-instruction-guard -->';
+            const pr = context.payload.pull_request;
+            const authorAssociation = context.payload.pull_request.author_association;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = pr.number;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            if (typeof pr.changed_files === 'number' && files.length < pr.changed_files) {
+              await failWithWarning([
+                'Unable to inspect all changed files.',
+                `GitHub returned ${files.length} of ${pr.changed_files}.`,
+                'Split the PR or ask a maintainer to review it manually.',
+              ]);
+              return;
+            }
+
+            const filenameFindings = [];
+            for (const file of files) {
+              for (const finding of findInvisibleUnicode(file.filename)) {
+                filenameFindings.push(formatFinding(file.filename, finding));
+              }
+            }
+
+            if (filenameFindings.length > 0) {
+              await failWithWarning([
+                'Changed file paths contain invisible Unicode or control characters.',
+                'Rename the files before merging.',
+                'Findings:',
+                ...filenameFindings,
+              ].join('\n'));
+              return;
+            }
+
+            const protectedBasenames = new Set([
+              '.cursorrules',
+              '.clinerules',
+              '.goosehints',
+              '.roorules',
+              '.roomodes',
+              '.windsurfrules',
+              'agent.md',
+              'agents.md',
+              'claude.md',
+              'codex.md',
+              'gemini.md',
+              'qwen.md',
+            ]);
+
+            const protectedExactPaths = new Set([
+              'codeowners',
+              '.github/codeowners',
+              '.github/copilot-instructions.md',
+              '.github/workflows/protect-ai-instructions.yml',
+              'docs/codeowners',
+            ]);
+
+            const protectedDirectoryMarkers = [
+              '.agents/',
+              '.augment/',
+              '.claude/',
+              '.codex/',
+              '.cursor/',
+              '.gemini/',
+              '.github/instructions/',
+              '.openhands/',
+              '.roo/',
+              '.windsurf/',
+            ];
+
+            function normalizePath(path) {
+              return path.replace(/\\/g, '/').toLowerCase();
+            }
+
+            function isInDirectory(path, marker) {
+              return path === marker.slice(0, -1) || path.startsWith(marker) || path.includes(`/${marker}`);
+            }
+
+            function isProtectedPath(filename) {
+              const path = normalizePath(filename);
+              const basename = path.split('/').pop();
+
+              if (protectedBasenames.has(basename) || protectedExactPaths.has(path)) {
+                return true;
+              }
+
+              return protectedDirectoryMarkers.some((marker) => isInDirectory(path, marker));
+            }
+
+            const blockedFiles = files
+              .map((file) => file.filename)
+              .filter(isProtectedPath);
+
+            if (blockedFiles.length === 0) {
+              core.info('No AI instruction files changed.');
+              return;
+            }
+
+            if (trustedAssociations.has(authorAssociation)) {
+              core.info(`Trusted PR author association ${authorAssociation}; allowing AI instruction file changes.`);
+              for (const filename of blockedFiles) {
+                core.info(`Allowed: ${JSON.stringify(filename)}`);
+              }
+
+              const unicodeFindings = await scanChangedFilesForInvisibleUnicode(blockedFiles);
+              if (unicodeFindings.length === 0) {
+                return;
+              }
+
+              await failWithWarning([
+                'AI instruction files contain invisible Unicode/control characters or could not be scanned.',
+                'Remove hidden characters and keep these files as scan-compatible UTF-8 text before merging.',
+                'Findings:',
+                ...unicodeFindings,
+              ].join('\n'));
+              return;
+            }
+
+            // Why: external PRs must not be able to change files that shape how
+            // local and hosted agents read the repository.
+            await failWithWarning([
+              'External pull requests cannot modify AI instruction or agent configuration files.',
+              'Ask a repository maintainer to make these changes from a trusted branch.',
+              'Blocked files:',
+              ...blockedFiles.map((filename) => `- ${JSON.stringify(filename)}`),
+            ].join('\n'));
+
+            async function failWithWarning(lines) {
+              const message = Array.isArray(lines) ? lines.join('\n') : lines;
+
+              try {
+                await upsertWarningComment(message);
+              } catch (error) {
+                core.warning(`Unable to post AI instruction guard warning comment: ${error.message}`);
+              }
+
+              core.setFailed(message);
+            }
+
+            async function upsertWarningComment(message) {
+              const body = buildWarningComment(message);
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pullNumber,
+                per_page: 100,
+              });
+
+              const existingComment = comments.find((comment) =>
+                comment.user?.type === 'Bot' &&
+                typeof comment.body === 'string' &&
+                comment.body.includes(commentMarker)
+              );
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullNumber,
+                body,
+              });
+            }
+
+            function buildWarningComment(message) {
+              const maxMessageLength = 50000;
+              const commentMessage = message.length > maxMessageLength
+                ? `${message.slice(0, maxMessageLength)}\n\n... truncated; open the failed check log for full details ...`
+                : message;
+
+              return [
+                commentMarker,
+                '# SECURITY WARNING: AI instruction file change blocked',
+                '',
+                'This PR changes files that control how AI coding agents read this repository, or it contains hidden Unicode/control characters in a changed path or protected instruction file.',
+                '',
+                'External contributors cannot modify these files directly. Ask a repository maintainer to make the change from a trusted branch after review.',
+                '',
+                '<details open>',
+                '<summary>Blocked by policy</summary>',
+                '',
+                '<pre>',
+                escapeHtml(commentMessage),
+                '</pre>',
+                '',
+                '</details>',
+              ].join('\n');
+            }
+
+            function escapeHtml(value) {
+              return value
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            }
+
+            async function scanChangedFilesForInvisibleUnicode(filenames) {
+              const findings = [];
+              const headOwner = pr.head.repo.owner.login;
+              const headRepo = pr.head.repo.name;
+              const ref = pr.head.sha;
+
+              for (const filename of filenames) {
+                const file = files.find((candidate) => candidate.filename === filename);
+                if (file?.status === 'removed') {
+                  continue;
+                }
+
+                const content = await github.rest.repos.getContent({
+                  owner: headOwner,
+                  repo: headRepo,
+                  path: filename,
+                  ref,
+                });
+
+                if (
+                  Array.isArray(content.data) ||
+                  content.data.type !== 'file' ||
+                  typeof content.data.content !== 'string' ||
+                  content.data.encoding !== 'base64'
+                ) {
+                  findings.push(`- ${JSON.stringify(filename)}: unable to scan content`);
+                  continue;
+                }
+
+                const text = Buffer.from(content.data.content, content.data.encoding).toString('utf8');
+                for (const finding of findInvisibleUnicode(text)) {
+                  findings.push(formatFinding(filename, finding));
+                }
+              }
+
+              return findings;
+            }
+
+            function findInvisibleUnicode(text) {
+              const findings = [];
+              let line = 1;
+              let column = 1;
+
+              for (const char of text) {
+                const codePoint = char.codePointAt(0);
+                const reason = getInvisibleUnicodeReason(codePoint);
+
+                if (reason) {
+                  findings.push({
+                    line,
+                    column,
+                    codePoint: formatCodePoint(codePoint),
+                    reason,
+                  });
+                }
+
+                if (char === '\n') {
+                  line += 1;
+                  column = 1;
+                } else {
+                  column += 1;
+                }
+              }
+
+              return findings;
+            }
+
+            function getInvisibleUnicodeReason(codePoint) {
+              if (codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d) {
+                return null;
+              }
+
+              if (codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+                return 'ASCII/C1 control character';
+              }
+
+              if (codePoint >= 0x202a && codePoint <= 0x202e) {
+                return 'bidirectional embedding/override control';
+              }
+
+              if (codePoint >= 0x2066 && codePoint <= 0x2069) {
+                return 'bidirectional isolate control';
+              }
+
+              if (codePoint >= 0xe0000 && codePoint <= 0xe007f) {
+                return 'Unicode tag character';
+              }
+
+              if ((codePoint >= 0xfe00 && codePoint <= 0xfe0f) || (codePoint >= 0xe0100 && codePoint <= 0xe01ef)) {
+                return 'variation selector';
+              }
+
+              const invisibleCharacters = new Map([
+                [0x00ad, 'soft hyphen'],
+                [0x034f, 'combining grapheme joiner'],
+                [0x061c, 'Arabic letter mark'],
+                [0x180e, 'Mongolian vowel separator'],
+                [0x200b, 'zero-width space'],
+                [0x200c, 'zero-width non-joiner'],
+                [0x200d, 'zero-width joiner'],
+                [0x200e, 'left-to-right mark'],
+                [0x200f, 'right-to-left mark'],
+                [0x2060, 'word joiner'],
+                [0x2061, 'function application'],
+                [0x2062, 'invisible times'],
+                [0x2063, 'invisible separator'],
+                [0x2064, 'invisible plus'],
+                [0x206a, 'inhibit symmetric swapping'],
+                [0x206b, 'activate symmetric swapping'],
+                [0x206c, 'inhibit Arabic form shaping'],
+                [0x206d, 'activate Arabic form shaping'],
+                [0x206e, 'national digit shapes'],
+                [0x206f, 'nominal digit shapes'],
+                [0xfeff, 'byte order mark / zero-width no-break space'],
+              ]);
+
+              return invisibleCharacters.get(codePoint) ?? null;
+            }
+
+            function formatCodePoint(codePoint) {
+              return `U+${codePoint.toString(16).toUpperCase().padStart(4, '0')}`;
+            }
+
+            function formatFinding(filename, finding) {
+              return `- ${JSON.stringify(filename)}:${finding.line}:${finding.column} ${finding.codePoint} ${finding.reason}`;
+            }


### PR DESCRIPTION
## Summary

- Add a required-check candidate that blocks external PR authors from changing AI instruction and agent config files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.cursor/**`, `.claude/**`, `.codex/**`, `.github/copilot-instructions.md`, CODEOWNERS paths, and related agent dirs).
- Keep the workflow on `pull_request_target`, but intentionally make it metadata/API-only: no checkout, no dependency install, and no shelling out to PR-controlled content.
- Use narrowly scoped permissions: `contents: read`, `pull-requests: read`, and `issues: write` only so the guard can post/update a visible warning comment on blocked PRs.
- Pin `actions/github-script` to a full commit SHA.
- Fail trusted-author instruction-file edits if changed paths or changed instruction-file contents contain invisible Unicode/control characters, bidi controls, zero-width marks, tag characters, or variation selectors.
- Fail closed if GitHub does not return the full changed-file list.

## User-facing behavior

- When the guard blocks a PR, it now creates or updates a single bot comment headed `SECURITY WARNING: AI instruction file change blocked`.
- The comment explains that AI instruction/config files cannot be changed directly by external contributors and includes the blocked reason/file list in an escaped `<pre>` block.
- The check still fails, so branch protection/rulesets can block merge.

## External contributor caveat

This repo currently has fork workflow approval set to `all_external_contributors`. That means an external fork PR's Actions run may sit in GitHub's "awaiting approval" state until a maintainer approves it. In that state this workflow cannot post the warning comment yet, because no Actions workflow is running. Once approved, it will run, comment, and fail if protected files were touched.

To make this enforce merges after this lands, add `Protect AI instruction files / reject-external-ai-instruction-changes` as a required branch-protection or ruleset status check. If we need an immediate warning without approving any Actions run, that requires a separate GitHub App/webhook outside Actions, or a GitHub push ruleset for path restriction where available.

## Research / rationale

- GitHub warns that running untrusted code on `pull_request_target` can expose write privileges/secrets and cause cache-poisoning risk: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
- GitHub Security Lab's pwn-request guidance specifically calls out `pull_request_target` plus explicit checkout of an untrusted PR as dangerous, so this workflow never checks out PR code: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
- GitHub's secure-use guidance recommends least-privilege `GITHUB_TOKEN` permissions and pinning third-party actions to full commit SHAs; this workflow uses only the permissions needed for metadata reads and the PR warning comment, and pins `actions/github-script`: https://docs.github.com/en/actions/reference/security/secure-use
- GitHub's List PR files API is capped at 3000 files, so the workflow compares the API result count with `pull_request.changed_files` and fails closed on truncation: https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
- Unicode bidirectional controls affect text layout while other processing may ignore them, which is the core hidden-text risk this guard is targeting: https://www.unicode.org/versions/Unicode17.0.0/core-spec/chapter-23/#G18062

## Review notes

- I checked whether we could add CODEOWNERS as a second layer. GitHub's CODEOWNERS validator rejects `@stablyai/stably-eng` for this repo because the team is closed and only has pull permission here. Since GitHub requires CODEOWNERS teams to be visible and have write access, I did not include a dead CODEOWNERS file. Once there is a visible/write maintainer team, add CODEOWNERS for these same paths.
- Optional stronger repo setting: add a push ruleset restricting these paths for non-maintainers.

## Validation

- Parsed workflow YAML and compiled the embedded `github-script` function locally.
- Simulated passing/failing PR cases:
  - external root/nested/case-variant instruction-file changes fail and create a warning comment
  - external `.cursor/**` and CODEOWNERS-path changes fail and create a warning comment
  - normal external source change passes without comment
  - invisible Unicode in a changed path fails and creates a warning comment
  - trusted clean instruction-file edit passes without comment
  - trusted hidden-Unicode or unscannable instruction-file content fails and creates a warning comment
  - truncated changed-file list fails closed and creates a warning comment
  - existing guard comment is updated instead of duplicated
  - hostile filename HTML is escaped in the comment body
- Ran `git diff --check` on the workflow.
- Scanned existing protected instruction files and the workflow for invisible Unicode; no findings.
