### PR TITLE
Move editor copy reset timers to handlers

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -50,6 +50,7 @@ function EditorPanelInner({
   const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
     null
   )
+  const copiedPathResetTimerRef = useRef<number | null>(null)
   const [showMarkdownTableOfContents, setShowMarkdownTableOfContents] = useState(false)
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
@@ -89,13 +90,6 @@ function EditorPanelInner({
   useEffect(() => acquireExportPdfListener(), [])
   useClosedEditorTabCleanup(openFiles)
   useMarkdownPreviewShortcut({ activeFile, panelRef, openMarkdownPreview })
-  useEffect(() => {
-    if (!copiedPathToast) {
-      return
-    }
-    const timeout = window.setTimeout(() => setCopiedPathToast(null), 1500)
-    return () => window.clearTimeout(timeout)
-  }, [copiedPathToast])
 
   const handleContentChangeForFile = useCallback(
     (file: typeof activeFile, content: string) => {
@@ -181,8 +175,19 @@ function EditorPanelInner({
     }
     try {
       await window.api.ui.writeClipboardText(copyState.copyText)
+      if (copiedPathResetTimerRef.current !== null) {
+        window.clearTimeout(copiedPathResetTimerRef.current)
+      }
       setCopiedPathToast({ fileId: activeFile.id, token: Date.now() })
+      copiedPathResetTimerRef.current = window.setTimeout(() => {
+        setCopiedPathToast(null)
+        copiedPathResetTimerRef.current = null
+      }, 1500)
     } catch {
+      if (copiedPathResetTimerRef.current !== null) {
+        window.clearTimeout(copiedPathResetTimerRef.current)
+        copiedPathResetTimerRef.current = null
+      }
       setCopiedPathToast(null)
     }
   }, [activeFile])

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -459,6 +459,7 @@ export default function MarkdownPreview({
   const [activeAnnotationBlockKey, setActiveAnnotationBlockKey] = useState<string | null>(null)
   const [reviewPanelOpen, setReviewPanelOpen] = useState(false)
   const [reviewNotesCopied, setReviewNotesCopied] = useState(false)
+  const reviewNotesCopiedResetTimerRef = useRef<number | null>(null)
   const [activeReviewCommentId, setActiveReviewCommentId] = useState<string | null>(null)
   const markdownReviewNotes = useMemo(
     () => sortMarkdownReviewNotes(markdownComments as MarkdownReviewNote[]),
@@ -716,19 +717,18 @@ export default function MarkdownPreview({
     }
     try {
       await window.api.ui.writeClipboardText(markdownReviewPrompt)
+      if (reviewNotesCopiedResetTimerRef.current !== null) {
+        window.clearTimeout(reviewNotesCopiedResetTimerRef.current)
+      }
       setReviewNotesCopied(true)
+      reviewNotesCopiedResetTimerRef.current = window.setTimeout(() => {
+        setReviewNotesCopied(false)
+        reviewNotesCopiedResetTimerRef.current = null
+      }, 1600)
     } catch {
       // Best-effort clipboard action; failures usually mean the window is not focused.
     }
   }, [markdownReviewNotes.length, markdownReviewPrompt])
-
-  useEffect(() => {
-    if (!reviewNotesCopied) {
-      return
-    }
-    const timeout = window.setTimeout(() => setReviewNotesCopied(false), 1600)
-    return () => window.clearTimeout(timeout)
-  }, [reviewNotesCopied])
 
   const scrollToReviewNote = useCallback((comment: DiffComment): void => {
     setActiveReviewCommentId(comment.id)


### PR DESCRIPTION
## Summary
- remove post-render timer Effects for editor path-copy and markdown review-note copy indicators
- start/reset the short clear timers directly in the successful copy handlers
- clear any existing timer before scheduling a replacement after repeated copy clicks

## Risk
MEDIUM - editor UI feedback. No persistence, IPC protocol, terminal, browser, source-control, SSH, or provider behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/EditorPanel.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 932 -> 930 on this branch

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.