### PR TITLE
Fix create workspace Enter flow after PR link selection

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -199,6 +199,7 @@ export default function SmartWorkspaceNameField({
   const [linearLoading, setLinearLoading] = useState(false)
   const [commandValue, setCommandValue] = useState('')
   const localInputRef = useRef<HTMLInputElement | null>(null)
+  const selectedSourceRef = useRef<HTMLDivElement | null>(null)
   const tabsListRef = useRef<HTMLDivElement | null>(null)
   const repoSlugCacheRef = useRef<Map<string, RepoSlug | null>>(new Map())
   const handledCrossRepoUrlRef = useRef<string | null>(null)
@@ -309,6 +310,9 @@ export default function SmartWorkspaceNameField({
   useEffect(() => {
     if (selectedSource) {
       setOpen(false)
+      // Why: after Enter accepts a PR/issue row, the input unmounts. Keep the
+      // keyboard flow on the source field so the next Enter advances to Agent.
+      requestAnimationFrame(() => selectedSourceRef.current?.focus({ preventScroll: true }))
     }
   }, [selectedSource])
 
@@ -974,7 +978,25 @@ export default function SmartWorkspaceNameField({
                 // parent; without them the inner truncate's intrinsic
                 // min-content (long PR title) propagates up and pushes the
                 // dialog wider than its max-w.
-                <div className="flex h-9 w-full min-w-0 items-center gap-2 rounded-md border border-input bg-transparent px-2.5 text-sm shadow-xs focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+                <div
+                  ref={selectedSourceRef}
+                  tabIndex={0}
+                  onKeyDown={(event) => {
+                    if (
+                      event.currentTarget !== event.target ||
+                      event.key !== 'Enter' ||
+                      event.metaKey ||
+                      event.ctrlKey ||
+                      event.shiftKey ||
+                      event.altKey
+                    ) {
+                      return
+                    }
+                    event.preventDefault()
+                    onPlainEnter?.()
+                  }}
+                  className="flex h-9 w-full min-w-0 items-center gap-2 rounded-md border border-input bg-transparent px-2.5 text-sm shadow-xs outline-none focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50"
+                >
                   <SelectionIcon kind={selectedSource.kind} />
                   <span className="min-w-0 flex-1 truncate font-medium leading-none text-foreground">
                     {selectedSource.label}


### PR DESCRIPTION
## Summary
- focus the selected PR/issue source pill after accepting a source from the create-workspace name field
- route plain Enter on that focused pill to the existing form-advance handler so keyboard creation continues to Agent/Create
- keep explicit open-link and clear-source icon button Enter behavior intact

## Verification
- pnpm exec oxlint src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
- pnpm exec oxfmt --check src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/new-workspace-enter-guard.test.ts src/renderer/src/lib/smart-github-submit.test.ts

Made with [Orca](https://github.com/stablyai/orca) 🐋
