### PR TITLE
test: cover markdown ordered list exits

### DIFF
--- a/tests/e2e/helpers/markdown-ordered-list-exit.ts
+++ b/tests/e2e/helpers/markdown-ordered-list-exit.ts
@@ -1,0 +1,282 @@
+import { randomUUID } from 'crypto'
+import { mkdir, rm, writeFile } from 'fs/promises'
+import path from 'path'
+import type { Locator, Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+
+const MARKDOWN_HYDRATION_TIMEOUT_MS = 25_000
+const DRAFT_SERIALIZATION_TIMEOUT_MS = 10_000
+
+export type ActiveWorktreeContext = {
+  worktreeId: string
+  rootPath: string
+}
+
+export type MatrixRow = {
+  name: string
+  slug: string
+  sentinel: string
+  initialMarkdown: string
+  run: (page: Page, sentinel: string) => Promise<void>
+}
+
+type ActiveEditorFile = {
+  filePath: string
+}
+
+export async function getActiveWorktreeContext(page: Page): Promise<ActiveWorktreeContext> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      throw new Error('No active worktree is selected')
+    }
+
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === worktreeId)
+    if (!worktree) {
+      throw new Error(`Active worktree was not found in store: ${worktreeId}`)
+    }
+
+    return { worktreeId, rootPath: worktree.path }
+  })
+}
+
+export async function createMarkdownFixture(
+  context: ActiveWorktreeContext,
+  slug: string,
+  workerIndex: number,
+  initialMarkdown: string
+): Promise<string> {
+  const directory = path.join(context.rootPath, '.orca-e2e-markdown-ordered-list')
+  await mkdir(directory, { recursive: true })
+
+  const filePath = path.join(directory, `${slug}-${workerIndex}-${Date.now()}-${randomUUID()}.md`)
+  await writeFile(filePath, initialMarkdown, 'utf8')
+
+  return filePath
+}
+
+export async function cleanupMarkdownFixture(filePath: string | null): Promise<void> {
+  if (!filePath) {
+    return
+  }
+
+  try {
+    await rm(filePath, { force: true })
+  } catch {
+    // Best-effort cleanup must not hide the editor regression assertion.
+  }
+}
+
+export async function openMarkdownFixture(
+  page: Page,
+  context: ActiveWorktreeContext,
+  filePath: string
+): Promise<ActiveEditorFile> {
+  const relativePath = path.relative(context.rootPath, filePath)
+
+  await page.evaluate(
+    ({ filePath, relativePath, worktreeId }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+
+      store.getState().openFile({
+        filePath,
+        relativePath,
+        worktreeId,
+        language: 'markdown',
+        mode: 'edit'
+      })
+    },
+    { filePath, relativePath, worktreeId: context.worktreeId }
+  )
+
+  let activeFile: ActiveEditorFile | null = null
+  await expect
+    .poll(
+      async () => {
+        activeFile = await page.evaluate(() => {
+          const store = window.__store
+          if (!store) {
+            return null
+          }
+
+          const state = store.getState()
+          const file = state.openFiles.find((entry) => entry.id === state.activeFileId)
+          return file ? { filePath: file.filePath } : null
+        })
+        return activeFile?.filePath ?? null
+      },
+      {
+        timeout: 5_000,
+        message: `Active editor file did not become ${filePath}`
+      }
+    )
+    .toBe(filePath)
+
+  if (!activeFile) {
+    throw new Error(`Active editor file was not available after opening ${filePath}`)
+  }
+
+  return activeFile
+}
+
+export async function waitForRichMarkdownEditor(page: Page): Promise<Locator> {
+  const editor = page.locator('.rich-markdown-editor')
+  await expect(editor).toBeVisible({ timeout: MARKDOWN_HYDRATION_TIMEOUT_MS })
+  return editor
+}
+
+export async function expectSentinelParagraphOutsideOrderedList(
+  page: Page,
+  sentinel: string
+): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate((sentinel) => {
+          const editor = document.querySelector('.rich-markdown-editor')
+          if (!editor) {
+            return false
+          }
+
+          return Array.from(editor.querySelectorAll('p')).some((paragraph) => {
+            return (
+              paragraph.textContent?.trim() === sentinel &&
+              !paragraph.closest('ol') &&
+              !paragraph.closest('li')
+            )
+          })
+        }, sentinel),
+      {
+        timeout: 5_000,
+        message: `${sentinel} did not render in a paragraph outside an ordered list`
+      }
+    )
+    .toBe(true)
+}
+
+export async function expectSerializedDraftOutsideOrderedList(
+  page: Page,
+  draftKey: string,
+  sentinel: string
+): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          ({ draftKey, sentinel }) => {
+            const draft = window.__store?.getState().editorDrafts[draftKey]
+            if (typeof draft !== 'string') {
+              return false
+            }
+
+            const sentinelLines = draft
+              .split(/\r\n|\r|\n/)
+              .filter((line) => line.includes(sentinel))
+            return {
+              hasPlainLine: sentinelLines.some((line) => line.trim() === sentinel),
+              appearsOnNumberedLine: sentinelLines.some((line) => /^\s*\d+\.\s+/.test(line))
+            }
+          },
+          { draftKey, sentinel }
+        ),
+      {
+        timeout: DRAFT_SERIALIZATION_TIMEOUT_MS,
+        message: `${sentinel} did not serialize as a plain paragraph in editorDrafts[${draftKey}]`
+      }
+    )
+    .toEqual({ hasPlainLine: true, appearsOnNumberedLine: false })
+}
+
+export async function assertLoadedThirdEmptyOrderedListItem(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const editor = document.querySelector('.rich-markdown-editor')
+          const listItems = Array.from(editor?.querySelectorAll('ol > li') ?? [])
+          const thirdItem = listItems[2]
+          const paragraph = thirdItem?.querySelector('p') ?? null
+          const rect = paragraph?.getBoundingClientRect()
+          return Boolean(
+            thirdItem &&
+            paragraph &&
+            thirdItem.textContent?.trim() === '' &&
+            rect &&
+            rect.width > 0 &&
+            rect.height > 0
+          )
+        }),
+      {
+        timeout: 5_000,
+        message: 'Loaded markdown did not expose an editable empty third ordered-list item'
+      }
+    )
+    .toBe(true)
+}
+
+async function selectionIsInsideThirdEmptyOrderedListItem(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const editor = document.querySelector('.rich-markdown-editor')
+    const thirdItem = editor?.querySelectorAll('ol > li')[2]
+    const selection = window.getSelection()
+    const anchorNode = selection?.anchorNode ?? null
+    if (!thirdItem || !anchorNode || !selection?.isCollapsed) {
+      return false
+    }
+
+    const prosemirrorNodeName = (
+      thirdItem as Element & { pmViewDesc?: { node?: { type?: { name?: string } } } }
+    ).pmViewDesc?.node?.type?.name
+    const anchorElement =
+      anchorNode.nodeType === Node.ELEMENT_NODE ? anchorNode : anchorNode.parentElement
+    return (
+      prosemirrorNodeName === 'listItem' &&
+      Boolean(anchorElement && thirdItem.contains(anchorElement))
+    )
+  })
+}
+
+export async function placeCaretInLoadedThirdEmptyItem(page: Page): Promise<void> {
+  const thirdItemParagraph = page.locator('.rich-markdown-editor ol > li').nth(2).locator('p')
+  await thirdItemParagraph.click()
+
+  if (!(await selectionIsInsideThirdEmptyOrderedListItem(page))) {
+    await page.evaluate(() => {
+      const editor = document.querySelector<HTMLElement>('.rich-markdown-editor')
+      const thirdItem = editor?.querySelectorAll('ol > li')[2]
+      const paragraph = thirdItem?.querySelector('p')
+      if (!editor || !paragraph) {
+        throw new Error('Cannot place caret in the loaded empty ordered-list item')
+      }
+
+      // Why: headless Electron can click an empty paragraph without producing a
+      // stable caret; force the same collapsed DOM selection before pressing Enter.
+      const range = document.createRange()
+      range.setStart(paragraph, 0)
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      editor.focus()
+      document.dispatchEvent(new Event('selectionchange'))
+    })
+  }
+
+  await expect
+    .poll(async () => selectionIsInsideThirdEmptyOrderedListItem(page), {
+      timeout: 3_000,
+      message: 'Selection was not inside the loaded empty third ordered-list item'
+    })
+    .toBe(true)
+}

--- a/tests/e2e/markdown-ordered-list-exit.spec.ts
+++ b/tests/e2e/markdown-ordered-list-exit.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  assertLoadedThirdEmptyOrderedListItem,
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  expectSentinelParagraphOutsideOrderedList,
+  expectSerializedDraftOutsideOrderedList,
+  getActiveWorktreeContext,
+  openMarkdownFixture,
+  placeCaretInLoadedThirdEmptyItem,
+  type MatrixRow,
+  waitForRichMarkdownEditor
+} from './helpers/markdown-ordered-list-exit'
+
+const rows: MatrixRow[] = [
+  {
+    name: 'typed ordered-list marker exits to a paragraph',
+    slug: 'typed-marker',
+    sentinel: 'afterTypedMarkerExit',
+    initialMarkdown: '',
+    run: async (page, sentinel) => {
+      const editor = await waitForRichMarkdownEditor(page)
+      await editor.click()
+      await page.keyboard.type('1. first')
+      await page.keyboard.press('Enter')
+      await page.keyboard.press('Enter')
+      await page.keyboard.type(sentinel)
+    }
+  },
+  {
+    name: 'toolbar-created ordered list exits to a paragraph',
+    slug: 'toolbar-list',
+    sentinel: 'afterToolbarListExit',
+    initialMarkdown: '',
+    run: async (page, sentinel) => {
+      const editor = await waitForRichMarkdownEditor(page)
+      await editor.click()
+      await page.getByRole('button', { name: 'Numbered list' }).click()
+      await expect(editor.locator('ol')).toHaveCount(1, { timeout: 5_000 })
+      await page.keyboard.type('first')
+      await page.keyboard.press('Enter')
+      await page.keyboard.press('Enter')
+      await page.keyboard.type(sentinel)
+    }
+  },
+  {
+    name: 'loaded existing-note ordered-list continuation exits to a paragraph',
+    slug: 'loaded-continuation',
+    sentinel: 'afterLoadedContinuationExit',
+    initialMarkdown: '1. Item 1\n2. Item 2\n3. \n\n## Next section\n',
+    run: async (page, sentinel) => {
+      await waitForRichMarkdownEditor(page)
+      await assertLoadedThirdEmptyOrderedListItem(page)
+      await placeCaretInLoadedThirdEmptyItem(page)
+      await page.keyboard.press('Enter')
+      await page.keyboard.type(sentinel)
+    }
+  }
+]
+
+test.describe('Markdown ordered-list exit regression', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  for (const row of rows) {
+    test(row.name, async ({ orcaPage }, testInfo) => {
+      const context = await getActiveWorktreeContext(orcaPage)
+      let filePath: string | null = null
+
+      try {
+        filePath = await createMarkdownFixture(
+          context,
+          row.slug,
+          testInfo.workerIndex,
+          row.initialMarkdown
+        )
+        const activeFile = await openMarkdownFixture(orcaPage, context, filePath)
+        const draftKey = activeFile.filePath
+
+        await row.run(orcaPage, row.sentinel)
+
+        await expectSentinelParagraphOutsideOrderedList(orcaPage, row.sentinel)
+        await expectSerializedDraftOutsideOrderedList(orcaPage, draftKey, row.sentinel)
+      } finally {
+        await cleanupMarkdownFixture(filePath)
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Adds Electron E2E regression coverage for the markdown editor numbered-list issue reported in stablyai/orca-internal#251.

Current `origin/main` did not reproduce the basic failure, so this PR is test-only: it pins the user-facing flows that should keep accepting text after a numbered list.

Covered paths:
- typed ordered-list marker: `1. first`, Enter, Enter, follow-up text
- toolbar-created numbered list, then default list exit
- loaded existing note with an empty third ordered-list item, then list exit

## Design approach

The reviewed design uses a three-row Electron matrix instead of changing runtime editor behavior. Each row creates its own markdown file, sentinel, and draft key; opens the file through the real editor store path; verifies the sentinel renders in a paragraph outside `ol`/`li`; and verifies the debounced markdown draft serializes the sentinel as a plain paragraph line, not a numbered-list line.

Scratch design doc: `.tmp/markdown-numbered-list-regression-design.md` (not committed).

## Design review outcome

`auto-design-review-fix` completed clean for P0/P1. It expanded the original single repro into the three-row matrix, required structural DOM and serialized draft assertions, added per-row isolation, and scoped closure evidence to validated OS coverage.

## Implementation

Added:
- `tests/e2e/markdown-ordered-list-exit.spec.ts`
- `tests/e2e/helpers/markdown-ordered-list-exit.ts`

No product runtime code changed. Deviation from design: none.

## Completeness verification

Read-only verification confirmed the implementation satisfies the design: three independent rows, unique fixtures/sentinels/draft keys, active-file assertion, cross-platform path usage, DOM outside-list assertions, serialized outside-list assertions, loaded-row selection-context assertion, and cleanup.

## Code review loop

Round 1:
- Reviewer A: found max-lines lint failure in the single spec file.
- Reviewer B: found the same max-lines lint failure.
- Fix: split behavior-specific setup/assertions into `tests/e2e/helpers/markdown-ordered-list-exit.ts`.

Round 2:
- Reviewer A: clean, no actionable findings.
- Reviewer B: clean, no actionable findings.

## Brennan test changes

Verdict: land.

Validated:
- focused E2E matrix passed: typed marker, toolbar-created list, loaded existing-note continuation
- launched this exact worktree in Electron and verified branch/repo identity
- manual product-surface validation in a temporary git repo for all three paths
- verified no renderer console errors related to the editor path

Accepted gaps:
- no SSH/remoting pass, because this PR only adds local Electron editor E2E coverage and does not change SSH/runtime behavior
- manual product validation was on macOS/local Electron

## Checks

- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-list-continuation.test.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/markdown-ordered-list-exit.spec.ts --config tests/playwright.config.ts --project=electron-headless`
- `pnpm exec oxlint tests/e2e/markdown-ordered-list-exit.spec.ts tests/e2e/helpers/markdown-ordered-list-exit.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check --cached && git diff --check`

Note: local commands emitted the existing Node engine warning because the shell is on Node v26 while the package wants Node 24; checks still passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
