### PR TITLE
Remove SSH reset dialog cleanup effect

### DIFF
--- a/src/renderer/src/components/settings/SshTargetDestructiveActions.tsx
+++ b/src/renderer/src/components/settings/SshTargetDestructiveActions.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { SshConnectionState } from '../../../../shared/ssh-types'
 import { SshDestructiveActionDialog } from './SshDestructiveActionDialog'
-import { isSshTargetConnecting, type SshTargetBusyAction } from './ssh-target-action-state'
+import {
+  isSshTargetConnecting,
+  shouldClearPendingSshReset,
+  type SshTargetBusyAction
+} from './ssh-target-action-state'
 
 type PendingTargetAction = { id: string; label: string }
 
@@ -93,12 +97,17 @@ export function SshTargetDestructiveActions({
     pendingReset !== null && isSshTargetConnecting(pendingResetStatus)
   const pendingTerminateIsBusy =
     pendingTerminate !== null && targetActionsInFlight.get(pendingTerminate.id) === 'terminate'
-
-  useEffect(() => {
-    if (pendingResetBlockedByConnection && !pendingResetIsBusy) {
-      setPendingReset(null)
-    }
-  }, [pendingResetBlockedByConnection, pendingResetIsBusy])
+  const shouldClearReset = shouldClearPendingSshReset({
+    pendingTargetId: pendingReset?.id ?? null,
+    pendingResetIsBusy,
+    connectionStatus: pendingResetStatus
+  })
+  if (shouldClearReset) {
+    // Why: a reconnecting target cannot safely reset its relay; clear the
+    // pending dialog before it paints stale destructive UI.
+    setPendingReset(null)
+  }
+  const dialogPendingReset = shouldClearReset ? null : pendingReset
 
   const confirmResetRelay = async (): Promise<void> => {
     if (!pendingReset) {
@@ -160,10 +169,10 @@ export function SshTargetDestructiveActions({
       />
 
       <SshDestructiveActionDialog
-        open={!!pendingReset && (!pendingResetBlockedByConnection || pendingResetIsBusy)}
+        open={!!dialogPendingReset && (!pendingResetBlockedByConnection || pendingResetIsBusy)}
         title="Reset Remote Relay?"
         description="This force-stops the remote relay for this SSH target. Active remote terminals and port forwards for this target will end."
-        targetLabel={pendingReset?.label}
+        targetLabel={dialogPendingReset?.label}
         actionLabel="Reset Relay"
         busyLabel="Resetting"
         isBusy={pendingResetIsBusy}

--- a/src/renderer/src/components/settings/ssh-target-action-state.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-action-state.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { shouldClearPendingSshReset } from './ssh-target-action-state'
+
+describe('shouldClearPendingSshReset', () => {
+  it('clears idle reset confirmation while a target is connecting', () => {
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: 'target-1',
+        pendingResetIsBusy: false,
+        connectionStatus: 'connecting'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps reset confirmation while reset is already running', () => {
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: 'target-1',
+        pendingResetIsBusy: true,
+        connectionStatus: 'reconnecting'
+      })
+    ).toBe(false)
+  })
+
+  it('keeps reset confirmation for non-connecting target states', () => {
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: 'target-1',
+        pendingResetIsBusy: false,
+        connectionStatus: 'connected'
+      })
+    ).toBe(false)
+  })
+
+  it('ignores missing pending reset targets', () => {
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: null,
+        pendingResetIsBusy: false,
+        connectionStatus: 'connecting'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/ssh-target-action-state.ts
+++ b/src/renderer/src/components/settings/ssh-target-action-state.ts
@@ -11,3 +11,15 @@ const SSH_TARGET_CONNECTING_STATUSES: ReadonlySet<SshConnectionStatus> = new Set
 export function isSshTargetConnecting(status: SshConnectionStatus): boolean {
   return SSH_TARGET_CONNECTING_STATUSES.has(status)
 }
+
+export function shouldClearPendingSshReset({
+  pendingTargetId,
+  pendingResetIsBusy,
+  connectionStatus
+}: {
+  pendingTargetId: string | null
+  pendingResetIsBusy: boolean
+  connectionStatus: SshConnectionStatus
+}): boolean {
+  return pendingTargetId !== null && !pendingResetIsBusy && isSshTargetConnecting(connectionStatus)
+}


### PR DESCRIPTION
## Summary
- move SSH reset-relay dialog clearing into `shouldClearPendingSshReset`
- clear invalid pending reset state before stale destructive UI can render when a target starts connecting/reconnecting/deploying relay
- cover idle, busy, non-connecting, and no-pending-target cases in unit tests

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/SshTargetDestructiveActions.tsx src/renderer/src/components/settings/ssh-target-action-state.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: 926 -> 925

## Risk
High. The implementation is small, but this touches SSH destructive-action confirmation behavior and the reset-relay path for remote targets.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.