### PR TITLE
Record source control selection cleanup PR in audit

### DIFF
--- a/docs/reference/react-performance-audit.md
+++ b/docs/reference/react-performance-audit.md
@@ -49,7 +49,7 @@ Initial inventory:
 
 Current count after low-risk PRs #3038, #3041, #3042, #3044, #3051, #3052, #3053, #3054, #3055, #3056, #3058, #3059, #3060, #3062, #3063, #3064, #3065, #3066, #3067, #3068, and #3069: 936 Effect hook call sites.
 
-Open medium-risk PRs #3070 and #3073 each lower their branch count to 935 Effect hook call sites, but are not counted in the merged baseline until reviewed and merged.
+Open medium-risk PRs #3070 and #3073 each lower their branch count to 935 Effect hook call sites, and open high-risk PR #3075 lowers its branch count to 932 Effect hook call sites. These are not counted in the merged baseline until reviewed and merged.
 
 | Area                           | Files / signal                                                                                           | Scan status                                   | Notes                                                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -105,6 +105,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | PR AC        | Onboarding persisted theme ref                        | The theme cleanup ref mirrors the latest persisted setting through an Effect.                               | `use-onboarding-flow.ts` covered by #3069                                                                                | Low            |
 | PR AD        | Terminal window blur restart snapshot                 | A mount-only Effect rewrites the same startup blur snapshot already captured by the lazy ref initializer.   | `TerminalWindowSection.tsx` covered by #3070                                                                             | Medium         |
 | PR AE        | New-workspace composer note ref                       | A note ref mirror Effect runs after each note edit so stable PR/MR selection callbacks can read latest text. | `useComposerState.ts` covered by #3073                                                                                   | Medium         |
+| PR AF        | Source-control selection ref mirrors                  | Four ref mirror Effects keep stable source-control row handlers pointed at latest selection inputs.         | `useSourceControlSelection.ts` covered by #3075                                                                          | High           |
 
 ## Merge Risk Scale
 
@@ -141,6 +142,7 @@ These are candidate batches, not final conclusions. Each item needs code inspect
 | #3069 | `nwparker/react-perf-onboarding-theme-ref` | Onboarding persisted theme ref mirror moves out of an Effect | Low  | Merged | `pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts`; `pnpm run typecheck:web`. |
 | #3070 | `nwparker/react-perf-terminal-window-ref` | Terminal window blur startup snapshot removes redundant mount Effect | Medium | Open   | `pnpm exec oxlint src/renderer/src/components/settings/TerminalWindowSection.tsx`; `pnpm run typecheck:web`. |
 | #3073 | `nwparker/react-perf-composer-note-ref` | New-workspace composer note ref mirror moves out of an Effect | Medium | Open   | `pnpm exec oxlint src/renderer/src/hooks/useComposerState.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/composer-branch-selection.test.ts`; `pnpm run typecheck:web`. |
+| #3075 | `nwparker/react-perf-source-control-selection-refs` | Source-control selection ref mirrors move out of Effects | High | Open   | `pnpm exec oxlint src/renderer/src/components/right-sidebar/useSourceControlSelection.ts`; `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useSourceControlSelection.test.ts`; `pnpm run typecheck:web`. |
 
 ## Reproduction Commands
 


### PR DESCRIPTION
## Summary
- record open high-risk PR #3075 in the React performance audit ledger
- keep the merged Effect count at 936 while noting open branch-only reductions for #3070, #3073, and #3075

## Risk
Low. Documentation-only audit ledger update.

## Verification
- git diff --check