### PR TITLE
Move quick command dialog reset out of effect

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, and #3063: 947 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, and #3064: 946 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -95,6 +95,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR U         | Feature-wall tour workflow resets                     | Four local reset Effects run after workflow changes or close instead of in the selection/close path.      | `FeatureWallTourSurface.tsx` covered by #3060                                                                            | Low            |
 | PR V         | Workspace board selection pruning                     | Local kanban selection is repaired in an Effect after the drawer closes or board rows change.             | `use-workspace-kanban-selection.ts` covered by #3062                                                                     | Low            |
 | PR W         | Workspace board column resize                         | Two mirror Effects sync the latest commit callback and external committed width after render.             | `use-workspace-kanban-column-resize.ts` covered by #3063                                                                 | Low            |
+| PR X         | Terminal quick-command dialog draft                   | Dialog draft and agent preset search are reset in an Effect after the dialog opens or retargets.          | `TerminalQuickCommandDialog.tsx` covered by #3064                                                                        | Low            |
 
 ## Merge Risk Scale
 
@@ -123,6 +124,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3060 | `nwparker/react-perf-feature-tour-resets` | Feature-wall tour reset state moves into workflow/close transitions | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx`; `pnpm run typecheck:web`. |
 | #3062 | `nwparker/react-perf-kanban-selection` | Workspace board selection pruning moves out of an Effect          | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/use-workspace-kanban-selection.ts`; `pnpm run typecheck:web`. |
 | #3063 | `nwparker/react-perf-kanban-column` | Workspace board column width mirror Effects move to render-time synchronization | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/use-workspace-kanban-column-resize.ts`; `pnpm run typecheck:web`. |
+| #3064 | `nwparker/react-perf-quick-command-dialog` | Terminal quick-command dialog resets draft state during render | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import type {
   Repo,
@@ -97,6 +97,8 @@ export function TerminalQuickCommandDialog({
   const [draft, setDraft] = useState<TerminalQuickCommand>(command)
   const [agentPresetOpen, setAgentPresetOpen] = useState(false)
   const [agentPresetQuery, setAgentPresetQuery] = useState('')
+  const wasOpenRef = useRef(open)
+  const syncedCommandRef = useRef(command)
   const agentCmdOverrides = useAppStore(
     (s) => s.settings?.agentCmdOverrides ?? EMPTY_AGENT_CMD_OVERRIDES
   )
@@ -110,13 +112,21 @@ export function TerminalQuickCommandDialog({
   const selectedRepoId = selectedRepo?.id ?? ''
   const selectedRepoMissing = selectedScope.type === 'repo' && selectedRepo === null
 
-  useEffect(() => {
-    if (open) {
-      setDraft({ ...command })
+  if (!open) {
+    wasOpenRef.current = false
+  } else if (!wasOpenRef.current || syncedCommandRef.current !== command) {
+    wasOpenRef.current = true
+    syncedCommandRef.current = command
+    // Why: opening or retargeting the dialog should render the new command
+    // draft immediately instead of repairing it in a follow-up Effect.
+    setDraft({ ...command })
+    if (agentPresetOpen) {
       setAgentPresetOpen(false)
+    }
+    if (agentPresetQuery) {
       setAgentPresetQuery('')
     }
-  }, [command, open])
+  }
 
   const agentPresets = useMemo(() => {
     return AGENT_CATALOG.map((entry, index) => {


### PR DESCRIPTION
## Summary
- replace the terminal quick-command dialog open reset Effect with a guarded render-time reset
- keep draft seeding, preset popover close, and preset query clearing behavior intact when opening or retargeting the dialog

## Risk
Low. This is isolated local dialog draft state for the terminal quick-command editor. It does not touch terminal execution, persistence, IPC, browser, source control, mobile, or SSH behavior.

## Verification
- pnpm exec oxlint src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
- pnpm run typecheck:web
- AST Effect count: 947 -> 946