### PR TITLE
Support aborting rebases from source control

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -42,6 +42,7 @@ vi.mock('fs', () => ({
 
 import {
   abortMerge,
+  abortRebase,
   bulkStageFiles,
   bulkDiscardChanges,
   bulkUnstageFiles,
@@ -672,6 +673,20 @@ describe('abortMerge', () => {
     await abortMerge('/repo')
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['merge', '--abort'], { cwd: '/repo' })
+  })
+})
+
+describe('abortRebase', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('runs git rebase --abort in the worktree', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+
+    await abortRebase('/repo')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['rebase', '--abort'], { cwd: '/repo' })
   })
 })
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -467,6 +467,10 @@ export async function abortMerge(worktreePath: string): Promise<void> {
   await gitExecFileAsync(['merge', '--abort'], { cwd: worktreePath })
 }
 
+export async function abortRebase(worktreePath: string): Promise<void> {
+  await gitExecFileAsync(['rebase', '--abort'], { cwd: worktreePath })
+}
+
 export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
 

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -16,6 +16,7 @@ const {
   commitChangesMock,
   getStatusMock,
   abortMergeMock,
+  abortRebaseMock,
   getDiffMock,
   getBranchCompareMock,
   getBranchDiffMock,
@@ -48,6 +49,7 @@ const {
   commitChangesMock: vi.fn(),
   getStatusMock: vi.fn(),
   abortMergeMock: vi.fn(),
+  abortRebaseMock: vi.fn(),
   getDiffMock: vi.fn(),
   getBranchCompareMock: vi.fn(),
   getBranchDiffMock: vi.fn(),
@@ -92,6 +94,7 @@ vi.mock('../git/status', () => ({
   commitChanges: commitChangesMock,
   getStatus: getStatusMock,
   abortMerge: abortMergeMock,
+  abortRebase: abortRebaseMock,
   getDiff: getDiffMock,
   getBranchCompare: getBranchCompareMock,
   getBranchDiff: getBranchDiffMock,
@@ -201,6 +204,8 @@ describe('registerFilesystemHandlers', () => {
       lstatMock,
       commitChangesMock,
       getStatusMock,
+      abortMergeMock,
+      abortRebaseMock,
       getDiffMock,
       getBranchCompareMock,
       getBranchDiffMock,
@@ -600,6 +605,26 @@ describe('registerFilesystemHandlers', () => {
 
     expect(abortMergeMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH)
     expect(sshProvider.abortMerge).toHaveBeenCalledWith('/remote/repo')
+  })
+
+  it('routes abort rebase through local and SSH git providers', async () => {
+    registerWorktreeRootsForRepo(store as never, 'repo-1', [REPO_PATH, WORKTREE_FEATURE_PATH])
+    abortRebaseMock.mockResolvedValue(undefined)
+    const sshProvider = {
+      abortRebase: vi.fn().mockResolvedValue(undefined)
+    }
+    getSshGitProviderMock.mockReturnValue(sshProvider)
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:abortRebase')!(null, { worktreePath: WORKTREE_FEATURE_PATH })
+    await handlers.get('git:abortRebase')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'ssh-1'
+    })
+
+    expect(abortRebaseMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH)
+    expect(sshProvider.abortRebase).toHaveBeenCalledWith('/remote/repo')
   })
 
   it('rejects git file paths that escape the selected worktree', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -33,6 +33,7 @@ import {
 import {
   getStatus,
   abortMerge,
+  abortRebase,
   detectConflictOperation,
   getDiff,
   commitChanges,
@@ -710,6 +711,21 @@ export function registerFilesystemHandlers(
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       await abortMerge(worktreePath)
+    }
+  )
+
+  ipcMain.handle(
+    'git:abortRebase',
+    async (_event, args: { worktreePath: string; connectionId?: string }): Promise<void> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(`No git provider for connection "${args.connectionId}"`)
+        }
+        return provider.abortRebase(args.worktreePath)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      await abortRebase(worktreePath)
     }
   )
 

--- a/src/main/providers/ssh-git-provider-merge.test.ts
+++ b/src/main/providers/ssh-git-provider-merge.test.ts
@@ -18,4 +18,21 @@ describe('SshGitProvider merge operations', () => {
       worktreePath: '/home/user/repo'
     })
   })
+
+  it('abortRebase sends git.abortRebase request', async () => {
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn(),
+      onNotification: vi.fn(),
+      dispose: vi.fn(),
+      isDisposed: vi.fn().mockReturnValue(false)
+    }
+    const provider = new SshGitProvider('conn-1', mux as never)
+
+    await provider.abortRebase('/home/user/repo')
+
+    expect(mux.request).toHaveBeenCalledWith('git.abortRebase', {
+      worktreePath: '/home/user/repo'
+    })
+  })
 })

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -285,6 +285,10 @@ export class SshGitProvider implements IGitProvider {
     await this.mux.request('git.abortMerge', { worktreePath })
   }
 
+  async abortRebase(worktreePath: string): Promise<void> {
+    await this.mux.request('git.abortRebase', { worktreePath })
+  }
+
   async getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult> {
     return (await this.mux.request('git.branchCompare', {
       worktreePath,

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -173,6 +173,7 @@ export type IGitProvider = {
   bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void>
   detectConflictOperation(worktreePath: string): Promise<GitConflictOperation>
   abortMerge(worktreePath: string): Promise<void>
+  abortRebase(worktreePath: string): Promise<void>
   getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult>
   getCommitCompare(worktreePath: string, commitId: string): Promise<GitCommitCompareResult>
   getUpstreamStatus(worktreePath: string, pushTarget?: GitPushTarget): Promise<GitUpstreamStatus>

--- a/src/main/runtime/orca-runtime-git.test.ts
+++ b/src/main/runtime/orca-runtime-git.test.ts
@@ -9,6 +9,7 @@ import { RuntimeGitCommands, type ResolvedRuntimeGitWorktree } from './orca-runt
 
 const mocks = vi.hoisted(() => ({
   abortMerge: vi.fn(),
+  abortRebase: vi.fn(),
   getStagedCommitContext: vi.fn(),
   generateCommitMessageFromContext: vi.fn(),
   resolveCommitMessageSettings: vi.fn(),
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../git/status', async () => ({
   ...(await vi.importActual<typeof GitStatusModule>('../git/status')),
   abortMerge: mocks.abortMerge,
+  abortRebase: mocks.abortRebase,
   getStagedCommitContext: mocks.getStagedCommitContext
 }))
 
@@ -60,6 +62,7 @@ function makeCommands(worktreePath: string): RuntimeGitCommands {
 describe('RuntimeGitCommands', () => {
   beforeEach(() => {
     mocks.abortMerge.mockReset()
+    mocks.abortRebase.mockReset()
     mocks.getStagedCommitContext.mockReset()
     mocks.generateCommitMessageFromContext.mockReset()
     mocks.resolveCommitMessageSettings.mockReset()
@@ -98,6 +101,34 @@ describe('RuntimeGitCommands', () => {
 
     expect(provider.abortMerge).toHaveBeenCalledWith('/remote/repo')
     expect(mocks.abortMerge).not.toHaveBeenCalled()
+  })
+
+  it('aborts a local rebase through the resolved worktree', async () => {
+    const worktreePath = mkdtempSync(join(tmpdir(), 'orca-runtime-git-'))
+    tempDirs.push(worktreePath)
+    const commands = makeCommands(worktreePath)
+    mocks.abortRebase.mockResolvedValue(undefined)
+
+    await expect(commands.abortRuntimeGitRebase('id:wt-1')).resolves.toEqual({ ok: true })
+
+    expect(mocks.abortRebase).toHaveBeenCalledWith(worktreePath)
+  })
+
+  it('aborts a remote rebase through the SSH git provider', async () => {
+    const provider = { abortRebase: vi.fn().mockResolvedValue(undefined) }
+    mocks.getSshGitProvider.mockReturnValue(provider)
+    const commands = new RuntimeGitCommands({
+      resolveRuntimeGitTarget: async () => ({
+        worktree: makeWorktree('/remote/repo'),
+        connectionId: 'conn-1'
+      }),
+      getRuntimeSettings: () => ({}) as GlobalSettings
+    })
+
+    await expect(commands.abortRuntimeGitRebase('id:wt-1')).resolves.toEqual({ ok: true })
+
+    expect(provider.abortRebase).toHaveBeenCalledWith('/remote/repo')
+    expect(mocks.abortRebase).not.toHaveBeenCalled()
   })
 
   it('rejects slash-only git mutation paths before they can target the worktree root', async () => {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -21,6 +21,7 @@ import type { SourceControlAiOperation } from '../../shared/source-control-ai-ty
 import { getRemoteFileUrl } from '../git/repo'
 import {
   abortMerge,
+  abortRebase,
   bulkDiscardChanges,
   bulkStageFiles,
   bulkUnstageFiles,
@@ -188,6 +189,20 @@ export class RuntimeGitCommands {
       return { ok: true }
     }
     await abortMerge(target.worktree.path)
+    return { ok: true }
+  }
+
+  async abortRuntimeGitRebase(worktreeSelector: string): Promise<{ ok: true }> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      await provider.abortRebase(target.worktree.path)
+      return { ok: true }
+    }
+    await abortRebase(target.worktree.path)
     return { ok: true }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2076,6 +2076,8 @@ export class OrcaRuntimeService {
     this.gitCommands.getRuntimeGitConflictOperation.bind(this.gitCommands)
   abortRuntimeGitMerge: RuntimeGitCommands['abortRuntimeGitMerge'] =
     this.gitCommands.abortRuntimeGitMerge.bind(this.gitCommands)
+  abortRuntimeGitRebase: RuntimeGitCommands['abortRuntimeGitRebase'] =
+    this.gitCommands.abortRuntimeGitRebase.bind(this.gitCommands)
   getRuntimeGitDiff: RuntimeGitCommands['getRuntimeGitDiff'] =
     this.gitCommands.getRuntimeGitDiff.bind(this.gitCommands)
   getRuntimeGitBranchCompare: RuntimeGitCommands['getRuntimeGitBranchCompare'] =

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -198,6 +198,7 @@ describe('git RPC methods', () => {
       }),
       cancelRuntimeGenerateCommitMessage: vi.fn().mockResolvedValue({ ok: true }),
       abortRuntimeGitMerge: vi.fn().mockResolvedValue({ ok: true }),
+      abortRuntimeGitRebase: vi.fn().mockResolvedValue({ ok: true }),
       pushRuntimeGit: vi.fn().mockResolvedValue({ ok: true }),
       getRuntimeGitRemoteFileUrl: vi.fn().mockResolvedValue('https://example.com/file#L3')
     } as unknown as OrcaRuntimeService
@@ -218,6 +219,7 @@ describe('git RPC methods', () => {
       makeRequest('git.cancelGenerateCommitMessage', { worktree: 'id:wt-1' })
     )
     await dispatcher.dispatch(makeRequest('git.abortMerge', { worktree: 'id:wt-1' }))
+    await dispatcher.dispatch(makeRequest('git.abortRebase', { worktree: 'id:wt-1' }))
     await dispatcher.dispatch(
       makeRequest('git.push', {
         worktree: 'id:wt-1',
@@ -240,6 +242,7 @@ describe('git RPC methods', () => {
     })
     expect(runtime.cancelRuntimeGenerateCommitMessage).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.abortRuntimeGitMerge).toHaveBeenCalledWith('id:wt-1')
+    expect(runtime.abortRuntimeGitRebase).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.pushRuntimeGit).toHaveBeenCalledWith(
       'id:wt-1',
       true,

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -57,6 +57,11 @@ export const GIT_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) => runtime.abortRuntimeGitMerge(params.worktree)
   }),
   defineMethod({
+    name: 'git.abortRebase',
+    params: WorktreeSelector,
+    handler: async (params, { runtime }) => runtime.abortRuntimeGitRebase(params.worktree)
+  }),
+  defineMethod({
     name: 'git.diff',
     params: GitDiff,
     handler: async (params, { runtime }) =>

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -762,6 +762,7 @@ describe('OrcaRuntimeRpcServer', () => {
       .mockResolvedValue({ hasUpstream: true, ahead: 1, behind: 0 })
     const rebaseRuntimeGitFromBase = vi.fn().mockResolvedValue({ ok: true })
     const abortRuntimeGitMerge = vi.fn().mockResolvedValue({ ok: true })
+    const abortRuntimeGitRebase = vi.fn().mockResolvedValue({ ok: true })
     const bulkStageRuntimeGitPaths = vi.fn().mockResolvedValue({ ok: true })
     const bulkUnstageRuntimeGitPaths = vi.fn().mockResolvedValue({ ok: true })
     const getRuntimeGitDiff = vi.fn().mockResolvedValue({
@@ -844,6 +845,7 @@ describe('OrcaRuntimeRpcServer', () => {
       getRuntimeGitUpstreamStatus,
       rebaseRuntimeGitFromBase,
       abortRuntimeGitMerge,
+      abortRuntimeGitRebase,
       bulkStageRuntimeGitPaths,
       bulkUnstageRuntimeGitPaths,
       getRuntimeGitDiff,
@@ -1414,6 +1416,16 @@ describe('OrcaRuntimeRpcServer', () => {
     )
     await server['handleWebSocketMessage'](
       JSON.stringify({
+        id: 'req_git_abort_rebase',
+        method: 'git.abortRebase',
+        deviceToken: mobile.token,
+        params: { worktree: 'id:wt-1' }
+      }),
+      (response) => replies.push(JSON.parse(response) as Record<string, unknown>),
+      () => {}
+    )
+    await server['handleWebSocketMessage'](
+      JSON.stringify({
         id: 'req_git_bulk_unstage',
         method: 'git.bulkUnstage',
         deviceToken: mobile.token,
@@ -1626,6 +1638,9 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_git_bulk_stage', ok: true }))
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_git_abort_merge', ok: true }))
     expect(replies).toContainEqual(
+      expect.objectContaining({ id: 'req_git_abort_rebase', ok: true })
+    )
+    expect(replies).toContainEqual(
       expect.objectContaining({ id: 'req_git_bulk_unstage', ok: true })
     )
     expect(replies).toContainEqual(expect.objectContaining({ id: 'req_select_claude', ok: true }))
@@ -1660,6 +1675,7 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(getRuntimeGitUpstreamStatus).toHaveBeenCalledWith('id:wt-1')
     expect(bulkStageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['a.ts', 'b.ts'])
     expect(abortRuntimeGitMerge).toHaveBeenCalledWith('id:wt-1')
+    expect(abortRuntimeGitRebase).toHaveBeenCalledWith('id:wt-1')
     expect(bulkUnstageRuntimeGitPaths).toHaveBeenCalledWith('id:wt-1', ['c.ts'])
     expect(openMobileDiff).toHaveBeenCalledWith('id:wt-1', 'docs/readme.md', true)
     expect(getRuntimeGitDiff).toHaveBeenCalledWith('id:wt-1', 'docs/readme.md', false, undefined)

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -146,6 +146,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'files.openDiff',
   'files.read',
   'git.abortMerge',
+  'git.abortRebase',
   'git.bulkStage',
   'git.bulkUnstage',
   'git.commit',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1613,6 +1613,7 @@ export type PreloadApi = {
       connectionId?: string
     }) => Promise<GitConflictOperation>
     abortMerge: (args: { worktreePath: string; connectionId?: string }) => Promise<void>
+    abortRebase: (args: { worktreePath: string; connectionId?: string }) => Promise<void>
     diff: (args: {
       worktreePath: string
       filePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2198,6 +2198,8 @@ const api = {
       ipcRenderer.invoke('git:conflictOperation', args),
     abortMerge: (args: { worktreePath: string; connectionId?: string }): Promise<void> =>
       ipcRenderer.invoke('git:abortMerge', args),
+    abortRebase: (args: { worktreePath: string; connectionId?: string }): Promise<void> =>
+      ipcRenderer.invoke('git:abortRebase', args),
     diff: (args: {
       worktreePath: string
       filePath: string

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -46,6 +46,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.bulkStage')
     expect(methods).toContain('git.bulkUnstage')
     expect(methods).toContain('git.abortMerge')
+    expect(methods).toContain('git.abortRebase')
     expect(methods).toContain('git.discard')
     expect(methods).toContain('git.bulkDiscard')
     expect(methods).toContain('git.conflictOperation')
@@ -91,6 +92,37 @@ describe('GitHandler', () => {
 
       await expect(fs.access(path.join(tmpDir, '.git', 'MERGE_HEAD'))).rejects.toThrow()
       await expect(fs.readFile(path.join(tmpDir, 'file.txt'), 'utf-8')).resolves.toBe('main\n')
+    })
+  })
+
+  describe('abortRebase', () => {
+    it('aborts an in-progress rebase', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'base\n')
+      gitCommit(tmpDir, 'initial')
+      const baseBranch = execFileSync('git', ['branch', '--show-current'], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        stdio: 'pipe'
+      }).trim()
+      execFileSync('git', ['checkout', '-b', 'feature'], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'feature\n')
+      gitCommit(tmpDir, 'feature change')
+      execFileSync('git', ['checkout', baseBranch], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'file.txt'), 'main\n')
+      gitCommit(tmpDir, 'main change')
+      execFileSync('git', ['checkout', 'feature'], { cwd: tmpDir, stdio: 'pipe' })
+
+      expect(() =>
+        execFileSync('git', ['rebase', baseBranch], { cwd: tmpDir, stdio: 'pipe' })
+      ).toThrow()
+      await expect(fs.access(path.join(tmpDir, '.git', 'rebase-merge'))).resolves.toBeUndefined()
+
+      await dispatcher.callRequest('git.abortRebase', { worktreePath: tmpDir })
+
+      await expect(fs.access(path.join(tmpDir, '.git', 'rebase-merge'))).rejects.toThrow()
+      await expect(fs.access(path.join(tmpDir, '.git', 'rebase-apply'))).rejects.toThrow()
+      await expect(fs.readFile(path.join(tmpDir, 'file.txt'), 'utf-8')).resolves.toBe('feature\n')
     })
   })
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -65,6 +65,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.bulkStage', (p) => this.bulkStage(p))
     this.dispatcher.onRequest('git.bulkUnstage', (p) => this.bulkUnstage(p))
     this.dispatcher.onRequest('git.abortMerge', (p) => this.abortMerge(p))
+    this.dispatcher.onRequest('git.abortRebase', (p) => this.abortRebase(p))
     this.dispatcher.onRequest('git.discard', (p) => this.discard(p))
     this.dispatcher.onRequest('git.bulkDiscard', (p) => this.bulkDiscard(p))
     this.dispatcher.onRequest('git.conflictOperation', (p) => this.conflictOperation(p))
@@ -190,6 +191,11 @@ export class GitHandler {
   private async abortMerge(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
     await this.git(['merge', '--abort'], worktreePath)
+  }
+
+  private async abortRebase(params: Record<string, unknown>) {
+    const worktreePath = params.worktreePath as string
+    await this.git(['rebase', '--abort'], worktreePath)
   }
 
   private normalizeGitPathForCompare(filePath: string): string {

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { CommitArea, ConflictSummaryCard } from './SourceControl'
+import { CommitArea, ConflictSummaryCard, OperationBanner } from './SourceControl'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
 import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -334,13 +334,13 @@ describe('ConflictSummaryCard', () => {
     expect(markup.indexOf('Resolve with AI')).toBeLessThan(markup.indexOf('Review conflicts'))
   })
 
-  it('shows Abort merge only for merge conflicts', () => {
+  it('shows the matching abort action for merge and rebase conflicts only', () => {
     const mergeMarkup = renderToStaticMarkup(
       <ConflictSummaryCard
         conflictOperation="merge"
         unresolvedCount={1}
         isResolvingWithAI={false}
-        onAbortMerge={vi.fn()}
+        onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
         onReview={vi.fn()}
       />
@@ -350,14 +350,28 @@ describe('ConflictSummaryCard', () => {
         conflictOperation="rebase"
         unresolvedCount={1}
         isResolvingWithAI={false}
-        onAbortMerge={vi.fn()}
+        onAbortOperation={vi.fn()}
+        onResolveWithAI={vi.fn()}
+        onReview={vi.fn()}
+      />
+    )
+    const cherryPickMarkup = renderToStaticMarkup(
+      <ConflictSummaryCard
+        conflictOperation="cherry-pick"
+        unresolvedCount={1}
+        isResolvingWithAI={false}
+        onAbortOperation={vi.fn()}
         onResolveWithAI={vi.fn()}
         onReview={vi.fn()}
       />
     )
 
     expect(mergeMarkup).toContain('Abort merge')
+    expect(mergeMarkup).not.toContain('Abort rebase')
+    expect(rebaseMarkup).toContain('Abort rebase')
     expect(rebaseMarkup).not.toContain('Abort merge')
+    expect(cherryPickMarkup).not.toContain('Abort merge')
+    expect(cherryPickMarkup).not.toContain('Abort rebase')
   })
 
   it('renders the Sparkles icon on the idle Resolve with AI button', () => {
@@ -374,5 +388,24 @@ describe('ConflictSummaryCard', () => {
     expect(markup).toContain('Resolve with AI')
     expect(markup).toContain('lucide-sparkles')
     expect(markup).not.toMatch(/\blucide-sparkle(?!s)\b/)
+  })
+})
+
+describe('OperationBanner', () => {
+  it('shows abort actions for merge and rebase but not cherry-pick', () => {
+    const mergeMarkup = renderToStaticMarkup(
+      <OperationBanner conflictOperation="merge" onAbortOperation={vi.fn()} />
+    )
+    const rebaseMarkup = renderToStaticMarkup(
+      <OperationBanner conflictOperation="rebase" onAbortOperation={vi.fn()} />
+    )
+    const cherryPickMarkup = renderToStaticMarkup(
+      <OperationBanner conflictOperation="cherry-pick" onAbortOperation={vi.fn()} />
+    )
+
+    expect(mergeMarkup).toContain('Abort merge')
+    expect(rebaseMarkup).toContain('Abort rebase')
+    expect(cherryPickMarkup).not.toContain('Abort merge')
+    expect(cherryPickMarkup).not.toContain('Abort rebase')
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -118,6 +118,7 @@ import {
 import { getConnectionId } from '@/lib/connection-context'
 import {
   abortRuntimeGitMerge,
+  abortRuntimeGitRebase,
   bulkDiscardRuntimeGitPaths,
   bulkStageRuntimeGitPaths,
   bulkUnstageRuntimeGitPaths,
@@ -178,7 +179,9 @@ import { getRepositorySourceControlAiSectionId } from '@/components/settings/rep
 import { hasExpandedCommitFailureDetails, summarizeCommitFailure } from './commit-failure-summary'
 
 export type SourceControlScope = 'all' | 'uncommitted'
-type SourceControlActionError = { kind: RemoteOpKind | 'abort_merge'; message: string }
+type AbortConflictOperation = Extract<GitConflictOperation, 'merge' | 'rebase'>
+type AbortActionErrorKind = 'abort_merge' | 'abort_rebase'
+type SourceControlActionError = { kind: RemoteOpKind | AbortActionErrorKind; message: string }
 type SourceControlAiInstructionGuidance = {
   operation: SourceControlAiOperation
   repoBacked: boolean
@@ -1132,10 +1135,10 @@ function SourceControlInner(): React.JSX.Element {
   const [commitInFlightByWorktree, setCommitInFlightByWorktree] = useState<Record<string, boolean>>(
     {}
   )
-  const [abortMergeInFlightByWorktree, setAbortMergeInFlightByWorktree] = useState<
+  const [abortOperationInFlightByWorktree, setAbortOperationInFlightByWorktree] = useState<
     Record<string, boolean>
   >({})
-  const isAbortingMerge = abortMergeInFlightByWorktree[activeWorktreeId ?? ''] ?? false
+  const isAbortingOperation = abortOperationInFlightByWorktree[activeWorktreeId ?? ''] ?? false
   const confirmAction = useConfirmationDialog()
   const isCommitting = commitInFlightByWorktree[activeWorktreeId ?? ''] ?? false
   // Why: parallel state to commit. Same per-worktree shape so navigating between
@@ -1747,7 +1750,7 @@ function SourceControlInner(): React.JSX.Element {
     setCommitErrors((prev) => pruneRecord(prev))
     setRemoteActionErrors((prev) => pruneRecord(prev))
     setCommitInFlightByWorktree((prev) => pruneRecord(prev))
-    setAbortMergeInFlightByWorktree((prev) => pruneRecord(prev))
+    setAbortOperationInFlightByWorktree((prev) => pruneRecord(prev))
     setGenerateInFlightByWorktree((prev) => pruneRecord(prev))
     setGenerateErrors((prev) => pruneRecord(prev))
     setGitHistoryByWorktree((prev) => pruneRecord(prev))
@@ -2084,52 +2087,91 @@ function SourceControlInner(): React.JSX.Element {
     ]
   )
 
-  const handleAbortMerge = useCallback(async (): Promise<void> => {
-    if (!activeWorktreeId || !worktreePath || conflictOperation !== 'merge' || isAbortingMerge) {
-      return
-    }
+  const handleAbortOperation = useCallback(
+    async (requestedOperation: AbortConflictOperation): Promise<void> => {
+      if (
+        !activeWorktreeId ||
+        !worktreePath ||
+        conflictOperation !== requestedOperation ||
+        isAbortingOperation
+      ) {
+        return
+      }
 
-    const confirmed = await confirmAction({
-      title: 'Abort merge?',
-      description:
-        'This cancels the merge in progress and can discard conflict resolutions made during this merge.',
-      confirmLabel: 'Abort merge',
-      confirmVariant: 'destructive'
-    })
-    if (!confirmed) {
-      return
-    }
-
-    const connectionId = getConnectionId(activeWorktreeId) ?? undefined
-    setAbortMergeInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
-    setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
-    try {
-      await abortRuntimeGitMerge({
-        settings: useAppStore.getState().settings,
-        worktreeId: activeWorktreeId,
-        worktreePath,
-        connectionId
+      const isRebase = requestedOperation === 'rebase'
+      const label = isRebase ? 'rebase' : 'merge'
+      const title = isRebase ? 'Abort rebase?' : 'Abort merge?'
+      const description = isRebase
+        ? 'This cancels the rebase in progress and can discard conflict resolutions made during this rebase.'
+        : 'This cancels the merge in progress and can discard conflict resolutions made during this merge.'
+      const confirmed = await confirmAction({
+        title,
+        description,
+        confirmLabel: `Abort ${label}`,
+        confirmVariant: 'destructive'
       })
-      await refreshActiveGitStatusAfterMutation()
-      void refreshGitHistoryRef.current()
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to abort merge'
-      toast.error('Abort merge failed', { description: message })
-      setRemoteActionErrors((prev) => ({
-        ...prev,
-        [activeWorktreeId]: { kind: 'abort_merge', message }
-      }))
-    } finally {
-      setAbortMergeInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
-    }
-  }, [
-    activeWorktreeId,
-    confirmAction,
-    conflictOperation,
-    isAbortingMerge,
-    refreshActiveGitStatusAfterMutation,
-    worktreePath
-  ])
+      if (!confirmed) {
+        return
+      }
+
+      const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+      setAbortOperationInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: true }))
+      setRemoteActionErrors((prev) => ({ ...prev, [activeWorktreeId]: null }))
+      try {
+        const context = {
+          settings: useAppStore.getState().settings,
+          worktreeId: activeWorktreeId,
+          worktreePath,
+          connectionId
+        }
+        const abortGitOperation = isRebase ? abortRuntimeGitRebase : abortRuntimeGitMerge
+        await abortGitOperation(context)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : `Failed to abort ${label}`
+        toast.error(`Abort ${label} failed`, { description: message })
+        setRemoteActionErrors((prev) => ({
+          ...prev,
+          [activeWorktreeId]: { kind: isRebase ? 'abort_rebase' : 'abort_merge', message }
+        }))
+      } finally {
+        setAbortOperationInFlightByWorktree((prev) => ({ ...prev, [activeWorktreeId]: false }))
+        refreshSourceControlAfterRemoteAction({
+          refreshGitStatus: refreshActiveGitStatusAfterMutation,
+          refreshBranchCompare: refreshBranchCompareRef.current,
+          refreshGitHistory: refreshGitHistoryRef.current
+        })
+      }
+    },
+    [
+      activeWorktreeId,
+      confirmAction,
+      conflictOperation,
+      isAbortingOperation,
+      refreshActiveGitStatusAfterMutation,
+      worktreePath
+    ]
+  )
+
+  const handleAbortMerge = useCallback(async (): Promise<void> => {
+    await handleAbortOperation('merge')
+  }, [handleAbortOperation])
+
+  const handleAbortRebase = useCallback(async (): Promise<void> => {
+    await handleAbortOperation('rebase')
+  }, [handleAbortOperation])
+
+  const handleAbortOperationForConflict = useCallback(
+    (operation: GitConflictOperation): void => {
+      if (operation === 'merge') {
+        void handleAbortMerge()
+        return
+      }
+      if (operation === 'rebase') {
+        void handleAbortRebase()
+      }
+    },
+    [handleAbortMerge, handleAbortRebase]
+  )
 
   // Why: compound actions must commit first and only run the follow-up remote
   // op when the commit succeeds. handleCommit's return value carries that
@@ -2627,7 +2669,7 @@ function SourceControlInner(): React.JSX.Element {
       hasMessage: commitMessage.trim().length > 0,
       hasUnresolvedConflicts: unresolvedConflicts.length > 0,
       isCommitting,
-      isRemoteOperationActive: isRemoteOperationActive || isAbortingMerge,
+      isRemoteOperationActive: isRemoteOperationActive || isAbortingOperation,
       upstreamStatus: remoteStatus,
       prState: hostedReview?.state ?? null,
       isPRStateLoading: isHostedReviewStateLoading,
@@ -2645,7 +2687,7 @@ function SourceControlInner(): React.JSX.Element {
     hasUnstagedChanges,
     hasPartiallyStagedChanges,
     isCommitting,
-    isAbortingMerge,
+    isAbortingOperation,
     isRemoteOperationActive,
     inFlightRemoteOpKind,
     hostedReviewCreation,
@@ -2667,7 +2709,7 @@ function SourceControlInner(): React.JSX.Element {
         hasMessage: commitMessage.trim().length > 0,
         hasUnresolvedConflicts: unresolvedConflicts.length > 0,
         isCommitting,
-        isRemoteOperationActive: isRemoteOperationActive || isAbortingMerge,
+        isRemoteOperationActive: isRemoteOperationActive || isAbortingOperation,
         conflictOperation,
         upstreamStatus: remoteStatus,
         prState: hostedReview?.state ?? null,
@@ -2686,7 +2728,7 @@ function SourceControlInner(): React.JSX.Element {
       hasPartiallyStagedChanges,
       isCommitting,
       conflictOperation,
-      isAbortingMerge,
+      isAbortingOperation,
       isRemoteOperationActive,
       inFlightRemoteOpKind,
       hostedReviewCreation,
@@ -2724,6 +2766,9 @@ function SourceControlInner(): React.JSX.Element {
         case 'abort_merge':
           void handleAbortMerge()
           return
+        case 'abort_rebase':
+          void handleAbortRebase()
+          return
         case 'create_pr':
           void handleCreatePullRequest()
           return
@@ -2751,6 +2796,7 @@ function SourceControlInner(): React.JSX.Element {
       handleCommit,
       handleCreatePullRequest,
       handleAbortMerge,
+      handleAbortRebase,
       isCreatingPr,
       prGenerating,
       runCompoundCommitAction,
@@ -4004,8 +4050,8 @@ function SourceControlInner(): React.JSX.Element {
                 conflictOperation={conflictOperation}
                 unresolvedCount={unresolvedConflictReviewEntries.length}
                 isResolvingWithAI={isLaunchingConflictAgent}
-                isAbortingMerge={isAbortingMerge}
-                onAbortMerge={() => void handleAbortMerge()}
+                isAbortingOperation={isAbortingOperation}
+                onAbortOperation={handleAbortOperationForConflict}
                 onResolveWithAI={() => {
                   void handleResolveConflictsWithAI()
                 }}
@@ -4031,8 +4077,8 @@ function SourceControlInner(): React.JSX.Element {
             <div className="px-3 pb-2">
               <OperationBanner
                 conflictOperation={conflictOperation}
-                isAbortingMerge={isAbortingMerge}
-                onAbortMerge={() => void handleAbortMerge()}
+                isAbortingOperation={isAbortingOperation}
+                onAbortOperation={handleAbortOperationForConflict}
               />
             </div>
           )}
@@ -4144,7 +4190,7 @@ function SourceControlInner(): React.JSX.Element {
                 }
                 stagedCount={grouped.staged.length}
                 hasUnresolvedConflicts={unresolvedConflicts.length > 0}
-                isRemoteOperationActive={isRemoteOperationActive || isAbortingMerge}
+                isRemoteOperationActive={isRemoteOperationActive || isAbortingOperation}
                 inFlightRemoteOpKind={inFlightRemoteOpKind}
                 primaryAction={primaryAction}
                 dropdownItems={dropdownItems}
@@ -5853,16 +5899,16 @@ export function ConflictSummaryCard({
   conflictOperation,
   unresolvedCount,
   isResolvingWithAI,
-  isAbortingMerge = false,
-  onAbortMerge,
+  isAbortingOperation = false,
+  onAbortOperation,
   onResolveWithAI,
   onReview
 }: {
   conflictOperation: GitConflictOperation
   unresolvedCount: number
   isResolvingWithAI: boolean
-  isAbortingMerge?: boolean
-  onAbortMerge?: () => void
+  isAbortingOperation?: boolean
+  onAbortOperation?: (operation: GitConflictOperation) => void
   onResolveWithAI: () => void
   onReview: () => void
 }): React.JSX.Element {
@@ -5915,17 +5961,17 @@ export function ConflictSummaryCard({
           <GitMerge className="size-3.5" />
           Review conflicts
         </Button>
-        {conflictOperation === 'merge' && onAbortMerge ? (
+        {(conflictOperation === 'merge' || conflictOperation === 'rebase') && onAbortOperation ? (
           <Button
             type="button"
             variant="destructive"
             size="sm"
             className="mt-1.5 h-7 w-full text-xs"
-            disabled={isResolvingWithAI || isAbortingMerge}
-            onClick={onAbortMerge}
+            disabled={isResolvingWithAI || isAbortingOperation}
+            onClick={() => onAbortOperation(conflictOperation)}
           >
-            {isAbortingMerge ? <RefreshCw className="size-3.5 animate-spin" /> : null}
-            Abort merge
+            {isAbortingOperation ? <RefreshCw className="size-3.5 animate-spin" /> : null}
+            {conflictOperation === 'rebase' ? 'Abort rebase' : 'Abort merge'}
           </Button>
         ) : null}
       </div>
@@ -5938,14 +5984,14 @@ export function ConflictSummaryCard({
 // rebase steps, or after resolving all conflicts but before --continue. The
 // user needs to see the operation state so they know the worktree is mid-rebase
 // and that they should run `git rebase --continue` or `--abort`.
-function OperationBanner({
+export function OperationBanner({
   conflictOperation,
-  isAbortingMerge = false,
-  onAbortMerge
+  isAbortingOperation = false,
+  onAbortOperation
 }: {
   conflictOperation: GitConflictOperation
-  isAbortingMerge?: boolean
-  onAbortMerge?: () => void
+  isAbortingOperation?: boolean
+  onAbortOperation?: (operation: GitConflictOperation) => void
 }): React.JSX.Element {
   const label =
     conflictOperation === 'merge'
@@ -5964,17 +6010,17 @@ function OperationBanner({
         <Icon className="size-4 shrink-0 text-amber-600 dark:text-amber-400" />
         <span className="text-xs font-medium text-foreground">{label}</span>
       </div>
-      {conflictOperation === 'merge' && onAbortMerge ? (
+      {(conflictOperation === 'merge' || conflictOperation === 'rebase') && onAbortOperation ? (
         <Button
           type="button"
           variant="destructive"
           size="sm"
           className="mt-2 h-7 w-full text-xs"
-          disabled={isAbortingMerge}
-          onClick={onAbortMerge}
+          disabled={isAbortingOperation}
+          onClick={() => onAbortOperation(conflictOperation)}
         >
-          {isAbortingMerge ? <RefreshCw className="size-3.5 animate-spin" /> : null}
-          Abort merge
+          {isAbortingOperation ? <RefreshCw className="size-3.5 animate-spin" /> : null}
+          {conflictOperation === 'rebase' ? 'Abort rebase' : 'Abort merge'}
         </Button>
       ) : null}
     </div>

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -214,15 +214,24 @@ describe('resolveDropdownItems', () => {
     }
   })
 
-  it('shows a destructive Abort merge item only while a merge is in progress', () => {
+  it('shows a destructive abort item only while merge or rebase is in progress', () => {
     const mergeItems = resolveDropdownItems(
       inputs({
         conflictOperation: 'merge',
         upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
       })
     )
+    const rebaseItems = resolveDropdownItems(
+      inputs({
+        conflictOperation: 'rebase',
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      })
+    )
     const mergeByKind = Object.fromEntries(
       mergeItems.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    const rebaseByKind = Object.fromEntries(
+      rebaseItems.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
 
     expect(mergeByKind.abort_merge).toMatchObject({
@@ -231,14 +240,23 @@ describe('resolveDropdownItems', () => {
       disabled: false,
       variant: 'destructive'
     })
+    expect(rebaseByKind.abort_rebase).toMatchObject({
+      label: 'Abort rebase',
+      title: 'Abort the rebase in progress',
+      disabled: false,
+      variant: 'destructive'
+    })
+    expect(mergeByKind.abort_rebase).toBeUndefined()
+    expect(rebaseByKind.abort_merge).toBeUndefined()
 
-    for (const conflictOperation of ['unknown', 'rebase', 'cherry-pick'] as const) {
+    for (const conflictOperation of ['unknown', 'cherry-pick'] as const) {
       const items = resolveDropdownItems(inputs({ conflictOperation }))
       expect(items.some((entry) => entry.kind === 'abort_merge')).toBe(false)
+      expect(items.some((entry) => entry.kind === 'abort_rebase')).toBe(false)
     }
   })
 
-  it('disables Abort merge while another action is busy', () => {
+  it('disables conflict abort actions while another action is busy', () => {
     const items = resolveDropdownItems(
       inputs({
         conflictOperation: 'merge',
@@ -246,9 +264,21 @@ describe('resolveDropdownItems', () => {
         upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
       })
     )
+    const rebaseItems = resolveDropdownItems(
+      inputs({
+        conflictOperation: 'rebase',
+        isRemoteOperationActive: true,
+        upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+      })
+    )
     const abortMerge = items.find((entry) => entry.kind === 'abort_merge')
+    const abortRebase = rebaseItems.find((entry) => entry.kind === 'abort_rebase')
 
     expect(abortMerge).toMatchObject({
+      disabled: true,
+      title: 'Operation in progress…'
+    })
+    expect(abortRebase).toMatchObject({
       disabled: true,
       title: 'Operation in progress…'
     })

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -16,6 +16,7 @@ export type DropdownActionKind =
   | 'commit_push'
   | 'commit_sync'
   | 'abort_merge'
+  | 'abort_rebase'
   | 'create_pr'
   | 'push_create_pr'
   | 'push'
@@ -419,13 +420,15 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     fetchItem,
     publishItem
   ]
-  if (conflictOperation === 'merge') {
+  if (conflictOperation === 'merge' || conflictOperation === 'rebase') {
+    const isRebase = conflictOperation === 'rebase'
+    const label = isRebase ? 'Abort rebase' : 'Abort merge'
     entries.push(
       { kind: 'separator' },
       {
-        kind: 'abort_merge',
-        label: 'Abort merge',
-        title: globalBusy ? 'Operation in progress…' : 'Abort the merge in progress',
+        kind: isRebase ? 'abort_rebase' : 'abort_merge',
+        label,
+        title: globalBusy ? 'Operation in progress…' : `Abort the ${conflictOperation} in progress`,
         disabled: globalBusy,
         variant: 'destructive'
       }

--- a/src/renderer/src/runtime/runtime-git-client-merge.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client-merge.test.ts
@@ -3,10 +3,11 @@ import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
 } from './runtime-compatibility-test-fixture'
-import { abortRuntimeGitMerge } from './runtime-git-client'
+import { abortRuntimeGitMerge, abortRuntimeGitRebase } from './runtime-git-client'
 import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
 
 const gitAbortMerge = vi.fn()
+const gitAbortRebase = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 const runtimeCall = vi.fn()
@@ -14,6 +15,7 @@ const runtimeCall = vi.fn()
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   gitAbortMerge.mockReset()
+  gitAbortRebase.mockReset()
   runtimeEnvironmentCall.mockReset()
   runtimeEnvironmentTransportCall.mockReset()
   runtimeCall.mockReset()
@@ -22,7 +24,7 @@ beforeEach(() => {
   })
   vi.stubGlobal('window', {
     api: {
-      git: { abortMerge: gitAbortMerge },
+      git: { abortMerge: gitAbortMerge, abortRebase: gitAbortRebase },
       runtime: { call: runtimeCall },
       runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
     }
@@ -64,5 +66,42 @@ describe('runtime git client merge operations', () => {
       timeoutMs: 30_000
     })
     expect(gitAbortMerge).not.toHaveBeenCalled()
+  })
+
+  it('uses local git IPC when aborting a rebase without an active runtime', async () => {
+    gitAbortRebase.mockResolvedValue(undefined)
+
+    await abortRuntimeGitRebase({
+      settings: { activeRuntimeEnvironmentId: null },
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      connectionId: 'ssh-1'
+    })
+
+    expect(gitAbortRebase).toHaveBeenCalledWith({ connectionId: 'ssh-1', worktreePath: '/repo' })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  it('routes abort rebase through the active runtime', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: { success: true },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+
+    await abortRuntimeGitRebase({
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      worktreeId: 'wt-1',
+      worktreePath: '/repo'
+    })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'git.abortRebase',
+      params: { worktree: 'wt-1' },
+      timeoutMs: 30_000
+    })
+    expect(gitAbortRebase).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -196,6 +196,23 @@ export async function abortRuntimeGitMerge(context: RuntimeGitContext): Promise<
   )
 }
 
+export async function abortRuntimeGitRebase(context: RuntimeGitContext): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    await window.api.git.abortRebase({
+      worktreePath: context.worktreePath,
+      connectionId: context.connectionId
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'git.abortRebase',
+    { worktree: context.worktreeId },
+    { timeoutMs: 30_000 }
+  )
+}
+
 export async function getRuntimeGitDiff(
   context: RuntimeGitContext,
   args: { filePath: string; staged: boolean; compareAgainstHead?: boolean }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1068,6 +1068,10 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       await callRuntimeResult('git.abortMerge', { worktree: worktree.id })
     },
+    abortRebase: async ({ worktreePath }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      await callRuntimeResult('git.abortRebase', { worktree: worktree.id })
+    },
     diff: async ({ worktreePath, filePath, staged, compareAgainstHead }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
       return callRuntimeResult('git.diff', {


### PR DESCRIPTION
## Summary
- add git abort-rebase plumbing across local, SSH, relay, runtime RPC, preload, and web runtime paths
- expose Abort rebase actions in source control conflict UI and dropdowns
- cover abort-rebase behavior with unit and relay tests, including mobile runtime RPC allowlist coverage

## Tests
- pnpm typecheck
- pnpm exec vitest run src/main/runtime/runtime-rpc.test.ts src/renderer/src/runtime/runtime-git-client-merge.test.ts src/relay/git-handler.test.ts --config config/vitest.config.ts