### PR TITLE
Resolve smart workspace command value during render

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -50,6 +50,7 @@ import type {
   GitLabWorkItem,
   LinearIssue
 } from '../../../../shared/types'
+import { resolveSmartWorkspaceCommandValue } from './smart-workspace-command-value'
 
 type SmartNameMode = 'smart' | 'github' | 'gitlab' | 'branches' | 'linear' | 'text'
 
@@ -781,36 +782,12 @@ export default function SmartWorkspaceNameField({
     return null
   }, [linearAvailable, value])
 
-  useEffect(() => {
-    if (rows.length === 0) {
-      return
-    }
-    if (isQueryStale) {
-      const typedTextRow = rows.find(
-        (row) => row.kind === 'use-name' || row.kind === 'create-branch'
-      )
-      // No typed-text fallback in this mode (GitHub/Linear): clear the
-      // highlight so cmdk doesn't auto-select a stale source on Enter.
-      setCommandValue(typedTextRow ? typedTextRow.value : '')
-      return
-    }
-    if (sourceIntent === 'github') {
-      const githubRow = rows.find((row) => row.kind === 'github')
-      if (githubRow) {
-        setCommandValue(githubRow.value)
-        return
-      }
-    } else if (sourceIntent === 'linear') {
-      const linearRow = rows.find((row) => row.kind === 'linear')
-      if (linearRow) {
-        setCommandValue(linearRow.value)
-        return
-      }
-    }
-    setCommandValue((current) =>
-      rows.some((row) => row.value === current) ? current : rows[0].value
-    )
-  }, [isQueryStale, rows, sourceIntent])
+  const resolvedCommandValue = resolveSmartWorkspaceCommandValue({
+    currentValue: commandValue,
+    rows,
+    isQueryStale,
+    sourceIntent
+  })
 
   const loading = githubLoading || gitlabLoading || branchesLoading || linearLoading
   const ActiveInputIcon = mode === 'text' ? CaseSensitive : loading ? LoaderCircle : Search
@@ -966,7 +943,7 @@ export default function SmartWorkspaceNameField({
         onOpenChange={(next) => setOpen(disabled ? false : next)}
       >
         <Command
-          value={commandValue}
+          value={resolvedCommandValue}
           onValueChange={setCommandValue}
           shouldFilter={false}
           className="overflow-visible bg-transparent"
@@ -1078,7 +1055,7 @@ export default function SmartWorkspaceNameField({
                         !event.shiftKey
                       ) {
                         if (open && rows.length > 0) {
-                          const row = rows.find((entry) => entry.value === commandValue)
+                          const row = rows.find((entry) => entry.value === resolvedCommandValue)
                           if (row) {
                             event.preventDefault()
                             handleSelect(row)

--- a/src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveSmartWorkspaceCommandValue,
+  type SmartWorkspaceCommandRow
+} from './smart-workspace-command-value'
+
+function row(kind: SmartWorkspaceCommandRow['kind'], value: string): SmartWorkspaceCommandRow {
+  return { kind, value }
+}
+
+describe('resolveSmartWorkspaceCommandValue', () => {
+  it('keeps the current command value when the row still exists', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'github-12',
+        rows: [row('use-name', 'use-name-fix'), row('github', 'github-12')],
+        isQueryStale: false,
+        sourceIntent: null
+      })
+    ).toBe('github-12')
+  })
+
+  it('falls back to the first row when the current value is no longer rendered', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'github-12',
+        rows: [row('use-name', 'use-name-fix'), row('branch', 'branch-main')],
+        isQueryStale: false,
+        sourceIntent: null
+      })
+    ).toBe('use-name-fix')
+  })
+
+  it('uses typed-text rows while source results are stale', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'github-12',
+        rows: [row('use-name', 'use-name-fix'), row('github', 'github-12')],
+        isQueryStale: true,
+        sourceIntent: null
+      })
+    ).toBe('use-name-fix')
+  })
+
+  it('clears selection while stale source-only rows have no typed fallback', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'github-12',
+        rows: [row('github', 'github-12')],
+        isQueryStale: true,
+        sourceIntent: null
+      })
+    ).toBe('')
+  })
+
+  it('prefers matching source-intent rows once fresh results arrive', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'use-name-123',
+        rows: [row('use-name', 'use-name-123'), row('github', 'github-123')],
+        isQueryStale: false,
+        sourceIntent: 'github'
+      })
+    ).toBe('github-123')
+
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'use-name-eng-123',
+        rows: [row('use-name', 'use-name-eng-123'), row('linear', 'linear-ENG-123')],
+        isQueryStale: false,
+        sourceIntent: 'linear'
+      })
+    ).toBe('linear-ENG-123')
+  })
+
+  it('leaves the current value alone when no rows are rendered', () => {
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: 'github-12',
+        rows: [],
+        isQueryStale: false,
+        sourceIntent: null
+      })
+    ).toBe('github-12')
+  })
+})

--- a/src/renderer/src/components/new-workspace/smart-workspace-command-value.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-command-value.ts
@@ -1,0 +1,49 @@
+export type SmartWorkspaceCommandRowKind =
+  | 'use-name'
+  | 'create-branch'
+  | 'github'
+  | 'gitlab'
+  | 'branch'
+  | 'linear'
+
+export type SmartWorkspaceCommandRow = {
+  kind: SmartWorkspaceCommandRowKind
+  value: string
+}
+
+export type SmartWorkspaceSourceIntent = 'github' | 'linear' | null
+
+export function resolveSmartWorkspaceCommandValue({
+  currentValue,
+  rows,
+  isQueryStale,
+  sourceIntent
+}: {
+  currentValue: string
+  rows: readonly SmartWorkspaceCommandRow[]
+  isQueryStale: boolean
+  sourceIntent: SmartWorkspaceSourceIntent
+}): string {
+  if (rows.length === 0) {
+    return currentValue
+  }
+
+  if (isQueryStale) {
+    const typedTextRow = rows.find((row) => row.kind === 'use-name' || row.kind === 'create-branch')
+    return typedTextRow?.value ?? ''
+  }
+
+  if (sourceIntent === 'github') {
+    const githubRow = rows.find((row) => row.kind === 'github')
+    if (githubRow) {
+      return githubRow.value
+    }
+  } else if (sourceIntent === 'linear') {
+    const linearRow = rows.find((row) => row.kind === 'linear')
+    if (linearRow) {
+      return linearRow.value
+    }
+  }
+
+  return rows.some((row) => row.value === currentValue) ? currentValue : rows[0].value
+}


### PR DESCRIPTION
## Summary
- replace the SmartWorkspaceNameField command-value repair effect with a render-time resolver
- use the resolved command value for cmdk selection and Enter handling
- add focused tests for stale query, source-intent, missing-row, and empty-row cases

## Risk
Medium - this affects keyboard highlight/Enter behavior in the smart new-workspace source picker across GitHub, Linear, GitLab, and branch rows.

## Validation
- pnpm exec oxlint src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx src/renderer/src/components/new-workspace/smart-workspace-command-value.ts src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.