### PR TITLE
Add file-opening commands to Orca CLI

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -65,7 +65,9 @@ export function supportsBrowserPageFlag(commandPath: string[]): boolean {
     return false
   }
   if (
-    ['automations', 'repo', 'worktree', 'terminal', 'computer', 'note'].includes(commandPath[0])
+    ['automations', 'repo', 'worktree', 'terminal', 'file', 'computer', 'note'].includes(
+      commandPath[0]
+    )
   ) {
     return false
   }
@@ -87,6 +89,7 @@ export function isCommandGroup(commandPath: string[]): boolean {
         'repo',
         'worktree',
         'terminal',
+        'file',
         'tab',
         'cookie',
         'intercept',

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -4,6 +4,7 @@ import { CORE_HANDLERS } from './handlers/core'
 import { AUTOMATION_HANDLERS } from './handlers/automations'
 import { REPO_HANDLERS } from './handlers/repo'
 import { WORKTREE_HANDLERS } from './handlers/worktree'
+import { FILE_HANDLERS } from './handlers/file'
 import { TERMINAL_HANDLERS } from './handlers/terminal'
 import { BROWSER_NAV_HANDLERS } from './handlers/browser-nav'
 import { BROWSER_INTERACT_HANDLERS } from './handlers/browser-interact'
@@ -33,6 +34,7 @@ function buildHandlers(): Map<string, CommandHandler> {
     AUTOMATION_HANDLERS,
     REPO_HANDLERS,
     WORKTREE_HANDLERS,
+    FILE_HANDLERS,
     TERMINAL_HANDLERS,
     BROWSER_NAV_HANDLERS,
     BROWSER_INTERACT_HANDLERS,

--- a/src/cli/handlers/file.test.ts
+++ b/src/cli/handlers/file.test.ts
@@ -1,0 +1,265 @@
+/* eslint-disable max-lines -- Why: file CLI coverage shares one mocked runtime setup across command contracts. */
+import path from 'path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('../runtime-client', () => {
+  class RuntimeClient {
+    readonly isRemote: boolean
+    call = callMock
+    getCliStatus = vi.fn()
+    openOrca = vi.fn()
+
+    constructor(
+      _userDataPath?: string,
+      _requestTimeoutMs?: number,
+      remotePairingCode?: string | null,
+      environmentSelector?: string | null
+    ) {
+      this.isRemote = Boolean(remotePairingCode || environmentSelector)
+    }
+  }
+
+  class RuntimeClientError extends Error {
+    readonly code: string
+
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  class RuntimeRpcFailureError extends RuntimeClientError {
+    readonly response: unknown
+
+    constructor(response: unknown) {
+      super('runtime_error', 'runtime_error')
+      this.response = response
+    }
+  }
+
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError
+  }
+})
+
+import { main } from '../index'
+import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from '../test-fixtures'
+
+describe('orca file CLI handlers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    callMock.mockReset()
+    process.exitCode = undefined
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('prints group help with file commands', async () => {
+    await main(['file', '--help'], '/tmp/repo')
+
+    const output = vi.mocked(console.log).mock.calls[0][0]
+    expect(output).toContain('open')
+    expect(output).toContain('diff')
+    expect(output).toContain('open-changed')
+  })
+
+  it('opens a positional path in the inferred current worktree', async () => {
+    queueFixtures(
+      callMock,
+      worktreeListFixture([buildWorktree('/tmp/repo', 'feature')]),
+      okFixture('req_open', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(['file', 'open', 'src/App.tsx'], '/tmp/repo/src')
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'worktree.list', { limit: 10_000 })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+      worktree: `path:${path.resolve('/tmp/repo')}`,
+      relativePath: 'src/App.tsx'
+    })
+    expect(vi.mocked(console.log).mock.calls[0][0]).toBe('Opened src/App.tsx.')
+  })
+
+  it('opens a staged diff for an explicit worktree without cwd inference', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_diff', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(
+      ['file', 'diff', '--path', 'src/App.tsx', '--staged', '--worktree', 'id:wt-1'],
+      '/tmp/elsewhere'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('files.openDiff', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx',
+      staged: true
+    })
+  })
+
+  it('opens git-changed files as diffs by default', async () => {
+    queueFixtures(
+      callMock,
+      worktreeListFixture([buildWorktree('/tmp/repo', 'feature')]),
+      okFixture('req_status', {
+        entries: [
+          { path: 'src/App.tsx', status: 'modified', area: 'unstaged' },
+          { path: 'package.json', status: 'modified', area: 'staged' },
+          { path: 'docs/new.md', status: 'untracked', area: 'untracked' }
+        ],
+        conflictOperation: 'unknown'
+      }),
+      okFixture('req_diff_1', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      }),
+      okFixture('req_diff_2', {
+        worktree: 'wt-1',
+        relativePath: 'package.json',
+        kind: 'text',
+        opened: true
+      }),
+      okFixture('req_diff_3', {
+        worktree: 'wt-1',
+        relativePath: 'docs/new.md',
+        kind: 'markdown',
+        opened: true
+      })
+    )
+
+    await main(['file', 'open-changed'], '/tmp/repo/src')
+
+    expect(callMock).toHaveBeenNthCalledWith(2, 'git.status', {
+      worktree: `path:${path.resolve('/tmp/repo')}`
+    })
+    expect(callMock).toHaveBeenNthCalledWith(3, 'files.openDiff', {
+      worktree: `path:${path.resolve('/tmp/repo')}`,
+      relativePath: 'src/App.tsx',
+      staged: false
+    })
+    expect(callMock).toHaveBeenNthCalledWith(4, 'files.openDiff', {
+      worktree: `path:${path.resolve('/tmp/repo')}`,
+      relativePath: 'package.json',
+      staged: true
+    })
+    expect(callMock).toHaveBeenNthCalledWith(5, 'files.openDiff', {
+      worktree: `path:${path.resolve('/tmp/repo')}`,
+      relativePath: 'docs/new.md',
+      staged: false
+    })
+    expect(vi.mocked(console.log).mock.calls[0][0]).toBe('Opened 3 changed file targets.')
+  })
+
+  it('opens changed files in both edit and diff modes while skipping deleted edit targets', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_status', {
+        entries: [
+          { path: 'src/App.tsx', status: 'modified', area: 'unstaged' },
+          { path: 'src/App.tsx', status: 'modified', area: 'staged' },
+          { path: 'docs/old.md', status: 'deleted', area: 'unstaged' }
+        ],
+        conflictOperation: 'unknown'
+      }),
+      okFixture('req_open', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      }),
+      okFixture('req_diff_1', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      }),
+      okFixture('req_diff_2', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      }),
+      okFixture('req_diff_3', {
+        worktree: 'wt-1',
+        relativePath: 'docs/old.md',
+        kind: 'markdown',
+        opened: true
+      })
+    )
+
+    await main(
+      ['file', 'open-changed', '--mode', 'both', '--worktree', 'id:wt-1'],
+      '/tmp/elsewhere'
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'git.status', { worktree: 'id:wt-1' })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.open', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(3, 'files.openDiff', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx',
+      staged: false
+    })
+    expect(callMock).toHaveBeenNthCalledWith(4, 'files.openDiff', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx',
+      staged: true
+    })
+    expect(callMock).toHaveBeenNthCalledWith(5, 'files.openDiff', {
+      worktree: 'id:wt-1',
+      relativePath: 'docs/old.md',
+      staged: false
+    })
+    const output = vi.mocked(console.log).mock.calls[0][0]
+    expect(output).toContain('Opened 4 changed file targets.')
+    expect(output).toContain('docs/old.md: deleted file has no edit target')
+  })
+
+  it('requires an explicit worktree for remote file commands', async () => {
+    const priorExitCode = process.exitCode
+
+    await main(['file', 'open-changed', '--pairing-code', 'remote-runtime'], '/tmp/repo/src')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(vi.mocked(console.error).mock.calls[0][0]).toContain(
+      'Remote file commands require --worktree'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('validates mode before resolving a worktree', async () => {
+    const priorExitCode = process.exitCode
+
+    await main(['file', 'open-changed', '--mode', 'invalid'], '/tmp/repo/src')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(vi.mocked(console.error).mock.calls[0][0]).toContain(
+      'Invalid --mode. Use edit, diff, or both.'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+})

--- a/src/cli/handlers/file.test.ts
+++ b/src/cli/handlers/file.test.ts
@@ -113,6 +113,18 @@ describe('orca file CLI handlers', () => {
     })
   })
 
+  it('rejects --worktree without a value before cwd inference or RPC calls', async () => {
+    const priorExitCode = process.exitCode
+
+    await main(['file', 'open', 'src/App.tsx', '--worktree'], '/tmp/repo/src')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(vi.mocked(console.error).mock.calls[0][0]).toContain('Missing value for --worktree.')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('opens git-changed files as diffs by default', async () => {
     queueFixtures(
       callMock,
@@ -166,6 +178,45 @@ describe('orca file CLI handlers', () => {
       staged: false
     })
     expect(vi.mocked(console.log).mock.calls[0][0]).toBe('Opened 3 changed file targets.')
+  })
+
+  it('skips unresolved conflict entries in diff mode without opening a normal diff', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_status', {
+        entries: [
+          {
+            path: 'src/conflicted.ts',
+            status: 'modified',
+            area: 'unstaged',
+            conflictStatus: 'unresolved'
+          },
+          { path: 'src/App.tsx', status: 'modified', area: 'staged' }
+        ],
+        conflictOperation: 'merge'
+      }),
+      okFixture('req_diff', {
+        worktree: 'wt-1',
+        relativePath: 'src/App.tsx',
+        kind: 'text',
+        opened: true
+      })
+    )
+
+    await main(['file', 'open-changed', '--worktree', 'id:wt-1'], '/tmp/elsewhere')
+
+    expect(callMock).toHaveBeenCalledTimes(2)
+    expect(callMock).toHaveBeenNthCalledWith(1, 'git.status', { worktree: 'id:wt-1' })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'files.openDiff', {
+      worktree: 'id:wt-1',
+      relativePath: 'src/App.tsx',
+      staged: true
+    })
+    const output = vi.mocked(console.log).mock.calls[0][0]
+    expect(output).toContain('Opened 1 changed file targets.')
+    expect(output).toContain(
+      'src/conflicted.ts: unresolved conflict may not have a single diff target'
+    )
   })
 
   it('opens changed files in both edit and diff modes while skipping deleted edit targets', async () => {
@@ -243,6 +294,20 @@ describe('orca file CLI handlers', () => {
     expect(callMock).not.toHaveBeenCalled()
     expect(vi.mocked(console.error).mock.calls[0][0]).toContain(
       'Remote file commands require --worktree'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
+  it('rejects --mode without a value before cwd inference or RPC calls', async () => {
+    const priorExitCode = process.exitCode
+
+    await main(['file', 'open-changed', '--mode'], '/tmp/repo/src')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(vi.mocked(console.error).mock.calls[0][0]).toContain(
+      'Missing value for --mode. Use edit, diff, or both.'
     )
     expect(process.exitCode).toBe(1)
 

--- a/src/cli/handlers/file.ts
+++ b/src/cli/handlers/file.ts
@@ -28,6 +28,10 @@ type FileOpenChangedResult = {
 }
 
 async function getFileWorktreeSelector({ flags, cwd, client }: HandlerContext): Promise<string> {
+  const worktree = flags.get('worktree')
+  if (flags.has('worktree') && (typeof worktree !== 'string' || worktree.length === 0)) {
+    throw new RuntimeClientError('invalid_argument', 'Missing value for --worktree.')
+  }
   const explicit = await getOptionalWorktreeSelector(flags, 'worktree', cwd, client)
   if (explicit) {
     return explicit
@@ -42,6 +46,13 @@ async function getFileWorktreeSelector({ flags, cwd, client }: HandlerContext): 
 }
 
 function getOpenChangedMode(flags: Map<string, string | boolean>): OpenChangedMode {
+  const value = flags.get('mode')
+  if (flags.has('mode') && (typeof value !== 'string' || value.length === 0)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Missing value for --mode. Use edit, diff, or both.'
+    )
+  }
   const mode = getOptionalStringFlag(flags, 'mode') ?? 'diff'
   if (mode === 'edit' || mode === 'diff' || mode === 'both') {
     return mode
@@ -170,7 +181,19 @@ export const FILE_HANDLERS: Record<string, CommandHandler> = {
       }
 
       if (mode === 'diff' || mode === 'both') {
-        opened.push(await openFileDiff(ctx, worktree, entry.path, entry.area === 'staged'))
+        const staged = entry.area === 'staged'
+        if (entry.conflictStatus === 'unresolved') {
+          skipped.push({
+            path: entry.path,
+            mode: 'diff',
+            staged,
+            opened: false,
+            skipped: true,
+            reason: 'unresolved conflict may not have a single diff target'
+          })
+        } else {
+          opened.push(await openFileDiff(ctx, worktree, entry.path, staged))
+        }
       }
     }
 

--- a/src/cli/handlers/file.ts
+++ b/src/cli/handlers/file.ts
@@ -1,0 +1,192 @@
+import type { GitStatusEntry, GitStatusResult } from '../../shared/git-status-types'
+import type { RuntimeFileOpenResult } from '../../shared/runtime-types'
+import type { CommandHandler, HandlerContext } from '../dispatch'
+import { getOptionalStringFlag, getRequiredStringFlag } from '../flags'
+import { printResult } from '../format'
+import { RuntimeClientError } from '../runtime-client'
+import { getOptionalWorktreeSelector, resolveCurrentWorktreeSelector } from '../selectors'
+
+type FileOpenMode = 'edit' | 'diff'
+type OpenChangedMode = FileOpenMode | 'both'
+
+type FileOpenRecord = {
+  path: string
+  mode: FileOpenMode
+  staged?: boolean
+  opened: boolean
+  kind?: RuntimeFileOpenResult['kind']
+  skipped?: boolean
+  reason?: string
+}
+
+type FileOpenChangedResult = {
+  worktree: string
+  mode: OpenChangedMode
+  opened: FileOpenRecord[]
+  skipped: FileOpenRecord[]
+  totalChanged: number
+}
+
+async function getFileWorktreeSelector({ flags, cwd, client }: HandlerContext): Promise<string> {
+  const explicit = await getOptionalWorktreeSelector(flags, 'worktree', cwd, client)
+  if (explicit) {
+    return explicit
+  }
+  if (client.isRemote) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Remote file commands require --worktree because the client cwd cannot identify a server worktree.'
+    )
+  }
+  return await resolveCurrentWorktreeSelector(cwd, client)
+}
+
+function getOpenChangedMode(flags: Map<string, string | boolean>): OpenChangedMode {
+  const mode = getOptionalStringFlag(flags, 'mode') ?? 'diff'
+  if (mode === 'edit' || mode === 'diff' || mode === 'both') {
+    return mode
+  }
+  throw new RuntimeClientError('invalid_argument', 'Invalid --mode. Use edit, diff, or both.')
+}
+
+function canOpenEntryForEdit(entry: GitStatusEntry): string | null {
+  if (entry.status === 'deleted') {
+    return 'deleted file has no edit target'
+  }
+  if (entry.conflictStatus === 'unresolved') {
+    return 'unresolved conflict may not have a single editable file'
+  }
+  return null
+}
+
+async function openFileEdit(
+  ctx: HandlerContext,
+  worktree: string,
+  path: string
+): Promise<FileOpenRecord> {
+  const result = await ctx.client.call<RuntimeFileOpenResult>('files.open', {
+    worktree,
+    relativePath: path
+  })
+  return {
+    path,
+    mode: 'edit',
+    opened: result.result.opened,
+    kind: result.result.kind,
+    ...(result.result.opened ? {} : { skipped: true, reason: `${result.result.kind} file` })
+  }
+}
+
+async function openFileDiff(
+  ctx: HandlerContext,
+  worktree: string,
+  path: string,
+  staged: boolean
+): Promise<FileOpenRecord> {
+  const result = await ctx.client.call<RuntimeFileOpenResult>('files.openDiff', {
+    worktree,
+    relativePath: path,
+    staged
+  })
+  return {
+    path,
+    mode: 'diff',
+    staged,
+    opened: result.result.opened,
+    kind: result.result.kind
+  }
+}
+
+function formatOpenChangedResult(result: FileOpenChangedResult): string {
+  if (result.totalChanged === 0) {
+    return 'No changed files.'
+  }
+  const lines = [`Opened ${result.opened.length} changed file targets.`]
+  if (result.skipped.length > 0) {
+    lines.push(`Skipped ${result.skipped.length} changed file targets:`)
+    for (const skipped of result.skipped) {
+      lines.push(`- ${skipped.path}: ${skipped.reason ?? 'not opened'}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function formatFileOpen(result: RuntimeFileOpenResult): string {
+  return result.opened
+    ? `Opened ${result.relativePath}.`
+    : `Did not open ${result.relativePath}: ${result.kind} file.`
+}
+
+function formatFileDiff(result: RuntimeFileOpenResult): string {
+  return `Opened diff for ${result.relativePath}.`
+}
+
+export const FILE_HANDLERS: Record<string, CommandHandler> = {
+  'file open': async (ctx) => {
+    const relativePath = getRequiredStringFlag(ctx.flags, 'path')
+    const worktree = await getFileWorktreeSelector(ctx)
+    const result = await ctx.client.call<RuntimeFileOpenResult>('files.open', {
+      worktree,
+      relativePath
+    })
+    printResult(result, ctx.json, formatFileOpen)
+  },
+  'file diff': async (ctx) => {
+    const relativePath = getRequiredStringFlag(ctx.flags, 'path')
+    const staged = ctx.flags.get('staged') === true
+    const worktree = await getFileWorktreeSelector(ctx)
+    const result = await ctx.client.call<RuntimeFileOpenResult>('files.openDiff', {
+      worktree,
+      relativePath,
+      staged
+    })
+    printResult(result, ctx.json, formatFileDiff)
+  },
+  'file open-changed': async (ctx) => {
+    const mode = getOpenChangedMode(ctx.flags)
+    const worktree = await getFileWorktreeSelector(ctx)
+    const status = await ctx.client.call<GitStatusResult>('git.status', { worktree })
+    const opened: FileOpenRecord[] = []
+    const skipped: FileOpenRecord[] = []
+    const openedEditPaths = new Set<string>()
+
+    for (const entry of status.result.entries) {
+      if (mode === 'edit' || mode === 'both') {
+        const editSkipReason = canOpenEntryForEdit(entry)
+        if (editSkipReason) {
+          skipped.push({
+            path: entry.path,
+            mode: 'edit',
+            opened: false,
+            skipped: true,
+            reason: editSkipReason
+          })
+        } else if (!openedEditPaths.has(entry.path)) {
+          openedEditPaths.add(entry.path)
+          const record = await openFileEdit(ctx, worktree, entry.path)
+          const records = record.opened ? opened : skipped
+          records.push(record)
+        }
+      }
+
+      if (mode === 'diff' || mode === 'both') {
+        opened.push(await openFileDiff(ctx, worktree, entry.path, entry.area === 'staged'))
+      }
+    }
+
+    printResult(
+      {
+        ...status,
+        result: {
+          worktree,
+          mode,
+          opened,
+          skipped,
+          totalChanged: status.result.entries.length
+        }
+      },
+      ctx.json,
+      formatOpenChangedResult
+    )
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -42,6 +42,11 @@ Worktrees:
   worktree rm               Remove a worktree from Orca and git
   worktree ps               Show a compact orchestration summary across worktrees
 
+Files:
+  file open                 Open a workspace file in the Orca editor
+  file diff                 Open a workspace file diff in the Orca editor
+  file open-changed         Open all git-changed files for a workspace
+
 Terminals:
   terminal list             List live Orca-managed terminals
   terminal show             Show terminal metadata and preview
@@ -167,6 +172,9 @@ Common Commands:
   orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--comment <text>] [--parent-worktree <selector>|--no-parent] [--json]
   orca worktree rm --worktree <selector> [--force] [--run-hooks] [--json]
   orca worktree ps [--limit <n>] [--json]
+  orca file open <path> [--worktree <selector>] [--json]
+  orca file diff <path> [--staged] [--worktree <selector>] [--json]
+  orca file open-changed [--mode edit|diff|both] [--worktree <selector>] [--json]
   orca terminal list [--worktree <selector>] [--limit <n>] [--json]
   orca terminal show [--terminal <handle>] [--json]
   orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--json]
@@ -252,6 +260,8 @@ Examples:
   $ orca worktree current
   $ orca worktree set --worktree active --comment "waiting on review"
   $ orca worktree ps --limit 10
+  $ orca file open-changed --mode diff
+  $ orca file open src/App.tsx
   $ orca terminal list --worktree path:/Users/me/orca/workspaces/orca/cli-test-1 --json
   $ orca terminal send --terminal term_123 --text "hi" --enter
   $ orca terminal wait --terminal term_123 --for exit --timeout-ms 60000 --json
@@ -353,6 +363,7 @@ export function formatFlagHelp(flag: string): string {
     json: '--json                 Emit machine-readable JSON',
     key: '--key <key>            Key or combo to press, e.g. Escape or CmdOrCtrl+L',
     limit: '--limit <n>            Maximum number of rows to return',
+    mode: '--mode <mode>          Mode such as edit, diff, or both',
     'mouse-button': '--mouse-button <btn>   Mouse button: left, right, or middle',
     name: '--name <name>          Name for the new worktree or automation',
     'no-parent': '--no-parent            Force no parent lineage for unrelated work',
@@ -360,7 +371,7 @@ export function formatFlagHelp(flag: string): string {
     pages: '--pages <n>           Number of scroll pages',
     'parent-worktree':
       '--parent-worktree <selector> Parent selector; create infers the caller/current worktree by default',
-    path: '--path <path>          Filesystem path to the repo',
+    path: '--path <path>          Path argument for the command',
     query: '--query <text>        Search text for matching refs',
     ref: '--ref <ref>            Base ref to persist for the repo',
     repo: '--repo <selector>      Repo selector such as id:<id>, name:<name>, or path:<path>',
@@ -378,6 +389,7 @@ export function formatFlagHelp(flag: string): string {
       '--worktree <selector>  Worktree selector such as id:<id>, branch:<branch>, issue:<number>, path:<path>, or active/current',
     workspace: '--workspace <selector> Existing worktree selector for automation runs',
     prompt: '--prompt <text>        Automation prompt to pass to the agent',
+    staged: '--staged               Open staged source-control changes',
     provider: '--provider <agent>     Agent id such as codex, claude, or gemini',
     trigger: '--trigger <schedule>   Automation schedule preset, cron, or RRULE',
     schedule: '--schedule <schedule>  Alias for --trigger',

--- a/src/cli/specs/file.ts
+++ b/src/cli/specs/file.ts
@@ -1,0 +1,48 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const FILE_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['file', 'open'],
+    summary: 'Open a workspace file in the Orca editor',
+    usage: 'orca file open <path> [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'path', 'worktree'],
+    positionalArgs: ['path'],
+    notes: [
+      'The path is relative to the selected worktree. When --worktree is omitted, local CLI calls infer the current Orca worktree from cwd.'
+    ],
+    examples: [
+      'orca file open src/App.tsx',
+      'orca file open --path docs/readme.md --worktree active'
+    ]
+  },
+  {
+    path: ['file', 'diff'],
+    summary: 'Open a workspace file diff in the Orca editor',
+    usage: 'orca file diff <path> [--staged] [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'path', 'staged', 'worktree'],
+    positionalArgs: ['path'],
+    notes: [
+      'Diffs default to unstaged changes. Pass --staged to open the staged source-control diff.'
+    ],
+    examples: [
+      'orca file diff src/App.tsx',
+      'orca file diff --path package.json --staged --worktree branch:feature'
+    ]
+  },
+  {
+    path: ['file', 'open-changed'],
+    summary: 'Open all git-changed files for a workspace',
+    usage: 'orca file open-changed [--mode edit|diff|both] [--worktree <selector>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'mode', 'worktree'],
+    notes: [
+      'For v1, changed files come from git status for the selected worktree.',
+      'The default mode is diff. Edit mode skips deleted files because there is no file to open.'
+    ],
+    examples: [
+      'orca file open-changed',
+      'orca file open-changed --mode both',
+      'orca file open-changed --mode diff --worktree active'
+    ]
+  }
+]

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -3,12 +3,14 @@ import { BROWSER_ADVANCED_COMMAND_SPECS } from './browser-advanced'
 import { BROWSER_BASIC_COMMAND_SPECS } from './browser-basic'
 import { AUTOMATION_COMMAND_SPECS } from './automations'
 import { CORE_COMMAND_SPECS } from './core'
+import { FILE_COMMAND_SPECS } from './file'
 import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
 import { COMPUTER_COMMAND_SPECS } from './computer'
 import { ENVIRONMENT_COMMAND_SPECS } from './environment'
 
 export const COMMAND_SPECS: CommandSpec[] = [
   ...CORE_COMMAND_SPECS,
+  ...FILE_COMMAND_SPECS,
   ...AUTOMATION_COMMAND_SPECS,
   ...BROWSER_BASIC_COMMAND_SPECS,
   ...BROWSER_ADVANCED_COMMAND_SPECS,


### PR DESCRIPTION
## Summary
- Add `orca file open`, `orca file diff`, and `orca file open-changed` command specs and handlers.
- Wire the `file` command group into CLI help, validation, and dispatch.
- Add focused tests for cwd worktree inference, explicit worktree targeting, changed-file diff opening, malformed flags, and unresolved conflict skips.

## Auto Review-Fix
- Ran two review iterations across `/review-code` and `/review-algorithm-architecture`.
- Iteration 1 found 3 issues; all were validated and fixed.
- Iteration 2 follow-up reviews reported no in-scope issues.

## Validation
- `pnpm vitest run src/cli/handlers/file.test.ts src/cli/index.test.ts src/cli/args.test.ts`
- `pnpm run typecheck:cli`
- `pnpm exec oxfmt --check src/cli/args.ts src/cli/dispatch.ts src/cli/help.ts src/cli/specs/index.ts src/cli/specs/file.ts src/cli/handlers/file.ts src/cli/handlers/file.test.ts`
- `pnpm exec oxlint src/cli/args.ts src/cli/dispatch.ts src/cli/help.ts src/cli/specs/index.ts src/cli/specs/file.ts src/cli/handlers/file.ts src/cli/handlers/file.test.ts`
- `pnpm run build:cli`
- Live smoke: `node out/cli/index.js file open-changed --mode diff --json` opened changed-file diffs through the running Orca runtime.

Made with [Orca](https://github.com/stablyai/orca) 🐋
