### PR TITLE
perf: precompute lowercased paths for QuickOpen fuzzy matching (#2933)

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -21,9 +21,10 @@ import {
  * within the target string (case-insensitive). Returns a score (lower = better)
  * or -1 if no match.
  */
-function fuzzyMatch(query: string, target: string): number {
-  const q = query.toLowerCase()
-  const t = target.toLowerCase()
+// Why: q, t, and filename are pre-lowercased by the caller. Lowercasing the
+// target (and filename) here would repeat that work over the entire file list
+// on every keystroke; the caller memoizes it per file instead.
+export function fuzzyMatch(q: string, t: string, filename: string): number {
   let qi = 0
   let score = 0
   let lastMatchIdx = -1
@@ -47,8 +48,6 @@ function fuzzyMatch(query: string, target: string): number {
   }
 
   // Prefer matches where query appears in the filename (last segment)
-  const lastSlash = target.lastIndexOf('/')
-  const filename = target.slice(lastSlash + 1).toLowerCase()
   if (filename.includes(q)) {
     score -= 100 // strong reward for filename match
   }
@@ -296,23 +295,34 @@ export default function QuickOpen(): React.JSX.Element | null {
     }
   }, [visible, activeWorktreeId, worktreePath, connectionId, excludePathsKey, filesRequestKey])
 
+  // Why: lowercase each path (and its filename segment) once per file-list
+  // change instead of re-lowercasing the whole list on every keystroke.
+  const searchableFiles = useMemo(
+    () =>
+      files.map((path) => {
+        const lower = path.toLowerCase()
+        return { path, lower, filename: lower.slice(lower.lastIndexOf('/') + 1) }
+      }),
+    [files]
+  )
+
   // Filter files by fuzzy match
   const filtered = useMemo(() => {
-    const normalizedQuery = deferredQuery.trim()
+    const normalizedQuery = deferredQuery.trim().toLowerCase()
     if (!normalizedQuery) {
       // Show first 50 files when no query
       return files.slice(0, 50).map((f) => ({ path: f, score: 0 }))
     }
     const results: { path: string; score: number }[] = []
-    for (const f of files) {
-      const score = fuzzyMatch(normalizedQuery, f)
+    for (const f of searchableFiles) {
+      const score = fuzzyMatch(normalizedQuery, f.lower, f.filename)
       if (score !== -1) {
-        results.push({ path: f, score })
+        results.push({ path: f.path, score })
       }
     }
     results.sort((a, b) => a.score - b.score)
     return results.slice(0, 50)
-  }, [deferredQuery, files])
+  }, [deferredQuery, files, searchableFiles])
 
   const handleSelect = useCallback(
     (relativePath: string) => {

--- a/src/renderer/src/components/quick-open-fuzzy-match.test.ts
+++ b/src/renderer/src/components/quick-open-fuzzy-match.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { fuzzyMatch } from './QuickOpen'
+
+// fuzzyMatch receives pre-lowercased inputs (the component lowercases each path
+// and the query once, rather than per-keystroke over the whole file list).
+function match(query: string, path: string): number {
+  const lower = path.toLowerCase()
+  return fuzzyMatch(query.toLowerCase(), lower, lower.slice(lower.lastIndexOf('/') + 1))
+}
+
+describe('fuzzyMatch', () => {
+  it('returns -1 when not all query characters appear in order', () => {
+    expect(match('xyz', 'src/index.ts')).toBe(-1) // no y/z in the path
+    expect(match('zzz', 'src/app.ts')).toBe(-1)
+  })
+
+  it('matches subsequences case-insensitively', () => {
+    expect(match('IDX', 'src/index.ts')).not.toBe(-1)
+    expect(match('appts', 'SRC/App.TS')).not.toBe(-1)
+  })
+
+  it('rewards a query that appears in the filename over a path-only match', () => {
+    // 'app' is in the filename of the first, only in the dir of the second.
+    const inFilename = match('app', 'src/app.ts')
+    const inDirOnly = match('app', 'app/main.ts')
+    expect(inFilename).toBeLessThan(inDirOnly)
+  })
+
+  it('ranks a contiguous filename match better than a scattered one', () => {
+    const contiguous = match('index', 'src/index.ts')
+    const scattered = match('index', 'i/n/d/e/x-other.ts')
+    expect(contiguous).toBeLessThan(scattered)
+  })
+})


### PR DESCRIPTION
## Summary

Quick Open's filtering already uses `useDeferredValue` + `useMemo` + a 50-result render cap, so it no longer recomputes synchronously on every keystroke. The remaining per-keystroke cost was inside `fuzzyMatch`: it called `target.toLowerCase()` (and a second `.toLowerCase()` for the filename segment) on **every** file on **every** deferred recompute — re-lowercasing the entire file list each time the query changed.

This precomputes each path's lowercased form and filename segment **once per file-list change** (memoized), and passes the pre-lowercased strings into `fuzzyMatch`. The query is lowercased once per filter pass. Matching and ranking behavior is unchanged.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (web config clean)
- [x] `pnpm test` (new `quick-open-fuzzy-match` unit suite: 4 passed — covers no-match, case-insensitivity, filename-match reward, contiguous-vs-scattered ranking)
- [ ] `pnpm build` (not run — renderer logic change)
- [x] Exported `fuzzyMatch` and added focused tests locking in the match/scoring contract

## AI Review Report

Self-reviewed (localized refactor). Confirmed behavior-preserving: lowercasing moved out of the hot loop into a memoized precompute; the filename segment is derived from the lowercased path via `lastIndexOf('/')` (equivalent to the prior original-path computation since `/` is case-invariant). `fuzzyMatch` is module-local (no other callers), so the signature change is contained. Cross-platform: pure string logic, no platform branches. Note: the original finding (against an older revision) cited "no debounce"; `useDeferredValue` + memoization + the result cap were already present on `main`, so this PR targets the residual repeated-lowercasing cost rather than re-adding deferral.

## Security Audit

No input handling, auth, secrets, or IPC surface changes — a pure client-side perf refactor of in-memory filtering.

## Notes

Behavior is identical; only the amount of repeated work per keystroke changes. For very large repos the win scales with file count.
