### PR TITLE
fix(sidebar): reveal new worktree rows below the sticky header

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -236,17 +236,26 @@ function getMountedWorktreeBounds(
 
 export function getScrollTopToRevealBounds(
   container: HTMLElement,
-  bounds: Pick<VirtualItemBounds, 'start' | 'end'>
+  bounds: Pick<VirtualItemBounds, 'start' | 'end'>,
+  // Why: the active group/repo header sticks at the viewport top and paints over
+  // content, so the unobstructed region starts below it. Reveal a row to clear
+  // the header instead of aligning its top behind it.
+  stickyHeaderHeight = 0
 ): number | null {
-  const viewportTop = container.scrollTop
-  const viewportBottom = viewportTop + container.clientHeight
+  const viewportTop = container.scrollTop + stickyHeaderHeight
+  const viewportBottom = container.scrollTop + container.clientHeight
   if (bounds.start < viewportTop) {
-    return bounds.start
+    return bounds.start - stickyHeaderHeight
   }
   if (bounds.end > viewportBottom) {
     return bounds.end - container.clientHeight
   }
   return null
+}
+
+function getActiveStickyHeaderHeight(container: HTMLElement): number {
+  const header = container.querySelector<HTMLElement>('[data-worktree-sticky-header-active]')
+  return header?.getBoundingClientRect().height ?? 0
 }
 
 function revealMountedWorktreeElement(
@@ -258,7 +267,11 @@ function revealMountedWorktreeElement(
   if (!bounds) {
     return false
   }
-  const nextScrollTop = getScrollTopToRevealBounds(container, bounds)
+  const nextScrollTop = getScrollTopToRevealBounds(
+    container,
+    bounds,
+    getActiveStickyHeaderHeight(container)
+  )
   if (nextScrollTop !== null) {
     container.scrollTo({ top: Math.max(0, nextScrollTop), behavior })
   }

--- a/src/renderer/src/components/sidebar/worktree-scroll-to-current-button.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-scroll-to-current-button.test.ts
@@ -19,4 +19,22 @@ describe('getScrollTopToRevealBounds', () => {
   it('does not scroll when the current workspace card is already fully visible', () => {
     expect(getScrollTopToRevealBounds(makeContainer(100, 200), { start: 125, end: 260 })).toBeNull()
   })
+
+  it('offsets the upward reveal so the card clears a sticky header overlay', () => {
+    expect(getScrollTopToRevealBounds(makeContainer(100, 200), { start: 60, end: 120 }, 28)).toBe(
+      32
+    )
+  })
+
+  it('treats a card behind the sticky header as obstructed and scrolls it clear', () => {
+    expect(getScrollTopToRevealBounds(makeContainer(100, 200), { start: 110, end: 180 }, 28)).toBe(
+      82
+    )
+  })
+
+  it('still reports no scroll when the card sits below the sticky header band', () => {
+    expect(
+      getScrollTopToRevealBounds(makeContainer(100, 200), { start: 130, end: 260 }, 28)
+    ).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

Creating a new worktree in a grouped sidebar view used to leave its row cut off at the top edge — the list scrolled the row's top flush with the viewport, where the sticky group/repo header sits and paints over it, so the top of the freshly-created row was hidden behind the header. Growing the card (e.g. adding a session) kept it pinned in that obstructed band.

## Root Cause

The reveal-scroll math (`getScrollTopToRevealBounds`) treated the visible region as starting at the scroll container's top, ignoring the sticky header overlay. It now accounts for the active header's height: the unobstructed region starts below the header, and above-viewport reveals scroll to `bounds.start - stickyHeaderHeight` so the row clears it. `revealMountedWorktreeElement` measures the live `[data-worktree-sticky-header-active]` element and passes its height through; the default of `0` leaves ungrouped mode (which has no headers) unchanged. The same path backs the "scroll to current workspace" button, which gets the fix too.

## Tests

Covered by three new unit tests for the header-offset reveal, the "behind the header band" case the old logic wrongly reported as visible, and the below-band no-scroll case.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
