### PR TITLE
Update Dock badge for automatic unread worktrees

### DIFF
--- a/src/renderer/src/hooks/useUnreadDockBadge.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.ts
@@ -6,6 +6,7 @@ export function useUnreadDockBadge(): void {
   const unreadCount = useAppStore((state) =>
     getUnreadBadgeCount({
       worktreesByRepo: state.worktreesByRepo,
+      detectedWorktreesByRepo: state.detectedWorktreesByRepo,
       tabsByWorktree: state.tabsByWorktree,
       unreadTerminalTabs: state.unreadTerminalTabs
     })

--- a/src/renderer/src/lib/unread-badge-count.test.ts
+++ b/src/renderer/src/lib/unread-badge-count.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { TerminalTab, Worktree } from '../../../shared/types'
+import type { DetectedWorktreeListResult, TerminalTab, Worktree } from '../../../shared/types'
 import { getUnreadBadgeCount } from './unread-badge-count'
 
 function worktree(id: string, isUnread: boolean): Worktree {
@@ -8,6 +8,23 @@ function worktree(id: string, isUnread: boolean): Worktree {
 
 function tab(id: string): TerminalTab {
   return { id } as TerminalTab
+}
+
+function detectedWorktree(id: string, isUnread: boolean): DetectedWorktreeListResult {
+  return {
+    repoId: 'repo',
+    authoritative: true,
+    source: 'git',
+    worktrees: [
+      {
+        ...worktree(id, isUnread),
+        repoId: 'repo',
+        ownership: 'orca-managed',
+        selectedCheckout: false,
+        visible: true
+      }
+    ]
+  } as DetectedWorktreeListResult
 }
 
 describe('getUnreadBadgeCount', () => {
@@ -39,5 +56,16 @@ describe('getUnreadBadgeCount', () => {
         unreadTerminalTabs: { 'tab-1': true, 'tab-2': true }
       })
     ).toBe(2)
+  })
+
+  it('counts automatic unread markers on detected worktrees', () => {
+    expect(
+      getUnreadBadgeCount({
+        worktreesByRepo: { repo: [] },
+        detectedWorktreesByRepo: { repo: detectedWorktree('wt-detected', true) },
+        tabsByWorktree: {},
+        unreadTerminalTabs: {}
+      })
+    ).toBe(1)
   })
 })

--- a/src/renderer/src/lib/unread-badge-count.ts
+++ b/src/renderer/src/lib/unread-badge-count.ts
@@ -1,11 +1,13 @@
-import type { TerminalTab, Worktree } from '../../../shared/types'
+import type { DetectedWorktreeListResult, TerminalTab, Worktree } from '../../../shared/types'
 
 export function getUnreadBadgeCount({
   worktreesByRepo,
+  detectedWorktreesByRepo = {},
   tabsByWorktree,
   unreadTerminalTabs
 }: {
   worktreesByRepo: Record<string, Worktree[]>
+  detectedWorktreesByRepo?: Record<string, DetectedWorktreeListResult>
   tabsByWorktree: Record<string, TerminalTab[]>
   unreadTerminalTabs: Record<string, true>
 }): number {
@@ -13,6 +15,16 @@ export function getUnreadBadgeCount({
 
   for (const worktrees of Object.values(worktreesByRepo)) {
     for (const worktree of worktrees) {
+      if (worktree.isUnread) {
+        unreadWorktreeIds.add(worktree.id)
+      }
+    }
+  }
+
+  // Why: automatic agent attention can land while a worktree is only present
+  // in detectedWorktreesByRepo; the Dock badge must mirror that unread marker.
+  for (const result of Object.values(detectedWorktreesByRepo)) {
+    for (const worktree of result.worktrees) {
       if (worktree.isUnread) {
         unreadWorktreeIds.add(worktree.id)
       }


### PR DESCRIPTION
## Summary
- Include unread detected worktrees in the Dock badge count so automatic agent completion/permission attention updates the badge before the regular worktree list catches up.
- Subscribe the Dock badge hook to detected worktree changes.
- Add a regression test for the detected-worktree automatic unread case.

Closes #2995

## Evidence
- Reproduced in unit coverage: before the fix, `counts automatic unread markers on detected worktrees` failed with `expected 0 to be 1`.
- `pnpm vitest run --config config/vitest.config.ts src/main/dock/unread-badge.test.ts src/renderer/src/lib/unread-badge-count.test.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts` (14 tests)
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "dispatches agent-task-complete on working→idle and raises tab/worktree unread"` (1 test, 90 skipped)
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/hooks/useUnreadDockBadge.ts src/renderer/src/lib/unread-badge-count.ts src/renderer/src/lib/unread-badge-count.test.ts`
- `git diff --check HEAD~1 HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `d795b8d415306aea49a80f54cc86b343f52e2cd8`