### PR TITLE
Fix terminal URL click fallback regression

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -810,6 +810,44 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(element.removeEventListener).toHaveBeenCalledWith('mouseup', mouseUp, { capture: true })
   })
 
+  it('does not intercept regular URL clicks in the file-path fallback', async () => {
+    setPlatform('Macintosh')
+    const rows = [
+      makeBufferLine('PR opened: https://github.com/stablyai/orca-marketing-website/pull/82')
+    ]
+    const { terminal, element } = makeFallbackTerminal(rows)
+    const disposable = installFilePathLinkClickFallback(1, terminal, {
+      startupCwd: '/tmp',
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp',
+      runtimeEnvironmentId: null,
+      managerRef: { current: null },
+      linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
+      pathExistsCache: new Map<string, boolean>()
+    })
+    const mouseUp = getRegisteredMouseUpHandler(element)
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+
+    mouseUp({
+      button: 0,
+      metaKey: true,
+      ctrlKey: false,
+      clientX: 230,
+      clientY: 25,
+      preventDefault,
+      stopPropagation
+    } as unknown as MouseEvent)
+    await flushAsyncWork()
+
+    expect(openFileMock).not.toHaveBeenCalled()
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+
+    disposable.dispose()
+  })
+
   it('opens a deeply wrapped absolute path from its final short continuation row', async () => {
     setPlatform('Macintosh')
     const rows = [

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -14,6 +14,14 @@ describe('terminal path helpers', () => {
   })
 
   describe('extractTerminalFileLinks bare-filename tokens', () => {
+    it('does not treat regular URL hosts as local file paths', () => {
+      expect(
+        extractTerminalFileLinks(
+          'PR opened: https://github.com/stablyai/orca-marketing-website/pull/82'
+        )
+      ).toEqual([])
+    })
+
     it('emits tentative link candidates for each token in ls-style output', () => {
       const line = 'CLAUDE.md    package.json    pnpm-lock.yaml    README.md'
       const links = extractTerminalFileLinks(line)

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -7,22 +7,14 @@ export type ParsedTerminalFileLink = {
   displayText: string
 }
 
-export type ResolvedTerminalFileLink = {
+export type ResolvedTerminalFileLink = Pick<ParsedTerminalFileLink, 'line' | 'column'> & {
   absolutePath: string
-  line: number | null
-  column: number | null
 }
 
-// Ported from VSCode's terminal link detectors (MIT).
-//   Local paths:  src/vs/workbench/contrib/terminalContrib/links/browser/terminalLocalLinkDetector.ts
-//   Bare words:   src/vs/workbench/contrib/terminalContrib/links/browser/terminalWordLinkDetector.ts
-//
-// Two passes, matching VSCode's split between `TerminalLocalLinkDetector`
-// (paths with a separator, including line:col suffix) and
-// `TerminalWordLinkDetector` (bare whitespace-delimited tokens that only
-// become links if they resolve against the cwd). The provider runs fs.stat
-// on every candidate, so the word-pass stays conservative to keep fan-out
-// small.
+// Ported from VSCode's terminal link detectors (MIT): local paths from
+// `terminalLocalLinkDetector.ts`, bare words from `terminalWordLinkDetector.ts`.
+// Two passes match VSCode's split: separator paths, plus conservative bare
+// filename tokens that only become links if they resolve against the cwd.
 
 // Matches a path with at least one `/` separator, optionally followed by
 // `:line` and `:col` suffixes (e.g. `src/foo.ts:12:3`, `./bin`, `/abs/path`).
@@ -220,7 +212,6 @@ function looksLikeFilename(token: string): boolean {
 }
 
 type DetectedRange = { startIndex: number; endIndex: number; text: string }
-
 // Shared tokenization: run a regex over the line, trim boundary punctuation,
 // hand each surviving range to the caller. Collapses the three near-copies
 // of this loop the module had grown.
@@ -235,11 +226,13 @@ function* detectRanges(lineText: string, regex: RegExp): Generator<DetectedRange
 }
 
 function isInsideUriScheme(lineText: string, range: DetectedRange): boolean {
-  if (range.text.includes('://')) {
-    return true
-  }
   const prefix = lineText.slice(0, range.startIndex)
-  return /[A-Za-z][A-Za-z0-9+.-]*:\/\/$/.test(prefix)
+  // Why: local-path matching can start at the `//host/path` portion of a URL.
+  return (
+    range.text.includes('://') ||
+    (/[A-Za-z][A-Za-z0-9+.-]*:(?:\/\/)?$/.test(prefix) &&
+      (prefix.endsWith('://') || range.text.startsWith('//')))
+  )
 }
 
 function toParsedLink(range: DetectedRange): ParsedTerminalFileLink | null {


### PR DESCRIPTION
## Summary
- prevent terminal file-link parsing from claiming the //host/path portion of regular http(s) URLs
- add regression coverage for URL parsing and the modifier-click fallback not intercepting regular URLs

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
