### PR TITLE
Widen SSH status popover

### DIFF
--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -273,7 +273,12 @@ export function SshStatusSegment({
           )}
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-[220px]">
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-[min(20rem,calc(100vw-1rem))]"
+      >
         <div className="px-2 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
           SSH Connections
         </div>


### PR DESCRIPTION
## Summary
- widen the SSH status dropdown so connection sync labels have more room
- cap the width against the viewport to avoid overflow in narrow windows

## Validation
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/status-bar/SshStatusSegment.tsx

Made with [Orca](https://github.com/stablyai/orca) 🐋
