### PR TITLE
Move notebook cell editor refs out of effect

### DIFF
--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -248,6 +248,10 @@ function CodeCell({
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const onDeactivateRef = useRef(onDeactivate)
   const onSaveRequestRef = useRef(onSaveRequest)
+  // Why: Monaco commands/listeners are installed once on mount and need the
+  // latest callbacks without rebuilding the embedded editor.
+  onDeactivateRef.current = onDeactivate
+  onSaveRequestRef.current = onSaveRequest
   const fontSize = computeEditorFontSize(settings?.terminalFontSize ?? 13, editorFontZoomLevel)
   const lineCount = Math.max(3, source.split('\n').length + 1)
   const editorHeight = Math.min(520, Math.max(96, lineCount * (fontSize + 8)))
@@ -272,11 +276,6 @@ function CodeCell({
       onDeactivateRef.current()
     })
   }, [])
-
-  useEffect(() => {
-    onDeactivateRef.current = onDeactivate
-    onSaveRequestRef.current = onSaveRequest
-  }, [onDeactivate, onSaveRequest])
 
   useEffect(() => {
     monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')


### PR DESCRIPTION
## Summary
- replace the notebook code-cell callback ref mirror Effect with render-time ref updates
- keep Monaco save/Escape/blur handlers stable while letting them call the latest callbacks
- leave Monaco theme and notebook lifecycle Effects unchanged

## Risk
Medium. This touches notebook editor save/deactivate callbacks inside embedded Monaco editors. It does not change notebook parsing, persistence APIs, terminal/browser/source-control, mobile, or SSH behavior, but notebook edit/save UX should be reviewed before merge.

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/IpynbViewer.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/ipynb-parse.test.ts
- pnpm run typecheck:web
- AST Effect count on branch: 936 -> 935

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.