### PR TITLE
Update mobile APK release link

### DIFF
--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -42,7 +42,7 @@ export const PLATFORM_COPY: Record<
   android: {
     description: 'Scan with your Android camera to download the latest APK from GitHub Releases.',
     ctaLabel: 'Download APK',
-    url: 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.9'
+    url: 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.10'
   }
 }
 


### PR DESCRIPTION
## Summary
- update the mobile page Android APK link to the latest mobile-v0.0.10 release

## Verification
- git diff --check
- git grep -n "mobile-v0.0.9\|mobile-v0.0.8" -- .