### PR TITLE
fix: stop clone-abort from deleting an unowned destination (#2929)

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -5,6 +5,10 @@ duplicate the hoisted mocks and the `../git/repo` partial-real/partial-stub
 setup. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { EventEmitter } from 'events'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import type * as RepoModule from '../git/repo'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
 
@@ -517,6 +521,50 @@ describe('repos:add + repos:clone', () => {
 
     expect(gitSpawnMock).not.toHaveBeenCalled()
     expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
+  it('cloneAbort does not delete a pre-existing destination directory', async () => {
+    // Real filesystem: a directory the user already owns must survive an abort.
+    const parent = await mkdtemp(join(tmpdir(), 'orca-clone-abort-'))
+    try {
+      const existingRepoDir = join(parent, 'orca')
+      await mkdir(existingRepoDir)
+      const sentinel = join(existingRepoDir, 'keep.txt')
+      await writeFile(sentinel, 'precious')
+
+      // A clone process that stays alive until killed; kill settles the clone
+      // promise the way git does on SIGTERM. Signal when spawn is reached so the
+      // abort only fires once activeCloneProc is set (no setImmediate race).
+      let signalSpawned: () => void
+      const spawned = new Promise<void>((resolve) => {
+        signalSpawned = resolve
+      })
+      gitSpawnMock.mockImplementation(() => {
+        const proc = new EventEmitter() as EventEmitter & {
+          stderr: EventEmitter
+          kill: () => void
+        }
+        proc.stderr = new EventEmitter()
+        proc.kill = () => proc.emit('close', null, 'SIGTERM')
+        signalSpawned()
+        return proc
+      })
+
+      const clonePromise = handlers.get('repos:clone')!(null, {
+        url: 'https://example.com/orca.git',
+        destination: parent
+      })
+      const settled = expect(clonePromise).rejects.toThrow('Clone aborted')
+      await spawned
+
+      await handlers.get('repos:cloneAbort')!(null, undefined)
+      await settled
+
+      // The pre-existing directory and its contents must be untouched.
+      expect(existsSync(sentinel)).toBe(true)
+    } finally {
+      await rm(parent, { recursive: true, force: true })
+    }
   })
 })
 

--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -497,6 +497,27 @@ describe('repos:add + repos:clone', () => {
     expect(result).toHaveProperty('badgeColor', '#8b5cf6')
     expect(mockStore.addRepo).not.toHaveBeenCalled()
   })
+
+  it('rejects a clone whose derived directory name resolves to the destination', async () => {
+    // basename(...) === '.', so clonePath would be the destination itself; abort
+    // cleanup must never be able to rm the user's chosen directory.
+    await expect(
+      handlers.get('repos:clone')!(null, { url: 'file:///tmp/source/.', destination: '/tmp' })
+    ).rejects.toThrow('valid repository directory name')
+
+    expect(gitSpawnMock).not.toHaveBeenCalled()
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
+  it('rejects a clone whose derived directory name escapes the destination', async () => {
+    // basename(...) === '..', so clonePath would be the destination's parent.
+    await expect(
+      handlers.get('repos:clone')!(null, { url: 'https://example.com/..', destination: '/tmp' })
+    ).rejects.toThrow('valid repository directory name')
+
+    expect(gitSpawnMock).not.toHaveBeenCalled()
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
 })
 
 describe('repos:getBaseRefDefault envelope', () => {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -698,11 +698,13 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
       // Why: record whether the clone target already existed so abort cleanup
       // never removes a pre-existing user directory (only one this clone made).
+      // Only ENOENT proves the path is absent; any other error (e.g. EACCES) is
+      // treated as "not ours to remove" so abort never deletes an unowned path.
       let cloneCreatedDir = false
       try {
         await access(clonePath)
-      } catch {
-        cloneCreatedDir = true
+      } catch (err) {
+        cloneCreatedDir = (err as NodeJS.ErrnoException).code === 'ENOENT'
       }
 
       // Why: use spawn instead of execFile so there is no maxBuffer limit.

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -19,7 +19,7 @@ import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'child_process'
 import { access, mkdir, readdir, rm } from 'fs/promises'
 import { gitExecFileAsync, gitSpawn } from '../git/runner'
-import { basename, isAbsolute, join } from 'path'
+import { basename, dirname, isAbsolute, join, resolve } from 'path'
 import {
   isGitRepo,
   getGitUsername,
@@ -67,7 +67,10 @@ function emitRepoAdded(method: RepoMethod, alreadyExisted: boolean): void {
 // registerRepoHandlers is called again when a new BrowserWindow is created,
 // and a function-scoped variable would lose the reference to an in-flight clone.
 let activeCloneProc: ChildProcess | null = null
-let activeClonePath: string | null = null
+// Why: only a directory THIS clone created may be removed on abort — never a
+// pre-existing directory the user owns. Set only when the clone target did not
+// exist before the clone started.
+let activeCloneRemovablePath: string | null = null
 
 export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): void {
   // Remove any previously registered handlers so we can re-register them
@@ -646,10 +649,14 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
   ipcMain.handle('repos:cloneAbort', async () => {
     if (activeCloneProc) {
-      const pathToClean = activeClonePath
+      // Why: only remove a directory this clone created — never a pre-existing
+      // path the user owns (e.g. when the derived name collided with an existing
+      // empty dir). The strict-child validation in repos:clone already prevents
+      // the destination itself or a parent from ever becoming the clone target.
+      const pathToClean = activeCloneRemovablePath
       activeCloneProc.kill()
       activeCloneProc = null
-      activeClonePath = null
+      activeCloneRemovablePath = null
       // Why: git clone creates the target directory before it finishes.
       // Without cleanup, retrying the same URL/destination fails with
       // "destination path already exists and is not an empty directory".
@@ -672,11 +679,31 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       if (!repoName) {
         throw new Error('Could not determine repository name from URL')
       }
+      const clonePath = join(args.destination, repoName)
+      // Why: a URL whose basename is '.', '..', or contains separators could make
+      // clonePath resolve to the destination itself or escape it. Abort cleanup
+      // would then rm a directory the user owns. Require a strict child directory.
+      const resolvedDestination = resolve(args.destination)
+      const resolvedClonePath = resolve(clonePath)
+      if (
+        resolvedClonePath === resolvedDestination ||
+        dirname(resolvedClonePath) !== resolvedDestination
+      ) {
+        throw new Error('Could not determine a valid repository directory name from URL')
+      }
       // Why: gitSpawn uses args.destination as cwd, so it must exist before
       // spawn — fresh installs may have a defaulted parent dir that does not
       // exist yet (e.g. ~/orca). recursive: true is a no-op when present.
       await mkdir(args.destination, { recursive: true })
-      const clonePath = join(args.destination, repoName)
+
+      // Why: record whether the clone target already existed so abort cleanup
+      // never removes a pre-existing user directory (only one this clone made).
+      let cloneCreatedDir = false
+      try {
+        await access(clonePath)
+      } catch {
+        cloneCreatedDir = true
+      }
 
       // Why: use spawn instead of execFile so there is no maxBuffer limit.
       // git clone writes progress to stderr which can exceed Node's default
@@ -695,7 +722,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           stdio: ['ignore', 'ignore', 'pipe']
         })
         activeCloneProc = proc
-        activeClonePath = clonePath
+        activeCloneRemovablePath = cloneCreatedDir ? clonePath : null
 
         let stderrTail = ''
         proc.stderr!.on('data', (chunk: Buffer) => {
@@ -726,7 +753,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           // new clone unabortable.
           if (activeCloneProc === proc) {
             activeCloneProc = null
-            activeClonePath = null
+            activeCloneRemovablePath = null
           }
           if (signal === 'SIGTERM') {
             reject(new Error('Clone aborted'))


### PR DESCRIPTION
## Summary

`repos:clone` derived the clone directory from the URL basename (`basename(url.replace(/\.git\/?$/, ''))`) and only guarded against an empty string. A URL whose basename is `.` (e.g. `file:///tmp/source/.`) made `clonePath` equal to the **destination directory itself**; `..` made it the destination's **parent**. `repos:cloneAbort` then ran `rm(clonePath, { recursive: true, force: true })`, recursively deleting a directory the user owns.

Two guards:
1. **Strict-child validation** — the derived clone path must resolve to a direct child of the destination (not the destination itself, not an escape). `.`, `..`, and separator-bearing names are rejected before any filesystem work or spawn.
2. **Ownership-scoped cleanup** — abort now only removes a directory this clone actually created (the target did not exist beforehand), never a pre-existing user directory.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (node config clean)
- [x] `pnpm test` (repos-remote suite: 34 passed, incl. new "resolves to destination" and "escapes destination" rejection cases)
- [ ] `pnpm build` (not run — main-process IPC logic change)
- [x] Added regression tests asserting both bad-name shapes reject before spawn and never add a repo

## AI Review Report

Main risk: rejecting legitimate clone URLs. Validation only rejects names that aren't a strict child of the destination — normal `org/repo.git` → `repo` is unaffected (verified by the existing happy-path clone tests still passing). The ownership check uses `access()` to detect pre-existence before spawn; the happy path (target absent) is unchanged. Confirmed `git clone` already refuses a non-empty existing dir, so the residual ownership concern was an empty pre-existing dir, now also protected. Cross-platform: uses `path.resolve`/`dirname`; no separator assumptions. The `--` URL separator (command-injection guard) is retained.

## Security Audit

Closes a destructive path-handling bug: an abort could `rm -rf` the user's chosen destination or its parent via a crafted/edge-case URL basename. Cleanup is now scoped to clone-created paths and the target is constrained to a child of the destination. No auth/secrets changes; URL is still isolated with `--`.

## Notes

Behavior change: a clone URL that yields a directory name of `.`/`..` (or otherwise not a direct child of the destination) now fails fast with "Could not determine a valid repository directory name from URL" instead of proceeding.
