### PR TITLE
Use amber for permission status indicator

### DIFF
--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -25,6 +25,13 @@ describe('StatusIndicator', () => {
     expect(classNames).toContain('animate-spin')
   })
 
+  it('renders permission as an amber attention dot', () => {
+    const classNames = renderDotClassNames('permission')
+
+    expect(classNames).toContain('bg-amber-500')
+    expect(classNames).not.toContain('bg-red-500')
+  })
+
   it('renders active as full emerald dot', () => {
     const classNames = renderDotClassNames('active')
 

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -48,7 +48,7 @@ const StatusIndicator = React.memo(function StatusIndicator({
         className={cn(
           'block size-2 rounded-full',
           status === 'permission'
-            ? 'bg-red-500'
+            ? 'bg-amber-500'
             : status === 'done' || status === 'active'
               ? // Green dot for both hook-reported 'done' and the heuristic
                 // 'active' (terminal open, quiet). Working uses a yellow


### PR DESCRIPTION
## Summary
- Change the shared sidebar `StatusIndicator` permission dot from red to amber.
- Add a focused render regression test so permission stays amber and does not use the red class.

## Context
Refs https://github.com/stablyai/orca-internal/issues/373. Slack feedback was that the red dot reads as an error; this state is `Needs permission`, so amber better communicates action required without implying failure/destructive/error.

## Scope note
This PR intentionally changes only `StatusIndicator`, which covers worktree sidebar cards, lineage child rows, kanban cards, and `WorktreeJumpPalette`. `AgentStateDot` dashboard/inline agent rows are left unchanged in this narrow pass.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/StatusIndicator.test.ts src/renderer/src/lib/worktree-status.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- Captured controlled Electron proof screenshots rendered inside the Orca dev app. Local evidence files are intentionally not committed:
  - `validation-screenshots/status-indicator-proof-light.png`
  - `validation-screenshots/status-indicator-proof-dark.png`

Screenshot note: these are controlled proof overlays using the real rendered styling in the Orca dev app, not a live blocked-agent sidebar card.