### PR TITLE
Persist right sidebar visibility globally

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -257,6 +257,8 @@ describe('Store', () => {
     const store = await createStore()
     const ui = store.getUI()
     expect(ui.sidebarWidth).toBe(280)
+    expect(ui.rightSidebarOpen).toBe(true)
+    expect(ui.rightSidebarTab).toBe('explorer')
     expect(ui.groupBy).toBe('repo')
     expect(ui.lastActiveRepoId).toBeNull()
     expect(ui.dismissedUpdateVersion).toBeNull()
@@ -732,6 +734,8 @@ describe('Store', () => {
     // ui should have defaults
     const ui = store.getUI()
     expect(ui.sidebarWidth).toBe(280)
+    expect(ui.rightSidebarOpen).toBe(true)
+    expect(ui.rightSidebarTab).toBe('explorer')
     // settings should preserve the overridden value
     expect(store.getSettings().theme).toBe('dark')
     // new fields get defaults when missing from persisted data
@@ -1263,7 +1267,7 @@ describe('Store', () => {
     expect(store.getSettings().editorAutoSave).toBe(true)
   })
 
-  it('preserves rightSidebarOpenByDefault when set to true in persisted data', async () => {
+  it('keeps legacy rightSidebarOpenByDefault readable from persisted data', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [],
@@ -1544,7 +1548,7 @@ describe('Store', () => {
     expect(store.getSettings().editorAutoSave).toBe(false)
   })
 
-  it('updateSettings toggles rightSidebarOpenByDefault', async () => {
+  it('keeps legacy rightSidebarOpenByDefault writable for backward compatibility', async () => {
     const store = await createStore()
     expect(store.getSettings().rightSidebarOpenByDefault).toBe(true)
 
@@ -1701,6 +1705,81 @@ describe('Store', () => {
     expect(ui.sidebarWidth).toBe(400)
     expect(ui.groupBy).toBe('repo') // default preserved
     expect(ui.dismissedUpdateVersion).toBeNull()
+  })
+
+  it('migrates missing rightSidebarOpen from the legacy default setting', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { rightSidebarOpenByDefault: false },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().rightSidebarOpen).toBe(false)
+  })
+
+  it('migrates missing rightSidebarOpen to open when the legacy default was open', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { rightSidebarOpenByDefault: true },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().rightSidebarOpen).toBe(true)
+  })
+
+  it('keeps explicit rightSidebarOpen authoritative over the legacy default setting', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { rightSidebarOpenByDefault: true },
+      ui: { rightSidebarOpen: false },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().rightSidebarOpen).toBe(false)
+  })
+
+  it('preserves explicit rightSidebarTab in persisted UI', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: { rightSidebarTab: 'checks' },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().rightSidebarTab).toBe('checks')
+  })
+
+  it('normalizes invalid rightSidebarTab in persisted UI', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: { rightSidebarTab: 'bogus' },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().rightSidebarTab).toBe('explorer')
   })
 
   it('updateUI restores fixed card properties from direct UI writes', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -231,6 +231,19 @@ function normalizeSortBy(sortBy: unknown): PersistedState['ui']['sortBy'] {
   return getDefaultUIState().sortBy
 }
 
+function normalizeRightSidebarTab(tab: unknown): PersistedState['ui']['rightSidebarTab'] {
+  if (
+    tab === 'explorer' ||
+    tab === 'search' ||
+    tab === 'source-control' ||
+    tab === 'checks' ||
+    tab === 'ports'
+  ) {
+    return tab
+  }
+  return getDefaultUIState().rightSidebarTab
+}
+
 function normalizeNotificationSettings(value: unknown): NotificationSettings {
   const defaults = getDefaultNotificationSettings()
   const candidate =
@@ -1546,6 +1559,15 @@ export class Store {
             const rawSort = parsed.ui?.sortBy
             const sort = normalizeSortBy(rawSort)
             const migrate = !parsed.ui?._sortBySmartMigrated && rawSort === 'recent'
+            const rightSidebarOpen =
+              typeof parsed.ui?.rightSidebarOpen === 'boolean'
+                ? parsed.ui.rightSidebarOpen
+                : typeof parsed.settings?.rightSidebarOpenByDefault === 'boolean'
+                  ? parsed.settings.rightSidebarOpenByDefault
+                  : defaults.ui.rightSidebarOpen
+            if (typeof parsed.ui?.rightSidebarOpen !== 'boolean') {
+              this.loadNeedsSave = true
+            }
             const workspaceStatusesDefaultOrderMigrated =
               parsed.ui?._workspaceStatusesDefaultOrderMigrated === true
             // Why: the default workflow changed to Done -> Review -> Progress -> Todo.
@@ -1652,6 +1674,10 @@ export class Store {
             return {
               ...defaults.ui,
               ...parsed.ui,
+              // Why: migrate once from the retired Appearance setting only
+              // when no explicit persisted chrome preference exists yet.
+              rightSidebarOpen,
+              rightSidebarTab: normalizeRightSidebarTab(parsed.ui?.rightSidebarTab),
               sortBy: migrate ? ('smart' as const) : sort,
               workspaceStatuses,
               _workspaceStatusesDefaultOrderMigrated: true,
@@ -2509,6 +2535,7 @@ export class Store {
       ...this.state.ui,
       groupBy: normalizeGroupBy(this.state.ui?.groupBy),
       sortBy: normalizeSortBy(this.state.ui?.sortBy),
+      rightSidebarTab: normalizeRightSidebarTab(this.state.ui?.rightSidebarTab),
       worktreeCardProperties: normalizeWorktreeCardProperties(
         this.state.ui?.worktreeCardProperties
       ),
@@ -2531,6 +2558,10 @@ export class Store {
       sortBy: updates.sortBy
         ? normalizeSortBy(updates.sortBy)
         : normalizeSortBy(this.state.ui?.sortBy),
+      rightSidebarTab:
+        updates.rightSidebarTab !== undefined
+          ? normalizeRightSidebarTab(updates.rightSidebarTab)
+          : normalizeRightSidebarTab(this.state.ui?.rightSidebarTab),
       worktreeCardProperties:
         updates.worktreeCardProperties !== undefined
           ? normalizeWorktreeCardProperties(updates.worktreeCardProperties)

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -108,6 +108,8 @@ describe('client UI RPC methods', () => {
   it('persists UI updates on the runtime host and returns the updated state', async () => {
     const updated: PersistedUIState = {
       ...getDefaultUIState(),
+      rightSidebarOpen: false,
+      rightSidebarTab: 'checks',
       showActiveOnly: true,
       filterRepoIds: ['repo-1']
     }
@@ -119,6 +121,8 @@ describe('client UI RPC methods', () => {
 
     const response = await dispatcher.dispatch(
       makeRequest('ui.set', {
+        rightSidebarOpen: false,
+        rightSidebarTab: 'checks',
         showActiveOnly: true,
         hideSleepingWorkspaces: true,
         filterRepoIds: ['repo-1']
@@ -126,6 +130,8 @@ describe('client UI RPC methods', () => {
     )
 
     expect(runtime.updateUIState).toHaveBeenCalledWith({
+      rightSidebarOpen: false,
+      rightSidebarTab: 'checks',
       showActiveOnly: true,
       hideSleepingWorkspaces: true,
       filterRepoIds: ['repo-1']

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -93,6 +93,8 @@ const UiUpdate = z
     lastActiveRepoId: NullableString.optional(),
     lastActiveWorktreeId: NullableString.optional(),
     sidebarWidth: z.number().finite().optional(),
+    rightSidebarOpen: z.boolean().optional(),
+    rightSidebarTab: z.enum(['explorer', 'search', 'source-control', 'checks', 'ports']).optional(),
     rightSidebarWidth: z.number().finite().optional(),
     groupBy: z.enum(['none', 'workspace-status', 'repo', 'pr-status']).optional(),
     showWorkspaceLineage: z.boolean().optional(),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ import {
 import logo from '../../../resources/logo.svg'
 import { SYNC_FIT_PANES_EVENT, TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
+import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import { buildAppFontFamily } from '@/lib/app-font-family'
 import { toast } from 'sonner'
 import { Toaster } from '@/components/ui/sonner'
@@ -399,6 +400,7 @@ function App(): React.JSX.Element {
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth)
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
+  const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const isFullScreen = useAppStore((s) => s.isFullScreen)
   const settings = useAppStore((s) => s.settings)
   const primarySelectionMiddleClickPaste = resolvePrimarySelectionMiddleClickPaste(
@@ -890,6 +892,8 @@ function App(): React.JSX.Element {
     const timer = window.setTimeout(() => {
       void window.api.ui.set({
         sidebarWidth,
+        rightSidebarOpen,
+        rightSidebarTab,
         rightSidebarWidth,
         groupBy,
         sortBy,
@@ -911,6 +915,8 @@ function App(): React.JSX.Element {
   }, [
     persistedUIReady,
     sidebarWidth,
+    rightSidebarOpen,
+    rightSidebarTab,
     rightSidebarWidth,
     groupBy,
     sortBy,
@@ -990,14 +996,7 @@ function App(): React.JSX.Element {
   const workspaceActive = activeView === 'terminal' && activeWorktreeId !== null
   // Why: suppress right sidebar controls on full-page navigation surfaces
   // since those surfaces intentionally own the full content area.
-  const showRightSidebarControls =
-    activeView !== 'settings' &&
-    activeView !== 'tasks' &&
-    activeView !== 'activity' &&
-    activeView !== 'automations' &&
-    activeView !== 'space' &&
-    activeView !== 'skills' &&
-    activeView !== 'mobile'
+  const showRightSidebarControls = canShowRightSidebarForView(activeView)
 
   const handleToggleExpand = (): void => {
     if (!effectiveActiveTabId) {
@@ -1056,13 +1055,7 @@ function App(): React.JSX.Element {
         })
       }
 
-      const canRevealRightSidebar =
-        activeView !== 'tasks' &&
-        activeView !== 'activity' &&
-        activeView !== 'automations' &&
-        activeView !== 'space' &&
-        activeView !== 'skills' &&
-        activeView !== 'mobile'
+      const canRevealRightSidebar = canShowRightSidebarForView(activeView)
 
       const openSearchSidebar = (query: string | null): void => {
         if (query && activeWorktreeId) {
@@ -1451,22 +1444,6 @@ function App(): React.JSX.Element {
       </TooltipContent>
     </Tooltip>
   ) : null
-
-  useEffect(() => {
-    if (
-      (activeView === 'tasks' ||
-        activeView === 'activity' ||
-        activeView === 'automations' ||
-        activeView === 'space' ||
-        activeView === 'skills' ||
-        activeView === 'mobile') &&
-      rightSidebarOpen
-    ) {
-      // Why: hide the right sidebar immediately when entering full-page
-      // navigation views so previous side-panel state cannot occlude them.
-      actions.setRightSidebarOpen(false)
-    }
-  }, [activeView, rightSidebarOpen, actions])
 
   return (
     <div

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -148,27 +148,9 @@ export function AppearancePane({
     ) : null,
     matchesSettingsSearch(searchQuery, LAYOUT_ENTRIES) ? (
       <section key="layout" className="space-y-3">
-        <SettingsSubsectionHeader
-          title="Layout"
-          description="Default layout when creating new worktrees."
-        />
+        <SettingsSubsectionHeader title="File Explorer" />
 
         <div className="divide-y divide-border/40">
-          <SearchableSetting
-            title="Open Right Sidebar by Default"
-            description="Automatically expand the file explorer panel when creating a new worktree."
-            keywords={['layout', 'file explorer', 'sidebar']}
-          >
-            <SettingsSwitchRow
-              label="Open Right Sidebar by Default"
-              description="Automatically expand the file explorer panel when creating a new worktree."
-              checked={settings.rightSidebarOpenByDefault}
-              onChange={() =>
-                updateSettings({ rightSidebarOpenByDefault: !settings.rightSidebarOpenByDefault })
-              }
-            />
-          </SearchableSetting>
-
           <SearchableSetting
             title="Show Git-Ignored Files"
             description="Show files matched by .gitignore in the file explorer."

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -88,11 +88,6 @@ export const TYPOGRAPHY_ENTRIES: SettingsSearchEntry[] = [
 
 export const LAYOUT_ENTRIES: SettingsSearchEntry[] = [
   {
-    title: 'Open Right Sidebar by Default',
-    description: 'Automatically expand the file explorer panel when creating a new worktree.',
-    keywords: ['layout', 'file explorer', 'sidebar']
-  },
-  {
     title: 'Show Git-Ignored Files',
     description: 'Dim files matched by .gitignore in the file explorer.',
     keywords: ['git', 'gitignore', 'ignored', 'file explorer', 'sidebar', 'hide']

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -251,8 +251,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       createWorktree: s.createWorktree,
       updateWorktreeMeta: s.updateWorktreeMeta,
       setSidebarOpen: s.setSidebarOpen,
-      setRightSidebarOpen: s.setRightSidebarOpen,
-      setRightSidebarTab: s.setRightSidebarTab,
       closeModal: s.closeModal,
       openSettingsPage: s.openSettingsPage,
       openSettingsTarget: s.openSettingsTarget,
@@ -266,8 +264,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     createWorktree,
     updateWorktreeMeta,
     setSidebarOpen,
-    setRightSidebarOpen,
-    setRightSidebarTab,
     closeModal,
     openSettingsPage,
     openSettingsTarget,
@@ -1802,10 +1798,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         })
       }
       setSidebarOpen(true)
-      if (settings?.rightSidebarOpenByDefault) {
-        setRightSidebarTab('explorer')
-        setRightSidebarOpen(true)
-      }
       if (persistDraft) {
         clearNewWorkspaceDraft()
       }
@@ -1845,9 +1837,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     selectedRepoRequiresConnection,
     settings?.agentCmdOverrides,
     settings?.agentStatusHooksEnabled,
-    settings?.rightSidebarOpenByDefault,
-    setRightSidebarOpen,
-    setRightSidebarTab,
     setSidebarOpen,
     setupDecision,
     sparseEnabled,
@@ -2052,10 +2041,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           })
         }
         setSidebarOpen(true)
-        if (settings?.rightSidebarOpenByDefault) {
-          setRightSidebarTab('explorer')
-          setRightSidebarOpen(true)
-        }
         if (persistDraft) {
           clearNewWorkspaceDraft()
         }
@@ -2094,9 +2079,6 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       selectedRepoRequiresConnection,
       settings?.agentCmdOverrides,
       settings?.agentStatusHooksEnabled,
-      settings?.rightSidebarOpenByDefault,
-      setRightSidebarOpen,
-      setRightSidebarTab,
       setSidebarOpen,
       setupDecision,
       sparseEnabled,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -32,6 +32,7 @@ import type {
 import { importRemoteWorkspaceSession } from '../../../shared/remote-workspace-session-projection'
 import { zoomLevelToPercent, ZOOM_MIN, ZOOM_MAX } from '@/components/settings/SettingsConstants'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
+import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import { resolveZoomTarget } from './resolve-zoom-target'
 import {
   handleSwitchRecentTab,
@@ -661,7 +662,11 @@ export function useIpcEvents(): void {
 
     unsubs.push(
       window.api.ui.onToggleRightSidebar(() => {
-        useAppStore.getState().toggleRightSidebar()
+        const store = useAppStore.getState()
+        if (!canShowRightSidebarForView(store.activeView)) {
+          return
+        }
+        store.toggleRightSidebar()
       })
     )
 

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -341,10 +341,6 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
   }
 
   store.setSidebarOpen(true)
-  if (settings?.rightSidebarOpenByDefault) {
-    store.setRightSidebarTab('explorer')
-    store.setRightSidebarOpen(true)
-  }
 
   // Why: at this point the workspace is live and the agent (if any) has
   // been queued on `primaryTabId`. The post-launch paste step below only

--- a/src/renderer/src/lib/right-sidebar-visibility.test.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canShowRightSidebarForView,
+  rightSidebarShowsPullRequestData
+} from './right-sidebar-visibility'
+import type { AppState } from '@/store/types'
+
+function makeState(
+  overrides: Partial<Parameters<typeof rightSidebarShowsPullRequestData>[0]> = {}
+): Parameters<typeof rightSidebarShowsPullRequestData>[0] {
+  return {
+    activeView: 'terminal',
+    activeWorktreeId: 'wt-1',
+    repos: [
+      {
+        id: 'repo-1',
+        path: '/repo',
+        displayName: 'Repo',
+        badgeColor: '#000000',
+        addedAt: 1,
+        kind: 'git'
+      }
+    ],
+    rightSidebarOpen: true,
+    rightSidebarTab: 'checks',
+    worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
+    ...overrides
+  } as Parameters<typeof rightSidebarShowsPullRequestData>[0]
+}
+
+describe('right sidebar visibility helpers', () => {
+  it('suppresses right sidebar controls on full-page views', () => {
+    for (const view of [
+      'settings',
+      'tasks',
+      'activity',
+      'automations',
+      'space',
+      'skills',
+      'mobile'
+    ]) {
+      expect(canShowRightSidebarForView(view as AppState['activeView'])).toBe(false)
+    }
+  })
+
+  it('allows right sidebar controls on workspace views', () => {
+    expect(canShowRightSidebarForView('terminal')).toBe(true)
+  })
+
+  it('does not treat hidden full-page sidebars as visible PR panels', () => {
+    expect(rightSidebarShowsPullRequestData(makeState({ activeView: 'tasks' }))).toBe(false)
+  })
+
+  it('does not treat hidden folder-repo fallbacks as visible PR panels', () => {
+    expect(
+      rightSidebarShowsPullRequestData(
+        makeState({
+          repos: [
+            {
+              id: 'repo-1',
+              path: '/repo',
+              displayName: 'Repo',
+              badgeColor: '#000000',
+              addedAt: 1,
+              kind: 'folder'
+            }
+          ]
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('detects visible PR panels in workspace views', () => {
+    expect(
+      rightSidebarShowsPullRequestData(
+        makeState({
+          rightSidebarTab: 'source-control'
+        })
+      )
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/right-sidebar-visibility.ts
+++ b/src/renderer/src/lib/right-sidebar-visibility.ts
@@ -1,0 +1,50 @@
+import type { AppState } from '@/store/types'
+import { isFolderRepo } from '../../../shared/repo-kind'
+
+type ActiveView = AppState['activeView']
+
+const RIGHT_SIDEBAR_SUPPRESSED_VIEWS = new Set<ActiveView>([
+  'settings',
+  'tasks',
+  'activity',
+  'automations',
+  'space',
+  'skills',
+  'mobile'
+])
+
+export function canShowRightSidebarForView(activeView: ActiveView): boolean {
+  return !RIGHT_SIDEBAR_SUPPRESSED_VIEWS.has(activeView)
+}
+
+export function rightSidebarShowsPullRequestData(
+  state: Pick<
+    AppState,
+    | 'activeView'
+    | 'activeWorktreeId'
+    | 'repos'
+    | 'rightSidebarOpen'
+    | 'rightSidebarTab'
+    | 'worktreesByRepo'
+  >
+): boolean {
+  if (
+    !canShowRightSidebarForView(state.activeView) ||
+    !state.rightSidebarOpen ||
+    (state.rightSidebarTab !== 'checks' && state.rightSidebarTab !== 'source-control')
+  ) {
+    return false
+  }
+
+  const activeWorktree = Object.values(state.worktreesByRepo)
+    .flat()
+    .find((worktree) => worktree.id === state.activeWorktreeId)
+  const activeRepo = activeWorktree
+    ? state.repos.find((repo) => repo.id === activeWorktree.repoId)
+    : null
+  if (!activeRepo || isFolderRepo(activeRepo)) {
+    return false
+  }
+
+  return true
+}

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -35,6 +35,8 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     lastActiveRepoId: null,
     lastActiveWorktreeId: null,
     sidebarWidth: 280,
+    rightSidebarOpen: true,
+    rightSidebarTab: 'explorer',
     rightSidebarWidth: 350,
     groupBy: 'repo',
     sortBy: 'name',

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -93,13 +93,13 @@ describe('createEditorSlice right sidebar state', () => {
     expect(store.getState().rightSidebarOpen).toBe(false)
   })
 
-  it('setRightSidebarTab writes the active worktree entry', () => {
+  it('setRightSidebarTab updates the global tab without writing a worktree entry', () => {
     const store = createEditorStore()
 
     store.getState().setRightSidebarTab('search')
 
     expect(store.getState().rightSidebarTab).toBe('search')
-    expect(store.getState().rightSidebarTabByWorktree).toEqual({ 'wt-1': 'search' })
+    expect(store.getState().rightSidebarTabByWorktree).toEqual({})
   })
 
   it('setRightSidebarTab with no active worktree does not mutate the worktree map', () => {
@@ -113,22 +113,20 @@ describe('createEditorSlice right sidebar state', () => {
     expect(store.getState().rightSidebarTabByWorktree).toBe(remembered)
   })
 
-  it('revealInExplorer records explorer for the target worktree', () => {
+  it('revealInExplorer selects explorer globally without writing a worktree entry', () => {
     const store = createEditorStore()
+    const remembered = { 'wt-1': 'search' as const, 'wt-2': 'checks' as const }
     store.setState({
       activeWorktreeId: 'wt-1',
       rightSidebarTab: 'search',
-      rightSidebarTabByWorktree: { 'wt-1': 'search', 'wt-2': 'checks' }
+      rightSidebarTabByWorktree: remembered
     })
 
     store.getState().revealInExplorer('wt-2', '/repo/file.ts')
 
     expect(store.getState().rightSidebarOpen).toBe(true)
     expect(store.getState().rightSidebarTab).toBe('explorer')
-    expect(store.getState().rightSidebarTabByWorktree).toEqual({
-      'wt-1': 'search',
-      'wt-2': 'explorer'
-    })
+    expect(store.getState().rightSidebarTabByWorktree).toBe(remembered)
     expect(store.getState().pendingExplorerReveal).toMatchObject({
       worktreeId: 'wt-2',
       filePath: '/repo/file.ts'

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -23,6 +23,7 @@ import type {
   Tab,
   TabGroup,
   GitUpstreamStatus,
+  RightSidebarTab,
   SearchResult,
   WorkspaceSessionState,
   WorkspaceVisibleTabType
@@ -47,6 +48,8 @@ import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
 import { createUntitledMarkdownFile } from '@/lib/create-untitled-markdown'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
+
+export type { RightSidebarTab } from '../../../../shared/types'
 
 export type DiffSource =
   | 'unstaged'
@@ -178,7 +181,6 @@ export type OpenFile = {
   mode: 'edit' | 'diff' | 'conflict-review' | 'markdown-preview'
 }
 
-export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks' | 'ports'
 export type ActivityBarPosition = 'top' | 'side'
 
 export type MarkdownViewMode = 'source' | 'rich' | 'preview'
@@ -1063,13 +1065,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   toggleRightSidebar: () => set((s) => ({ rightSidebarOpen: !s.rightSidebarOpen })),
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
   setRightSidebarWidth: (width) => set({ rightSidebarWidth: width }),
-  setRightSidebarTab: (tab) =>
-    set((s) => ({
-      rightSidebarTab: tab,
-      rightSidebarTabByWorktree: s.activeWorktreeId
-        ? { ...s.rightSidebarTabByWorktree, [s.activeWorktreeId]: tab }
-        : s.rightSidebarTabByWorktree
-    })),
+  setRightSidebarTab: (tab) => set({ rightSidebarTab: tab }),
   setActivityBarPosition: (position) => set({ activityBarPosition: position }),
 
   // File explorer
@@ -1114,15 +1110,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     }),
   pendingExplorerReveal: null,
   revealInExplorer: (worktreeId, filePath) =>
-    set((s) => ({
+    set({
       rightSidebarOpen: true,
       rightSidebarTab: 'explorer',
-      rightSidebarTabByWorktree: {
-        ...s.rightSidebarTabByWorktree,
-        [worktreeId]: 'explorer'
-      },
       pendingExplorerReveal: { worktreeId, filePath, requestId: Date.now() }
-    })),
+    }),
   clearPendingExplorerReveal: () => set({ pendingExplorerReveal: null }),
 
   // Open files

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -2241,6 +2241,7 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
       repos: [{ id: 'repo-1', path: repoPath, name: 'repo', kind: 'git' }],
       groupBy: 'repo',
       worktreeCardProperties: ['comment'],
+      activeWorktreeId: worktreeId,
       rightSidebarOpen: true,
       rightSidebarTab: 'source-control',
       worktreesByRepo: {
@@ -2396,6 +2397,7 @@ describe('createGitHubSlice.refreshAllGitHub', () => {
       repos: [{ id: 'repo-1', path: repoPath, name: 'repo', kind: 'git' }],
       groupBy: 'repo',
       worktreeCardProperties: ['comment'],
+      activeWorktreeId: 'wt-1',
       rightSidebarOpen: true,
       rightSidebarTab: 'source-control',
       worktreesByRepo: {
@@ -2440,6 +2442,7 @@ describe('createGitHubSlice.refreshAllGitHub', () => {
       repos: [{ id: 'repo-1', path: repoPath, name: 'repo', kind: 'git' }],
       groupBy: 'repo',
       worktreeCardProperties: ['comment'],
+      activeWorktreeId: 'wt-1',
       rightSidebarOpen: true,
       rightSidebarTab: 'source-control',
       worktreesByRepo: {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -35,6 +35,7 @@ import {
 } from '../../../../shared/work-items'
 import { deriveCheckStatusFromChecks, syncPRChecksStatus } from './github-checks'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rpc-client'
+import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
 import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 import { getHostedReviewCacheKey, linkedReviewHintKey } from './hosted-review-cache-identity'
 import { getGitHubPRCacheKey, getGitHubRepoCacheKey } from './github-cache-key'
@@ -2503,9 +2504,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const cardProps = state.worktreeCardProperties ?? []
     const shouldRefreshIssues = shouldRefreshIssueDecorations(state)
     const isPRStatusGrouping = state.groupBy === 'pr-status'
-    const rightSidebarShowsPR =
-      state.rightSidebarOpen &&
-      (state.rightSidebarTab === 'checks' || state.rightSidebarTab === 'source-control')
+    const rightSidebarShowsPR = rightSidebarShowsPullRequestData(state)
     const shouldRefreshPRs =
       isPRStatusGrouping ||
       rightSidebarShowsPR ||
@@ -2780,8 +2779,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       state.groupBy === 'pr-status' ||
       cardProps.includes('pr') ||
       cardProps.includes('ci') ||
-      (state.rightSidebarOpen &&
-        (state.rightSidebarTab === 'checks' || state.rightSidebarTab === 'source-control'))
+      rightSidebarShowsPullRequestData(state)
 
     if (shouldRefreshPR && !worktree.isBare && branch) {
       const candidate = buildPRRefreshCandidate(state, worktree)

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -471,7 +471,7 @@ describe('setActiveWorktree', () => {
     expect(worktrees.map((worktree) => worktree.id)).toEqual([backgroundId, focusedId])
   })
 
-  it('restores the remembered right sidebar tab per worktree', () => {
+  it('keeps the current right sidebar tab when switching worktrees', () => {
     const store = createTestStore()
     const wt1 = 'repo1::/path/wt1'
     const wt2 = 'repo1::/path/wt2'
@@ -483,20 +483,21 @@ describe('setActiveWorktree', () => {
           makeWorktree({ id: wt2, repoId: 'repo1', path: '/path/wt2' })
         ]
       },
-      rightSidebarTabByWorktree: { [wt1]: 'search', [wt2]: 'checks' }
+      rightSidebarTab: 'checks',
+      rightSidebarTabByWorktree: { [wt1]: 'search', [wt2]: 'explorer' }
     })
 
     store.getState().setActiveWorktree(wt1)
-    expect(store.getState().rightSidebarTab).toBe('search')
+    expect(store.getState().rightSidebarTab).toBe('checks')
 
     store.getState().setActiveWorktree(wt2)
     expect(store.getState().rightSidebarTab).toBe('checks')
 
     store.getState().setActiveWorktree(wt1)
-    expect(store.getState().rightSidebarTab).toBe('search')
+    expect(store.getState().rightSidebarTab).toBe('checks')
   })
 
-  it('defaults new worktrees without remembered right sidebar state to explorer', () => {
+  it('does not reset the right sidebar tab for worktrees without remembered sidebar state', () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'
 
@@ -509,7 +510,7 @@ describe('setActiveWorktree', () => {
 
     store.getState().setActiveWorktree(wt)
 
-    expect(store.getState().rightSidebarTab).toBe('explorer')
+    expect(store.getState().rightSidebarTab).toBe('checks')
   })
 
   it('does not clobber the current right sidebar tab when clearing the active worktree', () => {

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -25,6 +25,7 @@ function createUIStore(): StoreApi<AppState> {
   return createStore<any>()((...args: any[]) => ({
     repos: [],
     worktreesByRepo: {},
+    rightSidebarOpen: false,
     rightSidebarWidth: 280,
     ...createWorktreeNavHistorySlice(...(args as Parameters<typeof createWorktreeNavHistorySlice>)),
     ...createUISlice(...(args as Parameters<typeof createUISlice>))
@@ -59,6 +60,10 @@ function makePersistedUI(overrides: Partial<PersistedUIState> = {}): PersistedUI
 }
 
 describe('createUISlice hydratePersistedUI', () => {
+  it('defaults persisted right sidebar visibility to open', () => {
+    expect(getDefaultUIState().rightSidebarOpen).toBe(true)
+  })
+
   it('defaults to showing sleeping workspaces', () => {
     const store = createUIStore()
 
@@ -75,6 +80,42 @@ describe('createUISlice hydratePersistedUI', () => {
     })
 
     expect(store.getState().rightSidebarWidth).toBe(360)
+  })
+
+  it('hydrates a persisted closed right sidebar preference', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(makePersistedUI({ rightSidebarOpen: false }))
+
+    expect(store.getState().rightSidebarOpen).toBe(false)
+  })
+
+  it('hydrates a persisted open right sidebar preference', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(makePersistedUI({ rightSidebarOpen: true }))
+
+    expect(store.getState().rightSidebarOpen).toBe(true)
+  })
+
+  it('hydrates a persisted right sidebar tab preference', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(makePersistedUI({ rightSidebarTab: 'checks' }))
+
+    expect(store.getState().rightSidebarTab).toBe('checks')
+  })
+
+  it('falls back to explorer for invalid persisted right sidebar tabs', () => {
+    const store = createUIStore()
+
+    store
+      .getState()
+      .hydratePersistedUI(
+        makePersistedUI({ rightSidebarTab: 'bogus' as PersistedUIState['rightSidebarTab'] })
+      )
+
+    expect(store.getState().rightSidebarTab).toBe('explorer')
   })
 
   it('clamps persisted sidebar widths into the supported range', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -104,6 +104,21 @@ function migrateStatusBarItems(items: readonly string[] | undefined): StatusBarI
   return out as StatusBarItem[]
 }
 
+function normalizePersistedRightSidebarTab(
+  tab: PersistedUIState['rightSidebarTab'] | unknown
+): PersistedUIState['rightSidebarTab'] {
+  if (
+    tab === 'explorer' ||
+    tab === 'search' ||
+    tab === 'source-control' ||
+    tab === 'checks' ||
+    tab === 'ports'
+  ) {
+    return tab
+  }
+  return 'explorer'
+}
+
 const MIN_SIDEBAR_WIDTH = 220
 const MAX_LEFT_SIDEBAR_WIDTH = 500
 // Why: the right sidebar drag-resize is window-relative (see right-sidebar
@@ -1164,6 +1179,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
           s.rightSidebarWidth,
           MAX_RIGHT_SIDEBAR_WIDTH
         ),
+        rightSidebarOpen: typeof ui.rightSidebarOpen === 'boolean' ? ui.rightSidebarOpen : true,
+        rightSidebarTab: normalizePersistedRightSidebarTab(ui.rightSidebarTab),
         groupBy: (ui.groupBy as UISlice['groupBy'] | 'parent') === 'parent' ? 'repo' : ui.groupBy,
         sortBy,
         // Why: Active-only was retired. Force the old persisted flag off so an

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1673,7 +1673,6 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const restoredFileId = s.activeFileIdByWorktree[worktreeId] ?? null
       const restoredBrowserTabId = s.activeBrowserTabIdByWorktree[worktreeId] ?? null
       const restoredTabType = s.activeTabTypeByWorktree[worktreeId] ?? 'terminal'
-      const restoredRightSidebarTab = s.rightSidebarTabByWorktree[worktreeId] ?? 'explorer'
       const activeGroupId =
         s.activeGroupIdByWorktree[worktreeId] ?? s.groupsByWorktree[worktreeId]?.[0]?.id ?? null
       const activeGroup = activeGroupId
@@ -1843,7 +1842,6 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         activeFileId,
         activeBrowserTabId,
         activeTabType,
-        rightSidebarTab: restoredRightSidebarTab,
         activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: activeTabType },
         activeTabId,
         everActivatedWorktreeIds: nextEverActivated,

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -170,6 +170,33 @@ describe('web keybindings preload API', () => {
   })
 })
 
+describe('web UI preload API', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('migrates missing right sidebar visibility from the effective web legacy default', async () => {
+    const { api } = await installApi('Linux')
+
+    const ui = await api.ui.get()
+
+    expect(ui.rightSidebarOpen).toBe(false)
+  })
+
+  it('keeps explicit local right sidebar visibility over the legacy default', async () => {
+    const { api, storage } = await installApi('Linux')
+    storage.setItem('orca.web.ui.v1', JSON.stringify({ rightSidebarOpen: true }))
+
+    const ui = await api.ui.get()
+
+    expect(ui.rightSidebarOpen).toBe(true)
+  })
+})
+
 describe('web worktree preload API', () => {
   beforeEach(() => {
     vi.resetModules()

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2016,10 +2016,18 @@ function closeWebOnboarding(base: OnboardingState): OnboardingState {
 }
 
 function readLocalWebUIState(): PersistedUIState {
-  return mergeWebUIState(
-    getDefaultUIState(),
-    readJson<Partial<PersistedUIState>>(UI_STORAGE_KEY, {})
-  )
+  const defaults = getDefaultUIState()
+  const stored = readJson<Partial<PersistedUIState>>(UI_STORAGE_KEY, {})
+  if (typeof stored.rightSidebarOpen === 'boolean') {
+    return mergeWebUIState(defaults, stored)
+  }
+  const storedSettings = getStoredSettings()
+  return mergeWebUIState(defaults, {
+    ...stored,
+    // Why: web fallback lacks main-process normalization, so migrate the
+    // retired setting only when the local UI preference is still absent.
+    rightSidebarOpen: storedSettings.rightSidebarOpenByDefault
+  })
 }
 
 function mergeWebUIState(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -352,6 +352,8 @@ export function getDefaultUIState(): PersistedUIState {
     lastActiveRepoId: null,
     lastActiveWorktreeId: null,
     sidebarWidth: 280,
+    rightSidebarOpen: true,
+    rightSidebarTab: 'explorer',
     rightSidebarWidth: 350,
     groupBy: 'repo',
     sortBy: 'recent',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1658,6 +1658,7 @@ export type GlobalSettings = {
   openLinksInApp: boolean
   /** Extra launcher rows for the worktree "Open in" submenu. VS Code is always shown first. */
   openInApplications?: OpenInApplication[]
+  /** Deprecated: migration/backward-compat only. Use PersistedUIState.rightSidebarOpen. */
   rightSidebarOpenByDefault: boolean
   showGitIgnoredFiles?: boolean
   /** Preferred Source Control changes layout. Per-user, not per-workspace. */
@@ -2064,10 +2065,14 @@ export type TaskResumeState = {
   linearQuery?: string
 }
 
+export type RightSidebarTab = 'explorer' | 'search' | 'source-control' | 'checks' | 'ports'
+
 export type PersistedUIState = {
   lastActiveRepoId: string | null
   lastActiveWorktreeId: string | null
   sidebarWidth: number
+  rightSidebarOpen: boolean
+  rightSidebarTab: RightSidebarTab
   rightSidebarWidth: number
   groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'


### PR DESCRIPTION
## Summary
- Persist right-sidebar open/closed state and selected right-sidebar page as global UI chrome via `PersistedUIState.rightSidebarOpen` and `rightSidebarTab`.
- Deprecate `settings.rightSidebarOpenByDefault` as migration/backward-compatibility data only and remove its Appearance setting/search entry.
- Stop new workspace creation and workspace switching from force-opening or resetting the right sidebar to Files.
- Keep explicit reveal actions able to select Files, while preserving the selected Checks/Search/Source Control/Ports page across workspace switches and restarts.
- Keep full-page views from mutating the persisted right-sidebar preference, including main-process shortcut/menu toggle paths and PR refresh visibility heuristics.

## Pipeline Evidence
- Design approach: use persisted UI state for global chrome visibility, migrate missing UI state from the retired setting once, and keep right-sidebar page selection global after follow-up feedback.
- Design review: `auto-design-review-fix` subagent found no P0/P1/P2 issues; design was clean.
- Implementation: matched the reviewed design, then incorporated follow-up PR feedback that selected right-sidebar page must also remain global across workspace switches.
- Completeness verification: read-only verifier confirmed all original requirements satisfied, including desktop/web/RPC persistence, settings deprecation, full-page behavior, and test coverage.
- Code review loop: Round 1 found three actionable issues; all fixed. Round 2 found one UI-copy issue; fixed. Round 3 had two independent clean reviews. Reran after the follow-up sidebar-tab fix; one folder-repo fallback issue was found, fixed, and followed by two independent clean reviews.
- Brennan test changes: result `land`. Electron validation launched this exact worktree, verified branch/root identity, used `demo-project`, exercised real sidebar toggle persistence, full-page suppression and `Meta+L`, Settings → Appearance removal/search, and creating a new demo-project workspace with the sidebar closed.

## Tests
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/right-sidebar-visibility.test.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/store/slices/ui.test.ts src/main/persistence.test.ts src/main/runtime/rpc/methods/client-ui.test.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/store/slices/store-cascades.test.ts` (7 files / 380 tests)
- [x] Brennan validation focused tests: 7 files / 323 tests, including GitHub slice and IPC events coverage.
- [x] Electron product validation on `demo-project`.
- [x] Focused Brennan rerun for the folder-repo sidebar fallback: exact PR Electron identity verified; clicked Checks on `demo-project`, switched to a disposable folder repo, observed Files/Explorer fallback with Source Control/Checks hidden while raw `rightSidebarTab` stayed `checks`, and instrumented `refreshAllGitHub()` enqueued 0 PR refreshes.

## Assumptions and Gaps
- No live SSH pass was run because this change does not alter SSH transport or remote PTY behavior; the preference remains client-local UI state and runtime UI RPC coverage is included.
- The legacy `rightSidebarOpenByDefault` field remains typed/readable/writable for compatibility, but no longer drives renderer behavior except migration fallback.