### PR TITLE
Fix blocked terminal clipboard write guidance

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -59,6 +59,7 @@ import { GhosttyImportModal } from './GhosttyImportModal'
 import type { UseGhosttyImportReturn } from './useGhosttyImport'
 import { ManageSessionsSection } from './ManageSessionsSection'
 import { TerminalSettingsPreview } from './TerminalSettingsPreview'
+import { OSC52_CLIPBOARD_SETTING_ID } from '../terminal-pane/osc52-clipboard-setting-anchor'
 
 type TerminalPaneProps = {
   settings: GlobalSettings
@@ -587,6 +588,7 @@ export function TerminalPane({
           </SearchableSetting>
 
           <SearchableSetting
+            id={OSC52_CLIPBOARD_SETTING_ID}
             title="Allow TUI Clipboard Writes (OSC 52)"
             description="Let tmux, Neovim, and fzf copy to the system clipboard over the PTY (including over SSH)."
             keywords={[

--- a/src/renderer/src/components/settings/terminal-clipboard-search.ts
+++ b/src/renderer/src/components/settings/terminal-clipboard-search.ts
@@ -1,0 +1,39 @@
+import type { SettingsSearchEntry } from './settings-search'
+
+export const TERMINAL_CLIPBOARD_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Copy on Select',
+    description:
+      'Automatically copy terminal selections to the clipboard as soon as a selection is made.',
+    keywords: [
+      'clipboard',
+      'copy',
+      'select',
+      'selection',
+      'auto',
+      'automatic',
+      'x11',
+      'linux',
+      'gnome',
+      'paste'
+    ]
+  },
+  {
+    title: 'Allow TUI Clipboard Writes (OSC 52)',
+    description:
+      'Let programs in the terminal copy to the system clipboard through OSC 52, including over SSH.',
+    keywords: [
+      'osc 52',
+      'osc52',
+      'clipboard',
+      'tmux',
+      'neovim',
+      'nvim',
+      'fzf',
+      'ssh',
+      'remote',
+      'copy',
+      'paste'
+    ]
+  }
+]

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -51,6 +51,21 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(entriesLinux.some((entry) => entry.title === 'Manage Sessions')).toBe(true)
   })
 
+  it('includes the OSC 52 clipboard setting on all platforms', () => {
+    const entriesWindows = getTerminalPaneSearchEntries({ isWindows: true, isMac: false })
+    const entriesMac = getTerminalPaneSearchEntries({ isWindows: false, isMac: true })
+    const entriesLinux = getTerminalPaneSearchEntries({ isWindows: false, isMac: false })
+    expect(
+      entriesWindows.some((entry) => entry.title === 'Allow TUI Clipboard Writes (OSC 52)')
+    ).toBe(true)
+    expect(entriesMac.some((entry) => entry.title === 'Allow TUI Clipboard Writes (OSC 52)')).toBe(
+      true
+    )
+    expect(
+      entriesLinux.some((entry) => entry.title === 'Allow TUI Clipboard Writes (OSC 52)')
+    ).toBe(true)
+  })
+
   it('includes the Ghostty import setting on all platforms', () => {
     const entriesWindows = getTerminalPaneSearchEntries({ isWindows: true, isMac: false })
     const entriesMac = getTerminalPaneSearchEntries({ isWindows: false, isMac: true })

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -1,4 +1,5 @@
 import type { SettingsSearchEntry } from './settings-search'
+import { TERMINAL_CLIPBOARD_SEARCH_ENTRIES } from './terminal-clipboard-search'
 import { TERMINAL_WINDOWS_SEARCH_ENTRIES } from './terminal-windows-search'
 
 export const TERMINAL_TYPOGRAPHY_SEARCH_ENTRIES: SettingsSearchEntry[] = [
@@ -95,23 +96,7 @@ export const TERMINAL_PANE_STYLE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       "Hovering a terminal pane activates it without needing to click. Mirrors Ghostty's focus-follows-mouse setting. Selections and window switching stay safe.",
     keywords: ['focus', 'follows', 'mouse', 'hover', 'pane', 'ghostty', 'active']
   },
-  {
-    title: 'Copy on Select',
-    description:
-      'Automatically copy terminal selections to the clipboard as soon as a selection is made.',
-    keywords: [
-      'clipboard',
-      'copy',
-      'select',
-      'selection',
-      'auto',
-      'automatic',
-      'x11',
-      'linux',
-      'gnome',
-      'paste'
-    ]
-  }
+  ...TERMINAL_CLIPBOARD_SEARCH_ENTRIES
 ]
 
 export const TERMINAL_DARK_THEME_SEARCH_ENTRIES: SettingsSearchEntry[] = [

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
+import type * as Osc52ClipboardBlockedToastModule from './osc52-clipboard-blocked-toast'
+
+const { toastInfoMock, storeMock } = vi.hoisted(() => ({
+  toastInfoMock: vi.fn(),
+  storeMock: {
+    setSettingsSearchQuery: vi.fn(),
+    openSettingsTarget: vi.fn(),
+    openSettingsPage: vi.fn()
+  }
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: toastInfoMock
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => storeMock
+  }
+}))
+
+async function importToastModule(): Promise<typeof Osc52ClipboardBlockedToastModule> {
+  return import('./osc52-clipboard-blocked-toast')
+}
+
+describe('showOsc52ClipboardBlockedToast', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    toastInfoMock.mockReset()
+    storeMock.setSettingsSearchQuery.mockReset()
+    storeMock.openSettingsTarget.mockReset()
+    storeMock.openSettingsPage.mockReset()
+  })
+
+  it('deep-links to the OSC 52 terminal setting', async () => {
+    const { showOsc52ClipboardBlockedToast } = await importToastModule()
+
+    showOsc52ClipboardBlockedToast()
+
+    const options = toastInfoMock.mock.calls[0]?.[1]
+    expect(options).toMatchObject({
+      action: {
+        label: 'Open Setting'
+      }
+    })
+
+    options.action.onClick()
+
+    expect(storeMock.setSettingsSearchQuery).toHaveBeenCalledWith('')
+    expect(storeMock.openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'terminal',
+      repoId: null,
+      sectionId: OSC52_CLIPBOARD_SETTING_ID
+    })
+    expect(storeMock.openSettingsPage).toHaveBeenCalled()
+  })
+
+  it('only shows once per renderer session', async () => {
+    const { showOsc52ClipboardBlockedToast } = await importToastModule()
+
+    showOsc52ClipboardBlockedToast()
+    showOsc52ClipboardBlockedToast()
+
+    expect(toastInfoMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
@@ -1,0 +1,33 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
+
+let hasShownOsc52ClipboardBlockedToast = false
+
+export function showOsc52ClipboardBlockedToast(): void {
+  if (hasShownOsc52ClipboardBlockedToast) {
+    return
+  }
+  hasShownOsc52ClipboardBlockedToast = true
+
+  toast.info('Terminal clipboard write blocked', {
+    description:
+      'Enable TUI clipboard writes in Terminal settings to copy from SSH, tmux, Neovim, or fzf.',
+    duration: 12_000,
+    action: {
+      label: 'Open Setting',
+      onClick: () => {
+        const store = useAppStore.getState()
+        // Why: open the exact row instead of a generic Terminal page so the
+        // remote-copy failure points to the setting named by the shell message.
+        store.setSettingsSearchQuery('')
+        store.openSettingsTarget({
+          pane: 'terminal',
+          repoId: null,
+          sectionId: OSC52_CLIPBOARD_SETTING_ID
+        })
+        store.openSettingsPage()
+      }
+    }
+  })
+}

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-setting-anchor.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-setting-anchor.ts
@@ -1,0 +1,1 @@
+export const OSC52_CLIPBOARD_SETTING_ID = 'terminal-osc52-clipboard'

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { parseOsc52 } from './osc52-clipboard'
+import { describe, expect, it, vi } from 'vitest'
+import { handleOsc52ClipboardRequest, parseOsc52 } from './osc52-clipboard'
 
 function b64(s: string): string {
   return Buffer.from(s, 'utf-8').toString('base64')
@@ -65,5 +65,48 @@ describe('parseOsc52', () => {
   it('rejects payloads larger than the size cap', () => {
     const huge = 'A'.repeat(128 * 1024 + 100) // valid base64 alphabet char
     expect(parseOsc52(`c;${huge}`)).toMatchObject({ kind: 'invalid' })
+  })
+})
+
+describe('handleOsc52ClipboardRequest', () => {
+  it('writes valid OSC 52 clipboard payloads when enabled', () => {
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+
+    expect(
+      handleOsc52ClipboardRequest(`c;${b64('from remote')}`, {
+        allowClipboardWrite: true,
+        writeClipboardText
+      })
+    ).toBe(true)
+
+    expect(writeClipboardText).toHaveBeenCalledWith('from remote')
+  })
+
+  it('surfaces a blocked valid write when OSC 52 clipboard writes are disabled', () => {
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+    const onBlockedWrite = vi.fn()
+
+    expect(
+      handleOsc52ClipboardRequest(`c;${b64('from remote')}`, {
+        allowClipboardWrite: false,
+        writeClipboardText,
+        onBlockedWrite
+      })
+    ).toBe(true)
+
+    expect(writeClipboardText).not.toHaveBeenCalled()
+    expect(onBlockedWrite).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not surface blocked queries because Orca must not answer them', () => {
+    const onBlockedWrite = vi.fn()
+
+    handleOsc52ClipboardRequest('c;?', {
+      allowClipboardWrite: false,
+      writeClipboardText: vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined),
+      onBlockedWrite
+    })
+
+    expect(onBlockedWrite).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -22,7 +22,33 @@ export type Osc52ParseResult =
   | { kind: 'query' }
   | { kind: 'invalid'; reason: string }
 
+export type Osc52ClipboardRequestOptions = {
+  allowClipboardWrite: boolean
+  writeClipboardText: (text: string) => Promise<void>
+  onBlockedWrite?: () => void
+}
+
 const MAX_OSC52_BYTES = 128 * 1024
+
+export function handleOsc52ClipboardRequest(
+  data: string,
+  options: Osc52ClipboardRequestOptions
+): boolean {
+  const parsed = parseOsc52(data)
+  if (parsed.kind !== 'write') {
+    return true
+  }
+
+  if (!options.allowClipboardWrite) {
+    options.onBlockedWrite?.()
+    return true
+  }
+
+  void options.writeClipboardText(parsed.text).catch(() => {
+    /* ignore clipboard write failures */
+  })
+  return true
+}
 
 export function parseOsc52(data: string): Osc52ParseResult {
   const semi = data.indexOf(';')

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -33,7 +33,8 @@ import {
   installMode2031Handlers,
   mode2031SequenceFor
 } from './terminal-appearance'
-import { parseOsc52 } from './osc52-clipboard'
+import { handleOsc52ClipboardRequest } from './osc52-clipboard'
+import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { shouldBypassXtermKeyboardEvent } from './xterm-bypass-policy'
@@ -463,22 +464,13 @@ export function useTerminalPaneLifecycle({
         // both the enabled and disabled paths so xterm doesn't fall
         // through to any other OSC 52 handler and so our intentional drop
         // in the disabled path is explicit.
-        const osc52Disposable = pane.terminal.parser.registerOscHandler(52, (data) => {
-          if (!settingsRef.current?.terminalAllowOsc52Clipboard) {
-            return true
-          }
-          const parsed = parseOsc52(data)
-          if (parsed.kind !== 'write') {
-            // Queries and malformed payloads are intentionally dropped —
-            // answering a query would leak the user's clipboard to any
-            // process writing to the PTY.
-            return true
-          }
-          void window.api.ui.writeClipboardText(parsed.text).catch(() => {
-            /* ignore clipboard write failures */
+        const osc52Disposable = pane.terminal.parser.registerOscHandler(52, (data) =>
+          handleOsc52ClipboardRequest(data, {
+            allowClipboardWrite: settingsRef.current?.terminalAllowOsc52Clipboard === true,
+            writeClipboardText: window.api.ui.writeClipboardText,
+            onBlockedWrite: showOsc52ClipboardBlockedToast
           })
-          return true
-        })
+        )
         osc52DisposablesRef.current.set(pane.id, osc52Disposable)
 
         // OSC 7 — shell-reported current working directory. Drives split-pane


### PR DESCRIPTION
## Summary\n- Show a one-time in-app hint when a valid terminal clipboard write is blocked by the OSC 52 setting\n- Deep-link that hint to the exact Terminal setting and make the setting discoverable through Settings search\n- Keep clipboard writes opt-in and continue dropping clipboard queries and invalid payloads\n\nCloses #2840\n\n## Verification\n- pnpm lint\n- pnpm typecheck\n- pnpm test