### PR TITLE
fix: sync worktree card title on terminal branch switch

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -910,6 +910,44 @@ describe('updateWorktreeGitIdentity', () => {
     expect(mockApi.worktrees.list).not.toHaveBeenCalled()
     expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
   })
+
+  it('follows the new branch in the title when displayName was auto-derived from the branch', () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/feature',
+      displayName: 'feature'
+    })
+
+    store.setState({ worktreesByRepo: { repo1: [existing] } } as Partial<AppState>)
+
+    store.getState().updateWorktreeGitIdentity('repo1::/path/wt1', {
+      branch: 'refs/heads/main'
+    })
+
+    expect(store.getState().worktreesByRepo.repo1[0].displayName).toBe('main')
+  })
+
+  it('preserves a custom title when displayName differs from the branch', () => {
+    const store = createTestStore()
+    const existing = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      branch: 'refs/heads/feature',
+      displayName: 'My Cool Work'
+    })
+
+    store.setState({ worktreesByRepo: { repo1: [existing] } } as Partial<AppState>)
+
+    store.getState().updateWorktreeGitIdentity('repo1::/path/wt1', {
+      branch: 'refs/heads/main'
+    })
+
+    expect(store.getState().worktreesByRepo.repo1[0].displayName).toBe('My Cool Work')
+  })
 })
 
 describe('createWorktree base status merge', () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -29,6 +29,7 @@ import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-k
 import { moveFocusToRendererBeforeFocusedWebviewHidden } from './browser-webview-cleanup'
 import { toast } from 'sonner'
 import { requestVirtualizedScrollAnchorRecord } from '@/hooks/requestVirtualizedScrollAnchorRecord'
+import { branchName } from '@/lib/git-utils'
 export type { WorktreeSlice, WorktreeDeleteState } from './worktree-helpers'
 
 // Why: old runtime servers only have `worktree.list`; preserve the large-list
@@ -838,13 +839,10 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           return worktree
         }
         changed = true
-        // Why: when the user hasn't set a custom name, mergeWorktree derives the
-        // title from the branch. A terminal branch switch only patches branch/head
-        // here, so re-derive the title too when it was auto-derived (matches the
-        // branch) — otherwise the card title stays frozen on the old branch name.
-        const branchShort = (b: string): string => b.replace(/^refs\/heads\//, '')
-        const wasAutoDerived = worktree.displayName === branchShort(worktree.branch)
-        const nextDisplayName = wasAutoDerived ? branchShort(nextBranch) : worktree.displayName
+        // Why: terminal branch switches only patch branch/head here; auto-derived
+        // titles need the same branch derivation that full worktree listing uses.
+        const wasAutoDerived = worktree.displayName === branchName(worktree.branch)
+        const nextDisplayName = wasAutoDerived ? branchName(nextBranch) : worktree.displayName
         return { ...worktree, head: nextHead, branch: nextBranch, displayName: nextDisplayName }
       })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -838,7 +838,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           return worktree
         }
         changed = true
-        return { ...worktree, head: nextHead, branch: nextBranch }
+        // Why: when the user hasn't set a custom name, mergeWorktree derives the
+        // title from the branch. A terminal branch switch only patches branch/head
+        // here, so re-derive the title too when it was auto-derived (matches the
+        // branch) — otherwise the card title stays frozen on the old branch name.
+        const branchShort = (b: string): string => b.replace(/^refs\/heads\//, '')
+        const wasAutoDerived = worktree.displayName === branchShort(worktree.branch)
+        const nextDisplayName = wasAutoDerived ? branchShort(nextBranch) : worktree.displayName
+        return { ...worktree, head: nextHead, branch: nextBranch, displayName: nextDisplayName }
       })
 
       if (!changed) {


### PR DESCRIPTION
## What

A worktree card's title now updates to match the live branch when you switch branches from a terminal, instead of staying frozen on the branch name the worktree happened to be on when it was last listed.

## Why

For worktrees without a custom name, the card title is derived from the current branch. That title was only ever recomputed during a full worktree re-list — which Orca's own branch-switch flows trigger, but an out-of-band `git checkout` in a terminal (or over SSH) does not. A terminal switch reaches the renderer only through the periodic git-status poll, which updated `head`/`branch` but never re-derived the title. The result: the card subtitle correctly showed the new branch (`main`) while the title still read the old one (`fix/review-feedback-gates`).

## How

`updateWorktreeGitIdentity` now re-derives `displayName` from the new branch, but only when the title was auto-derived — i.e. it still equals the old branch's short name. This mirrors `mergeWorktree`'s own derivation rule, so a later full re-list produces the same value. Titles the user set explicitly (which differ from the branch) are left untouched.

The change is renderer-only — no IPC, schema, or main-process changes. It naturally covers SSH and terminal-driven switches alike, since both arrive through the same git-status poll.

## Tests

Two cases added to `updateWorktreeGitIdentity` store tests:
- Auto-derived title follows the branch on switch (`feature` → `main`).
- A custom title (`My Cool Work`) is preserved across a branch switch.

The pre-existing identity test only asserted `head`/`branch`, never `displayName`, which is why the stale-title gap went unnoticed.
