### PR TITLE
Fix Electron package installer download

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
-import { createHash } from 'node:crypto'
 import {
-  createReadStream,
-  createWriteStream,
   existsSync,
   mkdtempSync,
   readdirSync,
@@ -15,8 +12,6 @@ import {
 import { createRequire } from 'node:module'
 import { platform as osPlatform, tmpdir } from 'node:os'
 import { dirname, resolve } from 'node:path'
-import { Readable } from 'node:stream'
-import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
 
 const require = createRequire(import.meta.url)
@@ -24,25 +19,35 @@ const projectDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const electronPackageDir = resolve(projectDir, 'node_modules/electron')
 const electronRequire = createRequire(resolve(electronPackageDir, 'package.json'))
 const { version: electronVersion } = electronRequire('./package.json')
+const { downloadArtifact } = electronRequire('@electron/get')
 const extract = electronRequire('extract-zip')
 const platformPath = getElectronPlatformPath()
 
-if (electronPackageLoads()) {
-  process.exit(0)
-}
-
-// Why: PR tests run under system Node after native modules are rebuilt for
-// Node. Install only Electron's npm package binary here; do not run the full
-// Electron native-module rebuild path, which would undo the Node ABI rebuild.
-console.log('[electron-package] Electron package binary is missing; running Electron install.')
-await installElectronPackageBinary()
-
-repairElectronPathFile()
-
-if (!electronPackageLoads()) {
+main().catch((error) => {
+  console.error('[electron-package] Failed to install Electron package binary.')
+  console.error(error)
   logElectronInstallDiagnostics()
-  console.error('[electron-package] Electron package is still unavailable after install.')
   process.exit(1)
+})
+
+async function main() {
+  if (electronPackageLoads()) {
+    return
+  }
+
+  // Why: PR tests run under system Node after native modules are rebuilt for
+  // Node. Install only Electron's npm package binary here; do not run the full
+  // Electron native-module rebuild path, which would undo the Node ABI rebuild.
+  console.log('[electron-package] Electron package binary is missing; running Electron install.')
+  await installElectronPackageBinary()
+
+  repairElectronPathFile()
+
+  if (!electronPackageLoads()) {
+    logElectronInstallDiagnostics()
+    console.error('[electron-package] Electron package is still unavailable after install.')
+    process.exit(1)
+  }
 }
 
 function electronPackageLoads() {
@@ -76,13 +81,18 @@ function repairElectronPathFile() {
 
 async function installElectronPackageBinary() {
   const electronDistDir = resolve(electronPackageDir, 'dist')
-  const artifactName = getElectronArtifactName()
   const tempDir = mkdtempSync(resolve(tmpdir(), 'orca-electron-'))
-  const zipPath = resolve(tempDir, artifactName)
 
   try {
-    await downloadElectronArtifact(artifactName, zipPath)
-    await verifyElectronArtifactChecksum(artifactName, zipPath)
+    const zipPath = await downloadArtifact({
+      version: electronVersion,
+      artifactName: 'electron',
+      platform: process.env.npm_config_platform || osPlatform(),
+      arch: process.env.npm_config_arch || process.arch,
+      force: true,
+      tempDirectory: tempDir,
+      ...(shouldUseRemoteChecksums() ? {} : { checksums: electronRequire('./checksums.json') })
+    })
 
     rmSync(electronDistDir, { recursive: true, force: true })
     await extract(zipPath, { dir: electronDistDir })
@@ -96,54 +106,11 @@ async function installElectronPackageBinary() {
   }
 }
 
-async function downloadElectronArtifact(artifactName, zipPath) {
-  const artifactUrl = new URL(`v${electronVersion}/${artifactName}`, getElectronReleaseBaseUrl())
-  console.log(`[electron-package] Downloading ${artifactUrl}`)
-
-  const response = await fetch(artifactUrl)
-  if (!response.ok) {
-    throw new Error(`Failed to download ${artifactName}: ${response.status} ${response.statusText}`)
-  }
-  if (!response.body) {
-    throw new Error(`Failed to download ${artifactName}: empty response body`)
-  }
-
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(zipPath))
-}
-
-async function verifyElectronArtifactChecksum(artifactName, zipPath) {
-  if (
+function shouldUseRemoteChecksums() {
+  return Boolean(
     process.env.electron_use_remote_checksums ||
     process.env.npm_config_electron_use_remote_checksums
-  ) {
-    return
-  }
-
-  const expected = electronRequire('./checksums.json')[artifactName]
-  if (!expected) {
-    throw new Error(`Missing Electron checksum for ${artifactName}`)
-  }
-
-  const hash = createHash('sha256')
-  for await (const chunk of createReadStream(zipPath)) {
-    hash.update(chunk)
-  }
-  const actual = hash.digest('hex')
-  if (actual !== expected) {
-    throw new Error(`Checksum mismatch for ${artifactName}: expected ${expected}, got ${actual}`)
-  }
-}
-
-function getElectronArtifactName() {
-  return `electron-v${electronVersion}-${process.env.npm_config_platform || osPlatform()}-${
-    process.env.npm_config_arch || process.arch
-  }.zip`
-}
-
-function getElectronReleaseBaseUrl() {
-  const configuredMirror = process.env.ELECTRON_MIRROR || process.env.npm_config_electron_mirror
-  const baseUrl = configuredMirror || 'https://github.com/electron/electron/releases/download/'
-  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+  )
 }
 
 function logElectronInstallDiagnostics() {


### PR DESCRIPTION
## Summary
- replace the PR Electron installer's native fetch pipeline with Electron's package downloader
- wrap installer execution in an explicit async main error boundary so Node 24 does not exit on unsettled top-level await
- keep checksum validation using Electron's bundled checksums unless remote checksum mode is configured

## Test plan
- pnpm exec oxfmt --check config/scripts/install-electron-package-binary.mjs
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs
- forced missing path.txt and ran node config/scripts/install-electron-package-binary.mjs, then verified require('electron') loads

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.