### PR TITLE
Fix nested repo project group imports

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -234,6 +234,65 @@ describe('projectGroups IPC validation', () => {
     })
   })
 
+  it('imports a small selection from a large nested SSH scan', async () => {
+    const group = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/srv/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const repoPaths = Array.from(
+      { length: 87 },
+      (_, index) => `/srv/platform/service-${String(index + 1).padStart(2, '0')}`
+    )
+    const selectedPaths = [repoPaths[2], repoPaths[41], repoPaths[86]]
+    mockStore.addRepo.mockClear()
+    mockStore.createProjectGroup.mockReturnValue(group)
+    mockGitProvider.isGitRepoAsync.mockImplementation(async (path: string) => ({
+      isRepo: repoPaths.includes(path),
+      rootPath: null
+    }))
+    mockFilesystemProvider.readDir.mockImplementation(async (dirPath: string) =>
+      dirPath === '/srv/platform'
+        ? repoPaths.map((repoPath) => ({
+            name: repoPath.split('/').at(-1) ?? repoPath,
+            isDirectory: true,
+            isSymlink: false
+          }))
+        : []
+    )
+
+    const result = await handlers.get('projectGroups:importNested')!(null, {
+      parentPath: '/srv/platform',
+      groupName: 'Platform',
+      projectPaths: selectedPaths,
+      connectionId: 'conn-1',
+      mode: 'group'
+    })
+
+    expect(result).toMatchObject({
+      importedCount: 3,
+      alreadyKnownCount: 0,
+      failedCount: 0
+    })
+    expect(mockStore.addRepo).toHaveBeenCalledTimes(3)
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ path: selectedPaths[0], projectGroupId: group.id })
+    )
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ path: selectedPaths[1], projectGroupId: group.id })
+    )
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ path: selectedPaths[2], projectGroupId: group.id })
+    )
+  })
+
   it('sanitizes unexpected nested import errors before returning results', async () => {
     const group = {
       id: 'group-1',

--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -287,7 +287,9 @@ export default function OnboardingFlow({
                     currentStep.id === 'agentSetup'
                       ? 'mt-4'
                       : currentStep.id === 'repo'
-                        ? 'mt-6'
+                        ? flow.nestedScan
+                          ? 'mt-6 overflow-hidden'
+                          : 'mt-6'
                         : 'mt-10'
                   )
             )}

--- a/src/renderer/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingFlow.tsx
@@ -367,7 +367,7 @@ export default function OnboardingFlow({
               busyLabel={busyLabel}
               onSkipToRepo={() => void flow.skipToRepo()}
               stepIndex={stepIndex}
-              onBack={flow.back}
+              onBack={flow.nestedScan ? flow.cancelNested : flow.back}
               showPrimary={currentStep.id !== 'repo' || flow.hasExistingProject}
               primaryBusy={shouldShowFooterBusy}
               primaryLabel={footerPrimaryLabel}

--- a/src/renderer/src/components/onboarding/RepoStep.tsx
+++ b/src/renderer/src/components/onboarding/RepoStep.tsx
@@ -61,9 +61,9 @@ export function RepoStep({
   const disabled = Boolean(busyLabel)
   if (nestedScan) {
     return (
-      <div className="space-y-3">
-        <div className="rounded-lg border border-border bg-muted/30 p-5">
-          <div className="flex items-center gap-4">
+      <div className="flex h-full min-h-0 min-w-0 flex-col gap-3">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-muted/30 p-5">
+          <div className="flex min-w-0 shrink-0 items-center gap-4">
             <div className="grid size-11 shrink-0 place-items-center rounded-lg bg-muted text-foreground">
               <FolderTree className="size-5" />
             </div>
@@ -79,29 +79,28 @@ export function RepoStep({
               </div>
             </div>
           </div>
-          <div className="mt-4 space-y-1">
+          <div className="mt-4 min-w-0 shrink-0 space-y-1">
             <label className="text-[11px] font-medium text-muted-foreground">Group name</label>
             <input
-              className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground outline-none transition focus:border-foreground/50 focus:ring-2 focus:ring-foreground/15"
+              className="w-full min-w-0 rounded-lg border border-border bg-background px-4 py-3 text-sm text-foreground outline-none transition focus:border-foreground/50 focus:ring-2 focus:ring-foreground/15"
               value={nestedGroupName}
               disabled={disabled}
               onChange={(event) => onNestedGroupNameChange(event.target.value)}
             />
           </div>
-          <div className="mt-3">
-            <NestedRepoTreePreview
-              scan={nestedScan}
-              selectedPaths={nestedSelectedPaths}
-              onSelectedPathsChange={onNestedSelectedPathsChange}
-              disabled={disabled}
-            />
-          </div>
+          <NestedRepoTreePreview
+            scan={nestedScan}
+            selectedPaths={nestedSelectedPaths}
+            onSelectedPathsChange={onNestedSelectedPathsChange}
+            disabled={disabled}
+            className="mt-3 flex-1"
+          />
           {nestedScan.truncated || nestedScan.timedOut ? (
-            <div className="mt-2 text-[11px] text-muted-foreground">
+            <div className="mt-2 shrink-0 text-[11px] text-muted-foreground">
               Showing partial results from a bounded scan.
             </div>
           ) : null}
-          <div className="mt-4 flex items-center gap-2">
+          <div className="mt-4 flex shrink-0 items-center gap-2">
             <button
               type="button"
               className="inline-flex items-center gap-1 rounded-lg px-3 py-3 text-sm text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:opacity-40"
@@ -132,12 +131,12 @@ export function RepoStep({
           </div>
         </div>
         {busyLabel && (
-          <div className="rounded-lg border border-blue-400/30 bg-blue-400/10 px-4 py-2.5 text-sm text-blue-700 dark:text-blue-200">
+          <div className="shrink-0 rounded-lg border border-blue-400/30 bg-blue-400/10 px-4 py-2.5 text-sm text-blue-700 dark:text-blue-200">
             {busyLabel}
           </div>
         )}
         {error && (
-          <div className="rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-2.5 text-sm text-red-700 dark:text-red-200">
+          <div className="shrink-0 rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-2.5 text-sm text-red-700 dark:text-red-200">
             {error}
           </div>
         )}

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -694,7 +694,10 @@ export function useOnboardingFlow(
             .filter((projectId): projectId is string => typeof projectId === 'string') ?? []
         const projectId = importedRepoIds[0]
         if (!projectId) {
-          throw new Error('No repositories imported')
+          const firstFailure = result?.projects.find((entry) => entry.status === 'failed')?.error
+          throw new Error(
+            firstFailure ? `No repositories imported: ${firstFailure}` : 'No repositories imported'
+          )
         }
         for (const importedRepoId of importedRepoIds) {
           await fetchWorktrees(importedRepoId)

--- a/src/renderer/src/components/repo/NestedRepoTreePreview.tsx
+++ b/src/renderer/src/components/repo/NestedRepoTreePreview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from 'react'
 import { FolderTree, GitBranch } from 'lucide-react'
 import type { NestedRepoCandidate, NestedRepoScanResult } from '../../../../shared/types'
+import { cn } from '@/lib/utils'
 
 type TreeFolder = {
   key: string
@@ -130,7 +131,7 @@ function NestedRepoSelectAllRow({
     }
   }, [isMixed])
   return (
-    <label className="flex cursor-pointer items-center gap-2.5 bg-muted/30 px-3 py-2 text-sm hover:bg-muted/50">
+    <label className="flex min-w-0 cursor-pointer items-center gap-2.5 bg-muted/30 px-3 py-2 text-sm hover:bg-muted/50">
       <input
         ref={checkboxRef}
         type="checkbox"
@@ -140,10 +141,10 @@ function NestedRepoSelectAllRow({
         onChange={onToggle}
         aria-label={allSelected ? 'Deselect all' : 'Select all'}
       />
-      <span className="text-[12.5px] font-semibold text-foreground">
+      <span className="min-w-0 truncate text-[12.5px] font-semibold text-foreground">
         {allSelected ? 'Deselect all' : 'Select all'}
       </span>
-      <span className="ml-auto text-[11px] text-muted-foreground">
+      <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
         {selectedCount} of {total} selected
       </span>
     </label>
@@ -154,17 +155,24 @@ export function NestedRepoTreePreview({
   scan,
   selectedPaths,
   onSelectedPathsChange,
-  disabled = false
+  disabled = false,
+  className
 }: {
   scan: NestedRepoScanResult
   selectedPaths: Set<string>
   onSelectedPathsChange: Dispatch<SetStateAction<Set<string>>>
   disabled?: boolean
+  className?: string
 }) {
   const rows = useMemo(() => buildRows(scan), [scan])
 
   return (
-    <div className="overflow-hidden rounded-md border border-border bg-background/60">
+    <div
+      className={cn(
+        'flex max-h-64 min-h-0 min-w-0 max-w-full flex-col overflow-hidden rounded-md border border-border bg-background/60',
+        className
+      )}
+    >
       <NestedRepoSelectAllRow
         total={scan.repos.length}
         selectedCount={selectedPaths.size}
@@ -178,12 +186,12 @@ export function NestedRepoTreePreview({
           })
         }}
       />
-      <ul className="scrollbar-sleek max-h-64 overflow-y-auto">
+      <ul className="scrollbar-sleek min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
         {rows.map((row) =>
           row.type === 'folder' ? (
             <li
               key={`folder:${row.key}`}
-              className="flex items-center gap-2.5 border-t border-border bg-muted/20 px-3 py-2 text-sm"
+              className="flex min-w-0 max-w-full items-center gap-2.5 overflow-hidden border-t border-border bg-muted/20 px-3 py-2 text-sm"
               style={{ paddingLeft: 12 + row.depth * 18 }}
             >
               <FolderTree className="size-3.5 shrink-0 text-muted-foreground" />
@@ -200,7 +208,7 @@ export function NestedRepoTreePreview({
           ) : (
             <li key={row.repo.path}>
               <label
-                className="flex cursor-pointer items-center gap-2.5 border-t border-border px-3 py-2 text-sm hover:bg-accent"
+                className="flex min-w-0 max-w-full cursor-pointer items-center gap-2.5 overflow-hidden border-t border-border px-3 py-2 text-sm hover:bg-accent"
                 style={{ paddingLeft: 12 + row.depth * 18 }}
               >
                 <input

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -289,7 +289,10 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
           .filter((projectId): projectId is string => typeof projectId === 'string')
         const firstRepoId = importedRepoIds[0]
         if (!firstRepoId) {
-          toast.error('No repositories imported')
+          const firstFailure = result.projects.find((entry) => entry.status === 'failed')?.error
+          toast.error('No repositories imported', {
+            description: firstFailure ?? undefined
+          })
           return
         }
         for (const projectId of importedRepoIds) {
@@ -581,7 +584,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         }
       }}
     >
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent
+        className={`min-w-0 overflow-hidden sm:max-w-lg [&>*]:min-w-0 ${
+          step === 'nested' ? 'max-h-[calc(100vh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)]' : ''
+        }`}
+      >
         {/* Step indicator row — back button (step 2 only), dots, X is rendered by DialogContent */}
         <div className="flex items-center justify-center -mt-1">
           {(step === 'clone' || step === 'remote' || step === 'create') && (
@@ -822,8 +829,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
               </DialogDescription>
             </DialogHeader>
 
-            <div className="space-y-3 pt-1">
-              <div className="flex items-center gap-3 rounded-md border border-border bg-muted/30 p-3">
+            <div className="flex min-h-0 min-w-0 max-w-full flex-col gap-3 overflow-hidden pt-1">
+              <div className="flex min-w-0 max-w-full items-center gap-3 overflow-hidden rounded-md border border-border bg-muted/30 p-3">
                 <div className="grid size-9 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground">
                   <FolderTree className="size-4" />
                 </div>
@@ -837,7 +844,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
                 </div>
               </div>
 
-              <div className="space-y-1">
+              <div className="min-w-0 space-y-1">
                 <label className="text-[11px] font-medium text-muted-foreground">Group name</label>
                 <Input
                   value={nestedGroupName}
@@ -851,13 +858,14 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
                 selectedPaths={nestedSelectedPaths}
                 onSelectedPathsChange={setNestedSelectedPaths}
                 disabled={isAdding}
+                className="flex-1"
               />
               {nestedScan.truncated || nestedScan.timedOut ? (
                 <div className="text-[11px] text-muted-foreground">
                   Showing partial results from a bounded scan.
                 </div>
               ) : null}
-              <div className="flex items-center gap-2">
+              <div className="shrink-0 flex items-center gap-2">
                 <Button onClick={handleBack} disabled={isAdding} variant="ghost">
                   <ArrowLeft className="size-3.5" />
                   Back

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -1,7 +1,8 @@
+/* eslint-disable max-lines -- Why: WorktreeList render tests share expensive mocks so focused sidebar regressions can exercise the real component boundary. */
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
-import type { Repo, Worktree, WorktreeLineage } from '../../../../shared/types'
+import type { ProjectGroup, Repo, Worktree, WorktreeLineage } from '../../../../shared/types'
 
 const mockStore = vi.hoisted(() => ({
   state: {} as Record<string, unknown>
@@ -101,6 +102,12 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenuItem: ({ children }: { children: React.ReactNode }) =>
     React.createElement('div', null, children),
   DropdownMenuSeparator: () => React.createElement('hr'),
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children)
 }))
@@ -230,6 +237,72 @@ function setLineageFixtureState(groupBy: 'none' | 'repo' = 'none'): void {
   }
 }
 
+function setProjectGroupWithoutWorktreeRowsState(): void {
+  const group: ProjectGroup = {
+    id: 'group-1',
+    name: 'Imported Services',
+    parentPath: '/tmp/imported-services',
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const repo: Repo = {
+    ...makeRepo(),
+    projectGroupId: group.id
+  }
+
+  mockStore.state = {
+    activeModal: '',
+    activeView: 'terminal',
+    activeWorktreeId: null,
+    agentStatusByPaneKey: {},
+    browserTabsByWorktree: {},
+    clearPendingRevealWorktreeId: vi.fn(),
+    collapsedGroups: new Set<string>(),
+    filterRepoIds: [],
+    groupBy: 'repo',
+    hideDefaultBranchWorkspace: false,
+    issueCache: {},
+    migrationUnsupportedByPtyId: {},
+    openModal: vi.fn(),
+    pendingRevealWorktree: null,
+    prCache: {},
+    prVisibleRefreshGeneration: 0,
+    projectGroups: [group],
+    ptyIdsByTabId: {},
+    reorderRepos: vi.fn(),
+    reportVisibleGitHubPRRefreshCandidates: vi.fn(),
+    repos: [repo],
+    runtimePaneTitlesByTabId: {},
+    setFilterRepoIds: vi.fn(),
+    setHideDefaultBranchWorkspace: vi.fn(),
+    setShowSleepingWorkspaces: vi.fn(),
+    setSortBy: vi.fn(),
+    settings: null,
+    showSleepingWorkspaces: true,
+    sortBy: 'recent',
+    sortEpoch: 0,
+    sshConnectedGeneration: 0,
+    sshConnectionStates: new Map(),
+    sshTargetLabels: new Map(),
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    toggleCollapsedGroup: vi.fn(),
+    updateWorktreeMeta: vi.fn(),
+    updateWorktreesMeta: vi.fn(),
+    workspaceStatuses: [],
+    worktreeCardProperties: ['status', 'inline-agents'],
+    worktreeLineageById: {},
+    worktreesByRepo: {
+      [repo.id]: []
+    }
+  }
+}
+
 async function renderWorktreeListMarkup(): Promise<string> {
   const { default: WorktreeList } = await import('./WorktreeList')
 
@@ -242,6 +315,14 @@ async function renderWorktreeListMarkup(): Promise<string> {
 }
 
 describe('WorktreeList lineage child card renderer', () => {
+  it('renders project group headers when repos import before worktree rows load', async () => {
+    setProjectGroupWithoutWorktreeRowsState()
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('Imported Services')
+    expect(markup).not.toContain('No workspaces found')
+  })
+
   it('renders nested inline agent rows before the nested child-count toggle', async () => {
     setLineageFixtureState()
     const markup = await renderWorktreeListMarkup()

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -237,7 +237,7 @@ function setLineageFixtureState(groupBy: 'none' | 'repo' = 'none'): void {
   }
 }
 
-function setProjectGroupWithoutWorktreeRowsState(): void {
+function setProjectGroupWithoutWorktreeRowsState(filterRepoIds: string[] = []): void {
   const group: ProjectGroup = {
     id: 'group-1',
     name: 'Imported Services',
@@ -263,7 +263,7 @@ function setProjectGroupWithoutWorktreeRowsState(): void {
     browserTabsByWorktree: {},
     clearPendingRevealWorktreeId: vi.fn(),
     collapsedGroups: new Set<string>(),
-    filterRepoIds: [],
+    filterRepoIds,
     groupBy: 'repo',
     hideDefaultBranchWorkspace: false,
     issueCache: {},
@@ -321,6 +321,15 @@ describe('WorktreeList lineage child card renderer', () => {
 
     expect(markup).toContain('Imported Services')
     expect(markup).not.toContain('No workspaces found')
+  })
+
+  it('shows Clear Filters when filters exclude pre-worktree project groups', async () => {
+    setProjectGroupWithoutWorktreeRowsState(['another-repo'])
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('No workspaces found')
+    expect(markup).toContain('Clear Filters')
+    expect(markup).not.toContain('Imported Services')
   })
 
   it('renders nested inline agent rows before the nested child-count toggle', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -3407,7 +3407,9 @@ const WorktreeList = React.memo(function WorktreeList({
     }
   }, [handleRevealCurrentWorkspaceRequest])
 
-  if (worktrees.length === 0) {
+  // Why: Project Group headers can be renderable before any workspace rows are
+  // loaded, especially after importing many nested repos from a folder scan.
+  if (rows.length === 0) {
     return (
       <div data-worktree-sidebar-container className="relative min-h-0 flex-1">
         <div className="worktree-sidebar-scrollbar flex h-full flex-col overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek pt-px">

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -164,6 +164,7 @@ type ProjectGroupDeleteDialogState = {
 const SORT_SETTLE_MS = 3_000
 const USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 500
 const WORKTREE_REVEAL_TOP_CLEARANCE = 6
+const EMPTY_PROJECT_GROUPS: readonly ProjectGroup[] = []
 export const WORKTREE_SIDEBAR_REVEAL_TOP_INSET =
   GROUP_HEADER_ROW_HEIGHT + WORKTREE_REVEAL_TOP_CLEARANCE
 const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
@@ -3007,12 +3008,24 @@ const WorktreeList = React.memo(function WorktreeList({
   // Why: manual repo header order is bound to state.repos. Recent/Smart derive
   // header order from the sorted visible worktree stream instead.
   const repos = useAppStore((s) => s.repos)
-  const projectGroups = useAppStore((s) => s.projectGroups)
+  const projectGroups = useAppStore((s) => s.projectGroups ?? EMPTY_PROJECT_GROUPS)
   const repoOrder = useMemo(() => {
     const map = new Map<string, number>()
     repos.forEach((r, i) => map.set(r.id, i))
     return map
   }, [repos])
+  const placeholderRepoIds = useMemo(() => {
+    if (groupBy !== 'repo' || projectGroups.length === 0) {
+      return new Set<string>()
+    }
+    const filterSet = filterRepoIds.length > 0 ? new Set(filterRepoIds) : null
+    return new Set(
+      repos
+        .filter((repo) => (worktreesByRepo[repo.id]?.length ?? 0) === 0)
+        .filter((repo) => filterSet === null || filterSet.has(repo.id))
+        .map((repo) => repo.id)
+    )
+  }, [filterRepoIds, groupBy, projectGroups.length, repos, worktreesByRepo])
   const allRepoIds = useMemo(() => repos.map((r) => r.id), [repos])
   const reorderReposAction = useAppStore((s) => s.reorderRepos)
   const projectGroupOrdering = getProjectGroupOrdering(groupBy, sortBy)
@@ -3033,7 +3046,8 @@ const WorktreeList = React.memo(function WorktreeList({
         worktreeMap,
         true,
         settings,
-        projectGroups
+        projectGroups,
+        placeholderRepoIds
       ),
     [
       groupBy,
@@ -3047,7 +3061,8 @@ const WorktreeList = React.memo(function WorktreeList({
       worktreeLineageById,
       worktreeMap,
       settings,
-      projectGroups
+      projectGroups,
+      placeholderRepoIds
     ]
   )
   // Why: header/mode changes can shift entire groups, so remount the
@@ -3407,9 +3422,10 @@ const WorktreeList = React.memo(function WorktreeList({
     }
   }, [handleRevealCurrentWorkspaceRequest])
 
-  // Why: Project Group headers can be renderable before any workspace rows are
-  // loaded, especially after importing many nested repos from a folder scan.
-  if (rows.length === 0) {
+  const filtersHideAllRows = hasFilters && worktrees.length === 0 && placeholderRepoIds.size === 0
+  // Why: Project Group headers can render before workspace rows load, but when
+  // active filters hide everything the Clear Filters empty state must win.
+  if (rows.length === 0 || filtersHideAllRows) {
     return (
       <div data-worktree-sidebar-container className="relative min-h-0 flex-1">
         <div className="worktree-sidebar-scrollbar flex h-full flex-col overflow-y-scroll overflow-x-hidden pl-1 scrollbar-sleek pt-px">

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -491,7 +491,8 @@ describe('project groups', () => {
       new Map(),
       false,
       undefined,
-      [group]
+      [group],
+      new Set([groupedRepo.id])
     )
 
     expect(rows[0]).toMatchObject({
@@ -499,6 +500,43 @@ describe('project groups', () => {
       key: 'project-group:group-1',
       count: 1
     })
+  })
+
+  it('does not resurrect filtered repos as empty Project Group headers', () => {
+    const group: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const groupedRepo: Repo = { ...repo, projectGroupId: group.id }
+
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map([[groupedRepo.id, groupedRepo]]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map(),
+      false,
+      undefined,
+      [group]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-1'
+    ])
+    expect(rows[0]).toMatchObject({ count: 0 })
   })
 
   it('renders ungrouped repos as top-level repo rows when Project Groups exist', () => {
@@ -720,7 +758,8 @@ describe('project groups', () => {
       undefined,
       false,
       undefined,
-      [rootGroup, platformGroup, servicesGroup]
+      [rootGroup, platformGroup, servicesGroup],
+      new Set([serviceA.id, serviceB.id])
     )
 
     expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
@@ -731,7 +770,7 @@ describe('project groups', () => {
       'repo:repo-service-b'
     ])
     expect(rows.filter((row) => row.type === 'header').map((row) => row.count)).toEqual([
-      1, 1, 2, 0, 0
+      2, 2, 2, 0, 0
     ])
   })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -439,7 +439,7 @@ describe('project groups', () => {
     const rows = buildRows(
       'repo',
       [],
-      repoMap,
+      new Map(),
       null,
       new Set(),
       undefined,
@@ -460,6 +460,80 @@ describe('project groups', () => {
         count: 0,
         projectGroup: group
       })
+    ])
+  })
+
+  it('counts grouped repos before their visible worktrees are loaded', () => {
+    const group: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const groupedRepo: Repo = { ...repo, projectGroupId: group.id }
+
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map([[groupedRepo.id, groupedRepo]]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map(),
+      false,
+      undefined,
+      [group]
+    )
+
+    expect(rows[0]).toMatchObject({
+      type: 'header',
+      key: 'project-group:group-1',
+      count: 1
+    })
+  })
+
+  it('renders ungrouped repos as top-level repo rows when Project Groups exist', () => {
+    const group: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    const rows = buildRows(
+      'repo',
+      [worktree],
+      repoMap,
+      null,
+      new Set(),
+      new Map([[repo.id, 0]]),
+      undefined,
+      'manual',
+      {},
+      new Map([[worktree.id, worktree]]),
+      false,
+      undefined,
+      [group]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-1',
+      'repo:repo-1'
     ])
   })
 
@@ -585,6 +659,82 @@ describe('project groups', () => {
     expect(rows[0]).toMatchObject({ count: 1 })
   })
 
+  it('renders imported repos under nested Project Groups before worktree rows load', () => {
+    const rootGroup: ProjectGroup = {
+      id: 'group-root',
+      name: 'Root',
+      parentPath: '/monorepo',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const platformGroup: ProjectGroup = {
+      ...rootGroup,
+      id: 'group-platform',
+      name: 'Platform',
+      parentGroupId: rootGroup.id,
+      tabOrder: 1
+    }
+    const servicesGroup: ProjectGroup = {
+      ...rootGroup,
+      id: 'group-services',
+      name: 'Services',
+      parentGroupId: platformGroup.id,
+      tabOrder: 2
+    }
+    const serviceA: Repo = {
+      ...repo,
+      id: 'repo-service-a',
+      displayName: 'service-a',
+      projectGroupId: servicesGroup.id,
+      projectGroupOrder: 0
+    }
+    const serviceB: Repo = {
+      ...repo,
+      id: 'repo-service-b',
+      displayName: 'service-b',
+      projectGroupId: servicesGroup.id,
+      projectGroupOrder: 1
+    }
+
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map([
+        [serviceA.id, serviceA],
+        [serviceB.id, serviceB]
+      ]),
+      null,
+      new Set(),
+      new Map([
+        [serviceA.id, 0],
+        [serviceB.id, 1]
+      ]),
+      undefined,
+      'manual',
+      undefined,
+      undefined,
+      false,
+      undefined,
+      [rootGroup, platformGroup, servicesGroup]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-root',
+      'project-group:group-platform',
+      'project-group:group-services',
+      'repo:repo-service-a',
+      'repo:repo-service-b'
+    ])
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.count)).toEqual([
+      1, 1, 2, 0, 0
+    ])
+  })
+
   it('returns both parent Project Group and repo keys for grouped repo reveals', () => {
     const groupedRepo: Repo = { ...repo, projectGroupId: 'group-1' }
 
@@ -593,11 +743,8 @@ describe('project groups', () => {
     ).toEqual(['project-group:group-1', 'repo:repo-1'])
   })
 
-  it('returns the Ungrouped parent key for ungrouped repo reveals', () => {
-    expect(getGroupKeysForWorktree('repo', worktree, repoMap, null)).toEqual([
-      'project-group:ungrouped',
-      'repo:repo-1'
-    ])
+  it('returns only the repo key for ungrouped repo reveals', () => {
+    expect(getGroupKeysForWorktree('repo', worktree, repoMap, null)).toEqual(['repo:repo-1'])
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -363,7 +363,8 @@ export function buildRows(
   ),
   nestLineage = false,
   settings?: AppState['settings'],
-  projectGroups: readonly ProjectGroup[] = []
+  projectGroups: readonly ProjectGroup[] = [],
+  placeholderRepoIds: ReadonlySet<string> = new Set()
 ): Row[] {
   const result: Row[] = []
 
@@ -422,12 +423,13 @@ export function buildRows(
     grouped.get(key)!.items.push(w)
   }
   if (groupBy === 'repo' && projectGroups.length > 0) {
-    for (const repo of repoMap.values()) {
-      const key = `repo:${repo.id}`
+    for (const repoId of placeholderRepoIds) {
+      const repo = repoMap.get(repoId)
+      const key = `repo:${repoId}`
       if (!grouped.has(key)) {
         // Why: nested repo imports can persist repos before their worktree rows
-        // are available; the sidebar still needs a project row to expand to.
-        grouped.set(key, { label: repo.displayName, items: [], repo })
+        // are available, but filters must not resurrect hidden repo headers.
+        grouped.set(key, { label: repo?.displayName ?? 'Unknown', items: [], repo })
       }
     }
   }
@@ -586,6 +588,15 @@ export function buildRows(
     )
   }
 
+  const getProjectGroupSubtreeCount = (groupId: string): number => {
+    const directCount = groupByProjectGroupId.get(groupId)?.length ?? 0
+    const children = childGroupsByParentId.get(groupId) ?? []
+    return children.reduce(
+      (count, child) => count + getProjectGroupSubtreeCount(child.id),
+      directCount
+    )
+  }
+
   const appendProjectGroup = (projectGroup: ProjectGroup, depth: number): void => {
     const repoEntries = sortRepoEntriesWithinGroup(groupByProjectGroupId.get(projectGroup.id) ?? [])
     const childGroups = childGroupsByParentId.get(projectGroup.id) ?? []
@@ -594,7 +605,7 @@ export function buildRows(
       type: 'header',
       key,
       label: projectGroup.name,
-      count: repoEntries.length + childGroups.length,
+      count: getProjectGroupSubtreeCount(projectGroup.id),
       tone: PROJECT_GROUP_META.tone,
       icon: PROJECT_GROUP_META.icon,
       projectGroup,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -421,6 +421,16 @@ export function buildRows(
     }
     grouped.get(key)!.items.push(w)
   }
+  if (groupBy === 'repo' && projectGroups.length > 0) {
+    for (const repo of repoMap.values()) {
+      const key = `repo:${repo.id}`
+      if (!grouped.has(key)) {
+        // Why: nested repo imports can persist repos before their worktree rows
+        // are available; the sidebar still needs a project row to expand to.
+        grouped.set(key, { label: repo.displayName, items: [], repo })
+      }
+    }
+  }
 
   const orderedGroups: [string, { label: string; items: Worktree[]; repo?: Repo }][] = []
   if (groupBy === 'pr-status') {
@@ -576,15 +586,6 @@ export function buildRows(
     )
   }
 
-  const getProjectGroupSubtreeCount = (groupId: string): number => {
-    const directCount = groupByProjectGroupId.get(groupId)?.length ?? 0
-    const children = childGroupsByParentId.get(groupId) ?? []
-    return children.reduce(
-      (count, child) => count + getProjectGroupSubtreeCount(child.id),
-      directCount
-    )
-  }
-
   const appendProjectGroup = (projectGroup: ProjectGroup, depth: number): void => {
     const repoEntries = sortRepoEntriesWithinGroup(groupByProjectGroupId.get(projectGroup.id) ?? [])
     const childGroups = childGroupsByParentId.get(projectGroup.id) ?? []
@@ -593,7 +594,7 @@ export function buildRows(
       type: 'header',
       key,
       label: projectGroup.name,
-      count: getProjectGroupSubtreeCount(projectGroup.id),
+      count: repoEntries.length + childGroups.length,
       tone: PROJECT_GROUP_META.tone,
       icon: PROJECT_GROUP_META.icon,
       projectGroup,
@@ -612,22 +613,7 @@ export function buildRows(
     appendProjectGroup(projectGroup, 0)
   }
 
-  const ungrouped = sortRepoEntriesWithinGroup(groupByProjectGroupId.get(null) ?? [])
-  if (ungrouped.length > 0) {
-    const key = getProjectGroupHeaderKey(null)
-    result.push({
-      type: 'header',
-      key,
-      label: 'Ungrouped',
-      count: ungrouped.length,
-      tone: PROJECT_GROUP_META.tone,
-      icon: PROJECT_GROUP_META.icon,
-      projectGroup: { id: null, name: 'Ungrouped', tabOrder: Number.MAX_SAFE_INTEGER }
-    })
-    if (!collapsedGroups.has(key)) {
-      appendOrderedGroups(ungrouped, 1)
-    }
-  }
+  appendOrderedGroups(sortRepoEntriesWithinGroup(groupByProjectGroupId.get(null) ?? []), 0)
 
   return result
 }
@@ -686,10 +672,5 @@ export function getGroupKeysForWorktree(
     const parentId = groupsById.get(currentGroupId)?.parentGroupId ?? null
     currentGroupId = parentId && groupsById.has(parentId) ? parentId : null
   }
-  return [
-    ...(groupIds.length > 0
-      ? groupIds.map((id) => getProjectGroupHeaderKey(id))
-      : [getProjectGroupHeaderKey(null)]),
-    groupKey
-  ]
+  return [...groupIds.map((id) => getProjectGroupHeaderKey(id)), groupKey]
 }

--- a/tests/e2e/folder-setup.spec.ts
+++ b/tests/e2e/folder-setup.spec.ts
@@ -39,6 +39,38 @@ async function createNestedRepoFixture(): Promise<{
   }
 }
 
+async function createLargeNestedRepoFixture(): Promise<{
+  parentPath: string
+  projectPaths: string[]
+  groupName: string
+  selectedProjectPaths: string[]
+}> {
+  const parentPath = await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-large-folder-setup-'))
+  tempRoots.push(parentPath)
+  const nestedParent = path.join(
+    parentPath,
+    'products-with-long-folder-name',
+    'platform-domain-with-long-folder-name',
+    'region-alpha-with-long-folder-name'
+  )
+  const projectPaths = Array.from({ length: 87 }, (_, index) => {
+    const repoName = `service-${String(index + 1).padStart(2, '0')}-with-long-repository-name`
+    return path.join(nestedParent, repoName)
+  })
+
+  for (const repoPath of projectPaths) {
+    mkdirSync(path.join(repoPath, '.git'), { recursive: true })
+    writeFileSync(path.join(repoPath, 'README.md'), `# ${path.basename(repoPath)}\n`)
+  }
+
+  return {
+    parentPath,
+    projectPaths,
+    groupName: path.basename(parentPath),
+    selectedProjectPaths: [projectPaths[2], projectPaths[41], projectPaths[86]]
+  }
+}
+
 test.afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -125,5 +157,90 @@ test.describe('Folder setup', () => {
       state?.setGroupBy('repo')
     })
     await expect(orcaPage.getByText(fixture.groupName)).toBeVisible()
+  })
+
+  test('imports a small selection from a large nested folder without modal overflow', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const fixture = await createLargeNestedRepoFixture()
+    await chooseFolderInNativeDialog(electronApp, fixture.parentPath)
+
+    await orcaPage
+      .getByRole('button', { name: /Add Project/i })
+      .first()
+      .click()
+    const dialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: /Browse folder/i }).click()
+
+    const importDialog = orcaPage.getByRole('dialog', { name: /Import as project group/i })
+    await expect(importDialog.getByText('Found 87 git repositories in this folder.')).toBeVisible()
+    await expect
+      .poll(async () =>
+        importDialog.locator('ul').evaluate((list) => {
+          const dialog = list.closest('[role="dialog"]')
+          if (!dialog) {
+            return 0
+          }
+          const dialogRight = dialog.getBoundingClientRect().right
+          return [...list.querySelectorAll('li, label, span')].filter(
+            (node) => node.getBoundingClientRect().right > dialogRight + 1
+          ).length
+        })
+      )
+      .toBe(0)
+
+    await importDialog.getByLabel('Deselect all').click()
+    for (const projectPath of fixture.selectedProjectPaths) {
+      const repoName = path.basename(projectPath)
+      await importDialog
+        .locator('label')
+        .filter({ hasText: repoName })
+        .locator('input[type="checkbox"]')
+        .check()
+    }
+    await importDialog.getByRole('button', { name: /Import as project group/i }).click()
+
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate((args) => {
+            const state = window.__store?.getState()
+            if (!state) {
+              return null
+            }
+            const importedRepos = state.repos.filter((repo) =>
+              args.selectedProjectPaths.includes(repo.path)
+            )
+            const group = state.projectGroups.find((entry) => entry.parentPath === args.parentPath)
+            const groupsById = new Map(state.projectGroups.map((entry) => [entry.id, entry]))
+            const isInGroupSubtree = (groupId: string | null | undefined): boolean => {
+              let currentId = groupId ?? null
+              while (currentId) {
+                if (currentId === group?.id) {
+                  return true
+                }
+                currentId = groupsById.get(currentId)?.parentGroupId ?? null
+              }
+              return false
+            }
+            return {
+              importedCount: importedRepos.length,
+              allSelectedInGroup:
+                group !== undefined &&
+                importedRepos.every((repo) => isInGroupSubtree(repo.projectGroupId))
+            }
+          }, fixture),
+        {
+          timeout: 20_000,
+          message: 'selected repos from the large nested scan were not imported into the group'
+        }
+      )
+      .toEqual({
+        importedCount: 3,
+        allSelectedInGroup: true
+      })
   })
 })

--- a/tests/e2e/folder-setup.spec.ts
+++ b/tests/e2e/folder-setup.spec.ts
@@ -59,8 +59,16 @@ async function createLargeNestedRepoFixture(): Promise<{
   })
 
   for (const repoPath of projectPaths) {
-    mkdirSync(path.join(repoPath, '.git'), { recursive: true })
+    mkdirSync(repoPath, { recursive: true })
+    execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })
+    execFileSync('git', ['config', 'user.email', 'e2e@test.local'], {
+      cwd: repoPath,
+      stdio: 'pipe'
+    })
+    execFileSync('git', ['config', 'user.name', 'E2E Test'], { cwd: repoPath, stdio: 'pipe' })
     writeFileSync(path.join(repoPath, 'README.md'), `# ${path.basename(repoPath)}\n`)
+    execFileSync('git', ['add', 'README.md'], { cwd: repoPath, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: repoPath, stdio: 'pipe' })
   }
 
   return {
@@ -121,7 +129,7 @@ test.describe('Folder setup', () => {
     await expect
       .poll(
         () =>
-          orcaPage.evaluate((args) => {
+          orcaPage.evaluate(async (args) => {
             const state = window.__store?.getState()
             if (!state) {
               return null
@@ -206,7 +214,7 @@ test.describe('Folder setup', () => {
     await expect
       .poll(
         () =>
-          orcaPage.evaluate((args) => {
+          orcaPage.evaluate(async (args) => {
             const state = window.__store?.getState()
             if (!state) {
               return null
@@ -214,6 +222,7 @@ test.describe('Folder setup', () => {
             const importedRepos = state.repos.filter((repo) =>
               args.selectedProjectPaths.includes(repo.path)
             )
+            const fixtureRepos = state.repos.filter((repo) => args.projectPaths.includes(repo.path))
             const group = state.projectGroups.find((entry) => entry.parentPath === args.parentPath)
             const groupsById = new Map(state.projectGroups.map((entry) => [entry.id, entry]))
             const isInGroupSubtree = (groupId: string | null | undefined): boolean => {
@@ -226,11 +235,21 @@ test.describe('Folder setup', () => {
               }
               return false
             }
+            const worktreeCounts = await Promise.all(
+              importedRepos.map(async (repo) => {
+                const result = await window.api.worktrees.listDetected({ repoId: repo.id })
+                return result.worktrees.length
+              })
+            )
             return {
               importedCount: importedRepos.length,
+              fixtureImportCount: fixtureRepos.length,
               allSelectedInGroup:
                 group !== undefined &&
-                importedRepos.every((repo) => isInGroupSubtree(repo.projectGroupId))
+                importedRepos.every((repo) => isInGroupSubtree(repo.projectGroupId)),
+              allSelectedHaveWorktrees:
+                importedRepos.length === args.selectedProjectPaths.length &&
+                worktreeCounts.every((count) => count > 0)
             }
           }, fixture),
         {
@@ -240,7 +259,9 @@ test.describe('Folder setup', () => {
       )
       .toEqual({
         importedCount: 3,
-        allSelectedInGroup: true
+        fixtureImportCount: 3,
+        allSelectedInGroup: true,
+        allSelectedHaveWorktrees: true
       })
   })
 })


### PR DESCRIPTION
## Summary
- constrain nested repo import previews so long nested paths stay inside the modal/onboarding card and keep action buttons visible
- keep Project Group repo headers visible before worktree rows load, while scoping placeholder headers so repo filters, hide-default, and other sidebar filters still produce the correct empty state
- preserve recursive Project Group badge counts for nested groups
- render ungrouped repos as top-level repo rows instead of a synthetic Ungrouped Project Group
- make onboarding footer Back cancel the nested-repo review when it is active, matching the in-card Back behavior
- surface the first backend failure reason when nested import returns no imported repos
- strengthen regression coverage for large nested imports, filtered placeholder rows, recursive nested group counts, and real Git detection

## Review outcome
- Initial review found that placeholder repo headers were being injected from the global repo map, bypassing active sidebar filters and hiding the Clear Filters empty state.
- Follow-up review found the large-folder e2e needed to prove unselected repos stayed unimported.
- Follow-up review found Project Group subtree counts had regressed and onboarding nested Back behavior was inconsistent.
- Final two-reviewer round returned clean with no actionable findings.

## Validation
- `git diff --check origin/main...HEAD`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts src/main/ipc/repos-remote.test.ts` — 3 files, 111 tests passed
- `pnpm run test:e2e -- tests/e2e/folder-setup.spec.ts -g "imports a small selection from a large nested folder without modal overflow"` — 6 Electron e2e tests passed
- Manual Electron validation on this worktree confirmed:
  - hidden repo headers no longer render when repo filters exclude them
  - Clear Filters appears when filters hide all placeholder rows
  - unfiltered pre-worktree placeholder rows still render for newly imported repos

## Notes
- SSH/remoting behavior is covered by the existing mocked IPC remote import test path; no live SSH target was exercised for this PR.

Made with [Orca](https://github.com/stablyai/orca)