### PR TITLE
Suppress GPU shutdown crash prompts

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -24,6 +24,16 @@ describe('shouldRecordProcessGoneCrash', () => {
         expectedTeardown: 'app-shutdown'
       })
     ).toBe(false)
+
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 9,
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
   })
 
   it('records real crash reasons during expected renderer-only teardown', () => {

--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -9,6 +9,7 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: 'killed',
         exitCode: 15,
         expectedTeardown: 'renderer-reload'
@@ -17,6 +18,7 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'child',
+        processType: 'GPU',
         reason: 'killed',
         exitCode: 15,
         expectedTeardown: 'app-shutdown'
@@ -24,10 +26,11 @@ describe('shouldRecordProcessGoneCrash', () => {
     ).toBe(false)
   })
 
-  it('records real crash reasons even during expected lifecycle teardown', () => {
+  it('records real crash reasons during expected renderer-only teardown', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: 'crashed',
         exitCode: 5,
         expectedTeardown: 'renderer-reload'
@@ -36,9 +39,46 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: 'oom',
         exitCode: null,
         expectedTeardown: 'renderer-reload'
+      })
+    ).toBe(true)
+  })
+
+  it('suppresses crash-shaped GPU child exits during expected app shutdown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'crashed',
+        exitCode: 5,
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(false)
+  })
+
+  it('still records crash-shaped non-GPU child exits during expected app shutdown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        reason: 'crashed',
+        exitCode: 5,
+        expectedTeardown: 'app-shutdown'
+      })
+    ).toBe(true)
+  })
+
+  it('still records crash-shaped renderer exits during expected app shutdown', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: 5,
+        expectedTeardown: 'app-shutdown'
       })
     ).toBe(true)
   })
@@ -47,6 +87,7 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: 'killed',
         exitCode: 15,
         expectedTeardown: 'none'
@@ -58,6 +99,7 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: 'killed',
         exitCode: 9,
         expectedTeardown: 'none'
@@ -69,6 +111,7 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'child',
+        processType: 'GPU',
         reason: 'killed',
         exitCode: 9,
         expectedTeardown: 'renderer-reload'

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -3,15 +3,26 @@ export type ExpectedTeardownScope = 'none' | 'renderer-reload' | 'app-shutdown'
 
 export function shouldRecordProcessGoneCrash({
   source,
+  processType,
   reason,
   exitCode,
   expectedTeardown
 }: {
   source: ProcessGoneSource
+  processType: string
   reason: string
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
 }): boolean {
+  // Why: Chromium's GPU helper can emit a crash-shaped exit while Electron is
+  // already intentionally exiting/relaunching; that is shutdown noise.
+  if (
+    expectedTeardown === 'app-shutdown' &&
+    source === 'child' &&
+    processType.toLowerCase() === 'gpu'
+  ) {
+    return false
+  }
   // Why: Electron reports intentional reload/update/quit teardown as `killed`.
   // Real renderer OOMs and Chromium crashes should still reach crash reporting.
   if (reason !== 'killed') {
@@ -20,9 +31,6 @@ export function shouldRecordProcessGoneCrash({
   // Why: Electron reports expected Chromium teardown during reload/update as
   // `killed` + SIGTERM. Treat real crash reasons as reportable, but skip this.
   if (exitCode === 15) {
-    return false
-  }
-  if (expectedTeardown === 'app-shutdown') {
     return false
   }
   return !(source === 'renderer' && expectedTeardown === 'renderer-reload')

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -33,6 +33,9 @@ export function shouldRecordProcessGoneCrash({
   if (exitCode === 15) {
     return false
   }
+  if (expectedTeardown === 'app-shutdown') {
+    return false
+  }
   return !(source === 'renderer' && expectedTeardown === 'renderer-reload')
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -337,6 +337,7 @@ function openMainWindow(): BrowserWindow {
     shouldRecordRendererCrash: (details, webContentsId) =>
       shouldRecordProcessGoneCrash({
         source: 'renderer',
+        processType: 'renderer',
         reason: details.reason,
         exitCode: details.exitCode ?? null,
         expectedTeardown: getExpectedTeardownScope(webContentsId)
@@ -398,7 +399,12 @@ function openMainWindow(): BrowserWindow {
     },
     agentAwakeService ?? undefined,
     crashReports ?? undefined,
-    keybindings
+    keybindings,
+    {
+      onBeforeRelaunch: () => {
+        isQuitting = true
+      }
+    }
   )
   automations.setWebContents(window.webContents)
   automations.start()
@@ -524,6 +530,7 @@ function recordProcessGoneCrash(
   if (
     !shouldRecordProcessGoneCrash({
       source,
+      processType,
       reason,
       exitCode,
       expectedTeardown: getExpectedTeardownScope(webContentsId)

--- a/src/main/ipc/app.test.ts
+++ b/src/main/ipc/app.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handlers, appExitMock, appRelaunchMock } = vi.hoisted(() => ({
+  handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
+  appExitMock: vi.fn(),
+  appRelaunchMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    exit: appExitMock,
+    getAppPath: vi.fn(() => '/test/app'),
+    isPackaged: false,
+    relaunch: appRelaunchMock
+  },
+  BrowserWindow: {
+    fromWebContents: vi.fn(() => null)
+  },
+  dialog: {
+    showOpenDialog: vi.fn()
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (_event: unknown, args?: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    })
+  }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: { dev: true }
+}))
+
+import { registerAppHandlers } from './app'
+
+describe('registerAppHandlers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    handlers.clear()
+    appExitMock.mockReset()
+    appRelaunchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('marks relaunch as expected shutdown before exiting', () => {
+    const onBeforeRelaunch = vi.fn()
+    registerAppHandlers({} as never, { onBeforeRelaunch })
+
+    handlers.get('app:relaunch')?.(null)
+
+    expect(onBeforeRelaunch).toHaveBeenCalledTimes(1)
+    expect(appRelaunchMock).not.toHaveBeenCalled()
+    expect(appExitMock).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(150)
+
+    expect(appRelaunchMock).toHaveBeenCalledTimes(1)
+    expect(appExitMock).toHaveBeenCalledWith(0)
+  })
+})

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -22,6 +22,10 @@ import { isMarkdownDocumentName, markdownDocumentFromFilePath } from './markdown
 
 const execFileAsync = promisify(execFile)
 
+type RegisterAppHandlersOptions = {
+  onBeforeRelaunch?: () => void
+}
+
 async function pickFloatingMarkdownDocument(
   event: IpcMainInvokeEvent
 ): Promise<MarkdownDocument | null> {
@@ -96,7 +100,7 @@ function resolveDevFeatureWallAssetDir(): string {
   return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
 }
 
-export function registerAppHandlers(store: Store): void {
+export function registerAppHandlers(store: Store, options: RegisterAppHandlersOptions = {}): void {
   ipcMain.handle('app:getFeatureWallAssetBaseUrl', (): string => getFeatureWallAssetBaseUrl())
 
   ipcMain.handle('app:getIdentity', (): AppIdentity => {
@@ -166,6 +170,8 @@ export function registerAppHandlers(store: Store): void {
     // UI state before the window tears down. `app.relaunch()` schedules a
     // spawn; `app.exit(0)` triggers the actual quit without invoking
     // before-quit handlers that could block on confirmation dialogs.
+    // Mark shutdown first because app.exit() can bypass the usual quit latch.
+    options.onBeforeRelaunch?.()
     setTimeout(() => {
       app.relaunch()
       app.exit(0)

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -331,6 +331,7 @@ describe('registerCoreHandlers', () => {
     const claudeAccounts = { marker: 'claudeAccounts' }
     const rateLimits = { marker: 'rateLimits' }
     const agentAwakeService = { marker: 'agentAwakeService' }
+    const onBeforeRelaunch = vi.fn()
 
     registerCoreHandlers(
       store as never,
@@ -345,13 +346,16 @@ describe('registerCoreHandlers', () => {
       null,
       undefined,
       undefined,
-      agentAwakeService as never
+      agentAwakeService as never,
+      undefined,
+      undefined,
+      { onBeforeRelaunch }
     )
 
     expect(registerClaudeUsageHandlersMock).toHaveBeenCalledWith(claudeUsage)
     expect(registerCodexUsageHandlersMock).toHaveBeenCalledWith(codexUsage)
     expect(registerOpenCodeUsageHandlersMock).toHaveBeenCalledWith(openCodeUsage)
-    expect(registerAppHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerAppHandlersMock).toHaveBeenCalledWith(store, { onBeforeRelaunch })
     expect(registerCodexAccountHandlersMock).toHaveBeenCalledWith(codexAccounts)
     expect(registerAgentHookHandlersMock).toHaveBeenCalled()
     expect(registerPetHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -63,6 +63,10 @@ import type { KeybindingService } from '../keybindings/keybinding-service'
 
 let registered = false
 
+type CoreHandlerLifecycleOptions = {
+  onBeforeRelaunch?: () => void
+}
+
 export function registerCoreHandlers(
   store: Store,
   runtime: OrcaRuntimeService,
@@ -78,7 +82,8 @@ export function registerCoreHandlers(
   commitMessageAgentEnv?: CommitMessageAgentEnvironmentResolvers,
   agentAwakeService?: AgentAwakeService,
   crashReports?: CrashReportStore,
-  keybindings?: KeybindingService
+  keybindings?: KeybindingService,
+  lifecycleOptions: CoreHandlerLifecycleOptions = {}
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -91,7 +96,7 @@ export function registerCoreHandlers(
   }
   registered = true
 
-  registerAppHandlers(store)
+  registerAppHandlers(store, { onBeforeRelaunch: lifecycleOptions.onBeforeRelaunch })
   registerCliHandlers()
   registerPreflightHandlers()
   registerClaudeUsageHandlers(claudeUsage)


### PR DESCRIPTION
## Summary
- mark relaunches as expected shutdown before `app.exit(0)` so restart teardown is classified correctly
- suppress GPU child-process crash-shaped exits during expected app shutdown while keeping renderer and non-GPU child crashes reportable
- preserve the existing app-shutdown `killed` suppression found during review, with regression coverage for non-SIGTERM shutdown kills

## Review / Verification
- Design/implementation were already present in the existing PR; this pass covered the requested downstream review and manual verification stages.
- Review round 1: two independent `review-code` agents both found that app-shutdown `killed` events with non-15 exit codes could be recorded as false crash reports.
- Fix: added commit `4ce9a81d1` to restore app-shutdown `killed` suppression and cover `renderer` + `killed` + exit `9` + `app-shutdown`.
- Review round 2: two fresh `review-code` agents returned no actionable findings.
- Brennan manual verification: launched this PR worktree in Electron with CDP, verified identity for branch `brennanb2025/restart-orca-crash-report` and root `/Users/thebr/orca/workspaces/orca/restart-orca-crash-report`, activated `demo-project`, clicked the real restart-required UI, and verified after relaunch/reload that `crashReports.getLatestPending()` and `getLatestReport()` returned `null` and no crash-report prompt was visible.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/ipc/app.test.ts src/main/ipc/register-core-handlers.test.ts`
- [x] Brennan manual pass also ran focused Vitest for `src/main/crash-reporting/crash-report-store.test.ts` and `src/main/ipc/crash-reporting.test.ts`
- [x] Electron restart crash-report check: no pending/latest crash report after restart-time process teardown
- [ ] Dev Electron window returned to the renderer without manual reload: accepted gap. `app:relaunch` still uses the same `app.relaunch()`/`app.exit(0)` mechanism as `main`; under `electron-vite` the relaunched dev window can briefly land on Chromium's error page before the renderer dev server is ready. A manual reload restored the same PR app identity and clean crash-report state.

## Residual Risk
- SSH/remoting behavior is not touched.
- The remaining gap is limited to dev-runner relaunch timing under `ELECTRON_RENDERER_URL`; packaged production restart does not load the renderer from the Vite dev server.

Made with [Orca](https://github.com/stablyai/orca) 🐋
