### PR TITLE
Reveal new worktrees in sidebar

### DIFF
--- a/docs/new-worktree-sidebar-reveal.md
+++ b/docs/new-worktree-sidebar-reveal.md
@@ -1,0 +1,79 @@
+# New Worktree Sidebar Reveal
+
+## Problem
+
+Issue https://github.com/stablyai/orca-internal/issues/350 asks that newly created worktrees jump into view in the left sidebar list with no scroll animation.
+
+Current behavior:
+
+- `activateAndRevealWorktree(...)` always calls `state.revealWorktreeInSidebar(worktreeId)` with no options.
+- `revealWorktreeInSidebar` defaults `behavior` to `'smooth'` (`ui.ts`).
+- `WorktreeList` forwards that behavior to `virtualizer.scrollToIndex(..., { behavior })`.
+
+Result: off-screen targets animate by default, including freshly created worktrees.
+
+## Root Cause
+
+`activateAndRevealWorktree` conflates two intents:
+
+1. activate existing worktree navigation (smooth reveal is fine);
+2. activate a just-created worktree (must jump immediately).
+
+Created-worktree callers cannot currently express reveal intent, so they inherit `'smooth'`.
+
+## Scope and Non-goals
+
+- Add an opt-in reveal behavior at activation call sites.
+- Apply `'auto'` only where the worktree is newly created/added in that flow.
+- Preserve existing behavior for normal worktree navigation (clicks, keyboard, history nav, palette selection of existing worktrees, port/status-driven activation) unless a caller opts in.
+- Do not change direct raw reveal paths in IPC handlers that intentionally call `store.revealWorktreeInSidebar(...)` outside `activateAndRevealWorktree` (terminal/editor/mobile focus paths remain smooth).
+- Do not change sorting/grouping/filter UI, list virtualization strategy, or sidebar styling.
+
+## Design
+
+1. Extend `activateAndRevealWorktree` options:
+   - `sidebarRevealBehavior?: PendingSidebarWorktreeReveal['behavior']`.
+2. In `activateAndRevealWorktree`, call:
+   - `state.revealWorktreeInSidebar(worktreeId, { behavior: opts.sidebarRevealBehavior })` when provided;
+   - otherwise keep `state.revealWorktreeInSidebar(worktreeId)` so default behavior stays unchanged.
+3. Pass `sidebarRevealBehavior: 'auto'` only from created/added-worktree flows:
+   - `useComposerState` full-create path;
+   - `useComposerState` quick-create path;
+   - `useIpcEvents` `onActivateWorktree` only when the event corresponds to a newly created worktree;
+   - `launch-work-item-direct`;
+   - folder add/create flows that activate a newly-added synthetic folder worktree (`AddRepoCreateStep` folder branch, `NonGitFolderDialog`, and `repos` slice `addNonGitFolder` path).
+4. Keep existing navigation activations smooth, including:
+   - `AddRepoDialog` / `ProjectAddedDialog` “open primary worktree” actions (these can target pre-existing worktrees, not guaranteed newly created);
+   - all existing `activateAndRevealWorktree(...)` callers that do not opt in.
+5. Keep `WorktreeList` reveal effect unchanged; it already honors `pendingRevealWorktree.behavior`.
+
+## Correctness Notes and Edge Cases
+
+- Repo-filter clearing remains unchanged: `activateAndRevealWorktree` only clears `filterRepoIds` when target repo is excluded.
+- Other visibility constraints are not auto-cleared. If the target exists but is hidden by other sidebar state, `resolvePendingSidebarReveal(...)` keeps the reveal pending.
+- The reveal effect uncollapses lineage/group containers before scroll; behavior changes only animation mode, not visibility resolution.
+- Pending reveal is a single store slot (`pendingRevealWorktree`). Concurrent reveal requests are last-writer-wins; this change should not alter that behavior.
+- If activation cannot resolve the worktree (`getKnownWorktreeById` miss), behavior remains unchanged (`false`, no reveal queued).
+- `ui:activateWorktree` is an overloaded IPC used by both creation and non-creation activation paths. The renderer must choose `'auto'` only for create cases (for example, worktree absent before fetch and present after fetch), and keep default smooth reveal for existing-worktree activations.
+- Multi-window consistency remains per renderer window store; each window applies its own reveal behavior locally.
+- This change is renderer-only; it does not add main-process coordination and does not make reveal ordering transactional across concurrent async creators.
+
+## Tests
+
+Add/adjust focused tests in `worktree-activation` coverage:
+
+- explicit `sidebarRevealBehavior: 'auto'` is forwarded to `revealWorktreeInSidebar(worktreeId, { behavior: 'auto' })`;
+- no option still calls `revealWorktreeInSidebar(worktreeId)` (store default remains smooth).
+
+Add call-site regression tests (recommended, small):
+
+- one composer create path passes `'auto'`;
+- one non-created navigation path stays default (no behavior option).
+
+## Rollout
+
+1. Add `sidebarRevealBehavior` option in `activateAndRevealWorktree`.
+2. Update created-worktree callers to pass `'auto'`.
+3. Add tests above.
+4. Run targeted Vitest tests, then `pnpm typecheck` and `pnpm lint`.
+5. Validate in Electron: with sidebar overflow, create a worktree and verify the list jumps to it without smooth animation.

--- a/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
@@ -145,7 +145,7 @@ export function useCreateRepo(
         }
         const folderWorktree = useAppStore.getState().worktreesByRepo[repo.id]?.[0]
         if (folderWorktree) {
-          activateAndRevealWorktree(folderWorktree.id)
+          activateAndRevealWorktree(folderWorktree.id, { sidebarRevealBehavior: 'auto' })
         }
         closeModal()
       }

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -57,7 +57,10 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
               onboarding,
               hadProjectBeforeAdd
             )
-            activateAndRevealWorktree(folderWorktree.id, startup ? { startup } : undefined)
+            activateAndRevealWorktree(folderWorktree.id, {
+              sidebarRevealBehavior: 'auto',
+              ...(startup ? { startup } : {})
+            })
           }
         } catch (err) {
           // This code path calls addRemote directly (not through the store),

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -1779,6 +1779,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         request_kind: 'new'
       }
       activateAndRevealWorktree(worktree.id, {
+        sidebarRevealBehavior: 'auto',
         setup: result.setup,
         issueCommand,
         ...(startupPlan
@@ -2020,6 +2021,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 request_kind: 'new'
               }
         activateAndRevealWorktree(worktree.id, {
+          sidebarRevealBehavior: 'auto',
           setup: result.setup,
           ...(startupPlan
             ? {

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1829,9 +1829,12 @@ describe('useIpcEvents CLI-created worktree activation', () => {
   // the back/forward buttons ignoring the CLI-driven switch. This test pins
   // the handler to the canonical `activateAndRevealWorktree` helper, which
   // is the single place that records the visit in history.
-  it('routes CLI-driven activation through activateAndRevealWorktree so back/forward history is recorded', async () => {
+  it('uses immediate reveal only for newly fetched ui:activateWorktree targets', async () => {
     const activateAndRevealWorktree = vi.fn()
-    const fetchWorktrees = vi.fn().mockResolvedValue(undefined)
+    let worktreeKnown = false
+    const fetchWorktrees = vi.fn().mockImplementation(async () => {
+      worktreeKnown = true
+    })
     const activateWorktreeListenerRef: {
       current:
         | ((data: {
@@ -1862,6 +1865,12 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           activeModal: null,
           closeModal: vi.fn(),
           openModal: vi.fn(),
+          getKnownWorktreeById: vi.fn((id: string) => {
+            if (id === 'wt-existing') {
+              return { id, repoId: 'repo-1' }
+            }
+            return worktreeKnown && id === 'wt-new' ? { id, repoId: 'repo-1' } : undefined
+          }),
           activeWorktreeId: 'wt-old',
           activeView: 'terminal',
           setActiveView: vi.fn(),
@@ -2044,7 +2053,24 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     // mis-aliased into `startup`, which was a latent bug in the original
     // hand-rolled path.
     expect(activateAndRevealWorktree).toHaveBeenCalledTimes(1)
-    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-new', { setup })
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-new', {
+      setup,
+      sidebarRevealBehavior: 'auto'
+    })
+
+    activateAndRevealWorktree.mockClear()
+    fetchWorktrees.mockClear()
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing'
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
+    expect(activateAndRevealWorktree).toHaveBeenCalledTimes(1)
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-existing', {})
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -780,16 +780,24 @@ export function useIpcEvents(): void {
             // not this local Electron event.
             return
           }
+          const existedBeforeFetch = Boolean(
+            useAppStore.getState().getKnownWorktreeById(worktreeId)
+          )
           // Why: fetch worktrees first so the activation helper can resolve
           // the CLI-created worktree via findWorktreeById — it arrived from
           // the main process and is not yet in the renderer state.
           await useAppStore.getState().fetchWorktrees(repoId)
+          const existsAfterFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
           // Why: route through activateAndRevealWorktree so CLI-created
           // worktrees share the canonical activation path with UI-created
           // ones. This records the visit in the back/forward history stack
           // (recordWorktreeVisit), without which the nav buttons would
           // ignore the CLI-driven workspace switch.
-          activateAndRevealWorktree(worktreeId, { setup, startup })
+          activateAndRevealWorktree(worktreeId, {
+            ...(setup ? { setup } : {}),
+            ...(startup ? { startup } : {}),
+            ...(!existedBeforeFetch && existsAfterFetch ? { sidebarRevealBehavior: 'auto' } : {})
+          })
         })().catch((error) => {
           console.error('Failed to activate CLI-created worktree:', error)
         })

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -322,6 +322,7 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
     }
 
     const activation = activateAndRevealWorktree(worktreeId, {
+      sidebarRevealBehavior: 'auto',
       setup: result.setup,
       ...buildStartupOpts(effectiveAgent, startupPlan, launchSource)
     })

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -37,6 +37,7 @@ function makeWorktree(): Worktree {
 describe('activateAndRevealWorktree created agent reopen', () => {
   it('reopens an empty worktree with the agent selected at creation time', () => {
     const worktree = makeWorktree()
+    const revealWorktreeInSidebar = vi.fn()
 
     useAppStore.setState({
       repos: [
@@ -71,7 +72,7 @@ describe('activateAndRevealWorktree created agent reopen', () => {
       markWorktreeVisited: vi.fn(),
       recordWorktreeVisit: vi.fn(),
       refreshGitHubForWorktreeIfStale: vi.fn(),
-      revealWorktreeInSidebar: vi.fn()
+      revealWorktreeInSidebar
     })
 
     const result = activateAndRevealWorktree(worktree.id)
@@ -88,6 +89,53 @@ describe('activateAndRevealWorktree created agent reopen', () => {
         request_kind: 'resume'
       }
     })
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+  })
+
+  it('forwards an explicit sidebar reveal behavior', () => {
+    const worktree = makeWorktree()
+    const revealWorktreeInSidebar = vi.fn()
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      activeRepoId: 'repo-1',
+      activeView: 'terminal',
+      tabsByWorktree: {},
+      unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      browserTabsByWorktree: {},
+      activeFileIdByWorktree: {},
+      activeBrowserTabIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      activeTabIdByWorktree: {},
+      tabBarOrderByWorktree: {},
+      pendingStartupByTabId: {},
+      settings: {
+        agentCmdOverrides: {},
+        setupScriptLaunchMode: 'new-tab'
+      } as unknown as ReturnType<typeof useAppStore.getState>['settings'],
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      revealWorktreeInSidebar
+    })
+
+    const result = activateAndRevealWorktree(worktree.id, { sidebarRevealBehavior: 'auto' })
+
+    expect(result).toEqual({ primaryTabId: expect.any(String) })
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id, { behavior: 'auto' })
   })
 
   it('asks the host runtime to activate the worktree in the paired web client', async () => {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -6,6 +6,7 @@ import { buildAgentStartupPlan } from './tui-agent-startup'
 import { CLIENT_PLATFORM } from './new-workspace'
 import { tuiAgentToAgentKind } from './telemetry'
 import { useAppStore } from '@/store'
+import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
 import {
   activateWebRuntimeSessionWorktree,
   isWebRuntimeSessionActive
@@ -125,6 +126,7 @@ export function activateAndRevealWorktree(
     }
     setup?: WorktreeSetupLaunch
     issueCommand?: IssueCommandLaunch
+    sidebarRevealBehavior?: PendingSidebarWorktreeReveal['behavior']
   }
 ): ActivateAndRevealResult | false {
   const state = useAppStore.getState()
@@ -188,7 +190,11 @@ export function activateAndRevealWorktree(
   }
 
   // 6. Reveal in sidebar
-  state.revealWorktreeInSidebar(worktreeId)
+  if (opts?.sidebarRevealBehavior) {
+    state.revealWorktreeInSidebar(worktreeId, { behavior: opts.sidebarRevealBehavior })
+  } else {
+    state.revealWorktreeInSidebar(worktreeId)
+  }
 
   return { primaryTabId }
 }

--- a/src/renderer/src/store/slices/repos-onboarding-folder-startup.test.ts
+++ b/src/renderer/src/store/slices/repos-onboarding-folder-startup.test.ts
@@ -56,6 +56,7 @@ describe('repo slice skipped-onboarding folder startup', () => {
       1,
       'folder-1::/folder',
       {
+        sidebarRevealBehavior: 'auto',
         startup: {
           command: 'codex',
           telemetry: {
@@ -69,7 +70,7 @@ describe('repo slice skipped-onboarding folder startup', () => {
     expect(worktreeActivation.activateAndRevealWorktree).toHaveBeenNthCalledWith(
       2,
       'folder-2::/folder',
-      undefined
+      { sidebarRevealBehavior: 'auto' }
     )
   })
 })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -220,7 +220,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           onboarding,
           hadProjectBeforeAdd
         )
-        activateAndRevealWorktree(folderWorktree.id, startup ? { startup } : undefined)
+        activateAndRevealWorktree(folderWorktree.id, {
+          sidebarRevealBehavior: 'auto',
+          ...(startup ? { startup } : {})
+        })
       }
       return repo
     } catch (err) {


### PR DESCRIPTION
## Summary
- Reveals newly created worktrees in the sidebar after creation, including launches that start an agent.
- Keeps existing worktree activation behavior intact while centralizing the reveal intent around the work item launch flow.
- Adds coverage for created-agent activation, IPC reveal handling, and onboarding folder startup behavior.

## Design Doc
- docs/new-worktree-sidebar-reveal.md

## Validation
- pnpm test -- src/renderer/src/lib/worktree-activation-created-agent.test.ts src/renderer/src/lib/worktree-activation.test.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/store/slices/repos-onboarding-folder-startup.test.ts passed.
- pnpm typecheck passed.
- pnpm lint passed.
- git diff --check passed.
- Electron/CDP synthetic overflow sidebar validation passed: cold created reveal, existing default reveal, repeat created reveal, and adjacent existing smoke.

Local reviewer screenshots are uncommitted under validation-screenshots/: 01-cold-created-reveal-pass.png, 02-existing-default-reveal-pass.png, 03-repeat-created-reveal-pass.png, and 04-adjacent-existing-smoke-pass.png.

Refs stablyai/orca-internal#350

Made with [Orca](https://github.com/stablyai/orca) 🐋
