### PR TITLE
fix: persist SSH managers across handler re-registration (#2932)

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -15,8 +15,12 @@ const {
   mockPtyProvider,
   mockFsProvider,
   mockGitProvider,
-  mockPortForwardManager
+  mockPortForwardManager,
+  connectionManagerCtorMock,
+  portForwardManagerCtorMock
 } = vi.hoisted(() => ({
+  connectionManagerCtorMock: vi.fn(),
+  portForwardManagerCtorMock: vi.fn(),
   handleMock: vi.fn(),
   powerMonitorOffMock: vi.fn(),
   powerMonitorOnMock: vi.fn(),
@@ -89,6 +93,7 @@ vi.mock('../ssh/ssh-connection-store', () => ({
 vi.mock('../ssh/ssh-connection', () => ({
   SshConnectionManager: class MockSshConnectionManager {
     constructor() {
+      connectionManagerCtorMock()
       return mockConnectionManager
     }
   }
@@ -161,6 +166,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 vi.mock('../ssh/ssh-port-forward', () => ({
   SshPortForwardManager: class MockPortForwardManager {
     constructor() {
+      portForwardManagerCtorMock()
       return mockPortForwardManager
     }
   }
@@ -255,6 +261,20 @@ describe('SSH IPC handlers', () => {
     expect(channels).toContain('ssh:resetRelay')
     expect(channels).toContain('ssh:getState')
     expect(channels).toContain('ssh:testConnection')
+  })
+
+  it('does not reconstruct managers on re-registration (window reactivation)', () => {
+    // Why: recreating the connection/port-forward managers on macOS window
+    // reactivation would orphan live sessions' port forwards (the new empty
+    // managers can't list/remove/rebind them). beforeEach already registered
+    // once; a second registration must reuse the existing managers.
+    const connCtorCalls = connectionManagerCtorMock.mock.calls.length
+    const forwardCtorCalls = portForwardManagerCtorMock.mock.calls.length
+
+    registerSshHandlers(mockStore as never, () => mockWindow as never)
+
+    expect(connectionManagerCtorMock.mock.calls.length).toBe(connCtorCalls)
+    expect(portForwardManagerCtorMock.mock.calls.length).toBe(forwardCtorCalls)
   })
 
   it('ssh:listTargets returns targets from store', async () => {

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -45,6 +45,16 @@ let registeredGetSshState: ((targetId: string) => SshConnectionState | undefined
 let persistedStore: Store | null = null
 let advertisedUrlWatcherUnsubscribe: (() => void) | null = null
 let powerMonitorUnsubscribe: (() => void) | null = null
+// Why: the connection/port-forward managers persist for the process lifetime
+// (recreating them on macOS window reactivation would strand live sessions'
+// port forwards). Their callbacks therefore read the current main window and the
+// credential-tracking set through these module refs rather than per-call closures.
+let currentGetMainWindow: () => BrowserWindow | null = () => null
+// Why: tracks whether a credential prompt was triggered during the current
+// ssh:connect call, so startup reconnect can defer passphrase-protected targets.
+// Module-scoped so the persistent manager callbacks and re-registered handlers
+// share one set across window reactivation.
+const credentialRequestedForTarget = new Set<string>()
 
 export async function connectRegisteredSshTarget(targetId: string): Promise<SshConnectionState> {
   if (!registeredConnectSshTarget) {
@@ -370,21 +380,20 @@ export function registerSshHandlers(
     ipcMain.removeHandler(ch)
   }
 
+  // Why: point the persistent manager callbacks at the current window. On macOS
+  // reactivation getMainWindow is a fresh closure over the new BrowserWindow.
+  currentGetMainWindow = getMainWindow
+
   sshStore = new SshConnectionStore(store)
   persistedStore = store
   registerAdvertisedUrlRefresh(getMainWindow)
 
   registerCredentialHandler(getMainWindow)
 
-  // Why: tracks whether a credential prompt was triggered during the current
-  // ssh:connect call. Used to set lastRequiredPassphrase on the target so
-  // startup reconnect can defer passphrase-protected targets to tab focus.
-  const credentialRequestedForTarget = new Set<string>()
-
   const callbacks: SshConnectionCallbacks = {
     onCredentialRequest: (targetId, kind, detail) => {
       credentialRequestedForTarget.add(targetId)
-      return requestCredential(getMainWindow, targetId, kind, detail)
+      return requestCredential(currentGetMainWindow, targetId, kind, detail)
     },
     onStateChange: (targetId: string, state: SshConnectionState) => {
       if (testingTargets.has(targetId)) {
@@ -407,7 +416,7 @@ export function registerSshHandlers(
         // Why: SSH is connected before the relay providers are rebuilt. Keep
         // renderer actions gated until SshRelaySession reaches ready again.
         publishRelayOverride(
-          getMainWindow,
+          currentGetMainWindow,
           targetId,
           'reconnecting',
           'Relay channel reconnecting...',
@@ -415,7 +424,7 @@ export function registerSshHandlers(
         )
       } else {
         clearRelayStateOverride(targetId)
-        broadcastSshState(getMainWindow, targetId, state)
+        broadcastSshState(currentGetMainWindow, targetId, state)
       }
 
       if (!session) {
@@ -435,8 +444,12 @@ export function registerSshHandlers(
     }
   }
 
-  connectionManager = new SshConnectionManager(callbacks)
-  portForwardManager = new SshPortForwardManager()
+  // Why: create once and reuse for the process lifetime. Replacing these on
+  // window reactivation would orphan live sessions' port forwards — the new
+  // empty managers can't list/remove/rebind forwards bound by the old ones.
+  // The callbacks read currentGetMainWindow so they still target the new window.
+  connectionManager ??= new SshConnectionManager(callbacks)
+  portForwardManager ??= new SshPortForwardManager()
   registerPowerMonitorReconnect()
   registerSshBrowseHandler(() => connectionManager)
 


### PR DESCRIPTION
## Summary

`registerSshHandlers` runs again every time macOS reactivates the app (a new `BrowserWindow`). It unconditionally rebuilt the connection and port-forward managers:

```ts
connectionManager = new SshConnectionManager(callbacks)
portForwardManager = new SshPortForwardManager()
```

But `activeSessions` still held live sessions whose port forwards were bound in the **old** `portForwardManager`. After reactivation the new, empty managers couldn't see them: `ssh:listPortForwards` returned empty, `ssh:removePortForward` couldn't find old ids, `ssh:disconnect` didn't close the old listener, and rebinding the same local port failed because the old server was still bound.

Fix: create both managers **once** for the process lifetime (`??=`). Because their callbacks previously closed over the per-call `getMainWindow` (a fresh closure over each new window) and a per-call credential-tracking `Set`, those two are now module-level refs (`currentGetMainWindow`, updated each registration; `credentialRequestedForTarget`) so the persistent callbacks still target the reactivated window and stay consistent with the re-registered handlers. `registerAdvertisedUrlRefresh`/`registerPowerMonitorReconnect` already tear down and re-subscribe per call, so they were left as-is.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (node config clean)
- [x] `pnpm test` (ssh IPC suite: 25 passed, incl. a new test asserting re-registration does **not** reconstruct either manager — verified it fails on the old `=` code)
- [ ] `pnpm build` (not run — main-process logic change)
- [x] Added a regression test (construction-count guard) that fails on the pre-fix behavior

## AI Review Report

Ran an independent correctness reviewer. It confirmed the production fix is complete: it enumerated every variable the persistent callbacks close over (`credentialRequestedForTarget`, `currentGetMainWindow`, `testingTargets`, `activeSessions`, `sshStore`, `connectionManager` — all module-level or call-invariant) and found no missed per-call state; confirmed the `??=` return stays non-null/typechecks, the re-registered handlers stay consistent with the persistent callbacks, and no double-subscription leak. It flagged that my first test (instance `toBe`) didn't actually distinguish the fix from the bug because the mock manager is a singleton — I replaced it with a construction-count assertion and verified it fails on the old code. Cross-platform: the bug is macOS-reactivation-specific; the fix is platform-neutral. SSH is the affected surface.

## Security Audit

No new input handling, auth, secrets, or IPC surface. The change is lifecycle-only; it prevents leaked port-forward listeners (a resource leak) rather than introducing any new exposure.

## Notes

Managers now live for the process lifetime by design. Their callbacks read `currentGetMainWindow`, which is repointed at the current window on every registration.
