### PR TITLE
Fix macOS Option-letter floating terminal shortcut

### DIFF
--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -1252,12 +1252,36 @@ function modifierStateMatches(
   )
 }
 
-function letterKeyMatches(input: KeybindingInput, letter: string): boolean {
+function shouldUseMacOptionLetterPhysicalFallback(
+  parsed: ParsedKeybinding,
+  input: KeybindingInput,
+  platform: NodeJS.Platform
+): boolean {
+  // Why: macOS Option+letter can report composed characters (Option+A -> å),
+  // leaving no logical Latin key for app shortcuts that intentionally use Alt.
+  return (
+    getKeybindingPlatform(platform) === 'darwin' &&
+    parsed.alt &&
+    hasModifier(input, 'alt') &&
+    logicalKeyTokenFromInput(input) === null
+  )
+}
+
+function letterKeyMatches(
+  input: KeybindingInput,
+  letter: string,
+  parsed: ParsedKeybinding,
+  platform: NodeJS.Platform
+): boolean {
   const logicalKey = logicalKeyTokenFromInput(input)
   if (logicalKey && logicalKey.length === 1 && logicalKey >= 'A' && logicalKey <= 'Z') {
     return logicalKey === letter.toUpperCase()
   }
-  return canUsePhysicalCodeFallback(input) && input.code === `Key${letter.toUpperCase()}`
+  return (
+    (canUsePhysicalCodeFallback(input) ||
+      shouldUseMacOptionLetterPhysicalFallback(parsed, input, platform)) &&
+    input.code === `Key${letter.toUpperCase()}`
+  )
 }
 
 function digitKeyMatches(input: KeybindingInput, digit: string): boolean {
@@ -1310,7 +1334,7 @@ function keyMatches(
   platform: NodeJS.Platform
 ): boolean {
   if (parsedKey.length === 1 && parsedKey >= 'A' && parsedKey <= 'Z') {
-    return letterKeyMatches(input, parsedKey)
+    return letterKeyMatches(input, parsedKey, parsed, platform)
   }
   if (parsedKey.length === 1 && parsedKey >= '0' && parsedKey <= '9') {
     return digitKeyMatches(input, parsedKey)

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -373,6 +373,22 @@ describe('resolveWindowShortcutAction', () => {
     ).toEqual({ type: 'toggleFloatingTerminal' })
   })
 
+  it('resolves the floating terminal chord when macOS Option composes the letter', () => {
+    expect(
+      resolveWindowShortcutAction(
+        {
+          code: 'KeyA',
+          key: 'å',
+          meta: true,
+          control: false,
+          alt: true,
+          shift: false
+        },
+        'darwin'
+      )
+    ).toEqual({ type: 'toggleFloatingTerminal' })
+  })
+
   it('rejects floating terminal chord variants with Shift or opposite primary modifier', () => {
     expect(
       resolveWindowShortcutAction(


### PR DESCRIPTION
## Summary
- allow macOS Option-letter shortcuts to fall back to physical key code when Option composes a non-Latin key value
- cover Cmd+Option+A arriving as key=å/code=KeyA for the floating terminal toggle

## Repro / verification
- Reproduced in Electron dev app: OS-level Cmd+Option+A produced key=å/code=KeyA and did not open the floating terminal before the fix
- Verified after fix: same OS-level shortcut opened the floating terminal panel
- pnpm exec vitest run src/shared/window-shortcut-policy.test.ts src/shared/keybindings.test.ts --reporter=dot

Fixes regression from #2867.

Made with [Orca](https://github.com/stablyai/orca) 🐋
