### PR TITLE
Hydrate onboarding settings before commit

### DIFF
--- a/src/renderer/src/components/onboarding/onboarding-settings-hydration.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-settings-hydration.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { resolveOnboardingSettingsHydration } from './onboarding-settings-hydration'
+import type { GlobalSettings } from '../../../../shared/types'
+
+const settings = {
+  theme: 'light',
+  defaultTuiAgent: 'codex'
+} as GlobalSettings
+
+describe('resolveOnboardingSettingsHydration', () => {
+  it('does nothing before settings hydrate', () => {
+    expect(
+      resolveOnboardingSettingsHydration({
+        settings: null,
+        settingsHydrated: false,
+        themeInteracted: false,
+        agentInteracted: false,
+        currentTheme: 'dark',
+        currentAgent: null
+      })
+    ).toBeNull()
+  })
+
+  it('does nothing after the first settings hydration pass', () => {
+    expect(
+      resolveOnboardingSettingsHydration({
+        settings,
+        settingsHydrated: true,
+        themeInteracted: false,
+        agentInteracted: false,
+        currentTheme: 'dark',
+        currentAgent: null
+      })
+    ).toBeNull()
+  })
+
+  it('hydrates theme and default agent when the user has not interacted', () => {
+    expect(
+      resolveOnboardingSettingsHydration({
+        settings,
+        settingsHydrated: false,
+        themeInteracted: false,
+        agentInteracted: false,
+        currentTheme: 'dark',
+        currentAgent: null
+      })
+    ).toEqual({
+      settingsHydrated: true,
+      theme: 'light',
+      selectedAgent: 'codex'
+    })
+  })
+
+  it('does not overwrite fields the user already changed', () => {
+    expect(
+      resolveOnboardingSettingsHydration({
+        settings,
+        settingsHydrated: false,
+        themeInteracted: true,
+        agentInteracted: true,
+        currentTheme: 'dark',
+        currentAgent: 'claude'
+      })
+    ).toEqual({ settingsHydrated: true })
+  })
+
+  it('does not clear an existing agent when settings have no default agent', () => {
+    expect(
+      resolveOnboardingSettingsHydration({
+        settings: { ...settings, defaultTuiAgent: 'blank' },
+        settingsHydrated: false,
+        themeInteracted: false,
+        agentInteracted: false,
+        currentTheme: 'light',
+        currentAgent: 'claude'
+      })
+    ).toEqual({ settingsHydrated: true })
+  })
+
+  it('skips redundant value updates when current local state already matches settings', () => {
+    expect(
+      resolveOnboardingSettingsHydration({
+        settings,
+        settingsHydrated: false,
+        themeInteracted: false,
+        agentInteracted: false,
+        currentTheme: 'light',
+        currentAgent: 'codex'
+      })
+    ).toEqual({ settingsHydrated: true })
+  })
+})

--- a/src/renderer/src/components/onboarding/onboarding-settings-hydration.ts
+++ b/src/renderer/src/components/onboarding/onboarding-settings-hydration.ts
@@ -1,0 +1,45 @@
+import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
+
+export type OnboardingSettingsHydrationUpdate = {
+  settingsHydrated: boolean
+  theme?: GlobalSettings['theme']
+  selectedAgent?: TuiAgent
+}
+
+export function resolveOnboardingSettingsHydration({
+  settings,
+  settingsHydrated,
+  themeInteracted,
+  agentInteracted,
+  currentTheme,
+  currentAgent
+}: {
+  settings: GlobalSettings | null
+  settingsHydrated: boolean
+  themeInteracted: boolean
+  agentInteracted: boolean
+  currentTheme: GlobalSettings['theme']
+  currentAgent: TuiAgent | null
+}): OnboardingSettingsHydrationUpdate | null {
+  if (!settings || settingsHydrated) {
+    return null
+  }
+
+  const update: OnboardingSettingsHydrationUpdate = {
+    settingsHydrated: true
+  }
+
+  if (!themeInteracted && currentTheme !== settings.theme) {
+    update.theme = settings.theme
+  }
+
+  const settingsAgent =
+    settings.defaultTuiAgent && settings.defaultTuiAgent !== 'blank'
+      ? settings.defaultTuiAgent
+      : null
+  if (!agentInteracted && settingsAgent !== null && currentAgent !== settingsAgent) {
+    update.selectedAgent = settingsAgent
+  }
+
+  return update
+}

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -45,6 +45,7 @@ import {
 import { persistStep, useCloseWith, usePersistCurrentStep } from './use-onboarding-flow-persistence'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { buildOnboardingFolderAgentStartup } from '@/lib/onboarding-folder-agent-startup'
+import { resolveOnboardingSettingsHydration } from './onboarding-settings-hydration'
 
 export { STEPS } from './use-onboarding-flow-types'
 export type { StepId, StepNumber } from './use-onboarding-flow-types'
@@ -153,29 +154,28 @@ export function useOnboardingFlow(
   const tourOutcomeTrackerRef = useRef(createOnboardingTourOutcomeTracker())
 
   // Why: settings load async; the lazy useState initializers above run before
-  // settings hydrates. Re-sync once when settings transitions to non-null,
-  // unless the user has already interacted with that field.
+  // settings hydrates. Re-sync once before commit so children never paint the
+  // fallback defaults, unless the user already interacted with that field.
   const themeInteractedRef = useRef(false)
   const agentInteractedRef = useRef(false)
-  const settingsHydratedRef = useRef(false)
-  useEffect(() => {
-    if (!settings || settingsHydratedRef.current) {
-      return
+  const [settingsHydrated, setSettingsHydrated] = useState(settings != null)
+  const settingsHydration = resolveOnboardingSettingsHydration({
+    settings,
+    settingsHydrated,
+    themeInteracted: themeInteractedRef.current,
+    agentInteracted: agentInteractedRef.current,
+    currentTheme: theme,
+    currentAgent: selectedAgent
+  })
+  if (settingsHydration) {
+    setSettingsHydrated(settingsHydration.settingsHydrated)
+    if (settingsHydration.theme !== undefined) {
+      setTheme(settingsHydration.theme)
     }
-    settingsHydratedRef.current = true
-    if (!themeInteractedRef.current) {
-      setTheme(settings.theme)
+    if (settingsHydration.selectedAgent !== undefined) {
+      setSelectedAgent(settingsHydration.selectedAgent)
     }
-    if (!agentInteractedRef.current) {
-      const fromSettings =
-        settings.defaultTuiAgent && settings.defaultTuiAgent !== 'blank'
-          ? settings.defaultTuiAgent
-          : null
-      if (fromSettings !== null) {
-        setSelectedAgent(fromSettings)
-      }
-    }
-  }, [settings])
+  }
 
   // Why: track user interaction so async settings hydration above doesn't
   // overwrite a value the user explicitly chose.


### PR DESCRIPTION
## Summary
- replace the onboarding settings hydration effect with a guarded render-time resolver
- keep saved theme/default-agent defaults from painting fallback values after async settings load
- preserve the user-interaction guards and the existing blank-agent behavior

## Risk
Medium - this affects onboarding theme/default-agent hydration from persisted settings, so it needs review even though runtime detection and persistence paths are unchanged.

## Validation
- pnpm exec oxlint src/renderer/src/components/onboarding/use-onboarding-flow.ts src/renderer/src/components/onboarding/onboarding-settings-hydration.ts src/renderer/src/components/onboarding/onboarding-settings-hydration.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/onboarding-settings-hydration.test.ts src/renderer/src/components/onboarding/agent-picked-payload.test.ts src/renderer/src/components/onboarding/ThemeStep.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.