### PR TITLE
Remove ready-to-merge badge from checks panel

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1424,14 +1424,11 @@ export default function ChecksPanel(): React.JSX.Element {
     if (activeReviewClassification.needsResponse) {
       badges.push('Needs response')
     }
-    if (activeReviewClassification.readyToMerge) {
-      badges.push('Ready to merge')
-    }
     // Why: viewer/author/requestedReviewer signals are not wired into the
     // ChecksPanel call site yet, so `state` and `requested` would mis-classify
     // every PR (collapsing to 'teammate'). Suppress those badges until the
-    // inputs are available; needs-response / ready-to-merge work from PR
-    // metadata alone and remain accurate.
+    // inputs are available; needs-response works from PR metadata alone and
+    // remains accurate.
     return badges
   }, [activeReviewClassification])
 


### PR DESCRIPTION
## Summary
- Removes the `Ready to merge` badge from the checks panel review classification badges.
- Updates the related comment to reflect that only the needs-response badge remains based on PR metadata alone.