### PR TITLE
fix: clear deleted profile session policies

### DIFF
--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -33,6 +33,7 @@ function installModuleMocks(
     setPermissionCheckHandler: vi.fn(),
     setDisplayMediaRequestHandler: vi.fn(),
     on: vi.fn(),
+    removeListener: vi.fn(),
     clearStorageData: vi.fn().mockResolvedValue(undefined),
     clearCache: vi.fn().mockResolvedValue(undefined)
   }))

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -41,6 +41,7 @@ describe('BrowserSessionRegistry', () => {
       setPermissionCheckHandler: vi.fn(),
       setDisplayMediaRequestHandler: vi.fn(),
       on: vi.fn(),
+      removeListener: vi.fn(),
       clearStorageData: vi.fn().mockResolvedValue(undefined),
       clearCache: vi.fn().mockResolvedValue(undefined)
     })
@@ -141,6 +142,22 @@ describe('BrowserSessionRegistry', () => {
     expect(deleted).toBe(true)
     expect(browserSessionRegistry.isAllowedPartition(profile!.partition)).toBe(false)
     expect(browserSessionRegistry.getProfile(profile!.id)).toBeNull()
+  })
+
+  it('clears session policy callbacks when deleting a profile', async () => {
+    const profile = browserSessionRegistry.createProfile('isolated', 'Policy Delete Test')
+    expect(profile).not.toBeNull()
+    const mockSession = sessionFromPartitionMock.mock.results[0]?.value
+    const downloadHandler = mockSession.on.mock.calls.find(
+      ([eventName]) => eventName === 'will-download'
+    )?.[1]
+
+    await expect(browserSessionRegistry.deleteProfile(profile!.id)).resolves.toBe(true)
+
+    expect(mockSession.removeListener).toHaveBeenCalledWith('will-download', downloadHandler)
+    expect(mockSession.setPermissionRequestHandler).toHaveBeenLastCalledWith(null)
+    expect(mockSession.setPermissionCheckHandler).toHaveBeenLastCalledWith(null)
+    expect(mockSession.setDisplayMediaRequestHandler).toHaveBeenLastCalledWith(null)
   })
 
   it('refuses to delete the default profile', async () => {

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -3,6 +3,7 @@
    per-partition permission/download policies. Splitting further would scatter the
    security boundary across modules. */
 import { app, session } from 'electron'
+import type { Session } from 'electron'
 import { randomUUID } from 'node:crypto'
 import {
   copyFileSync,
@@ -374,6 +375,7 @@ class BrowserSessionRegistry {
     // lingering after the user deletes an imported or isolated session profile.
     try {
       const sess = session.fromPartition(profile.partition)
+      this.clearSessionPolicies(profile.partition, sess)
       await sess.clearStorageData()
       await sess.clearCache()
     } catch {
@@ -449,6 +451,13 @@ class BrowserSessionRegistry {
   // session partitions would silently allow permissions and downloads that the
   // shared partition correctly denies.
   private readonly configuredPartitions = new Set<string>()
+  private readonly handleWillDownload = (
+    _event: Electron.Event,
+    item: Electron.DownloadItem,
+    webContents: Electron.WebContents
+  ): void => {
+    browserManager.handleGuestWillDownload({ guestWebContentsId: webContents.id, item })
+  }
 
   private setupSessionPolicies(partition: string): void {
     if (this.configuredPartitions.has(partition)) {
@@ -518,9 +527,19 @@ class BrowserSessionRegistry {
     sess.setDisplayMediaRequestHandler((_request, callback) => {
       callback({ video: undefined, audio: undefined })
     })
-    sess.on('will-download', (_event, item, webContents) => {
-      browserManager.handleGuestWillDownload({ guestWebContentsId: webContents.id, item })
-    })
+    sess.removeListener('will-download', this.handleWillDownload)
+    sess.on('will-download', this.handleWillDownload)
+  }
+
+  private clearSessionPolicies(partition: string, sess: Session): void {
+    // Why: isolated/imported browser partitions can be deleted while the
+    // Electron Session object survives; clear policy callbacks and listener
+    // bookkeeping so removed profiles do not leave retained closures behind.
+    this.configuredPartitions.delete(partition)
+    sess.removeListener('will-download', this.handleWillDownload)
+    sess.setPermissionRequestHandler(null)
+    sess.setPermissionCheckHandler(null)
+    sess.setDisplayMediaRequestHandler(null)
   }
 }
 


### PR DESCRIPTION
## Summary
- Clears deleted isolated/imported browser profile partition policy callbacks, download listener, and configured-partition bookkeeping.

## Risk level
Medium, reduced by a second pass - touches browser-session policy teardown for deleted profiles; active profile setup behavior is unchanged and delete cleanup has regression coverage.

## Additional risk pass
- Re-reviewed setup/delete ownership so shared persistent policies still register normally, while deleted partitions release permission/display-media handlers and download listener references.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/browser/browser-session-registry.test.ts src/main/browser/browser-session-registry.persistence.test.ts`\n- `pnpm run typecheck:node`