### PR TITLE
Handle stale Codex hook trust indices

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -252,6 +252,58 @@ describe('CodexHookService', () => {
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
   })
 
+  it('mirrors system user hook approvals when the system trust indices are stale', () => {
+    const systemCodexHome = join(tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify(
+        {
+          hooks: {
+            Stop: [
+              { hooks: [{ type: 'command', command: 'first-stop-hook' }] },
+              { hooks: [{ type: 'command', command: 'second-stop-hook' }] }
+            ]
+          }
+        },
+        null,
+        2
+      )}\n`,
+      'utf-8'
+    )
+    writeFileSync(
+      join(systemCodexHome, 'config.toml'),
+      upsertHookTrustEntriesInContent('model = "system-model"\n', [
+        {
+          sourcePath: systemHooksPath,
+          eventLabel: 'stop',
+          groupIndex: 0,
+          handlerIndex: 0,
+          command: 'second-stop-hook'
+        },
+        {
+          sourcePath: systemHooksPath,
+          eventLabel: 'stop',
+          groupIndex: 1,
+          handlerIndex: 0,
+          command: 'first-stop-hook'
+        }
+      ]),
+      'utf-8'
+    )
+
+    expect(new CodexHookService().install().state).toBe('installed')
+
+    const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+    const managedHooksPath = join(managedCodexHome, 'hooks.json')
+    const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
+    expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
+    expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:1:0`))
+  })
+
   it('skips plugin-placeholder system hooks when mirroring into runtime CODEX_HOME', () => {
     const pluginCommands = [
       'node "${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.mjs"',

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -312,6 +312,7 @@ function getTrustedSystemUserHookSignatures(
     console.warn('[codex-hook-service] failed to read system hook trust entries', error)
     return signatures
   }
+  const trustedHashesByEvent = getTrustedSystemHookHashesByEvent(systemConfigPath, trustEntries)
   for (const [eventName, definitions] of Object.entries(systemHooks)) {
     if (!Array.isArray(definitions)) {
       continue
@@ -333,20 +334,54 @@ function getTrustedSystemUserHookSignatures(
         if (!entry) {
           return
         }
+        const expectedHash = computeTrustedHash(entry)
         const state = trustEntries.get(computeTrustKey(entry))
-        if (state?.trustedHash === computeTrustedHash(entry)) {
-          const signature = getTrustSignature(entry)
-          const enabled = state.enabled !== false
-          // Why: runtime deduping collapses identical system hook definitions;
-          // if any duplicate remains enabled, keep the mirrored hook enabled.
-          if (enabled || !signatures.has(signature)) {
-            signatures.set(signature, enabled)
-          }
+        const enabled =
+          state?.trustedHash === expectedHash
+            ? state.enabled !== false
+            : trustedHashesByEvent.get(entry.eventLabel)?.get(expectedHash)
+        if (enabled === undefined) {
+          return
+        }
+        const signature = getTrustSignature(entry)
+        // Why: runtime deduping collapses identical system hook definitions;
+        // if any duplicate remains enabled, keep the mirrored hook enabled.
+        if (enabled || !signatures.has(signature)) {
+          signatures.set(signature, enabled)
         }
       })
     })
   }
   return signatures
+}
+
+function getTrustedSystemHookHashesByEvent(
+  systemConfigPath: string,
+  trustEntries: ReadonlyMap<string, CodexHookTrustState>
+): Map<CodexEventLabel, Map<string, boolean>> {
+  const trustedHashesByEvent = new Map<CodexEventLabel, Map<string, boolean>>()
+  const canonicalSystemConfigPath = getCodexCanonicalTrustPath(systemConfigPath)
+  for (const [key, state] of trustEntries) {
+    const parsed = parseTrustKey(key)
+    if (!parsed || !state.trustedHash) {
+      continue
+    }
+    if (getCodexCanonicalTrustPath(parsed.sourcePath) !== canonicalSystemConfigPath) {
+      continue
+    }
+    let hashes = trustedHashesByEvent.get(parsed.eventLabel)
+    if (!hashes) {
+      hashes = new Map()
+      trustedHashesByEvent.set(parsed.eventLabel, hashes)
+    }
+    const enabled = state.enabled !== false
+    // Why: Codex trust keys include hook indices. If a user reorders hooks,
+    // the hash still proves the same event+command identity was approved.
+    if (enabled || !hashes.has(state.trustedHash)) {
+      hashes.set(state.trustedHash, enabled)
+    }
+  }
+  return trustedHashesByEvent
 }
 
 function collectMirroredRuntimeUserHookTrustEntries(


### PR DESCRIPTION
## Summary
- preserve mirrored Codex hook trust when hook position keys are stale but the trusted hook identity still matches
- add regression coverage for stale system hook trust indices during runtime trust mirroring

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/hook-service.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-config-mirror.test.ts src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.test.ts
- pnpm run typecheck:node
- Electron e2e: launched this branch with an isolated home/profile, exercised the real settings hook-toggle path, and verified runtime hook trust was written for stale-position user hooks
- Codex TUI smoke: launched Codex with the authenticated Orca runtime CODEX_HOME and observed the normal composer screen without a hook review prompt