### PR TITLE
Fix Cmd+J create workspace selection

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -34,6 +34,7 @@ import {
   CREATE_WORKTREE_ITEM_ID,
   createWorktreePaletteRequestGuard,
   getNextWorktreePaletteSelection,
+  getWorktreePaletteSelectionItemIds,
   getWorktreePaletteCreateActionState
 } from '@/lib/worktree-palette-create-action'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
@@ -571,16 +572,13 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     [paletteSections]
   )
 
-  const selectableItemIds = useMemo(() => selectableItems.map((item) => item.id), [selectableItems])
-
   const { createWorktreeName, showCreateAction } = useMemo(
     () =>
       getWorktreePaletteCreateActionState({
         canCreateWorktree,
-        query: deferredQuery,
-        selectableItemIds
+        query: deferredQuery
       }),
-    [canCreateWorktree, deferredQuery, selectableItemIds]
+    [canCreateWorktree, deferredQuery]
   )
 
   const listEntries = useMemo<PaletteListEntry[]>(() => {
@@ -650,6 +648,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     }
     return entries
   }, [hasQuery, paletteSections, showCreateAction, worktreeItems.length])
+
+  const selectionItemIds = useMemo(
+    () => getWorktreePaletteSelectionItemIds(listEntries),
+    [listEntries]
+  )
 
   // Why: empty-state / "has any worktrees?" uses the full visible list
   // (including current) so the palette never claims to be empty just
@@ -721,7 +724,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     const nextSelectedItemId = getNextWorktreePaletteSelection({
       currentSelectedItemId: selectedItemId,
       queryChanged,
-      selectableItemIds,
+      selectableItemIds: selectionItemIds,
       showCreateAction
     })
     if (queryChanged) {
@@ -733,7 +736,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     if (nextSelectedItemId !== selectedItemId) {
       setSelectedItemId(nextSelectedItemId)
     }
-  }, [deferredQuery, selectedItemId, showCreateAction, visible, selectableItemIds])
+  }, [deferredQuery, selectedItemId, showCreateAction, visible, selectionItemIds])
 
   const focusFallbackSurface = useCallback(() => {
     requestAnimationFrame(() => {

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -3,60 +3,71 @@ import {
   CREATE_WORKTREE_ITEM_ID,
   createWorktreePaletteRequestGuard,
   getNextWorktreePaletteSelection,
+  getWorktreePaletteSelectionItemIds,
   getWorktreePaletteCreateActionState
 } from './worktree-palette-create-action'
 
 describe('worktree-palette-create-action', () => {
-  it('shows create for typed queries with workspace matches but selects the first real row', () => {
+  it('shows create for typed queries with workspace matches but selects the first workspace row', () => {
     const state = getWorktreePaletteCreateActionState({
       canCreateWorktree: true,
-      query: 'feature',
-      selectableItemIds: ['worktree:one']
+      query: 'feature'
     })
 
     expect(state).toEqual({
       createWorktreeName: 'feature',
-      showCreateAction: true,
-      shouldDefaultToCreate: false
+      showCreateAction: true
     })
     expect(
       getNextWorktreePaletteSelection({
         currentSelectedItemId: '',
         queryChanged: true,
-        selectableItemIds: ['worktree:one'],
+        selectableItemIds: ['worktree:one', CREATE_WORKTREE_ITEM_ID, 'settings:provider'],
         showCreateAction: state.showCreateAction
       })
     ).toBe('worktree:one')
   })
 
-  it('shows create for typed queries with browser-only matches but selects the browser row', () => {
+  it('selects create when it appears before actions, settings, and browser rows', () => {
     const state = getWorktreePaletteCreateActionState({
       canCreateWorktree: true,
-      query: 'localhost',
-      selectableItemIds: ['browser-page:one']
+      query: 'opencode-issue'
     })
 
     expect(state.showCreateAction).toBe(true)
-    expect(state.shouldDefaultToCreate).toBe(false)
     expect(
       getNextWorktreePaletteSelection({
         currentSelectedItemId: '',
         queryChanged: true,
-        selectableItemIds: ['browser-page:one'],
+        selectableItemIds: [
+          CREATE_WORKTREE_ITEM_ID,
+          'settings:ai-provider-accounts',
+          'quick-action:new-terminal',
+          'browser-page:one'
+        ],
         showCreateAction: state.showCreateAction
       })
-    ).toBe('browser-page:one')
+    ).toBe(CREATE_WORKTREE_ITEM_ID)
+  })
+
+  it('selects create when it appears before a browser-only match', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: '',
+        queryChanged: true,
+        selectableItemIds: [CREATE_WORKTREE_ITEM_ID, 'browser-page:one'],
+        showCreateAction: true
+      })
+    ).toBe(CREATE_WORKTREE_ITEM_ID)
   })
 
   it('defaults to create for typed queries with no real matches', () => {
     const state = getWorktreePaletteCreateActionState({
       canCreateWorktree: true,
-      query: 'new-workspace',
-      selectableItemIds: []
+      query: 'new-workspace'
     })
 
     expect(state.showCreateAction).toBe(true)
-    expect(state.shouldDefaultToCreate).toBe(true)
     expect(
       getNextWorktreePaletteSelection({
         currentSelectedItemId: '',
@@ -65,6 +76,28 @@ describe('worktree-palette-create-action', () => {
         showCreateAction: state.showCreateAction
       })
     ).toBe(CREATE_WORKTREE_ITEM_ID)
+  })
+
+  it('returns empty selection when no create action or rows are available', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: '',
+        queryChanged: true,
+        selectableItemIds: [],
+        showCreateAction: false
+      })
+    ).toBe('')
+  })
+
+  it('does not keep create selected after the create row disappears', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: CREATE_WORKTREE_ITEM_ID,
+        queryChanged: false,
+        selectableItemIds: ['settings:ai-provider-accounts'],
+        showCreateAction: false
+      })
+    ).toBe('settings:ai-provider-accounts')
   })
 
   it('moves selection back to the first real row when the query changes after manual create selection', () => {
@@ -93,8 +126,7 @@ describe('worktree-palette-create-action', () => {
     expect(
       getWorktreePaletteCreateActionState({
         canCreateWorktree: false,
-        query: 'new-workspace',
-        selectableItemIds: []
+        query: 'new-workspace'
       }).showCreateAction
     ).toBe(false)
   })
@@ -103,10 +135,31 @@ describe('worktree-palette-create-action', () => {
     expect(
       getWorktreePaletteCreateActionState({
         canCreateWorktree: true,
-        query: '   ',
-        selectableItemIds: []
+        query: '   '
       }).showCreateAction
     ).toBe(false)
+  })
+
+  it('derives selection ids from rendered entries while skipping headers and hints', () => {
+    expect(
+      getWorktreePaletteSelectionItemIds([
+        { id: '__header_worktrees__', type: 'section-header' },
+        { id: 'worktree:one', type: 'worktree' },
+        { id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' },
+        { id: '__hint_worktree_cap__', type: 'hint' },
+        { id: '__header_actions_settings__', type: 'section-header' },
+        { id: 'settings:ai-provider-accounts', type: 'settings' },
+        { id: 'quick-action:new-terminal', type: 'quick-action' },
+        { id: '__header_browser__', type: 'section-header' },
+        { id: 'browser-page:one', type: 'browser-page' }
+      ])
+    ).toEqual([
+      'worktree:one',
+      CREATE_WORKTREE_ITEM_ID,
+      'settings:ai-provider-accounts',
+      'quick-action:new-terminal',
+      'browser-page:one'
+    ])
   })
 
   it('falls back deterministically when the selected row disappears', () => {

--- a/src/renderer/src/lib/worktree-palette-create-action.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.ts
@@ -3,25 +3,55 @@ export const CREATE_WORKTREE_ITEM_ID = '__create_worktree__'
 export type WorktreePaletteCreateActionState = {
   createWorktreeName: string
   showCreateAction: boolean
-  shouldDefaultToCreate: boolean
 }
 
 export function getWorktreePaletteCreateActionState({
   canCreateWorktree,
-  query,
-  selectableItemIds
+  query
 }: {
   canCreateWorktree: boolean
   query: string
-  selectableItemIds: readonly string[]
 }): WorktreePaletteCreateActionState {
   const createWorktreeName = query.trim()
   const showCreateAction = canCreateWorktree && createWorktreeName.length > 0
   return {
     createWorktreeName,
-    showCreateAction,
-    shouldDefaultToCreate: showCreateAction && selectableItemIds.length === 0
+    showCreateAction
   }
+}
+
+type WorktreePaletteSelectionCandidateEntry = {
+  id: string
+  type: string
+}
+
+type WorktreePaletteSelectableEntryType =
+  | 'worktree'
+  | 'create-worktree'
+  | 'settings'
+  | 'quick-action'
+  | 'browser-page'
+
+export function isSelectableWorktreePaletteEntry(
+  entry: WorktreePaletteSelectionCandidateEntry
+): entry is WorktreePaletteSelectionCandidateEntry & {
+  type: WorktreePaletteSelectableEntryType
+} {
+  return (
+    entry.type === 'worktree' ||
+    entry.type === 'create-worktree' ||
+    entry.type === 'settings' ||
+    entry.type === 'quick-action' ||
+    entry.type === 'browser-page'
+  )
+}
+
+export function getWorktreePaletteSelectionItemIds<
+  T extends WorktreePaletteSelectionCandidateEntry
+>(entries: readonly T[]): string[] {
+  // Why: keyboard focus should mirror rendered order, including synthetic
+  // action rows, while skipping headers and explanatory hint rows.
+  return entries.filter(isSelectableWorktreePaletteEntry).map((entry) => entry.id)
 }
 
 export function getNextWorktreePaletteSelection({


### PR DESCRIPTION
## Summary
- Fix Cmd+J selection ordering so the synthetic `Create workspace "<query>"` row participates in keyboard default selection at the same position where it is rendered.
- Derive palette selection IDs from rendered `listEntries`, skipping headers and hints, instead of separately deriving selection from only real workspace/settings/action/browser items.
- Keep settings/action ranking and row styling unchanged.

## Design approach
The reviewed design identified drift between render order and selection order: the create row was rendered above Actions & Settings but omitted from the default selection ID list. The fix makes rendered order the source of truth for actionable selection IDs, preserving existing fallback/manual-selection behavior in `getNextWorktreePaletteSelection`.

Scratch design doc: `design-docs/cmd-j-create-workspace-selection.md` (ignored, not included in product diff).

## Design review outcome
`auto-design-review-fix` completed clean after 2 review iterations. Iteration 2 had two independent reviewers return no issues. The design was updated to derive selection IDs from `listEntries` through a concrete selection-entry guard.

## Implementation
- `WorktreeJumpPalette.tsx`: passes `getWorktreePaletteSelectionItemIds(listEntries)` into selection fallback logic.
- `worktree-palette-create-action.ts`: adds the selection-entry filter and removes the now-unused `shouldDefaultToCreate` field.
- `worktree-palette-create-action.test.ts`: covers workspace-before-create, create-before-actions/settings/browser, create-before-browser-only, hidden-create fallback, empty selection, and header/hint exclusion.

Deviations from design doc: none.

## Completeness verification
Read-only completeness verification confirmed:
- Create is selected when visually before Actions & Settings.
- Real workspace matches still win when above create.
- Settings/action ranking and styling are unchanged.
- SSH/cross-platform/provider behavior is unaffected because the change is renderer-only selection state.

Two minor test gaps found in the initial pass were fixed before code review: browser-only create ordering and no-create/no-rows empty selection.

## Code review loop
Round 1 used two independent `review-code` subagents in parallel.
- Reviewer 1: clean, no actionable findings. Focused Vitest passed with 13 tests.
- Reviewer 2: clean, no actionable findings. `git diff --check`, focused Vitest, and `pnpm run typecheck:web` passed.

Stopping condition met: both reviewers in the same round returned clean.

## Brennan test changes
`brennan-test-changes` verdict: land.

Product validation:
- Launched Electron dev app from this exact worktree.
- Opened the rendered worktree/search palette, typed `opencode-issue`.
- Verified `Create workspace "opencode-issue"` rendered above Actions & Settings / AI Provider Accounts.
- Verified selected row had `value="__create_worktree__"` and `data-selected=true`.
- Pressed Enter and confirmed it opened Create Worktree with project `demo-project` and name prefilled as `opencode-issue`, not Settings.
- Verified no `opencode-issue` worktree was created in app state or git worktree list.

Accepted gaps:
- Playwright `Meta+J` did not open the palette while Monaco had focus in the validation session, so the tester used the rendered Search control to reach the same palette and exercised the changed keyboard selection/Enter path. Shortcut routing was not part of this diff.
- Existing Radix dialog description warnings and unrelated local startup metadata noise were observed; no console errors.

## Checks
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-palette-create-action.test.ts` passed: 13 tests.
- `pnpm exec oxlint src/renderer/src/components/WorktreeJumpPalette.tsx src/renderer/src/lib/worktree-palette-create-action.ts src/renderer/src/lib/worktree-palette-create-action.test.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/components/WorktreeJumpPalette.tsx src/renderer/src/lib/worktree-palette-create-action.ts src/renderer/src/lib/worktree-palette-create-action.test.ts` passed.
- `pnpm run typecheck:web` passed.
- `pnpm run typecheck` passed in Brennan test pass.
- `pnpm run lint` passed in Brennan test pass.
- `git diff --check` passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
