### PR TITLE
Add agent command templates to quick commands

### DIFF
--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -119,25 +119,20 @@ export function TerminalQuickCommandDialog({
   }, [command, open])
 
   const agentPresets = useMemo(() => {
-    return (
-      AGENT_CATALOG.map((entry, index) => {
-        const preset = buildTerminalAgentQuickCommandPreset({
-          agent: entry.id,
-          label: entry.label,
-          cmdOverrides: agentCmdOverrides,
-          platform: CLIENT_PLATFORM
-        })
-        return preset ? { preset, index } : null
+    return AGENT_CATALOG.map((entry, index) => {
+      const preset = buildTerminalAgentQuickCommandPreset({
+        agent: entry.id,
+        label: entry.label,
+        cmdOverrides: agentCmdOverrides,
+        platform: CLIENT_PLATFORM
       })
-        .filter((item): item is { preset: TerminalAgentQuickCommandPreset; index: number } =>
-          Boolean(item)
-        )
-        // Why: the picker inserts a one-line command template. Agents that can
-        // only receive prompts after startup cannot be represented by that text.
-        .filter((item) => item.preset.startsWithPrompt)
-        .sort((a, b) => a.index - b.index)
-        .map((item) => item.preset)
-    )
+      return preset ? { preset, index } : null
+    })
+      .filter((item): item is { preset: TerminalAgentQuickCommandPreset; index: number } =>
+        Boolean(item)
+      )
+      .sort((a, b) => a.index - b.index)
+      .map((item) => item.preset)
   }, [agentCmdOverrides])
 
   const visibleAgentPresets = useMemo(
@@ -222,7 +217,7 @@ export function TerminalQuickCommandDialog({
                     <ChevronDown className="size-3" />
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent align="end" className="w-[min(14rem,calc(100vw-2rem))] p-0">
+                <PopoverContent align="end" className="w-[min(17rem,calc(100vw-2rem))] p-0">
                   <Command shouldFilter={false}>
                     <CommandInput
                       autoFocus
@@ -238,11 +233,25 @@ export function TerminalQuickCommandDialog({
                         <CommandItem
                           key={preset.agent}
                           value={`${preset.agent} ${preset.label}`}
-                          onSelect={() => selectAgentPreset(preset)}
-                          className="h-9 items-center gap-2 px-3"
+                          disabled={!preset.startsWithPrompt}
+                          onSelect={() => {
+                            if (preset.startsWithPrompt) {
+                              selectAgentPreset(preset)
+                            }
+                          }}
+                          className="min-h-11 items-start gap-2 px-3 py-2"
                         >
-                          <AgentIcon agent={preset.agent} size={16} />
-                          <span className="truncate text-sm font-medium">{preset.label}</span>
+                          <span className="mt-0.5">
+                            <AgentIcon agent={preset.agent} size={16} />
+                          </span>
+                          <span className="flex min-w-0 flex-1 flex-col">
+                            <span className="truncate text-sm font-medium">{preset.label}</span>
+                            {!preset.startsWithPrompt ? (
+                              <span className="truncate text-xs text-muted-foreground">
+                                Does not support prompt commands
+                              </span>
+                            ) : null}
+                          </span>
                         </CommandItem>
                       ))}
                     </CommandList>

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import type {
   Repo,
   TerminalQuickCommand,
@@ -7,6 +8,13 @@ import type {
 import { getTerminalQuickCommandScope } from '../../../../shared/terminal-quick-commands'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
 import {
   Dialog,
   DialogContent,
@@ -24,11 +32,21 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
 import { isMacUserAgent } from '@/components/terminal-pane/pane-helpers'
+import { AGENT_CATALOG, AgentIcon } from '@/lib/agent-catalog'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
+import { useAppStore } from '@/store'
+import {
+  buildTerminalAgentQuickCommandPreset,
+  type TerminalAgentQuickCommandPreset
+} from './terminal-agent-quick-command-presets'
 
 type TerminalQuickCommandDialogMode = 'add' | 'edit'
+
+const EMPTY_AGENT_CMD_OVERRIDES = {}
 
 type TerminalQuickCommandDialogProps = {
   open: boolean
@@ -55,6 +73,19 @@ function getRepoLabel(repo: Pick<Repo, 'displayName' | 'path'>): string {
   return repo.displayName || repo.path
 }
 
+function filterAgentPresets(
+  presets: TerminalAgentQuickCommandPreset[],
+  rawQuery: string
+): TerminalAgentQuickCommandPreset[] {
+  const query = rawQuery.trim().toLowerCase()
+  if (!query) {
+    return presets
+  }
+  return presets.filter((preset) => {
+    return preset.label.toLowerCase().includes(query) || preset.agent.toLowerCase().includes(query)
+  })
+}
+
 export function TerminalQuickCommandDialog({
   open,
   mode,
@@ -64,6 +95,11 @@ export function TerminalQuickCommandDialog({
   onSave
 }: TerminalQuickCommandDialogProps): React.JSX.Element {
   const [draft, setDraft] = useState<TerminalQuickCommand>(command)
+  const [agentPresetOpen, setAgentPresetOpen] = useState(false)
+  const [agentPresetQuery, setAgentPresetQuery] = useState('')
+  const agentCmdOverrides = useAppStore(
+    (s) => s.settings?.agentCmdOverrides ?? EMPTY_AGENT_CMD_OVERRIDES
+  )
   const selectedScope = getTerminalQuickCommandScope(draft)
   // Why: repo-scoped commands can outlive the current repo list; only an
   // explicit selection should replace the saved repo id.
@@ -77,8 +113,46 @@ export function TerminalQuickCommandDialog({
   useEffect(() => {
     if (open) {
       setDraft({ ...command })
+      setAgentPresetOpen(false)
+      setAgentPresetQuery('')
     }
   }, [command, open])
+
+  const agentPresets = useMemo(() => {
+    return (
+      AGENT_CATALOG.map((entry, index) => {
+        const preset = buildTerminalAgentQuickCommandPreset({
+          agent: entry.id,
+          label: entry.label,
+          cmdOverrides: agentCmdOverrides,
+          platform: CLIENT_PLATFORM
+        })
+        return preset ? { preset, index } : null
+      })
+        .filter((item): item is { preset: TerminalAgentQuickCommandPreset; index: number } =>
+          Boolean(item)
+        )
+        // Why: the picker inserts a one-line command template. Agents that can
+        // only receive prompts after startup cannot be represented by that text.
+        .filter((item) => item.preset.startsWithPrompt)
+        .sort((a, b) => a.index - b.index)
+        .map((item) => item.preset)
+    )
+  }, [agentCmdOverrides])
+
+  const visibleAgentPresets = useMemo(
+    () => filterAgentPresets(agentPresets, agentPresetQuery),
+    [agentPresetQuery, agentPresets]
+  )
+
+  const selectAgentPreset = (preset: TerminalAgentQuickCommandPreset): void => {
+    setDraft((current) => ({
+      ...current,
+      command: preset.command
+    }))
+    setAgentPresetOpen(false)
+    setAgentPresetQuery('')
+  }
 
   const saveDraft = (): void => {
     const next = {
@@ -133,7 +207,49 @@ export function TerminalQuickCommandDialog({
           </div>
 
           <div className="space-y-2">
-            <Label>Command Text</Label>
+            <div className="flex items-center justify-between gap-2">
+              <Label>Command Text</Label>
+              <Popover open={agentPresetOpen} onOpenChange={setAgentPresetOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    className="h-7 shrink-0 gap-1 px-2 text-xs font-normal"
+                    aria-label="Insert an agent command"
+                  >
+                    Insert agent command
+                    <ChevronDown className="size-3" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align="end" className="w-[min(14rem,calc(100vw-2rem))] p-0">
+                  <Command shouldFilter={false}>
+                    <CommandInput
+                      autoFocus
+                      placeholder="Search agents"
+                      value={agentPresetQuery}
+                      onValueChange={setAgentPresetQuery}
+                      className="h-9 text-xs"
+                      wrapperClassName="px-3"
+                    />
+                    <CommandList className="max-h-64">
+                      <CommandEmpty>No agents match your search.</CommandEmpty>
+                      {visibleAgentPresets.map((preset) => (
+                        <CommandItem
+                          key={preset.agent}
+                          value={`${preset.agent} ${preset.label}`}
+                          onSelect={() => selectAgentPreset(preset)}
+                          className="h-9 items-center gap-2 px-3"
+                        >
+                          <AgentIcon agent={preset.agent} size={16} />
+                          <span className="truncate text-sm font-medium">{preset.label}</span>
+                        </CommandItem>
+                      ))}
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
             <textarea
               value={draft.command}
               onChange={(event) =>

--- a/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
@@ -1,7 +1,56 @@
 import { describe, expect, it } from 'vitest'
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
+import type { TuiAgent } from '../../../../shared/types'
 import { buildTerminalAgentQuickCommandPreset } from './terminal-agent-quick-command-presets'
 
 describe('terminal agent quick command presets', () => {
+  it('matches the supported one-line startup commands for every prompt-starting agent', () => {
+    const expectedCommands: Partial<Record<TuiAgent, string>> = {
+      claude: "claude 'your prompt here'",
+      codex: "codex 'your prompt here'",
+      copilot: "copilot -i 'your prompt here'",
+      opencode: "opencode --prompt 'your prompt here'",
+      pi: "pi 'your prompt here'",
+      gemini: "gemini --prompt-interactive 'your prompt here'",
+      antigravity: "agy --prompt-interactive 'your prompt here'",
+      cursor: "cursor-agent 'your prompt here'",
+      droid: "droid 'your prompt here'"
+    }
+
+    const promptStartingCommands = Object.keys(TUI_AGENT_CONFIG)
+      .map((agent) =>
+        buildTerminalAgentQuickCommandPreset({
+          agent: agent as TuiAgent,
+          label: agent,
+          cmdOverrides: {},
+          platform: 'linux'
+        })
+      )
+      .filter((preset): preset is NonNullable<typeof preset> => preset?.startsWithPrompt === true)
+
+    expect(
+      Object.fromEntries(promptStartingCommands.map((preset) => [preset.agent, preset.command]))
+    ).toEqual(expectedCommands)
+  })
+
+  it('does not expose post-start paste agents as insertable command templates', () => {
+    const insertableAgents = Object.keys(TUI_AGENT_CONFIG).filter((agent) => {
+      return (
+        buildTerminalAgentQuickCommandPreset({
+          agent: agent as TuiAgent,
+          label: agent,
+          cmdOverrides: {},
+          platform: 'linux'
+        })?.startsWithPrompt === true
+      )
+    })
+
+    expect(insertableAgents).not.toContain('aider')
+    expect(insertableAgents).not.toContain('goose')
+    expect(insertableAgents).not.toContain('amp')
+    expect(insertableAgents).not.toContain('qwen-code')
+  })
+
   it('builds prompt-starting commands for argv agents', () => {
     expect(
       buildTerminalAgentQuickCommandPreset({

--- a/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { buildTerminalAgentQuickCommandPreset } from './terminal-agent-quick-command-presets'
+
+describe('terminal agent quick command presets', () => {
+  it('builds prompt-starting commands for argv agents', () => {
+    expect(
+      buildTerminalAgentQuickCommandPreset({
+        agent: 'claude',
+        label: 'Claude',
+        cmdOverrides: {},
+        platform: 'darwin'
+      })
+    ).toEqual({
+      agent: 'claude',
+      label: 'Claude',
+      command: "claude 'your prompt here'",
+      startsWithPrompt: true
+    })
+  })
+
+  it('uses interactive prompt flags when the agent requires them', () => {
+    expect(
+      buildTerminalAgentQuickCommandPreset({
+        agent: 'gemini',
+        label: 'Gemini',
+        cmdOverrides: {},
+        platform: 'linux'
+      })?.command
+    ).toBe("gemini --prompt-interactive 'your prompt here'")
+  })
+
+  it('marks post-start paste agents as launch-only', () => {
+    expect(
+      buildTerminalAgentQuickCommandPreset({
+        agent: 'aider',
+        label: 'Aider',
+        cmdOverrides: {},
+        platform: 'linux'
+      })
+    ).toEqual({
+      agent: 'aider',
+      label: 'Aider',
+      command: 'aider',
+      startsWithPrompt: false
+    })
+  })
+
+  it('preserves configured command overrides', () => {
+    expect(
+      buildTerminalAgentQuickCommandPreset({
+        agent: 'codex',
+        label: 'Codex',
+        cmdOverrides: { codex: '/opt/bin/codex' },
+        platform: 'linux'
+      })?.command
+    ).toBe("/opt/bin/codex 'your prompt here'")
+  })
+})

--- a/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.ts
@@ -1,0 +1,43 @@
+import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
+import type { AgentStartupShell } from '../../../../shared/tui-agent-startup'
+import type { TuiAgent } from '../../../../shared/types'
+
+export const TERMINAL_AGENT_QUICK_COMMAND_PRESET_PROMPT = 'your prompt here'
+
+export type TerminalAgentQuickCommandPreset = {
+  agent: TuiAgent
+  label: string
+  command: string
+  startsWithPrompt: boolean
+}
+
+export function buildTerminalAgentQuickCommandPreset(args: {
+  agent: TuiAgent
+  label: string
+  cmdOverrides: Partial<Record<TuiAgent, string>>
+  platform: NodeJS.Platform
+  shell?: AgentStartupShell
+}): TerminalAgentQuickCommandPreset | null {
+  const plan = buildAgentStartupPlan({
+    agent: args.agent,
+    prompt: TERMINAL_AGENT_QUICK_COMMAND_PRESET_PROMPT,
+    cmdOverrides: args.cmdOverrides,
+    platform: args.platform,
+    ...(args.shell ? { shell: args.shell } : {})
+  })
+  if (!plan) {
+    return null
+  }
+
+  // Why: quick commands only store one terminal input string. Agents that need
+  // a post-start paste can still be launched, but the prompt cannot be encoded
+  // in the saved quick-command text without runtime readiness handling.
+  const startsWithPrompt = plan.followupPrompt === null
+
+  return {
+    agent: args.agent,
+    label: args.label,
+    command: plan.launchCommand,
+    startsWithPrompt
+  }
+}


### PR DESCRIPTION
## Summary
- add an Insert agent command picker to terminal quick commands
- derive inserted command templates from the shared TUI agent startup config
- show agents that cannot be represented as prompt commands as disabled options with explanatory copy
- add regression coverage for the exact prompt-command templates

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts src/renderer/src/lib/tui-agent-startup.test.ts
- pnpm run typecheck:web
- visually checked the Add Quick Command dialog in the dev app: enabled agents insert command text; unsupported agents render disabled with "Does not support prompt commands"

Made with [Orca](https://github.com/stablyai/orca) 🐋
