### PR TITLE
Fix Claude approval status clearing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install native build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3 zsh
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1235,6 +1235,100 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('lets Claude permission clear when approved PostToolUse matches the preceding tool use id', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postClaudeHook = async (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await postClaudeHook({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/orca-2824-permission-target' },
+        tool_use_id: 'toolu-approved-by-claude'
+      })
+      await postClaudeHook({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/orca-2824-permission-target' }
+      })
+      await postClaudeHook({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/orca-2824-permission-target' },
+        tool_use_id: 'toolu-approved-by-claude'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'working',
+          agentType: 'claude',
+          toolName: 'Bash',
+          toolInput: 'rm -rf /tmp/orca-2824-permission-target'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('keeps Claude permission visible when another tool use completes after permission', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postClaudeHook = async (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await postClaudeHook({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm test' },
+        tool_use_id: 'toolu-permission-owner'
+      })
+      await postClaudeHook({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm test' }
+      })
+      await postClaudeHook({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm test' },
+        tool_use_id: 'toolu-other-subagent'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'waiting',
+          agentType: 'claude',
+          toolName: 'Bash',
+          toolInput: 'pnpm test'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
   it('lets Claude permission clear when same explicit agent type starts the approved tool', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1282,6 +1282,98 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('lets Claude permission clear by tool use id when tool input is not previewable', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postClaudeHook = async (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await postClaudeHook({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'BespokeTool',
+        tool_input: { opaque: 'request-a' },
+        tool_use_id: 'toolu-approved-opaque'
+      })
+      await postClaudeHook({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'BespokeTool',
+        tool_input: { opaque: 'request-a' }
+      })
+      await postClaudeHook({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'BespokeTool',
+        tool_input: { opaque: 'request-a' },
+        tool_use_id: 'toolu-approved-opaque'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'working',
+          agentType: 'claude',
+          toolName: 'BespokeTool'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('keeps Claude permission visible for unpreviewable tool input with another tool use id', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postClaudeHook = async (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await postClaudeHook({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'BespokeTool',
+        tool_input: { opaque: 'request-a' },
+        tool_use_id: 'toolu-permission-owner-opaque'
+      })
+      await postClaudeHook({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'BespokeTool',
+        tool_input: { opaque: 'request-a' }
+      })
+      await postClaudeHook({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'BespokeTool',
+        tool_input: { opaque: 'request-b' },
+        tool_use_id: 'toolu-other-opaque'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'waiting',
+          agentType: 'claude',
+          toolName: 'BespokeTool'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
   it('keeps Claude permission visible when another tool use completes after permission', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })
@@ -1313,6 +1405,56 @@ describe('AgentHookServer listener replay', () => {
         tool_name: 'Bash',
         tool_input: { command: 'pnpm test' },
         tool_use_id: 'toolu-other-subagent'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'waiting',
+          agentType: 'claude',
+          toolName: 'Bash',
+          toolInput: 'pnpm test'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('keeps Claude permission visible when an explicit agent type reports another tool use id', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postClaudeHook = async (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await postClaudeHook({
+        hook_event_name: 'PreToolUse',
+        agent_type: 'main',
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm test' },
+        tool_use_id: 'toolu-permission-owner-type'
+      })
+      await postClaudeHook({
+        hook_event_name: 'PermissionRequest',
+        agent_type: 'main',
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm test' }
+      })
+      await postClaudeHook({
+        hook_event_name: 'PostToolUse',
+        agent_type: 'main',
+        tool_name: 'Bash',
+        tool_input: { command: 'pnpm test' },
+        tool_use_id: 'toolu-other-type'
       })
 
       expect(server.getStatusSnapshot()).toEqual([

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -269,17 +269,72 @@ function isClaudePermissionResumingApprovedTool(
     hasMatchingConcreteAgentId &&
     previous.payload.toolInput === undefined &&
     next.payload.toolInput === undefined
+  const hasMatchingToolUseId =
+    typeof previous.toolUseId === 'string' &&
+    previous.toolUseId.trim().length > 0 &&
+    previous.toolUseId === next.toolUseId
 
   return (
-    next.hookEventName === 'PreToolUse' &&
+    (next.hookEventName === 'PreToolUse' || next.hookEventName === 'PostToolUse') &&
     typeof next.toolUseId === 'string' &&
     next.toolUseId.trim().length > 0 &&
     // Why: subagents can share `agent_type`; a concrete agent id is the
     // strongest available signal that the permission owner resumed execution.
-    (hasMatchingConcreteAgentId || hasSameExplicitAgentType) &&
+    // Claude's approval path omits identity but preserves the original
+    // tool_use_id on PostToolUse, so that exact id is also a safe clear signal.
+    (hasMatchingConcreteAgentId || hasSameExplicitAgentType || hasMatchingToolUseId) &&
     sameToolName &&
     (sameKnownToolInput || sameUnknownInputFromConcreteAgent)
   )
+}
+
+function shouldInheritClaudeToolUseIdForPermission(
+  previous: EnrichedAgentHookEventPayload | undefined,
+  next: AgentHookEventPayload
+): boolean {
+  if (
+    previous?.payload.agentType !== 'claude' ||
+    previous.payload.state !== 'working' ||
+    previous.hookEventName !== 'PreToolUse' ||
+    typeof previous.toolUseId !== 'string' ||
+    previous.toolUseId.trim().length === 0 ||
+    next.payload.agentType !== 'claude' ||
+    next.payload.state !== 'waiting' ||
+    next.hookEventName !== 'PermissionRequest' ||
+    next.toolUseId !== undefined
+  ) {
+    return false
+  }
+  if (
+    previous.toolAgentId !== next.toolAgentId ||
+    previous.toolAgentType !== next.toolAgentType ||
+    previous.payload.toolName === undefined ||
+    previous.payload.toolName !== next.payload.toolName ||
+    previous.payload.toolInput === undefined ||
+    previous.payload.toolInput !== next.payload.toolInput
+  ) {
+    return false
+  }
+  return true
+}
+
+function attachClaudePermissionToolUseId(
+  previous: EnrichedAgentHookEventPayload | undefined,
+  next: AgentHookEventPayload
+): AgentHookEventPayload {
+  const inheritedToolUseId = previous?.toolUseId
+  if (
+    !shouldInheritClaudeToolUseIdForPermission(previous, next) ||
+    typeof inheritedToolUseId !== 'string'
+  ) {
+    return next
+  }
+  return {
+    ...next,
+    // Why: Claude emits PermissionRequest without tool_use_id, then reports the
+    // approved command as PostToolUse with the original PreToolUse id.
+    toolUseId: inheritedToolUseId
+  }
 }
 
 export class AgentHookServer {
@@ -466,7 +521,8 @@ export class AgentHookServer {
     const previous = this.state.lastStatusByPaneKey.get(payload.paneKey) as
       | EnrichedAgentHookEventPayload
       | undefined
-    if (previous && shouldKeepClaudePermissionVisible(previous, payload)) {
+    const effectivePayload = attachClaudePermissionToolUseId(previous, payload)
+    if (previous && shouldKeepClaudePermissionVisible(previous, effectivePayload)) {
       return previous
     }
     // Why: some TUIs can emit a delayed tool/working hook after Ctrl+C already
@@ -474,9 +530,9 @@ export class AgentHookServer {
     if (
       previous?.payload.state === 'done' &&
       previous.payload.interrupted === true &&
-      payload.payload.state === 'done' &&
-      previous.payload.agentType === payload.payload.agentType &&
-      previous.payload.prompt === payload.payload.prompt &&
+      effectivePayload.payload.state === 'done' &&
+      previous.payload.agentType === effectivePayload.payload.agentType &&
+      previous.payload.prompt === effectivePayload.payload.prompt &&
       Date.now() - previous.receivedAt <= INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS
     ) {
       return previous
@@ -484,19 +540,22 @@ export class AgentHookServer {
     if (
       previous?.payload.state === 'done' &&
       previous.payload.interrupted === true &&
-      payload.payload.state === 'working' &&
-      previous.payload.agentType === payload.payload.agentType &&
-      previous.payload.prompt === payload.payload.prompt &&
-      (payload.isReplay === true ||
-        (payload.hasExplicitPrompt !== true &&
+      effectivePayload.payload.state === 'working' &&
+      previous.payload.agentType === effectivePayload.payload.agentType &&
+      previous.payload.prompt === effectivePayload.payload.prompt &&
+      (effectivePayload.isReplay === true ||
+        (effectivePayload.hasExplicitPrompt !== true &&
           Date.now() - previous.receivedAt <= INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS))
     ) {
       return previous
     }
-    if (payload.payload.state !== 'done' || payload.payload.lastAssistantMessage) {
-      this.clearAssistantMessageRetry(payload.paneKey)
+    if (
+      effectivePayload.payload.state !== 'done' ||
+      effectivePayload.payload.lastAssistantMessage
+    ) {
+      this.clearAssistantMessageRetry(effectivePayload.paneKey)
     }
-    const enriched = this.attachStatusTiming(payload)
+    const enriched = this.attachStatusTiming(effectivePayload)
     this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
     this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
     this.scheduleStatusPersist()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -251,6 +251,8 @@ function isClaudePermissionResumingApprovedTool(
   previous: EnrichedAgentHookEventPayload,
   next: AgentHookEventPayload
 ): boolean {
+  const previousToolUseId = previous.toolUseId?.trim() || undefined
+  const nextToolUseId = next.toolUseId?.trim() || undefined
   const previousAgentId = previous.toolAgentId?.trim() || undefined
   const nextAgentId = next.toolAgentId?.trim() || undefined
   const hasAgentId = previousAgentId !== undefined || nextAgentId !== undefined
@@ -270,21 +272,27 @@ function isClaudePermissionResumingApprovedTool(
     previous.payload.toolInput === undefined &&
     next.payload.toolInput === undefined
   const hasMatchingToolUseId =
-    typeof previous.toolUseId === 'string' &&
-    previous.toolUseId.trim().length > 0 &&
-    previous.toolUseId === next.toolUseId
+    previousToolUseId !== undefined && previousToolUseId === nextToolUseId
+  const hasConflictingToolUseId =
+    previousToolUseId !== undefined &&
+    nextToolUseId !== undefined &&
+    previousToolUseId !== nextToolUseId
+  const sameUnknownInputFromToolUseId =
+    hasMatchingToolUseId &&
+    previous.payload.toolInput === undefined &&
+    next.payload.toolInput === undefined
 
   return (
     (next.hookEventName === 'PreToolUse' || next.hookEventName === 'PostToolUse') &&
-    typeof next.toolUseId === 'string' &&
-    next.toolUseId.trim().length > 0 &&
+    nextToolUseId !== undefined &&
+    !hasConflictingToolUseId &&
     // Why: subagents can share `agent_type`; a concrete agent id is the
     // strongest available signal that the permission owner resumed execution.
     // Claude's approval path omits identity but preserves the original
     // tool_use_id on PostToolUse, so that exact id is also a safe clear signal.
     (hasMatchingConcreteAgentId || hasSameExplicitAgentType || hasMatchingToolUseId) &&
     sameToolName &&
-    (sameKnownToolInput || sameUnknownInputFromConcreteAgent)
+    (sameKnownToolInput || sameUnknownInputFromConcreteAgent || sameUnknownInputFromToolUseId)
   )
 }
 
@@ -305,13 +313,17 @@ function shouldInheritClaudeToolUseIdForPermission(
   ) {
     return false
   }
+  const sameKnownToolInput =
+    previous.payload.toolInput !== undefined &&
+    previous.payload.toolInput === next.payload.toolInput
+  const sameUnknownToolInput =
+    previous.payload.toolInput === undefined && next.payload.toolInput === undefined
   if (
     previous.toolAgentId !== next.toolAgentId ||
     previous.toolAgentType !== next.toolAgentType ||
     previous.payload.toolName === undefined ||
     previous.payload.toolName !== next.payload.toolName ||
-    previous.payload.toolInput === undefined ||
-    previous.payload.toolInput !== next.payload.toolInput
+    (!sameKnownToolInput && !sameUnknownToolInput)
   ) {
     return false
   }

--- a/src/relay/agent-hook-integration.test.ts
+++ b/src/relay/agent-hook-integration.test.ts
@@ -212,6 +212,65 @@ describe('Integration: relay hook server → mux → AgentHookServer.ingestRemot
     ])
   })
 
+  it('clears remote Claude permission when approved PostToolUse matches the preceding tool use id', async () => {
+    const { port, token } = hookServer.getCoordinates()
+    const postClaude = async (payload: Record<string, unknown>): Promise<Response> =>
+      fetch(`http://127.0.0.1:${port}/hook/claude`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': token
+        },
+        body: JSON.stringify({
+          paneKey: `tab-7:${LEAF_7}`,
+          tabId: 'tab-7',
+          worktreeId: 'wt-7',
+          env: 'remote',
+          version: '1',
+          payload
+        })
+      })
+
+    await expect(
+      postClaude({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/orca-2824-permission-target' },
+        tool_use_id: 'toolu-approved-remote-post'
+      })
+    ).resolves.toMatchObject({ status: 204 })
+    await expect(
+      postClaude({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/orca-2824-permission-target' }
+      })
+    ).resolves.toMatchObject({ status: 204 })
+    await expect(
+      postClaude({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/orca-2824-permission-target' },
+        tool_use_id: 'toolu-approved-remote-post'
+      })
+    ).resolves.toMatchObject({ status: 204 })
+
+    const start = Date.now()
+    while (orcaServer.getStatusSnapshot()[0]?.state !== 'working' && Date.now() - start < 1500) {
+      await new Promise((r) => setImmediate(r))
+    }
+    expect(orcaServer.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: `tab-7:${LEAF_7}`,
+        connectionId: 'conn-test',
+        state: 'working',
+        agentType: 'claude',
+        toolName: 'Bash',
+        toolInput: 'rm -rf /tmp/orca-2824-permission-target'
+      })
+    ])
+  })
+
   it('replays the cached last-status on agent_hook.requestReplay', async () => {
     // Why: register the listener BEFORE the initial POST so live notifications
     // are observed. setListener on a non-empty cache replays cached entries


### PR DESCRIPTION
## Summary
- Preserve Claude `tool_use_id` across `PermissionRequest` events when the preceding `PreToolUse` matches the same tool
- Clear the sticky permission state when the approved `PostToolUse` reports that `tool_use_id`, including unpreviewable tool inputs
- Keep permission visible when a different `tool_use_id` completes, even with matching tool name or explicit agent type
- Add local and SSH/relay regressions for the reproduced approval sequence
- Install `zsh` in PR checks so shell-ready tests run on Ubuntu CI

Fixes #2824

## Verification
- `pnpm test src/main/agent-hooks/server.test.ts -t "approved PostToolUse matches the preceding tool use id|tool input is not previewable|unpreviewable tool input with another tool use id|explicit agent type reports another tool use id|same explicit agent type starts the approved tool"`
- `pnpm test src/main/agent-hooks/server.test.ts src/shared/agent-hook-listener.test.ts src/relay/agent-hook-server.test.ts src/relay/agent-hook-integration.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts src/relay/agent-hook-integration.test.ts`
- `pnpm exec oxfmt --check src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts src/relay/agent-hook-integration.test.ts`
- `git diff --check`
- `pnpm test src/main/providers/__tests__/shell-ready-framework-example.test.ts`
- GitHub PR Checks / `verify`: passed