### PR TITLE
Add failed automation rerun action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Rebuild better-sqlite3 for Node
         run: pnpm rebuild better-sqlite3
 
+      # Why: install intentionally blocks Electron's package postinstall, but
+      # some unit tests import `electron` under Node and require path.txt.
+      - name: Install Electron package binary for tests
+        run: |
+          pnpm rebuild electron --pending
+          node -e "require('electron')"
+
       - name: Test
         run: pnpm test
 

--- a/docs/failed-automation-rerun-action.md
+++ b/docs/failed-automation-rerun-action.md
@@ -1,0 +1,50 @@
+# Failed Automation Rerun Action
+
+## Problem
+
+- Failed Orca automation run details show only the disabled/open-target action when no workspace launched, so a user who sees a `dispatch_failed` error has no local recovery action in the failed-run view: `src/renderer/src/components/automations/AutomationsPage.tsx:1858`.
+- The reusable detail header already accepts actions, but the run detail action set is limited to `getAutomationRunViewState`/`openRunWorkspace`: `src/renderer/src/components/automations/AutomationRunPageFrame.tsx:9`, `src/renderer/src/components/automations/automation-run-view-state.ts:13`.
+- Manual rerun behavior already exists as `runNow`, which creates a fresh manual run for the automation; the renderer wrapper currently refreshes the page after calling it: `src/renderer/src/components/automations/AutomationsPage.tsx:1033`, `src/main/automations/service.ts:66`.
+
+## Goal
+
+Add an easy rerun button to Orca automation run detail pages for failed launch/recovery statuses. The button creates a fresh manual run for the same automation through the existing `runNow` path.
+
+## Non-goals
+
+- Do not mutate or replay the failed run record.
+- Do not add backend APIs or provider-specific rerun behavior.
+- Do not add rerun support for external Hermes/OpenClaw run details in this change.
+- Do not bypass existing SSH availability, worktree creation, or dispatch failure handling.
+
+## Design
+
+1. Add a small pure predicate near the run view state code, for example `canRerunAutomationRun({ automation, run })`.
+   - Return `true` only when an Orca automation still exists, `run.automationId === automation.id`, and the run status is one of `dispatch_failed`, `skipped_unavailable`, or `skipped_needs_interactive_auth`.
+   - Do not show rerun for `pending`, `dispatching`, `dispatched`, `completed`, or `skipped_missed`. `skipped_missed` is scheduler catch-up history, not a launch failure the detail page should recover.
+2. In `AutomationsPage`, render a `Rerun` action in `AutomationRunPageFrame.actions` when that predicate is true for `selected` and `selectedAutomationRunPage`.
+3. The action calls `window.api.automations.runNow({ id: selected.id })` through a small handler, then `refresh()`, then shows the existing queued toast. Wrap the call in `try/catch/finally`: if the automation was deleted or the IPC rejects, toast the error and refresh so the stale run detail can disappear.
+4. Preserve dispatch behavior by reusing `runNow`; do not duplicate local/SSH dispatch logic in the renderer. `runNow` creates a new manual run and `AutomationService.requestDispatch` sends the existing `automations:dispatchRequested` payload to the renderer, where `useAutomationDispatchEvents` handles SSH reconnect, interactive-auth skips, worktree creation/reuse, and terminal launch.
+5. Add a local in-flight state keyed by the failed run id. Disable only that rerun button while pending so repeated clicks in one window cannot queue duplicates before the first request settles.
+6. Keep the existing `View run` / `Open workspace` action beside the new rerun action. Do not gate rerun on `selectedAutomationRunPageViewState.canOpen`; failed runs with no launch should still show the disabled view action plus enabled rerun.
+7. Use existing shadcn `Button`, lucide icon sizing, and styleguide tokens. The button should be compact (`size="sm"`), outline-level emphasis, and fit the existing header action row.
+8. Add focused tests for the pure predicate in `automation-run-view-state.test.ts`. Avoid component-level tests unless a harness already exists locally.
+
+## Edge cases
+
+- Failed run has no workspace because base ref refresh, SSH connection, missing project/workspace, or renderer availability failed: rerun remains available and lets the existing dispatch path try again.
+- Failed run has a workspace but terminal is closed: rerun stays available, and open workspace behavior remains unchanged.
+- Automation was deleted while the request is in flight or by another window: `runNow` can throw `Automation not found.`; catch it, clear pending state, and refresh.
+- Selection changed while the request is in flight: capture `automation.id` and `run.id` before awaiting, clear that run id in `finally`, and avoid reading mutable `selected` after the await.
+- SSH automation cannot reconnect or needs credentials: rerun still goes through `runNow`; existing dispatch code records `skipped_unavailable` or `skipped_needs_interactive_auth` as a new run.
+- The user clicks rerun repeatedly in the same window: disable the rerun button while the request is pending.
+- The user clicks rerun in two windows: the renderer guard will not prevent duplicate manual runs across windows. Do not claim backend idempotency unless a service-level dedupe key is added.
+- Refresh after rerun may leave the failed run detail selected because `selectedAutomationRunPageId` still points at the old run. That is acceptable for this change, but the run list count and rows must refresh so the new manual run is visible after navigating back.
+- `runNow` itself does not broadcast `orca:automations-changed`; the initiating page must call `refresh()` after the IPC resolves. Other windows update only when dispatch result handling fires the existing event or when focus/visibility refresh runs.
+
+## Rollout
+
+1. Add a small predicate/helper for rerun action visibility and unit tests if it can live near automation run view state without mixing responsibilities.
+2. Add rerun pending state, error handling, and handler in `AutomationsPage`.
+3. Render the new action in the selected Orca run detail header.
+4. Run focused tests, then `pnpm typecheck` and `pnpm lint`.

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -68,7 +68,11 @@ import {
   formatAutomationTokens,
   summarizeAutomationRunUsage
 } from './automation-usage-model'
-import { getAutomationRunViewState } from './automation-run-view-state'
+import {
+  canRerunAutomationRun,
+  getAutomationRerunPendingRemainingMs,
+  getAutomationRunViewState
+} from './automation-run-view-state'
 import { getAutomationRunWorkspaceDisplay } from './automation-run-workspace-display'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import { AutomationDetail } from './AutomationDetail'
@@ -220,6 +224,14 @@ function isMissingExternalRunsApiError(error: unknown): boolean {
   return /listExternalRuns|automations:listExternalRuns|No handler registered/i.test(message)
 }
 
+async function waitForAutomationRerunPendingVisibility(pendingStartedAt: number): Promise<void> {
+  const remainingMs = getAutomationRerunPendingRemainingMs({ pendingStartedAt })
+  if (remainingMs <= 0) {
+    return
+  }
+  await new Promise<void>((resolve) => window.setTimeout(resolve, remainingMs))
+}
+
 export default function AutomationsPage(): React.JSX.Element {
   const repos = useAppStore((s) => s.repos)
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
@@ -252,6 +264,9 @@ export default function AutomationsPage(): React.JSX.Element {
   }>({ automationId: null, runs: [] })
   const [externalManagers, setExternalManagers] = useState<ExternalAutomationManager[]>([])
   const [externalActionKey, setExternalActionKey] = useState<string | null>(null)
+  const [rerunRunIdsInFlight, setRerunRunIdsInFlight] = useState<ReadonlySet<string>>(
+    () => new Set()
+  )
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
@@ -282,6 +297,7 @@ export default function AutomationsPage(): React.JSX.Element {
   const editRequestRef = useRef(0)
   const deleteConfirmButtonRef = useRef<HTMLButtonElement>(null)
   const completionInFlightRef = useRef<Set<string>>(new Set())
+  const rerunRunIdsInFlightRef = useRef<Set<string>>(new Set())
   const workspaceNameCacheRef = useRef<Map<string, string>>(new Map())
   const [draft, setDraft] = useState<AutomationDraft>({
     name: '',
@@ -417,6 +433,11 @@ export default function AutomationsPage(): React.JSX.Element {
           : false
       })
     : null
+  const canRerunSelectedAutomationRunPage =
+    selectedAutomationRunPage !== null &&
+    canRerunAutomationRun({ automation: selected, run: selectedAutomationRunPage })
+  const isSelectedAutomationRunPageRerunPending =
+    selectedAutomationRunPage !== null && rerunRunIdsInFlight.has(selectedAutomationRunPage.id)
   const selectedRepo = selected ? (repoMap.get(selected.projectId) ?? null) : null
   const selectedWorktree =
     selected && selected.workspaceId ? (worktreeMap.get(selected.workspaceId) ?? null) : null
@@ -1034,6 +1055,30 @@ export default function AutomationsPage(): React.JSX.Element {
     await window.api.automations.runNow({ id: automation.id })
     await refresh()
     toast.message('Automation run queued.')
+  }
+
+  const rerunAutomationRun = async (automation: Automation, run: AutomationRun): Promise<void> => {
+    const automationId = automation.id
+    const runId = run.id
+    if (rerunRunIdsInFlightRef.current.has(runId)) {
+      return
+    }
+    const pendingStartedAt = Date.now()
+    rerunRunIdsInFlightRef.current.add(runId)
+    setRerunRunIdsInFlight(new Set(rerunRunIdsInFlightRef.current))
+    try {
+      await window.api.automations.runNow({ id: automationId })
+      await refresh()
+      toast.message('Automation run queued.')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to rerun automation.')
+      await refresh()
+    } finally {
+      // Why: fast skipped/failed reruns can settle before users or validation can see the guard.
+      await waitForAutomationRerunPendingVisibility(pendingStartedAt)
+      rerunRunIdsInFlightRef.current.delete(runId)
+      setRerunRunIdsInFlight(new Set(rerunRunIdsInFlightRef.current))
+    }
   }
 
   const runExternalAction = async (
@@ -1858,18 +1903,39 @@ export default function AutomationsPage(): React.JSX.Element {
                     statusLabel={getAutomationRunStatusLabel(selectedAutomationRunPage.status)}
                     statusVariant={getAutomationRunStatusVariant(selectedAutomationRunPage.status)}
                     actions={
-                      selectedAutomationRunPageViewState ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          disabled={!selectedAutomationRunPageViewState.canOpen}
-                          onClick={() => openRunWorkspace(selectedAutomationRunPage)}
-                        >
-                          <Eye className="size-3.5" />
-                          {selectedAutomationRunPageViewState.actionLabel}
-                        </Button>
-                      ) : null
+                      <>
+                        {canRerunSelectedAutomationRunPage && selected ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={isSelectedAutomationRunPageRerunPending}
+                            onClick={() =>
+                              void rerunAutomationRun(selected, selectedAutomationRunPage)
+                            }
+                          >
+                            <RefreshCw
+                              className={cn(
+                                'size-3.5',
+                                isSelectedAutomationRunPageRerunPending && 'animate-spin'
+                              )}
+                            />
+                            Rerun
+                          </Button>
+                        ) : null}
+                        {selectedAutomationRunPageViewState ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={!selectedAutomationRunPageViewState.canOpen}
+                            onClick={() => openRunWorkspace(selectedAutomationRunPage)}
+                          >
+                            <Eye className="size-3.5" />
+                            {selectedAutomationRunPageViewState.actionLabel}
+                          </Button>
+                        ) : null}
+                      </>
                     }
                     onBack={() => setSelectedAutomationRunPageId(null)}
                   >

--- a/src/renderer/src/components/automations/automation-run-view-state.test.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it } from 'vitest'
-import type { AutomationRun } from '../../../../shared/automations-types'
-import { getAutomationRunViewState } from './automation-run-view-state'
+import type { Automation, AutomationRun } from '../../../../shared/automations-types'
+import {
+  AUTOMATION_RERUN_PENDING_MIN_VISIBLE_MS,
+  canRerunAutomationRun,
+  getAutomationRerunPendingRemainingMs,
+  getAutomationRunViewState
+} from './automation-run-view-state'
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: 'automation-1',
+    name: 'Automation 1',
+    prompt: 'Run checks',
+    agentId: 'codex',
+    projectId: 'repo-1',
+    executionTargetType: 'local',
+    executionTargetId: 'local',
+    schedulerOwner: 'local_host_service',
+    workspaceMode: 'new_per_run',
+    workspaceId: null,
+    baseBranch: null,
+    reuseSession: false,
+    timezone: 'UTC',
+    rrule: 'FREQ=DAILY',
+    dtstart: 1,
+    enabled: true,
+    nextRunAt: 1,
+    missedRunPolicy: 'run_once_within_grace',
+    missedRunGraceMinutes: 720,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
 
 function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
   return {
@@ -103,5 +135,78 @@ describe('automation run view state', () => {
       statusLabel: 'Showing saved run snapshot.',
       canOpen: false
     })
+  })
+})
+
+describe('canRerunAutomationRun', () => {
+  it.each(['dispatch_failed', 'skipped_unavailable', 'skipped_needs_interactive_auth'] as const)(
+    'allows rerun for recoverable launch status %s',
+    (status) => {
+      expect(
+        canRerunAutomationRun({
+          automation: makeAutomation(),
+          run: makeRun({ status })
+        })
+      ).toBe(true)
+    }
+  )
+
+  it.each(['pending', 'dispatching', 'dispatched', 'completed', 'skipped_missed'] as const)(
+    'hides rerun for non-recoverable status %s',
+    (status) => {
+      expect(
+        canRerunAutomationRun({
+          automation: makeAutomation(),
+          run: makeRun({ status })
+        })
+      ).toBe(false)
+    }
+  )
+
+  it('requires the failed run to belong to the selected automation', () => {
+    expect(
+      canRerunAutomationRun({
+        automation: makeAutomation({ id: 'automation-2' }),
+        run: makeRun({ status: 'dispatch_failed' })
+      })
+    ).toBe(false)
+  })
+
+  it('hides rerun when the automation no longer exists in the Orca list', () => {
+    expect(
+      canRerunAutomationRun({
+        automation: null,
+        run: makeRun({ status: 'dispatch_failed' })
+      })
+    ).toBe(false)
+  })
+})
+
+describe('getAutomationRerunPendingRemainingMs', () => {
+  it('keeps a short pending visibility window for fast rerun results', () => {
+    expect(
+      getAutomationRerunPendingRemainingMs({
+        pendingStartedAt: 1_000,
+        now: 1_000
+      })
+    ).toBe(AUTOMATION_RERUN_PENDING_MIN_VISIBLE_MS)
+  })
+
+  it('returns only the remaining pending visibility time', () => {
+    expect(
+      getAutomationRerunPendingRemainingMs({
+        pendingStartedAt: 1_000,
+        now: 1_250
+      })
+    ).toBe(AUTOMATION_RERUN_PENDING_MIN_VISIBLE_MS - 250)
+  })
+
+  it('does not add delay after the pending visibility window has elapsed', () => {
+    expect(
+      getAutomationRerunPendingRemainingMs({
+        pendingStartedAt: 1_000,
+        now: 2_000
+      })
+    ).toBe(0)
   })
 })

--- a/src/renderer/src/components/automations/automation-run-view-state.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.ts
@@ -1,4 +1,4 @@
-import type { AutomationRun } from '../../../../shared/automations-types'
+import type { Automation, AutomationRun } from '../../../../shared/automations-types'
 
 export type AutomationRunViewAvailability = 'terminal' | 'workspace' | 'snapshot' | 'metadata'
 
@@ -7,6 +7,35 @@ export type AutomationRunViewState = {
   actionLabel: string
   statusLabel: string
   canOpen: boolean
+}
+
+export const AUTOMATION_RERUN_PENDING_MIN_VISIBLE_MS = 800
+
+export function getAutomationRerunPendingRemainingMs({
+  pendingStartedAt,
+  now = Date.now()
+}: {
+  pendingStartedAt: number
+  now?: number
+}): number {
+  return Math.max(0, pendingStartedAt + AUTOMATION_RERUN_PENDING_MIN_VISIBLE_MS - now)
+}
+
+export function canRerunAutomationRun({
+  automation,
+  run
+}: {
+  automation: Automation | null
+  run: AutomationRun
+}): boolean {
+  if (!automation || run.automationId !== automation.id) {
+    return false
+  }
+  return (
+    run.status === 'dispatch_failed' ||
+    run.status === 'skipped_unavailable' ||
+    run.status === 'skipped_needs_interactive_auth'
+  )
 }
 
 export function getAutomationRunViewState({


### PR DESCRIPTION
## Summary
- Adds a Rerun action for recoverable failed automation runs in the run detail view.
- Keeps a short pending state visible while rerun dispatch is in flight and refreshes automation runs afterward.
- Adds focused tests for recoverable rerun eligibility and pending visibility timing.

## Design Doc
- docs/failed-automation-rerun-action.md

## Validation
- Electron validation passed in round 2 for these scenarios:
  - dispatch failed recoverable run shows and triggers Rerun
  - pending click state is visible after clicking Rerun
  - non-recoverable run does not show Rerun
  - SSH recoverable skipped run shows Rerun
- Local reviewer screenshots are intentionally uncommitted under validation-screenshots/:
  - [01-round2-dispatch-failed-pass.png](/Users/jinjingliang/Documents/projects/orca/allow-easy-rerun-automation/validation-screenshots/01-round2-dispatch-failed-pass.png)
  - [02-round2-pending-click-pass.png](/Users/jinjingliang/Documents/projects/orca/allow-easy-rerun-automation/validation-screenshots/02-round2-pending-click-pass.png)
  - [03-round2-non-recoverable-pass.png](/Users/jinjingliang/Documents/projects/orca/allow-easy-rerun-automation/validation-screenshots/03-round2-non-recoverable-pass.png)
  - [04-round2-ssh-recoverable-pass.png](/Users/jinjingliang/Documents/projects/orca/allow-easy-rerun-automation/validation-screenshots/04-round2-ssh-recoverable-pass.png)

## Checks
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/automations/automation-run-view-state.test.ts
- pnpm typecheck
- pnpm lint (passed with one unrelated existing warning in src/renderer/src/components/browser-pane/browser-automation-visibility.ts)
- git diff --check