### PR TITLE
Cache visible project table without effect

### DIFF
--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -47,6 +47,11 @@ import ProjectPicker, { type ResolvedProjectSelection } from './ProjectPicker'
 import ProjectViewList from './ProjectViewList'
 import ProjectItemSlugDialog from './ProjectItemSlugDialog'
 import { filterProjectTableRowsByOpenRepos } from './project-row-filtering'
+import {
+  getNextVisibleProjectTableCache,
+  getVisibleProjectTable,
+  type CachedVisibleProjectTable
+} from './project-visible-table-cache'
 
 type Props = Record<string, never>
 
@@ -303,27 +308,23 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
     () => (table && slugIndexReady ? filterProjectTableRowsByOpenRepos(table, lookupSlug) : null),
     [table, slugIndexReady, lookupSlug]
   )
-  const [lastFilteredTable, setLastFilteredTable] = useState<{
-    cacheKey: string
-    table: GitHubProjectTable
-  } | null>(null)
-
-  useEffect(() => {
-    if (!currentCacheKey || !table) {
-      setLastFilteredTable(null)
-      return
-    }
-    if (slugIndexReady && filteredTable) {
-      setLastFilteredTable({ cacheKey: currentCacheKey, table: filteredTable })
-    }
-  }, [currentCacheKey, table, slugIndexReady, filteredTable])
-
-  const visibleTable =
-    slugIndexReady || !currentCacheKey
-      ? filteredTable
-      : lastFilteredTable?.cacheKey === currentCacheKey
-        ? lastFilteredTable.table
-        : null
+  const lastFilteredTableRef = useRef<CachedVisibleProjectTable | null>(null)
+  // Why: this cache only prevents a blank table while the repo slug index
+  // rebuilds; a ref preserves the previous render value without scheduling
+  // a second render after every filtered-table change.
+  lastFilteredTableRef.current = getNextVisibleProjectTableCache({
+    currentCacheKey,
+    sourceTable: table,
+    slugIndexReady,
+    filteredTable,
+    previous: lastFilteredTableRef.current
+  })
+  const visibleTable = getVisibleProjectTable({
+    currentCacheKey,
+    slugIndexReady,
+    filteredTable,
+    cachedTable: lastFilteredTableRef.current
+  })
 
   // Parent-dropped toast, once per table.
   useEffect(() => {

--- a/src/renderer/src/components/github-project/project-visible-table-cache.test.ts
+++ b/src/renderer/src/components/github-project/project-visible-table-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubProjectTable } from '../../../../shared/github-project-types'
+import {
+  getNextVisibleProjectTableCache,
+  getVisibleProjectTable
+} from './project-visible-table-cache'
+
+function table(id: string): GitHubProjectTable {
+  return { id } as unknown as GitHubProjectTable
+}
+
+describe('project visible table cache', () => {
+  it('stores the filtered table while the slug index is ready', () => {
+    const sourceTable = table('source')
+    const filteredTable = table('filtered')
+
+    expect(
+      getNextVisibleProjectTableCache({
+        currentCacheKey: 'project:view',
+        sourceTable,
+        slugIndexReady: true,
+        filteredTable,
+        previous: null
+      })
+    ).toEqual({ cacheKey: 'project:view', table: filteredTable })
+  })
+
+  it('keeps the previous cache while the slug index is rebuilding', () => {
+    const previous = { cacheKey: 'project:view', table: table('previous') }
+
+    expect(
+      getNextVisibleProjectTableCache({
+        currentCacheKey: 'project:view',
+        sourceTable: table('source'),
+        slugIndexReady: false,
+        filteredTable: null,
+        previous
+      })
+    ).toBe(previous)
+  })
+
+  it('drops the cache when there is no current table', () => {
+    const previous = { cacheKey: 'project:view', table: table('previous') }
+
+    expect(
+      getNextVisibleProjectTableCache({
+        currentCacheKey: null,
+        sourceTable: null,
+        slugIndexReady: false,
+        filteredTable: null,
+        previous
+      })
+    ).toBeNull()
+  })
+
+  it('shows a matching cached table while the slug index is rebuilding', () => {
+    const cachedTable = { cacheKey: 'project:view', table: table('cached') }
+
+    expect(
+      getVisibleProjectTable({
+        currentCacheKey: 'project:view',
+        slugIndexReady: false,
+        filteredTable: null,
+        cachedTable
+      })
+    ).toBe(cachedTable.table)
+  })
+
+  it('does not show stale cached data for a different cache key', () => {
+    const cachedTable = { cacheKey: 'other:view', table: table('cached') }
+
+    expect(
+      getVisibleProjectTable({
+        currentCacheKey: 'project:view',
+        slugIndexReady: false,
+        filteredTable: null,
+        cachedTable
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/github-project/project-visible-table-cache.ts
+++ b/src/renderer/src/components/github-project/project-visible-table-cache.ts
@@ -1,0 +1,34 @@
+import type { GitHubProjectTable } from '../../../../shared/github-project-types'
+
+export type CachedVisibleProjectTable = {
+  cacheKey: string
+  table: GitHubProjectTable
+}
+
+export function getNextVisibleProjectTableCache(input: {
+  currentCacheKey: string | null
+  sourceTable: GitHubProjectTable | null
+  slugIndexReady: boolean
+  filteredTable: GitHubProjectTable | null
+  previous: CachedVisibleProjectTable | null
+}): CachedVisibleProjectTable | null {
+  if (!input.currentCacheKey || !input.sourceTable) {
+    return null
+  }
+  if (input.slugIndexReady && input.filteredTable) {
+    return { cacheKey: input.currentCacheKey, table: input.filteredTable }
+  }
+  return input.previous
+}
+
+export function getVisibleProjectTable(input: {
+  currentCacheKey: string | null
+  slugIndexReady: boolean
+  filteredTable: GitHubProjectTable | null
+  cachedTable: CachedVisibleProjectTable | null
+}): GitHubProjectTable | null {
+  if (input.slugIndexReady || !input.currentCacheKey) {
+    return input.filteredTable
+  }
+  return input.cachedTable?.cacheKey === input.currentCacheKey ? input.cachedTable.table : null
+}


### PR DESCRIPTION
## Summary
- Replace the ProjectViewWrapper last-filtered-table state Effect with a render ref cache
- Keep the stale-while-slug-index-rebuild table behavior without scheduling an extra render
- Add focused cache resolver coverage

## Risk
Medium - GitHub Projects table rendering. No GitHub API or mutation contract changes, but this affects the visible table fallback while repo slug indexing rebuilds.

## Validation
- pnpm exec oxlint src/renderer/src/components/github-project/ProjectViewWrapper.tsx src/renderer/src/components/github-project/project-visible-table-cache.ts src/renderer/src/components/github-project/project-visible-table-cache.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/github-project/project-visible-table-cache.test.ts src/renderer/src/components/github-project/project-row-filtering.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.