### PR TITLE
Auto-detect repo icons when adding projects

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -39,6 +39,7 @@ import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import type { RepoMethod } from '../../shared/telemetry-events'
+import { detectRepoIcon } from '../repo-icon-autodetect'
 
 // Why: `method` answers "which entry point did the user take?", not "what did
 // they add?" — so the IPC the renderer invoked IS the method. We never send
@@ -111,11 +112,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         return { repo: existing }
       }
 
+      const repoIcon = await detectRepoIcon({ repoPath: args.path, kind: repoKind })
       const repo: Repo = {
         id: randomUUID(),
         path: args.path,
         displayName: getRepoName(args.path),
         badgeColor: DEFAULT_REPO_BADGE_COLOR,
+        ...(repoIcon ? { repoIcon } : {}),
         addedAt: Date.now(),
         kind: repoKind,
         ...(repoKind === 'git'
@@ -216,11 +219,17 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         }
       }
 
+      const repoIcon = await detectRepoIcon({
+        repoPath: resolvedPath,
+        kind: repoKind,
+        connectionId: args.connectionId
+      })
       const repo: Repo = {
         id: randomUUID(),
         path: resolvedPath,
         displayName,
         badgeColor: DEFAULT_REPO_BADGE_COLOR,
+        ...(repoIcon ? { repoIcon } : {}),
         addedAt: Date.now(),
         kind: repoKind,
         connectionId: args.connectionId,
@@ -421,11 +430,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         return { repo: raceWinner }
       }
 
+      const repoIcon = await detectRepoIcon({ repoPath: targetPath, kind: repoKind })
       const repo: Repo = {
         id: randomUUID(),
         path: targetPath,
         displayName: name,
         badgeColor: DEFAULT_REPO_BADGE_COLOR,
+        ...(repoIcon ? { repoIcon } : {}),
         addedAt: Date.now(),
         kind: repoKind,
         ...(repoKind === 'git'
@@ -735,11 +746,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         return existing
       }
 
+      const repoIcon = await detectRepoIcon({ repoPath: clonePath, kind: 'git' })
       const repo: Repo = {
         id: randomUUID(),
         path: clonePath,
         displayName: getRepoName(clonePath),
         badgeColor: DEFAULT_REPO_BADGE_COLOR,
+        ...(repoIcon ? { repoIcon } : {}),
         addedAt: Date.now(),
         kind: 'git',
         externalWorktreeVisibility: 'hide',

--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -1,0 +1,105 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { gitExecFileAsync } from './git/runner'
+import { detectRepoIcon } from './repo-icon-autodetect'
+
+const PNG_1X1_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+
+const tempDirs: string[] = []
+
+async function makeTempRepoDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'orca-repo-icon-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('detectRepoIcon', () => {
+  it('uses a small repo-local favicon PNG first', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(join(repoPath, 'favicon.png'), Buffer.from(PNG_1X1_BASE64, 'base64'))
+    await writeFile(
+      join(repoPath, 'package.json'),
+      JSON.stringify({ homepage: 'https://example.com' })
+    )
+
+    await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toEqual({
+      type: 'image',
+      src: `data:image/png;base64,${PNG_1X1_BASE64}`,
+      source: 'file',
+      label: 'favicon.png'
+    })
+  })
+
+  it('uses a package homepage favicon when no local icon file exists', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(
+      join(repoPath, 'package.json'),
+      JSON.stringify({ homepage: 'https://app.example.com/docs' })
+    )
+
+    await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toEqual({
+      type: 'image',
+      src: 'https://www.google.com/s2/favicons?domain=app.example.com&sz=64',
+      source: 'favicon',
+      label: 'Website favicon'
+    })
+  })
+
+  it('resolves declared icon hrefs from project source files', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(join(repoPath, 'index.html'), '<link rel="icon" href="/brand/icon.png">')
+    await mkdir(join(repoPath, 'public', 'brand'), { recursive: true })
+    await writeFile(
+      join(repoPath, 'public', 'brand', 'icon.png'),
+      Buffer.from(PNG_1X1_BASE64, 'base64')
+    )
+
+    await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toEqual({
+      type: 'image',
+      src: `data:image/png;base64,${PNG_1X1_BASE64}`,
+      source: 'file',
+      label: 'public/brand/icon.png'
+    })
+  })
+
+  it('falls back to the GitHub owner avatar for GitHub repos', async () => {
+    const repoPath = await makeTempRepoDir()
+    await gitExecFileAsync(['init'], { cwd: repoPath })
+    await gitExecFileAsync(['remote', 'add', 'origin', 'git@github.com:stablyai/orca.git'], {
+      cwd: repoPath
+    })
+
+    await expect(detectRepoIcon({ repoPath, kind: 'git' })).resolves.toEqual({
+      type: 'image',
+      src: 'https://github.com/stablyai.png?size=64',
+      source: 'github',
+      label: 'stablyai/orca'
+    })
+  })
+
+  it('skips code-host package homepages so GitHub remotes stay repo-specific', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(
+      join(repoPath, 'package.json'),
+      JSON.stringify({ homepage: 'https://github.com/stablyai/orca' })
+    )
+    await gitExecFileAsync(['init'], { cwd: repoPath })
+    await gitExecFileAsync(['remote', 'add', 'origin', 'https://github.com/stablyai/orca.git'], {
+      cwd: repoPath
+    })
+
+    await expect(detectRepoIcon({ repoPath, kind: 'git' })).resolves.toEqual({
+      type: 'image',
+      src: 'https://github.com/stablyai.png?size=64',
+      source: 'github',
+      label: 'stablyai/orca'
+    })
+  })
+})

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -1,0 +1,299 @@
+import { readFile, stat } from 'fs/promises'
+import type { RepoKind } from '../shared/types'
+import {
+  faviconUrlFromWebsite,
+  MAX_REPO_ICON_UPLOAD_BYTES,
+  type RepoIcon
+} from '../shared/repo-icon'
+import { getRepoSlug } from './github/client'
+import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
+import type { IFilesystemProvider } from './providers/types'
+import { joinWorktreeRelativePath } from './runtime/runtime-relative-paths'
+
+const REPO_ICON_FILE_CANDIDATES = [
+  'favicon.png',
+  'public/favicon.png',
+  'app/favicon.png',
+  'app/icon.png',
+  'src/favicon.png',
+  'src/app/icon.png',
+  'assets/favicon.png',
+  'assets/icon.png',
+  'static/favicon.png',
+  'logo.png',
+  'public/logo.png'
+]
+
+const REPO_ICON_SOURCE_FILE_CANDIDATES = [
+  'index.html',
+  'public/index.html',
+  'app/routes/__root.tsx',
+  'src/routes/__root.tsx',
+  'app/root.tsx',
+  'src/root.tsx',
+  'src/index.html'
+]
+
+const LINK_ICON_HTML_RE =
+  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
+const LINK_ICON_OBJECT_RE =
+  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
+
+const WEBSITE_HOSTS_TO_SKIP = new Set([
+  'github.com',
+  'www.github.com',
+  'gitlab.com',
+  'www.gitlab.com',
+  'bitbucket.org',
+  'www.bitbucket.org'
+])
+
+function isPngBuffer(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  )
+}
+
+function shouldUseWebsiteFavicon(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl.includes('://') ? rawUrl : `https://${rawUrl}`)
+    return !WEBSITE_HOSTS_TO_SKIP.has(url.hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+function extractIconHref(source: string): string | null {
+  return source.match(LINK_ICON_HTML_RE)?.[1] ?? source.match(LINK_ICON_OBJECT_RE)?.[1] ?? null
+}
+
+function iconHrefCandidates(href: string): string[] {
+  const clean = href.replace(/^\/+/, '')
+  return [`public/${clean}`, clean]
+}
+
+async function readLocalPngIcon(repoPath: string, relativePath: string): Promise<RepoIcon | null> {
+  const filePath = joinWorktreeRelativePath(repoPath, relativePath)
+  const info = await stat(filePath)
+  if (!info.isFile() || info.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+    return null
+  }
+  const buffer = await readFile(filePath)
+  if (!isPngBuffer(buffer)) {
+    return null
+  }
+  return {
+    type: 'image',
+    src: `data:image/png;base64,${buffer.toString('base64')}`,
+    source: 'file',
+    label: relativePath
+  }
+}
+
+async function readRemotePngIcon(
+  repoPath: string,
+  fsProvider: IFilesystemProvider,
+  relativePath: string
+): Promise<RepoIcon | null> {
+  const filePath = joinWorktreeRelativePath(repoPath, relativePath)
+  const info = await fsProvider.stat(filePath)
+  if (info.type !== 'file' || info.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+    return null
+  }
+  const result = await fsProvider.readFile(filePath)
+  if (!result.isBinary || result.mimeType !== 'image/png' || !result.content) {
+    return null
+  }
+  const buffer = Buffer.from(result.content, 'base64')
+  if (!isPngBuffer(buffer)) {
+    return null
+  }
+  return {
+    type: 'image',
+    src: `data:image/png;base64,${buffer.toString('base64')}`,
+    source: 'file',
+    label: relativePath
+  }
+}
+
+async function detectLocalPngIcon(repoPath: string): Promise<RepoIcon | null> {
+  for (const relativePath of REPO_ICON_FILE_CANDIDATES) {
+    try {
+      const icon = await readLocalPngIcon(repoPath, relativePath)
+      if (icon) {
+        return icon
+      }
+    } catch {
+      // Try the next conventional icon path.
+    }
+  }
+  for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
+    try {
+      const source = await readFile(joinWorktreeRelativePath(repoPath, sourceFile), 'utf8')
+      const href = extractIconHref(source)
+      if (!href) {
+        continue
+      }
+      for (const relativePath of iconHrefCandidates(href)) {
+        try {
+          const icon = await readLocalPngIcon(repoPath, relativePath)
+          if (icon) {
+            return icon
+          }
+        } catch {
+          // Try the next href resolution.
+        }
+      }
+    } catch {
+      // Try the next source file.
+    }
+  }
+  return null
+}
+
+async function detectRemotePngIcon(
+  repoPath: string,
+  fsProvider: IFilesystemProvider
+): Promise<RepoIcon | null> {
+  for (const relativePath of REPO_ICON_FILE_CANDIDATES) {
+    try {
+      const icon = await readRemotePngIcon(repoPath, fsProvider, relativePath)
+      if (icon) {
+        return icon
+      }
+    } catch {
+      // Try the next conventional icon path.
+    }
+  }
+  for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
+    try {
+      const result = await fsProvider.readFile(joinWorktreeRelativePath(repoPath, sourceFile))
+      if (result.isBinary) {
+        continue
+      }
+      const href = extractIconHref(result.content)
+      if (!href) {
+        continue
+      }
+      for (const relativePath of iconHrefCandidates(href)) {
+        try {
+          const icon = await readRemotePngIcon(repoPath, fsProvider, relativePath)
+          if (icon) {
+            return icon
+          }
+        } catch {
+          // Try the next href resolution.
+        }
+      }
+    } catch {
+      // Try the next source file.
+    }
+  }
+  return null
+}
+
+function packageHomepageIcon(packageJson: unknown): RepoIcon | null {
+  if (!packageJson || typeof packageJson !== 'object') {
+    return null
+  }
+  const homepage = (packageJson as { homepage?: unknown }).homepage
+  if (typeof homepage !== 'string' || !shouldUseWebsiteFavicon(homepage)) {
+    return null
+  }
+  const src = faviconUrlFromWebsite(homepage)
+  return src ? { type: 'image', src, source: 'favicon', label: 'Website favicon' } : null
+}
+
+async function detectLocalPackageHomepageIcon(repoPath: string): Promise<RepoIcon | null> {
+  try {
+    const packageJsonPath = joinWorktreeRelativePath(repoPath, 'package.json')
+    const info = await stat(packageJsonPath)
+    if (!info.isFile() || info.size > 128 * 1024) {
+      return null
+    }
+    return packageHomepageIcon(JSON.parse(await readFile(packageJsonPath, 'utf8')))
+  } catch {
+    return null
+  }
+}
+
+async function detectRemotePackageHomepageIcon(
+  repoPath: string,
+  fsProvider: IFilesystemProvider
+): Promise<RepoIcon | null> {
+  try {
+    const packageJsonPath = joinWorktreeRelativePath(repoPath, 'package.json')
+    const info = await fsProvider.stat(packageJsonPath)
+    if (info.type !== 'file' || info.size > 128 * 1024) {
+      return null
+    }
+    const result = await fsProvider.readFile(packageJsonPath)
+    if (result.isBinary) {
+      return null
+    }
+    return packageHomepageIcon(JSON.parse(result.content))
+  } catch {
+    return null
+  }
+}
+
+async function detectGitHubAvatarIcon(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<RepoIcon | null> {
+  try {
+    const slug = await getRepoSlug(repoPath, connectionId)
+    return slug
+      ? {
+          type: 'image',
+          src: `https://github.com/${encodeURIComponent(slug.owner)}.png?size=64`,
+          source: 'github',
+          label: `${slug.owner}/${slug.repo}`
+        }
+      : null
+  } catch {
+    return null
+  }
+}
+
+export async function detectRepoIcon({
+  repoPath,
+  kind,
+  connectionId
+}: {
+  repoPath: string
+  kind: RepoKind
+  connectionId?: string | null
+}): Promise<RepoIcon | undefined> {
+  try {
+    const fsProvider = connectionId ? getSshFilesystemProvider(connectionId) : undefined
+    const fileIcon = fsProvider
+      ? await detectRemotePngIcon(repoPath, fsProvider)
+      : await detectLocalPngIcon(repoPath)
+    if (fileIcon) {
+      return fileIcon
+    }
+
+    const homepageIcon = fsProvider
+      ? await detectRemotePackageHomepageIcon(repoPath, fsProvider)
+      : await detectLocalPackageHomepageIcon(repoPath)
+    if (homepageIcon) {
+      return homepageIcon
+    }
+
+    if (kind === 'git') {
+      return (await detectGitHubAvatarIcon(repoPath, connectionId)) ?? undefined
+    }
+  } catch {
+    // Repo creation must not fail because a best-effort icon probe failed.
+  }
+  return undefined
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -357,6 +357,7 @@ import type { IFilesystemProvider, IPtyProvider } from '../providers/types'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { getSshGitProvider, requireSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getActiveMultiplexer } from '../ipc/ssh'
+import { detectRepoIcon } from '../repo-icon-autodetect'
 import type { ClaudeAccountService } from '../claude-accounts/service'
 import type { CodexAccountService } from '../codex-accounts/service'
 import type { RateLimitService } from '../rate-limits/service'
@@ -5069,11 +5070,13 @@ export class OrcaRuntimeService {
       return existing
     }
 
+    const repoIcon = await detectRepoIcon({ repoPath: path, kind })
     const repo: Repo = {
       id: randomUUID(),
       path,
       displayName: getRepoName(path),
       badgeColor: DEFAULT_REPO_BADGE_COLOR,
+      ...(repoIcon ? { repoIcon } : {}),
       addedAt: Date.now(),
       kind,
       ...(kind === 'git'
@@ -5183,11 +5186,13 @@ export class OrcaRuntimeService {
       return { repo: raceWinner }
     }
 
+    const repoIcon = await detectRepoIcon({ repoPath: targetPath, kind: repoKind })
     const repo: Repo = {
       id: randomUUID(),
       path: targetPath,
       displayName: trimmedName,
       badgeColor: DEFAULT_REPO_BADGE_COLOR,
+      ...(repoIcon ? { repoIcon } : {}),
       addedAt: Date.now(),
       kind: repoKind,
       ...(repoKind === 'git'
@@ -5256,11 +5261,13 @@ export class OrcaRuntimeService {
       return existing
     }
 
+    const repoIcon = await detectRepoIcon({ repoPath: clonePath, kind: 'git' })
     const repo: Repo = {
       id: randomUUID(),
       path: clonePath,
       displayName: getRepoName(clonePath),
       badgeColor: DEFAULT_REPO_BADGE_COLOR,
+      ...(repoIcon ? { repoIcon } : {}),
       addedAt: Date.now(),
       kind: 'git',
       externalWorktreeVisibility: 'hide',

--- a/src/renderer/src/components/settings/RepositoryIconPicker.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconPicker.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Github, Image, Link2, RotateCcw } from 'lucide-react'
 import type { Repo } from '../../../../shared/types'
-import type { RepoIcon } from '../../../../shared/repo-icon'
+import { faviconUrlFromWebsite, type RepoIcon } from '../../../../shared/repo-icon'
 import { REPO_COLORS } from '../../../../shared/constants'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -16,23 +16,6 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-cl
 
 const EMOJI_OPTIONS = ['🚀', '✨', '💻', '🧠', '📦', '🔧', '🎨', '🌐', '📊', '🔒', '⚡', '✅']
 
-function faviconUrlFromWebsite(rawUrl: string): string | null {
-  const trimmed = rawUrl.trim()
-  if (!trimmed) {
-    return null
-  }
-
-  try {
-    const url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`)
-    if (!['http:', 'https:'].includes(url.protocol) || !url.hostname) {
-      return null
-    }
-    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(url.hostname)}&sz=64`
-  } catch {
-    return null
-  }
-}
-
 export function RepositoryIconPicker({
   repo,
   updateRepo
@@ -45,8 +28,11 @@ export function RepositoryIconPicker({
   const activeRuntimeEnvironmentId = useAppStore(
     (state) => state.settings?.activeRuntimeEnvironmentId ?? null
   )
-  const selectedLucideName = repo.repoIcon?.type === 'lucide' ? repo.repoIcon.name : 'Folder'
+  const selectedLucideName =
+    repo.repoIcon?.type === 'lucide' ? repo.repoIcon.name : repo.repoIcon == null ? 'Folder' : null
   const selectedEmoji = repo.repoIcon?.type === 'emoji' ? repo.repoIcon.emoji : ''
+  const initialTab =
+    repo.repoIcon?.type === 'image' ? 'image' : repo.repoIcon?.type === 'emoji' ? 'emoji' : 'icon'
   const runtimeTarget = useMemo(
     () => getActiveRuntimeTarget({ activeRuntimeEnvironmentId }),
     [activeRuntimeEnvironmentId]
@@ -167,7 +153,7 @@ export function RepositoryIconPicker({
         ))}
       </div>
 
-      <Tabs defaultValue="icon" className="gap-3">
+      <Tabs defaultValue={initialTab} className="gap-3">
         <TabsList variant="line" className="h-8">
           <TabsTrigger value="icon" className="h-7 text-xs">
             Icon

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -652,7 +652,12 @@ function Settings(): React.JSX.Element {
     .filter((section) => section.id.startsWith('repo-'))
     .map((section) => {
       const repo = repos.find((entry) => entry.id === section.id.replace('repo-', ''))
-      return { ...section, badgeColor: repo?.badgeColor, isRemote: !!repo?.connectionId }
+      return {
+        ...section,
+        badgeColor: repo?.badgeColor,
+        isRemote: !!repo?.connectionId,
+        repoIcon: repo?.repoIcon
+      }
     })
   const isSectionMounted = (sectionId: string): boolean => neededSectionIds.has(sectionId)
 

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -1,8 +1,9 @@
 import type { RefObject } from 'react'
 import { ArrowLeft, Search, Server, type LucideIcon, type LucideProps } from 'lucide-react'
+import type { RepoIcon } from '../../../../shared/repo-icon'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { cn } from '@/lib/utils'
-import { RepoBadgeMark } from '../repo/RepoBadgeLabel'
+import { RepoIconGlyph } from '../repo/repo-icon'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 
@@ -22,6 +23,7 @@ type NavGroup = {
 type RepoNavSection = NavSection & {
   badgeColor?: string
   isRemote?: boolean
+  repoIcon?: RepoIcon | null
 }
 
 type SettingsSidebarProps = {
@@ -162,12 +164,11 @@ export function SettingsSidebar({
                       }
                       className={navItemClassName(isActive)}
                     >
-                      <RepoBadgeMark
+                      <RepoIconGlyph
+                        repoIcon={section.repoIcon}
                         color={section.badgeColor}
-                        className={cn(
-                          'size-2.5',
-                          section.badgeColor ? null : 'bg-muted-foreground'
-                        )}
+                        className="size-4 shrink-0 text-muted-foreground"
+                        iconClassName="size-3.5"
                       />
                       <span className="truncate">{section.title}</span>
                       {section.isRemote && (

--- a/src/shared/repo-icon.test.ts
+++ b/src/shared/repo-icon.test.ts
@@ -46,6 +46,17 @@ describe('sanitizeRepoIcon', () => {
       src: 'data:image/png;base64,aGVsbG8=',
       source: 'upload'
     })
+    expect(
+      sanitizeRepoIcon({
+        type: 'image',
+        src: 'data:image/png;base64,aGVsbG8=',
+        source: 'file'
+      })
+    ).toEqual({
+      type: 'image',
+      src: 'data:image/png;base64,aGVsbG8=',
+      source: 'file'
+    })
   })
 
   it('keeps null as an explicit reset', () => {

--- a/src/shared/repo-icon.ts
+++ b/src/shared/repo-icon.ts
@@ -1,4 +1,4 @@
-export type RepoIconImageSource = 'upload' | 'favicon' | 'github'
+export type RepoIconImageSource = 'upload' | 'file' | 'favicon' | 'github'
 
 export type RepoIcon =
   | { type: 'lucide'; name: string }
@@ -10,10 +10,27 @@ export const MAX_REPO_ICON_DATA_URL_LENGTH = 400 * 1024
 
 const LUCIDE_ICON_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/
 const isRepoIconImageSource = (value: string): value is RepoIconImageSource =>
-  value === 'upload' || value === 'favicon' || value === 'github'
+  value === 'upload' || value === 'file' || value === 'favicon' || value === 'github'
+
+export function faviconUrlFromWebsite(rawUrl: string): string | null {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`)
+    if (!['http:', 'https:'].includes(url.protocol) || !url.hostname) {
+      return null
+    }
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(url.hostname)}&sz=64`
+  } catch {
+    return null
+  }
+}
 
 function isSupportedImageSrc(src: string, source: RepoIconImageSource): boolean {
-  if (source === 'upload') {
+  if (source === 'upload' || source === 'file') {
     return /^data:image\/png;base64,[A-Za-z0-9+/=\s]+$/i.test(src)
   }
 


### PR DESCRIPTION
## Summary
- Auto-detect project icons when repos are added, created, or cloned.
- Prefer repo-local PNG icons and declared PNG icon links before website favicons and GitHub owner avatars.
- Share favicon URL handling and keep persisted image icons sanitized.
- Keep image-backed repo icons on the Image picker tab instead of marking a fallback icon as selected.
- Show configured project icons in the settings project list instead of color-only square markers.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/shared/repo-icon.test.ts src/main/repo-icon-autodetect.test.ts
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm run typecheck:cli
- pnpm exec oxlint src/shared/repo-icon.ts src/shared/repo-icon.test.ts src/main/repo-icon-autodetect.ts src/main/repo-icon-autodetect.test.ts src/main/ipc/repos.ts src/main/runtime/orca-runtime.ts src/renderer/src/components/settings/RepositoryIconPicker.tsx src/renderer/src/components/settings/Settings.tsx src/renderer/src/components/settings/SettingsSidebar.tsx
- Electron dev app verification with throwaway repos for local PNG, website favicon, and GitHub avatar detection
- Electron dev app verification that image-backed repo icons open on the Image tab and do not select a fallback icon
- Electron dev app verification that the settings project list renders the configured repo icon
