### PR TITLE
fix: release CDP proxy resources on startup failure

### DIFF
--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -24,8 +24,19 @@ export class CdpWsProxy {
     return new Promise<string>((resolve, reject) => {
       this.httpServer = createServer((req, res) => this.handleHttpRequest(req, res))
       this.wss = new WebSocketServer({ server: this.httpServer })
-      const onListenError = (error: Error): void => {
+      const failStart = (error: Error): void => {
+        this.httpServer?.removeListener('error', onListenError)
+        this.wss?.close()
+        this.wss = null
+        this.httpServer?.close()
+        this.httpServer = null
+        // Why: a bind failure happens after debugger attach; release it here
+        // because callers cannot safely call stop() on a failed start.
+        this.detachDebugger()
         reject(error)
+      }
+      const onListenError = (error: Error): void => {
+        failStart(error)
       }
       this.wss.on('connection', (ws) => {
         if (this.client) {
@@ -46,7 +57,7 @@ export class CdpWsProxy {
           this.port = addr.port
           resolve(`ws://127.0.0.1:${this.port}`)
         } else {
-          reject(new Error('Failed to bind proxy server'))
+          failStart(new Error('Failed to bind proxy server'))
         }
       })
       this.httpServer.once('error', onListenError)


### PR DESCRIPTION
## Summary
- Clean up partially-created CDP proxy HTTP/WebSocket servers when startup fails.
- Detach the Electron debugger if binding fails after the debugger was already attached.
- Preserve the existing successful startup path.

## Risk level
Low. This only changes the error path after proxy startup fails; successful CDP proxy operation is unchanged.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/main/browser/cdp-ws-proxy.test.ts
- pnpm run typecheck:node
