### PR TITLE
Fix unread badge for background agent completions

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -28,6 +28,7 @@ function leafIdForPane(paneId: number): string {
 }
 
 type StoreState = {
+  activeWorktreeId: string | null
   tabsByWorktree: Record<string, { id: string; ptyId: string | null; title?: string }[]>
   ptyIdsByTabId?: Record<string, string[]>
   unreadTerminalTabs?: Record<string, true>
@@ -68,6 +69,7 @@ type StoreState = {
   consumePendingSnapshot: ReturnType<typeof vi.fn>
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
   agentStatusByPaneKey: Record<string, unknown>
+  markWorktreeUnread: ReturnType<typeof vi.fn>
   setAgentStatus: ReturnType<typeof vi.fn>
   removeAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
@@ -383,6 +385,7 @@ describe('connectPanePty', () => {
     createdTransportOptions = []
     storeSubscribers = []
     mockStoreState = {
+      activeWorktreeId: 'wt-1',
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
       },
@@ -406,6 +409,7 @@ describe('connectPanePty', () => {
       consumePendingSnapshot: vi.fn(() => null),
       runtimePaneTitlesByTabId: {},
       agentStatusByPaneKey: {},
+      markWorktreeUnread: vi.fn(),
       setAgentStatus: vi.fn((paneKey: string, payload: Record<string, unknown>) => {
         mockStoreState.agentStatusByPaneKey[paneKey] = {
           ...payload,
@@ -4150,10 +4154,11 @@ describe('connectPanePty', () => {
   })
 
   // Why: the working→idle transition fires an 'agent-task-complete' OS
-  // notification (user-toggleable in Settings) but MUST NOT raise tab/worktree
-  // unread — those stay BEL-only so non-agent long-running tasks remain
-  // first-class attention sources. Double-firing with a concurrent BEL is
-  // collapsed by the per-worktree dedupe in main/ipc/notifications.ts.
+  // notification (user-toggleable in Settings). When the user has switched
+  // away, the notification dispatch boundary also raises the workspace unread
+  // bell so the Dock badge and sidebar agree with the system notification.
+  // Double-firing with a concurrent BEL is collapsed by the per-worktree
+  // dedupe in main/ipc/notifications.ts.
   //
   // This test deliberately wires the real useNotificationDispatch hook into
   // connectPanePty instead of a vi.fn() stub. A stub would let the producer
@@ -4161,7 +4166,7 @@ describe('connectPanePty', () => {
   // routing through the real hook to window.api.notifications.dispatch means
   // removing the producer breaks the IPC assertion, which is the user-facing
   // contract.
-  it('dispatches agent-task-complete on working→idle but does not raise tab/worktree unread', async () => {
+  it('dispatches agent-task-complete on working→idle and marks a switched-away worktree unread', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { useNotificationDispatch } = await vi.importActual<typeof UseNotificationDispatchModule>(
       './use-notification-dispatch'
@@ -4197,6 +4202,7 @@ describe('connectPanePty', () => {
       { id: 'wt-2', repoId: 'repo2', path: '/tmp/wt-2', displayName: 'feat/other' }
     ]
     mockStoreState.repos.push({ id: 'repo2', connectionId: null, displayName: 'docs' })
+    mockStoreState.activeWorktreeId = 'wt-2'
 
     const pane = createPane(1)
     const manager = createManager(1)
@@ -4215,6 +4221,7 @@ describe('connectPanePty', () => {
     idleHandler('* Claude done')
 
     expect(deps.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockStoreState.markWorktreeUnread).not.toHaveBeenCalled()
     expect(deps.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(dispatchNotification).not.toHaveBeenCalled()
 
@@ -4226,6 +4233,7 @@ describe('connectPanePty', () => {
       terminalTitle: '* Claude done',
       paneKey
     })
+    expect(mockStoreState.markWorktreeUnread).toHaveBeenCalledWith('wt-1')
     expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'agent-task-complete',

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -859,17 +859,17 @@ export function connectPanePty(
     }
   })
 
-  // ─── Agent task-complete: OS notification, not tab attention ──────────
+  // ─── Agent task-complete: OS notification + background workspace unread ─
   //
   // The working→idle title transition drives two independent concerns:
   //   1. The Claude prompt-cache countdown in the sidebar.
   //   2. The "Agent Task Complete" OS notification users toggle in Settings.
   //
-  // We intentionally do NOT raise tab/worktree unread from here — that
-  // remains BEL-only so non-agent long-running tasks stay first-class and
-  // so unread state only reflects what the terminal byte stream actually
-  // signals. OS notifications are a separate channel: not every agent CLI
-  // reliably emits BEL on completion (Gemini, some Codex flows), and
+  // We intentionally do NOT raise tab-level unread from here. The shared
+  // notification dispatcher marks switched-away workspaces unread, while BEL
+  // remains the terminal-byte attention source for tab bells and non-agent
+  // long-running tasks. OS notifications are a separate channel: not every
+  // agent CLI reliably emits BEL on completion (Gemini, some Codex flows), and
   // without this dispatch the Settings toggle would have zero producers.
   // Double-firing with a concurrent BEL is handled by delaying the BEL OS
   // notification below; main still keeps a 5 s per-worktree dedupe as the

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -25,6 +25,7 @@ type MockState = {
       customSoundPath?: string | null
     }
   }
+  markWorktreeUnread: ReturnType<typeof vi.fn>
 }
 
 const playDesktopNotificationSound = vi.hoisted(() => vi.fn())
@@ -87,7 +88,8 @@ describe('dispatchTerminalNotification', () => {
         ]
       },
       repos: [{ id: 'repo1', displayName: 'orca', connectionId: null }],
-      settings: { notifications: { customSoundPath: null } }
+      settings: { notifications: { customSoundPath: null } },
+      markWorktreeUnread: vi.fn()
     }
     ;(globalThis as unknown as { window: unknown }).window = {
       api: {
@@ -120,6 +122,20 @@ describe('dispatchTerminalNotification', () => {
         agentLastAssistantMessage: 'Done.'
       })
     )
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
+  })
+
+  it('does not mark the visible worktree unread for agent completion notifications', () => {
+    mockState.activeWorktreeId = 'wt-primary'
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
   })
 
   it('still drops stale notifications when neither worktree nor pane has a live pty', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -158,6 +158,12 @@ export function dispatchTerminalNotification(
     return
   }
 
+  if (event.source === 'agent-task-complete' && state.activeWorktreeId !== worktreeId) {
+    // Why: a task-complete notification for a background workspace must leave
+    // the same durable unread signal that drives the sidebar bell and Dock badge.
+    state.markWorktreeUnread(worktreeId)
+  }
+
   // Why: prefer worktree.repoId over string-parsing the worktreeId. The
   // `${repoId}::${path}` format is an implementation detail of id
   // construction; coupling the notification dispatcher to it would silently


### PR DESCRIPTION
## Summary
- Mark switched-away workspaces unread when agent-complete notifications dispatch
- Preserve visible-workspace behavior so active completions do not create unread state
- Add regression coverage for hook/title completion notification paths

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/unread-badge-count.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/terminal-pane/use-notification-dispatch.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts
- Electron/CDP runtime check: agent-complete dispatch for a non-active workspace rendered the sidebar as Mark as read / Unread
