### PR TITLE
Remove quick command add intent effect

### DIFF
--- a/src/renderer/src/components/settings/QuickCommandsPane.tsx
+++ b/src/renderer/src/components/settings/QuickCommandsPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { Check, ChevronsUpDown, Pencil, Plus, Trash2 } from 'lucide-react'
 import type {
   GlobalSettings,
@@ -120,17 +120,16 @@ export function QuickCommandsPane({
     return createTerminalQuickCommandDraft({ type: 'global' })
   }, [activeRepoId, effectiveSelection, repoById, showAll])
 
-  useEffect(() => {
-    const intentSignal = addCommandIntentSignal
-    if (
-      typeof intentSignal !== 'number' ||
-      !shouldOpenQuickCommandAddIntent(intentSignal, consumedAddIntentSignalRef.current)
-    ) {
-      return
-    }
+  const intentSignal = addCommandIntentSignal
+  if (
+    typeof intentSignal === 'number' &&
+    shouldOpenQuickCommandAddIntent(intentSignal, consumedAddIntentSignalRef.current)
+  ) {
+    // Why: Settings deep-links use this one-shot signal to open the add dialog;
+    // consume it before paint so the pane never flashes without the editor.
     consumedAddIntentSignalRef.current = intentSignal
     setEditor({ mode: 'add', command: createDraftForCurrentFilter() })
-  }, [addCommandIntentSignal, createDraftForCurrentFilter])
+  }
 
   const toggleScope = (key: string): void => {
     const current = new Set(effectiveSelection)


### PR DESCRIPTION
## Summary
- consume Quick Commands add-intent signal during render instead of in an Effect
- keep the existing consumed-signal guard so each deep-link intent opens the add dialog once

## Risk
Medium - settings UI for terminal quick commands. No transport/protocol changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/settings/QuickCommandsPane.tsx src/renderer/src/components/settings/QuickCommandsPane.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/QuickCommandsPane.test.ts
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 926 -> 925

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.