### PR TITLE
Rename Smart sort to Agent Activity

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -50,7 +50,7 @@ const SORT_OPTIONS = [
   { id: 'name', label: 'Name', description: null },
   {
     id: 'smart',
-    label: 'Smart',
+    label: 'Agent Activity',
     description: 'Agents that need attention, then most recent activity.'
   },
   { id: 'recent', label: 'Recent', description: null },


### PR DESCRIPTION
## Summary

Renames the visible Workspaces `Sort by` option for internal `sortBy: 'smart'` from `Smart` to `Agent Activity`.

The design intentionally keeps the persisted key, comparator behavior, migrations, telemetry identifiers, and `smart-*` implementation names unchanged to avoid storage/API churn for a copy-only UI change.

## Brennan YOLO Lite Evidence

Design approach: label-only renderer UI change in `SidebarWorkspaceOptionsMenu.tsx`; no layout, state, migration, telemetry, or SSH/runtime behavior changes.

Design review: `auto-design-review-fix` completed clean. The reviewed doc kept the scope label-only and tightened validation around the longer label fitting without overlap/truncation.

Implementation: changed only the `SORT_OPTIONS` label for `id: 'smart'` to `Agent Activity`. No deviations from the reviewed design.

Completeness verification: read-only verifier confirmed the implementation satisfies the design: `id: 'smart'` is preserved, the active sort summary derives from the updated option label, selecting the option still writes `smart`, internal types/persistence/comparator remain unchanged, and the separate inline `Agent activity` card-property label is untouched.

Code review loop: round 1 ran two independent `review-code` reviewers in parallel. Both returned clean with no actionable findings, so the loop stopped.

`brennan-test-changes`: verdict `land`. Electron launched from this exact worktree; `window.api.app.getIdentity()` confirmed branch `brennanb2025/Rename-sort-smart-to-agent-status` and the expected root. The real Workspaces options UI was exercised with `demo-project` context: Sort by showed `Agent Activity`, selecting it restored backing state to `sortBy: "smart"`, and the active summary showed `Agent Activity`. Normal scale and temporary 125% CSS zoom showed no visible clipping/overlap or DOM text overflow. Renderer console had 0 errors and 0 warnings. Cleanup restored sort, active repo/worktree, group/filter state, and zoom, and stopped the launched Electron process.

## Tests

- `git diff --check`
- `pnpm exec oxlint src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `pnpm run typecheck`
- Pre-commit lint-staged hook: `oxlint` and `oxfmt --write` on the staged TSX file

## Assumptions / Gaps

- `brennan-test-ssh` was not run because this branch does not touch SSH/remoting behavior.
- Internal `smart` naming is intentionally retained for persisted state, migrations, telemetry, comparator code, and tests.

Made with [Orca](https://github.com/stablyai/orca) 🐋
