### PR TITLE
refactor(sidebar): compact worktree cards and consolidate title-row icons

### DIFF
--- a/src/renderer/src/components/sidebar/CacheTimer.tsx
+++ b/src/renderer/src/components/sidebar/CacheTimer.tsx
@@ -17,21 +17,31 @@ import { getMostUrgentPromptCacheStartedAt } from './prompt-cache-timer-selectio
  * uncached input tokens — up to 10x more expensive. Showing a countdown lets
  * users decide whether to resume interaction before the cache drops.
  */
+/**
+ * The most-urgent cache start time when a countdown should show, else null.
+ * Shared so the worktree card can decide whether the timer occupies its
+ * metadata row without subscribing to the per-second tick.
+ */
+export function usePromptCacheCountdownStartedAt(worktreeId: string): number | null {
+  const enabled = useAppStore((s) => s.settings?.promptCacheTimerEnabled ?? false)
+  const ttlMs = useAppStore((s) => s.settings?.promptCacheTtlMs ?? 0)
+  const startedAt = useAppStore((s) =>
+    getMostUrgentPromptCacheStartedAt(s.tabsByWorktree[worktreeId], s.cacheTimerByKey)
+  )
+  return enabled && ttlMs > 0 && startedAt != null ? startedAt : null
+}
+
 export default function CacheTimer({
   worktreeId
 }: {
   worktreeId: string
 }): React.JSX.Element | null {
-  const enabled = useAppStore((s) => s.settings?.promptCacheTimerEnabled ?? false)
   const ttlMs = useAppStore((s) => s.settings?.promptCacheTtlMs ?? 0)
+  const startedAt = usePromptCacheCountdownStartedAt(worktreeId)
 
-  const mostUrgentStartedAt = useAppStore((s) => {
-    return getMostUrgentPromptCacheStartedAt(s.tabsByWorktree[worktreeId], s.cacheTimerByKey)
-  })
-
-  const countdownActive = enabled && mostUrgentStartedAt != null && ttlMs > 0
+  const countdownActive = startedAt != null
   const now = usePromptCacheCountdownNow(countdownActive)
-  const remainingMs = countdownActive ? Math.max(0, ttlMs - (now - mostUrgentStartedAt)) : null
+  const remainingMs = countdownActive ? Math.max(0, ttlMs - (now - startedAt)) : null
 
   if (remainingMs === null) {
     return null

--- a/src/renderer/src/components/sidebar/CacheTimer.tsx
+++ b/src/renderer/src/components/sidebar/CacheTimer.tsx
@@ -6,21 +6,13 @@ import { usePromptCacheCountdownNow } from './prompt-cache-countdown-clock'
 import { getMostUrgentPromptCacheStartedAt } from './prompt-cache-timer-selection'
 
 /**
- * Per-worktree prompt-cache countdown, shown in the sidebar worktree card.
- *
- * When a worktree has multiple Claude tabs, the timer shows the *most urgent*
- * (shortest remaining) countdown — if any tab's cache is about to expire, the
- * user should know.
- *
- * Why: prompt caching (Anthropic API / Bedrock) has a TTL (default 5 min).
- * When the cache expires, the next request re-sends the full conversation as
- * uncached input tokens — up to 10x more expensive. Showing a countdown lets
- * users decide whether to resume interaction before the cache drops.
- */
-/**
  * The most-urgent cache start time when a countdown should show, else null.
- * Shared so the worktree card can decide whether the timer occupies its
- * metadata row without subscribing to the per-second tick.
+ * The worktree card uses it to both gate its metadata row and feed CacheTimer,
+ * so neither the card nor the timer subscribes twice to the same store slices.
+ *
+ * When a worktree has multiple Claude tabs, this resolves the *most urgent*
+ * (shortest remaining) start time — if any tab's cache is about to expire, the
+ * user should know.
  */
 export function usePromptCacheCountdownStartedAt(worktreeId: string): number | null {
   const enabled = useAppStore((s) => s.settings?.promptCacheTimerEnabled ?? false)
@@ -31,21 +23,24 @@ export function usePromptCacheCountdownStartedAt(worktreeId: string): number | n
   return enabled && ttlMs > 0 && startedAt != null ? startedAt : null
 }
 
+/**
+ * Per-worktree prompt-cache countdown, shown in the sidebar worktree card. The
+ * card renders this only once a cache is active, so it's a pure countdown view.
+ *
+ * Why: prompt caching (Anthropic API / Bedrock) has a TTL (default 5 min).
+ * When the cache expires, the next request re-sends the full conversation as
+ * uncached input tokens — up to 10x more expensive. Showing a countdown lets
+ * users decide whether to resume interaction before the cache drops.
+ */
 export default function CacheTimer({
-  worktreeId
+  startedAt,
+  ttlMs
 }: {
-  worktreeId: string
-}): React.JSX.Element | null {
-  const ttlMs = useAppStore((s) => s.settings?.promptCacheTtlMs ?? 0)
-  const startedAt = usePromptCacheCountdownStartedAt(worktreeId)
-
-  const countdownActive = startedAt != null
-  const now = usePromptCacheCountdownNow(countdownActive)
-  const remainingMs = countdownActive ? Math.max(0, ttlMs - (now - startedAt)) : null
-
-  if (remainingMs === null) {
-    return null
-  }
+  startedAt: number
+  ttlMs: number
+}): React.JSX.Element {
+  const now = usePromptCacheCountdownNow(true)
+  const remainingMs = Math.max(0, ttlMs - (now - startedAt))
 
   const totalSeconds = Math.ceil(remainingMs / 1000)
   const minutes = Math.floor(totalSeconds / 60)

--- a/src/renderer/src/components/sidebar/WorktreeCard.lineage.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.lineage.test.tsx
@@ -43,7 +43,8 @@ vi.mock('@/components/ui/tooltip', () => ({
 }))
 
 vi.mock('./CacheTimer', () => ({
-  default: () => null
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
 }))
 
 vi.mock('./WorktreeCardAgents', () => ({

--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -52,7 +52,8 @@ vi.mock('./use-worktree-activity-status', () => ({
 }))
 
 vi.mock('./CacheTimer', () => ({
-  default: () => null
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
 }))
 
 vi.mock('./WorktreeCardAgents', () => ({

--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -52,7 +52,8 @@ vi.mock('./use-worktree-activity-status', () => ({
 }))
 
 vi.mock('./CacheTimer', () => ({
-  default: () => null
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
 }))
 
 vi.mock('./WorktreeCardAgents', () => ({

--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -126,6 +126,41 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('data-workspace-board-preserve-open=""')
   })
 
+  it('hides the branch row when it repeats the workspace title', () => {
+    worktreeCardProperties = []
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ displayName: 'quick-action', branch: 'quick-action' })}
+        repo={makeRepo()}
+        isActive={false}
+        hideRepoBadge
+      />
+    )
+
+    expect(markup).not.toContain('text-[11px] text-muted-foreground truncate leading-none')
+    expect(markup).not.toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('tabindex="0"')
+  })
+
+  it('keeps the branch row when the workspace has a custom title', () => {
+    worktreeCardProperties = []
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ displayName: 'Custom workspace', branch: 'quick-action' })}
+        repo={makeRepo()}
+        isActive={false}
+        hideRepoBadge
+      />
+    )
+
+    expect(markup).toContain('Custom workspace')
+    expect(markup).toContain('quick-action')
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('text-[11px] text-muted-foreground truncate leading-none')
+  })
+
   it('shows delete as the top-right quick action for an inactive workspace', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -544,7 +544,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
     comment: metaComment
   })
   const hasPorts = showPorts && workspacePorts.length > 0
-  const cacheTimerVisible = usePromptCacheCountdownStartedAt(worktree.id) != null
+  const cacheStartedAt = usePromptCacheCountdownStartedAt(worktree.id)
+  const cacheTtlMs = useAppStore((s) => s.settings?.promptCacheTtlMs ?? 0)
   // Why: render the branch/badge sub-line only when it carries something, so an
   // un-renamed single-line worktree collapses to one row instead of an empty band.
   const hasMetaRow =
@@ -552,7 +553,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     isFolder ||
     showBranch ||
     (!!conflictOperation && conflictOperation !== 'unknown') ||
-    cacheTimerVisible
+    cacheStartedAt != null
 
   const cardBody = (
     <div
@@ -585,13 +586,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
         </div>
       )}
 
-      {/* Why: the status dot sits alone on the left so the card height tracks
-           its content; the unread toggle moved inline next to the title (right
-           cluster below) rather than stacking under the dot and padding the card. */}
+      {/* Why: keep this column to just the dot — stacking anything else here
+           (e.g. the unread toggle, which now lives in the title-row cluster)
+           sets a height floor that pads single-line cards. */}
       {cardProps.includes('status') && (
-        <div className="flex flex-col items-center justify-start pt-[2px] shrink-0">
-          <WorktreeActivityStatusIndicator worktreeId={worktree.id} />
-        </div>
+        <WorktreeActivityStatusIndicator worktreeId={worktree.id} className="mt-[2px] shrink-0" />
       )}
 
       {/* Content area */}
@@ -817,7 +816,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 </Badge>
               )}
 
-              <CacheTimer worktreeId={worktree.id} />
+              {cacheStartedAt != null && (
+                <CacheTimer startedAt={cacheStartedAt} ttlMs={cacheTtlMs} />
+              )}
             </div>
           </div>
         )}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -13,10 +13,11 @@ import {
   LoaderCircle,
   Server,
   ServerOff,
+  Star,
   Trash2,
   Workflow
 } from 'lucide-react'
-import CacheTimer from './CacheTimer'
+import CacheTimer, { usePromptCacheCountdownStartedAt } from './CacheTimer'
 import WorktreeContextMenu from './WorktreeContextMenu'
 import { SshDisconnectedDialog } from './SshDisconnectedDialog'
 import WorktreeCardAgents from './WorktreeCardAgents'
@@ -180,6 +181,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const branch = branchDisplayName(worktree.branch)
   const isFolder = repo ? isFolderRepo(repo) : false
+  // Why: the branch repeats the title for un-renamed worktrees, so it's hidden
+  // when they match — only show the branch sub-line when it adds information.
+  const showBranch = !isFolder && branch !== worktree.displayName
   const hostedReviewCacheKey =
     repo && branch
       ? getHostedReviewCacheKey(repo.path, branch, settings, repo.id, repo.connectionId)
@@ -540,6 +544,15 @@ const WorktreeCard = React.memo(function WorktreeCard({
     comment: metaComment
   })
   const hasPorts = showPorts && workspacePorts.length > 0
+  const cacheTimerVisible = usePromptCacheCountdownStartedAt(worktree.id) != null
+  // Why: render the branch/badge sub-line only when it carries something, so an
+  // un-renamed single-line worktree collapses to one row instead of an empty band.
+  const hasMetaRow =
+    (!!repo && !hideRepoBadge) ||
+    isFolder ||
+    showBranch ||
+    (!!conflictOperation && conflictOperation !== 'unknown') ||
+    cacheTimerVisible
 
   const cardBody = (
     <div
@@ -572,40 +585,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
         </div>
       )}
 
-      {/* Status indicator on the left */}
-      {(cardProps.includes('status') || cardProps.includes('unread')) && (
-        <div className="flex flex-col items-center justify-start pt-[2px] gap-2 shrink-0">
-          {cardProps.includes('status') && (
-            <WorktreeActivityStatusIndicator worktreeId={worktree.id} />
-          )}
-
-          {cardProps.includes('unread') && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  data-workspace-board-preserve-open=""
-                  onPointerDown={stopQuickActionPointerPropagation}
-                  onClick={handleToggleUnreadQuick}
-                  className={cn(
-                    'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
-                    'hover:bg-accent/80 active:scale-95',
-                    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
-                  )}
-                  aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
-                >
-                  {worktree.isUnread ? (
-                    <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
-                  ) : (
-                    <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={8}>
-                <span>{unreadTooltip}</span>
-              </TooltipContent>
-            </Tooltip>
-          )}
+      {/* Why: the status dot sits alone on the left so the card height tracks
+           its content; the unread toggle moved inline next to the title (right
+           cluster below) rather than stacking under the dot and padding the card. */}
+      {cardProps.includes('status') && (
+        <div className="flex flex-col items-center justify-start pt-[2px] shrink-0">
+          <WorktreeActivityStatusIndicator worktreeId={worktree.id} />
         </div>
       )}
 
@@ -646,26 +631,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
               onRename={handleRenameTitle}
             />
 
-            {/* Why: the primary worktree (the original clone directory) cannot be
-                 deleted via `git worktree remove`. Placing this badge next to the
-                 name makes it immediately visible and avoids confusion with the
-                 branch name "main" shown below. */}
-            {worktree.isMainWorktree && !isFolder && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
-                  >
-                    primary
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  Primary worktree (original clone directory)
-                </TooltipContent>
-              </Tooltip>
-            )}
-
             {worktree.isSparse && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -690,115 +655,172 @@ const WorktreeCard = React.memo(function WorktreeCard({
             )}
           </div>
 
-          {showDeleteQuickAction && !isDeleting && (
-            <div className="ml-auto flex shrink-0 items-center justify-center pr-1.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    data-workspace-board-preserve-open=""
-                    onPointerDown={stopQuickActionPointerPropagation}
-                    onClick={handleWorkspaceQuickAction}
-                    className={cn(
-                      'inline-flex size-4 items-center justify-center rounded bg-transparent opacity-0 transition-colors transition-opacity',
-                      'group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
-                      'text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:bg-transparent focus-visible:text-foreground'
+          {((worktree.isMainWorktree && !isFolder) ||
+            hasDetails ||
+            hasPorts ||
+            cardProps.includes('unread') ||
+            (showDeleteQuickAction && !isDeleting)) && (
+            <div className="ml-auto flex shrink-0 items-center justify-center gap-1 pr-1.5">
+              {/* Why: unread toggle leads the right cluster (left of the primary
+                   star and PR/ports indicators); the rest right-align on the title
+                   line so a single-line card stays one line and icons line up. */}
+              {cardProps.includes('unread') && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      data-workspace-board-preserve-open=""
+                      onPointerDown={stopQuickActionPointerPropagation}
+                      onClick={handleToggleUnreadQuick}
+                      className={cn(
+                        'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
+                        'hover:bg-accent/80 active:scale-95',
+                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+                      )}
+                      aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
+                    >
+                      {worktree.isUnread ? (
+                        <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
+                      ) : (
+                        <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    <span>{unreadTooltip}</span>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {worktree.isMainWorktree && !isFolder && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="shrink-0 inline-flex items-center"
+                      aria-label="Primary worktree"
+                    >
+                      <Star className="size-3 fill-amber-400 text-amber-400" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    Primary worktree (original clone directory)
+                  </TooltipContent>
+                </Tooltip>
+              )}
+
+              {(hasDetails || hasPorts) && (
+                <WorktreeCardDetailsHover
+                  issue={metaIssue}
+                  linearIssue={metaLinearIssue}
+                  review={metaReview}
+                  comment={metaComment}
+                  detailsAfter={
+                    hasPorts ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null
+                  }
+                  onEditIssue={handleEditIssue}
+                  onEditComment={handleEditComment}
+                  onOpenGitHubIssueInOrca={
+                    metaIssue && 'url' in metaIssue && metaIssue.url
+                      ? handleOpenGitHubIssueInOrca
+                      : undefined
+                  }
+                  onOpenLinearIssueInOrca={
+                    linearIssue?.url ? handleOpenLinearIssueInOrca : undefined
+                  }
+                  onOpenReviewInOrca={
+                    metaReview?.url && metaReview.provider === 'github'
+                      ? handleOpenReviewInOrca
+                      : undefined
+                  }
+                >
+                  <div className="flex shrink-0 items-center gap-1">
+                    {hasPorts && <WorktreeCardPortsTrigger ports={workspacePorts} />}
+                    {hasDetails && (
+                      <WorktreeCardMetaBadges
+                        issue={metaIssue}
+                        linearIssue={metaLinearIssue}
+                        review={metaReview}
+                        comment={metaComment}
+                        className="ml-0 pr-0"
+                      />
                     )}
-                    aria-label="Delete workspace"
-                  >
-                    <Trash2 className="size-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="right" sideOffset={8}>
-                  Delete workspace
-                </TooltipContent>
-              </Tooltip>
+                  </div>
+                </WorktreeCardDetailsHover>
+              )}
+
+              {showDeleteQuickAction && !isDeleting && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      data-workspace-board-preserve-open=""
+                      onPointerDown={stopQuickActionPointerPropagation}
+                      onClick={handleWorkspaceQuickAction}
+                      className={cn(
+                        'inline-flex size-4 items-center justify-center rounded bg-transparent opacity-0 transition-colors transition-opacity',
+                        'group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100',
+                        'text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:bg-transparent focus-visible:text-foreground'
+                      )}
+                      aria-label="Delete workspace"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    Delete workspace
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
           )}
         </div>
 
-        {/* Why: the left metadata lane clips before the right metadata badges,
-             so long lineage labels truncate instead of painting underneath icons. */}
-        <div className="flex items-center gap-1.5 min-w-0">
-          <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-            {repo && !hideRepoBadge && (
-              <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
-                <RepoBadgeMark color={repo.badgeColor} />
-                <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
-                  {repo.displayName}
+        {/* Why: the branch/badge sub-line only renders when it carries something,
+             so an un-renamed single-line worktree collapses to one row instead of
+             leaving an empty band. The PR/ports indicators now live on the title row. */}
+        {hasMetaRow && (
+          <div className="flex items-center gap-1.5 min-w-0">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+              {repo && !hideRepoBadge && (
+                <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
+                  <RepoBadgeMark color={repo.badgeColor} />
+                  <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
+                    {repo.displayName}
+                  </span>
+                </div>
+              )}
+
+              {isFolder ? (
+                <Badge
+                  variant="secondary"
+                  className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 text-muted-foreground bg-accent border border-border dark:bg-accent/80 dark:border-border/50 leading-none"
+                >
+                  {repo ? getRepoKindLabel(repo) : 'Folder'}
+                </Badge>
+              ) : showBranch ? (
+                <span className="min-w-0 text-[11px] text-muted-foreground truncate leading-none">
+                  {branch}
                 </span>
-              </div>
-            )}
+              ) : null}
 
-            {isFolder ? (
-              <Badge
-                variant="secondary"
-                className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 text-muted-foreground bg-accent border border-border dark:bg-accent/80 dark:border-border/50 leading-none"
-              >
-                {repo ? getRepoKindLabel(repo) : 'Folder'}
-              </Badge>
-            ) : branch === worktree.displayName ? null : (
-              // Why: the branch defaults to the display name for un-renamed
-              // worktrees, so showing it again is pure duplication — omit it
-              // when they match (the title's tooltip recovers a clipped name).
-              <span className="min-w-0 text-[11px] text-muted-foreground truncate leading-none">
-                {branch}
-              </span>
-            )}
+              {/* Why: the conflict operation (merge/rebase/cherry-pick) is the
+                   only signal that the worktree is in an incomplete operation state.
+                   Showing it on the card lets the user spot worktrees that need
+                   attention without switching to them first. */}
+              {conflictOperation && conflictOperation !== 'unknown' && (
+                <Badge
+                  variant="outline"
+                  className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 text-amber-600 border-amber-500/30 bg-amber-500/5 dark:text-amber-400 dark:border-amber-400/30 dark:bg-amber-400/5 leading-none"
+                >
+                  <GitMerge className="size-2.5" />
+                  {CONFLICT_OPERATION_LABELS[conflictOperation]}
+                </Badge>
+              )}
 
-            {/* Why: the conflict operation (merge/rebase/cherry-pick) is the
-                 only signal that the worktree is in an incomplete operation state.
-                 Showing it on the card lets the user spot worktrees that need
-                 attention without switching to them first. */}
-            {conflictOperation && conflictOperation !== 'unknown' && (
-              <Badge
-                variant="outline"
-                className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 gap-1 text-amber-600 border-amber-500/30 bg-amber-500/5 dark:text-amber-400 dark:border-amber-400/30 dark:bg-amber-400/5 leading-none"
-              >
-                <GitMerge className="size-2.5" />
-                {CONFLICT_OPERATION_LABELS[conflictOperation]}
-              </Badge>
-            )}
-
-            <CacheTimer worktreeId={worktree.id} />
+              <CacheTimer worktreeId={worktree.id} />
+            </div>
           </div>
-
-          <div className="ml-auto flex shrink-0 items-center gap-1 pr-1.5">
-            <WorktreeCardDetailsHover
-              issue={metaIssue}
-              linearIssue={metaLinearIssue}
-              review={metaReview}
-              comment={metaComment}
-              detailsAfter={hasPorts ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null}
-              onEditIssue={handleEditIssue}
-              onEditComment={handleEditComment}
-              onOpenGitHubIssueInOrca={
-                metaIssue && 'url' in metaIssue && metaIssue.url
-                  ? handleOpenGitHubIssueInOrca
-                  : undefined
-              }
-              onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
-              onOpenReviewInOrca={
-                metaReview?.url && metaReview.provider === 'github'
-                  ? handleOpenReviewInOrca
-                  : undefined
-              }
-            >
-              <div className="flex shrink-0 items-center gap-1">
-                {hasPorts && <WorktreeCardPortsTrigger ports={workspacePorts} />}
-                {hasDetails && (
-                  <WorktreeCardMetaBadges
-                    issue={metaIssue}
-                    linearIssue={metaLinearIssue}
-                    review={metaReview}
-                    comment={metaComment}
-                    className="ml-0 pr-0"
-                  />
-                )}
-              </div>
-            </WorktreeCardDetailsHover>
-          </div>
-        </div>
+        )}
 
         {remoteBranchConflict && (
           <div className="mt-0.5 flex items-start gap-1.5 rounded border border-amber-500/25 bg-amber-500/5 px-1.5 py-1 text-[10.5px] leading-snug text-amber-700 dark:text-amber-300">

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -778,7 +778,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
              so an un-renamed single-line worktree collapses to one row instead of
              leaving an empty band. The PR/ports indicators now live on the title row. */}
         {hasMetaRow && (
-          <div className="flex items-center gap-1.5 min-w-0">
+          <div className="flex items-center gap-1.5 min-w-0" data-worktree-card-meta-row="">
             <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
               {repo && !hideRepoBadge && (
                 <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -737,7 +737,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
               >
                 {repo ? getRepoKindLabel(repo) : 'Folder'}
               </Badge>
-            ) : (
+            ) : branch === worktree.displayName ? null : (
+              // Why: the branch defaults to the display name for un-renamed
+              // worktrees, so showing it again is pure duplication — omit it
+              // when they match (the title's tooltip recovers a clipped name).
               <span className="min-w-0 text-[11px] text-muted-foreground truncate leading-none">
                 {branch}
               </span>

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import {
   WorktreeTitleInlineRename,
   getWorktreeTitleRenameCommit
@@ -25,15 +26,19 @@ describe('getWorktreeTitleRenameCommit', () => {
 describe('WorktreeTitleInlineRename', () => {
   it('renders the title as the double-click inline rename target', () => {
     const markup = renderToStaticMarkup(
-      <WorktreeTitleInlineRename
-        displayName="Feature workspace"
-        showUnreadEmphasis
-        onRename={vi.fn()}
-      />
+      <TooltipProvider>
+        <WorktreeTitleInlineRename
+          displayName="Feature workspace"
+          showUnreadEmphasis
+          onRename={vi.fn()}
+        />
+      </TooltipProvider>
     )
 
     expect(markup).toContain('data-worktree-title-inline-rename=""')
     expect(markup).not.toContain('cursor-text')
+    expect(markup).not.toContain('title="Feature workspace"')
+    expect(markup).toContain('tabindex="0"')
     expect(markup).toContain('Unread:')
     expect(markup).toContain('Feature workspace')
   })

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 export type WorktreeTitleRenameCommit = { kind: 'cancel' } | { kind: 'save'; displayName: string }
@@ -173,23 +174,29 @@ export function WorktreeTitleInlineRename({
     )
   }
 
-  return (
+  const title = (
     <span
       className={cn(
-        'block min-w-0 truncate leading-tight text-foreground',
+        'block min-w-0 truncate leading-tight text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring',
         showUnreadEmphasis ? 'font-semibold' : 'font-normal',
         className
       )}
       data-worktree-title-inline-rename=""
       onDoubleClick={startRename}
-      // Why: the title truncates and the branch sub-line is hidden when it
-      // matches the title, so the native tooltip is the only way to recover the
-      // full name when it's clipped.
-      title={displayName}
+      tabIndex={disabled ? undefined : 0}
     >
       {/* Why: visible text alone misses the unread state for assistive tech. */}
       {showUnreadEmphasis && <span className="sr-only">Unread: </span>}
       {displayName}
     </span>
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{title}</TooltipTrigger>
+      <TooltipContent side="right" sideOffset={8}>
+        {displayName}
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -182,6 +182,10 @@ export function WorktreeTitleInlineRename({
       )}
       data-worktree-title-inline-rename=""
       onDoubleClick={startRename}
+      // Why: the title truncates and the branch sub-line is hidden when it
+      // matches the title, so the native tooltip is the only way to recover the
+      // full name when it's clipped.
+      title={displayName}
     >
       {/* Why: visible text alone misses the unread state for assistive tech. */}
       {showUnreadEmphasis && <span className="sr-only">Unread: </span>}


### PR DESCRIPTION
## Summary

Workspace sidebar cards wasted vertical space on every worktree. Two things drove it:

- Un-renamed worktrees showed their branch on a **second line that just repeated the title** (display name defaults to the branch).
- The card reserved a **tall left column to stack the unread bell under the status dot**, setting a height floor.

So a single-identifier worktree rendered as a two-line card with a blank band under the name. This collapses a card to one tight line whenever there's no genuine second-line content, and consolidates the right-side indicators onto the title row.

<img width="300" src="https://github.com/user-attachments/assets/3441991e-7473-447e-abbb-9d10c2d283b6" />

## What changed

- **Branch sub-line hides when redundant** — renders only when the branch actually differs from the display name (or for folders). The title gained a native tooltip so a clipped name stays recoverable.
- **Unread bell moved off the left column** — it used to stack under the status dot (the height floor). It now leads the title row's right-aligned cluster; the left column is just the status dot, so card height tracks content.
- **PR / review / ports indicators moved to the title row** — once the branch line was hidden these stranded on their own line; they now sit right-aligned on the title row.
- **Metadata sub-line is gated** — renders only when it carries a branch, repo badge, conflict, or active cache timer; otherwise the card stays one line.
- **`primary` badge → amber star** — the spelled-out pill consumed width next to short names like `main`; replaced with a compact star (amber is theme-safe and already accents the unread bell).

## Layout / cleanup

- Right-cluster icon order is consistent across rows: **unread bell → primary star → PR/ports → delete**, all right-aligned.
- `CacheTimer` is now presentational (takes `startedAt` / `ttlMs` props) so the card and timer don't double-subscribe to the same store slices.
- Collapsed the now single-child status-dot wrapper.

## Testing

- `tsgo` typecheck + `oxlint`: clean.
- Sidebar card test suites pass (`WorktreeCard.quick-actions`, `.pr-display`, `.lineage`, `WorktreeTitleInlineRename`, cache-timer); updated the `./CacheTimer` mocks for the new hook export.

<img width="300" alt="CleanShot 2026-05-26 at 11 28 05@2x" src="https://github.com/user-attachments/assets/dfaae2e4-8bdd-40ad-b1f8-9dc33ecd1ab8" />

When a worktree has a custom name, it then shows that name and the worktree path:
<img width="300" src="https://github.com/user-attachments/assets/7d656f9d-cc97-44ec-b063-3ea0b6f8a4a1" />


---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
