### PR TITLE
Remove static feature tour step repair effects

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -106,7 +106,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3044 | `nwparker/react-perf-low-risk-2`     | Diff note card removes saved-body-to-draft mirror Effect                      | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/diff-comments/DiffCommentCard.tsx`; `pnpm run typecheck:web`.  |
 | #3051 | `nwparker/react-perf-low-risk-3`     | Status-bar account submenus collapse in provider menu open-change handlers    | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx`; `pnpm run typecheck:web`.           |
 | #3052 | `nwparker/react-perf-low-risk-4`     | Browser tab favicon failure reset happens during render for new favicon IDs   | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/tab-bar/BrowserTab.tsx`; `pnpm run typecheck:web`.             |
-| #3053 | `nwparker/react-perf-low-risk-5`     | Inline workspace-title rename removes inactive draft sync Effect              | Low  | Open   | `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx`; `pnpm run typecheck:web`. |
+| #3053 | `nwparker/react-perf-low-risk-5`     | Inline workspace-title rename removes inactive draft sync Effect              | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, and #3053: 962 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, and #3054: 959 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -87,6 +87,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR M         | Status-bar account menus                              | Extra render pass from closing Claude/Codex account submenus in Effects after the provider menu closes.  | `StatusBar.tsx` covered by #3051                                                                                         | Low            |
 | PR N         | Browser tab favicon fallback                          | Extra render pass from resetting failed favicon state in an Effect after tab favicon identity changes.   | `BrowserTab.tsx` covered by #3052                                                                                        | Low            |
 | PR O         | Workspace title rename draft                          | Redundant draft sync Effect runs while the inline title rename input is not mounted.                     | `WorktreeTitleInlineRename.tsx` covered by #3053                                                                         | Low            |
+| PR P         | Feature-wall tour static substep repair               | Three no-op Effects scan static step arrays and repair ids that are only written from those arrays.      | `FeatureWallTourSurface.tsx` covered by #3054                                                                            | Low            |
 
 ## Merge Risk Scale
 
@@ -107,6 +108,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3051 | `nwparker/react-perf-low-risk-3`     | Status-bar account submenus collapse in provider menu open-change handlers    | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx`; `pnpm run typecheck:web`.           |
 | #3052 | `nwparker/react-perf-low-risk-4`     | Browser tab favicon failure reset happens during render for new favicon IDs   | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/tab-bar/BrowserTab.tsx`; `pnpm run typecheck:web`.             |
 | #3053 | `nwparker/react-perf-low-risk-5`     | Inline workspace-title rename removes inactive draft sync Effect              | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx`; `pnpm run typecheck:web`. |
+| #3054 | `nwparker/react-perf-low-risk-6`     | Feature-wall tour removes static substep id repair Effects                    | Low  | Open   | `pnpm exec oxlint src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
@@ -110,22 +110,6 @@ export function FeatureWallTourSurface({
     getDepthSummary: completion.getTourDepthSummary
   })
 
-  useEffect(() => {
-    if (!agentsSteps.some((s) => s.id === agentsStepId)) {
-      setAgentsStepId(agentsSteps[0]?.id ?? 'statuses')
-    }
-  }, [agentsSteps, agentsStepId])
-  useEffect(() => {
-    if (!workbenchSteps.some((s) => s.id === workbenchStepId)) {
-      setWorkbenchStepId(workbenchSteps[0]?.id ?? 'terminal')
-    }
-  }, [workbenchSteps, workbenchStepId])
-  useEffect(() => {
-    if (!reviewSteps.some((s) => s.id === reviewStepId)) {
-      setReviewStepId(reviewSteps[0]?.id ?? 'notes')
-    }
-  }, [reviewSteps, reviewStepId])
-
   const agentsActiveStep =
     selected.id === 'agents-orchestration'
       ? (agentsSteps.find((s) => s.id === agentsStepId) ?? agentsSteps[0] ?? null)


### PR DESCRIPTION
## Summary
- remove three no-op feature-wall tour substep repair Effects
- keep existing fallback lookup for active substeps, while relying on static step arrays and existing setters for valid state
- mark #3053 merged in the React performance audit ledger

## Risk
Low. Feature-wall tour UI state only; no telemetry event changes, completion persistence changes, IPC, terminal, browser webview, source-control, or settings behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
- pnpm run typecheck:web