### PR TITLE
Avoid auto-submitting orchestration mail to Cursor Agent

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -413,14 +413,18 @@ afterEach(() => {
   getIssueMock.mockResolvedValue(null)
 })
 
-function syncSinglePty(runtime: OrcaRuntimeService, ptyId: string | null = 'pty-1'): void {
+function syncSinglePty(
+  runtime: OrcaRuntimeService,
+  ptyId: string | null = 'pty-1',
+  options: { tabTitle?: string | null; paneTitle?: string | null } = {}
+): void {
   runtime.attachWindow(1)
   runtime.syncWindowGraph(1, {
     tabs: [
       {
         tabId: 'tab-1',
         worktreeId: TEST_WORKTREE_ID,
-        title: 'Codex',
+        title: options.tabTitle ?? 'Codex',
         activeLeafId: 'pane:1',
         layout: null
       }
@@ -432,7 +436,7 @@ function syncSinglePty(runtime: OrcaRuntimeService, ptyId: string | null = 'pty-
         leafId: 'pane:1',
         paneRuntimeId: 1,
         ptyId,
-        paneTitle: null
+        paneTitle: options.paneTitle ?? null
       }
     ]
   })
@@ -4008,6 +4012,36 @@ describe('OrcaRuntimeService', () => {
       expect(unread).toHaveLength(1)
       expect(unread[0].read).toBe(0)
       expect(unread[0].delivered_at).not.toBeNull()
+      db.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still auto-submits to a non-Cursor agent when its idle title mentions Cursor Agent', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const db = new InMemoryOrchestrationMessages()
+      const write = vi.fn().mockReturnValue(true)
+      setInMemoryOrchestrationMessages(runtime, db)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime, 'pty-1', { tabTitle: 'cursor-repro-branch' })
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', '\x1b]0;. Investigate Cursor Agent\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;* Investigate Cursor Agent\x07', 101)
+      db.insertMessage({ from: 'term_sender', to: terminal.handle, subject: 'hello claude' })
+
+      runtime.deliverPendingMessagesForHandle(terminal.handle)
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(write).toHaveBeenCalledWith('pty-1', expect.stringContaining('Subject: hello claude'))
+      expect(write).toHaveBeenCalledWith('pty-1', '\r')
       db.close()
     } finally {
       vi.useRealTimers()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3973,6 +3973,47 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('injects pending orchestration messages into Cursor Agent without auto-submitting', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const db = new InMemoryOrchestrationMessages()
+      const write = vi.fn().mockReturnValue(true)
+      setInMemoryOrchestrationMessages(runtime, db)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', '\x1b]0;\u280b Cursor Agent\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;Cursor ready\x07', 101)
+      db.insertMessage({ from: 'term_sender', to: terminal.handle, subject: 'hello cursor' })
+
+      runtime.deliverPendingMessagesForHandle(terminal.handle)
+
+      expect(write).toHaveBeenCalledWith('pty-1', expect.stringContaining('Subject: hello cursor'))
+      await vi.advanceTimersByTimeAsync(500)
+      const submitWrites = write.mock.calls.filter(
+        ([ptyId, text]) => ptyId === 'pty-1' && text === '\r'
+      )
+      expect(submitWrites).toHaveLength(0)
+
+      // Why: Cursor Agent treats injected PTY text as editable prompt input.
+      // The user must submit it manually, but the banner should not replay on
+      // the next idle transition.
+      const unread = db.getUnreadMessages(terminal.handle)
+      expect(unread).toHaveLength(1)
+      expect(unread[0].read).toBe(0)
+      expect(unread[0].delivered_at).not.toBeNull()
+      db.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not replay an already-delivered message on a later idle transition', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4,7 +4,6 @@
 import {
   extractLastOscTitle,
   detectAgentStatusFromTitle,
-  getAgentLabel,
   isShellProcess
 } from '../../shared/agent-detection'
 import type { AgentStatus } from '../../shared/agent-detection'
@@ -558,9 +557,25 @@ function isCursorAgentOrchestrationTarget(
   leaf: RuntimeLeafRecord,
   tabTitle: string | null | undefined
 ): boolean {
-  return [leaf.lastOscTitle, leaf.paneTitle, tabTitle].some(
-    (title) => typeof title === 'string' && getAgentLabel(title) === 'Cursor'
-  )
+  return [leaf.lastOscTitle, leaf.paneTitle, tabTitle].some(isCursorAgentTitle)
+}
+
+function isCursorAgentTitle(title: string | null | undefined): boolean {
+  if (typeof title !== 'string') {
+    return false
+  }
+  const trimmed = title.trim()
+  const lower = trimmed.toLowerCase()
+  if (
+    lower === 'cursor agent' ||
+    lower === 'cursor ready' ||
+    lower === 'cursor - action required'
+  ) {
+    return true
+  }
+  // Why: display labels can mention Cursor in another agent's task text. Only
+  // treat the controlled synthetic Cursor spinner title as Cursor identity.
+  return /^[\u2800-\u28ff] Cursor Agent$/u.test(trimmed)
 }
 
 type RuntimePtyWorktreeRecord = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4,6 +4,7 @@
 import {
   extractLastOscTitle,
   detectAgentStatusFromTitle,
+  getAgentLabel,
   isShellProcess
 } from '../../shared/agent-detection'
 import type { AgentStatus } from '../../shared/agent-detection'
@@ -551,6 +552,15 @@ type RuntimeLeafRecord = RuntimeSyncedLeaf & {
   // serving a stale `lastAgentStatus` after the agent process exits and the
   // shell takes over the title — the bug behind issue #1437.
   lastOscTitle: string | null
+}
+
+function isCursorAgentOrchestrationTarget(
+  leaf: RuntimeLeafRecord,
+  tabTitle: string | null | undefined
+): boolean {
+  return [leaf.lastOscTitle, leaf.paneTitle, tabTitle].some(
+    (title) => typeof title === 'string' && getAgentLabel(title) === 'Cursor'
+  )
 }
 
 type RuntimePtyWorktreeRecord = {
@@ -11686,6 +11696,15 @@ export class OrcaRuntimeService {
     const payload = formatMessagesForInjection(unread)
     const wrote = this.ptyController?.write(leaf.ptyId, payload) ?? false
     if (!wrote) {
+      return
+    }
+
+    const tabTitle = this.tabs.get(leaf.tabId)?.title
+    if (isCursorAgentOrchestrationTarget(leaf, tabTitle)) {
+      // Why: Cursor Agent treats injected PTY text as editable prompt input.
+      // Push-on-idle may surface the message, but submitting it must stay
+      // under user control.
+      this._orchestrationDb.markAsDelivered(unread.map((m) => m.id))
       return
     }
 


### PR DESCRIPTION
Fixes #3034

Summary:
- Detect Cursor Agent terminals during push-on-idle orchestration delivery.
- Inject pending orchestration mail into Cursor Agent without sending the delayed Enter key.
- Mark injected Cursor deliveries as delivered so the banner does not replay while leaving unread semantics intact.
- Add a regression test covering Cursor Agent injection-only delivery.

Validation:
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` (206 tests)
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD` -> 88f3b45521d0ca5178b7afe11d051592d2bc5c80