### PR TITLE
Filter plugin-only Codex hooks from runtime mirror

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -252,6 +252,89 @@ describe('CodexHookService', () => {
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
   })
 
+  it('skips plugin-placeholder system hooks when mirroring into runtime CODEX_HOME', () => {
+    const pluginCommands = [
+      'node "${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.mjs"',
+      'node "${CLAUDE_PLUGIN_DATA}/scripts/on-stop.mjs"',
+      'node "${PLUGIN_ROOT}/scripts/on-stop.mjs"',
+      'node "${PLUGIN_DATA}/scripts/on-stop.mjs"'
+    ]
+    const userCommand = 'user-stop-hook'
+    const stopEventLabel = 'stop' as const
+    const systemCodexHome = join(tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify(
+        {
+          hooks: {
+            Stop: [
+              {
+                hooks: [
+                  ...pluginCommands.map((command) => ({ type: 'command', command })),
+                  { type: 'command', command: userCommand }
+                ]
+              }
+            ],
+            PreCompact: pluginCommands.map((command) => ({
+              hooks: [{ type: 'command', command }]
+            }))
+          }
+        },
+        null,
+        2
+      )}\n`,
+      'utf-8'
+    )
+    writeFileSync(
+      join(systemCodexHome, 'config.toml'),
+      upsertHookTrustEntriesInContent('model = "system-model"\n', [
+        ...pluginCommands.map((command, handlerIndex) => ({
+          sourcePath: systemHooksPath,
+          eventLabel: stopEventLabel,
+          groupIndex: 0,
+          handlerIndex,
+          command
+        })),
+        {
+          sourcePath: systemHooksPath,
+          eventLabel: stopEventLabel,
+          groupIndex: 0,
+          handlerIndex: pluginCommands.length,
+          command: userCommand
+        }
+      ]),
+      'utf-8'
+    )
+
+    expect(new CodexHookService().install().state).toBe('installed')
+
+    const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+    const managedHooksPath = join(managedCodexHome, 'hooks.json')
+    const runtimeHooksText = readFileSync(managedHooksPath, 'utf-8')
+    const runtimeHooks = JSON.parse(runtimeHooksText) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+    const stopCommands =
+      runtimeHooks.hooks.Stop?.flatMap(
+        (definition) => definition.hooks?.map((hook) => hook.command ?? '') ?? []
+      ) ?? []
+
+    expect(stopCommands).toContain(userCommand)
+    expect(stopCommands.some((command) => command.includes('codex-hook'))).toBe(true)
+    expect(runtimeHooks.hooks.PreCompact).toBeUndefined()
+    for (const command of pluginCommands) {
+      expect(runtimeHooksText).not.toContain(command)
+    }
+
+    const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
+    for (const command of pluginCommands) {
+      expect(runtimeToml).not.toContain(command)
+    }
+  })
+
   it('mirrors compact-event user hook approvals and disabled trust entries', () => {
     const systemCodexHome = join(tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -82,6 +82,13 @@ const CODEX_HOOK_EVENT_LABEL: Record<string, CodexEventLabel> = {
   PostCompact: 'post_compact'
 }
 
+const CODEX_PLUGIN_ONLY_HOOK_PLACEHOLDERS = [
+  '${CLAUDE_PLUGIN_ROOT}',
+  '${CLAUDE_PLUGIN_DATA}',
+  '${PLUGIN_ROOT}',
+  '${PLUGIN_DATA}'
+] as const
+
 const LEGACY_ORCA_PROFILE_NAME = 'orca-agent-status'
 const LEGACY_ORCA_PROFILE_BLOCK_START = '# BEGIN ORCA AGENT STATUS HOOKS'
 const LEGACY_ORCA_PROFILE_BLOCK_END = '# END ORCA AGENT STATUS HOOKS'
@@ -223,6 +230,20 @@ function getTrustSignature(entry: CodexTrustEntry): string {
   })
 }
 
+function commandUsesCodexPluginOnlyPlaceholder(command: string | undefined): boolean {
+  return (
+    typeof command === 'string' &&
+    CODEX_PLUGIN_ONLY_HOOK_PLACEHOLDERS.some((placeholder) => command.includes(placeholder))
+  )
+}
+
+function removeCodexPluginEnvironmentCommands(definitions: HookDefinition[]): HookDefinition[] {
+  // Why: Orca mirrors system hooks into a plain runtime hooks.json. Plugin
+  // placeholders only work for Codex plugin hook sources, so copying those
+  // commands here strips the environment they require and turns them into 127s.
+  return removeManagedCommands(definitions, commandUsesCodexPluginOnlyPlaceholder)
+}
+
 function getRuntimeHooksWithSystemUserHooks(
   runtimeHooks: Record<string, HookDefinition[]> | undefined,
   isManagedCommand: (command: string | undefined) => boolean
@@ -252,7 +273,9 @@ function getRuntimeHooksWithSystemUserHooks(
       continue
     }
 
-    const systemUserDefinitions = removeManagedCommands(systemDefinitions, isManagedCommand)
+    const systemUserDefinitions = removeCodexPluginEnvironmentCommands(
+      removeManagedCommands(systemDefinitions, isManagedCommand)
+    )
     if (systemUserDefinitions.length === 0) {
       continue
     }


### PR DESCRIPTION
## Summary

Filters Codex plugin-only placeholder hook commands when Orca mirrors system hooks into the managed runtime `CODEX_HOME`.

This preserves ordinary user hooks and Orca-managed runtime hooks, while avoiding copied `${CLAUDE_PLUGIN_ROOT}` / `${PLUGIN_ROOT}` style commands that only have meaning inside Codex plugin hook sources and fail when run from the plain runtime hooks file.

## Screenshots

No visual change.

## Testing

- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:

- [x] `git diff --check`
- [x] `pnpm vitest run --config config/vitest.config.ts src/main/codex/hook-service.test.ts`
- [x] Launched this exact worktree in Electron and verified `window.api.app.getIdentity()` pointed at `brennanb2025/codex-warp-hook`
- [x] Used `demo-project` with an isolated Orca profile and isolated HOME
- [x] Seeded system `~/.codex/hooks.json` with plugin-placeholder hooks plus a normal user hook
- [x] Verified managed runtime `hooks.json` dropped plugin-placeholder commands, preserved the normal user hook, and preserved Orca `codex-hook` commands
- [x] Spawned interactive `codex` TUI successfully; no plugin-placeholder hook failure
- [x] Spawned interactive `claude` TUI successfully and exited cleanly

## AI Review Report

Reviewed the fix direction against the investigation doc and kept the change scoped to the local managed-runtime mirror path. The main regression risks checked were: accidentally dropping normal user hooks, accidentally dropping Orca-managed hooks, trust-entry drift between `hooks.json` and `config.toml`, and affecting SSH/remote installation paths.

The implementation filters only commands containing known Codex plugin-only placeholders after removing Orca-managed commands. Cross-platform compatibility was checked: the new logic is string filtering only, does not add shell-specific syntax, does not change existing Windows `.cmd` vs POSIX `.sh` managed hook behavior, and leaves SSH remote installation untouched.

## Security Audit

Reviewed command execution and path handling risks. This PR reduces accidental execution of copied plugin-placeholder commands in the runtime hook file and does not add new command execution surfaces. It preserves user-authored non-plugin hooks and existing trust handling, while ensuring filtered plugin commands are not copied into runtime trust entries. No auth, secret, dependency, IPC, or provider-specific API behavior is added.

## Notes

Full `pnpm test` and `pnpm build` were not run; the changed module was covered by focused Vitest plus live Electron validation for both Codex and Claude terminal launches.

Made with [Orca](https://github.com/stablyai/orca) 🐋
