### PR TITLE
Remove feature wall persisted close reset effect

### DIFF
--- a/src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
@@ -66,7 +66,7 @@ export function useFeatureWallCompletion(
         : false)
 
   const [hasUsageAccount, setHasUsageAccount] = useState(false)
-  const persistedCompletion = usePersistedFeatureWallCompletion(isOpen)
+  const persistedCompletion = usePersistedFeatureWallCompletion()
   const {
     visitedWorkflows,
     visitedAgentSteps,

--- a/src/renderer/src/components/feature-wall/use-persisted-feature-wall-completion.ts
+++ b/src/renderer/src/components/feature-wall/use-persisted-feature-wall-completion.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import type { AgentsStepId } from '../../../../shared/agents-orchestration-steps'
 import type { FeatureWallWorkflowId } from '../../../../shared/feature-wall-workflows'
@@ -53,9 +53,7 @@ function addToSet<T>(setValue: Dispatch<SetStateAction<Set<T>>>, id: T): void {
   })
 }
 
-export function usePersistedFeatureWallCompletion(
-  isOpen: boolean
-): PersistedFeatureWallCompletionState {
+export function usePersistedFeatureWallCompletion(): PersistedFeatureWallCompletionState {
   const [visitedWorkflows, setVisitedWorkflows] = useState<Set<FeatureWallWorkflowId>>(() =>
     readPersistedVisitedWorkflows()
   )
@@ -80,21 +78,6 @@ export function usePersistedFeatureWallCompletion(
   const [completedReviewSteps, setCompletedReviewSteps] = useState<Set<ReviewStepId>>(() =>
     readPersistedCompletedReviewSteps()
   )
-
-  // Reset from persisted state on close so another window or tab's tour visit
-  // is reflected the next time this modal opens.
-  useEffect(() => {
-    if (!isOpen) {
-      setVisitedWorkflows(readPersistedVisitedWorkflows())
-      setVisitedAgentSteps(readPersistedVisitedAgentSteps())
-      setVisitedWorkbenchSteps(readPersistedVisitedWorkbenchSteps())
-      setVisitedReviewSteps(readPersistedVisitedReviewSteps())
-      setCompletedWorkflows(readPersistedCompletedWorkflows())
-      setCompletedAgentSteps(readPersistedCompletedAgentSteps())
-      setCompletedWorkbenchSteps(readPersistedCompletedWorkbenchSteps())
-      setCompletedReviewSteps(readPersistedCompletedReviewSteps())
-    }
-  }, [isOpen])
 
   const markWorkflowVisited = useCallback((id: FeatureWallWorkflowId): void => {
     persistVisitedWorkflow(id)


### PR DESCRIPTION
## Summary
- Remove the persisted feature-wall completion close-reset Effect
- Keep persisted completion hydration in the hook lazy initializers; the modal unmounts on close, so the next open re-reads storage without a passive reset render
- Drop the unused `isOpen` parameter from the persisted completion hook

## Risk
Medium - feature-wall persisted completion state. The change is small, but it touches localStorage-backed tour completion behavior.

## Validation
- pnpm exec oxlint src/renderer/src/components/feature-wall/use-persisted-feature-wall-completion.ts src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-completion.test.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.