### PR TITLE
[codex] support existing checkout workspaces

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -533,6 +533,50 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('creates an additional workspace for an existing git checkout without git worktree add', async () => {
+    const repo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepo.mockReturnValue(repo)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => makeWorktreeMeta(meta))
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'Main follow-up',
+      existingWorktreePath: '/workspace/repo',
+      createdWithAgent: 'codex'
+    })) as { worktree: { id: string; path: string; displayName: string } }
+
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+    expect(result.worktree).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^repo-1::\/workspace\/repo::workspace:[0-9a-f-]{36}$/),
+        repoId: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'Main follow-up',
+        instanceId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        createdWithAgent: 'codex',
+        isMainWorktree: false
+      })
+    )
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+      repoId: 'repo-1'
+    })
+  })
+
   it('checks out a selected existing local branch exactly', async () => {
     listWorktreesMock
       .mockResolvedValueOnce([
@@ -1640,6 +1684,55 @@ describe('registerWorktreeHandlers', () => {
     expect(listWorktreesMock).not.toHaveBeenCalled()
   })
 
+  it('lists additional git checkout workspaces backed by the same path', async () => {
+    const workspaceId = 'repo-1::/workspace/repo::workspace:123e4567-e89b-12d3-a456-426614174000'
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    })
+    store.getAllWorktreeMeta.mockReturnValue({
+      [workspaceId]: makeWorktreeMeta({
+        instanceId: '123e4567-e89b-12d3-a456-426614174000',
+        displayName: 'Main follow-up'
+      })
+    })
+    store.getWorktreeMeta.mockImplementation((id) =>
+      id === workspaceId
+        ? makeWorktreeMeta({
+            instanceId: '123e4567-e89b-12d3-a456-426614174000',
+            displayName: 'Main follow-up'
+          })
+        : makeWorktreeMeta({ displayName: 'main' })
+    )
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    const listed = (await handlers['worktrees:list'](null, { repoId: 'repo-1' })) as {
+      id: string
+      path: string
+      displayName: string
+    }[]
+
+    expect(listed.map((worktree) => worktree.id)).toEqual(['repo-1::/workspace/repo', workspaceId])
+    expect(listed[1]).toEqual(
+      expect.objectContaining({
+        path: '/workspace/repo',
+        displayName: 'Main follow-up',
+        isMainWorktree: false
+      })
+    )
+  })
+
   it('returns reconstructed rows when an SSH provider is unavailable', async () => {
     const repo = {
       id: 'repo-ssh',
@@ -2518,6 +2611,26 @@ describe('registerWorktreeHandlers', () => {
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(worktreeId)
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
       repoId: 'repo-folder'
+    })
+  })
+
+  it('removes additional git checkout workspace metadata without removing the checkout', async () => {
+    const ptyProvider = {} as never
+    const worktreeId = 'repo-1::/workspace/repo::workspace:123e4567-e89b-12d3-a456-426614174000'
+    getLocalPtyProviderMock.mockReturnValue(ptyProvider)
+
+    await handlers['worktrees:remove'](null, { worktreeId })
+
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(removeWorktreeMock).not.toHaveBeenCalled()
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(worktreeId, {
+      runtime: runtimeStub,
+      localProvider: ptyProvider
+    })
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith(worktreeId)
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(worktreeId)
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+      repoId: 'repo-1'
     })
   })
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -53,6 +53,7 @@ import {
   mergeWorktree,
   parseWorktreeId,
   areWorktreePathsEqual,
+  sanitizeWorktreeDisplayName,
   formatWorktreeRemovalError,
   isOrphanCompatiblePreflightError,
   isOrphanedWorktreeError
@@ -85,7 +86,11 @@ import {
 } from '../worktree-removal-safety'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  WORKSPACE_INSTANCE_SEPARATOR,
+  stripWorkspaceInstanceSuffix
+} from '../../shared/worktree-id'
 
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
 
@@ -245,7 +250,9 @@ function pruneLineageForMissingRepoWorktrees(
   const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
   const repoPrefix = `${repo.id}::`
   for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
+    const canonicalChildId = stripWorkspaceInstanceSuffix(childId)
+    const canonicalParentId = stripWorkspaceInstanceSuffix(lineage.parentWorktreeId)
+    if (childId.startsWith(repoPrefix) && !liveIds.has(canonicalChildId)) {
       // Why: path-derived IDs can disappear and later be reused by a different
       // checkout. Once a successful scan proves the child is gone, drop its
       // lineage so a future same-path worktree cannot inherit it. Missing
@@ -253,7 +260,7 @@ function pruneLineageForMissingRepoWorktrees(
       // parent" state.
       store.removeWorktreeLineage(childId)
     }
-    if (lineage.parentWorktreeId.startsWith(repoPrefix) && !liveIds.has(lineage.parentWorktreeId)) {
+    if (lineage.parentWorktreeId.startsWith(repoPrefix) && !liveIds.has(canonicalParentId)) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: keep the child lineage so the UI can show "Missing parent", but
@@ -330,35 +337,55 @@ function listDisconnectedSshWorktrees(
 function buildDetectedGitWorktrees(
   store: Store,
   repo: Repo,
-  gitWorktrees: GitWorktreeInfo[]
+  gitWorktrees: GitWorktreeInfo[],
+  allMeta: Record<string, WorktreeMeta> = store.getAllWorktreeMeta()
 ): DetectedWorktree[] {
   const settings = store.getSettings()
   const knownOrcaLayouts = repo.connectionId ? [] : buildKnownOrcaWorkspaceLayouts(settings, repo)
   const isLegacyRepoForVisibility = isLegacyRepoForExternalWorktreeVisibility(repo)
-  return gitWorktrees.map((gitWorktree) => {
+  return gitWorktrees.flatMap((gitWorktree) => {
     const worktreeId = `${repo.id}::${gitWorktree.path}`
-    let meta = store.getWorktreeMeta(worktreeId)
-    const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
-    const detected = toDetectedWorktree({
-      repo,
-      worktree,
-      meta,
-      settings,
-      knownOrcaLayouts,
-      isLegacyRepoForVisibility
-    })
-    if (!detected.visible) {
-      return detected
-    }
+    const instancePrefix = `${worktreeId}${WORKSPACE_INSTANCE_SEPARATOR}`
+    const workspaceIds = [
+      worktreeId,
+      ...Object.keys(allMeta)
+        .filter((candidateId) => candidateId.startsWith(instancePrefix))
+        .sort()
+    ]
 
-    meta = resolveWorktreeMetaWithDiscoveryStamp(store, worktreeId)
-    return toDetectedWorktree({
-      repo,
-      worktree: mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
-      meta,
-      settings,
-      knownOrcaLayouts,
-      isLegacyRepoForVisibility
+    return workspaceIds.map((workspaceId) => {
+      let meta = store.getWorktreeMeta(workspaceId)
+      const isWorkspaceInstance = workspaceId !== worktreeId
+      const worktree = {
+        ...mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
+        id: workspaceId,
+        isMainWorktree: isWorkspaceInstance ? false : gitWorktree.isMainWorktree
+      }
+      const detected = toDetectedWorktree({
+        repo,
+        worktree,
+        meta,
+        settings,
+        knownOrcaLayouts,
+        isLegacyRepoForVisibility
+      })
+      if (!detected.visible) {
+        return detected
+      }
+
+      meta = resolveWorktreeMetaWithDiscoveryStamp(store, workspaceId)
+      return toDetectedWorktree({
+        repo,
+        worktree: {
+          ...mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
+          id: workspaceId,
+          isMainWorktree: isWorkspaceInstance ? false : gitWorktree.isMainWorktree
+        },
+        meta,
+        settings,
+        knownOrcaLayouts,
+        isLegacyRepoForVisibility
+      })
     })
   })
 }
@@ -369,7 +396,7 @@ function stampAndMergeVisibleDetectedWorktree(
   detected: DetectedWorktree
 ) {
   const meta = resolveWorktreeMetaWithDiscoveryStamp(store, detected.id)
-  return mergeWorktree(repo.id, detected, meta, repo.displayName)
+  return { ...mergeWorktree(repo.id, detected, meta, repo.displayName), id: detected.id }
 }
 
 function getFolderWorkspaceRootId(repo: Repo): string {
@@ -505,6 +532,54 @@ function createFolderWorkspace(
   return { worktree: mergeFolderWorkspace(repo, worktreeId, meta) }
 }
 
+async function createExistingCheckoutWorkspace(
+  args: CreateWorktreeArgs,
+  repo: Repo,
+  store: Store
+): Promise<CreateWorktreeResult> {
+  if (!args.existingWorktreePath) {
+    throw new Error('Existing worktree path is required.')
+  }
+  const existingWorktreePath = args.existingWorktreePath
+
+  const gitWorktrees = await listRepoWorktrees(repo)
+  const selected = gitWorktrees.find((worktree) =>
+    areWorktreePathsEqual(worktree.path, existingWorktreePath)
+  )
+  if (!selected) {
+    throw new Error('Existing checkout is not a worktree for this project.')
+  }
+
+  const now = Date.now()
+  const instanceId = randomUUID()
+  const worktreeId = `${repo.id}::${selected.path}${WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
+  const displayName =
+    sanitizeWorktreeDisplayName(args.displayName ?? args.name) || repo.displayName || args.name
+  const meta = store.setWorktreeMeta(worktreeId, {
+    instanceId,
+    displayName,
+    lastActivityAt: now,
+    createdAt: now,
+    orcaCreatedAt: now,
+    orcaCreationSource: repo.connectionId ? 'ssh' : 'desktop',
+    ...(args.createdWithAgent ? { createdWithAgent: args.createdWithAgent } : {}),
+    ...(args.linkedIssue !== undefined ? { linkedIssue: args.linkedIssue } : {}),
+    ...(args.linkedPR !== undefined ? { linkedPR: args.linkedPR } : {}),
+    ...(args.linkedLinearIssue !== undefined ? { linkedLinearIssue: args.linkedLinearIssue } : {}),
+    ...(args.manualOrder !== undefined ? { manualOrder: args.manualOrder } : {}),
+    ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {}),
+    ...(args.linkedGitLabIssue !== undefined ? { linkedGitLabIssue: args.linkedGitLabIssue } : {}),
+    ...(args.linkedGitLabMR !== undefined ? { linkedGitLabMR: args.linkedGitLabMR } : {})
+  })
+  return {
+    worktree: {
+      ...mergeWorktree(repo.id, selected, meta, repo.displayName),
+      id: worktreeId,
+      isMainWorktree: false
+    }
+  }
+}
+
 function buildDisconnectedDetectedWorktrees(
   store: Store,
   repo: Repo,
@@ -555,8 +630,9 @@ export function registerWorktreeHandlers(
 
   ipcMain.handle('worktrees:listAll', async () => {
     const repos = store.getRepos()
+    const allWorktreeMeta = store.getAllWorktreeMeta()
     const sshWorktreeMetaIndex = repos.some((repo) => repo.connectionId)
-      ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
+      ? createSshWorktreeMetaIndex(Object.entries(allWorktreeMeta))
       : new Map()
 
     // Why: repos are listed in parallel so total time = slowest repo, not
@@ -595,7 +671,7 @@ export function registerWorktreeHandlers(
           rememberLocalWorktreeRoots(store, repo, gitWorktrees)
           pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
           loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-          return buildDetectedGitWorktrees(store, repo, gitWorktrees)
+          return buildDetectedGitWorktrees(store, repo, gitWorktrees, allWorktreeMeta)
             .filter((worktree) => worktree.visible)
             .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree))
         } catch (err) {
@@ -774,11 +850,13 @@ export function registerWorktreeHandlers(
           // worktrees`) signal IPC-shape bugs, not the user-visible
           // git/filesystem failures the funnel cares about — bucketing them
           // into `unknown` would pollute the failure taxonomy.
-          result = isFolderRepo(repo)
-            ? createFolderWorkspace(args, repo, store)
-            : repo.connectionId
-              ? await createRemoteWorktree(args, repo, store, mainWindow)
-              : await createLocalWorktree(args, repo, store, mainWindow, runtime)
+          result = args.existingWorktreePath
+            ? await createExistingCheckoutWorkspace(args, repo, store)
+            : isFolderRepo(repo)
+              ? createFolderWorkspace(args, repo, store)
+              : repo.connectionId
+                ? await createRemoteWorktree(args, repo, store, mainWindow)
+                : await createLocalWorktree(args, repo, store, mainWindow, runtime)
         } catch (error) {
           track('workspace_create_failed', {
             source,
@@ -805,7 +883,7 @@ export function registerWorktreeHandlers(
           ...getCohortAtEmit()
         })
 
-        if (isFolderRepo(repo)) {
+        if (isFolderRepo(repo) || args.existingWorktreePath) {
           notifyWorktreesChanged(mainWindow, repo.id)
         }
 
@@ -921,6 +999,22 @@ export function registerWorktreeHandlers(
           }
           // Why: folder workspaces share one filesystem root, so there is no Git
           // remove step to close shells; sweep PTYs before dropping metadata.
+          await killAllProcessesForWorktree(args.worktreeId, {
+            runtime,
+            localProvider: getLocalPtyProvider()
+          }).catch((err) => {
+            console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
+          })
+          store.removeWorktreeMeta(args.worktreeId)
+          deleteWorktreeHistoryDir(args.worktreeId)
+          notifyWorktreesChanged(mainWindow, repoId)
+          return
+        }
+
+        if (stripWorkspaceInstanceSuffix(args.worktreeId) !== args.worktreeId) {
+          // Why: Git workspace instances share an existing checkout path. Remove
+          // only Orca session metadata; `git worktree remove` would delete the
+          // underlying checkout for every sibling workspace.
           await killAllProcessesForWorktree(args.worktreeId, {
             runtime,
             localProvider: getLocalPtyProvider()

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -7,11 +7,13 @@ import {
   ChevronDown,
   CornerDownLeft,
   FolderPlus,
+  Info,
   LoaderCircle,
   PlugZap,
   Settings2
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import RepoCombobox from '@/components/repo/RepoCombobox'
 import AgentCombobox from '@/components/agent/AgentCombobox'
@@ -46,6 +48,8 @@ type NewWorkspaceComposerCardProps = {
   eligibleRepos: RepoOption[]
   repoId: string
   selectedRepoIsGit: boolean
+  workspaceCreateMode: 'new-worktree' | 'open-existing'
+  onWorkspaceCreateModeChange: (mode: 'new-worktree' | 'open-existing') => void
   onRepoChange: (value: string) => void
   primaryActionLabel: string
   name: string
@@ -93,6 +97,23 @@ const SSH_STATUS_LABELS: Record<SshConnectionStatus, string> = {
   'reconnection-failed': 'SSH reconnection failed',
   error: 'SSH connection error'
 }
+
+const WORKSPACE_MODE_COPY = {
+  'new-worktree': {
+    label: 'New worktree',
+    blurb:
+      'Best for isolated branch work. Orca creates a separate checkout directory for this workspace.',
+    tooltip:
+      'Use this when agents or terminals should make changes without touching your main checkout.'
+  },
+  'open-existing': {
+    label: 'Existing checkout',
+    blurb:
+      'Best for extra sessions on the same files. Orca adds workspace state without creating a git worktree.',
+    tooltip:
+      'Use this for another agent, terminal, note, or task context on the current checkout. File and git state are shared.'
+  }
+} as const
 
 function SetupCommandPreview({
   setupConfig,
@@ -210,6 +231,8 @@ export default function NewWorkspaceComposerCard({
   eligibleRepos,
   repoId,
   selectedRepoIsGit,
+  workspaceCreateMode,
+  onWorkspaceCreateModeChange,
   onRepoChange,
   primaryActionLabel,
   name,
@@ -278,6 +301,8 @@ export default function NewWorkspaceComposerCard({
       nameInputRef?.current?.focus()
     })
   }, [nameInputRef])
+  const isOpeningExistingCheckout = selectedRepoIsGit && workspaceCreateMode === 'open-existing'
+  const workspaceModeCopy = WORKSPACE_MODE_COPY[workspaceCreateMode]
 
   const visibleQuickAgents = React.useMemo(
     () =>
@@ -307,6 +332,48 @@ export default function NewWorkspaceComposerCard({
       )}
     >
       <div className="min-w-0 space-y-4 pt-3">
+        {selectedRepoIsGit ? (
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <label className="text-xs font-medium text-muted-foreground">Workflow</label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    tabIndex={0}
+                    className="inline-flex size-5 items-center justify-center rounded-sm text-muted-foreground outline-none hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                    aria-label={`${workspaceModeCopy.label} guidance`}
+                  >
+                    <Info className="size-3.5" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={6} className="max-w-72">
+                  {workspaceModeCopy.tooltip}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            <ToggleGroup
+              type="single"
+              value={workspaceCreateMode}
+              onValueChange={(value) => {
+                if (value === 'new-worktree' || value === 'open-existing') {
+                  onWorkspaceCreateModeChange(value)
+                }
+              }}
+              variant="outline"
+              size="sm"
+              className="grid w-full grid-cols-2"
+            >
+              <ToggleGroupItem value="new-worktree" className="w-full text-xs">
+                New worktree
+              </ToggleGroupItem>
+              <ToggleGroupItem value="open-existing" className="w-full text-xs">
+                Existing checkout
+              </ToggleGroupItem>
+            </ToggleGroup>
+            <p className="text-[11px] leading-4 text-muted-foreground">{workspaceModeCopy.blurb}</p>
+          </div>
+        ) : null}
+
         <div className="space-y-1">
           <div className="flex items-center justify-between gap-2">
             <label className="text-xs font-medium text-muted-foreground">Project</label>
@@ -376,7 +443,11 @@ export default function NewWorkspaceComposerCard({
 
         <div className="min-w-0 space-y-1">
           <label className="text-xs font-medium text-muted-foreground">
-            {selectedRepoIsGit ? "Name or 'Create From'" : 'Workspace name'}{' '}
+            {isOpeningExistingCheckout
+              ? 'Workspace name'
+              : selectedRepoIsGit
+                ? "Name or 'Create From'"
+                : 'Workspace name'}{' '}
             <span className="text-muted-foreground/70">[Optional]</span>
           </label>
           <SmartWorkspaceNameField
@@ -394,7 +465,7 @@ export default function NewWorkspaceComposerCard({
             onClearSelectedSource={onClearSmartNameSelection}
             disabled={selectedRepoRequiresConnection}
             disabledPlaceholder="Connect this repo first"
-            textOnly={!selectedRepoIsGit}
+            textOnly={!selectedRepoIsGit || isOpeningExistingCheckout}
             onPlainEnter={() => {
               // Why: Enter on the workspace name advances focus to the next
               // field (Agent combobox) rather than submitting, letting the user
@@ -605,21 +676,25 @@ export default function NewWorkspaceComposerCard({
                 </div>
               ) : null}
 
-              <div className="space-y-1.5">
-                <label className="text-xs font-medium text-muted-foreground">Sparse checkout</label>
-                <SparseCheckoutPresetSelect
-                  repoId={repoId}
-                  presets={sparsePresets}
-                  selectedPresetId={sparseSelectedPresetId}
-                  onSelectPreset={onSparseSelectPreset}
-                  disabled={!canUseSparseCheckout}
-                />
-                {!canUseSparseCheckout ? (
-                  <p className="text-[11px] text-muted-foreground">
-                    Only available for local Git projects.
-                  </p>
-                ) : null}
-              </div>
+              {!isOpeningExistingCheckout ? (
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    Sparse checkout
+                  </label>
+                  <SparseCheckoutPresetSelect
+                    repoId={repoId}
+                    presets={sparsePresets}
+                    selectedPresetId={sparseSelectedPresetId}
+                    onSelectPreset={onSparseSelectPreset}
+                    disabled={!canUseSparseCheckout}
+                  />
+                  {!canUseSparseCheckout ? (
+                    <p className="text-[11px] text-muted-foreground">
+                      Only available for local Git projects.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           </div>
         </div>

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -151,7 +151,10 @@ function QuickTabBody({
   const handleCreate = useCallback(async (): Promise<void> => {
     await submitQuick(quickAgent)
   }, [quickAgent, submitQuick])
-  const primaryActionLabel = cardProps.selectedRepoIsGit ? 'Create Worktree' : 'Create Workspace'
+  const primaryActionLabel =
+    cardProps.selectedRepoIsGit && cardProps.workspaceCreateMode === 'new-worktree'
+      ? 'Create Worktree'
+      : 'Create Workspace'
 
   // Cmd/Ctrl+Enter submits, Esc first blurs the focused input (like the full page).
   useEffect(() => {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -114,6 +114,8 @@ export type ComposerCardProps = {
   eligibleRepos: ReturnType<typeof useAppStore.getState>['repos']
   repoId: string
   selectedRepoIsGit: boolean
+  workspaceCreateMode: 'new-worktree' | 'open-existing'
+  onWorkspaceCreateModeChange: (mode: 'new-worktree' | 'open-existing') => void
   onRepoChange: (value: string) => void
   name: string
   onNameValueChange: (value: string) => void
@@ -423,6 +425,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const [setupDecision, setSetupDecision] = useState<'run' | 'skip' | null>(null)
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<WorkspaceCreateErrorDisplay | null>(null)
+  const [workspaceCreateMode, setWorkspaceCreateMode] = useState<'new-worktree' | 'open-existing'>(
+    'new-worktree'
+  )
+  useEffect(() => {
+    if (!selectedRepoIsGit && workspaceCreateMode !== 'new-worktree') {
+      setWorkspaceCreateMode('new-worktree')
+    }
+  }, [selectedRepoIsGit, workspaceCreateMode])
   const [advancedOpen, setAdvancedOpen] = useState(
     persistDraft ? Boolean((newWorkspaceDraft?.note ?? '').trim()) : false
   )
@@ -555,7 +565,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   }, [normalizedSparseDirectories, sparsePresets, sparseSelectedPresetId])
 
   const sparseError = useMemo(() => {
-    if (!sparseEnabled) {
+    if (!sparseEnabled || workspaceCreateMode === 'open-existing') {
       return null
     }
     if (!selectedRepoIsGit) {
@@ -573,7 +583,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       return 'Use repo-relative directories, not root or parent paths.'
     }
     return null
-  }, [normalizedSparseDirectories, selectedRepo?.connectionId, selectedRepoIsGit, sparseEnabled])
+  }, [
+    normalizedSparseDirectories,
+    selectedRepo?.connectionId,
+    selectedRepoIsGit,
+    sparseEnabled,
+    workspaceCreateMode
+  ])
   const parsedLinkedIssueNumber = useMemo(
     () => (linkedIssue.trim() ? parseGitHubIssueOrPRNumber(linkedIssue) : null),
     [linkedIssue]
@@ -604,8 +620,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     return null
   }, [linkedPR, name, selectedRepoSlug])
   const setupConfig = useMemo(
-    () => (selectedRepoIsGit ? getSetupConfig(selectedRepo, yamlHooks) : null),
-    [selectedRepo, selectedRepoIsGit, yamlHooks]
+    () =>
+      selectedRepoIsGit && workspaceCreateMode === 'new-worktree'
+        ? getSetupConfig(selectedRepo, yamlHooks)
+        : null,
+    [selectedRepo, selectedRepoIsGit, workspaceCreateMode, yamlHooks]
   )
   const setupPolicy: SetupRunPolicy = selectedRepo?.hookSettings?.setupRunPolicy ?? 'run-by-default'
   const hasIssueAutomationConfig = enableIssueAutomation && issueCommandTemplate.length > 0
@@ -616,6 +635,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const willApplyIssueCommandAsPrompt =
     enableIssueAutomation && !agentPrompt.trim() && Boolean(linkedWorkItem)
   const shouldWaitForIssueAutomationCheck =
+    workspaceCreateMode === 'new-worktree' &&
     enableIssueAutomation &&
     (parsedLinkedIssueNumber !== null || willApplyIssueCommandAsPrompt) &&
     !hasLoadedIssueCommand
@@ -629,7 +649,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         ? 'run'
         : 'skip')
   const isSetupCheckPending = Boolean(repoId) && checkedHooksRepoId !== repoId
-  const shouldWaitForSetupCheck = Boolean(selectedRepo) && selectedRepoIsGit && isSetupCheckPending
+  const shouldWaitForSetupCheck =
+    Boolean(selectedRepo) &&
+    selectedRepoIsGit &&
+    workspaceCreateMode === 'new-worktree' &&
+    isSetupCheckPending
 
   // Why: when the user leaves the workspace name blank and provides no other
   // seed source (prompt, linked issue/PR), pick a repo-scoped unique marine
@@ -1704,7 +1728,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           : ((resolvedSetupDecision ?? 'inherit') as SetupDecision)
 
       let issueCommandTrustDecision: 'run' | 'skip' = 'run'
-      if (selectedRepoIsGit && shouldRunIssueAutomation) {
+      if (selectedRepoIsGit && workspaceCreateMode === 'new-worktree' && shouldRunIssueAutomation) {
         issueCommandTrustDecision =
           setupTrustDecision === 'skip'
             ? 'skip'
@@ -1719,9 +1743,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const result = await createWorktree(
         repoId,
         workspaceName,
-        selectedRepoIsGit ? baseBranch : undefined,
+        selectedRepoIsGit && workspaceCreateMode === 'new-worktree' ? baseBranch : undefined,
         effectiveSetupDecision,
-        selectedRepoIsGit && sparseEnabled
+        selectedRepoIsGit && workspaceCreateMode === 'new-worktree' && sparseEnabled
           ? {
               directories: normalizedSparseDirectories,
               ...(effectivePresetId ? { presetId: effectivePresetId } : {})
@@ -1735,7 +1759,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         tuiAgent,
         linkedLinearIssue,
         effectiveBranchNameOverride,
-        resolvedInitialWorkspaceStatus
+        resolvedInitialWorkspaceStatus,
+        undefined,
+        undefined,
+        selectedRepoIsGit && workspaceCreateMode === 'open-existing' ? selectedRepo.path : undefined
       )
       const worktree = result.worktree
 
@@ -1847,6 +1874,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     shouldWaitForIssueAutomationCheck,
     shouldWaitForSetupCheck,
     startupPrompt,
+    workspaceCreateMode,
     workspaceSeedName
   ])
 
@@ -1875,7 +1903,11 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       try {
         let submitSetupConfig = setupConfig
         let submitResolvedSetupDecision = resolvedSetupDecision
-        if (selectedRepoIsGit && checkedHooksRepoId !== repoId) {
+        if (
+          selectedRepoIsGit &&
+          workspaceCreateMode === 'new-worktree' &&
+          checkedHooksRepoId !== repoId
+        ) {
           let hookCheck: HookCheckResult
           try {
             hookCheck = await loadHookCheckForRepo(repoId)
@@ -1894,14 +1926,21 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 ? 'run'
                 : 'skip')
         }
-        if (selectedRepoIsGit && submitSetupConfig && setupPolicy === 'ask' && !setupDecision) {
+        if (
+          selectedRepoIsGit &&
+          workspaceCreateMode === 'new-worktree' &&
+          submitSetupConfig &&
+          setupPolicy === 'ask' &&
+          !setupDecision
+        ) {
           setAdvancedOpen(true)
           return
         }
 
-        const trustDecision = selectedRepoIsGit
-          ? await ensureHooksConfirmed(useAppStore.getState(), repoId, 'setup')
-          : 'skip'
+        const trustDecision =
+          selectedRepoIsGit && workspaceCreateMode === 'new-worktree'
+            ? await ensureHooksConfirmed(useAppStore.getState(), repoId, 'setup')
+            : 'skip'
         const effectiveSetupDecision: SetupDecision =
           trustDecision === 'skip'
             ? 'skip'
@@ -1915,9 +1954,9 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         const result = await createWorktree(
           repoId,
           workspaceName,
-          selectedRepoIsGit ? baseBranch : undefined,
+          selectedRepoIsGit && workspaceCreateMode === 'new-worktree' ? baseBranch : undefined,
           effectiveSetupDecision,
-          selectedRepoIsGit && sparseEnabled
+          selectedRepoIsGit && workspaceCreateMode === 'new-worktree' && sparseEnabled
             ? {
                 directories: normalizedSparseDirectories,
                 ...(effectivePresetId ? { presetId: effectivePresetId } : {})
@@ -1931,7 +1970,12 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           agent ?? undefined,
           linkedLinearIssue,
           effectiveBranchNameOverride,
-          resolvedInitialWorkspaceStatus
+          resolvedInitialWorkspaceStatus,
+          undefined,
+          undefined,
+          selectedRepoIsGit && workspaceCreateMode === 'open-existing'
+            ? selectedRepo.path
+            : undefined
         )
         const worktree = result.worktree
 
@@ -2086,7 +2130,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       commitHookCheckIfCurrent,
       loadHookCheckForRepo,
       setupConfig,
-      setupPolicy
+      setupPolicy,
+      workspaceCreateMode
     ]
   )
 
@@ -2109,6 +2154,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     eligibleRepos,
     repoId,
     selectedRepoIsGit,
+    workspaceCreateMode,
+    onWorkspaceCreateModeChange: setWorkspaceCreateMode,
     onRepoChange: handleRepoChange,
     name,
     onNameValueChange: handleNameValueChange,
@@ -2169,7 +2216,8 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     shouldWaitForSetupCheck,
     resolvedSetupDecision,
     createError,
-    canUseSparseCheckout: selectedRepoIsGit && !selectedRepo?.connectionId,
+    canUseSparseCheckout:
+      selectedRepoIsGit && workspaceCreateMode === 'new-worktree' && !selectedRepo?.connectionId,
     sparsePresets,
     sparseSelectedPresetId,
     onSparseSelectPreset: handleSparseSelectPreset

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -93,7 +93,8 @@ export type WorktreeSlice = {
     branchNameOverride?: string,
     workspaceStatus?: WorkspaceStatus,
     linkedGitLabMR?: number,
-    linkedGitLabIssue?: number
+    linkedGitLabIssue?: number,
+    existingWorktreePath?: string
   ) => Promise<CreateWorktreeResult>
   removeWorktree: (
     worktreeId: string,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -846,7 +846,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     branchNameOverride,
     workspaceStatus,
     linkedGitLabMR,
-    linkedGitLabIssue
+    linkedGitLabIssue,
+    existingWorktreePath
   ) => {
     const retryableConflictPatterns = [
       /already exists locally/i,
@@ -888,7 +889,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(manualOrder !== undefined ? { manualOrder } : {}),
             ...(workspaceStatus !== undefined ? { workspaceStatus } : {}),
             ...(linkedGitLabMR !== undefined ? { linkedGitLabMR } : {}),
-            ...(linkedGitLabIssue !== undefined ? { linkedGitLabIssue } : {})
+            ...(linkedGitLabIssue !== undefined ? { linkedGitLabIssue } : {}),
+            ...(existingWorktreePath ? { existingWorktreePath } : {})
           }
           const target = getActiveRuntimeTarget(get().settings)
           const result =
@@ -915,7 +917,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                     ...(manualOrder !== undefined ? { manualOrder } : {}),
                     ...(workspaceStatus !== undefined ? { workspaceStatus } : {}),
                     ...(linkedGitLabMR !== undefined ? { linkedGitLabMR } : {}),
-                    ...(linkedGitLabIssue !== undefined ? { linkedGitLabIssue } : {})
+                    ...(linkedGitLabIssue !== undefined ? { linkedGitLabIssue } : {}),
+                    ...(existingWorktreePath ? { existingWorktreePath } : {})
                   },
                   { timeoutMs: 10 * 60_000 }
                 )

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1302,6 +1302,9 @@ export type CreateWorktreeArgs = {
    *  pre-date this prop default to `unknown` at the IPC boundary instead
    *  of failing typecheck. */
   telemetrySource?: WorkspaceSource
+  /** Existing checkout/worktree path to open as another Orca workspace without
+   *  creating a new git worktree directory. */
+  existingWorktreePath?: string
 }
 
 export type CreateWorktreeResult = {

--- a/src/shared/worktree-id.test.ts
+++ b/src/shared/worktree-id.test.ts
@@ -1,15 +1,21 @@
 import { describe, expect, it } from 'vitest'
 import {
+  WORKSPACE_INSTANCE_SEPARATOR,
   WORKTREE_ID_SEPARATOR,
   getRepoIdFromWorktreeId,
   getWorktreePathBasenameFromId,
   splitWorktreeId,
-  splitWorktreeIdForFilesystem
+  splitWorktreeIdForFilesystem,
+  stripWorkspaceInstanceSuffix
 } from './worktree-id'
 
 describe('WORKTREE_ID_SEPARATOR', () => {
   it('is the literal "::" separator', () => {
     expect(WORKTREE_ID_SEPARATOR).toBe('::')
+  })
+
+  it('uses the same workspace instance separator for folder and git workspaces', () => {
+    expect(WORKSPACE_INSTANCE_SEPARATOR).toBe('::workspace:')
   })
 })
 
@@ -90,6 +96,28 @@ describe('splitWorktreeIdForFilesystem', () => {
     expect(
       splitWorktreeIdForFilesystem('repo::/folder::workspace:123e4567-e89b-12d3-a456-426614174000')
     ).toEqual({ repoId: 'repo', worktreePath: '/folder' })
+  })
+
+  it('strips git checkout workspace instance suffixes from the parsed path', () => {
+    expect(
+      splitWorktreeIdForFilesystem(
+        'repo::/repo/main::workspace:123e4567-e89b-12d3-a456-426614174000'
+      )
+    ).toEqual({ repoId: 'repo', worktreePath: '/repo/main' })
+  })
+})
+
+describe('stripWorkspaceInstanceSuffix', () => {
+  it('removes a workspace instance suffix from a path or id', () => {
+    expect(
+      stripWorkspaceInstanceSuffix(
+        'repo::/repo/main::workspace:123e4567-e89b-12d3-a456-426614174000'
+      )
+    ).toBe('repo::/repo/main')
+  })
+
+  it('leaves non-workspace values unchanged', () => {
+    expect(stripWorkspaceInstanceSuffix('repo::/repo/main')).toBe('repo::/repo/main')
   })
 })
 

--- a/src/shared/worktree-id.ts
+++ b/src/shared/worktree-id.ts
@@ -7,9 +7,10 @@ export type ParsedWorktreeId = {
   worktreePath: string
 }
 
-export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
-const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
-  `${FOLDER_WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
+export const WORKSPACE_INSTANCE_SEPARATOR = '::workspace:'
+export const FOLDER_WORKSPACE_INSTANCE_SEPARATOR = WORKSPACE_INSTANCE_SEPARATOR
+const WORKSPACE_INSTANCE_SUFFIX = new RegExp(
+  `${WORKSPACE_INSTANCE_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[0-9a-f-]{36}$`
 )
 
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
@@ -35,11 +36,15 @@ export function splitWorktreeIdForFilesystem(worktreeId: string): ParsedWorktree
   }
   return {
     repoId: parsed.repoId,
-    // Why: folder projects can have multiple workspace sessions backed by the
-    // same directory. Their IDs carry a UUID suffix, but filesystem callers
-    // still need the real folder path as cwd/root.
-    worktreePath: parsed.worktreePath.replace(FOLDER_WORKSPACE_INSTANCE_SUFFIX, '')
+    // Why: multiple workspace sessions can be backed by the same folder or
+    // Git checkout. Their IDs carry a UUID suffix, but filesystem callers
+    // still need the real path as cwd/root.
+    worktreePath: stripWorkspaceInstanceSuffix(parsed.worktreePath)
   }
+}
+
+export function stripWorkspaceInstanceSuffix(value: string): string {
+  return value.replace(WORKSPACE_INSTANCE_SUFFIX, '')
 }
 
 export function getWorktreePathBasenameFromId(worktreeId: string): string | null {


### PR DESCRIPTION
## Summary

This PR implements the remaining workflow from issue #2654: creating multiple Orca workspaces backed by an existing Git checkout, without creating a new `git worktree` directory. The new-workspace composer now exposes a Git-only workflow switch between `New worktree` and `Existing checkout`, with short inline guidance and an info tooltip so users can choose the right model before creating the workspace.

## User Impact

Before this change, users who wanted a separate Orca session on the repo's main checkout had no direct path. Every composer submit materialized a new Git worktree, and adding the repo again only reported that it already existed. That made useful workflows awkward or impossible, such as running another agent against `main`, keeping separate notes and terminals for a review task, or creating a temporary task context on the canonical checkout without adding disk and Git worktree clutter.

With this change, users can choose `Existing checkout`, name the workspace, and get a separate Orca workspace record with its own session state while sharing the same checkout path and Git state. Deleting one of these additional workspaces removes only Orca metadata/session state; it does not delete the underlying checkout.

## Root Cause

Orca's app-level workspace model still used worktree-path-derived IDs as the canonical identity. That meant one Git checkout path could only map to one workspace row. Folder projects had already gained UUID-suffixed workspace IDs, but Git checkouts still needed equivalent instance identity and list/delete behavior for shared-path workspace records.

## Changes

- Adds an optional `existingWorktreePath` create argument for workspace creation.
- Creates UUID-suffixed workspace IDs for additional Git checkout workspaces, reusing the same instance-suffix pattern already used for folder-backed workspaces.
- Updates Git worktree listing/detection to include persisted workspace instances that point at a live checkout path.
- Ensures filesystem/path parsing strips workspace instance suffixes so shared-path workspaces still resolve to the real checkout directory.
- Treats additional Git checkout workspace deletion as metadata/session cleanup instead of `git worktree remove`.
- Adds a composer workflow selector with inline copy and tooltips explaining when to use `New worktree` versus `Existing checkout`.
- Disables create-from branch/source behavior and sparse checkout controls when the user is opening an existing checkout, since no new checkout is being materialized.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/worktree-id.test.ts src/main/ipc/worktrees.test.ts src/renderer/src/store/slices/worktrees.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`

I also launched the Electron dev app locally and verified the renderer picked up the composer UI updates through Vite HMR for manual workflow testing.
