### PR TITLE
Focus settings search on open

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -276,6 +276,7 @@ function Settings(): React.JSX.Element {
   const [hiddenExperimentalUnlocked, setHiddenExperimentalUnlocked] = useState(false)
   const contentScrollRef = useRef<HTMLDivElement | null>(null)
   const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const settingsSearchAutofocusConsumedRef = useRef(false)
   const terminalFontsLoadedRef = useRef(false)
   const pendingNavSectionRef = useRef<string | null>(null)
   const pendingScrollTargetRef = useRef<string | null>(null)
@@ -355,6 +356,24 @@ function Settings(): React.JSX.Element {
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [closeSettingsPageWithPromptGuard])
+
+  useEffect(() => {
+    if (!settings || settingsSearchAutofocusConsumedRef.current) {
+      return
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      const input = searchInputRef.current
+      if (!input) {
+        return
+      }
+
+      settingsSearchAutofocusConsumedRef.current = true
+      input.focus({ preventScroll: true })
+    })
+
+    return () => cancelAnimationFrame(frameId)
+  }, [settings])
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent): void => {

--- a/tests/e2e/settings-search-autofocus.spec.ts
+++ b/tests/e2e/settings-search-autofocus.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+type OrcaPage = Parameters<typeof waitForSessionReady>[0]
+
+async function openSettings(page: OrcaPage, initialSearchQuery = ''): Promise<void> {
+  await page.evaluate((query) => {
+    const state = window.__store!.getState()
+    state.setSettingsSearchQuery(query)
+    state.openSettingsPage()
+  }, initialSearchQuery)
+}
+
+test.describe('Settings search autofocus', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+  })
+
+  test('focuses search on open without selecting existing text', async ({ orcaPage }) => {
+    const initialSearchQuery = 'terminal'
+
+    await openSettings(orcaPage, initialSearchQuery)
+
+    const searchInput = orcaPage.getByPlaceholder('Search settings')
+    await expect(searchInput).toBeVisible({ timeout: 10_000 })
+    await expect(searchInput).toHaveValue(initialSearchQuery)
+    await expect(searchInput).toBeFocused()
+
+    const selection = await searchInput.evaluate((element) => {
+      const input = element as HTMLInputElement
+      return {
+        start: input.selectionStart,
+        end: input.selectionEnd
+      }
+    })
+    expect(selection.start).toBe(selection.end)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds one-shot autofocus for the existing Settings sidebar `Search settings` input after Settings has loaded.
- Uses the repo-standard `useEffect` + `requestAnimationFrame` + input ref pattern for post-mount focus.
- Calls `focus({ preventScroll: true })` and does not select existing text, so the existing `settings.search` shortcut remains the path that focuses and selects the query.
- Adds a Settings-owned Electron E2E spec for the direct Settings open behavior.

## Design / Review Outcome

- Started with a design-first Brennan YOLO Lite pass and review loop.
- After follow-up discussion, simplified the implementation to the most standard/intuitive local pattern and removed the extra overlay/retry machinery.
- Product diff is scoped to `src/renderer/src/components/settings/Settings.tsx` and `tests/e2e/settings-search-autofocus.spec.ts`.
- `SettingsSidebar.tsx` and visual styling are unchanged.
- No telemetry, runtime, provider, path, or SSH behavior was changed.

## Validation

Current simplified PR validation:

- `pnpm exec oxfmt --write src/renderer/src/components/settings/Settings.tsx tests/e2e/settings-search-autofocus.spec.ts` passed.
- `pnpm exec oxlint src/renderer/src/components/settings/Settings.tsx tests/e2e/settings-search-autofocus.spec.ts` passed.
- `pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json` passed.
- `pnpm exec electron-vite build --mode e2e` passed.
- `SKIP_BUILD=1 pnpm run test:e2e -- tests/e2e/settings-search-autofocus.spec.ts` passed, 1 test.

Earlier broader validation before simplification also passed:

- `pnpm run typecheck` passed.
- `pnpm run lint` passed with 0 warnings/errors.
- `git diff --check` passed.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/Settings.load-performance.test.ts src/renderer/src/components/settings/RepositoryPane.test.ts` passed, 2 files / 6 tests.
- Product validation confirmed Settings search focused on open and search typing still filtered settings.

## Assumptions / Gaps

- Full E2E suite was not run.
- No live SSH validation was run because this is renderer-only DOM focus behavior with no SSH/runtime/remoting surface touched.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.