### PR TITLE
fix: require explicit scope for orchestration.reset (#2924)

### DIFF
--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+// Why: isolate the handler's flag-to-param mapping; printResult only writes output.
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+
+describe('orchestration reset CLI handler', () => {
+  beforeEach(() => {
+    callMock.mockReset().mockResolvedValue({ result: { reset: 'all' } })
+  })
+
+  const invoke = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration reset']({
+      flags,
+      client: { call: callMock },
+      json: true
+    } as never)
+
+  it('sends all: true for a bare `reset` (no scope flag)', async () => {
+    await invoke(new Map())
+    expect(callMock).toHaveBeenCalledWith('orchestration.reset', {
+      all: true,
+      tasks: undefined,
+      messages: undefined
+    })
+  })
+
+  it('sends only the tasks scope for --tasks', async () => {
+    await invoke(new Map([['tasks', true]]))
+    expect(callMock).toHaveBeenCalledWith('orchestration.reset', {
+      all: undefined,
+      tasks: true,
+      messages: undefined
+    })
+  })
+
+  it('sends only the all scope for --all (no implicit extra scopes)', async () => {
+    await invoke(new Map([['all', true]]))
+    expect(callMock).toHaveBeenCalledWith('orchestration.reset', {
+      all: true,
+      tasks: undefined,
+      messages: undefined
+    })
+  })
+})

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -136,8 +136,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['orchestration', 'reset'],
-    summary: 'Reset orchestration state',
-    usage: 'orca orchestration reset [--all] [--tasks] [--messages] [--json]',
+    summary: 'Reset orchestration state (one scope; bare command resets all)',
+    usage: 'orca orchestration reset [--all | --tasks | --messages] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'all', 'tasks', 'messages']
   }
 ]


### PR DESCRIPTION
## Summary

`orchestration.reset` could wipe **all** tasks and messages when called with no scope. The handler's final branch was an unconditional `db.resetAll()`, so any caller sending `{}` — including a bare `orca orchestration reset` (the CLI passes all-`undefined` when no flag is given) — silently destroyed all orchestration state.

This change makes the RPC contract require **exactly one** scope:

- `ResetParams` now `superRefine`s to reject empty (`{}`) and multiple scopes.
- The dangerous `resetAll()` fallthrough is replaced with a defensive `InvalidArgumentError` (unreachable once the schema holds).
- The CLI now passes `all: true` explicitly for the bare `reset` shortcut, so `orca orchestration reset` still means "reset all" — by intent, not by accidental fallthrough.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (oxlint clean on changed files; pre-commit lint-staged passed)
- [x] `pnpm typecheck` (node + cli configs clean)
- [x] `pnpm test` (orchestration RPC suite: 71 passed, incl. new empty-scope / multi-scope / no-mutation cases)
- [ ] `pnpm build` (not run — change is logic-only, no build-surface impact)
- [x] Added regression tests that fail on the old fallthrough behavior

## AI Review Report

Reviewed for behavior-preservation and blast radius. Main risk checked: breaking the existing `orca orchestration reset` UX. Traced the only caller (CLI handler) and confirmed bare `reset` previously relied on the empty-params fallthrough; preserved that UX explicitly. Confirmed the three single-scope paths (`all`/`tasks`/`messages`) are unchanged. Cross-platform: pure validation/logic in main + CLI, no OS-specific paths, shells, or shortcuts touched. Noted the SSH/remote use case is unaffected (same RPC layer).

## Security Audit

This *hardens* an input-handling footgun: the RPC no longer accepts an under-specified destructive request. Input validation moved into the schema; no command execution, path handling, auth, secrets, or IPC surface changes. No new external input is trusted.

## Notes

Behavior change to flag: passing two scopes at once (e.g. `--tasks --messages`) now errors instead of silently honoring the first. Use `--all` to reset everything.
