### PR TITLE
Remove add repo clone destination effect

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -17,7 +17,7 @@ import { track } from '@/lib/telemetry'
 import { RemoteStep, CloneStep, useRemoteRepo } from './AddRepoSteps'
 import { CreateStep, useCreateRepo } from './AddRepoCreateStep'
 import { getProjectAddedPrimaryBranchName, SetupStep } from './AddRepoSetupStep'
-import { getDefaultCloneParent } from './clone-defaults'
+import { getCloneDestinationAutoFill } from './clone-defaults'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
@@ -175,26 +175,21 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     return window.api.repos.onCloneProgress(setCloneProgress)
   }, [isCloning])
 
-  useEffect(() => {
-    if (step !== 'clone') {
-      cloneStepAutoFilledRef.current = false
-      return
-    }
-    if (cloneStepAutoFilledRef.current) {
-      return
-    }
-    if (cloneDestination) {
-      return
-    }
-    if (settings?.activeRuntimeEnvironmentId?.trim()) {
-      return
-    }
-    if (!settings?.workspaceDir) {
-      return
-    }
+  const cloneDestinationAutoFill = getCloneDestinationAutoFill({
+    step,
+    cloneDestination,
+    activeRuntimeEnvironmentId: settings?.activeRuntimeEnvironmentId,
+    workspaceDir: settings?.workspaceDir,
+    cloneStepAutoFilled: cloneStepAutoFilledRef.current
+  })
+  if (step !== 'clone') {
+    cloneStepAutoFilledRef.current = false
+  } else if (cloneDestinationAutoFill) {
+    // Why: late settings hydration should still seed the local clone path,
+    // but runtime/server clone flows must keep their destination user-entered.
     cloneStepAutoFilledRef.current = true
-    setCloneDestination(getDefaultCloneParent(settings.workspaceDir))
-  }, [step, cloneDestination, settings?.activeRuntimeEnvironmentId, settings?.workspaceDir])
+    setCloneDestination(cloneDestinationAutoFill.destination)
+  }
 
   const isOpen = activeModal === 'add-repo'
   const projectId = addedRepo?.id ?? ''

--- a/src/renderer/src/components/sidebar/clone-defaults.test.ts
+++ b/src/renderer/src/components/sidebar/clone-defaults.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getDefaultCloneParent } from './clone-defaults'
+import { getCloneDestinationAutoFill, getDefaultCloneParent } from './clone-defaults'
 
 describe('getDefaultCloneParent', () => {
   it('strips a POSIX workspaces suffix', () => {
@@ -44,5 +44,64 @@ describe('getDefaultCloneParent', () => {
     expect(getDefaultCloneParent('/Users/mvanhorn/orca/project-workspaces')).toBe(
       '/Users/mvanhorn/orca/project-workspaces'
     )
+  })
+})
+
+describe('getCloneDestinationAutoFill', () => {
+  it('fills the local clone destination from the workspace directory', () => {
+    expect(
+      getCloneDestinationAutoFill({
+        step: 'clone',
+        cloneDestination: '',
+        activeRuntimeEnvironmentId: null,
+        workspaceDir: '/Users/mvanhorn/orca/workspaces',
+        cloneStepAutoFilled: false
+      })
+    ).toEqual({ destination: '/Users/mvanhorn/orca' })
+  })
+
+  it('waits for a workspace directory before filling', () => {
+    expect(
+      getCloneDestinationAutoFill({
+        step: 'clone',
+        cloneDestination: '',
+        activeRuntimeEnvironmentId: null,
+        workspaceDir: null,
+        cloneStepAutoFilled: false
+      })
+    ).toBeNull()
+  })
+
+  it('does not overwrite typed destinations or repeat an auto-fill', () => {
+    expect(
+      getCloneDestinationAutoFill({
+        step: 'clone',
+        cloneDestination: '/tmp/project',
+        activeRuntimeEnvironmentId: null,
+        workspaceDir: '/Users/mvanhorn/orca/workspaces',
+        cloneStepAutoFilled: false
+      })
+    ).toBeNull()
+    expect(
+      getCloneDestinationAutoFill({
+        step: 'clone',
+        cloneDestination: '',
+        activeRuntimeEnvironmentId: null,
+        workspaceDir: '/Users/mvanhorn/orca/workspaces',
+        cloneStepAutoFilled: true
+      })
+    ).toBeNull()
+  })
+
+  it('does not fill server clone destinations for runtime environments', () => {
+    expect(
+      getCloneDestinationAutoFill({
+        step: 'clone',
+        cloneDestination: '',
+        activeRuntimeEnvironmentId: 'env-local-linux',
+        workspaceDir: '/Users/mvanhorn/orca/workspaces',
+        cloneStepAutoFilled: false
+      })
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/components/sidebar/clone-defaults.ts
+++ b/src/renderer/src/components/sidebar/clone-defaults.ts
@@ -25,3 +25,25 @@ export function getDefaultCloneParent(workspaceDir: string): string {
   }
   return parent
 }
+
+export function getCloneDestinationAutoFill({
+  step,
+  cloneDestination,
+  activeRuntimeEnvironmentId,
+  workspaceDir,
+  cloneStepAutoFilled
+}: {
+  step: string
+  cloneDestination: string
+  activeRuntimeEnvironmentId: string | null | undefined
+  workspaceDir: string | null | undefined
+  cloneStepAutoFilled: boolean
+}): { destination: string } | null {
+  if (step !== 'clone' || cloneStepAutoFilled || cloneDestination) {
+    return null
+  }
+  if (activeRuntimeEnvironmentId?.trim() || !workspaceDir) {
+    return null
+  }
+  return { destination: getDefaultCloneParent(workspaceDir) }
+}


### PR DESCRIPTION
## Summary
- move Add Repo clone destination auto-fill into `getCloneDestinationAutoFill`
- update the dialog to seed the clone destination during render when the clone step first has a local workspace directory
- cover local fill, late settings hydration, typed destination, one-shot fill, and runtime/server destination cases

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoDialog.tsx src/renderer/src/components/sidebar/clone-defaults.ts src/renderer/src/components/sidebar/clone-defaults.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/clone-defaults.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: 926 -> 925

## Risk
Medium. This preserves the current local clone default and runtime/server guard, but it touches the Add Repo clone workflow and the destination path shown before clone submit.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.