### PR TITLE
Implement background update downloads

### DIFF
--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -50,6 +50,17 @@ type UpdaterHandlerContext = {
   setUserInitiatedCheck: (value: boolean) => void
 }
 
+function getActionableUpdateUserInitiated(status: UpdateStatus): boolean | undefined {
+  if (
+    status.state === 'available' ||
+    status.state === 'downloading' ||
+    status.state === 'downloaded'
+  ) {
+    return status.userInitiated || undefined
+  }
+  return undefined
+}
+
 export function registerAutoUpdaterHandlers({
   autoUpdater,
   clearBackgroundCheckLaunchPending,
@@ -91,7 +102,8 @@ export function registerAutoUpdaterHandlers({
         sendStatus({
           state: 'downloaded',
           version: getPendingInstallVersion(),
-          releaseUrl: getKnownReleaseUrl()
+          releaseUrl: getKnownReleaseUrl(),
+          ...(getActionableUpdateUserInitiated(getCurrentStatus()) ? { userInitiated: true } : {})
         })
       })
     })
@@ -215,7 +227,12 @@ export function registerAutoUpdaterHandlers({
         }
       }
 
-      sendStatus({ state: 'available', version: info.version, changelog })
+      sendStatus({
+        state: 'available',
+        version: info.version,
+        ...(wasUserInitiated ? { userInitiated: true } : {}),
+        changelog
+      })
       startAvailableUpdateDownload()
     })()
   })
@@ -256,10 +273,12 @@ export function registerAutoUpdaterHandlers({
 
   autoUpdater.on('download-progress', (progress) => {
     clearBackgroundCheckLaunchPending()
+    const userInitiated = getActionableUpdateUserInitiated(getCurrentStatus())
     sendStatus({
       state: 'downloading',
       percent: Math.round(progress.percent),
-      version: getPendingInstallVersion()
+      version: getPendingInstallVersion(),
+      ...(userInitiated ? { userInitiated: true } : {})
     })
   })
 
@@ -281,10 +300,20 @@ export function registerAutoUpdaterHandlers({
     if (process.platform === 'darwin' && !isMacInstallerReady()) {
       // Squirrel is still processing. Keep the UI at 100% downloaded so the
       // user sees the handoff instead of a misleading "ready to install".
-      sendStatus({ state: 'downloading', percent: 100, version: info.version })
+      sendStatus({
+        state: 'downloading',
+        percent: 100,
+        version: info.version,
+        ...(getActionableUpdateUserInitiated(getCurrentStatus()) ? { userInitiated: true } : {})
+      })
       return
     }
-    sendStatus({ state: 'downloaded', version: info.version, releaseUrl: getKnownReleaseUrl() })
+    sendStatus({
+      state: 'downloaded',
+      version: info.version,
+      releaseUrl: getKnownReleaseUrl(),
+      ...(getActionableUpdateUserInitiated(getCurrentStatus()) ? { userInitiated: true } : {})
+    })
   })
 
   autoUpdater.on('error', (err) => {
@@ -298,7 +327,9 @@ export function registerAutoUpdaterHandlers({
     resetMacInstallState()
     suppressMissingManifestPrereleaseFallbackPromiseFailure(message)
     const missingManifestFallback = consumeMissingManifestPrereleaseFallbackResult()
-    const wasUserInitiated = missingManifestFallback?.userInitiated ?? getUserInitiatedCheck()
+    const wasUserInitiated =
+      (missingManifestFallback?.userInitiated ?? getUserInitiatedCheck()) ||
+      getActionableUpdateUserInitiated(getCurrentStatus())
     setUserInitiatedCheck(false)
     if (getCurrentStatus().state === 'checking') {
       void sendCheckFailureStatus(message, wasUserInitiated || undefined, 'event', err)

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -18,9 +18,11 @@ const AUTO_UPDATE_RETRY_INTERVAL_MS = 60 * 60 * 1000
 type UpdaterHandlerContext = {
   autoUpdater: ElectronAutoUpdater
   clearBackgroundCheckLaunchPending: () => void
+  clearActiveUpdateDownload: (version?: string) => void
   clearAvailableUpdateContext: () => void
   clearStagedUpdateContext: () => void
   consumeMissingManifestPrereleaseFallbackResult: () => { userInitiated: boolean } | null
+  getActiveDownloadVersion: () => string | null
   getPublishingWindowLastGoodCheck: () => { lastGoodTag: string } | null
   getMissingManifestPrereleaseFallbackUserInitiated: () => boolean | null
   getCurrentStatus: () => UpdateStatus
@@ -43,6 +45,7 @@ type UpdaterHandlerContext = {
   sendStatus: (status: UpdateStatus) => void
   scheduleAutomaticUpdateCheck: (delayMs: number) => void
   startAvailableUpdateDownload: () => void
+  shouldAcceptDownloadedUpdate: (version: string) => boolean
   shouldSuppressMissingManifestPrereleaseFallbackEvent: (message: string, error: unknown) => boolean
   suppressMissingManifestPrereleaseFallbackPromiseFailure: (message: string) => void
   setAvailableReleaseUrl: (releaseUrl: string | null) => void
@@ -64,9 +67,11 @@ function getActionableUpdateUserInitiated(status: UpdateStatus): boolean | undef
 export function registerAutoUpdaterHandlers({
   autoUpdater,
   clearBackgroundCheckLaunchPending,
+  clearActiveUpdateDownload,
   clearAvailableUpdateContext,
   clearStagedUpdateContext,
   consumeMissingManifestPrereleaseFallbackResult,
+  getActiveDownloadVersion,
   getPublishingWindowLastGoodCheck,
   getMissingManifestPrereleaseFallbackUserInitiated,
   getCurrentStatus,
@@ -84,6 +89,7 @@ export function registerAutoUpdaterHandlers({
   sendStatus,
   scheduleAutomaticUpdateCheck,
   startAvailableUpdateDownload,
+  shouldAcceptDownloadedUpdate,
   shouldSuppressMissingManifestPrereleaseFallbackEvent,
   suppressMissingManifestPrereleaseFallbackPromiseFailure,
   setAvailableReleaseUrl,
@@ -96,7 +102,10 @@ export function registerAutoUpdaterHandlers({
   // Track Squirrel readiness so we don't show "ready to install" prematurely.
   if (process.platform === 'darwin') {
     nativeUpdater.on('update-downloaded', () => {
-      handleMacInstallerReady(hasNewerDownloadedVersion(), performQuitAndInstall, () => {
+      if (!hasNewerDownloadedVersion()) {
+        return
+      }
+      handleMacInstallerReady(true, performQuitAndInstall, () => {
         // If we were holding the 'downloaded' status, send it now — but only
         // when the staged version is actually newer than what's running.
         sendStatus({
@@ -188,10 +197,6 @@ export function registerAutoUpdaterHandlers({
       return
     }
 
-    // A newer feed result supersedes the staged installer; don't keep offering
-    // restart for an update we now know is stale.
-    clearStagedUpdateContext()
-
     // Why: fetching changelog in the main process avoids CORS issues that
     // would block a renderer-side fetch to onorca.dev, and ensures the
     // card can render immediately without an async loading gap.
@@ -277,23 +282,28 @@ export function registerAutoUpdaterHandlers({
     sendStatus({
       state: 'downloading',
       percent: Math.round(progress.percent),
-      version: getPendingInstallVersion(),
+      version: getActiveDownloadVersion() ?? getPendingInstallVersion(),
       ...(userInitiated ? { userInitiated: true } : {})
     })
   })
 
   autoUpdater.on('update-downloaded', (info) => {
     clearBackgroundCheckLaunchPending()
+    if (!shouldAcceptDownloadedUpdate(info.version)) {
+      return
+    }
     // Don't show the banner if the downloaded version isn't actually newer
     // than what's running. This catches the exact-same-version case as well
     // as stale cached updates from an older release.
     if (compareVersions(info.version, app.getVersion()) <= 0) {
       clearAvailableUpdateContext()
       clearStagedUpdateContext()
+      clearActiveUpdateDownload(info.version)
       sendStatus({ state: 'not-available' })
       return
     }
     markStagedUpdate(info.version, getKnownReleaseUrl())
+    clearActiveUpdateDownload(info.version)
     // On macOS, defer the 'downloaded' status until Squirrel.Mac has finished
     // processing the update via the localhost proxy. On other platforms,
     // the update is ready immediately after electron-updater downloads it.
@@ -323,7 +333,11 @@ export function registerAutoUpdaterHandlers({
     if (shouldSuppressMissingManifestPrereleaseFallbackEvent(message, err)) {
       return
     }
+    const statusAtError = getCurrentStatus()
     clearBackgroundCheckLaunchPending()
+    if (statusAtError.state !== 'checking') {
+      clearActiveUpdateDownload()
+    }
     resetMacInstallState()
     suppressMissingManifestPrereleaseFallbackPromiseFailure(message)
     const missingManifestFallback = consumeMissingManifestPrereleaseFallbackResult()
@@ -331,7 +345,7 @@ export function registerAutoUpdaterHandlers({
       (missingManifestFallback?.userInitiated ?? getUserInitiatedCheck()) ||
       getActionableUpdateUserInitiated(getCurrentStatus())
     setUserInitiatedCheck(false)
-    if (getCurrentStatus().state === 'checking') {
+    if (statusAtError.state === 'checking') {
       void sendCheckFailureStatus(message, wasUserInitiated || undefined, 'event', err)
       return
     }

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -19,15 +19,18 @@ type UpdaterHandlerContext = {
   autoUpdater: ElectronAutoUpdater
   clearBackgroundCheckLaunchPending: () => void
   clearAvailableUpdateContext: () => void
+  clearStagedUpdateContext: () => void
   consumeMissingManifestPrereleaseFallbackResult: () => { userInitiated: boolean } | null
   getPublishingWindowLastGoodCheck: () => { lastGoodTag: string } | null
   getMissingManifestPrereleaseFallbackUserInitiated: () => boolean | null
   getCurrentStatus: () => UpdateStatus
   getKnownReleaseUrl: () => string | undefined
   getPendingInstallVersion: () => string
+  getStagedUpdateVersion: () => string | null
   getUserInitiatedCheck: () => boolean
   hasNewerDownloadedVersion: () => boolean
   markMissingManifestPrereleaseFallbackChecking: () => void
+  markStagedUpdate: (version: string, releaseUrl?: string) => void
   performQuitAndInstall: () => void
   recordCompletedUpdateCheck: () => void
   sendCheckFailureStatus: (
@@ -39,6 +42,7 @@ type UpdaterHandlerContext = {
   sendErrorStatus: (message: string, userInitiated?: boolean) => void
   sendStatus: (status: UpdateStatus) => void
   scheduleAutomaticUpdateCheck: (delayMs: number) => void
+  startAvailableUpdateDownload: () => void
   shouldSuppressMissingManifestPrereleaseFallbackEvent: (message: string, error: unknown) => boolean
   suppressMissingManifestPrereleaseFallbackPromiseFailure: (message: string) => void
   setAvailableReleaseUrl: (releaseUrl: string | null) => void
@@ -50,21 +54,25 @@ export function registerAutoUpdaterHandlers({
   autoUpdater,
   clearBackgroundCheckLaunchPending,
   clearAvailableUpdateContext,
+  clearStagedUpdateContext,
   consumeMissingManifestPrereleaseFallbackResult,
   getPublishingWindowLastGoodCheck,
   getMissingManifestPrereleaseFallbackUserInitiated,
   getCurrentStatus,
   getKnownReleaseUrl,
   getPendingInstallVersion,
+  getStagedUpdateVersion,
   getUserInitiatedCheck,
   hasNewerDownloadedVersion,
   markMissingManifestPrereleaseFallbackChecking,
+  markStagedUpdate,
   performQuitAndInstall,
   recordCompletedUpdateCheck,
   sendCheckFailureStatus,
   sendErrorStatus,
   sendStatus,
   scheduleAutomaticUpdateCheck,
+  startAvailableUpdateDownload,
   shouldSuppressMissingManifestPrereleaseFallbackEvent,
   suppressMissingManifestPrereleaseFallbackPromiseFailure,
   setAvailableReleaseUrl,
@@ -146,6 +154,32 @@ export function registerAutoUpdaterHandlers({
       return
     }
 
+    const stagedVersion = getStagedUpdateVersion()
+    if (stagedVersion && compareVersions(info.version, stagedVersion) <= 0) {
+      // Why: a freshness check should offer an already-staged update only when
+      // the feed does not point at a newer version.
+      clearAvailableUpdateContext()
+      if (missingManifestFallback || publishingWindowLastGoodCheck) {
+        scheduleAutomaticUpdateCheck(AUTO_UPDATE_RETRY_INTERVAL_MS)
+      } else {
+        recordCompletedUpdateCheck()
+        if (!wasUserInitiated) {
+          scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
+        }
+      }
+      sendStatus({
+        state: 'downloaded',
+        version: stagedVersion,
+        releaseUrl: getKnownReleaseUrl(),
+        userInitiated: wasUserInitiated || undefined
+      })
+      return
+    }
+
+    // A newer feed result supersedes the staged installer; don't keep offering
+    // restart for an update we now know is stale.
+    clearStagedUpdateContext()
+
     // Why: fetching changelog in the main process avoids CORS issues that
     // would block a renderer-side fetch to onorca.dev, and ensures the
     // card can render immediately without an async loading gap.
@@ -182,6 +216,7 @@ export function registerAutoUpdaterHandlers({
       }
 
       sendStatus({ state: 'available', version: info.version, changelog })
+      startAvailableUpdateDownload()
     })()
   })
 
@@ -204,6 +239,18 @@ export function registerAutoUpdaterHandlers({
         scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
       }
     }
+    const stagedVersion = getStagedUpdateVersion()
+    if (stagedVersion && compareVersions(stagedVersion, app.getVersion()) > 0) {
+      // Why: "not available" means no newer feed result, not that a previously
+      // staged update disappeared. Keep the restart action available.
+      sendStatus({
+        state: 'downloaded',
+        version: stagedVersion,
+        releaseUrl: getKnownReleaseUrl(),
+        userInitiated: wasUserInitiated || undefined
+      })
+      return
+    }
     sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
   })
 
@@ -223,9 +270,11 @@ export function registerAutoUpdaterHandlers({
     // as stale cached updates from an older release.
     if (compareVersions(info.version, app.getVersion()) <= 0) {
       clearAvailableUpdateContext()
+      clearStagedUpdateContext()
       sendStatus({ state: 'not-available' })
       return
     }
+    markStagedUpdate(info.version, getKnownReleaseUrl())
     // On macOS, defer the 'downloaded' status until Squirrel.Mac has finished
     // processing the update via the localhost proxy. On other platforms,
     // the update is ready immediately after electron-updater downloads it.

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { app, autoUpdater as nativeUpdater } from 'electron'
 import type { UpdateStatus } from '../shared/types'
 import {
@@ -44,6 +45,7 @@ type UpdaterHandlerContext = {
   sendErrorStatus: (message: string, userInitiated?: boolean) => void
   sendStatus: (status: UpdateStatus) => void
   scheduleAutomaticUpdateCheck: (delayMs: number) => void
+  startPendingReplacementDownload: () => boolean
   startAvailableUpdateDownload: () => void
   shouldAcceptDownloadedUpdate: (version: string) => boolean
   shouldSuppressMissingManifestPrereleaseFallbackEvent: (message: string, error: unknown) => boolean
@@ -63,6 +65,24 @@ function getActionableUpdateUserInitiated(status: UpdateStatus): boolean | undef
     return status.userInitiated || undefined
   }
   return undefined
+}
+
+function shouldShowDownloadedForStagedUpdate(): boolean {
+  return process.platform !== 'darwin' || isMacInstallerReady()
+}
+
+function shouldApplyAvailableResultAfterChangelog(status: UpdateStatus, version: string): boolean {
+  if (status.state === 'checking' || status.state === 'idle') {
+    return true
+  }
+  if (
+    status.state === 'available' ||
+    status.state === 'downloading' ||
+    status.state === 'downloaded'
+  ) {
+    return compareVersions(status.version, version) < 0
+  }
+  return false
 }
 
 export function registerAutoUpdaterHandlers({
@@ -89,6 +109,7 @@ export function registerAutoUpdaterHandlers({
   sendErrorStatus,
   sendStatus,
   scheduleAutomaticUpdateCheck,
+  startPendingReplacementDownload,
   startAvailableUpdateDownload,
   shouldAcceptDownloadedUpdate,
   shouldSuppressMissingManifestPrereleaseFallbackEvent,
@@ -98,6 +119,26 @@ export function registerAutoUpdaterHandlers({
   setUserInitiatedCheck
 }: UpdaterHandlerContext): void {
   let macNativeReadinessPendingVersion: string | null = null
+
+  const sendStagedUpdateStatus = (version: string, userInitiated: boolean): void => {
+    if (!shouldShowDownloadedForStagedUpdate()) {
+      // Why: on macOS the electron-updater artifact can be staged before ShipIt
+      // has finished pulling it from the localhost proxy.
+      sendStatus({
+        state: 'downloading',
+        percent: 100,
+        version,
+        ...(userInitiated ? { userInitiated: true } : {})
+      })
+      return
+    }
+    sendStatus({
+      state: 'downloaded',
+      version,
+      releaseUrl: getKnownReleaseUrl(),
+      ...(userInitiated ? { userInitiated: true } : {})
+    })
+  }
 
   // On macOS, electron-updater's MacUpdater downloads the ZIP from GitHub,
   // then serves it to Squirrel.Mac via a localhost proxy. The electron-updater
@@ -197,12 +238,7 @@ export function registerAutoUpdaterHandlers({
           scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
         }
       }
-      sendStatus({
-        state: 'downloaded',
-        version: stagedVersion,
-        releaseUrl: getKnownReleaseUrl(),
-        userInitiated: wasUserInitiated || undefined
-      })
+      sendStagedUpdateStatus(stagedVersion, wasUserInitiated)
       return
     }
 
@@ -217,7 +253,7 @@ export function registerAutoUpdaterHandlers({
       // currentStatus during that window, broadcasting 'available' here would
       // overwrite a more recent status. Guard against this by checking that the
       // state hasn't advanced past the point where 'available' makes sense.
-      if (getCurrentStatus().state !== 'checking' && getCurrentStatus().state !== 'idle') {
+      if (!shouldApplyAvailableResultAfterChangelog(getCurrentStatus(), info.version)) {
         return
       }
 
@@ -279,12 +315,7 @@ export function registerAutoUpdaterHandlers({
     if (stagedVersion && compareVersions(stagedVersion, app.getVersion()) > 0) {
       // Why: "not available" means no newer feed result, not that a previously
       // staged update disappeared. Keep the restart action available.
-      sendStatus({
-        state: 'downloaded',
-        version: stagedVersion,
-        releaseUrl: getKnownReleaseUrl(),
-        userInitiated: wasUserInitiated || undefined
-      })
+      sendStagedUpdateStatus(stagedVersion, wasUserInitiated)
       return
     }
     sendStatus({ state: 'not-available', userInitiated: wasUserInitiated || undefined })
@@ -304,6 +335,8 @@ export function registerAutoUpdaterHandlers({
   autoUpdater.on('update-downloaded', (info) => {
     clearBackgroundCheckLaunchPending()
     if (!shouldAcceptDownloadedUpdate(info.version)) {
+      clearActiveUpdateDownload(info.version)
+      startPendingReplacementDownload()
       return
     }
     // Don't show the banner if the downloaded version isn't actually newer
@@ -349,8 +382,11 @@ export function registerAutoUpdaterHandlers({
       return
     }
     const statusAtError = getCurrentStatus()
+    const activeDownloadVersionAtError = getActiveDownloadVersion()
     clearBackgroundCheckLaunchPending()
-    if (statusAtError.state !== 'checking') {
+    if (activeDownloadVersionAtError) {
+      clearActiveUpdateDownload(activeDownloadVersionAtError)
+    } else if (statusAtError.state !== 'checking') {
       clearActiveUpdateDownload()
     }
     resetMacInstallState()
@@ -360,8 +396,11 @@ export function registerAutoUpdaterHandlers({
       (missingManifestFallback?.userInitiated ?? getUserInitiatedCheck()) ||
       getActionableUpdateUserInitiated(getCurrentStatus())
     setUserInitiatedCheck(false)
-    if (statusAtError.state === 'checking') {
+    if (statusAtError.state === 'checking' && !activeDownloadVersionAtError) {
       void sendCheckFailureStatus(message, wasUserInitiated || undefined, 'event', err)
+      return
+    }
+    if (startPendingReplacementDownload()) {
       return
     }
     sendErrorStatus(message, wasUserInitiated || undefined)

--- a/src/main/updater-events.ts
+++ b/src/main/updater-events.ts
@@ -55,6 +55,7 @@ type UpdaterHandlerContext = {
 
 function getActionableUpdateUserInitiated(status: UpdateStatus): boolean | undefined {
   if (
+    status.state === 'checking' ||
     status.state === 'available' ||
     status.state === 'downloading' ||
     status.state === 'downloaded'
@@ -96,16 +97,23 @@ export function registerAutoUpdaterHandlers({
   setAvailableVersion,
   setUserInitiatedCheck
 }: UpdaterHandlerContext): void {
+  let macNativeReadinessPendingVersion: string | null = null
+
   // On macOS, electron-updater's MacUpdater downloads the ZIP from GitHub,
   // then serves it to Squirrel.Mac via a localhost proxy. The electron-updater
   // 'update-downloaded' event fires BEFORE Squirrel finishes its download.
   // Track Squirrel readiness so we don't show "ready to install" prematurely.
   if (process.platform === 'darwin') {
     nativeUpdater.on('update-downloaded', () => {
-      if (!hasNewerDownloadedVersion()) {
+      const readyVersion = macNativeReadinessPendingVersion
+      macNativeReadinessPendingVersion = null
+
+      if (!readyVersion && !hasNewerDownloadedVersion()) {
         return
       }
-      handleMacInstallerReady(true, performQuitAndInstall, () => {
+      const shouldUseNativeReadiness =
+        !readyVersion || (getStagedUpdateVersion() === readyVersion && hasNewerDownloadedVersion())
+      handleMacInstallerReady(shouldUseNativeReadiness, performQuitAndInstall, () => {
         // If we were holding the 'downloaded' status, send it now — but only
         // when the staged version is actually newer than what's running.
         sendStatus({
@@ -115,6 +123,7 @@ export function registerAutoUpdaterHandlers({
           ...(getActionableUpdateUserInitiated(getCurrentStatus()) ? { userInitiated: true } : {})
         })
       })
+      startAvailableUpdateDownload()
     })
   }
 
@@ -238,6 +247,11 @@ export function registerAutoUpdaterHandlers({
         ...(wasUserInitiated ? { userInitiated: true } : {}),
         changelog
       })
+      if (process.platform === 'darwin' && macNativeReadinessPendingVersion) {
+        // Why: Squirrel.Mac's native ready event has no version payload. Wait
+        // for the prior handoff before starting a replacement download.
+        return
+      }
       startAvailableUpdateDownload()
     })()
   })
@@ -308,6 +322,7 @@ export function registerAutoUpdaterHandlers({
     // processing the update via the localhost proxy. On other platforms,
     // the update is ready immediately after electron-updater downloads it.
     if (process.platform === 'darwin' && !isMacInstallerReady()) {
+      macNativeReadinessPendingVersion = info.version
       // Squirrel is still processing. Keep the UI at 100% downloaded so the
       // user sees the handoff instead of a misleading "ready to install".
       sendStatus({

--- a/src/main/updater-fallback.ts
+++ b/src/main/updater-fallback.ts
@@ -14,6 +14,7 @@ export function statusesEqual(left: UpdateStatus, right: UpdateStatus): boolean 
         left.version === right.version &&
         left.activeNudgeId === right.activeNudgeId &&
         left.releaseUrl === right.releaseUrl &&
+        left.userInitiated === right.userInitiated &&
         // Why: fetchChangelog creates a fresh object each time, so reference
         // equality is always false. Compare by presence — since update-available
         // fires at most once per check cycle, this is sufficient.
@@ -24,6 +25,7 @@ export function statusesEqual(left: UpdateStatus, right: UpdateStatus): boolean 
         right.state === 'downloading' &&
         left.version === right.version &&
         left.activeNudgeId === right.activeNudgeId &&
+        left.userInitiated === right.userInitiated &&
         left.percent === right.percent
       )
     case 'downloaded':
@@ -31,7 +33,8 @@ export function statusesEqual(left: UpdateStatus, right: UpdateStatus): boolean 
         right.state === 'downloaded' &&
         left.version === right.version &&
         left.activeNudgeId === right.activeNudgeId &&
-        left.releaseUrl === right.releaseUrl
+        left.releaseUrl === right.releaseUrl &&
+        left.userInitiated === right.userInitiated
       )
     case 'error':
       return (

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -31,7 +31,7 @@ const { appMock, browserWindowMock, nativeUpdaterMock, autoUpdaterMock, isMock, 
       eventHandlers.clear()
       on.mockClear()
       autoUpdaterMock.checkForUpdates.mockReset()
-      autoUpdaterMock.downloadUpdate.mockReset()
+      autoUpdaterMock.downloadUpdate.mockReset().mockResolvedValue([])
       autoUpdaterMock.quitAndInstall.mockReset()
       autoUpdaterMock.setFeedURL.mockClear()
     }

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -207,4 +207,56 @@ describe('updater mac install handoff', () => {
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
     }
   )
+
+  it('does not let stale native macOS readiness mark a replacement update ready', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    expect(nativeDownloadedHandler).toBeTypeOf('function')
+
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    sendMock.mockClear()
+
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.62' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    nativeDownloadedHandler?.()
+
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded' })
+    )
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.62' })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 100,
+      version: '1.0.62'
+    })
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded', version: '1.0.62' })
+    )
+
+    nativeDownloadedHandler?.()
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloaded',
+      version: '1.0.62',
+      releaseUrl: undefined
+    })
+  })
 })

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -44,7 +44,7 @@ const {
     eventHandlers.clear()
     on.mockClear()
     autoUpdaterMock.checkForUpdates.mockReset()
-    autoUpdaterMock.downloadUpdate.mockReset()
+    autoUpdaterMock.downloadUpdate.mockReset().mockResolvedValue([])
     autoUpdaterMock.quitAndInstall.mockReset()
   }
 

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -208,6 +208,64 @@ describe('updater mac install handoff', () => {
     }
   )
 
+  it('keeps staged mac updates pending through same-version fast paths until native readiness', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    const nativeDownloadedHandler = nativeUpdaterMock.on.mock.calls.find(
+      ([eventName]) => eventName === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    expect(nativeDownloadedHandler).toBeTypeOf('function')
+
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    sendMock.mockClear()
+    autoUpdaterMock.emit('checking-for-update')
+    sendMock.mockClear()
+    autoUpdaterMock.emit('update-not-available')
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 100,
+      version: '1.0.61'
+    })
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded' })
+    )
+
+    sendMock.mockClear()
+    autoUpdaterMock.emit('checking-for-update')
+    sendMock.mockClear()
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 100,
+      version: '1.0.61'
+    })
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded' })
+    )
+
+    nativeDownloadedHandler?.()
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloaded',
+      version: '1.0.61',
+      releaseUrl: undefined
+    })
+  })
+
   it('does not let stale native macOS readiness mark a replacement update ready', async () => {
     vi.stubGlobal('process', { ...process, platform: 'darwin' })
     autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -210,6 +210,7 @@ describe('updater mac install handoff', () => {
 
   it('does not let stale native macOS readiness mark a replacement update ready', async () => {
     vi.stubGlobal('process', { ...process, platform: 'darwin' })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
@@ -228,9 +229,13 @@ describe('updater mac install handoff', () => {
     autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
     sendMock.mockClear()
 
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+
     autoUpdaterMock.emit('checking-for-update')
     autoUpdaterMock.emit('update-available', { version: '1.0.62' })
     await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
 
     nativeDownloadedHandler?.()
 
@@ -238,6 +243,7 @@ describe('updater mac install handoff', () => {
       'updater:status',
       expect.objectContaining({ state: 'downloaded' })
     )
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(2)
 
     autoUpdaterMock.emit('update-downloaded', { version: '1.0.62' })
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -786,6 +786,50 @@ describe('updater', () => {
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
   })
 
+  it('preserves user initiation while a manual check auto-downloads', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, getUpdateStatus } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.61',
+        userInitiated: true,
+        changelog: null
+      })
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 42 })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 42,
+      version: '1.0.61',
+      userInitiated: true
+    })
+    expect(getUpdateStatus()).toEqual({
+      state: 'downloading',
+      percent: 42,
+      version: '1.0.61',
+      userInitiated: true
+    })
+  })
+
   it('surfaces automatic download failures against the cached update version', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')
@@ -901,6 +945,7 @@ describe('updater', () => {
       expect(sendMock).toHaveBeenCalledWith('updater:status', {
         state: 'available',
         version: '1.0.62',
+        userInitiated: true,
         changelog: null
       })
       expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
@@ -958,6 +1003,7 @@ describe('updater', () => {
     expect(sendMock).toHaveBeenCalledWith('updater:status', {
       state: 'available',
       version: '1.0.62',
+      userInitiated: true,
       changelog: null
     })
     expect(sendMock).not.toHaveBeenCalledWith(
@@ -1399,6 +1445,7 @@ describe('updater', () => {
       expect(sendMock).toHaveBeenCalledWith('updater:status', {
         state: 'available',
         version: '1.4.26',
+        userInitiated: true,
         changelog: null
       })
     })
@@ -1680,6 +1727,90 @@ describe('updater', () => {
       dismissNudge()
     }
 
+    expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
+    expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)
+    expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
+    expect(pendingNudgeId).toBe('campaign-1')
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000)
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+    autoUpdaterMock.emit('update-available', { version: '1.4.27' })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'available',
+      version: '1.4.27',
+      changelog: null,
+      activeNudgeId: 'campaign-1'
+    })
+  })
+
+  it('does not attach nudge dismissal to an already-staged last-good update', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    vi.setSystemTime(new Date('2026-05-24T21:40:00Z'))
+    appMock.getVersion.mockReturnValue('1.4.25')
+    let resolveNudge: ((nudge: { id: string; minVersion: string }) => void) | null = null
+    fetchNudgeMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveNudge = resolve
+      })
+    )
+    fetchNudgeMock.mockResolvedValue(null)
+    shouldApplyNudgeMock.mockReturnValue(true)
+    fetchNewerReleaseTagsMock
+      .mockResolvedValueOnce({
+        tags: [],
+        state: 'not-ready',
+        lastGoodTag: 'v1.4.26'
+      })
+      .mockResolvedValueOnce(['v1.4.27'])
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      if (autoUpdaterMock.checkForUpdates.mock.calls.length === 1) {
+        queueMicrotask(() => {
+          autoUpdaterMock.emit('update-available', { version: '1.4.26' })
+        })
+      }
+      return Promise.resolve(undefined)
+    })
+    let pendingNudgeId: string | null = null
+    const setPendingUpdateNudgeId = vi.fn((id: string | null) => {
+      pendingNudgeId = id
+    })
+    const setDismissedUpdateNudgeId = vi.fn()
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      getPendingUpdateNudgeId: () => pendingNudgeId,
+      getDismissedUpdateNudgeId: () => null,
+      setPendingUpdateNudgeId,
+      setDismissedUpdateNudgeId
+    })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.4.26' })
+    sendMock.mockClear()
+
+    resolveNudge?.({ id: 'campaign-1', minVersion: '1.0.0' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const lastGoodStatuses = sendMock.mock.calls
+      .filter(([channel]) => channel === 'updater:status')
+      .map(([, status]) => status)
+      .filter((status) => status.state === 'downloaded' && status.version === '1.4.26')
+    expect(lastGoodStatuses).not.toContainEqual(
+      expect.objectContaining({ activeNudgeId: 'campaign-1' })
+    )
     expect(setPendingUpdateNudgeId).toHaveBeenCalledWith('campaign-1')
     expect(setPendingUpdateNudgeId).not.toHaveBeenCalledWith(null)
     expect(setDismissedUpdateNudgeId).not.toHaveBeenCalled()
@@ -2292,6 +2423,7 @@ describe('updater', () => {
       expect(statuses).toContainEqual({
         state: 'available',
         version: '1.3.51-rc.6',
+        userInitiated: true,
         changelog: null
       })
     })

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -786,6 +786,36 @@ describe('updater', () => {
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
   })
 
+  it('does not start the same active background download again after progress arrives', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 42 })
+    checkForUpdatesFromMenu()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+  })
+
   it('preserves user initiation while a manual check auto-downloads', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')
@@ -954,6 +984,44 @@ describe('updater', () => {
       'updater:status',
       expect.objectContaining({ state: 'downloaded', version: '1.0.61' })
     )
+  })
+
+  it('ignores stale downloaded events while replacing a staged update', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, getUpdateStatus } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    sendMock.mockClear()
+
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.62' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded', version: '1.0.61' })
+    )
+    expect(getUpdateStatus()).toEqual({
+      state: 'available',
+      version: '1.0.62',
+      changelog: null
+    })
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.62' })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloaded',
+      version: '1.0.62',
+      releaseUrl: undefined
+    })
   })
 
   it('does not leak a nudge marker into a later ordinary update cycle', async () => {
@@ -1797,7 +1865,11 @@ describe('updater', () => {
     autoUpdaterMock.emit('update-downloaded', { version: '1.4.26' })
     sendMock.mockClear()
 
-    resolveNudge?.({ id: 'campaign-1', minVersion: '1.0.0' })
+    expect(resolveNudge).toBeTypeOf('function')
+    ;(resolveNudge as unknown as (nudge: { id: string; minVersion: string }) => void)({
+      id: 'campaign-1',
+      minVersion: '1.0.0'
+    })
 
     await vi.waitFor(() => {
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -45,7 +45,7 @@ const {
     eventHandlers.clear()
     on.mockClear()
     autoUpdaterMock.checkForUpdates.mockReset().mockResolvedValue(null)
-    autoUpdaterMock.downloadUpdate.mockReset()
+    autoUpdaterMock.downloadUpdate.mockReset().mockResolvedValue([])
     autoUpdaterMock.quitAndInstall.mockReset()
     autoUpdaterMock.setFeedURL.mockClear()
     autoUpdaterMock.updateConfigPath = undefined
@@ -719,6 +719,196 @@ describe('updater', () => {
     await vi.waitFor(() => {
       expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
     })
+  })
+
+  it('starts downloading automatically after an available update is announced', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    expect(autoUpdaterMock.autoDownload).toBe(false)
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'available',
+      version: '1.0.61',
+      changelog: null
+    })
+
+    const availableStatusCallIndex = sendMock.mock.calls.findIndex(
+      ([channel, status]) =>
+        channel === 'updater:status' &&
+        typeof status === 'object' &&
+        status !== null &&
+        status.state === 'available'
+    )
+    expect(availableStatusCallIndex).not.toBe(-1)
+    expect(sendMock.mock.invocationCallOrder[availableStatusCallIndex]).toBeLessThan(
+      autoUpdaterMock.downloadUpdate.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('deduplicates manual download clicks while the automatic download is starting', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater, downloadUpdate } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    downloadUpdate()
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces automatic download failures against the cached update version', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error('disk full'))
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: 'disk full'
+      })
+    })
+  })
+
+  it('shows a staged update after a user check confirms nothing newer is available', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-not-available')
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    sendMock.mockClear()
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'downloaded',
+        version: '1.0.61',
+        releaseUrl: undefined,
+        userInitiated: true
+      })
+    })
+  })
+
+  it('does not redownload when a user check finds the already-staged version', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    autoUpdaterMock.downloadUpdate.mockClear()
+    sendMock.mockClear()
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'downloaded',
+        version: '1.0.61',
+        releaseUrl: undefined,
+        userInitiated: true
+      })
+    })
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('downloads the newer feed version when a staged update is stale', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.62' })
+      })
+      return Promise.resolve(undefined)
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+    autoUpdaterMock.downloadUpdate.mockClear()
+    sendMock.mockClear()
+
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.62',
+        changelog: null
+      })
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded', version: '1.0.61' })
+    )
   })
 
   it('does not leak a nudge marker into a later ordinary update cycle', async () => {

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -975,6 +975,46 @@ describe('updater', () => {
     })
   })
 
+  it('keeps active download errors retryable when a manual check is visible', async () => {
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const sendMock = vi.fn()
+    const persistLastUpdateCheckAt = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      setLastUpdateCheckAt: persistLastUpdateCheckAt
+    })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 10 })
+    sendMock.mockClear()
+    persistLastUpdateCheckAt.mockClear()
+
+    checkForUpdatesFromMenu()
+    autoUpdaterMock.emit('error', new Error('disk full'))
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'error',
+      message: 'disk full',
+      userInitiated: true
+    })
+    expect(persistLastUpdateCheckAt).not.toHaveBeenCalled()
+
+    downloadUpdate()
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(2)
+  })
+
   it('surfaces automatic download failures against the cached update version', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')
@@ -1136,6 +1176,148 @@ describe('updater', () => {
       state: 'downloaded',
       version: '1.0.62',
       releaseUrl: undefined
+    })
+  })
+
+  it('queues a newer replacement while an older download is still active', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const { fetchChangelog } = await import('./updater-changelog')
+    vi.mocked(fetchChangelog).mockResolvedValue(null)
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 10 })
+    sendMock.mockClear()
+
+    let resolveNewerChangelog: (
+      value: Awaited<ReturnType<typeof fetchChangelog>>
+    ) => void = () => {}
+    vi.mocked(fetchChangelog).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveNewerChangelog = resolve
+        })
+    )
+
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.62' })
+
+    await vi.waitFor(() => {
+      expect(fetchChangelog).toHaveBeenCalledWith('1.0.62', '1.0.51')
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 42 })
+    resolveNewerChangelog(null)
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.62',
+        changelog: null
+      })
+    })
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+
+    autoUpdaterMock.emit('download-progress', { percent: 67 })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 67,
+      version: '1.0.61'
+    })
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(2)
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded', version: '1.0.61' })
+    )
+
+    autoUpdaterMock.emit('download-progress', { percent: 80 })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.62' })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 80,
+      version: '1.0.62'
+    })
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloaded',
+      version: '1.0.62',
+      releaseUrl: undefined
+    })
+  })
+
+  it('starts a queued replacement when the older active download fails', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    let rejectFirstDownload: (reason: Error) => void = () => {}
+    autoUpdaterMock.downloadUpdate
+      .mockImplementationOnce(
+        () =>
+          new Promise<string[]>((_resolve, reject) => {
+            rejectFirstDownload = reject
+          })
+      )
+      .mockImplementation(() => new Promise(() => {}))
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 10 })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.62' })
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.62',
+        changelog: null
+      })
+    })
+
+    sendMock.mockClear()
+    rejectFirstDownload(new Error('disk full'))
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(2)
+    })
+
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'error', message: 'disk full' })
+    )
+
+    autoUpdaterMock.emit('download-progress', { percent: 55 })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 55,
+      version: '1.0.62'
     })
   })
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -860,6 +860,39 @@ describe('updater', () => {
     })
   })
 
+  it('preserves user initiation when a manual auto-download emits an error before rejecting', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => {
+      autoUpdaterMock.emit('error', new Error('disk full'))
+      return Promise.reject(new Error('disk full'))
+    })
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      const errorStatuses = sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+        .filter(
+          (status) => typeof status === 'object' && status !== null && status.state === 'error'
+        )
+
+      expect(errorStatuses).toEqual([{ state: 'error', message: 'disk full', userInitiated: true }])
+    })
+  })
+
   it('surfaces automatic download failures against the cached update version', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -860,6 +860,88 @@ describe('updater', () => {
     })
   })
 
+  it('preserves user initiation when a manual check races active background download events', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 10 })
+    sendMock.mockClear()
+
+    const { checkForUpdatesFromMenu } = await import('./updater')
+    checkForUpdatesFromMenu()
+
+    autoUpdaterMock.emit('download-progress', { percent: 42 })
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'checking',
+      userInitiated: true
+    })
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 42,
+      version: '1.0.61',
+      userInitiated: true
+    })
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloaded',
+      version: '1.0.61',
+      releaseUrl: undefined,
+      userInitiated: true
+    })
+  })
+
+  it('preserves user initiation when a manual check races an active background download failure', async () => {
+    let rejectDownload: (reason: Error) => void = () => {}
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    autoUpdaterMock.downloadUpdate.mockImplementation(
+      () =>
+        new Promise<string[]>((_resolve, reject) => {
+          rejectDownload = reject
+        })
+    )
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 10 })
+    sendMock.mockClear()
+    checkForUpdatesFromMenu()
+    rejectDownload(new Error('disk full'))
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: 'disk full',
+        userInitiated: true
+      })
+    })
+  })
+
   it('preserves user initiation when a manual auto-download emits an error before rejecting', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -786,6 +786,69 @@ describe('updater', () => {
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
   })
 
+  it('does not launch a manual check while an automatic download is active before progress arrives', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    sendMock.mockClear()
+    checkForUpdatesFromMenu()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'checking',
+      userInitiated: true
+    })
+
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloaded',
+      version: '1.0.61',
+      releaseUrl: undefined,
+      userInitiated: true
+    })
+  })
+
+  it('does not launch a focus-triggered check while an automatic download is active before progress arrives', async () => {
+    let lastUpdateCheckAt = Date.now()
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const mainWindow = { webContents: { send: vi.fn() } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, {
+      getLastUpdateCheckAt: () => lastUpdateCheckAt
+    })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    lastUpdateCheckAt = Date.now() - 25 * 60 * 60 * 1000
+    appMock.emit('browser-window-focus')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+  })
+
   it('does not start the same active background download again after progress arrives', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {
       autoUpdaterMock.emit('checking-for-update')
@@ -824,6 +887,7 @@ describe('updater', () => {
       })
       return Promise.resolve(undefined)
     })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
 
     const sendMock = vi.fn()
     const mainWindow = { webContents: { send: sendMock } }
@@ -1177,6 +1241,46 @@ describe('updater', () => {
       version: '1.0.62',
       releaseUrl: undefined
     })
+  })
+
+  it('keeps a queued replacement across a later checking event before the older download finishes', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    autoUpdaterMock.downloadUpdate.mockImplementation(() => new Promise(() => {}))
+
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('download-progress', { percent: 10 })
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-available', { version: '1.0.62' })
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.62',
+        changelog: null
+      })
+    })
+
+    sendMock.mockClear()
+    autoUpdaterMock.emit('checking-for-update')
+    autoUpdaterMock.emit('update-downloaded', { version: '1.0.61' })
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(2)
+    expect(sendMock).not.toHaveBeenCalledWith(
+      'updater:status',
+      expect.objectContaining({ state: 'downloaded', version: '1.0.61' })
+    )
   })
 
   it('queues a newer replacement while an older download is still active', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -165,6 +165,7 @@ function sendStatus(status: UpdateStatus): void {
     (status.state === 'idle' ||
       status.state === 'not-available' ||
       status.state === 'available' ||
+      status.state === 'downloaded' ||
       status.state === 'error')
   if (awaitingNudgeCheckOutcome) {
     if (status.state === 'available' || status.state === 'downloaded') {
@@ -263,6 +264,17 @@ function getPendingInstallVersion(): string {
     return currentStatus.version
   }
   return ''
+}
+
+function getCurrentActionableUpdateUserInitiated(): boolean | undefined {
+  if (
+    currentStatus.state === 'available' ||
+    currentStatus.state === 'downloading' ||
+    currentStatus.state === 'downloaded'
+  ) {
+    return currentStatus.userInitiated || undefined
+  }
+  return undefined
 }
 
 function getCheckFailureKey(message: string, userInitiated?: boolean): string {
@@ -998,7 +1010,7 @@ function startAvailableUpdateDownload(): void {
     .downloadUpdate()
     .catch((err) => {
       downloadInFlight = false
-      sendErrorStatus(String(err?.message ?? err))
+      sendErrorStatus(String(err?.message ?? err), getCurrentActionableUpdateUserInitiated())
     })
 }
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -84,10 +84,10 @@ let _getPendingUpdateNudgeId: (() => string | null) | null = null
 let _getDismissedUpdateNudgeId: (() => string | null) | null = null
 let _setPendingUpdateNudgeId: ((id: string | null) => void) | null = null
 let _setDismissedUpdateNudgeId: ((id: string | null) => void) | null = null
-// Why: guards against duplicate download() calls when both the card and
-// Settings trigger a download before the first download-progress event
-// flips the status to 'downloading'.
-let downloadInFlight = false
+// Why: updater events can briefly move back to 'available'/'checking' while a
+// background download is still active, so the duplicate-download guard must be
+// version-scoped instead of tied to the visible status.
+let activeDownloadVersion: string | null = null
 /** Guards against the macOS `activate` handler re-opening the old version
  *  while Squirrel's ShipIt is replacing the .app bundle. */
 let quittingForUpdate = false
@@ -117,6 +117,16 @@ function getStagedUpdateVersion(): string | null {
 function markStagedUpdate(version: string, releaseUrl?: string): void {
   stagedUpdateVersion = version
   stagedUpdateReleaseUrl = releaseUrl ?? null
+}
+
+function getActiveDownloadVersion(): string | null {
+  return activeDownloadVersion
+}
+
+function clearActiveUpdateDownload(version?: string): void {
+  if (!version || !activeDownloadVersion || compareVersions(version, activeDownloadVersion) >= 0) {
+    activeDownloadVersion = null
+  }
 }
 
 function clearPrereleaseFallbackContext(): void {
@@ -212,16 +222,6 @@ function sendStatus(status: UpdateStatus): void {
     clearPublishingWindowLastGoodCheck()
   }
 
-  // Why: reset the in-flight guard when the status moves past the
-  // window where duplicate download() calls are possible.
-  if (
-    decoratedStatus.state === 'downloading' ||
-    decoratedStatus.state === 'downloaded' ||
-    decoratedStatus.state === 'error' ||
-    decoratedStatus.state === 'idle'
-  ) {
-    downloadInFlight = false
-  }
   if (statusesEqual(currentStatus, decoratedStatus)) {
     return
   }
@@ -249,21 +249,59 @@ function getKnownReleaseUrl(): string | undefined {
 }
 
 function hasNewerDownloadedVersion(): boolean {
-  const version = stagedUpdateVersion ?? availableVersion
-  return version !== null && compareVersions(version, app.getVersion()) > 0
+  if (!stagedUpdateVersion || compareVersions(stagedUpdateVersion, app.getVersion()) <= 0) {
+    return false
+  }
+  // Why: a newer feed result means the older staged installer is stale until
+  // its replacement is actually downloaded; don't let macOS readiness or quit
+  // flows report/install the wrong version.
+  if (availableVersion && compareVersions(availableVersion, stagedUpdateVersion) > 0) {
+    return false
+  }
+  if (activeDownloadVersion && compareVersions(activeDownloadVersion, stagedUpdateVersion) > 0) {
+    return false
+  }
+  return true
 }
 
 function getPendingInstallVersion(): string {
-  if (availableVersion) {
-    return availableVersion
-  }
-  if (stagedUpdateVersion) {
+  if (hasNewerDownloadedVersion() && stagedUpdateVersion) {
     return stagedUpdateVersion
   }
   if (currentStatus.state === 'downloading' || currentStatus.state === 'downloaded') {
     return currentStatus.version
   }
   return ''
+}
+
+function getPendingDownloadVersion(): string | null {
+  if (availableVersion && compareVersions(availableVersion, app.getVersion()) > 0) {
+    return availableVersion
+  }
+  if (
+    (currentStatus.state === 'available' || currentStatus.state === 'downloading') &&
+    compareVersions(currentStatus.version, app.getVersion()) > 0
+  ) {
+    return currentStatus.version
+  }
+  return null
+}
+
+function hasNewerAvailableVersion(): boolean {
+  return getPendingDownloadVersion() !== null
+}
+
+function shouldAcceptDownloadedUpdate(version: string): boolean {
+  if (activeDownloadVersion && compareVersions(version, activeDownloadVersion) < 0) {
+    return false
+  }
+  if (availableVersion && compareVersions(version, availableVersion) < 0) {
+    return false
+  }
+  if (stagedUpdateVersion && compareVersions(version, stagedUpdateVersion) < 0) {
+    return false
+  }
+  return true
 }
 
 function getCurrentActionableUpdateUserInitiated(): boolean | undefined {
@@ -921,9 +959,11 @@ export function setupAutoUpdater(
 
   registerAutoUpdaterHandlers({
     autoUpdater,
+    clearActiveUpdateDownload,
     clearAvailableUpdateContext,
     clearStagedUpdateContext,
     consumeMissingManifestPrereleaseFallbackResult,
+    getActiveDownloadVersion,
     getMissingManifestPrereleaseFallbackUserInitiated,
     getPublishingWindowLastGoodCheck,
     getCurrentStatus: () => currentStatus,
@@ -943,6 +983,7 @@ export function setupAutoUpdater(
     sendStatus,
     scheduleAutomaticUpdateCheck,
     startAvailableUpdateDownload,
+    shouldAcceptDownloadedUpdate,
     clearBackgroundCheckLaunchPending,
     setAvailableReleaseUrl: (releaseUrl) => {
       availableReleaseUrl = releaseUrl
@@ -991,7 +1032,11 @@ export function setupAutoUpdater(
 }
 
 function startAvailableUpdateDownload(): void {
-  if (downloadInFlight) {
+  const targetVersion = getPendingDownloadVersion()
+  if (!targetVersion) {
+    return
+  }
+  if (activeDownloadVersion === targetVersion) {
     return
   }
   // Why: permit retry from 'error' when we still have a cached availableVersion —
@@ -1000,16 +1045,16 @@ function startAvailableUpdateDownload(): void {
   // download. Without this, the button would appear to do nothing.
   const canStart =
     currentStatus.state === 'available' ||
-    (currentStatus.state === 'error' && hasNewerDownloadedVersion())
+    (currentStatus.state === 'error' && hasNewerAvailableVersion())
   if (!canStart) {
     return
   }
-  downloadInFlight = true
+  activeDownloadVersion = targetVersion
   beginMacUpdateDownload()
   getAutoUpdater()
     .downloadUpdate()
     .catch((err) => {
-      downloadInFlight = false
+      clearActiveUpdateDownload(targetVersion)
       sendErrorStatus(String(err?.message ?? err), getCurrentActionableUpdateUserInitiated())
     })
 }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -88,6 +88,7 @@ let _setDismissedUpdateNudgeId: ((id: string | null) => void) | null = null
 // background download is still active, so the duplicate-download guard must be
 // version-scoped instead of tied to the visible status.
 let activeDownloadVersion: string | null = null
+let pendingReplacementDownloadVersion: string | null = null
 /** Guards against the macOS `activate` handler re-opening the old version
  *  while Squirrel's ShipIt is replacing the .app bundle. */
 let quittingForUpdate = false
@@ -103,6 +104,7 @@ function getAutoUpdater(): ElectronAutoUpdater {
 function clearAvailableUpdateContext(): void {
   availableVersion = null
   availableReleaseUrl = null
+  pendingReplacementDownloadVersion = null
 }
 
 function clearStagedUpdateContext(): void {
@@ -127,6 +129,20 @@ function clearActiveUpdateDownload(version?: string): void {
   if (!version || !activeDownloadVersion || compareVersions(version, activeDownloadVersion) >= 0) {
     activeDownloadVersion = null
   }
+}
+
+function startPendingReplacementDownload(): boolean {
+  const pendingVersion = pendingReplacementDownloadVersion
+  if (!pendingVersion) {
+    return false
+  }
+  const targetVersion = getPendingDownloadVersion()
+  if (!targetVersion || compareVersions(targetVersion, pendingVersion) < 0) {
+    pendingReplacementDownloadVersion = null
+    return false
+  }
+  startAvailableUpdateDownload()
+  return activeDownloadVersion === targetVersion
 }
 
 function clearPrereleaseFallbackContext(): void {
@@ -261,6 +277,12 @@ function hasNewerDownloadedVersion(): boolean {
   if (activeDownloadVersion && compareVersions(activeDownloadVersion, stagedUpdateVersion) > 0) {
     return false
   }
+  if (
+    pendingReplacementDownloadVersion &&
+    compareVersions(pendingReplacementDownloadVersion, stagedUpdateVersion) > 0
+  ) {
+    return false
+  }
   return true
 }
 
@@ -293,6 +315,12 @@ function hasNewerAvailableVersion(): boolean {
 
 function shouldAcceptDownloadedUpdate(version: string): boolean {
   if (activeDownloadVersion && compareVersions(version, activeDownloadVersion) < 0) {
+    return false
+  }
+  if (
+    pendingReplacementDownloadVersion &&
+    compareVersions(version, pendingReplacementDownloadVersion) < 0
+  ) {
     return false
   }
   if (availableVersion && compareVersions(version, availableVersion) < 0) {
@@ -983,6 +1011,7 @@ export function setupAutoUpdater(
     recordCompletedUpdateCheck,
     sendStatus,
     scheduleAutomaticUpdateCheck,
+    startPendingReplacementDownload,
     startAvailableUpdateDownload,
     shouldAcceptDownloadedUpdate,
     clearBackgroundCheckLaunchPending,
@@ -1040,16 +1069,24 @@ function startAvailableUpdateDownload(): void {
   if (activeDownloadVersion === targetVersion) {
     return
   }
+  if (activeDownloadVersion) {
+    if (compareVersions(targetVersion, activeDownloadVersion) > 0) {
+      pendingReplacementDownloadVersion = targetVersion
+    }
+    return
+  }
   // Why: permit retry from 'error' when we still have a cached availableVersion —
   // a failed download leaves the status at 'error' but availableVersion intact,
   // and the error card's "Retry Download" button must be able to restart the
   // download. Without this, the button would appear to do nothing.
   const canStart =
     currentStatus.state === 'available' ||
-    (currentStatus.state === 'error' && hasNewerAvailableVersion())
+    (currentStatus.state === 'error' && hasNewerAvailableVersion()) ||
+    pendingReplacementDownloadVersion === targetVersion
   if (!canStart) {
     return
   }
+  pendingReplacementDownloadVersion = null
   activeDownloadVersion = targetVersion
   // Why: electron-updater can emit 'error' before downloadUpdate() rejects;
   // capture launch intent, then merge any manual promotion observed by catch.
@@ -1073,6 +1110,12 @@ function startAvailableUpdateDownload(): void {
         backgroundCheckPromotedToUserInitiated ||
         undefined
       clearActiveUpdateDownload(targetVersion)
+      if (startPendingReplacementDownload()) {
+        return
+      }
+      if (activeDownloadVersion && compareVersions(activeDownloadVersion, targetVersion) > 0) {
+        return
+      }
       sendErrorStatus(message, wasUserInitiated)
     })
 }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -47,6 +47,8 @@ let autoUpdaterInitialized = false
 let includePrereleaseActive = false
 let availableVersion: string | null = null
 let availableReleaseUrl: string | null = null
+let stagedUpdateVersion: string | null = null
+let stagedUpdateReleaseUrl: string | null = null
 let pendingCheckFailureKey: string | null = null
 let pendingCheckFailurePromise: Promise<void> | null = null
 let autoUpdateCheckTimer: ReturnType<typeof setTimeout> | null = null
@@ -103,6 +105,20 @@ function clearAvailableUpdateContext(): void {
   availableReleaseUrl = null
 }
 
+function clearStagedUpdateContext(): void {
+  stagedUpdateVersion = null
+  stagedUpdateReleaseUrl = null
+}
+
+function getStagedUpdateVersion(): string | null {
+  return stagedUpdateVersion
+}
+
+function markStagedUpdate(version: string, releaseUrl?: string): void {
+  stagedUpdateVersion = version
+  stagedUpdateReleaseUrl = releaseUrl ?? null
+}
+
 function clearPrereleaseFallbackContext(): void {
   pendingPrereleaseFallback = null
 }
@@ -151,9 +167,9 @@ function sendStatus(status: UpdateStatus): void {
       status.state === 'available' ||
       status.state === 'error')
   if (awaitingNudgeCheckOutcome) {
-    if (status.state === 'available') {
+    if (status.state === 'available' || status.state === 'downloaded') {
       if (shouldPreserveNudgeForPublishingWindow) {
-        // Why: a last-good available update is only a temporary fallback; don't
+        // Why: a last-good ready update is only a temporary fallback; don't
         // let dismissing that card consume the newest-release nudge campaign.
         deferPendingUpdateNudgeUntilRetry()
       } else {
@@ -189,6 +205,7 @@ function sendStatus(status: UpdateStatus): void {
     status.state === 'idle' ||
     status.state === 'not-available' ||
     status.state === 'available' ||
+    status.state === 'downloaded' ||
     status.state === 'error'
   ) {
     clearPublishingWindowLastGoodCheck()
@@ -198,6 +215,7 @@ function sendStatus(status: UpdateStatus): void {
   // window where duplicate download() calls are possible.
   if (
     decoratedStatus.state === 'downloading' ||
+    decoratedStatus.state === 'downloaded' ||
     decoratedStatus.state === 'error' ||
     decoratedStatus.state === 'idle'
   ) {
@@ -226,16 +244,20 @@ function sendErrorStatus(message: string, userInitiated?: boolean): void {
 }
 
 function getKnownReleaseUrl(): string | undefined {
-  return availableReleaseUrl ?? undefined
+  return availableReleaseUrl ?? stagedUpdateReleaseUrl ?? undefined
 }
 
 function hasNewerDownloadedVersion(): boolean {
-  return availableVersion !== null && compareVersions(availableVersion, app.getVersion()) > 0
+  const version = stagedUpdateVersion ?? availableVersion
+  return version !== null && compareVersions(version, app.getVersion()) > 0
 }
 
 function getPendingInstallVersion(): string {
   if (availableVersion) {
     return availableVersion
+  }
+  if (stagedUpdateVersion) {
+    return stagedUpdateVersion
   }
   if (currentStatus.state === 'downloading' || currentStatus.state === 'downloaded') {
     return currentStatus.version
@@ -831,6 +853,8 @@ export function setupAutoUpdater(
   }
 
   const autoUpdater = getAutoUpdater()
+  // Why: Orca fetches changelog and pins release context before downloading;
+  // letting electron-updater auto-start can race progress events ahead of that.
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
 
@@ -886,23 +910,27 @@ export function setupAutoUpdater(
   registerAutoUpdaterHandlers({
     autoUpdater,
     clearAvailableUpdateContext,
+    clearStagedUpdateContext,
     consumeMissingManifestPrereleaseFallbackResult,
     getMissingManifestPrereleaseFallbackUserInitiated,
     getPublishingWindowLastGoodCheck,
     getCurrentStatus: () => currentStatus,
     getKnownReleaseUrl,
     getPendingInstallVersion,
+    getStagedUpdateVersion,
     getUserInitiatedCheck: () => userInitiatedCheck,
     hasNewerDownloadedVersion,
     performQuitAndInstall,
     sendCheckFailureStatus,
     sendErrorStatus,
     markMissingManifestPrereleaseFallbackChecking,
+    markStagedUpdate,
     shouldSuppressMissingManifestPrereleaseFallbackEvent,
     suppressMissingManifestPrereleaseFallbackPromiseFailure,
     recordCompletedUpdateCheck,
     sendStatus,
     scheduleAutomaticUpdateCheck,
+    startAvailableUpdateDownload,
     clearBackgroundCheckLaunchPending,
     setAvailableReleaseUrl: (releaseUrl) => {
       availableReleaseUrl = releaseUrl
@@ -950,7 +978,7 @@ export function setupAutoUpdater(
   }
 }
 
-export function downloadUpdate(): void {
+function startAvailableUpdateDownload(): void {
   if (downloadInFlight) {
     return
   }
@@ -972,4 +1000,8 @@ export function downloadUpdate(): void {
       downloadInFlight = false
       sendErrorStatus(String(err?.message ?? err))
     })
+}
+
+export function downloadUpdate(): void {
+  startAvailableUpdateDownload()
 }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1050,12 +1050,15 @@ function startAvailableUpdateDownload(): void {
     return
   }
   activeDownloadVersion = targetVersion
+  // Why: electron-updater can emit 'error' before downloadUpdate() rejects; the
+  // catch must not recompute intent from the error status written by the event.
+  const downloadUserInitiated = getCurrentActionableUpdateUserInitiated()
   beginMacUpdateDownload()
   getAutoUpdater()
     .downloadUpdate()
     .catch((err) => {
       clearActiveUpdateDownload(targetVersion)
-      sendErrorStatus(String(err?.message ?? err), getCurrentActionableUpdateUserInitiated())
+      sendErrorStatus(String(err?.message ?? err), downloadUserInitiated)
     })
 }
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -306,6 +306,7 @@ function shouldAcceptDownloadedUpdate(version: string): boolean {
 
 function getCurrentActionableUpdateUserInitiated(): boolean | undefined {
   if (
+    currentStatus.state === 'checking' ||
     currentStatus.state === 'available' ||
     currentStatus.state === 'downloading' ||
     currentStatus.state === 'downloaded'
@@ -1050,15 +1051,29 @@ function startAvailableUpdateDownload(): void {
     return
   }
   activeDownloadVersion = targetVersion
-  // Why: electron-updater can emit 'error' before downloadUpdate() rejects; the
-  // catch must not recompute intent from the error status written by the event.
+  // Why: electron-updater can emit 'error' before downloadUpdate() rejects;
+  // capture launch intent, then merge any manual promotion observed by catch.
   const downloadUserInitiated = getCurrentActionableUpdateUserInitiated()
   beginMacUpdateDownload()
   getAutoUpdater()
     .downloadUpdate()
     .catch((err) => {
+      const message = String(err?.message ?? err)
+      const existingMatchingErrorUserInitiated =
+        currentStatus.state === 'error' && currentStatus.message === message
+          ? currentStatus.userInitiated
+          : undefined
+      // Why: a manual check can promote an active background download while
+      // the download promise is still pending; preserve that promotion.
+      const wasUserInitiated =
+        downloadUserInitiated ||
+        getCurrentActionableUpdateUserInitiated() ||
+        existingMatchingErrorUserInitiated ||
+        userInitiatedCheck ||
+        backgroundCheckPromotedToUserInitiated ||
+        undefined
       clearActiveUpdateDownload(targetVersion)
-      sendErrorStatus(String(err?.message ?? err), downloadUserInitiated)
+      sendErrorStatus(message, wasUserInitiated)
     })
 }
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -104,7 +104,6 @@ function getAutoUpdater(): ElectronAutoUpdater {
 function clearAvailableUpdateContext(): void {
   availableVersion = null
   availableReleaseUrl = null
-  pendingReplacementDownloadVersion = null
 }
 
 function clearStagedUpdateContext(): void {
@@ -305,6 +304,14 @@ function getPendingDownloadVersion(): string | null {
     compareVersions(currentStatus.version, app.getVersion()) > 0
   ) {
     return currentStatus.version
+  }
+  // Why: a follow-up freshness check can clear availableVersion while an older
+  // artifact is still finishing; the queued replacement remains the target.
+  if (
+    pendingReplacementDownloadVersion &&
+    compareVersions(pendingReplacementDownloadVersion, app.getVersion()) > 0
+  ) {
+    return pendingReplacementDownloadVersion
   }
   return null
 }
@@ -706,7 +713,7 @@ function retryPrereleaseFallbackAfterMissingManifest(
 function runBackgroundUpdateCheck(
   nudgeId: string | null = getPersistedPendingUpdateNudgeId()
 ): void {
-  if (backgroundCheckLaunchPending || currentStatus.state === 'checking') {
+  if (backgroundCheckLaunchPending || currentStatus.state === 'checking' || activeDownloadVersion) {
     return
   }
   if (!app.isPackaged || is.dev) {
@@ -785,7 +792,8 @@ export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean 
     enableIncludePrerelease()
   }
 
-  const checkAlreadyInFlight = backgroundCheckLaunchPending || currentStatus.state === 'checking'
+  const checkAlreadyInFlight =
+    backgroundCheckLaunchPending || currentStatus.state === 'checking' || activeDownloadVersion
   userInitiatedCheck = true
   // Why: a manual check is independent of any active nudge campaign. Reset the
   // nudge marker so the resulting status is not decorated with activeNudgeId,
@@ -859,7 +867,11 @@ async function checkForUpdateNudge(): Promise<void> {
       return
     }
 
-    if (currentStatus.state === 'checking' || currentStatus.state === 'downloading') {
+    if (
+      currentStatus.state === 'checking' ||
+      currentStatus.state === 'downloading' ||
+      activeDownloadVersion
+    ) {
       return
     }
 
@@ -1034,7 +1046,8 @@ export function setupAutoUpdater(
     if (
       backgroundCheckLaunchPending ||
       currentStatus.state === 'checking' ||
-      currentStatus.state === 'downloading'
+      currentStatus.state === 'downloading' ||
+      activeDownloadVersion
     ) {
       return
     }
@@ -1070,7 +1083,11 @@ function startAvailableUpdateDownload(): void {
     return
   }
   if (activeDownloadVersion) {
-    if (compareVersions(targetVersion, activeDownloadVersion) > 0) {
+    if (
+      compareVersions(targetVersion, activeDownloadVersion) > 0 &&
+      (!pendingReplacementDownloadVersion ||
+        compareVersions(targetVersion, pendingReplacementDownloadVersion) >= 0)
+    ) {
       pendingReplacementDownloadVersion = targetVersion
     }
     return
@@ -1094,6 +1111,10 @@ function startAvailableUpdateDownload(): void {
   beginMacUpdateDownload()
   getAutoUpdater()
     .downloadUpdate()
+    .then(() => {
+      clearActiveUpdateDownload(targetVersion)
+      startPendingReplacementDownload()
+    })
     .catch((err) => {
       const message = String(err?.message ?? err)
       const existingMatchingErrorUserInitiated =

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -321,12 +321,13 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
   if (status.state === 'idle') {
     return 'hidden'
   }
-  if (status.state === 'available' && !userInitiatedCycle && !isNudgeDriven) {
+  if (status.state === 'available' && !userInitiatedCycle && !isUserInitiated && !isNudgeDriven) {
     return 'hidden'
   }
   if (
     status.state === 'downloading' &&
     !userInitiatedCycle &&
+    !isUserInitiated &&
     !hasStartedDownload &&
     !isNudgeDriven
   ) {
@@ -346,7 +347,12 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
   }
 
   const effectiveVersion = 'version' in status ? status.version : cachedVersion
-  if (effectiveVersion && dismissedVersion === effectiveVersion) {
+  if (
+    effectiveVersion &&
+    dismissedVersion === effectiveVersion &&
+    !userInitiatedCycle &&
+    !isUserInitiated
+  ) {
     if (status.state !== 'downloading' && status.state !== 'error') {
       return 'hidden'
     }
@@ -473,6 +479,29 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('hidden')
   })
 
+  it('shows user-initiated available when the same version was dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'available', version: '1.2.0', changelog: null },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false,
+        userInitiatedCycle: true
+      })
+    ).toBe('visible')
+  })
+
+  it('shows hydrated user-initiated available when the same version was dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'available', version: '1.2.0', changelog: null, userInitiated: true },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('visible')
+  })
+
   it('shows downloading even when version is dismissed (user clicked Update after dismiss)', () => {
     expect(
       computeVisibility({
@@ -493,6 +522,17 @@ describe('UpdateCard visibility gates', () => {
         hasStartedDownload: false
       })
     ).toBe('hidden')
+  })
+
+  it('shows hydrated user-initiated download progress', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloading', percent: 42, version: '1.2.0', userInitiated: true },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('visible')
   })
 
   it('shows nudge-driven background download progress', () => {

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -6,6 +6,7 @@ import { getDefaultUIState } from '../../../shared/constants'
 import type { ChangelogData, UpdateStatus } from '../../../shared/types'
 import { createUISlice } from '../store/slices/ui'
 import type { AppState } from '../store/types'
+import { shouldShowUpdateStatusSegment } from './status-bar/update-status-segment-visibility'
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -231,6 +232,36 @@ describe('updateCardCollapsed', () => {
   })
 })
 
+// ── updateDownloadIntentVersion ─────────────────────────────────────
+
+describe('updateDownloadIntentVersion', () => {
+  it('marks the version whose download was explicitly started in the renderer', () => {
+    const store = createTestStore()
+
+    store.getState().markUpdateDownloadIntent('1.2.0')
+
+    expect(store.getState().updateDownloadIntentVersion).toBe('1.2.0')
+  })
+
+  it('clears explicit download intent on update cycle boundaries', () => {
+    const store = createTestStore()
+    store.getState().markUpdateDownloadIntent('1.2.0')
+
+    setState(store, { state: 'checking' })
+
+    expect(store.getState().updateDownloadIntentVersion).toBeNull()
+  })
+
+  it('clears explicit download intent when a different version becomes current', () => {
+    const store = createTestStore()
+    store.getState().markUpdateDownloadIntent('1.2.0')
+
+    setState(store, { state: 'downloading', percent: 10, version: '1.3.0' })
+
+    expect(store.getState().updateDownloadIntentVersion).toBeNull()
+  })
+})
+
 // ── markUpdateReassuranceSeen ────────────────────────────────────────
 
 describe('markUpdateReassuranceSeen', () => {
@@ -294,6 +325,7 @@ type VisibilityInput = {
   cachedVersion: string | null
   hasStartedDownload: boolean
   userInitiatedCycle?: boolean
+  downloadIntentVersion?: string | null
 }
 
 type VisibilityResult = 'hidden' | 'visible'
@@ -305,12 +337,16 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     dismissedVersion,
     cachedVersion,
     hasStartedDownload,
-    userInitiatedCycle = false
+    userInitiatedCycle = false,
+    downloadIntentVersion = null
   } = input
   const isUserInitiated = 'userInitiated' in status && status.userInitiated
   const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
+  const hasExplicitDownloadIntent =
+    cachedVersion !== null && downloadIntentVersion === cachedVersion
   const shouldShowDetailedErrorCard =
-    status.state === 'error' && (hasStartedDownload || cachedVersion !== null)
+    status.state === 'error' &&
+    (isUserInitiated || isNudgeDriven || hasStartedDownload || hasExplicitDownloadIntent)
 
   if (status.state === 'checking' && !isUserInitiated) {
     return 'hidden'
@@ -329,6 +365,7 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     !userInitiatedCycle &&
     !isUserInitiated &&
     !hasStartedDownload &&
+    !hasExplicitDownloadIntent &&
     !isNudgeDriven
   ) {
     return 'hidden'
@@ -337,6 +374,7 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     status.state === 'downloaded' &&
     !userInitiatedCycle &&
     !hasStartedDownload &&
+    !hasExplicitDownloadIntent &&
     !isNudgeDriven &&
     !isUserInitiated
   ) {
@@ -351,7 +389,9 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     effectiveVersion &&
     dismissedVersion === effectiveVersion &&
     !userInitiatedCycle &&
-    !isUserInitiated
+    !isUserInitiated &&
+    !hasExplicitDownloadIntent &&
+    !isNudgeDriven
   ) {
     if (status.state !== 'downloading' && status.state !== 'error') {
       return 'hidden'
@@ -535,6 +575,18 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
+  it('shows settings-initiated download progress even when the version was dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloading', percent: 42, version: '1.2.0' },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false,
+        downloadIntentVersion: '1.2.0'
+      })
+    ).toBe('visible')
+  })
+
   it('shows nudge-driven background download progress', () => {
     expect(
       computeVisibility({
@@ -551,7 +603,7 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
-  it('hides downloaded when version is dismissed (Settings-initiated, not card)', () => {
+  it('hides downloaded when version is dismissed and no explicit download is active', () => {
     expect(
       computeVisibility({
         status: { state: 'downloaded', version: '1.2.0' },
@@ -560,6 +612,18 @@ describe('UpdateCard visibility gates', () => {
         hasStartedDownload: false
       })
     ).toBe('hidden')
+  })
+
+  it('shows settings-initiated downloaded state even when the version was dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloaded', version: '1.2.0' },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false,
+        downloadIntentVersion: '1.2.0'
+      })
+    ).toBe('visible')
   })
 
   it('hides ordinary background downloaded updates until the user checks', () => {
@@ -617,13 +681,25 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
-  it('shows settings-initiated download errors when a version is cached', () => {
+  it('hides passive background download errors even when a version is cached', () => {
     expect(
       computeVisibility({
         status: { state: 'error', message: 'ENOSPC' },
         dismissedVersion: null,
         cachedVersion: '1.2.0',
         hasStartedDownload: false
+      })
+    ).toBe('hidden')
+  })
+
+  it('shows settings-initiated download errors when the download intent version is cached', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'error', message: 'ENOSPC' },
+        dismissedVersion: null,
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false,
+        downloadIntentVersion: '1.2.0'
       })
     ).toBe('visible')
   })
@@ -671,6 +747,48 @@ describe('UpdateCard visibility gates', () => {
         hasStartedDownload: false
       })
     ).toBe('hidden')
+  })
+})
+
+// ── Status-bar update segment gates ─────────────────────────────────
+
+describe('UpdateStatusSegment visibility gates', () => {
+  it('hides suppressed passive background download states', () => {
+    expect(
+      shouldShowUpdateStatusSegment({ state: 'downloading', percent: 50, version: '1.2.0' }, null)
+    ).toBe(false)
+    expect(shouldShowUpdateStatusSegment({ state: 'downloaded', version: '1.2.0' }, null)).toBe(
+      false
+    )
+  })
+
+  it('shows explicit and user-visible update states', () => {
+    expect(
+      shouldShowUpdateStatusSegment(
+        { state: 'downloading', percent: 50, version: '1.2.0' },
+        '1.2.0'
+      )
+    ).toBe(true)
+    expect(shouldShowUpdateStatusSegment({ state: 'downloaded', version: '1.2.0' }, '1.2.0')).toBe(
+      true
+    )
+    expect(shouldShowUpdateStatusSegment({ state: 'error', message: 'ENOSPC' }, '1.2.0')).toBe(true)
+    expect(
+      shouldShowUpdateStatusSegment(
+        { state: 'error', message: 'network', userInitiated: true },
+        null
+      )
+    ).toBe(true)
+    expect(
+      shouldShowUpdateStatusSegment(
+        { state: 'downloaded', version: '1.2.0', activeNudgeId: 'campaign-1' },
+        null
+      )
+    ).toBe(true)
+  })
+
+  it('hides passive background errors', () => {
+    expect(shouldShowUpdateStatusSegment({ state: 'error', message: 'network' }, null)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -260,6 +260,15 @@ describe('updateDownloadIntentVersion', () => {
 
     expect(store.getState().updateDownloadIntentVersion).toBeNull()
   })
+
+  it('clears explicit download intent when a different available version becomes current', () => {
+    const store = createTestStore()
+    store.getState().markUpdateDownloadIntent('1.2.0')
+
+    setState(store, { state: 'available', version: '1.3.0', changelog: null })
+
+    expect(store.getState().updateDownloadIntentVersion).toBeNull()
+  })
 })
 
 // ── markUpdateReassuranceSeen ────────────────────────────────────────
@@ -326,6 +335,7 @@ type VisibilityInput = {
   hasStartedDownload: boolean
   userInitiatedCycle?: boolean
   downloadIntentVersion?: string | null
+  locallyDismissedVersion?: string | null
 }
 
 type VisibilityResult = 'hidden' | 'visible'
@@ -338,7 +348,8 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     cachedVersion,
     hasStartedDownload,
     userInitiatedCycle = false,
-    downloadIntentVersion = null
+    downloadIntentVersion = null,
+    locallyDismissedVersion = null
   } = input
   const isUserInitiated = 'userInitiated' in status && status.userInitiated
   const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
@@ -375,13 +386,13 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
   }
 
   const effectiveVersion = 'version' in status ? status.version : cachedVersion
+  const isLocallyDismissedVersion =
+    effectiveVersion !== null && locallyDismissedVersion === effectiveVersion
   if (
     effectiveVersion &&
-    dismissedVersion === effectiveVersion &&
-    !userInitiatedCycle &&
-    !isUserInitiated &&
-    !hasExplicitDownloadIntent &&
-    !isNudgeDriven
+    (dismissedVersion === effectiveVersion || isLocallyDismissedVersion) &&
+    (isLocallyDismissedVersion ||
+      (!userInitiatedCycle && !isUserInitiated && !hasExplicitDownloadIntent && !isNudgeDriven))
   ) {
     if (
       status.state !== 'downloading' &&
@@ -534,6 +545,18 @@ describe('UpdateCard visibility gates', () => {
         hasStartedDownload: false
       })
     ).toBe('visible')
+  })
+
+  it('hides hydrated user-initiated available after the visible card is explicitly dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'available', version: '1.2.0', changelog: null, userInitiated: true },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false,
+        locallyDismissedVersion: '1.2.0'
+      })
+    ).toBe('hidden')
   })
 
   it('shows downloading even when version is dismissed (user clicked Update after dismiss)', () => {

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -293,14 +293,22 @@ type VisibilityInput = {
   dismissedVersion: string | null
   cachedVersion: string | null
   hasStartedDownload: boolean
+  userInitiatedCycle?: boolean
 }
 
 type VisibilityResult = 'hidden' | 'visible'
 
 /** Mirrors the visibility gates in UpdateCard's render path. */
 function computeVisibility(input: VisibilityInput): VisibilityResult {
-  const { status, dismissedVersion, cachedVersion, hasStartedDownload } = input
+  const {
+    status,
+    dismissedVersion,
+    cachedVersion,
+    hasStartedDownload,
+    userInitiatedCycle = false
+  } = input
   const isUserInitiated = 'userInitiated' in status && status.userInitiated
+  const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
   const shouldShowDetailedErrorCard =
     status.state === 'error' && (hasStartedDownload || cachedVersion !== null)
 
@@ -311,6 +319,26 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     return 'hidden'
   }
   if (status.state === 'idle') {
+    return 'hidden'
+  }
+  if (status.state === 'available' && !userInitiatedCycle && !isNudgeDriven) {
+    return 'hidden'
+  }
+  if (
+    status.state === 'downloading' &&
+    !userInitiatedCycle &&
+    !hasStartedDownload &&
+    !isNudgeDriven
+  ) {
+    return 'hidden'
+  }
+  if (
+    status.state === 'downloaded' &&
+    !userInitiatedCycle &&
+    !hasStartedDownload &&
+    !isNudgeDriven &&
+    !isUserInitiated
+  ) {
     return 'hidden'
   }
   if (status.state === 'error' && !shouldShowDetailedErrorCard && !isUserInitiated) {
@@ -383,7 +411,7 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
-  it('shows available update (simple mode)', () => {
+  it('hides background available while the update pre-download starts', () => {
     expect(
       computeVisibility({
         status: { state: 'available', version: '1.2.0', changelog: null },
@@ -391,13 +419,42 @@ describe('UpdateCard visibility gates', () => {
         cachedVersion: null,
         hasStartedDownload: false
       })
+    ).toBe('hidden')
+  })
+
+  it('shows user-initiated available update (simple mode)', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'available', version: '1.2.0', changelog: null },
+        dismissedVersion: null,
+        cachedVersion: null,
+        hasStartedDownload: false,
+        userInitiatedCycle: true
+      })
     ).toBe('visible')
   })
 
-  it('shows available update (rich mode)', () => {
+  it('shows user-initiated available update (rich mode)', () => {
     expect(
       computeVisibility({
         status: { state: 'available', version: '1.2.0', changelog: RICH_CHANGELOG },
+        dismissedVersion: null,
+        cachedVersion: null,
+        hasStartedDownload: false,
+        userInitiatedCycle: true
+      })
+    ).toBe('visible')
+  })
+
+  it('shows nudge-driven available update', () => {
+    expect(
+      computeVisibility({
+        status: {
+          state: 'available',
+          version: '1.2.0',
+          changelog: null,
+          activeNudgeId: 'campaign-1'
+        },
         dismissedVersion: null,
         cachedVersion: null,
         hasStartedDownload: false
@@ -427,6 +484,33 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
+  it('hides ordinary background download progress before the update is ready', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloading', percent: 42, version: '1.2.0' },
+        dismissedVersion: null,
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('hidden')
+  })
+
+  it('shows nudge-driven background download progress', () => {
+    expect(
+      computeVisibility({
+        status: {
+          state: 'downloading',
+          percent: 42,
+          version: '1.2.0',
+          activeNudgeId: 'campaign-1'
+        },
+        dismissedVersion: null,
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('visible')
+  })
+
   it('hides downloaded when version is dismissed (Settings-initiated, not card)', () => {
     expect(
       computeVisibility({
@@ -436,6 +520,28 @@ describe('UpdateCard visibility gates', () => {
         hasStartedDownload: false
       })
     ).toBe('hidden')
+  })
+
+  it('hides ordinary background downloaded updates until the user checks', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloaded', version: '1.2.0' },
+        dismissedVersion: null,
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('hidden')
+  })
+
+  it('shows downloaded updates after a user-initiated check', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloaded', version: '1.2.0', userInitiated: true },
+        dismissedVersion: null,
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false
+      })
+    ).toBe('visible')
   })
 
   it('hides background errors silently', () => {
@@ -499,7 +605,8 @@ describe('UpdateCard visibility gates', () => {
         status: { state: 'available', version: '1.3.0', changelog: null },
         dismissedVersion: '1.2.0',
         cachedVersion: '1.3.0',
-        hasStartedDownload: false
+        hasStartedDownload: false,
+        userInitiatedCycle: true
       })
     ).toBe('visible')
   })
@@ -589,7 +696,8 @@ describe('full update lifecycle through setUpdateStatus', () => {
         status: store.getState().updateStatus,
         dismissedVersion: store.getState().dismissedUpdateVersion,
         cachedVersion: '1.3.0',
-        hasStartedDownload: false
+        hasStartedDownload: false,
+        userInitiatedCycle: true
       })
     ).toBe('visible')
   })

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -370,16 +370,6 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
   ) {
     return 'hidden'
   }
-  if (
-    status.state === 'downloaded' &&
-    !userInitiatedCycle &&
-    !hasStartedDownload &&
-    !hasExplicitDownloadIntent &&
-    !isNudgeDriven &&
-    !isUserInitiated
-  ) {
-    return 'hidden'
-  }
   if (status.state === 'error' && !shouldShowDetailedErrorCard && !isUserInitiated) {
     return 'hidden'
   }
@@ -393,7 +383,11 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
     !hasExplicitDownloadIntent &&
     !isNudgeDriven
   ) {
-    if (status.state !== 'downloading' && status.state !== 'error') {
+    if (
+      status.state !== 'downloading' &&
+      status.state !== 'downloaded' &&
+      status.state !== 'error'
+    ) {
       return 'hidden'
     }
   }
@@ -603,7 +597,7 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
-  it('hides downloaded when version is dismissed and no explicit download is active', () => {
+  it('shows downloaded when version is dismissed and no explicit download is active', () => {
     expect(
       computeVisibility({
         status: { state: 'downloaded', version: '1.2.0' },
@@ -611,7 +605,7 @@ describe('UpdateCard visibility gates', () => {
         cachedVersion: '1.2.0',
         hasStartedDownload: false
       })
-    ).toBe('hidden')
+    ).toBe('visible')
   })
 
   it('shows settings-initiated downloaded state even when the version was dismissed', () => {
@@ -626,7 +620,7 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
-  it('hides ordinary background downloaded updates until the user checks', () => {
+  it('shows ordinary background downloaded updates once the update is ready to install', () => {
     expect(
       computeVisibility({
         status: { state: 'downloaded', version: '1.2.0' },
@@ -634,7 +628,7 @@ describe('UpdateCard visibility gates', () => {
         cachedVersion: '1.2.0',
         hasStartedDownload: false
       })
-    ).toBe('hidden')
+    ).toBe('visible')
   })
 
   it('shows downloaded updates after a user-initiated check', () => {
@@ -753,12 +747,15 @@ describe('UpdateCard visibility gates', () => {
 // ── Status-bar update segment gates ─────────────────────────────────
 
 describe('UpdateStatusSegment visibility gates', () => {
-  it('hides suppressed passive background download states', () => {
+  it('hides passive background download progress', () => {
     expect(
       shouldShowUpdateStatusSegment({ state: 'downloading', percent: 50, version: '1.2.0' }, null)
     ).toBe(false)
+  })
+
+  it('shows passive downloaded updates so the install UI is discoverable', () => {
     expect(shouldShowUpdateStatusSegment({ state: 'downloaded', version: '1.2.0' }, null)).toBe(
-      false
+      true
     )
   })
 

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -355,6 +355,8 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
   const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
   const hasExplicitDownloadIntent =
     cachedVersion !== null && downloadIntentVersion === cachedVersion
+  const isLocallyDismissedVersion =
+    cachedVersion !== null && locallyDismissedVersion === cachedVersion
   const shouldShowDetailedErrorCard =
     status.state === 'error' &&
     (isUserInitiated || isNudgeDriven || hasStartedDownload || hasExplicitDownloadIntent)
@@ -381,17 +383,26 @@ function computeVisibility(input: VisibilityInput): VisibilityResult {
   ) {
     return 'hidden'
   }
+  if (
+    status.state === 'downloading' &&
+    isLocallyDismissedVersion &&
+    !hasStartedDownload &&
+    !hasExplicitDownloadIntent &&
+    !isNudgeDriven
+  ) {
+    return 'hidden'
+  }
   if (status.state === 'error' && !shouldShowDetailedErrorCard && !isUserInitiated) {
     return 'hidden'
   }
 
   const effectiveVersion = 'version' in status ? status.version : cachedVersion
-  const isLocallyDismissedVersion =
+  const isEffectiveLocallyDismissedVersion =
     effectiveVersion !== null && locallyDismissedVersion === effectiveVersion
   if (
     effectiveVersion &&
-    (dismissedVersion === effectiveVersion || isLocallyDismissedVersion) &&
-    (isLocallyDismissedVersion ||
+    (dismissedVersion === effectiveVersion || isEffectiveLocallyDismissedVersion) &&
+    (isEffectiveLocallyDismissedVersion ||
       (!userInitiatedCycle && !isUserInitiated && !hasExplicitDownloadIntent && !isNudgeDriven))
   ) {
     if (
@@ -592,6 +603,18 @@ describe('UpdateCard visibility gates', () => {
     ).toBe('visible')
   })
 
+  it('hides user-initiated download progress after the visible available card is dismissed', () => {
+    expect(
+      computeVisibility({
+        status: { state: 'downloading', percent: 42, version: '1.2.0', userInitiated: true },
+        dismissedVersion: '1.2.0',
+        cachedVersion: '1.2.0',
+        hasStartedDownload: false,
+        locallyDismissedVersion: '1.2.0'
+      })
+    ).toBe('hidden')
+  })
+
   it('shows settings-initiated download progress even when the version was dismissed', () => {
     expect(
       computeVisibility({
@@ -599,7 +622,8 @@ describe('UpdateCard visibility gates', () => {
         dismissedVersion: '1.2.0',
         cachedVersion: '1.2.0',
         hasStartedDownload: false,
-        downloadIntentVersion: '1.2.0'
+        downloadIntentVersion: '1.2.0',
+        locallyDismissedVersion: '1.2.0'
       })
     ).toBe('visible')
   })

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -91,6 +91,8 @@ export function UpdateCard() {
   const dismissUpdate = useAppStore((s) => s.dismissUpdate)
   const collapsed = useAppStore((s) => s.updateCardCollapsed)
   const setCollapsed = useAppStore((s) => s.setUpdateCardCollapsed)
+  const downloadIntentVersion = useAppStore((s) => s.updateDownloadIntentVersion)
+  const markDownloadIntent = useAppStore((s) => s.markUpdateDownloadIntent)
   const reassuranceSeen = useAppStore((s) => s.updateReassuranceSeen)
   const markReassuranceSeen = useAppStore((s) => s.markUpdateReassuranceSeen)
   const hasStartedDownload = useRef(false)
@@ -207,9 +209,13 @@ export function UpdateCard() {
   // ── Visibility gates ──────────────────────────────────────────────
 
   const isUserInitiated = 'userInitiated' in status && status.userInitiated
+  const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
   const cachedVersion = versionRef.current
+  const hasExplicitDownloadIntent =
+    cachedVersion !== null && downloadIntentVersion === cachedVersion
   const shouldShowDetailedErrorCard =
-    status.state === 'error' && (hasStartedDownload.current || cachedVersion !== null)
+    status.state === 'error' &&
+    (isUserInitiated || isNudgeDriven || hasStartedDownload.current || hasExplicitDownloadIntent)
 
   // Why: track whether the current check cycle was user-initiated so the
   // dismiss gate doesn't hide the result of an explicit "Check for Updates"
@@ -239,7 +245,6 @@ export function UpdateCard() {
     return null
   }
 
-  const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
   // Why: ordinary background checks now pre-download updates; keep that path
   // quiet until the user explicitly checks, while explicit/nudge cycles stay visible.
   if (
@@ -255,6 +260,7 @@ export function UpdateCard() {
     !userInitiatedCycleRef.current &&
     !isUserInitiated &&
     !hasStartedDownload.current &&
+    !hasExplicitDownloadIntent &&
     !isNudgeDriven
   ) {
     return null
@@ -263,6 +269,7 @@ export function UpdateCard() {
     status.state === 'downloaded' &&
     !userInitiatedCycleRef.current &&
     !hasStartedDownload.current &&
+    !hasExplicitDownloadIntent &&
     !isNudgeDriven &&
     !isUserInitiated
   ) {
@@ -293,7 +300,9 @@ export function UpdateCard() {
     versionRef.current &&
     dismissedVersion === versionRef.current &&
     !userInitiatedCycleRef.current &&
-    !isUserInitiated
+    !isUserInitiated &&
+    !hasExplicitDownloadIntent &&
+    !isNudgeDriven
   ) {
     if (status.state !== 'downloading' && status.state !== 'error') {
       return null
@@ -313,6 +322,9 @@ export function UpdateCard() {
 
   const handleUpdate = () => {
     hasStartedDownload.current = true
+    if (cachedVersion) {
+      markDownloadIntent(cachedVersion)
+    }
     // Why: clicking "Update" implies the user is not worried about interruption,
     // so dismiss the reassurance tip permanently.
     if (!reassuranceSeen) {

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -242,12 +242,18 @@ export function UpdateCard() {
   const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
   // Why: ordinary background checks now pre-download updates; keep that path
   // quiet until the user explicitly checks, while explicit/nudge cycles stay visible.
-  if (status.state === 'available' && !userInitiatedCycleRef.current && !isNudgeDriven) {
+  if (
+    status.state === 'available' &&
+    !userInitiatedCycleRef.current &&
+    !isUserInitiated &&
+    !isNudgeDriven
+  ) {
     return null
   }
   if (
     status.state === 'downloading' &&
     !userInitiatedCycleRef.current &&
+    !isUserInitiated &&
     !hasStartedDownload.current &&
     !isNudgeDriven
   ) {
@@ -286,7 +292,8 @@ export function UpdateCard() {
   if (
     versionRef.current &&
     dismissedVersion === versionRef.current &&
-    !userInitiatedCycleRef.current
+    !userInitiatedCycleRef.current &&
+    !isUserInitiated
   ) {
     if (status.state !== 'downloading' && status.state !== 'error') {
       return null

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -120,6 +120,9 @@ export function UpdateCard() {
   // dismissed.  This ref tracks whether the current check cycle was user-initiated
   // so the dismiss gate can let the result through.
   const userInitiatedCycleRef = useRef(false)
+  // Why: status.userInitiated can outlive an explicit close click. Track that
+  // local close so dismissing a visible card wins until a new check/version.
+  const locallyDismissedVersionRef = useRef<string | null>(null)
 
   const changelog: ChangelogData | null = storeChangelog
 
@@ -149,6 +152,7 @@ export function UpdateCard() {
   if (status.state === 'available' && status.version !== prevVersionRef.current) {
     prevVersionRef.current = status.version
     hasStartedDownload.current = false
+    locallyDismissedVersionRef.current = null
     setMediaFailed(false)
     setMediaLoaded(false)
     setInstallError(null)
@@ -225,8 +229,10 @@ export function UpdateCard() {
   // even though the user explicitly asked to see the result.
   if (status.state === 'checking' && isUserInitiated) {
     userInitiatedCycleRef.current = true
+    locallyDismissedVersionRef.current = null
   } else if (status.state === 'idle' || (status.state === 'checking' && !isUserInitiated)) {
     userInitiatedCycleRef.current = false
+    locallyDismissedVersionRef.current = null
   }
 
   // Compact transient states: only show for user-initiated checks.
@@ -285,13 +291,16 @@ export function UpdateCard() {
   // Why: bypass the gate when the current cycle was user-initiated — the user
   // explicitly asked to check, so they expect to see the result even if they
   // dismissed the same version earlier.
+  const isLocallyDismissedVersion =
+    versionRef.current !== null && locallyDismissedVersionRef.current === versionRef.current
   if (
     versionRef.current &&
-    dismissedVersion === versionRef.current &&
-    !userInitiatedCycleRef.current &&
-    !isUserInitiated &&
-    !hasExplicitDownloadIntent &&
-    !isNudgeDriven
+    (dismissedVersion === versionRef.current || isLocallyDismissedVersion) &&
+    (isLocallyDismissedVersion ||
+      (!userInitiatedCycleRef.current &&
+        !isUserInitiated &&
+        !hasExplicitDownloadIntent &&
+        !isNudgeDriven))
   ) {
     if (
       status.state !== 'downloading' &&
@@ -333,6 +342,7 @@ export function UpdateCard() {
     // immediately — otherwise the card would reappear on the next render
     // because the bypass ref still overrides the persisted dismissal.
     userInitiatedCycleRef.current = false
+    locallyDismissedVersionRef.current = cachedVersion
     if (status.state === 'error') {
       setErrorDismissed(true)
       if (cachedVersion) {

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -239,6 +239,30 @@ export function UpdateCard() {
     return null
   }
 
+  const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
+  // Why: ordinary background checks now pre-download updates; keep that path
+  // quiet until the user explicitly checks, while explicit/nudge cycles stay visible.
+  if (status.state === 'available' && !userInitiatedCycleRef.current && !isNudgeDriven) {
+    return null
+  }
+  if (
+    status.state === 'downloading' &&
+    !userInitiatedCycleRef.current &&
+    !hasStartedDownload.current &&
+    !isNudgeDriven
+  ) {
+    return null
+  }
+  if (
+    status.state === 'downloaded' &&
+    !userInitiatedCycleRef.current &&
+    !hasStartedDownload.current &&
+    !isNudgeDriven &&
+    !isUserInitiated
+  ) {
+    return null
+  }
+
   // Error: show card for user-initiated check failures or for failures tied to
   // a concrete cached update version (card-initiated and Settings-initiated
   // download/install flows). Background check failures stay silent.

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -265,17 +265,6 @@ export function UpdateCard() {
   ) {
     return null
   }
-  if (
-    status.state === 'downloaded' &&
-    !userInitiatedCycleRef.current &&
-    !hasStartedDownload.current &&
-    !hasExplicitDownloadIntent &&
-    !isNudgeDriven &&
-    !isUserInitiated
-  ) {
-    return null
-  }
-
   // Error: show card for user-initiated check failures or for failures tied to
   // a concrete cached update version (card-initiated and Settings-initiated
   // download/install flows). Background check failures stay silent.
@@ -291,8 +280,8 @@ export function UpdateCard() {
   }
 
   // Dismiss gate: if the user previously dismissed this version, hide the card
-  // for passive reminder states. Keep active in-progress/error states visible so
-  // explicit install actions can still surface progress and failures.
+  // for passive reminder states. Keep in-progress/error and ready-to-install
+  // states visible so users can always finish or recover an update.
   // Why: bypass the gate when the current cycle was user-initiated — the user
   // explicitly asked to check, so they expect to see the result even if they
   // dismissed the same version earlier.
@@ -304,7 +293,11 @@ export function UpdateCard() {
     !hasExplicitDownloadIntent &&
     !isNudgeDriven
   ) {
-    if (status.state !== 'downloading' && status.state !== 'error') {
+    if (
+      status.state !== 'downloading' &&
+      status.state !== 'downloaded' &&
+      status.state !== 'error'
+    ) {
       return null
     }
   }

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -217,6 +217,8 @@ export function UpdateCard() {
   const cachedVersion = versionRef.current
   const hasExplicitDownloadIntent =
     cachedVersion !== null && downloadIntentVersion === cachedVersion
+  const isLocallyDismissedVersion =
+    cachedVersion !== null && locallyDismissedVersionRef.current === cachedVersion
   const shouldShowDetailedErrorCard =
     status.state === 'error' &&
     (isUserInitiated || isNudgeDriven || hasStartedDownload.current || hasExplicitDownloadIntent)
@@ -271,6 +273,17 @@ export function UpdateCard() {
   ) {
     return null
   }
+  // Why: closing the available card is also a request to keep the automatic
+  // pre-download quiet; explicit downloads and nudge campaigns still surface.
+  if (
+    status.state === 'downloading' &&
+    isLocallyDismissedVersion &&
+    !hasStartedDownload.current &&
+    !hasExplicitDownloadIntent &&
+    !isNudgeDriven
+  ) {
+    return null
+  }
   // Error: show card for user-initiated check failures or for failures tied to
   // a concrete cached update version (card-initiated and Settings-initiated
   // download/install flows). Background check failures stay silent.
@@ -291,8 +304,6 @@ export function UpdateCard() {
   // Why: bypass the gate when the current cycle was user-initiated — the user
   // explicitly asked to check, so they expect to see the result even if they
   // dismissed the same version earlier.
-  const isLocallyDismissedVersion =
-    versionRef.current !== null && locallyDismissedVersionRef.current === versionRef.current
   if (
     versionRef.current &&
     (dismissedVersion === versionRef.current || isLocallyDismissedVersion) &&

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -83,6 +83,7 @@ type GeneralPaneProps = {
 export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const updateStatus = useAppStore((s) => s.updateStatus)
+  const markUpdateDownloadIntent = useAppStore((s) => s.markUpdateDownloadIntent)
   // Why: the 'error' variant of UpdateStatus does not carry a `version` field.
   // The main process emits `{ state: 'error' }` for both check failures (no
   // version known yet) and download/install failures (version was known from
@@ -675,6 +676,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                 variant="default"
                 size="sm"
                 onClick={() => {
+                  markUpdateDownloadIntent(updateStatus.version)
                   void window.api.updater.download().catch((error) => {
                     toast.error('Could not start the update download.', {
                       description: String((error as Error)?.message ?? error)

--- a/src/renderer/src/components/status-bar/UpdateStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/UpdateStatusSegment.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 import { AlertCircle, CheckCircle2, Download } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppStore } from '../../store'
+import { shouldShowUpdateStatusSegment } from './update-status-segment-visibility'
 
 // Why: always rendered (not gated by `statusBarItems`). When the update card
 // is collapsed, this segment is the only way back to it — hiding it would
-// strand the user with an orphaned download or install.
+// strand the user with an orphaned explicit download or install.
 export function UpdateStatusSegment({
   iconOnly
 }: {
@@ -14,8 +15,12 @@ export function UpdateStatusSegment({
 }): React.JSX.Element | null {
   const status = useAppStore((s) => s.updateStatus)
   const collapsed = useAppStore((s) => s.updateCardCollapsed)
+  const downloadIntentVersion = useAppStore((s) => s.updateDownloadIntentVersion)
   const setCollapsed = useAppStore((s) => s.setUpdateCardCollapsed)
 
+  if (!shouldShowUpdateStatusSegment(status, downloadIntentVersion)) {
+    return null
+  }
   if (status.state !== 'downloading' && status.state !== 'downloaded' && status.state !== 'error') {
     return null
   }

--- a/src/renderer/src/components/status-bar/update-status-segment-visibility.ts
+++ b/src/renderer/src/components/status-bar/update-status-segment-visibility.ts
@@ -1,0 +1,21 @@
+import type { UpdateStatus } from '../../../../shared/types'
+
+export function shouldShowUpdateStatusSegment(
+  status: UpdateStatus,
+  downloadIntentVersion: string | null
+): boolean {
+  const isUserInitiated = 'userInitiated' in status && Boolean(status.userInitiated)
+  const isNudgeDriven = 'activeNudgeId' in status && Boolean(status.activeNudgeId)
+  const matchesExplicitDownload =
+    'version' in status &&
+    downloadIntentVersion !== null &&
+    status.version === downloadIntentVersion
+
+  if (status.state === 'downloading' || status.state === 'downloaded') {
+    return isUserInitiated || isNudgeDriven || matchesExplicitDownload
+  }
+  if (status.state === 'error') {
+    return isUserInitiated || isNudgeDriven || downloadIntentVersion !== null
+  }
+  return false
+}

--- a/src/renderer/src/components/status-bar/update-status-segment-visibility.ts
+++ b/src/renderer/src/components/status-bar/update-status-segment-visibility.ts
@@ -11,8 +11,13 @@ export function shouldShowUpdateStatusSegment(
     downloadIntentVersion !== null &&
     status.version === downloadIntentVersion
 
-  if (status.state === 'downloading' || status.state === 'downloaded') {
+  if (status.state === 'downloading') {
     return isUserInitiated || isNudgeDriven || matchesExplicitDownload
+  }
+  if (status.state === 'downloaded') {
+    // Why: passive background downloads are quiet while in progress, but once
+    // ready they need a persistent way back to the install UI.
+    return true
   }
   if (status.state === 'error') {
     return isUserInitiated || isNudgeDriven || downloadIntentVersion !== null

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -595,6 +595,11 @@ export type UISlice = {
   // Resets every session and on every phase transition (see setUpdateStatus).
   updateCardCollapsed: boolean
   setUpdateCardCollapsed: (collapsed: boolean) => void
+  // Why: Settings calls updater.download() directly, so main may report the
+  // same status shape as a passive predownload. Track the user's renderer-side
+  // click intent by version so progress/errors stay visible only for that path.
+  updateDownloadIntentVersion: string | null
+  markUpdateDownloadIntent: (version: string) => void
   updateReassuranceSeen: boolean
   markUpdateReassuranceSeen: () => void
   isFullScreen: boolean
@@ -1334,7 +1339,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setUpdateStatus: (status) => {
     const prevState = get().updateStatus.state
     const update: Partial<
-      Pick<UISlice, 'updateStatus' | 'updateChangelog' | 'updateCardCollapsed'>
+      Pick<
+        UISlice,
+        'updateStatus' | 'updateChangelog' | 'updateCardCollapsed' | 'updateDownloadIntentVersion'
+      >
     > = {
       updateStatus: status
     }
@@ -1352,6 +1360,13 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       // Why: reset on cycle-boundary states so stale rich content from a
       // previous update cycle cannot resurface.
       update.updateChangelog = null
+      update.updateDownloadIntentVersion = null
+    } else if (
+      'version' in status &&
+      get().updateDownloadIntentVersion !== null &&
+      get().updateDownloadIntentVersion !== status.version
+    ) {
+      update.updateDownloadIntentVersion = null
     }
     // For 'downloading', 'downloaded', 'error': leave updateChangelog untouched
     // so the card can keep showing rich content from the original 'available'.
@@ -1389,6 +1404,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     }),
   updateCardCollapsed: false,
   setUpdateCardCollapsed: (collapsed) => set({ updateCardCollapsed: collapsed }),
+  updateDownloadIntentVersion: null,
+  markUpdateDownloadIntent: (version) => set({ updateDownloadIntentVersion: version }),
   updateReassuranceSeen: false,
   markUpdateReassuranceSeen: () => {
     void window.api.ui.set({ updateReassuranceSeen: true }).catch(console.error)

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -1337,7 +1337,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
 
   updateStatus: { state: 'idle' },
   setUpdateStatus: (status) => {
-    const prevState = get().updateStatus.state
+    const state = get()
+    const prevState = state.updateStatus.state
+    const intentVersion = state.updateDownloadIntentVersion
     const update: Partial<
       Pick<
         UISlice,
@@ -1361,11 +1363,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       // previous update cycle cannot resurface.
       update.updateChangelog = null
       update.updateDownloadIntentVersion = null
-    } else if (
-      'version' in status &&
-      get().updateDownloadIntentVersion !== null &&
-      get().updateDownloadIntentVersion !== status.version
-    ) {
+    }
+    // Why: explicit download intent is version-scoped; keeping it after a new
+    // version appears makes passive failures look user-initiated.
+    if ('version' in status && intentVersion !== null && intentVersion !== status.version) {
       update.updateDownloadIntentVersion = null
     }
     // For 'downloading', 'downloaded', 'error': leave updateChangelog untouched

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1442,6 +1442,7 @@ export type UpdateStatus =
       // release-notes link fallback and for potential future use if the main
       // process starts extracting release URLs from electron-updater metadata.
       releaseUrl?: string
+      userInitiated?: boolean
       // Why: changelog is always explicitly set by the main process — null means
       // the fetch failed or the version wasn't in the JSON (simple mode), and a
       // populated object means rich mode. Using `| null` (not `?`) avoids a
@@ -1450,7 +1451,13 @@ export type UpdateStatus =
       changelog: ChangelogData | null
     }
   | { state: 'not-available'; userInitiated?: boolean }
-  | { state: 'downloading'; percent: number; version: string; activeNudgeId?: string }
+  | {
+      state: 'downloading'
+      percent: number
+      version: string
+      userInitiated?: boolean
+      activeNudgeId?: string
+    }
   | {
       state: 'downloaded'
       version: string

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1451,7 +1451,13 @@ export type UpdateStatus =
     }
   | { state: 'not-available'; userInitiated?: boolean }
   | { state: 'downloading'; percent: number; version: string; activeNudgeId?: string }
-  | { state: 'downloaded'; version: string; releaseUrl?: string; activeNudgeId?: string }
+  | {
+      state: 'downloaded'
+      version: string
+      releaseUrl?: string
+      userInitiated?: boolean
+      activeNudgeId?: string
+    }
   | { state: 'error'; message: string; userInitiated?: boolean; activeNudgeId?: string }
 
 // ─── Settings ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- pre-download available app updates after Orca records update metadata
- keep passive background update states quiet until the user explicitly checks or a nudge/manual flow is active
- validate staged updates on manual check so stale staged versions are superseded by newer downloads

## Tests
- pnpm vitest run src/main/updater.test.ts src/main/updater.mac-install.test.ts src/main/updater.check-failure.test.ts src/renderer/src/components/UpdateCard.test.ts
- pnpm run typecheck
- pnpm run lint

Refs stablyai/orca-internal#331

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.