### PR TITLE
Fix Windows release publish command

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -467,7 +467,7 @@ jobs:
               ~/Library/Caches/electron-builder
           - os: windows-latest
             platform: win
-            release_command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && pnpm exec electron-builder --config config/electron-builder.config.cjs --win --publish always
+            release_command: 'node config/scripts/ensure-native-runtime.mjs --runtime=electron; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; pnpm exec electron-builder --config config/electron-builder.config.cjs --win --publish always'
             eb_cache_path: |
               ~\AppData\Local\electron\Cache
               ~\AppData\Local\electron-builder\Cache

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
 
 const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const packageJson = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf8'))
@@ -34,14 +35,24 @@ describe('Electron runtime package contract', () => {
 
   it('guards release publishing before electron-builder runs', () => {
     const releaseWorkflow = readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
-    const releaseCommands = [...releaseWorkflow.matchAll(/release_command:\s*(.+)/g)].map(
-      ([, command]) => command
+    const parsedWorkflow = parse(releaseWorkflow)
+    const releaseCommands = new Map(
+      parsedWorkflow.jobs.build.strategy.matrix.include.map(({ platform, release_command }) => [
+        platform,
+        release_command
+      ])
     )
 
-    expect(releaseCommands).toHaveLength(3)
-    for (const command of releaseCommands) {
-      expect(command).toMatch(/^node config\/scripts\/ensure-native-runtime\.mjs --runtime=electron && /)
+    expect([...releaseCommands.keys()].sort()).toEqual(['linux', 'mac', 'win'])
+    for (const command of releaseCommands.values()) {
+      expect(command).toContain('node config/scripts/ensure-native-runtime.mjs --runtime=electron')
       expect(command).toContain('electron-builder')
+      expect(command.indexOf('ensure-native-runtime')).toBeLessThan(command.indexOf('electron-builder'))
     }
+    expect(releaseCommands.get('mac')).toContain(' && ORCA_MAC_RELEASE=1 ')
+    expect(releaseCommands.get('linux')).toContain(' && pnpm exec electron-builder ')
+    expect(releaseCommands.get('win')).toContain(
+      '; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; pnpm exec electron-builder '
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Use PowerShell-compatible command sequencing for the Windows release publish command.
- Keep macOS/Linux release commands on their existing POSIX shell syntax.
- Update the Electron runtime contract test to parse the workflow and assert platform-specific shell syntax.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs
- pnpm run lint
- git diff --check