### PR TITLE
Fix left sidebar resize hit target

### DIFF
--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -18,6 +18,9 @@ import type { VirtualizedScrollAnchor } from '@/hooks/useVirtualizedScrollAnchor
 
 const MIN_WIDTH = 220
 const MAX_WIDTH = 500
+// Why: match the right sidebar's 4px resize target; a 1px seam is too hard to acquire.
+export const WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME =
+  'absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize transition-colors hover:bg-ring/20 active:bg-ring/30'
 
 type SidebarProps = {
   worktreeScrollOffsetRef: React.MutableRefObject<number>
@@ -88,7 +91,7 @@ function Sidebar({
         {sidebarOpen && (
           <div
             data-sidebar-resize-handle=""
-            className="absolute top-0 right-0 z-10 h-full w-px cursor-col-resize transition-colors hover:bg-ring/20 active:bg-ring/30"
+            className={WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME}
             onMouseDown={onResizeStart}
           />
         )}

--- a/src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME } from './index'
+
+describe('worktree sidebar resize handle', () => {
+  it('keeps the hover target as wide as the right sidebar handle', () => {
+    const classes = new Set(WORKTREE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME.split(/\s+/))
+    expect(classes.has('w-1')).toBe(true)
+    expect(classes.has('w-px')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- widen the worktree left sidebar resize handle from 1px to 4px
- add a regression check that keeps the handle from shrinking back to `w-px`

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts src/renderer/src/hooks/useSidebarResize.test.ts`
- `pnpm exec oxlint src/renderer/src/components/sidebar/index.tsx src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/index.tsx src/renderer/src/components/sidebar/sidebar-resize-handle.test.ts`