### PR TITLE
Allow starting from primary worktree after adding repo

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -15,9 +15,10 @@ import { Input } from '@/components/ui/input'
 import { track } from '@/lib/telemetry'
 import { RemoteStep, CloneStep, useRemoteRepo } from './AddRepoSteps'
 import { CreateStep, useCreateRepo } from './AddRepoCreateStep'
-import { SetupStep } from './AddRepoSetupStep'
+import { getProjectAddedPrimaryBranchName, SetupStep } from './AddRepoSetupStep'
 import { getDefaultCloneParent } from './clone-defaults'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import type {
   AddRepoExistingWorkspaceSource,
@@ -47,6 +48,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
   const settings = useAppStore((s) => s.settings)
 
   const [step, setStep] = useState<'add' | 'clone' | 'remote' | 'create' | 'setup'>('add')
@@ -157,6 +159,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
       return a.displayName.localeCompare(b.displayName)
     })
   }, [worktrees])
+  const primaryWorktree = useMemo(
+    () => sortedWorktrees.find((worktree) => worktree.isMainWorktree) ?? null,
+    [sortedWorktrees]
+  )
+  const primaryBranchName = getProjectAddedPrimaryBranchName(primaryWorktree)
 
   const resetState = useCallback(() => {
     cloneGenRef.current++
@@ -362,6 +369,18 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     },
     [closeModal, openModal, repoId, trackSetupAction]
   )
+
+  const handleStartPrimaryWorktree = useCallback(() => {
+    if (!primaryWorktree) {
+      return
+    }
+    trackSetupAction('open_primary')
+    closeModal()
+    if (useAppStore.getState().hideDefaultBranchWorkspace) {
+      setHideDefaultBranchWorkspace(false)
+    }
+    activateAndRevealWorktree(primaryWorktree.id)
+  }, [closeModal, primaryWorktree, setHideDefaultBranchWorkspace, trackSetupAction])
 
   const handleConfigureRepo = useCallback(() => {
     trackSetupAction('configure')
@@ -677,6 +696,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
           <SetupStep
             repoName={addedRepo?.displayName ?? ''}
             hiddenWorktreeCount={hiddenWorktreeCount}
+            primaryBranchName={primaryBranchName}
+            onStartPrimaryWorktree={handleStartPrimaryWorktree}
             onUseExistingWorktrees={() => void handleUseExistingWorktrees()}
             onCreateWorktree={handleCreateWorktree}
             onConfigureRepo={handleConfigureRepo}

--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   getInitialProjectAddedChoice,
-  getInitialProjectAddedWorktreeName
+  getInitialProjectAddedWorktreeName,
+  getProjectAddedChoiceOrder,
+  getProjectAddedPrimaryBranchName
 } from './AddRepoSetupStep'
 
 describe('getInitialProjectAddedWorktreeName', () => {
@@ -23,5 +25,34 @@ describe('getInitialProjectAddedChoice', () => {
 
   it('defaults to creating a worktree when no linked worktrees were found', () => {
     expect(getInitialProjectAddedChoice(0)).toBe('create')
+  })
+
+  it('defaults to creating a worktree when the repo has a named primary branch', () => {
+    expect(getInitialProjectAddedChoice(0, 'main')).toBe('create')
+    expect(getInitialProjectAddedChoice(2, 'main')).toBe('create')
+  })
+})
+
+describe('getProjectAddedChoiceOrder', () => {
+  it('shows the primary checkout before worktree choices', () => {
+    expect(getProjectAddedChoiceOrder(2, 'main')).toEqual(['primary', 'existing', 'create'])
+  })
+
+  it('omits unavailable choices', () => {
+    expect(getProjectAddedChoiceOrder(0, '')).toEqual(['create'])
+    expect(getProjectAddedChoiceOrder(1, '')).toEqual(['existing', 'create'])
+    expect(getProjectAddedChoiceOrder(0, 'main')).toEqual(['primary', 'create'])
+  })
+})
+
+describe('getProjectAddedPrimaryBranchName', () => {
+  it('formats refs/heads branch names for the setup choice', () => {
+    expect(getProjectAddedPrimaryBranchName({ branch: 'refs/heads/main' })).toBe('main')
+    expect(getProjectAddedPrimaryBranchName({ branch: 'trunk' })).toBe('trunk')
+  })
+
+  it('returns an empty name for detached or missing primary worktrees', () => {
+    expect(getProjectAddedPrimaryBranchName({ branch: '' })).toBe('')
+    expect(getProjectAddedPrimaryBranchName(null)).toBe('')
   })
 })

--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
@@ -3,13 +3,16 @@ import { GitBranch, GitBranchPlus, Settings } from 'lucide-react'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import type { Worktree } from '../../../../shared/types'
 
-type ProjectAddedChoice = 'create' | 'existing'
+type ProjectAddedChoice = 'primary' | 'create' | 'existing'
 
 type ProjectAddedContentProps = {
   repoName: string
   hiddenWorktreeCount: number
+  primaryBranchName?: string
   defaultWorktreeName?: string
+  onStartPrimaryWorktree: () => void
   onUseExistingWorktrees: () => void
   onCreateWorktree: (name?: string) => void
   onConfigureRepo: () => void
@@ -25,7 +28,31 @@ export function getInitialProjectAddedWorktreeName(
   return defaultWorktreeName?.trim() ? defaultWorktreeName : DEFAULT_PROJECT_ADDED_WORKTREE_NAME
 }
 
-export function getInitialProjectAddedChoice(_hiddenWorktreeCount: number): ProjectAddedChoice {
+export function getProjectAddedPrimaryBranchName(
+  primaryWorktree: Pick<Worktree, 'branch'> | null | undefined
+): string {
+  return primaryWorktree?.branch.replace(/^refs\/heads\//, '').trim() ?? ''
+}
+
+export function getProjectAddedChoiceOrder(
+  hiddenWorktreeCount: number,
+  primaryBranchName?: string
+): ProjectAddedChoice[] {
+  const choices: ProjectAddedChoice[] = []
+  if (primaryBranchName?.trim()) {
+    choices.push('primary')
+  }
+  if (hiddenWorktreeCount > 0) {
+    choices.push('existing')
+  }
+  choices.push('create')
+  return choices
+}
+
+export function getInitialProjectAddedChoice(
+  _hiddenWorktreeCount: number,
+  _primaryBranchName?: string
+): ProjectAddedChoice {
   return 'create'
 }
 
@@ -61,7 +88,7 @@ function StartChoiceCard({
       data-choice={value}
       onClick={onSelect}
       onKeyDown={(event) => {
-        // Why: this is a true two-option decision, so arrow keys follow the
+        // Why: this is a true single-choice decision, so arrow keys follow the
         // WAI-ARIA radio pattern instead of acting like ordinary buttons.
         if (
           event.key === 'ArrowLeft' ||
@@ -102,7 +129,9 @@ function StartChoiceCard({
 export function ProjectAddedContent({
   repoName,
   hiddenWorktreeCount,
+  primaryBranchName = '',
   defaultWorktreeName = '',
+  onStartPrimaryWorktree,
   onUseExistingWorktrees,
   onCreateWorktree,
   onConfigureRepo
@@ -111,25 +140,31 @@ export function ProjectAddedContent({
     getInitialProjectAddedWorktreeName(defaultWorktreeName)
   )
   const [choice, setChoice] = useState<ProjectAddedChoice>(() =>
-    getInitialProjectAddedChoice(hiddenWorktreeCount)
+    getInitialProjectAddedChoice(hiddenWorktreeCount, primaryBranchName)
   )
   const radioGroupRef = useRef<HTMLDivElement>(null)
   const trimmedName = worktreeName.trim()
   const hasHiddenWorktrees = hiddenWorktreeCount > 0
-  const selectedChoice = hasHiddenWorktrees ? choice : 'create'
+  const normalizedPrimaryBranchName = primaryBranchName.trim()
+  const choices = getProjectAddedChoiceOrder(hiddenWorktreeCount, normalizedPrimaryBranchName)
+  const selectedChoice = choices.includes(choice) ? choice : (choices[0] ?? 'create')
 
   const cycleChoice = useCallback(() => {
-    const nextChoice: ProjectAddedChoice = selectedChoice === 'create' ? 'existing' : 'create'
+    const index = choices.indexOf(selectedChoice)
+    const nextChoice = choices[(index + 1) % choices.length] ?? 'create'
     setChoice(nextChoice)
     requestAnimationFrame(() => {
       radioGroupRef.current
         ?.querySelector<HTMLButtonElement>(`[data-choice="${nextChoice}"]`)
         ?.focus()
     })
-  }, [selectedChoice])
+  }, [choices, selectedChoice])
 
   const handlePrimaryAction = (): void => {
-    if (selectedChoice === 'existing') {
+    if (selectedChoice === 'primary') {
+      onStartPrimaryWorktree()
+      return
+    } else if (selectedChoice === 'existing') {
       onUseExistingWorktrees()
       return
     }
@@ -148,22 +183,35 @@ export function ProjectAddedContent({
       </DialogHeader>
 
       <div className="space-y-3 pt-1">
-        {hasHiddenWorktrees ? (
+        {choices.length > 1 ? (
           <div
             ref={radioGroupRef}
             role="radiogroup"
             aria-label="How to start working"
             className="space-y-2"
           >
-            <StartChoiceCard
-              value="existing"
-              selected={selectedChoice === 'existing'}
-              onSelect={() => setChoice('existing')}
-              onArrowNav={cycleChoice}
-              icon={<GitBranch className="size-4" />}
-              title="Use existing worktrees"
-              caption={`${formatWorktreeCount(hiddenWorktreeCount)} found in this repo.`}
-            />
+            {normalizedPrimaryBranchName ? (
+              <StartChoiceCard
+                value="primary"
+                selected={selectedChoice === 'primary'}
+                onSelect={() => setChoice('primary')}
+                onArrowNav={cycleChoice}
+                icon={<GitBranch className="size-4" />}
+                title={`Start from ${normalizedPrimaryBranchName}`}
+                caption="Use the primary checkout without creating a worktree."
+              />
+            ) : null}
+            {hasHiddenWorktrees ? (
+              <StartChoiceCard
+                value="existing"
+                selected={selectedChoice === 'existing'}
+                onSelect={() => setChoice('existing')}
+                onArrowNav={cycleChoice}
+                icon={<GitBranch className="size-4" />}
+                title="Use existing worktrees"
+                caption={`${formatWorktreeCount(hiddenWorktreeCount)} found in this repo.`}
+              />
+            ) : null}
             <StartChoiceCard
               value="create"
               selected={selectedChoice === 'create'}
@@ -205,7 +253,12 @@ export function ProjectAddedContent({
           Configure repo
         </button>
         <Button type="button" size="sm" onClick={handlePrimaryAction}>
-          {selectedChoice === 'existing' ? (
+          {selectedChoice === 'primary' ? (
+            <>
+              <GitBranch className="size-4" />
+              Start
+            </>
+          ) : selectedChoice === 'existing' ? (
             <>
               <GitBranch className="size-4" />
               Use existing

--- a/src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Repo } from '../../../../shared/types'
+import type { Repo, Worktree } from '../../../../shared/types'
 
 const mocks = vi.hoisted(() => ({
   state: {
@@ -14,7 +14,9 @@ const mocks = vi.hoisted(() => ({
     repos: [] as Repo[],
     updateRepo: vi.fn(),
     fetchWorktrees: vi.fn(),
-    detectedWorktreesByRepo: {}
+    detectedWorktreesByRepo: {},
+    worktreesByRepo: {} as Record<string, Worktree[]>,
+    setHideDefaultBranchWorkspace: vi.fn()
   }
 }))
 
@@ -32,6 +34,10 @@ vi.mock('@/store', () => ({
   useAppStore: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state)
 }))
 
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
 vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ open, children }: { open: boolean; children: ReactModule.ReactNode }) =>
     open ? <div>{children}</div> : null,
@@ -39,7 +45,19 @@ vi.mock('@/components/ui/dialog', () => ({
 }))
 
 vi.mock('./AddRepoSetupStep', () => ({
-  ProjectAddedContent: ({ repoName }: { repoName: string }) => <div>setup:{repoName}</div>
+  ProjectAddedContent: ({
+    repoName,
+    primaryBranchName
+  }: {
+    repoName: string
+    primaryBranchName?: string
+  }) => (
+    <div>
+      setup:{repoName}:{primaryBranchName ?? ''}
+    </div>
+  ),
+  getProjectAddedPrimaryBranchName: (worktree: Pick<Worktree, 'branch'> | null | undefined) =>
+    worktree?.branch.replace(/^refs\/heads\//, '').trim() ?? ''
 }))
 
 function makeRepo(overrides: Partial<Repo> = {}): Repo {
@@ -60,6 +78,7 @@ describe('ProjectAddedDialog', () => {
     mocks.state.modalData = { repoId: 'repo-1' }
     mocks.state.repos = [makeRepo()]
     mocks.state.detectedWorktreesByRepo = {}
+    mocks.state.worktreesByRepo = {}
   })
 
   it('renders the Git setup step for Git repos', async () => {
@@ -69,6 +88,37 @@ describe('ProjectAddedDialog', () => {
 
     expect(markup).toContain('setup:orca')
     expect(mocks.state.closeModal).not.toHaveBeenCalled()
+  })
+
+  it('passes the primary branch name to the setup step', async () => {
+    mocks.state.worktreesByRepo = {
+      'repo-1': [
+        {
+          id: 'repo-1::/repo',
+          repoId: 'repo-1',
+          path: '/repo',
+          displayName: 'main',
+          comment: '',
+          linkedIssue: null,
+          linkedPR: null,
+          linkedLinearIssue: null,
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 0,
+          lastActivityAt: 0,
+          head: 'abc',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ]
+    }
+    const { default: ProjectAddedDialog } = await import('./ProjectAddedDialog')
+
+    const markup = renderToStaticMarkup(<ProjectAddedDialog />)
+
+    expect(markup).toContain('setup:orca:main')
   })
 
   it('closes without rendering Git setup for folder repos', async () => {

--- a/src/renderer/src/components/sidebar/ProjectAddedDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectAddedDialog.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useEffect } from 'react'
 import { useAppStore } from '@/store'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
-import { ProjectAddedContent } from './AddRepoSetupStep'
+import { getProjectAddedPrimaryBranchName, ProjectAddedContent } from './AddRepoSetupStep'
 import type { WorkspaceCreateTelemetrySource } from '../../../../shared/types'
 import { isFolderRepo } from '../../../../shared/repo-kind'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import {
   effectiveExternalWorktreeVisibility,
   isLegacyRepoForExternalWorktreeVisibility
@@ -26,6 +27,8 @@ export default function ProjectAddedDialog(): React.JSX.Element | null {
   const updateRepo = useAppStore((s) => s.updateRepo)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const detectedWorktreesByRepo = useAppStore((s) => s.detectedWorktreesByRepo)
+  const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
 
   const repoId = typeof modalData?.repoId === 'string' ? modalData.repoId : ''
   const repo = repos.find((candidate) => candidate.id === repoId) ?? null
@@ -41,6 +44,10 @@ export default function ProjectAddedDialog(): React.JSX.Element | null {
     ? effectiveExternalWorktreeVisibility(repo, isLegacyRepoForExternalWorktreeVisibility(repo)) ===
       'show'
     : false
+  const primaryWorktree = (worktreesByRepo[repoId] ?? []).find(
+    (worktree) => worktree.isMainWorktree
+  )
+  const primaryBranchName = getProjectAddedPrimaryBranchName(primaryWorktree)
 
   useEffect(() => {
     if (activeModal === 'project-added' && isFolder) {
@@ -76,6 +83,17 @@ export default function ProjectAddedDialog(): React.JSX.Element | null {
     [closeModal, modalData?.telemetrySource, openModal, repoId]
   )
 
+  const handleStartPrimaryWorktree = useCallback(() => {
+    if (!primaryWorktree) {
+      return
+    }
+    closeModal()
+    if (useAppStore.getState().hideDefaultBranchWorkspace) {
+      setHideDefaultBranchWorkspace(false)
+    }
+    activateAndRevealWorktree(primaryWorktree.id)
+  }, [closeModal, primaryWorktree, setHideDefaultBranchWorkspace])
+
   const handleConfigureRepo = useCallback(() => {
     if (!repoId) {
       return
@@ -95,7 +113,9 @@ export default function ProjectAddedDialog(): React.JSX.Element | null {
         <ProjectAddedContent
           repoName={repo.displayName}
           hiddenWorktreeCount={hiddenWorktreeCount}
+          primaryBranchName={primaryBranchName}
           defaultWorktreeName={modalData?.defaultWorktreeName}
+          onStartPrimaryWorktree={handleStartPrimaryWorktree}
           onUseExistingWorktrees={() => void handleUseExistingWorktrees()}
           onCreateWorktree={handleCreateWorktree}
           onConfigureRepo={handleConfigureRepo}

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -92,11 +92,12 @@ export type ErrorClass = z.infer<typeof errorClassSchema>
 export const repoMethodSchema = z.enum(['folder_picker', 'clone_url', 'drag_drop'])
 export type RepoMethod = z.infer<typeof repoMethodSchema>
 
-// Five Setup-step affordances the user can pick after `repo_added` fires (see
+// Setup-step affordances the user can pick after `repo_added` fires (see
 // AddRepoSetupStep). One enum because every value lives on the same screen and
-// the funnel question is "which one did they pick" — adding a sixth value
-// later is additive-safe per the schema-evolution doctrine below.
+// the funnel question is "which one did they pick" — adding values later is
+// additive-safe per the schema-evolution doctrine below.
 export const addRepoSetupStepActionSchema = z.enum([
+  'open_primary',
   'create_worktree',
   'configure',
   'skip',


### PR DESCRIPTION
## Summary
- add a setup option to start from the repo primary checkout
- reveal the default branch workspace when that option is selected
- track the new setup action and cover setup ordering/branch-name behavior in tests

## Verification
- pnpm typecheck
- pnpm test -- --run src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx