### PR TITLE
Remove general settings draft sync effects

### DIFF
--- a/src/renderer/src/components/settings/GeneralPane.test.ts
+++ b/src/renderer/src/components/settings/GeneralPane.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, it } from 'vitest'
-import { getDesktopPlatformFromUserAgent, shouldCommitOpenInApplicationsDraft } from './GeneralPane'
+import {
+  createAutoSaveDelayDraftState,
+  getDesktopPlatformFromUserAgent,
+  shouldCommitOpenInApplicationsDraft,
+  updateAutoSaveDelayDraftState
+} from './GeneralPane'
+
+describe('GeneralPane auto-save delay drafts', () => {
+  it('keeps a committed draft tied to the current persisted source while settings save is pending', () => {
+    const current = createAutoSaveDelayDraftState(1000)
+
+    expect(updateAutoSaveDelayDraftState(current, 1000, '1500')).toEqual({
+      sourceDelayMs: 1000,
+      draft: '1500'
+    })
+  })
+
+  it('reconciles stale draft state before applying a new draft value', () => {
+    const stale = updateAutoSaveDelayDraftState(createAutoSaveDelayDraftState(1000), 1000, '1500')
+
+    expect(updateAutoSaveDelayDraftState(stale, 1250, '1750')).toEqual({
+      sourceDelayMs: 1250,
+      draft: '1750'
+    })
+  })
+})
 
 describe('GeneralPane open-in application drafts', () => {
   it('does not commit rows until both label and command are present', () => {

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -75,6 +75,50 @@ export function getDesktopPlatformFromUserAgent(userAgent: string): 'darwin' | '
 
 export { GENERAL_PANE_SEARCH_ENTRIES }
 
+type AutoSaveDelayDraftState = {
+  sourceDelayMs: number
+  draft: string
+}
+
+function createAutoSaveDelayDraftState(editorAutoSaveDelayMs: number): AutoSaveDelayDraftState {
+  return {
+    sourceDelayMs: editorAutoSaveDelayMs,
+    draft: String(editorAutoSaveDelayMs)
+  }
+}
+
+function resolveAutoSaveDelayDraftState(
+  state: AutoSaveDelayDraftState,
+  editorAutoSaveDelayMs: number
+): AutoSaveDelayDraftState {
+  return state.sourceDelayMs === editorAutoSaveDelayMs
+    ? state
+    : createAutoSaveDelayDraftState(editorAutoSaveDelayMs)
+}
+
+type OpenInApplicationsDraftState = {
+  sourceApplications: OpenInApplication[] | undefined
+  draft: OpenInApplication[]
+}
+
+function createOpenInApplicationsDraftState(
+  openInApplications: OpenInApplication[] | undefined
+): OpenInApplicationsDraftState {
+  return {
+    sourceApplications: openInApplications,
+    draft: openInApplications ?? []
+  }
+}
+
+function resolveOpenInApplicationsDraftState(
+  state: OpenInApplicationsDraftState,
+  openInApplications: OpenInApplication[] | undefined
+): OpenInApplicationsDraftState {
+  return state.sourceApplications === openInApplications
+    ? state
+    : createOpenInApplicationsDraftState(openInApplications)
+}
+
 type GeneralPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
@@ -108,11 +152,11 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     updateVersionRef.current = null
   }
   const [appVersion, setAppVersion] = useState<string | null>(null)
-  const [autoSaveDelayDraft, setAutoSaveDelayDraft] = useState(
-    String(settings.editorAutoSaveDelayMs)
+  const [autoSaveDelayDraftState, setAutoSaveDelayDraftState] = useState(() =>
+    createAutoSaveDelayDraftState(settings.editorAutoSaveDelayMs)
   )
-  const [openInApplicationsDraft, setOpenInApplicationsDraft] = useState<OpenInApplication[]>(
-    settings.openInApplications ?? []
+  const [openInApplicationsDraftState, setOpenInApplicationsDraftState] = useState(() =>
+    createOpenInApplicationsDraftState(settings.openInApplications)
   )
   // Why: the star state is derived from gh, not from settings, so it does not
   // live in the global settings store. 'hidden' covers the gh-unavailable and
@@ -164,13 +208,39 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     await window.api.starNag.complete()
   }
 
-  useEffect(() => {
-    setAutoSaveDelayDraft(String(settings.editorAutoSaveDelayMs))
-  }, [settings.editorAutoSaveDelayMs])
+  const resolvedAutoSaveDelayDraftState = resolveAutoSaveDelayDraftState(
+    autoSaveDelayDraftState,
+    settings.editorAutoSaveDelayMs
+  )
+  if (resolvedAutoSaveDelayDraftState !== autoSaveDelayDraftState) {
+    // Why: Settings can be updated outside this pane; reconcile drafts before
+    // paint so the visible input never lags behind the persisted value.
+    setAutoSaveDelayDraftState(resolvedAutoSaveDelayDraftState)
+  }
+  const autoSaveDelayDraft = resolvedAutoSaveDelayDraftState.draft
+  const updateAutoSaveDelayDraft = (draft: string): void => {
+    setAutoSaveDelayDraftState((current) => ({
+      ...resolveAutoSaveDelayDraftState(current, settings.editorAutoSaveDelayMs),
+      draft
+    }))
+  }
 
-  useEffect(() => {
-    setOpenInApplicationsDraft(settings.openInApplications ?? [])
-  }, [settings.openInApplications])
+  const resolvedOpenInApplicationsDraftState = resolveOpenInApplicationsDraftState(
+    openInApplicationsDraftState,
+    settings.openInApplications
+  )
+  if (resolvedOpenInApplicationsDraftState !== openInApplicationsDraftState) {
+    // Why: the Open In rows are a local draft, but Settings can reload them
+    // externally; sync before paint instead of after an Effect pass.
+    setOpenInApplicationsDraftState(resolvedOpenInApplicationsDraftState)
+  }
+  const openInApplicationsDraft = resolvedOpenInApplicationsDraftState.draft
+  const updateOpenInApplicationsDraft = (draft: OpenInApplication[]): void => {
+    setOpenInApplicationsDraftState((current) => ({
+      ...resolveOpenInApplicationsDraftState(current, settings.openInApplications),
+      draft
+    }))
+  }
 
   const commitOpenInApplications = (applications: OpenInApplication[]): void => {
     if (!shouldCommitOpenInApplicationsDraft(applications)) {
@@ -180,7 +250,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   }
 
   const applyOpenInApplicationsDraft = (applications: OpenInApplication[]): void => {
-    setOpenInApplicationsDraft(applications)
+    updateOpenInApplicationsDraft(applications)
     commitOpenInApplications(applications)
   }
 
@@ -194,13 +264,13 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   const commitAutoSaveDelay = (): void => {
     const trimmed = autoSaveDelayDraft.trim()
     if (trimmed === '') {
-      setAutoSaveDelayDraft(String(settings.editorAutoSaveDelayMs))
+      setAutoSaveDelayDraftState(createAutoSaveDelayDraftState(settings.editorAutoSaveDelayMs))
       return
     }
 
     const value = Number(trimmed)
     if (!Number.isFinite(value)) {
-      setAutoSaveDelayDraft(String(settings.editorAutoSaveDelayMs))
+      setAutoSaveDelayDraftState(createAutoSaveDelayDraftState(settings.editorAutoSaveDelayMs))
       return
     }
 
@@ -210,7 +280,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
       MAX_EDITOR_AUTO_SAVE_DELAY_MS
     )
     updateSettings({ editorAutoSaveDelayMs: next })
-    setAutoSaveDelayDraft(String(next))
+    setAutoSaveDelayDraftState(createAutoSaveDelayDraftState(next))
   }
 
   const handleRestartToUpdate = (): void => {
@@ -377,7 +447,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                   onChange={(event) => {
                     const next = [...openInApplicationsDraft]
                     next[index] = { ...app, label: event.target.value }
-                    setOpenInApplicationsDraft(next)
+                    updateOpenInApplicationsDraft(next)
                   }}
                   onBlur={() => commitOpenInApplications(openInApplicationsDraft)}
                   onKeyDown={(event) => {
@@ -392,7 +462,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                   onChange={(event) => {
                     const next = [...openInApplicationsDraft]
                     next[index] = { ...app, command: event.target.value }
-                    setOpenInApplicationsDraft(next)
+                    updateOpenInApplicationsDraft(next)
                   }}
                   onBlur={() => commitOpenInApplications(openInApplicationsDraft)}
                   onKeyDown={(event) => {
@@ -406,7 +476,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
                   size="sm"
                   onClick={() => {
                     const next = openInApplicationsDraft.filter((entry) => entry.id !== app.id)
-                    setOpenInApplicationsDraft(next)
+                    updateOpenInApplicationsDraft(next)
                     commitOpenInApplications(next)
                   }}
                 >
@@ -419,7 +489,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
             variant="outline"
             size="sm"
             onClick={() =>
-              setOpenInApplicationsDraft([...openInApplicationsDraft, createOpenInApplication()])
+              updateOpenInApplicationsDraft([...openInApplicationsDraft, createOpenInApplication()])
             }
             disabled={openInApplicationsDraft.length >= OPEN_IN_APPLICATIONS_MAX}
           >
@@ -468,7 +538,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
               max={MAX_EDITOR_AUTO_SAVE_DELAY_MS}
               step={250}
               value={autoSaveDelayDraft}
-              onChange={(e) => setAutoSaveDelayDraft(e.target.value)}
+              onChange={(e) => updateAutoSaveDelayDraft(e.target.value)}
               onBlur={commitAutoSaveDelay}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -75,12 +75,14 @@ export function getDesktopPlatformFromUserAgent(userAgent: string): 'darwin' | '
 
 export { GENERAL_PANE_SEARCH_ENTRIES }
 
-type AutoSaveDelayDraftState = {
+export type AutoSaveDelayDraftState = {
   sourceDelayMs: number
   draft: string
 }
 
-function createAutoSaveDelayDraftState(editorAutoSaveDelayMs: number): AutoSaveDelayDraftState {
+export function createAutoSaveDelayDraftState(
+  editorAutoSaveDelayMs: number
+): AutoSaveDelayDraftState {
   return {
     sourceDelayMs: editorAutoSaveDelayMs,
     draft: String(editorAutoSaveDelayMs)
@@ -94,6 +96,19 @@ function resolveAutoSaveDelayDraftState(
   return state.sourceDelayMs === editorAutoSaveDelayMs
     ? state
     : createAutoSaveDelayDraftState(editorAutoSaveDelayMs)
+}
+
+export function updateAutoSaveDelayDraftState(
+  state: AutoSaveDelayDraftState,
+  editorAutoSaveDelayMs: number,
+  draft: string
+): AutoSaveDelayDraftState {
+  return {
+    // Why: settings persistence is async, so a committed draft must stay tied
+    // to the current source until the persisted value reloads.
+    ...resolveAutoSaveDelayDraftState(state, editorAutoSaveDelayMs),
+    draft
+  }
 }
 
 type OpenInApplicationsDraftState = {
@@ -219,10 +234,9 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   }
   const autoSaveDelayDraft = resolvedAutoSaveDelayDraftState.draft
   const updateAutoSaveDelayDraft = (draft: string): void => {
-    setAutoSaveDelayDraftState((current) => ({
-      ...resolveAutoSaveDelayDraftState(current, settings.editorAutoSaveDelayMs),
-      draft
-    }))
+    setAutoSaveDelayDraftState((current) =>
+      updateAutoSaveDelayDraftState(current, settings.editorAutoSaveDelayMs, draft)
+    )
   }
 
   const resolvedOpenInApplicationsDraftState = resolveOpenInApplicationsDraftState(
@@ -280,7 +294,9 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
       MAX_EDITOR_AUTO_SAVE_DELAY_MS
     )
     updateSettings({ editorAutoSaveDelayMs: next })
-    setAutoSaveDelayDraftState(createAutoSaveDelayDraftState(next))
+    setAutoSaveDelayDraftState((current) =>
+      updateAutoSaveDelayDraftState(current, settings.editorAutoSaveDelayMs, String(next))
+    )
   }
 
   const handleRestartToUpdate = (): void => {


### PR DESCRIPTION
## Summary
- replace General settings auto-save delay draft sync Effect with source-keyed draft state
- replace Open In applications draft sync Effect with source-keyed draft state

## Risk
Medium - settings UI that persists editor delay and Open In launcher preferences. No transport/protocol changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/settings/GeneralPane.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/GeneralPane.test.ts
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 926 -> 924

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.