### PR TITLE
Fix Claude screenshot paste after interrupt

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -74,6 +74,7 @@ import {
   TerminalQuickCommandDialog
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
+import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 
 // Why: registry lives in a leaf module so the store slice can import it
 // without re-entering the `slice → TerminalPane → store → slice` cycle
@@ -1063,36 +1064,17 @@ export default function TerminalPane({
       return
     }
 
-    // Shared helper: try text first (fast path, single IPC call for the
-    // common case), then check for a clipboard image only when text is empty
-    // — which is the image-only clipboard scenario this fix targets.
     const pasteFromClipboard = (pane: ManagedPane): void => {
-      void window.api.ui
-        .readClipboardText()
-        .then((text) => {
-          if (text) {
-            pasteTerminalText(pane.terminal, text)
-            return
-          }
-          // Why: clipboard has no text — check for an image. This is the
-          // image-only clipboard case (e.g. screenshot) where Chromium's paste
-          // event would never fire on a textarea. We save the image to a temp
-          // file owned by the terminal host and paste that path.
-          const connectionId = getConnectionId(worktreeId) ?? null
-          return window.api.ui
-            .saveClipboardImageAsTempFile({ connectionId })
-            .then((filePath) => {
-              if (filePath) {
-                pasteTerminalText(pane.terminal, filePath)
-              }
-            })
-            .catch((error: unknown) => {
-              setTerminalError(formatClipboardImagePasteError(error))
-            })
-        })
-        .catch(() => {
-          /* ignore clipboard failures */
-        })
+      const connectionId = getConnectionId(worktreeId) ?? null
+      void pasteTerminalClipboard({
+        readClipboardText: window.api.ui.readClipboardText,
+        saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
+        connectionId,
+        pasteText: (text, options) => pasteTerminalText(pane.terminal, text, options),
+        onImagePasteError: (error) => setTerminalError(formatClipboardImagePasteError(error))
+      }).catch(() => {
+        /* ignore clipboard failures */
+      })
     }
 
     const isMac = navigator.userAgent.includes('Mac')

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -48,6 +48,53 @@ describe('terminal bracketed paste policy', () => {
     expect(observedIgnoreValues).toEqual([false])
   })
 
+  it('forces bracketed paste behavior when requested after Ctrl+C', () => {
+    const terminal = createTerminal(true)
+    const observedIgnoreValues: (boolean | undefined)[] = []
+    terminal.paste.mockImplementation(() => {
+      observedIgnoreValues.push(terminal.options.ignoreBracketedPasteMode)
+    })
+
+    markTerminalBracketedPasteInterrupted(terminal)
+    pasteTerminalText(terminal, '/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true
+    })
+
+    expect(terminal.paste).toHaveBeenCalledWith(
+      '\x1b[200~/tmp/orca-paste-1760000000000-id.png\x1b[201~'
+    )
+    expect(observedIgnoreValues).toEqual([true])
+    expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
+  })
+
+  it('forces bracketed paste behavior even when terminal mode is off', () => {
+    const terminal = createTerminal(false)
+    const observedIgnoreValues: (boolean | undefined)[] = []
+    terminal.paste.mockImplementation(() => {
+      observedIgnoreValues.push(terminal.options.ignoreBracketedPasteMode)
+    })
+
+    pasteTerminalText(terminal, '/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true
+    })
+
+    expect(terminal.paste).toHaveBeenCalledWith(
+      '\x1b[200~/tmp/orca-paste-1760000000000-id.png\x1b[201~'
+    )
+    expect(observedIgnoreValues).toEqual([true])
+    expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
+  })
+
+  it('renders embedded escape bytes inert when forcing bracketed paste', () => {
+    const terminal = createTerminal(false)
+
+    pasteTerminalText(terminal, '/tmp/before\x1b[201~after.png', {
+      forceBracketedPaste: true
+    })
+
+    expect(terminal.paste).toHaveBeenCalledWith('\x1b[200~/tmp/before\u241b[201~after.png\x1b[201~')
+  })
+
   it('does not change paste behavior when Ctrl+C happened outside bracketed paste mode', () => {
     const terminal = createTerminal(false)
     const observedIgnoreValues: (boolean | undefined)[] = []

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -11,9 +11,15 @@ type PasteTerminal = BracketedPasteTerminal & {
   paste: (text: string) => void
 }
 
+type PasteTerminalTextOptions = {
+  forceBracketedPaste?: boolean
+}
+
 const interruptedBracketedPasteTerminals = new WeakSet<object>()
 const bracketedPasteModeOutputTail = new WeakMap<object, string>()
 const ESCAPE = '\u001b'
+const BRACKETED_PASTE_START = `${ESCAPE}[200~`
+const BRACKETED_PASTE_END = `${ESCAPE}[201~`
 const BRACKETED_PASTE_MODE_SEQUENCE_RE = /^\[\?(?:\d+;)*2004(?:;\d+)*[hl]/
 const BRACKETED_PASTE_MODE_TAIL_MAX = 128
 const LINE_BREAK_RE = /[\r\n]/
@@ -26,6 +32,22 @@ function hasBracketedPasteModeSequence(data: string): boolean {
     }
   }
   return false
+}
+
+function sanitizeBracketedPasteText(text: string): string {
+  return text.split(ESCAPE).join('\u241b')
+}
+
+function forceBracketedPaste(terminal: PasteTerminal, text: string): void {
+  const previousIgnoreBracketedPasteMode = terminal.options.ignoreBracketedPasteMode
+  terminal.options.ignoreBracketedPasteMode = true
+  try {
+    terminal.paste(
+      `${BRACKETED_PASTE_START}${sanitizeBracketedPasteText(text)}${BRACKETED_PASTE_END}`
+    )
+  } finally {
+    terminal.options.ignoreBracketedPasteMode = previousIgnoreBracketedPasteMode
+  }
 }
 
 export function markTerminalBracketedPasteInterrupted(terminal: BracketedPasteTerminal): void {
@@ -50,7 +72,17 @@ export function observeTerminalBracketedPasteModeOutput(
   }
 }
 
-export function pasteTerminalText(terminal: PasteTerminal, text: string): void {
+export function pasteTerminalText(
+  terminal: PasteTerminal,
+  text: string,
+  options?: PasteTerminalTextOptions
+): void {
+  if (options?.forceBracketedPaste) {
+    // Why: generated image paths are paste payloads, even when they are a
+    // single line, so they must bypass stale Ctrl+C plain-text suppression.
+    forceBracketedPaste(terminal, text)
+    return
+  }
   if (!interruptedBracketedPasteTerminals.has(terminal)) {
     terminal.paste(text)
     return
@@ -71,7 +103,7 @@ export function pasteTerminalText(terminal: PasteTerminal, text: string): void {
   // process dies. Single-line paste does not need wrappers, so avoid leaking them.
   terminal.options.ignoreBracketedPasteMode = true
   try {
-    terminal.paste(text.split(ESCAPE).join('\u241b'))
+    terminal.paste(sanitizeBracketedPasteText(text))
   } finally {
     terminal.options.ignoreBracketedPasteMode = previousIgnoreBracketedPasteMode
   }

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import {
+  markTerminalBracketedPasteInterrupted,
+  pasteTerminalText
+} from './terminal-bracketed-paste'
+
+describe('terminal clipboard paste', () => {
+  it('forces bracketed paste for generated image-only clipboard paths', async () => {
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile: vi
+        .fn()
+        .mockResolvedValue(
+          '/var/folders/3l/b7w02vh17tg5r5s3nhhdf3kh0000gn/T/orca-paste-1760000000000-id.png'
+        ),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith(
+      '/var/folders/3l/b7w02vh17tg5r5s3nhhdf3kh0000gn/T/orca-paste-1760000000000-id.png',
+      { forceBracketedPaste: true }
+    )
+  })
+
+  it('forces generated image paste onto the native bracketed-paste path after Ctrl+C', async () => {
+    const observedIgnoreBracketedPasteMode: boolean[] = []
+    const terminal = {
+      modes: { bracketedPasteMode: true },
+      options: { ignoreBracketedPasteMode: false },
+      paste: vi.fn(() => {
+        observedIgnoreBracketedPasteMode.push(terminal.options.ignoreBracketedPasteMode)
+      })
+    }
+    markTerminalBracketedPasteInterrupted(terminal)
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile: vi
+        .fn()
+        .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+    })
+
+    expect(terminal.paste).toHaveBeenCalledWith(
+      '\x1b[200~/tmp/orca-paste-1760000000000-id.png\x1b[201~'
+    )
+    expect(observedIgnoreBracketedPasteMode).toEqual([true])
+    expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
+  })
+
+  it('forces generated image paste even when xterm bracketed paste mode is off', async () => {
+    const observedIgnoreBracketedPasteMode: boolean[] = []
+    const terminal = {
+      modes: { bracketedPasteMode: false },
+      options: { ignoreBracketedPasteMode: false },
+      paste: vi.fn(() => {
+        observedIgnoreBracketedPasteMode.push(terminal.options.ignoreBracketedPasteMode)
+      })
+    }
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile: vi
+        .fn()
+        .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+    })
+
+    expect(terminal.paste).toHaveBeenCalledWith(
+      '\x1b[200~/tmp/orca-paste-1760000000000-id.png\x1b[201~'
+    )
+    expect(observedIgnoreBracketedPasteMode).toEqual([true])
+    expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
+  })
+
+  it('forwards SSH connection context and bracket-pastes the returned remote image path', async () => {
+    const pasteText = vi.fn()
+    const saveClipboardImageAsTempFile = vi
+      .fn()
+      .mockResolvedValue('/var/tmp/orca-paste-1760000000000-id.png')
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile,
+      connectionId: 'ssh-1',
+      pasteText
+    })
+
+    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({ connectionId: 'ssh-1' })
+    expect(pasteText).toHaveBeenCalledWith('/var/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true
+    })
+  })
+
+  it('bracket-pastes generated image paths without relying on agent detection', async () => {
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile: vi
+        .fn()
+        .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true
+    })
+  })
+
+  it('preserves the text fast path without probing for images', async () => {
+    const saveClipboardImageAsTempFile = vi.fn()
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('hello'),
+      saveClipboardImageAsTempFile,
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('hello')
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+  })
+
+  it('keeps normal single-line text paste on the stale Ctrl+C protection path', async () => {
+    const observedIgnoreBracketedPasteMode: boolean[] = []
+    const terminal = {
+      modes: { bracketedPasteMode: true },
+      options: { ignoreBracketedPasteMode: false },
+      paste: vi.fn(() => {
+        observedIgnoreBracketedPasteMode.push(terminal.options.ignoreBracketedPasteMode)
+      })
+    }
+    const saveClipboardImageAsTempFile = vi.fn()
+    markTerminalBracketedPasteInterrupted(terminal)
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('a69ce28e1d092e0c8825cd1a109ac36409962bc1'),
+      saveClipboardImageAsTempFile,
+      pasteText: (text, options) => pasteTerminalText(terminal, text, options)
+    })
+
+    expect(terminal.paste).toHaveBeenCalledWith('a69ce28e1d092e0c8825cd1a109ac36409962bc1')
+    expect(observedIgnoreBracketedPasteMode).toEqual([true])
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -1,0 +1,43 @@
+type PasteTextOptions = {
+  forceBracketedPaste?: boolean
+}
+
+type SaveClipboardImageAsTempFile = (args?: {
+  connectionId?: string | null
+}) => Promise<string | null>
+
+type PasteTerminalClipboardDeps = {
+  readClipboardText: () => Promise<string>
+  saveClipboardImageAsTempFile: SaveClipboardImageAsTempFile
+  pasteText: (text: string, options?: PasteTextOptions) => void
+  connectionId?: string | null
+  onImagePasteError?: (error: unknown) => void
+}
+
+export async function pasteTerminalClipboard({
+  readClipboardText,
+  saveClipboardImageAsTempFile,
+  pasteText,
+  connectionId,
+  onImagePasteError
+}: PasteTerminalClipboardDeps): Promise<void> {
+  const text = await readClipboardText()
+  if (text) {
+    pasteText(text)
+    return
+  }
+
+  try {
+    const filePath = await saveClipboardImageAsTempFile({ connectionId })
+    if (!filePath) {
+      return
+    }
+    pasteText(filePath, {
+      // Why: a generated clipboard-image path is terminal image injection, not
+      // ordinary one-line text. Keep it off the Ctrl+C stale-text paste path.
+      forceBracketedPaste: true
+    })
+  } catch (error) {
+    onImagePasteError?.(error)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -7,6 +7,7 @@ import type { TerminalQuickCommand } from '../../../../shared/types'
 import { sendTerminalQuickCommandToPane } from './terminal-quick-command-dispatch'
 import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import { pasteTerminalText } from './terminal-bracketed-paste'
+import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -107,24 +108,17 @@ export function useTerminalPaneContextMenu({
     if (!pane) {
       return
     }
-    const text = await window.api.ui.readClipboardText()
-    if (text) {
-      pasteTerminalText(pane.terminal, text)
-      pane.terminal.focus()
-      return
-    }
-    // Why: clipboard has no text — check for an image (e.g. screenshot) and
-    // save it on the same host as this terminal before pasting the file path.
-    try {
-      const connectionId = getConnectionId(worktreeId) ?? null
-      const filePath = await window.api.ui.saveClipboardImageAsTempFile({ connectionId })
-      if (filePath) {
-        pasteTerminalText(pane.terminal, filePath)
+    const connectionId = getConnectionId(worktreeId) ?? null
+    await pasteTerminalClipboard({
+      readClipboardText: window.api.ui.readClipboardText,
+      saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
+      connectionId,
+      pasteText: (text, options) => pasteTerminalText(pane.terminal, text, options),
+      onImagePasteError: (error) => {
+        const detail = error instanceof Error ? error.message : String(error)
+        onPasteError(`Image paste failed: ${detail}`)
       }
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error)
-      onPasteError(`Image paste failed: ${detail}`)
-    }
+    })
     // Why: Radix returns focus to the menu trigger (the pane container) on
     // close, but xterm.js only accepts input when its own helper textarea is
     // focused. Without this, the user has to click the pane again before


### PR DESCRIPTION
## Summary
- Treat generated clipboard-image paths as terminal image injection, not ordinary one-line text.
- Always force bracketed paste for generated image paths so Ctrl+C stale-mode protection cannot turn them into visible raw file paths.
- Keep normal text paste on the existing conservative stale Ctrl+C path.
- Preserve SSH behavior by passing the connection ID into image persistence so the pasted path is the remote temp path.

## Test plan
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts src/main/window/clipboard-ipc-handlers.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json
- pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts src/main/window/clipboard-ipc-handlers.ts src/main/window/clipboard-ipc-handlers.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts src/main/window/clipboard-ipc-handlers.ts src/main/window/clipboard-ipc-handlers.test.ts && git diff --check

Fixes #2842