### PR TITLE
Preserve live PTYs during daemon resolver refresh

### DIFF
--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -64,11 +64,13 @@ const {
   const killStaleDaemonMock = vi.fn(async () => true)
   const getProcessStartedAtMsMock = vi.fn(() => 1_000_000)
 
-  const daemonClientMock = vi.fn().mockImplementation(() => ({
-    ensureConnected: vi.fn(async () => {}),
-    request: vi.fn(async () => ({ sessions: [] })),
-    disconnect: vi.fn()
-  }))
+  const daemonClientMock = vi.fn().mockImplementation(function MockDaemonClient() {
+    return {
+      ensureConnected: vi.fn(async () => {}),
+      request: vi.fn(async () => ({ sessions: [] })),
+      disconnect: vi.fn()
+    }
+  })
 
   // Why: every DaemonSpawner constructed under test pushes into this array so
   // assertions can check "was the *same* spawner reused across restart?".
@@ -435,6 +437,30 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(legacyAdapter.listProcesses).toHaveBeenCalled()
   })
 
+  it('routes affected v9 daemon sessions through a legacy adapter on launch', async () => {
+    const mod = await importFresh()
+    probeSocketExistsMock.mockImplementation((p?: string) => p?.endsWith('daemon-v9.sock') ?? false)
+    netConnectMock.mockImplementation(() => {
+      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+      return {
+        on(event: string, cb: () => void) {
+          handlers[event]?.push(cb)
+          if (event === 'connect') {
+            queueMicrotask(() => cb())
+          }
+          return this
+        },
+        destroy() {}
+      }
+    })
+
+    await mod.initDaemonPtyProvider()
+
+    const { DaemonPtyRouter } = await import('./daemon-pty-router')
+    expect(mod.getDaemonProvider()).toBeInstanceOf(DaemonPtyRouter)
+    expect(adapterInstances.some((instance) => instance.protocolVersion === 9)).toBe(true)
+  })
+
   it('restart path with no legacy adapters yields a bare DaemonPtyAdapter (not wrapped in a router)', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
@@ -732,6 +758,79 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       ['--socket', '/fake/socket', '--token', '/fake/token'],
       expect.objectContaining({ detached: true })
     )
+  })
+
+  it('preserves a resolver-unhealthy daemon when it owns live sessions', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'listSessions') {
+        return {
+          sessions: [
+            { sessionId: 'wt-1@@live', isAlive: true },
+            { sessionId: 'wt-1@@dead', isAlive: false }
+          ]
+        }
+      }
+      return {}
+    })
+    const disconnectMock = vi.fn()
+    daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: requestMock,
+        disconnect: disconnectMock
+      }
+    })
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+    getMacDaemonSystemResolverHealthMock.mockReturnValueOnce('unhealthy')
+
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(getMacDaemonSystemResolverHealthMock).toHaveBeenCalledWith('/fake/socket', '/fake/token')
+    expect(requestMock).toHaveBeenCalledWith('listSessions', undefined)
+    expect(disconnectMock).toHaveBeenCalledOnce()
+    expect(getDaemonLaunchIdentityMock).not.toHaveBeenCalled()
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+    expect(forkMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves a resolver-unhealthy daemon when live session state cannot be verified', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'listSessions') {
+        throw new Error('listSessions failed')
+      }
+      return {}
+    })
+    const disconnectMock = vi.fn()
+    daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: requestMock,
+        disconnect: disconnectMock
+      }
+    })
+
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+    getMacDaemonSystemResolverHealthMock.mockReturnValueOnce('unhealthy')
+
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(requestMock).toHaveBeenCalledWith('listSessions', undefined)
+    expect(disconnectMock).toHaveBeenCalledOnce()
+    expect(killStaleDaemonMock).not.toHaveBeenCalled()
+    expect(forkMock).not.toHaveBeenCalled()
   })
 
   it('uses the direct daemon entry when Electron app path is already out/main', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -99,6 +99,34 @@ function probeSocket(socketPath: string): Promise<boolean> {
   })
 }
 
+async function getAliveDaemonSessionCount(
+  socketPath: string,
+  tokenPath: string,
+  protocolVersion = PROTOCOL_VERSION
+): Promise<number | null> {
+  const client = new DaemonClient({ socketPath, tokenPath, protocolVersion })
+  try {
+    await client.ensureConnected()
+    const result = await client.request<ListSessionsResult>('listSessions', undefined)
+    return result.sessions.filter((session) => session.isAlive).length
+  } catch {
+    return null
+  } finally {
+    client.disconnect()
+  }
+}
+
+function createPreservedDaemonHandle(
+  runtimeDir: string,
+  protocolVersion = PROTOCOL_VERSION
+): { shutdown(): Promise<void> } {
+  return {
+    shutdown: async () => {
+      await cleanupDaemonForProtocol(runtimeDir, protocolVersion)
+    }
+  }
+}
+
 function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
   return async (socketPath, tokenPath) => {
     const entryPath = getDaemonEntryPath()
@@ -106,6 +134,15 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
     if (healthy) {
       const resolverHealth = await getMacDaemonSystemResolverHealth(socketPath, tokenPath)
       if (resolverHealth === 'unhealthy') {
+        const liveSessionCount = await getAliveDaemonSessionCount(socketPath, tokenPath)
+        if (liveSessionCount !== 0) {
+          console.warn(
+            liveSessionCount === null
+              ? '[daemon] Preserving daemon with unavailable macOS system resolver because live session state could not be verified'
+              : `[daemon] Preserving daemon with unavailable macOS system resolver because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
+          )
+          return createPreservedDaemonHandle(runtimeDir)
+        }
         console.warn('[daemon] Replacing daemon with unavailable macOS system resolver')
         await cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)
       } else {
@@ -122,11 +159,7 @@ function createOutOfProcessLauncher(runtimeDir: string): DaemonLauncher {
         } else {
           // Why: daemon is already running from a previous app session and
           // responded to a protocol-level ping. Safe to reuse.
-          return {
-            shutdown: async () => {
-              await cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)
-            }
-          }
+          return createPreservedDaemonHandle(runtimeDir)
         }
       }
     }

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -852,7 +852,52 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       await respawnServer?.shutdown()
     })
 
-    it('replaces an unhealthy macOS resolver daemon before creating a fresh session', async () => {
+    it('preserves an unhealthy macOS resolver daemon when it owns live sessions', async () => {
+      const respawnFn = vi.fn()
+      const exits: { id: string; code: number }[] = []
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+      respawnAdapter.onExit((payload) => exits.push(payload))
+      const existing = await respawnAdapter.spawn({ cols: 80, rows: 24 })
+      getMacDaemonSystemResolverHealthMock.mockResolvedValueOnce('unhealthy')
+
+      const next = await respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
+
+      expect(getMacDaemonSystemResolverHealthMock).toHaveBeenCalledWith(
+        socketPath,
+        tokenPath,
+        respawnAdapter.protocolVersion
+      )
+      expect(respawnFn).not.toHaveBeenCalled()
+      expect(exits).toEqual([])
+      expect(next.id).toBeDefined()
+      expect(next.id).not.toBe(existing.id)
+
+      respawnAdapter.dispose()
+    })
+
+    it('preserves an unhealthy macOS resolver daemon when live sessions have not been reconciled locally', async () => {
+      const respawnFn = vi.fn()
+      const background = await adapter.spawn({ cols: 80, rows: 24 })
+      const backgroundSubprocess = lastSubprocess
+      const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+      getMacDaemonSystemResolverHealthMock.mockResolvedValueOnce('unhealthy')
+
+      const next = await respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
+
+      expect(getMacDaemonSystemResolverHealthMock).toHaveBeenCalledWith(
+        socketPath,
+        tokenPath,
+        respawnAdapter.protocolVersion
+      )
+      expect(respawnFn).not.toHaveBeenCalled()
+      expect(next.id).toBeDefined()
+      expect(next.id).not.toBe(background.id)
+      expect(backgroundSubprocess.forceKill).not.toHaveBeenCalled()
+
+      respawnAdapter.dispose()
+    })
+
+    it('replaces an unhealthy macOS resolver daemon before creating a fresh session when no sessions are active', async () => {
       let respawnServer: DaemonServer | undefined
       const respawnFn = vi.fn(async () => {
         await server.shutdown()
@@ -867,7 +912,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       const exits: { id: string; code: number }[] = []
       const respawnAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
       respawnAdapter.onExit((payload) => exits.push(payload))
-      const existing = await respawnAdapter.spawn({ cols: 80, rows: 24 })
       getMacDaemonSystemResolverHealthMock.mockResolvedValueOnce('unhealthy')
 
       const replacement = await respawnAdapter.spawn({ cols: 80, rows: 24, isNewSession: true })
@@ -878,7 +922,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         respawnAdapter.protocolVersion
       )
       expect(respawnFn).toHaveBeenCalledOnce()
-      expect(exits).toContainEqual({ id: existing.id, code: -1 })
+      expect(exits).toEqual([])
       expect(replacement.id).toBeDefined()
 
       respawnAdapter.dispose()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -670,6 +670,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return
     }
 
+    const daemonLiveSessionCount = await this.getDaemonLiveSessionCount()
+    const liveSessionCount = Math.max(this.activeSessionIds.size, daemonLiveSessionCount ?? 0)
+    if (daemonLiveSessionCount === null || liveSessionCount > 0) {
+      console.warn(
+        daemonLiveSessionCount === null
+          ? '[daemon] macOS system resolver unavailable - preserving daemon because live session state could not be verified'
+          : `[daemon] macOS system resolver unavailable - preserving daemon because it owns ${liveSessionCount} live session${liveSessionCount === 1 ? '' : 's'}`
+      )
+      return
+    }
+
     // Why: replacing the daemon kills its sessions without daemon-side exit
     // fanout. Emit exits first so renderer panes do not write to dead PTYs.
     this.fanoutSyntheticExits(-1)
@@ -681,6 +692,16 @@ export class DaemonPtyAdapter implements IPtyProvider {
       })
     }
     await this.respawnPromise
+  }
+
+  private async getDaemonLiveSessionCount(): Promise<number | null> {
+    try {
+      await this.client.ensureConnected()
+      const result = await this.client.request<ListSessionsResult>('listSessions', undefined)
+      return result.sessions.filter((session) => session.isAlive).length
+    } catch {
+      return null
+    }
   }
 
   private async doRespawn(message = '[daemon] Daemon died — respawning'): Promise<void> {

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -1,10 +1,10 @@
 // ─── Protocol Version ────────────────────────────────────────────────
 // Why: daemons can survive app updates. Bump for IPC wire-shape changes, or
 // when daemon-baked behavior cannot be delivered by on-disk wrapper refresh.
-// Why: bumped from 8 -> 9 so new app launches do not reuse daemon processes
-// that cannot report their own macOS system resolver health.
-export const PROTOCOL_VERSION = 9
-export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const
+// Why: bumped from 9 -> 10 so affected v9 daemons are preserved as legacy
+// instead of being resolver-health replaced while they own live PTY sessions.
+export const PROTOCOL_VERSION = 10
+export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
 export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'


### PR DESCRIPTION
## Summary

This PR fixes the P0 class of failures where live terminal child processes can be killed even though Orca's detached terminal daemon is expected to survive app restarts.

The important correction from the investigation is that this is not Codex-specific. Codex was just the most visible workload because we keep many long-running Codex processes in Orca terminals. The failure mode is at the local daemon / PTY lifecycle layer, so it can affect any long-running terminal process.

## Root cause

PR #2835 added macOS system resolver-health detection for daemon reuse. That was directionally correct, but it introduced two replacement paths that could tear down a live daemon:

1. App launch path: if the current-protocol daemon passed protocol health but reported an unhealthy macOS resolver, `createOutOfProcessLauncher()` called `cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION)`.
2. New-terminal path: `DaemonPtyAdapter.replaceUnhealthyMacResolverDaemonBeforeNewPty()` could respawn the daemon before creating a new PTY.

Both replacement paths ultimately shut down or respawn the daemon. For the current daemon, that means live PTY child processes can be killed with `killSessions: true`. From the user's perspective, the terminal surface may still appear to persist, but the actual process inside it is gone.

That matches the clarified report: the issue is not primarily that Orca cannot find old session records. It is that the child processes themselves can exit despite the terminal daemon having a separate lifecycle from the app.

## Fix

This PR makes resolver-health replacement non-destructive for daemons that may own live work:

- On app launch, if resolver health is unhealthy, Orca now asks the daemon for `listSessions` before cleanup.
  - If live sessions exist, preserve the daemon.
  - If session state cannot be verified, preserve the daemon as the fail-safe.
  - Only replace when the daemon is unhealthy and reports zero live sessions.
- On new-terminal creation, the adapter now queries the daemon itself before respawning.
  - This is intentionally stronger than checking the adapter's local `activeSessionIds`, because after an app restart a fresh adapter can have an empty local set while the daemon still owns live sessions.
- The daemon protocol is bumped from v9 to v10, and v9 is added to the previous-protocol list.
  - This preserves already-running v9 daemons from affected builds by routing them as legacy daemons instead of running them through the current-protocol resolver-health replacement path.

## Why the protocol bump matters

Without the v10 bump, users who already have a v9 daemon from an affected build could relaunch into this patched build and still have that daemon treated as the current daemon. The launcher/adapters would then continue evaluating resolver health against it.

By making v10 current and v9 legacy:

- Existing v9 sessions stay attached to their existing daemon.
- New terminals use the fresh v10 daemon.
- Legacy v9 adapters do not get a respawn callback, so they do not resolver-health replace themselves and kill old sessions.

## Regression coverage

Added/updated tests for:

- Resolver-unhealthy app launch preserves a daemon that owns live sessions.
- Resolver-unhealthy app launch preserves when live session state cannot be verified.
- Affected v9 daemons are routed as legacy adapters on launch.
- Resolver-unhealthy new-terminal creation preserves when the current adapter already knows about live sessions.
- Resolver-unhealthy new-terminal creation preserves when live sessions exist in the daemon but have not been reconciled into the fresh adapter yet. This locks down the cross-restart gap found during review.
- Resolver-unhealthy replacement still happens when there are zero live sessions, preserving the original DNS-staleness mitigation.

## Verification

Ran locally:

```bash
pnpm vitest run --config config/vitest.config.ts src/main/daemon/daemon-init.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-pty-router.test.ts src/main/daemon/daemon-spawner.test.ts src/main/daemon/daemon-server.test.ts
pnpm lint src/main/daemon/types.ts src/main/daemon/daemon-init.ts src/main/daemon/daemon-pty-adapter.ts src/main/daemon/daemon-init.test.ts src/main/daemon/daemon-pty-adapter.test.ts
pnpm typecheck:node
git diff --check
```

Results:

- Daemon test suite: 5 files passed, 111 tests passed.
- Lint: passed.
- Node typecheck: passed.
- Diff whitespace check: passed.

Local environment note: commands emit the existing engine warning because this shell is Node v26 while the repo wants Node 24.

## Review notes

I asked subagents to review this specifically for daemon lifecycle, regression risk, and cross-platform/SSH implications.

They found one real blocker in the first version of the patch: checking only `activeSessionIds` was insufficient after app restart because a fresh adapter may not yet know about sessions owned by the daemon. This PR now fixes that by querying daemon `listSessions` before adapter-side replacement and includes the corresponding regression test.

Cross-platform/SSH review did not find blockers: resolver-health replacement is macOS-only (`unknown` elsewhere), and the touched paths are local daemon paths rather than SSH provider paths.

Made with [Orca](https://github.com/stablyai/orca) 🐋
