### PR TITLE
Keep Full Disk Access status checks passive

### DIFF
--- a/src/main/ipc/developer-permissions.test.ts
+++ b/src/main/ipc/developer-permissions.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  accessMock,
+  askForMediaAccessMock,
+  getMediaAccessStatusMock,
+  handleMock,
+  isTrustedAccessibilityClientMock,
+  openExternalMock
+} = vi.hoisted(() => ({
+  accessMock: vi.fn(),
+  askForMediaAccessMock: vi.fn(),
+  getMediaAccessStatusMock: vi.fn(),
+  handleMock: vi.fn(),
+  isTrustedAccessibilityClientMock: vi.fn(),
+  openExternalMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  access: accessMock
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  },
+  shell: {
+    openExternal: openExternalMock
+  },
+  systemPreferences: {
+    askForMediaAccess: askForMediaAccessMock,
+    getMediaAccessStatus: getMediaAccessStatusMock,
+    isTrustedAccessibilityClient: isTrustedAccessibilityClientMock
+  }
+}))
+
+import { registerDeveloperPermissionHandlers } from './developer-permissions'
+
+describe('registerDeveloperPermissionHandlers', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    accessMock.mockReset()
+    askForMediaAccessMock.mockReset()
+    getMediaAccessStatusMock.mockReset()
+    getMediaAccessStatusMock.mockReturnValue('not-determined')
+    handleMock.mockReset()
+    isTrustedAccessibilityClientMock.mockReset()
+    isTrustedAccessibilityClientMock.mockReturnValue(false)
+    openExternalMock.mockReset()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  })
+
+  it('keeps full-disk-access status passive', async () => {
+    registerDeveloperPermissionHandlers()
+
+    const handler = registeredHandler('developerPermissions:getStatus')
+    const result = await handler()
+
+    expect(result).toContainEqual({ id: 'full-disk-access', status: 'unknown' })
+    expect(accessMock).not.toHaveBeenCalled()
+  })
+
+  it('opens Full Disk Access settings without probing protected files', async () => {
+    registerDeveloperPermissionHandlers()
+
+    const handler = registeredHandler('developerPermissions:request')
+    await expect(handler(null, { id: 'full-disk-access' })).resolves.toEqual({
+      id: 'full-disk-access',
+      status: 'unknown',
+      openedSystemSettings: true
+    })
+
+    expect(openExternalMock).toHaveBeenCalledWith(
+      'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles'
+    )
+    expect(accessMock).not.toHaveBeenCalled()
+  })
+})
+
+function registeredHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const registration = handleMock.mock.calls.find(
+    ([registeredChannel]) => registeredChannel === channel
+  )
+  if (!registration) {
+    throw new Error(`Handler ${channel} was not registered`)
+  }
+  return registration[1] as (...args: unknown[]) => Promise<unknown>
+}

--- a/src/main/ipc/developer-permissions.ts
+++ b/src/main/ipc/developer-permissions.ts
@@ -1,8 +1,5 @@
 import { execFile } from 'node:child_process'
 import dgram from 'node:dgram'
-import { access } from 'node:fs/promises'
-import { homedir } from 'node:os'
-import path from 'node:path'
 import { ipcMain, shell, systemPreferences } from 'electron'
 import type {
   DeveloperPermissionId,
@@ -49,19 +46,14 @@ function getMediaStatus(mediaType: 'microphone' | 'camera' | 'screen'): Develope
   }
 }
 
-async function getFullDiskAccessStatus(): Promise<DeveloperPermissionStatus> {
+function getFullDiskAccessStatus(): DeveloperPermissionStatus {
   const unsupported = unsupportedOffMac()
   if (unsupported) {
     return unsupported
   }
-  try {
-    // Why: Safari bookmarks are TCC-protected, so read access is a practical
-    // Full Disk Access signal without touching user project contents.
-    await access(path.join(homedir(), 'Library', 'Safari', 'Bookmarks.plist'))
-    return 'granted'
-  } catch {
-    return 'unknown'
-  }
+  // Why: probing protected folders to infer this status can itself trigger
+  // macOS privacy prompts. Keep status passive and send users to Settings.
+  return 'unknown'
 }
 
 function getAccessibilityStatus(): DeveloperPermissionStatus {
@@ -129,7 +121,7 @@ async function getPermissionState(id: DeveloperPermissionId): Promise<DeveloperP
     case 'accessibility':
       return { id, status: getAccessibilityStatus() }
     case 'full-disk-access':
-      return { id, status: await getFullDiskAccessStatus() }
+      return { id, status: getFullDiskAccessStatus() }
     case 'automation':
     case 'local-network':
       return { id, status: unsupportedOffMac() ?? 'unknown' }


### PR DESCRIPTION
## Summary
- Stop Developer Permissions status from probing Safari bookmarks to infer Full Disk Access.
- Keep Full Disk Access status passive as unknown and route users to macOS Settings for the grant.
- Add regression coverage that status/request paths do not touch protected files.

## Tests
- `pnpm exec vitest run src/main/ipc/developer-permissions.test.ts`
- `pnpm exec oxlint src/main/ipc/developer-permissions.ts src/main/ipc/developer-permissions.test.ts`
- `pnpm run typecheck:node`