### PR TITLE
Fix project settings search for repo matches

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -26,6 +26,7 @@ type RepositoryHooksSectionProps = {
   hooksInspectionReady: boolean
   mayNeedUpdate: boolean
   copiedTemplate: boolean
+  forceVisible?: boolean
   onCopyTemplate: () => void
   onUpdateHookSettings: (settings: RepoHookSettings) => void
 }
@@ -553,6 +554,7 @@ export function RepositoryHooksSection({
   hooksInspectionReady,
   mayNeedUpdate,
   copiedTemplate,
+  forceVisible = false,
   onCopyTemplate,
   onUpdateHookSettings
 }: RepositoryHooksSectionProps): React.JSX.Element {
@@ -791,6 +793,7 @@ export function RepositoryHooksSection({
       <SearchableSetting
         title="Setup Script"
         description="Local and shared scripts that run after a new worktree is created."
+        forceVisible={forceVisible}
         keywords={[
           'setup',
           'script',
@@ -817,6 +820,7 @@ export function RepositoryHooksSection({
       <SearchableSetting
         title="When to Run Setup"
         description="Choose the default behavior when a setup script is available."
+        forceVisible={forceVisible}
         keywords={['setup run policy', 'ask', 'run by default', 'skip by default']}
       >
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border/50 bg-background/80 p-4 shadow-sm">
@@ -837,6 +841,7 @@ export function RepositoryHooksSection({
       <SearchableSetting
         title="Archive Script"
         description="Local and shared scripts that run before a worktree is archived."
+        forceVisible={forceVisible}
         keywords={[
           'archive',
           'script',
@@ -871,6 +876,7 @@ export function RepositoryHooksSection({
       <SearchableSetting
         title="Custom GitHub Issue Command"
         description="Optional per-user override for the linked-issue command."
+        forceVisible={forceVisible}
         keywords={['github issue command', 'issue command', 'workflow', 'agent', 'github']}
       >
         <div className="space-y-3 rounded-2xl border border-border/50 bg-background/80 p-4 shadow-sm">
@@ -906,6 +912,7 @@ export function RepositoryHooksSection({
       <SearchableSetting
         title="Advanced"
         description="Command source and orca.yaml details."
+        forceVisible={forceVisible}
         keywords={[
           'advanced',
           'command source',

--- a/src/renderer/src/components/settings/RepositoryPane.test.ts
+++ b/src/renderer/src/components/settings/RepositoryPane.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../../shared/types'
-import { getRepositoryPaneSearchEntries } from './RepositoryPane'
+import { useAppStore } from '../../store'
+import {
+  getRepositoryPaneSearchEntries,
+  matchesRepositoryIdentitySearch,
+  RepositoryPane
+} from './RepositoryPane'
 import { matchesSettingsSearch } from './settings-search'
+import { TooltipProvider } from '../ui/tooltip'
 
 const repo: Repo = {
   id: 'repo-1',
@@ -23,5 +31,46 @@ describe('RepositoryPane search entries', () => {
     expect(matchesSettingsSearch('advanced', entries)).toBe(true)
     expect(matchesSettingsSearch('command source', entries)).toBe(true)
     expect(matchesSettingsSearch('local settings scripts', entries)).toBe(true)
+  })
+
+  it('matches project identity searches on display name and path only', () => {
+    expect(matchesRepositoryIdentitySearch('example repo', repo)).toBe(true)
+    expect(matchesRepositoryIdentitySearch('/tmp/repo', repo)).toBe(true)
+    expect(matchesRepositoryIdentitySearch('setup script', repo)).toBe(false)
+  })
+
+  it('renders full hook controls when search matches the project name', () => {
+    useAppStore.setState({
+      settingsSearchQuery: 'Example Repo',
+      settingsSearchInputQuery: 'Example Repo'
+    })
+
+    try {
+      const html = renderToStaticMarkup(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(RepositoryPane, {
+            repo,
+            yamlHooks: null,
+            hasHooksFile: false,
+            hooksInspectionReady: true,
+            mayNeedUpdate: false,
+            updateRepo: vi.fn(),
+            removeProject: vi.fn()
+          })
+        )
+      )
+
+      expect(html).toContain('Worktree Hooks')
+      expect(html).toContain('Setup Script')
+      expect(html).toContain('Archive Script')
+      expect(html).toContain('Custom GitHub Issue Command')
+    } finally {
+      useAppStore.setState({
+        settingsSearchQuery: '',
+        settingsSearchInputQuery: ''
+      })
+    }
   })
 })

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -13,7 +13,7 @@ import { WorktreeSymlinksSection } from './WorktreeSymlinksSection'
 import { SparsePresetSettingsSection } from './SparsePresetSettingsSection'
 import { RepositorySourceControlAiSection } from './RepositorySourceControlAiSection'
 import { SearchableSetting } from './SearchableSetting'
-import { matchesSettingsSearch } from './settings-search'
+import { matchesSettingsSearch, normalizeSettingsSearchQuery } from './settings-search'
 import { useAppStore } from '../../store'
 import { getRepositoryIconSectionId } from './repository-settings-targets'
 import { RepositoryIconPicker } from './RepositoryIconPicker'
@@ -30,6 +30,16 @@ type RepositoryPaneProps = {
   removeProject: (repoId: string) => void
 }
 
+export function matchesRepositoryIdentitySearch(query: string, repo: Repo): boolean {
+  const normalizedQuery = normalizeSettingsSearchQuery(query)
+  if (!normalizedQuery) {
+    return false
+  }
+  return [repo.displayName, repo.path].some((value) =>
+    value.toLowerCase().includes(normalizedQuery)
+  )
+}
+
 export function RepositoryPane({
   repo,
   yamlHooks,
@@ -44,6 +54,9 @@ export function RepositoryPane({
   const symlinksEnabled = useAppStore((state) => state.settings?.experimentalWorktreeSymlinks)
   const [confirmingRemove, setConfirmingRemove] = useState<string | null>(null)
   const [copiedTemplate, setCopiedTemplate] = useState(false)
+  // Why: searching a project name is navigation to that project, not a
+  // request to hide every child row that does not repeat the project name.
+  const forceFullPaneForRepoMatch = matchesRepositoryIdentitySearch(searchQuery, repo)
 
   const handleRemoveProject = (repoId: string) => {
     if (confirmingRemove === repoId) {
@@ -96,7 +109,7 @@ export function RepositoryPane({
   const sourceControlAiEntries = allEntries.filter((entry) => entry.title === 'Source Control AI')
 
   const hooksSection =
-    !isFolder && matchesSettingsSearch(searchQuery, hooksEntries) ? (
+    !isFolder && (forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, hooksEntries)) ? (
       <RepositoryHooksSection
         key="hooks"
         repo={repo}
@@ -105,6 +118,7 @@ export function RepositoryPane({
         hooksInspectionReady={hooksInspectionReady}
         mayNeedUpdate={mayNeedUpdate}
         copiedTemplate={copiedTemplate}
+        forceVisible={forceFullPaneForRepoMatch}
         onCopyTemplate={() => void handleCopyTemplate()}
         onUpdateHookSettings={updateSelectedRepoHookSettings}
       />
@@ -114,7 +128,7 @@ export function RepositoryPane({
   // thing a user sees. Setup commands follow immediately because they're the
   // most-edited surface and should beat MCP/symlinks/sparse-presets.
   const visibleSections = [
-    matchesSettingsSearch(searchQuery, identityEntries) ? (
+    forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, identityEntries) ? (
       <section key="identity" className="space-y-8">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
@@ -135,6 +149,7 @@ export function RepositoryPane({
             title="Remove Project"
             description="Remove this project from Orca."
             keywords={[repo.displayName, 'delete', 'project', 'repository']}
+            forceVisible={forceFullPaneForRepoMatch}
           >
             <Button
               variant={confirmingRemove === repo.id ? 'destructive' : 'outline'}
@@ -154,6 +169,7 @@ export function RepositoryPane({
           description="Project-specific display details for the sidebar and tabs."
           keywords={[repo.displayName, repo.path, 'project name', 'repository name']}
           className="space-y-2"
+          forceVisible={forceFullPaneForRepoMatch}
         >
           <Label className="text-sm font-semibold">Display Name</Label>
           <Input
@@ -182,6 +198,7 @@ export function RepositoryPane({
           ]}
           className="space-y-2"
           id={getRepositoryIconSectionId(repo.id)}
+          forceVisible={forceFullPaneForRepoMatch}
         >
           <RepositoryIconPicker repo={repo} updateRepo={updateRepo} />
         </SearchableSetting>
@@ -192,6 +209,7 @@ export function RepositoryPane({
             description="Default base branch or ref when creating worktrees."
             keywords={[repo.displayName, 'base ref', 'branch']}
             className="space-y-3"
+            forceVisible={forceFullPaneForRepoMatch}
           >
             <Label className="text-sm font-semibold">Default Worktree Base</Label>
             <BaseRefPicker
@@ -205,7 +223,8 @@ export function RepositoryPane({
       </section>
     ) : null,
     hooksSection,
-    !isFolder && matchesSettingsSearch(searchQuery, sourceControlAiEntries) ? (
+    !isFolder &&
+    (forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, sourceControlAiEntries)) ? (
       <RepositorySourceControlAiSection
         key="source-control-ai"
         repo={repo}
@@ -215,13 +234,14 @@ export function RepositoryPane({
     !isFolder &&
     !repo.connectionId &&
     symlinksEnabled &&
-    matchesSettingsSearch(searchQuery, symlinkEntries) ? (
+    (forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, symlinkEntries)) ? (
       <WorktreeSymlinksSection key="symlinks" repo={repo} updateRepo={updateRepo} />
     ) : null,
-    !isFolder && matchesSettingsSearch(searchQuery, sparsePresetEntries) ? (
+    !isFolder &&
+    (forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, sparsePresetEntries)) ? (
       <SparsePresetSettingsSection key="sparse-presets" repoId={repo.id} />
     ) : null,
-    !isFolder && matchesSettingsSearch(searchQuery, mcpEntries) ? (
+    !isFolder && (forceFullPaneForRepoMatch || matchesSettingsSearch(searchQuery, mcpEntries)) ? (
       <McpConfigSection key="mcp-configs" repo={repo} />
     ) : null
   ].filter(Boolean)


### PR DESCRIPTION
## Summary
- Treat Settings search matches on a project display name/path as navigation to the full project settings pane.
- Keep setting-specific searches precise, while repo-name searches now reveal hook controls instead of only the Worktree Hooks heading.
- Add regression coverage for repo identity search and hook controls rendering.

## Validation
- Reproduced in Electron before the fix: searching `repo-worktree-bug` showed `Worktree Hooks` but hid the hook controls.
- Verified in Electron after the fix: the same search shows `Setup Script`, `When to run`, `Archive Script`, and `Custom GitHub Issue Command`.
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryPane.test.ts src/renderer/src/components/settings/RepositoryHooksSection.test.ts`
- `pnpm oxlint src/renderer/src/components/settings/RepositoryPane.tsx src/renderer/src/components/settings/RepositoryHooksSection.tsx src/renderer/src/components/settings/RepositoryPane.test.ts`
- `pnpm oxfmt --check src/renderer/src/components/settings/RepositoryPane.tsx src/renderer/src/components/settings/RepositoryHooksSection.tsx src/renderer/src/components/settings/RepositoryPane.test.ts`

## Review screenshots
Local screenshots are intentionally uncommitted under `validation-screenshots/`:
- `validation-screenshots/01-repo-name-search-before-fail.png`
- `validation-screenshots/02-repo-name-search-after-pass.png`
- `validation-screenshots/03-repo-name-search-hooks-pass.png`
- `validation-screenshots/README.md`

Note: local commands emitted the repo's existing Node engine warning because this shell is on Node v26.0.0 while package.json wants Node 24.
