### PR TITLE
Remove terminal window blur mount effect

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -49,6 +49,8 @@ Initial inventory:
 
 Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, #3066, #3067, #3068, and #3069: 936 Effect hook call sites.
 
+Open medium-risk PR #3070 lowers the branch count to 935 Effect hook call sites, but is not counted in the merged baseline until reviewed and merged.
+
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Renderer app shell             | `src/renderer/src/App.tsx`, root components                                                              | Inventory complete, manual review pending     | Check global listeners, beforeunload, media-query, sidebar resize, active-tab repair.                                              |
@@ -101,6 +103,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR AA        | Workspace board drag ref mirrors                      | Area-selection and card-drag pointer handlers receive latest board callbacks through Effect-updated refs.  | `use-workspace-kanban-area-selection.ts`, `use-workspace-kanban-card-pointer-drag.ts` covered by #3067                    | Low            |
 | PR AB        | Feature-wall tour telemetry refs                      | Close telemetry reads source/depth payload inputs through Effect-updated refs.                             | `use-feature-wall-tour-telemetry.ts` covered by #3068                                                                    | Low            |
 | PR AC        | Onboarding persisted theme ref                        | The theme cleanup ref mirrors the latest persisted setting through an Effect.                               | `use-onboarding-flow.ts` covered by #3069                                                                                | Low            |
+| PR AD        | Terminal window blur restart snapshot                 | A mount-only Effect rewrites the same startup blur snapshot already captured by the lazy ref initializer.   | `TerminalWindowSection.tsx` covered by #3070                                                                             | Medium         |
 
 ## Merge Risk Scale
 
@@ -135,6 +138,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3067 | `nwparker/react-perf-kanban-drag-refs` | Workspace board drag ref mirrors move out of Effects | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/sidebar/use-workspace-kanban-area-selection.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts src/renderer/src/components/sidebar/workspace-kanban-area-selection.test.ts`; `pnpm run typecheck:web`. |
 | #3068 | `nwparker/react-perf-feature-wall-telemetry-ref` | Feature-wall tour telemetry ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts`; `pnpm run typecheck:web`. |
 | #3069 | `nwparker/react-perf-onboarding-theme-ref` | Onboarding persisted theme ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts`; `pnpm run typecheck:web`. |
+| #3070 | `nwparker/react-perf-terminal-window-ref` | Terminal window blur startup snapshot removes redundant mount Effect | Medium | Open   | `pnpm exec oxlint src/renderer/src/components/settings/TerminalWindowSection.tsx`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { RotateCw } from 'lucide-react'
 import type { GlobalSettings, TerminalColorOverrides } from '../../../../shared/types'
 import { Button } from '../ui/button'
@@ -85,16 +85,6 @@ export function TerminalWindowSection({
   const blurAtMountRef = useRef<boolean>(settings.windowBackgroundBlur ?? false)
   const blurPendingRestart = (settings.windowBackgroundBlur ?? false) !== blurAtMountRef.current
   const [relaunchingBlur, setRelaunchingBlur] = useState(false)
-
-  // Why: the mount-time snapshot captures local state, not main-process state.
-  // If the setting is persisted and read correctly on next boot we never need
-  // to re-snapshot, but tests mount the component with arbitrary initial
-  // values — keep `blurAtMountRef` honest if the settings load asynchronously
-  // and the value arrives after mount.
-  useEffect(() => {
-    blurAtMountRef.current = settings.windowBackgroundBlur ?? false
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   const handleRelaunch = async (): Promise<void> => {
     if (relaunchingBlur) {


### PR DESCRIPTION
## Summary
- remove the redundant mount-only Effect that reassigns the terminal window blur startup snapshot
- keep the restart-required comparison based on the lazy ref initializer

## Risk
Medium. This touches settings UI for the terminal window blur restart-required banner. It does not change persistence writes, IPC handlers, terminal runtime, browser webviews, source-control providers, mobile, or SSH behavior, but settings restart UX should be reviewed before merge.

## Verification
- pnpm exec oxlint src/renderer/src/components/settings/TerminalWindowSection.tsx
- pnpm run typecheck:web
- AST Effect count on branch: 936 -> 935

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.