### PR TITLE
Move create PR close reset out of effect

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1494,7 +1494,10 @@ export default function ChecksPanel(): React.JSX.Element {
     return (
       <>
         {repo && (
+          /* Keyed to the same branch/worktree context as the panel's render-time
+             reset so dialog-local submission state cannot leak across contexts. */
           <CreatePullRequestDialog
+            key={panelContextKey}
             open={createPrDialogOpen}
             repoId={repo.id}
             repoPath={repo.path}

--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -383,7 +383,7 @@ export function CreatePullRequestDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
             Cancel
           </Button>
           <Button onClick={() => void handleSubmit()} disabled={submitDisabled}>

--- a/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
+++ b/src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Check, ChevronsUpDown, Loader2, Sparkles, Square, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -130,14 +130,11 @@ export function CreatePullRequestDialog({
     onBranchChangedByGeneration
   })
 
-  useEffect(() => {
-    if (open) {
-      return
-    }
+  const resetSubmissionState = useCallback((): void => {
     submitInFlightRef.current = false
     setSubmitting(false)
     setError(null)
-  }, [open])
+  }, [])
 
   const submitDisabled =
     submitting ||
@@ -178,6 +175,7 @@ export function CreatePullRequestDialog({
         if (prCreationDefaults.openAfterCreate) {
           window.api.shell.openUrl(result.url)
         }
+        resetSubmissionState()
         onOpenChange(false)
         return
       }
@@ -194,6 +192,7 @@ export function CreatePullRequestDialog({
         )
         if (number) {
           await onCreated({ number, url: result.existingReview.url })
+          resetSubmissionState()
           onOpenChange(false)
           return
         }
@@ -216,6 +215,7 @@ export function CreatePullRequestDialog({
     prCreationDefaults.openAfterCreate,
     prCreationDefaults.useTemplate,
     repoPath,
+    resetSubmissionState,
     submitDisabled,
     title,
     worktreePath
@@ -228,9 +228,12 @@ export function CreatePullRequestDialog({
       if (submitting && !nextOpen) {
         return
       }
+      if (!nextOpen) {
+        resetSubmissionState()
+      }
       onOpenChange(nextOpen)
     },
-    [onOpenChange, submitting]
+    [onOpenChange, resetSubmissionState, submitting]
   )
 
   return (


### PR DESCRIPTION
## Summary
- Remove the CreatePullRequestDialog Effect that reset submit/error state after close
- Reset submission state directly on close and successful create paths
- Key the dialog by the checks-panel context key so render-time branch/worktree resets remount dialog-local state

## Risk
Medium - source-control hosted review creation UI. No provider API contract changes, but it touches the PR creation dialog close/success behavior and checks-panel context switching.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/CreatePullRequestDialog.tsx src/renderer/src/components/right-sidebar/ChecksPanel.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/right-sidebar/checks-panel-git-status-snapshot.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.