### PR TITLE
fix: bound the eager PTY buffer and stop quadratic trimming (#2931)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -170,16 +170,28 @@ export function registerEagerPtyBuffer(
 ): EagerPtyHandle {
   ensurePtyDispatcher()
 
-  const buffer: string[] = []
+  // Why: a head index instead of Array.shift() — shift() is O(n), making
+  // pre-attach buffering quadratic under many small chunks. Compaction is deferred.
+  const chunks: string[] = []
+  let head = 0
   let bufferBytes = 0
 
   const dataHandler = (data: string): void => {
-    buffer.push(data)
-    bufferBytes += data.length
-    // Trim from the front when the buffer exceeds the cap, keeping the
-    // most recent output which contains the shell prompt.
-    while (bufferBytes > EAGER_BUFFER_MAX_BYTES && buffer.length > 1) {
-      bufferBytes -= buffer.shift()!.length
+    // A single chunk larger than the cap would otherwise bypass trimming and
+    // store the whole payload; keep only its most-recent tail.
+    const chunk = data.length > EAGER_BUFFER_MAX_BYTES ? data.slice(-EAGER_BUFFER_MAX_BYTES) : data
+    chunks.push(chunk)
+    bufferBytes += chunk.length
+    // Drop whole leading chunks (keeping the prompt-bearing tail) until within cap.
+    while (bufferBytes > EAGER_BUFFER_MAX_BYTES && head < chunks.length - 1) {
+      bufferBytes -= chunks[head].length
+      chunks[head] = ''
+      head += 1
+    }
+    // Compact when dead slots reach half the array so it can't grow unbounded.
+    if (head > 0 && head * 2 >= chunks.length) {
+      chunks.splice(0, head)
+      head = 0
     }
   }
   const exitHandler = (code: number): void => {
@@ -197,8 +209,10 @@ export function registerEagerPtyBuffer(
 
   const handle: EagerPtyHandle = {
     flush() {
-      const data = buffer.join('')
-      buffer.length = 0
+      const data = chunks.slice(head).join('')
+      chunks.length = 0
+      head = 0
+      bufferBytes = 0
       return data
     },
     dispose() {

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -154,6 +154,13 @@ export function subscribeToPtyExit(ptyId: string, watcher: (code: number) => voi
 
 export type EagerPtyHandle = { flush: () => string; dispose: () => void }
 const eagerPtyHandles = new Map<string, EagerPtyHandle>()
+const eagerBufferTextEncoder = new TextEncoder()
+const eagerBufferTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true })
+
+type EagerBufferChunk = {
+  data: string
+  bytes: number
+}
 
 export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefined {
   return eagerPtyHandles.get(ptyId)
@@ -164,6 +171,19 @@ export function getEagerPtyBufferHandle(ptyId: string): EagerPtyHandle | undefin
 // runs a long-lived command (e.g. tail -f) in a worktree the user never opens.
 const EAGER_BUFFER_MAX_BYTES = 512 * 1024
 
+function clampUtf8Tail(data: string, maxBytes: number): EagerBufferChunk {
+  const encoded = eagerBufferTextEncoder.encode(data)
+  if (encoded.byteLength <= maxBytes) {
+    return { data, bytes: encoded.byteLength }
+  }
+  let start = encoded.byteLength - maxBytes
+  while (start < encoded.byteLength && (encoded[start] & 0xc0) === 0x80) {
+    start += 1
+  }
+  const tail = eagerBufferTextDecoder.decode(encoded.subarray(start))
+  return { data: tail, bytes: encoded.byteLength - start }
+}
+
 export function registerEagerPtyBuffer(
   ptyId: string,
   onExit: (ptyId: string, code: number) => void
@@ -172,20 +192,20 @@ export function registerEagerPtyBuffer(
 
   // Why: a head index instead of Array.shift() — shift() is O(n), making
   // pre-attach buffering quadratic under many small chunks. Compaction is deferred.
-  const chunks: string[] = []
+  const chunks: EagerBufferChunk[] = []
   let head = 0
   let bufferBytes = 0
 
   const dataHandler = (data: string): void => {
     // A single chunk larger than the cap would otherwise bypass trimming and
     // store the whole payload; keep only its most-recent tail.
-    const chunk = data.length > EAGER_BUFFER_MAX_BYTES ? data.slice(-EAGER_BUFFER_MAX_BYTES) : data
+    const chunk = clampUtf8Tail(data, EAGER_BUFFER_MAX_BYTES)
     chunks.push(chunk)
-    bufferBytes += chunk.length
+    bufferBytes += chunk.bytes
     // Drop whole leading chunks (keeping the prompt-bearing tail) until within cap.
     while (bufferBytes > EAGER_BUFFER_MAX_BYTES && head < chunks.length - 1) {
-      bufferBytes -= chunks[head].length
-      chunks[head] = ''
+      bufferBytes -= chunks[head].bytes
+      chunks[head] = { data: '', bytes: 0 }
       head += 1
     }
     // Compact when dead slots reach half the array so it can't grow unbounded.
@@ -209,7 +229,10 @@ export function registerEagerPtyBuffer(
 
   const handle: EagerPtyHandle = {
     flush() {
-      const data = chunks.slice(head).join('')
+      const data = chunks
+        .slice(head)
+        .map((chunk) => chunk.data)
+        .join('')
       chunks.length = 0
       head = 0
       bufferBytes = 0

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -273,6 +273,59 @@ describe('createIpcPtyTransport', () => {
     expect(flushed.endsWith('TAIL$')).toBe(true)
   })
 
+  it('enforces the eager buffer cap in UTF-8 bytes for multi-byte output', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const cap = 512 * 1024
+    const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
+
+    onData?.({ id: 'pty-restored', data: `${'界'.repeat(cap)}PROMPT$` })
+
+    const flushed = handle.flush()
+    expect(new TextEncoder().encode(flushed).byteLength).toBeLessThanOrEqual(cap)
+    expect(flushed.endsWith('PROMPT$')).toBe(true)
+  })
+
+  it('preserves a BOM when it starts the retained oversized eager-buffer tail', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const cap = 512 * 1024
+    const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
+
+    onData?.({ id: 'pty-restored', data: `${'x'.repeat(16)}\uFEFF${'y'.repeat(cap - 3)}` })
+
+    const flushed = handle.flush()
+    expect(new TextEncoder().encode(flushed).byteLength).toBe(cap)
+    expect(flushed.startsWith('\uFEFF')).toBe(true)
+  })
+
+  it('does not use Array.shift while trimming many eager chunks', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
+    const originalShift = Array.prototype.shift
+
+    try {
+      // Why: this hot path used to call Array.shift() once per trim, which
+      // reindexed the live buffer and made many small chunks quadratic.
+      Object.defineProperty(Array.prototype, 'shift', {
+        configurable: true,
+        writable: true,
+        value() {
+          throw new Error('Array.shift should not be used by the eager buffer')
+        }
+      })
+      for (let i = 0; i < 2048; i += 1) {
+        onData?.({ id: 'pty-restored', data: 'x'.repeat(1024) })
+      }
+    } finally {
+      Object.defineProperty(Array.prototype, 'shift', {
+        configurable: true,
+        writable: true,
+        value: originalShift
+      })
+    }
+
+    expect(handle.flush().length).toBeLessThanOrEqual(512 * 1024)
+  })
+
   it('routes eager-buffered bytes through onReplayData so the renderer can engage the replay guard', async () => {
     const { createIpcPtyTransport, registerEagerPtyBuffer } = await import('./pty-transport')
 

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -242,6 +242,37 @@ describe('createIpcPtyTransport', () => {
     expect(onBell).toHaveBeenCalledTimes(1)
   })
 
+  it('bounds the eager buffer to its cap and keeps the most recent output', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const cap = 512 * 1024
+    const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
+
+    // 8 x 100 KB = 800 KB of distinct chunks, exceeding the 512 KB cap; the
+    // earliest chunks must be dropped while the prompt-bearing tail is kept.
+    for (let i = 0; i < 8; i += 1) {
+      onData?.({ id: 'pty-restored', data: String.fromCharCode(65 + i).repeat(100 * 1024) })
+    }
+    onData?.({ id: 'pty-restored', data: 'PROMPT$' })
+
+    const flushed = handle.flush()
+    expect(flushed.length).toBeLessThanOrEqual(cap)
+    expect(flushed.endsWith('PROMPT$')).toBe(true)
+    expect(flushed).not.toContain('A') // oldest chunk trimmed
+  })
+
+  it('caps a single oversized eager chunk to its most-recent tail', async () => {
+    const { registerEagerPtyBuffer } = await import('./pty-transport')
+    const cap = 512 * 1024
+    const handle = registerEagerPtyBuffer('pty-restored', vi.fn())
+
+    // One chunk larger than the cap must not be stored whole.
+    onData?.({ id: 'pty-restored', data: `${'x'.repeat(cap)}TAIL$` })
+
+    const flushed = handle.flush()
+    expect(flushed.length).toBeLessThanOrEqual(cap)
+    expect(flushed.endsWith('TAIL$')).toBe(true)
+  })
+
   it('routes eager-buffered bytes through onReplayData so the renderer can engage the replay guard', async () => {
     const { createIpcPtyTransport, registerEagerPtyBuffer } = await import('./pty-transport')
 


### PR DESCRIPTION
## Summary

The eager PTY reconnection buffer (which holds a restored shell's output before its terminal pane attaches) had two flaws in `registerEagerPtyBuffer`:

1. **Quadratic trimming** — it trimmed with `Array.shift()`, which is O(n) (reindexes the whole array). A shell emitting many small `pty:data` chunks before attach (e.g. a chatty restored session) turned buffering into O(n²).
2. **Cap bypass** — the trim loop guarded on `buffer.length > 1`, so a single chunk larger than the 512 KB cap could never be trimmed and the whole oversized payload was stored.

Fix: replace `shift()` with a head index (dropped chunks are released for GC; the array is compacted only when dead slots reach half its length, keeping each push amortized O(1)), and clamp an oversized single chunk to its most-recent 512 KB tail so the cap always holds. `flush()` now resets `bufferBytes` too.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (web config clean)
- [x] `pnpm test` (pty-transport suite: 25 passed, incl. new cap-enforcement and oversized-single-chunk tests)
- [ ] `pnpm build` (not run — renderer logic change)
- [x] Added regression tests: 800 KB across 8 chunks trims oldest + keeps prompt tail ≤ cap; one >cap chunk is clamped to its tail

## AI Review Report

Ran the simplify reviewers (quality/correctness + efficiency, sonnet). Both confirmed the cap invariant holds in all traced cases (chunk == cap, many tiny chunks, single-live-chunk guard), compaction is not off-by-one, `flush()` slices correctly from `head`, and the change is amortized O(1) per push with byte total hard-capped at 512 KB and slot count bounded by CAP/min-chunk-size. Trimmed an over-long comment per the project's 1–2 line WHY convention. Cross-platform: pure renderer logic, no platform branches.

## Security Audit

Closes an unbounded-work / memory-amplification path (a chatty restored shell could pin the UI thread and exceed the intended buffer cap). No input handling, auth, secrets, or IPC surface changes — same data, bounded retention.

## Notes

Behavior is unchanged for normal-sized output; only the trimming mechanism and the single-oversized-chunk edge differ.
