### PR TITLE
Remove untitled rename reset effect

### DIFF
--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { FolderOpen } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -36,19 +36,23 @@ export function UntitledFileRenameDialog({
   const [dir, setDir] = useState(worktreePath)
   const [error, setError] = useState<string | null>(null)
   const nameInputRef = useRef<HTMLInputElement>(null)
+  const seededOpenStateRef = useRef({ open: false, baseName, worktreePath })
 
   const displayError = externalError ?? error
 
-  useEffect(() => {
-    if (open) {
+  // Why: seed the drafts before the open dialog paints; focus is handled by
+  // Radix's open lifecycle below so this does not need a post-render Effect.
+  if (open) {
+    const seeded = seededOpenStateRef.current
+    if (!seeded.open || seeded.baseName !== baseName || seeded.worktreePath !== worktreePath) {
+      seededOpenStateRef.current = { open: true, baseName, worktreePath }
       setName(baseName)
       setDir(worktreePath)
       setError(null)
-      requestAnimationFrame(() => {
-        nameInputRef.current?.select()
-      })
     }
-  }, [open, baseName, worktreePath])
+  } else if (seededOpenStateRef.current.open) {
+    seededOpenStateRef.current = { open: false, baseName, worktreePath }
+  }
 
   const handleBrowse = useCallback(async () => {
     const picked = await window.api.shell.pickDirectory({ defaultPath: dir || worktreePath })
@@ -89,7 +93,17 @@ export function UntitledFileRenameDialog({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent showCloseButton={false} className="max-w-[340px]">
+      <DialogContent
+        showCloseButton={false}
+        className="max-w-[340px]"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          requestAnimationFrame(() => {
+            nameInputRef.current?.focus()
+            nameInputRef.current?.select()
+          })
+        }}
+      >
         <DialogHeader>
           <DialogTitle className="text-sm">Save as</DialogTitle>
           <DialogDescription className="text-xs">


### PR DESCRIPTION
## Summary
- seed the untitled-file rename dialog draft state before the open render paints
- move name-field focus/selection to Radix `onOpenAutoFocus`
- remove the post-render reset Effect from this local dialog

## Merge risk
Low: isolated local dialog state only. No persistence, IPC, browser, terminal, source-control, or provider behavior changes.

## Verification
- `pnpm exec oxlint src/renderer/src/components/editor/UntitledFileRenameDialog.tsx`
- `pnpm run typecheck:web`
- AST Effect count on branch: 936 -> 935
