### PR TITLE
Preserve Electron framework symlinks

### DIFF
--- a/config/scripts/install-electron-package-binary.mjs
+++ b/config/scripts/install-electron-package-binary.mjs
@@ -127,8 +127,7 @@ async function installElectronPackageBinary() {
       process.exit(1)
     }
 
-    rmSync(electronDistDir, { recursive: true, force: true })
-    cpSync(extractDir, electronDistDir, { recursive: true })
+    moveExtractedElectronDist(extractDir, electronDistDir)
 
     const srcTypeDefPath = resolve(electronDistDir, 'electron.d.ts')
     if (existsSync(srcTypeDefPath)) {
@@ -154,6 +153,24 @@ function extractElectronArchive(zipPath, extractDir) {
   }
   if (result.status !== 0) {
     throw new Error(formatExtractorFailure(command, result))
+  }
+}
+
+function moveExtractedElectronDist(extractDir, electronDistDir) {
+  rmSync(electronDistDir, { recursive: true, force: true })
+  try {
+    // Why: macOS Electron archives rely on framework symlinks. Moving the
+    // verified tree preserves them exactly; copying has broken them in CI.
+    renameSync(extractDir, electronDistDir)
+  } catch (/** @type {any} */ err) {
+    if (err?.code !== 'EXDEV') {
+      throw err
+    }
+    cpSync(extractDir, electronDistDir, {
+      recursive: true,
+      dereference: false,
+      verbatimSymlinks: true
+    })
   }
 }
 

--- a/config/scripts/install-electron-package-binary.test.mjs
+++ b/config/scripts/install-electron-package-binary.test.mjs
@@ -1,6 +1,7 @@
 import {
   copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -35,6 +36,13 @@ describe('install-electron-package-binary', () => {
       expect(readFileSync(join(projectDir, 'node_modules', 'electron', 'path.txt'), 'utf8')).toBe(
         'electron'
       )
+      if (process.platform !== 'win32') {
+        expect(
+          lstatSync(
+            join(projectDir, 'node_modules', 'electron', 'dist', 'version-link')
+          ).isSymbolicLink()
+        ).toBe(true)
+      }
       expect(result.stdout).toContain('Repaired Electron path.txt -> electron')
     } finally {
       rmSync(projectDir, { recursive: true, force: true })
@@ -153,13 +161,16 @@ function writeFakeExtractor(projectDir, { createExecutable }) {
   writeFileSync(
     join(projectDir, 'fake-extractor.cjs'),
     `
-const { mkdirSync, writeFileSync } = require('node:fs')
+const { mkdirSync, symlinkSync, writeFileSync } = require('node:fs')
 const { join } = require('node:path')
 const extractDir = process.argv[3]
 mkdirSync(join(extractDir, 'locales'), { recursive: true })
 if (${JSON.stringify(createExecutable)}) {
   writeFileSync(join(extractDir, 'electron'), '')
   writeFileSync(join(extractDir, 'version'), 'v41.5.0')
+  if (process.platform !== 'win32') {
+    symlinkSync('version', join(extractDir, 'version-link'))
+  }
 }
 `
   )


### PR DESCRIPTION
## Summary
- move the verified Electron extract tree into dist instead of copying it
- preserve macOS framework symlinks, with a symlink-preserving EXDEV fallback
- add installer coverage for symlink preservation

## Verification
- pnpm exec vitest run --config config/vitest.config.ts config/scripts/install-electron-package-binary.test.mjs config/scripts/rebuild-native-deps.test.mjs config/scripts/package-electron-runtime-contract.test.mjs
- pnpm exec oxlint config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs
- pnpm exec oxfmt --check config/scripts/install-electron-package-binary.mjs config/scripts/install-electron-package-binary.test.mjs
- pnpm run ensure:electron-runtime