### PR TITLE
fix: reject file writes with missing content (#2925)

### DIFF
--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -375,6 +375,25 @@ describe('file RPC methods', () => {
     expect(runtime.writeFileExplorerFileBase64).not.toHaveBeenCalled()
   })
 
+  it('rejects a base64 chunk write with missing content (inherits the schema)', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      writeFileExplorerFileBase64Chunk: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.writeBase64Chunk', {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/video.mov',
+        append: true
+      })
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(runtime.writeFileExplorerFileBase64Chunk).not.toHaveBeenCalled()
+  })
+
   it('commits staged runtime uploads without clobbering the final destination', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -330,16 +330,18 @@ describe('file RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { ok: true } })
   })
 
-  it('rejects a write with missing content instead of truncating the file', async () => {
+  it.each([
+    ['missing content', { worktree: 'id:wt-1', relativePath: 'src/index.ts' }],
+    ['null content', { worktree: 'id:wt-1', relativePath: 'src/index.ts', content: null }],
+    ['non-string content', { worktree: 'id:wt-1', relativePath: 'src/index.ts', content: 0 }]
+  ])('rejects a write with %s instead of truncating the file', async (_name, params) => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       writeFileExplorerFile: vi.fn().mockResolvedValue({ ok: true })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
 
-    const response = await dispatcher.dispatch(
-      makeRequest('files.write', { worktree: 'id:wt-1', relativePath: 'src/index.ts' })
-    )
+    const response = await dispatcher.dispatch(makeRequest('files.write', params))
 
     expect(response).toMatchObject({ ok: false })
     expect(runtime.writeFileExplorerFile).not.toHaveBeenCalled()
@@ -360,7 +362,7 @@ describe('file RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { ok: true } })
   })
 
-  it('rejects a base64 write with missing content', async () => {
+  it('allows writing explicit empty base64 content', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       writeFileExplorerFileBase64: vi.fn().mockResolvedValue({ ok: true })
@@ -368,14 +370,42 @@ describe('file RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
 
     const response = await dispatcher.dispatch(
-      makeRequest('files.writeBase64', { worktree: 'id:wt-1', relativePath: 'assets/logo.png' })
+      makeRequest('files.writeBase64', {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/logo.png',
+        contentBase64: ''
+      })
     )
+
+    expect(runtime.writeFileExplorerFileBase64).toHaveBeenCalledWith(
+      'id:wt-1',
+      'assets/logo.png',
+      ''
+    )
+    expect(response).toMatchObject({ ok: true, result: { ok: true } })
+  })
+
+  it.each([
+    ['missing content', { worktree: 'id:wt-1', relativePath: 'assets/logo.png' }],
+    ['null content', { worktree: 'id:wt-1', relativePath: 'assets/logo.png', contentBase64: null }],
+    [
+      'non-string content',
+      { worktree: 'id:wt-1', relativePath: 'assets/logo.png', contentBase64: 0 }
+    ]
+  ])('rejects a base64 write with %s', async (_name, params) => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      writeFileExplorerFileBase64: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('files.writeBase64', params))
 
     expect(response).toMatchObject({ ok: false })
     expect(runtime.writeFileExplorerFileBase64).not.toHaveBeenCalled()
   })
 
-  it('rejects a base64 chunk write with missing content (inherits the schema)', async () => {
+  it('allows writing an explicit empty base64 chunk', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       writeFileExplorerFileBase64Chunk: vi.fn().mockResolvedValue({ ok: true })
@@ -386,9 +416,55 @@ describe('file RPC methods', () => {
       makeRequest('files.writeBase64Chunk', {
         worktree: 'id:wt-1',
         relativePath: 'assets/video.mov',
+        contentBase64: '',
         append: true
       })
     )
+
+    expect(runtime.writeFileExplorerFileBase64Chunk).toHaveBeenCalledWith(
+      'id:wt-1',
+      'assets/video.mov',
+      '',
+      true
+    )
+    expect(response).toMatchObject({ ok: true, result: { ok: true } })
+  })
+
+  it.each([
+    [
+      'missing content',
+      {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/video.mov',
+        append: true
+      }
+    ],
+    [
+      'null content',
+      {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/video.mov',
+        contentBase64: null,
+        append: true
+      }
+    ],
+    [
+      'non-string content',
+      {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/video.mov',
+        contentBase64: 0,
+        append: true
+      }
+    ]
+  ])('rejects a base64 chunk write with %s (inherits the schema)', async (_name, params) => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      writeFileExplorerFileBase64Chunk: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('files.writeBase64Chunk', params))
 
     expect(response).toMatchObject({ ok: false })
     expect(runtime.writeFileExplorerFileBase64Chunk).not.toHaveBeenCalled()

--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -330,6 +330,51 @@ describe('file RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { ok: true } })
   })
 
+  it('rejects a write with missing content instead of truncating the file', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      writeFileExplorerFile: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.write', { worktree: 'id:wt-1', relativePath: 'src/index.ts' })
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(runtime.writeFileExplorerFile).not.toHaveBeenCalled()
+  })
+
+  it('still allows writing an explicit empty string (empty file)', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      writeFileExplorerFile: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.write', { worktree: 'id:wt-1', relativePath: 'src/index.ts', content: '' })
+    )
+
+    expect(runtime.writeFileExplorerFile).toHaveBeenCalledWith('id:wt-1', 'src/index.ts', '')
+    expect(response).toMatchObject({ ok: true, result: { ok: true } })
+  })
+
+  it('rejects a base64 write with missing content', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      writeFileExplorerFileBase64: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.writeBase64', { worktree: 'id:wt-1', relativePath: 'assets/logo.png' })
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(runtime.writeFileExplorerFileBase64).not.toHaveBeenCalled()
+  })
+
   it('commits staged runtime uploads without clobbering the final destination', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -30,18 +30,19 @@ const FileTreePath = WorktreeSelector.extend({
     .pipe(z.string())
 })
 
+// Why: write content must be a real string. Coercing a missing/non-string value
+// to '' silently truncated the target file to empty instead of erroring. An
+// explicit '' is still accepted (writing an empty file is legitimate).
 const FileWrite = FileOpen.extend({
   content: z
     .unknown()
-    .transform((v) => (typeof v === 'string' ? v : ''))
-    .pipe(z.string())
+    .refine((v): v is string => typeof v === 'string', { message: 'Missing file content' })
 })
 
 const FileWriteBase64 = FileOpen.extend({
   contentBase64: z
     .unknown()
-    .transform((v) => (typeof v === 'string' ? v : ''))
-    .pipe(z.string())
+    .refine((v): v is string => typeof v === 'string', { message: 'Missing file content' })
 })
 
 const FileWriteBase64Chunk = FileWriteBase64.extend({


### PR DESCRIPTION
## Summary

`files.write` and `files.writeBase64` coerced a missing or non-string `content` to an empty string and wrote it — silently truncating the target file to empty instead of rejecting the request. A malformed RPC (e.g. `{ worktree, relativePath }` with no `content`, or `content: null`) destroyed the file's contents.

The write-content schemas now require a real string. An explicit empty string is still accepted (writing an empty file is legitimate); only missing/non-string values are rejected. `files.writeBase64Chunk` inherits the fix via its base schema.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (oxlint clean; pre-commit lint-staged passed)
- [x] `pnpm typecheck` (node config clean; the `refine` type-guard narrows `content` to `string`)
- [x] `pnpm test` (files RPC suite: 22 passed, incl. new missing-content rejection, explicit-empty-string allow, and base64 missing-content cases)
- [ ] `pnpm build` (not run — schema-only change)
- [x] Added regression tests

## AI Review Report

Main risk checked: regressing the legitimate "write an empty file" case. Preserved it — the fix distinguishes an explicit `''` (valid) from missing/non-string (rejected) via a type-guard `refine` rather than a coercion. Confirmed the three write methods share the base schemas and all benefit. Cross-platform: pure schema validation in main, no paths/shell/shortcuts. SSH/remote writes go through the same RPC and are equally protected.

## Security Audit

Tightens input validation on a destructive operation (file write). No command execution, auth, secrets, or new IPC surface. Did not add base64-format validation for `contentBase64` (out of scope; would need care to avoid rejecting valid payloads) — flagged for a possible follow-up.

## Notes

Behavior change: a write request omitting `content` now returns an `invalid_argument` error instead of silently writing an empty file.
