### PR TITLE
Fix updater release asset readiness checks

### DIFF
--- a/config/scripts/verify-release-required-assets.test.mjs
+++ b/config/scripts/verify-release-required-assets.test.mjs
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  extractManifestAssetNames,
+  getRequiredReleaseAssetNames,
+  verifyRequiredReleaseAssets
+} from './verify-release-required-assets.mjs'
+
+function jsonResponse(body) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: vi.fn(async () => body),
+    text: vi.fn(async () => (typeof body === 'string' ? body : JSON.stringify(body)))
+  }
+}
+
+function releaseWithAssets(tag, assetNames) {
+  return {
+    tag_name: tag,
+    draft: true,
+    prerelease: false,
+    assets: assetNames.map((name, index) => ({
+      id: index + 1,
+      name,
+      state: 'uploaded',
+      size: 123
+    }))
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getRequiredReleaseAssetNames', () => {
+  it('includes both mac updater ZIP names for the tag version', () => {
+    expect(getRequiredReleaseAssetNames('v1.4.27')).toEqual(
+      expect.arrayContaining([
+        'Orca-1.4.27-mac.zip',
+        'Orca-1.4.27-mac.zip.blockmap',
+        'Orca-1.4.27-arm64-mac.zip',
+        'Orca-1.4.27-arm64-mac.zip.blockmap'
+      ])
+    )
+  })
+})
+
+describe('extractManifestAssetNames', () => {
+  it('extracts relative and absolute manifest asset names', () => {
+    expect(
+      extractManifestAssetNames(
+        [
+          'files:',
+          '  - url: Orca-1.4.27-arm64-mac.zip',
+          '  - url: https://example.com/downloads/orca-windows-setup.exe',
+          'path: orca-linux.AppImage'
+        ].join('\n')
+      )
+    ).toEqual(['Orca-1.4.27-arm64-mac.zip', 'orca-windows-setup.exe', 'orca-linux.AppImage'])
+  })
+})
+
+describe('verifyRequiredReleaseAssets', () => {
+  it('fails when a manifest-referenced asset has not been uploaded', async () => {
+    const tag = 'v1.4.27'
+    const required = getRequiredReleaseAssetNames(tag)
+    const assets = required.filter((name) => name !== 'Orca-1.4.27-arm64-mac.zip')
+    const release = releaseWithAssets(tag, assets)
+    const latestMacAsset = release.assets.find((asset) => asset.name === 'latest-mac.yml')
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([release]))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          [
+            'version: 1.4.27',
+            'files:',
+            '  - url: Orca-1.4.27-arm64-mac.zip',
+            '    sha512: test',
+            'path: Orca-1.4.27-arm64-mac.zip'
+          ].join('\n')
+        )
+      )
+      .mockResolvedValue(jsonResponse('version: 1.4.27\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      verifyRequiredReleaseAssets({ repo: 'stablyai/orca', tag, token: 'token' })
+    ).rejects.toThrow('Missing: Orca-1.4.27-arm64-mac.zip')
+    expect(latestMacAsset).toBeTruthy()
+  })
+})

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -79,6 +79,7 @@ export function isBenignCheckFailure(message: string): boolean {
   // During that window electron-updater may fail the check even though
   // nothing is wrong on the client side.
   return (
+    normalizedMessage.includes('latest release assets are still publishing') ||
     isGitHubReleaseTransitionFailure(normalizedMessage) ||
     normalizedMessage.includes('no published versions on github')
   )

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { netFetchMock } = vi.hoisted(() => ({
+  netFetchMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+function buildAtomFeed(tags: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><feed>${tags
+    .map(
+      (tag) =>
+        `<entry><link rel="alternate" type="text/html" href="https://github.com/stablyai/orca/releases/tag/${tag}"/><title>${tag}</title></entry>`
+    )
+    .join('')}</feed>`
+}
+
+function buildManifest(tag: string): string {
+  const version = tag.replace(/^v/i, '')
+  return [
+    `version: ${version}`,
+    'files:',
+    `  - url: Orca-${version}-arm64-mac.zip`,
+    '    sha512: test',
+    `path: Orca-${version}-arm64-mac.zip`
+  ].join('\n')
+}
+
+function isPlatformManifestRequest(url: string): boolean {
+  return /\/latest(?:-[a-z]+)?\.yml$/.test(url)
+}
+
+function respondWithAtom(
+  tags: string[],
+  missingManifestTags: string[] = [],
+  missingAssetTags: string[] = []
+): void {
+  const missingManifests = new Set(missingManifestTags)
+  const missingAssets = new Set(missingAssetTags)
+  netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+    if (url === 'https://github.com/stablyai/orca/releases.atom') {
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(buildAtomFeed(tags)) })
+    }
+
+    const manifestMatch = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
+    if (manifestMatch) {
+      const tag = decodeURIComponent(manifestMatch[1])
+      return Promise.resolve({
+        ok: !missingManifests.has(tag),
+        text: () => Promise.resolve(buildManifest(tag))
+      })
+    }
+
+    const assetMatch = url.match(/\/releases\/download\/([^/]+)\/(.+)$/)
+    if (assetMatch && init?.method === 'HEAD') {
+      return Promise.resolve({
+        ok: !missingAssets.has(decodeURIComponent(assetMatch[1])),
+        text: () => Promise.resolve('')
+      })
+    }
+
+    return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+  })
+}
+
+describe('fetchNewerReleaseTagsWithReadiness', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    netFetchMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('reports not-ready when newer tags exist but their manifest assets are unavailable', async () => {
+    respondWithAtom(['v1.4.27'], [], ['v1.4.27'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready'
+    })
+  })
+
+  it('reports no-newer separately from feed fetch failures', async () => {
+    respondWithAtom(['v1.4.26'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'no-newer'
+    })
+
+    netFetchMock.mockResolvedValue({ ok: false, text: () => Promise.resolve('') })
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'unavailable'
+    })
+  })
+
+  it('requires every asset referenced by the manifest files list to be reachable', async () => {
+    netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.28', 'v1.4.27']))
+        })
+      }
+
+      const manifestMatch = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
+      if (manifestMatch) {
+        const version = decodeURIComponent(manifestMatch[1]).replace(/^v/i, '')
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              [
+                `version: ${version}`,
+                'files:',
+                `  - url: Orca-${version}-mac.zip`,
+                '    sha512: test',
+                `  - url: Orca-${version}-arm64-mac.zip`,
+                '    sha512: test',
+                `path: Orca-${version}-mac.zip`
+              ].join('\n')
+            )
+        })
+      }
+
+      if (init?.method === 'HEAD') {
+        return Promise.resolve({
+          ok: !url.endsWith('/Orca-1.4.28-arm64-mac.zip'),
+          text: () => Promise.resolve('')
+        })
+      }
+
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    })
+
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+
+    expect(await fetchNewerReleaseTag('1.4.26')).toBe('v1.4.27')
+  })
+
+  it('accepts absolute manifest asset URLs without rewriting them to release asset paths', async () => {
+    const assetUrls: string[] = []
+    netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.27']))
+        })
+      }
+
+      if (isPlatformManifestRequest(url)) {
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              [
+                'version: 1.4.27',
+                'files:',
+                '  - url: https://downloads.example.com/Orca-1.4.27-arm64-mac.zip',
+                '    sha512: test'
+              ].join('\n')
+            )
+        })
+      }
+
+      if (init?.method === 'HEAD') {
+        assetUrls.push(url)
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('') })
+      }
+
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    })
+
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+
+    expect(await fetchNewerReleaseTag('1.4.26')).toBe('v1.4.27')
+    expect(assetUrls).toEqual(['https://downloads.example.com/Orca-1.4.27-arm64-mac.zip'])
+  })
+
+  it('treats malformed updater manifests as not ready', async () => {
+    netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
+      if (url === 'https://github.com/stablyai/orca/releases.atom') {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(buildAtomFeed(['v1.4.28', 'v1.4.27']))
+        })
+      }
+
+      if (url.includes('/releases/download/v1.4.28/')) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('files:\n  - url: [') })
+      }
+
+      if (url.includes('/releases/download/v1.4.27/') && isPlatformManifestRequest(url)) {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(buildManifest('v1.4.27')) })
+      }
+
+      if (init?.method === 'HEAD') {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('') })
+      }
+
+      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    })
+
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+
+    expect(await fetchNewerReleaseTag('1.4.26')).toBe('v1.4.27')
+  })
+})

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -20,9 +20,25 @@ function buildAtomFeed(tags: string[]): string {
   return `<?xml version="1.0" encoding="UTF-8"?><feed>${entries}</feed>`
 }
 
-function respondWithAtom(tags: string[], missingManifestTags: string[] = []): void {
+function buildManifest(tag: string): string {
+  const version = tag.replace(/^v/i, '')
+  return [
+    `version: ${version}`,
+    'files:',
+    `  - url: Orca-${version}-arm64-mac.zip`,
+    '    sha512: test',
+    `path: Orca-${version}-arm64-mac.zip`
+  ].join('\n')
+}
+
+function respondWithAtom(
+  tags: string[],
+  missingManifestTags: string[] = [],
+  missingAssetTags: string[] = []
+): void {
   const missingManifests = new Set(missingManifestTags)
-  netFetchMock.mockImplementation((url: string) => {
+  const missingAssets = new Set(missingAssetTags)
+  netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
     if (url === 'https://github.com/stablyai/orca/releases.atom') {
       return Promise.resolve({
         ok: true,
@@ -30,13 +46,25 @@ function respondWithAtom(tags: string[], missingManifestTags: string[] = []): vo
       })
     }
 
-    const match = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
-    if (!match) {
-      return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
+    const manifestMatch = url.match(/\/releases\/download\/([^/]+)\/latest(?:-[a-z]+)?\.yml$/)
+    if (manifestMatch) {
+      const tag = decodeURIComponent(manifestMatch[1])
+      return Promise.resolve({
+        ok: !missingManifests.has(tag),
+        text: () => Promise.resolve(buildManifest(tag))
+      })
+    }
+
+    const assetMatch = url.match(/\/releases\/download\/([^/]+)\/(.+)$/)
+    if (assetMatch && init?.method === 'HEAD') {
+      return Promise.resolve({
+        ok: !missingAssets.has(decodeURIComponent(assetMatch[1])),
+        text: () => Promise.resolve('')
+      })
     }
 
     return Promise.resolve({
-      ok: !missingManifests.has(decodeURIComponent(match[1])),
+      ok: false,
       text: () => Promise.resolve('')
     })
   })
@@ -83,8 +111,9 @@ describe('fetchNewerReleaseTag', () => {
     async (platform, manifestName) => {
       setPlatformForTest(platform)
       const manifestUrls: string[] = []
+      const assetUrls: string[] = []
 
-      netFetchMock.mockImplementation((url: string) => {
+      netFetchMock.mockImplementation((url: string, init?: { method?: string }) => {
         if (url === 'https://github.com/stablyai/orca/releases.atom') {
           return Promise.resolve({
             ok: true,
@@ -92,7 +121,17 @@ describe('fetchNewerReleaseTag', () => {
           })
         }
 
-        manifestUrls.push(url)
+        if (url.endsWith(manifestName)) {
+          manifestUrls.push(url)
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(buildManifest('v1.4.1'))
+          })
+        }
+
+        if (init?.method === 'HEAD') {
+          assetUrls.push(url)
+        }
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('')
@@ -104,6 +143,9 @@ describe('fetchNewerReleaseTag', () => {
       expect(await fetchNewerReleaseTag('1.4.0')).toBe('v1.4.1')
       expect(manifestUrls).toEqual([
         `https://github.com/stablyai/orca/releases/download/v1.4.1/${manifestName}`
+      ])
+      expect(assetUrls).toEqual([
+        'https://github.com/stablyai/orca/releases/download/v1.4.1/Orca-1.4.1-arm64-mac.zip'
       ])
     }
   )
@@ -160,6 +202,22 @@ describe('fetchNewerReleaseTag', () => {
     const { fetchNewerReleaseTags } = await import('./updater-prerelease-feed')
 
     expect(await fetchNewerReleaseTags('1.4.1-rc.1', 2)).toEqual(['v1.4.1-rc.2', 'v1.4.1-rc.1'])
+  })
+
+  it('skips feed tags whose manifest asset is not reachable yet', async () => {
+    respondWithAtom(['v1.4.3', 'v1.4.2', 'v1.4.1'], [], ['v1.4.3'])
+
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+
+    expect(await fetchNewerReleaseTag('1.4.0')).toBe('v1.4.2')
+  })
+
+  it('returns null when the only newer tag has a manifest but its asset still 404s', async () => {
+    respondWithAtom(['v1.4.27'], [], ['v1.4.27'])
+
+    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+
+    expect(await fetchNewerReleaseTag('1.4.26')).toBeNull()
   })
 
   it('does not return the current tag as the primary update when newer manifests are missing', async () => {

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -1,4 +1,5 @@
 import { net } from 'electron'
+import { parse } from 'yaml'
 import { compareVersions, isPrereleaseVersion, isValidVersion } from './updater-fallback'
 
 const ATOM_FEED_URL = 'https://github.com/stablyai/orca/releases.atom'
@@ -27,6 +28,10 @@ function getPlatformManifestName(): string {
 
 function getReleaseManifestUrl(tag: string): string {
   return `${getReleaseDownloadUrl(tag)}/${getPlatformManifestName()}`
+}
+
+function getReleaseAssetUrl(tag: string, assetName: string): string {
+  return `${getReleaseDownloadUrl(tag)}/${encodeURIComponent(assetName)}`
 }
 
 export function normalizeTagToVersion(tag: string): string {
@@ -67,15 +72,68 @@ async function fetchReleaseFeedTags(): Promise<ReleaseFeedTag[] | null> {
   }
 }
 
-async function hasPlatformManifest(tag: string): Promise<boolean> {
+type ManifestAssetEntry = {
+  url?: unknown
+  path?: unknown
+}
+
+function getManifestAssetNames(manifestText: string): string[] {
+  const parsed = parse(manifestText) as {
+    files?: ManifestAssetEntry[]
+    path?: unknown
+  } | null
+
+  const names = new Set<string>()
+  for (const file of Array.isArray(parsed?.files) ? parsed.files : []) {
+    const value = typeof file.url === 'string' ? file.url : file.path
+    if (typeof value === 'string' && value.trim()) {
+      names.add(value.trim())
+    }
+  }
+  if (typeof parsed?.path === 'string' && parsed.path.trim()) {
+    names.add(parsed.path.trim())
+  }
+  return [...names]
+}
+
+async function isReleaseAssetAvailable(tag: string, assetName: string): Promise<boolean> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    const assetUrl = assetName.startsWith('http')
+      ? assetName
+      : getReleaseAssetUrl(tag, assetName.split('/').filter(Boolean).at(-1) ?? assetName)
+    const res = await net.fetch(assetUrl, { method: 'HEAD', signal: controller.signal })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
 
   try {
     // Why: cancelled/draft releases can appear in GitHub's atom feed before
-    // they have updater manifests. Pinning to those tags makes every check 404.
-    const res = await net.fetch(getReleaseManifestUrl(tag), { signal: controller.signal })
-    return res.ok
+    // they have updater manifests or the ZIP/exe/AppImage assets referenced by
+    // those manifests. Pinning to those tags makes download clicks 404.
+    const manifestUrl = getReleaseManifestUrl(tag)
+    const res = await net.fetch(manifestUrl, { signal: controller.signal })
+    if (!res.ok) {
+      return false
+    }
+    const assetNames = getManifestAssetNames(await res.text())
+    if (assetNames.length === 0) {
+      return false
+    }
+    const assetResults = await Promise.all(
+      assetNames.map((assetName) => isReleaseAssetAvailable(tag, assetName))
+    )
+    return assetResults.every(Boolean)
   } catch {
     return false
   } finally {
@@ -100,6 +158,11 @@ type FetchNewerReleaseTagOptions = {
   includePrerelease?: boolean
 }
 
+export type FetchNewerReleaseTagsResult = {
+  tags: string[]
+  state: 'ready' | 'no-newer' | 'not-ready' | 'unavailable'
+}
+
 export async function fetchNewerReleaseTag(
   currentVersion: string,
   options: FetchNewerReleaseTagOptions = {}
@@ -112,10 +175,18 @@ export async function fetchNewerReleaseTags(
   maxTags: number,
   options: FetchNewerReleaseTagOptions = {}
 ): Promise<string[]> {
+  return (await fetchNewerReleaseTagsWithReadiness(currentVersion, maxTags, options)).tags
+}
+
+export async function fetchNewerReleaseTagsWithReadiness(
+  currentVersion: string,
+  maxTags: number,
+  options: FetchNewerReleaseTagOptions = {}
+): Promise<FetchNewerReleaseTagsResult> {
   const includePrerelease = options.includePrerelease ?? true
   const tags = await fetchReleaseFeedTags()
   if (!tags || maxTags <= 0) {
-    return []
+    return { tags: [], state: 'unavailable' }
   }
 
   const candidates = includePrerelease
@@ -125,7 +196,7 @@ export async function fetchNewerReleaseTags(
     ({ version }) => compareVersions(version, currentVersion) > 0
   )
   if (newestNewerIndex === -1) {
-    return []
+    return { tags: [], state: 'no-newer' }
   }
 
   // Why: a cancelled release can leave several feed entries without manifests,
@@ -138,7 +209,7 @@ export async function fetchNewerReleaseTags(
     probeCandidates.map(async ({ tag, version }) => ({
       tag,
       version,
-      hasManifest: await hasPlatformManifest(tag)
+      hasManifest: await hasReadyPlatformManifest(tag)
     }))
   )
 
@@ -146,12 +217,15 @@ export async function fetchNewerReleaseTags(
     ({ hasManifest, version }) => hasManifest && compareVersions(version, currentVersion) > 0
   )
   if (primaryIndex === -1) {
-    return []
+    return { tags: [], state: 'not-ready' }
   }
 
-  return manifestResults
-    .slice(primaryIndex)
-    .filter(({ hasManifest }) => hasManifest)
-    .slice(0, maxTags)
-    .map(({ tag }) => tag)
+  return {
+    tags: manifestResults
+      .slice(primaryIndex)
+      .filter(({ hasManifest }) => hasManifest)
+      .slice(0, maxTags)
+      .map(({ tag }) => tag),
+    state: 'ready'
+  }
 }

--- a/src/main/updater.fallback.test.ts
+++ b/src/main/updater.fallback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   compareVersions,
+  isBenignCheckFailure,
   isMissingUpdateManifestFailure,
   isPrereleaseVersion
 } from './updater-fallback'
@@ -39,5 +40,11 @@ describe('isMissingUpdateManifestFailure', () => {
     ).toBe(true)
     expect(isMissingUpdateManifestFailure('net::ERR_FAILED')).toBe(false)
     expect(isMissingUpdateManifestFailure('Unable to find latest version on GitHub')).toBe(false)
+  })
+})
+
+describe('isBenignCheckFailure', () => {
+  it('treats in-progress release asset publication as retryable', () => {
+    expect(isBenignCheckFailure('Latest release assets are still publishing')).toBe(true)
   })
 })

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -131,7 +131,12 @@ const { fetchNewerReleaseTagsMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('./updater-prerelease-feed', () => ({
-  fetchNewerReleaseTags: fetchNewerReleaseTagsMock,
+  fetchNewerReleaseTagsWithReadiness: async (...args: unknown[]) => {
+    const result = await fetchNewerReleaseTagsMock(...args)
+    return Array.isArray(result)
+      ? { tags: result, state: result.length > 0 ? 'ready' : 'no-newer' }
+      : result
+  },
   getReleaseDownloadUrl: (tag: string) =>
     `https://github.com/stablyai/orca/releases/download/${tag}`
 }))
@@ -893,6 +898,73 @@ describe('updater', () => {
     expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
       provider: 'generic',
       url: 'https://github.com/stablyai/orca/releases/latest/download'
+    })
+  })
+
+  it('does not fall back to the moving latest feed when newer release assets are still publishing', async () => {
+    appMock.getVersion.mockReturnValue('1.4.26')
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'not-ready' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    const setupFeedUrlCalls = autoUpdaterMock.setFeedURL.mock.calls.length
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      const statuses = sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+      expect(statuses).toContainEqual(
+        expect.objectContaining({
+          state: 'error',
+          userInitiated: true,
+          message: expect.stringContaining("Couldn't reach the update server")
+        })
+      )
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+    expect(autoUpdaterMock.setFeedURL.mock.calls.length).toBe(setupFeedUrlCalls)
+  })
+
+  it('keeps background checks retryable while newer release assets are still publishing', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
+    appMock.getVersion.mockReturnValue('1.4.26')
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({ tags: [], state: 'not-ready' })
+      .mockResolvedValueOnce(['v1.4.27'])
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const setLastUpdateCheckAt = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      setLastUpdateCheckAt
+    })
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledTimes(1)
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.27'
     })
   })
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -19,7 +19,10 @@ import {
   isPrereleaseVersion,
   statusesEqual
 } from './updater-fallback'
-import { fetchNewerReleaseTags, getReleaseDownloadUrl } from './updater-prerelease-feed'
+import {
+  fetchNewerReleaseTagsWithReadiness,
+  getReleaseDownloadUrl
+} from './updater-prerelease-feed'
 import { fetchNudge, shouldApplyNudge } from './updater-nudge'
 
 type CheckFailureSource = 'event' | 'promise' | 'fallback-promise'
@@ -436,11 +439,15 @@ async function pinDefaultReleaseFeed(): Promise<void> {
   // newer RC or the next stable. Stable users should only resolve stable tags.
   const currentVersion = app.getVersion()
   const includePrerelease = includePrereleaseActive || isPrereleaseVersion(currentVersion)
-  const releaseTags = await fetchNewerReleaseTags(currentVersion, includePrerelease ? 2 : 1, {
-    includePrerelease
-  })
-  const newerTag = releaseTags[0] ?? null
-  const fallbackTag = includePrerelease ? (releaseTags[1] ?? null) : null
+  const releaseTagsResult = await fetchNewerReleaseTagsWithReadiness(
+    currentVersion,
+    includePrerelease ? 2 : 1,
+    {
+      includePrerelease
+    }
+  )
+  const newerTag = releaseTagsResult.tags[0] ?? null
+  const fallbackTag = includePrerelease ? (releaseTagsResult.tags[1] ?? null) : null
   pendingPrereleaseFallback =
     includePrerelease && newerTag && fallbackTag
       ? {
@@ -466,6 +473,12 @@ async function pinDefaultReleaseFeed(): Promise<void> {
       `[updater] release feed pinned: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
     )
     autoUpdater.setFeedURL({ provider: 'generic', url })
+  } else if (releaseTagsResult.state === 'not-ready') {
+    clearPrereleaseFallbackContext()
+    console.info(
+      `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
+    )
+    throw new Error('Latest release assets are still publishing')
   } else {
     clearPrereleaseFallbackContext()
     const url = 'https://github.com/stablyai/orca/releases/latest/download'


### PR DESCRIPTION
## Summary
- verify updater manifests only become selectable after their referenced assets are reachable
- avoid falling back to GitHub's moving latest download feed while newer release assets are still publishing
- preserve pending update nudge campaigns through the transient release-publishing retry window
- add release verifier and updater regression coverage for manifest-present / asset-404 states

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/main/updater-prerelease-feed.test.ts src/main/updater-prerelease-feed-readiness.test.ts src/main/updater.test.ts src/main/updater.check-failure.test.ts src/main/updater.fallback.test.ts src/main/updater.mac-install.test.ts config/scripts/verify-release-required-assets.test.mjs config/scripts/publish-complete-draft-releases.test.mjs config/scripts/electron-builder-config.test.mjs
- pnpm run typecheck
- pnpm run lint
- git diff --check
- GITHUB_TOKEN=$(gh auth token) node config/scripts/verify-release-required-assets.mjs v1.4.27
- direct HEAD check of every asset referenced by v1.4.27 latest-mac.yml
- pnpm run build:electron-vite

## Notes
- Ran pnpm run test as a broad regression pass. It still has 4 unrelated failures outside this updater path: src/main/providers/local-pty-shell-ready.test.ts and src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx.
- Tried pnpm run build:unpack for a packaging-level smoke. It failed before electron-builder in native/computer-use-macos Swift Package manifest linking against the local CommandLineTools PackageDescription library, so it did not exercise updater packaging.