### PR TITLE
Add experimental compact worktree card setting

### DIFF
--- a/docs/experimental-compact-worktree-cards.md
+++ b/docs/experimental-compact-worktree-cards.md
@@ -1,0 +1,136 @@
+# Experimental Compact Worktree Cards
+
+## Problem
+
+PR #2843 made compact one-line worktree cards the default in
+`src/renderer/src/components/sidebar/WorktreeCard.tsx:183` and
+`src/renderer/src/components/sidebar/WorktreeCard.tsx:557`. The behavior is useful for dense
+sidebars, but it is visually different enough that it should be trialed behind Experimental first.
+Users also cannot infer why some cards remain two-line: the hidden row only disappears when it
+would carry no distinct visible metadata.
+
+## Goal
+
+Add an Experimental setting, off by default, that controls the compact-card behavior. When disabled,
+workspace cards use the pre-compact layout: branch line stays visible, unread remains in the left
+status column, PR/issue/comment/port badges stay in the metadata row, and the primary worktree uses
+the pre-compact `primary` badge instead of the compact star. When enabled, keep the current compact
+behavior from PR #2843.
+
+## Non-goals
+
+- Do not redesign worktree card metadata.
+- Do not remove card property settings such as PR, ports, issue, comment, unread, or status.
+- Do not change SSH, GitLab/GitHub provider lookup, prompt-cache timer, or workspace port logic.
+- Do not add per-repo or per-worktree compact preferences.
+
+## Design
+
+1. Add `experimentalCompactWorktreeCards: boolean` to `GlobalSettings`, defaulting to `false`.
+2. Add an Experimental pane toggle titled `Compact worktree cards`.
+   Copy must explain the rule: cards collapse only when the second line would be redundant or empty;
+   real metadata such as a different branch, repo badge, conflict/cache state, or folder badge keeps
+   the card taller.
+3. In `WorktreeCard`, derive `const compactCards =
+   settings?.experimentalCompactWorktreeCards === true` from the existing settings read and branch
+   layout:
+   - Disabled: show branch row for non-folder worktrees, keep unread in the left column, keep
+     PR/issue/comment/port details in the metadata row, and show the pre-compact `primary` badge.
+   - Enabled: use PR #2843 compact behavior, including title-row unread, details/ports cluster, and
+     primary star.
+4. Preserve the accessible title tooltip in `WorktreeTitleInlineRename`; it is useful in both modes
+   and replaces the native `title` attribute.
+5. Keep `CacheTimer` presentational. The card can still derive cache state, but the metadata-row gate
+   must only use compact gating when the experimental flag is enabled. In disabled mode, render the
+   metadata row even when the cache timer is inactive.
+
+## Data Flow
+
+- Main process persistence loads settings via `getDefaultSettings()`.
+- Renderer settings pane toggles `experimentalCompactWorktreeCards` through `updateSettings`.
+- `WorktreeCard` reads `settings?.experimentalCompactWorktreeCards === true`; missing/null settings
+  must behave as disabled so existing server-render tests and old profiles do not compact.
+- Card layout branches locally; no IPC, SSH, or provider data path changes.
+
+## Edge Cases
+
+- Missing legacy setting hydrates to `false`, so existing users get the less-surprising two-line
+  default after upgrade.
+- Folder repos keep their folder badge in the metadata row in both modes.
+- Custom display names keep branch metadata in compact mode because the branch differs.
+- Repo-grouped cards with `hideRepoBadge` can become one-line only when compact mode is enabled and
+  no other metadata is visible.
+- Active prompt-cache timer and conflict state keep the metadata row visible in compact mode.
+- SSH cards keep the SSH icon on the title row in both modes.
+- Sparse checkout badges, remote-branch conflict warnings, inline agents, and lineage child chips
+  are independent rows/badges and must not be hidden by the compact toggle.
+
+## Test Plan
+
+- Unit/render tests:
+  - default settings value is `false`;
+  - Experimental pane renders the toggle and explanatory copy;
+  - compact disabled renders a metadata row and branch when title equals branch;
+  - compact disabled keeps unread in the left status column, details/ports in the metadata row, and
+    the `primary` badge for the main worktree;
+  - compact enabled hides the redundant metadata row;
+  - compact enabled moves unread/details/ports to the title row and uses the primary star;
+  - compact enabled preserves branch row when title differs from branch;
+  - title tooltip remains focusable and does not use native `title`.
+- Validation:
+  - Electron screenshot with compact disabled: repeated branch cards are two-line.
+  - Electron screenshot with compact enabled: repeated branch cards collapse to one-line.
+  - Electron screenshot of Experimental setting showing explanatory copy.
+
+## UI Quality Bar
+
+- Toggle follows existing Experimental pane layout, spacing, typography, and switch style.
+- Copy is concise and explains what counts as metadata without teaching implementation details.
+- Sidebar cards do not overlap, clip icons, or jump unexpectedly when the setting changes.
+- Compact-disabled mode should look understandable rather than like an accidental regression.
+
+## Review Screenshots
+
+1. Experimental pane with `Compact worktree cards` toggle off.
+2. Sidebar card list with compact disabled: repeated branch cards show the second line.
+3. Sidebar card list with compact enabled: repeated branch cards collapse to one line.
+
+## Rollout
+
+1. Add setting type/default/search entry/persistence tests.
+2. Add Experimental pane UI.
+3. Branch `WorktreeCard` layout behind the setting.
+4. Update focused render tests.
+5. Validate with Electron screenshots.
+
+## Lightweight Eng Review
+
+- Scope: Keep the PR to one persisted Experimental flag, one settings row, and local card layout
+  branching. No new metadata model or card explanation surface.
+- Architecture/data flow: Settings persistence already merges defaults with parsed settings; adding
+  a default-off boolean is enough for old profiles and SSH/web clients because renderer state is
+  hydrated from the same settings object.
+- Failure modes covered:
+  - Old profiles unexpectedly compacting: default false.
+  - Toggle copy failing to explain mixed one-line/two-line cards: explicit description.
+  - Tests only checking branch text instead of row presence: use `data-worktree-card-meta-row`.
+  - Shipping a half-compact default: assert unread placement, details/ports placement, and
+    primary badge/star per mode.
+  - Prompt-cache/conflict metadata disappearing: metadata-row gate keeps these rows in compact mode.
+- Test coverage required:
+  - `src/shared/constants.test.ts` for default value.
+  - `src/renderer/src/components/settings/ExperimentalPane.test.tsx` or adjacent render test for
+    settings copy/toggle behavior.
+  - `src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx` for enabled/disabled
+    layout behavior.
+  - Existing `WorktreeTitleInlineRename.test.tsx` remains relevant for tooltip behavior.
+- Performance/blast radius: Reuse the existing settings read in `WorktreeCard`; no new polling, IPC,
+  file watching, or provider calls.
+- UI quality bar: Settings row should match existing Experimental rows; sidebar must remain dense
+  but mixed-height behavior should be explainable from the toggle copy.
+- Required review screenshots:
+  1. Experimental setting off.
+  2. Sidebar compact disabled.
+  3. Sidebar compact enabled.
+- Residual risks: The mixed card heights are still inherently subtle; this PR explains the rule in
+  settings but does not add per-card visible reasons.

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -122,6 +122,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalPet: false,
     experimentalActivity: true,
     experimentalTerminalAttention: false,
+    experimentalCompactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -109,6 +109,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
     experimentalPet: false,
     experimentalActivity: true,
     experimentalTerminalAttention: false,
+    experimentalCompactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsPowerShellImplementation: 'powershell.exe',

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { ExperimentalPane } from './ExperimentalPane'
+import { EXPERIMENTAL_SEARCH_ENTRY } from './experimental-search'
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { settingsSearchQuery: string }) => unknown) =>
+    selector({ settingsSearchQuery: '' })
+}))
+
+describe('ExperimentalPane', () => {
+  it('renders compact worktree cards as an off-by-default experimental switch', () => {
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane settings={getDefaultSettings('/tmp')} updateSettings={vi.fn()} />
+    )
+
+    expect(markup).toContain('Compact worktree cards')
+    expect(markup).toContain('aria-checked="false"')
+    expect(markup).toContain('Collapses a card only when its second line would be empty or repeat')
+    expect(markup).toContain('different branch')
+    expect(EXPERIMENTAL_SEARCH_ENTRY.compactWorktreeCards.keywords).toContain('metadata')
+  })
+})

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -27,6 +27,9 @@ export function ExperimentalPane({
   const showTerminalAttention = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.terminalAttention
   ])
+  const showCompactWorktreeCards = matchesSettingsSearch(searchQuery, [
+    EXPERIMENTAL_SEARCH_ENTRY.compactWorktreeCards
+  ])
   const showWorktreeSymlinks = matchesSettingsSearch(searchQuery, [
     EXPERIMENTAL_SEARCH_ENTRY.symlinks
   ])
@@ -142,6 +145,47 @@ export function ExperimentalPane({
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
                   settings.experimentalTerminalAttention ? 'translate-x-4' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+        </SearchableSetting>
+      ) : null}
+
+      {showCompactWorktreeCards ? (
+        <SearchableSetting
+          title="Compact worktree cards"
+          description="Hide redundant second lines in the worktree sidebar."
+          keywords={EXPERIMENTAL_SEARCH_ENTRY.compactWorktreeCards.keywords}
+          className="space-y-3 py-2"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 shrink space-y-0.5">
+              <Label>Compact worktree cards</Label>
+              <p className="text-xs text-muted-foreground">
+                Collapses a card only when its second line would be empty or repeat the title. Cards
+                with a different branch, repo badge, folder badge, cache timer, or conflict state
+                keep the second line.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={settings.experimentalCompactWorktreeCards}
+              onClick={() =>
+                updateSettings({
+                  experimentalCompactWorktreeCards: !settings.experimentalCompactWorktreeCards
+                })
+              }
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+                settings.experimentalCompactWorktreeCards
+                  ? 'bg-foreground'
+                  : 'bg-muted-foreground/30'
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
+                  settings.experimentalCompactWorktreeCards ? 'translate-x-4' : 'translate-x-0.5'
                 }`}
               />
             </button>

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -48,6 +48,22 @@ export const EXPERIMENTAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
     ]
   },
   {
+    title: 'Compact worktree cards',
+    description: 'Hide redundant second lines in the worktree sidebar.',
+    keywords: [
+      'experimental',
+      'worktree',
+      'worktrees',
+      'workspace',
+      'workspaces',
+      'compact',
+      'sidebar',
+      'cards',
+      'branch',
+      'metadata'
+    ]
+  },
+  {
     title: 'Symlinks on worktrees',
     description:
       'Automatically symlink configured files or folders into newly created worktrees so shared state (envs, caches, installs) stays connected.',
@@ -81,5 +97,6 @@ export const EXPERIMENTAL_SEARCH_ENTRY = {
   pet: findEntry('Pet'),
   activity: findEntry('Agents View'),
   terminalAttention: findEntry('Terminal attention'),
+  compactWorktreeCards: findEntry('Compact worktree cards'),
   symlinks: findEntry('Symlinks on worktrees')
 } as const

--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
+import type { GlobalSettings, Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
 import type WorktreeCardComponent from './WorktreeCard'
 
 const fetchHostedReviewForBranch = vi.fn()
@@ -13,6 +13,7 @@ let worktreeCardProperties: WorktreeCardProperty[] = ['status', 'unread']
 let tabsByWorktree: Record<string, { id: string }[]> = {}
 let ptyIdsByTabId: Record<string, string[]> = {}
 let browserTabsByWorktree: Record<string, { id: string }[]> = {}
+let settings: Partial<GlobalSettings> | null = null
 let WorktreeCard: typeof WorktreeCardComponent
 
 vi.mock('@/store', () => ({
@@ -26,7 +27,7 @@ vi.mock('@/store', () => ({
       issueCache: {},
       openModal,
       remoteBranchConflictByWorktreeId: {},
-      settings: null,
+      settings,
       sshConnectionStates: new Map(),
       sshTargetLabels: new Map(),
       browserTabsByWorktree,
@@ -115,6 +116,7 @@ describe('WorktreeCard quick actions', () => {
     tabsByWorktree = {}
     ptyIdsByTabId = {}
     browserTabsByWorktree = {}
+    settings = null
   })
 
   it('marks the unread toggle as a workspace-board-preserving action', () => {
@@ -126,7 +128,7 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('data-workspace-board-preserve-open=""')
   })
 
-  it('hides the branch row when it repeats the workspace title', () => {
+  it('keeps the branch row by default when it repeats the workspace title', () => {
     worktreeCardProperties = []
 
     const markup = renderToStaticMarkup(
@@ -138,13 +140,32 @@ describe('WorktreeCard quick actions', () => {
       />
     )
 
-    expect(markup).not.toContain('text-[11px] text-muted-foreground truncate leading-none')
+    expect(markup).toContain('quick-action')
+    expect(markup).toContain('text-[11px] text-muted-foreground truncate leading-none')
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('tabindex="0"')
+  })
+
+  it('hides the repeated branch row only when compact cards are enabled', () => {
+    worktreeCardProperties = []
+    settings = { experimentalCompactWorktreeCards: true }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ displayName: 'quick-action', branch: 'quick-action' })}
+        repo={makeRepo()}
+        isActive={false}
+        hideRepoBadge
+      />
+    )
+
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
     expect(markup).toContain('tabindex="0"')
   })
 
   it('keeps the branch row when the workspace has a custom title', () => {
     worktreeCardProperties = []
+    settings = { experimentalCompactWorktreeCards: true }
 
     const markup = renderToStaticMarkup(
       <WorktreeCard
@@ -159,6 +180,49 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('quick-action')
     expect(markup).toContain('data-worktree-card-meta-row=""')
     expect(markup).toContain('text-[11px] text-muted-foreground truncate leading-none')
+  })
+
+  it('uses the pre-compact unread lane and primary badge when compact cards are disabled', () => {
+    worktreeCardProperties = ['status', 'unread']
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({
+          displayName: 'main',
+          branch: 'main',
+          isMainWorktree: true
+        })}
+        repo={makeRepo()}
+        isActive={false}
+        hideRepoBadge
+      />
+    )
+
+    expect(markup).toContain('primary')
+    expect(markup).not.toContain('aria-label="Primary worktree"')
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+  })
+
+  it('moves unread and primary into the title row when compact cards are enabled', () => {
+    worktreeCardProperties = ['status', 'unread']
+    settings = { experimentalCompactWorktreeCards: true }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({
+          displayName: 'main',
+          branch: 'main',
+          isMainWorktree: true
+        })}
+        repo={makeRepo()}
+        isActive={false}
+        hideRepoBadge
+      />
+    )
+
+    expect(markup).toContain('aria-label="Primary worktree"')
+    expect(markup).not.toContain('>primary<')
+    expect(markup).not.toContain('data-worktree-card-meta-row=""')
   })
 
   it('shows delete as the top-right quick action for an inactive workspace', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -115,6 +115,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const fetchIssue = useAppStore((s) => s.fetchIssue)
   const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
+  const compactCards = settings?.experimentalCompactWorktreeCards === true
   const handleEditIssue = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -182,9 +183,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
 
   const branch = branchDisplayName(worktree.branch)
   const isFolder = repo ? isFolderRepo(repo) : false
-  // Why: the branch repeats the title for un-renamed worktrees, so it's hidden
-  // when they match — only show the branch sub-line when it adds information.
-  const showBranch = !isFolder && branch !== worktree.displayName
+  // Why: compact cards are experimental because mixed card heights can be
+  // surprising; the default keeps the explicit branch row visible.
+  const showBranch = !isFolder && (!compactCards || branch !== worktree.displayName)
   const hostedReviewCacheKey =
     repo && branch
       ? getHostedReviewCacheKey(repo.path, branch, settings, repo.id, repo.connectionId)
@@ -554,14 +555,85 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const hasPorts = showPorts && workspacePorts.length > 0
   const cacheStartedAt = usePromptCacheCountdownStartedAt(worktree.id)
   const cacheTtlMs = useAppStore((s) => s.settings?.promptCacheTtlMs ?? 0)
-  // Why: render the branch/badge sub-line only when it carries something, so an
-  // un-renamed single-line worktree collapses to one row instead of an empty band.
-  const hasMetaRow =
+  const hasMetadataBadge =
     (!!repo && !hideRepoBadge) ||
     isFolder ||
-    showBranch ||
-    (!!conflictOperation && conflictOperation !== 'unknown') ||
-    cacheStartedAt != null
+    (!!conflictOperation && conflictOperation !== 'unknown')
+  // Why: disabled mode intentionally restores the explicit metadata lane; only
+  // the experimental path removes the row when it would add no visible content.
+  const hasMetaRow = !compactCards || hasMetadataBadge || showBranch || cacheStartedAt != null
+  const showUnreadQuickAction = cardProps.includes('unread')
+  const showTitleRowUnread = compactCards && showUnreadQuickAction
+  const showLeftUnread = !compactCards && showUnreadQuickAction
+  const showTitleRowPrimary = compactCards && worktree.isMainWorktree && !isFolder
+  const showTitleRowDetails = compactCards && (hasDetails || hasPorts)
+  const showMetaRowDetails = !compactCards && (hasDetails || hasPorts)
+  const showHeaderActions =
+    showTitleRowUnread ||
+    showTitleRowPrimary ||
+    showTitleRowDetails ||
+    (showDeleteQuickAction && !isDeleting)
+
+  const unreadQuickAction = showUnreadQuickAction ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          data-workspace-board-preserve-open=""
+          onPointerDown={stopQuickActionPointerPropagation}
+          onClick={handleToggleUnreadQuick}
+          className={cn(
+            'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
+            'hover:bg-accent/80 active:scale-95',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+          )}
+          aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
+        >
+          {worktree.isUnread ? (
+            <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
+          ) : (
+            <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right" sideOffset={8}>
+        <span>{unreadTooltip}</span>
+      </TooltipContent>
+    </Tooltip>
+  ) : null
+
+  const detailsAndPorts =
+    hasDetails || hasPorts ? (
+      <WorktreeCardDetailsHover
+        issue={metaIssue}
+        linearIssue={metaLinearIssue}
+        review={metaReview}
+        comment={metaComment}
+        detailsAfter={hasPorts ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null}
+        onEditIssue={handleEditIssue}
+        onEditComment={handleEditComment}
+        onOpenGitHubIssueInOrca={
+          metaIssue && 'url' in metaIssue && metaIssue.url ? handleOpenGitHubIssueInOrca : undefined
+        }
+        onOpenLinearIssueInOrca={linearIssue?.url ? handleOpenLinearIssueInOrca : undefined}
+        onOpenReviewInOrca={
+          metaReview?.url && metaReview.provider === 'github' ? handleOpenReviewInOrca : undefined
+        }
+      >
+        <div className="flex shrink-0 items-center gap-1">
+          {hasPorts && <WorktreeCardPortsTrigger ports={workspacePorts} />}
+          {hasDetails && (
+            <WorktreeCardMetaBadges
+              issue={metaIssue}
+              linearIssue={metaLinearIssue}
+              review={metaReview}
+              comment={metaComment}
+              className="ml-0 pr-0"
+            />
+          )}
+        </div>
+      </WorktreeCardDetailsHover>
+    ) : null
 
   const cardBody = (
     <div
@@ -594,12 +666,17 @@ const WorktreeCard = React.memo(function WorktreeCard({
         </div>
       )}
 
-      {/* Why: keep this column to just the dot — stacking anything else here
-           (e.g. the unread toggle, which now lives in the title-row cluster)
-           sets a height floor that pads single-line cards. */}
-      {cardProps.includes('status') && (
+      {compactCards && cardProps.includes('status') ? (
         <WorktreeActivityStatusIndicator worktreeId={worktree.id} className="mt-[2px] shrink-0" />
-      )}
+      ) : cardProps.includes('status') || showLeftUnread ? (
+        <div className="flex flex-col items-center justify-start pt-[2px] gap-2 shrink-0">
+          {cardProps.includes('status') && (
+            <WorktreeActivityStatusIndicator worktreeId={worktree.id} />
+          )}
+
+          {showLeftUnread && unreadQuickAction}
+        </div>
+      ) : null}
 
       {/* Content area */}
       <div className="flex-1 min-w-0 flex flex-col gap-1.5">
@@ -638,6 +715,22 @@ const WorktreeCard = React.memo(function WorktreeCard({
               onRename={handleRenameTitle}
             />
 
+            {!compactCards && worktree.isMainWorktree && !isFolder && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 leading-none text-foreground/70 border-foreground/20 bg-foreground/[0.06]"
+                  >
+                    primary
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  Primary worktree (original clone directory)
+                </TooltipContent>
+              </Tooltip>
+            )}
+
             {worktree.isSparse && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -662,44 +755,11 @@ const WorktreeCard = React.memo(function WorktreeCard({
             )}
           </div>
 
-          {((worktree.isMainWorktree && !isFolder) ||
-            hasDetails ||
-            hasPorts ||
-            cardProps.includes('unread') ||
-            (showDeleteQuickAction && !isDeleting)) && (
+          {showHeaderActions && (
             <div className="ml-auto flex shrink-0 items-center justify-center gap-1 pr-1.5">
-              {/* Why: unread toggle leads the right cluster (left of the primary
-                   star and PR/ports indicators); the rest right-align on the title
-                   line so a single-line card stays one line and icons line up. */}
-              {cardProps.includes('unread') && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      data-workspace-board-preserve-open=""
-                      onPointerDown={stopQuickActionPointerPropagation}
-                      onClick={handleToggleUnreadQuick}
-                      className={cn(
-                        'group/unread flex size-4 cursor-pointer items-center justify-center rounded transition-all',
-                        'hover:bg-accent/80 active:scale-95',
-                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
-                      )}
-                      aria-label={worktree.isUnread ? 'Mark as read' : 'Mark as unread'}
-                    >
-                      {worktree.isUnread ? (
-                        <FilledBellIcon className="size-[13px] text-amber-500 drop-shadow-sm" />
-                      ) : (
-                        <Bell className="size-3 text-muted-foreground/40 opacity-0 group-hover:opacity-100 group-hover/unread:opacity-100 transition-opacity" />
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={8}>
-                    <span>{unreadTooltip}</span>
-                  </TooltipContent>
-                </Tooltip>
-              )}
+              {showTitleRowUnread && unreadQuickAction}
 
-              {worktree.isMainWorktree && !isFolder && (
+              {showTitleRowPrimary && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span
@@ -715,45 +775,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 </Tooltip>
               )}
 
-              {(hasDetails || hasPorts) && (
-                <WorktreeCardDetailsHover
-                  issue={metaIssue}
-                  linearIssue={metaLinearIssue}
-                  review={metaReview}
-                  comment={metaComment}
-                  detailsAfter={
-                    hasPorts ? <WorktreeCardPortsDetails ports={workspacePorts} /> : null
-                  }
-                  onEditIssue={handleEditIssue}
-                  onEditComment={handleEditComment}
-                  onOpenGitHubIssueInOrca={
-                    metaIssue && 'url' in metaIssue && metaIssue.url
-                      ? handleOpenGitHubIssueInOrca
-                      : undefined
-                  }
-                  onOpenLinearIssueInOrca={
-                    linearIssue?.url ? handleOpenLinearIssueInOrca : undefined
-                  }
-                  onOpenReviewInOrca={
-                    metaReview?.url && metaReview.provider === 'github'
-                      ? handleOpenReviewInOrca
-                      : undefined
-                  }
-                >
-                  <div className="flex shrink-0 items-center gap-1">
-                    {hasPorts && <WorktreeCardPortsTrigger ports={workspacePorts} />}
-                    {hasDetails && (
-                      <WorktreeCardMetaBadges
-                        issue={metaIssue}
-                        linearIssue={metaLinearIssue}
-                        review={metaReview}
-                        comment={metaComment}
-                        className="ml-0 pr-0"
-                      />
-                    )}
-                  </div>
-                </WorktreeCardDetailsHover>
-              )}
+              {showTitleRowDetails && detailsAndPorts}
 
               {showDeleteQuickAction && !isDeleting && (
                 <Tooltip>
@@ -782,9 +804,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
           )}
         </div>
 
-        {/* Why: the branch/badge sub-line only renders when it carries something,
-             so an un-renamed single-line worktree collapses to one row instead of
-             leaving an empty band. The PR/ports indicators now live on the title row. */}
         {hasMetaRow && (
           <div className="flex items-center gap-1.5 min-w-0" data-worktree-card-meta-row="">
             <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
@@ -828,6 +847,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 <CacheTimer startedAt={cacheStartedAt} ttlMs={cacheTtlMs} />
               )}
             </div>
+
+            {showMetaRowDetails && (
+              <div className="ml-auto flex shrink-0 items-center gap-1 pr-1.5">
+                {detailsAndPorts}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -31,6 +31,10 @@ describe('getDefaultSettings', () => {
       }
     })
   })
+
+  it('keeps compact worktree cards experimental and disabled by default', () => {
+    expect(getDefaultSettings('/tmp').experimentalCompactWorktreeCards).toBe(false)
+  })
 })
 
 describe('getDefaultPrimarySelectionMiddleClickPaste', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -275,6 +275,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     experimentalActivity: false,
     experimentalActivityDefaultedOffForAllUsers: true,
     experimentalTerminalAttention: false,
+    experimentalCompactWorktreeCards: false,
     experimentalWorktreeSymlinks: false,
     // Why: local desktop remains the default server until the user explicitly
     // selects a saved runtime environment.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1910,6 +1910,9 @@ export type GlobalSettings = {
    *  and agent-completion events. Opt-in while the signal/noise balance is
    *  being tested. */
   experimentalTerminalAttention: boolean
+  /** Experimental: compact worktree cards by hiding a redundant metadata row
+   *  when the title and branch already say the same thing. */
+  experimentalCompactWorktreeCards: boolean
   /** Experimental: when creating a worktree, automatically symlink a
    *  user-configured set of files/folders from the primary checkout (e.g.
    *  `.env`, `node_modules`) into the new worktree. Opt-in while the


### PR DESCRIPTION
## Summary
- Adds a default-off Experimental setting for compact worktree cards.
- Restores the pre-compact two-line card layout when the setting is disabled.
- Keeps the PR #2843 compact layout available when the setting is enabled.
- Adds focused tests for the setting default, Experimental pane copy, and enabled/disabled card layout behavior.

Design doc: docs/experimental-compact-worktree-cards.md

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/shared/constants.test.ts src/renderer/src/components/settings/ExperimentalPane.test.tsx src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/service.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check
- Electron validation passed with a temporary dev profile and injected demo worktrees:
  - Experimental toggle off
  - Sidebar compact disabled: all demo cards keep metadata rows
  - Sidebar compact enabled: redundant rows collapse, prefixed/custom-title cards keep metadata rows

Local validation screenshots are in validation-screenshots/ and are intentionally uncommitted.

Made with [Orca](https://github.com/stablyai/orca) 🐋
