### PR TITLE
Fix onboarding skip confirmation portal clicks

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -14,6 +14,7 @@ import { OnboardingTourStep } from './OnboardingTourStep'
 import { STEPS, useOnboardingFlow } from './use-onboarding-flow'
 import { OnboardingSkipConfirmationDialog } from './OnboardingSkipConfirmationDialog'
 import { OnboardingFooter } from './OnboardingFooter'
+import { shouldRequestOnboardingSkipConfirmation } from './onboarding-dismiss-target'
 import logo from '../../../../../resources/logo.svg'
 
 const stepCopy = {
@@ -172,11 +173,7 @@ export default function OnboardingFlow({
       className="fixed inset-0 z-[100] flex items-center justify-center overflow-hidden bg-black/50 p-4 text-foreground backdrop-blur-[2px]"
       data-onboarding-overlay
       onPointerDown={(event) => {
-        if (event.button !== 0) {
-          return
-        }
-        const target = event.target
-        if (!(target instanceof Element) || target.closest('[data-onboarding-modal]')) {
+        if (!shouldRequestOnboardingSkipConfirmation(event)) {
           return
         }
         requestSkipConfirmation('button')

--- a/src/renderer/src/components/onboarding/onboarding-dismiss-target.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-dismiss-target.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { shouldRequestOnboardingSkipConfirmation } from './onboarding-dismiss-target'
+
+function createTarget(matchingSelectorFragment: string | null): EventTarget {
+  return {
+    closest: vi.fn((selector: string) => {
+      if (matchingSelectorFragment && selector.includes(matchingSelectorFragment)) {
+        return {}
+      }
+      return null
+    })
+  } as unknown as EventTarget
+}
+
+describe('shouldRequestOnboardingSkipConfirmation', () => {
+  it('requests confirmation for primary clicks outside onboarding UI', () => {
+    expect(shouldRequestOnboardingSkipConfirmation({ button: 0, target: createTarget(null) })).toBe(
+      true
+    )
+  })
+
+  it('ignores non-primary clicks', () => {
+    expect(shouldRequestOnboardingSkipConfirmation({ button: 2, target: createTarget(null) })).toBe(
+      false
+    )
+  })
+
+  it('ignores clicks inside the onboarding modal', () => {
+    expect(
+      shouldRequestOnboardingSkipConfirmation({
+        button: 0,
+        target: createTarget('data-onboarding-modal')
+      })
+    ).toBe(false)
+  })
+
+  it('ignores clicks inside nested Radix dialog portals', () => {
+    expect(
+      shouldRequestOnboardingSkipConfirmation({
+        button: 0,
+        target: createTarget('data-slot="dialog-content"')
+      })
+    ).toBe(false)
+    expect(
+      shouldRequestOnboardingSkipConfirmation({
+        button: 0,
+        target: createTarget('data-slot="dialog-overlay"')
+      })
+    ).toBe(false)
+  })
+
+  it('ignores clicks inside notification sound select content', () => {
+    expect(
+      shouldRequestOnboardingSkipConfirmation({
+        button: 0,
+        target: createTarget('data-slot="select-content"')
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/onboarding/onboarding-dismiss-target.ts
+++ b/src/renderer/src/components/onboarding/onboarding-dismiss-target.ts
@@ -1,0 +1,33 @@
+type OnboardingPointerTarget = EventTarget & {
+  closest: Element['closest']
+}
+
+const ONBOARDING_INTERACTIVE_LAYER_SELECTOR = [
+  '[data-onboarding-modal]',
+  '[data-slot="dialog-content"]',
+  '[data-slot="dialog-overlay"]',
+  '[data-slot="select-content"]',
+  '[data-slot="popover-content"]',
+  '[data-slot="dropdown-menu-content"]',
+  '[data-slot="dropdown-menu-sub-content"]',
+  '[data-slot="context-menu-content"]',
+  '[data-slot="context-menu-sub-content"]',
+  '[data-slot="sheet-content"]',
+  '[data-slot="hover-card-content"]'
+].join(', ')
+
+function hasClosest(target: EventTarget | null): target is OnboardingPointerTarget {
+  return typeof (target as { closest?: unknown } | null)?.closest === 'function'
+}
+
+export function shouldRequestOnboardingSkipConfirmation(event: {
+  button: number
+  target: EventTarget | null
+}): boolean {
+  if (event.button !== 0 || !hasClosest(event.target)) {
+    return false
+  }
+  // Why: Radix portals remain inside the React tree, so their clicks bubble to
+  // the onboarding overlay even when the DOM target lives outside the modal.
+  return !event.target.closest(ONBOARDING_INTERACTIVE_LAYER_SELECTOR)
+}


### PR DESCRIPTION
## Summary
- keep onboarding skip confirmation limited to true backdrop clicks
- treat nested Radix portal layers like Linear dialogs and notification selects as onboarding-owned UI
- add regression coverage for portal/select click targets

Fixes #2917

## Test Plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/onboarding-dismiss-target.test.ts src/renderer/src/components/onboarding/OnboardingFlow.test.tsx src/renderer/src/components/onboarding/NotificationStep.test.tsx
- pnpm lint
- pnpm typecheck
- Electron CDP: verified Linear dialog input and notification sound select stay interactive without opening skip confirmation; verified true backdrop click still opens “Skip onboarding?”