### PR TITLE
Move combobox open focus out of effects

### DIFF
--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -138,6 +138,8 @@ export default function AgentCombobox({
   // the last-hovered agent visually selected while the mouse is on the footer.
   const [commandValue, setCommandValue] = useState('')
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
+  const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const focusFrameRef = React.useRef<number | null>(null)
 
   const selectedAgent = useMemo<AgentCatalogEntry | null>(
     () => (value ? (agents.find((agent) => agent.id === value) ?? null) : null),
@@ -152,15 +154,13 @@ export default function AgentCombobox({
     return 'blank terminal'.includes(q) || 'terminal'.startsWith(q)
   }, [query])
 
-  React.useEffect(() => {
-    if (!open) {
-      return
+  const focusSearchInput = useCallback(() => {
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
     }
-    setCommandValue(value ?? BLANK_VALUE)
-    const frame = requestAnimationFrame(() => {
-      const searchInput = document.querySelector<HTMLInputElement>(
-        '[data-agent-combobox-root="true"] [data-slot="command-input"]'
-      )
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
+      const searchInput = inputRef.current
       if (!searchInput) {
         return
       }
@@ -171,15 +171,23 @@ export default function AgentCombobox({
       const end = searchInput.value.length
       searchInput.setSelectionRange(end, end)
     })
-    return () => cancelAnimationFrame(frame)
-  }, [open, value])
-
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    setOpen(nextOpen)
-    if (!nextOpen) {
-      setQuery('')
-    }
   }, [])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (nextOpen) {
+        setCommandValue(value ?? BLANK_VALUE)
+        return
+      }
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current)
+        focusFrameRef.current = null
+      }
+      setQuery('')
+    },
+    [value]
+  )
 
   const handleSelect = useCallback(
     (nextValue: TuiAgent | null) => {
@@ -215,6 +223,7 @@ export default function AgentCombobox({
       }
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault()
+        setCommandValue(value ?? BLANK_VALUE)
         setOpen(true)
         return
       }
@@ -223,11 +232,12 @@ export default function AgentCombobox({
       }
       if (event.key.length === 1 && /\S/.test(event.key)) {
         event.preventDefault()
+        setCommandValue(value ?? BLANK_VALUE)
         setQuery(event.key)
         setOpen(true)
       }
     },
-    [open, onTriggerEnter]
+    [open, onTriggerEnter, value]
   )
 
   return (
@@ -271,10 +281,18 @@ export default function AgentCombobox({
             !allowNarrowTrigger && 'min-w-[18rem]'
           )}
           data-agent-combobox-root="true"
-          onOpenAutoFocus={(event) => event.preventDefault()}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+            focusSearchInput()
+          }}
         >
           <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
-            <CommandInput placeholder="Search agents..." value={query} onValueChange={setQuery} />
+            <CommandInput
+              ref={inputRef}
+              placeholder="Search agents..."
+              value={query}
+              onValueChange={setQuery}
+            />
             <CommandList>
               <CommandEmpty>No agents match your search.</CommandEmpty>
               {blankMatchesQuery

--- a/src/renderer/src/components/automations/CreateFromPicker.tsx
+++ b/src/renderer/src/components/automations/CreateFromPicker.tsx
@@ -44,6 +44,7 @@ export function CreateFromPicker({
   const repo = repoMap.get(repoId)
   const [open, setOpen] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const focusFrameRef = React.useRef<number | null>(null)
   const [defaultBaseRef, setDefaultBaseRef] = React.useState<string | null>(null)
   const [query, setQuery] = React.useState('')
   const [searchResults, setSearchResults] = React.useState<string[]>([])
@@ -69,13 +70,23 @@ export function CreateFromPicker({
     return Array.from(options).sort((left, right) => left.localeCompare(right))
   }, [effectiveDefault, searchResults, worktrees])
 
-  React.useEffect(() => {
-    if (!open) {
-      return
+  const focusSearchInput = React.useCallback(() => {
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
     }
-    const frame = requestAnimationFrame(() => inputRef.current?.focus())
-    return () => cancelAnimationFrame(frame)
-  }, [open])
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
+      inputRef.current?.focus()
+    })
+  }, [])
+
+  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen && focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
+      focusFrameRef.current = null
+    }
+  }, [])
 
   React.useEffect(() => {
     if (!repoId) {
@@ -142,7 +153,7 @@ export function CreateFromPicker({
 
   return (
     <div className="space-y-2">
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <Button
             type="button"
@@ -161,7 +172,10 @@ export function CreateFromPicker({
         <PopoverContent
           align="start"
           className="w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0"
-          onOpenAutoFocus={(event) => event.preventDefault()}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+            focusSearchInput()
+          }}
         >
           <Command>
             <CommandInput

--- a/src/renderer/src/components/automations/WorkspaceCombobox.tsx
+++ b/src/renderer/src/components/automations/WorkspaceCombobox.tsx
@@ -25,18 +25,29 @@ export function WorkspaceCombobox({
 }): React.JSX.Element {
   const [open, setOpen] = React.useState(false)
   const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const focusFrameRef = React.useRef<number | null>(null)
   const selected = worktrees.find((worktree) => worktree.id === value) ?? null
 
-  React.useEffect(() => {
-    if (!open) {
-      return
+  const focusSearchInput = React.useCallback(() => {
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
     }
-    const frame = requestAnimationFrame(() => inputRef.current?.focus())
-    return () => cancelAnimationFrame(frame)
-  }, [open])
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
+      inputRef.current?.focus()
+    })
+  }, [])
+
+  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen && focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
+      focusFrameRef.current = null
+    }
+  }, [])
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -54,7 +65,10 @@ export function WorkspaceCombobox({
       <PopoverContent
         align="start"
         className="w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0"
-        onOpenAutoFocus={(event) => event.preventDefault()}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          focusSearchInput()
+        }}
       >
         <Command>
           <CommandInput ref={inputRef} placeholder="Search workspaces..." />

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -42,11 +42,13 @@ export default function RepoCombobox({
   // Why: controlled cmdk selection so hovering the footer (which lives outside
   // the cmdk tree) can clear the list's highlighted item — otherwise cmdk keeps
   // the last-hovered repo visually selected while the mouse is on the footer.
-  const [commandValue, setCommandValue] = useState('')
+  const [commandValue, setCommandValue] = useState(() => (autoOpenOnMount ? value : ''))
   const addRepo = useAppStore((s) => s.addRepo)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const [isAdding, setIsAdding] = useState(false)
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
+  const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const focusFrameRef = React.useRef<number | null>(null)
 
   const selectedRepo = useMemo(
     () => repos.find((repo) => repo.id === value) ?? null,
@@ -54,15 +56,13 @@ export default function RepoCombobox({
   )
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
 
-  React.useEffect(() => {
-    if (!open) {
-      return
+  const focusSearchInput = useCallback(() => {
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
     }
-    setCommandValue(value)
-    const frame = requestAnimationFrame(() => {
-      const repoSearchInput = document.querySelector<HTMLInputElement>(
-        '[data-repo-combobox-root="true"] [data-slot="command-input"]'
-      )
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
+      const repoSearchInput = inputRef.current
       if (!repoSearchInput) {
         return
       }
@@ -73,18 +73,26 @@ export default function RepoCombobox({
       const end = repoSearchInput.value.length
       repoSearchInput.setSelectionRange(end, end)
     })
-    return () => cancelAnimationFrame(frame)
-  }, [open, value])
-
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    setOpen(nextOpen)
-    // Why: the create-worktree dialog delays its own field reset until after
-    // close animation, so the repo picker must clear its local filter here or a
-    // stale query can reopen to an apparently missing repo list.
-    if (!nextOpen) {
-      setQuery('')
-    }
   }, [])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (nextOpen) {
+        setCommandValue(value)
+        return
+      }
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current)
+        focusFrameRef.current = null
+      }
+      // Why: the create-worktree dialog delays its own field reset until after
+      // close animation, so the repo picker must clear its local filter here or a
+      // stale query can reopen to an apparently missing repo list.
+      setQuery('')
+    },
+    [value]
+  )
 
   const handleSelect = useCallback(
     (repoId: string) => {
@@ -108,6 +116,7 @@ export default function RepoCombobox({
       }
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault()
+        setCommandValue(value)
         setOpen(true)
         return
       }
@@ -119,11 +128,12 @@ export default function RepoCombobox({
       // the PopoverTrigger) instead of leaking into the query as a stray char.
       if (event.key.length === 1 && /\S/.test(event.key)) {
         event.preventDefault()
+        setCommandValue(value)
         setQuery(event.key)
         setOpen(true)
       }
     },
-    [open]
+    [open, value]
   )
 
   const handleAddFolder = useCallback(async () => {
@@ -187,10 +197,14 @@ export default function RepoCombobox({
           align="start"
           className="w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0"
           data-repo-combobox-root="true"
-          onOpenAutoFocus={(event) => event.preventDefault()}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+            focusSearchInput()
+          }}
         >
           <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
             <CommandInput
+              ref={inputRef}
               placeholder="Search projects/folders..."
               value={query}
               onValueChange={setQuery}


### PR DESCRIPTION
## Summary
- remove open-focus Effects from agent, repo, workspace, and branch-from comboboxes
- seed cmdk highlighted values in explicit open paths instead of after render
- focus the search input from Radix onOpenAutoFocus and cancel pending animation frames on close

## Risk
LOW - isolated combobox focus/highlight UI state only. No persistence, IPC protocol, terminal/browser/source-control behavior, SSH behavior, or provider behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/agent/AgentCombobox.tsx src/renderer/src/components/repo/RepoCombobox.tsx src/renderer/src/components/automations/WorkspaceCombobox.tsx src/renderer/src/components/automations/CreateFromPicker.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 932 -> 928 on this branch