### PR TITLE
Move feature wall telemetry refs out of effect

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, #3066, and #3067: 938 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, #3066, #3067, and #3068: 937 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -99,6 +99,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR Y         | Onboarding notification settings ref                  | A ref mirror Effect keeps notification handlers pointed at the latest settings.                            | `NotificationStep.tsx` covered by #3065                                                                                  | Low            |
 | PR Z         | Onboarding agent-selection ref mirrors                | Five ref mirror Effects keep stable onboarding handlers pointed at latest selection/detection snapshots.   | `use-onboarding-flow.ts` covered by #3066                                                                                | Low            |
 | PR AA        | Workspace board drag ref mirrors                      | Area-selection and card-drag pointer handlers receive latest board callbacks through Effect-updated refs.  | `use-workspace-kanban-area-selection.ts`, `use-workspace-kanban-card-pointer-drag.ts` covered by #3067                    | Low            |
+| PR AB        | Feature-wall tour telemetry refs                      | Close telemetry reads source/depth payload inputs through Effect-updated refs.                             | `use-feature-wall-tour-telemetry.ts` covered by #3068                                                                    | Low            |
 
 ## Merge Risk Scale
 
@@ -131,6 +132,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3065 | `nwparker/react-perf-notification-step-ref` | Onboarding notification settings ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/NotificationStep.tsx`; `pnpm run typecheck:web`. |
 | #3066 | `nwparker/react-perf-onboarding-agent-refs` | Onboarding agent-selection ref mirrors move out of Effects | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/agent-picked-payload.test.ts`; `pnpm run typecheck:web`. |
 | #3067 | `nwparker/react-perf-kanban-drag-refs` | Workspace board drag ref mirrors move out of Effects | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/use-workspace-kanban-area-selection.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts src/renderer/src/components/sidebar/workspace-kanban-area-selection.test.ts`; `pnpm run typecheck:web`. |
+| #3068 | `nwparker/react-perf-feature-wall-telemetry-ref` | Feature-wall tour telemetry ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
@@ -78,10 +78,10 @@ export function useFeatureWallTourTelemetry(args: {
   const telemetryRef = useRef<FeatureWallTourTelemetryState>(createFeatureWallTourTelemetryState())
   const sourceRef = useRef(source)
   const getDepthSummaryRef = useRef(getDepthSummary)
-  useEffect(() => {
-    sourceRef.current = source
-    getDepthSummaryRef.current = getDepthSummary
-  }, [getDepthSummary, source])
+  // Why: close telemetry may emit from stable callbacks; keep the payload
+  // inputs current before open/close Effects or unmount cleanup can run.
+  sourceRef.current = source
+  getDepthSummaryRef.current = getDepthSummary
 
   const emitCloseTelemetry = useCallback(() => {
     const payload = buildFeatureWallClosedTelemetry(


### PR DESCRIPTION
## Summary
- replace the feature-wall tour source/depth ref mirror Effect with render-time ref updates
- keep open/close/unmount telemetry Effects in place, since they emit lifecycle analytics

## Risk
Low. This only updates local telemetry input refs for feature-wall tour close events. It does not change persistence, IPC, terminal/browser/source-control, mobile, or SSH behavior.

## Verification
- pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts
- pnpm run typecheck:web
- AST Effect count: 938 -> 937