### PR TITLE
Fix floating workspace link routing

### DIFF
--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { openHttpLink, registerHttpLinkStoreAccessor } from './http-link-routing'
 
 const openUrlMock = vi.fn()
@@ -49,6 +50,20 @@ describe('openHttpLink', () => {
     openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
 
     expect(createBrowserTabMock).toHaveBeenCalled()
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('routes floating workspace links into Orca without changing the active repo worktree', () => {
+    storeState.settings = { openLinksInApp: true }
+
+    openHttpLink('https://example.com/', { worktreeId: FLOATING_TERMINAL_WORKTREE_ID })
+
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'https://example.com/',
+      { activate: true }
+    )
     expect(openUrlMock).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -1,3 +1,5 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+
 export type OpenHttpLinkOptions = {
   worktreeId?: string | null
   forceSystemBrowser?: boolean
@@ -40,7 +42,11 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     // history entry — the user isn't changing worktrees, they're opening a tab
     // in the one they're already in. activateAndRevealWorktree is reserved for
     // file-link jumps that genuinely switch worktrees.
-    state.setActiveWorktree(worktreeId)
+    if (worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
+      // Why: the floating workspace uses a synthetic worktree id. Promoting it
+      // to the global activeWorktreeId deselects the real repo workspace.
+      state.setActiveWorktree(worktreeId)
+    }
     state.createBrowserTab(worktreeId, url, { activate: true })
     return
   }


### PR DESCRIPTION
## Summary
- keep floating workspace HTTP link routing from activating the synthetic floating worktree globally
- continue opening routed links as browser tabs inside the floating workspace
- add a regression test for floating workspace link routing

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/http-link-routing.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
