### PR TITLE
Fix Antigravity agent status stability

### DIFF
--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -75,6 +75,8 @@ describe('AntigravityHookService', () => {
     expect(script).toContain('/hook/antigravity')
     expect(script).toContain('hook_event_name=${ORCA_ANTIGRAVITY_EVENT}')
     expect(script).toContain('payload=$(cat)')
+    expect(script).toContain("payload='{}'")
+    expect(script).not.toContain('if [ -z "$payload" ]; then\n  exit 0\nfi')
     expect(script).toContain('{"decision":""}')
   })
 
@@ -154,6 +156,8 @@ describe('AntigravityHookService', () => {
       )
       expect(script).toContain('/hook/antigravity')
       expect(script).toContain('hook_event_name=$env:ORCA_ANTIGRAVITY_EVENT')
+      expect(script).toContain('[string]::IsNullOrWhiteSpace($inputData)) { @{} }')
+      expect(script).not.toContain('[string]::IsNullOrWhiteSpace($inputData)) { exit 0 }')
     })
   })
 

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -120,7 +120,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     'fi',
     'payload=$(cat)',
     'if [ -z "$payload" ]; then',
-    '  exit 0',
+    // Why: some Antigravity hook events can arrive without stdin. Still post
+    // the event name so Orca shows a status row instead of silently dropping it.
+    "  payload='{}'",
     'fi',
     'curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/antigravity" \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
@@ -158,7 +160,7 @@ function getWindowsWrapperScript(eventName: string): string {
 }
 
 function buildWindowsAntigravityHookPostCommand(): string {
-  return `powershell -NoProfile -ExecutionPolicy Bypass -Command "$utf8=[System.Text.UTF8Encoding]::new($false); [Console]::InputEncoding=$utf8; [Console]::OutputEncoding=$utf8; $inputData=[Console]::In.ReadToEnd(); if ([string]::IsNullOrWhiteSpace($inputData)) { exit 0 }; try { $body=@{ paneKey=$env:ORCA_PANE_KEY; tabId=$env:ORCA_TAB_ID; worktreeId=$env:ORCA_WORKTREE_ID; env=$env:ORCA_AGENT_HOOK_ENV; version=$env:ORCA_AGENT_HOOK_VERSION; hook_event_name=$env:ORCA_ANTIGRAVITY_EVENT; payload=($inputData | ConvertFrom-Json) } | ConvertTo-Json -Depth 100 -Compress; $bodyBytes=$utf8.GetBytes($body); Invoke-WebRequest -UseBasicParsing -Method Post -Uri ('http://127.0.0.1:' + $env:ORCA_AGENT_HOOK_PORT + '/hook/antigravity') -ContentType 'application/json; charset=utf-8' -Headers @{ 'X-Orca-Agent-Hook-Token'=$env:ORCA_AGENT_HOOK_TOKEN } -Body $bodyBytes | Out-Null } catch {}"`
+  return `powershell -NoProfile -ExecutionPolicy Bypass -Command "$utf8=[System.Text.UTF8Encoding]::new($false); [Console]::InputEncoding=$utf8; [Console]::OutputEncoding=$utf8; $inputData=[Console]::In.ReadToEnd(); try { $payload=if ([string]::IsNullOrWhiteSpace($inputData)) { @{} } else { $inputData | ConvertFrom-Json }; $body=@{ paneKey=$env:ORCA_PANE_KEY; tabId=$env:ORCA_TAB_ID; worktreeId=$env:ORCA_WORKTREE_ID; env=$env:ORCA_AGENT_HOOK_ENV; version=$env:ORCA_AGENT_HOOK_VERSION; hook_event_name=$env:ORCA_ANTIGRAVITY_EVENT; payload=$payload } | ConvertTo-Json -Depth 100 -Compress; $bodyBytes=$utf8.GetBytes($body); Invoke-WebRequest -UseBasicParsing -Method Post -Uri ('http://127.0.0.1:' + $env:ORCA_AGENT_HOOK_PORT + '/hook/antigravity') -ContentType 'application/json; charset=utf-8' -Headers @{ 'X-Orca-Agent-Hook-Token'=$env:ORCA_AGENT_HOOK_TOKEN } -Body $bodyBytes | Out-Null } catch {}"`
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -91,6 +91,18 @@ function tokenCount(markup: string, token: string): number {
   return classTokens(markup).filter((classToken) => classToken === token).length
 }
 
+function classTokensForTaggedElement(markup: string, dataAttribute: string): string[] {
+  const tagMatch = markup.match(new RegExp(`<[^>]+${dataAttribute}[^>]*>`))
+  if (!tagMatch) {
+    throw new Error(`Expected tagged element for ${dataAttribute}`)
+  }
+  const classMatch = tagMatch[0].match(/class="([^"]*)"/)
+  if (!classMatch) {
+    throw new Error(`Expected class attribute for ${dataAttribute}`)
+  }
+  return classMatch[1].split(/\s+/).filter(Boolean)
+}
+
 describe('DashboardAgentRow', () => {
   it('uses the hover background as the focused-pane row highlight', () => {
     const markup = renderToStaticMarkup(
@@ -191,6 +203,28 @@ describe('DashboardAgentRow', () => {
     expect(markup).not.toContain('data-slot="badge"')
     expect(interruptedIndex).toBeGreaterThan(promptIndex)
     expect(markup).not.toContain('lucide-circle-check')
+  })
+
+  it('reserves a real working tool line before tool metadata arrives', () => {
+    const emptyToolMarkup = renderRow(makeAgent())
+    const activeToolMarkup = renderRow(
+      makeAgent({}, { toolName: 'ListDir', toolInput: '/Users/nwparker/orca' })
+    )
+
+    // Why: Antigravity emits working hooks without tool metadata between
+    // tool-specific hooks; a whitespace placeholder collapses and makes the
+    // sidebar row jump from one secondary line to two.
+    expect(emptyToolMarkup).toContain('data-agent-row-tool-slot=""')
+    expect(activeToolMarkup).toContain('data-agent-row-tool-slot=""')
+    expect(
+      classTokensForTaggedElement(emptyToolMarkup, 'data-agent-row-tool-placeholder="true"')
+    ).toContain('h-[1lh]')
+    expect(
+      classTokensForTaggedElement(activeToolMarkup, 'data-agent-row-tool-header="true"')
+    ).toContain('h-[1lh]')
+    expect(emptyToolMarkup).not.toContain('lucide-wrench')
+    expect(activeToolMarkup).toContain('lucide-wrench')
+    expect(activeToolMarkup).toContain('ListDir')
   })
 
   it('renders orchestration child rows with a connector and tree level', () => {

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -465,13 +465,16 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
       </div>
       {/* Why: tool row and message row both carry different info — tool shows
           the mechanical step (Bash: ...), message shows the agent's narration
-          ("let me verify the test ordering"). Rendering both together would
-          cause the row to jump whenever one appeared/disappeared mid-turn,
-          so instead we always render both slots and fall back to a single-line
-          placeholder when empty. Tool slot only reserves height while working,
-          since done/blocked rows shouldn't show a dangling wrench. */}
+          ("let me verify the test ordering"). Antigravity can emit working
+          hooks without tool metadata between tool events, so the empty tool
+          slot must be a real line box instead of whitespace that can collapse.
+          Tool slot only reserves height while working, since done/blocked rows
+          shouldn't show a dangling wrench. */}
       {isWorking && (
-        <div className="mt-0.5 min-w-0 pl-5 text-[10px] leading-snug text-muted-foreground/70">
+        <div
+          data-agent-row-tool-slot=""
+          className="mt-0.5 min-w-0 pl-5 text-[10px] leading-snug text-muted-foreground/70"
+        >
           {toolName ? (
             <>
               {/* Why: header (wrench + tool name) stays on one line. When
@@ -480,7 +483,11 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
                   commands wrap to a consistent left margin instead of the
                   jagged shape that flex-wrapping produces. */}
               <div
-                className={cn('flex min-w-0 items-center gap-1', !expanded && 'overflow-hidden')}
+                data-agent-row-tool-header="true"
+                className={cn(
+                  'flex h-[1lh] min-w-0 items-center gap-1',
+                  !expanded && 'overflow-hidden'
+                )}
               >
                 <Wrench className="size-2.5 shrink-0" />
                 <code className="shrink-0 font-mono text-[10px]">{toolName}</code>
@@ -509,7 +516,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
               )}
             </>
           ) : (
-            ' '
+            <span data-agent-row-tool-placeholder="true" aria-hidden className="block h-[1lh]" />
           )}
         </div>
       )}

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -302,6 +302,29 @@ describe('shared agent-hook-listener', () => {
     })
   })
 
+  it('normalizes Antigravity events even when the hook body is empty', () => {
+    const started = normalizeHookPayload(
+      state,
+      'antigravity',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        hook_event_name: 'PreInvocation',
+        payload: {}
+      },
+      'production'
+    )
+
+    // Why: Antigravity can invoke managed hooks without stdin. The wrapper
+    // posts `{}` in that case, and the event name is still enough to keep the
+    // visible status alive.
+    expect(started?.payload).toMatchObject({
+      state: 'working',
+      prompt: '',
+      agentType: 'antigravity'
+    })
+  })
+
   it('reads Antigravity user requests from the transcript', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'orca-antigravity-prompt-'))
     const transcriptPath = join(tmpDir, 'transcript.jsonl')
@@ -507,7 +530,7 @@ describe('shared agent-hook-listener', () => {
     }
   })
 
-  it('normalizes Antigravity Stop to done even when fullyIdle is false', () => {
+  it('keeps Antigravity Stop working while fullyIdle is false', () => {
     const event = normalizeHookPayload(
       state,
       'antigravity',
@@ -520,8 +543,44 @@ describe('shared agent-hook-listener', () => {
     )
 
     expect(event?.payload).toMatchObject({
-      state: 'done',
+      state: 'working',
       agentType: 'antigravity'
+    })
+  })
+
+  it('keeps Antigravity tool hooks active after a non-idle Stop for the same transcript', () => {
+    const transcriptPath = '/tmp/antigravity-non-idle-transcript.jsonl'
+    const stop = normalizeHookPayload(
+      state,
+      'antigravity',
+      {
+        paneKey: PANE_KEY,
+        hook_event_name: 'Stop',
+        payload: { transcriptPath, fullyIdle: false }
+      },
+      'production'
+    )
+    expect(stop?.payload.state).toBe('working')
+
+    const nextTool = normalizeHookPayload(
+      state,
+      'antigravity',
+      {
+        paneKey: PANE_KEY,
+        hook_event_name: 'PostToolUse',
+        payload: {
+          transcriptPath,
+          toolCall: { name: 'run_command', args: { CommandLine: 'pwd' } }
+        }
+      },
+      'production'
+    )
+
+    expect(nextTool?.payload).toMatchObject({
+      state: 'working',
+      agentType: 'antigravity',
+      toolName: 'run_command',
+      toolInput: 'pwd'
     })
   })
 
@@ -570,6 +629,12 @@ describe('shared agent-hook-listener', () => {
           transcriptPath: '/tmp/antigravity-transcript.jsonl',
           last_assistant_message: 'done'
         }
+      })
+    ).toBe(false)
+    expect(
+      hasPendingAgentResultText('antigravity', {
+        hook_event_name: 'Stop',
+        payload: { fullyIdle: false, transcriptPath: '/tmp/antigravity-transcript.jsonl' }
       })
     ).toBe(false)
   })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -801,6 +801,9 @@ export function hasPendingAgentResultText(source: AgentHookSource, body: unknown
     record.hook_event_name ??
     record.hookEventName
   if (source === 'antigravity' && eventName === 'Stop') {
+    if (isAntigravityStopStillBusy(record)) {
+      return false
+    }
     const transcriptPath = record.transcriptPath ?? record.transcript_path
     return typeof transcriptPath === 'string' && transcriptPath.trim().length > 0
   }
@@ -1019,6 +1022,9 @@ function extractAntigravityToolFields(
     )
   }
   if (eventName === 'Stop') {
+    if (isAntigravityStopStillBusy(hookPayload)) {
+      return {}
+    }
     const message =
       readString(hookPayload, 'last_assistant_message') ??
       readLastAssistantFromTranscript(hookPayload.transcriptPath ?? hookPayload.transcript_path)
@@ -1789,6 +1795,10 @@ function isAntigravityFeedbackTool(toolName: string | undefined): boolean {
   return toolName === 'ask_question' || toolName === 'ask_permission'
 }
 
+function isAntigravityStopStillBusy(hookPayload: Record<string, unknown>): boolean {
+  return hookPayload.fullyIdle === false || hookPayload.fully_idle === false
+}
+
 function normalizeAntigravityEvent(
   state: HookListenerState,
   eventName: unknown,
@@ -1810,11 +1820,14 @@ function normalizeAntigravityEvent(
   }
 
   const toolName = readAntigravityToolCall(hookPayload).toolName
+  const stopStillBusy = eventName === 'Stop' && isAntigravityStopStillBusy(hookPayload)
   const stateName =
     eventName === 'PreToolUse' && isAntigravityFeedbackTool(toolName)
       ? 'waiting'
       : eventName === 'Stop'
-        ? 'done'
+        ? stopStillBusy
+          ? 'working'
+          : 'done'
         : eventName === 'PreInvocation' ||
             eventName === 'PostInvocation' ||
             eventName === 'PreToolUse' ||
@@ -1851,7 +1864,10 @@ function normalizeAntigravityEvent(
       lastAssistantMessage: snapshot.lastAssistantMessage
     })
   )
-  if (eventName === 'Stop' && transcriptPath) {
+  // Why: Antigravity can emit Stop with fullyIdle=false between tool steps.
+  // Only a fully idle Stop is terminal; otherwise the sidebar would bounce
+  // done -> working during tool-heavy turns and ignore later tool updates.
+  if (eventName === 'Stop' && !stopStillBusy && transcriptPath) {
     state.antigravityCompletedTranscriptByPaneKey.set(paneKey, transcriptPath)
   }
   return payload


### PR DESCRIPTION
## Summary
- keep Antigravity agent rows at a stable two-line height while tool metadata appears and clears
- keep non-idle Antigravity `Stop` events in `working` instead of treating them as terminal
- post empty Antigravity hook events as `{}` instead of dropping them before Orca sees them

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/main/antigravity/hook-service.test.ts src/shared/agent-hook-listener.test.ts src/main/agent-hooks/server.test.ts src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx` — 222 tests passed
- `pnpm run typecheck` — passed
- `pnpm exec oxlint src/main/antigravity/hook-service.ts src/main/antigravity/hook-service.test.ts src/shared/agent-hook-listener.ts src/shared/agent-hook-listener.test.ts src/renderer/src/components/dashboard/DashboardAgentRow.tsx src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx` — 0 warnings/errors
- `git diff --check` — passed
- Live Electron verification: simulated Antigravity no-tool -> ListDir -> no-tool -> Read -> no-tool transitions; sidebar card, row, tool slot, and next-row position stayed stable across every transition
- Live Electron verification: ran the exact installed Antigravity `hooks.json` PostInvocation command with empty stdin; Orca received/rendered `state: working`, `agentType: antigravity`, `prompt: ''`