### PR TITLE
Derive repo hook local editor visibility

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -464,15 +464,7 @@ function ScriptEditor({
     }
   }, [value])
 
-  useEffect(() => {
-    // Why: when the repo or its persisted local script changes (e.g. switching repos),
-    // re-evaluate whether the local block should be visible by default.
-    if (value.length > 0) {
-      setShowLocal(true)
-    }
-  }, [value])
-
-  const showLocalEditor = showLocal || !hasShared
+  const showLocalEditor = showLocal || value.length > 0 || !hasShared
   const lineCount = value ? value.split('\n').length : 0
 
   return (


### PR DESCRIPTION
## Summary
- remove the repository hook script editor Effect that set local editor visibility after a non-empty value arrived
- derive visibility from explicit user-open state, non-empty persisted local script content, or absence of shared hook content

## Risk
MEDIUM - settings UI for repository hook scripts; no transport/protocol change, but this affects persisted local hook script visibility when switching repos/settings.

## Verification
- pnpm exec oxlint src/renderer/src/components/settings/RepositoryHooksSection.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 932 -> 931 on this branch

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.