### PR TITLE
Add inline workspace title rename

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -12,6 +12,7 @@ import { WorktreeActivityStatusIndicator } from './WorktreeActivityStatusIndicat
 import WorktreeContextMenu from './WorktreeContextMenu'
 import { getWorkspaceKanbanDetailsHoverOpenState } from './workspace-kanban-details-hover'
 import { writeWorkspaceDragData } from './workspace-status'
+import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
 
 type WorkspaceKanbanCardProps = {
   worktree: Worktree
@@ -106,8 +107,11 @@ function WorkspaceKanbanCompactCard({
   onContextMenuSelect
 }: Omit<WorkspaceKanbanCardProps, 'compact'>): React.JSX.Element {
   const deleteState = useAppStore((s) => s.deleteStateByWorktreeId[worktree.id])
+  const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
+  const openModal = useAppStore((s) => s.openModal)
   const isDeleting = deleteState?.isDeleting ?? false
   const [detailsOpen, setDetailsOpen] = useState(false)
+  const [titleRenaming, setTitleRenaming] = useState(false)
   const contextMenuOpenRef = useRef(false)
   const contextWorktrees = useMemo(
     () =>
@@ -126,7 +130,7 @@ function WorkspaceKanbanCompactCard({
   }, [isDeleting, onActivate, worktree.id])
 
   const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
+    (event: React.MouseEvent<HTMLElement>) => {
       const selectionOnly = onSelectionGesture(event, worktree.id)
       if (selectionOnly) {
         event.preventDefault()
@@ -138,8 +142,19 @@ function WorkspaceKanbanCompactCard({
     [handleActivate, onSelectionGesture, worktree.id]
   )
 
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (titleRenaming || isDeleting || (event.key !== 'Enter' && event.key !== ' ')) {
+        return
+      }
+      event.preventDefault()
+      handleActivate()
+    },
+    [handleActivate, isDeleting, titleRenaming]
+  )
+
   const handleDragStart = useCallback(
-    (event: React.DragEvent<HTMLButtonElement>) => {
+    (event: React.DragEvent<HTMLElement>) => {
       if (isDeleting) {
         event.preventDefault()
         return
@@ -152,6 +167,28 @@ function WorkspaceKanbanCompactCard({
     },
     [contextWorktrees, isDeleting, isSelected, worktree.id]
   )
+
+  const handleRenameTitle = useCallback(
+    (displayName: string) => updateWorktreeMeta(worktree.id, { displayName }),
+    [updateWorktreeMeta, worktree.id]
+  )
+
+  const handleDoubleClick = useCallback(() => {
+    openModal('edit-meta', {
+      worktreeId: worktree.id,
+      currentDisplayName: worktree.displayName,
+      currentIssue: worktree.linkedIssue,
+      currentPR: worktree.linkedPR,
+      currentComment: worktree.comment
+    })
+  }, [
+    openModal,
+    worktree.comment,
+    worktree.displayName,
+    worktree.id,
+    worktree.linkedIssue,
+    worktree.linkedPR
+  ])
 
   const handleDetailsOpenChange = useCallback((requestedOpen: boolean) => {
     setDetailsOpen(
@@ -193,11 +230,14 @@ function WorkspaceKanbanCompactCard({
         closeDelay={100}
       >
         <HoverCardTrigger asChild>
-          <button
-            type="button"
-            draggable={nativeDragEnabled && !isDeleting}
+          <div
+            role="button"
+            tabIndex={isDeleting ? -1 : 0}
+            draggable={nativeDragEnabled && !isDeleting && !titleRenaming}
             onDragStart={nativeDragEnabled ? handleDragStart : undefined}
             onClick={handleClick}
+            onDoubleClick={handleDoubleClick}
+            onKeyDown={handleKeyDown}
             className={cn(
               'flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border px-2 text-left text-[12px] outline-none transition-colors',
               isActive
@@ -208,6 +248,7 @@ function WorkspaceKanbanCompactCard({
               isActive && isSelected && 'ring-1 ring-sidebar-ring/35',
               'data-[workspace-board-card-area-selected=true]:border-sidebar-ring/50 data-[workspace-board-card-area-selected=true]:bg-sidebar-accent/75 data-[workspace-board-card-area-selected=true]:ring-1 data-[workspace-board-card-area-selected=true]:ring-sidebar-ring/30',
               !nativeDragEnabled && !isDeleting && '!cursor-grab',
+              titleRenaming && '!border-transparent !bg-transparent !ring-0 cursor-default',
               isDeleting && 'cursor-not-allowed opacity-50 grayscale'
             )}
             data-workspace-board-card-mode="compact"
@@ -217,10 +258,17 @@ function WorkspaceKanbanCompactCard({
               nativeDragEnabled || isDeleting ? undefined : 'true'
             }
             aria-label={`Open ${worktree.displayName}`}
+            aria-disabled={isDeleting ? true : undefined}
             aria-busy={isDeleting}
           >
             <WorktreeActivityStatusIndicator worktreeId={worktree.id} className="mr-1" />
-            <span className="min-w-0 flex-1 truncate">{worktree.displayName}</span>
+            <WorktreeTitleInlineRename
+              displayName={worktree.displayName}
+              disabled={isDeleting}
+              className="flex-1 text-[12px]"
+              onEditingChange={setTitleRenaming}
+              onRename={handleRenameTitle}
+            />
             {repo ? (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -242,7 +290,7 @@ function WorkspaceKanbanCompactCard({
                 </TooltipContent>
               </Tooltip>
             ) : null}
-          </button>
+          </div>
         </HoverCardTrigger>
         <HoverCardContent
           side="right"

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -46,6 +46,7 @@ import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import { hasActiveWorkspaceActivity } from '@/lib/worktree-activity-state'
 import { installWindowVisibilityInterval, isWindowVisible } from '@/lib/window-visibility-interval'
 import { runWorktreeDelete } from './delete-worktree-flow'
+import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
 
 type WorktreeCardProps = {
   worktree: Worktree
@@ -160,6 +161,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   })
   const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
   const [showDisconnectedDialog, setShowDisconnectedDialog] = useState(false)
+  const [titleRenaming, setTitleRenaming] = useState(false)
 
   // Why: on restart the previously-active worktree is auto-restored without a
   // click, so the dialog never opens. Auto-show it for the active card when SSH
@@ -388,6 +390,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
     [worktree.id, isSshDisconnected, onActivate, onSelectionGesture]
   )
 
+  const handleRenameTitle = useCallback(
+    (displayName: string) => updateWorktreeMeta(worktree.id, { displayName }),
+    [updateWorktreeMeta, worktree.id]
+  )
+
   const handleDoubleClick = useCallback(() => {
     openModal('edit-meta', {
       worktreeId: worktree.id,
@@ -397,12 +404,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
       currentComment: worktree.comment
     })
   }, [
-    worktree.id,
-    worktree.displayName,
-    worktree.linkedIssue,
-    worktree.linkedPR,
+    openModal,
     worktree.comment,
-    openModal
+    worktree.displayName,
+    worktree.id,
+    worktree.linkedIssue,
+    worktree.linkedPR
   ])
 
   const handleToggleUnreadQuick = useCallback(
@@ -415,8 +422,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   )
   // Why: deleting the active/current workspace or one with live activity is a
   // disruptive hover action; keep the quick action delete-only and passive.
-  const showDeleteQuickAction =
-    !isCurrentWorktree && !hasActiveActivity && !worktree.isMainWorktree
+  const showDeleteQuickAction = !isCurrentWorktree && !hasActiveActivity && !worktree.isMainWorktree
   const handleWorkspaceQuickAction = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault()
@@ -545,12 +551,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
             ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
             : 'border border-transparent hover:bg-sidebar-accent/40',
         isActiveSurface && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
+        titleRenaming && '!border-transparent !bg-transparent !shadow-none !ring-0',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',
         isSshDisconnected && !isDeleting && 'opacity-60'
       )}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
-      draggable={nativeDragEnabled && !isDeleting}
+      draggable={nativeDragEnabled && !isDeleting && !titleRenaming}
       onDragStart={nativeDragEnabled ? handleDragStart : undefined}
       onDragEnd={nativeDragEnabled ? onCardDragEnd : undefined}
       aria-busy={isDeleting}
@@ -628,18 +635,15 @@ const WorktreeCard = React.memo(function WorktreeCard({
                  hierarchy against the muted branch row below (muting the
                  title as well flattened the card — same reasoning as the
                  repo chip comment below). */}
-            <div
-              className={cn(
-                'text-[12px] truncate leading-tight text-foreground',
-                showUnreadEmphasis ? 'font-semibold' : 'font-normal'
-              )}
-            >
-              {/* Why: the card root is a non-interactive <div>, so aria-label
-                   on it is announced inconsistently across screen readers.
-                   A visible-text prefix inside the accessible name is reliable. */}
-              {showUnreadEmphasis && <span className="sr-only">Unread: </span>}
-              {worktree.displayName}
-            </div>
+            <WorktreeTitleInlineRename
+              displayName={worktree.displayName}
+              disabled={isDeleting}
+              showUnreadEmphasis={showUnreadEmphasis}
+              className="text-[12px]"
+              editingClassName="flex-1"
+              onEditingChange={setTitleRenaming}
+              onRename={handleRenameTitle}
+            />
 
             {/* Why: the primary worktree (the original clone directory) cannot be
                  deleted via `git worktree remove`. Placing this badge next to the

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  WorktreeTitleInlineRename,
+  getWorktreeTitleRenameCommit
+} from './WorktreeTitleInlineRename'
+
+describe('getWorktreeTitleRenameCommit', () => {
+  it('cancels blank or unchanged inline titles', () => {
+    expect(getWorktreeTitleRenameCommit('feature/login', '')).toEqual({ kind: 'cancel' })
+    expect(getWorktreeTitleRenameCommit('feature/login', '   ')).toEqual({ kind: 'cancel' })
+    expect(getWorktreeTitleRenameCommit('feature/login', ' feature/login ')).toEqual({
+      kind: 'cancel'
+    })
+  })
+
+  it('trims and saves changed inline titles', () => {
+    expect(getWorktreeTitleRenameCommit('feature/login', ' Login polish ')).toEqual({
+      kind: 'save',
+      displayName: 'Login polish'
+    })
+  })
+})
+
+describe('WorktreeTitleInlineRename', () => {
+  it('renders the title as the double-click inline rename target', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeTitleInlineRename
+        displayName="Feature workspace"
+        showUnreadEmphasis
+        onRename={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('data-worktree-title-inline-rename=""')
+    expect(markup).not.toContain('cursor-text')
+    expect(markup).toContain('Unread:')
+    expect(markup).toContain('Feature workspace')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -1,0 +1,191 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { LoaderCircle } from 'lucide-react'
+import { toast } from 'sonner'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+export type WorktreeTitleRenameCommit = { kind: 'cancel' } | { kind: 'save'; displayName: string }
+
+export function getWorktreeTitleRenameCommit(
+  currentDisplayName: string,
+  nextDisplayName: string
+): WorktreeTitleRenameCommit {
+  const trimmed = nextDisplayName.trim()
+  if (!trimmed || trimmed === currentDisplayName) {
+    return { kind: 'cancel' }
+  }
+  return { kind: 'save', displayName: trimmed }
+}
+
+type WorktreeTitleInlineRenameProps = {
+  displayName: string
+  disabled?: boolean
+  showUnreadEmphasis?: boolean
+  className?: string
+  editingClassName?: string
+  inputClassName?: string
+  onEditingChange?: (editing: boolean) => void
+  onRename: (displayName: string) => Promise<void> | void
+}
+
+export function WorktreeTitleInlineRename({
+  displayName,
+  disabled = false,
+  showUnreadEmphasis = false,
+  className,
+  editingClassName,
+  inputClassName,
+  onEditingChange,
+  onRename
+}: WorktreeTitleInlineRenameProps): React.JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const savingRef = useRef(false)
+  const [editing, setEditing] = useState(false)
+  const [value, setValue] = useState(displayName)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!editing) {
+      setValue(displayName)
+    }
+  }, [displayName, editing])
+
+  useEffect(() => {
+    onEditingChange?.(editing)
+    return () => {
+      if (editing) {
+        onEditingChange?.(false)
+      }
+    }
+  }, [editing, onEditingChange])
+
+  useEffect(() => {
+    if (!editing) {
+      return
+    }
+    const input = inputRef.current
+    input?.focus()
+    // Why: double-click rename should make replacing the workspace title a one-keystroke action.
+    input?.select()
+  }, [editing])
+
+  const stopCardEvent = useCallback((event: React.SyntheticEvent) => {
+    event.stopPropagation()
+  }, [])
+
+  const startRename = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (disabled) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      setValue(displayName)
+      setEditing(true)
+    },
+    [disabled, displayName]
+  )
+
+  const cancelRename = useCallback(() => {
+    setValue(displayName)
+    setEditing(false)
+  }, [displayName])
+
+  const commitRename = useCallback(async () => {
+    if (savingRef.current) {
+      return
+    }
+
+    const commit = getWorktreeTitleRenameCommit(displayName, value)
+    if (commit.kind === 'cancel') {
+      cancelRename()
+      return
+    }
+
+    savingRef.current = true
+    setSaving(true)
+    try {
+      await onRename(commit.displayName)
+      setEditing(false)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to rename workspace.')
+    } finally {
+      savingRef.current = false
+      setSaving(false)
+    }
+  }, [cancelRename, displayName, onRename, value])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation()
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        void commitRename()
+      } else if (event.key === 'Escape') {
+        event.preventDefault()
+        cancelRename()
+      }
+    },
+    [cancelRename, commitRename]
+  )
+
+  if (editing) {
+    return (
+      <span
+        className={cn(
+          'relative grid min-w-0 truncate leading-tight text-foreground',
+          showUnreadEmphasis ? 'font-semibold' : 'font-normal',
+          className,
+          editingClassName
+        )}
+        data-worktree-title-inline-rename="editing"
+      >
+        <span
+          className="invisible col-start-1 row-start-1 min-w-0 truncate whitespace-pre"
+          aria-hidden="true"
+        >
+          {displayName}
+        </span>
+        <Input
+          ref={inputRef}
+          value={value}
+          style={{ font: 'inherit' }}
+          disabled={saving}
+          aria-label="Rename workspace"
+          data-worktree-title-rename-input="true"
+          onChange={(event) => setValue(event.target.value)}
+          onBlur={() => void commitRename()}
+          onClick={stopCardEvent}
+          onDoubleClick={stopCardEvent}
+          onPointerDown={stopCardEvent}
+          onKeyDown={handleKeyDown}
+          className={cn(
+            'col-start-1 row-start-1 h-[1lh] min-w-0 select-text truncate rounded-none border-0 !border-transparent !bg-transparent p-0 text-foreground !shadow-none outline-none dark:!bg-transparent',
+            'focus-visible:border-transparent focus-visible:ring-0 focus-visible:outline-none',
+            saving && 'pr-4',
+            inputClassName
+          )}
+        />
+        {saving ? (
+          <LoaderCircle className="pointer-events-none absolute right-0 top-1/2 size-3 -translate-y-1/2 animate-spin text-muted-foreground" />
+        ) : null}
+      </span>
+    )
+  }
+
+  return (
+    <span
+      className={cn(
+        'block min-w-0 truncate leading-tight text-foreground',
+        showUnreadEmphasis ? 'font-semibold' : 'font-normal',
+        className
+      )}
+      data-worktree-title-inline-rename=""
+      onDoubleClick={startRename}
+    >
+      {/* Why: visible text alone misses the unread state for assistive tech. */}
+      {showUnreadEmphasis && <span className="sr-only">Unread: </span>}
+      {displayName}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- Add inline rename for workspace card titles on double-click
- Keep non-title double-click opening the existing edit dialog
- Preserve full-width editing, visible selected text, and transparent inline/card edit styling

## Verification
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
- pnpm run typecheck:web
- Electron visual verification in light mode: full title selection visible, input/card background transparent