### PR TITLE
Remove activity selection repair effect

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -1299,6 +1299,14 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     () => buildAgentPaneThreads({ events: allEvents, liveAgentByPaneKey }),
     [allEvents, liveAgentByPaneKey]
   )
+  const selectedPaneKeyIsLive =
+    selectedPaneKey === null || allThreads.some((thread) => thread.paneKey === selectedPaneKey)
+  const effectiveSelectedPaneKey = selectedPaneKeyIsLive ? selectedPaneKey : null
+  if (!selectedPaneKeyIsLive) {
+    // Why: Activity rows disappear when agent retention or tab state changes;
+    // clear stale selection before detail/portal rendering can target it.
+    setSelectedPaneKey(null)
+  }
 
   const visibleThreads = useMemo(() => {
     const trimmedQuery = query.trim().toLowerCase()
@@ -1306,25 +1314,23 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       // Why: keep the just-selected thread visible even after auto-mark-read
       // flips it to read, otherwise clicking a row in unread-only mode makes it
       // vanish from the left list while staying selected on the right.
-      if (readFilter === 'unread' && !thread.unread && thread.paneKey !== selectedPaneKey) {
+      if (
+        readFilter === 'unread' &&
+        !thread.unread &&
+        thread.paneKey !== effectiveSelectedPaneKey
+      ) {
         return false
       }
       return activityThreadMatchesSearchQuery({ thread, searchQuery: trimmedQuery })
     })
-  }, [allThreads, readFilter, query, selectedPaneKey])
+  }, [allThreads, readFilter, query, effectiveSelectedPaneKey])
   const visibleThreadGroups = useMemo(
     () => buildActivityThreadGroups(visibleThreads, groupBy),
     [visibleThreads, groupBy]
   )
 
-  useEffect(() => {
-    if (selectedPaneKey && !allThreads.some((thread) => thread.paneKey === selectedPaneKey)) {
-      setSelectedPaneKey(null)
-    }
-  }, [allThreads, selectedPaneKey])
-
-  const selectedThread = selectedPaneKey
-    ? (allThreads.find((thread) => thread.paneKey === selectedPaneKey) ?? null)
+  const selectedThread = effectiveSelectedPaneKey
+    ? (allThreads.find((thread) => thread.paneKey === effectiveSelectedPaneKey) ?? null)
     : null
   const selectedTabId = selectedThread?.tab.id ?? null
   // Why: repo-less terminal buckets can still produce Activity rows, but the
@@ -1538,20 +1544,20 @@ export default function ActivityPrototypePage(): React.JSX.Element {
       !selectedThread ||
       !selectedThread.unread ||
       stagedThread ||
-      selectedThread.paneKey !== selectedPaneKey
+      selectedThread.paneKey !== effectiveSelectedPaneKey
     ) {
       return
     }
     const selectedThreadHasDetailOnlyView =
       !selectedHasLiveTab || selectedThread.migrationUnsupportedPtyId !== undefined
     const selectedThreadIsVisibleTerminal =
-      visibleThread?.paneKey === selectedPaneKey && visiblePortalReady
+      visibleThread?.paneKey === effectiveSelectedPaneKey && visiblePortalReady
     if (selectedThreadHasDetailOnlyView || selectedThreadIsVisibleTerminal) {
       storeData.acknowledgeAgents([selectedThread.paneKey])
     }
   }, [
     selectedHasLiveTab,
-    selectedPaneKey,
+    effectiveSelectedPaneKey,
     selectedThread,
     stagedThread,
     storeData,


### PR DESCRIPTION
## Summary
- derive the live Activity selected pane key from the current thread list
- clear stale selected pane state during render so detail and portal rendering never target a removed row for an extra Effect pass

## Verification
- pnpm exec oxlint src/renderer/src/components/activity/ActivityPrototypePage.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 926 -> 925

## Risk
- Medium: Activity page selection and terminal portal-adjacent UI; no IPC channel, terminal transport, PTY lifecycle, persistence, browser webview, provider, or SSH transport behavior changed.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.