### PR TITLE
Fix inactive hook completions with empty terminal layouts

### DIFF
--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -14,8 +14,8 @@ type MockStoreState = {
   terminalLayoutsByTabId: Record<
     string,
     {
-      root: { type: 'leaf'; leafId: string }
-      activeLeafId: string
+      root: { type: 'leaf'; leafId: string } | null
+      activeLeafId: string | null
       expandedLeafId: string | null
       ptyIdsByLeafId?: Record<string, string>
     }
@@ -106,6 +106,38 @@ describe('agent hook completion notifications', () => {
       'tab-1': {
         root: { type: 'leaf', leafId: '11111111-1111-4111-8111-111111111111' },
         activeLeafId: '11111111-1111-4111-8111-111111111111',
+        expandedLeafId: null,
+        ptyIdsByLeafId: {}
+      }
+    }
+    const { observeAgentHookCompletionForNotification } =
+      await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('working')
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('done')
+    })
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        paneKey
+      })
+    )
+  })
+
+  it('uses tab-level PTY liveness when an inactive layout is empty', async () => {
+    mockStoreState.terminalLayoutsByTabId = {
+      'tab-1': {
+        root: null,
+        activeLeafId: null,
         expandedLeafId: null,
         ptyIdsByLeafId: {}
       }

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -57,6 +57,12 @@ function getPtyIdForPaneKey(paneKey: string): string | null {
     if (leafPtyId && tabPtyIds.includes(leafPtyId)) {
       return leafPtyId
     }
+    if (!layout?.root) {
+      // Why: inactive worktree switches can temporarily preserve only tab-level
+      // PTY liveness; do not drop hook completions just because layout metadata
+      // is at the empty snapshot.
+      return tabPtyIds[0] ?? null
+    }
     // Why: switching worktrees can unmount the terminal pane and clear the
     // leaf binding before the hook completion arrives, while the tab PTY is
     // still live. Keep closed leaves suppressed by requiring the leaf in layout.

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2734,6 +2734,80 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
+  it('applies ready push events for inactive terminal tabs with empty layout snapshots', async () => {
+    const setAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Inactive Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: null,
+          activeLeafId: null,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'done',
+      prompt: 'inactive prompt',
+      agentType: 'codex',
+      lastAssistantMessage: 'inactive completion',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_699_999_999_100
+    })
+
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatus).toHaveBeenCalledWith(
+      FUTURE_PANE_KEY,
+      expect.objectContaining({
+        state: 'done',
+        prompt: 'inactive prompt',
+        agentType: 'codex',
+        lastAssistantMessage: 'inactive completion'
+      }),
+      'Inactive Tab',
+      { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 }
+    )
+  })
+
   it('buffers ready push events until a mounted tab contains the pane leaf', async () => {
     const setAgentStatus = vi.fn()
     const track = vi.fn()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2423,7 +2423,10 @@ function resolvePaneKey(
       owningWorktreeId
     }
   }
-  const leafExists = layout ? collectLeafIdsInOrder(layout.root).includes(leafId) : true
+  // Why: inactive worktree switches can leave the tab's layout at the empty
+  // snapshot while the tab and PTY are still live. Treat that like missing
+  // layout metadata; a non-empty layout that lacks the leaf still means closed.
+  const leafExists = layout?.root ? collectLeafIdsInOrder(layout.root).includes(leafId) : true
   if (!leafExists) {
     return {
       exists: false,


### PR DESCRIPTION
## Summary
- Treat empty terminal layout snapshots like temporarily missing layout metadata for agent hook routing
- Let inactive hook completion notifications fall back to tab-level PTY liveness in that state
- Add focused regression coverage for empty-layout inactive hook completion delivery

## Verification
- pnpm exec oxfmt --check src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/hooks/agent-hook-completion-notifications.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
- pnpm exec oxlint src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/hooks/agent-hook-completion-notifications.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
- pnpm run test:e2e -- tests/e2e/droid-notification.spec.ts