### PR TITLE
Reduce combined diff state repair effects

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -187,6 +187,12 @@ export default function CombinedDiffViewer({
   const [sectionHeights, setSectionHeights] = useState<Record<number, number>>({})
   const [clearNotesDialogOpen, setClearNotesDialogOpen] = useState(false)
   const [isClearingNotes, setIsClearingNotes] = useState(false)
+  const clearNotesDialogVisible = clearNotesDialogOpen && (diffCommentCount > 0 || isClearingNotes)
+  if (clearNotesDialogOpen && !clearNotesDialogVisible) {
+    // Why: notes may be cleared outside this dialog; keep the modal closed in
+    // the same render instead of showing an empty confirmation for one frame.
+    setClearNotesDialogOpen(false)
+  }
   const [notesCopied, setNotesCopied] = useState(false)
   const mountedRef = useRef(true)
   // Why: copy feedback is created by the copy action, so the same handler owns
@@ -674,10 +680,17 @@ export default function CombinedDiffViewer({
     () => createCombinedDiffSectionIndexMap(sections),
     [sections]
   )
-  const [activeTreeSectionKey, setActiveTreeSectionKey] = useState<string | null>(null)
-  useEffect(() => {
-    setActiveTreeSectionKey(null)
-  }, [entrySignature])
+  const [activeTreeSectionState, setActiveTreeSectionState] = useState<{
+    entrySignature: string
+    key: string | null
+  }>(() => ({ entrySignature, key: null }))
+  const activeTreeSectionKey =
+    activeTreeSectionState.entrySignature === entrySignature ? activeTreeSectionState.key : null
+  if (activeTreeSectionState.entrySignature !== entrySignature) {
+    // Why: the tree highlight belongs to one diff entry set and must not flash
+    // on another entry set before an Effect reset would run.
+    setActiveTreeSectionState({ entrySignature, key: null })
+  }
   const viewedSectionKeys = React.useMemo(
     () => new Set(sections.filter((section) => !section.loading).map((section) => section.key)),
     [sections]
@@ -693,10 +706,13 @@ export default function CombinedDiffViewer({
         scrollToIndex: (index) => virtualizer.scrollToIndex(index, { align: 'start' })
       })
       if (navigatedIndex !== null) {
-        setActiveTreeSectionKey(sectionsRef.current[navigatedIndex]?.key ?? null)
+        setActiveTreeSectionState({
+          entrySignature,
+          key: sectionsRef.current[navigatedIndex]?.key ?? null
+        })
       }
     },
-    [sectionIndexByKey, toggleSection, treeMode, virtualizer]
+    [entrySignature, sectionIndexByKey, toggleSection, treeMode, virtualizer]
   )
 
   const setAllSectionsCollapsed = useCallback((collapsed: boolean) => {
@@ -1009,12 +1025,6 @@ export default function CombinedDiffViewer({
     },
     [updateCombinedDiffScrollbar]
   )
-
-  useEffect(() => {
-    if (diffCommentCount === 0 && !isClearingNotes) {
-      setClearNotesDialogOpen(false)
-    }
-  }, [diffCommentCount, isClearingNotes])
 
   const handleCopyNotes = useCallback(async (): Promise<void> => {
     if (diffCommentCount === 0) {
@@ -1368,7 +1378,7 @@ export default function CombinedDiffViewer({
         </div>
       </div>
       <Dialog
-        open={clearNotesDialogOpen}
+        open={clearNotesDialogVisible}
         onOpenChange={(open) => {
           if (!open && !isClearingNotes) {
             setClearNotesDialogOpen(false)


### PR DESCRIPTION
## Summary
- reset combined-diff file tree highlight during render by tagging the active key with the current entry signature
- derive the clear-notes dialog open state from live note count / clear-in-flight state so externally cleared notes close without a follow-up Effect

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/CombinedDiffViewer.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 927 -> 925

## Risk
- Medium: editor diff UI state changes; no git IPC, provider, terminal, browser webview, persistence, or SSH transport behavior changed.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.