### PR TITLE
fix(terminal): flatten multiline quick commands into semicolon-separated lines

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -9,8 +9,8 @@ export type PtyConnectionDeps = {
   cwd?: string
   startup?: {
     command: string
-    /** Renderer-delivered startup input. Used when terminal paste semantics
-     *  matter, such as multiline quick commands. */
+    /** Renderer-delivered startup input for callers that need xterm paste
+     *  semantics before the submit Enter. */
     delivery?: 'terminal-paste'
     env?: Record<string, string>
     /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1698,8 +1698,8 @@ export function connectPanePty(
               return
             }
             if (shouldDeliverStartupViaTerminalPaste) {
-              // Why: multiline quick commands must be delivered as terminal paste
-              // before Enter, otherwise foreground commands can read later lines.
+              // Why: this mode must pass through xterm so bracketed-paste
+              // wrapping is applied before the submit Enter.
               pasteTerminalText(pane.terminal, command)
               transport.sendInput('\r')
             } else {

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts
@@ -4,10 +4,7 @@ import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatc
 function createPane() {
   return {
     terminal: {
-      focus: vi.fn(),
-      modes: { bracketedPasteMode: true },
-      options: { ignoreBracketedPasteMode: false },
-      paste: vi.fn()
+      focus: vi.fn()
     }
   }
 }
@@ -30,7 +27,6 @@ describe('sendTerminalQuickCommandToPane', () => {
 
     expect(sent).toBe(true)
     expect(sendInput).toHaveBeenCalledWith('git status\r')
-    expect(pane.terminal.paste).not.toHaveBeenCalled()
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
   })
 
@@ -51,11 +47,10 @@ describe('sendTerminalQuickCommandToPane', () => {
 
     expect(sent).toBe(false)
     expect(sendInput).toHaveBeenCalledWith('npm test')
-    expect(pane.terminal.paste).not.toHaveBeenCalled()
     expect(pane.terminal.focus).not.toHaveBeenCalled()
   })
 
-  it('pastes multiline commands before appending enter', () => {
+  it('flattens multiline commands with semicolons before sending', () => {
     const sendInput = vi.fn(() => true)
     const pane = createPane()
     const commandText = 'cd packages\nbun run build\ncd ..'
@@ -72,12 +67,11 @@ describe('sendTerminalQuickCommandToPane', () => {
     })
 
     expect(sent).toBe(true)
-    expect(pane.terminal.paste).toHaveBeenCalledWith(commandText)
-    expect(sendInput).toHaveBeenCalledWith('\r')
+    expect(sendInput).toHaveBeenCalledWith('cd packages; bun run build; cd ..\r')
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
   })
 
-  it('pastes multiline insert-only commands without submitting', () => {
+  it('flattens multiline insert-only commands without submitting', () => {
     const sendInput = vi.fn(() => true)
     const pane = createPane()
     const commandText = 'echo one\necho two'
@@ -94,8 +88,7 @@ describe('sendTerminalQuickCommandToPane', () => {
     })
 
     expect(sent).toBe(true)
-    expect(pane.terminal.paste).toHaveBeenCalledWith(commandText)
-    expect(sendInput).not.toHaveBeenCalled()
+    expect(sendInput).toHaveBeenCalledWith('echo one; echo two')
     expect(pane.terminal.focus).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts
@@ -1,25 +1,18 @@
 import type { TerminalQuickCommand } from '../../../../shared/types'
-import { buildTerminalQuickCommandInput } from '../../../../shared/terminal-quick-commands'
-import { pasteTerminalText } from './terminal-bracketed-paste'
+import {
+  buildTerminalQuickCommandInput,
+  flattenTerminalQuickCommand
+} from '../../../../shared/terminal-quick-commands'
 
 type QuickCommandPane = {
   terminal: {
     focus: () => void
-    modes: {
-      bracketedPasteMode: boolean
-    }
-    options: {
-      ignoreBracketedPasteMode?: boolean
-    }
-    paste: (text: string) => void
   }
 }
 
 type QuickCommandTransport = {
   sendInput: (data: string) => boolean
 }
-
-const LINE_BREAK_RE = /[\r\n]/
 
 export function sendTerminalQuickCommandToPane({
   command,
@@ -34,18 +27,9 @@ export function sendTerminalQuickCommandToPane({
     return false
   }
 
-  if (LINE_BREAK_RE.test(command.command)) {
-    // Why: sending multiline quick commands as raw queued PTY input lets a
-    // foreground command consume later lines before the shell sees them.
-    pasteTerminalText(pane.terminal, command.command)
-    const sent = command.appendEnter ? transport.sendInput('\r') : true
-    if (sent) {
-      pane.terminal.focus()
-    }
-    return sent
-  }
-
-  const sent = transport.sendInput(buildTerminalQuickCommandInput(command))
+  const sent = transport.sendInput(
+    buildTerminalQuickCommandInput(flattenTerminalQuickCommand(command))
+  )
   if (sent) {
     pane.terminal.focus()
   }

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.test.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.test.ts
@@ -41,7 +41,7 @@ describe('runQuickCommandInNewTab', () => {
     mockState = createStoreState()
   })
 
-  it('queues multiline quick commands for terminal-paste delivery', () => {
+  it('flattens multiline quick commands before queuing', () => {
     const result = runQuickCommandInNewTab({
       command: {
         id: 'build',
@@ -55,13 +55,12 @@ describe('runQuickCommandInNewTab', () => {
 
     expect(result).toEqual({ tabId: 'tab-new' })
     expect(mockState.queueTabStartupCommand).toHaveBeenCalledWith('tab-new', {
-      command: 'cd packages\nbun run build\ncd ..',
-      delivery: 'terminal-paste'
+      command: 'cd packages; bun run build; cd ..'
     })
     expect(mockState.setRecentQuickCommandForGroup).toHaveBeenCalledWith('group-1', 'build')
   })
 
-  it('keeps single-line quick commands on the standard startup path', () => {
+  it('keeps single-line quick commands unchanged', () => {
     runQuickCommandInNewTab({
       command: {
         id: 'status',

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.ts
@@ -1,8 +1,7 @@
 import { useAppStore } from '@/store'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
+import { flattenTerminalQuickCommand } from '../../../shared/terminal-quick-commands'
 import type { TerminalQuickCommand } from '../../../shared/types'
-
-const LINE_BREAK_RE = /[\r\n]/
 
 export type RunQuickCommandInNewTabArgs = {
   command: TerminalQuickCommand
@@ -36,8 +35,7 @@ export function runQuickCommandInNewTab({
   const tab = store.createTab(worktreeId, groupId)
 
   store.queueTabStartupCommand(tab.id, {
-    command: command.command,
-    ...(LINE_BREAK_RE.test(command.command) ? { delivery: 'terminal-paste' as const } : {})
+    command: flattenTerminalQuickCommand(command).command
   })
 
   // Why: match `+` button's createNewTerminalTab — without this, a worktree

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -194,8 +194,8 @@ export type TerminalSlice = {
     string,
     {
       command: string
-      /** Renderer-delivered startup input. Used by multiline quick commands so
-       *  xterm can use bracketed paste before the submit Enter is sent. */
+      /** Renderer-delivered startup input for callers that need xterm paste
+       *  semantics before the submit Enter. */
       delivery?: 'terminal-paste'
       env?: Record<string, string>
       /** Initial prompt-start status for agents that lack native prompt hooks. */

--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildTerminalQuickCommandInput,
+  flattenTerminalQuickCommand,
   getDefaultTerminalQuickCommands,
   normalizeTerminalQuickCommands,
   terminalQuickCommandMatchesRepo
@@ -166,5 +167,57 @@ describe('terminal quick commands', () => {
         appendEnter: false
       })
     ).toBe('git status')
+  })
+})
+
+describe('flattenTerminalQuickCommand', () => {
+  it('returns the same object when there are no line breaks', () => {
+    const command = {
+      id: 'test',
+      label: 'Test',
+      command: 'git status',
+      appendEnter: true
+    } as const
+    expect(flattenTerminalQuickCommand(command)).toBe(command)
+  })
+
+  it('replaces newlines with semicolons and spaces', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: 'cd packages\nbun run build\ncd ..',
+      appendEnter: true
+    })
+    expect(result.command).toBe('cd packages; bun run build; cd ..')
+  })
+
+  it('collapses consecutive newlines into a single separator', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: 'echo one\n\n\necho two',
+      appendEnter: true
+    })
+    expect(result.command).toBe('echo one; echo two')
+  })
+
+  it('handles Windows-style CRLF endings', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: 'echo one\r\necho two',
+      appendEnter: true
+    })
+    expect(result.command).toBe('echo one; echo two')
+  })
+
+  it('drops empty edge lines without leaving dangling separators', () => {
+    const result = flattenTerminalQuickCommand({
+      id: 'test',
+      label: 'Test',
+      command: '\n  echo one  \n\n  echo two\n',
+      appendEnter: true
+    })
+    expect(result.command).toBe('echo one; echo two')
   })
 })

--- a/src/shared/terminal-quick-commands.ts
+++ b/src/shared/terminal-quick-commands.ts
@@ -96,3 +96,21 @@ export function normalizeTerminalQuickCommands(input: unknown): TerminalQuickCom
 export function buildTerminalQuickCommandInput(command: TerminalQuickCommand): string {
   return command.appendEnter ? `${command.command}\r` : command.command
 }
+
+const LINE_BREAK_RE = /\r\n|\r|\n/
+
+// Why: quick-command lines are independent shell commands; one shell command
+// list prevents foreground programs from reading later lines as stdin.
+export function flattenTerminalQuickCommand(command: TerminalQuickCommand): TerminalQuickCommand {
+  if (!LINE_BREAK_RE.test(command.command)) {
+    return command
+  }
+  return {
+    ...command,
+    command: command.command
+      .split(LINE_BREAK_RE)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .join('; ')
+  }
+}


### PR DESCRIPTION
## Summary

Fixes multiline terminal quick commands by flattening newline-separated quick-command lines into a semicolon-delimited shell command list before dispatching to the active terminal or queuing startup input for a new tab.

This gives quick commands command-list semantics directly: the shell parses the list once, later commands wait for earlier foreground commands to exit, `cd` changes stay in the active shell, and later lines are not delivered as stdin to the foreground program.

This supersedes the quick-command `terminal-paste` path introduced in #2779. Terminal paste protects later lines from stdin-consuming foreground programs, but it also displays the whole pasted block before execution; a shell command list avoids both the stdin leak and the confusing pasted-block behavior.

### Files changed

- `src/shared/terminal-quick-commands.ts` - added `flattenTerminalQuickCommand()`
- `src/shared/terminal-quick-commands.test.ts` - added flattening coverage for LF, CRLF, consecutive blank lines, and empty edge lines
- `src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.ts` - flatten active-pane quick commands before `sendInput`
- `src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts` - updated dispatch expectations
- `src/renderer/src/lib/run-quick-command-in-new-tab.ts` - flatten new-tab quick commands before startup queuing
- `src/renderer/src/lib/run-quick-command-in-new-tab.test.ts` - updated new-tab expectations
- `src/renderer/src/components/terminal-pane/pty-connection*.ts` and `src/renderer/src/store/slices/terminals.ts` - updated stale `terminal-paste` comments now that quick commands no longer use that path

## Screenshots

No visual change.

## Testing

- [x] `pnpm vitest run --config config/vitest.config.ts src/shared/terminal-quick-commands.test.ts src/renderer/src/components/terminal-pane/terminal-quick-command-dispatch.test.ts src/renderer/src/lib/run-quick-command-in-new-tab.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` - 4 files, 106 tests passed
- [x] Manual `node-pty` bash repro: raw newline delivery leaked later lines to a foreground stdin consumer; flattened `;` command-list delivery did not leak stdin and `pwd` ran from `/tmp`
- [x] `pnpm run typecheck` - passed
- [x] `pnpm lint` - passed with one existing warning outside this PR: `src/renderer/src/components/browser-pane/browser-automation-visibility.ts:81`
- [x] `pnpm test` - 985 files passed, 1 skipped; 10,440 tests passed, 10 skipped

Fixes #2844