### PR TITLE
Use Pierre for read-only diff rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@linear/sdk": "^82.1.0",
     "@monaco-editor/react": "^4.7.0",
     "@parcel/watcher": "^2.5.6",
+    "@pierre/diffs": "1.2.2",
     "@tanstack/react-virtual": "^3.13.24",
     "@tiptap/extension-code-block-lowlight": "^3.22.5",
     "@tiptap/extension-image": "^3.22.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
+      '@pierre/diffs':
+        specifier: 1.2.2
+        version: 1.2.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-virtual':
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1488,6 +1491,16 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
+  '@pierre/diffs@1.2.2':
+    resolution: {integrity: sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@1.0.3':
+    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
+    engines: {vscode: ^1.0.0}
+
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
@@ -2358,6 +2371,30 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/transformers@3.23.0':
+    resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
@@ -3760,6 +3797,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -4273,6 +4314,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -4734,6 +4778,9 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
+
   lucide-react@0.577.0:
     resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
@@ -5130,6 +5177,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -5524,6 +5577,15 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
 
@@ -5736,6 +5798,9 @@ packages:
 
   sherpa-onnx@1.12.37:
     resolution: {integrity: sha512-3luwSdHwR8BtJiiFwqHfb15FE2FX0KsN4aOBbfq9Ma23r3w9C3bprFc/WBusXk56nUbzcEN5YczN7t9w1JwdtQ==}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -7356,6 +7421,19 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@pierre/diffs@1.2.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@pierre/theme': 1.0.3
+      '@shikijs/transformers': 3.23.0
+      diff: 8.0.3
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      shiki: 3.23.0
+
+  '@pierre/theme@1.0.3': {}
+
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
@@ -8219,6 +8297,44 @@ snapshots:
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/transformers@3.23.0':
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@simple-git/args-pathspec@1.0.3': {}
 
@@ -9667,6 +9783,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@8.0.3: {}
+
   diff@8.0.4: {}
 
   dijkstrajs@1.0.3: {}
@@ -10372,6 +10490,20 @@ snapshots:
       '@ungap/structured-clone': 1.3.1
       unist-util-position: 5.0.0
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -10777,6 +10909,8 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lru_map@0.4.1: {}
 
   lucide-react@0.577.0(react@19.2.5):
     dependencies:
@@ -11415,6 +11549,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -11943,6 +12085,16 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   rehype-highlight@7.0.2:
     dependencies:
       '@types/hast': 3.0.4
@@ -12267,6 +12419,17 @@ snapshots:
     optional: true
 
   sherpa-onnx@1.12.37: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.1:
     dependencies:

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -36,6 +36,7 @@ import { cn } from '@/lib/utils'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 import { Button } from '@/components/ui/button'
 import { installEditorSaveShortcut } from './editor-shortcuts'
+import { PierreTextDiff } from './PierreTextDiff'
 
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
 
@@ -166,12 +167,13 @@ export function DiffSectionItem({
     }
     return diffComments.some((c) => c.id === scrollToDiffCommentId) ? scrollToDiffCommentId : null
   }, [scrollToDiffCommentId, diffComments])
+  const visibleComments = inlineComments ?? (worktreeId ? diffComments : [])
 
   useDiffCommentDecorator({
-    editor: hasLineCommentAction ? modifiedEditor : null,
+    editor: hasLineCommentAction && isEditable ? modifiedEditor : null,
     filePath: section.path,
     worktreeId: worktreeId ?? '',
-    comments: inlineComments ?? (worktreeId ? diffComments : []),
+    comments: visibleComments,
     commentableLineNumbers: getCommentableLineNumbers?.(section),
     addButtonLabel: addLineCommentLabel,
     onAddCommentClick: ({ lineNumber, startLine, top }) =>
@@ -224,6 +226,34 @@ export function DiffSectionItem({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modifiedEditor, popover?.lineNumber])
 
+  const handleAddLineCommentForLine = useCallback(
+    async (args: { lineNumber: number; startLine?: number; body: string }): Promise<boolean> => {
+      if (onAddLineComment) {
+        return onAddLineComment(section, args)
+      }
+      if (!worktreeId) {
+        return false
+      }
+      // Why: await persistence before closing the popover. If addDiffComment
+      // resolves to null, the store rolled back the optimistic insert; keeping
+      // the popover open preserves the user's draft so they can retry.
+      const result = await addDiffComment({
+        worktreeId,
+        filePath: section.path,
+        source: 'diff',
+        startLine: args.startLine,
+        lineNumber: args.lineNumber,
+        body: args.body,
+        side: 'modified'
+      })
+      if (!result) {
+        console.error('Failed to add diff comment - draft preserved')
+      }
+      return Boolean(result)
+    },
+    [addDiffComment, onAddLineComment, section, worktreeId]
+  )
+
   useEffect(() => {
     const diffEditor = diffEditorRef.current
     if (!diffEditor) {
@@ -241,37 +271,13 @@ export function DiffSectionItem({
     if (!popover) {
       return
     }
-    if (onAddLineComment) {
-      const ok = await onAddLineComment(section, {
-        lineNumber: popover.lineNumber,
-        startLine: popover.startLine,
-        body
-      })
-      if (ok) {
-        setPopover(null)
-      }
-      return
-    }
-    if (!worktreeId) {
-      return
-    }
-    // Why: await persistence before closing the popover. If addDiffComment
-    // resolves to null, the store rolled back the optimistic insert; keeping
-    // the popover open preserves the user's draft so they can retry instead
-    // of silently losing their text.
-    const result = await addDiffComment({
-      worktreeId,
-      filePath: section.path,
-      source: 'diff',
-      startLine: popover.startLine,
+    const ok = await handleAddLineCommentForLine({
       lineNumber: popover.lineNumber,
-      body,
-      side: 'modified'
+      startLine: popover.startLine,
+      body
     })
-    if (result) {
+    if (ok) {
       setPopover(null)
-    } else {
-      console.error('Failed to add diff comment — draft preserved')
     }
   }
 
@@ -307,6 +313,17 @@ export function DiffSectionItem({
     changedLineCount,
     useIntrinsicImageHeight
   })
+  const handlePierreContentHeightChange = useCallback(
+    (contentHeight: number): void => {
+      setSectionHeights((prev) => {
+        if (prev[index] === contentHeight) {
+          return prev
+        }
+        return { ...prev, [index]: contentHeight }
+      })
+    },
+    [index, setSectionHeights]
+  )
 
   const handleMount: DiffOnMount = (editor, _monaco) => {
     diffEditorRef.current = editor
@@ -499,6 +516,31 @@ export function DiffSectionItem({
                 </div>
               </div>
             )
+          ) : !isEditable ? (
+            <PierreTextDiff
+              originalContent={section.originalContent}
+              modifiedContent={section.modifiedContent}
+              filePath={section.path}
+              language={language}
+              sideBySide={sideBySide}
+              isDark={isDark}
+              fontSize={editorFontSize}
+              fontFamily={settings?.terminalFontFamily}
+              comments={visibleComments}
+              commentableLineNumbers={getCommentableLineNumbers?.(section)}
+              addLineCommentLabel={addLineCommentLabel}
+              addLineCommentPlaceholder={addLineCommentPlaceholder}
+              onAddLineComment={hasLineCommentAction ? handleAddLineCommentForLine : undefined}
+              onDeleteComment={
+                worktreeId ? (id) => void deleteDiffComment(worktreeId, id) : undefined
+              }
+              onUpdateComment={
+                worktreeId ? (id, body) => updateDiffComment(worktreeId, id, body) : undefined
+              }
+              pendingScrollCommentId={pendingScrollForThisSection}
+              onPendingScrollConsumed={() => setScrollToDiffCommentId(null)}
+              onContentHeightChange={handlePierreContentHeightChange}
+            />
           ) : (
             <DiffEditor
               height="100%"

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -17,6 +17,7 @@ import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-opti
 import type { DiffComment } from '../../../../shared/types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut } from './editor-shortcuts'
+import { PierreDiffViewer } from './PierreDiffViewer'
 
 type DiffViewerProps = {
   modelKey: string
@@ -45,7 +46,29 @@ type DiffViewerProps = {
   onSave?: (content: string) => void
 }
 
-export default function DiffViewer({
+export default function DiffViewer(props: DiffViewerProps): React.JSX.Element {
+  if (!props.editable) {
+    return (
+      <PierreDiffViewer
+        originalContent={props.originalContent}
+        modifiedContent={props.modifiedContent}
+        language={props.language}
+        filePath={props.filePath}
+        relativePath={props.relativePath}
+        sideBySide={props.sideBySide}
+        worktreeId={props.worktreeId}
+        onAddLineComment={props.onAddLineComment}
+        commentableLineNumbers={props.commentableLineNumbers}
+        addLineCommentLabel={props.addLineCommentLabel}
+        addLineCommentPlaceholder={props.addLineCommentPlaceholder}
+      />
+    )
+  }
+
+  return <MonacoDiffViewer {...props} />
+}
+
+function MonacoDiffViewer({
   modelKey,
   originalModelKey,
   modifiedModelKey,

--- a/src/renderer/src/components/editor/PierreDiffViewer.tsx
+++ b/src/renderer/src/components/editor/PierreDiffViewer.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo } from 'react'
+import { useAppStore } from '@/store'
+import { computeEditorFontSize } from '@/lib/editor-font-zoom'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { isDiffComment } from '@/lib/diff-comment-compat'
+import type { DiffComment } from '../../../../shared/types'
+import { PierreTextDiff } from './PierreTextDiff'
+
+type PierreDiffViewerProps = {
+  originalContent: string
+  modifiedContent: string
+  language: string
+  filePath: string
+  relativePath: string
+  sideBySide: boolean
+  worktreeId?: string
+  onAddLineComment?: (args: {
+    lineNumber: number
+    startLine?: number
+    body: string
+  }) => Promise<boolean>
+  commentableLineNumbers?: readonly number[]
+  addLineCommentLabel?: string
+  addLineCommentPlaceholder?: string
+}
+
+export function PierreDiffViewer({
+  originalContent,
+  modifiedContent,
+  language,
+  filePath,
+  relativePath,
+  sideBySide,
+  worktreeId,
+  onAddLineComment,
+  commentableLineNumbers,
+  addLineCommentLabel,
+  addLineCommentPlaceholder
+}: PierreDiffViewerProps): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  const addDiffComment = useAppStore((s) => s.addDiffComment)
+  const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
+  const updateDiffComment = useAppStore((s) => s.updateDiffComment)
+  const scrollToDiffCommentId = useAppStore((s) => s.scrollToDiffCommentId)
+  const setScrollToDiffCommentId = useAppStore((s) => s.setScrollToDiffCommentId)
+  const allDiffComments = useAppStore((s): DiffComment[] | undefined =>
+    worktreeId ? findWorktreeById(s.worktreesByRepo, worktreeId)?.diffComments : undefined
+  )
+  const diffComments = useMemo(
+    () => (allDiffComments ?? []).filter((c) => c.filePath === relativePath && isDiffComment(c)),
+    [allDiffComments, relativePath]
+  )
+  const editorFontSize = computeEditorFontSize(
+    settings?.terminalFontSize ?? 13,
+    editorFontZoomLevel
+  )
+  const isDark =
+    settings?.theme === 'dark' ||
+    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const pendingScrollForThisViewer =
+    worktreeId && scrollToDiffCommentId && diffComments.some((c) => c.id === scrollToDiffCommentId)
+      ? scrollToDiffCommentId
+      : null
+
+  const handleAddLineComment = async (args: {
+    lineNumber: number
+    startLine?: number
+    body: string
+  }): Promise<boolean> => {
+    if (onAddLineComment) {
+      return onAddLineComment(args)
+    }
+    if (!worktreeId) {
+      return false
+    }
+    const result = await addDiffComment({
+      worktreeId,
+      filePath: relativePath,
+      source: 'diff',
+      startLine: args.startLine,
+      lineNumber: args.lineNumber,
+      body: args.body,
+      side: 'modified'
+    })
+    if (!result) {
+      console.error('Failed to add diff comment - draft preserved')
+    }
+    return Boolean(result)
+  }
+
+  return (
+    <PierreTextDiff
+      originalContent={originalContent}
+      modifiedContent={modifiedContent}
+      filePath={filePath || relativePath}
+      language={language}
+      sideBySide={sideBySide}
+      isDark={isDark}
+      fontSize={editorFontSize}
+      fontFamily={settings?.terminalFontFamily}
+      scrollable
+      comments={worktreeId ? diffComments : []}
+      commentableLineNumbers={commentableLineNumbers}
+      addLineCommentLabel={addLineCommentLabel}
+      addLineCommentPlaceholder={addLineCommentPlaceholder}
+      onAddLineComment={worktreeId || onAddLineComment ? handleAddLineComment : undefined}
+      onDeleteComment={worktreeId ? (id) => void deleteDiffComment(worktreeId, id) : undefined}
+      onUpdateComment={
+        worktreeId ? (id, body) => updateDiffComment(worktreeId, id, body) : undefined
+      }
+      pendingScrollCommentId={pendingScrollForThisViewer}
+      onPendingScrollConsumed={() => setScrollToDiffCommentId(null)}
+    />
+  )
+}

--- a/src/renderer/src/components/editor/PierreTextDiff.tsx
+++ b/src/renderer/src/components/editor/PierreTextDiff.tsx
@@ -1,0 +1,416 @@
+import {
+  MultiFileDiff,
+  WorkerPoolContextProvider,
+  type DiffLineAnnotation,
+  type SelectedLineRange
+} from '@pierre/diffs/react'
+import type { FileDiffOptions } from '@pierre/diffs'
+import PierreDiffWorker from '@pierre/diffs/worker/worker.js?worker'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { DiffCommentCard } from '../diff-comments/DiffCommentCard'
+import type { DecoratedDiffComment } from '../diff-comments/useDiffCommentDecorator'
+import { cn } from '@/lib/utils'
+import { createPierreFileContents, getPierreCommentTarget } from './pierre-diff-model'
+import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
+
+type PierreTextDiffProps = {
+  originalContent: string
+  modifiedContent: string
+  filePath: string
+  language: string
+  sideBySide: boolean
+  isDark: boolean
+  fontSize: number
+  fontFamily?: string
+  scrollable?: boolean
+  className?: string
+  style?: React.CSSProperties
+  comments?: readonly DecoratedDiffComment[]
+  commentableLineNumbers?: readonly number[]
+  addLineCommentLabel?: string
+  addLineCommentPlaceholder?: string
+  onAddLineComment?: (args: {
+    lineNumber: number
+    startLine?: number
+    body: string
+  }) => Promise<boolean>
+  onDeleteComment?: (commentId: string) => void
+  onUpdateComment?: (commentId: string, body: string) => Promise<boolean>
+  pendingScrollCommentId?: string | null
+  onPendingScrollConsumed?: () => void
+  onContentHeightChange?: (height: number) => void
+}
+
+type PierreDiffStyle = React.CSSProperties & Record<`--${string}`, string | number>
+
+type PendingPopover = {
+  lineNumber: number
+  startLine?: number
+  top: number
+}
+
+const PIERRE_WORKER_POOL_SIZE =
+  typeof navigator === 'undefined'
+    ? 2
+    : Math.max(1, Math.min(4, navigator.hardwareConcurrency || 2))
+const PIERRE_RENDER_RETRY_DELAYS_MS = [50, 150, 300, 600, 1_000]
+
+function createPierreWorker(): Worker {
+  return new PierreDiffWorker()
+}
+
+function hasRenderedDiffLines(container: HTMLElement | null): boolean {
+  if (!container) {
+    return false
+  }
+  return Array.from(container.querySelectorAll('diffs-container')).some((host) =>
+    host.shadowRoot?.querySelector('[data-line]')
+  )
+}
+
+function findRenderedLine(container: HTMLElement, lineNumber: number): HTMLElement | null {
+  const hosts = Array.from(container.querySelectorAll('diffs-container'))
+  const selectors = [
+    `[data-additions] [data-line="${lineNumber}"]`,
+    `[data-line="${lineNumber}"][data-line-type="change-addition"]`,
+    `[data-line="${lineNumber}"][data-line-type="context"]`,
+    `[data-line="${lineNumber}"]`
+  ]
+
+  for (const host of hosts) {
+    const shadowRoot = host.shadowRoot
+    if (!shadowRoot) {
+      continue
+    }
+    for (const selector of selectors) {
+      const match = shadowRoot.querySelector(selector)
+      if (match instanceof HTMLElement) {
+        return match
+      }
+    }
+  }
+
+  return null
+}
+
+function getLineTop(container: HTMLElement, lineNumber: number): number | null {
+  const line = findRenderedLine(container, lineNumber)
+  if (!line) {
+    return null
+  }
+  const lineRect = line.getBoundingClientRect()
+  const containerRect = container.getBoundingClientRect()
+  return Math.max(0, lineRect.top - containerRect.top + container.scrollTop)
+}
+
+export function PierreTextDiff({
+  originalContent,
+  modifiedContent,
+  filePath,
+  language,
+  sideBySide,
+  isDark,
+  fontSize,
+  fontFamily,
+  scrollable = false,
+  className,
+  style,
+  comments = [],
+  commentableLineNumbers,
+  addLineCommentLabel,
+  addLineCommentPlaceholder,
+  onAddLineComment,
+  onDeleteComment,
+  onUpdateComment,
+  pendingScrollCommentId,
+  onPendingScrollConsumed,
+  onContentHeightChange
+}: PierreTextDiffProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [popover, setPopover] = useState<PendingPopover | null>(null)
+  const [renderRetry, setRenderRetry] = useState(0)
+
+  const oldFile = useMemo(
+    () =>
+      createPierreFileContents({
+        filePath,
+        contents: originalContent,
+        language
+      }),
+    [filePath, language, originalContent]
+  )
+  const newFile = useMemo(
+    () =>
+      createPierreFileContents({
+        filePath,
+        contents: modifiedContent,
+        language
+      }),
+    [filePath, language, modifiedContent]
+  )
+
+  const reportContentHeight = useCallback(() => {
+    const content = contentRef.current
+    if (!content || !onContentHeightChange) {
+      return
+    }
+    onContentHeightChange(content.scrollHeight)
+  }, [onContentHeightChange])
+
+  useEffect(() => {
+    if (!onContentHeightChange || !contentRef.current) {
+      return
+    }
+    const content = contentRef.current
+    const report = (): void => reportContentHeight()
+    report()
+    const observer = new ResizeObserver(report)
+    observer.observe(content)
+    return () => observer.disconnect()
+  }, [onContentHeightChange, reportContentHeight])
+
+  const lineAnnotations = useMemo<DiffLineAnnotation<DecoratedDiffComment>[]>(
+    () =>
+      comments.map((comment) => ({
+        side: 'additions',
+        lineNumber: comment.lineNumber,
+        metadata: comment
+      })),
+    [comments]
+  )
+
+  const handleAddTarget = useCallback(
+    (range: SelectedLineRange) => {
+      if (!onAddLineComment) {
+        return
+      }
+      const target = getPierreCommentTarget(range, commentableLineNumbers)
+      if (!target || !containerRef.current) {
+        return
+      }
+      const top = getLineTop(containerRef.current, target.lineNumber)
+      if (top == null) {
+        return
+      }
+      setPopover({ ...target, top })
+    },
+    [commentableLineNumbers, onAddLineComment]
+  )
+
+  const options = useMemo<FileDiffOptions<DecoratedDiffComment>>(
+    () => ({
+      theme: isDark ? 'github-dark' : 'github-light',
+      themeType: isDark ? 'dark' : 'light',
+      diffStyle: sideBySide ? 'split' : 'unified',
+      diffIndicators: 'classic',
+      disableFileHeader: true,
+      hunkSeparators: 'line-info',
+      overflow: 'scroll',
+      lineDiffType: 'word',
+      maxLineDiffLength: 1_000,
+      tokenizeMaxLineLength: 1_000,
+      unsafeCSS:
+        renderRetry === 0 ? undefined : `:host{--orca-pierre-render-retry:${renderRetry};}`,
+      lineHoverHighlight: onAddLineComment ? 'both' : 'disabled',
+      enableGutterUtility: Boolean(onAddLineComment),
+      enableLineSelection: Boolean(onAddLineComment),
+      onGutterUtilityClick: onAddLineComment ? handleAddTarget : undefined,
+      onPostRender: () => {
+        requestAnimationFrame(reportContentHeight)
+      }
+    }),
+    [handleAddTarget, isDark, onAddLineComment, renderRetry, reportContentHeight, sideBySide]
+  )
+
+  const diffStyle = useMemo<PierreDiffStyle>(
+    () => ({
+      '--diffs-font-size': `${fontSize}px`,
+      '--diffs-line-height': `${Math.max(18, Math.round(fontSize * 1.45))}px`,
+      '--diffs-font-family': fontFamily || 'var(--font-mono)',
+      '--diffs-header-font-family': 'var(--font-sans)',
+      '--diffs-light-bg': 'var(--editor-surface)',
+      '--diffs-dark-bg': 'var(--editor-surface)',
+      '--diffs-light': 'var(--foreground)',
+      '--diffs-dark': 'var(--foreground)',
+      '--diffs-addition-color': 'var(--git-decoration-added)',
+      '--diffs-deletion-color': 'var(--git-decoration-deleted)',
+      '--diffs-modified-color': 'var(--git-decoration-modified)',
+      '--diffs-bg-hover-override': 'var(--accent)',
+      ...style
+    }),
+    [fontFamily, fontSize, style]
+  )
+
+  const renderAnnotation = useCallback(
+    (annotation: DiffLineAnnotation<DecoratedDiffComment>): React.ReactNode => {
+      const comment = annotation.metadata
+      if (!comment) {
+        return null
+      }
+      return (
+        <div className="orca-diff-comment-inline">
+          <DiffCommentCard
+            lineNumber={comment.lineNumber}
+            startLine={comment.startLine}
+            body={comment.body}
+            sentAt={comment.sentAt}
+            author={comment.author}
+            authorAvatarUrl={comment.authorAvatarUrl}
+            createdAtLabel={comment.createdAtLabel}
+            url={comment.url}
+            onDelete={
+              comment.canDelete === false || !onDeleteComment
+                ? undefined
+                : () => onDeleteComment(comment.id)
+            }
+            onSubmitEdit={
+              onUpdateComment && comment.canEdit !== false
+                ? (body) => onUpdateComment(comment.id, body)
+                : undefined
+            }
+            onContentResize={() => requestAnimationFrame(reportContentHeight)}
+          />
+        </div>
+      )
+    },
+    [onDeleteComment, onUpdateComment, reportContentHeight]
+  )
+
+  useEffect(() => {
+    setRenderRetry(0)
+  }, [filePath, language, modifiedContent, originalContent, sideBySide])
+
+  useEffect(() => {
+    if (originalContent === modifiedContent || hasRenderedDiffLines(containerRef.current)) {
+      return
+    }
+    const delay = PIERRE_RENDER_RETRY_DELAYS_MS[renderRetry]
+    if (delay === undefined) {
+      return
+    }
+
+    // Why: @pierre/diffs 1.2.2 can complete async highlighting without
+    // scheduling a rerender. A no-op option revision flushes the cached result.
+    const timeout = window.setTimeout(() => {
+      if (!hasRenderedDiffLines(containerRef.current)) {
+        setRenderRetry((prev) => Math.min(prev + 1, PIERRE_RENDER_RETRY_DELAYS_MS.length))
+      }
+    }, delay)
+    return () => window.clearTimeout(timeout)
+  }, [filePath, language, modifiedContent, originalContent, renderRetry, sideBySide])
+
+  useEffect(() => {
+    if (!pendingScrollCommentId || !containerRef.current) {
+      return
+    }
+    const comment = comments.find((candidate) => candidate.id === pendingScrollCommentId)
+    if (!comment) {
+      return
+    }
+
+    let cancelled = false
+    let attempts = 0
+    const scrollToComment = (): void => {
+      if (cancelled || !containerRef.current) {
+        return
+      }
+      const line = findRenderedLine(containerRef.current, comment.lineNumber)
+      if (!line) {
+        if (attempts++ < 30) {
+          requestAnimationFrame(scrollToComment)
+        }
+        return
+      }
+      line.scrollIntoView({ block: 'center' })
+      onPendingScrollConsumed?.()
+    }
+
+    requestAnimationFrame(scrollToComment)
+    return () => {
+      cancelled = true
+    }
+  }, [comments, onPendingScrollConsumed, pendingScrollCommentId])
+
+  const workerPoolOptions = useMemo(
+    () => ({
+      workerFactory: createPierreWorker,
+      poolSize: PIERRE_WORKER_POOL_SIZE,
+      totalASTLRUCacheSize: 80
+    }),
+    []
+  )
+  const highlighterOptions = useMemo(
+    () => ({
+      langs: [oldFile.lang ?? 'text', newFile.lang ?? 'text'],
+      theme: options.theme,
+      lineDiffType: options.lineDiffType,
+      maxLineDiffLength: options.maxLineDiffLength,
+      tokenizeMaxLineLength: options.tokenizeMaxLineLength
+    }),
+    [
+      newFile.lang,
+      oldFile.lang,
+      options.lineDiffType,
+      options.maxLineDiffLength,
+      options.theme,
+      options.tokenizeMaxLineLength
+    ]
+  )
+
+  const handleSubmitComment = async (body: string): Promise<void> => {
+    if (!popover || !onAddLineComment) {
+      return
+    }
+    const ok = await onAddLineComment({
+      lineNumber: popover.lineNumber,
+      startLine: popover.startLine,
+      body
+    })
+    if (ok) {
+      setPopover(null)
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      data-diff-renderer="pierre"
+      className={cn(
+        'relative min-h-0 bg-editor-surface',
+        scrollable ? 'h-full overflow-auto scrollbar-editor' : 'overflow-visible',
+        className
+      )}
+      style={diffStyle}
+    >
+      {popover && onAddLineComment && (
+        <DiffCommentPopover
+          key={`${popover.startLine ?? popover.lineNumber}:${popover.lineNumber}`}
+          lineNumber={popover.lineNumber}
+          startLine={popover.startLine}
+          top={popover.top}
+          placeholder={addLineCommentPlaceholder}
+          submitLabel={addLineCommentLabel}
+          submittingLabel="Posting..."
+          onCancel={() => setPopover(null)}
+          onSubmit={handleSubmitComment}
+        />
+      )}
+      <WorkerPoolContextProvider
+        poolOptions={workerPoolOptions}
+        highlighterOptions={highlighterOptions}
+      >
+        <div ref={contentRef}>
+          <MultiFileDiff
+            oldFile={oldFile}
+            newFile={newFile}
+            options={options}
+            lineAnnotations={lineAnnotations}
+            renderAnnotation={renderAnnotation}
+            className="block min-w-full"
+          />
+        </div>
+      </WorkerPoolContextProvider>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/pierre-diff-model.test.ts
+++ b/src/renderer/src/components/editor/pierre-diff-model.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createPierreFileContents,
+  getPierreCommentTarget,
+  normalizePierreLanguage
+} from './pierre-diff-model'
+
+describe('pierre-diff-model', () => {
+  it('normalizes Monaco language names for Pierre', () => {
+    expect(normalizePierreLanguage('plaintext')).toBe('text')
+    expect(normalizePierreLanguage('shellscript')).toBe('bash')
+    expect(normalizePierreLanguage('TypeScript')).toBe('typescript')
+  })
+
+  it('creates Pierre file contents with a display path and language', () => {
+    expect(
+      createPierreFileContents({
+        filePath: 'src/App.tsx',
+        contents: 'export const App = () => null\n',
+        language: 'typescript'
+      })
+    ).toEqual({
+      name: 'src/App.tsx',
+      contents: 'export const App = () => null\n',
+      lang: 'typescript'
+    })
+  })
+
+  it('maps addition-side selections to comment targets', () => {
+    expect(getPierreCommentTarget({ start: 7, end: 5, side: 'additions' })).toEqual({
+      startLine: 5,
+      lineNumber: 7
+    })
+    expect(getPierreCommentTarget({ start: 4, end: 4, side: 'additions' })).toEqual({
+      lineNumber: 4
+    })
+  })
+
+  it('rejects deletion-side and uncommentable selections', () => {
+    expect(getPierreCommentTarget({ start: 3, end: 3, side: 'deletions' })).toBeNull()
+    expect(getPierreCommentTarget({ start: 2, end: 4, side: 'additions' }, [2, 4])).toBeNull()
+    expect(getPierreCommentTarget({ start: 2, end: 4, side: 'additions' }, [2, 3, 4])).toEqual({
+      startLine: 2,
+      lineNumber: 4
+    })
+  })
+})

--- a/src/renderer/src/components/editor/pierre-diff-model.ts
+++ b/src/renderer/src/components/editor/pierre-diff-model.ts
@@ -1,0 +1,69 @@
+import type { FileContents, SelectedLineRange, SupportedLanguages } from '@pierre/diffs/react'
+
+const PIERRE_LANGUAGE_ALIASES: Record<string, SupportedLanguages> = {
+  plain: 'text',
+  plaintext: 'text',
+  shell: 'bash',
+  shellscript: 'bash',
+  sh: 'bash'
+}
+
+export type PierreCommentTarget = {
+  lineNumber: number
+  startLine?: number
+}
+
+export function normalizePierreLanguage(language: string): SupportedLanguages {
+  const normalized = language.trim().toLowerCase()
+  if (!normalized) {
+    return 'text'
+  }
+  return PIERRE_LANGUAGE_ALIASES[normalized] ?? (normalized as SupportedLanguages)
+}
+
+export function createPierreFileContents({
+  filePath,
+  contents,
+  language
+}: {
+  filePath: string
+  contents: string
+  language: string
+}): FileContents {
+  return {
+    name: filePath || 'diff.txt',
+    contents,
+    lang: normalizePierreLanguage(language)
+  }
+}
+
+export function getPierreCommentTarget(
+  range: SelectedLineRange,
+  commentableLineNumbers?: readonly number[]
+): PierreCommentTarget | null {
+  const startSide = range.side ?? 'additions'
+  const endSide = range.endSide ?? startSide
+  if (startSide !== 'additions' || endSide !== 'additions') {
+    return null
+  }
+
+  const startLine = Math.min(range.start, range.end)
+  const lineNumber = Math.max(range.start, range.end)
+  if (startLine < 1 || lineNumber < 1) {
+    return null
+  }
+
+  if (commentableLineNumbers) {
+    const allowed = new Set(commentableLineNumbers)
+    for (let line = startLine; line <= lineNumber; line++) {
+      if (!allowed.has(line)) {
+        return null
+      }
+    }
+  }
+
+  return {
+    lineNumber,
+    startLine: startLine === lineNumber ? undefined : startLine
+  }
+}

--- a/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
@@ -5,18 +5,18 @@ import { buildTerminalAgentQuickCommandPreset } from './terminal-agent-quick-com
 
 describe('terminal agent quick command presets', () => {
   it('matches the supported one-line startup commands for every prompt-starting agent', () => {
-    const expectedCommands: Partial<Record<TuiAgent, string>> = {
-      claude: "claude 'your prompt here'",
-      codex: "codex 'your prompt here'",
-      copilot: "copilot -i 'your prompt here'",
-      omp: "omp 'your prompt here'",
-      opencode: "opencode --prompt 'your prompt here'",
-      pi: "pi 'your prompt here'",
-      gemini: "gemini --prompt-interactive 'your prompt here'",
-      antigravity: "agy --prompt-interactive 'your prompt here'",
-      cursor: "cursor-agent 'your prompt here'",
-      droid: "droid 'your prompt here'"
-    }
+    const expectedCommandEntries: [TuiAgent, string][] = [
+      ['claude', "claude 'your prompt here'"],
+      ['codex', "codex 'your prompt here'"],
+      ['copilot', "copilot -i 'your prompt here'"],
+      ['omp', "omp 'your prompt here'"],
+      ['opencode', "opencode --prompt 'your prompt here'"],
+      ['pi', "pi 'your prompt here'"],
+      ['gemini', "gemini --prompt-interactive 'your prompt here'"],
+      ['antigravity', "agy --prompt-interactive 'your prompt here'"],
+      ['cursor', "cursor-agent 'your prompt here'"],
+      ['droid', "droid 'your prompt here'"]
+    ]
 
     const promptStartingCommands = Object.keys(TUI_AGENT_CONFIG)
       .map((agent) =>
@@ -31,7 +31,7 @@ describe('terminal agent quick command presets', () => {
 
     expect(
       Object.fromEntries(promptStartingCommands.map((preset) => [preset.agent, preset.command]))
-    ).toEqual(expectedCommands)
+    ).toEqual(Object.fromEntries(expectedCommandEntries))
   })
 
   it('does not expose post-start paste agents as insertable command templates', () => {

--- a/tests/e2e/diff-viewer-renderer.spec.ts
+++ b/tests/e2e/diff-viewer-renderer.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+type SeededDiffFile = {
+  absolutePath: string
+  relativePath: string
+  worktreePath: string
+}
+
+async function seedModifiedTypeScriptFile(
+  page: Parameters<typeof waitForSessionReady>[0],
+  worktreeId: string
+): Promise<SeededDiffFile> {
+  return page.evaluate(async (wId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const worktree = Object.values(store.getState().worktreesByRepo)
+      .flat()
+      .find((entry) => entry.id === wId)
+    if (!worktree) {
+      throw new Error(`worktree not found: ${wId}`)
+    }
+
+    const separator = worktree.path.includes('\\') ? '\\' : '/'
+    const relativePath = `src${separator}pierre-renderer-check-${Date.now()}.ts`
+    const absolutePath = `${worktree.path}${separator}${relativePath}`
+    await window.api.fs.writeFile({
+      filePath: absolutePath,
+      content: [
+        'export const renderer = "monaco";',
+        'export const keepsComments = false;',
+        ''
+      ].join('\n')
+    })
+    await window.api.git.stage({ worktreePath: worktree.path, filePath: relativePath })
+    await window.api.git.commit({
+      worktreePath: worktree.path,
+      message: 'Add renderer fixture for E2E'
+    })
+    await window.api.fs.writeFile({
+      filePath: absolutePath,
+      content: [
+        'export const renderer = "pierre";',
+        'export const keepsComments = true;',
+        'export const changedLine = 3;',
+        ''
+      ].join('\n')
+    })
+
+    return { absolutePath, relativePath, worktreePath: worktree.path }
+  }, worktreeId)
+}
+
+async function waitForPierreDiffLines(page: Parameters<typeof waitForSessionReady>[0]) {
+  await page.waitForFunction(
+    () =>
+      Array.from(document.querySelectorAll('[data-diff-renderer="pierre"]')).some((diffRoot) => {
+        const rect = diffRoot.getBoundingClientRect()
+        if (rect.width <= 0 || rect.height <= 0) {
+          return false
+        }
+        return Array.from(diffRoot.querySelectorAll('diffs-container')).some((host) =>
+          host.shadowRoot?.querySelector('[data-line]')
+        )
+      }),
+    null,
+    { timeout: 20_000 }
+  )
+}
+
+test.describe('Diff viewer renderer', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('uses Pierre for read-only diffs while preserving Monaco for editable diffs', async ({
+    orcaPage
+  }) => {
+    const worktreeId = await waitForActiveWorktree(orcaPage)
+    const seededFile = await seedModifiedTypeScriptFile(orcaPage, worktreeId)
+
+    await orcaPage.evaluate(
+      ({ wId, absolutePath, relativePath }) => {
+        window.__store?.getState().openDiff(wId, absolutePath, relativePath, 'typescript', false)
+      },
+      {
+        wId: worktreeId,
+        absolutePath: seededFile.absolutePath,
+        relativePath: seededFile.relativePath
+      }
+    )
+
+    await expect(orcaPage.locator('.monaco-diff-editor').first()).toBeVisible({ timeout: 20_000 })
+    await expect(orcaPage.locator('[data-diff-renderer="pierre"]')).toHaveCount(0)
+
+    await orcaPage.evaluate(
+      async ({ worktreePath, relativePath }) => {
+        await window.api.git.stage({ worktreePath, filePath: relativePath })
+      },
+      { worktreePath: seededFile.worktreePath, relativePath: seededFile.relativePath }
+    )
+
+    const noteResult = await orcaPage.evaluate(
+      async ({ wId, relativePath }) => {
+        return window.__store?.getState().addDiffComment({
+          worktreeId: wId,
+          filePath: relativePath,
+          lineNumber: 2,
+          body: 'comment rendered through Pierre',
+          side: 'modified'
+        })
+      },
+      { wId: worktreeId, relativePath: seededFile.relativePath }
+    )
+    expect(noteResult, 'expected addDiffComment to persist a staged diff note').not.toBeNull()
+
+    await orcaPage.evaluate(
+      ({ wId, absolutePath, relativePath }) => {
+        window.__store?.getState().openDiff(wId, absolutePath, relativePath, 'typescript', true)
+      },
+      {
+        wId: worktreeId,
+        absolutePath: seededFile.absolutePath,
+        relativePath: seededFile.relativePath
+      }
+    )
+
+    const pierreDiff = orcaPage.locator('[data-diff-renderer="pierre"]').first()
+    await expect(pierreDiff).toBeVisible({ timeout: 20_000 })
+    await waitForPierreDiffLines(orcaPage)
+
+    const card = orcaPage
+      .locator('.orca-diff-comment-card')
+      .filter({ has: orcaPage.locator('.orca-diff-comment-body') })
+      .first()
+    await expect(card, 'staged diff note should render on the Pierre annotation path').toBeVisible()
+    await expect(card.locator('.orca-diff-comment-body')).toHaveText(
+      'comment rendered through Pierre'
+    )
+
+    await orcaPage.evaluate(
+      async ({ wId, worktreePath }) => {
+        const status = await window.api.git.status({ worktreePath })
+        window.__store?.getState().setGitStatus(wId, status)
+        window.__store?.getState().openAllDiffs(wId, worktreePath, undefined, 'staged')
+      },
+      { wId: worktreeId, worktreePath: seededFile.worktreePath }
+    )
+
+    await expect(orcaPage.getByText('1 changed files')).toBeVisible({ timeout: 20_000 })
+    await expect(orcaPage.locator('[data-diff-renderer="pierre"]:visible').first()).toBeVisible({
+      timeout: 20_000
+    })
+    await waitForPierreDiffLines(orcaPage)
+    await expect(orcaPage.locator('.monaco-diff-editor')).toHaveCount(0)
+    const combinedCardBody = orcaPage
+      .locator('.orca-diff-comment-card:visible .orca-diff-comment-body')
+      .first()
+    await expect(
+      combinedCardBody,
+      'combined staged diff should preserve Pierre annotations'
+    ).toHaveText('comment rendered through Pierre')
+  })
+})


### PR DESCRIPTION
## Summary
- Render read-only single-file and combined text diffs with `@pierre/diffs`.
- Keep editable unstaged diffs on Monaco so existing editing, save, dirty-state, and comment-decoration behavior remains intact.
- Preserve inline diff notes through the Pierre annotation path and add focused model plus Electron coverage for renderer selection.

## Evidence
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/pierre-diff-model.test.ts`
- `pnpm exec oxlint src/renderer/src/components/editor/DiffViewer.tsx src/renderer/src/components/editor/DiffSectionItem.tsx src/renderer/src/components/editor/PierreDiffViewer.tsx src/renderer/src/components/editor/PierreTextDiff.tsx src/renderer/src/components/editor/pierre-diff-model.ts src/renderer/src/components/editor/pierre-diff-model.test.ts tests/e2e/diff-viewer-renderer.spec.ts`
- `pnpm run typecheck:web`
- `pnpm run build:web`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/diff-viewer-renderer.spec.ts --config tests/playwright.config.ts --project=electron-headless`

Representative combined-diff benchmark in a local Electron build with 80 modified TypeScript files and 24 lines per file:

| Renderer path | First visible diff rows | Long tasks | Mounted Monaco editors | Pierre roots |
| --- | ---: | ---: | ---: | ---: |
| Monaco combined section path | 410 ms | 1 task / 109 ms total | 6 | 0 |
| Pierre read-only combined path | 81 ms | 0 tasks / 0 ms total | 0 | 7 |

This benchmark targets the combined/read-only diff pages affected by the PR; the previous implementation mounted one Monaco diff editor per visible file section there.

## Notes
- `@pierre/diffs@1.2.2` is used because the repo's npm minimum-release-age setting currently blocks `1.2.3`.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.