### PR TITLE
Preserve mobile microphone usage description

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -69,7 +69,7 @@
         "expo-camera",
         {
           "cameraPermission": "Allow Orca to use the camera for QR code scanning.",
-          "microphonePermission": false,
+          "microphonePermission": "Allow Orca to use your microphone for voice dictation sent to your paired desktop for transcription.",
           "recordAudioAndroid": false
         }
       ],


### PR DESCRIPTION
## Summary
- Keep the iOS microphone usage string in Expo config after prebuild plugin resolution

## Verification
- npx expo config --type introspect --json | node -e "let s=''; process.stdin.on('data',d=>s+=d).on('end',()=>{const cfg=JSON.parse(s); const info=cfg.modResults?.ios?.infoPlist || cfg.ios?.infoPlist || {}; console.log(info.NSMicrophoneUsageDescription || 'missing');})"
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
