### PR TITLE
Move rich markdown editor refs out of effects

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -1336,9 +1336,7 @@ export default function RichMarkdownEditor({
     }
   })
 
-  useEffect(() => {
-    editorRef.current = editor ?? null
-  }, [editor])
+  editorRef.current = editor ?? null
 
   const clearAnnotationHighlight = useCallback((): void => {
     const ed = editorRef.current
@@ -1507,10 +1505,7 @@ export default function RichMarkdownEditor({
   }, [editor, markdownDocuments])
 
   const handleLocalImagePick = useLocalImagePick(editor, filePath, worktreeId, runtimeEnvironmentId)
-
-  useEffect(() => {
-    handleLocalImagePickRef.current = handleLocalImagePick
-  }, [handleLocalImagePick])
+  handleLocalImagePickRef.current = handleLocalImagePick
 
   const {
     handleLinkSave,
@@ -1556,9 +1551,7 @@ export default function RichMarkdownEditor({
     rootRef,
     scrollContainerRef
   })
-  useEffect(() => {
-    openSearchRef.current = openSearch
-  }, [openSearch])
+  openSearchRef.current = openSearch
 
   const navigateToTableOfContentsItem = useCallback(
     (id: string): void => {
@@ -1675,9 +1668,7 @@ export default function RichMarkdownEditor({
     setAnnotationTarget(null)
   }, [annotationTarget, canAnnotateRichMarkdown, markdownComments, markdownSourceLineOffset])
 
-  useEffect(() => {
-    handleEmojiPickRef.current = openEmojiMenu
-  }, [openEmojiMenu])
+  handleEmojiPickRef.current = openEmojiMenu
 
   const filteredSlashCommands = useMemo(() => {
     const query = slashMenu?.query.trim().toLowerCase() ?? ''


### PR DESCRIPTION
## Summary
- replace nine RichMarkdownEditor ref mirror Effects with render-time ref updates
- keep ProseMirror key handlers, context commands, slash/doc-link menus, emoji insertion, image picking, and search callbacks reading fresh state before events run
- leave lifecycle, subscription, menu-index repair, and programmatic editor update Effects unchanged

## Risk
Medium. This touches rich markdown editor UI behavior around slash/doc-link menus, search, image insertion, emoji insertion, and editor instance refs. It does not change file persistence, IPC handlers, terminal/browser/source-control, mobile, or SSH behavior, but rich-editor interaction paths should be reviewed before merge.

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/RichMarkdownEditor.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts src/renderer/src/components/editor/RichMarkdownSlashMenu.test.tsx src/renderer/src/components/editor/markdown-doc-completions.test.ts src/renderer/src/components/editor/rich-markdown-commands.test.ts
- pnpm run typecheck:web
- AST Effect count on branch: 936 -> 926

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.