### PR TITLE
Open attached workspace for GitHub PRs

### DIFF
--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -25,6 +25,7 @@ import {
   Copy,
   ExternalLink,
   FileText,
+  FolderKanban,
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
@@ -34,6 +35,7 @@ import {
   MessageSquarePlus,
   PanelLeftOpen,
   Pencil,
+  Plus,
   RefreshCw,
   Send,
   UndoDot,
@@ -98,6 +100,7 @@ import {
   type PRCommentGroup
 } from '@/lib/pr-comment-groups'
 import { useAppStore } from '@/store'
+import { useAllWorktrees } from '@/store/selectors'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { useRepoLabels, useRepoAssignees, useImmediateMutation } from '@/hooks/useIssueMetadata'
 import { useRepoLabelsBySlug, useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
@@ -108,6 +111,10 @@ import {
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { getConnectionId } from '@/lib/connection-context'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import {
+  findGithubPrWorkspaceAttachment,
+  getGithubPrWorkspaceAttachmentLabel
+} from '@/lib/github-pr-workspace-attachment'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import { launchWorkItemDirect } from '@/lib/launch-work-item-direct'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -125,8 +132,7 @@ import type {
   PRCheckDetail,
   PRCheckRunDetails,
   PRComment,
-  TuiAgent,
-  Worktree
+  TuiAgent
 } from '../../../shared/types'
 
 // Why: the GH item dialog can be opened from any work-item list surface and
@@ -3355,19 +3361,6 @@ function buildFixBrokenChecksPrompt(item: GitHubWorkItem, checks: PRCheckDetail[
   ].join('\n')
 }
 
-function findWorkspaceAttachedToPR(
-  worktrees: Worktree[],
-  repoId: string,
-  prNumber: number
-): Worktree | null {
-  return (
-    worktrees.find(
-      (worktree) =>
-        worktree.repoId === repoId && worktree.linkedPR === prNumber && !worktree.isArchived
-    ) ?? null
-  )
-}
-
 function pickDefaultAgent(
   defaultAgent: TuiAgent | 'blank' | null | undefined,
   detectedAgents: TuiAgent[]
@@ -3533,7 +3526,7 @@ function ChecksTab({
     try {
       const prompt = buildFixBrokenChecksPrompt(item, list)
       const store = useAppStore.getState()
-      const attachedWorkspace = findWorkspaceAttachedToPR(
+      const attachedWorkspace = findGithubPrWorkspaceAttachment(
         store.allWorktrees(),
         targetRepoId,
         item.number
@@ -4955,6 +4948,17 @@ export default function PullRequestPage({
   const workItemLabels = workItem?.labels
   const workItemType = workItem?.type
   const effectiveRepoId = repoId ?? workItem?.repoId ?? null
+  const allWorktrees = useAllWorktrees()
+  const attachedWorkspace = useMemo(
+    () =>
+      workItem?.type === 'pr'
+        ? findGithubPrWorkspaceAttachment(allWorktrees, effectiveRepoId, workItem.number)
+        : null,
+    [allWorktrees, effectiveRepoId, workItem]
+  )
+  const attachedWorkspaceLabel = attachedWorkspace
+    ? getGithubPrWorkspaceAttachmentLabel(attachedWorkspace)
+    : null
 
   // Why: the cache key has to include the issue source preference so a user
   // toggling between origin/upstream for the same issue number doesn't read
@@ -4994,6 +4998,39 @@ export default function PullRequestPage({
     const nextTab = workItemType === 'pr' ? (initialTab ?? 'conversation') : 'conversation'
     setTab(nextTab)
   }, [workItemId, workItemType, initialTab])
+
+  const handleUseWorkItem = useCallback((): void => {
+    if (!workItem) {
+      return
+    }
+    const targetRepoId = effectiveRepoId
+    onUse(
+      targetRepoId && targetRepoId !== workItem.repoId
+        ? { ...workItem, repoId: targetRepoId }
+        : workItem
+    )
+  }, [effectiveRepoId, onUse, workItem])
+
+  const handleOpenOrUsePR = useCallback((): void => {
+    if (!workItem) {
+      return
+    }
+    const targetRepoId = effectiveRepoId
+    const currentAttached = findGithubPrWorkspaceAttachment(
+      useAppStore.getState().allWorktrees(),
+      targetRepoId,
+      workItem.number
+    )
+    if (!currentAttached) {
+      handleUseWorkItem()
+      return
+    }
+
+    const result = activateAndRevealWorktree(currentAttached.id)
+    if (result === false) {
+      toast.error('Unable to open the workspace attached to this pull request.')
+    }
+  }, [effectiveRepoId, handleUseWorkItem, workItem])
 
   // Why: track comments added optimistically before the detail fetch resolves
   // so they can be merged into the fetch result instead of being overwritten.
@@ -5413,16 +5450,39 @@ export default function PullRequestPage({
           <div className="flex shrink-0 items-center gap-2">
             {/* Why: Orca's signature affordance — keep this primary so it stands out
                 against GitHub's familiar surface. */}
-            <Button
-              type="button"
-              size="sm"
-              onClick={() => onUse(workItem)}
-              className="gap-1.5 whitespace-nowrap"
-              aria-label="Start workspace from PR"
-            >
-              Start workspace from PR
-              <ArrowRight className="size-3.5" />
-            </Button>
+            <DropdownMenu modal={false}>
+              <ButtonGroup>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleOpenOrUsePR}
+                  className="gap-1.5 whitespace-nowrap"
+                  aria-label={
+                    attachedWorkspace ? 'Open workspace attached to PR' : 'Start workspace from PR'
+                  }
+                >
+                  {attachedWorkspace ? 'Open workspace' : 'Start workspace from PR'}
+                  <ArrowRight className="size-3.5" />
+                </Button>
+                <DropdownMenuTrigger asChild>
+                  <Button type="button" size="icon-sm" aria-label="More PR workspace actions">
+                    <ChevronDown className="size-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+              </ButtonGroup>
+              <DropdownMenuContent align="end">
+                {attachedWorkspace ? (
+                  <DropdownMenuItem onSelect={handleUseWorkItem}>
+                    <Plus className="size-4" />
+                    Start new workspace
+                  </DropdownMenuItem>
+                ) : null}
+                <DropdownMenuItem onSelect={() => window.api.shell.openUrl(workItem.url)}>
+                  <ExternalLink className="size-4" />
+                  Open on GitHub
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-2 text-[13px] text-muted-foreground">
@@ -5457,6 +5517,12 @@ export default function PullRequestPage({
               · updated {formatRelativeTime(workItem.updatedAt)}
             </span>
           </span>
+          {attachedWorkspaceLabel ? (
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <FolderKanban className="size-3.5 shrink-0" />
+              <span className="truncate">{attachedWorkspaceLabel}</span>
+            </span>
+          ) : null}
         </div>
       </div>
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -42,9 +42,10 @@ import {
 import { toast } from 'sonner'
 
 import { useAppStore } from '@/store'
-import { useRepoMap } from '@/store/selectors'
+import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { Button } from '@/components/ui/button'
+import { ButtonGroup } from '@/components/ui/button-group'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -98,6 +99,11 @@ import {
 } from '../../../shared/linear-links'
 import PRFilterDropdowns, { type PRFilterChange } from '@/components/github/PRFilterDropdowns'
 import { buildGitHubRepoUrl, parseGitHubIssueOrPRLink } from '@/lib/github-links'
+import {
+  findGithubPrWorkspaceAttachment,
+  getGithubPrWorkspaceAttachmentLabel
+} from '@/lib/github-pr-workspace-attachment'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
 import PullRequestPage from '@/components/PullRequestPage'
@@ -1957,6 +1963,7 @@ export default function TaskPage(): React.JSX.Element {
   const activeModal = useAppStore((s) => s.activeModal)
   const repos = useAppStore((s) => s.repos)
   const repoMap = useRepoMap()
+  const allWorktrees = useAllWorktrees()
   const openModal = useAppStore((s) => s.openModal)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const fetchWorkItemsAcrossRepos = useAppStore((s) => s.fetchWorkItemsAcrossRepos)
@@ -3797,6 +3804,26 @@ export default function TaskPage(): React.JSX.Element {
     [openComposerForItem]
   )
 
+  const handleOpenOrUseGitHubPR = useCallback(
+    (item: GitHubWorkItem): void => {
+      const currentAttached = findGithubPrWorkspaceAttachment(
+        useAppStore.getState().allWorktrees(),
+        item.repoId,
+        item.number
+      )
+      if (!currentAttached) {
+        handleUseWorkItem(item)
+        return
+      }
+
+      const result = activateAndRevealWorktree(currentAttached.id)
+      if (result === false) {
+        toast.error('Unable to open the workspace attached to this pull request.')
+      }
+    },
+    [handleUseWorkItem]
+  )
+
   const openComposerForGitLabItem = useCallback(
     (item: GitLabWorkItem): void => {
       const linkedWorkItem: LinkedWorkItemSummary = {
@@ -5144,6 +5171,13 @@ export default function TaskPage(): React.JSX.Element {
                   {!showGitHubTaskSkeletons &&
                     filteredWorkItems.map((item) => {
                       const itemRepo = repoMap.get(item.repoId) ?? null
+                      const attachedWorkspace =
+                        item.type === 'pr'
+                          ? findGithubPrWorkspaceAttachment(allWorktrees, item.repoId, item.number)
+                          : null
+                      const attachedWorkspaceLabel = attachedWorkspace
+                        ? getGithubPrWorkspaceAttachmentLabel(attachedWorkspace)
+                        : null
                       return (
                         // Why: the row is a clickable container rather than a
                         // <button> because it holds nested interactive elements
@@ -5226,6 +5260,12 @@ export default function TaskPage(): React.JSX.Element {
                                   {formatPRDelta(item)}
                                 </span>
                               ) : null}
+                              {attachedWorkspaceLabel ? (
+                                <span className="inline-flex min-w-0 items-center gap-1">
+                                  <FolderKanban className="size-3 shrink-0" />
+                                  <span className="truncate">{attachedWorkspaceLabel}</span>
+                                </span>
+                              ) : null}
                               {item.labels.slice(0, 3).map((label) => (
                                 <span
                                   key={label}
@@ -5283,37 +5323,96 @@ export default function TaskPage(): React.JSX.Element {
                           </Tooltip>
 
                           <div className="flex items-center justify-start gap-1 lg:justify-end">
-                            <button
-                              type="button"
-                              onClick={(event) => {
-                                event.stopPropagation()
-                                handleUseWorkItem(item)
-                              }}
-                              className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60"
-                            >
-                              Start
-                              <ArrowRight className="size-3" />
-                            </button>
-                            <DropdownMenu modal={false}>
-                              <DropdownMenuTrigger asChild>
-                                <button
-                                  type="button"
+                            {item.type === 'pr' ? (
+                              <DropdownMenu modal={false}>
+                                <ButtonGroup>
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="xs"
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      handleOpenOrUseGitHubPR(item)
+                                    }}
+                                    className="bg-background/80"
+                                    aria-label={
+                                      attachedWorkspace
+                                        ? 'Open workspace attached to PR'
+                                        : 'Start workspace from PR'
+                                    }
+                                  >
+                                    {attachedWorkspace ? 'Open' : 'Start'}
+                                    <ArrowRight className="size-3" />
+                                  </Button>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      type="button"
+                                      variant="outline"
+                                      size="icon-xs"
+                                      onClick={(event) => event.stopPropagation()}
+                                      className="bg-background/80"
+                                      aria-label="More PR actions"
+                                    >
+                                      <ChevronDown className="size-3" />
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                </ButtonGroup>
+                                <DropdownMenuContent
+                                  align="end"
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  {attachedWorkspace ? (
+                                    <DropdownMenuItem onSelect={() => handleUseWorkItem(item)}>
+                                      <Plus className="size-4" />
+                                      Start new workspace
+                                    </DropdownMenuItem>
+                                  ) : null}
+                                  <DropdownMenuItem
+                                    onSelect={() => window.api.shell.openUrl(item.url)}
+                                  >
+                                    <ExternalLink className="size-4" />
+                                    Open in browser
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  handleUseWorkItem(item)
+                                }}
+                                className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60"
+                              >
+                                Start
+                                <ArrowRight className="size-3" />
+                              </button>
+                            )}
+                            {item.type !== 'pr' ? (
+                              <DropdownMenu modal={false}>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    type="button"
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
+                                    aria-label="More actions"
+                                  >
+                                    <EllipsisVertical className="size-4" />
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                  align="end"
                                   onClick={(e) => e.stopPropagation()}
-                                  className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
-                                  aria-label="More actions"
                                 >
-                                  <EllipsisVertical className="size-4" />
-                                </button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-                                <DropdownMenuItem
-                                  onSelect={() => window.api.shell.openUrl(item.url)}
-                                >
-                                  <ExternalLink className="size-4" />
-                                  Open in browser
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
+                                  <DropdownMenuItem
+                                    onSelect={() => window.api.shell.openUrl(item.url)}
+                                  >
+                                    <ExternalLink className="size-4" />
+                                    Open in browser
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            ) : null}
                           </div>
                         </div>
                       )

--- a/src/renderer/src/lib/github-pr-workspace-attachment.test.ts
+++ b/src/renderer/src/lib/github-pr-workspace-attachment.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findGithubPrWorkspaceAttachment,
+  getGithubPrWorkspaceAttachmentLabel
+} from './github-pr-workspace-attachment'
+import type { Worktree } from '../../../shared/types'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: overrides.id ?? 'wt-1',
+    repoId: overrides.repoId ?? 'repo-1',
+    path: overrides.path ?? '/tmp/repo-1/wt-1',
+    head: 'abc123',
+    branch: overrides.branch ?? 'refs/heads/feature/pr-workspace',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: overrides.displayName ?? 'PR workspace',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('github PR workspace attachment', () => {
+  it('finds the first non-archived workspace linked to the repo PR', () => {
+    const first = worktree({ id: 'first', linkedPR: 42 })
+    const second = worktree({ id: 'second', linkedPR: 42 })
+
+    expect(findGithubPrWorkspaceAttachment([first, second], 'repo-1', 42)).toBe(first)
+  })
+
+  it('does not match workspaces from a different repo', () => {
+    const attachedElsewhere = worktree({ repoId: 'repo-2', linkedPR: 42 })
+
+    expect(findGithubPrWorkspaceAttachment([attachedElsewhere], 'repo-1', 42)).toBeNull()
+  })
+
+  it('does not match archived workspaces', () => {
+    const archived = worktree({ linkedPR: 42, isArchived: true })
+
+    expect(findGithubPrWorkspaceAttachment([archived], 'repo-1', 42)).toBeNull()
+  })
+
+  it('returns null when no GitHub PR attachment exists', () => {
+    const unlinked = worktree({ linkedPR: null })
+
+    expect(findGithubPrWorkspaceAttachment([unlinked], 'repo-1', 42)).toBeNull()
+  })
+
+  it('does not treat GitLab MR metadata as a GitHub PR attachment', () => {
+    const gitlabOnly = worktree({ linkedPR: null, linkedGitLabMR: 42 })
+
+    expect(findGithubPrWorkspaceAttachment([gitlabOnly], 'repo-1', 42)).toBeNull()
+  })
+
+  it('labels attachments without exposing a full path when display or branch is available', () => {
+    expect(getGithubPrWorkspaceAttachmentLabel(worktree({ displayName: '  Named PR  ' }))).toBe(
+      'Named PR'
+    )
+    expect(
+      getGithubPrWorkspaceAttachmentLabel(
+        worktree({ displayName: '', branch: 'refs/heads/fix-ci' })
+      )
+    ).toBe('fix-ci')
+    expect(
+      getGithubPrWorkspaceAttachmentLabel(
+        worktree({ displayName: '', branch: '', path: 'C:\\repo\\workspace-tail' })
+      )
+    ).toBe('workspace-tail')
+  })
+})

--- a/src/renderer/src/lib/github-pr-workspace-attachment.ts
+++ b/src/renderer/src/lib/github-pr-workspace-attachment.ts
@@ -1,0 +1,46 @@
+import type { Worktree } from '../../../shared/types'
+import { basename } from './path'
+
+export function findGithubPrWorkspaceAttachment(
+  worktrees: readonly Worktree[],
+  repoId: string | null | undefined,
+  prNumber: number
+): Worktree | null {
+  if (!repoId) {
+    return null
+  }
+
+  return (
+    worktrees.find(
+      (worktree) =>
+        worktree.repoId === repoId && worktree.linkedPR === prNumber && !worktree.isArchived
+    ) ?? null
+  )
+}
+
+export function getGithubPrWorkspaceAttachmentLabel(worktree: Worktree): string {
+  const displayName = worktree.displayName.trim()
+  if (displayName) {
+    return displayName
+  }
+
+  const branch = getBranchLabel(worktree.branch)
+  if (branch) {
+    return branch
+  }
+
+  return basename(worktree.path) || worktree.path
+}
+
+function getBranchLabel(branch: string | null | undefined): string | null {
+  const trimmed = branch?.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  if (trimmed.startsWith('refs/heads/')) {
+    return trimmed.slice('refs/heads/'.length)
+  }
+
+  return trimmed
+}


### PR DESCRIPTION
## Summary
- Detect non-archived workspaces already linked to GitHub PRs and show their label in PR list/detail views.
- Change GitHub PR actions to open the attached workspace when one exists, while keeping a menu option to start a new workspace.
- Extract PR workspace attachment lookup/labeling into a shared helper with tests.

## Testing
- Added `github-pr-workspace-attachment` unit coverage for matching, archived workspaces, GitLab MR separation, and label fallback behavior.