### PR TITLE
Await Electron package installer

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -24,12 +24,16 @@ const { downloadArtifact } = electronRequire('@electron/get')
 const extract = electronRequire('extract-zip')
 const platformPath = getElectronPlatformPath()
 
-main().catch((error) => {
+try {
+  // Why: Electron's own install.js can exit 0 while an async extract promise is
+  // still unsettled, leaving a partial dist/. Top-level await makes that fail.
+  await main()
+} catch (error) {
   console.error('[electron-package] Failed to install Electron package binary.')
   console.error(error)
   logElectronInstallDiagnostics()
   process.exit(1)
-})
+}
 
 async function main() {
   if (electronPackageIsUsable()) {

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -1,6 +1,7 @@
 import {
   chmodSync,
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -58,6 +59,24 @@ describe('install-electron-package-binary', () => {
       expect(result.status).toBe(1)
       expect(result.stderr).toContain('Electron archive extract did not contain executable')
       expect(result.stderr).toContain('extractEntries=locales')
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not exit successfully when Electron extract never settles', () => {
+    const projectDir = mkTempProject()
+
+    try {
+      writeFakeElectronPackage(projectDir)
+      writeFakeElectronGet(projectDir)
+      writeFakeExtractZip(projectDir, { createExecutable: false, neverSettles: true })
+
+      const result = runInstallScript(projectDir)
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('Detected unsettled top-level await')
+      expect(existsSync(join(projectDir, 'node_modules', 'electron', 'path.txt'))).toBe(false)
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
     }
@@ -127,7 +146,7 @@ exports.downloadArtifact = async function downloadArtifact(details) {
   )
 }
 
-function writeFakeExtractZip(projectDir, { createExecutable }) {
+function writeFakeExtractZip(projectDir, { createExecutable, neverSettles = false }) {
   const extractDir = join(projectDir, 'node_modules', 'electron', 'node_modules', 'extract-zip')
   mkdirSync(extractDir, { recursive: true })
   writeFileSync(
@@ -137,6 +156,9 @@ const { mkdirSync, writeFileSync } = require('node:fs')
 const { join } = require('node:path')
 module.exports = async function extract(_zipPath, options) {
   mkdirSync(join(options.dir, 'locales'), { recursive: true })
+  if (${JSON.stringify(neverSettles)}) {
+    return new Promise(() => {})
+  }
   if (${JSON.stringify(createExecutable)}) {
     writeFileSync(join(options.dir, 'electron'), '')
     writeFileSync(join(options.dir, 'version'), 'v41.5.0')


### PR DESCRIPTION
## Summary
- await the Electron package installer at top level so unresolved async extraction cannot exit successfully
- add regression coverage for a partial extract promise that never settles

## Verification
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/install-electron-package-binary.test.mjs config/scripts/rebuild-native-deps.test.mjs config/scripts/package-electron-runtime-contract.test.mjs
- pnpm exec oxlint config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs
- pnpm exec oxfmt --check config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs
- pnpm run ensure:electron-runtime