### PR TITLE
Extract Electron package with host unzip

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -3,6 +3,7 @@
 import {
   cpSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
@@ -10,6 +11,7 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { platform as osPlatform, tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -21,7 +23,6 @@ const electronPackageDir = resolve(projectDir, 'node_modules/electron')
 const electronRequire = createRequire(resolve(electronPackageDir, 'package.json'))
 const { version: electronVersion } = electronRequire('./package.json')
 const { downloadArtifact } = electronRequire('@electron/get')
-const extract = electronRequire('extract-zip')
 const platformPath = getElectronPlatformPath()
 
 try {
@@ -116,7 +117,7 @@ async function installElectronPackageBinary() {
 
     // Why: CI has observed partial extracts directly under node_modules/electron
     // that leave only dist/locales. Verify in temp before replacing package dist.
-    await extract(zipPath, { dir: extractDir })
+    extractElectronArchive(zipPath, extractDir)
     const extractedExecutable = resolve(extractDir, platformPath)
     if (!existsSync(extractedExecutable)) {
       console.error('[electron-package] Electron archive extract did not contain executable.')
@@ -136,6 +137,72 @@ async function installElectronPackageBinary() {
   } finally {
     rmSync(tempDir, { recursive: true, force: true })
   }
+}
+
+function extractElectronArchive(zipPath, extractDir) {
+  mkdirSync(extractDir, { recursive: true })
+  // Why: extract-zip/Electron install.js can leave Node 24 with an unsettled
+  // promise and no active handles on CI. Host unzip tools fail synchronously.
+  const command = getExtractorCommand(zipPath, extractDir)
+  const result = spawnSync(command.file, command.args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    throw new Error(formatExtractorFailure(command, result))
+  }
+}
+
+function getExtractorCommand(zipPath, extractDir) {
+  if (process.env.ORCA_ELECTRON_PACKAGE_EXTRACTOR) {
+    return {
+      file: process.execPath,
+      args: [process.env.ORCA_ELECTRON_PACKAGE_EXTRACTOR, zipPath, extractDir],
+      label: `node ${process.env.ORCA_ELECTRON_PACKAGE_EXTRACTOR}`
+    }
+  }
+
+  if (osPlatform() === 'win32') {
+    return {
+      file: process.env.ORCA_POWERSHELL_BIN || 'powershell',
+      args: [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        [
+          "$ErrorActionPreference = 'Stop'",
+          `Expand-Archive -LiteralPath ${quotePowerShellLiteral(zipPath)} -DestinationPath ${quotePowerShellLiteral(extractDir)} -Force`
+        ].join('; ')
+      ],
+      label: 'powershell Expand-Archive'
+    }
+  }
+
+  return {
+    file: process.env.ORCA_UNZIP_BIN || 'unzip',
+    args: ['-q', zipPath, '-d', extractDir],
+    label: 'unzip'
+  }
+}
+
+function quotePowerShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function formatExtractorFailure(command, result) {
+  return [
+    `[electron-package] ${command.label} failed with status ${result.status}.`,
+    result.stdout ? `stdout:\n${result.stdout.trim()}` : '',
+    result.stderr ? `stderr:\n${result.stderr.trim()}` : ''
+  ]
+    .filter(Boolean)
+    .join('\n')
 }
 
 function shouldUseRemoteChecksums() {

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -1,5 +1,4 @@
 import {
-  chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
@@ -25,7 +24,7 @@ describe('install-electron-package-binary', () => {
     try {
       writeFakeElectronPackage(projectDir)
       writeFakeElectronGet(projectDir)
-      writeFakeExtractZip(projectDir, { createExecutable: true })
+      writeFakeExtractor(projectDir, { createExecutable: true })
 
       const result = runInstallScript(projectDir)
 
@@ -48,7 +47,7 @@ describe('install-electron-package-binary', () => {
     try {
       writeFakeElectronPackage(projectDir)
       writeFakeElectronGet(projectDir)
-      writeFakeExtractZip(projectDir, { createExecutable: false })
+      writeFakeExtractor(projectDir, { createExecutable: false })
       mkdirSync(join(projectDir, 'node_modules', 'electron', 'dist', 'locales'), {
         recursive: true
       })
@@ -64,13 +63,13 @@ describe('install-electron-package-binary', () => {
     }
   })
 
-  it('does not exit successfully when Electron extract never settles', () => {
+  it('does not exit successfully when Electron download never settles', () => {
     const projectDir = mkTempProject()
 
     try {
       writeFakeElectronPackage(projectDir)
-      writeFakeElectronGet(projectDir)
-      writeFakeExtractZip(projectDir, { createExecutable: false, neverSettles: true })
+      writeFakeElectronGet(projectDir, { downloadNeverSettles: true })
+      writeFakeExtractor(projectDir, { createExecutable: false })
 
       const result = runInstallScript(projectDir)
 
@@ -100,7 +99,8 @@ function runInstallScript(projectDir) {
     env: {
       ...process.env,
       npm_config_platform: 'linux',
-      npm_config_arch: 'x64'
+      npm_config_arch: 'x64',
+      ORCA_ELECTRON_PACKAGE_EXTRACTOR: join(projectDir, 'fake-extractor.cjs')
     }
   })
 }
@@ -127,7 +127,7 @@ module.exports = path.join(__dirname, 'dist', fs.readFileSync(pathFile, 'utf8'))
   )
 }
 
-function writeFakeElectronGet(projectDir) {
+function writeFakeElectronGet(projectDir, { downloadNeverSettles = false } = {}) {
   const getDir = join(projectDir, 'node_modules', 'electron', 'node_modules', '@electron', 'get')
   mkdirSync(getDir, { recursive: true })
   writeFileSync(
@@ -137,6 +137,9 @@ const { mkdirSync, writeFileSync, appendFileSync } = require('node:fs')
 const { join } = require('node:path')
 exports.downloadArtifact = async function downloadArtifact(details) {
   appendFileSync('electron-get.log', 'cacheRoot=' + details.cacheRoot + '\\n')
+  if (${JSON.stringify(downloadNeverSettles)}) {
+    return new Promise(() => {})
+  }
   mkdirSync(details.cacheRoot, { recursive: true })
   const artifactPath = join(details.cacheRoot, 'electron.zip')
   writeFileSync(artifactPath, 'fake zip')
@@ -146,25 +149,18 @@ exports.downloadArtifact = async function downloadArtifact(details) {
   )
 }
 
-function writeFakeExtractZip(projectDir, { createExecutable, neverSettles = false }) {
-  const extractDir = join(projectDir, 'node_modules', 'electron', 'node_modules', 'extract-zip')
-  mkdirSync(extractDir, { recursive: true })
+function writeFakeExtractor(projectDir, { createExecutable }) {
   writeFileSync(
-    join(extractDir, 'index.js'),
+    join(projectDir, 'fake-extractor.cjs'),
     `
 const { mkdirSync, writeFileSync } = require('node:fs')
 const { join } = require('node:path')
-module.exports = async function extract(_zipPath, options) {
-  mkdirSync(join(options.dir, 'locales'), { recursive: true })
-  if (${JSON.stringify(neverSettles)}) {
-    return new Promise(() => {})
-  }
-  if (${JSON.stringify(createExecutable)}) {
-    writeFileSync(join(options.dir, 'electron'), '')
-    writeFileSync(join(options.dir, 'version'), 'v41.5.0')
-  }
+const extractDir = process.argv[3]
+mkdirSync(join(extractDir, 'locales'), { recursive: true })
+if (${JSON.stringify(createExecutable)}) {
+  writeFileSync(join(extractDir, 'electron'), '')
+  writeFileSync(join(extractDir, 'version'), 'v41.5.0')
 }
 `
   )
-  chmodSync(join(extractDir, 'index.js'), 0o755)
 }


### PR DESCRIPTION
## Summary
- replace extract-zip in the Electron package installer with host unzip/PowerShell extraction
- keep top-level await protection for unsettled downloads
- update installer tests to use a command extractor override

## Verification
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/install-electron-package-binary.test.mjs config/scripts/rebuild-native-deps.test.mjs config/scripts/package-electron-runtime-contract.test.mjs
- pnpm exec oxlint config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs
- pnpm exec oxfmt --check config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs
- pnpm run ensure:electron-runtime