### PR TITLE
Add powerMonitor to electron mock in attach-main-window-services test

### DIFF
--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -54,6 +54,10 @@ vi.mock('electron', () => ({
     removeAllListeners: removeAllListenersMock,
     removeHandler: removeHandlerMock,
     handle: handleMock
+  },
+  powerMonitor: {
+    on: vi.fn(),
+    off: vi.fn()
   }
 }))
 


### PR DESCRIPTION
## Summary
- PR #2854 added `powerMonitor.on('suspend'/'resume', ...)` in `registerPowerMonitorReconnect` (`src/main/ipc/ssh.ts`) but didn't update the `electron` mock in `src/main/window/attach-main-window-services.test.ts`.
- Result: every PR's `verify` check fails with `[vitest] No "powerMonitor" export is defined on the "electron" mock` (#2854 itself was merged with this check failing).
- Fix: add a `powerMonitor: { on: vi.fn(), off: vi.fn() }` stub to the existing `vi.mock('electron', ...)` block — same pattern already used in `src/main/ipc/ssh.test.ts`.

## Test plan
- [x] `pnpm vitest run src/main/window/attach-main-window-services.test.ts` — 9/9 pass locally.
- [ ] CI `verify` check passes on this PR.

Made with [Orca](https://github.com/stablyai/orca) 🐋
