### PR TITLE
Remove Linear text draft sync effect

### DIFF
--- a/src/renderer/src/components/LinearIssueTextEditor.tsx
+++ b/src/renderer/src/components/LinearIssueTextEditor.tsx
@@ -13,6 +13,10 @@ import {
   getLinearIssueTextSavePlan,
   type LinearIssueTextField
 } from './linear-issue-text-save-plan'
+import {
+  createLinearIssueTextDraftState,
+  resolveLinearIssueTextDraftState
+} from './linear-issue-text-draft-state'
 
 type LinearIssueTextEditorProps = {
   issue: LinearIssue
@@ -44,43 +48,43 @@ export function LinearIssueTextEditor({
 }: LinearIssueTextEditorProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const patchLinearIssue = useAppStore((s) => s.patchLinearIssue)
-  const [titleDraft, setTitleDraft] = useState(issue.title)
-  const [descriptionDraft, setDescriptionDraft] = useState(issue.description ?? '')
-  const [savingField, setSavingField] = useState<'title' | 'description' | null>(null)
-  const submitShortcutLabel = getScreenSubmitShortcutLabel()
-  const titleRef = useAutosizeTextArea(titleDraft)
+  const [draftState, setDraftState] = useState(() => createLinearIssueTextDraftState(issue))
+  const [savingField, setSavingField] = useState<LinearIssueTextField | null>(null)
   const lastIssueIdRef = useRef(issue.id)
   const mountedRef = useMountedRef()
-  const lastSyncedTitleRef = useRef(issue.title)
-  const lastSyncedDescriptionRef = useRef(issue.description ?? '')
-
-  useEffect(() => {
-    const nextDescription = issue.description ?? ''
-    if (issue.id !== lastIssueIdRef.current) {
-      lastIssueIdRef.current = issue.id
-      lastSyncedTitleRef.current = issue.title
-      lastSyncedDescriptionRef.current = nextDescription
-      setTitleDraft(issue.title)
-      setDescriptionDraft(nextDescription)
+  const resolvedDraftState = resolveLinearIssueTextDraftState(draftState, issue)
+  const issueChanged = draftState.issueId !== issue.id
+  if (resolvedDraftState !== draftState) {
+    // Why: Linear can push updated title/description while another field has
+    // unsaved edits; reconcile only untouched drafts before the next paint.
+    setDraftState(resolvedDraftState)
+    if (issueChanged && savingField !== null) {
       setSavingField(null)
-      return
     }
-
-    const previousTitle = lastSyncedTitleRef.current
-    const previousDescription = lastSyncedDescriptionRef.current
-
-    // Why: optimistic saves can update one field while the user has unsaved
-    // edits in the other; only sync fields that still match the last source.
-    if (issue.title !== previousTitle && titleDraft === previousTitle) {
-      setTitleDraft(issue.title)
-    }
-    if (nextDescription !== previousDescription && descriptionDraft === previousDescription) {
-      setDescriptionDraft(nextDescription)
-    }
-
-    lastSyncedTitleRef.current = issue.title
-    lastSyncedDescriptionRef.current = nextDescription
-  }, [descriptionDraft, issue.description, issue.id, issue.title, titleDraft])
+    lastIssueIdRef.current = issue.id
+  }
+  const titleDraft = resolvedDraftState.title
+  const descriptionDraft = resolvedDraftState.description
+  const submitShortcutLabel = getScreenSubmitShortcutLabel()
+  const titleRef = useAutosizeTextArea(titleDraft)
+  const updateTitleDraft = useCallback(
+    (title: string): void => {
+      setDraftState((current) => ({
+        ...resolveLinearIssueTextDraftState(current, issue),
+        title
+      }))
+    },
+    [issue]
+  )
+  const updateDescriptionDraft = useCallback(
+    (description: string): void => {
+      setDraftState((current) => ({
+        ...resolveLinearIssueTextDraftState(current, issue),
+        description
+      }))
+    },
+    [issue]
+  )
 
   const saveField = useCallback(
     async (field: LinearIssueTextField, descriptionOverride?: string) => {
@@ -91,7 +95,7 @@ export function LinearIssueTextEditor({
         titleDraft
       })
       if (savePlan.kind === 'empty-title') {
-        setTitleDraft(issue.title)
+        updateTitleDraft(issue.title)
         toast.error('Title is required')
         return
       }
@@ -120,9 +124,9 @@ export function LinearIssueTextEditor({
         patchLinearIssue(issue.id, revert)
         if (stillEditingIssue) {
           if (field === 'title') {
-            setTitleDraft(issue.title)
+            updateTitleDraft(issue.title)
           } else {
-            setDescriptionDraft(issue.description ?? '')
+            updateDescriptionDraft(issue.description ?? '')
           }
         }
         toast.error(error instanceof Error ? error.message : `Failed to update ${field}`)
@@ -142,7 +146,9 @@ export function LinearIssueTextEditor({
       onIssueChange,
       patchLinearIssue,
       settings,
-      titleDraft
+      titleDraft,
+      updateDescriptionDraft,
+      updateTitleDraft
     ]
   )
 
@@ -159,10 +165,10 @@ export function LinearIssueTextEditor({
 
   const saveDescriptionValue = useCallback(
     (value: string) => {
-      setDescriptionDraft(value)
+      updateDescriptionDraft(value)
       void saveField('description', value)
     },
-    [saveField]
+    [saveField, updateDescriptionDraft]
   )
 
   const handleTitleKeyDown = useCallback(
@@ -188,7 +194,7 @@ export function LinearIssueTextEditor({
           <textarea
             ref={titleRef}
             value={titleDraft}
-            onChange={(event) => setTitleDraft(event.target.value)}
+            onChange={(event) => updateTitleDraft(event.target.value)}
             onBlur={() => void saveField('title')}
             onKeyDown={handleTitleKeyDown}
             disabled={savingField === 'title'}
@@ -215,7 +221,7 @@ export function LinearIssueTextEditor({
         <div className="relative">
           <LinearIssueMarkdownDescriptionEditor
             value={descriptionDraft}
-            onChange={setDescriptionDraft}
+            onChange={updateDescriptionDraft}
             onSave={saveDescriptionValue}
             density={density}
             disabled={savingField === 'description'}

--- a/src/renderer/src/components/linear-issue-text-draft-state.test.ts
+++ b/src/renderer/src/components/linear-issue-text-draft-state.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createLinearIssueTextDraftState,
+  resolveLinearIssueTextDraftState
+} from './linear-issue-text-draft-state'
+
+describe('linear issue text draft state', () => {
+  it('creates drafts from the issue source values', () => {
+    expect(
+      createLinearIssueTextDraftState({
+        description: undefined,
+        id: 'issue-1',
+        title: 'Initial title'
+      })
+    ).toEqual({
+      description: '',
+      issueId: 'issue-1',
+      sourceDescription: '',
+      sourceTitle: 'Initial title',
+      title: 'Initial title'
+    })
+  })
+
+  it('resets both drafts when the issue changes', () => {
+    const state = createLinearIssueTextDraftState({
+      description: 'Old body',
+      id: 'issue-1',
+      title: 'Old title'
+    })
+
+    expect(
+      resolveLinearIssueTextDraftState(
+        { ...state, description: 'Unsaved body', title: 'Unsaved title' },
+        {
+          description: 'New body',
+          id: 'issue-2',
+          title: 'New title'
+        }
+      )
+    ).toEqual({
+      description: 'New body',
+      issueId: 'issue-2',
+      sourceDescription: 'New body',
+      sourceTitle: 'New title',
+      title: 'New title'
+    })
+  })
+
+  it('reconciles untouched fields while preserving unsaved edits', () => {
+    const state = createLinearIssueTextDraftState({
+      description: 'Old body',
+      id: 'issue-1',
+      title: 'Old title'
+    })
+
+    expect(
+      resolveLinearIssueTextDraftState(
+        { ...state, title: 'Unsaved title' },
+        {
+          description: 'Remote body',
+          id: 'issue-1',
+          title: 'Remote title'
+        }
+      )
+    ).toEqual({
+      description: 'Remote body',
+      issueId: 'issue-1',
+      sourceDescription: 'Remote body',
+      sourceTitle: 'Remote title',
+      title: 'Unsaved title'
+    })
+  })
+})

--- a/src/renderer/src/components/linear-issue-text-draft-state.ts
+++ b/src/renderer/src/components/linear-issue-text-draft-state.ts
@@ -1,0 +1,49 @@
+import type { LinearIssue } from '../../../shared/types'
+
+type LinearIssueTextDraftSource = Pick<LinearIssue, 'description' | 'id' | 'title'>
+
+export type LinearIssueTextDraftState = {
+  issueId: string
+  sourceTitle: string
+  sourceDescription: string
+  title: string
+  description: string
+}
+
+function getLinearIssueDescription(issue: LinearIssueTextDraftSource): string {
+  return issue.description ?? ''
+}
+
+export function createLinearIssueTextDraftState(
+  issue: LinearIssueTextDraftSource
+): LinearIssueTextDraftState {
+  const description = getLinearIssueDescription(issue)
+  return {
+    issueId: issue.id,
+    sourceTitle: issue.title,
+    sourceDescription: description,
+    title: issue.title,
+    description
+  }
+}
+
+export function resolveLinearIssueTextDraftState(
+  state: LinearIssueTextDraftState,
+  issue: LinearIssueTextDraftSource
+): LinearIssueTextDraftState {
+  const sourceDescription = getLinearIssueDescription(issue)
+  if (state.issueId !== issue.id) {
+    return createLinearIssueTextDraftState(issue)
+  }
+  if (state.sourceTitle === issue.title && state.sourceDescription === sourceDescription) {
+    return state
+  }
+  return {
+    issueId: state.issueId,
+    sourceTitle: issue.title,
+    sourceDescription,
+    title: state.title === state.sourceTitle ? issue.title : state.title,
+    description:
+      state.description === state.sourceDescription ? sourceDescription : state.description
+  }
+}


### PR DESCRIPTION
## Summary
- key Linear issue title/description drafts by issue id and last source values
- reconcile changed source values during render, preserving unsaved edits in the other field

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/linear-issue-text-draft-state.test.ts
- pnpm exec oxlint src/renderer/src/components/LinearIssueTextEditor.tsx src/renderer/src/components/linear-issue-text-draft-state.ts src/renderer/src/components/linear-issue-text-draft-state.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/LinearIssueTextEditor.tsx src/renderer/src/components/linear-issue-text-draft-state.ts src/renderer/src/components/linear-issue-text-draft-state.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

## Risk
Low. Renderer-only Linear text-editor draft-state change with focused unit coverage. No Linear API contract, IPC, persistence, terminal/browser/source-control behavior, or SSH transport changed.