### PR TITLE
Reset project group dialogs during render

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, and #3056: 957 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, and #3058: 955 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -90,6 +90,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR P         | Feature-wall tour static substep repair               | Three no-op Effects scan static step arrays and repair ids that are only written from those arrays.      | `FeatureWallTourSurface.tsx` covered by #3054                                                                            | Low            |
 | PR Q         | Repo combobox mount-open state                        | Mount-only auto-open path uses an Effect and ref guard instead of initializing state from the prop.       | `RepoCombobox.tsx` covered by #3055                                                                                      | Low            |
 | PR R         | Quick Open query reset                                | Extra render pass from clearing the Quick Open input after the dialog opens.                             | `QuickOpen.tsx` covered by #3056                                                                                         | Low            |
+| PR S         | Project group dialog open resets                      | Extra render pass from seeding name/delete dialog local state after the dialog opens.                    | `ProjectGroupNameDialog.tsx`, `ProjectGroupDeleteDialog.tsx` covered by #3058                                            | Low            |
 
 ## Merge Risk Scale
 
@@ -113,6 +114,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3054 | `nwparker/react-perf-low-risk-6`     | Feature-wall tour removes static substep id repair Effects                    | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx`; `pnpm run typecheck:web`. |
 | #3055 | `nwparker/react-perf-low-risk-7`     | Repo combobox initializes mount-open state without an Effect                  | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/repo/RepoCombobox.tsx`; `pnpm run typecheck:web`.              |
 | #3056 | `nwparker/react-perf-low-risk-8`     | Quick Open clears its query on the open edge without a reset Effect           | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/QuickOpen.tsx`; `pnpm run typecheck:web`.                      |
+| #3058 | `nwparker/react-perf-project-group-dialogs` | Project group dialogs reset local open-state during render              | Low  | Open   | `pnpm exec oxlint src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -23,12 +23,16 @@ export function ProjectGroupDeleteDialog({
   onConfirm
 }: ProjectGroupDeleteDialogProps): React.JSX.Element {
   const [deleting, setDeleting] = useState(false)
+  const [wasOpen, setWasOpen] = useState(open)
 
-  useEffect(() => {
-    if (open) {
+  // Why: opening the dialog must clear a stale in-flight state before the
+  // destructive button renders; an Effect would leave one disabled frame.
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open && deleting) {
       setDeleting(false)
     }
-  }, [open])
+  }
 
   const handleConfirm = useCallback(async () => {
     if (deleting) {

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
+import React, { useCallback, useId, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -34,14 +34,18 @@ export function ProjectGroupNameDialog({
   const inputId = useId()
   const [name, setName] = useState(initialName)
   const [submitting, setSubmitting] = useState(false)
+  const [previousOpenState, setPreviousOpenState] = useState({ open, initialName })
   const trimmedName = name.trim()
 
-  useEffect(() => {
+  // Why: the input should mount already seeded and selectable for the active
+  // group; Effect-based hydration shows one frame with the prior draft.
+  if (open !== previousOpenState.open || initialName !== previousOpenState.initialName) {
+    setPreviousOpenState({ open, initialName })
     if (open) {
       setName(initialName)
       setSubmitting(false)
     }
-  }, [initialName, open])
+  }
 
   const handleSubmit = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
## Summary
- move project-group name/delete dialog local resets from Effects to render-time open-edge handling
- remove two Effect hook sites while keeping the same initial draft and deleting-state reset behavior

## Risk
Low. Isolated project-group dialog local UI state only; no persistence, worktree, source-control, terminal, browser webview, IPC, or SSH behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
- pnpm run typecheck:web