### PR TITLE
Fix floating terminal close shortcut when empty

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -603,6 +603,56 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.activateTab).toHaveBeenCalledWith('created-tab')
   })
 
+  it('preserves terminal focus when dragging the titlebar from inside the floating panel', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    const activeElement = { closest: vi.fn().mockReturnValue(panelElement) }
+    const titlebarTarget = { closest: vi.fn().mockReturnValue(null) }
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(titlebarTarget, HTMLElement.prototype)
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+    vi.stubGlobal('document', { activeElement })
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture: vi.fn() },
+      pointerId: 1,
+      target: titlebarTarget
+    })
+
+    expect(panelElement.focus).not.toHaveBeenCalled()
+  })
+
+  it('focuses the floating panel for titlebar shortcuts when focus starts outside it', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const titlebar = findByProp(element, 'data-floating-terminal-shortcut-surface')
+    const panelElement = { focus: vi.fn() }
+    const activeElement = { closest: vi.fn().mockReturnValue(null) }
+    const titlebarTarget = { closest: vi.fn().mockReturnValue(null) }
+    Object.setPrototypeOf(activeElement, HTMLElement.prototype)
+    Object.setPrototypeOf(titlebarTarget, HTMLElement.prototype)
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+    vi.stubGlobal('document', { activeElement })
+
+    ;(titlebar.props.onPointerDown as (event: unknown) => void)({
+      button: 0,
+      clientX: 10,
+      clientY: 20,
+      currentTarget: { setPointerCapture: vi.fn() },
+      pointerId: 1,
+      target: titlebarTarget
+    })
+
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
   it('minimizes the empty floating workspace on Cmd+W after landing focus', async () => {
     const onOpenChange = vi.fn()
     const element = await renderPanel(true, onOpenChange)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -554,6 +554,17 @@ describe('FloatingTerminalPanel close behavior', () => {
     expect(mocks.closeBrowserTab).not.toHaveBeenCalled()
   })
 
+  it('focuses the empty floating workspace so Cmd+W can minimize after tabs close', async () => {
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const panelElement = { focus: vi.fn() }
+    ;(panel.props.ref as { current: unknown }).current = panelElement
+
+    runEffects()
+
+    expect(panelElement.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
   it('creates new floating terminal tabs without globally activating createTab', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -642,6 +642,15 @@ export function FloatingTerminalPanel({
   }, [activeGroup, closeFloatingItems])
 
   const focusPanelForShortcuts = useCallback(() => {
+    const active = document.activeElement
+    if (
+      active instanceof HTMLElement &&
+      active.closest('[data-floating-terminal-panel]') !== null
+    ) {
+      // Why: dragging the titlebar while xterm/editor already has focus should
+      // not steal the typing target just to keep panel shortcuts scoped.
+      return
+    }
     panelRef.current?.focus({ preventScroll: true })
   }, [])
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -346,6 +346,15 @@ export function FloatingTerminalPanel({
     focusTerminalTabSurface(activeTerminalId)
   }, [activeTerminalId, open])
 
+  useEffect(() => {
+    if (!open || activeTab !== null) {
+      return
+    }
+    // Why: after the last tab closes, focus can fall back outside the panel;
+    // keep the empty floating workspace able to receive Cmd/Ctrl+W.
+    panelRef.current?.focus({ preventScroll: true })
+  }, [activeTab, open])
+
   const refreshOrchestrationSetupVisibility = useCallback(async (): Promise<void> => {
     if (isOrchestrationSetupDismissed()) {
       setShowOrchestrationSetup(false)


### PR DESCRIPTION
## Summary
- keep floating terminal shortcut focus scoped without stealing focus while dragging from an active terminal/editor
- focus the empty floating terminal panel after the last tab closes so Cmd/Ctrl-W minimizes it
- add focused coverage for empty-state minimize/focus behavior

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm run tc:web

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.