### PR TITLE
Update xterm and document upstream patch tracking

### DIFF
--- a/config/patches/@xterm__addon-webgl@0.20.0-beta.219.patch
+++ b/config/patches/@xterm__addon-webgl@0.20.0-beta.219.patch
@@ -24,13 +24,14 @@ diff --git a/src/GlyphRenderer.ts b/src/GlyphRenderer.ts
 index 46b8efe..4b36a78 100644
 --- a/src/GlyphRenderer.ts
 +++ b/src/GlyphRenderer.ts
-@@ -387,8 +387,12 @@ export class GlyphRenderer extends Disposable {
+@@ -387,8 +387,13 @@ export class GlyphRenderer extends Disposable {
      gl.bindTexture(gl.TEXTURE_2D, this._atlasTextures[i].texture);
      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 +    // Why: glyph atlas pages are sampled 1:1. ANGLE/OpenGL drivers on Linux
 +    // Wayland can fail mipmap allocation for large atlas uploads, corrupting
 +    // terminal glyph textures instead of cleanly losing the WebGL context.
++    // Separate from upstream atlas-merge fix: https://github.com/xtermjs/xterm.js/pull/5883
 +    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 +    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, atlas.pages[i].canvas);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ patchedDependencies:
     hash: df21db050a4d85552cafbe583ece863d7fa19ed634a1219210a0455b986b6634
     path: config/patches/@xterm__addon-ligatures@0.11.0-beta.220.patch
   '@xterm/addon-webgl@0.20.0-beta.219':
-    hash: 8d780f977823d471ad1121434bdf874278f9008c35b62296ca5b1a4c652acb43
+    hash: b7465b48cca8d596e3bf0e441f939100c95adaddef13e85df089ed0ad6f6b1ea
     path: config/patches/@xterm__addon-webgl@0.20.0-beta.219.patch
   node-pty@1.1.0:
     hash: 93c259888173175ad66ab303977deb17f2aee9e276cb35522dc61815c65358d4
@@ -111,7 +111,7 @@ importers:
         version: 0.13.0-beta.220(@xterm/xterm@6.1.0-beta.220)
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.219
-        version: 0.20.0-beta.219(patch_hash=8d780f977823d471ad1121434bdf874278f9008c35b62296ca5b1a4c652acb43)(@xterm/xterm@6.1.0-beta.220)
+        version: 0.20.0-beta.219(patch_hash=b7465b48cca8d596e3bf0e441f939100c95adaddef13e85df089ed0ad6f6b1ea)(@xterm/xterm@6.1.0-beta.220)
       '@xterm/headless':
         specifier: 6.1.0-beta.220
         version: 6.1.0-beta.220
@@ -8948,7 +8948,7 @@ snapshots:
     dependencies:
       '@xterm/xterm': 6.1.0-beta.220
 
-  '@xterm/addon-webgl@0.20.0-beta.219(patch_hash=8d780f977823d471ad1121434bdf874278f9008c35b62296ca5b1a4c652acb43)(@xterm/xterm@6.1.0-beta.220)':
+  '@xterm/addon-webgl@0.20.0-beta.219(patch_hash=b7465b48cca8d596e3bf0e441f939100c95adaddef13e85df089ed0ad6f6b1ea)(@xterm/xterm@6.1.0-beta.220)':
     dependencies:
       '@xterm/xterm': 6.1.0-beta.220
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -4,8 +4,8 @@ import { FitAddon } from '@xterm/addon-fit'
 // Upstream packaging bug: @xterm/addon-ligatures declares `"main":
 // "lib/addon-ligatures.js"` but ships only the `.mjs` entry, so Vite fails to
 // resolve the bare import. Fixed locally via config/patches/@xterm__addon-ligatures*.
-// Tracking upstream: https://github.com/xtermjs/xterm.js/issues/5822 — drop
-// the patch once that lands.
+// Tracking upstream: https://github.com/xtermjs/xterm.js/issues/5822 and
+// https://github.com/xtermjs/xterm.js/pull/5828 — drop the patch once that lands.
 import { LigaturesAddon } from '@xterm/addon-ligatures'
 import { SearchAddon } from '@xterm/addon-search'
 import { Unicode11Addon } from '@xterm/addon-unicode11'


### PR DESCRIPTION
## Summary
- update xterm core/headless to 6.1.0-beta.220 and matching addons to beta.220
- keep @xterm/addon-webgl on latest published 0.20.0-beta.219 and rebase the local WebGL atlas patch
- link xterm upstream tracking in comments for the ligatures packaging workaround and WebGL atlas context

Supersedes #2751 with the upstream tracking comments added.

## Validation
- pnpm run typecheck
- pnpm run lint
- pnpm test (from #2751 before the comment-only follow-up)