### PR TITLE
fix(cli): reject RPC promptly when runtime closes socket without responding

### DIFF
--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -85,4 +85,33 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
       result: { satisfied: true }
     })
   })
+
+  it('rejects promptly when the runtime closes the socket before responding', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-transport-'))
+    const endpoint = join(userDataPath, 'runtime.sock')
+    const server = createServer((socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      // Read the request, then close cleanly without writing a terminal frame.
+      socket.once('data', () => socket.end())
+    })
+    servers.add(server)
+    await new Promise<void>((resolve) => server.listen(endpoint, resolve))
+
+    const metadata: RuntimeMetadata = {
+      runtimeId: 'runtime-1',
+      pid: 123,
+      transports: [{ kind: 'unix', endpoint }],
+      authToken: 'token',
+      startedAt: 1
+    }
+
+    // A generous timeout: a passing fix rejects on close well before this; the
+    // pre-fix behavior would hang the full duration and trip vitest's own limit.
+    const start = Date.now()
+    await expect(
+      sendRequest(metadata, 'status.get', undefined, 60000)
+    ).rejects.toMatchObject({ code: 'runtime_unavailable' })
+    expect(Date.now() - start).toBeLessThan(5000)
+  })
 })

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -66,6 +66,19 @@ export async function sendRequest<TResult>(
         )
       })
     })
+    // Why: a clean peer close (FIN, no 'error') before a terminal frame never
+    // settles the promise, so the call would otherwise hang until the full
+    // timeout fires. Reject promptly. finish() guards double-settle, so this
+    // no-ops on the normal success/error paths that already called socket.end().
+    socket.once('close', () => {
+      finish({
+        ok: false,
+        error: new RuntimeClientError(
+          'runtime_unavailable',
+          'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+        )
+      })
+    })
     socket.on('data', (chunk) => {
       buffer += chunk
       // Why: the server may interleave `{"_keepalive":true}\n` frames with the


### PR DESCRIPTION
## What

`sendRequest` in `src/cli/runtime/transport.ts` rejects immediately when the Orca runtime closes the RPC socket without sending a response, instead of stalling the command until the timeout elapses.

## Why

The socket handler covered `'error'`, `'data'`, and `'connect'`, but not `'close'`/`'end'`. When the runtime closed the connection cleanly (FIN, no `error` event) **before** writing a terminal RPC frame — e.g. the runtime crashing or dropping the connection mid-request — nothing settled the promise. The call hung until the per-call timeout fired: **60s by default, and up to 10 minutes** once keepalive frames had refreshed the client-side timer. Every such failure cost the user a long, silent wait before getting an actionable error.

## How

Added `socket.once('close', …)` that rejects with `runtime_unavailable` ("The Orca runtime closed the connection before responding…") if the socket closes before a terminal frame settles the request. `finish()` already guards against double-settle and clears the timeout, so the new handler no-ops on the normal success/error paths (which call `socket.end()` themselves).

## Verification

- New regression test in `transport.test.ts`: server reads the request then closes without a terminal frame; asserts `sendRequest` rejects with `runtime_unavailable` well under the timeout. The test **fails without the fix** (the call hangs ~5.5s and trips vitest's limit) and passes with it.
- `typecheck:cli` clean, `oxlint` clean.
- Cross-platform: the test is gated `skipIf(win32)`, matching the existing Unix-domain-socket tests in the file; the source change is platform-agnostic.