### PR TITLE
Move composer note ref sync out of effect

### DIFF
--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -473,9 +473,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   // Why: read the latest note inside handleBaseBranchPrSelect without adding
   // `note` to its deps (which would rebuild the callback on every keystroke).
   const noteRef = useRef<string>(note)
-  useEffect(() => {
-    noteRef.current = note
-  }, [note])
+  noteRef.current = note
   const composerRef = useRef<HTMLDivElement | null>(null)
   const promptTextareaRef = useRef<HTMLTextAreaElement | null>(null)
   const nameInputRef = useRef<HTMLInputElement | null>(null)


### PR DESCRIPTION
## Summary
- replace the new-workspace composer note ref mirror Effect with the same render-time ref sync pattern used by adjacent composer refs
- keep `handleBaseBranchPrSelect` stable without a follow-up render after every note edit

## Risk
Medium. This touches the new-workspace composer path for PR/MR note auto-fill behavior. It does not change workspace creation IPC, persistence writes, terminal/browser/source-control providers, mobile, or SSH behavior, but composer prefill flows should be reviewed before merge.

## Verification
- pnpm exec oxlint src/renderer/src/hooks/useComposerState.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/composer-branch-selection.test.ts
- pnpm run typecheck:web
- AST Effect count on branch: 936 -> 935

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.