### PR TITLE
Derive worktree palette selection during render

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -255,7 +255,6 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const activeGroupSnapshotRef = useRef<CmdJActiveGroupSnapshot | null>(null)
   const wasVisibleRef = useRef(false)
   const skipRestoreFocusRef = useRef(false)
-  const prevQueryRef = useRef('')
   const listRef = useRef<HTMLDivElement>(null)
   const createLookupGuard = useMemo(() => createWorktreePaletteRequestGuard(), [])
   const preserveCreateLookupOnCloseRef = useRef(false)
@@ -688,9 +687,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
           ? 'address-bar'
           : 'webview'
       skipRestoreFocusRef.current = false
-      prevQueryRef.current = ''
       setQuery('')
       setSelectedItemId('')
+      listRef.current?.scrollTo(0, 0)
     }
 
     if (!visible && wasVisibleRef.current) {
@@ -714,29 +713,18 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     visible
   ])
 
-  useEffect(() => {
-    if (!visible) {
-      return
-    }
-    const queryChanged = deferredQuery !== prevQueryRef.current
-    prevQueryRef.current = deferredQuery
+  const commandSelectedItemId = getNextWorktreePaletteSelection({
+    currentSelectedItemId: selectedItemId,
+    queryChanged: false,
+    selectableItemIds: selectionItemIds,
+    showCreateAction
+  })
 
-    const nextSelectedItemId = getNextWorktreePaletteSelection({
-      currentSelectedItemId: selectedItemId,
-      queryChanged,
-      selectableItemIds: selectionItemIds,
-      showCreateAction
-    })
-    if (queryChanged) {
-      setSelectedItemId(nextSelectedItemId)
-      listRef.current?.scrollTo(0, 0)
-      return
-    }
-
-    if (nextSelectedItemId !== selectedItemId) {
-      setSelectedItemId(nextSelectedItemId)
-    }
-  }, [deferredQuery, selectedItemId, showCreateAction, visible, selectionItemIds])
+  const handleQueryChange = useCallback((nextQuery: string) => {
+    setQuery(nextQuery)
+    setSelectedItemId('')
+    listRef.current?.scrollTo(0, 0)
+  }, [])
 
   const focusFallbackSurface = useCallback(() => {
     requestAnimationFrame(() => {
@@ -1089,7 +1077,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       contentClassName="top-[13%] w-[736px] max-w-[94vw] overflow-hidden rounded-xl border border-border/70 bg-background/96 shadow-[0_26px_84px_rgba(0,0,0,0.32)] backdrop-blur-xl"
       commandProps={{
         loop: true,
-        value: selectedItemId,
+        value: commandSelectedItemId,
         onValueChange: setSelectedItemId,
         className: 'bg-transparent'
       }}
@@ -1097,7 +1085,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       <CommandInput
         placeholder="Search workspaces, settings, tabs, and actions..."
         value={query}
-        onValueChange={setQuery}
+        onValueChange={handleQueryChange}
         wrapperClassName="mx-3 mt-3 rounded-lg border border-border/55 bg-muted/28 px-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
         iconClassName="mr-2.5 h-4 w-4 text-muted-foreground/60"
         className="h-12 text-[14px] placeholder:text-muted-foreground/75"

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -89,6 +89,17 @@ describe('worktree-palette-create-action', () => {
     ).toBe('')
   })
 
+  it('falls back to the first row when render-time selection state is empty', () => {
+    expect(
+      getNextWorktreePaletteSelection({
+        currentSelectedItemId: '',
+        queryChanged: false,
+        selectableItemIds: ['worktree:first', 'browser-page:second'],
+        showCreateAction: true
+      })
+    ).toBe('worktree:first')
+  })
+
   it('does not keep create selected after the create row disappears', () => {
     expect(
       getNextWorktreePaletteSelection({


### PR DESCRIPTION
## Summary
- Remove the Cmd+J worktree palette Effect that repaired the selected row after query/list changes
- Derive the controlled command selection during render from the current selected id and rendered selectable rows
- Reset manual selection and scroll the list in the query/open paths that already own those transitions

## Risk
Low - local command-palette keyboard selection state only; no persistence, IPC, SSH, provider, terminal, browser webview, or source-control behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/WorktreeJumpPalette.tsx src/renderer/src/lib/worktree-palette-create-action.ts src/renderer/src/lib/worktree-palette-create-action.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-palette-create-action.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 925 -> 924