### PR TITLE
Resolve commit failure dialog identity before commit

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -178,6 +178,10 @@ import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../../share
 import { getRuntimeGitScope } from '@/runtime/runtime-git-client'
 import { getRepositorySourceControlAiSectionId } from '@/components/settings/repository-settings-targets'
 import { hasExpandedCommitFailureDetails, summarizeCommitFailure } from './commit-failure-summary'
+import {
+  resolveCommitFailureDialogState,
+  type CommitFailureDialogState
+} from './commit-failure-dialog-state'
 
 export type SourceControlScope = 'all' | 'uncommitted'
 type AbortConflictOperation = Extract<GitConflictOperation, 'merge' | 'rebase'>
@@ -5219,12 +5223,18 @@ export function CommitArea({
     [commitError, commitFailureSummary]
   )
   const commitFailureIdentity = `${worktreeId ?? 'no-worktree'}:${commitError ?? ''}`
-  const [commitFailureDialogState, setCommitFailureDialogState] = useState<{
-    identity: string
-    open: boolean
-  }>({ identity: commitFailureIdentity, open: false })
+  const [commitFailureDialogState, setCommitFailureDialogState] =
+    useState<CommitFailureDialogState>({ identity: commitFailureIdentity, open: false })
+  const resolvedCommitFailureDialogState = resolveCommitFailureDialogState(
+    commitFailureDialogState,
+    commitFailureIdentity
+  )
+  if (resolvedCommitFailureDialogState !== commitFailureDialogState) {
+    setCommitFailureDialogState(resolvedCommitFailureDialogState)
+  }
   const isCommitFailureDialogOpen =
-    commitFailureDialogState.open && commitFailureDialogState.identity === commitFailureIdentity
+    resolvedCommitFailureDialogState.open &&
+    resolvedCommitFailureDialogState.identity === commitFailureIdentity
   const setCommitFailureDialogOpen = useCallback(
     (open: boolean) => {
       setCommitFailureDialogState({ identity: commitFailureIdentity, open })
@@ -5241,14 +5251,6 @@ export function CommitArea({
   const handleCommitFailureAgentPromptDelivered = useCallback(() => {
     setCommitFailureDialogOpen(false)
   }, [setCommitFailureDialogOpen])
-
-  useEffect(() => {
-    setCommitFailureDialogState((current) =>
-      current.identity === commitFailureIdentity
-        ? current
-        : { identity: commitFailureIdentity, open: false }
-    )
-  }, [commitFailureIdentity])
 
   // Why: most primary-kind labels are anchored by a directional icon so
   // the affirmative Commit (✓) reads distinctly from the remote-state

--- a/src/renderer/src/components/right-sidebar/commit-failure-dialog-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/commit-failure-dialog-state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCommitFailureDialogState } from './commit-failure-dialog-state'
+
+describe('resolveCommitFailureDialogState', () => {
+  it('keeps the dialog state when the commit failure identity still matches', () => {
+    const state = { identity: 'wt-1:error-a', open: true }
+
+    expect(resolveCommitFailureDialogState(state, 'wt-1:error-a')).toBe(state)
+  })
+
+  it('closes the dialog when the active commit failure identity changes', () => {
+    expect(
+      resolveCommitFailureDialogState({ identity: 'wt-1:error-a', open: true }, 'wt-1:')
+    ).toEqual({
+      identity: 'wt-1:',
+      open: false
+    })
+  })
+
+  it('does not reopen an older failure when its identity comes back later', () => {
+    const cleared = resolveCommitFailureDialogState(
+      { identity: 'wt-1:error-a', open: true },
+      'wt-1:error-b'
+    )
+
+    expect(resolveCommitFailureDialogState(cleared, 'wt-1:error-a')).toEqual({
+      identity: 'wt-1:error-a',
+      open: false
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/commit-failure-dialog-state.ts
+++ b/src/renderer/src/components/right-sidebar/commit-failure-dialog-state.ts
@@ -1,0 +1,11 @@
+export type CommitFailureDialogState = {
+  identity: string
+  open: boolean
+}
+
+export function resolveCommitFailureDialogState(
+  state: CommitFailureDialogState,
+  currentIdentity: string
+): CommitFailureDialogState {
+  return state.identity === currentIdentity ? state : { identity: currentIdentity, open: false }
+}


### PR DESCRIPTION
## Summary
- replace the CommitArea commit-failure dialog identity repair effect with a render-time resolver
- preserve the behavior that identity changes close stale details dialogs and prevent old failures from reopening later
- add focused tests for matching, changed, and returning commit-failure identities

## Risk
Medium - this affects Source Control commit failure dialog UI state, but does not change git operations, provider behavior, commit execution, or AI recovery prompts.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/SourceControl.tsx src/renderer/src/components/right-sidebar/commit-failure-dialog-state.ts src/renderer/src/components/right-sidebar/commit-failure-dialog-state.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/commit-failure-dialog-state.test.ts src/renderer/src/components/right-sidebar/CommitArea.test.tsx src/renderer/src/components/right-sidebar/commit-failure-summary.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.