### PR TITLE
fix: abort relay requests on dispatcher dispose

### DIFF
--- a/src/relay/client-request-aborts.ts
+++ b/src/relay/client-request-aborts.ts
@@ -27,6 +27,13 @@ export class ClientRequestAborts {
     }
   }
 
+  abortAll(): void {
+    for (const [, controller] of this.controllers) {
+      controller.abort()
+    }
+    this.controllers.clear()
+  }
+
   private key(clientId: number, requestId: number): string {
     return `${clientId}:${requestId}`
   }

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -310,6 +310,28 @@ describe('RelayDispatcher', () => {
     await vi.advanceTimersByTimeAsync(0)
   })
 
+  it('aborts in-flight request contexts on dispose', async () => {
+    let observedSignal: AbortSignal | undefined
+    let resolveHandler!: () => void
+    dispatcher.onRequest(
+      'slow.method',
+      (_params, context) =>
+        new Promise((resolve) => {
+          observedSignal = context.signal
+          resolveHandler = () => resolve(null)
+        })
+    )
+
+    const req: JsonRpcRequest = { jsonrpc: '2.0', id: 101, method: 'slow.method' }
+    dispatcher.feed(encodeJsonRpcFrame(req, 1, 0))
+    await vi.advanceTimersByTimeAsync(0)
+    dispatcher.dispose()
+
+    expect(observedSignal?.aborted).toBe(true)
+    resolveHandler()
+    await vi.advanceTimersByTimeAsync(0)
+  })
+
   it('notifies listeners when the primary client is invalidated', () => {
     const listener = vi.fn()
     dispatcher.onClientDetached(listener)

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -162,6 +162,9 @@ export class RelayDispatcher {
       clearInterval(this.keepaliveTimer)
       this.keepaliveTimer = null
     }
+    // Why: dispose means this relay instance cannot send responses anymore;
+    // abort in-flight request work so stale SSH-side scans/watchers release.
+    this.requestAborts.abortAll()
   }
 
   private createClient(write: (data: Buffer) => void): RelayClient {


### PR DESCRIPTION
## Summary
- Add a relay request-abort cleanup path for dispatcher disposal.
- Abort all tracked in-flight request contexts when the relay dispatcher is disposed.
- Add coverage for disposal while a request handler is still pending.

## Risk level
Low. The change only runs after dispatcher disposal, when the relay can no longer send valid responses; normal request handling is unchanged.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/relay/dispatcher.test.ts
- pnpm run typecheck:node
