### PR TITLE
Unpack yaml for packaged Orca CLI

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -72,6 +72,7 @@ module.exports = {
     'node_modules/ws/**',
     'node_modules/tweetnacl/**',
     'node_modules/zod/**',
+    'node_modules/yaml/**',
     'node_modules/sherpa-onnx*/**'
   ],
   afterPack: async (context) => {

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -20,7 +20,8 @@ describe('packaged CLI assets', () => {
       expect.arrayContaining([
         'node_modules/ws/**',
         'node_modules/tweetnacl/**',
-        'node_modules/zod/**'
+        'node_modules/zod/**',
+        'node_modules/yaml/**'
       ])
     )
   })


### PR DESCRIPTION
## Summary
- fixes the installed `/Applications/Orca.app/Contents/Resources/bin/orca ...` CLI failure introduced by the new agent-hooks CLI path
- adds `node_modules/yaml/**` to `asarUnpack` because the packaged CLI runs under `ELECTRON_RUN_AS_NODE` from `app.asar.unpacked`, where dependencies inside `app.asar` are not visible to normal Node resolution
- extends the packaged CLI asset test to guard the new unpacked dependency

## Verification
- reproduced on installed 1.4.28-rc.3: `/Applications/Orca.app/Contents/Resources/bin/orca status --json` and `agent hooks status --json` failed with `Cannot find module 'yaml'`\n- `pnpm vitest run --config config/vitest.config.ts src/main/cli/packaged-cli-assets.test.ts --reporter=dot`\n- `pnpm run typecheck:node`\n- `pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --dir`\n- verified `dist/mac-arm64/Orca.app/Contents/Resources/app.asar.unpacked/node_modules/yaml` exists\n- verified `dist/mac-arm64/Orca.app/Contents/Resources/bin/orca status --json` succeeds\n- verified `dist/mac-arm64/Orca.app/Contents/Resources/bin/orca agent hooks status --json` succeeds

Made with [Orca](https://github.com/stablyai/orca) 🐋
