### PR TITLE
Fix hidden pet startup flash

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as Fs from 'fs'
 import type * as FsPromises from 'fs/promises'

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -96,6 +96,7 @@ import {
   getStartupErrorFallbackUI,
   hydratePersistedUIAfterStartupRead
 } from './lib/startup-ui-hydration'
+import { shouldRenderPetOverlay } from './components/pet/pet-overlay-visibility'
 import { applyDocumentTheme } from './lib/document-theme'
 import { getSystemPrefersDark } from './lib/terminal-theme'
 import { isEditableTarget } from './lib/editable-target'
@@ -413,6 +414,11 @@ function App(): React.JSX.Element {
   usePrimarySelectionPaste(primarySelectionMiddleClickPaste)
   const petEnabled = useAppStore((s) => s.settings?.experimentalPet === true)
   const petVisible = useAppStore((s) => s.petVisible)
+  const renderPetOverlay = shouldRenderPetOverlay({
+    persistedUIReady,
+    petEnabled,
+    petVisible
+  })
   const canGoBackWorktree = useAppStore(canGoBackWorktreeHistory)
   const canGoForwardWorktree = useAppStore(canGoForwardWorktreeHistory)
   const titlebarLeftControlsRef = useRef<HTMLDivElement | null>(null)
@@ -1700,11 +1706,10 @@ function App(): React.JSX.Element {
             {mountedLazyModalIds.has('feature-wall') ? <FeatureWallModal /> : null}
             {mountedLazyModalIds.has('feature-tips') ? <FeatureTipsModal /> : null}
           </Suspense>
-          {/* Why: mount PetOverlay only when the experimental flag is on AND
-          the user hasn't hit "Hide pet" in the status-bar menu. Both
-          conditions must be true — see design doc (pet-overlay.md) on why
-          the two toggles are kept independent. */}
-          {petEnabled && petVisible ? (
+          {/* Why: mount PetOverlay only after persisted UI hydration, with
+          both independent pet toggles allowing it; otherwise a hidden pet
+          flashes while the store still has default visibility. */}
+          {renderPetOverlay ? (
             <Suspense fallback={null}>
               <PetOverlay />
             </Suspense>

--- a/src/renderer/src/components/pet/pet-overlay-visibility.test.ts
+++ b/src/renderer/src/components/pet/pet-overlay-visibility.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRenderPetOverlay } from './pet-overlay-visibility'
+
+describe('shouldRenderPetOverlay', () => {
+  it('does not render before persisted UI hydration even when the feature is enabled', () => {
+    expect(
+      shouldRenderPetOverlay({
+        persistedUIReady: false,
+        petEnabled: true,
+        petVisible: true
+      })
+    ).toBe(false)
+  })
+
+  it('renders only after hydration when both pet switches allow it', () => {
+    expect(
+      shouldRenderPetOverlay({
+        persistedUIReady: true,
+        petEnabled: true,
+        petVisible: true
+      })
+    ).toBe(true)
+    expect(
+      shouldRenderPetOverlay({
+        persistedUIReady: true,
+        petEnabled: true,
+        petVisible: false
+      })
+    ).toBe(false)
+    expect(
+      shouldRenderPetOverlay({
+        persistedUIReady: true,
+        petEnabled: false,
+        petVisible: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/pet/pet-overlay-visibility.ts
+++ b/src/renderer/src/components/pet/pet-overlay-visibility.ts
@@ -1,0 +1,13 @@
+export function shouldRenderPetOverlay({
+  persistedUIReady,
+  petEnabled,
+  petVisible
+}: {
+  persistedUIReady: boolean
+  petEnabled: boolean
+  petVisible: boolean
+}): boolean {
+  // Why: petVisible defaults true until persisted UI hydrates. Waiting avoids
+  // flashing the pet for users who previously hid it.
+  return persistedUIReady && petEnabled && petVisible
+}


### PR DESCRIPTION
## Summary
- Gate the pet overlay on persisted UI hydration so a hidden pet does not flash during startup
- Add a focused visibility helper and regression test for the startup race
- Add the existing max-lines lint disable to the oversized runtime files test so lint remains green

## Verification
- pnpm lint
- pnpm run typecheck
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/pet/pet-overlay-visibility.test.ts src/renderer/src/components/pet/pet-agent-state.test.ts src/main/runtime/orca-runtime-files.test.ts

Note: local pnpm warned that Node v26.0.0 is active while the repo wants Node 24.

Made with [Orca](https://github.com/stablyai/orca) 🐋
