### PR TITLE
fix: remove SSH startup listeners after connect

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -35,6 +35,11 @@ vi.mock('ssh2', () => {
     on(event: string, handler: (...args: unknown[]) => void) {
       eventHandlers?.set(event, handler)
     }
+    off(event: string, handler: (...args: unknown[]) => void) {
+      if (eventHandlers?.get(event) === handler) {
+        eventHandlers.delete(event)
+      }
+    }
     connect(config?: unknown) {
       this.lastConnectConfig = config
       setTimeout(() => {
@@ -174,6 +179,16 @@ describe('SshConnection', () => {
 
     expect(clientInstances).toHaveLength(1)
     expect(clientInstances[0].setNoDelay).toHaveBeenCalledWith(true)
+  })
+
+  it('removes startup listeners after ssh2 connect succeeds', async () => {
+    const conn = new SshConnection(createTarget(), createCallbacks())
+
+    await conn.connect()
+
+    expect(eventHandlers.has('ready')).toBe(false)
+    // The remaining error listener is the steady-state disconnect handler.
+    expect(eventHandlers.has('error')).toBe(true)
   })
 
   it('enables TCP_NODELAY on the new ssh2 client after a reconnect cycle', async () => {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -446,10 +446,17 @@ export class SshConnection {
     return new Promise<void>((resolve, reject) => {
       const client = new SshClient()
       let settled = false
-      client.on('ready', () => {
+
+      const cleanupStartupListeners = (): void => {
+        client.off('ready', onReady)
+        client.off('error', onStartupError)
+      }
+
+      const onReady = (): void => {
         if (settled) {
           return
         }
+        cleanupStartupListeners()
         // Why: connect() completion races with explicit disconnect(). Once a
         // newer connect attempt or disconnect bumps the generation/disposed
         // state, this late ready event must not resurrect the torn-down client.
@@ -482,15 +489,20 @@ export class SshConnection {
         this.setState('connected')
         this.setupDisconnectHandler(client)
         resolve()
-      })
-      client.on('error', (err) => {
+      }
+
+      const onStartupError = (err: Error): void => {
         if (settled) {
           return
         }
+        cleanupStartupListeners()
         settled = true
         client.destroy()
         reject(err)
-      })
+      }
+
+      client.on('ready', onReady)
+      client.on('error', onStartupError)
       client.connect(config)
     })
   }


### PR DESCRIPTION
## Summary
- Removes temporary ssh2 `ready`/`error` startup listeners once connect resolves or rejects, while leaving steady-state disconnect handling unchanged.

## Risk level
Medium, reduced by a second pass - touches SSH connection setup, including remote use cases; regression coverage verifies startup listeners are removed after successful connect.

## Additional risk pass
- Re-reviewed connect/disconnect generation checks so late `ready` events still cannot resurrect disposed clients, and steady-state SSH errors remain owned by the disconnect handler.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts`\n- `pnpm run typecheck:node`