### PR TITLE
Handle already-bumped patch release cuts

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -388,7 +388,14 @@ jobs:
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"
           fi
-          git commit -m "$commit_message"
+          if git diff --cached --quiet; then
+            # Why: a failed cut can push the version bump to main before the
+            # release is published. Re-cutting then needs a fresh taggable
+            # release commit even though package.json is already at VERSION.
+            git commit --allow-empty -m "$commit_message"
+          else
+            git commit -m "$commit_message"
+          fi
           git tag -a "v$VERSION" -m "v$VERSION"
           echo "tag=v$VERSION" >>"$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >>"$GITHUB_OUTPUT"

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -61,6 +61,20 @@ describe('Electron runtime package contract', () => {
     )
   })
 
+  it('lets release-cut tag a version that is already present on main', () => {
+    const releaseWorkflow = readFileSync(
+      join(projectDir, '.github/workflows/release-cut.yml'),
+      'utf8'
+    )
+    const parsedWorkflow = parse(releaseWorkflow)
+    const bumpStep = parsedWorkflow.jobs.cut.steps.find(
+      (step) => step.name === 'Bump package.json and tag'
+    )
+
+    expect(bumpStep.run).toContain('git diff --cached --quiet')
+    expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
+  })
+
   it('installs the Electron package binary in PR checks without changing native module ABI', () => {
     const prWorkflow = readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8')
     const parsedWorkflow = parse(prWorkflow)


### PR DESCRIPTION
## Summary
- Allow the release-cut bump step to create an empty release commit when `package.json` already equals the computed release version.
- Add a workflow contract test for that recovery path.

## Why
The previous failed `v1.4.31` cut fast-forwarded `main` to `package.json` version `1.4.31`, but the release was never published. A new patch cut correctly computed `1.4.31` from the latest published stable `v1.4.30`; however, `npm version --allow-same-version` produced no diff and `git commit` failed with `nothing to commit` before tagging.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxlint config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxfmt --check config/scripts/package-electron-runtime-contract.test.mjs .github/workflows/release-cut.yml`
