### PR TITLE
Fix OMP agent status routing

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -3034,6 +3034,30 @@ describe('Pi hook normalization', () => {
     expect(result?.payload.prompt).toBe('rename this fn')
   })
 
+  it('OMP uses Pi-compatible events but keeps OMP agent attribution', () => {
+    const started = _internals.normalizeHookPayload(
+      'omp',
+      buildBody({ hook_event_name: 'before_agent_start', prompt: 'status for omp' }),
+      'production'
+    )
+    expect(started?.payload).toMatchObject({
+      state: 'working',
+      prompt: 'status for omp',
+      agentType: 'omp'
+    })
+
+    const done = _internals.normalizeHookPayload(
+      'omp',
+      buildBody({ hook_event_name: 'agent_end' }),
+      'production'
+    )
+    expect(done?.payload).toMatchObject({
+      state: 'done',
+      prompt: 'status for omp',
+      agentType: 'omp'
+    })
+  })
+
   it('agent_start without a prompt keeps the cached prompt from the current turn', () => {
     _internals.normalizeHookPayload(
       'pi',

--- a/src/main/pi/agent-status-extension-source.ts
+++ b/src/main/pi/agent-status-extension-source.ts
@@ -3,7 +3,7 @@
 // etc.). To get pi panes into the unified agent-hooks pipeline alongside
 // Claude/Codex/Gemini/OpenCode/Cursor, we ship a bundled extension into
 // the per-PTY Pi overlay (PiTitlebarExtensionService) that POSTs to
-// /hook/pi using the same ORCA_AGENT_HOOK_* + ORCA_PANE_KEY env that every
+// /hook/<kind> using the same ORCA_AGENT_HOOK_* + ORCA_PANE_KEY env that every
 // PTY already receives from ipc/pty.ts.
 //
 // The overlay is per-PTY, so each pi process boots with its own copy of
@@ -11,16 +11,18 @@
 // returned source is a string (loaded by jiti from disk inside the pi
 // process), so we keep the source body in plain JS without TS types and
 // avoid pulling pi or any Orca dep into the pi runtime.
+import type { PiAgentKind } from '../../shared/pi-agent-kind'
+
 export const ORCA_PI_AGENT_STATUS_EXTENSION_FILE = 'orca-agent-status.ts'
 
-export function getPiAgentStatusExtensionSource(): string {
+export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): string {
   // Why: keep this string self-contained — it runs inside the pi process,
   // so it cannot import from Orca's main bundle. fs/http coords come from
   // the same endpoint file the OpenCode plugin reads (process.env is frozen
   // at PTY spawn, so on Orca restart we have to re-read it from disk).
   return [
-    "import type { ExtensionAPI } from '@mariozechner/pi-coding-agent'",
-    '',
+    '// Why: no package-specific type import here. Pi and OMP expose the same',
+    '// extension API, but publish their types under different package names.',
     '// Why: warn-once so a recurring parse error on a malformed endpoint',
     '// file does not spam stderr inside the pi TUI on every event.',
     'let warnedBadEndpoint = false',
@@ -79,11 +81,35 @@ export function getPiAgentStatusExtensionSource(): string {
     '  }',
     '}',
     '',
+    'function processName(value: unknown): string {',
+    "  return String(value || '').split(/[\\\\/]/).pop()?.toLowerCase() || ''",
+    '}',
+    '',
+    'function resolveHookPath(): string {',
+    `  const configuredPath = '/hook/${kind}'`,
+    '  const executableNames = [',
+    '    processName(process.title),',
+    '    processName(process.env._),',
+    '    processName(process.argv[1]),',
+    '    processName(process.argv[0])',
+    '  ]',
+    '  const isOmpExecutable = executableNames.some((name) =>',
+    "    ['omp', 'omp.js', 'omp.sh', 'omp.cmd', 'omp.exe', 'omp.bat'].includes(name)",
+    '  )',
+    '  // Why: a bare shell gets the Pi overlay at spawn time, but may later',
+    '  // launch OMP. Runtime executable detection keeps that status labeled',
+    '  // as OMP instead of silently reporting it as Pi.',
+    '  if (isOmpExecutable) {',
+    "    return '/hook/omp'",
+    '  }',
+    '  return configuredPath',
+    '}',
+    '',
     'async function post(hookEventName: string, extra: Record<string, unknown> = {}): Promise<void> {',
     '  const coords = resolveHookCoords()',
     '  const paneKey = process.env.ORCA_PANE_KEY',
     '  if (!coords.port || !coords.token || !paneKey) return',
-    '  const url = `http://127.0.0.1:${coords.port}/hook/pi`',
+    '  const url = `http://127.0.0.1:${coords.port}${resolveHookPath()}`',
     '  const body = JSON.stringify({',
     '    paneKey,',
     "    tabId: process.env.ORCA_TAB_ID || '',",
@@ -134,7 +160,7 @@ export function getPiAgentStatusExtensionSource(): string {
     '// etc.), so we forward the raw object verbatim under the same field',
     '// names Claude uses (tool_name / tool_input) and let the server pick the',
     '// preview. Keeps tool-name knowledge centralized on the receiver side.',
-    'export default function (pi: ExtensionAPI): void {',
+    'export default function (pi): void {',
     "  pi.on('before_agent_start', async (event) => {",
     "    await post('before_agent_start', { prompt: event.prompt ?? '' })",
     '  })',

--- a/src/main/pi/titlebar-extension-service.test.ts
+++ b/src/main/pi/titlebar-extension-service.test.ts
@@ -94,6 +94,13 @@ describe('PiTitlebarExtensionService', () => {
       'orca-titlebar-spinner.ts',
       'user-ext'
     ])
+    const statusExtensionSource = readFileSync(
+      join(env.PI_CODING_AGENT_DIR!, 'extensions', 'orca-agent-status.ts'),
+      'utf-8'
+    )
+    expect(statusExtensionSource).toContain('/hook/pi')
+    expect(statusExtensionSource).toContain('process.title')
+    expect(statusExtensionSource).toContain("return '/hook/omp'")
     // User's top-level resources are reachable via the overlay.
     expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'skills', 'my-skill', 'SKILL.md'))).toBe(true)
     expect(existsSync(join(env.PI_CODING_AGENT_DIR!, 'auth.json'))).toBe(true)
@@ -212,6 +219,12 @@ describe('PiTitlebarExtensionService', () => {
         const overlayExtensions = readdirSync(join(env.PI_CODING_AGENT_DIR!, 'extensions')).sort()
         expect(overlayExtensions).toContain('omp-ext')
         expect(overlayExtensions).not.toContain('pi-ext')
+        expect(
+          readFileSync(
+            join(env.PI_CODING_AGENT_DIR!, 'extensions', 'orca-agent-status.ts'),
+            'utf-8'
+          )
+        ).toContain('/hook/omp')
         // Pi's overlay root MUST NOT have been touched by the OMP launch.
         expect(existsSync(join(userDataDir, 'pi-agent-overlays', 'pty-omp-both'))).toBe(false)
       } finally {

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -233,12 +233,12 @@ export class PiTitlebarExtensionService {
       )
       // Why: bundled status extension that bridges the in-process event API
       // (`pi.on('agent_start', ...)` etc., identical between Pi and OMP) to the
-      // unified /hook/pi endpoint. Without this, panes would have no entry in
+      // unified /hook/<kind> endpoint. Without this, panes would have no entry in
       // agentStatusByPaneKey and the dashboard would fall back to terminal-title
       // heuristics like any uninstrumented CLI.
       writeFileSync(
         join(extensionsDir, ORCA_PI_AGENT_STATUS_EXTENSION_FILE),
-        getPiAgentStatusExtensionSource()
+        getPiAgentStatusExtensionSource(kind)
       )
     } catch {
       // Why: overlay creation is best-effort - permission errors (EPERM/EACCES)

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -179,6 +179,11 @@ describe('SshRelaySession', () => {
       ([method]) => method === AGENT_HOOK_INSTALL_PLUGINS_METHOD
     )
     expect(installPluginsCallIndex).toBeGreaterThanOrEqual(0)
+    const installPluginsParams = muxRequestMock.mock.calls[installPluginsCallIndex]?.[1]
+    expect(installPluginsParams).toMatchObject({
+      piExtensionSource: expect.stringContaining('/hook/pi'),
+      ompExtensionSource: expect.stringContaining('/hook/omp')
+    })
     expect(mockConn.sftp).toHaveBeenCalledTimes(1)
     expect(installRemoteManagedAgentHooksMock).toHaveBeenCalledWith(sftp, '/home/orca')
     expect(sftp.end).toHaveBeenCalledTimes(1)

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -526,7 +526,8 @@ export class SshRelaySession {
     try {
       await mux.request(AGENT_HOOK_INSTALL_PLUGINS_METHOD, {
         opencodePluginSource: openCodeInternals.getOpenCodePluginSource(),
-        piExtensionSource: getPiAgentStatusExtensionSource()
+        piExtensionSource: getPiAgentStatusExtensionSource('pi'),
+        ompExtensionSource: getPiAgentStatusExtensionSource('omp')
       })
     } catch (err) {
       // Why: -32601 = older relay without the handler (treat as soft skip).

--- a/src/relay/plugin-overlay.test.ts
+++ b/src/relay/plugin-overlay.test.ts
@@ -78,6 +78,25 @@ describe('PluginOverlayManager', () => {
     expect(existsSync(file)).toBe(true)
   })
 
+  it('uses the kind-specific Pi-compatible extension source when available', () => {
+    manager.setSources({
+      piExtensionSource: '// pi extension',
+      ompExtensionSource: '// omp extension'
+    })
+
+    const piDir = manager.materializePi('tab-kind-pi:0', undefined, 'pi')
+    const ompDir = manager.materializePi('tab-kind-omp:0', undefined, 'omp')
+
+    expect(piDir).not.toBeNull()
+    expect(ompDir).not.toBeNull()
+    expect(readFileSync(join(piDir!, 'extensions', 'orca-agent-status.ts'), 'utf8')).toBe(
+      '// pi extension'
+    )
+    expect(readFileSync(join(ompDir!, 'extensions', 'orca-agent-status.ts'), 'utf8')).toBe(
+      '// omp extension'
+    )
+  })
+
   it('mirrors the remote default Pi agent dir before adding Orca status extension', () => {
     const piAgentDir = join(homeDir, '.pi', 'agent')
     mkdirSync(join(piAgentDir, 'skills', 'my-skill'), { recursive: true })
@@ -201,7 +220,8 @@ describe('PluginOverlayManager', () => {
   it('clearOverlay removes opencode + every Pi-kind overlay root for an id', () => {
     manager.setSources({
       opencodePluginSource: 'opencode',
-      piExtensionSource: 'pi'
+      piExtensionSource: 'pi',
+      ompExtensionSource: 'omp'
     })
     const opencodeDir = manager.materializeOpenCode('tab-3:0')!
     const piDir = manager.materializePi('tab-3:0', undefined, 'pi')!

--- a/src/relay/plugin-overlay.ts
+++ b/src/relay/plugin-overlay.ts
@@ -65,13 +65,18 @@ function isUsableId(id: string): boolean {
 export type PluginSources = {
   /** Source body of `orca-opencode-status.js` to drop into <overlay>/plugins/. */
   opencodePluginSource?: string
-  /** Source body of `orca-agent-status.ts` to drop into <overlay>/extensions/. */
+  /** Source body of Pi's `orca-agent-status.ts` to drop into <overlay>/extensions/. */
   piExtensionSource?: string
+  /** Source body of OMP's `orca-agent-status.ts` to drop into <overlay>/extensions/. */
+  ompExtensionSource?: string
 }
 
 export class PluginOverlayManager {
   private opencodePluginSource: string | null = null
-  private piExtensionSource: string | null = null
+  private piExtensionSources: Record<PiAgentKind, string | null> = {
+    pi: null,
+    omp: null
+  }
   private homeDir: string
   private opencodeRoot: string
   private piRoots: Record<PiAgentKind, string>
@@ -99,7 +104,10 @@ export class PluginOverlayManager {
       this.opencodePluginSource = sources.opencodePluginSource
     }
     if (typeof sources.piExtensionSource === 'string') {
-      this.piExtensionSource = sources.piExtensionSource
+      this.piExtensionSources.pi = sources.piExtensionSource
+    }
+    if (typeof sources.ompExtensionSource === 'string') {
+      this.piExtensionSources.omp = sources.ompExtensionSource
     }
   }
 
@@ -107,8 +115,15 @@ export class PluginOverlayManager {
     return this.opencodePluginSource !== null
   }
 
-  hasPiSource(): boolean {
-    return this.piExtensionSource !== null
+  hasPiSource(kind?: PiAgentKind): boolean {
+    if (kind) {
+      return this.getPiExtensionSource(kind) !== null
+    }
+    return this.piExtensionSources.pi !== null || this.piExtensionSources.omp !== null
+  }
+
+  private getPiExtensionSource(kind: PiAgentKind): string | null {
+    return this.piExtensionSources[kind] ?? this.piExtensionSources.pi
   }
 
   private mirrorOpenCodeConfig(sourceDir: string, overlayDir: string): void {
@@ -244,7 +259,8 @@ export class PluginOverlayManager {
    *  materializes the overlay from empty (Orca extensions only) rather than
    *  silently mirroring the other agent's state. */
   materializePi(id: string, existingAgentDir?: string, kind: PiAgentKind = 'pi'): string | null {
-    if (!this.piExtensionSource || !isUsableId(id)) {
+    const extensionSource = this.getPiExtensionSource(kind)
+    if (!extensionSource || !isUsableId(id)) {
       return null
     }
     const root = this.piRoots[kind]
@@ -263,7 +279,7 @@ export class PluginOverlayManager {
       this.mirrorPiAgentDir(sourceAgentDir, dir)
       const extensionsDir = join(dir, 'extensions')
       mkdirSync(extensionsDir, { recursive: true })
-      writeFileSync(join(extensionsDir, PI_EXTENSION_FILE), this.piExtensionSource)
+      writeFileSync(join(extensionsDir, PI_EXTENSION_FILE), extensionSource)
       return dir
     } catch (err) {
       process.stderr.write(

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -439,16 +439,20 @@ async function main(): Promise<void> {
   dispatcher.onRequest(AGENT_HOOK_INSTALL_PLUGINS_METHOD, async (params) => {
     const opencode = params.opencodePluginSource
     const pi = params.piExtensionSource
+    const omp = params.ompExtensionSource
     assertPluginSourceUnderByteCap('opencodePluginSource', opencode)
     assertPluginSourceUnderByteCap('piExtensionSource', pi)
+    assertPluginSourceUnderByteCap('ompExtensionSource', omp)
     pluginOverlay.setSources({
       opencodePluginSource: typeof opencode === 'string' ? opencode : undefined,
-      piExtensionSource: typeof pi === 'string' ? pi : undefined
+      piExtensionSource: typeof pi === 'string' ? pi : undefined,
+      ompExtensionSource: typeof omp === 'string' ? omp : undefined
     })
     return {
       installed: {
         opencode: pluginOverlay.hasOpenCodeSource(),
-        pi: pluginOverlay.hasPiSource()
+        pi: pluginOverlay.hasPiSource('pi'),
+        omp: pluginOverlay.hasPiSource('omp')
       }
     }
   })

--- a/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-agent-quick-command-presets.test.ts
@@ -15,8 +15,7 @@ describe('terminal agent quick command presets', () => {
       gemini: "gemini --prompt-interactive 'your prompt here'",
       antigravity: "agy --prompt-interactive 'your prompt here'",
       cursor: "cursor-agent 'your prompt here'",
-      droid: "droid 'your prompt here'",
-      omp: "omp 'your prompt here'"
+      droid: "droid 'your prompt here'"
     }
 
     const promptStartingCommands = Object.keys(TUI_AGENT_CONFIG)

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -119,6 +119,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   cursor: 'Cursor',
   aider: 'Aider',
   pi: 'Pi',
+  omp: 'OMP',
   droid: 'Droid',
   grok: 'Grok',
   hermes: 'Hermes'

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -42,6 +42,8 @@ describe('shared agent-hook-listener', () => {
     expect(resolveHookSource('/hook/antigravity')).toBe('antigravity')
     expect(resolveHookSource('/hook/grok')).toBe('grok')
     expect(resolveHookSource('/hook/hermes')).toBe('hermes')
+    expect(resolveHookSource('/hook/pi')).toBe('pi')
+    expect(resolveHookSource('/hook/omp')).toBe('omp')
     expect(resolveHookSource('/hook/unknown')).toBeNull()
     expect(resolveHookSource('/')).toBeNull()
   })
@@ -75,6 +77,55 @@ describe('shared agent-hook-listener', () => {
     expect(event!.payload.state).toBe('working')
     expect(event!.payload.prompt).toBe('hello')
     expect(event!.payload.agentType).toBe('claude')
+  })
+
+  it('normalizes OMP Pi-compatible hooks with OMP attribution', () => {
+    const event = normalizeHookPayload(
+      state,
+      'omp',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        payload: {
+          hook_event_name: 'before_agent_start',
+          prompt: 'wire omp status'
+        }
+      },
+      'production'
+    )
+    expect(event?.payload).toMatchObject({
+      state: 'working',
+      prompt: 'wire omp status',
+      agentType: 'omp'
+    })
+
+    const tool = normalizeHookPayload(
+      state,
+      'omp',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        payload: {
+          hook_event_name: 'tool_call',
+          tool_name: 'bash',
+          tool_input: { command: 'pnpm test' }
+        }
+      },
+      'production'
+    )
+    expect(tool?.payload).toMatchObject({
+      state: 'working',
+      prompt: 'wire omp status',
+      agentType: 'omp',
+      toolName: 'bash',
+      toolInput: 'pnpm test'
+    })
   })
 
   it('trims surrounding whitespace from extracted prompt text', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1529,6 +1529,7 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
     case 'cursor':
       return eventName === 'beforeSubmitPrompt' || eventName === 'sessionStart'
     case 'pi':
+    case 'omp':
       return eventName === 'before_agent_start'
     case 'droid':
       return eventName === 'UserPromptSubmit'
@@ -1569,6 +1570,7 @@ function extractToolFields(
     case 'cursor':
       return extractCursorToolFields(eventName, hookPayload)
     case 'pi':
+    case 'omp':
       return extractPiToolFields(eventName, hookPayload)
     case 'droid':
       return extractDroidToolFields(eventName, hookPayload)
@@ -1956,8 +1958,9 @@ function normalizeCopilotEvent(
   )
 }
 
-function normalizePiEvent(
+function normalizePiCompatibleEvent(
   state: HookListenerState,
+  agentType: 'pi' | 'omp',
   eventName: unknown,
   promptText: string,
   paneKey: string,
@@ -1982,17 +1985,17 @@ function normalizePiEvent(
   const snapshot = resolveToolState(
     state,
     paneKey,
-    extractToolFields('pi', eventName, hookPayload),
-    { resetOnNewTurn: isNewTurnEvent('pi', eventName) }
+    extractToolFields(agentType, eventName, hookPayload),
+    { resetOnNewTurn: isNewTurnEvent(agentType, eventName) }
   )
 
   return parseAgentStatusPayload(
     JSON.stringify({
       state: stateName,
       prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('pi', eventName)
+        resetOnNewTurn: isNewTurnEvent(agentType, eventName)
       }),
-      agentType: 'pi',
+      agentType,
       toolName: snapshot.toolName,
       toolInput: snapshot.toolInput,
       lastAssistantMessage: snapshot.lastAssistantMessage
@@ -2274,7 +2277,24 @@ export function normalizeHookPayload(
       payload = normalizeCursorEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
     case 'pi':
-      payload = normalizePiEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
+      payload = normalizePiCompatibleEvent(
+        state,
+        'pi',
+        eventName,
+        promptText,
+        paneKey,
+        hookPayloadRecord
+      )
+      break
+    case 'omp':
+      payload = normalizePiCompatibleEvent(
+        state,
+        'omp',
+        eventName,
+        promptText,
+        paneKey,
+        hookPayloadRecord
+      )
       break
     case 'droid':
       payload = normalizeDroidEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
@@ -2325,6 +2345,7 @@ export const HOOK_SOURCE_BY_PATHNAME: Readonly<Record<string, AgentHookSource>> 
   '/hook/opencode': 'opencode',
   '/hook/cursor': 'cursor',
   '/hook/pi': 'pi',
+  '/hook/omp': 'omp',
   '/hook/droid': 'droid',
   '/hook/grok': 'grok',
   '/hook/copilot': 'copilot',

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -38,6 +38,7 @@ export type AgentHookSource =
   | 'opencode'
   | 'cursor'
   | 'pi'
+  | 'omp'
   | 'droid'
   | 'grok'
   | 'copilot'

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -21,6 +21,7 @@ export type WellKnownAgentType =
   | 'copilot'
   | 'aider'
   | 'pi'
+  | 'omp'
   | 'droid'
   | 'grok'
   | 'hermes'

--- a/src/shared/pi-agent-kind.ts
+++ b/src/shared/pi-agent-kind.ts
@@ -54,9 +54,7 @@ export function detectPiAgentKindFromCommand(command: string | undefined): PiAge
   }
   // Why: PI launches and the no-command (bare-shell) fallback both resolve to
   // 'pi'. A bare shell that later invokes `pi` keeps the historical default;
-  // a bare shell that later invokes `omp` will load the Pi overlay, which
-  // matches today's pre-fix behavior for that user-driven path. The fix
-  // targets the launch-time resolution, which is where Orca actually owns
-  // the agent-kind decision.
+  // if it later invokes `omp`, the status extension re-routes at runtime based
+  // on the executable name so attribution still lands on OMP.
   return 'pi'
 }


### PR DESCRIPTION
## Summary
- route OMP Pi-compatible status extension events to `/hook/omp` and preserve `agentType: omp` through normalization
- install distinct Pi and OMP status extension sources for local launches, SSH relay sessions, and remote plugin overlays
- add a runtime OMP executable fallback so bare shells that inherited the Pi overlay still report OMP attribution when they launch `omp`

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-hook-listener.test.ts src/main/agent-hooks/server.test.ts src/main/pi/titlebar-extension-service.test.ts src/relay/plugin-overlay.test.ts src/main/ssh/ssh-relay-session.test.ts src/shared/pi-agent-kind.test.ts`
- `pnpm run typecheck`
- Electron dev app: verified OMP launch overlay writes `orca-agent-status.ts` with `/hook/omp`; posted a synthetic OMP hook event to the active pane endpoint and confirmed the store entry has `agentType: "omp"` and the workspace board renders the working row with the OMP prompt. Screenshot evidence kept in `/tmp/orca-omp-status-board.png`.

Note: real OMP execution in this local environment failed before completion with a Bedrock 400 model-throughput configuration error, so the end-to-end completion event was not available to validate naturally.