### PR TITLE
Fix git history graph scope

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -29,22 +29,29 @@ const extract = electronRequire('extract-zip')
 const platformPath = getElectronPlatformPath()
 const MAX_DOWNLOAD_REDIRECTS = 5
 
-if (electronPackageLoads()) {
-  process.exit(0)
-}
-
-// Why: PR tests run under system Node after native modules are rebuilt for
-// Node. Install only Electron's npm package binary here; do not run the full
-// Electron native-module rebuild path, which would undo the Node ABI rebuild.
-console.log('[electron-package] Electron package binary is missing; running Electron install.')
-await installElectronPackageBinary()
-
-repairElectronPathFile()
-
-if (!electronPackageLoads()) {
-  logElectronInstallDiagnostics()
-  console.error('[electron-package] Electron package is still unavailable after install.')
+main().catch((error) => {
+  console.error(error)
   process.exit(1)
+})
+
+async function main() {
+  if (electronPackageLoads()) {
+    return
+  }
+
+  // Why: PR tests run under system Node after native modules are rebuilt for
+  // Node. Install only Electron's npm package binary here; do not run the full
+  // Electron native-module rebuild path, which would undo the Node ABI rebuild.
+  console.log('[electron-package] Electron package binary is missing; running Electron install.')
+  await installElectronPackageBinary()
+
+  repairElectronPathFile()
+
+  if (!electronPackageLoads()) {
+    logElectronInstallDiagnostics()
+    console.error('[electron-package] Electron package is still unavailable after install.')
+    process.exit(1)
+  }
 }
 
 function electronPackageLoads() {

--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -12,10 +12,11 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs'
+import { get as httpGet } from 'node:http'
+import { get as httpsGet } from 'node:https'
 import { createRequire } from 'node:module'
 import { platform as osPlatform, tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
-import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
 
@@ -26,6 +27,7 @@ const electronRequire = createRequire(resolve(electronPackageDir, 'package.json'
 const { version: electronVersion } = electronRequire('./package.json')
 const extract = electronRequire('extract-zip')
 const platformPath = getElectronPlatformPath()
+const MAX_DOWNLOAD_REDIRECTS = 5
 
 if (electronPackageLoads()) {
   process.exit(0)
@@ -100,15 +102,53 @@ async function downloadElectronArtifact(artifactName, zipPath) {
   const artifactUrl = new URL(`v${electronVersion}/${artifactName}`, getElectronReleaseBaseUrl())
   console.log(`[electron-package] Downloading ${artifactUrl}`)
 
-  const response = await fetch(artifactUrl)
-  if (!response.ok) {
-    throw new Error(`Failed to download ${artifactName}: ${response.status} ${response.statusText}`)
-  }
-  if (!response.body) {
-    throw new Error(`Failed to download ${artifactName}: empty response body`)
+  await downloadUrlToFile(artifactUrl, zipPath, artifactName)
+}
+
+async function downloadUrlToFile(url, zipPath, artifactName, redirectCount = 0) {
+  const response = await requestUrl(url)
+  const status = response.statusCode ?? 0
+
+  if (status >= 300 && status < 400 && response.headers.location) {
+    response.resume()
+    if (redirectCount >= MAX_DOWNLOAD_REDIRECTS) {
+      throw new Error(`Failed to download ${artifactName}: too many redirects`)
+    }
+
+    const nextUrl = new URL(response.headers.location, url)
+    console.log(`[electron-package] Following redirect to ${nextUrl.origin}${nextUrl.pathname}`)
+    await downloadUrlToFile(nextUrl, zipPath, artifactName, redirectCount + 1)
+    return
   }
 
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(zipPath))
+  if (status < 200 || status >= 300) {
+    response.resume()
+    throw new Error(
+      `Failed to download ${artifactName}: ${status} ${response.statusMessage ?? ''}`.trim()
+    )
+  }
+
+  await pipeline(response, createWriteStream(zipPath))
+}
+
+function requestUrl(url) {
+  const get = url.protocol === 'http:' ? httpGet : url.protocol === 'https:' ? httpsGet : undefined
+  if (!get) {
+    throw new Error(`Unsupported Electron download protocol: ${url.protocol}`)
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = get(
+      url,
+      {
+        headers: {
+          'user-agent': 'orca-electron-package-installer'
+        }
+      },
+      resolve
+    )
+    request.on('error', reject)
+  })
 }
 
 async function verifyElectronArtifactChecksum(artifactName, zipPath) {

--- a/src/shared/git-history-boundary-rows.ts
+++ b/src/shared/git-history-boundary-rows.ts
@@ -1,0 +1,190 @@
+import type { GitHistoryGraphColorId, GitHistoryItem, GitHistoryItemRef } from './git-history'
+import { GIT_HISTORY_REF_COLOR, GIT_HISTORY_REMOTE_REF_COLOR } from './git-history'
+import type { GitHistoryGraphNode, GitHistoryItemViewModel } from './git-history-graph'
+
+export const GIT_HISTORY_INCOMING_CHANGES_ID = 'git-history-incoming-changes'
+export const GIT_HISTORY_OUTGOING_CHANGES_ID = 'git-history-outgoing-changes'
+
+function cloneNode(node: GitHistoryGraphNode): GitHistoryGraphNode {
+  return { id: node.id, color: node.color }
+}
+
+function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index] as T)) {
+      return index
+    }
+  }
+  return -1
+}
+
+function hasNode(
+  nodes: readonly GitHistoryGraphNode[],
+  id: string,
+  color?: GitHistoryGraphColorId
+): boolean {
+  return nodes.some((node) => node.id === id && (color === undefined || node.color === color))
+}
+
+function remoteBoundaryInputNode(
+  node: GitHistoryGraphNode,
+  mergeBase: string
+): GitHistoryGraphNode {
+  return node.id === mergeBase && node.color === GIT_HISTORY_REMOTE_REF_COLOR
+    ? { ...node, id: GIT_HISTORY_INCOMING_CHANGES_ID }
+    : cloneNode(node)
+}
+
+function ensureIncomingRemoteLane(
+  inputSwimlanes: GitHistoryGraphNode[],
+  outputSwimlanes: GitHistoryGraphNode[],
+  mergeBase: string
+): void {
+  // Why: HEAD-only history omits upstream commits, so the graph must still
+  // synthesize the remote lane that used to arrive from those hidden rows.
+  if (!hasNode(outputSwimlanes, mergeBase, GIT_HISTORY_REMOTE_REF_COLOR)) {
+    if (!hasNode(outputSwimlanes, mergeBase, GIT_HISTORY_REF_COLOR)) {
+      outputSwimlanes.push({ id: mergeBase, color: GIT_HISTORY_REF_COLOR })
+    }
+    outputSwimlanes.push({ id: mergeBase, color: GIT_HISTORY_REMOTE_REF_COLOR })
+  }
+
+  if (hasNode(inputSwimlanes, GIT_HISTORY_INCOMING_CHANGES_ID, GIT_HISTORY_REMOTE_REF_COLOR)) {
+    return
+  }
+
+  const remoteMergeBaseIndex = outputSwimlanes.findIndex(
+    (node) => node.id === mergeBase && node.color === GIT_HISTORY_REMOTE_REF_COLOR
+  )
+  inputSwimlanes.splice(
+    remoteMergeBaseIndex === -1 ? inputSwimlanes.length : remoteMergeBaseIndex,
+    0,
+    { id: GIT_HISTORY_INCOMING_CHANGES_ID, color: GIT_HISTORY_REMOTE_REF_COLOR }
+  )
+}
+
+export function addIncomingOutgoingChangesHistoryItems(
+  viewModels: GitHistoryItemViewModel[],
+  currentRef?: GitHistoryItemRef,
+  remoteRef?: GitHistoryItemRef,
+  addIncomingChanges?: boolean,
+  addOutgoingChanges?: boolean,
+  mergeBase?: string
+): void {
+  if (currentRef?.revision === remoteRef?.revision || !mergeBase) {
+    return
+  }
+
+  if (addIncomingChanges && remoteRef && remoteRef.revision !== mergeBase) {
+    addIncomingChangesHistoryItem(viewModels, remoteRef, mergeBase)
+  }
+
+  if (addOutgoingChanges && currentRef?.revision && currentRef.revision !== mergeBase) {
+    addOutgoingChangesHistoryItem(viewModels, currentRef)
+  }
+}
+
+function addIncomingChangesHistoryItem(
+  viewModels: GitHistoryItemViewModel[],
+  remoteRef: GitHistoryItemRef,
+  mergeBase: string
+): void {
+  const beforeHistoryItemIndex = findLastIndex(viewModels, (viewModel) =>
+    viewModel.outputSwimlanes.some((node) => node.id === mergeBase)
+  )
+  const afterHistoryItemIndex = viewModels.findIndex(
+    (viewModel) => viewModel.historyItem.id === mergeBase
+  )
+  if (afterHistoryItemIndex === -1) {
+    return
+  }
+
+  const before = beforeHistoryItemIndex !== -1 ? viewModels[beforeHistoryItemIndex] : undefined
+  const incomingChangeMerged =
+    before?.historyItem.parentIds.length === 2 && before.historyItem.parentIds.includes(mergeBase)
+  if (incomingChangeMerged) {
+    return
+  }
+
+  const after = viewModels[afterHistoryItemIndex] as GitHistoryItemViewModel
+  const inputSwimlanes =
+    before?.outputSwimlanes.map((node) => remoteBoundaryInputNode(node, mergeBase)) ??
+    after.inputSwimlanes.map(cloneNode)
+  const outputSwimlanes = after.inputSwimlanes.map(cloneNode)
+  ensureIncomingRemoteLane(inputSwimlanes, outputSwimlanes, mergeBase)
+
+  if (before !== undefined) {
+    viewModels[beforeHistoryItemIndex] = {
+      ...before,
+      inputSwimlanes: before.inputSwimlanes.map((node) => remoteBoundaryInputNode(node, mergeBase)),
+      outputSwimlanes: inputSwimlanes.map(cloneNode)
+    }
+  }
+
+  const displayIdLength = viewModels[0]?.historyItem.displayId?.length ?? 0
+  const incomingChangesHistoryItem: GitHistoryItem = {
+    id: GIT_HISTORY_INCOMING_CHANGES_ID,
+    displayId: '0'.repeat(displayIdLength),
+    parentIds: [mergeBase],
+    author: remoteRef.name,
+    subject: 'Incoming Changes',
+    message: ''
+  }
+
+  viewModels.splice(afterHistoryItemIndex, 0, {
+    historyItem: incomingChangesHistoryItem,
+    kind: 'incoming-changes',
+    inputSwimlanes,
+    outputSwimlanes
+  })
+
+  viewModels[afterHistoryItemIndex + 1] = {
+    ...after,
+    inputSwimlanes: outputSwimlanes.map(cloneNode)
+  }
+}
+
+function addOutgoingChangesHistoryItem(
+  viewModels: GitHistoryItemViewModel[],
+  currentRef: GitHistoryItemRef
+): void {
+  const currentRevision = currentRef.revision
+  if (!currentRevision) {
+    return
+  }
+
+  const currentRefIndex = viewModels.findIndex(
+    (viewModel) => viewModel.kind === 'HEAD' && viewModel.historyItem.id === currentRevision
+  )
+  if (currentRefIndex === -1) {
+    return
+  }
+
+  const displayIdLength = viewModels[0]?.historyItem.displayId?.length ?? 0
+  const outgoingChangesHistoryItem: GitHistoryItem = {
+    id: GIT_HISTORY_OUTGOING_CHANGES_ID,
+    displayId: '0'.repeat(displayIdLength),
+    parentIds: [currentRevision],
+    author: currentRef.name,
+    subject: 'Outgoing Changes',
+    message: ''
+  }
+
+  const inputSwimlanes = viewModels[currentRefIndex]!.inputSwimlanes.map(cloneNode)
+  const outputSwimlanes = inputSwimlanes.concat({
+    id: currentRevision,
+    color: GIT_HISTORY_REF_COLOR
+  })
+
+  viewModels.splice(currentRefIndex, 0, {
+    historyItem: outgoingChangesHistoryItem,
+    kind: 'outgoing-changes',
+    inputSwimlanes,
+    outputSwimlanes
+  })
+
+  viewModels[currentRefIndex + 1]!.inputSwimlanes.push({
+    id: currentRevision,
+    color: GIT_HISTORY_REF_COLOR
+  })
+}

--- a/src/shared/git-history-graph.test.ts
+++ b/src/shared/git-history-graph.test.ts
@@ -80,7 +80,7 @@ describe('git history graph model', () => {
     expect(getGitHistoryMergeParentLaneIndex(viewModels[0]!, 'B')).toBe(1)
   })
 
-  it('inserts VS Code-style incoming and outgoing boundary rows at the merge base', () => {
+  it('inserts incoming and outgoing boundary rows at the merge base', () => {
     const currentRef = branch('feature', 'A')
     const remoteRef = remote('origin/feature', 'R')
     const viewModels = buildGitHistoryViewModels(
@@ -111,6 +111,74 @@ describe('git history graph model', () => {
     expect(viewModels[3]!.historyItem.id).toBe(GIT_HISTORY_INCOMING_CHANGES_ID)
     expect(viewModels[3]!.inputSwimlanes).toContainEqual({
       id: GIT_HISTORY_INCOMING_CHANGES_ID,
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
+  })
+
+  it('inserts an incoming boundary when HEAD-only history is behind upstream', () => {
+    const currentRef = branch('feature', 'B')
+    const remoteRef = remote('origin/feature', 'R')
+    const viewModels = buildGitHistoryViewModels(
+      [item('B', ['C'], [currentRef]), item('C', [])],
+      buildDefaultGitHistoryColorMap({ currentRef, remoteRef }),
+      currentRef,
+      remoteRef,
+      undefined,
+      true,
+      false,
+      'B'
+    )
+
+    expect(viewModels.map((viewModel) => viewModel.kind)).toEqual([
+      'incoming-changes',
+      'HEAD',
+      'node'
+    ])
+    expect(viewModels[0]!.inputSwimlanes).toContainEqual({
+      id: GIT_HISTORY_INCOMING_CHANGES_ID,
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
+    expect(viewModels[0]!.outputSwimlanes).toContainEqual({
+      id: 'B',
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
+    expect(viewModels[1]!.inputSwimlanes).toContainEqual({
+      id: 'B',
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
+  })
+
+  it('colors incoming boundary lanes as remote when upstream commits are omitted', () => {
+    const currentRef = branch('feature', 'A')
+    const remoteRef = remote('origin/feature', 'R')
+    const viewModels = buildGitHistoryViewModels(
+      [item('A', ['B'], [currentRef]), item('B', ['C']), item('C', [])],
+      buildDefaultGitHistoryColorMap({ currentRef, remoteRef }),
+      currentRef,
+      remoteRef,
+      undefined,
+      true,
+      true,
+      'B'
+    )
+
+    expect(viewModels.map((viewModel) => viewModel.kind)).toEqual([
+      'outgoing-changes',
+      'HEAD',
+      'incoming-changes',
+      'node',
+      'node'
+    ])
+    expect(viewModels[2]!.inputSwimlanes).toContainEqual({
+      id: GIT_HISTORY_INCOMING_CHANGES_ID,
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
+    expect(viewModels[2]!.outputSwimlanes).toContainEqual({
+      id: 'B',
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
+    expect(viewModels[3]!.inputSwimlanes).toContainEqual({
+      id: 'B',
       color: GIT_HISTORY_REMOTE_REF_COLOR
     })
   })

--- a/src/shared/git-history-graph.ts
+++ b/src/shared/git-history-graph.ts
@@ -1,13 +1,17 @@
 import type { GitHistoryGraphColorId, GitHistoryItem, GitHistoryItemRef } from './git-history'
 import {
+  GIT_HISTORY_INCOMING_CHANGES_ID,
+  GIT_HISTORY_OUTGOING_CHANGES_ID,
+  addIncomingOutgoingChangesHistoryItems
+} from './git-history-boundary-rows'
+import {
   GIT_HISTORY_BASE_REF_COLOR,
   GIT_HISTORY_LANE_COLORS,
   GIT_HISTORY_REF_COLOR,
   GIT_HISTORY_REMOTE_REF_COLOR
 } from './git-history'
 
-export const GIT_HISTORY_INCOMING_CHANGES_ID = 'git-history-incoming-changes'
-export const GIT_HISTORY_OUTGOING_CHANGES_ID = 'git-history-outgoing-changes'
+export { GIT_HISTORY_INCOMING_CHANGES_ID, GIT_HISTORY_OUTGOING_CHANGES_ID }
 
 export type GitHistoryGraphNode = {
   id: string
@@ -85,105 +89,6 @@ export function compareGitHistoryRefs(
   }
 
   return order(ref1) - order(ref2)
-}
-
-function addIncomingOutgoingChangesHistoryItems(
-  viewModels: GitHistoryItemViewModel[],
-  currentRef?: GitHistoryItemRef,
-  remoteRef?: GitHistoryItemRef,
-  addIncomingChanges?: boolean,
-  addOutgoingChanges?: boolean,
-  mergeBase?: string
-): void {
-  if (currentRef?.revision === remoteRef?.revision || !mergeBase) {
-    return
-  }
-
-  if (addIncomingChanges && remoteRef && remoteRef.revision !== mergeBase) {
-    const beforeHistoryItemIndex = findLastIndex(viewModels, (viewModel) =>
-      viewModel.outputSwimlanes.some((node) => node.id === mergeBase)
-    )
-    const afterHistoryItemIndex = viewModels.findIndex(
-      (viewModel) => viewModel.historyItem.id === mergeBase
-    )
-
-    if (beforeHistoryItemIndex !== -1 && afterHistoryItemIndex !== -1) {
-      const before = viewModels[beforeHistoryItemIndex] as GitHistoryItemViewModel
-      const incomingChangeMerged =
-        before.historyItem.parentIds.length === 2 &&
-        before.historyItem.parentIds.includes(mergeBase)
-
-      if (!incomingChangeMerged) {
-        viewModels[beforeHistoryItemIndex] = {
-          ...before,
-          inputSwimlanes: before.inputSwimlanes.map((node) =>
-            node.id === mergeBase && node.color === GIT_HISTORY_REMOTE_REF_COLOR
-              ? { ...node, id: GIT_HISTORY_INCOMING_CHANGES_ID }
-              : node
-          ),
-          outputSwimlanes: before.outputSwimlanes.map((node) =>
-            node.id === mergeBase && node.color === GIT_HISTORY_REMOTE_REF_COLOR
-              ? { ...node, id: GIT_HISTORY_INCOMING_CHANGES_ID }
-              : node
-          )
-        }
-
-        const displayIdLength = viewModels[0]?.historyItem.displayId?.length ?? 0
-        const incomingChangesHistoryItem: GitHistoryItem = {
-          id: GIT_HISTORY_INCOMING_CHANGES_ID,
-          displayId: '0'.repeat(displayIdLength),
-          parentIds: [mergeBase],
-          author: remoteRef.name,
-          subject: 'Incoming Changes',
-          message: ''
-        }
-
-        viewModels.splice(afterHistoryItemIndex, 0, {
-          historyItem: incomingChangesHistoryItem,
-          kind: 'incoming-changes',
-          inputSwimlanes: viewModels[beforeHistoryItemIndex]!.outputSwimlanes.map(cloneNode),
-          outputSwimlanes: viewModels[afterHistoryItemIndex]!.inputSwimlanes.map(cloneNode)
-        })
-      }
-    }
-  }
-
-  if (addOutgoingChanges && currentRef?.revision && currentRef.revision !== mergeBase) {
-    const currentRefIndex = viewModels.findIndex(
-      (viewModel) => viewModel.kind === 'HEAD' && viewModel.historyItem.id === currentRef.revision
-    )
-    if (currentRefIndex === -1) {
-      return
-    }
-
-    const displayIdLength = viewModels[0]?.historyItem.displayId?.length ?? 0
-    const outgoingChangesHistoryItem: GitHistoryItem = {
-      id: GIT_HISTORY_OUTGOING_CHANGES_ID,
-      displayId: '0'.repeat(displayIdLength),
-      parentIds: [currentRef.revision],
-      author: currentRef.name,
-      subject: 'Outgoing Changes',
-      message: ''
-    }
-
-    const inputSwimlanes = viewModels[currentRefIndex]!.inputSwimlanes.map(cloneNode)
-    const outputSwimlanes = inputSwimlanes.concat({
-      id: currentRef.revision,
-      color: GIT_HISTORY_REF_COLOR
-    })
-
-    viewModels.splice(currentRefIndex, 0, {
-      historyItem: outgoingChangesHistoryItem,
-      kind: 'outgoing-changes',
-      inputSwimlanes,
-      outputSwimlanes
-    })
-
-    viewModels[currentRefIndex + 1]!.inputSwimlanes.push({
-      id: currentRef.revision,
-      color: GIT_HISTORY_REF_COLOR
-    })
-  }
 }
 
 export function buildGitHistoryViewModels(

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -63,13 +63,14 @@ function createHistoryExecutor(limitRecords = 2): {
       return { stdout: `${BASE_OID}\n` }
     }
     if (command === 'log') {
+      const includesRemoteRoot = args.includes(REMOTE_OID)
       return {
         stdout: Array.from({ length: limitRecords }, (_, index) =>
           logRecord({
             hash:
               index === 0
                 ? HEAD_OID
-                : index === 1
+                : includesRemoteRoot && index === 1
                   ? REMOTE_OID
                   : (index % 16).toString(16).repeat(40),
             parents: [BASE_OID],
@@ -129,15 +130,86 @@ describe('git history loader', () => {
         '--topo-order',
         '--decorate=full',
         '-n51',
-        HEAD_OID,
-        REMOTE_OID
+        HEAD_OID
       ])
     )
+    expect(logCall).not.toContain(REMOTE_OID)
     expect(calls.filter((args) => args[0] === 'log')).toHaveLength(1)
     expect(result.items).toHaveLength(2)
+    expect(result.items.map((item) => item.id)).not.toContain(REMOTE_OID)
     expect(result.hasIncomingChanges).toBe(true)
     expect(result.hasOutgoingChanges).toBe(true)
     expect(result.mergeBase).toBe(BASE_OID)
+  })
+
+  it('does not list newly fetched upstream commits in old workspace history', async () => {
+    const upstreamOnlyOid = 'd'.repeat(40)
+    const calls: string[][] = []
+    const executor = vi.fn(async (args: string[], cwd: string) => {
+      expect(cwd).toBe('/repo')
+      calls.push(args)
+      const command = args[0]
+
+      if (command === 'rev-parse' && args.includes('HEAD^{commit}')) {
+        return { stdout: `${HEAD_OID}\n` }
+      }
+      if (command === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
+        return { stdout: `${REMOTE_OID}\n` }
+      }
+      if (command === 'rev-parse' && args.includes('origin/main^{commit}')) {
+        return { stdout: `${REMOTE_OID}\n` }
+      }
+      if (command === 'rev-parse' && args.includes('origin/main')) {
+        return { stdout: 'refs/remotes/origin/main\n' }
+      }
+      if (command === 'symbolic-ref') {
+        return { stdout: 'old-workspace\n' }
+      }
+      if (command === 'for-each-ref') {
+        return { stdout: 'refs/remotes/origin/main\0origin/main\n' }
+      }
+      if (command === 'merge-base') {
+        return { stdout: `${HEAD_OID}\n` }
+      }
+      if (command === 'log') {
+        const includesRemoteRoot = args.includes(REMOTE_OID)
+        return {
+          stdout: includesRemoteRoot
+            ? [
+                logRecord({
+                  hash: upstreamOnlyOid,
+                  parents: [REMOTE_OID],
+                  message: 'new upstream commit'
+                }),
+                logRecord({
+                  hash: HEAD_OID,
+                  decorations: 'HEAD -> refs/heads/old-workspace',
+                  message: 'old workspace base'
+                })
+              ].join('')
+            : logRecord({
+                hash: HEAD_OID,
+                decorations: 'HEAD -> refs/heads/old-workspace',
+                message: 'old workspace base'
+              })
+        }
+      }
+
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', {
+      limit: 50,
+      baseRef: 'origin/main'
+    })
+
+    const logCall = calls.find((args) => args[0] === 'log')
+    expect(logCall).not.toContain(REMOTE_OID)
+    expect(result.remoteRef?.revision).toBe(REMOTE_OID)
+    expect(result.baseRef).toBeUndefined()
+    expect(result.hasIncomingChanges).toBe(true)
+    expect(result.hasOutgoingChanges).toBe(false)
+    expect(result.items.map((item) => item.id)).toEqual([HEAD_OID])
   })
 
   it('clamps oversized limits before shelling out to git log', async () => {

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -183,13 +183,9 @@ export async function loadGitHistoryFromExecutor(
       ? rawBaseRef
       : undefined
 
-  const revisions = Array.from(
-    new Set(
-      [currentRef.revision, remoteRef?.revision, baseRef?.revision].filter(
-        (revision): revision is string => Boolean(revision)
-      )
-    )
-  )
+  // Why: this panel is scoped to the active workspace. Upstream and base refs
+  // stay as comparison metadata so old workspaces do not list newly fetched upstream/base commits.
+  const historyRevisions = [headOid]
 
   let mergeBase: string | undefined
   if (remoteRef?.revision && currentRef.revision && remoteRef.revision !== currentRef.revision) {
@@ -209,7 +205,7 @@ export async function loadGitHistoryFromExecutor(
       '--topo-order',
       '--decorate=full',
       `-n${limit + 1}`,
-      ...revisions
+      ...historyRevisions
     ],
     cwd
   )


### PR DESCRIPTION
## Summary
- Scope the right-sidebar git history log to the active workspace HEAD instead of expanding it with upstream/base revisions.
- Keep upstream/base refs as comparison metadata, and synthesize incoming boundary rows when upstream commits are intentionally omitted from the displayed history.
- Add regression coverage for old workspaces, behind-only branches, and divergent HEAD-only graph histories.
- Fix the PR check Electron package install path so CI can download/verify the Electron binary before tests.

## Investigation
The old workspace report reproduced because the loader resolved HEAD, upstream, and the configured base ref, then passed all resolved revisions to one `git log` call. That made newly fetched upstream/base commits appear as normal graph rows in old workspaces even when the workspace branch had not moved.

Auto-review then caught a follow-up graph issue: once upstream commits are omitted, the graph can no longer infer the incoming lane from remote-only commits. The PR now preserves the visual incoming boundary by synthesizing that lane from comparison metadata.

Internal issue: stablyai/orca-internal#299

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/shared/git-history.test.ts src/shared/git-history-graph.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/main/runtime/rpc/methods/git.test.ts src/main/providers/ssh-git-provider.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with an existing warning in `src/renderer/src/components/browser-pane/browser-automation-visibility.ts`)
- GitHub `verify` check passed on the latest PR head
