### PR TITLE
Fix Codex hook trust hashing for undispatched matchers

### DIFF
--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -147,6 +147,42 @@ describe('computeTrustedHash', () => {
     expect(a).not.toBe(b)
   })
 
+  it('ignores matcher for Codex events whose matchers are not dispatched', () => {
+    const stopWithoutMatcher = computeTrustedHash({
+      sourcePath: '/x/hooks.json',
+      eventLabel: 'stop',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'foo'
+    })
+    const stopWithMatcher = computeTrustedHash({
+      sourcePath: '/x/hooks.json',
+      eventLabel: 'stop',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'foo',
+      matcher: 'ignored'
+    })
+    const promptWithMatcher = computeTrustedHash({
+      sourcePath: '/x/hooks.json',
+      eventLabel: 'user_prompt_submit',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'foo',
+      matcher: 'ignored'
+    })
+    const promptWithoutMatcher = computeTrustedHash({
+      sourcePath: '/x/hooks.json',
+      eventLabel: 'user_prompt_submit',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: 'foo'
+    })
+
+    expect(stopWithMatcher).toBe(stopWithoutMatcher)
+    expect(promptWithMatcher).toBe(promptWithoutMatcher)
+  })
+
   it('produces a different hash when statusMessage is set', () => {
     const a = computeTrustedHash({
       sourcePath: '/x/hooks.json',

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -95,7 +95,7 @@ export function computeTrustedHash(entry: CodexTrustEntry): string {
     event_name: entry.eventLabel,
     hooks: [handler]
   }
-  if (entry.matcher !== undefined) {
+  if (entry.matcher !== undefined && codexEventSupportsMatcher(entry.eventLabel)) {
     identity.matcher = entry.matcher
   }
   const serialized = JSON.stringify(canonicalize(identity))
@@ -179,6 +179,12 @@ function isCodexEventLabel(value: string): value is CodexEventLabel {
     value === 'user_prompt_submit' ||
     value === 'stop'
   )
+}
+
+function codexEventSupportsMatcher(eventLabel: CodexEventLabel): boolean {
+  // Why: Codex accepts matcher fields on every event shape but ignores them for
+  // these two events before hashing and dispatching.
+  return eventLabel !== 'user_prompt_submit' && eventLabel !== 'stop'
 }
 
 // Why: TOML 1.0 forbids BOMs but real-world editors (especially on Windows) sometimes

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -226,7 +226,6 @@ describe('CodexHookService', () => {
           command: 'user-hook',
           timeoutSec: 12,
           async: true,
-          matcher: '*',
           statusMessage: 'Running user hook'
         }
       ]),


### PR DESCRIPTION
## Summary
- Align Codex hook trust hashing with Codex matcher behavior for Stop and UserPromptSubmit hooks
- Keep mirrored runtime hook trust valid when those hook definitions carry ignored matcher fields
- Add regression coverage for the no-op matcher hash case

## Testing
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/config-toml-trust.test.ts src/main/codex/hook-service.test.ts src/main/codex/codex-config-mirror.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts
- pnpm run typecheck:node
- git diff --check

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.