### PR TITLE
Fix floating workspace terminal shortcut focus

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -73,7 +73,7 @@ import {
 } from '@/runtime/web-runtime-session'
 import {
   createFloatingWorkspaceTerminalTab,
-  isFloatingWorkspacePanelVisible
+  isFloatingWorkspacePanelFocused
 } from '@/lib/floating-workspace-terminal-actions'
 import {
   keybindingMatchesAction,
@@ -1127,7 +1127,7 @@ function Terminal(): React.JSX.Element | null {
       if (!e.repeat && matchShortcut('tab.newTerminal')) {
         e.preventDefault()
         notifyTerminalCapture('tab.newTerminal')
-        if (isFloatingWorkspacePanelVisible()) {
+        if (isFloatingWorkspacePanelFocused()) {
           void createFloatingWorkspaceTerminalTab(useAppStore.getState())
           return
         }

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -507,6 +507,10 @@ describe('FloatingTerminalPanel close behavior', () => {
         ui: { setFloatingTerminalInputFocused: vi.fn() }
       },
       innerWidth: 1200,
+      requestAnimationFrame: vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      }),
       removeEventListener: vi.fn()
     })
     vi.stubGlobal('navigator', { userAgent: 'Macintosh' })
@@ -542,6 +546,17 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.createTab).not.toHaveBeenCalled()
   })
 
+  it('focuses the empty floating workspace when opened for immediate shortcuts', async () => {
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const panelElement = { focus: vi.fn() }
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+
+    runEffects()
+
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
   it('minimizes the empty floating workspace from the empty state', async () => {
     const onOpenChange = vi.fn()
     const element = await renderPanel(true, onOpenChange)
@@ -553,6 +568,19 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.closeTab).not.toHaveBeenCalled()
     expect(mocks.closeFile).not.toHaveBeenCalled()
     expect(mocks.closeBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('shows the empty state when only stale unified tabs remain', async () => {
+    const state = storeBox.state as FloatingPanelStoreState
+    const staleTab = makeTab({ id: 'stale-tab' })
+    setFloatingTabs([staleTab])
+    state.tabsByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: [] }
+    state.activeTabIdByWorktree = { [FLOATING_TERMINAL_WORKTREE_ID]: null }
+
+    const element = await renderPanel(true)
+    const emptyState = findByTypeName(element, 'FloatingTerminalEmptyState')
+
+    expect(emptyState).toBeTruthy()
   })
 
   it('creates new floating terminal tabs without globally activating createTab', async () => {
@@ -605,6 +633,119 @@ describe('FloatingTerminalPanel close behavior', () => {
       { activate: false }
     )
     expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
+  })
+
+  it('routes titlebar Cmd+Shift+O to the floating markdown picker', async () => {
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebarTarget = {
+      closest: vi.fn().mockReturnValue({}),
+      getAttribute: vi.fn().mockReturnValue(null)
+    }
+    Object.setPrototypeOf(titlebarTarget, HTMLElement.prototype)
+    const preventDefault = vi.fn()
+
+    ;(panel.props.onKeyDownCapture as (event: unknown) => void)({
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: 'o',
+      metaKey: true,
+      preventDefault,
+      repeat: false,
+      shiftKey: true,
+      target: titlebarTarget
+    })
+    await flushAsyncWork()
+
+    expect(preventDefault).toHaveBeenCalledWith()
+    expect(mocks.pickFloatingMarkdownDocument).toHaveBeenCalledWith()
+  })
+
+  it('keeps the empty floating workspace focused after Cmd+W closes the last tab', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const panelElement = { contains: vi.fn().mockReturnValue(true), focus: vi.fn() }
+    const activeElement = { closest: vi.fn().mockReturnValue(panelElement) }
+    const target = { classList: { contains: vi.fn().mockReturnValue(true) }, closest: vi.fn() }
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(target, HTMLElement.prototype)
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+    vi.stubGlobal('document', {
+      activeElement,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+    runEffects()
+    const keydownListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === 'keydown')?.[1] as
+      | ((event: unknown) => void)
+      | undefined
+    if (!keydownListener) {
+      throw new Error('keydown listener not registered')
+    }
+
+    keydownListener({
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: 'w',
+      metaKey: true,
+      preventDefault: vi.fn(),
+      repeat: false,
+      shiftKey: false,
+      stopImmediatePropagation: vi.fn(),
+      stopPropagation: vi.fn(),
+      target
+    })
+
+    expect(mocks.closeTab).toHaveBeenCalledWith('tab-1')
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('does not steal focus from the next floating tab after Cmd+W closes one of many tabs', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' }), makeTab({ id: 'tab-2' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const panelElement = { contains: vi.fn().mockReturnValue(true), focus: vi.fn() }
+    const activeElement = { closest: vi.fn().mockReturnValue(panelElement) }
+    const target = { classList: { contains: vi.fn().mockReturnValue(true) }, closest: vi.fn() }
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(target, HTMLElement.prototype)
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+    vi.stubGlobal('document', {
+      activeElement,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+    runEffects()
+    const keydownListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === 'keydown')?.[1] as
+      | ((event: unknown) => void)
+      | undefined
+    if (!keydownListener) {
+      throw new Error('keydown listener not registered')
+    }
+
+    keydownListener({
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: 'w',
+      metaKey: true,
+      preventDefault: vi.fn(),
+      repeat: false,
+      shiftKey: false,
+      stopImmediatePropagation: vi.fn(),
+      stopPropagation: vi.fn(),
+      target
+    })
+
+    expect(mocks.closeTab).toHaveBeenCalledWith('tab-1')
+    expect(panelElement.focus).not.toHaveBeenCalled()
   })
 
   it('preserves terminal focus when dragging the titlebar from inside the floating panel', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -3,13 +3,15 @@
  * handling in one surface so the floating worktree does not drift from the
  * main tab model while still keeping the DOM-mounted panes local. */
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FileText, Globe, TerminalSquare } from 'lucide-react'
+import { FileText, Globe, Minus, TerminalSquare } from 'lucide-react'
 import { toast } from 'sonner'
 import BrowserPane from '@/components/browser-pane/BrowserPane'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import TabBar from '@/components/tab-bar/TabBar'
 import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
 import { Button } from '@/components/ui/button'
+import { useShortcutKeys } from '@/hooks/useShortcutLabel'
 import {
   Dialog,
   DialogContent,
@@ -30,6 +32,7 @@ import {
   isFloatingWorkspaceTerminalInputTarget
 } from '@/lib/floating-workspace-terminal-actions'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import {
   ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY,
   ORCHESTRATION_SETUP_STATE_EVENT,
@@ -48,6 +51,11 @@ import {
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import {
+  keybindingMatchesAction,
+  type KeybindingActionId,
+  type KeybindingContext
+} from '../../../../shared/keybindings'
 import type {
   BrowserTab as BrowserTabState,
   Tab,
@@ -110,6 +118,11 @@ export function FloatingTerminalPanel({
   const openFile = useAppStore((s) => s.openFile)
   const browserDefaultUrl = useAppStore((s) => s.browserDefaultUrl)
   const floatingTerminalCwd = useAppStore((s) => s.settings?.floatingTerminalCwd ?? '')
+  const newTerminalShortcutKeys = useShortcutKeys('tab.newTerminal')
+  const newBrowserShortcutKeys = useShortcutKeys('tab.newBrowser')
+  const newMarkdownShortcutKeys = useShortcutKeys('tab.newMarkdown')
+  const openMarkdownShortcutKeys = useShortcutKeys('tab.openMarkdown')
+  const closeShortcutKeys = useShortcutKeys('tab.close')
 
   const [cwd, setCwd] = useState<string | null>(null)
   const [markdownCwd, setMarkdownCwd] = useState<string | null>(null)
@@ -213,6 +226,12 @@ export function FloatingTerminalPanel({
         .filter((file): file is OpenFile & { tabId: string } => file !== null),
     [floatingFiles, groupTabs]
   )
+  // Why: restored sessions can retain unified tabs whose backing terminal/file/browser
+  // records are gone; the empty landing should follow what the user can see.
+  const hasVisibleFloatingTabs =
+    terminalItems.length > 0 || browserItems.length > 0 || editorItems.length > 0
+  const visibleFloatingItemCount = terminalItems.length + browserItems.length + editorItems.length
+  const activeClosableTab = hasVisibleFloatingTabs ? activeTab : null
   const tabBarOrder = useMemo(
     () =>
       (activeGroup?.tabOrder ?? []).map((tabId) => {
@@ -350,6 +369,15 @@ export function FloatingTerminalPanel({
     }
     focusTerminalTabSurface(activeTerminalId)
   }, [activeTerminalId, open])
+
+  useEffect(() => {
+    if (!open || hasVisibleFloatingTabs) {
+      return
+    }
+    // Why: opening an empty floating workspace from the global shortcut leaves
+    // focus on the previous page; focus the panel so immediate tab shortcuts work.
+    panelRef.current?.focus({ preventScroll: true })
+  }, [hasVisibleFloatingTabs, open])
 
   const refreshOrchestrationSetupVisibility = useCallback(async (): Promise<void> => {
     if (isOrchestrationSetupDismissed()) {
@@ -646,9 +674,10 @@ export function FloatingTerminalPanel({
     )
   }, [activeGroup, closeFloatingItems])
 
-  const focusPanelForShortcuts = useCallback(() => {
+  const focusPanelForShortcuts = useCallback((preserveExistingPanelFocus = true) => {
     const active = document.activeElement
     if (
+      preserveExistingPanelFocus &&
       active instanceof HTMLElement &&
       active.closest('[data-floating-terminal-panel]') !== null
     ) {
@@ -658,6 +687,18 @@ export function FloatingTerminalPanel({
     }
     panelRef.current?.focus({ preventScroll: true })
   }, [])
+
+  const focusPanelForShortcutsAfterClose = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const focusPanel = (): void => focusPanelForShortcuts(false)
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(focusPanel)
+      return
+    }
+    globalThis.setTimeout(focusPanel, 0)
+  }, [focusPanelForShortcuts])
 
   const setFloatingTerminalInputFocused = useCallback((target: EventTarget | null): void => {
     window.api.ui.setFloatingTerminalInputFocused(isFloatingWorkspaceTerminalInputTarget(target))
@@ -703,31 +744,165 @@ export function FloatingTerminalPanel({
         createFloatingMarkdownTab()
         return
       }
+      if (event.shiftKey && key === 'o') {
+        event.preventDefault()
+        openFloatingMarkdownTab()
+        return
+      }
       if (!event.shiftKey && key === 'w') {
         event.preventDefault()
-        if (activeTab) {
-          closeFloatingItem(activeTab.id)
+        if (activeClosableTab) {
+          closeFloatingItem(activeClosableTab.id)
+          if (visibleFloatingItemCount <= 1) {
+            // Why: closing the final xterm removes the focused textarea; keep
+            // the empty floating workspace as the owner for the next Cmd/Ctrl+T.
+            focusPanelForShortcutsAfterClose()
+          }
         } else {
           onOpenChange(false)
         }
       }
     },
     [
-      activeTab,
+      activeClosableTab,
       closeFloatingItem,
       createFloatingBrowserTab,
       createFloatingMarkdownTab,
       createFloatingTerminalTab,
+      focusPanelForShortcutsAfterClose,
       onOpenChange,
-      open
+      openFloatingMarkdownTab,
+      open,
+      visibleFloatingItemCount
     ]
   )
+
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') {
+      return
+    }
+
+    const handleFloatingPanelKeyDown = (event: KeyboardEvent): void => {
+      if (event.defaultPrevented || event.repeat) {
+        return
+      }
+      const panel = panelRef.current
+      const active = document.activeElement
+      if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
+        return
+      }
+
+      const state = useAppStore.getState()
+      const context: KeybindingContext = isFloatingWorkspaceTerminalInputTarget(event.target)
+        ? 'terminal'
+        : 'app'
+      const matches = (actionId: KeybindingActionId): boolean =>
+        keybindingMatchesAction(actionId, event, getShortcutPlatform(), state.keybindings, {
+          context,
+          terminalShortcutPolicy: state.settings?.terminalShortcutPolicy
+        })
+      const consume = (): void => {
+        event.preventDefault()
+        event.stopPropagation()
+        event.stopImmediatePropagation()
+      }
+
+      if (matches('tab.newTerminal')) {
+        consume()
+        createFloatingTerminalTab()
+        return
+      }
+      if (matches('tab.newBrowser')) {
+        consume()
+        createFloatingBrowserTab()
+        return
+      }
+      if (matches('tab.newMarkdown')) {
+        consume()
+        createFloatingMarkdownTab()
+        return
+      }
+      if (matches('tab.openMarkdown')) {
+        consume()
+        openFloatingMarkdownTab()
+        return
+      }
+      if (matches('tab.close')) {
+        consume()
+        if (activeClosableTab) {
+          closeFloatingItem(activeClosableTab.id)
+          if (visibleFloatingItemCount <= 1) {
+            // Why: closing the final xterm removes the focused textarea; keep
+            // the empty floating workspace as the owner for the next Cmd/Ctrl+T.
+            focusPanelForShortcutsAfterClose()
+          }
+        } else {
+          onOpenChange(false)
+        }
+      }
+    }
+
+    // Why: the main Terminal view is not mounted on Landing/Settings, but the
+    // floating workspace must still own its tab shortcuts while it has focus.
+    window.addEventListener('keydown', handleFloatingPanelKeyDown, { capture: true })
+    return () =>
+      window.removeEventListener('keydown', handleFloatingPanelKeyDown, { capture: true })
+  }, [
+    activeClosableTab,
+    closeFloatingItem,
+    createFloatingBrowserTab,
+    createFloatingMarkdownTab,
+    createFloatingTerminalTab,
+    focusPanelForShortcutsAfterClose,
+    onOpenChange,
+    openFloatingMarkdownTab,
+    open,
+    visibleFloatingItemCount
+  ])
 
   useEffect(() => {
     if (!open) {
       window.api.ui.setFloatingTerminalInputFocused(false)
     }
     return () => window.api.ui.setFloatingTerminalInputFocused(false)
+  }, [open])
+
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') {
+      return
+    }
+
+    const handleOutsidePointerDown = (event: PointerEvent): void => {
+      const panel = panelRef.current
+      if (!panel || !(event.target instanceof Node) || panel.contains(event.target)) {
+        return
+      }
+      window.api.ui.setFloatingTerminalInputFocused(false)
+      const active = document.activeElement
+      if (active instanceof HTMLElement && panel.contains(active)) {
+        // Why: regular tab strip items are non-focusable, so clicking them can
+        // leave xterm's hidden textarea focused unless we explicitly release it.
+        active.blur()
+      }
+    }
+    const handleWindowBlur = (): void => {
+      const panel = panelRef.current
+      const active = document.activeElement
+      if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
+        return
+      }
+      // Why: browser webviews focus out-of-process and do not emit renderer
+      // pointerdown events, so release floating ownership on renderer blur too.
+      window.api.ui.setFloatingTerminalInputFocused(false)
+      active.blur()
+    }
+
+    document.addEventListener('pointerdown', handleOutsidePointerDown, true)
+    window.addEventListener('blur', handleWindowBlur)
+    return () => {
+      document.removeEventListener('pointerdown', handleOutsidePointerDown, true)
+      window.removeEventListener('blur', handleWindowBlur)
+    }
   }, [open])
 
   const toggleMaximized = useCallback(() => {
@@ -807,7 +982,7 @@ export function FloatingTerminalPanel({
       data-floating-terminal-panel
       aria-hidden={!open}
       tabIndex={-1}
-      className={`fixed z-50 flex min-h-[280px] min-w-[420px] overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] ${open ? 'opacity-100' : 'invisible pointer-events-none opacity-0'}`}
+      className={`fixed z-50 flex min-h-[280px] min-w-[420px] overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] outline-none ${open ? 'opacity-100' : 'invisible pointer-events-none opacity-0'}`}
       style={{
         visibility: open ? 'visible' : 'hidden',
         left: bounds.left,
@@ -954,7 +1129,7 @@ export function FloatingTerminalPanel({
               </Suspense>
             </div>
           ) : null}
-          {unifiedTabs.length === 0 ? (
+          {!hasVisibleFloatingTabs ? (
             <FloatingTerminalEmptyState
               onNewTerminal={() => createFloatingTerminalTab()}
               onNewMarkdown={createFloatingMarkdownTab}
@@ -962,6 +1137,11 @@ export function FloatingTerminalPanel({
               onNewBrowser={createFloatingBrowserTab}
               onClose={() => onOpenChange(false)}
               onFocusPanel={focusPanelForShortcuts}
+              newTerminalShortcutKeys={newTerminalShortcutKeys}
+              newBrowserShortcutKeys={newBrowserShortcutKeys}
+              newMarkdownShortcutKeys={newMarkdownShortcutKeys}
+              openMarkdownShortcutKeys={openMarkdownShortcutKeys}
+              closeShortcutKeys={closeShortcutKeys}
             />
           ) : null}
         </div>
@@ -1058,7 +1238,12 @@ function FloatingTerminalEmptyState({
   onOpenMarkdown,
   onNewBrowser,
   onClose,
-  onFocusPanel
+  onFocusPanel,
+  newTerminalShortcutKeys,
+  newBrowserShortcutKeys,
+  newMarkdownShortcutKeys,
+  openMarkdownShortcutKeys,
+  closeShortcutKeys
 }: {
   onNewTerminal: () => void
   onNewMarkdown: () => void
@@ -1066,6 +1251,11 @@ function FloatingTerminalEmptyState({
   onNewBrowser: () => void
   onClose: () => void
   onFocusPanel: () => void
+  newTerminalShortcutKeys: string[]
+  newBrowserShortcutKeys: string[]
+  newMarkdownShortcutKeys: string[]
+  openMarkdownShortcutKeys: string[]
+  closeShortcutKeys: string[]
 }): React.JSX.Element {
   return (
     <div
@@ -1073,52 +1263,71 @@ function FloatingTerminalEmptyState({
       data-floating-terminal-shortcut-surface
       onPointerDown={onFocusPanel}
     >
-      <div className="flex w-[230px] flex-col items-center gap-1.5" data-floating-terminal-no-drag>
+      <div className="flex w-[360px] flex-col items-center gap-1.5" data-floating-terminal-no-drag>
         <Button
           type="button"
           variant="ghost"
-          className="h-8 justify-center gap-2.5 rounded-md px-3 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           onClick={onNewTerminal}
         >
           <TerminalSquare className="size-3.5 opacity-80" />
-          New Terminal
+          <span className="truncate text-left leading-none">New Terminal</span>
+          <FloatingEmptyStateShortcut keys={newTerminalShortcutKeys} />
         </Button>
         <Button
           type="button"
           variant="ghost"
-          className="h-8 justify-center gap-2.5 rounded-md px-3 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           onClick={onNewBrowser}
         >
           <Globe className="size-3.5 opacity-80" />
-          New Browser
+          <span className="truncate text-left leading-none">New Browser</span>
+          <FloatingEmptyStateShortcut keys={newBrowserShortcutKeys} />
         </Button>
         <Button
           type="button"
           variant="ghost"
-          className="h-8 justify-center gap-2.5 rounded-md px-3 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           onClick={onNewMarkdown}
         >
           <FileText className="size-3.5 opacity-80" />
-          New Markdown Note
+          <span className="truncate text-left leading-none">New Markdown Note</span>
+          <FloatingEmptyStateShortcut keys={newMarkdownShortcutKeys} />
         </Button>
         <Button
           type="button"
           variant="ghost"
-          className="h-8 justify-center gap-2.5 rounded-md px-3 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           onClick={onOpenMarkdown}
         >
           <FileText className="size-3.5 opacity-80" />
-          Open Markdown Note
+          <span className="truncate text-left leading-none">Open Markdown Note</span>
+          <FloatingEmptyStateShortcut keys={openMarkdownShortcutKeys} />
         </Button>
         <Button
           type="button"
           variant="ghost"
-          className="h-8 justify-center gap-2.5 rounded-md px-3 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           onClick={onClose}
         >
-          Minimize
+          <Minus className="size-3.5 opacity-80" />
+          <span className="truncate text-left leading-none">Minimize</span>
+          <FloatingEmptyStateShortcut keys={closeShortcutKeys} />
         </Button>
       </div>
     </div>
+  )
+}
+
+function FloatingEmptyStateShortcut({ keys }: { keys: string[] }): React.JSX.Element {
+  if (keys.length === 0) {
+    return <span aria-hidden />
+  }
+  return (
+    <ShortcutKeyCombo
+      keys={keys}
+      className="self-center justify-self-end opacity-75"
+      separatorClassName="mx-0 text-[9px] text-muted-foreground"
+    />
   )
 }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -679,8 +679,12 @@ describe('useIpcEvents updater integration', () => {
     const queueTabStartupCommand = vi.fn()
     const updateTabPtyId = vi.fn()
     const setTabLayout = vi.fn()
+    const setTabBarOrder = vi.fn()
     const replyTerminalCreate = vi.fn()
     const dispatchEvent = vi.fn()
+    const createFloatingWorkspaceTerminalTab = vi.fn()
+    const createWebRuntimeSessionTerminal = vi.fn().mockResolvedValue(false)
+    let floatingPanelFocused = false
     const storeState = {
       setUpdateStatus: vi.fn(),
       createTab,
@@ -695,6 +699,10 @@ describe('useIpcEvents updater integration', () => {
       updateTabPtyId,
       setTabLayout,
       tabsByWorktree: {} as Record<string, { id: string; ptyId?: string | null; title?: string }[]>,
+      openFiles: [],
+      browserTabsByWorktree: {},
+      tabBarOrderByWorktree: {},
+      setTabBarOrder,
       ptyIdsByTabId: {} as Record<string, string[]>,
       terminalLayoutsByTabId: {} as Record<string, unknown>,
       fetchRepos: vi.fn(),
@@ -750,6 +758,7 @@ describe('useIpcEvents updater integration', () => {
           }) => void)
         | null
     } = { current: null }
+    const newTerminalTabListenerRef: { current: (() => void) | null } = { current: null }
 
     vi.resetModules()
     vi.unstubAllGlobals()
@@ -792,6 +801,20 @@ describe('useIpcEvents updater integration', () => {
     }))
     vi.doMock('@/lib/zoom-events', () => ({
       dispatchZoomLevelChanged: vi.fn()
+    }))
+    vi.doMock('@/lib/floating-workspace-terminal-actions', () => ({
+      createFloatingWorkspaceTerminalTab,
+      isFloatingWorkspacePanelFocused: () => floatingPanelFocused
+    }))
+    vi.doMock('@/runtime/web-runtime-session', () => ({
+      activateWebRuntimeSessionTab: vi.fn(),
+      closeWebRuntimeSessionTab: vi.fn(),
+      createWebRuntimeSessionBrowserTab: vi.fn().mockResolvedValue(false),
+      createWebRuntimeSessionTerminal,
+      isWebRuntimeSessionActive: vi.fn(() => false)
+    }))
+    vi.doMock('@/lib/focus-terminal-tab-surface', () => ({
+      focusTerminalTabSurface: vi.fn()
     }))
 
     vi.stubGlobal('window', {
@@ -865,7 +888,10 @@ describe('useIpcEvents updater integration', () => {
           replyTabClose: vi.fn(),
           onRequestTabSetProfile: () => () => {},
           replyTabSetProfile: () => {},
-          onNewTerminalTab: () => () => {},
+          onNewTerminalTab: (listener: () => void) => {
+            newTerminalTabListenerRef.current = listener
+            return () => {}
+          },
           onCloseActiveTab: () => () => {},
           onSwitchTab: () => () => {},
           onSwitchTabAcrossAllTypes: () => () => {},
@@ -926,6 +952,32 @@ describe('useIpcEvents updater integration', () => {
     if (typeof createTerminalListenerRef.current !== 'function') {
       throw new Error('Expected create-terminal listener to be registered')
     }
+    if (typeof newTerminalTabListenerRef.current !== 'function') {
+      throw new Error('Expected new-terminal-tab listener to be registered')
+    }
+
+    floatingPanelFocused = true
+    newTerminalTabListenerRef.current()
+    expect(createFloatingWorkspaceTerminalTab).toHaveBeenCalledWith(storeState)
+    expect(createTab).not.toHaveBeenCalled()
+
+    floatingPanelFocused = false
+    createFloatingWorkspaceTerminalTab.mockClear()
+    createTab.mockClear()
+    newTerminalTabListenerRef.current()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(createFloatingWorkspaceTerminalTab).not.toHaveBeenCalled()
+    expect(createWebRuntimeSessionTerminal).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      activate: true
+    })
+    expect(createTab).toHaveBeenCalledWith('wt-1')
+    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
+
+    createWebRuntimeSessionTerminal.mockClear()
+    createTab.mockClear()
+    setActiveTabType.mockClear()
 
     createTerminalListenerRef.current({
       worktreeId: 'wt-2',

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -72,7 +72,7 @@ import {
 } from '@/runtime/web-runtime-session'
 import {
   createFloatingWorkspaceTerminalTab,
-  isFloatingWorkspacePanelVisible
+  isFloatingWorkspacePanelFocused
 } from '@/lib/floating-workspace-terminal-actions'
 import {
   observeAgentHookCompletionForNotification,
@@ -1535,7 +1535,7 @@ export function useIpcEvents(): void {
     unsubs.push(
       window.api.ui.onNewTerminalTab(() => {
         const store = useAppStore.getState()
-        if (isFloatingWorkspacePanelVisible()) {
+        if (isFloatingWorkspacePanelFocused()) {
           void createFloatingWorkspaceTerminalTab(store)
           return
         }

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -112,6 +112,13 @@ describe('isFloatingWorkspacePanelFocused', () => {
     expect(isFloatingWorkspacePanelFocused({ activeElement } as never)).toBe(true)
     expect(activeElement.closest).toHaveBeenCalledWith('[data-floating-terminal-panel]')
   })
+
+  it('ignores focus outside the floating workspace panel', () => {
+    installFakeHTMLElement()
+    const activeElement = makeElement({})
+
+    expect(isFloatingWorkspacePanelFocused({ activeElement } as never)).toBe(false)
+  })
 })
 
 describe('isFloatingWorkspaceTerminalInputTarget', () => {
@@ -166,7 +173,9 @@ describe('isFloatingWorkspacePanelShortcut', () => {
     ['Cmd+Shift+B', true, { key: 'b', metaKey: true, shiftKey: true }],
     ['Ctrl+Shift+B', false, { key: 'b', ctrlKey: true, shiftKey: true }],
     ['Cmd+Shift+M', true, { key: 'm', metaKey: true, shiftKey: true }],
-    ['Ctrl+Shift+M', false, { key: 'm', ctrlKey: true, shiftKey: true }]
+    ['Ctrl+Shift+M', false, { key: 'm', ctrlKey: true, shiftKey: true }],
+    ['Cmd+Shift+O', true, { key: 'o', metaKey: true, shiftKey: true }],
+    ['Ctrl+Shift+O', false, { key: 'o', ctrlKey: true, shiftKey: true }]
   ])('claims %s', (_label, isMacPlatform, overrides) => {
     expect(isFloatingWorkspacePanelShortcut(shortcutSurfaceEvent(overrides), isMacPlatform)).toBe(
       true

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -69,7 +69,9 @@ export function isFloatingWorkspacePanelShortcut(
   }
 
   const key = event.key.toLowerCase()
-  const claimedChord = event.shiftKey ? key === 'b' || key === 'm' : key === 't' || key === 'w'
+  const claimedChord = event.shiftKey
+    ? key === 'b' || key === 'm' || key === 'o'
+    : key === 't' || key === 'w'
   return claimedChord && isFloatingWorkspacePanelShortcutTarget(event.target, panelRoot)
 }
 

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -81,6 +81,11 @@ describe('keybindings', () => {
     expect(formatKeybindingList([], 'win32')).toBe('Unassigned')
   })
 
+  it('defines a default shortcut for opening markdown notes', () => {
+    expect(getEffectiveKeybindingsForAction('tab.openMarkdown', 'darwin')).toEqual(['Mod+Shift+O'])
+    expect(formatKeybindingList(['Mod+Shift+O'], 'darwin')).toBe('⌘⇧O')
+  })
+
   it('uses overrides as the complete effective binding list for an action', () => {
     const overrides = {
       'worktree.quickOpen': ['Ctrl+Alt+O', 'not-a-shortcut']

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -50,6 +50,7 @@ export type KeybindingActionId =
   | 'tab.newTerminal'
   | 'tab.newBrowser'
   | 'tab.newMarkdown'
+  | 'tab.openMarkdown'
   | 'tab.close'
   | 'tab.reopenClosed'
   | 'tab.nextSameType'
@@ -384,6 +385,14 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'markdown', 'file', 'new'],
     defaultBindings: platformBindings(['Mod+Shift+M'])
+  },
+  {
+    id: 'tab.openMarkdown',
+    title: 'Open markdown tab',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: ['shortcut', 'tab', 'markdown', 'file', 'open'],
+    defaultBindings: platformBindings(['Mod+Shift+O'])
   },
   {
     id: 'tab.close',


### PR DESCRIPTION
## Summary
- Route Cmd/Ctrl+T to the floating workspace only while the floating panel owns focus
- Add a focused floating-panel shortcut handler so Cmd/Ctrl+T works even when the main terminal view is not mounted
- Release stale floating terminal focus on outside clicks/window blur so regular tabs regain shortcut ownership

Internal issue: stablyai/orca-internal#318

## Tests
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/lib/floating-workspace-terminal-actions.test.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm exec tsc --noEmit -p config/tsconfig.tc.web.json --pretty false
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/Terminal.tsx src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/lib/floating-workspace-terminal-actions.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
