### PR TITLE
Verify Electron archive before package install

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import {
+  cpSync,
   existsSync,
   mkdtempSync,
   readdirSync,
@@ -95,6 +96,7 @@ async function installElectronPackageBinary() {
   const electronDistDir = resolve(electronPackageDir, 'dist')
   const tempDir = mkdtempSync(resolve(tmpdir(), 'orca-electron-'))
   const cacheRoot = join(tempDir, 'cache')
+  const extractDir = join(tempDir, 'extract')
 
   try {
     const zipPath = await downloadArtifact({
@@ -108,8 +110,20 @@ async function installElectronPackageBinary() {
       ...(shouldUseRemoteChecksums() ? {} : { checksums: electronRequire('./checksums.json') })
     })
 
+    // Why: CI has observed partial extracts directly under node_modules/electron
+    // that leave only dist/locales. Verify in temp before replacing package dist.
+    await extract(zipPath, { dir: extractDir })
+    const extractedExecutable = resolve(extractDir, platformPath)
+    if (!existsSync(extractedExecutable)) {
+      console.error('[electron-package] Electron archive extract did not contain executable.')
+      console.error(`  platformPath=${platformPath}`)
+      console.error(`  extractDir=${extractDir}`)
+      console.error(`  extractEntries=${safeReaddir(extractDir).join(', ')}`)
+      process.exit(1)
+    }
+
     rmSync(electronDistDir, { recursive: true, force: true })
-    await extract(zipPath, { dir: electronDistDir })
+    cpSync(extractDir, electronDistDir, { recursive: true })
 
     const srcTypeDefPath = resolve(electronDistDir, 'electron.d.ts')
     if (existsSync(srcTypeDefPath)) {
@@ -123,7 +137,7 @@ async function installElectronPackageBinary() {
 function shouldUseRemoteChecksums() {
   return Boolean(
     process.env.electron_use_remote_checksums ||
-      process.env.npm_config_electron_use_remote_checksums
+    process.env.npm_config_electron_use_remote_checksums
   )
 }
 

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -1,4 +1,12 @@
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -48,10 +56,8 @@ describe('install-electron-package-binary', () => {
       const result = runInstallScript(projectDir)
 
       expect(result.status).toBe(1)
-      expect(result.stderr).toContain('Electron package is still unavailable after install')
-      expect(result.stderr).toContain('distEntries=locales')
-      expect(result.stderr).toContain('pathFile=')
-      expect(result.stderr).toContain('exists=false')
+      expect(result.stderr).toContain('Electron archive extract did not contain executable')
+      expect(result.stderr).toContain('extractEntries=locales')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- Extract Electron downloads into a temp directory first.
- Verify the expected platform executable exists before replacing `node_modules/electron/dist`.
- Copy only verified extraction output into the Electron package directory.

## Why
The release runner still accepted a broken Electron install where `dist` only contained `locales` and no executable/path.txt. Extracting and verifying out-of-tree prevents partial package-directory state from being treated as installed and gives a sharper diagnostic if the archive extraction is incomplete.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/install-electron-package-binary.test.mjs config/scripts/rebuild-native-deps.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`
- `pnpm exec oxlint config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs`
- `pnpm exec oxfmt --check config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs`
