### PR TITLE
Move feature wall visited markers to events

### DIFF
--- a/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
@@ -119,6 +119,14 @@ export function FeatureWallTourSurface({
     source,
     getDepthSummary: completion.getTourDepthSummary
   })
+  const {
+    markWorkflowVisited,
+    markAgentStepVisited,
+    markWorkbenchStepVisited,
+    markReviewStepVisited
+  } = completion
+  const markWorkflowVisitedRef = useRef(markWorkflowVisited)
+  markWorkflowVisitedRef.current = markWorkflowVisited
 
   const agentsActiveStep =
     selected.id === 'agents-orchestration'
@@ -143,6 +151,7 @@ export function FeatureWallTourSurface({
 
   useEffect(() => {
     if (isOpen) {
+      markWorkflowVisitedRef.current(DEFAULT_FEATURE_WALL_WORKFLOW_ID)
       track('feature_wall_group_selected', {
         group_id: DEFAULT_FEATURE_WALL_WORKFLOW_ID,
         source
@@ -161,33 +170,6 @@ export function FeatureWallTourSurface({
     }
   }, [isOpen, source])
 
-  const {
-    markWorkflowVisited,
-    markAgentStepVisited,
-    markWorkbenchStepVisited,
-    markReviewStepVisited
-  } = completion
-  useEffect(() => {
-    if (isOpen) {
-      markWorkflowVisited(selected.id)
-    }
-  }, [isOpen, markWorkflowVisited, selected.id])
-  useEffect(() => {
-    if (isOpen && agentsActiveStep) {
-      markAgentStepVisited(agentsActiveStep.id)
-    }
-  }, [agentsActiveStep, isOpen, markAgentStepVisited])
-  useEffect(() => {
-    if (isOpen && workbenchActiveStep) {
-      markWorkbenchStepVisited(workbenchActiveStep.id)
-    }
-  }, [isOpen, markWorkbenchStepVisited, workbenchActiveStep])
-  useEffect(() => {
-    if (isOpen && reviewActiveStep) {
-      markReviewStepVisited(reviewActiveStep.id)
-    }
-  }, [isOpen, markReviewStepVisited, reviewActiveStep])
-
   const handleSelect = useCallback(
     (workflow: FeatureWallWorkflow): void => {
       markWorkflowVisited(workflow.id)
@@ -196,11 +178,17 @@ export function FeatureWallTourSurface({
       }
       setSelectedId(workflow.id)
       if (workflow.id === 'agents-orchestration') {
-        setAgentsStepId(agentsSteps[0]?.id ?? 'statuses')
+        const nextStepId = agentsSteps[0]?.id ?? 'statuses'
+        markAgentStepVisited(nextStepId)
+        setAgentsStepId(nextStepId)
       } else if (workflow.id === 'workbench') {
-        setWorkbenchStepId(workbenchSteps[0]?.id ?? 'terminal')
+        const nextStepId = workbenchSteps[0]?.id ?? 'terminal'
+        markWorkbenchStepVisited(nextStepId)
+        setWorkbenchStepId(nextStepId)
       } else if (workflow.id === 'review') {
-        setReviewStepId(reviewSteps[0]?.id ?? 'notes')
+        const nextStepId = reviewSteps[0]?.id ?? 'notes'
+        markReviewStepVisited(nextStepId)
+        setReviewStepId(nextStepId)
       }
       track('feature_wall_group_selected', { group_id: workflow.id, source })
       const tile = getFeatureWallMediaTile(workflow.primaryTileId)
@@ -213,7 +201,41 @@ export function FeatureWallTourSurface({
         track('feature_wall_tile_focused', { tile_id: tile.id })
       }
     },
-    [agentsSteps, markWorkflowVisited, reviewSteps, selectedId, source, workbenchSteps]
+    [
+      agentsSteps,
+      markAgentStepVisited,
+      markReviewStepVisited,
+      markWorkbenchStepVisited,
+      markWorkflowVisited,
+      reviewSteps,
+      selectedId,
+      source,
+      workbenchSteps
+    ]
+  )
+
+  const handleSelectAgentsStep = useCallback(
+    (id: AgentsStepId): void => {
+      markAgentStepVisited(id)
+      setAgentsStepId(id)
+    },
+    [markAgentStepVisited]
+  )
+
+  const handleSelectWorkbenchStep = useCallback(
+    (id: WorkbenchStepId): void => {
+      markWorkbenchStepVisited(id)
+      setWorkbenchStepId(id)
+    },
+    [markWorkbenchStepVisited]
+  )
+
+  const handleSelectReviewStep = useCallback(
+    (id: ReviewStepId): void => {
+      markReviewStepVisited(id)
+      setReviewStepId(id)
+    },
+    [markReviewStepVisited]
   )
 
   const handleRailKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number): void => {
@@ -258,25 +280,28 @@ export function FeatureWallTourSurface({
   const handleContinue = useCallback((): void => {
     markWorkflowVisited(selected.id)
     if (selected.id === 'agents-orchestration') {
-      completion.markAgentStepVisited(agentsStepId)
+      markAgentStepVisited(agentsStepId)
       const nextStep = agentsSteps[agentsStepIndex >= 0 ? agentsStepIndex + 1 : 0]
       if (nextStep) {
+        markAgentStepVisited(nextStep.id)
         setAgentsStepId(nextStep.id)
         return
       }
     }
     if (selected.id === 'workbench') {
-      completion.markWorkbenchStepVisited(workbenchStepId)
+      markWorkbenchStepVisited(workbenchStepId)
       const nextStep = workbenchSteps[workbenchStepIndex >= 0 ? workbenchStepIndex + 1 : 0]
       if (nextStep) {
+        markWorkbenchStepVisited(nextStep.id)
         setWorkbenchStepId(nextStep.id)
         return
       }
     }
     if (selected.id === 'review') {
-      completion.markReviewStepVisited(reviewStepId)
+      markReviewStepVisited(reviewStepId)
       const nextStep = reviewSteps[reviewStepIndex >= 0 ? reviewStepIndex + 1 : 0]
       if (nextStep) {
+        markReviewStepVisited(nextStep.id)
         setReviewStepId(nextStep.id)
         return
       }
@@ -308,10 +333,12 @@ export function FeatureWallTourSurface({
     agentsStepId,
     agentsStepIndex,
     agentsSteps,
-    completion,
     handleSelect,
     isLastWorkflow,
+    markAgentStepVisited,
     markExitAction,
+    markReviewStepVisited,
+    markWorkbenchStepVisited,
     markWorkflowVisited,
     onDone,
     reviewStepId,
@@ -373,13 +400,13 @@ export function FeatureWallTourSurface({
       onRailKeyDown={handleRailKeyDown}
       agentsSteps={agentsSteps}
       agentsActiveStep={agentsActiveStep}
-      onSelectAgentsStep={setAgentsStepId}
+      onSelectAgentsStep={handleSelectAgentsStep}
       workbenchSteps={workbenchSteps}
       workbenchActiveStep={workbenchActiveStep}
-      onSelectWorkbenchStep={setWorkbenchStepId}
+      onSelectWorkbenchStep={handleSelectWorkbenchStep}
       reviewSteps={reviewSteps}
       reviewActiveStep={reviewActiveStep}
-      onSelectReviewStep={setReviewStepId}
+      onSelectReviewStep={handleSelectReviewStep}
       posterUrl={posterUrl}
       gifUrl={gifUrl}
       showGif={showGif}


### PR DESCRIPTION
## Summary
- remove four feature-wall tour Effects that marked the visible workflow/substep as visited after render
- mark the default workflow when the tour opens, and mark workflow/substep visits inside rail selection and Continue handlers
- keep the default analytics Effect scoped to open/source changes while reading the current visit marker via a render-synchronized ref

## Risk
MEDIUM - feature-wall tour progress is persisted and feeds completion/depth telemetry. No transport, terminal, browser, source-control, SSH, or provider behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-completion.test.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 932 -> 928 on this branch

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.