### PR TITLE
Center Settings content in right pane

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -705,7 +705,7 @@ function Settings(): React.JSX.Element {
         >
           <div
             className={cn(
-              'flex w-full max-w-4xl flex-col gap-10 px-8 pt-10',
+              'mx-auto flex w-full max-w-4xl flex-col gap-10 px-8 pt-10',
               isFocusedShortcutsPane ? 'h-full pb-6' : 'pb-24'
             )}
           >


### PR DESCRIPTION
## Description

This PR centers the constrained Settings content container within the right-hand Settings pane. It improves visual balance on wide and ultra-wide screens while preserving the existing readable content width and left-aligned form layout.

## What Changed

- Added `mx-auto` to the shared Settings content wrapper in `Settings.tsx`.
- Kept the existing `max-w-5xl`, padding, spacing, scroll container, and sidebar layout unchanged.

## Why

The Settings content already had a constrained max width, but it was anchored to the left edge of the right pane. On wide screens this left excessive empty space on the far right and made the layout feel visually unbalanced.

Using `mx-auto` is the smallest fix because it centers the existing constrained wrapper without changing individual Settings pages or the internal alignment of labels, controls, and text.

## UI Changes

This changes the Settings layout on wide screens:

- Before: the Settings content block was left-aligned inside the right pane.
<img width="2876" height="1864" alt="orca-original-setting-ui" src="https://github.com/user-attachments/assets/2f1012cd-6255-4aeb-ab89-9941a6ca1b48" />

- After: the Settings content block is horizontally centered inside the right pane.
<img width="2876" height="1864" alt="orca-center-settings-ui" src="https://github.com/user-attachments/assets/190d8f3a-10dd-4a28-964b-31fa1042cc94" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
