### PR TITLE
Show update check feedback immediately

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -179,7 +179,7 @@ describe('updater', () => {
   })
 
   it('deduplicates identical check errors from the event and rejected promise', async () => {
-    autoUpdaterMock.checkForUpdates.mockResolvedValueOnce(undefined).mockImplementationOnce(() => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')
       queueMicrotask(() => {
         autoUpdaterMock.emit('error', new Error('boom'))
@@ -192,7 +192,7 @@ describe('updater', () => {
 
     const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
 
-    setupAutoUpdater(mainWindow as never)
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
     await vi.waitFor(() => {
       const statuses = sendMock.mock.calls
@@ -210,7 +210,7 @@ describe('updater', () => {
   })
 
   it('surfaces net::ERR_FAILED to user-initiated checks with a friendly message', async () => {
-    autoUpdaterMock.checkForUpdates.mockResolvedValueOnce(undefined).mockImplementationOnce(() => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')
       queueMicrotask(() => {
         autoUpdaterMock.emit('error', new Error('net::ERR_FAILED'))
@@ -223,7 +223,7 @@ describe('updater', () => {
 
     const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
 
-    setupAutoUpdater(mainWindow as never)
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
     checkForUpdatesFromMenu()
     await vi.waitFor(() => {
       const statuses = sendMock.mock.calls
@@ -248,6 +248,199 @@ describe('updater', () => {
     expect(statuses).not.toContainEqual(
       expect.objectContaining({ state: 'error', message: 'net::ERR_FAILED' })
     )
+  })
+
+  it('shows checking immediately for a user-initiated check while feed pinning is pending', async () => {
+    let resolveTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    fetchNewerReleaseTagsMock.mockImplementation(
+      () =>
+        new Promise<{ tags: string[]; state: 'no-newer' }>((resolve) => {
+          resolveTags = resolve
+        })
+    )
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      return new Promise(() => {})
+    })
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'checking',
+      userInitiated: true
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+
+    resolveTags({ tags: [], state: 'no-newer' })
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+
+    const checkingStatuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+      .filter(
+        (status) => typeof status === 'object' && status !== null && status.state === 'checking'
+      )
+
+    expect(checkingStatuses).toEqual([{ state: 'checking', userInitiated: true }])
+  })
+
+  it('keeps background checks event-driven before checking-for-update fires', async () => {
+    let resolveTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    fetchNewerReleaseTagsMock.mockImplementation(
+      () =>
+        new Promise<{ tags: string[]; state: 'no-newer' }>((resolve) => {
+          resolveTags = resolve
+        })
+    )
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => new Promise(() => {}))
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+
+    expect(
+      sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+        .some(
+          (status) => typeof status === 'object' && status !== null && status.state === 'checking'
+        )
+    ).toBe(false)
+
+    resolveTags({ tags: [], state: 'no-newer' })
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('checking-for-update')
+    expect(sendMock).toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'checking' })
+    )
+  })
+
+  it('promotes a pending background check to user-initiated without launching a duplicate check', async () => {
+    let resolveTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    fetchNewerReleaseTagsMock.mockImplementation(
+      () =>
+        new Promise<{ tags: string[]; state: 'no-newer' }>((resolve) => {
+          resolveTags = resolve
+        })
+    )
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+    checkForUpdatesFromMenu()
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'checking',
+      userInitiated: true
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+
+    resolveTags({ tags: [], state: 'no-newer' })
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('update-not-available')
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'not-available',
+      userInitiated: true
+    })
+  })
+
+  it('keeps promoted background promise failures user-initiated after a paired error event', async () => {
+    let resolveTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    fetchNewerReleaseTagsMock.mockImplementation(
+      () =>
+        new Promise<{ tags: string[]; state: 'no-newer' }>((resolve) => {
+          resolveTags = resolve
+        })
+    )
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('error', new Error('net::ERR_FAILED'))
+      })
+      return Promise.reject(new Error('net::ERR_FAILED'))
+    })
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+    checkForUpdatesFromMenu()
+    resolveTags({ tags: [], state: 'no-newer' })
+
+    await vi.waitFor(() => {
+      const statuses = sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+      expect(statuses).toContainEqual(
+        expect.objectContaining({
+          state: 'error',
+          userInitiated: true,
+          message: expect.stringContaining("Couldn't reach the update server")
+        })
+      )
+    })
+
+    const resultStatuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+      .filter(
+        (status) =>
+          typeof status === 'object' &&
+          status !== null &&
+          (status.state === 'idle' || status.state === 'error')
+      )
+
+    expect(resultStatuses).toEqual([
+      expect.objectContaining({
+        state: 'error',
+        userInitiated: true,
+        message: expect.stringContaining("Couldn't reach the update server")
+      })
+    ])
+  })
+
+  it('deduplicates repeated manual checks while the immediate checking status is active', async () => {
+    let resolveTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    fetchNewerReleaseTagsMock.mockImplementation(
+      () =>
+        new Promise<{ tags: string[]; state: 'no-newer' }>((resolve) => {
+          resolveTags = resolve
+        })
+    )
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => new Promise(() => {}))
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+    checkForUpdatesFromMenu()
+
+    resolveTags({ tags: [], state: 'no-newer' })
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+    expect(fetchNewerReleaseTagsMock).toHaveBeenCalledTimes(1)
   })
 
   it('opts into the RC channel when checkForUpdatesFromMenu is called with includePrerelease', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -55,6 +55,9 @@ let pendingQuitAndInstallTimer: ReturnType<typeof setTimeout> | null = null
 let persistLastUpdateCheckAt: ((timestamp: number) => void) | null = null
 let _getLastUpdateCheckAt: (() => number | null) | null = null
 let backgroundCheckLaunchPending = false
+// Why: a manually promoted background check can emit an error event before the
+// paired promise catch runs; keep the promotion attached to that launch.
+let backgroundCheckPromotedToUserInitiated = false
 let activeUpdateNudgeId: string | null = null
 let awaitingNudgeCheckOutcome = false
 let nudgeCheckInFlight = false
@@ -620,14 +623,21 @@ function runBackgroundUpdateCheck(
   // currentStatus flips to 'checking'. Track the launch in memory to dedupe
   // that gap without persisting a successful-check timestamp before the result.
   backgroundCheckLaunchPending = true
+  backgroundCheckPromotedToUserInitiated = false
   // Don't send 'checking' here — the 'checking-for-update' event handler does it,
   // and sending it from both places causes duplicate notifications (issue #35).
   const autoUpdater = getAutoUpdater()
   const launch = (): Promise<unknown> => autoUpdater.checkForUpdates()
   const run = pinDefaultReleaseFeed().then(launch)
   void Promise.resolve(run).catch((err) => {
+    const wasUserInitiated =
+      userInitiatedCheck || backgroundCheckPromotedToUserInitiated || undefined
     backgroundCheckLaunchPending = false
-    void sendCheckFailureStatus(String(err?.message ?? err), undefined, 'promise', err)
+    backgroundCheckPromotedToUserInitiated = false
+    if (wasUserInitiated) {
+      userInitiatedCheck = false
+    }
+    void sendCheckFailureStatus(String(err?.message ?? err), wasUserInitiated, 'promise', err)
   })
 }
 
@@ -674,13 +684,20 @@ export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean 
     enableIncludePrerelease()
   }
 
+  const checkAlreadyInFlight = backgroundCheckLaunchPending || currentStatus.state === 'checking'
   userInitiatedCheck = true
   // Why: a manual check is independent of any active nudge campaign. Reset the
   // nudge marker so the resulting status is not decorated with activeNudgeId,
   // which would cause a later dismiss to consume the campaign by accident.
   activeUpdateNudgeId = null
-  // Don't send 'checking' here — the 'checking-for-update' event handler does it,
-  // and sending it from both places causes duplicate notifications (issue #35).
+  // Why: manual checks should visibly respond before feed pinning or the
+  // electron-updater event fires; duplicate event broadcasts are suppressed by
+  // status equality below.
+  sendStatus({ state: 'checking', userInitiated: true })
+  if (checkAlreadyInFlight) {
+    backgroundCheckPromotedToUserInitiated = true
+    return
+  }
 
   const autoUpdater = getAutoUpdater()
   const launch = (): Promise<unknown> => autoUpdater.checkForUpdates()


### PR DESCRIPTION
## Summary
- send the manual updater checking status immediately so the Settings button disables and shows the spinner before feed pinning/electron-updater events complete
- dedupe manual checks that arrive while a background or manual check is already in flight
- preserve user-initiated failure handling for promoted background checks

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/updater.test.ts
- pnpm typecheck
- pnpm lint (passes with existing react-hooks warning in browser-automation-visibility.ts)
- Electron screenshots captured locally in validation-screenshots/ (ignored): idle, checking, result states

Note: PR evidence screenshots are local-only and intentionally not committed. See validation-screenshots/README.md in this worktree.

Made with [Orca](https://github.com/stablyai/orca) 🐋
