### PR TITLE
fix: clear CDP proxy startup error listener

### DIFF
--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -94,6 +94,14 @@ describe('CdpWsProxy', () => {
     expect(proxy.getPort()).toBeGreaterThan(0)
   })
 
+  it('does not retain an extra startup server error listener after binding', () => {
+    const server = (
+      proxy as unknown as { httpServer: { listenerCount: (event: string) => number } }
+    ).httpServer
+
+    expect(server.listenerCount('error')).toBeLessThanOrEqual(1)
+  })
+
   it('attaches debugger on start', () => {
     expect(mock.webContents.debugger.attach).toHaveBeenCalledWith('1.3')
   })

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -24,6 +24,9 @@ export class CdpWsProxy {
     return new Promise<string>((resolve, reject) => {
       this.httpServer = createServer((req, res) => this.handleHttpRequest(req, res))
       this.wss = new WebSocketServer({ server: this.httpServer })
+      const onListenError = (error: Error): void => {
+        reject(error)
+      }
       this.wss.on('connection', (ws) => {
         if (this.client) {
           this.client.close()
@@ -37,6 +40,7 @@ export class CdpWsProxy {
         })
       })
       this.httpServer.listen(0, '127.0.0.1', () => {
+        this.httpServer?.removeListener('error', onListenError)
         const addr = this.httpServer!.address()
         if (typeof addr === 'object' && addr) {
           this.port = addr.port
@@ -45,7 +49,7 @@ export class CdpWsProxy {
           reject(new Error('Failed to bind proxy server'))
         }
       })
-      this.httpServer.on('error', reject)
+      this.httpServer.once('error', onListenError)
     })
   }
 


### PR DESCRIPTION
## Summary
- Removes the temporary HTTP server startup `error` listener once the CDP WebSocket proxy successfully binds, and adds a regression assertion for retained error listeners.

## Risk level
Low - startup listener cleanup after successful bind; proxy request and WebSocket handling are unchanged.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/browser/cdp-ws-proxy.test.ts`