### PR TITLE
Fix update checks during release publishing

### DIFF
--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -20,6 +20,7 @@ type UpdaterHandlerContext = {
   clearBackgroundCheckLaunchPending: () => void
   clearAvailableUpdateContext: () => void
   consumeMissingManifestPrereleaseFallbackResult: () => { userInitiated: boolean } | null
+  getPublishingWindowLastGoodCheck: () => { lastGoodTag: string } | null
   getMissingManifestPrereleaseFallbackUserInitiated: () => boolean | null
   getCurrentStatus: () => UpdateStatus
   getKnownReleaseUrl: () => string | undefined
@@ -50,6 +51,7 @@ export function registerAutoUpdaterHandlers({
   clearBackgroundCheckLaunchPending,
   clearAvailableUpdateContext,
   consumeMissingManifestPrereleaseFallbackResult,
+  getPublishingWindowLastGoodCheck,
   getMissingManifestPrereleaseFallbackUserInitiated,
   getCurrentStatus,
   getKnownReleaseUrl,
@@ -123,13 +125,14 @@ export function registerAutoUpdaterHandlers({
     clearBackgroundCheckLaunchPending()
     // --- synchronous preamble (runs before any await) ---
     const missingManifestFallback = consumeMissingManifestPrereleaseFallbackResult()
+    const publishingWindowLastGoodCheck = getPublishingWindowLastGoodCheck()
     const wasUserInitiated = missingManifestFallback?.userInitiated ?? getUserInitiatedCheck()
     setUserInitiatedCheck(false)
 
     // Guard: don't show an update that isn't actually newer than what's running.
     if (compareVersions(info.version, app.getVersion()) <= 0) {
       clearAvailableUpdateContext()
-      if (missingManifestFallback) {
+      if (missingManifestFallback || publishingWindowLastGoodCheck) {
         // Why: a fallback manifest at the current version is still the result of
         // a transient missing primary manifest, so keep the short retry cadence.
         scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)
@@ -166,10 +169,10 @@ export function registerAutoUpdaterHandlers({
       // timestamp persisted for a check that never showed a result.
       setAvailableVersion(info.version)
       setAvailableReleaseUrl(null)
-      if (missingManifestFallback) {
-        // Why: offering the previous good release is only a temporary fallback;
-        // keep probing soon so users can move to the newest tag once its
-        // platform manifest finishes publishing.
+      if (missingManifestFallback || publishingWindowLastGoodCheck) {
+        // Why: offering a previous/last-good release is only a temporary
+        // fallback; keep probing soon so users can move to the newest tag once
+        // its platform manifest finishes publishing.
         scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)
       } else {
         recordCompletedUpdateCheck()
@@ -186,12 +189,14 @@ export function registerAutoUpdaterHandlers({
     clearBackgroundCheckLaunchPending()
     resetMacInstallState()
     const missingManifestFallback = consumeMissingManifestPrereleaseFallbackResult()
+    const publishingWindowLastGoodCheck = getPublishingWindowLastGoodCheck()
     const wasUserInitiated = missingManifestFallback?.userInitiated ?? getUserInitiatedCheck()
     setUserInitiatedCheck(false)
     clearAvailableUpdateContext()
-    if (missingManifestFallback) {
-      // Why: the primary/newest release manifest was missing, so fallback
-      // not-available is still a transient release-transition outcome.
+    if (missingManifestFallback || publishingWindowLastGoodCheck) {
+      // Why: the primary/newest release manifest/assets were missing, so a
+      // last-good not-available result is still a transient release-transition
+      // outcome and must not suppress the next retry for 24 hours.
       scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)
     } else {
       recordCompletedUpdateCheck()

--- a/src/main/updater-prerelease-feed-readiness.test.ts
+++ b/src/main/updater-prerelease-feed-readiness.test.ts
@@ -75,8 +75,20 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
     vi.unstubAllGlobals()
   })
 
-  it('reports not-ready when newer tags exist but their manifest assets are unavailable', async () => {
-    respondWithAtom(['v1.4.27'], [], ['v1.4.27'])
+  it('reports not-ready with a verified last-good tag when the newest assets are unavailable', async () => {
+    respondWithAtom(['v1.4.27', 'v1.4.26'], [], ['v1.4.27'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.26'
+    })
+  })
+
+  it('does not return a last-good tag whose manifest asset is unavailable', async () => {
+    respondWithAtom(['v1.4.27', 'v1.4.26'], [], ['v1.4.27', 'v1.4.26'])
 
     const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
 
@@ -142,9 +154,15 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
     })
 
-    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+    const { fetchNewerReleaseTag, fetchNewerReleaseTagsWithReadiness } =
+      await import('./updater-prerelease-feed')
 
-    expect(await fetchNewerReleaseTag('1.4.26')).toBe('v1.4.27')
+    expect(await fetchNewerReleaseTag('1.4.26')).toBeNull()
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.27'
+    })
   })
 
   it('accepts absolute manifest asset URLs without rewriting them to release asset paths', async () => {
@@ -210,8 +228,60 @@ describe('fetchNewerReleaseTagsWithReadiness', () => {
       return Promise.resolve({ ok: false, text: () => Promise.resolve('') })
     })
 
-    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+    const { fetchNewerReleaseTag, fetchNewerReleaseTagsWithReadiness } =
+      await import('./updater-prerelease-feed')
 
-    expect(await fetchNewerReleaseTag('1.4.26')).toBe('v1.4.27')
+    expect(await fetchNewerReleaseTag('1.4.26')).toBeNull()
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.26', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.27'
+    })
+  })
+
+  it('returns not-ready with an older ready update as last-good while newest is publishing', async () => {
+    respondWithAtom(['v1.4.27', 'v1.4.26'], ['v1.4.27'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.25', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.26'
+    })
+  })
+
+  it('uses prerelease last-good tags only for prerelease-aware checks', async () => {
+    respondWithAtom(['v1.4.27-rc.2', 'v1.4.27-rc.1', 'v1.4.26'], ['v1.4.27-rc.2'])
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.27-rc.1', 1, { includePrerelease: true })
+    ).resolves.toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.27-rc.1'
+    })
+    await expect(
+      fetchNewerReleaseTagsWithReadiness('1.4.26', 1, { includePrerelease: false })
+    ).resolves.toEqual({
+      tags: [],
+      state: 'no-newer'
+    })
+  })
+
+  it('does not guess a last-good tag outside the bounded probe window', async () => {
+    respondWithAtom(
+      ['v1.4.33', 'v1.4.32', 'v1.4.31', 'v1.4.30', 'v1.4.29', 'v1.4.28', 'v1.4.27'],
+      ['v1.4.33', 'v1.4.32', 'v1.4.31', 'v1.4.30', 'v1.4.29', 'v1.4.28']
+    )
+
+    const { fetchNewerReleaseTagsWithReadiness } = await import('./updater-prerelease-feed')
+
+    await expect(fetchNewerReleaseTagsWithReadiness('1.4.27', 1)).resolves.toEqual({
+      tags: [],
+      state: 'not-ready'
+    })
   })
 })

--- a/src/main/updater-prerelease-feed.test.ts
+++ b/src/main/updater-prerelease-feed.test.ts
@@ -193,23 +193,35 @@ describe('fetchNewerReleaseTag', () => {
     expect(await fetchNewerReleaseTags('1.3.51-rc.6', 2)).toEqual(['v1.3.51-rc.7', 'v1.3.51-rc.6'])
   })
 
-  it('skips feed tags whose platform updater manifest is missing', async () => {
+  it('reports not-ready with last-good when newer platform updater manifests are missing', async () => {
     respondWithAtom(
       ['v1.4.1-rc.4', 'v1.4.1-rc.3', 'v1.4.1-rc.2', 'v1.4.1-rc.1'],
       ['v1.4.1-rc.4', 'v1.4.1-rc.3']
     )
 
-    const { fetchNewerReleaseTags } = await import('./updater-prerelease-feed')
+    const { fetchNewerReleaseTag, fetchNewerReleaseTagsWithReadiness } =
+      await import('./updater-prerelease-feed')
 
-    expect(await fetchNewerReleaseTags('1.4.1-rc.1', 2)).toEqual(['v1.4.1-rc.2', 'v1.4.1-rc.1'])
+    expect(await fetchNewerReleaseTag('1.4.1-rc.1')).toBeNull()
+    expect(await fetchNewerReleaseTagsWithReadiness('1.4.1-rc.1', 2)).toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.1-rc.2'
+    })
   })
 
-  it('skips feed tags whose manifest asset is not reachable yet', async () => {
+  it('reports not-ready with last-good when newer manifest assets are not reachable yet', async () => {
     respondWithAtom(['v1.4.3', 'v1.4.2', 'v1.4.1'], [], ['v1.4.3'])
 
-    const { fetchNewerReleaseTag } = await import('./updater-prerelease-feed')
+    const { fetchNewerReleaseTag, fetchNewerReleaseTagsWithReadiness } =
+      await import('./updater-prerelease-feed')
 
-    expect(await fetchNewerReleaseTag('1.4.0')).toBe('v1.4.2')
+    expect(await fetchNewerReleaseTag('1.4.0')).toBeNull()
+    expect(await fetchNewerReleaseTagsWithReadiness('1.4.0', 1)).toEqual({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.2'
+    })
   })
 
   it('returns null when the only newer tag has a manifest but its asset still 404s', async () => {

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -161,6 +161,7 @@ type FetchNewerReleaseTagOptions = {
 export type FetchNewerReleaseTagsResult = {
   tags: string[]
   state: 'ready' | 'no-newer' | 'not-ready' | 'unavailable'
+  lastGoodTag?: string
 }
 
 export async function fetchNewerReleaseTag(
@@ -217,7 +218,14 @@ export async function fetchNewerReleaseTagsWithReadiness(
     ({ hasManifest, version }) => hasManifest && compareVersions(version, currentVersion) > 0
   )
   if (primaryIndex === -1) {
-    return { tags: [], state: 'not-ready' }
+    const lastGoodTag = manifestResults.find(({ hasManifest }) => hasManifest)?.tag
+    return lastGoodTag
+      ? { tags: [], state: 'not-ready', lastGoodTag }
+      : { tags: [], state: 'not-ready' }
+  }
+
+  if (primaryIndex > 0) {
+    return { tags: [], state: 'not-ready', lastGoodTag: manifestResults[primaryIndex].tag }
   }
 
   return {

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1239,6 +1239,85 @@ describe('updater', () => {
     })
   })
 
+  it('does not attach nudge dismissal to an older last-good available update', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
+    appMock.getVersion.mockReturnValue('1.4.25')
+    fetchNudgeMock.mockResolvedValueOnce({ id: 'campaign-1', minVersion: '1.0.0' })
+    fetchNudgeMock.mockResolvedValue(null)
+    shouldApplyNudgeMock.mockReturnValue(true)
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({
+        tags: [],
+        state: 'not-ready',
+        lastGoodTag: 'v1.4.26'
+      })
+      .mockResolvedValueOnce(['v1.4.27'])
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      if (autoUpdaterMock.checkForUpdates.mock.calls.length === 1) {
+        queueMicrotask(() => {
+          autoUpdaterMock.emit('update-available', { version: '1.4.26' })
+        })
+      }
+      return Promise.resolve(undefined)
+    })
+    let pendingNudgeId: string | null = null
+    const setPendingUpdateNudgeId = vi.fn((id: string | null) => {
+      pendingNudgeId = id
+    })
+    const setDismissedUpdateNudgeId = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, dismissNudge } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getPendingUpdateNudgeId: () => pendingNudgeId,
+      getDismissedUpdateNudgeId: () => null,
+      setPendingUpdateNudgeId,
+      setDismissedUpdateNudgeId
+    })
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.4.26',
+        changelog: null
+      })
+    })
+    const statuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+    const lastGoodStatus = statuses.find(
+      (status) => status.state === 'available' && status.version === '1.4.26'
+    )
+    if (lastGoodStatus && 'activeNudgeId' in lastGoodStatus) {
+      dismissNudge()
+    }
+
+    expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
+    expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)
+    expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
+    expect(pendingNudgeId).toBe('campaign-1')
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+    autoUpdaterMock.emit('update-available', { version: '1.4.27' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'available',
+      version: '1.4.27',
+      changelog: null,
+      activeNudgeId: 'campaign-1'
+    })
+  })
+
   it('retries a prerelease check once against the previous feed tag when the manifest is missing', async () => {
     appMock.getVersion.mockReturnValue('1.3.51-rc.6')
     fetchNewerReleaseTagsMock.mockResolvedValue(['v1.3.51-rc.7', 'v1.3.51-rc.6'])

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -934,10 +934,20 @@ describe('updater', () => {
     })
   })
 
-  it('does not fall back to the moving latest feed when newer release assets are still publishing', async () => {
+  it('uses last-good concrete feed when a user-initiated check lands during publishing', async () => {
     appMock.getVersion.mockReturnValue('1.4.26')
-    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: [], state: 'not-ready' })
-    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    fetchNewerReleaseTagsMock.mockResolvedValue({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.26'
+    })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-not-available')
+      })
+      return Promise.resolve(undefined)
+    })
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
@@ -945,7 +955,7 @@ describe('updater', () => {
     const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
 
     setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
-    const setupFeedUrlCalls = autoUpdaterMock.setFeedURL.mock.calls.length
+    const feedCallsBeforeCheck = autoUpdaterMock.setFeedURL.mock.calls.length
 
     checkForUpdatesFromMenu()
 
@@ -953,16 +963,121 @@ describe('updater', () => {
       const statuses = sendMock.mock.calls
         .filter(([channel]) => channel === 'updater:status')
         .map(([, status]) => status)
-      expect(statuses).toContainEqual(
-        expect.objectContaining({
-          state: 'error',
-          userInitiated: true,
-          message: expect.stringContaining("Couldn't reach the update server")
-        })
-      )
+      expect(statuses).toContainEqual({ state: 'checking', userInitiated: true })
+      expect(statuses).toContainEqual({ state: 'not-available', userInitiated: true })
     })
-    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
-    expect(autoUpdaterMock.setFeedURL.mock.calls.length).toBe(setupFeedUrlCalls)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.26'
+    })
+    expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.27'
+    })
+    expect(autoUpdaterMock.setFeedURL.mock.calls.slice(feedCallsBeforeCheck)).not.toContainEqual([
+      {
+        provider: 'generic',
+        url: 'https://github.com/stablyai/orca/releases/latest/download'
+      }
+    ])
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'error' })
+    )
+  })
+
+  it('can offer an older fully published update while the newest release is publishing', async () => {
+    appMock.getVersion.mockReturnValue('1.4.25')
+    fetchNewerReleaseTagsMock.mockResolvedValue({
+      tags: [],
+      state: 'not-ready',
+      lastGoodTag: 'v1.4.26'
+    })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.4.26' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.4.26',
+        changelog: null
+      })
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.26'
+    })
+  })
+
+  it('keeps background publishing-window fallback on the short retry cadence', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
+    appMock.getVersion.mockReturnValue('1.4.26')
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({
+        tags: [],
+        state: 'not-ready',
+        lastGoodTag: 'v1.4.26'
+      })
+      .mockResolvedValueOnce(['v1.4.27'])
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      return new Promise(() => {})
+    })
+    const setLastUpdateCheckAt = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => null,
+      setLastUpdateCheckAt
+    })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.26'
+    })
+    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
+
+    autoUpdaterMock.emit('update-not-available')
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', { state: 'not-available' })
+    })
+    expect(setLastUpdateCheckAt).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(59 * 60 * 1000)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(60 * 1000)
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.27'
+    })
   })
 
   it('keeps background checks retryable while newer release assets are still publishing', async () => {
@@ -1005,7 +1120,8 @@ describe('updater', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
     appMock.getVersion.mockReturnValue('1.4.26')
-    fetchNudgeMock.mockResolvedValue({ id: 'campaign-1', minVersion: '1.0.0' })
+    fetchNudgeMock.mockResolvedValueOnce({ id: 'campaign-1', minVersion: '1.0.0' })
+    fetchNudgeMock.mockResolvedValue(null)
     shouldApplyNudgeMock.mockReturnValue(true)
     fetchNewerReleaseTagsMock
       .mockResolvedValueOnce({ tags: [], state: 'not-ready' })
@@ -1055,6 +1171,72 @@ describe('updater', () => {
       activeNudgeId: 'campaign-1'
     })
     expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
+  })
+
+  it('does not dismiss a nudge when last-good fallback is current during publishing', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
+    appMock.getVersion.mockReturnValue('1.4.26')
+    fetchNudgeMock.mockResolvedValue({ id: 'campaign-1', minVersion: '1.0.0' })
+    shouldApplyNudgeMock.mockReturnValue(true)
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({
+        tags: [],
+        state: 'not-ready',
+        lastGoodTag: 'v1.4.26'
+      })
+      .mockResolvedValueOnce(['v1.4.27'])
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      if (autoUpdaterMock.checkForUpdates.mock.calls.length === 1) {
+        queueMicrotask(() => {
+          autoUpdaterMock.emit('update-not-available')
+        })
+      }
+      return Promise.resolve(undefined)
+    })
+    let pendingNudgeId: string | null = null
+    const setPendingUpdateNudgeId = vi.fn((id: string | null) => {
+      pendingNudgeId = id
+    })
+    const setDismissedUpdateNudgeId = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getPendingUpdateNudgeId: () => pendingNudgeId,
+      getDismissedUpdateNudgeId: () => null,
+      setPendingUpdateNudgeId,
+      setDismissedUpdateNudgeId
+    })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+      expect(sendMock).toHaveBeenCalledWith('updater:status', { state: 'not-available' })
+    })
+
+    expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
+    expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)
+    expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
+    expect(pendingNudgeId).toBe('campaign-1')
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+    autoUpdaterMock.emit('update-available', { version: '1.4.27' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'available',
+      version: '1.4.27',
+      changelog: null,
+      activeNudgeId: 'campaign-1'
+    })
   })
 
   it('retries a prerelease check once against the previous feed tag when the manifest is missing', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -143,10 +143,19 @@ function decorateStatusWithActiveNudge(status: UpdateStatus): UpdateStatus {
 function sendStatus(status: UpdateStatus): void {
   const shouldPreserveNudgeForPublishingWindow =
     publishingWindowLastGoodCheck !== null &&
-    (status.state === 'idle' || status.state === 'not-available' || status.state === 'error')
+    (status.state === 'idle' ||
+      status.state === 'not-available' ||
+      status.state === 'available' ||
+      status.state === 'error')
   if (awaitingNudgeCheckOutcome) {
     if (status.state === 'available') {
-      awaitingNudgeCheckOutcome = false
+      if (shouldPreserveNudgeForPublishingWindow) {
+        // Why: a last-good available update is only a temporary fallback; don't
+        // let dismissing that card consume the newest-release nudge campaign.
+        deferPendingUpdateNudgeUntilRetry()
+      } else {
+        awaitingNudgeCheckOutcome = false
+      }
     } else if (
       status.state === 'idle' ||
       status.state === 'not-available' ||

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -59,6 +59,7 @@ let activeUpdateNudgeId: string | null = null
 let awaitingNudgeCheckOutcome = false
 let nudgeCheckInFlight = false
 let lastNudgeCheckAt = 0
+let publishingWindowLastGoodCheck: { lastGoodTag: string } | null = null
 let pendingPrereleaseFallback: {
   primaryTag: string
   fallbackTag: string
@@ -114,6 +115,14 @@ function deferPendingUpdateNudgeUntilRetry(): void {
   awaitingNudgeCheckOutcome = false
 }
 
+function clearPublishingWindowLastGoodCheck(): void {
+  publishingWindowLastGoodCheck = null
+}
+
+function getPublishingWindowLastGoodCheck(): { lastGoodTag: string } | null {
+  return publishingWindowLastGoodCheck
+}
+
 function getPersistedPendingUpdateNudgeId(): string | null {
   return _getPendingUpdateNudgeId?.() ?? null
 }
@@ -132,6 +141,9 @@ function decorateStatusWithActiveNudge(status: UpdateStatus): UpdateStatus {
 }
 
 function sendStatus(status: UpdateStatus): void {
+  const shouldPreserveNudgeForPublishingWindow =
+    publishingWindowLastGoodCheck !== null &&
+    (status.state === 'idle' || status.state === 'not-available' || status.state === 'error')
   if (awaitingNudgeCheckOutcome) {
     if (status.state === 'available') {
       awaitingNudgeCheckOutcome = false
@@ -140,20 +152,35 @@ function sendStatus(status: UpdateStatus): void {
       status.state === 'not-available' ||
       status.state === 'error'
     ) {
-      // Why: when a nudge-triggered check finds no update (or errors out),
-      // move the campaign to dismissed so it doesn't re-fire on the next
-      // poll cycle. Without this, a nudge whose version range includes
-      // already-up-to-date users would loop every 30 minutes, each time
-      // triggering a redundant checkForUpdates() and clearing the persisted
-      // dismissedUpdateVersion.
-      if (activeUpdateNudgeId) {
-        _setDismissedUpdateNudgeId?.(activeUpdateNudgeId)
+      if (shouldPreserveNudgeForPublishingWindow) {
+        // Why: last-good checks can legitimately say "not available" while
+        // the campaign's newest release is still publishing.
+        deferPendingUpdateNudgeUntilRetry()
+      } else {
+        // Why: when a nudge-triggered check finds no update (or errors out),
+        // move the campaign to dismissed so it doesn't re-fire on the next
+        // poll cycle. Without this, a nudge whose version range includes
+        // already-up-to-date users would loop every 30 minutes, each time
+        // triggering a redundant checkForUpdates() and clearing the persisted
+        // dismissedUpdateVersion.
+        if (activeUpdateNudgeId) {
+          _setDismissedUpdateNudgeId?.(activeUpdateNudgeId)
+        }
+        clearPendingUpdateNudge()
       }
-      clearPendingUpdateNudge()
     }
   }
 
   const decoratedStatus = decorateStatusWithActiveNudge(status)
+
+  if (
+    status.state === 'idle' ||
+    status.state === 'not-available' ||
+    status.state === 'available' ||
+    status.state === 'error'
+  ) {
+    clearPublishingWindowLastGoodCheck()
+  }
 
   // Why: reset the in-flight guard when the status moves past the
   // window where duplicate download() calls are possible.
@@ -480,6 +507,7 @@ async function pinDefaultReleaseFeed(): Promise<void> {
   // the updater on a user's machine when something goes wrong. Cheap to keep,
   // invaluable when triaging.
   if (newerTag) {
+    clearPublishingWindowLastGoodCheck()
     const url = getReleaseDownloadUrl(newerTag)
     console.info(
       `[updater] release feed pinned: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
@@ -487,12 +515,25 @@ async function pinDefaultReleaseFeed(): Promise<void> {
     autoUpdater.setFeedURL({ provider: 'generic', url })
   } else if (releaseTagsResult.state === 'not-ready') {
     clearPrereleaseFallbackContext()
+    if (releaseTagsResult.lastGoodTag) {
+      // Why: during a publish window the newest tag is unsafe, but a verified
+      // last-good concrete feed lets electron-updater emit a real result.
+      const url = getReleaseDownloadUrl(releaseTagsResult.lastGoodTag)
+      console.info(
+        `[updater] release feed pinned to last-good: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
+      )
+      publishingWindowLastGoodCheck = { lastGoodTag: releaseTagsResult.lastGoodTag }
+      autoUpdater.setFeedURL({ provider: 'generic', url })
+      return
+    }
+    clearPublishingWindowLastGoodCheck()
     console.info(
       `[updater] release feed deferred: current=${currentVersion} includePrerelease=${includePrerelease}; newest release assets are still publishing`
     )
     throw new Error('Latest release assets are still publishing')
   } else {
     clearPrereleaseFallbackContext()
+    clearPublishingWindowLastGoodCheck()
     const url = 'https://github.com/stablyai/orca/releases/latest/download'
     console.info(
       `[updater] release feed fallback: current=${currentVersion} includePrerelease=${includePrerelease} → ${url}`
@@ -821,6 +862,7 @@ export function setupAutoUpdater(
     clearAvailableUpdateContext,
     consumeMissingManifestPrereleaseFallbackResult,
     getMissingManifestPrereleaseFallbackUserInitiated,
+    getPublishingWindowLastGoodCheck,
     getCurrentStatus: () => currentStatus,
     getKnownReleaseUrl,
     getPendingInstallVersion,


### PR DESCRIPTION
## Summary
- Keep update checks usable while a newer release is still publishing by pinning to a verified concrete last-good release feed instead of surfacing the generic update-server error.
- Preserve ZIP safety by only using a last-good tag after its platform manifest and referenced assets pass readiness checks, and never using /releases/latest/download for publishing-window fallback.
- Keep publishing-window last-good results on the short retry cadence and preserve pending nudges until the newest release is ready.

## Design Review
- Used brennan-yolo-lite design-first flow with scratch doc at design-docs/update-publishing-last-good-check.md (ignored, not committed).
- Design review found the initial /latest fallback would reintroduce moving-redirect ZIP risk; design was revised to require a concrete verified lastGoodTag.
- Completeness verification initially flagged an overbroad RC/no-newer interpretation; design was clarified to scope the /latest prohibition to publishing-window not-ready fallback. Final completeness pass was clean.

## Implementation
- Added optional lastGoodTag to the release readiness resolver.
- Updated updater feed pinning to use /releases/download/<lastGoodTag> during publishing windows and still run checkForUpdates().
- Plumbed publishing-window context into updater event handling so last-good not-available/available results do not suppress the next retry for 24h.
- Added regression tests for manual no-error behavior, older-build update availability, no moving-feed fallback, no not-ready tag pinning, short retry cadence, and nudge preservation.

## Review Loop
- Round 1: two review-code agents found the same high-severity issue: last-good not-available was recorded as a completed daily check and delayed retry for 24h.
- Fixed by carrying publishing-window context into updater events and adding short-retry regression coverage.
- Round 2: two fresh review-code agents returned clean.

## Validation
- pnpm install --frozen-lockfile
- pnpm vitest run --config config/vitest.config.ts src/main/updater-prerelease-feed.test.ts src/main/updater-prerelease-feed-readiness.test.ts src/main/updater.test.ts (3 files, 75 tests)
- pnpm run typecheck
- pnpm run lint (passed with existing unrelated warning in src/renderer/src/components/browser-pane/browser-automation-visibility.ts:81)
- git diff --check
- brennan-test-changes: land
  - focused updater/feed tests passed
  - adjacent updater/UI tests passed: 7 files, 84 tests
  - release publishing script regressions passed: 2 files, 6 tests
  - Electron dev validation passed for Settings > General > Check for Updates with no console errors

## Remaining Risk
- Did not run a packaged live GitHub publishing-window e2e; dev Electron short-circuits updater checks. The packaged-only release-publishing behavior is covered by main-process regression tests.