### PR TITLE
Add external links for task filters

### DIFF
--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -5,6 +5,7 @@ import type {
   LinearMember,
   LinearWorkspaceSelection
 } from '../../shared/types'
+import { buildLinearTeamUrl } from '../../shared/linear-links'
 import { acquire, release, getClients, isAuthError, clearToken } from './client'
 
 export async function listTeams(
@@ -25,7 +26,12 @@ export async function listTeams(
           workspaceId: entry.workspace.id,
           workspaceName: entry.workspace.organizationName,
           name: t.name,
-          key: t.key
+          key: t.key,
+          url:
+            buildLinearTeamUrl({
+              organizationUrlKey: entry.workspace.organizationUrlKey,
+              teamKey: t.key
+            }) ?? undefined
         }))
       } catch (error) {
         if (isAuthError(error)) {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -88,8 +88,12 @@ import {
   getLinearStatePillStyle
 } from '@/components/linear-state-pill-style'
 import { parseTaskQuery, stripRepoQualifiers, withQualifier } from '../../../shared/task-query'
+import {
+  buildLinearTeamUrl,
+  getLinearOrganizationUrlKeyFromIssueUrl
+} from '../../../shared/linear-links'
 import PRFilterDropdowns, { type PRFilterChange } from '@/components/github/PRFilterDropdowns'
-import { parseGitHubIssueOrPRLink } from '@/lib/github-links'
+import { buildGitHubRepoUrl, parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
 import PullRequestPage from '@/components/PullRequestPage'
@@ -2832,7 +2836,12 @@ export default function TaskPage(): React.JSX.Element {
         workspaceId: issue.workspaceId,
         workspaceName: issue.workspaceName,
         name: issue.team.name,
-        key: issue.team.key
+        key: issue.team.key,
+        url:
+          buildLinearTeamUrl({
+            organizationUrlKey: getLinearOrganizationUrlKeyFromIssueUrl(issue.url),
+            teamKey: issue.team.key
+          }) ?? undefined
       })
     }
     return teams.sort((a, b) => a.name.localeCompare(b.name))
@@ -2840,7 +2849,21 @@ export default function TaskPage(): React.JSX.Element {
 
   // Why: the full Linear team fetch is async and can temporarily be empty.
   // Keep the selector usable from issue metadata until the complete list lands.
-  const linearTeamOptions = availableTeams.length > 0 ? availableTeams : linearIssueTeams
+  const linearTeamOptions = useMemo(() => {
+    if (availableTeams.length === 0) {
+      return linearIssueTeams
+    }
+    const issueTeamById = new Map(linearIssueTeams.map((team) => [team.id, team]))
+    return availableTeams.map((team) => {
+      if (team.url) {
+        return team
+      }
+      return {
+        ...team,
+        url: issueTeamById.get(team.id)?.url
+      }
+    })
+  }, [availableTeams, linearIssueTeams])
 
   // Why: team IDs belong to one Linear workspace. Switching workspaces while a
   // saved subset exists must not leave the task list filtered by stale team IDs.
@@ -2861,6 +2884,14 @@ export default function TaskPage(): React.JSX.Element {
     }
     return displayedLinearIssues.filter((issue) => linearTeamSelection.has(issue.team.id))
   }, [displayedLinearIssues, linearTeamSelection])
+
+  const selectedLinearTeamForExternalLink = useMemo(() => {
+    if (linearTeamSelection.size !== 1) {
+      return null
+    }
+    const [teamId] = linearTeamSelection
+    return linearTeamOptions.find((team) => team.id === teamId && team.url) ?? null
+  }, [linearTeamOptions, linearTeamSelection])
 
   const effectiveLinearDisplayProperties = useMemo(() => {
     const next = new Set(linearDisplayProperties)
@@ -3073,6 +3104,20 @@ export default function TaskPage(): React.JSX.Element {
   const [linearConnectError, setLinearConnectError] = useState<string | null>(null)
 
   const activeGithubTaskKind = getGitHubTaskKind(activeTaskPreset, appliedTaskSearch)
+  const selectedGitHubRepoExternalLink = useMemo(() => {
+    if (selectedRepos.length !== 1) {
+      return null
+    }
+    const [repo] = selectedRepos
+    const sourceState = perRepoSourceState.find((state) => state.repoId === repo.id)
+    const sources = sourceState?.sources
+    const slug =
+      activeGithubTaskKind === 'issues'
+        ? (sources?.issues ?? sources?.prs)
+        : (sources?.prs ?? sources?.issues)
+    const url = buildGitHubRepoUrl(slug)
+    return url ? { url, label: slug ? `${slug.owner}/${slug.repo}` : repo.displayName } : null
+  }, [activeGithubTaskKind, perRepoSourceState, selectedRepos])
 
   // Why: defense-in-depth safety net applied to the current page's items.
   // The active tab scopes requests to issues or PRs, and this keeps stale
@@ -4231,6 +4276,34 @@ export default function TaskPage(): React.JSX.Element {
                           </SelectContent>
                         </Select>
                       ) : null}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon-sm"
+                            onClick={() => {
+                              if (!selectedLinearTeamForExternalLink?.url) {
+                                return
+                              }
+                              void window.api.shell.openUrl(selectedLinearTeamForExternalLink.url)
+                            }}
+                            aria-label={
+                              selectedLinearTeamForExternalLink
+                                ? `Open ${selectedLinearTeamForExternalLink.name} in Linear`
+                                : 'Select one Linear team to open in Linear'
+                            }
+                            className="h-8 w-8 rounded-md border-border/50 bg-muted/50 text-foreground shadow-sm transition hover:bg-muted/50"
+                          >
+                            <ExternalLink className="size-3.5" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" sideOffset={6}>
+                          {selectedLinearTeamForExternalLink
+                            ? `Open ${selectedLinearTeamForExternalLink.name} in Linear`
+                            : 'Select one team to open in Linear'}
+                        </TooltipContent>
+                      </Tooltip>
                       <div className="min-w-0 w-full sm:w-[200px]">
                         <TeamMultiCombobox
                           teams={linearTeamOptions}
@@ -4298,26 +4371,56 @@ export default function TaskPage(): React.JSX.Element {
                         inert — hide it to avoid suggesting it does
                         something. */}
                     {githubMode !== 'project' && (
-                      <div className="min-w-0 max-w-[220px] shrink-0">
-                        <RepoMultiCombobox
-                          repos={eligibleRepos}
-                          selected={repoSelection}
-                          onChange={(next) => {
-                            setRepoSelection(next)
-                            void updateSettings({ defaultRepoSelection: [...next] }).catch(() => {
-                              toast.error('Failed to save project selection.')
-                            })
-                          }}
-                          onSelectAll={() => {
-                            const allIds = new Set(eligibleRepos.map((r) => r.id))
-                            setRepoSelection(allIds)
-                            void updateSettings({ defaultRepoSelection: null }).catch(() => {
-                              toast.error('Failed to save project selection.')
-                            })
-                          }}
-                          triggerClassName="h-8 w-auto max-w-[220px] rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
-                        />
-                      </div>
+                      <>
+                        <div className="min-w-0 max-w-[220px] shrink-0">
+                          <RepoMultiCombobox
+                            repos={eligibleRepos}
+                            selected={repoSelection}
+                            onChange={(next) => {
+                              setRepoSelection(next)
+                              void updateSettings({ defaultRepoSelection: [...next] }).catch(() => {
+                                toast.error('Failed to save project selection.')
+                              })
+                            }}
+                            onSelectAll={() => {
+                              const allIds = new Set(eligibleRepos.map((r) => r.id))
+                              setRepoSelection(allIds)
+                              void updateSettings({ defaultRepoSelection: null }).catch(() => {
+                                toast.error('Failed to save project selection.')
+                              })
+                            }}
+                            triggerClassName="h-8 w-auto max-w-[220px] rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
+                          />
+                        </div>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon-sm"
+                              onClick={() => {
+                                if (!selectedGitHubRepoExternalLink?.url) {
+                                  return
+                                }
+                                void window.api.shell.openUrl(selectedGitHubRepoExternalLink.url)
+                              }}
+                              aria-label={
+                                selectedGitHubRepoExternalLink
+                                  ? `Open ${selectedGitHubRepoExternalLink.label} in GitHub`
+                                  : 'Select one GitHub project to open in GitHub'
+                              }
+                              className="h-8 w-8 rounded-md border-border/50 bg-muted/50 text-foreground shadow-sm transition hover:bg-muted/50"
+                            >
+                              <ExternalLink className="size-3.5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" sideOffset={6}>
+                            {selectedGitHubRepoExternalLink
+                              ? `Open ${selectedGitHubRepoExternalLink.label} in GitHub`
+                              : 'Select one project to open in GitHub'}
+                          </TooltipContent>
+                        </Tooltip>
+                      </>
                     )}
                   </div>
                 ) : null}

--- a/src/renderer/src/components/ui/team-multi-combobox.tsx
+++ b/src/renderer/src/components/ui/team-multi-combobox.tsx
@@ -110,7 +110,12 @@ export default function TeamMultiCombobox({
           <ChevronsUpDown className="size-3.5 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent
+        align="start"
+        // Why: team filter triggers can collapse in narrow toolbars; the menu
+        // needs room for names and keys while still fitting small viewports.
+        className="w-[min(320px,calc(100vw-1rem))] min-w-[var(--radix-popover-trigger-width)] p-0"
+      >
         <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
           <CommandInput
             autoFocus
@@ -159,8 +164,8 @@ export default function TeamMultiCombobox({
                     )}
                   />
                   <div className="min-w-0 flex-1">
-                    <span className="inline-flex items-center gap-1.5 text-xs">
-                      <span>{team.name}</span>
+                    <span className="inline-flex max-w-full items-center gap-1.5 text-xs">
+                      <span className="min-w-0 truncate">{team.name}</span>
                       <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
                         {team.key}
                       </span>

--- a/src/renderer/src/lib/github-links.test.ts
+++ b/src/renderer/src/lib/github-links.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildGitHubRepoUrl,
   normalizeGitHubLinkQuery,
   parseGitHubIssueOrPRLink,
   parseGitHubIssueOrPRNumber
 } from './github-links'
+
+describe('buildGitHubRepoUrl', () => {
+  it('builds a GitHub repository URL from an owner/repo slug', () => {
+    expect(buildGitHubRepoUrl({ owner: 'stablyai', repo: 'orca' })).toBe(
+      'https://github.com/stablyai/orca'
+    )
+  })
+
+  it('encodes path segments', () => {
+    expect(buildGitHubRepoUrl({ owner: 'stably ai', repo: 'orca/tools' })).toBe(
+      'https://github.com/stably%20ai/orca%2Ftools'
+    )
+  })
+})
 
 describe('parseGitHubIssueOrPRNumber', () => {
   it('parses plain issue numbers and GitHub pull request URLs', () => {

--- a/src/renderer/src/lib/github-links.ts
+++ b/src/renderer/src/lib/github-links.ts
@@ -10,6 +10,13 @@ export type GitHubLinkQuery = {
   directNumber: number | null
 }
 
+export function buildGitHubRepoUrl(slug: RepoSlug | null | undefined): string | null {
+  if (!slug?.owner || !slug.repo) {
+    return null
+  }
+  return `https://github.com/${encodeURIComponent(slug.owner)}/${encodeURIComponent(slug.repo)}`
+}
+
 function matchGitHubItemPath(url: URL): RegExpExecArray | null {
   return GH_ITEM_PATH_RE.exec(url.pathname.replace(/\/+$/, ''))
 }

--- a/src/shared/linear-links.test.ts
+++ b/src/shared/linear-links.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLinearTeamUrl, getLinearOrganizationUrlKeyFromIssueUrl } from './linear-links'
+
+describe('linear links', () => {
+  it('builds team URLs from workspace and team keys', () => {
+    expect(buildLinearTeamUrl({ organizationUrlKey: 'acme', teamKey: 'ENG' })).toBe(
+      'https://linear.app/acme/team/ENG/all'
+    )
+  })
+
+  it('encodes URL path segments', () => {
+    expect(buildLinearTeamUrl({ organizationUrlKey: 'acme inc', teamKey: 'A/B' })).toBe(
+      'https://linear.app/acme%20inc/team/A%2FB/all'
+    )
+  })
+
+  it('extracts the workspace URL key from Linear issue URLs', () => {
+    expect(getLinearOrganizationUrlKeyFromIssueUrl('https://linear.app/acme/issue/ENG-1')).toBe(
+      'acme'
+    )
+  })
+})

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -1,0 +1,26 @@
+export function buildLinearTeamUrl(args: {
+  organizationUrlKey?: string | null
+  teamKey?: string | null
+}): string | null {
+  const organizationUrlKey = args.organizationUrlKey?.trim()
+  const teamKey = args.teamKey?.trim()
+  if (!organizationUrlKey || !teamKey) {
+    return null
+  }
+  return `https://linear.app/${encodeURIComponent(organizationUrlKey)}/team/${encodeURIComponent(teamKey)}/all`
+}
+
+export function getLinearOrganizationUrlKeyFromIssueUrl(issueUrl?: string | null): string | null {
+  if (!issueUrl) {
+    return null
+  }
+  try {
+    const parsed = new URL(issueUrl)
+    if (parsed.hostname !== 'linear.app') {
+      return null
+    }
+    return parsed.pathname.split('/').filter(Boolean)[0] ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1216,6 +1216,7 @@ export type LinearTeam = {
   workspaceName?: string
   name: string
   key: string
+  url?: string
 }
 
 // ─── Hooks (orca.yaml) ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds external-link buttons for single selected Linear team and GitHub project filters, with shared URL builders and tests.

## Screenshots

UI change; screenshot evidence captured locally as `linear-team-open-link.png` and intentionally not committed.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` via `pnpm exec vitest run src/renderer/src/lib/github-links.test.ts src/shared/linear-links.test.ts`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Ran a single-agent review against `origin/main` for correctness, security, type safety, error handling, performance, dead code, and unused imports. It found no issues. The review included cross-platform compatibility for macOS, Linux, and Windows; this PR does not add shortcuts, file path handling, shell behavior, or platform-specific Electron behavior.

## Security Audit

Reviewed URL construction and shell open behavior. URLs are built from known Linear/GitHub metadata with encoded path segments, and opening is routed through the existing `window.api.shell.openUrl` IPC. No command execution, secrets, dependency, auth, or filesystem path handling changes.

## Notes

Untracked local artifacts `.antigravitycli/` and `linear-team-open-link.png` were left out of the commit.
