### PR TITLE
Remove quick agent selection repair effect

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -4,8 +4,10 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import NewWorkspaceComposerCard from '@/components/NewWorkspaceComposerCard'
 import AgentSettingsDialog from '@/components/agent/AgentSettingsDialog'
 import { useComposerState } from '@/hooks/useComposerState'
-import { isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
-import { pickQuickWorkspaceAgent } from '@/lib/quick-workspace-agent-selection'
+import {
+  pickQuickWorkspaceAgent,
+  resolveQuickWorkspaceAgentSelection
+} from '@/lib/quick-workspace-agent-selection'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { shouldAllowComposerEnterSubmitTarget } from '@/lib/new-workspace-enter-guard'
 import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
@@ -143,24 +145,18 @@ function QuickTabBody({
     // prior catalog fallback while filtering disabled agents out of that choice.
     return pickQuickWorkspaceAgent(pref, cardProps.detectedAgentIds, settings?.disabledTuiAgents)
   }, [cardProps.detectedAgentIds, settings?.defaultTuiAgent, settings?.disabledTuiAgents])
-  const quickAgent = quickAgentOverride === undefined ? preferredQuickAgent : quickAgentOverride
-
-  useEffect(() => {
-    if (
-      quickAgentOverride === undefined ||
-      quickAgentOverride === null ||
-      (isTuiAgentEnabled(quickAgentOverride, settings?.disabledTuiAgents) &&
-        (cardProps.detectedAgentIds === null || cardProps.detectedAgentIds.has(quickAgentOverride)))
-    ) {
-      return
-    }
-    setQuickAgentOverride(preferredQuickAgent)
-  }, [
-    cardProps.detectedAgentIds,
-    preferredQuickAgent,
+  const resolvedQuickAgentSelection = resolveQuickWorkspaceAgentSelection({
     quickAgentOverride,
-    settings?.disabledTuiAgents
-  ])
+    preferredQuickAgent,
+    detectedAgentIds: cardProps.detectedAgentIds,
+    disabledTuiAgents: settings?.disabledTuiAgents
+  })
+  if (resolvedQuickAgentSelection.quickAgentOverride !== quickAgentOverride) {
+    // Why: detection/settings changes can invalidate a user-picked agent; repair
+    // before the child selector renders an unavailable option for one commit.
+    setQuickAgentOverride(resolvedQuickAgentSelection.quickAgentOverride)
+  }
+  const quickAgent = resolvedQuickAgentSelection.quickAgent
 
   const handleQuickAgentChange = useCallback((agent: TuiAgent | null) => {
     setQuickAgentOverride(agent)

--- a/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
+++ b/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { TUI_AGENT_AUTO_PICK_ORDER } from '../../../shared/tui-agent-selection'
 import { AGENT_CATALOG } from './agent-catalog'
-import { pickQuickWorkspaceAgent } from './quick-workspace-agent-selection'
+import {
+  pickQuickWorkspaceAgent,
+  resolveQuickWorkspaceAgentSelection
+} from './quick-workspace-agent-selection'
 
 describe('pickQuickWorkspaceAgent', () => {
   it('keeps the fallback order in sync with the desktop agent catalog', () => {
@@ -23,5 +26,51 @@ describe('pickQuickWorkspaceAgent', () => {
   it('uses detected enabled agents after detection resolves', () => {
     expect(pickQuickWorkspaceAgent(null, ['codex'], ['claude'])).toBe('codex')
     expect(pickQuickWorkspaceAgent('codex', ['claude', 'codex'], ['codex'])).toBe('claude')
+  })
+})
+
+describe('resolveQuickWorkspaceAgentSelection', () => {
+  it('uses the preferred quick agent until the user picks an override', () => {
+    expect(
+      resolveQuickWorkspaceAgentSelection({
+        quickAgentOverride: undefined,
+        preferredQuickAgent: 'claude',
+        detectedAgentIds: ['claude', 'codex'],
+        disabledTuiAgents: []
+      })
+    ).toEqual({ quickAgent: 'claude', quickAgentOverride: undefined })
+  })
+
+  it('keeps explicit blank overrides stable', () => {
+    expect(
+      resolveQuickWorkspaceAgentSelection({
+        quickAgentOverride: null,
+        preferredQuickAgent: 'claude',
+        detectedAgentIds: ['claude'],
+        disabledTuiAgents: []
+      })
+    ).toEqual({ quickAgent: null, quickAgentOverride: null })
+  })
+
+  it('keeps an available user override', () => {
+    expect(
+      resolveQuickWorkspaceAgentSelection({
+        quickAgentOverride: 'codex',
+        preferredQuickAgent: 'claude',
+        detectedAgentIds: new Set(['claude', 'codex']),
+        disabledTuiAgents: []
+      })
+    ).toEqual({ quickAgent: 'codex', quickAgentOverride: 'codex' })
+  })
+
+  it('replaces an unavailable override with the preferred quick agent', () => {
+    expect(
+      resolveQuickWorkspaceAgentSelection({
+        quickAgentOverride: 'codex',
+        preferredQuickAgent: 'claude',
+        detectedAgentIds: ['claude'],
+        disabledTuiAgents: []
+      })
+    ).toEqual({ quickAgent: 'claude', quickAgentOverride: 'claude' })
   })
 })

--- a/src/renderer/src/lib/quick-workspace-agent-selection.ts
+++ b/src/renderer/src/lib/quick-workspace-agent-selection.ts
@@ -1,5 +1,9 @@
 import type { TuiAgent } from '../../../shared/types'
-import { pickTuiAgent, TUI_AGENT_AUTO_PICK_ORDER } from '../../../shared/tui-agent-selection'
+import {
+  isTuiAgentEnabled,
+  pickTuiAgent,
+  TUI_AGENT_AUTO_PICK_ORDER
+} from '../../../shared/tui-agent-selection'
 
 export function pickQuickWorkspaceAgent(
   preferred: TuiAgent | 'blank' | null | undefined,
@@ -8,4 +12,53 @@ export function pickQuickWorkspaceAgent(
 ): TuiAgent | null {
   const candidates = detectedAgentIds ?? TUI_AGENT_AUTO_PICK_ORDER
   return pickTuiAgent(preferred, candidates, disabledTuiAgents)
+}
+
+function hasDetectedAgent(detectedAgentIds: Iterable<TuiAgent>, agent: TuiAgent): boolean {
+  if (detectedAgentIds instanceof Set) {
+    return detectedAgentIds.has(agent)
+  }
+  for (const detectedAgentId of detectedAgentIds) {
+    if (detectedAgentId === agent) {
+      return true
+    }
+  }
+  return false
+}
+
+function isQuickWorkspaceAgentAvailable(
+  agent: TuiAgent,
+  detectedAgentIds: Iterable<TuiAgent> | null,
+  disabledTuiAgents?: Iterable<unknown> | null
+): boolean {
+  if (!isTuiAgentEnabled(agent, disabledTuiAgents)) {
+    return false
+  }
+  return detectedAgentIds === null || hasDetectedAgent(detectedAgentIds, agent)
+}
+
+export function resolveQuickWorkspaceAgentSelection({
+  quickAgentOverride,
+  preferredQuickAgent,
+  detectedAgentIds,
+  disabledTuiAgents
+}: {
+  quickAgentOverride: TuiAgent | null | undefined
+  preferredQuickAgent: TuiAgent | null
+  detectedAgentIds: Iterable<TuiAgent> | null
+  disabledTuiAgents?: Iterable<unknown> | null
+}): {
+  quickAgent: TuiAgent | null
+  quickAgentOverride: TuiAgent | null | undefined
+} {
+  if (quickAgentOverride === undefined || quickAgentOverride === null) {
+    return {
+      quickAgent: quickAgentOverride === undefined ? preferredQuickAgent : null,
+      quickAgentOverride
+    }
+  }
+  if (isQuickWorkspaceAgentAvailable(quickAgentOverride, detectedAgentIds, disabledTuiAgents)) {
+    return { quickAgent: quickAgentOverride, quickAgentOverride }
+  }
+  return { quickAgent: preferredQuickAgent, quickAgentOverride: preferredQuickAgent }
 }


### PR DESCRIPTION
## Summary
- move quick workspace agent override repair into `resolveQuickWorkspaceAgentSelection`
- update the composer modal to repair unavailable quick-agent overrides during render before the selector renders
- cover preferred, explicit blank, available override, and invalid override cases in unit tests

## Validation
- `pnpm exec oxlint src/renderer/src/components/NewWorkspaceComposerModal.tsx src/renderer/src/lib/quick-workspace-agent-selection.ts src/renderer/src/lib/quick-workspace-agent-selection.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/NewWorkspaceComposerModal.tsx src/renderer/src/lib/quick-workspace-agent-selection.ts src/renderer/src/lib/quick-workspace-agent-selection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/quick-workspace-agent-selection.test.ts`
- `pnpm run typecheck:web`
- `git diff --check HEAD~1..HEAD`
- Electron: launched this worktree with CDP, verified the intended dev identity, opened the Create Worktree composer, confirmed the selected agent renders, disabled that agent through settings, and confirmed the open composer repaired to an available agent with no console errors.

## Risk
Low. The merged change is isolated to quick-workspace agent selection repair, has focused unit coverage for the fallback cases, typechecks cleanly, and the visible composer repair path was smoke-tested in Electron.