### PR TITLE
Guard untracked discard against symlink escapes

### DIFF
--- a/src/main/git/status-discard-symlink.test.ts
+++ b/src/main/git/status-discard-symlink.test.ts
@@ -76,4 +76,30 @@ describe('discardChanges symlink safety', () => {
     await expect(access(linkPath)).rejects.toThrow()
     await expect(access(outsideFile)).resolves.toBeUndefined()
   })
+
+  it('removes ignored paths selected for discard', async () => {
+    const { repo } = await createRepoWithOutsideDirectory()
+    await writeFile(path.join(repo, '.gitignore'), 'ignored/\n')
+    execFileSync('git', ['add', '.gitignore'], { cwd: repo })
+    execFileSync('git', ['commit', '-q', '-m', 'ignore ignored dir'], { cwd: repo })
+    const ignoredFile = path.join(repo, 'ignored', 'file.txt')
+    await mkdir(path.dirname(ignoredFile))
+    await writeFile(ignoredFile, 'ignored')
+
+    await discardChanges(repo, 'ignored')
+
+    await expect(access(path.join(repo, 'ignored'))).rejects.toThrow()
+  })
+
+  it('removes untracked nested git repos selected for discard', async () => {
+    const { repo } = await createRepoWithOutsideDirectory()
+    const nestedRepo = path.join(repo, 'nested')
+    await mkdir(nestedRepo)
+    execFileSync('git', ['init', '-q'], { cwd: nestedRepo })
+    await writeFile(path.join(nestedRepo, 'file.txt'), 'nested')
+
+    await discardChanges(repo, 'nested')
+
+    await expect(access(nestedRepo)).rejects.toThrow()
+  })
 })

--- a/src/main/git/status-discard-symlink.test.ts
+++ b/src/main/git/status-discard-symlink.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'child_process'
+import { mkdtemp, mkdir, rm, symlink, writeFile, access, readFile } from 'fs/promises'
+import * as path from 'path'
+import { tmpdir } from 'os'
+import { bulkDiscardChanges, discardChanges } from './status'
+
+const tempRoots: string[] = []
+
+async function createRepoWithOutsideDirectory(): Promise<{
+  repo: string
+  outsideDir: string
+  outsideFile: string
+}> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-discard-symlink-'))
+  tempRoots.push(root)
+  const repo = path.join(root, 'repo')
+  const outsideDir = path.join(root, 'outside')
+  const outsideFile = path.join(outsideDir, 'keep.txt')
+
+  await mkdir(repo)
+  await mkdir(outsideDir)
+  execFileSync('git', ['init', '-q'], { cwd: repo })
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo })
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo })
+  await writeFile(path.join(repo, '.gitkeep'), '')
+  execFileSync('git', ['add', '.gitkeep'], { cwd: repo })
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo })
+  await writeFile(outsideFile, 'outside')
+
+  return { repo, outsideDir, outsideFile }
+}
+
+async function createDirectoryLink(target: string, linkPath: string): Promise<void> {
+  await symlink(target, linkPath, process.platform === 'win32' ? 'junction' : 'dir')
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('discardChanges symlink safety', () => {
+  it('rejects an untracked child path through a symlinked parent', async () => {
+    const { repo, outsideDir, outsideFile } = await createRepoWithOutsideDirectory()
+    await createDirectoryLink(outsideDir, path.join(repo, 'link'))
+
+    await expect(discardChanges(repo, 'link/keep.txt')).rejects.toThrow(
+      'resolves outside the worktree'
+    )
+    await expect(access(outsideFile)).resolves.toBeUndefined()
+  })
+
+  it('rejects bulk untracked child paths through symlinked parents before deleting anything', async () => {
+    const { repo, outsideDir, outsideFile } = await createRepoWithOutsideDirectory()
+    const untrackedFile = path.join(repo, 'new.txt')
+    const trackedFile = path.join(repo, '.gitkeep')
+    await writeFile(trackedFile, 'modified')
+    await writeFile(untrackedFile, 'untracked')
+    await createDirectoryLink(outsideDir, path.join(repo, 'link'))
+
+    await expect(
+      bulkDiscardChanges(repo, ['.gitkeep', 'new.txt', 'link/keep.txt'])
+    ).rejects.toThrow('resolves outside the worktree')
+    await expect(access(outsideFile)).resolves.toBeUndefined()
+    await expect(access(untrackedFile)).resolves.toBeUndefined()
+    await expect(readFile(trackedFile, 'utf8')).resolves.toBe('modified')
+  })
+
+  it('removes an untracked symlink leaf without deleting its target', async () => {
+    const { repo, outsideDir, outsideFile } = await createRepoWithOutsideDirectory()
+    const linkPath = path.join(repo, 'outside-link')
+    await createDirectoryLink(outsideDir, linkPath)
+
+    await discardChanges(repo, 'outside-link')
+
+    await expect(access(linkPath)).rejects.toThrow()
+    await expect(access(outsideFile)).resolves.toBeUndefined()
+  })
+})

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -6,6 +6,7 @@ const {
   gitExecFileAsyncMock,
   gitExecFileAsyncBufferMock,
   lstatMock,
+  realpathMock,
   readFileMock,
   rmMock,
   existsSyncMock
@@ -13,6 +14,7 @@ const {
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileAsyncBufferMock: vi.fn(),
   lstatMock: vi.fn(),
+  realpathMock: vi.fn(),
   readFileMock: vi.fn(),
   rmMock: vi.fn(),
   existsSyncMock: vi.fn()
@@ -29,6 +31,7 @@ vi.mock('./runner', () => ({
 
 vi.mock('fs/promises', () => ({
   lstat: lstatMock,
+  realpath: realpathMock,
   readFile: readFileMock,
   rm: rmMock
 }))
@@ -55,8 +58,12 @@ describe('discardChanges', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
     gitExecFileAsyncBufferMock.mockReset()
+    lstatMock.mockReset()
+    realpathMock.mockReset()
     readFileMock.mockReset()
     rmMock.mockReset()
+    lstatMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    realpathMock.mockImplementation(async (targetPath: string) => path.resolve(targetPath))
   })
 
   it('restores tracked files from HEAD', async () => {
@@ -113,7 +120,11 @@ describe('discardChanges', () => {
 describe('bulk git helpers', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    lstatMock.mockReset()
+    realpathMock.mockReset()
     rmMock.mockReset()
+    lstatMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    realpathMock.mockImplementation(async (targetPath: string) => path.resolve(targetPath))
   })
 
   it('chunks bulk stage requests to avoid oversized argv payloads', async () => {

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -94,13 +94,15 @@ describe('discardChanges', () => {
 
     await discardChanges('/repo', 'src/new-file.ts')
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
-    // Why: discardChanges uses path.resolve(worktreePath, filePath) to build
-    // the absolute rm target, which on Windows prepends a drive letter.
-    expect(rmMock).toHaveBeenCalledWith(path.resolve('/repo', 'src', 'new-file.ts'), {
-      force: true,
-      recursive: true
-    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['clean', '-ffdx', '--', 'src/new-file.ts'],
+      {
+        cwd: '/repo'
+      }
+    )
+    expect(rmMock).not.toHaveBeenCalled()
   })
 
   it('rejects paths that traverse outside the worktree', async () => {
@@ -189,14 +191,14 @@ describe('bulk git helpers', () => {
         cwd: '/repo'
       }
     )
-    expect(rmMock).toHaveBeenCalledWith(path.resolve('/repo', 'src', 'new-file.ts'), {
-      force: true,
-      recursive: true
-    })
-    expect(rmMock).toHaveBeenCalledWith(path.resolve('/repo', 'scratch'), {
-      force: true,
-      recursive: true
-    })
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      ['clean', '-ffdx', '--', 'src/new-file.ts', 'scratch'],
+      {
+        cwd: '/repo'
+      }
+    )
+    expect(rmMock).not.toHaveBeenCalled()
   })
 
   it('rejects bulk discard paths that traverse outside the worktree', async () => {

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { existsSync } from 'fs'
-import { readFile, rm } from 'fs/promises'
+import { readFile } from 'fs/promises'
 import * as path from 'path'
 import type {
   GitBranchChangeEntry,
@@ -29,7 +29,10 @@ import {
   type GitLineStats
 } from '../../shared/git-uncommitted-line-stats'
 import { gitExecFileAsync, gitExecFileAsyncBuffer, gitOptionalLocksDisabledEnv } from './runner'
-import { resolveSafeUntrackedDiscardTarget } from '../../shared/git-discard-path-safety'
+import {
+  removeSafeUntrackedDiscardTarget,
+  removeSafeUntrackedDiscardTargets
+} from '../../shared/git-discard-path-safety'
 
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
@@ -1113,8 +1116,7 @@ export async function discardChanges(worktreePath: string, filePath: string): Pr
     return
   }
 
-  const safeTarget = await resolveSafeUntrackedDiscardTarget(worktreePath, filePath)
-  await rm(safeTarget, { force: true, recursive: true })
+  await removeSafeUntrackedDiscardTarget(worktreePath, filePath)
 }
 
 function normalizeGitPathForCompare(filePath: string): string {
@@ -1165,18 +1167,14 @@ export async function bulkDiscardChanges(worktreePath: string, filePaths: string
   const untrackedPaths = filePaths.filter(
     (filePath) => !isTrackedPathSpec(filePath, trackedPathSpecs)
   )
-  const untrackedTargets = await Promise.all(
-    untrackedPaths.map((filePath) => resolveSafeUntrackedDiscardTarget(worktreePath, filePath))
-  )
-
-  for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
-    const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
-    await gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', ...chunk], {
-      cwd: worktreePath
-    })
-  }
-
-  await Promise.all(untrackedTargets.map((target) => rm(target, { force: true, recursive: true })))
+  await removeSafeUntrackedDiscardTargets(worktreePath, untrackedPaths, async () => {
+    for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
+      await gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', ...chunk], {
+        cwd: worktreePath
+      })
+    }
+  })
 }
 
 export function isWithinWorktree(

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1116,7 +1116,9 @@ export async function discardChanges(worktreePath: string, filePath: string): Pr
     return
   }
 
-  await removeSafeUntrackedDiscardTarget(worktreePath, filePath)
+  await removeSafeUntrackedDiscardTarget(worktreePath, filePath, (targetPath) =>
+    cleanUntrackedPaths(worktreePath, [targetPath])
+  )
 }
 
 function normalizeGitPathForCompare(filePath: string): string {
@@ -1146,6 +1148,19 @@ async function listTrackedPathSpecs(
   return trackedPaths
 }
 
+async function cleanUntrackedPaths(
+  worktreePath: string,
+  filePaths: readonly string[]
+): Promise<void> {
+  for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
+    const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
+    if (chunk.length > 0) {
+      // Why: Git pathspec cleanup avoids raw recursive deletion through symlinked parents.
+      await gitExecFileAsync(['clean', '-ffdx', '--', ...chunk], { cwd: worktreePath })
+    }
+  }
+}
+
 /**
  * Discard working tree changes for many paths in a small number of subprocesses.
  */
@@ -1167,14 +1182,19 @@ export async function bulkDiscardChanges(worktreePath: string, filePaths: string
   const untrackedPaths = filePaths.filter(
     (filePath) => !isTrackedPathSpec(filePath, trackedPathSpecs)
   )
-  await removeSafeUntrackedDiscardTargets(worktreePath, untrackedPaths, async () => {
-    for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
-      const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
-      await gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', ...chunk], {
-        cwd: worktreePath
-      })
+  await removeSafeUntrackedDiscardTargets(
+    worktreePath,
+    untrackedPaths,
+    (targetPaths) => cleanUntrackedPaths(worktreePath, targetPaths),
+    async () => {
+      for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
+        const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
+        await gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', ...chunk], {
+          cwd: worktreePath
+        })
+      }
     }
-  })
+  )
 }
 
 export function isWithinWorktree(

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -29,6 +29,7 @@ import {
   type GitLineStats
 } from '../../shared/git-uncommitted-line-stats'
 import { gitExecFileAsync, gitExecFileAsyncBuffer, gitOptionalLocksDisabledEnv } from './runner'
+import { resolveSafeUntrackedDiscardTarget } from '../../shared/git-discard-path-safety'
 
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
@@ -1105,11 +1106,15 @@ export async function discardChanges(worktreePath: string, filePath: string): Pr
     // File is not tracked by git
   }
 
-  await (tracked
-    ? gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', filePath], {
-        cwd: worktreePath
-      })
-    : rm(resolvedTarget, { force: true, recursive: true }))
+  if (tracked) {
+    await gitExecFileAsync(['restore', '--worktree', '--source=HEAD', '--', filePath], {
+      cwd: worktreePath
+    })
+    return
+  }
+
+  const safeTarget = await resolveSafeUntrackedDiscardTarget(worktreePath, filePath)
+  await rm(safeTarget, { force: true, recursive: true })
 }
 
 function normalizeGitPathForCompare(filePath: string): string {
@@ -1160,6 +1165,9 @@ export async function bulkDiscardChanges(worktreePath: string, filePaths: string
   const untrackedPaths = filePaths.filter(
     (filePath) => !isTrackedPathSpec(filePath, trackedPathSpecs)
   )
+  const untrackedTargets = await Promise.all(
+    untrackedPaths.map((filePath) => resolveSafeUntrackedDiscardTarget(worktreePath, filePath))
+  )
 
   for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
     const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
@@ -1168,11 +1176,7 @@ export async function bulkDiscardChanges(worktreePath: string, filePaths: string
     })
   }
 
-  await Promise.all(
-    untrackedPaths.map((filePath) =>
-      rm(path.resolve(worktreePath, filePath), { force: true, recursive: true })
-    )
-  )
+  await Promise.all(untrackedTargets.map((target) => rm(target, { force: true, recursive: true })))
 }
 
 export function isWithinWorktree(

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -7,7 +7,7 @@ import { GitHandler } from './git-handler'
 import { RelayContext } from './context'
 import * as fs from 'fs/promises'
 import * as path from 'path'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'fs'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import {
@@ -452,6 +452,59 @@ describe('GitHandler', () => {
           filePaths: ['file.txt', '../../../etc/passwd']
         })
       ).rejects.toThrow('outside the worktree')
+    })
+
+    it('rejects untracked child paths through symlinked parents', async () => {
+      gitInit(tmpDir)
+      gitCommit(tmpDir, 'initial')
+      const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-git-outside-'))
+      const outsideFile = path.join(outsideDir, 'keep.txt')
+      writeFileSync(outsideFile, 'outside')
+      symlinkSync(
+        outsideDir,
+        path.join(tmpDir, 'link'),
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+
+      try {
+        await expect(
+          dispatcher.callRequest('git.discard', {
+            worktreePath: tmpDir,
+            filePath: 'link/keep.txt'
+          })
+        ).rejects.toThrow('outside the worktree')
+        await expect(fs.access(outsideFile)).resolves.toBeUndefined()
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects bulk untracked child paths through symlinked parents before deleting anything', async () => {
+      gitInit(tmpDir)
+      gitCommit(tmpDir, 'initial')
+      const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-git-outside-'))
+      const outsideFile = path.join(outsideDir, 'keep.txt')
+      const untrackedFile = path.join(tmpDir, 'new.txt')
+      writeFileSync(outsideFile, 'outside')
+      writeFileSync(untrackedFile, 'untracked')
+      symlinkSync(
+        outsideDir,
+        path.join(tmpDir, 'link'),
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+
+      try {
+        await expect(
+          dispatcher.callRequest('git.bulkDiscard', {
+            worktreePath: tmpDir,
+            filePaths: ['new.txt', 'link/keep.txt']
+          })
+        ).rejects.toThrow('outside the worktree')
+        await expect(fs.access(outsideFile)).resolves.toBeUndefined()
+        await expect(fs.access(untrackedFile)).resolves.toBeUndefined()
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true })
+      }
     })
   })
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -2,7 +2,6 @@
 protocol surface so local and SSH git behavior stay in one dispatch table. */
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import { rm } from 'fs/promises'
 import * as path from 'path'
 import type { RelayDispatcher } from './dispatcher'
 import type { RelayContext } from './context'
@@ -36,7 +35,10 @@ import {
 } from '../shared/git-effective-upstream'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import { buildRelayCommandEnv } from './relay-command-env'
-import { resolveSafeUntrackedDiscardTarget } from '../shared/git-discard-path-safety'
+import {
+  removeSafeUntrackedDiscardTarget,
+  removeSafeUntrackedDiscardTargets
+} from '../shared/git-discard-path-safety'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -238,8 +240,7 @@ export class GitHandler {
       return
     }
 
-    const safeTarget = await resolveSafeUntrackedDiscardTarget(worktreePath, filePath)
-    await rm(safeTarget, { force: true, recursive: true })
+    await removeSafeUntrackedDiscardTarget(worktreePath, filePath)
   }
 
   private async bulkDiscard(params: Record<string, unknown>) {
@@ -266,18 +267,12 @@ export class GitHandler {
     const untrackedPaths = filePaths.filter(
       (filePath) => !this.isTrackedPathSpec(filePath, trackedPathSpecs)
     )
-    const untrackedTargets = await Promise.all(
-      untrackedPaths.map((filePath) => resolveSafeUntrackedDiscardTarget(worktreePath, filePath))
-    )
-
-    for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
-      const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
-      await this.git(['restore', '--worktree', '--source=HEAD', '--', ...chunk], worktreePath)
-    }
-
-    await Promise.all(
-      untrackedTargets.map((target) => rm(target, { force: true, recursive: true }))
-    )
+    await removeSafeUntrackedDiscardTargets(worktreePath, untrackedPaths, async () => {
+      for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
+        const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
+        await this.git(['restore', '--worktree', '--source=HEAD', '--', ...chunk], worktreePath)
+      }
+    })
   }
 
   private async conflictOperation(params: Record<string, unknown>) {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -240,7 +240,9 @@ export class GitHandler {
       return
     }
 
-    await removeSafeUntrackedDiscardTarget(worktreePath, filePath)
+    await removeSafeUntrackedDiscardTarget(worktreePath, filePath, (targetPath) =>
+      this.cleanUntrackedPaths(worktreePath, [targetPath])
+    )
   }
 
   private async bulkDiscard(params: Record<string, unknown>) {
@@ -267,12 +269,27 @@ export class GitHandler {
     const untrackedPaths = filePaths.filter(
       (filePath) => !this.isTrackedPathSpec(filePath, trackedPathSpecs)
     )
-    await removeSafeUntrackedDiscardTargets(worktreePath, untrackedPaths, async () => {
-      for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
-        const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
-        await this.git(['restore', '--worktree', '--source=HEAD', '--', ...chunk], worktreePath)
+    await removeSafeUntrackedDiscardTargets(
+      worktreePath,
+      untrackedPaths,
+      (targetPaths) => this.cleanUntrackedPaths(worktreePath, targetPaths),
+      async () => {
+        for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
+          const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
+          await this.git(['restore', '--worktree', '--source=HEAD', '--', ...chunk], worktreePath)
+        }
       }
-    })
+    )
+  }
+
+  private async cleanUntrackedPaths(worktreePath: string, filePaths: readonly string[]) {
+    for (let i = 0; i < filePaths.length; i += BULK_CHUNK_SIZE) {
+      const chunk = filePaths.slice(i, i + BULK_CHUNK_SIZE)
+      if (chunk.length > 0) {
+        // Why: Git pathspec cleanup avoids raw recursive deletion through symlinked parents.
+        await this.git(['clean', '-ffdx', '--', ...chunk], worktreePath)
+      }
+    }
   }
 
   private async conflictOperation(params: Record<string, unknown>) {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -36,6 +36,7 @@ import {
 } from '../shared/git-effective-upstream'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import { buildRelayCommandEnv } from './relay-command-env'
+import { resolveSafeUntrackedDiscardTarget } from '../shared/git-discard-path-safety'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
@@ -222,7 +223,7 @@ export class GitHandler {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
 
-    const resolved = this.assertInWorktree(worktreePath, filePath)
+    this.assertInWorktree(worktreePath, filePath)
 
     let tracked = false
     try {
@@ -232,9 +233,13 @@ export class GitHandler {
       // untracked
     }
 
-    await (tracked
-      ? this.git(['restore', '--worktree', '--source=HEAD', '--', filePath], worktreePath)
-      : rm(resolved, { force: true, recursive: true }))
+    if (tracked) {
+      await this.git(['restore', '--worktree', '--source=HEAD', '--', filePath], worktreePath)
+      return
+    }
+
+    const safeTarget = await resolveSafeUntrackedDiscardTarget(worktreePath, filePath)
+    await rm(safeTarget, { force: true, recursive: true })
   }
 
   private async bulkDiscard(params: Record<string, unknown>) {
@@ -261,6 +266,9 @@ export class GitHandler {
     const untrackedPaths = filePaths.filter(
       (filePath) => !this.isTrackedPathSpec(filePath, trackedPathSpecs)
     )
+    const untrackedTargets = await Promise.all(
+      untrackedPaths.map((filePath) => resolveSafeUntrackedDiscardTarget(worktreePath, filePath))
+    )
 
     for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
       const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
@@ -268,9 +276,7 @@ export class GitHandler {
     }
 
     await Promise.all(
-      untrackedPaths.map((filePath) =>
-        rm(path.resolve(worktreePath, filePath), { force: true, recursive: true })
-      )
+      untrackedTargets.map((target) => rm(target, { force: true, recursive: true }))
     )
   }
 

--- a/src/shared/git-discard-path-safety.test.ts
+++ b/src/shared/git-discard-path-safety.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import * as path from 'path'
+import { tmpdir } from 'os'
+import { removeSafeUntrackedDiscardTarget } from './git-discard-path-safety'
+
+const tempRoots: string[] = []
+
+async function createWorktree(): Promise<string> {
+  const worktreePath = await mkdtemp(path.join(tmpdir(), 'orca-discard-safety-'))
+  tempRoots.push(worktreePath)
+  return worktreePath
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('removeSafeUntrackedDiscardTarget', () => {
+  it('rejects empty and root targets before removing anything', async () => {
+    const worktreePath = await createWorktree()
+    const keepFile = path.join(worktreePath, 'keep.txt')
+    await writeFile(keepFile, 'keep')
+
+    await expect(removeSafeUntrackedDiscardTarget(worktreePath, '')).rejects.toThrow(
+      'resolves outside the worktree'
+    )
+    await expect(removeSafeUntrackedDiscardTarget(worktreePath, '.')).rejects.toThrow(
+      'resolves outside the worktree'
+    )
+    await expect(removeSafeUntrackedDiscardTarget(worktreePath, 'child/..')).rejects.toThrow(
+      'resolves outside the worktree'
+    )
+
+    await expect(access(keepFile)).resolves.toBeUndefined()
+  })
+
+  it('allows missing child paths whose nearest existing parent is the worktree', async () => {
+    const worktreePath = await createWorktree()
+    await mkdir(path.join(worktreePath, 'existing'))
+
+    await expect(
+      removeSafeUntrackedDiscardTarget(worktreePath, 'existing/missing.txt')
+    ).resolves.toBeUndefined()
+    await expect(
+      removeSafeUntrackedDiscardTarget(worktreePath, 'new-dir/missing.txt')
+    ).resolves.toBeUndefined()
+    await expect(
+      removeSafeUntrackedDiscardTarget(worktreePath, 'missing.txt')
+    ).resolves.toBeUndefined()
+    await expect(access(worktreePath)).resolves.toBeUndefined()
+  })
+})

--- a/src/shared/git-discard-path-safety.test.ts
+++ b/src/shared/git-discard-path-safety.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { access, mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import * as path from 'path'
 import { tmpdir } from 'os'
@@ -20,34 +20,40 @@ describe('removeSafeUntrackedDiscardTarget', () => {
   it('rejects empty and root targets before removing anything', async () => {
     const worktreePath = await createWorktree()
     const keepFile = path.join(worktreePath, 'keep.txt')
+    const removePath = vi.fn(async () => undefined)
     await writeFile(keepFile, 'keep')
 
-    await expect(removeSafeUntrackedDiscardTarget(worktreePath, '')).rejects.toThrow(
+    await expect(removeSafeUntrackedDiscardTarget(worktreePath, '', removePath)).rejects.toThrow(
       'resolves outside the worktree'
     )
-    await expect(removeSafeUntrackedDiscardTarget(worktreePath, '.')).rejects.toThrow(
+    await expect(removeSafeUntrackedDiscardTarget(worktreePath, '.', removePath)).rejects.toThrow(
       'resolves outside the worktree'
     )
-    await expect(removeSafeUntrackedDiscardTarget(worktreePath, 'child/..')).rejects.toThrow(
-      'resolves outside the worktree'
-    )
+    await expect(
+      removeSafeUntrackedDiscardTarget(worktreePath, 'child/..', removePath)
+    ).rejects.toThrow('resolves outside the worktree')
 
     await expect(access(keepFile)).resolves.toBeUndefined()
+    expect(removePath).not.toHaveBeenCalled()
   })
 
   it('allows missing child paths whose nearest existing parent is the worktree', async () => {
     const worktreePath = await createWorktree()
+    const removePath = vi.fn(async () => undefined)
     await mkdir(path.join(worktreePath, 'existing'))
 
     await expect(
-      removeSafeUntrackedDiscardTarget(worktreePath, 'existing/missing.txt')
+      removeSafeUntrackedDiscardTarget(worktreePath, 'existing/missing.txt', removePath)
     ).resolves.toBeUndefined()
     await expect(
-      removeSafeUntrackedDiscardTarget(worktreePath, 'new-dir/missing.txt')
+      removeSafeUntrackedDiscardTarget(worktreePath, 'new-dir/missing.txt', removePath)
     ).resolves.toBeUndefined()
     await expect(
-      removeSafeUntrackedDiscardTarget(worktreePath, 'missing.txt')
+      removeSafeUntrackedDiscardTarget(worktreePath, 'missing.txt', removePath)
     ).resolves.toBeUndefined()
     await expect(access(worktreePath)).resolves.toBeUndefined()
+    expect(removePath).toHaveBeenNthCalledWith(1, 'existing/missing.txt')
+    expect(removePath).toHaveBeenNthCalledWith(2, 'new-dir/missing.txt')
+    expect(removePath).toHaveBeenNthCalledWith(3, 'missing.txt')
   })
 })

--- a/src/shared/git-discard-path-safety.ts
+++ b/src/shared/git-discard-path-safety.ts
@@ -1,4 +1,4 @@
-import { lstat, realpath, rm } from 'fs/promises'
+import { lstat, realpath } from 'fs/promises'
 import * as path from 'path'
 
 function isENOENT(error: unknown): boolean {
@@ -98,15 +98,17 @@ async function validateUntrackedDiscardTarget(
 
 export async function removeSafeUntrackedDiscardTarget(
   worktreePath: string,
-  filePath: string
+  filePath: string,
+  removePath: (filePath: string) => Promise<void>
 ): Promise<void> {
-  const target = await validateUntrackedDiscardTarget(worktreePath, filePath)
-  await rm(target, { force: true, recursive: true })
+  await validateUntrackedDiscardTarget(worktreePath, filePath)
+  await removePath(filePath)
 }
 
 export async function removeSafeUntrackedDiscardTargets(
   worktreePath: string,
   filePaths: readonly string[],
+  removePaths: (filePaths: readonly string[]) => Promise<void>,
   beforeRemove?: () => Promise<void>
 ): Promise<void> {
   await Promise.all(
@@ -114,10 +116,11 @@ export async function removeSafeUntrackedDiscardTargets(
   )
 
   // Why: bulk discard must validate every untracked path before mutating
-  // tracked files, while this module still owns the eventual recursive rm.
+  // tracked files, then recheck before the caller's Git-bounded cleanup runs.
   await beforeRemove?.()
 
-  for (const filePath of filePaths) {
-    await removeSafeUntrackedDiscardTarget(worktreePath, filePath)
-  }
+  await Promise.all(
+    filePaths.map((filePath) => validateUntrackedDiscardTarget(worktreePath, filePath))
+  )
+  await removePaths(filePaths)
 }

--- a/src/shared/git-discard-path-safety.ts
+++ b/src/shared/git-discard-path-safety.ts
@@ -1,0 +1,75 @@
+import { lstat, realpath } from 'fs/promises'
+import * as path from 'path'
+
+function isENOENT(error: unknown): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT'
+  )
+}
+
+function isInsideOrEqual(rootPath: string, candidatePath: string): boolean {
+  const relativePath = path.relative(rootPath, candidatePath)
+  return (
+    relativePath === '' ||
+    (relativePath !== '..' &&
+      !relativePath.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativePath))
+  )
+}
+
+async function assertRealPathInsideWorktree(
+  realWorktreePath: string,
+  candidatePath: string,
+  originalFilePath: string
+): Promise<void> {
+  const realCandidatePath = path.resolve(await realpath(candidatePath))
+  if (!isInsideOrEqual(realWorktreePath, realCandidatePath)) {
+    throw new Error(`Path "${originalFilePath}" resolves outside the worktree`)
+  }
+}
+
+async function assertNearestExistingParentInsideWorktree(
+  realWorktreePath: string,
+  candidatePath: string,
+  originalFilePath: string
+): Promise<void> {
+  let parentPath = path.dirname(candidatePath)
+  while (parentPath !== path.dirname(parentPath)) {
+    try {
+      await assertRealPathInsideWorktree(realWorktreePath, parentPath, originalFilePath)
+      return
+    } catch (error) {
+      if (!isENOENT(error)) {
+        throw error
+      }
+      parentPath = path.dirname(parentPath)
+    }
+  }
+
+  throw new Error(`Path "${originalFilePath}" resolves outside the worktree`)
+}
+
+export async function resolveSafeUntrackedDiscardTarget(
+  worktreePath: string,
+  filePath: string
+): Promise<string> {
+  const resolvedTarget = path.resolve(worktreePath, filePath)
+  const realWorktreePath = path.resolve(await realpath(worktreePath))
+
+  try {
+    const targetStats = await lstat(resolvedTarget)
+    // Why: discard should remove a symlink leaf itself, but symlinked parents
+    // must not redirect recursive removal outside the real worktree.
+    const pathToValidate = targetStats.isSymbolicLink()
+      ? path.dirname(resolvedTarget)
+      : resolvedTarget
+    await assertRealPathInsideWorktree(realWorktreePath, pathToValidate, filePath)
+  } catch (error) {
+    if (!isENOENT(error)) {
+      throw error
+    }
+    await assertNearestExistingParentInsideWorktree(realWorktreePath, resolvedTarget, filePath)
+  }
+
+  return resolvedTarget
+}

--- a/src/shared/git-discard-path-safety.ts
+++ b/src/shared/git-discard-path-safety.ts
@@ -1,4 +1,4 @@
-import { lstat, realpath } from 'fs/promises'
+import { lstat, realpath, rm } from 'fs/promises'
 import * as path from 'path'
 
 function isENOENT(error: unknown): boolean {
@@ -49,11 +49,33 @@ async function assertNearestExistingParentInsideWorktree(
   throw new Error(`Path "${originalFilePath}" resolves outside the worktree`)
 }
 
-export async function resolveSafeUntrackedDiscardTarget(
+function assertTargetIsWorktreeChild(
+  resolvedWorktreePath: string,
+  resolvedTarget: string,
+  originalFilePath: string
+): void {
+  const relativeTarget = path.relative(resolvedWorktreePath, resolvedTarget)
+  // Why: force-removing the worktree root is never a valid untracked discard,
+  // even when callers accidentally pass an empty or self-referential path.
+  if (
+    relativeTarget === '' ||
+    relativeTarget === '.' ||
+    relativeTarget === '..' ||
+    relativeTarget.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeTarget)
+  ) {
+    throw new Error(`Path "${originalFilePath}" resolves outside the worktree`)
+  }
+}
+
+async function validateUntrackedDiscardTarget(
   worktreePath: string,
   filePath: string
 ): Promise<string> {
+  const resolvedWorktreePath = path.resolve(worktreePath)
   const resolvedTarget = path.resolve(worktreePath, filePath)
+  assertTargetIsWorktreeChild(resolvedWorktreePath, resolvedTarget, filePath)
+
   const realWorktreePath = path.resolve(await realpath(worktreePath))
 
   try {
@@ -72,4 +94,30 @@ export async function resolveSafeUntrackedDiscardTarget(
   }
 
   return resolvedTarget
+}
+
+export async function removeSafeUntrackedDiscardTarget(
+  worktreePath: string,
+  filePath: string
+): Promise<void> {
+  const target = await validateUntrackedDiscardTarget(worktreePath, filePath)
+  await rm(target, { force: true, recursive: true })
+}
+
+export async function removeSafeUntrackedDiscardTargets(
+  worktreePath: string,
+  filePaths: readonly string[],
+  beforeRemove?: () => Promise<void>
+): Promise<void> {
+  await Promise.all(
+    filePaths.map((filePath) => validateUntrackedDiscardTarget(worktreePath, filePath))
+  )
+
+  // Why: bulk discard must validate every untracked path before mutating
+  // tracked files, while this module still owns the eventual recursive rm.
+  await beforeRemove?.()
+
+  for (const filePath of filePaths) {
+    await removeSafeUntrackedDiscardTarget(worktreePath, filePath)
+  }
 }


### PR DESCRIPTION
## Summary
- add a discard target safety check that resolves real worktree boundaries before untracked cleanup
- use `git clean -ffdx -- <path>` for local and SSH relay untracked discard cleanup after validation
- add regression coverage for symlinked parent paths, bulk discard atomicity, root-target rejection, symlink-leaf discard behavior, ignored paths, and nested repo targets

Fixes #2928

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/git-discard-path-safety.test.ts src/main/git/status.test.ts src/main/git/status-discard-symlink.test.ts src/relay/git-handler.test.ts`
- `pnpm run tc`
- `pnpm run lint`
- `git diff --check`
- adversarial Git cleanup probes for symlinked parents, ignored targets, and nested repo targets