### PR TITLE
fix: preserve copy-on-select in mouse-mode TUIs

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createForcedSelectionMouseEvent,
+  installCopyOnSelectMouseSelectionForcing,
+  isXtermScreenMouseTarget,
+  shouldForceCopyOnSelectMouseSelection
+} from './terminal-mouse-selection-forcing'
+
+function mouseEvent(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return {
+    altKey: false,
+    button: 0,
+    buttons: 1,
+    ctrlKey: false,
+    defaultPrevented: false,
+    metaKey: false,
+    shiftKey: false,
+    type: 'mousedown',
+    ...overrides
+  } as MouseEvent
+}
+
+type FakeMouseListener = (event: FakeMouseEvent) => void
+
+class FakeMouseEvent {
+  readonly altKey: boolean
+  readonly bubbles: boolean
+  readonly button: number
+  readonly buttons: number
+  readonly clientX: number
+  readonly ctrlKey: boolean
+  readonly metaKey: boolean
+  readonly shiftKey: boolean
+  readonly type: string
+  defaultPrevented = false
+  target: FakeElement | null = null
+  stopped = false
+
+  constructor(type: string, init: MouseEventInit = {}) {
+    this.type = type
+    this.altKey = init.altKey ?? false
+    this.bubbles = init.bubbles ?? false
+    this.button = init.button ?? 0
+    this.buttons = init.buttons ?? 0
+    this.clientX = init.clientX ?? 0
+    this.ctrlKey = init.ctrlKey ?? false
+    this.metaKey = init.metaKey ?? false
+    this.shiftKey = init.shiftKey ?? false
+  }
+
+  preventDefault(): void {
+    this.defaultPrevented = true
+  }
+
+  stopImmediatePropagation(): void {
+    this.stopped = true
+  }
+}
+
+class FakeElement {
+  private listeners = new Map<string, { capture: boolean; listener: FakeMouseListener }[]>()
+  className = ''
+  parentElement: FakeElement | null = null
+
+  appendChild(child: FakeElement): void {
+    child.parentElement = this
+  }
+
+  addEventListener(
+    type: string,
+    listener: FakeMouseListener,
+    options?: AddEventListenerOptions | boolean
+  ): void {
+    const listeners = this.listeners.get(type) ?? []
+    const capture = typeof options === 'boolean' ? options : options?.capture === true
+    listeners.push({ capture, listener })
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(
+    type: string,
+    listener: FakeMouseListener,
+    options?: EventListenerOptions | boolean
+  ): void {
+    const capture = typeof options === 'boolean' ? options : options?.capture === true
+    const listeners = this.listeners.get(type) ?? []
+    this.listeners.set(
+      type,
+      listeners.filter((entry) => entry.listener !== listener || entry.capture !== capture)
+    )
+  }
+
+  dispatchEvent(event: FakeMouseEvent): boolean {
+    event.target ??= this
+    const path = this.eventPath()
+    for (const node of path) {
+      node.emit(event, true)
+      if (event.stopped) {
+        return !event.defaultPrevented
+      }
+    }
+    const bubblePath = event.bubbles ? [...path].reverse() : [this]
+    for (const node of bubblePath) {
+      node.emit(event, false)
+      if (event.stopped) {
+        return !event.defaultPrevented
+      }
+    }
+    return !event.defaultPrevented
+  }
+
+  closest(selector: string): FakeElement | null {
+    if (selector !== '.xterm-screen') {
+      return null
+    }
+    if (this.className.split(/\s+/).includes('xterm-screen')) {
+      return this
+    }
+    return this.parentElement?.closest(selector) ?? null
+  }
+
+  private eventPath(): FakeElement[] {
+    return this.parentElement ? [...this.parentElement.eventPath(), this] : [this]
+  }
+
+  private emit(event: FakeMouseEvent, capture: boolean): void {
+    for (const { listener } of this.listeners
+      .get(event.type)
+      ?.filter((entry) => entry.capture === capture) ?? []) {
+      listener(event)
+      if (event.stopped) {
+        return
+      }
+    }
+  }
+}
+
+function installDomGlobals(): void {
+  vi.stubGlobal('Element', FakeElement)
+  vi.stubGlobal('MouseEvent', FakeMouseEvent)
+}
+
+function fakeElement(className = ''): FakeElement {
+  const element = new FakeElement()
+  element.className = className
+  return element
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('shouldForceCopyOnSelectMouseSelection', () => {
+  it('forces selection for plain primary mousedown in TUI mouse mode when copy-on-select is enabled', () => {
+    expect(
+      shouldForceCopyOnSelectMouseSelection(mouseEvent(), {
+        copyOnSelect: true,
+        isMac: false,
+        mouseTrackingMode: 'drag'
+      })
+    ).toBe(true)
+  })
+
+  it('does not force selection when copy-on-select is disabled', () => {
+    expect(
+      shouldForceCopyOnSelectMouseSelection(mouseEvent(), {
+        copyOnSelect: false,
+        isMac: false,
+        mouseTrackingMode: 'drag'
+      })
+    ).toBe(false)
+  })
+
+  it('does not force selection when the TUI is not using mouse mode', () => {
+    expect(
+      shouldForceCopyOnSelectMouseSelection(mouseEvent(), {
+        copyOnSelect: true,
+        isMac: false,
+        mouseTrackingMode: 'none'
+      })
+    ).toBe(false)
+  })
+
+  it('leaves non-primary buttons and existing modified clicks alone', () => {
+    const options = { copyOnSelect: true, isMac: false, mouseTrackingMode: 'drag' } as const
+
+    expect(shouldForceCopyOnSelectMouseSelection(mouseEvent({ button: 1 }), options)).toBe(false)
+    expect(shouldForceCopyOnSelectMouseSelection(mouseEvent({ ctrlKey: true }), options)).toBe(
+      false
+    )
+    expect(shouldForceCopyOnSelectMouseSelection(mouseEvent({ metaKey: true }), options)).toBe(
+      false
+    )
+    expect(shouldForceCopyOnSelectMouseSelection(mouseEvent({ shiftKey: true }), options)).toBe(
+      false
+    )
+  })
+
+  it('does not force selection after another handler prevents the event', () => {
+    expect(
+      shouldForceCopyOnSelectMouseSelection(mouseEvent({ defaultPrevented: true }), {
+        copyOnSelect: true,
+        isMac: false,
+        mouseTrackingMode: 'drag'
+      })
+    ).toBe(false)
+  })
+
+  it('uses Option as the existing force-selection modifier on macOS', () => {
+    expect(
+      shouldForceCopyOnSelectMouseSelection(mouseEvent({ altKey: true }), {
+        copyOnSelect: true,
+        isMac: true,
+        mouseTrackingMode: 'drag'
+      })
+    ).toBe(false)
+    expect(
+      shouldForceCopyOnSelectMouseSelection(mouseEvent({ shiftKey: true }), {
+        copyOnSelect: true,
+        isMac: true,
+        mouseTrackingMode: 'drag'
+      })
+    ).toBe(true)
+  })
+})
+
+describe('isXtermScreenMouseTarget', () => {
+  it('matches events inside the xterm screen only', () => {
+    installDomGlobals()
+    const outside = fakeElement()
+    const screen = fakeElement('xterm-screen')
+    const row = fakeElement()
+    screen.appendChild(row)
+
+    expect(isXtermScreenMouseTarget(outside as never)).toBe(false)
+    expect(isXtermScreenMouseTarget(screen as never)).toBe(true)
+    expect(isXtermScreenMouseTarget(row as never)).toBe(true)
+  })
+})
+
+describe('createForcedSelectionMouseEvent', () => {
+  it('adds Shift on Windows/Linux', () => {
+    installDomGlobals()
+    const event = new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 10 })
+    const forced = createForcedSelectionMouseEvent(event, false)
+
+    expect(forced.shiftKey).toBe(true)
+    expect(forced.altKey).toBe(false)
+    expect(forced.button).toBe(0)
+    expect(forced.clientX).toBe(10)
+  })
+
+  it('adds Option on macOS', () => {
+    installDomGlobals()
+    const event = new MouseEvent('mousedown', { bubbles: true, button: 0, shiftKey: false })
+    const forced = createForcedSelectionMouseEvent(event, true)
+
+    expect(forced.altKey).toBe(true)
+    expect(forced.shiftKey).toBe(false)
+  })
+})
+
+describe('installCopyOnSelectMouseSelectionForcing', () => {
+  it('redispatches a force-selection mouse event and stops the original event', () => {
+    installDomGlobals()
+    const container = fakeElement()
+    const screen = fakeElement('xterm-screen')
+    const target = fakeElement()
+    screen.appendChild(target)
+    container.appendChild(screen)
+    const seenShiftStates: boolean[] = []
+    target.addEventListener('mousedown', (event) => {
+      seenShiftStates.push(event.shiftKey)
+    })
+    const dispose = installCopyOnSelectMouseSelectionForcing({
+      container: container as never,
+      getCopyOnSelect: () => true,
+      isMac: false,
+      terminal: { modes: { mouseTrackingMode: 'drag' } } as never
+    })
+
+    target.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, button: 0, buttons: 1 }) as never
+    )
+
+    expect(seenShiftStates).toEqual([true])
+    dispose()
+  })
+
+  it('does not redispatch when copy-on-select is off', () => {
+    installDomGlobals()
+    const container = fakeElement()
+    const screen = fakeElement('xterm-screen')
+    const target = fakeElement()
+    screen.appendChild(target)
+    container.appendChild(screen)
+    const listener = vi.fn()
+    target.addEventListener('mousedown', listener)
+    const dispose = installCopyOnSelectMouseSelectionForcing({
+      container: container as never,
+      getCopyOnSelect: () => false,
+      isMac: false,
+      terminal: { modes: { mouseTrackingMode: 'drag' } } as never
+    })
+
+    target.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, button: 0, buttons: 1 }) as never
+    )
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0]?.[0].shiftKey).toBe(false)
+    dispose()
+  })
+
+  it('does not redispatch outside the xterm screen', () => {
+    installDomGlobals()
+    const container = fakeElement()
+    const target = fakeElement()
+    container.appendChild(target)
+    const listener = vi.fn()
+    target.addEventListener('mousedown', listener)
+    const dispose = installCopyOnSelectMouseSelectionForcing({
+      container: container as never,
+      getCopyOnSelect: () => true,
+      isMac: false,
+      terminal: { modes: { mouseTrackingMode: 'drag' } } as never
+    })
+
+    target.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, button: 0, buttons: 1 }) as never
+    )
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0]?.[0].shiftKey).toBe(false)
+    dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.ts
@@ -1,0 +1,105 @@
+import type { Terminal } from '@xterm/xterm'
+
+type MouseSelectionForcingEvent = Pick<
+  MouseEvent,
+  'type' | 'button' | 'altKey' | 'ctrlKey' | 'defaultPrevented' | 'metaKey' | 'shiftKey'
+>
+
+type MouseSelectionForcingOptions = {
+  copyOnSelect: boolean
+  isMac: boolean
+  mouseTrackingMode: Terminal['modes']['mouseTrackingMode']
+}
+
+function hasSelectionModifier(
+  event: Pick<MouseEvent, 'altKey' | 'shiftKey'>,
+  isMac: boolean
+): boolean {
+  return isMac ? event.altKey : event.shiftKey
+}
+
+export function shouldForceCopyOnSelectMouseSelection(
+  event: MouseSelectionForcingEvent,
+  options: MouseSelectionForcingOptions
+): boolean {
+  if (event.defaultPrevented || !options.copyOnSelect || options.mouseTrackingMode === 'none') {
+    return false
+  }
+  if (event.type !== 'mousedown' || event.button !== 0) {
+    return false
+  }
+  if (event.ctrlKey || event.metaKey || hasSelectionModifier(event, options.isMac)) {
+    return false
+  }
+  return true
+}
+
+export function createForcedSelectionMouseEvent(event: MouseEvent, isMac: boolean): MouseEvent {
+  return new MouseEvent(event.type, {
+    altKey: isMac ? true : event.altKey,
+    bubbles: true,
+    button: event.button,
+    buttons: event.buttons,
+    cancelable: true,
+    clientX: event.clientX,
+    clientY: event.clientY,
+    composed: event.composed,
+    ctrlKey: event.ctrlKey,
+    detail: event.detail,
+    metaKey: event.metaKey,
+    screenX: event.screenX,
+    screenY: event.screenY,
+    shiftKey: isMac ? event.shiftKey : true,
+    view: event.view
+  })
+}
+
+export function isXtermScreenMouseTarget(target: EventTarget | null): target is Element {
+  return target instanceof Element && target.closest('.xterm-screen') !== null
+}
+
+export function installCopyOnSelectMouseSelectionForcing(args: {
+  container: HTMLElement
+  getCopyOnSelect: () => boolean
+  isMac: boolean
+  terminal: Pick<Terminal, 'modes'>
+}): () => void {
+  let redispatching = false
+  const onMouseDown = (event: MouseEvent): void => {
+    if (redispatching) {
+      return
+    }
+    const target = event.target
+    if (!isXtermScreenMouseTarget(target)) {
+      return
+    }
+    if (
+      !shouldForceCopyOnSelectMouseSelection(event, {
+        copyOnSelect: args.getCopyOnSelect(),
+        isMac: args.isMac,
+        mouseTrackingMode: args.terminal.modes.mouseTrackingMode
+      })
+    ) {
+      return
+    }
+
+    // Why: xterm disables its selection service when a TUI enables mouse
+    // reporting. Re-dispatching with the platform's existing force-selection
+    // modifier lets xterm's own selection/copy path run instead of sending the
+    // drag to the TUI.
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    const forcedEvent = createForcedSelectionMouseEvent(event, args.isMac)
+    redispatching = true
+    try {
+      target.dispatchEvent(forcedEvent)
+    } finally {
+      redispatching = false
+    }
+  }
+
+  args.container.addEventListener('mousedown', onMouseDown, { capture: true })
+  return () => {
+    args.container.removeEventListener('mousedown', onMouseDown, { capture: true })
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -48,6 +48,7 @@ import { isPaneReplaying, type ReplayingPanesRef } from './replay-guard'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
 import { registerRuntimeTerminalTab, scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { e2eConfig } from '@/lib/e2e-config'
+import { installCopyOnSelectMouseSelectionForcing } from './terminal-mouse-selection-forcing'
 import {
   PRIMARY_SELECTION_MAX_LENGTH,
   isPrimarySelectionEnabled,
@@ -272,6 +273,7 @@ export function useTerminalPaneLifecycle({
   // Why: read settingsRef at fire time so toggling "copy on select" takes
   // effect without recreating panes.
   const selectionDisposablesRef = useRef(new Map<number, IDisposable>())
+  const forcedSelectionDisposablesRef = useRef(new Map<number, () => void>())
   const selectionCaptureTimersRef = useRef(new Map<number, number>())
   const mode2031DisposablesRef = useRef(new Map<number, IDisposable[]>())
   const osc52DisposablesRef = useRef(new Map<number, IDisposable>())
@@ -337,6 +339,7 @@ export function useTerminalPaneLifecycle({
     const panePtyBindings = panePtyBindingsRef.current
     const linkDisposables = linkProviderDisposablesRef.current
     const selectionDisposables = selectionDisposablesRef.current
+    const forcedSelectionDisposables = forcedSelectionDisposablesRef.current
     const selectionCaptureTimers = selectionCaptureTimersRef.current
     const mouseHideDisposables = mouseHideDisposablesRef.current
     const worktreePath =
@@ -523,6 +526,14 @@ export function useTerminalPaneLifecycle({
           })
         })
 
+        const disposeForcedSelection = installCopyOnSelectMouseSelectionForcing({
+          container: pane.container,
+          getCopyOnSelect: () => settingsRef.current?.terminalClipboardOnSelect === true,
+          isMac: navigator.userAgent.includes('Mac'),
+          terminal: pane.terminal
+        })
+        forcedSelectionDisposablesRef.current.set(pane.id, disposeForcedSelection)
+
         const linkProviderDisposable = pane.terminal.registerLinkProvider(
           createFilePathLinkProvider(pane.id, linkDeps, pane.linkTooltip, fileOpenLinkHint)
         )
@@ -657,6 +668,11 @@ export function useTerminalPaneLifecycle({
         if (selectionDisposable) {
           selectionDisposable.dispose()
           selectionDisposablesRef.current.delete(paneId)
+        }
+        const forcedSelectionDisposable = forcedSelectionDisposablesRef.current.get(paneId)
+        if (forcedSelectionDisposable) {
+          forcedSelectionDisposable()
+          forcedSelectionDisposablesRef.current.delete(paneId)
         }
         const selectionCaptureTimer = selectionCaptureTimersRef.current.get(paneId)
         if (selectionCaptureTimer !== undefined) {
@@ -1063,6 +1079,10 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       selectionDisposables.clear()
+      for (const dispose of forcedSelectionDisposables.values()) {
+        dispose()
+      }
+      forcedSelectionDisposables.clear()
       for (const timer of selectionCaptureTimers.values()) {
         window.clearTimeout(timer)
       }


### PR DESCRIPTION
## Summary

Preserves terminal copy-on-select when a TUI has enabled xterm mouse tracking.

Plain left-button drags in the terminal screen are re-dispatched with xterm's existing force-selection modifier so xterm's normal selection/copy path runs instead of forwarding the drag to the TUI. Modified clicks and explicit selection modifiers are left unchanged.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full suite is blocked locally: `ensure-native-runtime` rebuilds `better-sqlite3` under Node v25.6.0 despite the repo requiring Node 24, then Vitest exits with `Segmentation fault (core dumped)`. The focused regression test below passes.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional focused checks:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.test.ts`
- [x] `pnpm run typecheck:web`
- [x] `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.ts src/renderer/src/components/terminal-pane/terminal-mouse-selection-forcing.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts`

## AI Review Report

I reviewed the change for terminal interaction regressions, event propagation risks, cleanup/disposal behavior, and cross-platform force-selection behavior.

Main checks:

- Confirmed the interception only applies to plain left-button `mousedown` events inside `.xterm-screen`.
- Confirmed copy-on-select must be enabled and xterm mouse tracking must be active before the redispatch path runs.
- Confirmed modified clicks are not hijacked: Ctrl/Cmd clicks, existing force-selection modifiers, non-left clicks, prevented events, and non-screen targets are ignored.
- Confirmed macOS uses Alt as xterm's force-selection modifier while Linux/Windows use Shift, matching xterm's existing selection behavior.
- Confirmed the pane cleanup path disposes the capture listener both on pane close and component teardown.
- Confirmed this PR does not touch shortcut labels, file paths, shell command execution, or provider-specific git behavior.

The review flagged event recursion and listener cleanup as the main risks; the implementation guards redispatch with a local `redispatching` flag and stores/removes a per-pane disposable. Regression tests cover those paths.

## Security Audit

Reviewed input handling, event spoofing scope, command execution, path handling, auth/secrets, dependencies, and IPC impact.

- Input handling: the handler only inspects browser `MouseEvent` properties and xterm mode/settings state; it does not parse terminal output or user text.
- Command execution: no commands are created or executed.
- Path handling: no filesystem paths are read or written.
- Auth/secrets: no auth, token, or secret surfaces are touched.
- Dependencies: no dependencies are added or changed.
- IPC: no new IPC calls are introduced; existing clipboard-on-selection behavior remains the clipboard write path.

No follow-up security work identified.

## Notes

Platform behavior is intentionally different only for the xterm force-selection modifier: macOS receives Alt, while Linux/Windows receive Shift.

X handle: @_Codename_11
