### PR TITLE
Improve mobile terminal startup and scrolling

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -54,6 +54,7 @@ import {
 import {
   TerminalWebView,
   type TerminalKeyboardAvoidanceMetrics,
+  type MobileTerminalTheme,
   type TerminalModes,
   type TerminalWebViewHandle
 } from '../../../../src/terminal/TerminalWebView'
@@ -85,13 +86,16 @@ import {
   type MobileSyntaxSegment,
   type MobileSyntaxTokenKind
 } from '../../../../src/session/mobile-file-syntax'
+import {
+  getTerminalRecordsFromSessionTabs,
+  mergeTerminalListWithKnownRecords,
+  mergeTerminalRecordsByCurrentOrder,
+  terminalRecordsEqual,
+  type TerminalRecord
+} from '../../../../src/session/mobile-terminal-records'
 import { colors, spacing, radii, typography } from '../../../../src/theme/mobile-theme'
 
-type Terminal = {
-  handle: string
-  title: string
-  isActive: boolean
-}
+type Terminal = TerminalRecord
 
 type MobileSessionTabType = 'terminal' | 'markdown' | 'file' | 'browser'
 
@@ -104,6 +108,7 @@ type MobileSessionTab =
       leafId?: string
       status?: 'pending-handle' | 'ready'
       terminal: string | null
+      terminalTheme?: MobileTerminalTheme
       isActive: boolean
     }
   | {
@@ -187,33 +192,6 @@ type DirtyMarkdownDraft = {
   content: string
 }
 
-function mergeTerminalRecordsByCurrentOrder(
-  terminalTabs: Terminal[],
-  currentTerminals: Terminal[]
-): Terminal[] {
-  if (currentTerminals.length === 0) {
-    return terminalTabs
-  }
-  const terminalTabsByHandle = new Map(terminalTabs.map((tab) => [tab.handle, tab]))
-  const currentHandles = new Set(currentTerminals.map((terminal) => terminal.handle))
-  return [
-    ...currentTerminals.map((terminal) => terminalTabsByHandle.get(terminal.handle) ?? terminal),
-    ...terminalTabs.filter((terminal) => !currentHandles.has(terminal.handle))
-  ]
-}
-
-function terminalRecordsEqual(a: Terminal[], b: Terminal[]): boolean {
-  return (
-    a.length === b.length &&
-    a.every(
-      (terminal, index) =>
-        terminal.handle === b[index]?.handle &&
-        terminal.title === b[index]?.title &&
-        terminal.isActive === b[index]?.isActive
-    )
-  )
-}
-
 function mobileSessionTabsEqual(a: MobileSessionTab[], b: MobileSessionTab[]): boolean {
   return a.length === b.length && a.every((tab, index) => mobileSessionTabEqual(tab, b[index]))
 }
@@ -235,7 +213,8 @@ function mobileSessionTabEqual(a: MobileSessionTab, b: MobileSessionTab | undefi
         a.parentTabId === b.parentTabId &&
         a.leafId === b.leafId &&
         a.status === b.status &&
-        a.terminal === b.terminal
+        a.terminal === b.terminal &&
+        JSON.stringify(a.terminalTheme ?? null) === JSON.stringify(b.terminalTheme ?? null)
       )
     case 'markdown':
       return (
@@ -347,6 +326,7 @@ function TerminalPaneView({
   handle,
   active,
   keyboardLift,
+  terminalTheme,
   onRef,
   onWebReady,
   onSelectionMode,
@@ -360,6 +340,7 @@ function TerminalPaneView({
   handle: string
   active: boolean
   keyboardLift: number
+  terminalTheme?: MobileTerminalTheme
   onRef: (handle: string, ref: TerminalWebViewHandle | null) => void
   onWebReady: (handle: string) => void
   onSelectionMode: (handle: string, active: boolean) => void
@@ -389,6 +370,7 @@ function TerminalPaneView({
       <TerminalWebView
         ref={setRef}
         style={styles.terminalWebView}
+        terminalTheme={terminalTheme}
         onWebReady={() => onWebReady(handle)}
         onSelectionMode={(a) => onSelectionMode(handle, a)}
         onSelectionCopy={(t) => onSelectionCopy(handle, t)}
@@ -775,6 +757,7 @@ export default function SessionScreen() {
   const activeSessionTabTypeRef = useRef<MobileSessionTabType | null>(null)
   const pendingActiveSessionTabIdRef = useRef<string | null>(null)
   const pendingActiveTerminalHandleRef = useRef<string | null>(null)
+  const initialEmptySessionAutoCreateRef = useRef<string | null>(null)
   const markdownSaveSeqRef = useRef<Map<string, number>>(new Map())
   const markdownSaveInFlightRef = useRef<Set<string>>(new Set())
   const subscribeSeqRef = useRef<Map<string, number>>(new Map())
@@ -1205,8 +1188,15 @@ export default function SessionScreen() {
             return true
           })
 
-          setTerminals(deduped)
-          terminalsRef.current = deduped
+          const mergedTerminals = mergeTerminalListWithKnownRecords(
+            deduped,
+            terminalsRef.current,
+            sessionTabsRef.current
+          )
+          setTerminals((prev) =>
+            terminalRecordsEqual(prev, mergedTerminals) ? prev : mergedTerminals
+          )
+          terminalsRef.current = mergedTerminals
 
           // Session tabs are the UI authority. terminal.list only refreshes
           // per-handle metadata for existing ready terminal surfaces.
@@ -1248,12 +1238,7 @@ export default function SessionScreen() {
       // Why: subscribe snapshots often repeat identical tab payloads. Avoid a
       // render loop where the subscription effect tears down and replays itself.
       setSessionTabs((prev) => (mobileSessionTabsEqual(prev, nextTabs) ? prev : nextTabs))
-      const terminalTabs = nextTabs.flatMap((tab): Terminal[] => {
-        if (tab.type !== 'terminal' || typeof tab.terminal !== 'string') {
-          return []
-        }
-        return [{ handle: tab.terminal, title: tab.title || 'Terminal', isActive: tab.isActive }]
-      })
+      const terminalTabs = getTerminalRecordsFromSessionTabs(nextTabs)
       const mergedTerminalsForActive = mergeTerminalRecordsByCurrentOrder(
         terminalTabs,
         terminalsRef.current
@@ -1822,6 +1807,7 @@ export default function SessionScreen() {
     activeSessionTabTypeRef.current = null
     pendingActiveSessionTabIdRef.current = null
     pendingActiveTerminalHandleRef.current = null
+    initialEmptySessionAutoCreateRef.current = null
     for (const queued of terminalGestureInputQueuesRef.current.values()) {
       if (queued.timer) clearTimeout(queued.timer)
     }
@@ -2533,14 +2519,21 @@ export default function SessionScreen() {
           activeHandleRef.current = createdHandle
           setActiveHandle(createdHandle)
           setTerminals((prev) => {
-            if (prev.some((t) => t.handle === createdHandle)) {
-              terminalsRef.current = prev
-              return prev
+            const existing = prev.find((terminal) => terminal.handle === createdHandle)
+            const createdTerminal: Terminal = {
+              handle: createdHandle,
+              title: created.title || existing?.title || 'Terminal',
+              terminalTheme: created.terminalTheme ?? existing?.terminalTheme,
+              isActive: true
             }
-            const next = [
-              ...prev,
-              { handle: createdHandle, title: created.title || 'Terminal', isActive: true }
-            ]
+            if (existing) {
+              const next = prev.map((terminal) =>
+                terminal.handle === createdHandle ? { ...terminal, ...createdTerminal } : terminal
+              )
+              terminalsRef.current = next
+              return terminalRecordsEqual(prev, next) ? prev : next
+            }
+            const next = [...prev, createdTerminal]
             terminalsRef.current = next
             return next
           })
@@ -2773,6 +2766,25 @@ export default function SessionScreen() {
   const showLoadingState = connState === 'connected' && !terminalsLoaded && visibleTabs.length === 0
   const showEmptyState =
     connState === 'connected' && terminalsLoaded && visibleTabs.length === 0 && !activeHandle
+
+  useEffect(() => {
+    if (
+      !client ||
+      !showEmptyState ||
+      creating ||
+      creatingBrowser ||
+      creatingMarkdown ||
+      initialEmptySessionAutoCreateRef.current === worktreeId
+    ) {
+      return
+    }
+    // Why: a sleeping/new workspace can hydrate with zero session tabs. Create
+    // the first terminal once on initial load instead of leaving mobile blank.
+    initialEmptySessionAutoCreateRef.current = worktreeId
+    setCreateError('')
+    void handleCreateTerminal()
+  }, [client, creating, creatingBrowser, creatingMarkdown, showEmptyState, worktreeId])
+
   const terminalSummary =
     connState === 'connected'
       ? showLoadingState
@@ -3063,6 +3075,7 @@ export default function SessionScreen() {
                 handle={terminal.handle}
                 active={terminal.handle === activeHandle}
                 keyboardLift={terminal.handle === activeHandle ? activeTerminalKeyboardLift : 0}
+                terminalTheme={terminal.terminalTheme}
                 onRef={setTerminalWebViewRef}
                 onWebReady={handleTerminalWebReady}
                 onSelectionMode={handleSelectionMode}

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+  new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
+  'utf8'
+)
+
+function sliceBetween(startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('mobile session startup', () => {
+  it('auto-creates one terminal for an initially empty connected session', () => {
+    expect(source).toContain('const initialEmptySessionAutoCreateRef = useRef<string | null>(null)')
+    expect(source).toContain('initialEmptySessionAutoCreateRef.current = null')
+
+    const autoCreateEffect = sliceBetween(
+      'if (\n      !client ||\n      !showEmptyState',
+      'const terminalSummary ='
+    )
+    expect(autoCreateEffect).toContain('initialEmptySessionAutoCreateRef.current === worktreeId')
+    expect(autoCreateEffect).toContain('initialEmptySessionAutoCreateRef.current = worktreeId')
+    expect(autoCreateEffect).toContain("setCreateError('')")
+    expect(autoCreateEffect).toContain('void handleCreateTerminal()')
+  })
+})

--- a/mobile/src/session/mobile-terminal-records.test.ts
+++ b/mobile/src/session/mobile-terminal-records.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTerminalRecordsFromSessionTabs,
+  mergeTerminalListWithKnownRecords,
+  type MobileTerminalSessionTab,
+  type TerminalRecord
+} from './mobile-terminal-records'
+
+const lightTheme = {
+  mode: 'light' as const,
+  theme: {
+    background: '#ffffff',
+    foreground: '#111111'
+  }
+}
+
+const darkTheme = {
+  mode: 'dark' as const,
+  theme: {
+    background: '#111111',
+    foreground: '#eeeeee'
+  }
+}
+
+describe('mobile terminal records', () => {
+  it('keeps session-tab terminal themes when terminal.list omits them', () => {
+    const terminalList: TerminalRecord[] = [
+      { handle: 'pty-1', title: 'Terminal', isActive: true },
+      { handle: 'pty-2', title: 'Logs', isActive: false }
+    ]
+    const currentTerminals: TerminalRecord[] = [
+      { handle: 'pty-1', title: 'Terminal', terminalTheme: darkTheme, isActive: true }
+    ]
+    const sessionTabs: MobileTerminalSessionTab[] = [
+      {
+        type: 'terminal',
+        id: 'term-1::leaf-1',
+        title: 'Terminal',
+        terminal: 'pty-1',
+        terminalTheme: lightTheme,
+        isActive: true
+      }
+    ]
+
+    expect(mergeTerminalListWithKnownRecords(terminalList, currentTerminals, sessionTabs)).toEqual([
+      { handle: 'pty-1', title: 'Terminal', terminalTheme: lightTheme, isActive: true },
+      { handle: 'pty-2', title: 'Logs', isActive: false }
+    ])
+  })
+
+  it('falls back to the current terminal theme while waiting for session tabs', () => {
+    const terminalList: TerminalRecord[] = [{ handle: 'pty-1', title: 'Terminal', isActive: true }]
+    const currentTerminals: TerminalRecord[] = [
+      { handle: 'pty-1', title: 'Terminal', terminalTheme: darkTheme, isActive: true }
+    ]
+
+    expect(mergeTerminalListWithKnownRecords(terminalList, currentTerminals, [])).toEqual([
+      { handle: 'pty-1', title: 'Terminal', terminalTheme: darkTheme, isActive: true }
+    ])
+  })
+
+  it('ignores pending terminal tabs without a handle', () => {
+    expect(
+      getTerminalRecordsFromSessionTabs([
+        {
+          type: 'terminal',
+          id: 'pending',
+          title: 'Terminal',
+          terminal: null,
+          terminalTheme: lightTheme,
+          isActive: true
+        }
+      ])
+    ).toEqual([])
+  })
+})

--- a/mobile/src/session/mobile-terminal-records.ts
+++ b/mobile/src/session/mobile-terminal-records.ts
@@ -1,0 +1,104 @@
+import type { MobileTerminalTheme } from '../terminal/TerminalWebView'
+
+export type TerminalRecord = {
+  handle: string
+  title: string
+  terminalTheme?: MobileTerminalTheme
+  isActive: boolean
+}
+
+export type MobileTerminalSessionTab = {
+  type: 'terminal'
+  id: string
+  title: string
+  parentTabId?: string
+  leafId?: string
+  status?: 'pending-handle' | 'ready'
+  terminal: string | null
+  terminalTheme?: MobileTerminalTheme
+  isActive: boolean
+}
+
+type MobileSessionTabLike =
+  | MobileTerminalSessionTab
+  | {
+      type: string
+      title?: string
+      terminal?: unknown
+      terminalTheme?: MobileTerminalTheme
+      isActive?: boolean
+    }
+
+export function mergeTerminalRecordsByCurrentOrder(
+  terminalTabs: TerminalRecord[],
+  currentTerminals: TerminalRecord[]
+): TerminalRecord[] {
+  if (currentTerminals.length === 0) {
+    return terminalTabs
+  }
+  const terminalTabsByHandle = new Map(terminalTabs.map((tab) => [tab.handle, tab]))
+  const currentHandles = new Set(currentTerminals.map((terminal) => terminal.handle))
+  return [
+    ...currentTerminals.map((terminal) => terminalTabsByHandle.get(terminal.handle) ?? terminal),
+    ...terminalTabs.filter((terminal) => !currentHandles.has(terminal.handle))
+  ]
+}
+
+export function getTerminalRecordsFromSessionTabs(
+  tabs: readonly MobileSessionTabLike[]
+): TerminalRecord[] {
+  return tabs.flatMap((tab): TerminalRecord[] => {
+    if (tab.type !== 'terminal' || typeof tab.terminal !== 'string') {
+      return []
+    }
+    return [
+      {
+        handle: tab.terminal,
+        title: tab.title || 'Terminal',
+        terminalTheme: tab.terminalTheme,
+        isActive: tab.isActive === true
+      }
+    ]
+  })
+}
+
+export function mergeTerminalListWithKnownRecords(
+  terminalList: TerminalRecord[],
+  currentTerminals: TerminalRecord[],
+  sessionTabs: readonly MobileSessionTabLike[]
+): TerminalRecord[] {
+  const currentTerminalsByHandle = new Map(
+    currentTerminals.map((terminal) => [terminal.handle, terminal])
+  )
+  const sessionTerminalsByHandle = new Map(
+    getTerminalRecordsFromSessionTabs(sessionTabs).map((terminal) => [terminal.handle, terminal])
+  )
+  return terminalList.map((terminal) => {
+    const sessionTerminal = sessionTerminalsByHandle.get(terminal.handle)
+    const currentTerminal = currentTerminalsByHandle.get(terminal.handle)
+    // Why: terminal.list summaries can omit the mobile theme; keep the richer
+    // session-tab/current record so polling cannot reset TerminalWebView.
+    return {
+      ...terminal,
+      terminalTheme:
+        sessionTerminal?.terminalTheme ?? currentTerminal?.terminalTheme ?? terminal.terminalTheme
+    }
+  })
+}
+
+export function terminalRecordsEqual(
+  a: readonly TerminalRecord[],
+  b: readonly TerminalRecord[]
+): boolean {
+  return (
+    a.length === b.length &&
+    a.every(
+      (terminal, index) =>
+        terminal.handle === b[index]?.handle &&
+        terminal.title === b[index]?.title &&
+        JSON.stringify(terminal.terminalTheme ?? null) ===
+          JSON.stringify(b[index]?.terminalTheme ?? null) &&
+        terminal.isActive === b[index]?.isActive
+    )
+  )
+}

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -1,7 +1,8 @@
-import { useRef, useCallback, forwardRef, useImperativeHandle } from 'react'
+import { useRef, useCallback, forwardRef, useImperativeHandle, useEffect, useMemo } from 'react'
 import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native'
 import { WebView } from 'react-native-webview'
 import type { WebViewMessageEvent } from 'react-native-webview'
+import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-types'
 import { colors } from '../theme/mobile-theme'
 
 type TerminalMouseTrackingMode = 'none' | 'x10' | 'vt200' | 'drag' | 'any'
@@ -19,6 +20,8 @@ export type TerminalKeyboardAvoidanceMetrics = {
   rows: number
   altScreen: boolean
 }
+
+export type MobileTerminalTheme = RuntimeMobileTerminalTheme
 
 export type TerminalSelectionEvents = {
   onSelectionMode?: (active: boolean) => void
@@ -48,18 +51,52 @@ export type TerminalWebViewHandle = {
 
 type Props = {
   style?: StyleProp<ViewStyle>
+  terminalTheme?: MobileTerminalTheme
   onWebReady?: () => void
 } & TerminalSelectionEvents
 
 type TerminalMessage =
   | { type: 'write'; id?: number; data: string }
-  | { type: 'init'; id?: number; cols: number; rows: number; initialData?: string }
+  | {
+      type: 'init'
+      id?: number
+      cols: number
+      rows: number
+      initialData?: string
+      terminalTheme?: MobileTerminalTheme
+    }
   | { type: 'resize'; id?: number; cols: number; rows: number }
   | { type: 'clear'; id?: number }
   | { type: 'measure'; id?: number; containerHeight?: number }
   | { type: 'reset-zoom'; id?: number }
   | { type: 'cancel-select'; id?: number }
   | { type: 'do-select-all'; id?: number }
+  | { type: 'set-theme'; id?: number; terminalTheme?: MobileTerminalTheme }
+
+const DEFAULT_TERMINAL_THEME: MobileTerminalTheme['theme'] = {
+  background: colors.terminalBg,
+  foreground: '#c0caf5',
+  cursor: '#c0caf5',
+  cursorAccent: colors.terminalBg,
+  selectionBackground: '#33467c',
+  selectionForeground: '#c0caf5',
+  black: '#15161e',
+  red: '#f7768e',
+  green: '#9ece6a',
+  yellow: '#e0af68',
+  blue: '#7aa2f7',
+  magenta: '#bb9af7',
+  cyan: '#7dcfff',
+  white: '#a9b1d6',
+  brightBlack: '#414868',
+  brightRed: '#f7768e',
+  brightGreen: '#9ece6a',
+  brightYellow: '#e0af68',
+  brightBlue: '#7aa2f7',
+  brightMagenta: '#bb9af7',
+  brightCyan: '#7dcfff',
+  brightWhite: '#c0caf5'
+}
 
 // Why: TUI apps (Claude Code / Ink) emit escape codes with absolute cursor
 // positioning designed for the desktop's terminal dimensions (~150+ cols).
@@ -95,6 +132,46 @@ const XTERM_HTML = `<!DOCTYPE html>
     display: inline-block;
   }
   .xterm { -webkit-user-select: none; user-select: none; }
+  .xterm .xterm-viewport {
+    overflow-y: hidden !important;
+    scrollbar-width: none !important;
+    -ms-overflow-style: none;
+  }
+  .xterm .xterm-viewport::-webkit-scrollbar {
+    display: none !important;
+    width: 0 !important;
+    height: 0 !important;
+    background: transparent !important;
+  }
+  .xterm .xterm-scrollable-element > .xterm-scrollbar,
+  .xterm .xterm-scrollbar {
+    display: none !important;
+    width: 0 !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+  #scroll-indicator {
+    position: fixed;
+    top: 4px;
+    right: 3px;
+    bottom: 4px;
+    width: 3px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 120ms linear;
+    z-index: 7;
+  }
+  #scroll-indicator.visible { opacity: 0.72; }
+  #scroll-thumb {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 3px;
+    min-height: 24px;
+    border-radius: 999px;
+    background: ${colors.textSecondary};
+    will-change: transform, height;
+  }
   /* Why: selection overlay sits in unscaled viewport coords, above the
      transformed surface, so handle hit areas and Copy menu positions
      don't depend on getTotalScale() for their on-screen size. */
@@ -171,6 +248,7 @@ const XTERM_HTML = `<!DOCTYPE html>
 <div id="terminal-container">
   <div id="terminal-surface"></div>
 </div>
+<div id="scroll-indicator"><div id="scroll-thumb"></div></div>
 <div id="selection-overlay">
   <div id="sel-handle-start" class="sel-handle start"></div>
   <div id="sel-handle-end" class="sel-handle end"></div>
@@ -187,6 +265,9 @@ const XTERM_HTML = `<!DOCTYPE html>
   var C1_CSI = String.fromCharCode(155);
   var PRIVATE_MODE_SCAN_TAIL_LIMIT = 4096;
   var term = null;
+  var scrollIndicator = document.getElementById('scroll-indicator');
+  var scrollThumb = document.getElementById('scroll-thumb');
+  var scrollIndicatorHideTimer = null;
   var writeQueue = [];
   var writesDraining = false;
   var afterDrainCallbacks = [];
@@ -195,8 +276,13 @@ const XTERM_HTML = `<!DOCTYPE html>
   var userScale = 1;
   var panX = 0;
   var panY = 0;
+  var smoothScrollOffsetY = 0;
+  var pendingNormalScrollDeltaY = 0;
+  var normalScrollFrameId = null;
   var initRows = 24;
   var terminalGeneration = 0;
+  var defaultTheme = ${JSON.stringify(DEFAULT_TERMINAL_THEME)};
+  var terminalTheme = defaultTheme;
   var activeAltScreenSnapshot = false;
   var trackedMouseTrackingMode = 'none';
   var sgrMouseMode = false;
@@ -253,7 +339,55 @@ const XTERM_HTML = `<!DOCTYPE html>
 
   function updateTransform() {
     surface.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + getTotalScale() + ')';
+    updateScrollIndicator(false);
     if (selMode === 'select') repositionOverlay();
+  }
+
+  function updateScrollIndicator(reveal) {
+    if (!scrollIndicator || !scrollThumb || !term || !term.buffer || !term.buffer.active) return;
+    var buffer = term.buffer.active;
+    var maxViewportY = buffer.baseY || 0;
+    if (maxViewportY <= 0 || shouldRouteScrollToTerminalInput()) {
+      scrollIndicator.classList.remove('visible');
+      return;
+    }
+    var trackHeight = Math.max(0, window.innerHeight - 8);
+    var totalRows = maxViewportY + (term.rows || 0);
+    if (trackHeight <= 0 || totalRows <= 0) return;
+    var thumbHeight = Math.max(24, trackHeight * (term.rows || 0) / totalRows);
+    var maxTop = Math.max(0, trackHeight - thumbHeight);
+    var top = maxViewportY > 0 ? (buffer.viewportY / maxViewportY) * maxTop : 0;
+    scrollThumb.style.height = thumbHeight + 'px';
+    scrollThumb.style.transform = 'translateY(' + top + 'px)';
+    if (!reveal) return;
+    scrollIndicator.classList.add('visible');
+    if (scrollIndicatorHideTimer) clearTimeout(scrollIndicatorHideTimer);
+    scrollIndicatorHideTimer = setTimeout(function() {
+      scrollIndicator.classList.remove('visible');
+      scrollIndicatorHideTimer = null;
+    }, 550);
+  }
+
+  function normalizeTerminalTheme(input) {
+    var source = input && typeof input === 'object' && input.theme && typeof input.theme === 'object'
+      ? input.theme
+      : null;
+    if (!source) return defaultTheme;
+    var next = {};
+    var keys = Object.keys(defaultTheme);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      if (typeof source[key] === 'string') next[key] = source[key];
+    }
+    return Object.assign({}, defaultTheme, next);
+  }
+
+  function applyTerminalTheme(input) {
+    terminalTheme = normalizeTerminalTheme(input);
+    var background = terminalTheme.background || '${colors.terminalBg}';
+    document.documentElement.style.background = background;
+    document.body.style.background = background;
+    if (term) term.options.theme = terminalTheme;
   }
 
   function getCellHeight() {
@@ -376,6 +510,7 @@ const XTERM_HTML = `<!DOCTYPE html>
     userScale = 1;
     panX = 0;
     panY = 0;
+    smoothScrollOffsetY = 0;
     updateTransform();
     adjustRowsForViewport();
 
@@ -494,7 +629,7 @@ const XTERM_HTML = `<!DOCTYPE html>
     pumpWrites(terminalGeneration);
   }
 
-  function init(cols, rows, initialData) {
+  function init(cols, rows, initialData, nextTheme) {
     terminalGeneration++;
     var gen = terminalGeneration;
     ready = false;
@@ -503,6 +638,7 @@ const XTERM_HTML = `<!DOCTYPE html>
     afterDrainCallbacks = [];
     initRows = rows || 24;
     firstDataPending = true;
+    smoothScrollOffsetY = 0;
     mouseModeScanTail = '';
     trackedMouseTrackingMode = 'none';
     sgrMouseMode = false;
@@ -535,32 +671,11 @@ const XTERM_HTML = `<!DOCTYPE html>
       oldSurface.removeAttribute('id');
     }
 
+    applyTerminalTheme(nextTheme);
     term = new Terminal({
       cols: cols || 80,
       rows: rows || 24,
-      theme: {
-        background: '${colors.terminalBg}',
-        foreground: '#c0caf5',
-        cursor: '#c0caf5',
-        cursorAccent: '${colors.terminalBg}',
-        selectionBackground: '#33467c',
-        black: '#15161e',
-        red: '#f7768e',
-        green: '#9ece6a',
-        yellow: '#e0af68',
-        blue: '#7aa2f7',
-        magenta: '#bb9af7',
-        cyan: '#7dcfff',
-        white: '#a9b1d6',
-        brightBlack: '#414868',
-        brightRed: '#f7768e',
-        brightGreen: '#9ece6a',
-        brightYellow: '#e0af68',
-        brightBlue: '#7aa2f7',
-        brightMagenta: '#bb9af7',
-        brightCyan: '#7dcfff',
-        brightWhite: '#c0caf5'
-      },
+      theme: terminalTheme,
       fontFamily: '"Menlo", "Consolas", "DejaVu Sans Mono", monospace',
       fontSize: 13,
       scrollback: 5000,
@@ -693,7 +808,7 @@ const XTERM_HTML = `<!DOCTYPE html>
       if (handledMessageIds.length > 256) handledMessageIds.shift();
     }
     if (msg.type === 'init') {
-      init(msg.cols, msg.rows, msg.initialData);
+      init(msg.cols, msg.rows, msg.initialData, msg.terminalTheme);
     } else if (msg.type === 'resize') {
       resize(msg.cols, msg.rows);
     } else if (msg.type === 'write') {
@@ -718,6 +833,8 @@ const XTERM_HTML = `<!DOCTYPE html>
       measureFitDimensions(msg.containerHeight);
     } else if (msg.type === 'reset-zoom') {
       applyFitScale('reset-zoom-msg');
+    } else if (msg.type === 'set-theme') {
+      applyTerminalTheme(msg.terminalTheme);
     } else if (msg.type === 'cancel-select') {
       if (selMode === 'select') cancelSelect();
     } else if (msg.type === 'do-select-all') {
@@ -849,6 +966,7 @@ const XTERM_HTML = `<!DOCTYPE html>
   function attachTermObservers() {
     if (!term) return;
     try { term.onLineFeed(logFeedAndEvict); } catch (e) {}
+    try { term.onScroll(function() { updateScrollIndicator(false); }); } catch (e) {}
     // Why: emit modes on every parsed write so RN's mirror stays current
     // without round-trip; covers \\x1b[?2004h/l and alt-screen toggles.
     try {
@@ -975,6 +1093,10 @@ const XTERM_HTML = `<!DOCTYPE html>
     return mode !== 'none' && mode !== 'x10';
   }
 
+  function shouldRouteScrollToTerminalInput() {
+    return isWheelMouseTrackingMode(getMouseTrackingMode()) || isAlternateBufferActive();
+  }
+
   function buildMouseWheelScrollInput(lines, clientX, clientY) {
     var count = Math.min(Math.abs(lines), 32);
     if (count === 0) return '';
@@ -1022,6 +1144,83 @@ const XTERM_HTML = `<!DOCTYPE html>
       return;
     }
     term.scrollLines(lines);
+  }
+
+  function clampNormalScrollLines(lines) {
+    if (!term || !term.buffer || !term.buffer.active || lines === 0) return 0;
+    var buffer = term.buffer.active;
+    if (lines > 0) {
+      return Math.min(lines, Math.max(0, buffer.baseY - buffer.viewportY));
+    }
+    return Math.max(lines, -buffer.viewportY);
+  }
+
+  function canScrollNormalBufferDelta(deltaY) {
+    if (!term || !term.buffer || !term.buffer.active || deltaY === 0) return false;
+    var buffer = term.buffer.active;
+    if (deltaY > 0) return buffer.viewportY < buffer.baseY;
+    return buffer.viewportY > 0;
+  }
+
+  function applyNormalBufferScrollDelta(deltaY) {
+    if (!term || deltaY === 0) return false;
+    var effectiveCellH = getCellHeight() * getTotalScale();
+    if (effectiveCellH <= 0) return false;
+    if (!canScrollNormalBufferDelta(deltaY)) {
+      resetSmoothScrollOffset();
+      return false;
+    }
+    smoothScrollOffsetY -= deltaY;
+    var lines = Math.trunc(-smoothScrollOffsetY / effectiveCellH);
+    if (lines !== 0) {
+      var applied = clampNormalScrollLines(lines);
+      if (applied !== 0) {
+        term.scrollLines(applied);
+        // Why: xterm's renderer is row-based. Buffer touch pixels and only
+        // commit whole rows so TUI canvas layers do not shimmer between
+        // fractional transforms and xterm repaints.
+        smoothScrollOffsetY += applied * effectiveCellH;
+      }
+      if (applied !== lines) smoothScrollOffsetY = 0;
+    }
+    var limit = effectiveCellH - 1;
+    if (smoothScrollOffsetY > limit) smoothScrollOffsetY = limit;
+    if (smoothScrollOffsetY < -limit) smoothScrollOffsetY = -limit;
+    updateScrollIndicator(true);
+    return true;
+  }
+
+  function enqueueNormalBufferScrollDelta(deltaY) {
+    if (!term || deltaY === 0) return false;
+    if (!canScrollNormalBufferDelta(deltaY)) {
+      resetSmoothScrollOffset();
+      return false;
+    }
+    pendingNormalScrollDeltaY += deltaY;
+    if (normalScrollFrameId !== null) return true;
+    // Why: dense terminal rows are expensive to repaint. Coalesce touchmove
+    // deltas into one xterm row-scroll per frame instead of repainting from
+    // the input event stream.
+    normalScrollFrameId = requestAnimationFrame(function() {
+      normalScrollFrameId = null;
+      var delta = pendingNormalScrollDeltaY;
+      pendingNormalScrollDeltaY = 0;
+      if (!applyNormalBufferScrollDelta(delta)) {
+        resetSmoothScrollOffset();
+      }
+    });
+    return true;
+  }
+
+  function resetSmoothScrollOffset() {
+    pendingNormalScrollDeltaY = 0;
+    if (normalScrollFrameId !== null) {
+      cancelAnimationFrame(normalScrollFrameId);
+      normalScrollFrameId = null;
+    }
+    if (smoothScrollOffsetY === 0) return;
+    smoothScrollOffsetY = 0;
+    updateScrollIndicator(false);
   }
 
   function cellToViewportPx(col, absRow) {
@@ -1392,6 +1591,15 @@ const XTERM_HTML = `<!DOCTYPE html>
     pinchDist: 0, pinchScale: 0, pinchSurfX: 0, pinchSurfY: 0
   };
 
+  function updateTouchVelocity(deltaY, dt) {
+    if (dt <= 0) return;
+    var instantVelocity = deltaY / dt;
+    if (!isFinite(instantVelocity)) return;
+    // Why: touchmove cadence is uneven in WebView. Blend recent samples so
+    // momentum launch doesn't inherit a one-frame spike or stall.
+    ts.velY = ts.velY === 0 ? instantVelocity : ts.velY * 0.55 + instantVelocity * 0.45;
+  }
+
   function getDistance(a, b) {
     var dx = a.clientX - b.clientX, dy = a.clientY - b.clientY;
     return Math.sqrt(dx * dx + dy * dy);
@@ -1413,6 +1621,7 @@ const XTERM_HTML = `<!DOCTYPE html>
       }
       if (e.touches.length === 2) {
         ts.isPinching = true;
+        smoothScrollOffsetY = 0;
         ts.pinchDist = getDistance(e.touches[0], e.touches[1]);
         ts.pinchScale = userScale;
         var mx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
@@ -1458,20 +1667,30 @@ const XTERM_HTML = `<!DOCTYPE html>
         var dt = now - ts.lastTime;
 
         if (userScale > 1.05) {
+          smoothScrollOffsetY = 0;
           panX += x - ts.lastX;
           panY += y - ts.lastY;
           clampPan();
           updateTransform();
         } else {
           var deltaY = ts.lastY - y;
-          if (dt > 0) ts.velY = deltaY / dt;
           ts.lastTime = now;
-          var effectiveCellH = getCellHeight() * currentScale;
-          ts.accumDelta += deltaY;
-          var lines = Math.trunc(ts.accumDelta / effectiveCellH);
-          if (lines !== 0) {
-            ts.accumDelta -= lines * effectiveCellH;
-            routeScrollLines(lines, x, y);
+          if (shouldRouteScrollToTerminalInput()) {
+            updateTouchVelocity(deltaY, dt);
+            resetSmoothScrollOffset();
+            var effectiveCellH = getCellHeight() * getTotalScale();
+            ts.accumDelta += deltaY;
+            var lines = Math.trunc(ts.accumDelta / effectiveCellH);
+            if (lines !== 0) {
+              ts.accumDelta -= lines * effectiveCellH;
+              routeScrollLines(lines, x, y);
+            }
+          } else {
+            if (enqueueNormalBufferScrollDelta(deltaY)) {
+              updateTouchVelocity(deltaY, dt);
+            } else {
+              ts.velY = 0;
+            }
           }
         }
         ts.lastX = x;
@@ -1501,17 +1720,26 @@ const XTERM_HTML = `<!DOCTYPE html>
 
       if (e.touches.length === 0 && userScale <= 1.05) {
         var vel = ts.velY;
-        var FRICTION = 0.95;
-        var MIN_VEL = 0.02;
+        var FRICTION = 0.972;
+        var MIN_VEL = 0.012;
         function momentumStep() {
           vel *= FRICTION;
           if (Math.abs(vel) < MIN_VEL) { ts.momentumId = null; return; }
-          var effectiveCellH = getCellHeight() * currentScale;
-          ts.accumDelta += vel * 16;
-          var lines = Math.trunc(ts.accumDelta / effectiveCellH);
-          if (lines !== 0) {
-            ts.accumDelta -= lines * effectiveCellH;
-            routeScrollLines(lines, ts.lastX, ts.lastY);
+          var delta = vel * 16;
+          if (shouldRouteScrollToTerminalInput()) {
+            resetSmoothScrollOffset();
+            var effectiveCellH = getCellHeight() * getTotalScale();
+            ts.accumDelta += delta;
+            var lines = Math.trunc(ts.accumDelta / effectiveCellH);
+            if (lines !== 0) {
+              ts.accumDelta -= lines * effectiveCellH;
+              routeScrollLines(lines, ts.lastX, ts.lastY);
+            }
+          } else {
+            if (!applyNormalBufferScrollDelta(delta)) {
+              ts.momentumId = null;
+              return;
+            }
           }
           ts.momentumId = requestAnimationFrame(momentumStep);
         }
@@ -1561,6 +1789,7 @@ const XTERM_HTML = `<!DOCTYPE html>
 export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function TerminalWebView(
   {
     style,
+    terminalTheme,
     onWebReady,
     onSelectionMode,
     onSelectionCopy,
@@ -1576,6 +1805,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
   const isWebReadyRef = useRef(false)
   const pendingMessagesRef = useRef<TerminalMessage[]>([])
   const messageIdRef = useRef(0)
+  const terminalThemeKey = useMemo(() => JSON.stringify(terminalTheme ?? null), [terminalTheme])
   const measureResolveRef = useRef<
     ((result: { cols: number; rows: number } | null) => void) | null
   >(null)
@@ -1710,6 +1940,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     isWebReadyRef.current = false
   }, [])
 
+  useEffect(() => {
+    postMessage({ type: 'set-theme', terminalTheme })
+  }, [postMessage, terminalThemeKey, terminalTheme])
+
   useImperativeHandle(
     ref,
     () => ({
@@ -1733,7 +1967,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         readyPromiseRef.current = new Promise<void>((resolve) => {
           readyResolveRef.current = resolve
         })
-        postMessage({ type: 'init', cols, rows, initialData })
+        postMessage({ type: 'init', cols, rows, initialData, terminalTheme })
       },
       resize(cols: number, rows: number) {
         postMessage({ type: 'resize', cols, rows })
@@ -1778,7 +2012,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         await Promise.race([p, new Promise<void>((resolve) => setTimeout(resolve, 3000))])
       }
     }),
-    [postMessage, sendToWebView]
+    [postMessage, sendToWebView, terminalTheme]
   )
 
   return (
@@ -1788,7 +2022,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
       style={[styles.webview, style]}
       originWhitelist={['*']}
       javaScriptEnabled
-      scrollEnabled={true}
+      scrollEnabled={false}
       scalesPageToFit={false}
       onLoadStart={handleLoadStart}
       onMessage={handleMessage}

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('./TerminalWebView.tsx', import.meta.url), 'utf8')
+
+function sliceBetween(startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('TerminalWebView scroll routing', () => {
+  it('routes alternate-screen and mouse-aware scroll before smooth normal scroll', () => {
+    expect(source).toContain(
+      'return isWheelMouseTrackingMode(getMouseTrackingMode()) || isAlternateBufferActive();'
+    )
+
+    const touchMoveBlock = sliceBetween(
+      "targetSurface.addEventListener('touchmove'",
+      '}, { capture: true, passive: false });'
+    )
+    expect(touchMoveBlock.indexOf('if (shouldRouteScrollToTerminalInput())')).toBeLessThan(
+      touchMoveBlock.indexOf('if (enqueueNormalBufferScrollDelta(deltaY))')
+    )
+    expect(touchMoveBlock).toContain('routeScrollLines(lines, x, y);')
+
+    const momentumBlock = sliceBetween('function momentumStep()', 'if (Math.abs(vel) > MIN_VEL)')
+    expect(momentumBlock.indexOf('if (shouldRouteScrollToTerminalInput())')).toBeLessThan(
+      momentumBlock.indexOf('if (!applyNormalBufferScrollDelta(delta))')
+    )
+    expect(momentumBlock).toContain('routeScrollLines(lines, ts.lastX, ts.lastY);')
+  })
+
+  it('does not rubber-band normal scroll at scrollback edges', () => {
+    expect(source).toContain('function canScrollNormalBufferDelta(deltaY)')
+    const smoothScrollBlock = sliceBetween(
+      'function applyNormalBufferScrollDelta(deltaY)',
+      'function enqueueNormalBufferScrollDelta(deltaY)'
+    )
+    expect(smoothScrollBlock).toContain('if (!canScrollNormalBufferDelta(deltaY))')
+    expect(smoothScrollBlock).toContain('resetSmoothScrollOffset();')
+    expect(smoothScrollBlock).toContain('return false;')
+    expect(smoothScrollBlock).toContain('return true;')
+
+    const touchMoveBlock = sliceBetween(
+      "targetSurface.addEventListener('touchmove'",
+      '}, { capture: true, passive: false });'
+    )
+    expect(touchMoveBlock).toContain('if (enqueueNormalBufferScrollDelta(deltaY))')
+    expect(touchMoveBlock).toContain('ts.velY = 0;')
+
+    const momentumBlock = sliceBetween('function momentumStep()', 'if (Math.abs(vel) > MIN_VEL)')
+    expect(momentumBlock).toContain('if (!applyNormalBufferScrollDelta(delta))')
+    expect(momentumBlock).toContain('ts.momentumId = null;')
+  })
+
+  it('coalesces normal touch scroll row commits onto animation frames', () => {
+    const enqueueBlock = sliceBetween(
+      'function enqueueNormalBufferScrollDelta(deltaY)',
+      'function resetSmoothScrollOffset()'
+    )
+    expect(enqueueBlock).toContain('pendingNormalScrollDeltaY += deltaY;')
+    expect(enqueueBlock).toContain('if (normalScrollFrameId !== null) return true;')
+    expect(enqueueBlock).toContain('normalScrollFrameId = requestAnimationFrame(function()')
+    expect(enqueueBlock).toContain('applyNormalBufferScrollDelta(delta)')
+
+    const resetBlock = sliceBetween(
+      'function resetSmoothScrollOffset()',
+      'function cellToViewportPx'
+    )
+    expect(resetBlock).toContain('pendingNormalScrollDeltaY = 0;')
+    expect(resetBlock).toContain('cancelAnimationFrame(normalScrollFrameId);')
+  })
+
+  it('hides xterm scrollbars and drives the mobile scroll indicator from committed rows', () => {
+    expect(source).toContain('<div id="scroll-indicator"><div id="scroll-thumb"></div></div>')
+    expect(source).toContain('.xterm .xterm-viewport::-webkit-scrollbar')
+    expect(source).toContain('.xterm .xterm-scrollable-element > .xterm-scrollbar')
+    expect(source).toContain('overflow-y: hidden !important;')
+    expect(source).toContain('display: none !important;')
+    expect(source).toContain('function updateScrollIndicator(reveal)')
+    expect(source).toContain('buffer.viewportY / maxViewportY')
+    expect(source).not.toContain('fractionalRows')
+    expect(source).toContain('scrollThumb.style.transform =')
+    expect(source).toContain('updateScrollIndicator(true);')
+  })
+
+  it('does not apply fractional smooth scroll transforms to terminal content', () => {
+    const updateTransformBlock = sliceBetween(
+      'function updateTransform()',
+      'function updateScrollIndicator(reveal)'
+    )
+    expect(updateTransformBlock).toContain(
+      "surface.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + getTotalScale() + ')';"
+    )
+    expect(source).not.toContain("querySelector('.xterm-screen')")
+    expect(source).not.toContain('updateTerminalScreenTransform')
+    expect(updateTransformBlock).not.toContain("getVisualPanY() + 'px) scale('")
+    expect(updateTransformBlock).not.toContain('smoothScrollOffsetY')
+  })
+
+  it('smooths velocity samples and uses lower friction for mobile momentum', () => {
+    expect(source).toContain('function updateTouchVelocity(deltaY, dt)')
+    expect(source).toContain('ts.velY * 0.55 + instantVelocity * 0.45')
+    expect(source).toContain('var FRICTION = 0.972;')
+    expect(source).toContain('var MIN_VEL = 0.012;')
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10468,6 +10468,7 @@ export class OrcaRuntimeService {
         leafId: tab.leafId,
         title: leaf?.paneTitle ?? syncedTab?.title ?? pty?.title ?? tab.title,
         ...(tab.ptyId ? { ptyId: tab.ptyId } : {}),
+        ...(tab.terminalTheme ? { terminalTheme: tab.terminalTheme } : {}),
         ...(tab.agentStatus ? { agentStatus: tab.agentStatus } : {}),
         ...(tab.parentLayout ? { parentLayout: tab.parentLayout } : {}),
         isActive: tab.isActive,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -97,6 +97,7 @@ import {
   hydratePersistedUIAfterStartupRead
 } from './lib/startup-ui-hydration'
 import { applyDocumentTheme } from './lib/document-theme'
+import { getSystemPrefersDark } from './lib/terminal-theme'
 import { isEditableTarget } from './lib/editable-target'
 import { getSelectedTextForFileSearch } from './lib/file-search-selection'
 import { useShortcutLabel } from './hooks/useShortcutLabel'
@@ -776,14 +777,27 @@ function App(): React.JSX.Element {
   useEffect(() => {
     let previousKey = getRuntimeMobileSessionSyncKey(useAppStore.getState())
     return useAppStore.subscribe((state, previousState) => {
+      const systemPrefersDark = getSystemPrefersDark()
       // Why: skip the key build entirely when every input field is unchanged
       // by reference. Mirrors every field used by
       // getRuntimeMobileSessionSyncKey so this gate covers every "could the
       // key have changed?" case.
-      if (canSkipRuntimeMobileSessionSyncKeyBuild(state, previousState)) {
+      if (
+        canSkipRuntimeMobileSessionSyncKeyBuild(
+          state,
+          previousState,
+          systemPrefersDark,
+          previousKey.systemPrefersDark
+        )
+      ) {
         return
       }
-      const nextKey = getRuntimeMobileSessionSyncKey(state, previousState, previousKey)
+      const nextKey = getRuntimeMobileSessionSyncKey(
+        state,
+        previousState,
+        previousKey,
+        systemPrefersDark
+      )
       if (runtimeMobileSessionSyncKeysEqual(nextKey, previousKey)) {
         return
       }
@@ -942,7 +956,12 @@ function App(): React.JSX.Element {
       // system
       const mq = window.matchMedia('(prefers-color-scheme: dark)')
       applyDocumentTheme('system')
-      const handler = (): void => applyDocumentTheme('system')
+      const handler = (): void => {
+        applyDocumentTheme('system')
+        // Why: system theme changes do not mutate the store, so mobile
+        // terminal colors need an explicit graph republish.
+        scheduleRuntimeGraphSync()
+      }
       mq.addEventListener('change', handler)
       return () => mq.removeEventListener('change', handler)
     }

--- a/src/renderer/src/runtime/sync-runtime-graph.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.test.ts
@@ -7,6 +7,7 @@ import {
   runtimeMobileSessionSyncKeysEqual
 } from './sync-runtime-graph'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { getDefaultSettings } from '../../../shared/constants'
 import type { AppState } from '../store/types'
 
 function makeState(overrides: Partial<AppState> = {}): AppState {
@@ -389,6 +390,45 @@ describe('getRuntimeMobileSessionSyncKey', () => {
 
     expect(canSkipRuntimeMobileSessionSyncKeyBuild(after, before)).toBe(true)
   })
+
+  it('changes and does not skip when terminal theme settings change', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const beforeSettings = {
+      ...getDefaultSettings('/tmp'),
+      theme: 'dark' as const,
+      terminalColorOverrides: { foreground: '#eeeeee' }
+    }
+    const afterSettings = {
+      ...beforeSettings,
+      terminalColorOverrides: { foreground: '#111111' }
+    }
+    const before = makeState({ ...sharedOverrides, settings: beforeSettings })
+    const beforeKey = getRuntimeMobileSessionSyncKey(before)
+    const after = makeState({ ...sharedOverrides, settings: afterSettings })
+    const afterKey = getRuntimeMobileSessionSyncKey(after, before, beforeKey)
+
+    expect(canSkipRuntimeMobileSessionSyncKeyBuild(after, before)).toBe(false)
+    expect(runtimeMobileSessionSyncKeysEqual(beforeKey, afterKey)).toBe(false)
+  })
+
+  it('changes and does not skip when system terminal appearance changes', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const settings = {
+      ...getDefaultSettings('/tmp'),
+      theme: 'system' as const,
+      terminalUseSeparateLightTheme: true
+    }
+    const before = makeState({ ...sharedOverrides, settings })
+    const beforeKey = getRuntimeMobileSessionSyncKey(before, undefined, undefined, false)
+    const after = makeState({ ...sharedOverrides, settings })
+    const afterKey = getRuntimeMobileSessionSyncKey(after, before, beforeKey, true)
+
+    expect(canSkipRuntimeMobileSessionSyncKeyBuild(after, before, true, false)).toBe(false)
+    expect(beforeKey.systemPrefersDark).toBe(false)
+    expect(afterKey.systemPrefersDark).toBe(true)
+    expect(afterKey.terminalThemeProjection).not.toBe(beforeKey.terminalThemeProjection)
+    expect(runtimeMobileSessionSyncKeysEqual(beforeKey, afterKey)).toBe(false)
+  })
 })
 
 describe('buildMobileSessionTabSnapshots', () => {
@@ -544,6 +584,86 @@ describe('buildMobileSessionTabSnapshots', () => {
           agentType: 'codex',
           paneKey
         }
+      }
+    ])
+  })
+
+  it('publishes the desktop-resolved terminal theme for mobile terminal tabs', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const state = makeState({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        theme: 'light',
+        terminalUseSeparateLightTheme: true,
+        terminalColorOverrides: {
+          background: '#f8f8f8',
+          foreground: '#101010',
+          cursor: '#202020'
+        },
+        terminalBackgroundOpacity: 0.8,
+        terminalCursorOpacity: 0.5
+      },
+      tabBarOrderByWorktree: { 'wt-1': ['term-1'] },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'term-1', title: 'Terminal', customTitle: null, ptyId: 'pty-1' }]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        'term-1': {
+          root: { type: 'leaf', leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: 'pty-1' }
+        }
+      } as AppState['terminalLayoutsByTabId']
+    })
+
+    expect(buildMobileSessionTabSnapshots(state)[0]?.tabs).toMatchObject([
+      {
+        type: 'terminal',
+        terminalTheme: {
+          mode: 'light',
+          theme: {
+            background: 'rgba(248, 248, 248, 0.8)',
+            foreground: '#101010',
+            cursor: 'rgba(32, 32, 32, 0.5)'
+          }
+        }
+      }
+    ])
+  })
+
+  it('uses the explicit system appearance for mobile terminal theme snapshots', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const state = makeState({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        theme: 'system',
+        terminalUseSeparateLightTheme: true
+      },
+      tabBarOrderByWorktree: { 'wt-1': ['term-1'] },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'term-1', title: 'Terminal', customTitle: null, ptyId: 'pty-1' }]
+      } as unknown as AppState['tabsByWorktree'],
+      terminalLayoutsByTabId: {
+        'term-1': {
+          root: { type: 'leaf', leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: 'pty-1' }
+        }
+      } as AppState['terminalLayoutsByTabId']
+    })
+
+    expect(buildMobileSessionTabSnapshots(state, false)[0]?.tabs).toMatchObject([
+      {
+        type: 'terminal',
+        terminalTheme: { mode: 'light' }
+      }
+    ])
+    expect(buildMobileSessionTabSnapshots(state, true)[0]?.tabs).toMatchObject([
+      {
+        type: 'terminal',
+        terminalTheme: { mode: 'dark' }
       }
     ])
   })

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -8,6 +8,7 @@ import { warnTerminalLifecycleAnomaly } from '@/components/terminal-pane/termina
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
+import { getSystemPrefersDark, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { sanitizeTerminalLayoutPaneTitles } from '@/lib/terminal-pane-title-sanitization'
 import type { AppState } from '@/store/types'
 import type {
@@ -16,6 +17,7 @@ import type {
   RuntimeMobileSessionMarkdownTab,
   RuntimeMobileSessionTabGroup,
   RuntimeMobileSessionSnapshotTab,
+  RuntimeMobileTerminalTheme,
   RuntimeMobileSessionTabsSnapshot,
   RuntimeSyncWindowGraph
 } from '../../../shared/runtime-types'
@@ -182,6 +184,8 @@ export type RuntimeMobileSessionSyncKey = {
   activeBrowserTabIdByWorktree: AppState['activeBrowserTabIdByWorktree']
   agentStatusEpoch: number
   agentStatusProjection: string
+  systemPrefersDark: boolean | null
+  terminalThemeProjection: string
   // Why: these projections still need value-level inspection because the
   // underlying references churn even when the mobile-relevant shape is
   // unchanged (`tabsByWorktree` reallocates on every OSC title frame).
@@ -194,9 +198,17 @@ export type RuntimeMobileSessionSyncKey = {
 
 export function canSkipRuntimeMobileSessionSyncKeyBuild(
   state: AppState,
-  previousState: AppState
+  previousState: AppState,
+  systemPrefersDark?: boolean,
+  previousSystemPrefersDark: boolean | null | undefined = systemPrefersDark
 ): boolean {
+  const terminalThemeSystemPrefersDark = getTerminalThemeSystemPrefersDark(state, systemPrefersDark)
+  const previousTerminalThemeSystemPrefersDark = getTerminalThemeSystemPrefersDark(
+    previousState,
+    previousSystemPrefersDark
+  )
   return (
+    terminalThemeSystemPrefersDark === previousTerminalThemeSystemPrefersDark &&
     state.tabsByWorktree === previousState.tabsByWorktree &&
     state.groupsByWorktree === previousState.groupsByWorktree &&
     state.activeGroupIdByWorktree === previousState.activeGroupIdByWorktree &&
@@ -210,6 +222,7 @@ export function canSkipRuntimeMobileSessionSyncKeyBuild(
     state.activeBrowserTabIdByWorktree === previousState.activeBrowserTabIdByWorktree &&
     state.openFiles === previousState.openFiles &&
     state.editorDrafts === previousState.editorDrafts &&
+    state.settings === previousState.settings &&
     state.activeTabId === previousState.activeTabId &&
     state.terminalLayoutsByTabId === previousState.terminalLayoutsByTabId &&
     state.runtimePaneTitlesByTabId === previousState.runtimePaneTitlesByTabId &&
@@ -218,12 +231,21 @@ export function canSkipRuntimeMobileSessionSyncKeyBuild(
   )
 }
 
+function getTerminalThemeSystemPrefersDark(
+  state: Pick<AppState, 'settings'>,
+  systemPrefersDark: boolean | null | undefined
+): boolean | null {
+  return state.settings?.theme === 'system' ? (systemPrefersDark ?? null) : null
+}
+
 export function getRuntimeMobileSessionSyncKey(
   state: AppState,
   previousState?: AppState,
-  previousKey?: RuntimeMobileSessionSyncKey
+  previousKey?: RuntimeMobileSessionSyncKey,
+  systemPrefersDark = getSystemPrefersDark()
 ): RuntimeMobileSessionSyncKey {
   const canReusePrevious = previousState !== undefined && previousKey !== undefined
+  const terminalThemeSystemPrefersDark = getTerminalThemeSystemPrefersDark(state, systemPrefersDark)
   const browserTabsByWorktree = getBrowserTabsByWorktree(state)
   const browserPagesByWorkspace = getBrowserPagesByWorkspace(state)
   const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_AGENT_STATUS_BY_PANE_KEY
@@ -258,6 +280,13 @@ export function getRuntimeMobileSessionSyncKey(
       canReusePrevious && agentStatusByPaneKey === previousAgentStatusByPaneKey
         ? previousKey.agentStatusProjection
         : buildRuntimeMobileAgentStatusProjection(agentStatusByPaneKey),
+    systemPrefersDark: terminalThemeSystemPrefersDark,
+    terminalThemeProjection:
+      canReusePrevious &&
+      state.settings === previousState.settings &&
+      previousKey.systemPrefersDark === terminalThemeSystemPrefersDark
+        ? previousKey.terminalThemeProjection
+        : JSON.stringify(resolveMobileTerminalTheme(state, systemPrefersDark) ?? null),
     // Why: background agent title ticks can change runtimePaneTitlesByTabId
     // many times per second while the user types elsewhere. Reuse unchanged
     // projections so those ticks do not rescan all tabs, files, and drafts.
@@ -435,6 +464,8 @@ export function runtimeMobileSessionSyncKeysEqual(
     a.activeBrowserTabIdByWorktree === b.activeBrowserTabIdByWorktree &&
     a.agentStatusEpoch === b.agentStatusEpoch &&
     a.agentStatusProjection === b.agentStatusProjection &&
+    a.systemPrefersDark === b.systemPrefersDark &&
+    a.terminalThemeProjection === b.terminalThemeProjection &&
     a.tabsProjection === b.tabsProjection &&
     a.openFilesProjection === b.openFilesProjection &&
     a.browserProjection === b.browserProjection &&
@@ -451,6 +482,7 @@ async function syncRuntimeGraph(): Promise<void> {
   // Injecting the getter from App keeps the runtime graph path out of the
   // store construction cycle and avoids test-time partial initialization.
   const state = getStoreState()
+  const systemPrefersDark = getSystemPrefersDark()
   // Why: sync can run after high-churn terminal/title mutations. Build lookup
   // maps once per sync instead of flattening every worktree's tabs for each
   // registered terminal.
@@ -462,7 +494,7 @@ async function syncRuntimeGraph(): Promise<void> {
   const graph: RuntimeSyncWindowGraph = {
     tabs: [],
     leaves: [],
-    mobileSessionTabs: buildMobileSessionTabSnapshots(state)
+    mobileSessionTabs: buildMobileSessionTabSnapshots(state, systemPrefersDark)
   }
 
   for (const [tabId, registeredTab] of registeredTabs) {
@@ -524,7 +556,8 @@ async function syncRuntimeGraph(): Promise<void> {
 }
 
 export function buildMobileSessionTabSnapshots(
-  state: AppState
+  state: AppState,
+  systemPrefersDark = getSystemPrefersDark()
 ): RuntimeMobileSessionTabsSnapshot[] {
   // Why: mobile publication can run on high-frequency background agent title
   // ticks. Cache open-file indexes and draft hashes by immutable store-slice
@@ -571,7 +604,15 @@ export function buildMobileSessionTabSnapshots(
         if (isWebOnlyMirroredTerminalTab(state, terminal)) {
           continue
         }
-        tabs.push(...buildMobileTerminalSurfaceTabs(state, terminal, worktreeId, item.tabId))
+        tabs.push(
+          ...buildMobileTerminalSurfaceTabs(
+            state,
+            terminal,
+            worktreeId,
+            systemPrefersDark,
+            item.tabId
+          )
+        )
       } else if (item.type === 'editor') {
         const file = openFileIndexes.byWorktreeAndId.get(worktreeId)?.get(item.id)
         if (!file) {
@@ -807,6 +848,58 @@ function mobileTerminalSurfaceId(parentTabId: string, leafId: string): string {
   return `${parentTabId}::${leafId}`
 }
 
+function hexToRgba(hex: string, alpha: number): string {
+  let clean = hex.replace('#', '')
+  if (clean.length === 3) {
+    clean = clean
+      .split('')
+      .map((c) => c + c)
+      .join('')
+  }
+  const r = parseInt(clean.slice(0, 2), 16)
+  const g = parseInt(clean.slice(2, 4), 16)
+  const b = parseInt(clean.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+function isHexColor(value: string | undefined): value is string {
+  return typeof value === 'string' && /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value)
+}
+
+function resolveMobileTerminalTheme(
+  state: AppState,
+  systemPrefersDark: boolean
+): RuntimeMobileTerminalTheme | undefined {
+  const settings = state.settings
+  if (!settings) {
+    return undefined
+  }
+  const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
+  const resolvedTheme = appearance.theme
+    ? { ...appearance.theme, ...settings.terminalColorOverrides }
+    : undefined
+  if (!resolvedTheme) {
+    return undefined
+  }
+  if (settings.terminalBackgroundOpacity !== undefined && isHexColor(resolvedTheme.background)) {
+    resolvedTheme.background = hexToRgba(
+      resolvedTheme.background,
+      settings.terminalBackgroundOpacity
+    )
+  }
+  if (settings.terminalCursorOpacity !== undefined && isHexColor(resolvedTheme.cursor)) {
+    resolvedTheme.cursor = hexToRgba(resolvedTheme.cursor, settings.terminalCursorOpacity)
+  }
+
+  const theme: Record<string, string> = {}
+  for (const [key, value] of Object.entries(resolvedTheme)) {
+    if (typeof value === 'string') {
+      theme[key] = value
+    }
+  }
+  return { mode: appearance.mode, theme: theme as RuntimeMobileTerminalTheme['theme'] }
+}
+
 function fallbackLayoutForLeafIds(leafIds: readonly string[]): TerminalPaneLayoutNode | null {
   const leaves = leafIds.filter(isTerminalLeafId)
   if (leaves.length === 0) {
@@ -847,6 +940,7 @@ function buildMobileTerminalSurfaceTabs(
   state: AppState,
   terminal: NonNullable<AppState['tabsByWorktree'][string]>[number],
   worktreeId: string,
+  systemPrefersDark: boolean,
   unifiedTabId?: string
 ): RuntimeMobileSessionSnapshotTab[] {
   const registered = registeredTabs.get(terminal.id)
@@ -870,6 +964,7 @@ function buildMobileTerminalSurfaceTabs(
     ? sanitizeTerminalLayoutPaneTitles(savedLayout, terminal)
     : undefined
   const savedPtyIdsByLeafId = sanitizedSavedLayout?.ptyIdsByLeafId ?? {}
+  const terminalTheme = resolveMobileTerminalTheme(state, systemPrefersDark)
   const container = registered?.getContainer()
   const firstChild = container?.firstElementChild
   const liveLayoutRoot = serializePaneTree(
@@ -906,6 +1001,7 @@ function buildMobileTerminalSurfaceTabs(
       parentTabId: terminal.id,
       leafId,
       ptyId,
+      ...(terminalTheme ? { terminalTheme } : {}),
       ...(agentStatus ? { agentStatus } : {}),
       parentLayout,
       isActive: isDesktopTabActive && leafId === activeLeafId

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -8,6 +8,7 @@ import type {
   GitWorktreeInfo,
   Repo,
   TabGroupLayoutNode,
+  TerminalColorOverrides,
   TerminalLayoutSnapshot,
   Worktree,
   WorktreeLineage,
@@ -104,9 +105,15 @@ export type RuntimeMobileSessionTerminalTab = {
   parentTabId: string
   leafId: string
   ptyId?: string | null
+  terminalTheme?: RuntimeMobileTerminalTheme
   agentStatus?: AgentStatusEntry | null
   parentLayout?: TerminalLayoutSnapshot
   isActive: boolean
+}
+
+export type RuntimeMobileTerminalTheme = {
+  mode: 'dark' | 'light'
+  theme: TerminalColorOverrides
 }
 
 export type RuntimeMobileSessionMarkdownTab = {


### PR DESCRIPTION
## Summary
- auto-create the first mobile terminal when an active workspace opens with no terminal tabs
- normalize mobile terminal records from runtime sync payloads so mobile can recover missing tab metadata
- stabilize mobile terminal scrolling by hiding xterm scrollbar chrome, coalescing touch scroll commits to animation frames, and keeping terminal content row-aligned

## Testing
- cd mobile && pnpm exec vitest run src/terminal/terminal-webview-scroll-routing.test.ts src/terminal/terminal-gesture-input.test.ts src/session/mobile-session-startup-source.test.ts src/session/mobile-terminal-records.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/sync-runtime-graph.test.ts src/main/runtime/orca-runtime.test.ts src/main/daemon/headless-emulator.test.ts
- pnpm run typecheck
- pnpm run typecheck:web
- cd mobile && pnpm exec tsc --noEmit
- git diff --check