### PR TITLE
fix(checks): force-refresh CI checks after push regardless of headSha propagation

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -148,6 +148,10 @@ export default function ChecksPanel(): React.JSX.Element {
   const sshConnectionStatus = useAppStore((s) =>
     repoConnectionId ? s.sshConnectionStates.get(repoConnectionId)?.status : undefined
   )
+  const checksPostPushNonce = useAppStore((s) =>
+    activeWorktreeId ? (s.checksPostPushNonceByWorktree?.[activeWorktreeId] ?? 0) : 0
+  )
+  const lastSeenPostPushNonceRef = useRef(checksPostPushNonce)
   const panelContextKey = buildChecksPanelGitStatusContextKey({
     repoId: repo?.id,
     worktreeId: activeWorktreeId,
@@ -191,6 +195,7 @@ export default function ChecksPanel(): React.JSX.Element {
     prevChecksRef.current = ''
     conflictSummaryRefreshKeyRef.current = null
     refreshRequestKeyRef.current = null
+    lastSeenPostPushNonceRef.current = checksPostPushNonce
     if (gitStatusSnapshotRetryTimerRef.current) {
       clearTimeout(gitStatusSnapshotRetryTimerRef.current)
       gitStatusSnapshotRetryTimerRef.current = null
@@ -1001,6 +1006,22 @@ export default function ChecksPanel(): React.JSX.Element {
     prevChecksRef.current = ''
     handleEntryRefresh({ refreshChecks, refreshComments })
   }, [entryKey, prFetchedAt, checksFetchedAt, commentsFetchedAt, prNumber, handleEntryRefresh])
+
+  // Why: after a push the checksCache is invalidated and the nonce is bumped
+  // so the panel re-fetches CI checks immediately, even when GitHub's API
+  // hasn't propagated the new headSha yet (POST_PUSH_DELAY_MS is only 2.5 s).
+  useEffect(() => {
+    if (!isPanelVisible || !prNumber) {
+      return
+    }
+    if (checksPostPushNonce <= lastSeenPostPushNonceRef.current) {
+      return
+    }
+    lastSeenPostPushNonceRef.current = checksPostPushNonce
+    pollIntervalRef.current = 30_000
+    prevChecksRef.current = ''
+    void fetchChecks({ force: true })
+  }, [checksPostPushNonce, isPanelVisible, prNumber, fetchChecks])
 
   const handleStartEdit = useCallback(() => {
     if (!pr) {

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -581,6 +581,89 @@ describe('createGitHubSlice.fetchPRChecks', () => {
     expect(store.getState().prCache[repoScopedKey]?.data?.checksStatus).toBe('success')
     expect(store.getState().prCache[pathScopedKey]?.data?.checksStatus).toBe('pending')
   })
+
+  it('lets a forced checks refresh bypass a non-forced inflight request and keep the newer cache result', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-id'
+    const branch = 'feature/test'
+    const headSha = 'head-old'
+    const prCacheKey = `${repoId}::${branch}`
+    const checksCacheKey = `${repoId}::${prChecksCacheSuffix(12, null, headSha)}`
+    const staleChecks = [
+      { name: 'build', status: 'completed', conclusion: 'success', url: null } as const
+    ]
+    const freshChecks = [
+      { name: 'build', status: 'in_progress', conclusion: 'pending', url: null } as const
+    ]
+    let resolveInitial: (value: typeof staleChecks) => void = () => {}
+    const initialRequest = new Promise<typeof staleChecks>((resolve) => {
+      resolveInitial = resolve
+    })
+
+    store.setState({
+      prCache: {
+        [prCacheKey]: {
+          data: makePR({ headSha, checksStatus: 'pending' }),
+          fetchedAt: 1
+        }
+      }
+    })
+    mockApi.gh.prChecks.mockReturnValueOnce(initialRequest).mockResolvedValueOnce(freshChecks)
+
+    const initialFetch = store
+      .getState()
+      .fetchPRChecks(repoPath, 12, branch, headSha, null, { repoId })
+    await Promise.resolve()
+    const forcedFetch = store
+      .getState()
+      .fetchPRChecks(repoPath, 12, branch, headSha, null, { force: true, repoId })
+
+    await expect(forcedFetch).resolves.toEqual(freshChecks)
+    expect(mockApi.gh.prChecks).toHaveBeenCalledTimes(2)
+    expect(mockApi.gh.prChecks).toHaveBeenNthCalledWith(2, {
+      repoPath,
+      repoId,
+      prNumber: 12,
+      headSha,
+      prRepo: null,
+      noCache: true
+    })
+
+    resolveInitial(staleChecks)
+    await expect(initialFetch).resolves.toEqual(staleChecks)
+
+    expect(store.getState().checksCache[checksCacheKey]?.data).toEqual(freshChecks)
+    expect(store.getState().prCache[prCacheKey]?.data?.checksStatus).toBe('pending')
+  })
+
+  it('dedupes concurrent forced checks refreshes to avoid duplicate API calls', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-id'
+    const branch = 'feature/test'
+    const checks = [
+      { name: 'build', status: 'completed', conclusion: 'success', url: null } as const
+    ]
+    let resolveChecks: (value: typeof checks) => void = () => {}
+    const request = new Promise<typeof checks>((resolve) => {
+      resolveChecks = resolve
+    })
+
+    mockApi.gh.prChecks.mockReturnValueOnce(request)
+    const firstFetch = store
+      .getState()
+      .fetchPRChecks(repoPath, 12, branch, 'head-a', null, { force: true, repoId })
+    const secondFetch = store
+      .getState()
+      .fetchPRChecks(repoPath, 12, branch, 'head-a', null, { force: true, repoId })
+
+    resolveChecks(checks)
+    await expect(firstFetch).resolves.toEqual(checks)
+    await expect(secondFetch).resolves.toEqual(checks)
+
+    expect(mockApi.gh.prChecks).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('createGitHubSlice.fetchPRComments', () => {
@@ -2594,6 +2677,107 @@ describe('createGitHubSlice.refreshGitHubForWorktree', () => {
       params: { repo: 'repo-1', branch, linkedPRNumber: null },
       timeoutMs: 30_000
     })
+  })
+
+  it('invalidates cached PR checks and bumps a post-push nonce for a cached GitHub PR', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/checks'
+    const worktreeId = 'wt-checks'
+    const prRepo = { owner: 'Acme', repo: 'Widgets' }
+    const headChecksKey = `${repoId}::${prChecksCacheSuffix(12, prRepo, 'head-a')}`
+    const legacyChecksKey = `${repoId}::${prChecksCacheSuffix(12, prRepo)}`
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          {
+            id: worktreeId,
+            repoId,
+            path: '/repo/worktrees/checks',
+            branch,
+            displayName: 'checks',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false
+          }
+        ]
+      },
+      prCache: {
+        [`${repoId}::${branch}`]: {
+          data: makePR({ number: 12, headSha: 'head-a', prRepo }),
+          fetchedAt: 100
+        }
+      },
+      checksCache: {
+        [headChecksKey]: {
+          data: [{ name: 'build', status: 'completed', conclusion: 'success', url: null }],
+          fetchedAt: 100,
+          headSha: 'head-a'
+        },
+        [legacyChecksKey]: {
+          data: [{ name: 'legacy', status: 'completed', conclusion: 'success', url: null }],
+          fetchedAt: 100,
+          headSha: 'head-a'
+        }
+      }
+    } as unknown as Partial<AppState>)
+
+    store.getState().refreshGitHubForWorktree(worktreeId)
+
+    expect(store.getState().checksCache[headChecksKey]?.fetchedAt).toBe(0)
+    expect(store.getState().checksCache[legacyChecksKey]?.fetchedAt).toBe(0)
+    expect(store.getState().checksPostPushNonceByWorktree[worktreeId]).toBe(1)
+  })
+
+  it('does not emit a GitHub checks post-push nonce for a GitLab-only worktree', () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/gitlab'
+    const worktreeId = 'wt-gitlab'
+    const hostedReviewCacheKey = getHostedReviewCacheKey(repoPath, branch, null, repoId)
+
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }],
+      worktreesByRepo: {
+        [repoId]: [
+          {
+            id: worktreeId,
+            repoId,
+            path: '/repo/worktrees/gitlab',
+            branch,
+            displayName: 'gitlab',
+            isMainWorktree: false,
+            isBare: false,
+            isArchived: false,
+            linkedGitLabMR: 7
+          }
+        ]
+      },
+      hostedReviewCache: {
+        [hostedReviewCacheKey]: {
+          data: {
+            provider: 'gitlab',
+            number: 7,
+            title: 'GitLab MR',
+            state: 'open',
+            url: 'https://gitlab.com/acme/widgets/-/merge_requests/7',
+            status: 'pending',
+            updatedAt: '2026-05-26T00:00:00Z',
+            mergeable: 'UNKNOWN'
+          },
+          fetchedAt: 100
+        }
+      },
+      checksPostPushNonceByWorktree: { [worktreeId]: 3 }
+    } as unknown as Partial<AppState>)
+
+    store.getState().refreshGitHubForWorktree(worktreeId)
+
+    expect(store.getState().checksPostPushNonceByWorktree[worktreeId]).toBe(3)
   })
 })
 

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -960,6 +960,7 @@ export type GitHubSlice = {
   prRefreshSequences: Record<string, number>
   prRefreshStates: Record<string, PRRefreshState>
   prVisibleRefreshGeneration: number
+  checksPostPushNonceByWorktree: Record<string, number>
   // Why: keyed by repoId + limit + query so remote repos with the same path on
   // different SSH targets do not share issue/PR results.
   // from cache instantly on mount (and on hover-prefetch from sidebar buttons)
@@ -1162,6 +1163,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   prRefreshSequences: {},
   prRefreshStates: {},
   prVisibleRefreshGeneration: 0,
+  checksPostPushNonceByWorktree: {},
   workItemsCache: {},
   workItemsInvalidationNonce: 0,
   projectViewCache: {},
@@ -2595,6 +2597,48 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           ...s.issueCache,
           [issueKey]: { ...s.issueCache[issueKey], fetchedAt: 0 }
         }
+      }
+      // Invalidate the CI checks cache so a post-push fetch bypasses the TTL
+      // even when GitHub's API hasn't propagated the new headSha yet.
+      const prData = s.prCache[prKey]?.data
+      if (prData?.number) {
+        const checksKeysToInvalidate = [
+          prData.headSha
+            ? runtimeScopedRepoCacheKey(
+                repo.path,
+                repo.id,
+                prChecksCacheSuffix(prData.number, prData.prRepo, prData.headSha),
+                s.settings,
+                repo.connectionId
+              )
+            : null,
+          runtimeScopedRepoCacheKey(
+            repo.path,
+            repo.id,
+            prChecksCacheSuffix(prData.number, prData.prRepo),
+            s.settings,
+            repo.connectionId
+          )
+        ]
+        let nextChecksCache = s.checksCache
+        let checksChanged = false
+        for (const key of checksKeysToInvalidate) {
+          if (key && nextChecksCache[key]) {
+            nextChecksCache = {
+              ...nextChecksCache,
+              [key]: { ...nextChecksCache[key], fetchedAt: 0 }
+            }
+            checksChanged = true
+          }
+        }
+        if (checksChanged) {
+          updates.checksCache = nextChecksCache
+        }
+      }
+      // Signal the Checks panel to force-refresh immediately if it is open.
+      updates.checksPostPushNonceByWorktree = {
+        ...s.checksPostPushNonceByWorktree,
+        [worktreeId]: (s.checksPostPushNonceByWorktree[worktreeId] ?? 0) + 1
       }
       return updates
     })

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -348,7 +348,10 @@ const inflightPRRequests = new Map<
   { promise: Promise<PRInfo | null>; force: boolean; generation: number; lookupHintKey: string }
 >()
 const inflightIssueRequests = new Map<string, Promise<IssueInfo | null>>()
-const inflightChecksRequests = new Map<string, Promise<PRCheckDetail[]>>()
+const inflightChecksRequests = new Map<
+  string,
+  { promise: Promise<PRCheckDetail[]>; force: boolean; generation: number }
+>()
 const inflightCommentsRequests = new Map<string, Promise<PRComment[]>>()
 type InflightWorkItems = {
   promise: Promise<GitHubWorkItem[]>
@@ -356,6 +359,7 @@ type InflightWorkItems = {
 }
 const inflightWorkItemsRequests = new Map<string, InflightWorkItems>()
 const prRequestGenerations = new Map<string, number>()
+const checksRequestGenerations = new Map<string, number>()
 const prRefreshStartedHostedReviewEntries = new Map<
   string,
   AppState['hostedReviewCache'][string] | undefined
@@ -2091,10 +2095,12 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     }
 
     const inflightRequest = inflightChecksRequests.get(inflightKey)
-    if (inflightRequest) {
-      return inflightRequest
+    if (inflightRequest && (!options?.force || inflightRequest.force)) {
+      return inflightRequest.promise
     }
 
+    const generation = (checksRequestGenerations.get(inflightKey) ?? 0) + 1
+    checksRequestGenerations.set(inflightKey, generation)
     const request = (async () => {
       try {
         const runtimeRepo = getRuntimeRepoTarget(get(), repoPath, requestSettings)
@@ -2119,6 +2125,11 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               prRepo: prRepo ?? null,
               noCache: options?.force
             })) as PRCheckDetail[])
+        // Why: a post-push force refresh must beat an older polling request for
+        // the same stale head SHA; otherwise stale checks can overwrite fresh.
+        if (checksRequestGenerations.get(inflightKey) !== generation) {
+          return checks
+        }
         set((s) => {
           const nextState: Partial<AppState> = {
             checksCache: {
@@ -2154,11 +2165,18 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         }
         return []
       } finally {
-        inflightChecksRequests.delete(inflightKey)
+        const activeRequest = inflightChecksRequests.get(inflightKey)
+        if (activeRequest?.generation === generation) {
+          inflightChecksRequests.delete(inflightKey)
+        }
       }
     })()
 
-    inflightChecksRequests.set(inflightKey, request)
+    inflightChecksRequests.set(inflightKey, {
+      promise: request,
+      force: Boolean(options?.force),
+      generation
+    })
     return request
   },
 
@@ -2634,11 +2652,12 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         if (checksChanged) {
           updates.checksCache = nextChecksCache
         }
-      }
-      // Signal the Checks panel to force-refresh immediately if it is open.
-      updates.checksPostPushNonceByWorktree = {
-        ...s.checksPostPushNonceByWorktree,
-        [worktreeId]: (s.checksPostPushNonceByWorktree[worktreeId] ?? 0) + 1
+        // Why: this is a GitHub PR-only signal; GitLab/other hosted reviews
+        // should not see a checks refresh event from the GitHub slice.
+        updates.checksPostPushNonceByWorktree = {
+          ...s.checksPostPushNonceByWorktree,
+          [worktreeId]: (s.checksPostPushNonceByWorktree[worktreeId] ?? 0) + 1
+        }
       }
       return updates
     })


### PR DESCRIPTION
## Summary

- **Root cause**: `refreshGitHubForWorktree` (called after push) re-fetches the PR. If GitHub's API returns the same `headSha` within the 2.5s `POST_PUSH_DELAY_MS`, the `fetchChecks` useCallback reference doesn't change → the polling effect doesn't restart → stale CI checks remain for up to 120s (exponential backoff max).
- **Fix 1 (checksCache invalidation)**: `refreshGitHubForWorktree` now sets `fetchedAt: 0` on both the headSha-keyed and legacy checks cache entries for the current PR, so any subsequent `fetchPRChecks` call bypasses the 60s TTL regardless of whether the PR headSha has propagated.
- **Fix 2 (immediate force-refresh)**: Adds `checksPostPushNonceByWorktree` to the store. The nonce is bumped in `refreshGitHubForWorktree`. `ChecksPanel` subscribes to it and calls `fetchChecks({ force: true })` + resets exponential backoff immediately when the panel is visible.

## Test plan

- [ ] Push a commit via Orca's Push button with the Checks panel open → CI checks should immediately show the new headSha's (pending) checks, not the old commit's results
- [ ] Push a commit, close the Checks panel, then re-open it → should show fresh checks (cache was invalidated)
- [ ] Switch worktrees → no spurious refresh (nonce reset guards against this)
- [ ] Manual refresh button still works as before

Closes #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.

## ELI5

After push, CI checks could stay stale up to two minutes if GitHub still reported the old commit SHA. Checks cache is force-invalidated so fresh status loads.
