### PR TITLE
Fix Chrome cookie import schema drift

### DIFF
--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -274,12 +274,13 @@ describe('buildChromiumCookieInsertParams', () => {
     ])
   })
 
-  it('preserves null when a nullable source column is present', () => {
+  it('preserves null for nullable columns without defaults', () => {
     const decryptedValue = Buffer.from('decrypted-cookie-value')
     const columns: ChromiumCookieColumnInfo[] = [
       { name: 'creation_utc', type: 'INTEGER', notnull: 1 },
       { name: 'host_key', type: 'TEXT', notnull: 1 },
       { name: 'nullable_metadata', type: 'TEXT', notnull: 0 },
+      { name: 'target_only_nullable_metadata', type: 'TEXT', notnull: 0 },
       { name: 'last_update_utc', type: 'INTEGER', notnull: 1 }
     ]
     const sourceRow = {
@@ -290,6 +291,6 @@ describe('buildChromiumCookieInsertParams', () => {
 
     const params = buildChromiumCookieInsertParams(columns, sourceRow, decryptedValue)
 
-    expect(params).toEqual([133_000_000_000_000n, '.example.com', null, 133_000_000_000_000n])
+    expect(params).toEqual([133_000_000_000_000n, '.example.com', null, null, 133_000_000_000_000n])
   })
 })

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -11,7 +11,12 @@ vi.mock('electron', () => ({
   session: { fromPartition: sessionFromPartitionMock }
 }))
 
-import { importCookiesFromFile, detectInstalledBrowsers } from './browser-cookie-import'
+import {
+  buildChromiumCookieInsertParams,
+  importCookiesFromFile,
+  detectInstalledBrowsers,
+  type ChromiumCookieColumnInfo
+} from './browser-cookie-import'
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -231,5 +236,60 @@ describe('detectInstalledBrowsers', () => {
     for (const browser of browsers) {
       expect(validFamilies).toContain(browser.family)
     }
+  })
+})
+
+describe('buildChromiumCookieInsertParams', () => {
+  it('fills target-only NOT NULL Chromium cookie columns instead of inserting null', () => {
+    const decryptedValue = Buffer.from('decrypted-cookie-value')
+    const columns: ChromiumCookieColumnInfo[] = [
+      { name: 'creation_utc', type: 'INTEGER', notnull: 1 },
+      { name: 'host_key', type: 'TEXT', notnull: 1 },
+      { name: 'top_frame_site_key', type: 'TEXT', notnull: 1 },
+      { name: 'name', type: 'TEXT', notnull: 1 },
+      { name: 'value', type: 'TEXT', notnull: 1 },
+      { name: 'encrypted_value', type: 'BLOB', notnull: 1 },
+      { name: 'source_port', type: 'INTEGER', notnull: 1 },
+      { name: 'last_update_utc', type: 'INTEGER', notnull: 1 },
+      { name: 'has_cross_site_ancestor', type: 'INTEGER', notnull: 1, dflt_value: '0' }
+    ]
+    const sourceRow = {
+      creation_utc: 133_000_000_000_000n,
+      host_key: '.example.com',
+      name: 'sid'
+    }
+
+    const params = buildChromiumCookieInsertParams(columns, sourceRow, decryptedValue)
+
+    expect(params).toEqual([
+      133_000_000_000_000n,
+      '.example.com',
+      '',
+      'sid',
+      decryptedValue,
+      Buffer.alloc(0),
+      -1,
+      133_000_000_000_000n,
+      0
+    ])
+  })
+
+  it('preserves null when a nullable source column is present', () => {
+    const decryptedValue = Buffer.from('decrypted-cookie-value')
+    const columns: ChromiumCookieColumnInfo[] = [
+      { name: 'creation_utc', type: 'INTEGER', notnull: 1 },
+      { name: 'host_key', type: 'TEXT', notnull: 1 },
+      { name: 'nullable_metadata', type: 'TEXT', notnull: 0 },
+      { name: 'last_update_utc', type: 'INTEGER', notnull: 1 }
+    ]
+    const sourceRow = {
+      creation_utc: 133_000_000_000_000n,
+      host_key: '.example.com',
+      nullable_metadata: null
+    }
+
+    const params = buildChromiumCookieInsertParams(columns, sourceRow, decryptedValue)
+
+    expect(params).toEqual([133_000_000_000_000n, '.example.com', null, 133_000_000_000_000n])
   })
 })

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -829,6 +829,9 @@ function fallbackChromiumCookieColumnValue(
   if (defaultValue !== null) {
     return defaultValue
   }
+  if (!isSqliteNotNull(column)) {
+    return null
+  }
 
   switch (column.name) {
     case 'value':

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -32,6 +32,13 @@ function getDiagLogPath(): string {
   }
   return _diagLog
 }
+function reasonWithDiagLog(reason: string): string {
+  return `${reason} Details were written to ${getDiagLogPath()}.`
+}
+function describeImportError(err: unknown): string {
+  const raw = err instanceof Error && err.message ? err.message : String(err)
+  return raw.replace(/\s+/g, ' ').slice(0, 180)
+}
 function diag(msg: string): void {
   const line = `[${new Date().toISOString()}] ${msg}\n`
   try {
@@ -761,6 +768,117 @@ type EncryptionKeyResult = {
   fallbackKey?: Buffer
 }
 
+export type ChromiumCookieColumnInfo = {
+  name: string
+  type?: string
+  notnull?: number | bigint
+  dflt_value?: unknown
+}
+
+function parseSqliteDefaultValue(raw: unknown, type: string): string | number | Buffer | null {
+  if (raw === null || raw === undefined) {
+    return null
+  }
+  if (typeof raw !== 'string') {
+    return typeof raw === 'number' || typeof raw === 'bigint' ? Number(raw) : String(raw)
+  }
+
+  const trimmed = raw.trim()
+  if (!trimmed || trimmed.toUpperCase() === 'NULL') {
+    return null
+  }
+  if (/^X''$/i.test(trimmed) || type.includes('BLOB')) {
+    return Buffer.alloc(0)
+  }
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1).replaceAll("''", "'")
+  }
+  if (type.includes('INT')) {
+    const numeric = Number(trimmed)
+    return Number.isFinite(numeric) ? numeric : 0
+  }
+  return trimmed
+}
+
+function normalizeSqliteCookieValue(value: unknown): string | number | bigint | Buffer | null {
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value)
+  }
+  if (value === undefined || value === null) {
+    return null
+  }
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'string') {
+    return value
+  }
+  return String(value)
+}
+
+function isSqliteNotNull(column: ChromiumCookieColumnInfo): boolean {
+  return Number(column.notnull ?? 0) !== 0
+}
+
+function fallbackChromiumCookieColumnValue(
+  column: ChromiumCookieColumnInfo,
+  sourceRow: Record<string, unknown>
+): string | number | bigint | Buffer | null {
+  const type = (column.type ?? '').toUpperCase()
+  const defaultValue = parseSqliteDefaultValue(column.dflt_value, type)
+  if (defaultValue !== null) {
+    return defaultValue
+  }
+
+  switch (column.name) {
+    case 'value':
+    case 'encrypted_value':
+      return Buffer.alloc(0)
+    case 'top_frame_site_key':
+      return ''
+    case 'source_port':
+      return -1
+    case 'last_update_utc':
+      return normalizeSqliteCookieValue(sourceRow.creation_utc) ?? 0
+    default:
+      if (type.includes('BLOB')) {
+        return Buffer.alloc(0)
+      }
+      if (type.includes('INT')) {
+        return 0
+      }
+      return ''
+  }
+}
+
+export function buildChromiumCookieInsertParams(
+  targetColumns: ChromiumCookieColumnInfo[],
+  sourceRow: Record<string, unknown>,
+  decryptedValue: Buffer
+): (string | number | bigint | Buffer | null)[] {
+  return targetColumns.map((column) => {
+    if (column.name === 'encrypted_value') {
+      return Buffer.alloc(0)
+    }
+    if (column.name === 'value') {
+      return decryptedValue
+    }
+
+    const sourceHasColumn = Object.prototype.hasOwnProperty.call(sourceRow, column.name)
+    const sourceValue = sourceHasColumn ? normalizeSqliteCookieValue(sourceRow[column.name]) : null
+    if (sourceValue !== null) {
+      return sourceValue
+    }
+    if (sourceHasColumn && !isSqliteNotNull(column)) {
+      return null
+    }
+
+    // Why: Chromium cookie DB columns drift across Chrome/Electron versions.
+    // Missing NOT NULL target columns must get safe Chromium defaults, not NULL.
+    return fallbackChromiumCookieColumnValue(column, sourceRow)
+  })
+}
+
 function getEncryptionKey(
   keychainService: string,
   keychainAccount: string,
@@ -1382,10 +1500,10 @@ export async function importCookiesFromBrowser(
     sourceDb = new DatabaseSync(tmpCookiesPath, { readOnly: true, readBigInts: true })
     stagingDb = new DatabaseSync(stagingCookiesPath)
 
-    type PragmaRow = { name: string }
-    const targetCols: string[] = (
-      stagingDb.prepare('PRAGMA table_info(cookies)').all() as PragmaRow[]
-    ).map((r) => r.name)
+    const targetColumnInfo = stagingDb
+      .prepare('PRAGMA table_info(cookies)')
+      .all() as ChromiumCookieColumnInfo[]
+    const targetCols: string[] = targetColumnInfo.map((r) => r.name)
     const colList = targetCols.join(', ')
 
     stagingDb.exec('DELETE FROM cookies')
@@ -1511,25 +1629,7 @@ export async function importCookiesFromBrowser(
         expirationDate: expiresUtc > 0 ? expiresUtc : undefined
       })
 
-      const params = targetCols.map((col) => {
-        if (col === 'encrypted_value') {
-          return Buffer.alloc(0)
-        }
-        if (col === 'value') {
-          return decryptedValue
-        }
-        const v = sourceRow[col]
-        if (v instanceof Uint8Array) {
-          return Buffer.from(v)
-        }
-        if (v === undefined || v === null) {
-          return null
-        }
-        if (typeof v === 'number' || typeof v === 'bigint' || typeof v === 'string') {
-          return v
-        }
-        return String(v)
-      })
+      const params = buildChromiumCookieInsertParams(targetColumnInfo, sourceRow, decryptedValue)
       insertStmt.run(...params)
       imported++
     }
@@ -1636,7 +1736,9 @@ export async function importCookiesFromBrowser(
     diag(`  SQLite import failed: ${err}`)
     return {
       ok: false,
-      reason: `Could not import cookies from ${browser.label}. Check the diag log for details.`
+      reason: reasonWithDiagLog(
+        `Could not import cookies from ${browser.label}: ${describeImportError(err)}.`
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary
- tolerate Chromium cookie DB schema drift when copying Chrome cookies into Electron's cookie store
- fill target-only NOT NULL cookie columns with Chromium-safe defaults instead of NULL
- preserve NULL for nullable cookie columns without SQLite defaults
- include the actual cookie import diag log path in generic SQLite import failures
- add regression coverage for target-only NOT NULL columns and nullable columns

Fixes #2794

## Reproduction / verification
- Reproduced the suspected failure mode with a targeted regression: a target cookie DB column exists as NOT NULL but is absent from the Chrome source row.
- Also ran the real Electron import path against local Google Chrome in an isolated temp userData profile; local Chrome imported successfully, so this machine did not reproduce the exact user failure before the fix.
- Ran auto-review-fix; fixed the nullable target-only column issue found during review, then reran the scoped tests and checks.

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-cookie-import.test.ts src/main/browser/browser-cookie-import.comet.test.ts
- pnpm exec oxlint src/main/browser/browser-cookie-import.ts src/main/browser/browser-cookie-import.test.ts
- pnpm run typecheck:node
- git diff --check