### PR TITLE
Suppress milestone completion notifications

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -4113,6 +4113,19 @@ describe('Droid hook normalization', () => {
     expect(result).toBeNull()
   })
 
+  it('SubagentStop does not mark Droid done for mission progress', () => {
+    const result = _internals.normalizeHookPayload(
+      'droid',
+      buildBody({
+        hook_event_name: 'SubagentStop',
+        last_assistant_message: '# Completed Wrote the requested validation assertions'
+      }),
+      'production'
+    )
+
+    expect(result).toBeNull()
+  })
+
   it('PreToolUse maps to working and surfaces the tool name and input preview', () => {
     const result = _internals.normalizeHookPayload(
       'droid',

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -63,6 +63,7 @@ describe('DroidHookService', () => {
         'PreToolUse',
         'SessionStart',
         'Stop',
+        'SubagentStop',
         'UserPromptSubmit'
       ].sort()
     )

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -21,6 +21,9 @@ const DROID_EVENTS = [
   { eventName: 'SessionStart', definition: { hooks: [{ type: 'command', command: '' }] } },
   { eventName: 'UserPromptSubmit', definition: { hooks: [{ type: 'command', command: '' }] } },
   { eventName: 'Stop', definition: { hooks: [{ type: 'command', command: '' }] } },
+  // Why: sub-droid completion is mission progress, not parent Droid completion.
+  // The listener intentionally ignores SubagentStop so it cannot notify.
+  { eventName: 'SubagentStop', definition: { hooks: [{ type: 'command', command: '' }] } },
   {
     eventName: 'PreToolUse',
     definition: { matcher: '*', hooks: [{ type: 'command', command: '' }] }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1041,14 +1041,16 @@ function driveSyntheticTitleFromHook(
   // decorated "<Agent> ready" label rather than the bare native title — which
   // for cursor the detector deliberately treats as a no-op so cursor's own
   // per-turn re-emissions cannot clobber our synthesized state. The
-  // done/permission frames also carry a trailing BEL (0x07 outside of any OSC
-  // sequence) so the tab-level unread badge + notification dispatch in
-  // pty-connection lights up — those key off BEL, not the working→idle title
-  // transition.
+  // Permission frames also carry a trailing BEL (0x07 outside of any OSC
+  // sequence) so user-input-required states light up immediately. Done frames
+  // intentionally avoid the extra BEL: hook/status completion notifications
+  // own final-task attention and can cancel milestone noise during loops.
   stopSyntheticTitleSpinner(paneKey)
-  const label =
-    state === 'blocked' || state === 'waiting' ? profile.permissionLabel : profile.idleLabel
-  sendSyntheticTitle(ptyId, `\x1b]0;${label}\x07\x07`, { force: true })
+  const needsUserInput = state === 'blocked' || state === 'waiting'
+  const label = needsUserInput ? profile.permissionLabel : profile.idleLabel
+  sendSyntheticTitle(ptyId, `\x1b]0;${label}\x07${needsUserInput ? '\x07' : ''}`, {
+    force: true
+  })
 }
 
 app.whenReady().then(async () => {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -2,6 +2,11 @@ import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-t
 import type { GlobalSettings } from '../../../../shared/types'
 import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
 
+export type AgentCompletionDispatchMeta = {
+  source: 'hook' | 'title' | 'process-exit'
+  quietedHookDone: boolean
+}
+
 export type AgentCompletionCoordinatorOptions = {
   paneKey: string
   getPtyId: () => string | null
@@ -10,7 +15,7 @@ export type AgentCompletionCoordinatorOptions = {
     settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
     ptyId: string
   ) => Promise<RuntimeTerminalProcessInspection>
-  dispatchCompletion: (title: string) => void
+  dispatchCompletion: (title: string, meta?: AgentCompletionDispatchMeta) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
 }
@@ -21,6 +26,7 @@ export type AgentCompletionCoordinator = {
   observeTitleWorking: () => void
   observeHookStatus: (payload: ParsedAgentStatusPayload) => void
   startProcessTracking: () => void
+  hasPendingHookDoneCompletion: () => boolean
   resetCompletionState: (options?: { requireFreshWorking?: boolean }) => void
   dispose: () => void
 }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -33,6 +33,8 @@ function createRejectableDeferred<T>(): {
   return { promise, reject: rejectDeferred }
 }
 
+const HOOK_DONE_QUIET_MS = 1_500
+
 describe('agent completion coordinator', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -350,6 +352,7 @@ describe('agent completion coordinator', () => {
       agentType: 'codex'
     })
     coordinator.observeClassifiedTitleCompletion('codex done')
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
     expect(dispatchCompletion).toHaveBeenCalledWith('codex')
@@ -497,6 +500,7 @@ describe('agent completion coordinator', () => {
       prompt: '',
       agentType: 'codex'
     })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
@@ -589,6 +593,49 @@ describe('agent completion coordinator', () => {
     })
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels a hook completion when the same turn resumes work before the quiet window', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the goal',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the goal',
+      agentType: 'codex'
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS - 1)
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the goal',
+      agentType: 'codex'
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the goal',
+      agentType: 'codex'
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
   })
 
   it.each([

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -355,7 +355,10 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
+    expect(dispatchCompletion).toHaveBeenCalledWith('codex', {
+      source: 'hook',
+      quietedHookDone: true
+    })
   })
 
   it('ignores stale working title state after a hook completion already notified', () => {
@@ -616,6 +619,7 @@ describe('agent completion coordinator', () => {
       prompt: 'run the goal',
       agentType: 'codex'
     })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS - 1)
     expect(dispatchCompletion).not.toHaveBeenCalled()
 
@@ -624,6 +628,7 @@ describe('agent completion coordinator', () => {
       prompt: 'run the goal',
       agentType: 'codex'
     })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(false)
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
     expect(dispatchCompletion).not.toHaveBeenCalled()
 
@@ -635,7 +640,10 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
+    expect(dispatchCompletion).toHaveBeenCalledWith('codex', {
+      source: 'hook',
+      quietedHookDone: true
+    })
   })
 
   it.each([

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -28,6 +28,7 @@ const INSPECTION_TIMEOUT_MS = 15_000
 const PENDING_TITLE_TTL_MS = Math.max(2_000, INSPECTION_TIMEOUT_MS + 500)
 const PENDING_TITLE_MAX_TTL_MS = Math.max(30_000, PENDING_TITLE_TTL_MS)
 const COMPLETION_REPLAY_GUARD_MS = 1_000
+const HOOK_DONE_QUIET_MS = 1_500
 
 function isCompletionHookState(state: ParsedAgentStatusPayload['state']): boolean {
   return state === 'done' || state === 'waiting' || state === 'blocked'
@@ -51,6 +52,8 @@ export function createAgentCompletionCoordinator(
   let requiresFreshWorking = false
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let pendingTitleTimer: ReturnType<typeof setTimeout> | null = null
+  let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
+  let pendingHookDoneTitle: string | null = null
   let pendingTitleSequence = 0
   let pendingTitle: {
     id: number
@@ -80,6 +83,14 @@ export function createAgentCompletionCoordinator(
     pendingTitleTimer = null
   }
 
+  function clearPendingHookDone(): void {
+    if (pendingHookDoneTimer !== null) {
+      clearTimeout(pendingHookDoneTimer)
+      pendingHookDoneTimer = null
+    }
+    pendingHookDoneTitle = null
+  }
+
   function establishAgentEvidence(): void {
     agentIdentityEstablished = true
     hasAgentRunEvidence = true
@@ -104,6 +115,9 @@ export function createAgentCompletionCoordinator(
   }
 
   function dispatchCompletion(source: CompletionSource, title: string): void {
+    if (source !== 'hook' && pendingHookDoneTimer !== null) {
+      return
+    }
     if (requiresFreshWorking || lastCompletedTurn === currentTurn) {
       return
     }
@@ -121,6 +135,23 @@ export function createAgentCompletionCoordinator(
     lastCompletionSource = source
     workingStatusObserved = false
     options.dispatchCompletion(title)
+  }
+
+  function scheduleHookDoneCompletion(title: string): void {
+    pendingHookDoneTitle = title
+    if (pendingHookDoneTimer !== null) {
+      return
+    }
+    // Why: goal/mission agents can report a temporary done state between
+    // milestones. Wait for a short quiet window so resumed work can cancel it.
+    pendingHookDoneTimer = setTimeout(() => {
+      pendingHookDoneTimer = null
+      const pendingTitle = pendingHookDoneTitle
+      pendingHookDoneTitle = null
+      if (pendingTitle) {
+        dispatchCompletion('hook', pendingTitle)
+      }
+    }, HOOK_DONE_QUIET_MS)
   }
 
   function dropPendingTitle(): void {
@@ -393,6 +424,7 @@ export function createAgentCompletionCoordinator(
       establishAgentEvidence()
     }
     if (payload.state === 'working') {
+      clearPendingHookDone()
       workingStatusObserved = true
       requiresFreshWorking = false
       currentTurn += 1
@@ -400,6 +432,9 @@ export function createAgentCompletionCoordinator(
       return
     }
     if (isCompletionHookState(payload.state)) {
+      if (payload.state !== 'done') {
+        clearPendingHookDone()
+      }
       if (isRecognizedAgentType(payload.agentType)) {
         establishAgentEvidence()
       }
@@ -414,6 +449,10 @@ export function createAgentCompletionCoordinator(
         // backstops duplicate the same completion.
         currentTurn += 1
       }
+      if (payload.state === 'done' && workingStatusObserved) {
+        scheduleHookDoneCompletion(payload.agentType ?? options.paneKey)
+        return
+      }
       dispatchCompletion('hook', payload.agentType ?? options.paneKey)
     }
   }
@@ -423,6 +462,7 @@ export function createAgentCompletionCoordinator(
   }
 
   function resetCompletionState(options: { requireFreshWorking?: boolean } = {}): void {
+    clearPendingHookDone()
     dropPendingTitle()
     agentIdentityEstablished = false
     hasAgentRunEvidence = false
@@ -440,6 +480,7 @@ export function createAgentCompletionCoordinator(
   function dispose(): void {
     disposed = true
     clearPollTimer()
+    clearPendingHookDone()
     dropPendingTitle()
   }
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -114,7 +114,11 @@ export function createAgentCompletionCoordinator(
     return `${source}:${currentTurn}:${processSession}`
   }
 
-  function dispatchCompletion(source: CompletionSource, title: string): void {
+  function dispatchCompletion(
+    source: CompletionSource,
+    title: string,
+    optionsOverride: { quietedHookDone?: boolean } = {}
+  ): void {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
       return
     }
@@ -134,7 +138,14 @@ export function createAgentCompletionCoordinator(
     lastCompletedTurn = currentTurn
     lastCompletionSource = source
     workingStatusObserved = false
-    options.dispatchCompletion(title)
+    if (optionsOverride.quietedHookDone === true) {
+      options.dispatchCompletion(title, {
+        source,
+        quietedHookDone: true
+      })
+    } else {
+      options.dispatchCompletion(title)
+    }
   }
 
   function scheduleHookDoneCompletion(title: string): void {
@@ -149,7 +160,7 @@ export function createAgentCompletionCoordinator(
       const pendingTitle = pendingHookDoneTitle
       pendingHookDoneTitle = null
       if (pendingTitle) {
-        dispatchCompletion('hook', pendingTitle)
+        dispatchCompletion('hook', pendingTitle, { quietedHookDone: true })
       }
     }, HOOK_DONE_QUIET_MS)
   }
@@ -461,6 +472,10 @@ export function createAgentCompletionCoordinator(
     scheduleNextPoll()
   }
 
+  function hasPendingHookDoneCompletion(): boolean {
+    return pendingHookDoneTimer !== null
+  }
+
   function resetCompletionState(options: { requireFreshWorking?: boolean } = {}): void {
     clearPendingHookDone()
     dropPendingTitle()
@@ -490,6 +505,7 @@ export function createAgentCompletionCoordinator(
     observeTitleWorking,
     observeHookStatus,
     startProcessTracking,
+    hasPendingHookDoneCompletion,
     resetCompletionState,
     dispose
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -24,6 +24,7 @@ async function flushAsyncTicks(count = 6): Promise<void> {
 const toastInfo = vi.fn()
 const LEAF_1 = '11111111-1111-4111-8111-111111111111' as const
 const LEAF_2 = '22222222-2222-4222-8222-222222222222' as const
+const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1_500
 
 function leafIdForPane(paneId: number): string {
   return paneId === 2 ? LEAF_2 : LEAF_1
@@ -3886,7 +3887,7 @@ describe('connectPanePty', () => {
 
     bellHandler()
     idleHandler('* Codex done')
-    vi.advanceTimersByTime(250)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
     await flushAsyncTicks()
 
     expect(window.api.notifications.dispatch).toHaveBeenCalledTimes(1)
@@ -3937,7 +3938,7 @@ describe('connectPanePty', () => {
     expect(deps.dispatchNotification).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'terminal-bell' })
     )
-    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
     expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
       expect.objectContaining({ source: 'agent-task-complete' })
     )
@@ -4362,7 +4363,7 @@ describe('connectPanePty', () => {
     titleHandler('experimental-agent-observability', 'experimental-agent-observability')
     await flushAsyncTicks()
 
-    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
 
     expect(deps.dispatchNotification).toHaveBeenCalledWith({
       source: 'agent-task-complete',
@@ -4437,7 +4438,7 @@ describe('connectPanePty', () => {
       agentType: 'codex',
       lastAssistantMessage: 'Done.'
     })
-    vi.advanceTimersByTime(250)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
 
     expect(deps.dispatchNotification).toHaveBeenCalledWith({
       source: 'agent-task-complete',
@@ -4480,6 +4481,50 @@ describe('connectPanePty', () => {
     expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
       expect.objectContaining({ source: 'agent-task-complete' })
     )
+  })
+
+  it('cancels a title task-complete notification when the agent resumes before quiet', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    vi.useFakeTimers()
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+      | ((title: string) => void)
+      | undefined
+    const workingHandler = createdTransportOptions[0]?.onAgentBecameWorking as
+      | (() => void)
+      | undefined
+    if (!idleHandler || !workingHandler) {
+      throw new Error('Expected idle and working handlers to be registered')
+    }
+
+    idleHandler('* Codex done')
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS - 1)
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete' })
+    )
+
+    workingHandler()
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete' })
+    )
+
+    idleHandler('* Codex done')
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
+
+    expect(deps.dispatchNotification).toHaveBeenCalledWith({
+      source: 'agent-task-complete',
+      terminalTitle: '* Codex done',
+      paneKey: makePaneKey('tab-1', LEAF_1)
+    })
   })
 
   // Why: show-until-interact — a real keystroke through xterm onData is the
@@ -4804,7 +4849,7 @@ describe('connectPanePty', () => {
     expect(mockStoreState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(dispatchNotification).not.toHaveBeenCalled()
 
-    vi.advanceTimersByTime(250)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
     await flushAsyncTicks()
 
     expect(dispatchNotification).toHaveBeenCalledWith({
@@ -4934,7 +4979,7 @@ describe('connectPanePty', () => {
       lastAssistantMessage: 'Delayed status arrived.'
     }
 
-    vi.advanceTimersByTime(250)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
     await flushAsyncTicks()
 
     expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
@@ -4992,6 +5037,8 @@ describe('connectPanePty', () => {
     }
     notifyStoreSubscribers()
     await flushAsyncTicks()
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS - 350)
+    await flushAsyncTicks()
 
     expect(window.api.notifications.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -5043,7 +5090,7 @@ describe('connectPanePty', () => {
     }
 
     idleHandler('* Codex done')
-    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
     await flushAsyncTicks()
 
     const dispatchArgs = (window.api.notifications.dispatch as ReturnType<typeof vi.fn>).mock

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -24,6 +24,7 @@ async function flushAsyncTicks(count = 6): Promise<void> {
 const toastInfo = vi.fn()
 const LEAF_1 = '11111111-1111-4111-8111-111111111111' as const
 const LEAF_2 = '22222222-2222-4222-8222-222222222222' as const
+const AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS = 250
 const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1_500
 
 function leafIdForPane(paneId: number): string {
@@ -4445,6 +4446,123 @@ describe('connectPanePty', () => {
       terminalTitle: 'codex',
       paneKey: makePaneKey('tab-1', LEAF_1)
     })
+  })
+
+  it('lets delayed hook completion notifications win over concurrent terminal bells', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-hook')
+    transportFactoryQueue.push(transport)
+
+    vi.useFakeTimers()
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const statusHandler = createdTransportOptions[0]?.onAgentStatus as
+      | ((payload: {
+          state: 'working' | 'done'
+          prompt: string
+          agentType: 'codex'
+          lastAssistantMessage?: string
+        }) => void)
+      | undefined
+    const bellHandler = createdTransportOptions[0]?.onBell as (() => void) | undefined
+    if (!statusHandler || !bellHandler) {
+      throw new Error('Expected hook status and bell handlers to be registered')
+    }
+
+    statusHandler({
+      state: 'working',
+      prompt: 'finish the implementation',
+      agentType: 'codex'
+    })
+    statusHandler({
+      state: 'done',
+      prompt: 'finish the implementation',
+      agentType: 'codex',
+      lastAssistantMessage: 'Done.'
+    })
+    bellHandler()
+
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+
+    vi.advanceTimersByTime(
+      AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS - AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS
+    )
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
+    expect(deps.dispatchNotification).toHaveBeenCalledWith({
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey: makePaneKey('tab-1', LEAF_1)
+    })
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+  })
+
+  it('restores a suppressed terminal bell when a delayed hook completion resumes work', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-hook')
+    transportFactoryQueue.push(transport)
+
+    vi.useFakeTimers()
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const statusHandler = createdTransportOptions[0]?.onAgentStatus as
+      | ((payload: {
+          state: 'working' | 'done'
+          prompt: string
+          agentType: 'codex'
+          lastAssistantMessage?: string
+        }) => void)
+      | undefined
+    const bellHandler = createdTransportOptions[0]?.onBell as (() => void) | undefined
+    if (!statusHandler || !bellHandler) {
+      throw new Error('Expected hook status and bell handlers to be registered')
+    }
+
+    statusHandler({
+      state: 'working',
+      prompt: 'finish the implementation',
+      agentType: 'codex'
+    })
+    statusHandler({
+      state: 'done',
+      prompt: 'finish the implementation',
+      agentType: 'codex',
+      lastAssistantMessage: 'Done.'
+    })
+    bellHandler()
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+
+    statusHandler({
+      state: 'working',
+      prompt: 'finish the implementation',
+      agentType: 'codex'
+    })
+    vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS)
+
+    expect(deps.dispatchNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'terminal-bell' })
+    )
+    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'agent-task-complete' })
+    )
   })
 
   it('restores a suppressed terminal bell when the pending agent completion is canceled', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -80,7 +80,7 @@ const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
 const REMOTE_PTY_ID_PREFIX = 'remote:'
 const PTY_CONNECT_DIAG_LIMIT = 200
 const AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS = 250
-const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1000
+const AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS = 1500
 const AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS = 10_000
 const COMMAND_CODE_OUTPUT_DONE_SETTLE_MS = 1500
 const HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS = 5000
@@ -185,6 +185,13 @@ function hasAgentNotificationDetail(entry: AgentStatusEntry | undefined): boolea
     Date.now() - entry.updatedAt <= AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS &&
     (entry.lastAssistantMessage || entry.toolName || entry.toolInput)
   )
+}
+
+function canDispatchAgentNotificationAfterGrace(entry: AgentStatusEntry | undefined): boolean {
+  // Why: hook-backed goal/mission loops can report `done` between milestones.
+  // User-input states may notify as soon as detail arrives, but `done` waits
+  // for the max quiet window so resumed work can cancel the pending banner.
+  return hasAgentNotificationDetail(entry) && entry?.state !== 'done'
 }
 
 function recordPtyConnectDiagnostic(message: string): void {
@@ -979,7 +986,7 @@ export function connectPanePty(
         return
       }
       const entry = useAppStore.getState().agentStatusByPaneKey[cacheKey]
-      if (hasAgentNotificationDetail(entry)) {
+      if (canDispatchAgentNotificationAfterGrace(entry)) {
         dispatch()
       }
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -187,11 +187,17 @@ function hasAgentNotificationDetail(entry: AgentStatusEntry | undefined): boolea
   )
 }
 
-function canDispatchAgentNotificationAfterGrace(entry: AgentStatusEntry | undefined): boolean {
+function canDispatchAgentNotificationAfterGrace(
+  entry: AgentStatusEntry | undefined,
+  options: { allowDoneDetailAfterGrace?: boolean } = {}
+): boolean {
   // Why: hook-backed goal/mission loops can report `done` between milestones.
   // User-input states may notify as soon as detail arrives, but `done` waits
   // for the max quiet window so resumed work can cancel the pending banner.
-  return hasAgentNotificationDetail(entry) && entry?.state !== 'done'
+  return (
+    hasAgentNotificationDetail(entry) &&
+    (entry?.state !== 'done' || options.allowDoneDetailAfterGrace === true)
+  )
 }
 
 function recordPtyConnectDiagnostic(message: string): void {
@@ -665,7 +671,10 @@ export function connectPanePty(
     getPtyId: () => transport.getPtyId(),
     getSettings: () => useAppStore.getState().settings,
     inspectProcess: inspectRuntimeTerminalProcess,
-    dispatchCompletion: (title) => scheduleAgentTaskCompleteNotification(title),
+    dispatchCompletion: (title, meta) =>
+      scheduleAgentTaskCompleteNotification(title, {
+        allowDoneDetailAfterGrace: meta?.quietedHookDone
+      }),
     shouldPollProcessCadence: () =>
       isAgentTaskCompleteNotificationEnabled() && deps.isVisibleRef.current,
     isLive: () => {
@@ -913,7 +922,8 @@ export function connectPanePty(
 
   const hasPendingAgentTaskCompleteNotification = (): boolean =>
     isAgentTaskCompleteNotificationEnabled() &&
-    (agentTaskCompleteNotificationGraceTimer !== null ||
+    (agentCompletionCoordinator.hasPendingHookDoneCompletion() ||
+      agentTaskCompleteNotificationGraceTimer !== null ||
       agentTaskCompleteNotificationMaxTimer !== null ||
       agentTaskCompleteStatusUnsubscribe !== null)
 
@@ -953,7 +963,10 @@ export function connectPanePty(
     return enabled
   }
 
-  const scheduleAgentTaskCompleteNotification = (title: string): void => {
+  const scheduleAgentTaskCompleteNotification = (
+    title: string,
+    options: { allowDoneDetailAfterGrace?: boolean } = {}
+  ): void => {
     if (!syncAgentTaskCompleteNotificationEnabled()) {
       return
     }
@@ -986,7 +999,7 @@ export function connectPanePty(
         return
       }
       const entry = useAppStore.getState().agentStatusByPaneKey[cacheKey]
-      if (canDispatchAgentNotificationAfterGrace(entry)) {
+      if (canDispatchAgentNotificationAfterGrace(entry, options)) {
         dispatch()
       }
     }
@@ -1142,6 +1155,9 @@ export function connectPanePty(
       currentState.setAgentStatus(cacheKey, payload, title)
       if (syncAgentTaskCompleteNotificationEnabled()) {
         agentCompletionCoordinator.observeHookStatus(payload)
+      }
+      if (payload.state === 'working' && pendingTerminalBellNotification) {
+        scheduleTerminalBellNotification()
       }
     }
   }

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 
 const dispatchTerminalNotification = vi.fn()
@@ -23,6 +23,7 @@ type MockStoreState = {
 }
 
 let mockStoreState: MockStoreState
+const HOOK_DONE_QUIET_MS = 1_500
 
 vi.mock('@/store', () => ({
   useAppStore: {
@@ -48,6 +49,7 @@ describe('agent hook completion notifications', () => {
 
   beforeEach(() => {
     vi.resetModules()
+    vi.useFakeTimers()
     dispatchTerminalNotification.mockClear()
     mockStoreState = {
       settings: {
@@ -61,6 +63,10 @@ describe('agent hook completion notifications', () => {
       },
       terminalLayoutsByTabId: {}
     }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('requires fresh working after notifications start disabled and later re-enable', async () => {
@@ -91,6 +97,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -123,6 +130,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -155,6 +163,7 @@ describe('agent hook completion notifications', () => {
       worktreeId: 'wt-1',
       payload: hookStatus('done')
     })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchTerminalNotification).toHaveBeenCalledWith(
       'wt-1',
@@ -186,5 +195,47 @@ describe('agent hook completion notifications', () => {
     syncAgentHookCompletionNotificationSettings()
 
     expect(_getAgentHookCompletionNotificationCoordinatorCountForTest()).toBe(0)
+  })
+
+  it('suppresses an internal milestone completion when hook work resumes before quiet', async () => {
+    const { observeAgentHookCompletionForNotification } =
+      await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('working')
+    })
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('done')
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS - 1)
+    expect(dispatchTerminalNotification).not.toHaveBeenCalled()
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('working')
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    expect(dispatchTerminalNotification).not.toHaveBeenCalled()
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('done')
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchTerminalNotification).toHaveBeenCalledTimes(1)
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        paneKey
+      })
+    )
   })
 })


### PR DESCRIPTION
## Summary
- delay hook-backed `done` completion notifications through a short quiet window so resumed goal/mission work cancels milestone banners
- keep `waiting`/`blocked` user-input states immediate
- stop emitting an extra synthetic BEL for hook `done` titles, and install/ignore Droid `SubagentStop` as mission progress

Closes #2992.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/droid/hook-service.test.ts src/main/agent-hooks/server.test.ts -t "Droid hook normalization|DroidHookService"`
- `pnpm exec oxlint src/main/agent-hooks/server.test.ts src/main/droid/hook-service.test.ts src/main/droid/hook-service.ts src/main/index.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts`
- `pnpm exec oxfmt --write ...touched files...`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD` => `9cbff1efaa628730095ab141b5efb77ff38d1782`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.