### PR TITLE
fix: reject short SSH stream chunks instead of zero-filling reads (#2930)

### DIFF
--- a/src/main/providers/ssh-filesystem-provider-stream.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-stream.test.ts
@@ -209,4 +209,31 @@ describe('SshFilesystemProvider readFile streaming', () => {
     })
     await expect(provider.readFile('/home/x.bin')).rejects.toThrow(/length mismatch/i)
   })
+
+  it('rejects a short non-final chunk before later chunks arrive', async () => {
+    const totalSize = 256 * 1024 * 2
+    mux.request.mockImplementation(async () => {
+      setImmediate(() => {
+        mux._emitMethod('fs.streamChunk', {
+          streamId: 1,
+          seq: 0,
+          data: Buffer.alloc(1).toString('base64')
+        })
+        mux._emitMethod('fs.streamChunk', {
+          streamId: 1,
+          seq: 1,
+          data: Buffer.alloc(256 * 1024).toString('base64')
+        })
+        mux._emitMethod('fs.streamEnd', { streamId: 1 })
+      })
+      return {
+        streamId: 1,
+        totalSize,
+        isBinary: true,
+        chunkEncoding: 'base64',
+        resultEncoding: 'base64'
+      }
+    })
+    await expect(provider.readFile('/home/x.bin')).rejects.toThrow(/length mismatch/i)
+  })
 })

--- a/src/main/providers/ssh-filesystem-provider-stream.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-stream.test.ts
@@ -179,4 +179,34 @@ describe('SshFilesystemProvider readFile streaming', () => {
     })
     await expect(provider.readFile('/home/x.bin')).rejects.toThrow(/count mismatch/i)
   })
+
+  it('rejects a short final chunk instead of zero-filling the buffer', async () => {
+    // Two declared chunks, but the final one delivers a single byte. The chunk
+    // count matches (2), so the old code resolved with a zero-filled tail. The
+    // exact-length check must reject this.
+    const totalSize = 256 * 1024 * 2
+    mux.request.mockImplementation(async () => {
+      setImmediate(() => {
+        mux._emitMethod('fs.streamChunk', {
+          streamId: 1,
+          seq: 0,
+          data: Buffer.alloc(256 * 1024).toString('base64')
+        })
+        mux._emitMethod('fs.streamChunk', {
+          streamId: 1,
+          seq: 1,
+          data: Buffer.alloc(1).toString('base64')
+        })
+        mux._emitMethod('fs.streamEnd', { streamId: 1 })
+      })
+      return {
+        streamId: 1,
+        totalSize,
+        isBinary: true,
+        chunkEncoding: 'base64',
+        resultEncoding: 'base64'
+      }
+    })
+    await expect(provider.readFile('/home/x.bin')).rejects.toThrow(/length mismatch/i)
+  })
 })

--- a/src/main/ssh/ssh-filesystem-stream-reader.ts
+++ b/src/main/ssh/ssh-filesystem-stream-reader.ts
@@ -167,7 +167,7 @@ export async function readFileViaStream(
         return
       }
       // Why: redundant given the per-chunk length + count checks, but kept as a
-      // last-line invariant guard — never resolve with fewer bytes than declared.
+      // last-line invariant guard; never resolve with fewer bytes than declared.
       if (bytesReceived !== totalSize) {
         fail(
           new StreamProtocolError(

--- a/src/main/ssh/ssh-filesystem-stream-reader.ts
+++ b/src/main/ssh/ssh-filesystem-stream-reader.ts
@@ -64,6 +64,7 @@ export async function readFileViaStream(
     let expectedSeq = 0
     let receivedChunks = 0
     let totalChunks = 0
+    let bytesReceived = 0
     let settled = false
 
     // Why: chunk/end/error frames may arrive in the same dispatch tick as the
@@ -128,10 +129,13 @@ export async function readFileViaStream(
       }
       const offset = seq * STREAM_CHUNK_SIZE
       const decoded = Buffer.from(data, 'base64')
-      if (offset + decoded.length > totalSize) {
+      // Why: a short chunk would leave the pre-allocated buffer zero-filled and
+      // resolve as silently-corrupt data; validate each chunk's exact length.
+      const expectedLength = Math.min(STREAM_CHUNK_SIZE, totalSize - offset)
+      if (decoded.length !== expectedLength) {
         fail(
           new StreamProtocolError(
-            `Chunk overflows declared totalSize: offset=${offset} len=${decoded.length} total=${totalSize}`
+            `Chunk length mismatch for stream ${id}: seq=${seq} expected=${expectedLength} got=${decoded.length}`
           )
         )
         return
@@ -143,6 +147,7 @@ export async function readFileViaStream(
       decoded.copy(buffer, offset)
       expectedSeq += 1
       receivedChunks += 1
+      bytesReceived += decoded.length
     }
 
     const handleEnd = (params: Record<string, unknown>): void => {
@@ -157,6 +162,16 @@ export async function readFileViaStream(
         fail(
           new StreamProtocolError(
             `Chunk count mismatch for stream ${id}: expected ${totalChunks}, received ${receivedChunks}`
+          )
+        )
+        return
+      }
+      // Why: redundant given the per-chunk length + count checks, but kept as a
+      // last-line invariant guard — never resolve with fewer bytes than declared.
+      if (bytesReceived !== totalSize) {
+        fail(
+          new StreamProtocolError(
+            `Byte count mismatch for stream ${id}: expected ${totalSize}, received ${bytesReceived}`
           )
         )
         return

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -52,6 +52,15 @@ export type StreamMetadata = {
   empty?: boolean
 }
 
+type StreamChunkReader = {
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number
+  ): Promise<{ bytesRead: number }>
+}
+
 export async function readRelayFileStreamMetadata(
   filePath: string,
   dispatcher: RelayDispatcher,
@@ -142,11 +151,11 @@ async function pumpChunks(
           break
         }
         const want = Math.min(STREAM_CHUNK_SIZE, totalSize - offset)
-        const { bytesRead } = await entry.handle.read(buffer, 0, want, offset)
-        if (bytesRead === 0) {
+        const bytesRead = await readFullStreamChunk(entry.handle, buffer, want, offset)
+        if (bytesRead !== want) {
           endReason = 'error'
           errorCode = 'ESTREAMTRUNCATED'
-          errorMessage = `File truncated mid-stream: expected ${totalSize}, got ${offset}`
+          errorMessage = `File truncated mid-stream: expected ${totalSize}, got ${offset + bytesRead}`
           break
         }
         if (context.isStale()) {
@@ -200,6 +209,30 @@ async function pumpChunks(
   } finally {
     await registry.release(streamId)
   }
+}
+
+// Why: fs.read() may return fewer bytes than requested before EOF. Fill each
+// protocol chunk so strict clients reject corruption, not valid short reads.
+async function readFullStreamChunk(
+  handle: StreamChunkReader,
+  buffer: Buffer,
+  length: number,
+  offset: number
+): Promise<number> {
+  let totalRead = 0
+  while (totalRead < length) {
+    const { bytesRead } = await handle.read(
+      buffer,
+      totalRead,
+      length - totalRead,
+      offset + totalRead
+    )
+    if (bytesRead === 0) {
+      break
+    }
+    totalRead += bytesRead
+  }
+  return totalRead
 }
 
 export function isTooManyStreamsError(err: unknown): err is TooManyStreamsError {

--- a/src/relay/fs-handler-stream.test.ts
+++ b/src/relay/fs-handler-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { FsHandler } from './fs-handler'
 import { RelayContext } from './context'
 import type { RelayDispatcher } from './dispatcher'
+import { STREAM_CHUNK_SIZE } from './protocol'
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import { mkdtempSync, writeFileSync } from 'fs'
@@ -130,6 +131,50 @@ describe('FsHandler readFileStream', () => {
     const { chunks, end, err } = collectStream(dispatcher)
     expect(err).toBeNull()
     expect(end).toEqual({ streamId: meta.streamId })
+    const reassembled = Buffer.concat(chunks.map((c) => Buffer.from(c.data, 'base64')))
+    expect(reassembled.equals(content)).toBe(true)
+  })
+
+  it('fills protocol chunks when fs.read returns short before EOF', async () => {
+    const filePath = path.join(tmpDir, 'short-read.png')
+    const content = Buffer.alloc(STREAM_CHUNK_SIZE + 17, 0x42)
+    writeFileSync(filePath, content)
+
+    const sampleHandle = await fs.open(filePath, 'r')
+    const fileHandlePrototype = Object.getPrototypeOf(sampleHandle) as {
+      read: typeof sampleHandle.read
+    }
+    await sampleHandle.close()
+
+    type PositionedRead = (
+      this: typeof sampleHandle,
+      buffer: Buffer,
+      offset: number | null,
+      length: number | null,
+      position: number | null
+    ) => Promise<{ bytesRead: number; buffer: Buffer }>
+    const originalRead = fileHandlePrototype.read as unknown as PositionedRead
+    const readSpy = vi.spyOn(fileHandlePrototype, 'read').mockImplementation(async function (
+      this: typeof sampleHandle,
+      buffer: Buffer,
+      offset: number | null = 0,
+      length: number | null = buffer.byteLength,
+      position: number | null = null
+    ) {
+      const readLength = position === 0 && length !== null ? Math.min(length, 5) : length
+      return originalRead.call(this, buffer, offset, readLength, position)
+    } as typeof sampleHandle.read)
+    try {
+      await dispatcher.callRequest('fs.readFileStream', { filePath }, { isStale: () => false })
+      await waitFor(() => collectStream(dispatcher).end !== null)
+    } finally {
+      readSpy.mockRestore()
+    }
+
+    const { chunks, end, err } = collectStream(dispatcher)
+    expect(err).toBeNull()
+    expect(end).not.toBeNull()
+    expect(chunks.map((c) => Buffer.from(c.data, 'base64').length)).toEqual([STREAM_CHUNK_SIZE, 17])
     const reassembled = Buffer.concat(chunks.map((c) => Buffer.from(c.data, 'base64')))
     expect(reassembled.equals(content)).toBe(true)
   })


### PR DESCRIPTION
## Summary

The SSH file-stream reader validated the chunk **count** at `streamEnd` but never each chunk's **byte length**. A short chunk (e.g. a 1-byte final chunk for a file declared as two 256 KiB chunks) still satisfied `receivedChunks === totalChunks`, so the read resolved with the pre-allocated buffer's tail left **zero-filled** — silent corruption of the returned remote file.

Fix:
- Validate each chunk's exact decoded length: every chunk but the last must be `STREAM_CHUNK_SIZE`, and the last must fill the declared remainder.
- Add a last-line `bytesReceived === totalSize` invariant guard before resolving (redundant with the per-chunk + count checks, kept as defense-in-depth on a silent-corruption path).

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (node config clean)
- [x] `pnpm test` (provider stream suite: 7 passed, incl. new short-final-chunk rejection)
- [ ] `pnpm build` (not run — main-process logic change)
- [x] Added a regression test matching the issue's repro (2 declared chunks, short final chunk → rejects with "length mismatch")

## AI Review Report

Ran simplify reviewers (reuse/quality/efficiency). Reuse: the `Math.min(STREAM_CHUNK_SIZE, totalSize - offset)` formula mirrors the relay sender's read-size calc but lives across the process boundary with separate `protocol.ts` copies, so no shared helper is extractable. Quality: trimmed the new comments to the project's 1–2 line convention and made the end-guard's comment honest (it's an invariant guard, not the primary truncation catch). Efficiency: the added work is O(1) per chunk, no extra allocation/decode. Cross-platform: pure logic, no platform branches. SSH is the affected surface (remote reads).

## Security Audit

Closes a data-integrity bug on remote reads (a truncated/short transfer could surface as a silently zero-padded file). Validation tightened; no auth/secrets/IPC changes. Chunk length is bounded by the already-validated `totalSize` cap, so no new allocation risk.

## Notes

Behavior change: a stream that delivers a chunk of the wrong length now rejects with a `StreamProtocolError` instead of resolving with partial/zero-filled content.
