### PR TITLE
Fix release E2E drift

### DIFF
--- a/tests/e2e/feature-wall.spec.ts
+++ b/tests/e2e/feature-wall.spec.ts
@@ -63,7 +63,7 @@ test.describe('Feature tour modal', () => {
     await rail.getByRole('button', { name: /Browser/i }).click()
     await expect(
       orcaPage.getByText(
-        "Run your app in Orca's browser, send selected UI elements to agents, and let agents navigate, click, and verify pages."
+        "Run your app in Orca's browser, send selected UI elements to agents, and let your agents interact with your webpage."
       )
     ).toBeVisible()
     await expect(orcaPage.getByRole('heading', { name: 'Browser Use skill' })).toBeVisible()
@@ -116,11 +116,7 @@ test.describe('Feature tour modal', () => {
       .getByRole('navigation', { name: 'Workflows' })
       .getByRole('tab', { name: /Tasks/i })
       .click()
-    await expect(
-      orcaPage.getByText(
-        "See your GitHub and Linear tasks in one place, and start a workspace for each when you're ready to build."
-      )
-    ).toBeVisible()
+    await expect(orcaPage.getByText('Start work directly from GitHub or Linear.')).toBeVisible()
     await expect(orcaPage.getByText('Connect GitHub or Linear once')).toHaveCount(0)
     await expect(orcaPage.getByRole('dialog', { name: 'Get to know Orca' })).toBeVisible()
     await expect

--- a/tests/e2e/helpers/electron-launch-args.ts
+++ b/tests/e2e/helpers/electron-launch-args.ts
@@ -1,0 +1,9 @@
+export function getOrcaElectronLaunchArgs(mainPath: string, headful: boolean): string[] {
+  if (headful || process.platform !== 'linux') {
+    return [mainPath]
+  }
+
+  // Why: Ubuntu CI can fail headless Electron when Chromium's GPU subprocess
+  // cannot initialize; these switches keep rendering on a software-safe path.
+  return ['--disable-gpu', '--disable-dev-shm-usage', mainPath]
+}

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -28,6 +28,7 @@ import os from 'os'
 import path from 'path'
 import { TEST_REPO_PATH_FILE } from '../global-setup'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
+import { getOrcaElectronLaunchArgs } from './electron-launch-args'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 
 type OrcaTestFixtures = {
@@ -205,7 +206,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
       mkdirSync(recordVideoDir, { recursive: true })
     }
     const app = await electron.launch({
-      args: [mainPath],
+      args: getOrcaElectronLaunchArgs(mainPath, headful),
       ...(slowMo > 0 ? { slowMo } : {}),
       ...(recordVideoDir ? { recordVideo: { dir: recordVideoDir } } : {}),
       // Why: keep NODE_ENV=development so window.__store is exposed and

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import os from 'os'
 import path from 'path'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
+import { getOrcaElectronLaunchArgs } from './electron-launch-args'
 import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
 
 type LaunchedOrca = {
@@ -73,7 +74,7 @@ export function createRestartSession(testInfo: TestInfo): RestartSession {
 
   const launch = async (): Promise<LaunchedOrca> => {
     const app = await electron.launch({
-      args: [mainPath],
+      args: getOrcaElectronLaunchArgs(mainPath, headful),
       env: launchEnv(userDataDir, headful)
     })
     const page = await app.firstWindow({ timeout: 120_000 })

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -114,12 +114,34 @@ function onboardingFooterButton(page: Page, name: RegExp) {
   return onboardingFooter(page).getByRole('button', { name })
 }
 
+function onboardingNotificationSoundSelect(page: Page) {
+  return page.getByRole('combobox').first()
+}
+
+async function expectOnboardingNotificationSound(page: Page, name: RegExp): Promise<void> {
+  await expect(onboardingNotificationSoundSelect(page)).toContainText(name)
+}
+
+async function chooseOnboardingNotificationSound(page: Page, name: RegExp): Promise<void> {
+  const soundSelect = onboardingNotificationSoundSelect(page)
+  await soundSelect.click()
+  await page.getByRole('option', { name }).click()
+  await expect(soundSelect).toContainText(name)
+}
+
+async function expectOnboardingCustomSoundOption(page: Page): Promise<void> {
+  const soundSelect = onboardingNotificationSoundSelect(page)
+  await soundSelect.click()
+  await expect(page.getByRole('option', { name: /Choose Custom File/i })).toBeVisible()
+  await page.keyboard.press('Escape')
+}
+
 async function continueOnboarding(page: Page): Promise<void> {
   await onboardingFooterButton(page, /^Continue\b/).click()
 }
 
 async function setupOnboardingFeatures(page: Page): Promise<void> {
-  await onboardingFooterButton(page, /^Set up\b/).click()
+  await page.getByRole('button', { name: /^Enable capabilities$/i }).click()
 }
 
 async function continueFromFeatureSetupToRepo(page: Page): Promise<void> {
@@ -128,12 +150,10 @@ async function continueFromFeatureSetupToRepo(page: Page): Promise<void> {
   await expect(page.getByText('5 of 7')).toBeVisible()
   await continueOnboarding(page)
   await expect(page.getByText('6 of 7')).toBeVisible()
-  await expect(
-    page.getByRole('heading', { name: /Interested in Orca's advanced features/i })
-  ).toBeVisible()
-  await onboardingFooterButton(page, /^Continue\b/).click()
-  await expect(page.getByText('You can take the tour anytime')).toHaveCount(0)
-  await expect(page.getByText('Open Help > Explore Orca when you want the tour.')).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: /^Explore Orca$/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /^Take the tour$/i })).toBeVisible()
+  await continueOnboarding(page)
+  await expect(page.getByText(/Available later under Help > Explore Orca/i)).toHaveCount(0)
   await expect(page.getByRole('heading', { name: REPO_STEP_HEADING })).toBeVisible()
   await expect(page.getByText('7 of 7')).toBeVisible()
 }
@@ -250,12 +270,9 @@ test.describe('Onboarding flow', () => {
       .toBe(oppositeTheme)
 
     // --- Step 3: notifications ---
-    await expect(orcaPage.getByRole('button', { name: /System Default/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    await expectOnboardingNotificationSound(orcaPage, /System Default/i)
     await expect(orcaPage.getByRole('button', { name: /Send Test Notification/i })).toBeVisible()
-    await expect(orcaPage.getByText(/Advanced sound file/i)).toBeVisible()
+    await expectOnboardingCustomSoundOption(orcaPage)
     await continueOnboarding(orcaPage)
     await expect(orcaPage.getByRole('heading', { name: /Set up Orca for agents/i })).toBeVisible()
     await expect(orcaPage.getByText('4 of 7')).toBeVisible()
@@ -558,10 +575,7 @@ test.describe('Onboarding flow', () => {
         return { supported: true, platform: 'darwin', requested: true }
       }
     })
-    await expect(orcaPage.getByRole('button', { name: /System Default/i })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    await expectOnboardingNotificationSound(orcaPage, /System Default/i)
 
     await onboardingFooterButton(orcaPage, SKIP_TO_PROJECT_SETUP_BUTTON).click()
 
@@ -620,9 +634,7 @@ test.describe('Onboarding flow', () => {
     await continueOnboarding(orcaPage)
     await expect(orcaPage.getByRole('heading', { name: /Set up notifications/i })).toBeVisible()
 
-    const dingSound = orcaPage.getByRole('button', { name: /^Ding\b/i })
-    await dingSound.click()
-    await expect(dingSound).toHaveAttribute('aria-pressed', 'true')
+    await chooseOnboardingNotificationSound(orcaPage, /^Ding$/i)
 
     await continueOnboarding(orcaPage)
     await expect(orcaPage.getByRole('heading', { name: /Set up Orca for agents/i })).toBeVisible()


### PR DESCRIPTION
Fixes release E2E failures from run 26431304136.\n\nChanges are test-only:\n- Update feature-wall expectations to current workflow copy.\n- Update onboarding E2E selectors for the notification sound select, inline capability setup, and current tour intro.\n- Add Linux headless Electron launch switches for E2E helpers to avoid GPU subprocess failures on CI runners.\n\nVerification:\n- SKIP_BUILD=1 pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless tests/e2e/feature-wall.spec.ts tests/e2e/onboarding.spec.ts tests/e2e/markdown-ordered-list-exit.spec.ts