### PR TITLE
Update mobile 0.0.10 release links

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Control your agents from your phone.
 </p>
 
 - **iOS:** [Download from App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.9)
+- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.10)
 
 ---
 

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -11,7 +11,7 @@ import {
 export { MOBILE_SETTINGS_PANE_SEARCH_ENTRIES }
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
-const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.9'
+const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.10'
 
 type MobileSettingsPaneProps = {
   settings: GlobalSettings


### PR DESCRIPTION
## Summary
- Point Android mobile download links at the published mobile-v0.0.10 release

## Verification
- gh release view mobile-v0.0.10 --repo stablyai/orca --json tagName,url,isPrerelease,assets,publishedAt,name
- git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
