### PR TITLE
fix: drop mobile notification stream on cleanup

### DIFF
--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { subscribeToDesktopNotifications } from './mobile-notifications'
+import type { RpcClient } from '../transport/rpc-client'
+
+vi.mock('expo-notifications', () => ({
+  AndroidImportance: { HIGH: 'high' },
+  setNotificationChannelAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' }
+}))
+
+vi.mock('../storage/preferences', () => ({
+  loadPushNotificationsEnabled: vi.fn()
+}))
+
+describe('subscribeToDesktopNotifications', () => {
+  it('drops the local stream when disposed before the desktop returns ready', () => {
+    const unsubscribeStream = vi.fn()
+    const client = {
+      subscribe: vi.fn(() => unsubscribeStream),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn()
+    } as unknown as RpcClient
+
+    const unsubscribe = subscribeToDesktopNotifications(client, 'host-1')
+    unsubscribe()
+
+    expect(unsubscribeStream).toHaveBeenCalledTimes(1)
+    expect(client.sendRequest).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -114,8 +114,10 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     // unmount races with disconnect). sendRequest rejects immediately on a
     // closed client — swallow it since server-side cleanup happens via
     // connection-close anyway.
+    // Always drop the local stream first; readiness can race unmount and we
+    // must not retain the callback while waiting for a subscription id.
+    unsubscribeStream()
     if (subscriptionId) {
-      unsubscribeStream()
       unsubscribeServer(subscriptionId)
     }
   }


### PR DESCRIPTION
## Summary
- Always unsubscribes the local mobile notification stream during cleanup, even when unmount races the desktop `ready` response and no server subscription id exists yet.

## Risk level
Medium, reduced by a second pass - mobile subscription cleanup changes a race path and includes a regression test, but the mobile package test runner is not available in this workspace.

## Additional risk pass
- Re-reviewed the cleanup race: local stream teardown now happens before optional server unsubscribe, preserving server cleanup only when a subscription id exists.

## Validation
- `pnpm exec oxlint mobile/src/notifications/mobile-notifications.ts mobile/src/notifications/mobile-notifications.test.ts`\n- Attempted `./node_modules/.bin/vitest run mobile/src/notifications/mobile-notifications.test.ts`; blocked because this workspace cannot resolve mobile deps (`expo/tsconfig.base`).

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.