### PR TITLE
Fix terminal URL click fallback

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -6,12 +6,13 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import {
   createFilePathLinkProvider,
   getTerminalHtmlFileOpenHint,
-  handleOscLink,
   installFilePathLinkClickFallback,
   isTerminalLinkActivation,
   openFilePathLinkAtBufferPosition,
   openDetectedFilePath
 } from './terminal-link-handlers'
+import { handleOscLink } from './terminal-osc-link-routing'
+import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 import { getConnectionId } from '@/lib/connection-context'
 import {
@@ -637,7 +638,8 @@ describe('createFilePathLinkProvider range bounds', () => {
   }
 
   function makeFallbackTerminal(rows: TestBufferLine[]): {
-    terminal: Parameters<typeof installFilePathLinkClickFallback>[1]
+    terminal: Parameters<typeof installFilePathLinkClickFallback>[1] &
+      Parameters<typeof installHttpLinkClickFallback>[0]
     element: {
       addEventListener: ReturnType<typeof vi.fn>
       removeEventListener: ReturnType<typeof vi.fn>
@@ -683,6 +685,16 @@ describe('createFilePathLinkProvider range bounds', () => {
     )
     expect(registration, 'mouseup handler should be registered').toBeDefined()
     expect(registration![2]).toEqual({ capture: true })
+    return registration![1] as (event: MouseEvent) => void
+  }
+
+  function getRegisteredBubbleMouseUpHandler(element: {
+    addEventListener: ReturnType<typeof vi.fn>
+  }): (event: MouseEvent) => void {
+    const registration = element.addEventListener.mock.calls.find(
+      ([eventName, _handler, options]) => eventName === 'mouseup' && options === undefined
+    )
+    expect(registration, 'bubble mouseup handler should be registered').toBeDefined()
     return registration![1] as (event: MouseEvent) => void
   }
 
@@ -843,6 +855,65 @@ describe('createFilePathLinkProvider range bounds', () => {
     expect(openFileMock).not.toHaveBeenCalled()
     expect(preventDefault).not.toHaveBeenCalled()
     expect(stopPropagation).not.toHaveBeenCalled()
+    expect(terminal.clearSelection).not.toHaveBeenCalled()
+
+    disposable.dispose()
+  })
+
+  it('opens regular URLs from a direct modifier-click fallback when xterm did not handle them', async () => {
+    setPlatform('Macintosh')
+    storeState.settings = { openLinksInApp: false }
+    const rows = [
+      makeBufferLine('PR opened: https://github.com/stablyai/orca-marketing-website/pull/82')
+    ]
+    const { terminal, element } = makeFallbackTerminal(rows)
+    const disposable = installHttpLinkClickFallback(terminal, { worktreeId: 'wt-1' })
+    const mouseUp = getRegisteredBubbleMouseUpHandler(element)
+    const preventDefault = vi.fn()
+    const stopPropagation = vi.fn()
+
+    mouseUp({
+      button: 0,
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+      defaultPrevented: false,
+      clientX: 230,
+      clientY: 25,
+      preventDefault,
+      stopPropagation
+    } as unknown as MouseEvent)
+
+    expect(openUrlMock).toHaveBeenCalledWith(
+      'https://github.com/stablyai/orca-marketing-website/pull/82'
+    )
+    expect(preventDefault).toHaveBeenCalled()
+    expect(stopPropagation).not.toHaveBeenCalled()
+    expect(terminal.clearSelection).toHaveBeenCalled()
+
+    disposable.dispose()
+    expect(element.removeEventListener).toHaveBeenCalledWith('mouseup', mouseUp)
+  })
+
+  it('does not double-open URLs when xterm already handled the mouseup', () => {
+    setPlatform('Macintosh')
+    storeState.settings = { openLinksInApp: false }
+    const rows = [makeBufferLine('Open https://github.com/stablyai/orca/pull/2914')]
+    const { terminal, element } = makeFallbackTerminal(rows)
+    const disposable = installHttpLinkClickFallback(terminal, { worktreeId: 'wt-1' })
+    const mouseUp = getRegisteredBubbleMouseUpHandler(element)
+
+    mouseUp({
+      button: 0,
+      metaKey: true,
+      ctrlKey: false,
+      defaultPrevented: true,
+      clientX: 90,
+      clientY: 25,
+      preventDefault: vi.fn()
+    } as unknown as MouseEvent)
+
+    expect(openUrlMock).not.toHaveBeenCalled()
     expect(terminal.clearSelection).not.toHaveBeenCalled()
 
     disposable.dispose()

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -1,13 +1,7 @@
 import type { IDisposable, ILink, ILinkProvider, Terminal } from '@xterm/xterm'
-import {
-  extractTerminalFileLinks,
-  resolveTerminalFileLink,
-  resolveTerminalFileLinkText
-} from '@/lib/terminal-links'
+import { extractTerminalFileLinks, resolveTerminalFileLink } from '@/lib/terminal-links'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { openHttpLink } from '@/lib/http-link-routing'
 import { isRemoteRuntimeFileOperation, runtimePathExists } from '@/runtime/runtime-file-client'
-import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
 import {
   buildCandidateLogicalLinesForBufferPosition,
   dedupeLogicalLines,
@@ -38,9 +32,6 @@ export type LinkHandlerDeps = {
   runtimeEnvironmentId?: string | null
   getRuntimeEnvironmentIdForPane?: (paneId: number) => string | null
 }
-
-type TerminalLinkEvent = Pick<MouseEvent, 'metaKey' | 'ctrlKey'> &
-  Partial<Pick<MouseEvent, 'shiftKey' | 'preventDefault' | 'stopPropagation'>>
 
 type ProvidedFileLink = {
   link: ILink
@@ -274,58 +265,4 @@ export function isTerminalLinkActivation(
 ): boolean {
   const isMac = isMacPlatform()
   return isMac ? Boolean(event?.metaKey) : Boolean(event?.ctrlKey)
-}
-
-export function handleOscLink(
-  rawText: string,
-  event: TerminalLinkEvent | undefined,
-  deps: Pick<LinkHandlerDeps, 'worktreeId' | 'worktreePath'> &
-    Partial<Pick<LinkHandlerDeps, 'runtimeEnvironmentId' | 'startupCwd'>>
-): void {
-  if (!isTerminalLinkActivation(event)) {
-    return
-  }
-
-  // Why: xterm renders URL links as clickable anchors. Once Orca decides to
-  // handle a modified click itself, we must suppress the browser's default
-  // anchor navigation or Electron will still launch the system browser.
-  // Note: we intentionally do NOT stopPropagation here — xterm's
-  // SelectionService listens for mouseup on ownerDocument to clear the
-  // pending drag-select state initiated by the mousedown of the same click.
-  // Stopping propagation leaves SelectionService's mousemove/mouseup handlers
-  // attached, so returning focus to the terminal and moving the mouse (even
-  // without holding a button) extends a selection until the next click/Esc.
-  event?.preventDefault?.()
-
-  let parsed: URL
-  try {
-    parsed = new URL(rawText)
-  } catch {
-    const resolved = resolveTerminalFileLinkText(rawText, deps.startupCwd || deps.worktreePath)
-    if (resolved) {
-      openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, deps)
-    }
-    return
-  }
-
-  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-    openHttpLink(parsed.toString(), {
-      worktreeId: deps.worktreeId,
-      forceSystemBrowser: Boolean(event?.shiftKey)
-    })
-    return
-  }
-
-  if (parsed.protocol === 'file:') {
-    // Why: file:// URIs should open inside Orca, not via the OS default editor
-    // (shell.openPath). We extract the path from the URI and route it through
-    // the same openDetectedFilePath logic used for detected file-path links.
-    // Only local files are supported — remote hosts (file://remote/…) are rejected
-    // because we cannot open them as local paths.
-    const resolved = resolveTerminalFileUrlTarget(parsed)
-    if (!resolved) {
-      return
-    }
-    openDetectedFilePath(resolved.filePath, resolved.line, resolved.column, deps)
-  }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -1,0 +1,63 @@
+import { resolveTerminalFileLinkText } from '@/lib/terminal-links'
+import { openHttpLink } from '@/lib/http-link-routing'
+import type { LinkHandlerDeps } from './terminal-link-handlers'
+import { isTerminalLinkActivation } from './terminal-link-handlers'
+import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
+import { openDetectedFilePath } from './terminal-file-open-routing'
+
+type TerminalLinkEvent = Pick<MouseEvent, 'metaKey' | 'ctrlKey'> &
+  Partial<Pick<MouseEvent, 'shiftKey' | 'preventDefault' | 'stopPropagation'>>
+
+export function handleOscLink(
+  rawText: string,
+  event: TerminalLinkEvent | undefined,
+  deps: Pick<LinkHandlerDeps, 'worktreeId' | 'worktreePath'> &
+    Partial<Pick<LinkHandlerDeps, 'runtimeEnvironmentId' | 'startupCwd'>>
+): void {
+  if (!isTerminalLinkActivation(event)) {
+    return
+  }
+
+  // Why: xterm renders URL links as clickable anchors. Once Orca decides to
+  // handle a modified click itself, we must suppress the browser's default
+  // anchor navigation or Electron will still launch the system browser.
+  // Note: we intentionally do NOT stopPropagation here — xterm's
+  // SelectionService listens for mouseup on ownerDocument to clear the
+  // pending drag-select state initiated by the mousedown of the same click.
+  // Stopping propagation leaves SelectionService's mousemove/mouseup handlers
+  // attached, so returning focus to the terminal and moving the mouse (even
+  // without holding a button) extends a selection until the next click/Esc.
+  event?.preventDefault?.()
+
+  let parsed: URL
+  try {
+    parsed = new URL(rawText)
+  } catch {
+    const resolved = resolveTerminalFileLinkText(rawText, deps.startupCwd || deps.worktreePath)
+    if (resolved) {
+      openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, deps)
+    }
+    return
+  }
+
+  if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+    openHttpLink(parsed.toString(), {
+      worktreeId: deps.worktreeId,
+      forceSystemBrowser: Boolean(event?.shiftKey)
+    })
+    return
+  }
+
+  if (parsed.protocol === 'file:') {
+    // Why: file:// URIs should open inside Orca, not via the OS default editor
+    // (shell.openPath). We extract the path from the URI and route it through
+    // the same openDetectedFilePath logic used for detected file-path links.
+    // Only local files are supported — remote hosts (file://remote/...) are rejected
+    // because we cannot open them as local paths.
+    const resolved = resolveTerminalFileUrlTarget(parsed)
+    if (!resolved) {
+      return
+    }
+    openDetectedFilePath(resolved.filePath, resolved.line, resolved.column, deps)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
@@ -1,0 +1,157 @@
+import type { IBufferLine, IBufferRange, IDisposable, Terminal } from '@xterm/xterm'
+import { openHttpLink } from '@/lib/http-link-routing'
+import { buildCandidateLogicalLinesForBufferPosition } from './terminal-file-link-hit-testing'
+import { rangeForParsedFileLink } from './wrapped-terminal-link-ranges'
+
+type UrlLinkHitTestDeps = {
+  worktreeId: string
+  forceSystemBrowser?: boolean
+}
+
+type UrlLinkClickFallbackDeps = {
+  worktreeId: string
+}
+
+type ParsedTerminalHttpLink = {
+  url: string
+  startIndex: number
+  endIndex: number
+}
+
+// Mirrors @xterm/addon-web-links' strict URL matcher so fallback clicks use
+// the same visible URL span as xterm's hover-time WebLinksAddon provider.
+const TERMINAL_HTTP_URL_REGEX = /\bhttps?:\/\/[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/gi
+
+function extractTerminalHttpLinks(lineText: string): ParsedTerminalHttpLink[] {
+  const links: ParsedTerminalHttpLink[] = []
+  for (const match of lineText.matchAll(TERMINAL_HTTP_URL_REGEX)) {
+    const url = match[0]
+    const index = match.index ?? 0
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      continue
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      continue
+    }
+    links.push({ url: parsed.toString(), startIndex: index, endIndex: index + url.length })
+  }
+  return links
+}
+
+function isTerminalLinkActivation(
+  event: Pick<MouseEvent, 'metaKey' | 'ctrlKey'> | undefined
+): boolean {
+  const isMac = navigator.userAgent.includes('Mac')
+  return isMac ? Boolean(event?.metaKey) : Boolean(event?.ctrlKey)
+}
+
+function getTerminalScreenElement(terminal: Terminal): HTMLElement | null {
+  return terminal.element?.querySelector('.xterm-screen') ?? null
+}
+
+function getBufferPositionForTerminalMouseEvent(
+  terminal: Terminal,
+  event: MouseEvent
+): { x: number; y: number } | null {
+  const screenElement = getTerminalScreenElement(terminal)
+  if (!screenElement || terminal.cols <= 0 || terminal.rows <= 0) {
+    return null
+  }
+
+  const rect = screenElement.getBoundingClientRect()
+  const relativeX = event.clientX - rect.left
+  const relativeY = event.clientY - rect.top
+  if (relativeX < 0 || relativeY < 0 || relativeX >= rect.width || relativeY >= rect.height) {
+    return null
+  }
+
+  const cellWidth = rect.width / terminal.cols
+  const cellHeight = rect.height / terminal.rows
+  if (cellWidth <= 0 || cellHeight <= 0) {
+    return null
+  }
+
+  return {
+    x: Math.floor(relativeX / cellWidth) + 1,
+    y: Math.floor(relativeY / cellHeight) + terminal.buffer.active.viewportY + 1
+  }
+}
+
+export function installHttpLinkClickFallback(
+  terminal: Terminal,
+  deps: UrlLinkClickFallbackDeps
+): IDisposable {
+  const handleMouseUp = (event: MouseEvent): void => {
+    if (event.defaultPrevented || event.button !== 0 || !isTerminalLinkActivation(event)) {
+      return
+    }
+
+    const position = getBufferPositionForTerminalMouseEvent(terminal, event)
+    if (!position) {
+      return
+    }
+
+    // Why: xterm's WebLinksAddon only activates after hover state exists. This
+    // direct mouseup fallback preserves Cmd/Ctrl-click when the hover link was
+    // never established, while defaultPrevented avoids double-opening links
+    // that xterm already handled.
+    const opened = openHttpLinkAtBufferPosition(terminal.buffer.active, position, terminal.cols, {
+      worktreeId: deps.worktreeId,
+      forceSystemBrowser: event.shiftKey
+    })
+    if (opened) {
+      event.preventDefault()
+      terminal.clearSelection()
+    }
+  }
+
+  const terminalElement = terminal.element
+  terminalElement?.addEventListener('mouseup', handleMouseUp)
+  return {
+    dispose: () => {
+      terminalElement?.removeEventListener('mouseup', handleMouseUp)
+    }
+  }
+}
+
+export function openHttpLinkAtBufferPosition(
+  buffer: { getLine(y: number): IBufferLine | undefined },
+  position: { x: number; y: number },
+  terminalColumns: number,
+  deps: UrlLinkHitTestDeps
+): boolean {
+  const logicalLines = buildCandidateLogicalLinesForBufferPosition(buffer, position.y)
+  if (logicalLines.length === 0) {
+    return false
+  }
+
+  for (const logicalLine of logicalLines) {
+    for (const parsed of extractTerminalHttpLinks(logicalLine.text)) {
+      const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
+      if (!range || !rangeContainsBufferPosition(range, position, terminalColumns)) {
+        continue
+      }
+      openHttpLink(parsed.url, {
+        worktreeId: deps.worktreeId,
+        forceSystemBrowser: deps.forceSystemBrowser
+      })
+      return true
+    }
+  }
+
+  return false
+}
+
+function rangeContainsBufferPosition(
+  range: IBufferRange,
+  position: { x: number; y: number },
+  terminalColumns: number
+): boolean {
+  const lower = range.start.y * terminalColumns + range.start.x
+  const upper = range.end.y * terminalColumns + range.end.x
+  const current = position.y * terminalColumns + position.x
+  return lower <= current && current <= upper
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -9,10 +9,11 @@ import {
   createFilePathLinkProvider,
   getTerminalFileOpenHint,
   getTerminalUrlOpenHint,
-  handleOscLink,
   installFilePathLinkClickFallback
 } from './terminal-link-handlers'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
+import { handleOscLink } from './terminal-osc-link-routing'
+import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
 import type {
   GlobalSettings,
   SetupSplitDirection,
@@ -273,6 +274,7 @@ export function useTerminalPaneLifecycle({
   systemPrefersDarkRef.current = systemPrefersDark
   const linkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
   const fileLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
+  const httpLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
   // Why: read settingsRef at fire time so toggling "copy on select" takes
   // effect without recreating panes.
   const selectionDisposablesRef = useRef(new Map<number, IDisposable>())
@@ -341,6 +343,7 @@ export function useTerminalPaneLifecycle({
     const panePtyBindings = panePtyBindingsRef.current
     const linkDisposables = linkProviderDisposablesRef.current
     const fileLinkClickFallbackDisposables = fileLinkClickFallbackDisposablesRef.current
+    const httpLinkClickFallbackDisposables = httpLinkClickFallbackDisposablesRef.current
     const selectionDisposables = selectionDisposablesRef.current
     const selectionCaptureTimers = selectionCaptureTimersRef.current
     const mouseHideDisposables = mouseHideDisposablesRef.current
@@ -546,6 +549,11 @@ export function useTerminalPaneLifecycle({
           linkDeps
         )
         fileLinkClickFallbackDisposablesRef.current.set(pane.id, fileLinkClickFallbackDisposable)
+        const httpLinkClickFallbackDisposable = installHttpLinkClickFallback(
+          pane.terminal,
+          linkDeps
+        )
+        httpLinkClickFallbackDisposables.set(pane.id, httpLinkClickFallbackDisposable)
         // Why: skip empty selections so clicking to deselect doesn't clobber
         // whatever the user last copied elsewhere.
         const selectionDisposable = pane.terminal.onSelectionChange(() => {
@@ -677,6 +685,11 @@ export function useTerminalPaneLifecycle({
         if (fileLinkClickFallbackDisposable) {
           fileLinkClickFallbackDisposable.dispose()
           fileLinkClickFallbackDisposablesRef.current.delete(paneId)
+        }
+        const httpLinkClickFallbackDisposable = httpLinkClickFallbackDisposables.get(paneId)
+        if (httpLinkClickFallbackDisposable) {
+          httpLinkClickFallbackDisposable.dispose()
+          httpLinkClickFallbackDisposables.delete(paneId)
         }
         const selectionDisposable = selectionDisposablesRef.current.get(paneId)
         if (selectionDisposable) {
@@ -1088,6 +1101,10 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       fileLinkClickFallbackDisposables.clear()
+      for (const disposable of httpLinkClickFallbackDisposables.values()) {
+        disposable.dispose()
+      }
+      httpLinkClickFallbackDisposables.clear()
       for (const disposable of selectionDisposables.values()) {
         disposable.dispose()
       }


### PR DESCRIPTION
## Summary
- add a direct terminal HTTP URL mouseup fallback for Cmd/Ctrl-clicks when xterm has not established hover link state
- split OSC and URL link routing out of the oversized terminal link handler module
- keep file-link fallback behavior separate and avoid double-opening URLs already handled by xterm

## Testing
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/lib/terminal-links.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-link-handlers.ts src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
