### PR TITLE
Align incoming git graph boundary lanes

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -11,7 +11,7 @@ import {
 } from 'node:fs'
 import { createRequire } from 'node:module'
 import { platform as osPlatform, tmpdir } from 'node:os'
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const require = createRequire(import.meta.url)
@@ -31,7 +31,7 @@ main().catch((error) => {
 })
 
 async function main() {
-  if (electronPackageLoads()) {
+  if (electronPackageIsUsable()) {
     return
   }
 
@@ -39,24 +39,36 @@ async function main() {
   // Node. Install only Electron's npm package binary here; do not run the full
   // Electron native-module rebuild path, which would undo the Node ABI rebuild.
   console.log('[electron-package] Electron package binary is missing; running Electron install.')
+  resetPartialElectronInstall()
   await installElectronPackageBinary()
 
   repairElectronPathFile()
 
-  if (!electronPackageLoads()) {
+  if (!electronPackageIsUsable()) {
     logElectronInstallDiagnostics()
     console.error('[electron-package] Electron package is still unavailable after install.')
     process.exit(1)
   }
 }
 
-function electronPackageLoads() {
+function electronPackageIsUsable() {
   try {
-    require('electron')
-    return true
+    const electronPath = resolveElectronPath()
+    return existsSync(electronPath)
   } catch {
     return false
   }
+}
+
+function resolveElectronPath() {
+  const electronModulePath = require.resolve('electron')
+  delete require.cache[electronModulePath]
+  return require('electron')
+}
+
+function resetPartialElectronInstall() {
+  rmSync(resolve(electronPackageDir, 'dist'), { recursive: true, force: true })
+  rmSync(resolve(electronPackageDir, 'path.txt'), { force: true })
 }
 
 function repairElectronPathFile() {
@@ -82,6 +94,7 @@ function repairElectronPathFile() {
 async function installElectronPackageBinary() {
   const electronDistDir = resolve(electronPackageDir, 'dist')
   const tempDir = mkdtempSync(resolve(tmpdir(), 'orca-electron-'))
+  const cacheRoot = join(tempDir, 'cache')
 
   try {
     const zipPath = await downloadArtifact({
@@ -89,6 +102,7 @@ async function installElectronPackageBinary() {
       artifactName: 'electron',
       platform: process.env.npm_config_platform || osPlatform(),
       arch: process.env.npm_config_arch || process.arch,
+      cacheRoot,
       force: true,
       tempDirectory: tempDir,
       ...(shouldUseRemoteChecksums() ? {} : { checksums: electronRequire('./checksums.json') })

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -1,0 +1,142 @@
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const sourceScriptPath = fileURLToPath(
+  new URL('./install-electron-package-binary.mjs', import.meta.url)
+)
+
+describe('install-electron-package-binary', () => {
+  it('installs Electron from an isolated cache and repairs path.txt', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir)
+      writeFakeExtractZip(projectDir, { createExecutable: true })
+
+      const result = runInstallScript(projectDir)
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(readFileSync(join(projectDir, 'electron-get.log'), 'utf8')).toMatch(
+        /cacheRoot=.*orca-electron-.*cache/
+      )
+      expect(readFileSync(join(projectDir, 'node_modules', 'electron', 'path.txt'), 'utf8')).toBe(
+        'electron'
+      )
+      expect(result.stdout).toContain('Repaired Electron path.txt -> electron')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('fails instead of silently accepting a partial Electron extract', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir)
+      writeFakeExtractZip(projectDir, { createExecutable: false })
+      mkdirSync(join(projectDir, 'node_modules', 'electron', 'dist', 'locales'), {
+        recursive: true
+      })
+      writeFileSync(join(projectDir, 'node_modules', 'electron', 'path.txt'), 'stale-path')
+
+      const result = runInstallScript(projectDir)
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Electron package is still unavailable after install')
+      expect(result.stderr).toContain('distEntries=locales')
+      expect(result.stderr).toContain('pathFile=')
+      expect(result.stderr).toContain('exists=false')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+})
+
+function mkTempProject() {
+  const projectDir = mkdtempSync(join(tmpdir(), 'orca-install-electron-'))
+  mkdirSync(join(projectDir, 'config', 'scripts'), { recursive: true })
+  copyFileSync(
+    sourceScriptPath,
+    join(projectDir, 'config', 'scripts', 'install-electron-package-binary.mjs')
+  )
+  return projectDir
+}
+
+function runInstallScript(projectDir) {
+  return spawnSync(process.execPath, ['config/scripts/install-electron-package-binary.mjs'], {
+    cwd: projectDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_platform: 'linux',
+      npm_config_arch: 'x64'
+    }
+  })
+}
+
+function writeFakeElectronPackage(projectDir) {
+  const electronDir = join(projectDir, 'node_modules', 'electron')
+  mkdirSync(electronDir, { recursive: true })
+  writeFileSync(
+    join(electronDir, 'package.json'),
+    JSON.stringify({ name: 'electron', version: '41.5.0' })
+  )
+  writeFileSync(join(electronDir, 'checksums.json'), '{}')
+  writeFileSync(
+    join(electronDir, 'index.js'),
+    `
+const fs = require('node:fs')
+const path = require('node:path')
+const pathFile = path.join(__dirname, 'path.txt')
+if (!fs.existsSync(pathFile)) {
+  throw new Error('Electron failed to install correctly, please delete node_modules/electron and try installing again')
+}
+module.exports = path.join(__dirname, 'dist', fs.readFileSync(pathFile, 'utf8'))
+`
+  )
+}
+
+function writeFakeElectronGet(projectDir) {
+  const getDir = join(projectDir, 'node_modules', 'electron', 'node_modules', '@electron', 'get')
+  mkdirSync(getDir, { recursive: true })
+  writeFileSync(
+    join(getDir, 'index.js'),
+    `
+const { mkdirSync, writeFileSync, appendFileSync } = require('node:fs')
+const { join } = require('node:path')
+exports.downloadArtifact = async function downloadArtifact(details) {
+  appendFileSync('electron-get.log', 'cacheRoot=' + details.cacheRoot + '\\n')
+  mkdirSync(details.cacheRoot, { recursive: true })
+  const artifactPath = join(details.cacheRoot, 'electron.zip')
+  writeFileSync(artifactPath, 'fake zip')
+  return artifactPath
+}
+`
+  )
+}
+
+function writeFakeExtractZip(projectDir, { createExecutable }) {
+  const extractDir = join(projectDir, 'node_modules', 'electron', 'node_modules', 'extract-zip')
+  mkdirSync(extractDir, { recursive: true })
+  writeFileSync(
+    join(extractDir, 'index.js'),
+    `
+const { mkdirSync, writeFileSync } = require('node:fs')
+const { join } = require('node:path')
+module.exports = async function extract(_zipPath, options) {
+  mkdirSync(join(options.dir, 'locales'), { recursive: true })
+  if (${JSON.stringify(createExecutable)}) {
+    writeFileSync(join(options.dir, 'electron'), '')
+    writeFileSync(join(options.dir, 'version'), 'v41.5.0')
+  }
+}
+`
+  )
+  chmodSync(join(extractDir, 'index.js'), 0o755)
+}

--- a/src/shared/git-history-boundary-rows.ts
+++ b/src/shared/git-history-boundary-rows.ts
@@ -43,10 +43,15 @@ function ensureIncomingRemoteLane(
   // Why: HEAD-only history omits upstream commits, so the graph must still
   // synthesize the remote lane that used to arrive from those hidden rows.
   if (!hasNode(outputSwimlanes, mergeBase, GIT_HISTORY_REMOTE_REF_COLOR)) {
-    if (!hasNode(outputSwimlanes, mergeBase, GIT_HISTORY_REF_COLOR)) {
-      outputSwimlanes.push({ id: mergeBase, color: GIT_HISTORY_REF_COLOR })
-    }
-    outputSwimlanes.push({ id: mergeBase, color: GIT_HISTORY_REMOTE_REF_COLOR })
+    const localMergeBaseIndex = outputSwimlanes.findIndex(
+      (node) => node.id === mergeBase && node.color === GIT_HISTORY_REF_COLOR
+    )
+    const remoteMergeBaseIndex =
+      localMergeBaseIndex === -1 ? inputSwimlanes.length : localMergeBaseIndex + 1
+    outputSwimlanes.splice(remoteMergeBaseIndex, 0, {
+      id: mergeBase,
+      color: GIT_HISTORY_REMOTE_REF_COLOR
+    })
   }
 
   if (hasNode(inputSwimlanes, GIT_HISTORY_INCOMING_CHANGES_ID, GIT_HISTORY_REMOTE_REF_COLOR)) {

--- a/src/shared/git-history-graph.test.ts
+++ b/src/shared/git-history-graph.test.ts
@@ -146,6 +146,12 @@ describe('git history graph model', () => {
       id: 'B',
       color: GIT_HISTORY_REMOTE_REF_COLOR
     })
+    const incomingLaneIndex = viewModels[0]!.inputSwimlanes.findIndex(
+      (node) => node.id === GIT_HISTORY_INCOMING_CHANGES_ID
+    )
+    expect(viewModels[0]!.outputSwimlanes[incomingLaneIndex]?.color).toBe(
+      GIT_HISTORY_REMOTE_REF_COLOR
+    )
   })
 
   it('colors incoming boundary lanes as remote when upstream commits are omitted', () => {
@@ -181,6 +187,12 @@ describe('git history graph model', () => {
       id: 'B',
       color: GIT_HISTORY_REMOTE_REF_COLOR
     })
+    const incomingLaneIndex = viewModels[2]!.inputSwimlanes.findIndex(
+      (node) => node.id === GIT_HISTORY_INCOMING_CHANGES_ID
+    )
+    expect(viewModels[2]!.outputSwimlanes[incomingLaneIndex]?.color).toBe(
+      GIT_HISTORY_REMOTE_REF_COLOR
+    )
   })
 
   it('assigns stable colors to current, remote, and base refs', () => {


### PR DESCRIPTION
## Summary
- Align the synthesized incoming boundary input lane with the remote merge-base output lane.
- Add assertions that HEAD-only incoming boundaries render on the remote-colored lane.
- Harden the PR Electron package binary installer so partial installs/cache state cannot pass silently before `pnpm test`.

## Context
Follow-up from auto-review on #2919. After upstream-only commits were hidden from the right-sidebar history, the graph synthesizes incoming boundary lanes from comparison metadata. The follow-up review found that behind-only histories could place the incoming input lane and remote output lane at different indexes, disconnecting the visual lane.

While validating this follow-up, CI still failed in the Electron package install path on latest `main`. This PR now also hardens that installer with an isolated download cache, partial-install reset, executable-path verification, and direct regression coverage.

Internal issue: stablyai/orca-internal#299

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/shared/git-history-graph.test.ts src/shared/git-history.test.ts`
- `pnpm vitest run --config config/vitest.config.ts config/scripts/install-electron-package-binary.test.mjs`
- `node config/scripts/install-electron-package-binary.mjs && node -e "const fs=require('fs'); const electron=require('electron'); if (!fs.existsSync(electron)) { throw new Error('missing electron executable: '+electron) } console.log(electron)"`
- `pnpm typecheck`
- `pnpm lint`
