### PR TITLE
fix(sidebar): indent worktree rows under their project header

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -100,6 +100,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
     React.createElement(React.Fragment, null, children),
   DropdownMenuItem: ({ children }: { children: React.ReactNode }) =>
     React.createElement('div', null, children),
+  DropdownMenuSeparator: () => React.createElement('hr'),
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children)
 }))
@@ -229,17 +230,21 @@ function setLineageFixtureState(groupBy: 'none' | 'repo' = 'none'): void {
   }
 }
 
+async function renderWorktreeListMarkup(): Promise<string> {
+  const { default: WorktreeList } = await import('./WorktreeList')
+
+  return renderToStaticMarkup(
+    React.createElement(WorktreeList, {
+      scrollOffsetRef: { current: 0 },
+      scrollAnchorRef: { current: null }
+    })
+  )
+}
+
 describe('WorktreeList lineage child card renderer', () => {
   it('renders nested inline agent rows before the nested child-count toggle', async () => {
     setLineageFixtureState()
-    const { default: WorktreeList } = await import('./WorktreeList')
-
-    const markup = renderToStaticMarkup(
-      React.createElement(WorktreeList, {
-        scrollOffsetRef: { current: 0 },
-        scrollAnchorRef: { current: null }
-      })
-    )
+    const markup = await renderWorktreeListMarkup()
 
     const childStart = markup.indexOf('lineage child with agent')
     const agentRowIndex = markup.indexOf('Review fixture prompt', childStart)
@@ -253,18 +258,20 @@ describe('WorktreeList lineage child card renderer', () => {
 
   it('does not add group indentation when grouping is disabled', async () => {
     setLineageFixtureState('none')
-    const { default: WorktreeList } = await import('./WorktreeList')
-
-    const markup = renderToStaticMarkup(
-      React.createElement(WorktreeList, {
-        scrollOffsetRef: { current: 0 },
-        scrollAnchorRef: { current: null }
-      })
-    )
+    const markup = await renderWorktreeListMarkup()
 
     const parentRow = markup.match(/<div[^>]*id="worktree-list-option-parent"[^>]*>/)?.[0] ?? ''
 
     expect(parentRow).toContain('id="worktree-list-option-parent"')
     expect(parentRow).not.toContain('padding-left')
+  })
+
+  it('adds one group indentation step when grouped by project', async () => {
+    setLineageFixtureState('repo')
+    const markup = await renderWorktreeListMarkup()
+
+    const parentRow = markup.match(/<div[^>]*id="worktree-list-option-parent"[^>]*>/)?.[0] ?? ''
+
+    expect(parentRow).toContain('style="padding-left:18px"')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -155,7 +155,7 @@ function makeLineage(worktree: Worktree, parent: Worktree): WorktreeLineage {
   }
 }
 
-function setLineageFixtureState(): void {
+function setLineageFixtureState(groupBy: 'none' | 'repo' = 'none'): void {
   const repo = makeRepo()
   const parent = makeWorktree({
     id: 'parent',
@@ -188,7 +188,7 @@ function setLineageFixtureState(): void {
     clearPendingRevealWorktreeId: vi.fn(),
     collapsedGroups: new Set<string>(),
     filterRepoIds: [],
-    groupBy: 'none',
+    groupBy,
     hideDefaultBranchWorkspace: false,
     issueCache: {},
     migrationUnsupportedByPtyId: {},
@@ -249,5 +249,22 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(agentRowIndex).toBeGreaterThan(childStart)
     expect(childToggleIndex).toBeGreaterThan(childStart)
     expect(agentRowIndex).toBeLessThan(childToggleIndex)
+  })
+
+  it('does not add group indentation when grouping is disabled', async () => {
+    setLineageFixtureState('none')
+    const { default: WorktreeList } = await import('./WorktreeList')
+
+    const markup = renderToStaticMarkup(
+      React.createElement(WorktreeList, {
+        scrollOffsetRef: { current: 0 },
+        scrollAnchorRef: { current: null }
+      })
+    )
+
+    const parentRow = markup.match(/<div[^>]*id="worktree-list-option-parent"[^>]*>/)?.[0] ?? ''
+
+    expect(parentRow).toContain('id="worktree-list-option-parent"')
+    expect(parentRow).not.toContain('padding-left')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2233,9 +2233,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               // Why: child cards render inside the parent card body, so their
               // first nested level starts flush with that inset.
               const paddingDepth = nested ? Math.max(0, itemRow.depth - 1) : itemRow.depth
-              // Why: nested cards inherit the parent row's base indent, so only
-              // top-level rows add the group inset.
-              const basePadding = nested ? 0 : WORKTREE_GROUP_INDENT
+              // Why: ungrouped mode keeps workspace cards flush; grouped modes
+              // indent top-level cards under their visible section header.
+              const basePadding = !nested && groupBy !== 'none' ? WORKTREE_GROUP_INDENT : 0
               const paddingLeft = basePadding + paddingDepth * LINEAGE_INDENT
               const worktreeDragGroupKey = groupKeyByWorktreeId.get(itemRow.worktree.id)
               const worktreeDragGroupIndex = groupIndexByWorktreeId.get(itemRow.worktree.id)

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -274,6 +274,9 @@ function getWorktreeVisibilityMenuLabel(repo: Repo): string {
 }
 
 const LINEAGE_INDENT = 18
+// Why: top-level worktrees are children of their project header; indent the
+// group one step so the status dots nest under the folder icon for hierarchy.
+const WORKTREE_GROUP_INDENT = 18
 const SIDEBAR_POINTER_DRAG_THRESHOLD_PX = 4
 
 type VirtualizedWorktreeViewportProps = {
@@ -2230,6 +2233,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               // Why: child cards render inside the parent card body, so their
               // first nested level starts flush with that inset.
               const paddingDepth = nested ? Math.max(0, itemRow.depth - 1) : itemRow.depth
+              // Why: nested cards inherit the parent row's base indent, so only
+              // top-level rows add the group inset.
+              const basePadding = nested ? 0 : WORKTREE_GROUP_INDENT
+              const paddingLeft = basePadding + paddingDepth * LINEAGE_INDENT
               const worktreeDragGroupKey = groupKeyByWorktreeId.get(itemRow.worktree.id)
               const worktreeDragGroupIndex = groupIndexByWorktreeId.get(itemRow.worktree.id)
               return (
@@ -2262,7 +2269,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     nested ? undefined : handleWorktreeRowPointerDown(event, itemRow.worktree.id)
                   }
                   style={{
-                    paddingLeft: paddingDepth > 0 ? `${paddingDepth * LINEAGE_INDENT}px` : undefined
+                    paddingLeft: paddingLeft > 0 ? `${paddingLeft}px` : undefined
                   }}
                 >
                   <WorktreeCard


### PR DESCRIPTION
## Summary

Top-level worktree rows in the Projects sidebar had no left padding, so their status dots sat flush with the project folder icon above them — leaving the list visually flat with no parent/child relationship. This indents each worktree group by one indent step so the dots nest under the folder icon, making it read as a hierarchy.

## What changed

- Added a `WORKTREE_GROUP_INDENT` constant (18px, reusing the existing `LINEAGE_INDENT` rhythm) and apply it as a base inset to top-level worktree rows.
- `paddingLeft` is now `basePadding + paddingDepth * LINEAGE_INDENT`. Nested/lineage cards render inside the parent card body and inherit that base inset, so they pass `basePadding = 0` and keep their existing relative indentation.

## Effect

The project folder icon stays put (~12px); worktree status dots shift from ~10px to ~28px, giving a clear parent→child hierarchy without disturbing nested-task indentation.

Renderer-only layout change.

<img width="300" src="https://github.com/user-attachments/assets/e7581fad-7640-4337-af57-2029a6aafa23" />

