### PR TITLE
Preserve worktree state during dirty delete races

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3449,6 +3449,40 @@ describe('registerWorktreeHandlers', () => {
     await expect(first).resolves.toBeUndefined()
   })
 
+  it('rejects concurrent deletes for the same worktree id when only archive options differ', async () => {
+    mockKnownFeatureWorktree()
+    let removalStarted!: () => void
+    let finishRemoval!: () => void
+    const started = new Promise<void>((resolve) => {
+      removalStarted = resolve
+    })
+    removeWorktreeMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          removalStarted()
+          finishRemoval = resolve
+        })
+    )
+
+    const first = handlers['worktrees:remove'](null, {
+      worktreeId: 'repo-1::/workspace/feature-wt',
+      force: true
+    }) as Promise<void>
+
+    await started
+    await expect(
+      handlers['worktrees:remove'](null, {
+        worktreeId: 'repo-1::/workspace/feature-wt',
+        force: true,
+        skipArchive: true
+      })
+    ).rejects.toThrow('Worktree deletion already in progress')
+
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1)
+    finishRemoval()
+    await expect(first).resolves.toBeUndefined()
+  })
+
   it('still rejects forced unregistered delete paths that exist on disk', async () => {
     mockKnownFeatureWorktree('/workspace/real-feature')
 
@@ -3571,6 +3605,49 @@ describe('registerWorktreeHandlers', () => {
 
     expect(killAllProcessesForWorktreeMock).not.toHaveBeenCalled()
     expect(removeWorktreeMock).not.toHaveBeenCalled()
+  })
+
+  it('force deletes after a dirty non-force failure without reusing the dirty preflight result', async () => {
+    mockKnownFeatureWorktree()
+    getEffectiveHooksMock.mockReturnValue(null)
+    assertWorktreeCleanForRemovalMock.mockImplementation(async (_worktreePath, force) => {
+      if (force) {
+        return
+      }
+      throw Object.assign(new Error('Worktree has uncommitted or untracked changes.'), {
+        stdout: '?? scratch.txt\n'
+      })
+    })
+    removeWorktreeMock.mockResolvedValue(undefined)
+
+    await expect(
+      handlers['worktrees:remove'](null, {
+        worktreeId: 'repo-1::/workspace/feature-wt'
+      })
+    ).rejects.toThrow('Failed to delete worktree at /workspace/feature-wt. ?? scratch.txt')
+
+    await expect(
+      handlers['worktrees:remove'](null, {
+        worktreeId: 'repo-1::/workspace/feature-wt',
+        force: true
+      })
+    ).resolves.toBeUndefined()
+
+    expect(assertWorktreeCleanForRemovalMock).toHaveBeenNthCalledWith(
+      1,
+      '/workspace/feature-wt',
+      false
+    )
+    expect(assertWorktreeCleanForRemovalMock).toHaveBeenNthCalledWith(
+      2,
+      '/workspace/feature-wt',
+      true
+    )
+    expect(removeWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/feature-wt',
+      true
+    )
   })
 
   it('formats preflight subprocess failures and does not tear down PTYs', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8131,6 +8131,27 @@ describe('OrcaRuntimeService', () => {
     await expect(first).resolves.toEqual({})
   })
 
+  it('rejects concurrent runtime worktree removals for the same id when only hook options differ', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const removeStarted = deferred<void>()
+    const finishRemoval = deferred<void>()
+    vi.mocked(removeWorktree).mockImplementation(async () => {
+      removeStarted.resolve()
+      await finishRemoval.promise
+    })
+
+    const first = runtime.removeManagedWorktree(TEST_WORKTREE_ID, true, false)
+
+    await removeStarted.promise
+    await expect(runtime.removeManagedWorktree(TEST_WORKTREE_ID, true, true)).rejects.toThrow(
+      'Worktree deletion already in progress'
+    )
+
+    expect(removeWorktree).toHaveBeenCalledTimes(1)
+    finishRemoval.resolve()
+    await expect(first).resolves.toEqual({})
+  })
+
   it('treats forced runtime deletion of an already-missing unregistered worktree as cleanup', async () => {
     const parentDir = await mkdtemp(join(tmpdir(), 'orca-runtime-remove-'))
     const missingWorktreePath = join(parentDir, 'already-deleted')
@@ -8352,6 +8373,30 @@ describe('OrcaRuntimeService', () => {
 
     expect(killSpy).not.toHaveBeenCalled()
     expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
+  it('force deletes after a dirty non-force runtime failure without reusing the dirty preflight result', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    vi.mocked(getEffectiveHooks).mockReturnValue(null)
+    vi.mocked(assertWorktreeCleanForRemoval).mockImplementation(async (_worktreePath, force) => {
+      if (force) {
+        return
+      }
+      throw Object.assign(new Error('Worktree has uncommitted or untracked changes.'), {
+        stdout: '?? scratch.txt\n'
+      })
+    })
+    vi.mocked(removeWorktree).mockResolvedValue(undefined)
+
+    await expect(runtime.removeManagedWorktree(TEST_WORKTREE_ID)).rejects.toThrow(
+      `Failed to delete worktree at ${TEST_WORKTREE_PATH}. ?? scratch.txt`
+    )
+
+    await expect(runtime.removeManagedWorktree(TEST_WORKTREE_ID, true)).resolves.toEqual({})
+
+    expect(assertWorktreeCleanForRemoval).toHaveBeenNthCalledWith(1, TEST_WORKTREE_PATH, false)
+    expect(assertWorktreeCleanForRemoval).toHaveBeenNthCalledWith(2, TEST_WORKTREE_PATH, true)
+    expect(removeWorktree).toHaveBeenCalledWith(TEST_REPO_PATH, TEST_WORKTREE_PATH, true)
   })
 
   it('formats preflight subprocess failures and skips PTY teardown', async () => {

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -49,6 +49,7 @@ import { toast } from 'sonner'
 import {
   runWorktreeBatchDelete,
   runWorktreeDelete,
+  runWorktreeDeleteWithToast,
   runWorktreeDeletesInParallel
 } from './delete-worktree-flow'
 
@@ -297,5 +298,43 @@ describe('runWorktreeDeletesInParallel', () => {
 
     expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
     expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
+  })
+})
+
+describe('runWorktreeDeleteWithToast', () => {
+  beforeEach(() => {
+    mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
+    mocks.state.deleteStateByWorktreeId = {}
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.info).mockClear()
+  })
+
+  it('force deletes from the dirty-worktree prompt with force=true', async () => {
+    mocks.state.removeWorktree.mockImplementation(async (worktreeId: string, force?: boolean) => {
+      if (force) {
+        return { ok: true }
+      }
+      mocks.state.deleteStateByWorktreeId = {
+        [worktreeId]: {
+          isDeleting: false,
+          error: 'dirty worktree',
+          canForceDelete: true
+        }
+      }
+      return { ok: false, error: 'dirty worktree' }
+    })
+
+    await expect(runWorktreeDeleteWithToast('wt-1', 'feature')).resolves.toBe(false)
+
+    const toastOptions = vi.mocked(toast.info).mock.calls[0]?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    expect(toastOptions?.action?.onClick).toBeTypeOf('function')
+    toastOptions?.action?.onClick?.()
+
+    await vi.waitFor(() => {
+      expect(mocks.state.removeWorktree).toHaveBeenLastCalledWith('wt-1', true)
+    })
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -45,6 +45,7 @@ function runtimeScopedStateReset(): Partial<AppState> {
     worktreeLineageById: {},
     activeWorktreeId: null,
     deleteStateByWorktreeId: {},
+    worktreeDeleteEpochByRepo: {},
     baseStatusByWorktreeId: {},
     remoteBranchConflictByWorktreeId: {},
     sortEpoch: 0,

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -28,6 +28,7 @@ export type WorktreeSlice = {
   worktreeLineageById: Record<string, WorktreeLineage>
   activeWorktreeId: string | null
   deleteStateByWorktreeId: Record<string, WorktreeDeleteState>
+  worktreeDeleteEpochByRepo: Record<string, number>
   baseStatusByWorktreeId: Record<string, WorktreeBaseStatusEvent>
   remoteBranchConflictByWorktreeId: Record<string, WorktreeRemoteBranchConflictEvent>
   /**

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -374,6 +374,480 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('preserves workspace state when an authoritative refresh races a dirty delete failure', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({
+      id: 'repo1::/path/dirty',
+      repoId: 'repo1',
+      path: '/path/dirty'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    const dirtyError =
+      "Error invoking remote method 'worktrees:remove': Error: Failed to delete worktree at /path/dirty. ?? scratch.txt"
+    let rejectRemoval!: (error: Error) => void
+    mockApi.worktrees.remove.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      })
+    )
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(makeDetectedResult('repo1', [surviving]))
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    store.setState({
+      worktreesByRepo: { repo1: [dirty, surviving] },
+      sortEpoch: 7,
+      activeWorktreeId: dirty.id,
+      activeTabId: 'tab-dirty',
+      activeBrowserTabId: 'browser-dirty',
+      activeTabType: 'browser',
+      tabsByWorktree: {
+        [dirty.id]: [{ id: 'tab-dirty', worktreeId: dirty.id }],
+        [surviving.id]: [{ id: 'tab-surviving', worktreeId: surviving.id }]
+      },
+      rightSidebarTabByWorktree: {
+        [dirty.id]: 'source-control',
+        [surviving.id]: 'checks'
+      },
+      gitStatusByWorktree: {
+        [dirty.id]: [{ path: 'scratch.txt' }]
+      },
+      gitBranchChangesByWorktree: {
+        [dirty.id]: [{ path: 'scratch.txt' }]
+      },
+      gitBranchCompareSummaryByWorktree: {
+        [dirty.id]: { status: 'ready' }
+      },
+      gitBranchCompareRequestKeyByWorktree: {
+        [dirty.id]: 'dirty-compare'
+      },
+      openFiles: [
+        {
+          id: 'file-dirty',
+          filePath: '/path/dirty/scratch.txt',
+          relativePath: 'scratch.txt',
+          worktreeId: dirty.id,
+          language: 'text',
+          isDirty: true
+        }
+      ],
+      activeFileId: 'file-dirty',
+      activeFileIdByWorktree: {
+        [dirty.id]: 'file-dirty'
+      },
+      activeTabIdByWorktree: {
+        [dirty.id]: 'tab-dirty'
+      },
+      activeTabTypeByWorktree: {
+        [dirty.id]: 'browser'
+      },
+      editorDrafts: {
+        'file-dirty': 'unsaved draft'
+      },
+      browserTabsByWorktree: {
+        [dirty.id]: [
+          {
+            id: 'browser-dirty',
+            worktreeId: dirty.id,
+            url: 'https://example.com',
+            title: 'Example',
+            loading: false,
+            faviconUrl: null,
+            canGoBack: false,
+            canGoForward: false,
+            loadError: null,
+            createdAt: 1
+          }
+        ]
+      },
+      activeBrowserTabIdByWorktree: {
+        [dirty.id]: 'browser-dirty'
+      }
+    } as unknown as Partial<AppState>)
+
+    const deleteAttempt = store.getState().removeWorktree(dirty.id)
+    await vi.waitFor(() =>
+      expect(store.getState().deleteStateByWorktreeId[dirty.id]?.isDeleting).toBe(true)
+    )
+    await store.getState().fetchWorktrees('repo1')
+    rejectRemoval(new Error(dirtyError))
+
+    await expect(deleteAttempt).resolves.toEqual({ ok: false, error: dirtyError })
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([
+      dirty.id,
+      surviving.id
+    ])
+    expect(state.tabsByWorktree[dirty.id]).toEqual([{ id: 'tab-dirty', worktreeId: dirty.id }])
+    expect(state.rightSidebarTabByWorktree[dirty.id]).toBe('source-control')
+    expect(state.gitStatusByWorktree[dirty.id]).toEqual([{ path: 'scratch.txt' }])
+    expect(state.gitBranchChangesByWorktree[dirty.id]).toEqual([{ path: 'scratch.txt' }])
+    expect(state.gitBranchCompareSummaryByWorktree[dirty.id]).toEqual({ status: 'ready' })
+    expect(state.gitBranchCompareRequestKeyByWorktree[dirty.id]).toBe('dirty-compare')
+    expect(state.openFiles).toEqual([
+      {
+        id: 'file-dirty',
+        filePath: '/path/dirty/scratch.txt',
+        relativePath: 'scratch.txt',
+        worktreeId: dirty.id,
+        language: 'text',
+        isDirty: true
+      }
+    ])
+    expect(state.activeFileId).toBe('file-dirty')
+    expect(state.activeBrowserTabId).toBe('browser-dirty')
+    expect(state.activeTabType).toBe('browser')
+    expect(state.activeFileIdByWorktree[dirty.id]).toBe('file-dirty')
+    expect(state.activeTabIdByWorktree[dirty.id]).toBe('tab-dirty')
+    expect(state.activeTabTypeByWorktree[dirty.id]).toBe('browser')
+    expect(state.editorDrafts['file-dirty']).toBe('unsaved draft')
+    expect(state.browserTabsByWorktree[dirty.id]).toEqual([
+      {
+        id: 'browser-dirty',
+        worktreeId: dirty.id,
+        url: 'https://example.com',
+        title: 'Example',
+        loading: false,
+        faviconUrl: null,
+        canGoBack: false,
+        canGoForward: false,
+        loadError: null,
+        createdAt: 1
+      }
+    ])
+    expect(state.activeBrowserTabIdByWorktree[dirty.id]).toBe('browser-dirty')
+    expect(
+      new Set(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id))
+    ).toEqual(new Set([dirty.id, surviving.id]))
+    expect(state.activeWorktreeId).toBe(dirty.id)
+    expect(state.activeTabId).toBe('tab-dirty')
+    expect(state.deleteStateByWorktreeId[dirty.id]).toEqual({
+      isDeleting: false,
+      error: dirtyError,
+      canForceDelete: true
+    })
+    expect(state.shutdownWorktreeBrowsers).not.toHaveBeenCalled()
+    expect(state.shutdownWorktreeTerminals).not.toHaveBeenCalled()
+    expect(state.sortEpoch).toBe(7)
+  })
+
+  it('preserves workspace state when delete starts after refresh request but before scan result', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({
+      id: 'repo1::/path/dirty',
+      repoId: 'repo1',
+      path: '/path/dirty'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    const dirtyError =
+      "Error invoking remote method 'worktrees:remove': Error: Failed to delete worktree at /path/dirty. ?? scratch.txt"
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    let rejectRemoval!: (error: Error) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    store.setState({
+      worktreesByRepo: { repo1: [dirty, surviving] },
+      sortEpoch: 7,
+      activeWorktreeId: dirty.id,
+      tabsByWorktree: {
+        [dirty.id]: [{ id: 'tab-dirty', worktreeId: dirty.id }]
+      }
+    } as unknown as Partial<AppState>)
+
+    const refresh = store.getState().fetchWorktrees('repo1')
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    const deleteAttempt = store.getState().removeWorktree(dirty.id)
+    await vi.waitFor(() =>
+      expect(store.getState().deleteStateByWorktreeId[dirty.id]?.isDeleting).toBe(true)
+    )
+    resolveDetected(makeDetectedResult('repo1', [surviving]))
+    await refresh
+    rejectRemoval(new Error(dirtyError))
+
+    await expect(deleteAttempt).resolves.toEqual({ ok: false, error: dirtyError })
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([
+      dirty.id,
+      surviving.id
+    ])
+    expect(state.tabsByWorktree[dirty.id]).toEqual([{ id: 'tab-dirty', worktreeId: dirty.id }])
+    expect(state.activeWorktreeId).toBe(dirty.id)
+    expect(state.deleteStateByWorktreeId[dirty.id]).toEqual({
+      isDeleting: false,
+      error: dirtyError,
+      canForceDelete: true
+    })
+    expect(state.sortEpoch).toBe(7)
+  })
+
+  it('ignores a refresh result that started during a dirty delete attempt and resolves after failure', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({
+      id: 'repo1::/path/dirty',
+      repoId: 'repo1',
+      path: '/path/dirty'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    const dirtyError =
+      "Error invoking remote method 'worktrees:remove': Error: Failed to delete worktree at /path/dirty. ?? scratch.txt"
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    let rejectRemoval!: (error: Error) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    store.setState({
+      worktreesByRepo: { repo1: [dirty, surviving] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [dirty, surviving]) },
+      sortEpoch: 7,
+      activeWorktreeId: dirty.id,
+      tabsByWorktree: {
+        [dirty.id]: [{ id: 'tab-dirty', worktreeId: dirty.id }]
+      }
+    } as unknown as Partial<AppState>)
+
+    const refresh = store.getState().fetchWorktrees('repo1')
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    const deleteAttempt = store.getState().removeWorktree(dirty.id)
+    await vi.waitFor(() =>
+      expect(store.getState().deleteStateByWorktreeId[dirty.id]?.isDeleting).toBe(true)
+    )
+    rejectRemoval(new Error(dirtyError))
+    await expect(deleteAttempt).resolves.toEqual({ ok: false, error: dirtyError })
+    resolveDetected(makeDetectedResult('repo1', [surviving]))
+    await refresh
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([
+      dirty.id,
+      surviving.id
+    ])
+    expect(state.tabsByWorktree[dirty.id]).toEqual([{ id: 'tab-dirty', worktreeId: dirty.id }])
+    expect(state.activeWorktreeId).toBe(dirty.id)
+    expect(state.deleteStateByWorktreeId[dirty.id]).toEqual({
+      isDeleting: false,
+      error: dirtyError,
+      canForceDelete: true
+    })
+    expect(state.sortEpoch).toBe(7)
+  })
+
+  it('ignores a detected refresh result that started during a dirty delete attempt and resolves after failure', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({
+      id: 'repo1::/path/dirty',
+      repoId: 'repo1',
+      path: '/path/dirty'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    const dirtyError =
+      "Error invoking remote method 'worktrees:remove': Error: Failed to delete worktree at /path/dirty. ?? scratch.txt"
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    let rejectRemoval!: (error: Error) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    store.setState({
+      worktreesByRepo: { repo1: [dirty, surviving] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [dirty, surviving]) },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchDetectedWorktrees('repo1')
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    const deleteAttempt = store.getState().removeWorktree(dirty.id)
+    await vi.waitFor(() =>
+      expect(store.getState().deleteStateByWorktreeId[dirty.id]?.isDeleting).toBe(true)
+    )
+    rejectRemoval(new Error(dirtyError))
+    await expect(deleteAttempt).resolves.toEqual({ ok: false, error: dirtyError })
+    resolveDetected(makeDetectedResult('repo1', [surviving]))
+    await expect(refresh).resolves.toBeNull()
+
+    const state = store.getState()
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      dirty.id,
+      surviving.id
+    ])
+    expect(state.deleteStateByWorktreeId[dirty.id]).toEqual({
+      isDeleting: false,
+      error: dirtyError,
+      canForceDelete: true
+    })
+  })
+
+  it('removes preserved detected state when an in-flight delete succeeds', async () => {
+    const store = createTestStore()
+    const deleted = makeWorktree({
+      id: 'repo1::/path/deleted',
+      repoId: 'repo1',
+      path: '/path/deleted'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    let resolveRemoval!: () => void
+    mockApi.worktrees.remove.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveRemoval = resolve
+      })
+    )
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(makeDetectedResult('repo1', [surviving]))
+
+    store.setState({
+      worktreesByRepo: { repo1: [deleted, surviving] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [deleted, surviving]) },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const deleteAttempt = store.getState().removeWorktree(deleted.id)
+    await vi.waitFor(() =>
+      expect(store.getState().deleteStateByWorktreeId[deleted.id]?.isDeleting).toBe(true)
+    )
+    await store.getState().fetchWorktrees('repo1')
+    expect(
+      store.getState().detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)
+    ).toEqual([surviving.id, deleted.id])
+
+    resolveRemoval()
+    await expect(deleteAttempt).resolves.toEqual({ ok: true })
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([surviving.id])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      surviving.id
+    ])
+    expect(state.getKnownWorktreeById(deleted.id)).toBeUndefined()
+  })
+
+  it('ignores a refresh result that started before a delete succeeded', async () => {
+    const store = createTestStore()
+    const deleted = makeWorktree({
+      id: 'repo1::/path/deleted',
+      repoId: 'repo1',
+      path: '/path/deleted'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockResolvedValueOnce(undefined)
+
+    store.setState({
+      worktreesByRepo: { repo1: [deleted, surviving] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [deleted, surviving]) },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchWorktrees('repo1')
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    await expect(store.getState().removeWorktree(deleted.id)).resolves.toEqual({ ok: true })
+    resolveDetected(makeDetectedResult('repo1', [deleted, surviving]))
+    await refresh
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1.map((worktree) => worktree.id)).toEqual([surviving.id])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      surviving.id
+    ])
+    expect(state.getKnownWorktreeById(deleted.id)).toBeUndefined()
+  })
+
+  it('ignores a detected refresh result that started before a delete succeeded', async () => {
+    const store = createTestStore()
+    const deleted = makeWorktree({
+      id: 'repo1::/path/deleted',
+      repoId: 'repo1',
+      path: '/path/deleted'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockResolvedValueOnce(undefined)
+
+    store.setState({
+      worktreesByRepo: { repo1: [deleted, surviving] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [deleted, surviving]) },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchDetectedWorktrees('repo1')
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    await expect(store.getState().removeWorktree(deleted.id)).resolves.toEqual({ ok: true })
+    resolveDetected(makeDetectedResult('repo1', [deleted, surviving]))
+    await expect(refresh).resolves.toBeNull()
+
+    const state = store.getState()
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      surviving.id
+    ])
+    expect(state.getKnownWorktreeById(deleted.id)).toBeUndefined()
+  })
+
   it('purges remembered state for hidden worktrees removed by an authoritative refresh', async () => {
     const store = createTestStore()
     const visible = makeWorktree({
@@ -412,6 +886,86 @@ describe('fetchWorktrees', () => {
     expect(store.getState().rightSidebarTabByWorktree).toEqual({ [visible.id]: 'checks' })
     expect(store.getState().tabsByWorktree[hidden.id]).toBeUndefined()
     expect(store.getState().sortEpoch).toBe(7)
+  })
+
+  it('preserves hidden detected state when an authoritative refresh races an in-flight delete', async () => {
+    const store = createTestStore()
+    const visible = makeWorktree({
+      id: 'repo1::/path/visible',
+      repoId: 'repo1',
+      path: '/path/visible'
+    })
+    const hidden = makeWorktree({
+      id: 'repo1::/path/hidden',
+      repoId: 'repo1',
+      path: '/path/hidden'
+    })
+    const previousDetected = makeDetectedResult('repo1', [visible, hidden])
+    previousDetected.worktrees[1] = {
+      ...previousDetected.worktrees[1],
+      ownership: 'external',
+      visible: false
+    }
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(makeDetectedResult('repo1', [visible]))
+    store.setState({
+      worktreesByRepo: { repo1: [visible] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      deleteStateByWorktreeId: {
+        [hidden.id]: { isDeleting: true, error: null, canForceDelete: false }
+      },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1).toEqual([visible])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      visible.id,
+      hidden.id
+    ])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees[1]?.visible).toBe(false)
+    expect(state.sortEpoch).toBe(7)
+  })
+
+  it('preserves hidden detected state during an authoritative detected-only refresh', async () => {
+    const store = createTestStore()
+    const visible = makeWorktree({
+      id: 'repo1::/path/visible',
+      repoId: 'repo1',
+      path: '/path/visible'
+    })
+    const hidden = makeWorktree({
+      id: 'repo1::/path/hidden',
+      repoId: 'repo1',
+      path: '/path/hidden'
+    })
+    const previousDetected = makeDetectedResult('repo1', [visible, hidden])
+    previousDetected.worktrees[1] = {
+      ...previousDetected.worktrees[1],
+      ownership: 'external',
+      visible: false
+    }
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(makeDetectedResult('repo1', [visible]))
+    store.setState({
+      worktreesByRepo: { repo1: [visible] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      deleteStateByWorktreeId: {
+        [hidden.id]: { isDeleting: true, error: null, canForceDelete: false }
+      }
+    } as Partial<AppState>)
+
+    await expect(store.getState().fetchDetectedWorktrees('repo1')).resolves.toMatchObject({
+      authoritative: true,
+      source: 'git'
+    })
+
+    const state = store.getState()
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      visible.id,
+      hidden.id
+    ])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees[1]?.visible).toBe(false)
   })
 
   it('does not purge remembered state from a non-authoritative partial refresh', async () => {
@@ -458,6 +1012,221 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('preserves an in-flight delete row during a non-authoritative partial refresh', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({
+      id: 'repo1::/path/dirty',
+      repoId: 'repo1',
+      path: '/path/dirty'
+    })
+    const fallback = makeWorktree({
+      id: 'repo1::/path/fallback',
+      repoId: 'repo1',
+      path: '/path/fallback'
+    })
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [fallback], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [dirty, fallback] },
+      deleteStateByWorktreeId: {
+        [dirty.id]: { isDeleting: true, error: null, canForceDelete: false }
+      },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([dirty, fallback])
+    expect(store.getState().sortEpoch).toBe(7)
+  })
+
+  it('preserves a hidden in-flight delete row during a non-authoritative partial refresh', async () => {
+    const store = createTestStore()
+    const hidden = makeWorktree({
+      id: 'repo1::/path/hidden',
+      repoId: 'repo1',
+      path: '/path/hidden'
+    })
+    const fallback = makeWorktree({
+      id: 'repo1::/path/fallback',
+      repoId: 'repo1',
+      path: '/path/fallback'
+    })
+    const previousDetected = makeDetectedResult('repo1', [fallback, hidden])
+    previousDetected.worktrees[1] = {
+      ...previousDetected.worktrees[1],
+      ownership: 'external',
+      visible: false
+    }
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [fallback], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [fallback] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      deleteStateByWorktreeId: {
+        [hidden.id]: { isDeleting: true, error: null, canForceDelete: false }
+      },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1).toEqual([fallback])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      fallback.id,
+      hidden.id
+    ])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees[1]?.visible).toBe(false)
+    expect(state.sortEpoch).toBe(7)
+  })
+
+  it('preserves a hidden in-flight delete row during a non-authoritative empty refresh', async () => {
+    const store = createTestStore()
+    const hidden = makeWorktree({
+      id: 'repo1::/path/hidden',
+      repoId: 'repo1',
+      path: '/path/hidden'
+    })
+    const visible = makeWorktree({
+      id: 'repo1::/path/visible',
+      repoId: 'repo1',
+      path: '/path/visible'
+    })
+    const previousDetected = makeDetectedResult('repo1', [visible, hidden])
+    previousDetected.worktrees[1] = {
+      ...previousDetected.worktrees[1],
+      ownership: 'external',
+      visible: false
+    }
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [visible] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      deleteStateByWorktreeId: {
+        [hidden.id]: { isDeleting: true, error: null, canForceDelete: false }
+      },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repo1).toEqual([visible])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      hidden.id
+    ])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees[0]?.visible).toBe(false)
+    expect(state.sortEpoch).toBe(7)
+  })
+
+  it('preserves a hidden in-flight delete row during a detected-only empty refresh', async () => {
+    const store = createTestStore()
+    const hidden = makeWorktree({
+      id: 'repo1::/path/hidden',
+      repoId: 'repo1',
+      path: '/path/hidden'
+    })
+    const visible = makeWorktree({
+      id: 'repo1::/path/visible',
+      repoId: 'repo1',
+      path: '/path/visible'
+    })
+    const previousDetected = makeDetectedResult('repo1', [visible, hidden])
+    previousDetected.worktrees[1] = {
+      ...previousDetected.worktrees[1],
+      ownership: 'external',
+      visible: false
+    }
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [visible] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      deleteStateByWorktreeId: {
+        [hidden.id]: { isDeleting: true, error: null, canForceDelete: false }
+      }
+    } as Partial<AppState>)
+
+    await expect(store.getState().fetchDetectedWorktrees('repo1')).resolves.toMatchObject({
+      authoritative: false,
+      source: 'metadata-fallback'
+    })
+
+    const state = store.getState()
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      hidden.id
+    ])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees[0]?.visible).toBe(false)
+  })
+
+  it('preserves a hidden in-flight delete row during a detected-only partial refresh', async () => {
+    const store = createTestStore()
+    const hidden = makeWorktree({
+      id: 'repo1::/path/hidden',
+      repoId: 'repo1',
+      path: '/path/hidden'
+    })
+    const fallback = makeWorktree({
+      id: 'repo1::/path/fallback',
+      repoId: 'repo1',
+      path: '/path/fallback'
+    })
+    const previousDetected = makeDetectedResult('repo1', [fallback, hidden])
+    previousDetected.worktrees[1] = {
+      ...previousDetected.worktrees[1],
+      ownership: 'external',
+      visible: false
+    }
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [fallback], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [fallback] },
+      detectedWorktreesByRepo: { repo1: previousDetected },
+      deleteStateByWorktreeId: {
+        [hidden.id]: { isDeleting: true, error: null, canForceDelete: false }
+      }
+    } as Partial<AppState>)
+
+    await expect(store.getState().fetchDetectedWorktrees('repo1')).resolves.toMatchObject({
+      authoritative: false,
+      source: 'metadata-fallback'
+    })
+
+    const state = store.getState()
+    expect(state.detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.id)).toEqual([
+      fallback.id,
+      hidden.id
+    ])
+    expect(state.detectedWorktreesByRepo.repo1.worktrees[1]?.visible).toBe(false)
+  })
+
   it('does not purge remembered right sidebar tabs on a transient empty refresh', async () => {
     const store = createTestStore()
     const existing = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
@@ -478,6 +1247,39 @@ describe('fetchWorktrees', () => {
 
     expect(store.getState().worktreesByRepo.repo1).toEqual([existing])
     expect(store.getState().rightSidebarTabByWorktree).toEqual({ [existing.id]: 'search' })
+    expect(store.getState().sortEpoch).toBe(7)
+  })
+
+  it('keeps the full cached list when a transient empty refresh overlaps an in-flight delete', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({
+      id: 'repo1::/path/dirty',
+      repoId: 'repo1',
+      path: '/path/dirty'
+    })
+    const surviving = makeWorktree({
+      id: 'repo1::/path/surviving',
+      repoId: 'repo1',
+      path: '/path/surviving'
+    })
+
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(
+      makeDetectedResult('repo1', [], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    )
+    store.setState({
+      worktreesByRepo: { repo1: [dirty, surviving] },
+      deleteStateByWorktreeId: {
+        [dirty.id]: { isDeleting: true, error: null, canForceDelete: false }
+      },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(store.getState().worktreesByRepo.repo1).toEqual([dirty, surviving])
     expect(store.getState().sortEpoch).toBe(7)
   })
 
@@ -2241,6 +3043,132 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
 
     expect(mockApi.worktrees.list).toHaveBeenCalledTimes(4)
     expect(store.getState().tabsByWorktree['repoA::/a/new-zombie']).toBeDefined()
+  })
+
+  it('preserves an in-flight delete row during fetchAllWorktrees', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({ id: 'repoA::/a/dirty', repoId: 'repoA', path: '/a/dirty' })
+    const surviving = makeWorktree({
+      id: 'repoA::/a/surviving',
+      repoId: 'repoA',
+      path: '/a/surviving'
+    })
+    mockApi.worktrees.listDetected.mockResolvedValueOnce(makeDetectedResult('repoA', [surviving]))
+    store.setState({
+      repos: [repoA],
+      worktreesByRepo: { repoA: [dirty, surviving] },
+      detectedWorktreesByRepo: { repoA: makeDetectedResult('repoA', [dirty, surviving]) },
+      deleteStateByWorktreeId: {
+        [dirty.id]: { isDeleting: true, error: null, canForceDelete: false }
+      },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    await store.getState().fetchAllWorktrees()
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repoA.map((worktree) => worktree.id)).toEqual([
+      dirty.id,
+      surviving.id
+    ])
+    expect(state.detectedWorktreesByRepo.repoA.worktrees.map((worktree) => worktree.id)).toEqual([
+      surviving.id,
+      dirty.id
+    ])
+    expect(state.sortEpoch).toBe(7)
+    expect(state.hasHydratedWorktreePurge).toBe(true)
+  })
+
+  it('ignores a fetchAllWorktrees result that started before a delete succeeded', async () => {
+    const store = createTestStore()
+    const deleted = makeWorktree({ id: 'repoA::/a/deleted', repoId: 'repoA', path: '/a/deleted' })
+    const surviving = makeWorktree({
+      id: 'repoA::/a/surviving',
+      repoId: 'repoA',
+      path: '/a/surviving'
+    })
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockResolvedValueOnce(undefined)
+    store.setState({
+      repos: [repoA],
+      worktreesByRepo: { repoA: [deleted, surviving] },
+      detectedWorktreesByRepo: { repoA: makeDetectedResult('repoA', [deleted, surviving]) },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchAllWorktrees()
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    await expect(store.getState().removeWorktree(deleted.id)).resolves.toEqual({ ok: true })
+    resolveDetected(makeDetectedResult('repoA', [deleted, surviving]))
+    await refresh
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repoA.map((worktree) => worktree.id)).toEqual([surviving.id])
+    expect(state.detectedWorktreesByRepo.repoA.worktrees.map((worktree) => worktree.id)).toEqual([
+      surviving.id
+    ])
+    expect(state.hasHydratedWorktreePurge).toBe(false)
+  })
+
+  it('ignores a fetchAllWorktrees result that resolves after a dirty delete failure', async () => {
+    const store = createTestStore()
+    const dirty = makeWorktree({ id: 'repoA::/a/dirty', repoId: 'repoA', path: '/a/dirty' })
+    const surviving = makeWorktree({
+      id: 'repoA::/a/surviving',
+      repoId: 'repoA',
+      path: '/a/surviving'
+    })
+    const dirtyError =
+      "Error invoking remote method 'worktrees:remove': Error: Failed to delete worktree at /a/dirty. ?? scratch.txt"
+    let resolveDetected!: (result: DetectedWorktreeListResult) => void
+    let rejectRemoval!: (error: Error) => void
+    mockApi.worktrees.listDetected.mockReturnValueOnce(
+      new Promise<DetectedWorktreeListResult>((resolve) => {
+        resolveDetected = resolve
+      })
+    )
+    mockApi.worktrees.remove.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectRemoval = reject
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    store.setState({
+      repos: [repoA],
+      worktreesByRepo: { repoA: [dirty, surviving] },
+      detectedWorktreesByRepo: { repoA: makeDetectedResult('repoA', [dirty, surviving]) },
+      sortEpoch: 7
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchAllWorktrees()
+    await vi.waitFor(() => expect(mockApi.worktrees.listDetected).toHaveBeenCalledTimes(1))
+
+    const deleteAttempt = store.getState().removeWorktree(dirty.id)
+    await vi.waitFor(() =>
+      expect(store.getState().deleteStateByWorktreeId[dirty.id]?.isDeleting).toBe(true)
+    )
+    rejectRemoval(new Error(dirtyError))
+    await expect(deleteAttempt).resolves.toEqual({ ok: false, error: dirtyError })
+    resolveDetected(makeDetectedResult('repoA', [surviving]))
+    await refresh
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.repoA.map((worktree) => worktree.id)).toEqual([
+      dirty.id,
+      surviving.id
+    ])
+    expect(state.deleteStateByWorktreeId[dirty.id]).toEqual({
+      isDeleting: false,
+      error: dirtyError,
+      canForceDelete: true
+    })
+    expect(state.hasHydratedWorktreePurge).toBe(false)
   })
 })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -217,12 +217,110 @@ function toVisibleWorktrees(result: DetectedWorktreeListResult): Worktree[] {
   return result.worktrees.filter((worktree) => worktree.visible).map(toVisibleWorktree)
 }
 
+// Why: dirty non-force deletes can reject after a concurrent refresh. Until the
+// backend call resolves, the renderer must not make a missing scan row final.
+function preserveInFlightDeleteWorktrees(
+  current: Worktree[] | undefined,
+  refreshed: Worktree[],
+  inFlightDeleteIds: ReadonlySet<string>
+): Worktree[] {
+  if (!current || inFlightDeleteIds.size === 0) {
+    return refreshed
+  }
+
+  const refreshedById = new Map(refreshed.map((worktree) => [worktree.id, worktree]))
+  const next: Worktree[] = []
+  let preserved = false
+  for (const worktree of current) {
+    const refreshedWorktree = refreshedById.get(worktree.id)
+    if (refreshedWorktree) {
+      refreshedById.delete(worktree.id)
+      next.push(refreshedWorktree)
+      continue
+    }
+    if (inFlightDeleteIds.has(worktree.id)) {
+      preserved = true
+      next.push(worktree)
+    }
+  }
+
+  next.push(...refreshedById.values())
+  const orderChanged =
+    next.length === refreshed.length &&
+    next.some((worktree, index) => worktree.id !== refreshed[index].id)
+
+  if (!preserved && !orderChanged) {
+    return refreshed
+  }
+  return next
+}
+
 function getKnownWorktreeIdsForPurge(state: AppState, repoId: string): string[] {
   const detected = state.detectedWorktreesByRepo[repoId]
   if (detected?.authoritative === true) {
     return detected.worktrees.map((worktree) => worktree.id)
   }
   return (state.worktreesByRepo[repoId] ?? []).map((worktree) => worktree.id)
+}
+
+function getInFlightDeleteWorktreeIds(state: AppState, repoId: string): Set<string> {
+  const ids = new Set<string>()
+  for (const [worktreeId, deleteState] of Object.entries(state.deleteStateByWorktreeId)) {
+    if (deleteState.isDeleting && getRepoIdFromWorktreeId(worktreeId) === repoId) {
+      ids.add(worktreeId)
+    }
+  }
+  return ids
+}
+
+function preserveInFlightDeleteDetectedWorktrees(
+  state: AppState,
+  repoId: string,
+  detected: DetectedWorktreeListResult
+): DetectedWorktreeListResult {
+  const inFlightDeleteIds = getInFlightDeleteWorktreeIds(state, repoId)
+  if (inFlightDeleteIds.size === 0) {
+    return detected
+  }
+
+  const detectedIds = new Set(detected.worktrees.map((worktree) => worktree.id))
+  const previousDetectedById = new Map(
+    (state.detectedWorktreesByRepo[repoId]?.worktrees ?? []).map((worktree) => [
+      worktree.id,
+      worktree
+    ])
+  )
+  const currentVisibleById = new Map(
+    (state.worktreesByRepo[repoId] ?? []).map((worktree) => [worktree.id, worktree])
+  )
+  const preserved: DetectedWorktreeListResult['worktrees'] = []
+
+  for (const worktreeId of inFlightDeleteIds) {
+    if (detectedIds.has(worktreeId)) {
+      continue
+    }
+    const previousDetected = previousDetectedById.get(worktreeId)
+    if (previousDetected) {
+      preserved.push(previousDetected)
+      continue
+    }
+    if (!detected.authoritative) {
+      continue
+    }
+    const currentVisible = currentVisibleById.get(worktreeId)
+    if (currentVisible) {
+      preserved.push({
+        ...currentVisible,
+        ownership: 'orca-managed',
+        selectedCheckout: false,
+        visible: true
+      })
+    }
+  }
+
+  return preserved.length > 0
+    ? { ...detected, worktrees: [...detected.worktrees, ...preserved] }
+    : detected
 }
 
 function getRemovedWorktreeIdsAfterAuthoritativeScan(
@@ -234,7 +332,10 @@ function getRemovedWorktreeIdsAfterAuthoritativeScan(
     return []
   }
   const detectedIds = new Set(detected.worktrees.map((worktree) => worktree.id))
-  return getKnownWorktreeIdsForPurge(state, repoId).filter((id) => !detectedIds.has(id))
+  const inFlightDeleteIds = getInFlightDeleteWorktreeIds(state, repoId)
+  return getKnownWorktreeIdsForPurge(state, repoId).filter(
+    (id) => !detectedIds.has(id) && !inFlightDeleteIds.has(id)
+  )
 }
 
 function toLegacyDetectedWorktreeResult(
@@ -277,6 +378,26 @@ function applyDetectedWorktreeUpdates(
       return { ...worktree, ...updates }
     })
     nextByRepo[repoId] = repoChanged ? { ...result, worktrees: nextWorktrees } : result
+  }
+
+  return changed ? nextByRepo : detectedWorktreesByRepo
+}
+
+function removeDetectedWorktreeById(
+  detectedWorktreesByRepo: AppState['detectedWorktreesByRepo'],
+  worktreeId: string
+): AppState['detectedWorktreesByRepo'] {
+  let changed = false
+  const nextByRepo: AppState['detectedWorktreesByRepo'] = {}
+
+  for (const [repoId, result] of Object.entries(detectedWorktreesByRepo)) {
+    const nextWorktrees = result.worktrees.filter((worktree) => worktree.id !== worktreeId)
+    if (nextWorktrees.length !== result.worktrees.length) {
+      changed = true
+      nextByRepo[repoId] = { ...result, worktrees: nextWorktrees }
+    } else {
+      nextByRepo[repoId] = result
+    }
   }
 
   return changed ? nextByRepo : detectedWorktreesByRepo
@@ -609,6 +730,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   worktreeLineageById: {},
   activeWorktreeId: null,
   deleteStateByWorktreeId: {},
+  worktreeDeleteEpochByRepo: {},
   baseStatusByWorktreeId: {},
   remoteBranchConflictByWorktreeId: {},
   sortEpoch: 0,
@@ -618,13 +740,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
   fetchDetectedWorktrees: async (repoId) => {
     try {
+      const deleteEpochAtStart = get().worktreeDeleteEpochByRepo[repoId] ?? 0
       const result = await listDetectedWorktreesForRepo(get().settings, repoId)
+      const stateBeforeRefresh = get()
+      if ((stateBeforeRefresh.worktreeDeleteEpochByRepo[repoId] ?? 0) !== deleteEpochAtStart) {
+        return null
+      }
+      const detected = preserveInFlightDeleteDetectedWorktrees(stateBeforeRefresh, repoId, result)
       set((s) =>
-        areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], result)
+        areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[repoId], detected)
           ? s
-          : { detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [repoId]: result } }
+          : { detectedWorktreesByRepo: { ...s.detectedWorktreesByRepo, [repoId]: detected } }
       )
-      return result
+      return detected
     } catch (err) {
       console.error(`Failed to fetch detected worktrees for repo ${repoId}:`, err)
       return null
@@ -634,9 +762,27 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
   fetchWorktrees: async (repoId) => {
     try {
       const settings = get().settings
-      const detected = await listDetectedWorktreesForRepo(settings, repoId)
-      const worktrees = toVisibleWorktrees(detected)
-      const current = get().worktreesByRepo[repoId]
+      const deleteEpochAtStart = get().worktreeDeleteEpochByRepo[repoId] ?? 0
+      const refreshedDetected = await listDetectedWorktreesForRepo(settings, repoId)
+      const stateBeforeRefresh = get()
+      if ((stateBeforeRefresh.worktreeDeleteEpochByRepo[repoId] ?? 0) !== deleteEpochAtStart) {
+        return
+      }
+      const detected = preserveInFlightDeleteDetectedWorktrees(
+        stateBeforeRefresh,
+        repoId,
+        refreshedDetected
+      )
+      const current = stateBeforeRefresh.worktreesByRepo[repoId]
+      const visibleWorktrees = toVisibleWorktrees(detected)
+      const worktrees =
+        detected.authoritative || visibleWorktrees.length > 0
+          ? preserveInFlightDeleteWorktrees(
+              current,
+              visibleWorktrees,
+              getInFlightDeleteWorktreeIds(stateBeforeRefresh, repoId)
+            )
+          : visibleWorktrees
       if (areWorktreesEqual(current, worktrees)) {
         set((s) => {
           const removedIds = getRemovedWorktreeIdsAfterAuthoritativeScan(s, repoId, detected)
@@ -716,9 +862,27 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     const results = await Promise.all(
       repos.map(async (r) => {
         try {
-          const detected = await listDetectedWorktreesForRepo(get().settings, r.id)
-          const list = toVisibleWorktrees(detected)
-          const current = get().worktreesByRepo[r.id]
+          const deleteEpochAtStart = get().worktreeDeleteEpochByRepo[r.id] ?? 0
+          const refreshedDetected = await listDetectedWorktreesForRepo(get().settings, r.id)
+          const stateBeforeRefresh = get()
+          if ((stateBeforeRefresh.worktreeDeleteEpochByRepo[r.id] ?? 0) !== deleteEpochAtStart) {
+            return { repoId: r.id, ok: false as const }
+          }
+          const detected = preserveInFlightDeleteDetectedWorktrees(
+            stateBeforeRefresh,
+            r.id,
+            refreshedDetected
+          )
+          const current = stateBeforeRefresh.worktreesByRepo[r.id]
+          const visibleWorktrees = toVisibleWorktrees(detected)
+          const list =
+            detected.authoritative || visibleWorktrees.length > 0
+              ? preserveInFlightDeleteWorktrees(
+                  current,
+                  visibleWorktrees,
+                  getInFlightDeleteWorktreeIds(stateBeforeRefresh, r.id)
+                )
+              : visibleWorktrees
           if (
             !areWorktreesEqual(current, list) &&
             !(list.length === 0 && current && current.length > 0 && !detected.authoritative)
@@ -1185,8 +1349,22 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 return next
               })()
             : s.lastVisitedAtByWorktreeId
+        // Why: an in-flight delete refresh may temporarily preserve this row in
+        // detected state. Successful deletion must make later lookups miss it.
+        const nextDetectedWorktrees = removeDetectedWorktreeById(
+          s.detectedWorktreesByRepo,
+          worktreeId
+        )
+        const repoId = getRepoIdFromWorktreeId(worktreeId)
         return {
           worktreesByRepo: next,
+          detectedWorktreesByRepo: nextDetectedWorktrees,
+          // Why: refreshes that started before this successful delete can carry
+          // a pre-delete scan row. Advance an epoch so they cannot re-add it.
+          worktreeDeleteEpochByRepo: {
+            ...s.worktreeDeleteEpochByRepo,
+            [repoId]: (s.worktreeDeleteEpochByRepo[repoId] ?? 0) + 1
+          },
           worktreeLineageById: nextLineage,
           tabsByWorktree: nextTabs,
           ptyIdsByTabId: nextPtyIdsByTabId,
@@ -1252,7 +1430,15 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // handled user decision point surfaced by the delete toast, not an app error.
       console.warn('Failed to remove worktree:', err)
       const error = err instanceof Error ? err.message : String(err)
+      const repoId = getRepoIdFromWorktreeId(worktreeId)
       set((s) => ({
+        // Why: refreshes that started during this delete attempt may carry a
+        // missing-row payload. Once the attempt settles, they are stale even if
+        // the delete failed and the row must remain.
+        worktreeDeleteEpochByRepo: {
+          ...s.worktreeDeleteEpochByRepo,
+          [repoId]: (s.worktreeDeleteEpochByRepo[repoId] ?? 0) + 1
+        },
         deleteStateByWorktreeId: {
           ...s.deleteStateByWorktreeId,
           [worktreeId]: {


### PR DESCRIPTION
## Summary

Preserves renderer worktree state while a delete attempt is in flight so a dirty non-force delete failure cannot lose the workspace row, active tab state, browser/editor state, sidebar state, or git caches due to an overlapping refresh.

Design approach:
- Track in-flight delete worktree IDs by repo and preserve missing rows across authoritative refreshes.
- Preserve missing in-flight rows across non-authoritative partial/empty fallback results, including hidden detected-only rows.
- Add a per-repo delete epoch so refreshes that started before a delete attempt settled cannot apply stale payloads after success or dirty failure.
- Remove preserved detected rows during successful delete cleanup so known-worktree lookup does not resolve deleted workspaces.
- Keep force-delete retries fresh: the toast action calls a new `removeWorktree(worktreeId, true)`, while IPC/runtime dedupe only coalesces equivalent removal options.

## Pipeline Evidence

Design doc: `design-docs/dirty-delete-ui-state.md` (scratch, gitignored, not included in the PR diff).

Design review:
- `auto-design-review-fix` subagent completed clean after tightening invariants, lifecycle, edge cases, and validation expectations.

Implementation:
- Existing implementation was already present per Brennan's instruction, then patched during verification/review for uncovered races.
- Changed files: renderer worktree slice/type/reset, renderer worktree/delete-flow tests, IPC/runtime removal tests.

Completeness verification:
- Final completeness pass returned clean against the design doc.
- Earlier verifier findings led to fixes for non-authoritative fallback rows, stale refreshes after success/failure, detected-only refreshes, and hidden detected rows.

Code review loop:
- Multiple two-reviewer rounds were run.
- Final post-validation reviewer pair both returned clean with no actionable findings.

Brennan test result:
- Final `brennan-test-changes` verdict: land.
- Electron launched from this exact worktree and identity was verified.
- Live dirty-delete validation in `demo-project` verified dirty failure preserved visible/detected state and force retry removed visible state, detected state, git worktree entry, branch, and directory.
- IPC/runtime same-option dedupe was live-validated; option-conflict behavior is covered by unit tests.

## Validation

- `pnpm run typecheck` passed
- `pnpm run lint` passed with one pre-existing warning outside this diff: `browser-automation-visibility.ts`
- `git diff --check` passed
- Focused Vitest passed: 4 files, 377 tests
  - `src/renderer/src/store/slices/worktrees.test.ts`
  - `src/renderer/src/components/sidebar/delete-worktree-flow.test.ts`
  - `src/main/ipc/worktrees.test.ts`
  - `src/main/runtime/orca-runtime.test.ts`

## Notes / Accepted Gaps

- SSH transport behavior was reasoned through and remains behind existing provider/runtime abstractions; `brennan-test-ssh` was not run because the diff does not directly touch SSH transport code.
- The visible Sonner Force Delete button was not clicked in Electron because it was not present in the accessibility tree after the modal path failure; the toast action wiring is covered by focused Vitest, and live force retry was validated through renderer store + IPC.

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.