### PR TITLE
Tune light sidebar hover contrast

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -802,6 +802,33 @@
   transition: width 200ms ease;
 }
 
+/* Why: light-mode sidebar-accent/40 is nearly invisible on the sidebar, while
+   agent rows stack on top of the card hover. Keep nested rows quieter than the
+   workspace card without changing the established dark-mode balance. */
+.worktree-sidebar-card-hover:hover {
+  background: color-mix(in srgb, var(--sidebar-foreground) 4%, transparent);
+}
+
+.dark .worktree-sidebar-card-hover:hover {
+  background: color-mix(in srgb, var(--sidebar-accent) 40%, transparent);
+}
+
+.worktree-agent-row-hover:hover {
+  background: color-mix(in srgb, var(--sidebar-foreground) 1.25%, transparent);
+}
+
+.worktree-agent-row-hover[data-focused-agent-pane='true'] {
+  background: color-mix(in srgb, var(--sidebar-foreground) 6%, transparent);
+}
+
+.dark .worktree-agent-row-hover:hover {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.dark .worktree-agent-row-hover[data-focused-agent-pane='true'] {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
 @keyframes settings-shell-enter {
   from {
     opacity: 0;

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -108,10 +108,7 @@ describe('DashboardAgentRow', () => {
     )
 
     expect(markup).toContain('data-focused-agent-pane="true"')
-    expect(classTokens(markup)).toContain('hover:bg-black/[0.06]')
-    expect(classTokens(markup)).toContain('dark:hover:bg-accent/30')
-    expect(classTokens(markup)).toContain('bg-black/[0.06]')
-    expect(classTokens(markup)).toContain('dark:bg-accent/30')
+    expect(classTokens(markup)).toContain('worktree-agent-row-hover')
   })
 
   it('scopes the timestamp and dismiss hover swap to the row-owned group', () => {

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -233,14 +233,10 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
         // ancestor groups from workspace cards must not reveal every row's X.
         'group/agent-row relative flex flex-col -ml-2 py-1',
         isLineageChild ? 'pl-5 pr-2' : 'px-2',
-        // Why: hover tints have to go in opposite directions per theme —
-        // dark mode adds light on dark (bg-accent/30), light mode needs to
-        // add *dark* on white. Alpha-on-accent in light mode collapses to
-        // near-nothing because accent (#f5f5f5) is already ~white. Use a
-        // black alpha overlay in light mode (mirrors WorktreeCard.tsx's
-        // active-state pattern) so the lift is symmetric across themes.
-        'cursor-pointer rounded-sm hover:bg-black/[0.06] dark:hover:bg-accent/30',
-        isFocusedPane && 'bg-black/[0.06] dark:bg-accent/30'
+        // Why: inline agent rows sit inside a hoverable workspace card, so
+        // their hover wash must stay softer than the parent card highlight.
+        // The focused-pane state reuses the same class via data attribute.
+        'cursor-pointer rounded-sm worktree-agent-row-hover'
       )}
       data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
       title={tsParts.length > 0 ? tsParts.join(' • ') : undefined}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -550,7 +550,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
           : isMultiSelected
             ? 'border border-sidebar-ring/35 bg-sidebar-accent/70 ring-1 ring-sidebar-ring/30'
-            : 'border border-transparent hover:bg-sidebar-accent/40',
+            : 'border border-transparent worktree-sidebar-card-hover',
         isActiveSurface && isMultiSelected && 'ring-1 ring-sidebar-ring/35',
         titleRenaming && '!border-transparent !bg-transparent !shadow-none !ring-0',
         isDeleting && 'opacity-50 grayscale cursor-not-allowed',

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2200,7 +2200,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         'flex cursor-pointer items-start gap-1.5 rounded-md border border-transparent px-2 py-1.5 transition-colors',
                         isActive
                           ? 'border-black/[0.015] bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:border-border/40 dark:bg-white/[0.10] dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'
-                          : 'hover:bg-sidebar-accent/40'
+                          : 'worktree-sidebar-card-hover'
                       )}
                       onClick={handleClick}
                       onDoubleClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Summary
- make light-mode workspace card hover more visible in the left sidebar
- soften inline agent row hover while keeping focused/selected rows distinct
- apply the same card hover treatment to lightweight lineage child cards

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
- pnpm exec oxlint src/renderer/src/components/dashboard/DashboardAgentRow.tsx src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx src/renderer/src/components/sidebar/WorktreeCard.tsx src/renderer/src/components/sidebar/WorktreeList.tsx