### PR TITLE
feat(terminal): add terminalJISYenToBackslash setting

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -107,6 +107,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     keepComputerAwakeWhileAgentsRun: false,
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,
+    terminalJISYenToBackslash: false,
     experimentalMobile: false,
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -100,6 +100,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     keepComputerAwakeWhileAgentsRun: false,
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,
+    terminalJISYenToBackslash: false,
     experimentalMobile: false,
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -939,8 +939,8 @@ export function TerminalPane({
               </SearchableSetting>
 
               <SearchableSetting
-                title="JIS Yen(¥) to Backslash(\)"
-                description="Controls whether pressing the Japanese Yen (¥) key sends a backslash (\\) instead."
+                title="JIS Yen (¥) to Backslash (\\)"
+                description="Controls whether pressing the JIS Yen (¥) key sends a backslash (\\) instead."
                 keywords={[
                   'terminal',
                   'yen',
@@ -949,12 +949,13 @@ export function TerminalPane({
                   'keyboard',
                   'mac',
                   'macos',
-                  'jis'
+                  'jis',
+                  'intl'
                 ]}
               >
                 <SettingsSwitchRow
-                  label="JIS Yen(¥) to Backslash(\)"
-                  description="Pressing the Yen (¥) key sends a backslash (\\) instead."
+                  label="JIS Yen (¥) to Backslash (\\)"
+                  description="Pressing the JIS Yen (¥) key sends a backslash (\\) instead."
                   checked={settings.terminalJISYenToBackslash ?? false}
                   onChange={() =>
                     updateSettings({

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -44,6 +44,7 @@ import {
   TERMINAL_DARK_THEME_SEARCH_ENTRIES,
   TERMINAL_LIGHT_THEME_SEARCH_ENTRIES,
   TERMINAL_MAC_OPTION_SEARCH_ENTRIES,
+  TERMINAL_MAC_YEN_SEARCH_ENTRIES,
   TERMINAL_PANE_STYLE_SEARCH_ENTRIES,
   TERMINAL_RENDERING_SEARCH_ENTRIES,
   TERMINAL_SETUP_SCRIPT_SEARCH_ENTRIES,
@@ -721,7 +722,9 @@ export function TerminalPane({
         searchQuery,
         TERMINAL_WINDOWS_POWERSHELL_IMPLEMENTATION_SEARCH_ENTRY
       )) ||
-    (isMac && matchesSettingsSearch(searchQuery, TERMINAL_MAC_OPTION_SEARCH_ENTRIES)) ? (
+    (isMac &&
+      (matchesSettingsSearch(searchQuery, TERMINAL_MAC_OPTION_SEARCH_ENTRIES) ||
+        matchesSettingsSearch(searchQuery, TERMINAL_MAC_YEN_SEARCH_ENTRIES))) ? (
       <section key="advanced" className="space-y-3">
         <SettingsSubsectionHeader
           title="Advanced"
@@ -886,53 +889,81 @@ export function TerminalPane({
           ) : null}
 
           {isMac ? (
-            <SearchableSetting
-              title="Option as Alt"
-              description="Controls whether the macOS Option key sends Alt/Esc sequences or composes characters."
-              keywords={[
-                'terminal',
-                'option',
-                'alt',
-                'key',
-                'meta',
-                'compose',
-                'mac',
-                'macos',
-                'keyboard',
-                'german',
-                'international',
-                'readline',
-                'ghostty'
-              ]}
-            >
-              <SettingsRow
-                alignTop
-                label="Option as Alt"
-                description={
-                  settings.terminalMacOptionAsAlt === 'auto'
-                    ? `Auto — detected: ${detectedLayoutLabel}.`
-                    : settings.terminalMacOptionAsAlt === 'false'
-                      ? 'Option composes special characters for your keyboard layout.'
-                      : settings.terminalMacOptionAsAlt === 'true'
-                        ? 'Both Option keys send Alt/Esc sequences.'
-                        : `The ${settings.terminalMacOptionAsAlt} Option key sends Alt/Esc; the other composes special characters.`
-                }
-                control={
-                  <SettingsSegmentedControl
-                    ariaLabel="Option as Alt"
-                    value={settings.terminalMacOptionAsAlt}
-                    onChange={(option) => updateSettings({ terminalMacOptionAsAlt: option })}
-                    options={[
-                      { value: 'auto', label: 'Auto' },
-                      { value: 'true', label: 'Both' },
-                      { value: 'left', label: 'Left' },
-                      { value: 'right', label: 'Right' },
-                      { value: 'false', label: 'Off' }
-                    ]}
-                  />
-                }
-              />
-            </SearchableSetting>
+            <>
+              <SearchableSetting
+                title="Option as Alt"
+                description="Controls whether the macOS Option key sends Alt/Esc sequences or composes characters."
+                keywords={[
+                  'terminal',
+                  'option',
+                  'alt',
+                  'key',
+                  'meta',
+                  'compose',
+                  'mac',
+                  'macos',
+                  'keyboard',
+                  'german',
+                  'international',
+                  'readline',
+                  'ghostty'
+                ]}
+              >
+                <SettingsRow
+                  alignTop
+                  label="Option as Alt"
+                  description={
+                    settings.terminalMacOptionAsAlt === 'auto'
+                      ? `Auto — detected: ${detectedLayoutLabel}.`
+                      : settings.terminalMacOptionAsAlt === 'false'
+                        ? 'Option composes special characters for your keyboard layout.'
+                        : settings.terminalMacOptionAsAlt === 'true'
+                          ? 'Both Option keys send Alt/Esc sequences.'
+                          : `The ${settings.terminalMacOptionAsAlt} Option key sends Alt/Esc; the other composes special characters.`
+                  }
+                  control={
+                    <SettingsSegmentedControl
+                      ariaLabel="Option as Alt"
+                      value={settings.terminalMacOptionAsAlt}
+                      onChange={(option) => updateSettings({ terminalMacOptionAsAlt: option })}
+                      options={[
+                        { value: 'auto', label: 'Auto' },
+                        { value: 'true', label: 'Both' },
+                        { value: 'left', label: 'Left' },
+                        { value: 'right', label: 'Right' },
+                        { value: 'false', label: 'Off' }
+                      ]}
+                    />
+                  }
+                />
+              </SearchableSetting>
+
+              <SearchableSetting
+                title="JIS Yen(¥) to Backslash(\)"
+                description="Controls whether pressing the Japanese Yen (¥) key sends a backslash (\\) instead."
+                keywords={[
+                  'terminal',
+                  'yen',
+                  'backslash',
+                  'japanese',
+                  'keyboard',
+                  'mac',
+                  'macos',
+                  'jis'
+                ]}
+              >
+                <SettingsSwitchRow
+                  label="JIS Yen(¥) to Backslash(\)"
+                  description="Pressing the Yen (¥) key sends a backslash (\\) instead."
+                  checked={settings.terminalJISYenToBackslash ?? false}
+                  onChange={() =>
+                    updateSettings({
+                      terminalJISYenToBackslash: !settings.terminalJISYenToBackslash
+                    })
+                  }
+                />
+              </SearchableSetting>
+            </>
           ) : null}
         </div>
       </section>

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -32,6 +32,16 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(entries.some((entry) => entry.title === 'Option as Alt')).toBe(false)
   })
 
+  it('includes the JIS Yen mapping setting only on macOS', () => {
+    const entriesMac = getTerminalPaneSearchEntries({ isWindows: false, isMac: true })
+    const entriesLinux = getTerminalPaneSearchEntries({ isWindows: false, isMac: false })
+
+    expect(entriesMac.some((entry) => entry.title === 'JIS Yen (¥) to Backslash (\\)')).toBe(true)
+    expect(entriesLinux.some((entry) => entry.title === 'JIS Yen (¥) to Backslash (\\)')).toBe(
+      false
+    )
+  })
+
   it('includes the Manage Sessions entry on all platforms', () => {
     const entriesWindows = getTerminalPaneSearchEntries({ isWindows: true, isMac: false })
     const entriesMac = getTerminalPaneSearchEntries({ isWindows: false, isMac: true })

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -181,6 +181,15 @@ export const TERMINAL_MAC_OPTION_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const TERMINAL_MAC_YEN_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'JIS Yen(¥) to Backslash(\\)',
+    description:
+      'Controls whether pressing the Japanese Yen (¥) key sends a backslash (\\) instead.',
+    keywords: ['terminal', 'yen', 'backslash', 'japanese', 'keyboard', 'mac', 'macos', 'jis']
+  }
+]
+
 export const TERMINAL_GHOSTTY_IMPORT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Import from Ghostty',
@@ -286,6 +295,8 @@ export function getTerminalPaneSearchEntries(platform: {
     ...TERMINAL_GHOSTTY_IMPORT_SEARCH_ENTRIES,
     ...MANAGE_SESSIONS_SEARCH_ENTRIES,
     ...TERMINAL_ADVANCED_SEARCH_ENTRIES,
-    ...(platform.isMac ? TERMINAL_MAC_OPTION_SEARCH_ENTRIES : [])
+    ...(platform.isMac
+      ? [...TERMINAL_MAC_OPTION_SEARCH_ENTRIES, ...TERMINAL_MAC_YEN_SEARCH_ENTRIES]
+      : [])
   ]
 }

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -183,10 +183,19 @@ export const TERMINAL_MAC_OPTION_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 
 export const TERMINAL_MAC_YEN_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
-    title: 'JIS Yen(¥) to Backslash(\\)',
-    description:
-      'Controls whether pressing the Japanese Yen (¥) key sends a backslash (\\) instead.',
-    keywords: ['terminal', 'yen', 'backslash', 'japanese', 'keyboard', 'mac', 'macos', 'jis']
+    title: 'JIS Yen (¥) to Backslash (\\)',
+    description: 'Controls whether pressing the JIS Yen (¥) key sends a backslash (\\) instead.',
+    keywords: [
+      'terminal',
+      'yen',
+      'backslash',
+      'japanese',
+      'keyboard',
+      'mac',
+      'macos',
+      'jis',
+      'intl'
+    ]
   }
 ]
 

--- a/src/renderer/src/components/terminal-pane/terminal-jis-yen-input.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-jis-yen-input.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTerminalJisYenInput, type TerminalJisYenInputEvent } from './terminal-jis-yen-input'
+
+function event(overrides: Partial<TerminalJisYenInputEvent>): TerminalJisYenInputEvent {
+  return {
+    type: 'keydown',
+    key: '¥',
+    code: 'IntlYen',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides
+  }
+}
+
+describe('resolveTerminalJisYenInput', () => {
+  const enabledOnMac = { enabled: true, isMac: true }
+
+  it('translates a plain physical JIS Yen keydown to backslash on macOS', () => {
+    expect(resolveTerminalJisYenInput(event({}), enabledOnMac)).toEqual({
+      type: 'input',
+      data: '\\'
+    })
+  })
+
+  it('suppresses companion events after the translated keydown', () => {
+    expect(resolveTerminalJisYenInput(event({ type: 'keypress' }), enabledOnMac)).toEqual({
+      type: 'suppress'
+    })
+    expect(resolveTerminalJisYenInput(event({ type: 'keyup' }), enabledOnMac)).toEqual({
+      type: 'suppress'
+    })
+  })
+
+  it('does not rewrite arbitrary yen text from another physical key', () => {
+    expect(resolveTerminalJisYenInput(event({ code: 'KeyY' }), enabledOnMac)).toBeNull()
+  })
+
+  it('does not rewrite modified JIS Yen chords', () => {
+    const modifiedCases = [
+      event({ metaKey: true }),
+      event({ ctrlKey: true }),
+      event({ altKey: true }),
+      event({ shiftKey: true })
+    ]
+
+    for (const input of modifiedCases) {
+      expect(resolveTerminalJisYenInput(input, enabledOnMac)).toBeNull()
+    }
+  })
+
+  it('is gated by both the user setting and macOS', () => {
+    expect(resolveTerminalJisYenInput(event({}), { enabled: false, isMac: true })).toBeNull()
+    expect(resolveTerminalJisYenInput(event({}), { enabled: true, isMac: false })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-jis-yen-input.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-jis-yen-input.ts
@@ -1,0 +1,50 @@
+export type TerminalJisYenInputEvent = {
+  type: string
+  key: string
+  code?: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+}
+
+export type TerminalJisYenInputOptions = {
+  enabled: boolean
+  isMac: boolean
+}
+
+export type TerminalJisYenInputAction = { type: 'input'; data: string } | { type: 'suppress' }
+
+function isPlainPhysicalJisYenKey(event: TerminalJisYenInputEvent): boolean {
+  // Why: event.key='¥' can come from input methods or other layouts; IntlYen
+  // scopes the rewrite to the physical JIS key the setting names.
+  return (
+    event.code === 'IntlYen' &&
+    event.key === '¥' &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  )
+}
+
+export function resolveTerminalJisYenInput(
+  event: TerminalJisYenInputEvent,
+  options: TerminalJisYenInputOptions
+): TerminalJisYenInputAction | null {
+  if (!options.enabled || !options.isMac || !isPlainPhysicalJisYenKey(event)) {
+    return null
+  }
+
+  if (event.type === 'keydown') {
+    return { type: 'input', data: '\\' }
+  }
+
+  if (event.type === 'keypress' || event.type === 'keyup') {
+    // Why: suppress companion events so the translated keydown cannot be
+    // followed by a browser text event or xterm key-release sequence for ¥.
+    return { type: 'suppress' }
+  }
+
+  return null
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -517,6 +517,17 @@ export function useTerminalPaneLifecycle({
         // encoder runs, letting the browser and Electron paths fire normally.
         // See xterm-bypass-policy.ts for the rule derivation (Ghostty/VS Code).
         pane.terminal.attachCustomKeyEventHandler((e) => {
+          // JIS Yen (¥) key to Backslash (\) conversion logic
+          if (settingsRef.current?.terminalJISYenToBackslash === true && e.key === '¥') {
+            if (e.type === 'keydown') {
+              const transport = paneTransportsRef.current.get(pane.id)
+              if (transport) {
+                transport.sendInput('\\')
+              }
+            }
+            return false
+          }
+
           return !shouldBypassXtermKeyboardEvent(e, {
             isMac: navigator.userAgent.includes('Mac'),
             hasSelection: pane.terminal.hasSelection()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -35,6 +35,7 @@ import {
 } from './terminal-appearance'
 import { parseOsc52 } from './osc52-clipboard'
 import { parseOsc7 } from './parse-osc7'
+import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { shouldBypassXtermKeyboardEvent } from './xterm-bypass-policy'
 import type { PaneCwdMap } from './resolve-split-cwd'
 import { installMouseHideWhileTyping } from './mouse-hide-while-typing'
@@ -515,21 +516,24 @@ export function useTerminalPaneLifecycle({
         // matching keyups so kitty release sequences do not leak after a
         // bypassed press. Returning false here short-circuits xterm before the
         // encoder runs, letting the browser and Electron paths fire normally.
-        // See xterm-bypass-policy.ts for the rule derivation (Ghostty/VS Code).
+        // See xterm-bypass-policy.ts for the rule derivation.
         pane.terminal.attachCustomKeyEventHandler((e) => {
-          // JIS Yen (¥) key to Backslash (\) conversion logic
-          if (settingsRef.current?.terminalJISYenToBackslash === true && e.key === '¥') {
-            if (e.type === 'keydown') {
-              const transport = paneTransportsRef.current.get(pane.id)
-              if (transport) {
-                transport.sendInput('\\')
-              }
+          const isMac = navigator.userAgent.includes('Mac')
+          const jisYenInput = resolveTerminalJisYenInput(e, {
+            enabled: settingsRef.current?.terminalJISYenToBackslash === true,
+            isMac
+          })
+          if (jisYenInput) {
+            if (jisYenInput.type === 'input') {
+              // Why: this is a translated character, not a terminal shortcut.
+              // Keep it on xterm's onData path so PTY input guards still run.
+              pane.terminal.input(jisYenInput.data)
             }
             return false
           }
 
           return !shouldBypassXtermKeyboardEvent(e, {
-            isMac: navigator.userAgent.includes('Mac'),
+            isMac,
             hasSelection: pane.terminal.hasSelection()
           })
         })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -259,6 +259,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // the box (issue #903) while US users keep Option-as-Alt readline chords.
     terminalMacOptionAsAlt: 'auto',
     terminalMacOptionAsAltMigrated: false,
+    terminalJISYenToBackslash: false,
     experimentalMobile: false,
     // Why: indefinite hold by default — the desktop "Restore" banner is the
     // explicit return-to-desktop-size action, no wall-clock guess.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1792,6 +1792,11 @@ export type GlobalSettings = {
    *  detection, so no visible behavior change. Then we flip this flag to true
    *  and never migrate again. */
   terminalMacOptionAsAltMigrated: boolean
+  /** Controls whether pressing the Yen key (¥) on Japanese JIS keyboards sends a backslash (\).
+   *  On macOS, entering a backslash typically requires pressing Option+¥ (Alt+¥). Enabling this
+   *  setting allows users to input a backslash with a single keypress of the Yen key without
+   *  needing to hold the Option modifier. */
+  terminalJISYenToBackslash: boolean
   experimentalMobile: boolean
   /** Auto-restore window for a phone-fit PTY after the last mobile
    *  subscriber leaves. `null` (default) holds the PTY at phone size

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1792,10 +1792,8 @@ export type GlobalSettings = {
    *  detection, so no visible behavior change. Then we flip this flag to true
    *  and never migrate again. */
   terminalMacOptionAsAltMigrated: boolean
-  /** Controls whether pressing the Yen key (¥) on Japanese JIS keyboards sends a backslash (\).
-   *  On macOS, entering a backslash typically requires pressing Option+¥ (Alt+¥). Enabling this
-   *  setting allows users to input a backslash with a single keypress of the Yen key without
-   *  needing to hold the Option modifier. */
+  /** Controls whether macOS terminal input translates the physical JIS Yen (¥)
+   *  key to a backslash, matching the common terminal expectation for that key. */
   terminalJISYenToBackslash: boolean
   experimentalMobile: boolean
   /** Auto-restore window for a phone-fit PTY after the last mobile


### PR DESCRIPTION
> [!NOTE]
> Please note that since English is not my native language, the text below was generated using AI translation.
> If there is anything you don't understand, please let me know and I will clarify.

## Summary

This PR adds a new setting `terminalJISYenToBackslash` (UI label: `JIS Yen(¥) to Backslash(\)`) to Orca Terminal Advanced settings.

It seems that Terminal.app's default behavior is to replace `¥` with `\`, and this goal is to replicate a similar user experience in Orca's Terminal.

On Japanese JIS keyboards, the Yen key (`¥`) is rarely used within a terminal environment, whereas typing a backslash (`\`) typically requires pressing `Option+¥` (`Alt+¥`). This setting allows JIS keyboard users to input a backslash with a single press of the Yen key without needing to hold down the Option modifier, significantly streamlining the command-line experience.

## Screenshots

Added a `JIS Yen(¥) to Backslash(\)` toggle under the macOS "Option as Alt" setting inside TerminalPane.

<img width="802" height="85" alt="Screenshot 2026-05-26 10 45 18" src="https://github.com/user-attachments/assets/34ad3d8b-e77b-43a6-8a67-240015edb548" />

Toggle Off (default mode):

<img width="508" height="72" alt="Screenshot 2026-05-26 10 52 55" src="https://github.com/user-attachments/assets/7d3bb733-4afa-413b-9eb5-3a43b7f16061" />

Toggle On (JIS Yen to Backslash):

<img width="497" height="70" alt="Screenshot 2026-05-26 10 52 22" src="https://github.com/user-attachments/assets/08277881-b5b1-43a4-81f2-3acd068f9f27" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed (Updated existing unit test mock settings to satisfy type checking).

## AI Review Report

I ran a thorough review on the introduced code changes:
- **Cross-Platform Compatibility**: Verified that the JIS Yen to Backslash mapping logic is safely guarded by `terminalJISYenToBackslash` setting. The UI toggle itself is displayed exclusively on macOS (guarded by `isMac`). The key interception checks standard browser event properties (`e.key === '¥'`).
- **Input Integrity**: Implemented comprehensive event suppression. Initially, intercepting only `keydown` allowed subsequent browser events (such as `keypress`) to leak through and emit the original `¥` character, resulting in a dual input of `\¥`. The revised logic suppresses all events related to the `¥` key and outputs `\` strictly on `keydown`, eliminating duplication.

## Security Audit

- **Input Handling**: The keystroke redirection sends a strictly hardcoded backslash (`'\\'`) via xterm.js's input channel, presenting zero command injection risk.
- **Path and OS Handling**: No new filesystem path manipulations or IPC handlers were added.

## Notes

- This feature is primarily designed for macOS users with Japanese JIS keyboards.