### PR TITLE
Persist worktree creation base in git config

### DIFF
--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -18,7 +18,7 @@ vi.mock('./runner', () => ({
   translateWslOutputPaths: translateWslOutputPathsMock
 }))
 
-import { addWorktree, parseWorktreeList } from './worktree'
+import { addSparseWorktree, addWorktree, parseWorktreeList } from './worktree'
 
 describe('parseWorktreeList', () => {
   it('parses regular and bare worktree blocks from porcelain output', () => {
@@ -204,6 +204,10 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
   }
 
+  const resolveCreationBaseConfigWrite = () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
+  }
+
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
     gitExecFileSyncMock.mockReset()
@@ -213,6 +217,7 @@ describe('addWorktree', () => {
   it('creates the worktree without touching the local base ref by default', async () => {
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -232,6 +237,16 @@ describe('addWorktree', () => {
         ],
         { cwd: '/repo' }
       ],
+      [
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
+        { cwd: '/repo-feature' }
+      ],
       [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }],
       [['config', '--local', 'push.autoSetupRemote', 'true'], { cwd: '/repo-feature' }]
     ])
@@ -249,9 +264,50 @@ describe('addWorktree', () => {
     ])
   })
 
+  it('does not write branch base config when no base branch is provided', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+
+    await addWorktree('/repo', '/repo-feature', 'feature/no-base')
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [
+        ['worktree', 'add', '--no-track', '-b', 'feature/no-base', '/repo-feature'],
+        { cwd: '/repo' }
+      ],
+      [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }]
+    ])
+  })
+
+  it('warns and unsets stale branch base config when persisting the base fails', async () => {
+    resolveRemoteBase()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('config locked')) // config --local --replace-all branch.<branch>.base
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local --unset-all branch.<branch>.base
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(
+      addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
+    ).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'addWorktree: failed to set branch.feature/test.base for /repo-feature',
+      expect.any(Error)
+    )
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'config',
+      '--local',
+      '--unset-all',
+      'branch.feature/test.base'
+    ])
+    warnSpy.mockRestore()
+  })
+
   it('warns but does not throw when push.autoSetupRemote config fails', async () => {
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get (unset, expected)
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('config locked')) // config --local set fails
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -274,6 +330,7 @@ describe('addWorktree', () => {
     // value the user actually has.
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('parse error'), { code: 3 })) // --get fails non-unset
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -300,6 +357,16 @@ describe('addWorktree', () => {
         ],
         { cwd: '/repo' }
       ],
+      [
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
+        { cwd: '/repo-feature' }
+      ],
       [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }]
     ])
     warnSpy.mockRestore()
@@ -308,6 +375,7 @@ describe('addWorktree', () => {
   it('preserves existing push.autoSetupRemote value (does not overwrite user-set false)', async () => {
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'false\n' }) // config --get returns existing value
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
@@ -327,6 +395,16 @@ describe('addWorktree', () => {
         ],
         { cwd: '/repo' }
       ],
+      [
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
+        { cwd: '/repo-feature' }
+      ],
       [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }]
     ])
   })
@@ -337,6 +415,7 @@ describe('addWorktree', () => {
     // must not fall through to `--local set true` and overwrite that.
     resolveRemoteBase()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --get succeeds with empty value
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main')
@@ -354,6 +433,16 @@ describe('addWorktree', () => {
           'refs/remotes/origin/main'
         ],
         { cwd: '/repo' }
+      ],
+      [
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
+        { cwd: '/repo-feature' }
       ],
       [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }]
     ])
@@ -398,6 +487,7 @@ describe('addWorktree', () => {
       .mockResolvedValueOnce({ stdout: '' }) // reset --hard (in /repo)
       .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
       .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -421,6 +511,16 @@ describe('addWorktree', () => {
         ],
         { cwd: '/repo' }
       ],
+      [
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
+        { cwd: '/repo-feature' }
+      ],
       [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }],
       [['config', '--local', 'push.autoSetupRemote', 'true'], { cwd: '/repo-feature' }]
     ])
@@ -436,6 +536,7 @@ describe('addWorktree', () => {
       .mockResolvedValueOnce({ stdout: '' }) // reset --hard (in /repo-main-wt)
       .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
       .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -459,6 +560,7 @@ describe('addWorktree', () => {
       .mockResolvedValueOnce({ stdout: '' }) // update-ref
       .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
       .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -478,13 +580,14 @@ describe('addWorktree', () => {
       .mockResolvedValueOnce({ stdout: ' M package.json\n' }) // status --porcelain (dirty)
       .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
       .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
     await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true)
 
-    // No reset --hard or update-ref — just merge-base, worktree list, status, worktree add, config --get, config --local set
-    expect(gitExecFileAsyncMock.mock.calls).toHaveLength(7)
+    // No reset --hard or update-ref — just merge-base, worktree list, status, worktree add, base config, config --get, config --local set
+    expect(gitExecFileAsyncMock.mock.calls).toHaveLength(8)
     expect(gitExecFileAsyncMock.mock.calls[3]?.[0]).toEqual([
       'rev-parse',
       '--verify',
@@ -502,10 +605,17 @@ describe('addWorktree', () => {
     ])
     expect(gitExecFileAsyncMock.mock.calls[5]?.[0]).toEqual([
       'config',
+      '--local',
+      '--replace-all',
+      'branch.feature/test.base',
+      'refs/remotes/origin/main'
+    ])
+    expect(gitExecFileAsyncMock.mock.calls[6]?.[0]).toEqual([
+      'config',
       '--get',
       'push.autoSetupRemote'
     ])
-    expect(gitExecFileAsyncMock.mock.calls[6]?.[0]).toEqual([
+    expect(gitExecFileAsyncMock.mock.calls[7]?.[0]).toEqual([
       'config',
       '--local',
       'push.autoSetupRemote',
@@ -517,6 +627,7 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not a fast-forward'))
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -544,6 +655,16 @@ describe('addWorktree', () => {
         expect.objectContaining({ cwd: '/repo' })
       ],
       [
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
+        expect.objectContaining({ cwd: '/repo-feature' })
+      ],
+      [
         ['config', '--get', 'push.autoSetupRemote'],
         expect.objectContaining({ cwd: '/repo-feature' })
       ],
@@ -560,6 +681,7 @@ describe('addWorktree', () => {
     // Qualifying as refs/heads/main tells git exactly which object to use.
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/heads/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -587,6 +709,7 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('no remote ref')) // rev-parse refs/remotes/release/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/heads/release/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -604,6 +727,13 @@ describe('addWorktree', () => {
         '/repo-feature',
         'refs/heads/release/main'
       ],
+      [
+        'config',
+        '--local',
+        '--replace-all',
+        'branch.feature/release.base',
+        'refs/heads/release/main'
+      ],
       ['config', '--get', 'push.autoSetupRemote'],
       ['config', '--local', 'push.autoSetupRemote', 'true']
     ])
@@ -618,6 +748,7 @@ describe('addWorktree', () => {
       .mockResolvedValueOnce({ stdout: '' }) // reset --hard
       .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/upstream/main^{commit}
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
       .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
@@ -630,5 +761,38 @@ describe('addWorktree', () => {
       'upstream/main'
     ])
     expect(gitExecFileAsyncMock.mock.calls[3]?.[0]).toEqual(['reset', '--hard', 'upstream/main'])
+  })
+
+  it('unsets branch base config during sparse setup cleanup after creation succeeds', async () => {
+    const beforeRemoval =
+      'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
+    const afterPrune = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
+    resolveRemoteBase()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('sparse setup failed')) // sparse-checkout init
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local --unset-all branch.<branch>.base
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // worktree list before remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: afterPrune }) // worktree list after prune
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -D
+
+    await expect(
+      addSparseWorktree('/repo', '/repo-feature', 'feature/test', ['src'], 'origin/main')
+    ).rejects.toThrow('sparse setup failed')
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'config',
+      '--local',
+      '--unset-all',
+      'branch.feature/test.base'
+    ])
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'branch',
+      '-D',
+      'feature/test'
+    ])
   })
 })

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -39,6 +39,44 @@ function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
 
+async function persistWorktreeCreationBase(
+  worktreePath: string,
+  branch: string,
+  effectiveBase: string
+): Promise<void> {
+  const configKey = `branch.${branch}.base`
+  try {
+    await gitExecFileAsync(['config', '--local', '--replace-all', configKey, effectiveBase], {
+      cwd: worktreePath
+    })
+  } catch (error) {
+    console.warn(`addWorktree: failed to set ${configKey} for ${worktreePath}`, error)
+    try {
+      // Why: reused branch names may carry stale base metadata; if replacement
+      // fails, remove the old value so consumers do not trust outdated lineage.
+      await gitExecFileAsync(['config', '--local', '--unset-all', configKey], {
+        cwd: worktreePath
+      })
+    } catch (unsetError) {
+      console.warn(
+        `addWorktree: failed to unset stale ${configKey} for ${worktreePath}`,
+        unsetError
+      )
+    }
+  }
+}
+
+async function unsetWorktreeCreationBase(worktreePath: string, branch: string): Promise<void> {
+  try {
+    await gitExecFileAsync(['config', '--local', '--unset-all', `branch.${branch}.base`], {
+      cwd: worktreePath
+    })
+  } catch {
+    // Best-effort cleanup; missing keys and locked config both leave the
+    // original sparse setup error as the actionable failure.
+  }
+}
+
 function areWorktreePathsEqual(
   leftPath: string,
   rightPath: string,
@@ -160,9 +198,10 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
  * @param worktreePath - Absolute path where the worktree will be created
  * @param branch - Branch name for the new worktree
  * @param baseBranch - Optional base branch to create from (defaults to HEAD)
- * @remarks Side effect: passes `--no-track` and may write `push.autoSetupRemote=true`
- * to the repo's shared config (best-effort, warn-only on failure; preserves any
- * user-set value at any scope). See body comment below for the full rationale.
+ * @remarks Side effect: passes `--no-track`, writes `branch.<branch>.base`
+ * for new-branch worktrees with a base ref, and may write
+ * `push.autoSetupRemote=true` to the repo's shared config. Config writes are
+ * best-effort and warn-only. See body comments below for the full rationale.
  */
 export async function addWorktree(
   repoPath: string,
@@ -228,6 +267,7 @@ export async function addWorktree(
   }
 
   const args = ['worktree', 'add']
+  let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')
   }
@@ -242,7 +282,7 @@ export async function addWorktree(
     // below for the terminal ergonomics.
     args.push('--no-track', '-b', branch, worktreePath)
     if (baseBranch) {
-      const effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
+      effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
         hasWorktreeBaseCommitRef(repoPath, qualifiedRef)
       )
       args.push(effectiveBase)
@@ -254,7 +294,11 @@ export async function addWorktree(
     return
   }
 
-  // SSH parity: src/relay/git-handler.ts addWorktree mirrors this exact
+  if (effectiveBase) {
+    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase)
+  }
+
+  // SSH parity: src/relay/git-handler-worktree-ops.ts addWorktreeOp mirrors this exact
   // probe-and-write state machine. If you change the logic here, update
   // the relay handler in lockstep so local and SSH paths stay aligned.
   //
@@ -340,6 +384,9 @@ export async function addSparseWorktree(
     const wrapped: SparseWorktreeCreateError =
       error instanceof Error ? (error as SparseWorktreeCreateError) : new Error(String(error))
     if (created) {
+      if (!options.checkoutExistingBranch) {
+        await unsetWorktreeCreationBase(worktreePath, branch)
+      }
       try {
         await removeWorktree(repoPath, worktreePath, true, {
           deleteBranch: !options.checkoutExistingBranch

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -63,6 +63,22 @@ import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import type { IFilesystemProvider } from '../providers/types'
 
+async function unsetRemoteWorktreeCreationBase(
+  provider: SshGitProvider,
+  worktreePath: string,
+  branchName: string
+): Promise<void> {
+  try {
+    await provider.exec(
+      ['config', '--local', '--unset-all', `branch.${branchName}.base`],
+      worktreePath
+    )
+  } catch {
+    // Best-effort SSH sparse cleanup; keep the sparse setup error as the
+    // actionable failure and let removeWorktree handle the partial checkout.
+  }
+}
+
 async function findRemoteForUrl(repoPath: string, remoteUrl: string): Promise<string | null> {
   const target = parseGitHubOwnerRepo(remoteUrl)
   try {
@@ -846,6 +862,9 @@ export async function createRemoteWorktree(
       await provider.exec(['sparse-checkout', 'set', '--', ...sparseDirectories], remotePath)
       await provider.exec(['checkout', branchName], remotePath)
     } catch (err) {
+      if (!checkoutExistingBranch) {
+        await unsetRemoteWorktreeCreationBase(provider, remotePath, branchName)
+      }
       await provider.removeWorktree(remotePath, true).catch(() => undefined)
       throw err
     }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1295,6 +1295,59 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('unsets SSH branch base config before removing a sparse worktree after setup failure', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const setupError = new Error('sparse init failed')
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'sparse-checkout' && args[1] === 'init') {
+          throw setupError
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn()
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    store.getSparsePresets.mockReturnValue([])
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'sparse-dashboard',
+        sparseCheckout: {
+          directories: ['apps/mobile']
+        }
+      })
+    ).rejects.toThrow('sparse init failed')
+
+    expect(provider.exec).toHaveBeenCalledWith(
+      ['config', '--local', '--unset-all', 'branch.sparse-dashboard.base'],
+      '/remote/repo/../sparse-dashboard'
+    )
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo/../sparse-dashboard', true)
+  })
+
   it('does not create an SSH worktree when remote-tracking base refresh fails', async () => {
     const repo = {
       id: 'repo-ssh',

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { GitExec } from './git-handler-ops'
-import { removeWorktreeOp } from './git-handler-worktree-ops'
+import { addWorktreeOp, removeWorktreeOp } from './git-handler-worktree-ops'
 
 function worktreeList(...entries: { path: string; branch?: string }[]): string {
   return entries
@@ -13,6 +13,114 @@ function worktreeList(...entries: { path: string; branch?: string }[]): string {
     )
     .join('\n\n')
 }
+
+describe('addWorktreeOp', () => {
+  it('writes durable branch base config after creating an SSH new-branch worktree', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await addWorktreeOp(git, {
+      repoPath: '/repo',
+      branchName: 'feature/test',
+      targetDir: '/repo-feature',
+      base: 'origin/main'
+    })
+
+    expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
+      [
+        'worktree',
+        'add',
+        '--no-track',
+        '-b',
+        'feature/test',
+        '/repo-feature',
+        'refs/remotes/origin/main'
+      ],
+      [
+        'config',
+        '--local',
+        '--replace-all',
+        'branch.feature/test.base',
+        'refs/remotes/origin/main'
+      ],
+      ['config', '--get', 'push.autoSetupRemote']
+    ])
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'config',
+      '--local',
+      'branch.feature/test.remote',
+      'origin'
+    ])
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'config',
+      '--local',
+      'branch.feature/test.merge',
+      'refs/heads/main'
+    ])
+  })
+
+  it('does not write branch base config when checking out an existing SSH branch', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await addWorktreeOp(git, {
+      repoPath: '/repo',
+      branchName: 'feature/test',
+      targetDir: '/repo-feature',
+      base: 'origin/main',
+      checkoutExistingBranch: true
+    })
+
+    expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['worktree', 'add', '/repo-feature', 'feature/test']
+    ])
+  })
+
+  it('does not write branch base config when SSH creation has no base', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await addWorktreeOp(git, {
+      repoPath: '/repo',
+      branchName: 'feature/no-base',
+      targetDir: '/repo-feature'
+    })
+
+    expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['worktree', 'add', '--no-track', '-b', 'feature/no-base', '/repo-feature'],
+      ['config', '--get', 'push.autoSetupRemote']
+    ])
+  })
+
+  it('warns and unsets stale branch base config when SSH base persistence fails', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'config' && args[2] === '--replace-all') {
+        throw new Error('config locked')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, {
+        repoPath: '/repo',
+        branchName: 'feature/test',
+        targetDir: '/repo-feature',
+        base: 'origin/main'
+      })
+    ).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'relay addWorktree: failed to set branch.feature/test.base for /repo-feature',
+      expect.any(Error)
+    )
+    expect(git.mock.calls.map((call) => call[0])).toContainEqual([
+      'config',
+      '--local',
+      '--unset-all',
+      'branch.feature/test.base'
+    ])
+    warnSpy.mockRestore()
+  })
+})
 
 describe('removeWorktreeOp', () => {
   it('deletes the now-unused branch after removing an SSH worktree', async () => {

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -11,6 +11,30 @@ import { parseWorktreeList } from './git-handler-utils'
 
 // ─── Worktree management ─────────────────────────────────────────────
 
+async function persistRelayWorktreeCreationBase(
+  git: GitExec,
+  targetDir: string,
+  branchName: string,
+  effectiveBase: string
+): Promise<void> {
+  const configKey = `branch.${branchName}.base`
+  try {
+    await git(['config', '--local', '--replace-all', configKey, effectiveBase], targetDir)
+  } catch (error) {
+    console.warn(`relay addWorktree: failed to set ${configKey} for ${targetDir}`, error)
+    try {
+      // Why: SSH worktree creation shares branch config by name; clear stale
+      // metadata if replacing an old same-name base fails.
+      await git(['config', '--local', '--unset-all', configKey], targetDir)
+    } catch (unsetError) {
+      console.warn(
+        `relay addWorktree: failed to unset stale ${configKey} for ${targetDir}`,
+        unsetError
+      )
+    }
+  }
+}
+
 export async function addWorktreeOp(git: GitExec, params: Record<string, unknown>): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
@@ -59,6 +83,10 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
 
   if (checkoutExistingBranch) {
     return
+  }
+
+  if (effectiveBase) {
+    await persistRelayWorktreeCreationBase(git, targetDir, branchName, effectiveBase)
   }
 
   // Why: best-effort write so a deliberate user value (any scope) is

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -790,6 +790,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse refs/remotes/origin/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // --get
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // --local set
 
@@ -811,6 +812,13 @@ describe('GitHandler', () => {
           '/relay/wt',
           'refs/remotes/origin/main'
         ],
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/test.base',
+          'refs/remotes/origin/main'
+        ],
         ['config', '--get', 'push.autoSetupRemote'],
         ['config', '--local', 'push.autoSetupRemote', 'true']
       ])
@@ -819,6 +827,7 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls[1]?.[1]).toBe('/relay/repo')
       expect(gitMock.mock.calls[2]?.[1]).toBe('/relay/wt')
       expect(gitMock.mock.calls[3]?.[1]).toBe('/relay/wt')
+      expect(gitMock.mock.calls[4]?.[1]).toBe('/relay/wt')
     })
 
     it('checks out a selected existing local branch without creating a new branch', async () => {
@@ -846,6 +855,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse refs/heads/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // --get unset
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // --local set
 
@@ -859,6 +869,7 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls.map((c) => c[0])).toEqual([
         ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
         ['worktree', 'add', '--no-track', '-b', 'feature/disambig', '/relay/wt', 'refs/heads/main'],
+        ['config', '--local', '--replace-all', 'branch.feature/disambig.base', 'refs/heads/main'],
         ['config', '--get', 'push.autoSetupRemote'],
         ['config', '--local', 'push.autoSetupRemote', 'true']
       ])
@@ -869,6 +880,7 @@ describe('GitHandler', () => {
       gitMock.mockRejectedValueOnce(new Error('no remote ref')) // rev-parse refs/remotes/release/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse refs/heads/release/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // --get unset
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // --local set
 
@@ -891,6 +903,13 @@ describe('GitHandler', () => {
           '/relay/wt',
           'refs/heads/release/main'
         ],
+        [
+          'config',
+          '--local',
+          '--replace-all',
+          'branch.feature/release.base',
+          'refs/heads/release/main'
+        ],
         ['config', '--get', 'push.autoSetupRemote'],
         ['config', '--local', 'push.autoSetupRemote', 'true']
       ])
@@ -900,6 +919,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // rev-parse refs/remotes/origin/main
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // --get
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // --local set
 
@@ -927,6 +947,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockRejectedValueOnce(new Error('not a branch')) // rev-parse refs/heads/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockResolvedValueOnce({ stdout: 'false\n', stderr: '' }) // --get returns value
 
       await localDispatcher.callRequest('git.addWorktree', {
@@ -940,6 +961,7 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls.map((c) => c[0])).toEqual([
         ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
         ['worktree', 'add', '--no-track', '-b', 'feature/preserve', '/relay/wt', 'main'],
+        ['config', '--local', '--replace-all', 'branch.feature/preserve.base', 'main'],
         ['config', '--get', 'push.autoSetupRemote']
       ])
     })
@@ -952,6 +974,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockRejectedValueOnce(new Error('not a branch')) // rev-parse refs/heads/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // --get success, empty value
 
       await localDispatcher.callRequest('git.addWorktree', {
@@ -964,6 +987,7 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls.map((c) => c[0])).toEqual([
         ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
         ['worktree', 'add', '--no-track', '-b', 'feature/empty', '/relay/wt', 'main'],
+        ['config', '--local', '--replace-all', 'branch.feature/empty.base', 'main'],
         ['config', '--get', 'push.autoSetupRemote']
       ])
     })
@@ -976,6 +1000,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockRejectedValueOnce(new Error('not a branch')) // rev-parse refs/heads/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('parse error'), { code: 3 })) // --get non-unset
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -992,6 +1017,7 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls.map((c) => c[0])).toEqual([
         ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
         ['worktree', 'add', '--no-track', '-b', 'feature/corrupt', '/relay/wt', 'main'],
+        ['config', '--local', '--replace-all', 'branch.feature/corrupt.base', 'main'],
         ['config', '--get', 'push.autoSetupRemote']
       ])
       expect(warnSpy).toHaveBeenCalledWith(
@@ -1005,6 +1031,7 @@ describe('GitHandler', () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
       gitMock.mockRejectedValueOnce(new Error('not a branch')) // rev-parse refs/heads/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
+      gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // --get unset
       gitMock.mockRejectedValueOnce(new Error('config locked')) // --local set fails
 

--- a/src/shared/worktree-base-ref.test.ts
+++ b/src/shared/worktree-base-ref.test.ts
@@ -12,6 +12,19 @@ describe('resolveWorktreeAddBaseRef', () => {
     expect(refExists).not.toHaveBeenCalled()
   })
 
+  it('leaves provider review refs unchanged', async () => {
+    const refExists = vi.fn()
+
+    await expect(resolveWorktreeAddBaseRef('refs/pull/123/head', refExists)).resolves.toBe(
+      'refs/pull/123/head'
+    )
+    await expect(
+      resolveWorktreeAddBaseRef('refs/merge-requests/456/head', refExists)
+    ).resolves.toBe('refs/merge-requests/456/head')
+
+    expect(refExists).not.toHaveBeenCalled()
+  })
+
   it('qualifies a bare local branch name', async () => {
     const refExists = vi.fn(async (ref: string) => ref === 'refs/heads/main')
 


### PR DESCRIPTION
## Summary

This PR persists the creation base for Orca-created branch worktrees in Git config as `branch.<branch>.base`, in addition to the existing Orca worktree metadata. New local and SSH/relay worktrees now record the resolved base ref used for `git worktree add`, while keeping upstream tracking separate via `--no-track`.

The write is best-effort and warn-only. Orca skips it for existing-branch checkouts, no-base creation, and failed `worktree add` operations. Sparse checkout cleanup also best-effort unsets the base config so a later same-name branch does not inherit stale lineage.

## Design Review

Design review completed clean after tightening the contract around resolved base refs, stale config replacement, provider/user precedence for future consumers, sparse cleanup, and local/SSH parity. The scratch design doc remains local/ignored and is not included in this PR.

## Implementation Notes

- Local worktree creation writes `git config --local --replace-all branch.<branch>.base <resolvedBase>` after successful new-branch creation.
- Relay/SSH worktree creation mirrors the same behavior on the remote host.
- SSH sparse setup failure now unsets the base config before removing the partial worktree.
- Tests cover durable base config, no write for existing/no-base/failed creation, warn-only cleanup, provider review refs, and relay command parity.

Deviation from the initial implementation scope: `src/relay/git-handler.test.ts`, `src/main/ipc/worktree-remote.ts`, `src/main/ipc/worktrees.test.ts`, and `src/shared/worktree-base-ref.test.ts` were also updated because relay handler expectations, SSH sparse cleanup parity, and provider-ref validation needed coverage.

## Verification

Completeness verification: clean after fixing two findings:
- SSH sparse cleanup now unsets `branch.<branch>.base` before removing partial remote sparse worktrees.
- Provider review refs are explicitly covered in base-ref resolver tests.

Code review loop: round 1 had two independent reviewers; both returned clean with no actionable findings.

Verdict is to land this.

Checks and tests run:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/worktree.test.ts src/main/ipc/worktrees.test.ts src/relay/git-handler-worktree-ops.test.ts src/relay/git-handler.test.ts src/shared/worktree-base-ref.test.ts` passed, 165 tests.
- `pnpm exec oxlint src/main/git/worktree.ts src/main/git/worktree.test.ts src/main/ipc/worktree-remote.ts src/main/ipc/worktrees.test.ts src/relay/git-handler-worktree-ops.ts src/relay/git-handler-worktree-ops.test.ts src/relay/git-handler.test.ts src/shared/worktree-base-ref.test.ts` passed.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed.
- `pnpm build:relay` passed.
- `git diff --check` passed.
- Real Git smoke test confirmed a new branch worktree has `branch.<branch>.base = refs/remotes/origin/main` and no upstream tracking.
- Live local behavior validated for new-base, no-base, existing-branch, and failed-add cases.
- Live SSH/relay behavior validated against a throwaway Ubuntu Docker SSH target, including remote base config persistence and SSH sparse cleanup with no stale base config left behind.

## Assumptions and Accepted Gaps

- Existing worktrees are not migrated; missing `branch.<branch>.base` remains a supported state for older or external worktrees.
- Visual UI click-through was not performed because this is backing Git/worktree behavior with no visible UI change.
- Warn-only config-write failure and relay no-base behavior are covered by focused tests rather than live config-lock injection.

Made with [Orca](https://github.com/stablyai/orca) 🐋
