### PR TITLE
Fix terminal focus after tab bar menu launches

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const appStoreSnapshot: {
+  activeTabId: string | null
+  activeTabType: 'terminal' | 'editor' | 'browser' | null
+} = {
+  activeTabId: 'old-terminal',
+  activeTabType: 'terminal'
+}
+
 const useAppStoreMock = vi.fn(
   (
     selector: (state: {
+      activeTabId: string | null
+      activeTabType: 'terminal' | 'editor' | 'browser' | null
       gitStatusByWorktree: Record<string, never[]>
       settings: {
         terminalWindowsShell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
@@ -11,6 +21,8 @@ const useAppStoreMock = vi.fn(
     }) => unknown
   ) =>
     selector({
+      activeTabId: appStoreSnapshot.activeTabId,
+      activeTabType: appStoreSnapshot.activeTabType,
       gitStatusByWorktree: {},
       settings: {
         terminalWindowsShell: 'powershell.exe',
@@ -53,8 +65,20 @@ vi.mock('@dnd-kit/sortable', () => ({
   }
 }))
 
+const useAppStoreExport = (selector: Parameters<typeof useAppStoreMock>[0]): unknown =>
+  useAppStoreMock(selector)
+useAppStoreExport.getState = vi.fn(() => ({
+  activeTabId: appStoreSnapshot.activeTabId,
+  activeTabType: appStoreSnapshot.activeTabType,
+  gitStatusByWorktree: {},
+  settings: {
+    terminalWindowsShell: 'powershell.exe',
+    terminalWindowsPowerShellImplementation: 'auto'
+  }
+}))
+
 vi.mock('../../store', () => ({
-  useAppStore: (selector: Parameters<typeof useAppStoreMock>[0]) => useAppStoreMock(selector)
+  useAppStore: useAppStoreExport
 }))
 
 vi.mock('../right-sidebar/status-display', () => ({
@@ -209,10 +233,24 @@ describe('TabBar context menu wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.resetModules()
+    vi.useRealTimers()
+    appStoreSnapshot.activeTabId = 'old-terminal'
+    appStoreSnapshot.activeTabType = 'terminal'
     vi.stubGlobal('navigator', { userAgent: 'Mac' })
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('window', {
+      setTimeout,
+      clearTimeout,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -250,5 +288,40 @@ describe('TabBar context menu wiring', () => {
     const onClose = editorTabs[0].props.onCloseToRight as () => void
     onClose()
     expect(onCloseToRight).toHaveBeenCalledWith('unified-editor-1')
+  })
+
+  it('waits for async menu-created terminals before focusing xterm', async () => {
+    vi.useFakeTimers()
+    Object.assign(window, { setTimeout, clearTimeout })
+    const { focusTerminalTabSurface } = await import('@/lib/focus-terminal-tab-surface')
+    const element = await renderTabBar({
+      tabs: [TERMINAL_TAB],
+      activeTabId: 'old-terminal',
+      activeTabType: 'terminal',
+      onNewTerminalTab: () => {
+        window.setTimeout(() => {
+          appStoreSnapshot.activeTabId = 'new-terminal'
+          appStoreSnapshot.activeTabType = 'terminal'
+        }, 100)
+      }
+    })
+
+    const menuItems = findChildrenByType(element, 'DropdownMenuItem')
+    const newTerminalItem = menuItems[0]
+    const menuContent = findChildrenByType(element, 'DropdownMenuContent')[0]
+    expect(newTerminalItem).toBeTruthy()
+    expect(menuContent).toBeTruthy()
+
+    ;(newTerminalItem.props.onSelect as () => void)()
+    ;(menuContent.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
+      preventDefault: vi.fn()
+    })
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(focusTerminalTabSurface).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(focusTerminalTabSurface).toHaveBeenCalledWith('new-terminal')
+    expect(focusTerminalTabSurface).not.toHaveBeenCalledWith('old-terminal')
   })
 })

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -166,6 +166,25 @@ function TabBarInner({
   // clicks, so it misses webview clicks entirely. Listening for window blur
   // catches the moment focus leaves the renderer (including into a webview).
   const [newTabMenuOpen, setNewTabMenuOpen] = useState(false)
+  const pendingNewTabMenuFocusRef = useRef<(() => void) | null>(null)
+  const queueActiveTerminalFocusAfterNewTabMenuClose = (): void => {
+    pendingNewTabMenuFocusRef.current = () => {
+      const state = useAppStore.getState()
+      if (state.activeTabType === 'terminal' && state.activeTabId) {
+        focusTerminalTabSurface(state.activeTabId)
+      }
+    }
+  }
+  const queueTerminalTabFocusAfterNewTabMenuClose = (tabId: string): void => {
+    pendingNewTabMenuFocusRef.current = () => focusTerminalTabSurface(tabId)
+  }
+  const runPendingNewTabMenuFocusAfterClose = (): void => {
+    const pendingFocus = pendingNewTabMenuFocusRef.current
+    pendingNewTabMenuFocusRef.current = null
+    if (pendingFocus) {
+      requestAnimationFrame(pendingFocus)
+    }
+  }
   useEffect(() => {
     if (!newTabMenuOpen) {
       return
@@ -463,11 +482,11 @@ function TabBarInner({
           sideOffset={6}
           className="min-w-[11rem] rounded-[11px] border-border/80 p-1 shadow-[0_16px_36px_rgba(0,0,0,0.24)]"
           onCloseAutoFocus={(e) => {
-            // Why: selecting "New Terminal" activates a freshly-mounted xterm on
-            // the next frame. Radix's default focus restore sends focus back to
-            // the "+" trigger after close, which steals it from the new tab and
-            // makes the terminal look unfocused until the user clicks again.
+            // Why: terminal-producing menu actions activate a freshly-mounted
+            // xterm. Radix's default focus restore sends focus back to the "+"
+            // trigger after close, stealing it from the new terminal.
             e.preventDefault()
+            runPendingNewTabMenuFocusAfterClose()
           }}
         >
           {isWindows && onNewTerminalWithShell ? (
@@ -510,6 +529,7 @@ function TabBarInner({
                       // picked PowerShell 7+ in advanced settings, launching the
                       // "PowerShell" menu item must preserve that implementation
                       // instead of forcing inbox powershell.exe.
+                      queueActiveTerminalFocusAfterNewTabMenuClose()
                       onNewTerminalWithShell(
                         resolveWindowsShellLaunchTarget(
                           entry.shell,
@@ -532,6 +552,7 @@ function TabBarInner({
           ) : (
             <DropdownMenuItem
               onSelect={() => {
+                queueActiveTerminalFocusAfterNewTabMenuClose()
                 onNewTerminalTab()
               }}
               className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
@@ -576,7 +597,7 @@ function TabBarInner({
               <QuickLaunchAgentMenuItems
                 worktreeId={worktreeId}
                 groupId={resolvedGroupId}
-                onFocusTerminal={focusTerminalTabSurface}
+                onFocusTerminal={queueTerminalTabFocusAfterNewTabMenuClose}
               />
             </>
           ) : null}

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -38,6 +38,8 @@ import {
 } from '@/components/ui/dropdown-menu'
 
 const isWindows = navigator.userAgent.includes('Windows')
+const NEW_TAB_MENU_TERMINAL_FOCUS_RETRY_MS = 50
+const NEW_TAB_MENU_TERMINAL_FOCUS_TIMEOUT_MS = 5000
 type GitStatusEntries = ReturnType<typeof useAppStore.getState>['gitStatusByWorktree'][string]
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntries = []
 
@@ -167,12 +169,53 @@ function TabBarInner({
   // catches the moment focus leaves the renderer (including into a webview).
   const [newTabMenuOpen, setNewTabMenuOpen] = useState(false)
   const pendingNewTabMenuFocusRef = useRef<(() => void) | null>(null)
-  const queueActiveTerminalFocusAfterNewTabMenuClose = (): void => {
+  const pendingNewTabMenuFocusAnimationRef = useRef<number | null>(null)
+  const pendingNewTabMenuFocusRetryRef = useRef<number | null>(null)
+  const clearPendingNewTabMenuFocusAnimation = (): void => {
+    if (pendingNewTabMenuFocusAnimationRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(pendingNewTabMenuFocusAnimationRef.current)
+    pendingNewTabMenuFocusAnimationRef.current = null
+  }
+  const clearPendingNewTabMenuFocusRetry = (): void => {
+    if (pendingNewTabMenuFocusRetryRef.current === null) {
+      return
+    }
+    window.clearTimeout(pendingNewTabMenuFocusRetryRef.current)
+    pendingNewTabMenuFocusRetryRef.current = null
+  }
+  const focusNewActiveTerminalWhenReady = (
+    previousActiveTabId: string | null,
+    expiresAt: number
+  ): void => {
+    const state = useAppStore.getState()
+    if (
+      state.activeTabType === 'terminal' &&
+      state.activeTabId &&
+      state.activeTabId !== previousActiveTabId
+    ) {
+      focusTerminalTabSurface(state.activeTabId)
+      return
+    }
+    if (Date.now() >= expiresAt) {
+      return
+    }
+    pendingNewTabMenuFocusRetryRef.current = window.setTimeout(() => {
+      pendingNewTabMenuFocusRetryRef.current = null
+      focusNewActiveTerminalWhenReady(previousActiveTabId, expiresAt)
+    }, NEW_TAB_MENU_TERMINAL_FOCUS_RETRY_MS)
+  }
+  const queueNewActiveTerminalFocusAfterNewTabMenuClose = (): void => {
+    const previousActiveTabId = useAppStore.getState().activeTabId
     pendingNewTabMenuFocusRef.current = () => {
-      const state = useAppStore.getState()
-      if (state.activeTabType === 'terminal' && state.activeTabId) {
-        focusTerminalTabSurface(state.activeTabId)
-      }
+      // Why: paired web/SSH runtime tab creation is async; wait for the host
+      // snapshot to publish the newly active terminal instead of focusing the
+      // pre-existing active tab.
+      focusNewActiveTerminalWhenReady(
+        previousActiveTabId,
+        Date.now() + NEW_TAB_MENU_TERMINAL_FOCUS_TIMEOUT_MS
+      )
     }
   }
   const queueTerminalTabFocusAfterNewTabMenuClose = (tabId: string): void => {
@@ -181,10 +224,22 @@ function TabBarInner({
   const runPendingNewTabMenuFocusAfterClose = (): void => {
     const pendingFocus = pendingNewTabMenuFocusRef.current
     pendingNewTabMenuFocusRef.current = null
+    clearPendingNewTabMenuFocusAnimation()
+    clearPendingNewTabMenuFocusRetry()
     if (pendingFocus) {
-      requestAnimationFrame(pendingFocus)
+      pendingNewTabMenuFocusAnimationRef.current = requestAnimationFrame(() => {
+        pendingNewTabMenuFocusAnimationRef.current = null
+        pendingFocus()
+      })
     }
   }
+  useEffect(
+    () => () => {
+      clearPendingNewTabMenuFocusAnimation()
+      clearPendingNewTabMenuFocusRetry()
+    },
+    []
+  )
   useEffect(() => {
     if (!newTabMenuOpen) {
       return
@@ -529,7 +584,7 @@ function TabBarInner({
                       // picked PowerShell 7+ in advanced settings, launching the
                       // "PowerShell" menu item must preserve that implementation
                       // instead of forcing inbox powershell.exe.
-                      queueActiveTerminalFocusAfterNewTabMenuClose()
+                      queueNewActiveTerminalFocusAfterNewTabMenuClose()
                       onNewTerminalWithShell(
                         resolveWindowsShellLaunchTarget(
                           entry.shell,
@@ -552,7 +607,7 @@ function TabBarInner({
           ) : (
             <DropdownMenuItem
               onSelect={() => {
-                queueActiveTerminalFocusAfterNewTabMenuClose()
+                queueNewActiveTerminalFocusAfterNewTabMenuClose()
                 onNewTerminalTab()
               }}
               className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"

--- a/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const appStoreSnapshot: {
+  activeTabId: string | null
+  activeTabType: 'terminal' | 'editor' | 'browser' | null
+} = {
+  activeTabId: null,
+  activeTabType: null
+}
+
 const useAppStoreMock = vi.fn(
   (
     selector: (state: {
+      activeTabId: string | null
+      activeTabType: 'terminal' | 'editor' | 'browser' | null
       gitStatusByWorktree: Record<string, never[]>
       settings: {
         terminalWindowsShell: 'powershell.exe' | 'cmd.exe' | 'wsl.exe'
@@ -11,6 +21,8 @@ const useAppStoreMock = vi.fn(
     }) => unknown
   ) =>
     selector({
+      activeTabId: appStoreSnapshot.activeTabId,
+      activeTabType: appStoreSnapshot.activeTabType,
       gitStatusByWorktree: {},
       settings: {
         terminalWindowsShell: 'powershell.exe',
@@ -54,8 +66,20 @@ vi.mock('@dnd-kit/sortable', () => ({
   }
 }))
 
+const useAppStoreExport = (selector: Parameters<typeof useAppStoreMock>[0]): unknown =>
+  useAppStoreMock(selector)
+useAppStoreExport.getState = vi.fn(() => ({
+  activeTabId: appStoreSnapshot.activeTabId,
+  activeTabType: appStoreSnapshot.activeTabType,
+  gitStatusByWorktree: {},
+  settings: {
+    terminalWindowsShell: 'powershell.exe',
+    terminalWindowsPowerShellImplementation: 'pwsh.exe'
+  }
+}))
+
 vi.mock('../../store', () => ({
-  useAppStore: (selector: Parameters<typeof useAppStoreMock>[0]) => useAppStoreMock(selector)
+  useAppStore: useAppStoreExport
 }))
 
 vi.mock('../right-sidebar/status-display', () => ({
@@ -198,6 +222,8 @@ describe('TabBar PowerShell launch wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.resetModules()
+    appStoreSnapshot.activeTabId = null
+    appStoreSnapshot.activeTabType = null
     vi.stubGlobal('navigator', { userAgent: 'Windows' })
   })
 

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -74,13 +74,17 @@ test.describe('Tabs', () => {
   test('clicking "+" then "New Terminal" creates a new terminal tab', async ({ orcaPage }) => {
     const tabsBefore = await countRenderedTabs(orcaPage)
 
-    await orcaPage.getByRole('button', { name: 'New tab' }).click()
+    // Why: hidden-window Electron can keep the animated terminal surface
+    // invalidating Playwright's "stable" actionability check even though the
+    // tab-bar button is visible and enabled.
+    await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
     // Why: the "+" dropdown uses Radix <DropdownMenuItem>, which exposes the
     // label text as the accessible name once the menu is open.
     await orcaPage
       .getByRole('menuitem', { name: /New Terminal/i })
       .first()
-      .click()
+      .click({ force: true })
+    await orcaPage.keyboard.press('Escape')
 
     // Final assertion is on the rendered tab count — the tab bar itself must
     // gain an element, not just the store.
@@ -90,6 +94,13 @@ test.describe('Tabs', () => {
         message: 'Clicking + → New Terminal did not render a new tab in the tab bar'
       })
       .toBe(tabsBefore + 1)
+
+    const activeType = await getActiveTabType(orcaPage)
+    expect(activeType).toBe('terminal')
+
+    const storeActiveId = await getActiveTabId(orcaPage)
+    expect(storeActiveId).not.toBeNull()
+    await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(storeActiveId)
   })
 
   /**

--- a/tests/e2e/tabs.spec.ts
+++ b/tests/e2e/tabs.spec.ts
@@ -55,6 +55,16 @@ async function getDomActiveTabId(page: Page): Promise<string | null> {
   }, SORTABLE_TAB)
 }
 
+async function getFocusedTerminalTabId(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const active = document.activeElement
+    if (!(active instanceof HTMLElement) || !active.classList.contains('xterm-helper-textarea')) {
+      return null
+    }
+    return active.closest('[data-terminal-tab-id]')?.getAttribute('data-terminal-tab-id') ?? null
+  })
+}
+
 test.describe('Tabs', () => {
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
@@ -80,11 +90,9 @@ test.describe('Tabs', () => {
     await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
     // Why: the "+" dropdown uses Radix <DropdownMenuItem>, which exposes the
     // label text as the accessible name once the menu is open.
-    await orcaPage
-      .getByRole('menuitem', { name: /New Terminal/i })
-      .first()
-      .click({ force: true })
-    await orcaPage.keyboard.press('Escape')
+    const newTerminalMenuItem = orcaPage.getByRole('menuitem', { name: /New Terminal/i }).first()
+    await newTerminalMenuItem.click({ force: true })
+    await expect(newTerminalMenuItem).toBeHidden({ timeout: 3_000 })
 
     // Final assertion is on the rendered tab count — the tab bar itself must
     // gain an element, not just the store.
@@ -101,6 +109,12 @@ test.describe('Tabs', () => {
     const storeActiveId = await getActiveTabId(orcaPage)
     expect(storeActiveId).not.toBeNull()
     await expect.poll(() => getDomActiveTabId(orcaPage), { timeout: 3_000 }).toBe(storeActiveId)
+    await expect
+      .poll(() => getFocusedTerminalTabId(orcaPage), {
+        timeout: 5_000,
+        message: 'Menu-created terminal tab did not receive keyboard focus'
+      })
+      .toBe(storeActiveId)
   })
 
   /**


### PR DESCRIPTION
## Summary

This PR fixes focus handoff after launching terminal-backed tabs from the tab bar `+` menu. Terminal tabs created through menu actions now receive focus after the dropdown closes, matching the keyboard shortcut behavior.

## What Changed

- Queued terminal focus from the tab bar `+` menu close lifecycle instead of focusing immediately from menu item handlers.
- Applied the same focus handoff to terminal-producing menu actions:
  - New Terminal
  - Windows shell-specific terminal entries
  - Agent quick-launch entries such as Codex, Claude, and OpenCode
- Strengthened the tab bar E2E test to verify the menu-created terminal tab is active in the rendered tab bar.

## Why

Radix dropdown close behavior can restore focus to the `+` trigger after a menu item is selected. For terminal-producing actions, that meant the terminal tab was visible and active, but keyboard input did not land in xterm until the user clicked inside the pane.

The fix keeps focus handling local to the tab bar menu lifecycle and avoids broad changes to the shared terminal focus helper or unrelated terminal focus call sites.

## UI Changes

No visual UI changes. This changes interaction behavior only: terminal-backed tabs launched from the `+` menu should be ready for keyboard input immediately after selection.

Before: After clicking on `New Terminal`
<img width="1796" height="212" alt="screenshot-2026-05-26_23-14-06" src="https://github.com/user-attachments/assets/a6e3e985-4dc0-4f0e-8708-48590f548234" />

After: After clicking on `New Terminal`
<img width="1796" height="202" alt="screenshot-2026-05-26_23-14-25" src="https://github.com/user-attachments/assets/aef37da7-c529-46ec-8c2f-bdc6831e49f4" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional targeted validation run:

- [x] `pnpm run typecheck:web`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/focus-terminal-tab-surface.test.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts src/renderer/src/store/slices/cmd-j-create-actions.test.ts`
- [x] `pnpm exec playwright test tests/e2e/tabs.spec.ts --config tests/playwright.config.ts --project electron-headless --grep "clicking \"\+\" then \"New Terminal\" creates a new terminal tab" --workers=1`
- [x] `git diff --check`

## AI Review Report

AI review checked that the fix stays scoped to the tab bar `+` menu and does not broaden the shared `focusTerminalTabSurface` helper. It also checked risks around Radix dropdown focus restoration, terminal tab activation, agent quick-launch menu paths, non-terminal tab creation, and existing shortcut behavior.

The review initially flagged that a broader helper-level fallback would affect many unrelated terminal focus call sites. The implementation was simplified to a menu-local queued focus callback, preserving existing behavior for `Ctrl+T` and other terminal focus paths.

Cross-platform compatibility was explicitly reviewed for macOS, Linux, and Windows. The change does not alter shortcut handling, shortcut labels, file paths, IPC, or shell command construction. Windows shell-specific terminal menu entries are covered by the same post-close focus handoff without changing shell selection behavior.

## Security Audit

AI audit found no new command execution, dependency, auth, secret, path handling, or IPC surface. The change only queues a renderer-side focus callback after a dropdown closes.

Reviewed risks:

- Input handling: no user input parsing added.
- Command execution: no new shell commands or agent launch commands introduced.
- Path handling: no path logic changed.
- Auth/secrets: no auth or secret access changed.
- Dependencies: no new dependencies.
- IPC: no IPC calls added or modified.

No security follow-up is needed.

## Notes

`New Browser Tab` is intentionally unchanged because browser tab creation already owns URL-bar focus. `New Markdown` is also left unchanged because editor focus is a separate editor-surface behavior and not part of the terminal pane focus bug.