### PR TITLE
Prefer hardlinks for Codex session bridge

### DIFF
--- a/src/main/codex/codex-session-bridge.test.ts
+++ b/src/main/codex/codex-session-bridge.test.ts
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync
 } from 'node:fs'
 import type * as NodeFs from 'node:fs'
@@ -150,10 +151,40 @@ describe('syncSystemCodexSessionsIntoManagedHome', () => {
       'rollout-old.jsonl'
     )
     expect(readFileSync(runtimeSessionPath, 'utf-8')).toBe('{"type":"session_meta","id":"old"}\n')
+    expect(lstatSync(runtimeSessionPath).isSymbolicLink()).toBe(false)
     expectResourceLinked(runtimeSessionPath, systemSessionPath)
     expect(
       existsSync(join(getRuntimeCodexHomePath(), 'sessions', '2026', '05', '26', 'scratch.txt'))
     ).toBe(false)
+  })
+
+  it('falls back to symlinks when hardlinks are unavailable', () => {
+    fsMockState.failLink = true
+    const systemSessionPath = join(
+      getSystemCodexHomePath(),
+      'sessions',
+      '2026',
+      '05',
+      '26',
+      'rollout-symlink-fallback.jsonl'
+    )
+    mkdirSync(dirname(systemSessionPath), { recursive: true })
+    writeFileSync(systemSessionPath, '{"id":"system"}\n', 'utf-8')
+
+    syncSystemCodexSessionsIntoManagedHome()
+
+    const runtimeSessionPath = join(
+      getRuntimeCodexHomePath(),
+      'sessions',
+      '2026',
+      '05',
+      '26',
+      'rollout-symlink-fallback.jsonl'
+    )
+    expect(lstatSync(runtimeSessionPath).isSymbolicLink()).toBe(true)
+    expect(normalizeLinkTarget(readlinkSync(runtimeSessionPath))).toBe(
+      normalizeLinkTarget(systemSessionPath)
+    )
   })
 
   it('does not overwrite runtime-owned session files', () => {
@@ -168,6 +199,25 @@ describe('syncSystemCodexSessionsIntoManagedHome', () => {
     syncSystemCodexSessionsIntoManagedHome()
 
     expect(readFileSync(runtimeSessionPath, 'utf-8')).toBe('{"id":"runtime"}\n')
+  })
+
+  it('replaces existing symlink bridges with hardlinks', () => {
+    const relativeSessionPath = join('sessions', '2026', '05', '26', 'rollout-symlink.jsonl')
+    const systemSessionPath = join(getSystemCodexHomePath(), relativeSessionPath)
+    const runtimeSessionPath = join(getRuntimeCodexHomePath(), relativeSessionPath)
+    mkdirSync(dirname(systemSessionPath), { recursive: true })
+    mkdirSync(dirname(runtimeSessionPath), { recursive: true })
+    writeFileSync(systemSessionPath, '{"id":"system"}\n', 'utf-8')
+    symlinkSync(
+      systemSessionPath,
+      runtimeSessionPath,
+      process.platform === 'win32' ? 'file' : undefined
+    )
+
+    syncSystemCodexSessionsIntoManagedHome()
+
+    expect(lstatSync(runtimeSessionPath).isSymbolicLink()).toBe(false)
+    expectResourceLinked(runtimeSessionPath, systemSessionPath)
   })
 
   it('does not create independent session copies when file links are unavailable', () => {

--- a/src/main/codex/codex-session-bridge.ts
+++ b/src/main/codex/codex-session-bridge.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   renameSync,
   rmSync,
   symlinkSync
@@ -37,6 +38,15 @@ export function syncSystemCodexSessionsIntoManagedHome(): void {
     const relativePath = relative(systemSessionsRoot, systemSessionFilePath)
     const managedSessionFilePath = join(managedSessionsRoot, relativePath)
     if (existsSync(managedSessionFilePath)) {
+      if (
+        replaceSymlinkSessionBridgeWithHardlink(
+          systemSessionFilePath,
+          managedSessionFilePath,
+          relativePath
+        )
+      ) {
+        continue
+      }
       migrateLegacyCopiedSessionBridge(systemSessionFilePath, managedSessionFilePath, relativePath)
       continue
     }
@@ -77,21 +87,66 @@ function linkSystemCodexSessionFile(
 }
 
 function tryLinkSystemCodexSessionFile(sourcePath: string, targetPath: string): boolean {
+  if (tryHardlinkSystemCodexSessionFile(sourcePath, targetPath)) {
+    return true
+  }
   try {
-    // Why: old sessions must stay resumable under Orca's runtime CODEX_HOME
-    // without copying hooks/config/auth or rewriting Codex's SQLite state.
+    // Why fallback: hardlinks keep sessions visible to Codex resume, but can
+    // fail across volumes. A symlink is still better than a diverging copy.
     symlinkSync(sourcePath, targetPath, process.platform === 'win32' ? 'file' : undefined)
     return true
-  } catch (symlinkError) {
-    try {
-      linkSync(sourcePath, targetPath)
-      return true
-    } catch {
-      console.warn(
-        '[codex-session-bridge] Failed to link system Codex session:',
-        sourcePath,
-        symlinkError
-      )
+  } catch (error) {
+    console.warn('[codex-session-bridge] Failed to link system Codex session:', sourcePath, error)
+  }
+  return false
+}
+
+function tryHardlinkSystemCodexSessionFile(sourcePath: string, targetPath: string): boolean {
+  try {
+    // Why: Codex resume ignores symlinked JSONL sessions, while a hardlink
+    // preserves one physical log without copy divergence.
+    linkSync(sourcePath, targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function replaceSymlinkSessionBridgeWithHardlink(
+  sourcePath: string,
+  targetPath: string,
+  relativePath: string
+): boolean {
+  let replacementPath: string | null = null
+  try {
+    const targetStat = lstatSync(targetPath)
+    if (!targetStat.isSymbolicLink()) {
+      return false
+    }
+    const linkTarget = readlinkSync(targetPath)
+    const absoluteLinkTarget = isAbsolute(linkTarget)
+      ? linkTarget
+      : join(dirname(targetPath), linkTarget)
+    if (absoluteLinkTarget !== sourcePath) {
+      return false
+    }
+
+    replacementPath = `${targetPath}.orca-link-${process.pid}-${Date.now()}`
+    if (!tryHardlinkSystemCodexSessionFile(sourcePath, replacementPath)) {
+      return false
+    }
+    rmSync(targetPath, { force: true })
+    renameSync(replacementPath, targetPath)
+    clearLegacyCopiedSessionMarker(relativePath)
+    return true
+  } catch (error) {
+    console.warn(
+      '[codex-session-bridge] Failed to replace symlinked Codex session bridge:',
+      sourcePath,
+      error
+    )
+    if (replacementPath) {
+      rmSync(replacementPath, { force: true })
     }
   }
   return false


### PR DESCRIPTION
## Summary
- prefer hardlinks for bridged legacy Codex session JSONL files so Codex resume sees them as regular files
- migrate existing symlink bridges to hardlinks when they point at the expected system Codex session source
- keep symlink fallback when hardlinks are unavailable and preserve runtime-owned regular session files

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-session-bridge.test.ts src/main/codex/codex-home-paths.test.ts src/main/codex-usage/scanner-paths.test.ts
- pnpm run typecheck:node
- pnpm run lint

## Notes
- rc6 bridged sessions as symlinks; Codex resume appears to ignore symlinked JSONL files.
- On this machine, converting the existing runtime home changed 4,524 symlinked session files into regular hardlinked files with 0 failures, and rc6 then showed the legacy sessions.

Made with [Orca](https://github.com/stablyai/orca) 🐋
