### PR TITLE
fix(worktree): fail fast on dirty worktree before running archive hooks

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1046,6 +1046,25 @@ export function registerWorktreeHandlers(
         const canonicalWorktreePath = registeredWorktree.path
         const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
 
+        let shouldTearDownPtys = true
+
+        // Why: run the preflight check FIRST for local repos so we fail fast if
+        // the worktree has changes — without running archive hooks or removing
+        // symlinks first. Archive hooks are expensive (arbitrary user scripts) and
+        // should only run when deletion is actually possible.
+        if (!repo.connectionId) {
+          try {
+            await assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false)
+          } catch (error) {
+            if (!isOrphanCompatiblePreflightError(error)) {
+              throw new Error(
+                formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+              )
+            }
+            shouldTearDownPtys = false
+          }
+        }
+
         // Run archive hook before removal so teardown scripts still see the worktree directory.
         const hooks = await getArchiveHooksForRemoval(repo)
         if (hooks?.scripts.archive && !args.skipArchive) {
@@ -1085,20 +1104,6 @@ export function registerWorktreeHandlers(
         // deletion would require the Force Delete toast once the feature is on.
         if (repo.symlinkPaths && repo.symlinkPaths.length > 0) {
           await removeWorktreeSymlinks(canonicalWorktreePath, repo.symlinkPaths)
-        }
-
-        let shouldTearDownPtys = true
-        try {
-          await assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false)
-        } catch (error) {
-          if (!isOrphanCompatiblePreflightError(error)) {
-            throw new Error(
-              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-            )
-          }
-          // Why: orphan cleanup does not need live shells to be killed first,
-          // and preflight did not prove the worktree is cleanly removable.
-          shouldTearDownPtys = false
         }
 
         if (shouldTearDownPtys) {


### PR DESCRIPTION
## Summary

When deleting a workspace that has uncommitted or untracked changes, Orca would run the user's archive hook (an arbitrary shell script defined in `orca.yaml`) **before** checking if the worktree was actually deletable. Archive hooks have a 2-minute timeout and can be slow, causing the "Deleting..." state to persist for 20-30 seconds before failing.

This fix moves the preflight check (`git status --porcelain`) to run **first** for local repos. If the worktree is dirty, we now fail immediately without running any hooks or other cleanup operations.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`  
- [x] `pnpm test` (105 tests: 88 worktree IPC + 17 git remove-worktree)
- [x] `pnpm build`

## AI Review Report

**Change reviewed:** `src/main/ipc/worktrees.ts` - reordered operations in the `worktrees:remove` IPC handler

**Key change:** Moved `assertWorktreeCleanForRemoval()` to run **before** archive hooks and symlink cleanup, instead of after. This makes deletion fail fast when a worktree has changes, avoiding unnecessary work.

**Cross-platform compatibility:** 
- `git status --porcelain` and `git worktree remove` work identically on macOS, Linux, and Windows
- No platform-specific code paths were changed

**SSH/remote compatibility:**
- SSH repos still run hooks before the git-level dirty check (see Notes)

## Notes

**SSH worktrees:** A follow-up PR extends this fix to SSH repos via a dedicated preflight RPC call: https://github.com/stablyai/orca/pull/2912