### PR TITLE
Remove redundant sidebar live width effect

### DIFF
--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -59,10 +59,6 @@ function Sidebar({
     onDraftWidthChange: setLiveSidebarWidth
   })
 
-  useEffect(() => {
-    setLiveSidebarWidth(sidebarWidth)
-  }, [setLiveSidebarWidth, sidebarWidth])
-
   return (
     <TooltipProvider delayDuration={400}>
       <div


### PR DESCRIPTION
## Summary
- Remove the duplicate passive Effect that rewrote --workspace-sidebar-live-width from the sidebar component
- Keep live width synchronization owned by useSidebarResize, which already updates the CSS variable on committed width changes and draft resize frames

## Risk
Low - local sidebar UI cleanup; no persistence, transport, SSH, or provider behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/index.tsx src/renderer/src/hooks/useSidebarResize.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useSidebarResize.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 926 -> 925