### PR TITLE
Remove orca.yaml trust reset effect

### DIFF
--- a/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
+++ b/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -34,6 +34,16 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
   const [alwaysTrust, setAlwaysTrust] = useState(false)
 
   const isOpen = activeModal === 'confirm-orca-yaml-hooks'
+  const previousOpenRef = useRef(isOpen)
+
+  // Why: never show a stale "always trust" checkbox when a new hook prompt
+  // opens; resetting during render avoids one paint with the old decision.
+  if (previousOpenRef.current !== isOpen) {
+    previousOpenRef.current = isOpen
+    if (isOpen && alwaysTrust) {
+      setAlwaysTrust(false)
+    }
+  }
 
   const repoId = typeof modalData.repoId === 'string' ? modalData.repoId : ''
   const repoName = typeof modalData.repoName === 'string' ? modalData.repoName : 'this repository'
@@ -50,12 +60,6 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
     typeof modalData.onResolve === 'function'
       ? (modalData.onResolve as (decision: 'run' | 'skip') => void)
       : null
-
-  useEffect(() => {
-    if (isOpen) {
-      setAlwaysTrust(false)
-    }
-  }, [isOpen])
 
   const resolveAndClose = useCallback(
     (decision: 'run' | 'skip') => {


### PR DESCRIPTION
## Summary
- reset the `orca.yaml` hook trust checkbox on the dialog open edge during render
- remove the post-render reset Effect from `OrcaYamlTrustDialog`
- avoid one paint where a previous "always trust" choice could remain visible on a new prompt

## Merge risk
Medium: the code change is small and local UI state only, but this dialog controls trust decisions for repo hook scripts, so it should be reviewed before merge.

## Verification
- `pnpm exec oxlint src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count on branch: 933 -> 932

No direct component test exists for `OrcaYamlTrustDialog`; related hook-confirmation tests cover the trust decision flow outside this dialog.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.