### PR TITLE
Move onboarding persisted theme ref out of effect

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -47,7 +47,7 @@ Initial inventory:
 
 ## Coverage Ledger
 
-Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, #3066, #3067, and #3068: 937 Effect hook call sites.
+Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, #3066, #3067, #3068, and #3069: 936 Effect hook call sites.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -100,6 +100,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR Z         | Onboarding agent-selection ref mirrors                | Five ref mirror Effects keep stable onboarding handlers pointed at latest selection/detection snapshots.   | `use-onboarding-flow.ts` covered by #3066                                                                                | Low            |
 | PR AA        | Workspace board drag ref mirrors                      | Area-selection and card-drag pointer handlers receive latest board callbacks through Effect-updated refs.  | `use-workspace-kanban-area-selection.ts`, `use-workspace-kanban-card-pointer-drag.ts` covered by #3067                    | Low            |
 | PR AB        | Feature-wall tour telemetry refs                      | Close telemetry reads source/depth payload inputs through Effect-updated refs.                             | `use-feature-wall-tour-telemetry.ts` covered by #3068                                                                    | Low            |
+| PR AC        | Onboarding persisted theme ref                        | The theme cleanup ref mirrors the latest persisted setting through an Effect.                               | `use-onboarding-flow.ts` covered by #3069                                                                                | Low            |
 
 ## Merge Risk Scale
 
@@ -133,6 +134,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3066 | `nwparker/react-perf-onboarding-agent-refs` | Onboarding agent-selection ref mirrors move out of Effects | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/agent-picked-payload.test.ts`; `pnpm run typecheck:web`. |
 | #3067 | `nwparker/react-perf-kanban-drag-refs` | Workspace board drag ref mirrors move out of Effects | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/use-workspace-kanban-area-selection.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts src/renderer/src/components/sidebar/workspace-kanban-area-selection.test.ts`; `pnpm run typecheck:web`. |
 | #3068 | `nwparker/react-perf-feature-wall-telemetry-ref` | Feature-wall tour telemetry ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts`; `pnpm run typecheck:web`. |
+| #3069 | `nwparker/react-perf-onboarding-theme-ref` | Onboarding persisted theme ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -241,9 +241,7 @@ export function useOnboardingFlow(
   // Why: track the latest persisted theme in a ref so the unmount-only revert
   // below uses the freshest value without retriggering on each settings change.
   const persistedThemeRef = useRef<GlobalSettings['theme']>(settings?.theme ?? 'dark')
-  useEffect(() => {
-    persistedThemeRef.current = settings?.theme ?? 'dark'
-  }, [settings?.theme])
+  persistedThemeRef.current = settings?.theme ?? 'dark'
   const themeStepEntryThemeRef = useRef<GlobalSettings['theme'] | null>(null)
   const themeStepEntryCapturedRef = useRef(false)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- replace the onboarding persisted-theme ref mirror Effect with a render-time ref update
- keep the document theme apply/revert Effects unchanged

## Risk
Low. This only keeps a local ref current for onboarding theme cleanup on unmount. It does not change settings persistence, IPC, terminal/browser/source-control, mobile, or SSH behavior.

## Verification
- pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts
- pnpm run typecheck:web
- AST Effect count: 937 -> 936