### PR TITLE
Derive Linear sub-issue list from optimistic additions

### DIFF
--- a/src/renderer/src/components/LinearIssueWorkspace.tsx
+++ b/src/renderer/src/components/LinearIssueWorkspace.tsx
@@ -108,13 +108,25 @@ function LinearIssueSubIssueButton({
   const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
-  const [subIssues, setSubIssues] = useState<LinearIssueChildSummary[]>(issue.subIssues ?? [])
+  const [optimisticSubIssues, setOptimisticSubIssues] = useState<{
+    issueId: string
+    subIssues: LinearIssueChildSummary[]
+  }>(() => ({
+    issueId: issue.id,
+    subIssues: []
+  }))
   const [submitting, setSubmitting] = useState(false)
   const [openingSubIssueId, setOpeningSubIssueId] = useState<string | null>(null)
 
-  useEffect(() => {
-    setSubIssues(issue.subIssues ?? [])
-  }, [issue.id, issue.subIssues])
+  const subIssues = useMemo(() => {
+    const baseSubIssues = issue.subIssues ?? []
+    if (optimisticSubIssues.issueId !== issue.id || optimisticSubIssues.subIssues.length === 0) {
+      return baseSubIssues
+    }
+    const baseIds = new Set(baseSubIssues.map((subIssue) => subIssue.id))
+    const additions = optimisticSubIssues.subIssues.filter((subIssue) => !baseIds.has(subIssue.id))
+    return additions.length === 0 ? baseSubIssues : [...baseSubIssues, ...additions]
+  }, [issue.id, issue.subIssues, optimisticSubIssues])
 
   const handleOpenSubIssue = useCallback(
     async (subIssue: LinearIssueChildSummary) => {
@@ -156,9 +168,16 @@ function LinearIssueSubIssueButton({
           title: result.title || trimmed,
           url: result.url
         }
-        setSubIssues((prev) =>
-          prev.some((subIssue) => subIssue.id === child.id) ? prev : [...prev, child]
-        )
+        setOptimisticSubIssues((current) => {
+          const currentSubIssues = current.issueId === issue.id ? current.subIssues : []
+          if (
+            currentSubIssues.some((subIssue) => subIssue.id === child.id) ||
+            issue.subIssues?.some((subIssue) => subIssue.id === child.id)
+          ) {
+            return current
+          }
+          return { issueId: issue.id, subIssues: [...currentSubIssues, child] }
+        })
         toast.success(`Created ${result.identifier}`)
         setTitle('')
         setOpen(false)
@@ -170,7 +189,15 @@ function LinearIssueSubIssueButton({
     } finally {
       setSubmitting(false)
     }
-  }, [issue.id, issue.project?.id, issue.team.id, issue.workspaceId, settings, title])
+  }, [
+    issue.id,
+    issue.project?.id,
+    issue.subIssues,
+    issue.team.id,
+    issue.workspaceId,
+    settings,
+    title
+  ])
 
   return (
     <section className="mt-10 max-w-[820px]">


### PR DESCRIPTION
Summary:
- remove the sub-issue list mirror Effect in LinearIssueWorkspace
- derive visible sub-issues from the selected issue plus issue-scoped optimistic create results
- keep created child rows visible until the selected issue payload catches up

Verification:
- pnpm exec oxlint src/renderer/src/components/LinearIssueWorkspace.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count 927 -> 926

Risk: Medium (Linear issue sub-issue creation UI and provider-backed issue data)

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.