### PR TITLE
Move onboarding agent ref mirrors out of effects

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, and #3065: 945 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, and #3066: 940 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -97,6 +97,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR W         | Workspace board column resize                         | Two mirror Effects sync the latest commit callback and external committed width after render.             | `use-workspace-kanban-column-resize.ts` covered by #3063                                                                 | Low            |
 | PR X         | Terminal quick-command dialog draft                   | Dialog draft and agent preset search are reset in an Effect after the dialog opens or retargets.          | `TerminalQuickCommandDialog.tsx` covered by #3064                                                                        | Low            |
 | PR Y         | Onboarding notification settings ref                  | A ref mirror Effect keeps notification handlers pointed at the latest settings.                            | `NotificationStep.tsx` covered by #3065                                                                                  | Low            |
+| PR Z         | Onboarding agent-selection ref mirrors                | Five ref mirror Effects keep stable onboarding handlers pointed at latest selection/detection snapshots.   | `use-onboarding-flow.ts` covered by #3066                                                                                | Low            |
 
 ## Merge Risk Scale
 
@@ -127,6 +128,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3063 | `nwparker/react-perf-kanban-column` | Workspace board column width mirror Effects move to render-time synchronization | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/use-workspace-kanban-column-resize.ts`; `pnpm run typecheck:web`. |
 | #3064 | `nwparker/react-perf-quick-command-dialog` | Terminal quick-command dialog resets draft state during render | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx`; `pnpm run typecheck:web`. |
 | #3065 | `nwparker/react-perf-notification-step-ref` | Onboarding notification settings ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/NotificationStep.tsx`; `pnpm run typecheck:web`. |
+| #3066 | `nwparker/react-perf-onboarding-agent-refs` | Onboarding agent-selection ref mirrors move out of Effects | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/agent-picked-payload.test.ts`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -195,9 +195,13 @@ export function useOnboardingFlow(
   // detectedAgentIdsRef / isDetectingRef pattern.
   const pathSourceRef = useRef(pathSource)
   const pathFailureReasonRef = useRef(pathFailureReason)
-  useEffect(() => {
-    selectedAgentRef.current = selectedAgent
-  }, [selectedAgent])
+  // Why: stable onboarding handlers read these values at click/async time, so
+  // keep the mirrors fresh before events can run.
+  selectedAgentRef.current = selectedAgent
+  detectedAgentIdsRef.current = detectedAgentIds ?? []
+  isDetectingRef.current = isDetectingAgents
+  pathSourceRef.current = pathSource
+  pathFailureReasonRef.current = pathFailureReason
   const setSelectedAgentInteractive = useCallback(
     (value: TuiAgent | null, fromCollapsedSection = false) => {
       agentInteractedRef.current = true
@@ -230,23 +234,6 @@ export function useOnboardingFlow(
   const detectedSet = useMemo(() => new Set(detectedAgentIds ?? []), [detectedAgentIds])
   const currentStep = STEPS[stepIndex]
   const hasExistingProject = repos.length > 0
-
-  // Why: refs let `setSelectedAgentInteractive` (a stable useCallback) read
-  // the freshest detection snapshot at click time without re-rebinding the
-  // handler whenever the store flips a flag. Mirrors the
-  // `selectedAgentRef` pattern above.
-  useEffect(() => {
-    detectedAgentIdsRef.current = detectedAgentIds ?? []
-  }, [detectedAgentIds])
-  useEffect(() => {
-    isDetectingRef.current = isDetectingAgents
-  }, [isDetectingAgents])
-  useEffect(() => {
-    pathSourceRef.current = pathSource
-  }, [pathSource])
-  useEffect(() => {
-    pathFailureReasonRef.current = pathFailureReason
-  }, [pathFailureReason])
 
   // Why: pin start time once so onboarding_completed reports a real funnel duration.
   const startTimeRef = useRef<number>(Date.now())


### PR DESCRIPTION
## Summary
- replace five onboarding agent-selection ref mirror Effects with direct render-time ref updates
- keep the stable click/async handlers reading fresh selected-agent, detection, and PATH-hydration snapshots
- leave telemetry, theme, refresh, and lifecycle Effects unchanged

## Risk
Low. This only changes local ref freshness for onboarding agent-selection handlers and telemetry payload inputs. It does not change settings persistence, agent detection IPC, terminal/browser/source-control, mobile, or SSH behavior.

## Verification
- pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/agent-picked-payload.test.ts
- pnpm run typecheck:web
- AST Effect count: 945 -> 940