### PR TITLE
Speed up Quick Open ranking

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -15,46 +15,7 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
-
-/**
- * Simple fuzzy match: checks if all characters in the query appear in order
- * within the target string (case-insensitive). Returns a score (lower = better)
- * or -1 if no match.
- */
-function fuzzyMatch(query: string, target: string): number {
-  const q = query.toLowerCase()
-  const t = target.toLowerCase()
-  let qi = 0
-  let score = 0
-  let lastMatchIdx = -1
-
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) {
-      // Bonus for consecutive matches
-      const gap = lastMatchIdx === -1 ? 0 : ti - lastMatchIdx - 1
-      score += gap
-      // Bonus for matching after separator (/ or .)
-      if (ti > 0 && (t[ti - 1] === '/' || t[ti - 1] === '.' || t[ti - 1] === '-')) {
-        score -= 5 // reward
-      }
-      lastMatchIdx = ti
-      qi++
-    }
-  }
-
-  if (qi < q.length) {
-    return -1 // not all chars matched
-  }
-
-  // Prefer matches where query appears in the filename (last segment)
-  const lastSlash = target.lastIndexOf('/')
-  const filename = target.slice(lastSlash + 1).toLowerCase()
-  if (filename.includes(q)) {
-    score -= 100 // strong reward for filename match
-  }
-
-  return score
-}
+import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
 
 /**
  * Parses the install-ripgrep guidance message produced by the relay's
@@ -296,23 +257,11 @@ export default function QuickOpen(): React.JSX.Element | null {
     }
   }, [visible, activeWorktreeId, worktreePath, connectionId, excludePathsKey, filesRequestKey])
 
-  // Filter files by fuzzy match
-  const filtered = useMemo(() => {
-    const normalizedQuery = deferredQuery.trim()
-    if (!normalizedQuery) {
-      // Show first 50 files when no query
-      return files.slice(0, 50).map((f) => ({ path: f, score: 0 }))
-    }
-    const results: { path: string; score: number }[] = []
-    for (const f of files) {
-      const score = fuzzyMatch(normalizedQuery, f)
-      if (score !== -1) {
-        results.push({ path: f, score })
-      }
-    }
-    results.sort((a, b) => a.score - b.score)
-    return results.slice(0, 50)
-  }, [deferredQuery, files])
+  const indexedFiles = useMemo(() => prepareQuickOpenFiles(files), [files])
+  const filtered = useMemo(
+    () => rankQuickOpenFiles(deferredQuery, indexedFiles),
+    [deferredQuery, indexedFiles]
+  )
 
   const handleSelect = useCallback(
     (relativePath: string) => {

--- a/src/renderer/src/components/quick-open-search.test.ts
+++ b/src/renderer/src/components/quick-open-search.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  QUICK_OPEN_RESULT_LIMIT,
+  prepareQuickOpenFiles,
+  rankQuickOpenFiles
+} from './quick-open-search'
+
+describe('quick-open-search', () => {
+  it('returns the first 50 paths with score 0 for an empty query', () => {
+    const files = Array.from({ length: 75 }, (_, index) => `src/file-${index}.ts`)
+
+    expect(rankQuickOpenFiles('', prepareQuickOpenFiles(files))).toEqual(
+      files.slice(0, QUICK_OPEN_RESULT_LIMIT).map((path) => ({ path, score: 0 }))
+    )
+  })
+
+  it('treats a whitespace-only query as empty', () => {
+    const files = ['src/a.ts', 'src/b.ts', 'src/c.ts']
+
+    expect(rankQuickOpenFiles('   ', prepareQuickOpenFiles(files))).toEqual([
+      { path: 'src/a.ts', score: 0 },
+      { path: 'src/b.ts', score: 0 },
+      { path: 'src/c.ts', score: 0 }
+    ])
+  })
+
+  it('prefers filename substring matches over path-only matches', () => {
+    const files = ['button-area/deep/path/file.tsx', 'src/components/Button.tsx']
+
+    expect(
+      rankQuickOpenFiles('button', prepareQuickOpenFiles(files)).map((item) => item.path)
+    ).toEqual(['src/components/Button.tsx', 'button-area/deep/path/file.tsx'])
+  })
+
+  it('keeps first-seen order for tie-heavy results at the limit boundary', () => {
+    const files = Array.from({ length: 10 }, (_, index) => `src/path-${index}.bin`)
+
+    expect(rankQuickOpenFiles('s', prepareQuickOpenFiles(files), 4)).toEqual([
+      { path: 'src/path-0.bin', score: 0 },
+      { path: 'src/path-1.bin', score: 0 },
+      { path: 'src/path-2.bin', score: 0 },
+      { path: 'src/path-3.bin', score: 0 }
+    ])
+  })
+
+  it('returns 50 top-ranked results from a 100k synthetic list', () => {
+    const fillerCount = 99_940
+    const topCandidateCount = 60
+    const files = [
+      ...Array.from(
+        { length: fillerCount },
+        (_, index) => `n-x-e-x-e-x-d-x-l-x-e/group-${index}/file.ts`
+      ),
+      ...Array.from({ length: topCandidateCount }, (_, index) => `bulk/special-${index}/needle.ts`)
+    ]
+
+    const results = rankQuickOpenFiles('needle', prepareQuickOpenFiles(files))
+
+    expect(results).toHaveLength(QUICK_OPEN_RESULT_LIMIT)
+    expect(results.map((item) => item.path)).toEqual(
+      Array.from(
+        { length: QUICK_OPEN_RESULT_LIMIT },
+        (_, index) => `bulk/special-${index}/needle.ts`
+      )
+    )
+  })
+
+  it('returns scores sorted ascending', () => {
+    const files = [
+      'src/components/QuickOpen.tsx',
+      'quick/open/deep/path/file.tsx',
+      'src/q-u-i-c-k-open.ts'
+    ]
+
+    const scores = rankQuickOpenFiles('quick', prepareQuickOpenFiles(files)).map(
+      (item) => item.score
+    )
+
+    expect(scores).toEqual([...scores].sort((a, b) => a - b))
+  })
+
+  it('indexes normalized relative paths without changing path semantics', () => {
+    const files = [
+      'src/renderer/src/components/QuickOpen.tsx',
+      'packages/windows-origin/src/App.tsx',
+      'single-file.ts',
+      'legacy\\provider\\raw-path.ts'
+    ]
+
+    expect(prepareQuickOpenFiles(files)).toEqual([
+      {
+        path: 'src/renderer/src/components/QuickOpen.tsx',
+        lowerPath: 'src/renderer/src/components/quickopen.tsx',
+        lowerFilename: 'quickopen.tsx',
+        inputIndex: 0
+      },
+      {
+        path: 'packages/windows-origin/src/App.tsx',
+        lowerPath: 'packages/windows-origin/src/app.tsx',
+        lowerFilename: 'app.tsx',
+        inputIndex: 1
+      },
+      {
+        path: 'single-file.ts',
+        lowerPath: 'single-file.ts',
+        lowerFilename: 'single-file.ts',
+        inputIndex: 2
+      },
+      {
+        path: 'legacy\\provider\\raw-path.ts',
+        lowerPath: 'legacy\\provider\\raw-path.ts',
+        lowerFilename: 'legacy\\provider\\raw-path.ts',
+        inputIndex: 3
+      }
+    ])
+  })
+
+  it('returns no results for non-positive limits', () => {
+    const files = prepareQuickOpenFiles(['src/a.ts'])
+
+    expect(rankQuickOpenFiles('a', files, 0)).toEqual([])
+    expect(rankQuickOpenFiles('a', files, -1)).toEqual([])
+  })
+})

--- a/src/renderer/src/components/quick-open-search.ts
+++ b/src/renderer/src/components/quick-open-search.ts
@@ -1,0 +1,131 @@
+export const QUICK_OPEN_RESULT_LIMIT = 50
+
+export type QuickOpenIndexedFile = {
+  path: string
+  lowerPath: string
+  lowerFilename: string
+  inputIndex: number
+}
+
+export type QuickOpenSearchResult = {
+  path: string
+  score: number
+}
+
+export function prepareQuickOpenFiles(files: readonly string[]): QuickOpenIndexedFile[] {
+  return files.map((path, inputIndex) => {
+    const lastSlash = path.lastIndexOf('/')
+    return {
+      path,
+      lowerPath: path.toLowerCase(),
+      lowerFilename: path.slice(lastSlash + 1).toLowerCase(),
+      inputIndex
+    }
+  })
+}
+
+export function rankQuickOpenFiles(
+  query: string,
+  files: readonly QuickOpenIndexedFile[],
+  limit = QUICK_OPEN_RESULT_LIMIT
+): QuickOpenSearchResult[] {
+  if (limit <= 0) {
+    return []
+  }
+
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) {
+    return files.slice(0, limit).map((file) => ({ path: file.path, score: 0 }))
+  }
+
+  const results: QuickOpenRankedResult[] = []
+  for (const file of files) {
+    const score = fuzzyMatchIndexedFile(normalizedQuery, file)
+    if (score === -1) {
+      continue
+    }
+
+    insertTopResult(results, { path: file.path, score, inputIndex: file.inputIndex }, limit)
+  }
+
+  return results.map(({ path, score }) => ({ path, score }))
+}
+
+function fuzzyMatchIndexedFile(query: string, file: QuickOpenIndexedFile): number {
+  let qi = 0
+  let score = 0
+  let lastMatchIdx = -1
+
+  for (let ti = 0; ti < file.lowerPath.length && qi < query.length; ti++) {
+    if (file.lowerPath[ti] === query[qi]) {
+      // Preserve the existing Quick Open score semantics while avoiding
+      // repeated lowercase work for each candidate on every keystroke.
+      const gap = lastMatchIdx === -1 ? 0 : ti - lastMatchIdx - 1
+      score += gap
+      if (
+        ti > 0 &&
+        (file.lowerPath[ti - 1] === '/' ||
+          file.lowerPath[ti - 1] === '.' ||
+          file.lowerPath[ti - 1] === '-')
+      ) {
+        score -= 5
+      }
+      lastMatchIdx = ti
+      qi++
+    }
+  }
+
+  if (qi < query.length) {
+    return -1
+  }
+
+  if (file.lowerFilename.includes(query)) {
+    score -= 100
+  }
+
+  return score
+}
+
+type QuickOpenRankedResult = QuickOpenSearchResult & {
+  inputIndex: number
+}
+
+function insertTopResult(
+  results: QuickOpenRankedResult[],
+  candidate: QuickOpenRankedResult,
+  limit: number
+): void {
+  const worst = results.at(-1)
+  if (results.length === limit && worst && compareRankedResult(candidate, worst) >= 0) {
+    return
+  }
+
+  const insertAt = findInsertionIndex(results, candidate)
+  results.splice(insertAt, 0, candidate)
+  if (results.length > limit) {
+    results.pop()
+  }
+}
+
+function findInsertionIndex(
+  results: readonly QuickOpenRankedResult[],
+  candidate: QuickOpenRankedResult
+): number {
+  let low = 0
+  let high = results.length
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (compareRankedResult(candidate, results[mid]) < 0) {
+      high = mid
+    } else {
+      low = mid + 1
+    }
+  }
+
+  return low
+}
+
+function compareRankedResult(a: QuickOpenRankedResult, b: QuickOpenRankedResult): number {
+  return a.score - b.score || a.inputIndex - b.inputIndex
+}


### PR DESCRIPTION
## Summary

Fixes #2933.

Quick Open now precomputes searchable file fields when the file list changes and ranks typed queries through a bounded top-k selector for the visible 50 results. The dialog UI, file-open flow, deferred-query cadence, IPC/runtime loading, and backend file-listing behavior are unchanged.

## Design Approach

- Extracted pure Quick Open indexing/ranking into `quick-open-search.ts`.
- Indexed each file with original path, lowercased path, lowercased filename, and original input index.
- Preserved existing fuzzy scoring semantics while avoiding per-keystroke lowercase recomputation.
- Replaced full match-list sorting with bounded insertion that keeps only the best 50 results ordered by score, then original input order.

## Design Review Outcome

- Scratch design doc: `design-docs/quick-open-top-k-search.md` (ignored, not included in this PR).
- Design review completed clean after adding explicit tie ordering, deferred-query requirements, structural large-list validation, normalized-path invariant coverage, and UX non-regression criteria.

## Implementation / Deviations

- Implemented the reviewed design in `QuickOpen.tsx`, `quick-open-search.ts`, and `quick-open-search.test.ts`.
- No deviations from the reviewed design.
- No SSH, runtime provider, backend file listing, git provider, or source-control behavior changed.

## Completeness Verification

- Read-only completeness pass found the implementation complete against every design requirement, edge case, UX non-regression item, validation item, and SSH/cross-platform consideration.

## Code Review Loop

- Round 1: one reviewer clean; one reviewer found actionable lint failures (`interface` vs `type`, prefer `.at()`) and a non-diff concern. Lint issues were fixed; the non-diff concern was not changed.
- Round 2: one reviewer clean; one reviewer flagged the new module/test as untracked. Both files were staged for inclusion.
- Round 3: two fresh reviewers both returned clean in the same round.

## Brennan Test Changes Result

Verdict: land.

- Launched Electron from this exact PR worktree and verified app identity pointed at `Jinwoo-H/bug-quick-open-filters-and-sorts-the-entire-file`.
- Used a disposable demo project because no existing `demo-project` was registered/found; did not use the Orca repo as the project target.
- Quick Open showed the demo project files.
- Query `needle` filtered to `needle.ts src/features/search` with `1 files found`.
- Clicking the result opened `src/features/search/needle.ts`.
- Backing state confirmed active editor file `/private/tmp/demo-project.jgx9UX/src/features/search/needle.ts`, `isDirty: false`.
- Backing filesystem confirmed the file existed with `export const needle = true`.
- Query `nonexistentzzzz` showed `No matching files.` and `0 files found`.
- Renderer console had 0 errors; main logs had unrelated local environment warnings and no Quick Open failures.
- Disposable repo, temp directory, and Electron/CDP processes started for validation were cleaned up.

## Tests

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `git diff --check`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-search.test.ts`
- [x] Electron validation from PR worktree with app identity verified
- [x] Quick Open search/open workflow validated against disposable demo-project target
- [x] Console and app logs inspected for relevant Quick Open failures

## Assumptions / Remaining Risk

- `pnpm` emitted the local environment warning that the repo wants Node 24 while this shell used Node v26.0.0; all checks still passed.
- The global `Cmd+P` shortcut path could not be proven through Playwright in the validation session. The changed behavior is renderer-side search/ranking, so validation opened the modal via app setup and exercised the real Quick Open input/result click controls.
- SSH live validation was not run because this diff does not touch SSH, relay, remote runtime, provider, or filesystem-listing behavior.

Made with [Orca](https://github.com/stablyai/orca) 🐋
