### PR TITLE
Start-align mobile intro CTA

### DIFF
--- a/src/renderer/src/assets/mobile-page.css
+++ b/src/renderer/src/assets/mobile-page.css
@@ -256,13 +256,12 @@
 .mobile-page-root .mp-cta-row {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 14px;
   margin-top: auto;
   padding-top: 16px;
-  /* Why: the intro CTA should land exactly where the step-flow primary
-     button appears, so users can click through without moving the pointer. */
-  padding-right: var(--mp-flow-card-inset);
+  /* Why: the intro CTA is part of the hero copy, so it should start-align
+     with the headline and lead instead of matching the later flow footer. */
   padding-bottom: var(--mp-flow-card-inset);
 }
 


### PR DESCRIPTION
## Summary
- Aligns the mobile intro CTA with the hero headline and lead copy.
- Removes the footer-style right inset so the intro CTA reads as part of the hero content instead of the later step flow controls.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.