### PR TITLE
Use dropdown for onboarding notification sounds

### DIFF
--- a/src/renderer/src/components/onboarding/NotificationStep.test.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.test.tsx
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 import type { GlobalSettings } from '../../../../shared/types'
 import { NotificationStep } from './NotificationStep'
 
-function createSettings(): GlobalSettings {
+function createSettings(
+  notificationOverrides: Partial<GlobalSettings['notifications']> = {}
+): GlobalSettings {
   return {
     notifications: {
       enabled: true,
@@ -12,7 +14,8 @@ function createSettings(): GlobalSettings {
       suppressWhenFocused: false,
       customSoundId: 'system',
       customSoundPath: null,
-      customSoundVolume: 80
+      customSoundVolume: 80,
+      ...notificationOverrides
     }
   } as GlobalSettings
 }
@@ -31,5 +34,17 @@ describe('NotificationStep', () => {
     expect(html).not.toContain('Terminal bell')
     expect(html).not.toContain('Set up agent features')
     expect(html).not.toContain('Connect task sources')
+  })
+
+  it('does not render an onboarding volume slider for non-system sounds', () => {
+    const html = renderToStaticMarkup(
+      <NotificationStep
+        settings={createSettings({ customSoundId: 'two-tone' })}
+        updateSettings={vi.fn()}
+      />
+    )
+
+    expect(html).not.toContain('Notification sound volume')
+    expect(html).not.toContain('80%')
   })
 })

--- a/src/renderer/src/components/onboarding/NotificationStep.test.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.test.tsx
@@ -23,11 +23,10 @@ describe('NotificationStep', () => {
       <NotificationStep settings={createSettings()} updateSettings={vi.fn()} />
     )
 
-    expect(html).toContain('System Default')
-    expect(html).toContain('Two Tone')
-    expect(html).toContain('Sonar')
-    expect(html).toContain('Ding')
+    expect(html).toContain('Notification Sound')
+    expect(html).toContain('role="combobox"')
     expect(html).toContain('Send Test Notification')
+    expect(html).not.toContain('aria-pressed')
     expect(html).not.toContain('Agent task complete')
     expect(html).not.toContain('Terminal bell')
     expect(html).not.toContain('Set up agent features')

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable max-lines -- Why: this onboarding step owns the full notification setup surface, including macOS guidance, sound choices, upload, and volume controls. */
 import { useEffect, useRef, useState } from 'react'
-import { BellRing, Check, ChevronDown, FileAudio, Settings, Upload, Volume2, X } from 'lucide-react'
+import { BellRing, FileAudio, Settings, Upload, Volume2, X } from 'lucide-react'
 import { toast } from 'sonner'
 import type { GlobalSettings, NotificationPermissionStatusResult } from '../../../../shared/types'
-import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Slider } from '@/components/ui/slider'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import { sendNotificationSettingsTestNotification } from '@/components/settings/NotificationsPane'
 import { getNotificationSoundOptions } from '@/components/notification-sound-options'
 import logo from '../../../../../resources/logo.svg'
@@ -22,6 +28,18 @@ type NotificationStepProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => Promise<void> | void
 }
 
+const CHOOSE_CUSTOM_SOUND_VALUE = 'choose-custom-file'
+
+type NotificationSoundSelectValue =
+  | GlobalSettings['notifications']['customSoundId']
+  | typeof CHOOSE_CUSTOM_SOUND_VALUE
+
+function isNotificationSoundId(
+  value: NotificationSoundSelectValue
+): value is GlobalSettings['notifications']['customSoundId'] {
+  return value !== CHOOSE_CUSTOM_SOUND_VALUE
+}
+
 export function NotificationStep({
   settings,
   updateSettings
@@ -31,14 +49,20 @@ export function NotificationStep({
   const [permissionStatus, setPermissionStatus] =
     useState<NotificationPermissionStatusResult | null>(null)
   const [volumeDraft, setVolumeDraft] = useState(notificationSettings?.customSoundVolume ?? 100)
-  const [advancedOpen, setAdvancedOpen] = useState(false)
   const [isPickingSound, setIsPickingSound] = useState(false)
   const [showMacSettingsPreview, setShowMacSettingsPreview] = useState(false)
+  const [selectPortalRoot, setSelectPortalRoot] = useState<HTMLElement | null>(null)
 
   useEffect(() => {
     notificationSettingsRef.current = notificationSettings
     setVolumeDraft(notificationSettings?.customSoundVolume ?? 100)
   }, [notificationSettings])
+
+  useEffect(() => {
+    // Why: onboarding sits above body-level portals, so the select menu must
+    // portal into the overlay to stay clickable.
+    setSelectPortalRoot(document.querySelector<HTMLElement>('[data-onboarding-overlay]'))
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -91,13 +115,6 @@ export function NotificationStep({
     }
   }
 
-  const handleChooseBuiltInSound = async (
-    customSoundId: GlobalSettings['notifications']['customSoundId']
-  ): Promise<void> => {
-    await updateNotificationSettings({ customSoundId })
-    await previewSound(customSoundId)
-  }
-
   const handleChooseCustomSound = async (): Promise<void> => {
     setIsPickingSound(true)
     try {
@@ -105,11 +122,19 @@ export function NotificationStep({
       if (soundPath) {
         await updateNotificationSettings({ customSoundId: 'custom', customSoundPath: soundPath })
         await previewSound('custom')
-        setAdvancedOpen(true)
       }
     } finally {
       setIsPickingSound(false)
     }
+  }
+
+  const handleSoundSelect = async (value: NotificationSoundSelectValue): Promise<void> => {
+    if (!isNotificationSoundId(value)) {
+      await handleChooseCustomSound()
+      return
+    }
+    await updateNotificationSettings({ customSoundId: value })
+    await previewSound(value)
   }
 
   const handleVolumeCommit = (value: number): void => {
@@ -234,109 +259,66 @@ export function NotificationStep({
           </Button>
         </div>
 
-        <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
-          {soundOptions.map((option) => {
-            const selected = selectedSoundId === option.id
-            const OptionIcon = option.icon
-            return (
-              <button
-                key={option.id}
-                type="button"
-                aria-pressed={selected}
-                className={cn(
-                  'group relative flex min-h-14 items-center gap-3 overflow-hidden rounded-xl border p-3 text-left transition-all',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                  selected
-                    ? 'border-violet-500/60 bg-violet-500/10 text-foreground ring-2 ring-violet-500/30'
-                    : 'border-border bg-muted/20 text-muted-foreground hover:bg-muted/40'
-                )}
-                onClick={() => void handleChooseBuiltInSound(option.id)}
-              >
-                <span className="grid size-5 shrink-0 place-items-center text-muted-foreground">
-                  <OptionIcon className="size-4" />
-                </span>
-                <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                  {option.title}
-                </span>
-                {selected ? (
-                  <span
-                    aria-hidden
-                    className="grid size-5 shrink-0 place-items-center rounded-full bg-violet-500 text-white shadow-sm"
-                  >
-                    <Check className="size-3" strokeWidth={3} />
-                  </span>
-                ) : null}
-              </button>
-            )
-          })}
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <FileAudio className="size-4" />
+            Notification Sound
+          </div>
+          <Select
+            value={selectedSoundId}
+            disabled={isPickingSound}
+            onValueChange={(value) => void handleSoundSelect(value as NotificationSoundSelectValue)}
+          >
+            <SelectTrigger className="w-full max-w-[360px]" size="sm">
+              <SelectValue placeholder="Choose notification sound" />
+            </SelectTrigger>
+            <SelectContent
+              portalContainer={selectPortalRoot}
+              align="start"
+              className="w-[--radix-select-trigger-width]"
+            >
+              {soundOptions.map((option) => {
+                const OptionIcon = option.icon
+                return (
+                  <SelectItem key={option.id} value={option.id}>
+                    <OptionIcon className="size-4" />
+                    <span className="truncate">{option.title}</span>
+                  </SelectItem>
+                )
+              })}
+              <SelectSeparator />
+              <SelectItem value={CHOOSE_CUSTOM_SOUND_VALUE}>
+                <Upload className="size-4" />
+                <span>{customPath ? 'Change Custom File' : 'Choose Custom File'}</span>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          {customPath ? (
+            <p className="truncate font-mono text-[11px] text-muted-foreground" title={customPath}>
+              Custom: {customPath}
+            </p>
+          ) : null}
         </div>
 
         {canAdjustVolume ? (
-          <div className="rounded-lg border border-border bg-muted/20 px-4 py-3">
-            <div className="flex items-center gap-3">
-              <Volume2 className="size-4 text-muted-foreground" />
-              <Slider
-                value={[volumeDraft]}
-                min={0}
-                max={100}
-                step={5}
-                onValueChange={([value]) => setVolumeDraft(value)}
-                onValueCommit={([value]) => handleVolumeCommit(value)}
-                className="flex-1"
-                aria-label="Notification sound volume"
-              />
-              <span className="w-10 text-right font-mono text-xs tabular-nums text-muted-foreground">
-                {volumeDraft}%
-              </span>
-            </div>
+          <div className="flex items-center gap-3 pt-1">
+            <Volume2 className="size-4 text-muted-foreground" />
+            <Slider
+              value={[volumeDraft]}
+              min={0}
+              max={100}
+              step={5}
+              onValueChange={([value]) => setVolumeDraft(value)}
+              onValueCommit={([value]) => handleVolumeCommit(value)}
+              className="flex-1"
+              aria-label="Notification sound volume"
+            />
+            <span className="w-10 text-right font-mono text-xs tabular-nums text-muted-foreground">
+              {volumeDraft}%
+            </span>
           </div>
         ) : null}
       </section>
-
-      <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground"
-          >
-            <ChevronDown
-              className={cn('size-4 transition-transform', advancedOpen && 'rotate-180')}
-            />
-            Advanced sound file
-          </button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="mt-3 rounded-lg border border-border bg-muted/20 px-4 py-3">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="min-w-0 space-y-1">
-                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                  <FileAudio className="size-4" />
-                  Upload a sound
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  MP3, WAV, OGG, M4A, AAC, or FLAC. Orca stores only the local file path.
-                </p>
-                {customPath ? (
-                  <p className="truncate font-mono text-[11px] text-muted-foreground">
-                    {customPath}
-                  </p>
-                ) : null}
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="gap-2"
-                disabled={isPickingSound}
-                onClick={() => void handleChooseCustomSound()}
-              >
-                <Upload className="size-3.5" />
-                {customPath ? 'Change File' : 'Choose File'}
-              </Button>
-            </div>
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
     </div>
   )
 }

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -294,11 +294,6 @@ export function NotificationStep({
               Send Test Notification
             </Button>
           </div>
-          {customPath ? (
-            <p className="truncate font-mono text-[11px] text-muted-foreground" title={customPath}>
-              Custom: {customPath}
-            </p>
-          ) : null}
         </div>
 
         {canAdjustVolume ? (

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable max-lines -- Why: this onboarding step owns the full notification setup surface, including macOS guidance, sound choices, upload, and volume controls. */
+/* eslint-disable max-lines -- Why: this onboarding step owns the full notification setup surface, including macOS guidance, sound choices, and upload controls. */
 import { useEffect, useRef, useState } from 'react'
-import { BellRing, FileAudio, Settings, Upload, Volume2, X } from 'lucide-react'
+import { BellRing, FileAudio, Settings, Upload, X } from 'lucide-react'
 import { toast } from 'sonner'
 import type { GlobalSettings, NotificationPermissionStatusResult } from '../../../../shared/types'
 import { Button } from '@/components/ui/button'
-import { Slider } from '@/components/ui/slider'
 import {
   Select,
   SelectContent,
@@ -48,14 +47,12 @@ export function NotificationStep({
   const notificationSettingsRef = useRef(notificationSettings)
   const [permissionStatus, setPermissionStatus] =
     useState<NotificationPermissionStatusResult | null>(null)
-  const [volumeDraft, setVolumeDraft] = useState(notificationSettings?.customSoundVolume ?? 100)
   const [isPickingSound, setIsPickingSound] = useState(false)
   const [showMacSettingsPreview, setShowMacSettingsPreview] = useState(false)
   const [selectPortalRoot, setSelectPortalRoot] = useState<HTMLElement | null>(null)
 
   useEffect(() => {
     notificationSettingsRef.current = notificationSettings
-    setVolumeDraft(notificationSettings?.customSoundVolume ?? 100)
   }, [notificationSettings])
 
   useEffect(() => {
@@ -93,6 +90,9 @@ export function NotificationStep({
     })
   }
 
+  const getCustomSoundVolume = (): number =>
+    notificationSettingsRef.current?.customSoundVolume ?? 100
+
   const handleMacPermission = async (): Promise<void> => {
     setShowMacSettingsPreview(true)
     const status = await window.api.notifications.requestPermission()
@@ -108,7 +108,7 @@ export function NotificationStep({
     }
     const result = await window.api.notifications.playSound({
       force: true,
-      volume: volumeDraft
+      volume: getCustomSoundVolume()
     })
     if (!result.played) {
       toast.error('Notification sound could not be played')
@@ -137,18 +137,12 @@ export function NotificationStep({
     await previewSound(value)
   }
 
-  const handleVolumeCommit = (value: number): void => {
-    if (notificationSettingsRef.current?.customSoundVolume !== value) {
-      void updateNotificationSettings({ customSoundVolume: value })
-    }
-  }
-
   const handleSendTestNotification = async (): Promise<void> => {
     if (!notificationSettings) {
       toast.error('Notification settings are still loading')
       return
     }
-    await sendNotificationSettingsTestNotification(notificationSettings, volumeDraft)
+    await sendNotificationSettingsTestNotification(notificationSettings, getCustomSoundVolume())
   }
 
   if (!notificationSettings) {
@@ -162,7 +156,6 @@ export function NotificationStep({
   const customPath = notificationSettings.customSoundPath
   const selectedSoundId = notificationSettings.customSoundId
   const soundOptions = getNotificationSoundOptions(customPath)
-  const canAdjustVolume = selectedSoundId !== 'system'
   const isMac = permissionStatus?.platform === 'darwin'
 
   return (
@@ -295,25 +288,6 @@ export function NotificationStep({
             </Button>
           </div>
         </div>
-
-        {canAdjustVolume ? (
-          <div className="flex items-center gap-3 pt-1">
-            <Volume2 className="size-4 text-muted-foreground" />
-            <Slider
-              value={[volumeDraft]}
-              min={0}
-              max={100}
-              step={5}
-              onValueChange={([value]) => setVolumeDraft(value)}
-              onValueCommit={([value]) => handleVolumeCommit(value)}
-              className="flex-1"
-              aria-label="Notification sound volume"
-            />
-            <span className="w-10 text-right font-mono text-xs tabular-nums text-muted-foreground">
-              {volumeDraft}%
-            </span>
-          </div>
-        ) : null}
       </section>
     </div>
   )

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -176,7 +176,7 @@ export function NotificationStep({
                 Allow Orca in macOS
               </div>
               <p className="max-w-[58ch] text-[13px] leading-relaxed text-muted-foreground">
-                Open System Settings and make sure Orca is allowed to show alerts and play sounds.
+                Open System Settings and make sure Orca is allowed to send notifications.
               </p>
             </div>
             <Button

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -239,23 +239,11 @@ export function NotificationStep({
       ) : null}
 
       <section className="space-y-3">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="space-y-1">
-            <h2 className="text-sm font-semibold text-foreground">Choose a sound</h2>
-            <p className="text-[13px] leading-relaxed text-muted-foreground">
-              Pick the alert Orca plays after a desktop notification is delivered.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-2"
-            onClick={() => void handleSendTestNotification()}
-          >
-            <BellRing className="size-3.5" />
-            Send Test Notification
-          </Button>
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold text-foreground">Choose a sound</h2>
+          <p className="text-[13px] leading-relaxed text-muted-foreground">
+            Pick the alert Orca plays after a desktop notification is delivered.
+          </p>
         </div>
 
         <div className="space-y-2">
@@ -263,35 +251,49 @@ export function NotificationStep({
             <FileAudio className="size-4" />
             Notification Sound
           </div>
-          <Select
-            value={selectedSoundId}
-            disabled={isPickingSound}
-            onValueChange={(value) => void handleSoundSelect(value as NotificationSoundSelectValue)}
-          >
-            <SelectTrigger className="w-full max-w-[360px]" size="sm">
-              <SelectValue placeholder="Choose notification sound" />
-            </SelectTrigger>
-            <SelectContent
-              portalContainer={selectPortalRoot}
-              align="start"
-              className="w-[--radix-select-trigger-width]"
+          <div className="flex flex-wrap items-center gap-2">
+            <Select
+              value={selectedSoundId}
+              disabled={isPickingSound}
+              onValueChange={(value) =>
+                void handleSoundSelect(value as NotificationSoundSelectValue)
+              }
             >
-              {soundOptions.map((option) => {
-                const OptionIcon = option.icon
-                return (
-                  <SelectItem key={option.id} value={option.id}>
-                    <OptionIcon className="size-4" />
-                    <span className="truncate">{option.title}</span>
-                  </SelectItem>
-                )
-              })}
-              <SelectSeparator />
-              <SelectItem value={CHOOSE_CUSTOM_SOUND_VALUE}>
-                <Upload className="size-4" />
-                <span>{customPath ? 'Change Custom File' : 'Choose Custom File'}</span>
-              </SelectItem>
-            </SelectContent>
-          </Select>
+              <SelectTrigger className="w-[360px] max-w-full" size="sm">
+                <SelectValue placeholder="Choose notification sound" />
+              </SelectTrigger>
+              <SelectContent
+                portalContainer={selectPortalRoot}
+                align="start"
+                className="w-[--radix-select-trigger-width]"
+              >
+                {soundOptions.map((option) => {
+                  const OptionIcon = option.icon
+                  return (
+                    <SelectItem key={option.id} value={option.id}>
+                      <OptionIcon className="size-4" />
+                      <span className="truncate">{option.title}</span>
+                    </SelectItem>
+                  )
+                })}
+                <SelectSeparator />
+                <SelectItem value={CHOOSE_CUSTOM_SOUND_VALUE}>
+                  <Upload className="size-4" />
+                  <span>{customPath ? 'Change Custom File' : 'Choose Custom File'}</span>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              onClick={() => void handleSendTestNotification()}
+            >
+              <BellRing className="size-3.5" />
+              Send Test Notification
+            </Button>
+          </div>
           {customPath ? (
             <p className="truncate font-mono text-[11px] text-muted-foreground" title={customPath}>
               Custom: {customPath}

--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -176,8 +176,7 @@ export function NotificationStep({
                 Allow Orca in macOS
               </div>
               <p className="max-w-[58ch] text-[13px] leading-relaxed text-muted-foreground">
-                macOS controls notifications per app. Open System Settings and make sure Orca is
-                allowed to show alerts and play sounds.
+                Open System Settings and make sure Orca is allowed to show alerts and play sounds.
               </p>
             </div>
             <Button

--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -27,7 +27,7 @@ const stepCopy = {
   },
   notifications: {
     title: 'Set up notifications',
-    subtitle: 'Allow desktop alerts and choose the sound Orca uses when work needs attention.'
+    subtitle: 'Orca will notify you know when agents are done or need help.'
   },
   agentSetup: {
     title: 'Set up Orca for agents',


### PR DESCRIPTION
## Summary
- replace onboarding notification sound cards with the compact Select used in notification settings
- keep custom sound selection in the dropdown and preserve automatic preview playback
- portal the dropdown into the onboarding overlay so it remains clickable above the fullscreen layer

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/NotificationStep.test.tsx src/renderer/src/components/settings/NotificationsPane.test.tsx
- pnpm exec oxlint src/renderer/src/components/onboarding/NotificationStep.tsx src/renderer/src/components/onboarding/NotificationStep.test.tsx
- pnpm run typecheck:web
- git diff --check
- Electron UI check: opened onboarding Notifications step, opened sound dropdown, selected Two Tone, confirmed selected value updated in UI/store.

Note: Gemini visual review was not available locally because the CLI requires GEMINI_API_KEY.