### PR TITLE
fix: clear daemon server startup error listener

### DIFF
--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: daemon server RPC, auth, stream batching, and shutdown behavior share one socket/client harness; splitting would duplicate setup. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { connect, type Socket } from 'net'
+import { connect, type Server, type Socket } from 'net'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { mkdtempSync, rmSync, readFileSync } from 'fs'
@@ -44,6 +44,7 @@ function createMockSubprocess(): SubprocessHandle & {
 }
 
 type DaemonServerPrivate = {
+  server: Server | null
   clients: Map<
     string,
     {
@@ -95,6 +96,13 @@ describe('DaemonServer', () => {
 
       const token = readFileSync(tokenPath, 'utf-8')
       expect(token.length).toBeGreaterThan(0)
+    })
+
+    it('removes the startup error listener after listening', async () => {
+      await startServer()
+
+      const daemon = server as unknown as DaemonServerPrivate
+      expect(daemon.server?.listenerCount('error')).toBe(0)
     })
 
     it('accepts client connections', async () => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -63,12 +63,16 @@ export class DaemonServer {
   async start(): Promise<void> {
     return new Promise((resolve, reject) => {
       this.server = createServer((socket) => this.handleConnection(socket))
-
-      this.server.on('error', (err) => {
+      const onListenError = (err: Error): void => {
         reject(err)
-      })
+      }
+
+      this.server.once('error', onListenError)
 
       this.server.listen(this.socketPath, () => {
+        // Why: after bind, steady-state socket errors are handled per client;
+        // the startup promise listener would otherwise retain this closure.
+        this.server?.off('error', onListenError)
         writeFileSync(this.tokenPath, this.token, { mode: 0o600 })
         try {
           chmodSync(this.socketPath, 0o600)


### PR DESCRIPTION
## Summary
- Removes the daemon socket startup `error` listener after a successful bind and covers it with a regression test.

## Risk level
Low - listener cleanup is limited to startup promise state after the daemon server is already listening.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/daemon/daemon-server.test.ts`