### PR TITLE
Fix Resolve with AI icon

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,9 +89,7 @@ jobs:
       # Why: install intentionally blocks Electron's package postinstall, but
       # some unit tests import `electron` under Node and require path.txt.
       - name: Install Electron package binary for tests
-        run: |
-          pnpm rebuild electron --pending
-          node -e "require('electron')"
+        run: node config/scripts/install-electron-package-binary.mjs
 
       - name: Test
         run: pnpm test

--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import {
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
+import { platform as osPlatform, tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const electronPackageDir = resolve(projectDir, 'node_modules/electron')
+const electronRequire = createRequire(resolve(electronPackageDir, 'package.json'))
+const { version: electronVersion } = electronRequire('./package.json')
+const extract = electronRequire('extract-zip')
+const platformPath = getElectronPlatformPath()
+
+if (electronPackageLoads()) {
+  process.exit(0)
+}
+
+// Why: PR tests run under system Node after native modules are rebuilt for
+// Node. Install only Electron's npm package binary here; do not run the full
+// Electron native-module rebuild path, which would undo the Node ABI rebuild.
+console.log('[electron-package] Electron package binary is missing; running Electron install.')
+await installElectronPackageBinary()
+
+repairElectronPathFile()
+
+if (!electronPackageLoads()) {
+  logElectronInstallDiagnostics()
+  console.error('[electron-package] Electron package is still unavailable after install.')
+  process.exit(1)
+}
+
+function electronPackageLoads() {
+  try {
+    require('electron')
+    return true
+  } catch {
+    return false
+  }
+}
+
+function repairElectronPathFile() {
+  const electronExecutable = resolve(electronPackageDir, 'dist', platformPath)
+  if (!existsSync(electronExecutable)) {
+    return
+  }
+
+  const pathFile = resolve(electronPackageDir, 'path.txt')
+  let currentPath = ''
+  try {
+    currentPath = readFileSync(pathFile, 'utf8')
+  } catch {
+    // Missing path.txt is the common CI failure this script repairs.
+  }
+
+  if (currentPath !== platformPath) {
+    writeFileSync(pathFile, platformPath)
+    console.log(`[electron-package] Repaired Electron path.txt -> ${platformPath}`)
+  }
+}
+
+async function installElectronPackageBinary() {
+  const electronDistDir = resolve(electronPackageDir, 'dist')
+  const artifactName = getElectronArtifactName()
+  const tempDir = mkdtempSync(resolve(tmpdir(), 'orca-electron-'))
+  const zipPath = resolve(tempDir, artifactName)
+
+  try {
+    await downloadElectronArtifact(artifactName, zipPath)
+    await verifyElectronArtifactChecksum(artifactName, zipPath)
+
+    rmSync(electronDistDir, { recursive: true, force: true })
+    await extract(zipPath, { dir: electronDistDir })
+
+    const srcTypeDefPath = resolve(electronDistDir, 'electron.d.ts')
+    if (existsSync(srcTypeDefPath)) {
+      renameSync(srcTypeDefPath, resolve(electronPackageDir, 'electron.d.ts'))
+    }
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+async function downloadElectronArtifact(artifactName, zipPath) {
+  const artifactUrl = new URL(`v${electronVersion}/${artifactName}`, getElectronReleaseBaseUrl())
+  console.log(`[electron-package] Downloading ${artifactUrl}`)
+
+  const response = await fetch(artifactUrl)
+  if (!response.ok) {
+    throw new Error(`Failed to download ${artifactName}: ${response.status} ${response.statusText}`)
+  }
+  if (!response.body) {
+    throw new Error(`Failed to download ${artifactName}: empty response body`)
+  }
+
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(zipPath))
+}
+
+async function verifyElectronArtifactChecksum(artifactName, zipPath) {
+  if (
+    process.env.electron_use_remote_checksums ||
+    process.env.npm_config_electron_use_remote_checksums
+  ) {
+    return
+  }
+
+  const expected = electronRequire('./checksums.json')[artifactName]
+  if (!expected) {
+    throw new Error(`Missing Electron checksum for ${artifactName}`)
+  }
+
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(zipPath)) {
+    hash.update(chunk)
+  }
+  const actual = hash.digest('hex')
+  if (actual !== expected) {
+    throw new Error(`Checksum mismatch for ${artifactName}: expected ${expected}, got ${actual}`)
+  }
+}
+
+function getElectronArtifactName() {
+  return `electron-v${electronVersion}-${process.env.npm_config_platform || osPlatform()}-${
+    process.env.npm_config_arch || process.arch
+  }.zip`
+}
+
+function getElectronReleaseBaseUrl() {
+  const configuredMirror = process.env.ELECTRON_MIRROR || process.env.npm_config_electron_mirror
+  const baseUrl = configuredMirror || 'https://github.com/electron/electron/releases/download/'
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+}
+
+function logElectronInstallDiagnostics() {
+  const electronDistDir = resolve(electronPackageDir, 'dist')
+  const pathFile = resolve(electronPackageDir, 'path.txt')
+  console.error('[electron-package] Electron install diagnostics:')
+  console.error(`  packageDir=${electronPackageDir} exists=${existsSync(electronPackageDir)}`)
+  console.error(`  distDir=${electronDistDir} exists=${existsSync(electronDistDir)}`)
+  console.error(`  pathFile=${pathFile} exists=${existsSync(pathFile)}`)
+  console.error(`  platformPath=${platformPath}`)
+  if (existsSync(electronDistDir)) {
+    console.error(`  distEntries=${safeReaddir(electronDistDir).join(', ')}`)
+  }
+}
+
+function safeReaddir(targetPath) {
+  try {
+    return readdirSync(targetPath).slice(0, 40)
+  } catch {
+    return []
+  }
+}
+
+function getElectronPlatformPath() {
+  const targetPlatform = process.env.npm_config_platform || osPlatform()
+  switch (targetPlatform) {
+    case 'mas':
+    case 'darwin':
+      return 'Electron.app/Contents/MacOS/Electron'
+    case 'freebsd':
+    case 'openbsd':
+    case 'linux':
+      return 'electron'
+    case 'win32':
+      return 'electron.exe'
+    default:
+      throw new Error(`Electron builds are not available on platform: ${targetPlatform}`)
+  }
+}

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -34,7 +34,10 @@ describe('Electron runtime package contract', () => {
   })
 
   it('guards release publishing before electron-builder runs', () => {
-    const releaseWorkflow = readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+    const releaseWorkflow = readFileSync(
+      join(projectDir, '.github/workflows/release-cut.yml'),
+      'utf8'
+    )
     const parsedWorkflow = parse(releaseWorkflow)
     const releaseCommands = new Map(
       parsedWorkflow.jobs.build.strategy.matrix.include.map(({ platform, release_command }) => [
@@ -47,12 +50,24 @@ describe('Electron runtime package contract', () => {
     for (const command of releaseCommands.values()) {
       expect(command).toContain('node config/scripts/ensure-native-runtime.mjs --runtime=electron')
       expect(command).toContain('electron-builder')
-      expect(command.indexOf('ensure-native-runtime')).toBeLessThan(command.indexOf('electron-builder'))
+      expect(command.indexOf('ensure-native-runtime')).toBeLessThan(
+        command.indexOf('electron-builder')
+      )
     }
     expect(releaseCommands.get('mac')).toContain(' && ORCA_MAC_RELEASE=1 ')
     expect(releaseCommands.get('linux')).toContain(' && pnpm exec electron-builder ')
     expect(releaseCommands.get('win')).toContain(
       '; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; pnpm exec electron-builder '
     )
+  })
+
+  it('installs the Electron package binary in PR checks without changing native module ABI', () => {
+    const prWorkflow = readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8')
+    const parsedWorkflow = parse(prWorkflow)
+    const installStep = parsedWorkflow.jobs.verify.steps.find(
+      (step) => step.name === 'Install Electron package binary for tests'
+    )
+
+    expect(installStep.run).toBe('node config/scripts/install-electron-package-binary.mjs')
   })
 })

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -359,4 +359,20 @@ describe('ConflictSummaryCard', () => {
     expect(mergeMarkup).toContain('Abort merge')
     expect(rebaseMarkup).not.toContain('Abort merge')
   })
+
+  it('renders the Sparkles icon on the idle Resolve with AI button', () => {
+    const markup = renderToStaticMarkup(
+      <ConflictSummaryCard
+        conflictOperation="merge"
+        unresolvedCount={2}
+        isResolvingWithAI={false}
+        onResolveWithAI={vi.fn()}
+        onReview={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Resolve with AI')
+    expect(markup).toContain('lucide-sparkles')
+    expect(markup).not.toMatch(/\blucide-sparkle(?!s)\b/)
+  })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -5811,7 +5811,7 @@ export function ConflictSummaryCard({
           {isResolvingWithAI ? (
             <RefreshCw className="size-3.5 animate-spin" />
           ) : (
-            <Sparkle className="size-3.5" />
+            <Sparkles className="size-3.5" />
           )}
           Resolve with AI
         </Button>

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -56,4 +56,12 @@ describe('MergeConflictNotice', () => {
 
     expect(markup).toBe('')
   })
+
+  it('renders the Sparkles icon on the idle Resolve with AI button', () => {
+    const markup = renderNotice(makePR())
+
+    expect(markup).toContain('Resolve with AI')
+    expect(markup).toContain('lucide-sparkles')
+    expect(markup).not.toMatch(/\blucide-sparkle(?!s)\b/)
+  })
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -13,7 +13,7 @@ import {
   Check,
   MessageSquare,
   ChevronDown,
-  Sparkle,
+  Sparkles,
   RefreshCw,
   Wrench
 } from 'lucide-react'
@@ -95,7 +95,7 @@ function ResolveConflictsWithAIButton({
       {isResolvingWithAI ? (
         <RefreshCw className="size-3.5 animate-spin" />
       ) : (
-        <Sparkle className="size-3.5" />
+        <Sparkles className="size-3.5" />
       )}
       Resolve with AI
     </Button>


### PR DESCRIPTION
## Summary
- Updated every visible idle `Resolve with AI` button to use lucide `Sparkles`, matching AI commit-message and PR generation controls.
- Left loading spinners, labels, disabled states, handlers, telemetry, and unrelated AI recovery icons unchanged.
- Added focused static-render assertions that both changed surfaces render `lucide-sparkles` and not singular `lucide-sparkle`.
- Fixed the PR workflow Electron binary install step after GitHub Actions repeatedly failed before tests with missing `node_modules/electron/path.txt`.

## Design and Review
- Design doc created at `design-docs/resolve-with-ai-sparkles.md` as ignored scratch context, scoped by visible idle label exactly `Resolve with AI`.
- Design review via `auto-design-review-fix`: clean after two iterations; doc was tightened to require both known surfaces and explicit icon assertions.
- Self-check of reviewed doc confirmed it still matched Brennan's request and did not overreach into unrelated AI buttons.

## Implementation
- `SourceControl.tsx`: switched the source-control conflict summary `Resolve with AI` idle icon from `Sparkle` to `Sparkles`.
- `checks-panel-content.tsx`: switched the checks/PR conflict notice `Resolve with AI` idle icon from `Sparkle` to `Sparkles`.
- `CommitArea.test.tsx` and `checks-panel-content.test.tsx`: added explicit `lucide-sparkles` assertions for both surfaces.
- `.github/workflows/pr.yml`: replaced `pnpm rebuild electron --pending` with a purpose-built Electron package binary installer for PR tests.
- `config/scripts/install-electron-package-binary.mjs`: installs/verifies only the Electron package binary without rebuilding native modules back to Electron ABI before Node-based tests. It downloads the Electron zip directly, verifies the packaged checksum, extracts it, and repairs `path.txt`.
- `config/scripts/package-electron-runtime-contract.test.mjs`: added a workflow contract guard for the PR Electron binary install step.

## Completeness Verification
- Read-only verification confirmed exact production `Resolve with AI` renderer labels only appear in the two changed surfaces.
- Confirmed both idle states use `Sparkles`, loading states remain `RefreshCw animate-spin`, and unrelated singular `Sparkle` remains only for commit-failure recovery whose visible label is not `Resolve with AI`.
- `git diff --check` passed.

## Code Review Loop
- Round 1 reviewer A: clean, no findings. Ran focused Vitest and `git diff --check`.
- Round 1 reviewer B: clean, no findings. Ran `git diff --check` and the requested test command, which expanded to the full suite.
- Both reviewers in the same round returned clean; loop stopped.

## Brennan Test Changes
- Result: Land.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed with one unrelated existing warning in `browser-automation-visibility.ts`.
- `git diff --check` passed.
- Focused tests passed: `CommitArea.test.tsx` and `checks-panel-content.test.tsx`, 30 tests total before rebase.
- Electron product-surface validation launched from this exact worktree and verified both changed surfaces render `lucide lucide-sparkles size-3.5`, not singular `lucide-sparkle`.

## Rebase / CI Update
- Rebasing onto current `origin/main` produced one conflict in `CommitArea.test.tsx`; resolved by keeping the new base test for `Abort merge` and the new Sparkles icon assertion.
- Post-rebase validation passed: `git diff --check`, focused Vitest for both right-sidebar tests (`31 passed`), and `pnpm run typecheck:web`.
- Initial and rerun GitHub `verify` both failed at `Install Electron package binary for tests`; lint/typecheck had passed before the failure. Logs showed `pnpm install` ignored Electron's dependency build script, root postinstall retried Electron install but continued without `path.txt`, and `pnpm rebuild electron --pending` did not repair it.
- First helper iteration confirmed Electron's package `install.js` also exited without extracting the binary in Actions, and the `@electron/get` path exposed an unsettled top-level-await issue under Node 24. The final helper avoids that path by using Node `fetch` plus checksum verification and extraction directly.
- Final GitHub `verify` passed in run `26542653497`: install, lint, guards, typecheck, Node rebuild, Electron binary install, test, and build all green.

## Focused Tests / Static Checks
- `node config/scripts/install-electron-package-binary.mjs` passed locally.
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs src/renderer/src/components/right-sidebar/CommitArea.test.tsx src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx` passed: 3 files, 35 tests.
- `pnpm run typecheck:web` passed.
- `pnpm run lint` exited 0 with one unrelated existing warning in `browser-automation-visibility.ts`.
- `pnpm exec oxlint ...` on touched files found 0 warnings/errors; `pnpm exec oxfmt --write ...` completed cleanly.
- `git diff --check` passed.

## Assumptions and Gaps
- Did not click `Resolve with AI`; this PR changes only the icon and clicking would exercise/mutate the AI conflict-resolution workflow rather than validate renderer output.
- No live SSH/remoting/provider validation was run for the icon change because it is a renderer-only lucide icon import/render change with no IPC, path, shortcut, shell, provider, or remote-execution behavior.
- Electron checks-panel setup used temporary in-memory PR cache data to expose the UI surface without mutating a real PR. Expected fake-repo `gh` fetch errors were inspected and unrelated.
- Local `.npmrc` warning about `${GITHUB_TOKEN}` appeared during pnpm commands and did not affect validation.