### PR TITLE
Move mobile pairing stage repair into refresh path

### DIFF
--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -22,8 +22,10 @@ import {
   type MobileNetworkInterface
 } from '../settings/mobile-network-interface-selection'
 import { useMobilePairingDevicePolling } from '../settings/mobile-pairing-device-polling'
-
-type FlowStage = 'intro' | 'paired' | 'flow'
+import {
+  shouldShowPairedAfterDeviceRefresh,
+  type MobilePageStage as FlowStage
+} from './mobile-page-stage'
 
 async function renderQrDataUrl(text: string): Promise<string> {
   return QRCodeBrowser.toDataURL(text, {
@@ -69,19 +71,56 @@ export default function MobilePage(): React.JSX.Element {
   const [deviceCountAtPairStart, setDeviceCountAtPairStart] = useState<number | null>(null)
   const hasGeneratedRef = useRef(false)
   const mountedRef = useMountedRef()
-  // Tracks the previous stage so we can set the paired-view baseline exactly
-  // once on entry into 'paired', avoiding a polling-stop race when devices
-  // change while already in paired view.
-  const lastStageRef = useRef<FlowStage | null>(null)
+  const stageRef = useRef<FlowStage | null>(null)
+  const deviceCountAtPairStartRef = useRef<number | null>(null)
   const closeMobilePage = useAppStore((s) => s.closeMobilePage)
   const showMobileButton = useAppStore((s) => s.settings?.showMobileButton !== false)
   const updateSettings = useAppStore((s) => s.updateSettings)
+
+  const setPairingDeviceBaseline = useCallback(
+    (count: number | null): void => {
+      deviceCountAtPairStartRef.current = count
+      if (mountedRef.current) {
+        setDeviceCountAtPairStart(count)
+      }
+    },
+    [mountedRef]
+  )
+
+  const showStage = useCallback(
+    (nextStage: FlowStage | null): void => {
+      stageRef.current = nextStage
+      if (mountedRef.current) {
+        setStage(nextStage)
+      }
+    },
+    [mountedRef]
+  )
+
+  const showPairedDevices = useCallback(
+    (deviceCount: number): void => {
+      // Why: paired-view polling uses this baseline; setting it with the
+      // transition avoids the render-plus-Effect gap where polling stops.
+      setPairingDeviceBaseline(deviceCount)
+      showStage('paired')
+    },
+    [setPairingDeviceBaseline, showStage]
+  )
 
   const loadDevices = useCallback(async (): Promise<PairedDevice[]> => {
     try {
       const result = await window.api.mobile.listDevices()
       if (mountedRef.current) {
         setDevices(result.devices)
+        if (
+          shouldShowPairedAfterDeviceRefresh({
+            stage: stageRef.current,
+            deviceCountAtPairStart: deviceCountAtPairStartRef.current,
+            nextDeviceCount: result.devices.length
+          })
+        ) {
+          showPairedDevices(result.devices.length)
+        }
       }
       return result.devices
     } catch (err) {
@@ -90,7 +129,7 @@ export default function MobilePage(): React.JSX.Element {
       console.error('mobile.listDevices failed', err)
       return []
     }
-  }, [mountedRef])
+  }, [mountedRef, showPairedDevices])
 
   // Why: pick the initial stage based on whether any devices are already
   // paired so returning users don't see the marketing intro every time.
@@ -101,12 +140,16 @@ export default function MobilePage(): React.JSX.Element {
       if (cancelled) {
         return
       }
-      setStage(initialDevices.length > 0 ? 'paired' : 'intro')
+      if (initialDevices.length > 0) {
+        showPairedDevices(initialDevices.length)
+      } else {
+        showStage('intro')
+      }
     })()
     return () => {
       cancelled = true
     }
-  }, [loadDevices])
+  }, [loadDevices, showPairedDevices, showStage])
 
   const revokeDevice = useCallback(
     async (deviceId: string) => {
@@ -130,7 +173,7 @@ export default function MobilePage(): React.JSX.Element {
           toast.success('Device revoked')
         }
         if (remaining.length === 0 && mountedRef.current) {
-          setStage('intro')
+          showStage('intro')
         }
       } catch {
         if (mountedRef.current) {
@@ -142,7 +185,7 @@ export default function MobilePage(): React.JSX.Element {
         }
       }
     },
-    [loadDevices, mountedRef]
+    [loadDevices, mountedRef, showStage]
   )
 
   // Why: render install QRs lazily — only after the user enters the flow,
@@ -294,59 +337,35 @@ export default function MobilePage(): React.JSX.Element {
     loadDevices: polledLoadDevices
   })
 
-  useEffect(() => {
-    if (
-      stage === 'flow' &&
-      deviceCountAtPairStart !== null &&
-      devices.length > deviceCountAtPairStart
-    ) {
-      setStage('paired')
-    }
-  }, [stage, devices.length, deviceCountAtPairStart])
-
-  // Why: set the paired-view polling baseline exactly once on entry into
-  // 'paired'. Re-baselining on every devices.length change opened a small
-  // window where polling stopped then resumed; capturing the count once on
-  // transition lets newly added devices flow through naturally.
-  useEffect(() => {
-    if (stage === 'paired' && lastStageRef.current !== 'paired') {
-      setDeviceCountAtPairStart(devices.length)
-    }
-    lastStageRef.current = stage
-    // devices.length is intentionally excluded: we want to capture the count
-    // only at the moment of the stage transition, not re-run on every change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stage])
-
   const enterFlow = (): void => {
     setStepIdx(0)
-    setDeviceCountAtPairStart(devices.length)
+    setPairingDeviceBaseline(devices.length)
     // Force the auto-generate effect to mint a fresh pairing token on next
     // entry into Step 2, and clear stale QR state so we never flash an
     // expired code from a previous session.
     hasGeneratedRef.current = false
     setPairQrDataUrl(null)
     setPairingUrl(null)
-    setStage('flow')
+    showStage('flow')
   }
 
   // Why: from the paired summary, "Pair another device" jumps straight to
   // Step 2 since the app is presumably already installed on the user's phone.
   const pairAnotherDevice = (): void => {
     setStepIdx(1)
-    setDeviceCountAtPairStart(devices.length)
+    setPairingDeviceBaseline(devices.length)
     // Same reset as enterFlow — re-entering must mint a fresh pairing offer.
     hasGeneratedRef.current = false
     setPairQrDataUrl(null)
     setPairingUrl(null)
-    setStage('flow')
+    showStage('flow')
   }
 
   const handleBack = (): void => {
     if (stepIdx === 1) {
       setStepIdx(0)
     } else {
-      setStage('intro')
+      showStage('intro')
     }
   }
 
@@ -468,7 +487,7 @@ export default function MobilePage(): React.JSX.Element {
               refreshingNetworkInterfaces={refreshingNetworkInterfaces}
               onBack={handleBack}
               onContinue={handleContinue}
-              onDone={devices.length > 0 ? () => setStage('paired') : undefined}
+              onDone={devices.length > 0 ? () => showPairedDevices(devices.length) : undefined}
             />
           )}
         </div>

--- a/src/renderer/src/components/mobile/mobile-page-stage.test.ts
+++ b/src/renderer/src/components/mobile/mobile-page-stage.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowPairedAfterDeviceRefresh } from './mobile-page-stage'
+
+describe('mobile page stage', () => {
+  it('shows paired after a device refresh adds a phone during pairing flow', () => {
+    expect(
+      shouldShowPairedAfterDeviceRefresh({
+        stage: 'flow',
+        deviceCountAtPairStart: 1,
+        nextDeviceCount: 2
+      })
+    ).toBe(true)
+  })
+
+  it('keeps the flow while the refreshed device count is unchanged', () => {
+    expect(
+      shouldShowPairedAfterDeviceRefresh({
+        stage: 'flow',
+        deviceCountAtPairStart: 1,
+        nextDeviceCount: 1
+      })
+    ).toBe(false)
+  })
+
+  it('does not switch stages without a pairing baseline', () => {
+    expect(
+      shouldShowPairedAfterDeviceRefresh({
+        stage: 'flow',
+        deviceCountAtPairStart: null,
+        nextDeviceCount: 1
+      })
+    ).toBe(false)
+  })
+
+  it('only auto-switches from the pairing flow', () => {
+    expect(
+      shouldShowPairedAfterDeviceRefresh({
+        stage: 'paired',
+        deviceCountAtPairStart: 1,
+        nextDeviceCount: 2
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/mobile/mobile-page-stage.ts
+++ b/src/renderer/src/components/mobile/mobile-page-stage.ts
@@ -1,0 +1,17 @@
+export type MobilePageStage = 'intro' | 'paired' | 'flow'
+
+export type MobilePageDeviceRefreshState = {
+  stage: MobilePageStage | null
+  deviceCountAtPairStart: number | null
+  nextDeviceCount: number
+}
+
+export function shouldShowPairedAfterDeviceRefresh({
+  stage,
+  deviceCountAtPairStart,
+  nextDeviceCount
+}: MobilePageDeviceRefreshState): boolean {
+  return (
+    stage === 'flow' && deviceCountAtPairStart !== null && nextDeviceCount > deviceCountAtPairStart
+  )
+}


### PR DESCRIPTION
## Summary
- Remove the Mobile page Effects that repaired the pairing flow stage and paired-view polling baseline after render
- Transition to the paired summary directly when a device refresh observes a new phone during pairing
- Set the paired-view polling baseline in the same transition and cover the refresh predicate with focused tests

## Risk
Medium - mobile pairing local UI flow; no mobile transport or pairing IPC contract changes, but this affects the QR polling-to-paired transition.

## Validation
- pnpm exec oxlint src/renderer/src/components/mobile/MobilePage.tsx src/renderer/src/components/mobile/mobile-page-stage.ts src/renderer/src/components/mobile/mobile-page-stage.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/mobile/mobile-page-stage.test.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 923 -> 921

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.