### PR TITLE
Move browser ref mirrors out of effects

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -1778,10 +1778,8 @@ function RemoteBrowserPagePane({
     [closeMissingRemotePage, isCurrentRemoteStreamToken]
   )
 
-  useEffect(() => {
-    startRemoteStreamRef.current = startRemoteStream
-    restartRemoteStreamForViewportRef.current = restartRemoteStreamForViewport
-  }, [restartRemoteStreamForViewport, startRemoteStream])
+  startRemoteStreamRef.current = startRemoteStream
+  restartRemoteStreamForViewportRef.current = restartRemoteStreamForViewport
 
   useEffect(() => {
     return () => {
@@ -2555,6 +2553,9 @@ function BrowserPagePane({
   const initialBrowserUrlRef = useRef(browserTab.url)
   const browserTabUrlRef = useRef(browserTab.url)
   const activeLoadFailureRef = useRef<BrowserLoadError | null>(browserTab.loadError)
+  initialBrowserUrlRef.current = browserTab.url
+  browserTabUrlRef.current = browserTab.url
+  activeLoadFailureRef.current = browserTab.loadError
   // Why: CDP viewport emulation does not survive all renderer process swaps
   // (cross-origin navigations, crashes). We reapply on every dom-ready from
   // this ref so the persisted preset survives reloads without re-running the
@@ -2572,11 +2573,16 @@ function BrowserPagePane({
   const onSetUrlRef = useRef(onSetUrl)
   const addBrowserHistoryEntry = useAppStore((s) => s.addBrowserHistoryEntry)
   const addBrowserHistoryEntryRef = useRef(addBrowserHistoryEntry)
+  onUpdatePageStateRef.current = onUpdatePageState
+  onSetUrlRef.current = onSetUrl
+  addBrowserHistoryEntryRef.current = addBrowserHistoryEntry
   const [addressBarValue, setAddressBarValue] = useState(browserTab.url)
   const addressBarValueRef = useRef(browserTab.url)
+  addressBarValueRef.current = addressBarValue
   const [resourceNotice, setResourceNotice] = useState<string | null>(null)
   const [downloadState, setDownloadState] = useState<BrowserDownloadState | null>(null)
   const downloadStateRef = useRef<BrowserDownloadState | null>(null)
+  downloadStateRef.current = downloadState
   const [contextMenu, setContextMenu] = useState<{
     x: number
     y: number
@@ -2798,10 +2804,6 @@ function BrowserPagePane({
   }, [browserAnnotations.length, isActive, pendingAnnotationPayload])
 
   useEffect(() => {
-    initialBrowserUrlRef.current = browserTab.url
-  }, [browserTab.id, browserTab.url])
-
-  useEffect(() => {
     // Why: if the user is actively typing in the address bar (focused), do not
     // clobber their in-progress query when an async URL update lands (e.g., the
     // configured default URL resolving after a new tab opens). Syncing will
@@ -2811,22 +2813,6 @@ function BrowserPagePane({
     }
     setAddressBarValue(toDisplayUrl(browserTab.url))
   }, [browserTab.url])
-
-  useEffect(() => {
-    browserTabUrlRef.current = browserTab.url
-  }, [browserTab.url])
-
-  useEffect(() => {
-    activeLoadFailureRef.current = browserTab.loadError
-  }, [browserTab.loadError])
-
-  useEffect(() => {
-    addressBarValueRef.current = addressBarValue
-  }, [addressBarValue])
-
-  useEffect(() => {
-    downloadStateRef.current = downloadState
-  }, [downloadState])
 
   useEffect(() => {
     setResourceNotice(
@@ -3227,12 +3213,6 @@ function BrowserPagePane({
       webviewRef.current?.reloadIgnoringCache()
     })
   }, [isActive])
-
-  useEffect(() => {
-    onUpdatePageStateRef.current = onUpdatePageState
-    onSetUrlRef.current = onSetUrl
-    addBrowserHistoryEntryRef.current = addBrowserHistoryEntry
-  }, [onSetUrl, onUpdatePageState, addBrowserHistoryEntry])
 
   const syncNavigationState = useCallback(
     (webview: Electron.WebviewTag): void => {

--- a/src/renderer/src/components/browser-pane/useGrabMode.ts
+++ b/src/renderer/src/components/browser-pane/useGrabMode.ts
@@ -44,10 +44,7 @@ export function useGrabMode(browserPageId: string): GrabModeHook {
   const [contextMenu, setContextMenu] = useState(false)
   const activeOpIdRef = useRef<string | null>(null)
   const browserTabIdRef = useRef(browserPageId)
-
-  useEffect(() => {
-    browserTabIdRef.current = browserPageId
-  }, [browserPageId])
+  browserTabIdRef.current = browserPageId
 
   // Why: when the browser page changes while grab is active, cancel the
   // current grab operation so stale overlays don't survive tab switches.


### PR DESCRIPTION
## Summary
- move browser/webview latest-value ref mirrors from post-render Effects to render-time ref assignment
- remove one `useGrabMode` browser page id ref mirror Effect
- remove seven `BrowserPane` ref mirror Effects covering remote stream callbacks, tab URL/load state, address value, download state, and page-state callbacks

## Merge risk
High: browser/webview lifecycle, remote stream, and grab-mode paths are high-risk areas. This PR should be reviewed manually and is not auto-merged.

## Verification
- `pnpm exec oxlint src/renderer/src/components/browser-pane/useGrabMode.ts src/renderer/src/components/browser-pane/BrowserPane.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-pane-page-selection.test.ts src/renderer/src/components/browser-pane/context-menu-positioning.test.ts`
- `pnpm run typecheck:web`
- AST Effect count on branch: 936 -> 928
- Electron sanity: launched `react-perf @ nwparker/react-perf-browser-ref-mirrors` on CDP port 9333, attached with `playwright-cli`, confirmed app identity and zero console errors, and observed an existing browser webview target. Full toolbar/browser interaction was not completed because the restored address-bar input was hidden in that layout.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.