### PR TITLE
fix(cli): allow flag values that start with -- via --flag=value

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -10,4 +10,31 @@ describe('parseArgs', () => {
     expect(parsed.flags.get('value')).toBe('')
     expect(parsed.flags.get('json')).toBe(true)
   })
+
+  it('accepts a flag value that starts with -- via the = form', () => {
+    const parsed = parseArgs(['terminal', 'send', '--text=--help'])
+
+    expect(parsed.commandPath).toEqual(['terminal', 'send'])
+    expect(parsed.flags.get('text')).toBe('--help')
+  })
+
+  it('splits --flag=value on the first = so values may contain =', () => {
+    const parsed = parseArgs(['set', 'cookie', '--value=a=b=c'])
+
+    expect(parsed.flags.get('value')).toBe('a=b=c')
+  })
+
+  it('treats --flag= as an empty string value', () => {
+    const parsed = parseArgs(['--value='])
+
+    expect(parsed.flags.get('value')).toBe('')
+  })
+
+  it('still parses boolean flags and space-separated values', () => {
+    const parsed = parseArgs(['tab', 'create', '--json', '--url', 'https://example.com'])
+
+    expect(parsed.commandPath).toEqual(['tab', 'create'])
+    expect(parsed.flags.get('json')).toBe(true)
+    expect(parsed.flags.get('url')).toBe('https://example.com')
+  })
 })

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -29,7 +29,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
       continue
     }
 
-    const flag = token.slice(2)
+    const assignment = token.slice(2)
+    // Why: `--flag=value` is the only unambiguous way to pass a value that
+    // itself starts with `--` (e.g. `--text=--help`); the space-separated form
+    // treats a `--`-leading next token as a new flag, so it can't express one.
+    const equalsIndex = assignment.indexOf('=')
+    if (equalsIndex !== -1) {
+      flags.set(assignment.slice(0, equalsIndex), assignment.slice(equalsIndex + 1))
+      continue
+    }
+
+    const flag = assignment
     const hasNext = i + 1 < argv.length
     const next = argv[i + 1]
     if (!hasNext || next.startsWith('--')) {


### PR DESCRIPTION
## What

`orca <command> --flag=value` now works, so a flag value can start with `--` (e.g. `--text=--help`) or contain `=`.

## Why

`parseArgs` only consumed the next token as a flag's value when that token did **not** itself start with `--`:

```
if (!hasNext || next.startsWith('--')) { flags.set(flag, true); continue }
```

So `orca terminal send --text --help` parsed `--help` as a separate boolean flag rather than the text value, and there was **no way at all** to pass a value beginning with `--` — selectors, generated content, or URLs/strings with leading dashes. This hits the SSH/automation path hardest, where flag values are produced programmatically and can legitimately lead with `--`. (Flagged independently by two reviewers.)

## How

Support the standard `--flag=value` form: when a `--` token contains `=`, split on the **first** `=` into name and value. The value may then start with `--` or contain further `=` characters. Boolean flags (`--json`) and the space-separated value form (`--url https://…`) are unchanged.

## Verification

- New `parseArgs` cases in `args.test.ts`: value starting with `--` via `=`, value containing `=` (split on first only), `--flag=` empty-string value, and a guard that boolean + space-separated parsing still work. The `=`-form cases **fail without the fix** and pass with it.
- `typecheck:cli` clean, `oxlint` clean.
- **Full `src/cli` suite: 175/175 passing** — no regressions in command/flag handling.