### PR TITLE
feat: Add AdaL (SylphAI) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Orca supports any CLI agent (*not just this list*).
   <a href="https://kiro.dev/docs/cli/"><kbd><img src="https://www.google.com/s2/favicons?domain=kiro.dev&sz=64" width="16" valign="middle" /> Kiro</kbd></a> &nbsp;
   <a href="https://github.com/mistralai/mistral-vibe"><kbd><img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=64" width="16" valign="middle" /> Mistral Vibe</kbd></a> &nbsp;
   <a href="https://github.com/QwenLM/qwen-code"><kbd><img src="https://www.google.com/s2/favicons?domain=qwenlm.github.io&sz=64" width="16" valign="middle" /> Qwen Code</kbd></a> &nbsp;
-  <a href="https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/"><kbd><img src="https://www.google.com/s2/favicons?domain=atlassian.com&sz=64" width="16" valign="middle" /> Rovo Dev</kbd></a>
+  <a href="https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/"><kbd><img src="https://www.google.com/s2/favicons?domain=atlassian.com&sz=64" width="16" valign="middle" /> Rovo Dev</kbd></a> &nbsp;
+  <a href="https://docs.sylph.ai"><kbd><img src="https://www.google.com/s2/favicons?domain=sylph.ai&sz=64" width="16" valign="middle" /> AdaL</kbd></a>
 </p>
 
 ---

--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -32,7 +32,8 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'qwen-code',
   'rovo',
   'hermes',
-  'openclaw'
+  'openclaw',
+  'adal'
 ] as const satisfies readonly TuiAgent[]
 
 export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
@@ -64,7 +65,8 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   'qwen-code': 'Qwen Code',
   rovo: 'Rovo Dev',
   hermes: 'Hermes',
-  openclaw: 'OpenClaw'
+  openclaw: 'OpenClaw',
+  adal: 'AdaL'
 }
 
 export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>> = {
@@ -92,7 +94,8 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
   'qwen-code': 'qwenlm.github.io',
   rovo: 'atlassian.com',
   hermes: 'nousresearch.com',
-  openclaw: 'openclaw.ai'
+  openclaw: 'openclaw.ai',
+  adal: 'sylph.ai'
 }
 
 export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
@@ -124,7 +127,8 @@ export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
   'qwen-code': 'qwen-code',
   rovo: 'rovo',
   hermes: 'hermes',
-  openclaw: 'openclaw'
+  openclaw: 'openclaw',
+  adal: 'adal'
 }
 
 export function isMobileTuiAgent(value: unknown): value is TuiAgent {

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -44,6 +44,7 @@ export const AGENTS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'openclaw',
       'copilot',
       'grok',
+      'adal',
       'github',
       'github copilot',
       'command',

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -122,7 +122,8 @@ export const GENERAL_AGENT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
       'gemini',
       'aider',
       'copilot',
-      'grok'
+      'grok',
+      'adal'
     ]
   }
 ]

--- a/src/renderer/src/components/terminal-pane/title-agent-identity.ts
+++ b/src/renderer/src/components/terminal-pane/title-agent-identity.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../shared/agent-detection'
 
 const TITLE_AGENT_TOKEN_RE =
-  /(?<![\w./\\-])(claude|codex|gemini|antigravity|agy|opencode|openclaw|aider|copilot|cursor-agent|cursor|droid|hermes|grok|pi)(?![\w./\\-])/i
+  /(?<![\w./\\-])(claude|codex|gemini|antigravity|agy|opencode|openclaw|aider|copilot|cursor-agent|cursor|droid|hermes|grok|adal|pi)(?![\w./\\-])/i
 
 export function titleHasExplicitAgentIdentity(title: string): boolean {
   if (!title) {

--- a/src/renderer/src/lib/agent-catalog.test.tsx
+++ b/src/renderer/src/lib/agent-catalog.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import { TUI_AGENT_AUTO_PICK_ORDER } from '../../../shared/tui-agent-selection'
+import { AGENT_CATALOG } from './agent-catalog'
+
+describe('AGENT_CATALOG', () => {
+  it('stays in sync with the default TUI agent selection order', () => {
+    expect(AGENT_CATALOG.map((agent) => agent.id)).toEqual(TUI_AGENT_AUTO_PICK_ORDER)
+  })
+})

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -42,13 +42,6 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     homepageUrl: 'https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli'
   },
   {
-    id: 'adal',
-    label: 'AdaL',
-    cmd: 'adal',
-    faviconDomain: 'sylph.ai',
-    homepageUrl: 'https://docs.sylph.ai'
-  },
-  {
     id: 'opencode',
     label: 'OpenCode',
     cmd: 'opencode',
@@ -227,6 +220,13 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     cmd: 'openclaw',
     faviconDomain: 'openclaw.ai',
     homepageUrl: 'https://github.com/openclaw/openclaw'
+  },
+  {
+    id: 'adal',
+    label: 'AdaL',
+    cmd: 'adal',
+    faviconDomain: 'sylph.ai',
+    homepageUrl: 'https://docs.sylph.ai'
   }
 ]
 

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -42,6 +42,13 @@ export const AGENT_CATALOG: AgentCatalogEntry[] = [
     homepageUrl: 'https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli'
   },
   {
+    id: 'adal',
+    label: 'AdaL',
+    cmd: 'adal',
+    faviconDomain: 'sylph.ai',
+    homepageUrl: 'https://docs.sylph.ai'
+  },
+  {
     id: 'opencode',
     label: 'OpenCode',
     cmd: 'opencode',

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -207,6 +207,13 @@ describe('detectAgentStatusFromTitle', () => {
     expect(detectAgentStatusFromTitle('Hermes working')).toBe('working')
   })
 
+  it('classifies synthesized AdaL titles', () => {
+    expect(detectAgentStatusFromTitle('⠋ AdaL')).toBe('working')
+    expect(detectAgentStatusFromTitle('AdaL ready')).toBe('idle')
+    expect(detectAgentStatusFromTitle('AdaL - action required')).toBe('permission')
+    expect(detectAgentStatusFromTitle('AdaL working')).toBe('working')
+  })
+
   it('does not treat Factory Droid native needs-input titles as completion', () => {
     expect(detectAgentStatusFromTitle('Factory Droid needs input')).toBeNull()
     expect(detectAgentStatusFromTitle('Factory Droid needs your input')).toBeNull()
@@ -248,6 +255,11 @@ describe('detectAgentStatusFromTitle', () => {
   it('does not treat path fragments containing Hermes as agent activity', () => {
     expect(detectAgentStatusFromTitle('~/hermes/working')).not.toBe('working')
     expect(detectAgentStatusFromTitle('C:\\hermes\\ready')).toBeNull()
+  })
+
+  it('does not treat path fragments containing AdaL as agent activity', () => {
+    expect(detectAgentStatusFromTitle('~/adal/working')).not.toBe('working')
+    expect(detectAgentStatusFromTitle('C:\\adal\\ready')).toBeNull()
   })
 })
 
@@ -396,6 +408,8 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('Droid ready')).toBe('Droid')
     expect(getAgentLabel('⠋ Hermes')).toBe('Hermes')
     expect(getAgentLabel('Hermes ready')).toBe('Hermes')
+    expect(getAgentLabel('⠋ AdaL')).toBe('AdaL')
+    expect(getAgentLabel('AdaL ready')).toBe('AdaL')
   })
 
   it('labels GitHub Copilot CLI', () => {
@@ -406,6 +420,10 @@ describe('getAgentLabel', () => {
 
   it('does not label Android titles as Droid', () => {
     expect(getAgentLabel('android emulator ready')).toBeNull()
+  })
+
+  it('does not label AdaL path fragments as AdaL', () => {
+    expect(getAgentLabel('C:\\adal\\ready')).toBeNull()
   })
 })
 
@@ -717,6 +735,10 @@ describe('formatAgentTypeLabel', () => {
     expect(formatAgentTypeLabel('hermes')).toBe('Hermes')
   })
 
+  it("maps 'adal' to 'AdaL'", () => {
+    expect(formatAgentTypeLabel('adal')).toBe('AdaL')
+  })
+
   it("maps 'command-code' to 'Command Code'", () => {
     expect(formatAgentTypeLabel('command-code')).toBe('Command Code')
   })
@@ -743,6 +765,7 @@ describe('agentTypeToIconAgent', () => {
     expect(agentTypeToIconAgent('claude')).toBe('claude')
     expect(agentTypeToIconAgent('antigravity')).toBe('antigravity')
     expect(agentTypeToIconAgent('command-code')).toBe('command-code')
+    expect(agentTypeToIconAgent('adal')).toBe('adal')
   })
 
   it('returns null for arbitrary non-iconable strings', () => {

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -123,7 +123,8 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   droid: 'Droid',
   'command-code': 'Command Code',
   grok: 'Grok',
-  hermes: 'Hermes'
+  hermes: 'Hermes',
+  adal: 'AdaL'
 }
 
 export function formatAgentTypeLabel(agentType: AgentType | null | undefined): string {
@@ -176,7 +177,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   hermes: true,
   openclaw: true,
   copilot: true,
-  grok: true
+  grok: true,
+  adal: true
 }
 
 export function agentTypeToIconAgent(agentType: AgentType | null | undefined): TuiAgent | null {

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -150,6 +150,22 @@ describe('buildAgentStartupPlan', () => {
     })
   })
 
+  it('launches AdaL first and injects the prompt after startup', () => {
+    expect(
+      buildAgentStartupPlan({
+        agent: 'adal',
+        prompt: 'Trace the failing test',
+        cmdOverrides: {},
+        platform: 'linux'
+      })
+    ).toEqual({
+      agent: 'adal',
+      launchCommand: 'adal',
+      expectedProcess: 'adal',
+      followupPrompt: 'Trace the failing test'
+    })
+  })
+
   it('launches Command Code by its unambiguous binary with a positional prompt', () => {
     expect(
       buildAgentStartupPlan({

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: terminal-title agent detection is centralized so status inference stays consistent across renderer/runtime callers. */
 /**
  * Shared agent detection utilities — used by both the main process (stats
  * collection) and the renderer (activity indicators, unread badges).
@@ -31,8 +32,7 @@ export const AGENT_NAMES = [
   'opencode',
   'openclaw',
   'aider',
-  'grok',
-  'adal'
+  'grok'
 ]
 
 // Why: `android` contains `droid`; unlike the legacy agent names above, Droid
@@ -44,6 +44,7 @@ const DROID_AGENT_NAME_RE = /(?<![\w./\\-])droid(?![\w./\\-])/i
 // otherwise count as agent activity.
 const HERMES_AGENT_NAME_RE = /(?<![\w./\\-])hermes(?![\w./\\-])/i
 const AGY_AGENT_NAME_RE = /(?<![\w./\\-])agy(?![\w./\\-])/i
+const ADAL_AGENT_NAME_RE = /(?<![\w./\\-])adal(?![\w./\\-])/i
 
 // Why: idle keywords used inside `detectAgentStatusFromTitle` to map titles
 // like "Codex done", "OpenCode ready", "Aider idle" to AgentStatus 'idle'.
@@ -185,7 +186,8 @@ function containsAgentName(title: string): boolean {
     containsLegacyAgentName(title) ||
     AGY_AGENT_NAME_RE.test(title) ||
     DROID_AGENT_NAME_RE.test(title) ||
-    HERMES_AGENT_NAME_RE.test(title)
+    HERMES_AGENT_NAME_RE.test(title) ||
+    ADAL_AGENT_NAME_RE.test(title)
   )
 }
 
@@ -383,7 +385,7 @@ export function getAgentLabel(title: string): string | null {
   if (lower.includes('opencode')) {
     return 'OpenCode'
   }
-  if (lower.includes('adal')) {
+  if (ADAL_AGENT_NAME_RE.test(title)) {
     return 'AdaL'
   }
   if (lower.includes('aider')) {
@@ -463,8 +465,15 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   const hasDroidAgentName = DROID_AGENT_NAME_RE.test(title)
   const hasHermesAgentName = HERMES_AGENT_NAME_RE.test(title)
   const hasAgyAgentName = AGY_AGENT_NAME_RE.test(title)
+  const hasAdalAgentName = ADAL_AGENT_NAME_RE.test(title)
   const hasLegacyAgentName = containsLegacyAgentName(title)
-  if (hasLegacyAgentName || hasDroidAgentName || hasHermesAgentName || hasAgyAgentName) {
+  if (
+    hasLegacyAgentName ||
+    hasDroidAgentName ||
+    hasHermesAgentName ||
+    hasAgyAgentName ||
+    hasAdalAgentName
+  ) {
     if (containsAny(title, ['action required', 'permission', 'waiting'])) {
       return 'permission'
     }

--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -31,7 +31,8 @@ export const AGENT_NAMES = [
   'opencode',
   'openclaw',
   'aider',
-  'grok'
+  'grok',
+  'adal'
 ]
 
 // Why: `android` contains `droid`; unlike the legacy agent names above, Droid
@@ -381,6 +382,9 @@ export function getAgentLabel(title: string): string | null {
   }
   if (lower.includes('opencode')) {
     return 'OpenCode'
+  }
+  if (lower.includes('adal')) {
+    return 'AdaL'
   }
   if (lower.includes('aider')) {
     return 'Aider'

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -42,7 +42,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   hermes: 'hermes',
   openclaw: 'openclaw',
   copilot: 'copilot',
-  grok: 'grok'
+  grok: 'grok',
+  adal: 'adal'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -37,4 +37,12 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('cmd.exe')).toBe(false)
     expect(recognizeAgentProcess('cmd.exe')).toBeNull()
   })
+
+  it('recognizes AdaL process names from npm global bin paths', () => {
+    expect(recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\adal.cmd`)).toEqual({
+      agent: 'adal',
+      processName: 'adal'
+    })
+    expect(isRecognizedAgentType('adal')).toBe(true)
+  })
 })

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -77,6 +77,7 @@ export const AGENT_KIND_VALUES = [
   'openclaw',
   'copilot',
   'grok',
+  'adal',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -293,6 +293,12 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     launchCmd: 'grok',
     expectedProcess: 'grok',
     promptInjectionMode: 'stdin-after-start'
+  },
+  adal: {
+    detectCmd: 'adal',
+    launchCmd: 'adal',
+    expectedProcess: 'adal',
+    promptInjectionMode: 'stdin-after-start'
   }
 }
 

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -32,7 +32,8 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'qwen-code',
   'rovo',
   'hermes',
-  'openclaw'
+  'openclaw',
+  'adal'
 ] as const satisfies readonly TuiAgent[]
 
 export function pickTuiAgent(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1564,6 +1564,7 @@ export type TuiAgent =
   | 'openclaw' // OpenClaw
   | 'copilot' // GitHub Copilot CLI
   | 'grok' // xAI Grok CLI
+  | 'adal' // AdaL (SylphAI)
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 


### PR DESCRIPTION
## Summary

Adds [AdaL CLI](https://docs.sylph.ai) by SylphAI as a supported agent in Orca.

Closes #3085

## What is AdaL?

AdaL is a self-evolving agentic coding tool that runs in the terminal, created by [SylphAI](https://sylph.ai) and named after Ada Lovelace.

```bash
npm install -g @sylphai/adal-cli
adal
```

## Changes

| File | Change |
|------|--------|
| `src/shared/types.ts` | Add `adal` to `TuiAgent` union |
| `src/shared/telemetry-events.ts` | Add `adal` to `AGENT_KIND_VALUES` |
| `src/shared/agent-kind.ts` | Map `adal` → `adal` in telemetry lookup |
| `src/renderer/src/lib/agent-catalog.tsx` | Add catalog entry (cmd, favicon, homepage) |

## Testing

- TypeScript compiles without errors (exhaustive `satisfies` check in agent-kind.ts passes)
- No runtime changes beyond registering the new agent

## Links

- Docs: https://docs.sylph.ai
- GitHub: https://github.com/SylphAI-Inc/adal-cli
- npm: @sylphai/adal-cli

---
🌸 Generated with [AdaL](https://github.com/adal-cli/)

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.

## ELI5

Adds AdaL (SylphAI) as a supported terminal agent so you can launch and use the AdaL CLI from Orca like other agents.
