### PR TITLE
fix(ci): skip zsh shell example when zsh is unavailable

### DIFF
--- a/src/main/providers/__tests__/shell-ready-framework-example.test.ts
+++ b/src/main/providers/__tests__/shell-ready-framework-example.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdtempSync, rmSync } from 'fs'
+import { spawnSync } from 'child_process'
 import { shellScriptTest } from './shell-ready-framework/shell-script-test'
 
 const { getUserDataPathMock } = vi.hoisted(() => ({
@@ -24,9 +25,10 @@ vi.mock('electron', () => ({
   }
 }))
 
-const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasZsh = process.platform !== 'win32' && spawnSync('which', ['zsh']).status === 0
+const describeIfZsh = hasZsh ? describe : describe.skip
 
-describePosix('shell-script-literal framework example', () => {
+describeIfZsh('shell-script-literal framework example', () => {
   let userDataPath: string
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Skip the zsh shell-ready framework example test when the host does not have zsh installed, instead of only skipping on Windows.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Ran a review of the branch diff against `origin/main` for correctness, security, type safety, error handling, performance, dead code, and unused imports. The review found no issues. Cross-platform compatibility was checked for macOS, Linux, and Windows; this PR improves shell behavior by skipping the zsh-specific test on any platform where zsh is unavailable, while continuing to skip on Windows. No shortcut, label, path, or Electron platform behavior is touched.

## Security Audit

Reviewed the changed command execution in test setup. The new `spawnSync('which', ['zsh'])` call uses static arguments only, does not process user input, does not affect production code, and does not introduce auth, secrets, dependency, IPC, or path traversal risk.

## Notes

This is test-only CI hardening for environments without zsh.