### PR TITLE
fix(terminal): flatten multiline quick commands into semicolon-separated lines

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
@@ -4,10 +4,7 @@ import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatc
 function createPane() {
   return {
     terminal: {
-      focus: vi.fn(),
-      modes: { bracketedPasteMode: true },
-      options: { ignoreBracketedPasteMode: false },
-      paste: vi.fn()
+      focus: vi.fn()
     }
   }
 }
@@ -30,7 +27,6 @@ describe('sendTerminalQuickCommandToPane', () => {
 
     expect(sent).toBe(true)
     expect(sendInput).toHaveBeenCalledWith('git status\r')
-    expect(pane.terminal.paste).not.toHaveBeenCalled()
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
   })
 
@@ -51,11 +47,10 @@ describe('sendTerminalQuickCommandToPane', () => {
 
     expect(sent).toBe(false)
     expect(sendInput).toHaveBeenCalledWith('npm test')
-    expect(pane.terminal.paste).not.toHaveBeenCalled()
     expect(pane.terminal.focus).not.toHaveBeenCalled()
   })
 
-  it('pastes multiline commands before appending enter', () => {
+  it('flattens multiline commands with semicolons before sending', () => {
     const sendInput = vi.fn(() => true)
     const pane = createPane()
     const commandText = 'cd packages\nbun run build\ncd ..'
@@ -72,12 +67,11 @@ describe('sendTerminalQuickCommandToPane', () => {
     })
 
     expect(sent).toBe(true)
-    expect(pane.terminal.paste).toHaveBeenCalledWith(commandText)
-    expect(sendInput).toHaveBeenCalledWith('\r')
+    expect(sendInput).toHaveBeenCalledWith('cd packages; bun run build; cd ..\r')
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
   })
 
-  it('pastes multiline insert-only commands without submitting', () => {
+  it('flattens multiline insert-only commands without submitting', () => {
     const sendInput = vi.fn(() => true)
     const pane = createPane()
     const commandText = 'echo one\necho two'
@@ -94,8 +88,7 @@ describe('sendTerminalQuickCommandToPane', () => {
     })
 
     expect(sent).toBe(true)
-    expect(pane.terminal.paste).toHaveBeenCalledWith(commandText)
-    expect(sendInput).not.toHaveBeenCalled()
+    expect(sendInput).toHaveBeenCalledWith('echo one; echo two')
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
@@ -1,25 +1,18 @@
 import type { TerminalQuickCommand } from '../../../../shared/types'
-import { buildTerminalQuickCommandInput } from '../../../../shared/terminal-quick-commands'
-import { pasteTerminalText } from './terminal-bracketed-paste'
+import {
+  buildTerminalQuickCommandInput,
+  flattenTerminalQuickCommand
+} from '../../../../shared/terminal-quick-commands'
 
 type QuickCommandPane = {
   terminal: {
     focus: () => void
-    modes: {
-      bracketedPasteMode: boolean
-    }
-    options: {
-      ignoreBracketedPasteMode?: boolean
-    }
-    paste: (text: string) => void
   }
 }
 
 type QuickCommandTransport = {
   sendInput: (data: string) => boolean
 }
-
-const LINE_BREAK_RE = /[\r\n]/
 
 export function sendTerminalQuickCommandToPane({
   command,
@@ -34,18 +27,9 @@ export function sendTerminalQuickCommandToPane({
     return false
   }
 
-  if (LINE_BREAK_RE.test(command.command)) {
-    // Why: sending multiline quick commands as raw queued PTY input lets a
-    // foreground command consume later lines before the shell sees them.
-    pasteTerminalText(pane.terminal, command.command)
-    const sent = command.appendEnter ? transport.sendInput('\r') : true
-    if (sent) {
-      pane.terminal.focus()
-    }
-    return sent
-  }
-
-  const sent = transport.sendInput(buildTerminalQuickCommandInput(command))
+  const sent = transport.sendInput(
+    buildTerminalQuickCommandInput(flattenTerminalQuickCommand(command))
+  )
   if (sent) {
     pane.terminal.focus()
   }

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.test.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.test.ts
@@ -41,7 +41,7 @@ describe('runQuickCommandInNewTab', () => {
     mockState = createStoreState()
   })
 
-  it('queues multiline quick commands for terminal-paste delivery', () => {
+  it('flattens multiline quick commands before queuing', () => {
     const result = runQuickCommandInNewTab({
       command: {
         id: 'build',
@@ -55,13 +55,12 @@ describe('runQuickCommandInNewTab', () => {
 
     expect(result).toEqual({ tabId: 'tab-new' })
     expect(mockState.queueTabStartupCommand).toHaveBeenCalledWith('tab-new', {
-      command: 'cd packages\nbun run build\ncd ..',
-      delivery: 'terminal-paste'
+      command: 'cd packages; bun run build; cd ..'
     })
     expect(mockState.setRecentQuickCommandForGroup).toHaveBeenCalledWith('group-1', 'build')
   })
 
-  it('keeps single-line quick commands on the standard startup path', () => {
+  it('keeps single-line quick commands unchanged', () => {
     runQuickCommandInNewTab({
       command: {
         id: 'status',

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.ts
@@ -1,8 +1,7 @@
 import { useAppStore } from '@/store'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
+import { flattenTerminalQuickCommand } from '../../../shared/terminal-quick-commands'
 import type { TerminalQuickCommand } from '../../../shared/types'
-
-const LINE_BREAK_RE = /[\r\n]/
 
 export type RunQuickCommandInNewTabArgs = {
   command: TerminalQuickCommand
@@ -36,8 +35,7 @@ export function runQuickCommandInNewTab({
   const tab = store.createTab(worktreeId, groupId)
 
   store.queueTabStartupCommand(tab.id, {
-    command: command.command,
-    ...(LINE_BREAK_RE.test(command.command) ? { delivery: 'terminal-paste' as const } : {})
+    command: flattenTerminalQuickCommand(command).command
   })
 
   // Why: match `+` button's createNewTerminalTab — without this, a worktree

--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildTerminalQuickCommandInput,
+  flattenTerminalQuickCommand,
   getDefaultTerminalQuickCommands,
   normalizeTerminalQuickCommands,
   terminalQuickCommandMatchesRepo
@@ -166,5 +167,47 @@ describe('terminal quick commands', () => {
         appendEnter: false
       })
     ).toBe('git status')
+  })
+})
+
+describe('flattenTerminalQuickCommand', () => {
+  it('returns the same object when there are no line breaks', () => {
+    const command = {
+      id: 'test',
+      label: 'Test',
+      command: 'git status',
+      appendEnter: true
+    } as const
+    expect(flattenTerminalQuickCommand(command)).toBe(command)
+  })
+
+  it('replaces newlines with semicolons and spaces', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: 'cd packages\nbun run build\ncd ..',
+      appendEnter: true
+    })
+    expect(result.command).toBe('cd packages; bun run build; cd ..')
+  })
+
+  it('collapses consecutive newlines into a single separator', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: 'echo one\n\n\necho two',
+      appendEnter: true
+    })
+    expect(result.command).toBe('echo one; echo two')
+  })
+
+  it('handles Windows-style CRLF endings', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: 'echo one\r\necho two',
+      appendEnter: true
+    })
+    expect(result.command).toBe('echo one; echo two')
   })
 })

--- a/src/shared/terminal-quick-commands.ts
+++ b/src/shared/terminal-quick-commands.ts
@@ -96,3 +96,18 @@ export function normalizeTerminalQuickCommands(input: unknown): TerminalQuickCom
 export function buildTerminalQuickCommandInput(command: TerminalQuickCommand): string {
   return command.appendEnter ? `${command.command}\r` : command.command
 }
+
+const LINE_BREAK_RE = /[\r\n]/
+
+/** Convert a multiline quick command into a single semicolon-separated line so
+ *  it executes sequentially in the shell. xterm’s bracketed-paste path converts
+ *  all newlines to `\r`, which breaks sequential execution; flattening avoids that. */
+export function flattenTerminalQuickCommand(command: TerminalQuickCommand): TerminalQuickCommand {
+  if (!LINE_BREAK_RE.test(command.command)) {
+    return command
+  }
+  return {
+    ...command,
+    command: command.command.replace(/[\r\n]+/g, '; ')
+  }
+}


### PR DESCRIPTION
xterm.js bracketed-paste converts all \n to \r, which breaks sequential execution in the shell. Multi-line quick commands were being received as one giant line, causing later commands to appear while earlier ones were still running.

This flattens multi-line commands into single semicolon-separated lines so the shell executes them sequentially and directory changes are respected.

Fixes #2844

Made with [Orca](https://github.com/stablyai/orca) 🐋
