### PR TITLE
Clear delivered diff notes after sending

### DIFF
--- a/src/renderer/src/components/editor/DiffNotesSendMenu.tsx
+++ b/src/renderer/src/components/editor/DiffNotesSendMenu.tsx
@@ -42,19 +42,14 @@ export function DiffNotesSendMenu({
   iconClassName?: string
   align?: 'start' | 'center' | 'end'
 }): React.JSX.Element {
-  const markDiffCommentsSent = useAppStore((s) => s.markDiffCommentsSent)
+  const clearDeliveredDiffComments = useAppStore((s) => s.clearDeliveredDiffComments)
   const unsentNotes = useMemo(() => comments.filter((comment) => !comment.sentAt), [comments])
-  const unsentNoteIds = useMemo(() => unsentNotes.map((comment) => comment.id), [unsentNotes])
   const unsentPrompt = useMemo(() => formatDiffComments(unsentNotes), [unsentNotes])
   const fileNotes = useMemo(
     () => (filePath ? comments.filter((comment) => comment.filePath === filePath) : []),
     [comments, filePath]
   )
   const unsentFileNotes = useMemo(() => fileNotes.filter((comment) => !comment.sentAt), [fileNotes])
-  const unsentFileNoteIds = useMemo(
-    () => unsentFileNotes.map((comment) => comment.id),
-    [unsentFileNotes]
-  )
   const unsentFilePrompt = useMemo(() => formatDiffComments(unsentFileNotes), [unsentFileNotes])
   const hasUnsentNotes = unsentNotes.length > 0
   const canSendFileScope = showFileScope && Boolean(filePath)
@@ -116,7 +111,9 @@ export function DiffNotesSendMenu({
                   prompt={unsentFilePrompt}
                   promptDelivery="submit-after-ready"
                   launchSource="notes_send"
-                  onPromptDelivered={() => void markDiffCommentsSent(worktreeId, unsentFileNoteIds)}
+                  onPromptDelivered={() =>
+                    void clearDeliveredDiffComments(worktreeId, unsentFileNotes)
+                  }
                 />
               </DropdownMenuSubContent>
             </DropdownMenuSub>
@@ -135,7 +132,7 @@ export function DiffNotesSendMenu({
                   prompt={unsentPrompt}
                   promptDelivery="submit-after-ready"
                   launchSource="notes_send"
-                  onPromptDelivered={() => void markDiffCommentsSent(worktreeId, unsentNoteIds)}
+                  onPromptDelivered={() => void clearDeliveredDiffComments(worktreeId, unsentNotes)}
                 />
               </DropdownMenuSubContent>
             </DropdownMenuSub>
@@ -148,7 +145,7 @@ export function DiffNotesSendMenu({
             prompt={unsentPrompt}
             promptDelivery="submit-after-ready"
             launchSource="notes_send"
-            onPromptDelivered={() => void markDiffCommentsSent(worktreeId, unsentNoteIds)}
+            onPromptDelivered={() => void clearDeliveredDiffComments(worktreeId, unsentNotes)}
           />
         )}
       </DropdownMenuContent>

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -354,7 +354,7 @@ export default function MarkdownPreview({
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
   const updateDiffComment = useAppStore((s) => s.updateDiffComment)
-  const markDiffCommentsSent = useAppStore((s) => s.markDiffCommentsSent)
+  const clearDeliveredDiffComments = useAppStore((s) => s.clearDeliveredDiffComments)
   const keybindings = useAppStore((s) => s.keybindings)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
   const sourceOpenFile = useAppStore((s) =>
@@ -466,10 +466,6 @@ export default function MarkdownPreview({
   const unsentMarkdownReviewNotes = useMemo(
     () => markdownReviewNotes.filter((note) => !note.sentAt),
     [markdownReviewNotes]
-  )
-  const unsentMarkdownReviewNoteIds = useMemo(
-    () => unsentMarkdownReviewNotes.map((note) => note.id),
-    [unsentMarkdownReviewNotes]
   )
   const unsentMarkdownReviewPrompt = useMemo(
     () => formatMarkdownReviewNotes(unsentMarkdownReviewNotes, renderedContent),
@@ -1424,7 +1420,7 @@ export default function MarkdownPreview({
                     promptDelivery="submit-after-ready"
                     launchSource="notes_send"
                     onPromptDelivered={() =>
-                      void markDiffCommentsSent(sourceWorktree.id, unsentMarkdownReviewNoteIds)
+                      void clearDeliveredDiffComments(sourceWorktree.id, unsentMarkdownReviewNotes)
                     }
                   />
                 </DropdownMenuContent>
@@ -1487,7 +1483,7 @@ export default function MarkdownPreview({
           onSubmitEdit={(id, body) => updateDiffComment(sourceWorktree.id, id, body)}
           sendPrompt={unsentMarkdownReviewPrompt}
           worktreeId={sourceWorktree.id}
-          unsentNoteIds={unsentMarkdownReviewNoteIds}
+          unsentNotes={unsentMarkdownReviewNotes}
         />
       ) : null}
       {showTableOfContents ? (
@@ -1513,7 +1509,7 @@ function MarkdownReviewNotesPanel({
   onSubmitEdit,
   sendPrompt,
   worktreeId,
-  unsentNoteIds
+  unsentNotes
 }: {
   notes: MarkdownReviewNote[]
   content: string
@@ -1526,9 +1522,9 @@ function MarkdownReviewNotesPanel({
   onSubmitEdit: (id: string, body: string) => Promise<boolean>
   sendPrompt: string
   worktreeId: string
-  unsentNoteIds: readonly string[]
+  unsentNotes: readonly MarkdownReviewNote[]
 }): React.JSX.Element {
-  const markDiffCommentsSent = useAppStore((s) => s.markDiffCommentsSent)
+  const clearDeliveredDiffComments = useAppStore((s) => s.clearDeliveredDiffComments)
   return (
     <aside className="markdown-review-panel">
       <div className="markdown-review-panel-header">
@@ -1553,8 +1549,8 @@ function MarkdownReviewNotesPanel({
               <button
                 type="button"
                 className="markdown-review-icon-button"
-                disabled={unsentNoteIds.length === 0}
-                title={unsentNoteIds.length === 0 ? 'All notes sent' : 'Send notes to a new agent'}
+                disabled={unsentNotes.length === 0}
+                title={unsentNotes.length === 0 ? 'All notes sent' : 'Send notes to a new agent'}
                 aria-label="Send notes to a new agent"
               >
                 <Send className="size-3.5" />
@@ -1568,7 +1564,7 @@ function MarkdownReviewNotesPanel({
                 prompt={sendPrompt}
                 promptDelivery="submit-after-ready"
                 launchSource="notes_send"
-                onPromptDelivered={() => void markDiffCommentsSent(worktreeId, unsentNoteIds)}
+                onPromptDelivered={() => void clearDeliveredDiffComments(worktreeId, unsentNotes)}
               />
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -499,7 +499,7 @@ export default function RichMarkdownEditor({
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
   const updateDiffComment = useAppStore((s) => s.updateDiffComment)
-  const markDiffCommentsSent = useAppStore((s) => s.markDiffCommentsSent)
+  const clearDeliveredDiffComments = useAppStore((s) => s.clearDeliveredDiffComments)
   const allDiffComments = useAppStore((s): DiffComment[] | undefined => {
     for (const list of Object.values(s.worktreesByRepo)) {
       const worktree = list.find((candidate) => candidate.id === worktreeId)
@@ -590,10 +590,6 @@ export default function RichMarkdownEditor({
   const unsentMarkdownReviewNotes = useMemo(
     () => markdownReviewNotes.filter((note) => !note.sentAt),
     [markdownReviewNotes]
-  )
-  const unsentMarkdownReviewNoteIds = useMemo(
-    () => unsentMarkdownReviewNotes.map((note) => note.id),
-    [unsentMarkdownReviewNotes]
   )
   const unsentMarkdownReviewPrompt = useMemo(
     () => formatMarkdownReviewNotes(unsentMarkdownReviewNotes, markdownReviewContent),
@@ -1595,7 +1591,7 @@ export default function RichMarkdownEditor({
                   promptDelivery="submit-after-ready"
                   launchSource="notes_send"
                   onPromptDelivered={() =>
-                    void markDiffCommentsSent(worktreeId, unsentMarkdownReviewNoteIds)
+                    void clearDeliveredDiffComments(worktreeId, unsentMarkdownReviewNotes)
                   }
                 />
               </DropdownMenuContent>
@@ -1646,7 +1642,9 @@ export default function RichMarkdownEditor({
                           promptDelivery="submit-after-ready"
                           launchSource="notes_send"
                           onPromptDelivered={() =>
-                            void markDiffCommentsSent(worktreeId, [comment.id])
+                            void clearDeliveredDiffComments(worktreeId, [
+                              comment as MarkdownReviewNote
+                            ])
                           }
                         />
                       </DropdownMenuContent>

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -468,6 +468,72 @@ describe('markDiffCommentsSent', () => {
   })
 })
 
+describe('clearDeliveredDiffComments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearRuntimeCompatibilityCacheForTests()
+    runtimeEnvironmentTransportCall.mockReset()
+    runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+    })
+    updateMeta.mockResolvedValue({})
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: { ok: true },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+  })
+
+  it('clears delivered notes and persists the remaining pending notes', async () => {
+    const store = createTestStore()
+    const delivered = makeComment({ id: 'c1', filePath: 'src/foo.ts' })
+    const pending = makeComment({ id: 'c2', filePath: 'src/bar.ts' })
+    seed(store, [delivered, pending])
+
+    const ok = await store.getState().clearDeliveredDiffComments(WT, [delivered])
+
+    expect(ok).toBe(true)
+    expect(store.getState().getDiffComments(WT)).toEqual([pending])
+    expect(updateMeta).toHaveBeenCalledTimes(1)
+    expect(updateMeta).toHaveBeenCalledWith({
+      worktreeId: WT,
+      updates: { diffComments: [pending] }
+    })
+  })
+
+  it('keeps a note that changed while delivery was pending', async () => {
+    const store = createTestStore()
+    const sentSnapshot = makeComment({ id: 'c1', body: 'old body' })
+    const edited = makeComment({ id: 'c1', body: 'new body' })
+    const delivered = makeComment({ id: 'c2', body: 'unchanged' })
+    seed(store, [edited, delivered])
+
+    const ok = await store.getState().clearDeliveredDiffComments(WT, [sentSnapshot, delivered])
+
+    expect(ok).toBe(true)
+    expect(store.getState().getDiffComments(WT)).toEqual([edited])
+    expect(updateMeta).toHaveBeenCalledWith({
+      worktreeId: WT,
+      updates: { diffComments: [edited] }
+    })
+  })
+
+  it('rolls back delivered-note clearing on persist failure', async () => {
+    const store = createTestStore()
+    const comments = [makeComment({ id: 'c1' }), makeComment({ id: 'c2' })]
+    seed(store, comments)
+    updateMeta.mockRejectedValueOnce(new Error('disk full'))
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const ok = await store.getState().clearDeliveredDiffComments(WT, [comments[0]])
+
+    expect(ok).toBe(false)
+    expect(store.getState().getDiffComments(WT)).toBe(comments)
+    errSpy.mockRestore()
+  })
+})
+
 describe('bulk clear diff comments', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/renderer/src/store/slices/diffComments.ts
+++ b/src/renderer/src/store/slices/diffComments.ts
@@ -12,6 +12,10 @@ export type DiffCommentsSlice = {
   getDiffComments: (worktreeId: string | null | undefined) => DiffComment[]
   addDiffComment: (input: Omit<DiffComment, 'id' | 'createdAt'>) => Promise<DiffComment | null>
   updateDiffComment: (worktreeId: string, commentId: string, body: string) => Promise<boolean>
+  clearDeliveredDiffComments: (
+    worktreeId: string,
+    comments: readonly DiffCommentDeliverySnapshot[]
+  ) => Promise<boolean>
   markDiffCommentsSent: (
     worktreeId: string,
     commentIds: readonly string[],
@@ -21,6 +25,11 @@ export type DiffCommentsSlice = {
   clearDiffComments: (worktreeId: string) => Promise<boolean>
   clearDiffCommentsForFile: (worktreeId: string, filePath: string) => Promise<boolean>
 }
+
+export type DiffCommentDeliverySnapshot = Pick<
+  DiffComment,
+  'body' | 'filePath' | 'id' | 'lineNumber' | 'selectedText' | 'source' | 'startLine'
+>
 
 function generateId(): string {
   return createBrowserUuid()
@@ -59,6 +68,21 @@ function normalizeDiffComment(comment: DiffComment): DiffComment {
     ...(sentAt !== undefined ? { sentAt } : {}),
     ...(sentAt === undefined ? { sentAt: undefined } : {})
   }
+}
+
+function deliverySnapshotMatches(
+  comment: DiffComment,
+  snapshot: DiffCommentDeliverySnapshot
+): boolean {
+  return (
+    comment.id === snapshot.id &&
+    comment.body === snapshot.body &&
+    comment.filePath === snapshot.filePath &&
+    comment.lineNumber === snapshot.lineNumber &&
+    comment.startLine === snapshot.startLine &&
+    comment.selectedText === snapshot.selectedText &&
+    comment.source === snapshot.source
+  )
 }
 
 // Why: return a stable reference when no comments exist so selectors don't
@@ -312,6 +336,34 @@ export const createDiffCommentsSlice: StateCreator<AppState, [], [], DiffComment
       // Why: between the pre-check and the set updater, the comment vanished
       // or another mutation already wrote the same body. Treat as success so
       // the caller closes its editor.
+      return true
+    }
+    try {
+      await enqueuePersist(worktreeId, get)
+      return true
+    } catch (err) {
+      console.error('Failed to persist diff comments:', err)
+      rollback(set, worktreeId, result.previous, result.next)
+      return false
+    }
+  },
+
+  clearDeliveredDiffComments: async (worktreeId, comments) => {
+    if (comments.length === 0) {
+      return true
+    }
+    const snapshotsById = new Map(comments.map((comment) => [comment.id, comment]))
+    const result = mutateComments(set, worktreeId, (existing) => {
+      const next = existing.filter((comment) => {
+        const snapshot = snapshotsById.get(comment.id)
+        // Why: delivery is async. If the user edits a note before the prompt
+        // is accepted by the agent, the old snapshot was sent but the current
+        // note is a fresh pending note and must stay visible.
+        return !snapshot || !deliverySnapshotMatches(comment, snapshot)
+      })
+      return next.length === existing.length ? null : next
+    })
+    if (!result) {
       return true
     }
     try {


### PR DESCRIPTION
## Summary
- Replaces sent-marker handling with `clearDeliveredDiffComments` so delivered diff and markdown review notes are removed after prompt delivery.
- Preserves notes that were edited while delivery was pending by matching against the delivered snapshot before clearing.
- Updates editor send menus and markdown review panels to pass delivered note snapshots instead of note IDs.

## Testing
- Added `clearDeliveredDiffComments` store tests covering successful clearing, preserving edited notes, and rollback on persist failure.