### PR TITLE
Reset browser favicon fallback during render

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, and #3051: 964 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, and #3052: 963 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -85,6 +85,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR K         | Sidebar project filter                                | Extra render pass from mirroring the first filtered repo into command selection state.                   | `SidebarFilter.tsx` covered by #3042                                                                                     | Low            |
 | PR L         | Diff note edit draft                                  | Extra render pass from mirroring saved note body into edit draft while not editing.                      | `DiffCommentCard.tsx` covered by #3044                                                                                   | Low            |
 | PR M         | Status-bar account menus                              | Extra render pass from closing Claude/Codex account submenus in Effects after the provider menu closes.  | `StatusBar.tsx` covered by #3051                                                                                         | Low            |
+| PR N         | Browser tab favicon fallback                          | Extra render pass from resetting failed favicon state in an Effect after tab favicon identity changes.   | `BrowserTab.tsx` covered by #3052                                                                                        | Low            |
 
 ## Merge Risk Scale
 
@@ -103,6 +104,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3042 | `nwparker/react-perf-sidebar-filter` | Sidebar project filter command selection derived from filtered repos          | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/SidebarFilter.tsx`; `pnpm run typecheck:web`.          |
 | #3044 | `nwparker/react-perf-low-risk-2`     | Diff note card removes saved-body-to-draft mirror Effect                      | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/diff-comments/DiffCommentCard.tsx`; `pnpm run typecheck:web`.  |
 | #3051 | `nwparker/react-perf-low-risk-3`     | Status-bar account submenus collapse in provider menu open-change handlers    | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx`; `pnpm run typecheck:web`.           |
+| #3052 | `nwparker/react-perf-low-risk-4`     | Browser tab favicon failure reset happens during render for new favicon IDs   | Low  | Open   | `pnpm exec oxlint src/renderer/src/components/tab-bar/BrowserTab.tsx`; `pnpm run typecheck:web`.             |
 
 ## Reproduction Commands
 

--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -102,7 +102,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3041 | `nwparker/react-perf-pr-filter`      | PR reviewer filter mode derived from parsed query plus explicit user override | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/github/PRFilterDropdowns.tsx`; `pnpm run typecheck:web`.       |
 | #3042 | `nwparker/react-perf-sidebar-filter` | Sidebar project filter command selection derived from filtered repos          | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/SidebarFilter.tsx`; `pnpm run typecheck:web`.          |
 | #3044 | `nwparker/react-perf-low-risk-2`     | Diff note card removes saved-body-to-draft mirror Effect                      | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/diff-comments/DiffCommentCard.tsx`; `pnpm run typecheck:web`.  |
-| #3051 | `nwparker/react-perf-low-risk-3`     | Status-bar account submenus collapse in provider menu open-change handlers    | Low  | Open   | `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx`; `pnpm run typecheck:web`.           |
+| #3051 | `nwparker/react-perf-low-risk-3`     | Status-bar account submenus collapse in provider menu open-change handlers    | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx`; `pnpm run typecheck:web`.           |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -65,9 +65,14 @@ function BrowserTabFavicon({
   const displayFaviconUrl = faviconUrl?.trim() ? faviconUrl : null
   const [failedFavicon, setFailedFavicon] = useState<FailedFavicon | null>(null)
 
-  useEffect(() => {
+  // Why: reset during render so a new favicon identity retries before the tab
+  // commits one frame with the stale fallback icon.
+  if (
+    failedFavicon &&
+    (failedFavicon.tabId !== tabId || failedFavicon.faviconUrl !== displayFaviconUrl)
+  ) {
     setFailedFavicon(null)
-  }, [tabId, displayFaviconUrl])
+  }
 
   const currentFaviconFailed =
     failedFavicon?.tabId === tabId && failedFavicon.faviconUrl === displayFaviconUrl


### PR DESCRIPTION
## Summary
- reset browser tab favicon failure state during render when the tab id or favicon URL changes
- avoid committing a stale fallback icon frame and remove one local Effect hook site
- mark #3051 merged in the React performance audit ledger

## Risk
Low. Isolated tab-strip favicon presentation state only; no browser webview lifecycle, persistence, IPC, transport, terminal, or source-control behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/tab-bar/BrowserTab.tsx
- pnpm run typecheck:web