### PR TITLE
Prune sidebar worktree selection during render

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -3304,17 +3304,19 @@ const WorktreeList = React.memo(function WorktreeList({
   const [selectedWorktreeIds, setSelectedWorktreeIds] = useState<Set<string>>(new Set())
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null)
 
-  useEffect(() => {
-    setSelectedWorktreeIds((previous) => {
-      const pruned = pruneWorktreeSelection(previous, selectionAnchorId, renderedWorktreeIds)
-      if (pruned.anchorId !== selectionAnchorId) {
-        setSelectionAnchorId(pruned.anchorId)
-      }
-      return areWorktreeSelectionsEqual(previous, pruned.selectedIds)
-        ? previous
-        : pruned.selectedIds
-    })
-  }, [renderedWorktreeIds, selectionAnchorId])
+  const prunedSelection = pruneWorktreeSelection(
+    selectedWorktreeIds,
+    selectionAnchorId,
+    renderedWorktreeIds
+  )
+  // Why: filters/grouping can hide selected cards. Prune during render so
+  // context menus and child rows never see stale ids for unrendered worktrees.
+  if (!areWorktreeSelectionsEqual(selectedWorktreeIds, prunedSelection.selectedIds)) {
+    setSelectedWorktreeIds(prunedSelection.selectedIds)
+  }
+  if (selectionAnchorId !== prunedSelection.anchorId) {
+    setSelectionAnchorId(prunedSelection.anchorId)
+  }
 
   const selectedWorktrees = useMemo(() => {
     if (selectedWorktreeIds.size === 0) {


### PR DESCRIPTION
## Summary
- Remove the WorktreeList Effect that pruned selected sidebar worktree ids after filters/grouping changed
- Prune the local selection during render behind equality guards, matching the existing workspace board selection pattern
- Keep the external pointer listener cleanup behavior unchanged

## Risk
Low - isolated sidebar multi-selection UI state; no persistence, IPC, SSH, provider, terminal/browser, or source-control behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx src/renderer/src/components/sidebar/worktree-multi-selection.ts src/renderer/src/components/sidebar/worktree-multi-selection.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-multi-selection.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 924 -> 923