### PR TITLE
Fix floating workspace button startup position

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { PanelsTopLeft } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -8,22 +8,40 @@ import {
   clampFloatingTerminalTriggerPosition,
   getDefaultFloatingTerminalTriggerPosition,
   parseFloatingTerminalTriggerPosition,
-  type FloatingTerminalTriggerPosition
+  resolveFloatingTerminalTriggerPosition,
+  shouldReconcileFloatingTerminalTriggerPosition,
+  type FloatingTerminalTriggerPosition,
+  type FloatingTerminalTriggerPositionSource
 } from './floating-terminal-trigger-position'
 
 // Why: v2 resets older parked positions that sat too low over bottom bars.
 const FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY = 'orca-floating-terminal-trigger-position-v2'
 const FLOATING_TERMINAL_TRIGGER_DRAG_THRESHOLD = 4
 
-function readInitialTriggerPosition(): FloatingTerminalTriggerPosition {
+type FloatingTerminalTriggerPositionState = {
+  position: FloatingTerminalTriggerPosition
+  source: FloatingTerminalTriggerPositionSource
+}
+
+function readInitialTriggerPosition(): FloatingTerminalTriggerPositionState {
   if (typeof window === 'undefined') {
-    return getDefaultFloatingTerminalTriggerPosition()
+    return {
+      position: getDefaultFloatingTerminalTriggerPosition(),
+      source: 'default'
+    }
   }
-  return (
-    parseFloatingTerminalTriggerPosition(
-      window.localStorage.getItem(FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY)
-    ) ?? getDefaultFloatingTerminalTriggerPosition()
+  const persistedPosition = parseFloatingTerminalTriggerPosition(
+    window.localStorage.getItem(FLOATING_TERMINAL_TRIGGER_POSITION_STORAGE_KEY)
   )
+  return persistedPosition
+    ? {
+        position: persistedPosition,
+        source: 'user'
+      }
+    : {
+        position: getDefaultFloatingTerminalTriggerPosition(),
+        source: 'default'
+      }
 }
 
 function persistTriggerPosition(position: FloatingTerminalTriggerPosition): void {
@@ -41,7 +59,14 @@ export function FloatingTerminalToggleButton({
   onToggle: () => void
 }): React.JSX.Element {
   const shortcutLabel = useShortcutLabel('floatingTerminal.toggle')
-  const [position, setPosition] = useState(readInitialTriggerPosition)
+  const initialPositionState = useRef<FloatingTerminalTriggerPositionState | null>(null)
+  if (initialPositionState.current === null) {
+    initialPositionState.current = readInitialTriggerPosition()
+  }
+  const positionSourceRef = useRef<FloatingTerminalTriggerPositionSource>(
+    initialPositionState.current.source
+  )
+  const [position, setPosition] = useState(initialPositionState.current.position)
   const dragRef = useRef<{
     pointerId: number
     startX: number
@@ -53,22 +78,38 @@ export function FloatingTerminalToggleButton({
   const suppressClickRef = useRef(false)
 
   const updatePosition = useCallback((nextPosition: FloatingTerminalTriggerPosition): void => {
+    positionSourceRef.current = 'user'
     const clamped = clampFloatingTerminalTriggerPosition(nextPosition)
     setPosition(clamped)
     persistTriggerPosition(clamped)
   }, [])
 
+  const reconcilePosition = useCallback((): void => {
+    setPosition((current) => {
+      if (!shouldReconcileFloatingTerminalTriggerPosition(positionSourceRef.current)) {
+        // Why: a startup-size viewport must not overwrite an intentional saved
+        // drag position with the safety clamp before the renderer finishes sizing.
+        return current
+      }
+      const next = resolveFloatingTerminalTriggerPosition(current, positionSourceRef.current)
+      if (positionSourceRef.current === 'user') {
+        persistTriggerPosition(next)
+      }
+      return next
+    })
+  }, [])
+
+  useLayoutEffect(() => {
+    // Why: Electron can mount before the renderer has final viewport dimensions;
+    // default positions should re-anchor to bottom-right before first paint.
+    reconcilePosition()
+  }, [reconcilePosition])
+
   useEffect(() => {
-    const handleResize = (): void => {
-      setPosition((current) => {
-        const clamped = clampFloatingTerminalTriggerPosition(current)
-        persistTriggerPosition(clamped)
-        return clamped
-      })
-    }
+    const handleResize = (): void => reconcilePosition()
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
-  }, [])
+  }, [reconcilePosition])
 
   const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>): void => {
     if (event.button !== 0) {

--- a/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   clampFloatingTerminalTriggerPosition,
   getDefaultFloatingTerminalTriggerPosition,
-  parseFloatingTerminalTriggerPosition
+  hasUsableFloatingTerminalTriggerViewport,
+  parseFloatingTerminalTriggerPosition,
+  resolveFloatingTerminalTriggerPosition,
+  shouldReconcileFloatingTerminalTriggerPosition
 } from './floating-terminal-trigger-position'
 
 function stubViewport(width: number, height: number): void {
@@ -32,10 +35,58 @@ describe('floating terminal trigger position', () => {
     })
   })
 
+  it('re-anchors default positions when startup viewport dimensions change', () => {
+    stubViewport(0, 0)
+    const initialPosition = getDefaultFloatingTerminalTriggerPosition()
+
+    stubViewport(1200, 800)
+
+    expect(resolveFloatingTerminalTriggerPosition(initialPosition, 'default')).toEqual({
+      left: 1144,
+      top: 696
+    })
+  })
+
+  it('clamps user-placed positions instead of re-anchoring them on resize', () => {
+    stubViewport(1200, 800)
+
+    expect(resolveFloatingTerminalTriggerPosition({ left: 900, top: 500 }, 'user')).toEqual({
+      left: 900,
+      top: 500
+    })
+  })
+
   it('ignores malformed persisted positions', () => {
     stubViewport(640, 480)
 
     expect(parseFloatingTerminalTriggerPosition('not-json')).toBeNull()
     expect(parseFloatingTerminalTriggerPosition('{"left":"1","top":2}')).toBeNull()
+  })
+
+  it('does not clamp parsed positions before the viewport is settled', () => {
+    stubViewport(0, 0)
+
+    expect(parseFloatingTerminalTriggerPosition('{"left":900,"top":500}')).toEqual({
+      left: 900,
+      top: 500
+    })
+  })
+
+  it('detects whether the viewport is usable for persisted user-position clamps', () => {
+    stubViewport(0, 0)
+    expect(hasUsableFloatingTerminalTriggerViewport()).toBe(false)
+
+    stubViewport(1200, 800)
+    expect(hasUsableFloatingTerminalTriggerViewport()).toBe(true)
+  })
+
+  it('defers user-position reconciliation until the viewport is usable', () => {
+    stubViewport(0, 0)
+
+    expect(shouldReconcileFloatingTerminalTriggerPosition('default')).toBe(true)
+    expect(shouldReconcileFloatingTerminalTriggerPosition('user')).toBe(false)
+
+    stubViewport(1200, 800)
+    expect(shouldReconcileFloatingTerminalTriggerPosition('user')).toBe(true)
   })
 })

--- a/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.ts
@@ -9,6 +9,8 @@ export type FloatingTerminalTriggerPosition = {
   top: number
 }
 
+export type FloatingTerminalTriggerPositionSource = 'default' | 'user'
+
 function getViewport(): { width: number; height: number } {
   return {
     width: typeof window === 'undefined' ? 1200 : window.innerWidth,
@@ -40,6 +42,30 @@ export function clampFloatingTerminalTriggerPosition(
   }
 }
 
+export function hasUsableFloatingTerminalTriggerViewport(): boolean {
+  const viewport = getViewport()
+  return (
+    viewport.width >= TRIGGER_SIZE + DRAG_MARGIN * 2 &&
+    viewport.height >= TRIGGER_SIZE + TITLEBAR_SAFE_TOP + DRAG_MARGIN
+  )
+}
+
+export function shouldReconcileFloatingTerminalTriggerPosition(
+  source: FloatingTerminalTriggerPositionSource
+): boolean {
+  return source === 'default' || hasUsableFloatingTerminalTriggerViewport()
+}
+
+export function resolveFloatingTerminalTriggerPosition(
+  position: FloatingTerminalTriggerPosition,
+  source: FloatingTerminalTriggerPositionSource
+): FloatingTerminalTriggerPosition {
+  if (source === 'default') {
+    return getDefaultFloatingTerminalTriggerPosition()
+  }
+  return clampFloatingTerminalTriggerPosition(position)
+}
+
 export function parseFloatingTerminalTriggerPosition(
   serialized: string | null
 ): FloatingTerminalTriggerPosition | null {
@@ -51,7 +77,7 @@ export function parseFloatingTerminalTriggerPosition(
     if (!isFiniteCoordinate(parsed.left) || !isFiniteCoordinate(parsed.top)) {
       return null
     }
-    return clampFloatingTerminalTriggerPosition({ left: parsed.left, top: parsed.top })
+    return { left: parsed.left, top: parsed.top }
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- keep default floating workspace trigger positions anchored to the bottom right after Electron startup layout settles
- preserve user-dragged positions, including the safe top-left clamp coordinate
- avoid clamping and persisting saved user positions while the startup viewport is unusable

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts
- pnpm run typecheck
- pnpm lint
- Electron validation via CDP on this worktree: default bottom-right placement, top-left saved user placement, arbitrary saved user placement
- Independent subagent correctness review passed after fix-up

Local validation screenshots are ignored and available under validation-screenshots/.

Made with [Orca](https://github.com/stablyai/orca) 🐋
