### PR TITLE
Remove diagnostics bundle ref mirror effect

### DIFF
--- a/src/renderer/src/components/settings/PrivacyDiagnosticsSection.tsx
+++ b/src/renderer/src/components/settings/PrivacyDiagnosticsSection.tsx
@@ -52,10 +52,6 @@ export function PrivacyDiagnosticsSection(): React.JSX.Element {
     }
   }, [])
 
-  useEffect(() => {
-    activeBundleSubmissionIdRef.current = bundle?.bundleSubmissionId ?? null
-  }, [bundle])
-
   const handleOpenFolder = useCallback(async (): Promise<void> => {
     try {
       await window.api.diagnostics.openTraceFolder()
@@ -91,6 +87,9 @@ export function PrivacyDiagnosticsSection(): React.JSX.Element {
         await window.api.diagnostics.discardBundlePreview(nextBundle.bundleSubmissionId)
         return
       }
+      // Why: unmount cleanup may run before a passive ref mirror would fire;
+      // keep the retained preview id in sync at the creation/clear sites.
+      activeBundleSubmissionIdRef.current = nextBundle.bundleSubmissionId
       setBundle(nextBundle)
       setPreviewOpened(false)
       setTicketId(null)


### PR DESCRIPTION
## Summary
- Remove the Privacy diagnostics bundle ref-mirror Effect
- Update the retained preview id at the bundle creation/clear sites so unmount cleanup has the latest preview id before passive Effects run
- Preserve existing diagnostics IPC calls and bundle UI state

## Risk
Medium - the change is small, but it touches Privacy diagnostics bundle cleanup and retained diagnostic-preview discard behavior.

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/PrivacyDiagnosticsSection.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/PrivacyPane.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.