### PR TITLE
Support repo-relative workspace directories

### DIFF
--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -1,8 +1,12 @@
+/* eslint-disable max-lines -- Why: filesystem authorization keeps root
+discovery, canonicalization, and registered-worktree cache checks together so
+the security boundary is auditable end to end. */
 import { resolve, relative, dirname, basename, isAbsolute } from 'path'
 import { realpathSync } from 'fs'
 import { realpath } from 'fs/promises'
 import type { Store } from '../persistence'
 import { isRepoRoot, listRepoWorktrees } from '../repo-worktrees'
+import { computeWorkspaceRoot } from './worktree-logic'
 
 export const PATH_ACCESS_DENIED_MESSAGE =
   'Access denied: path resolves outside allowed directories. If this blocks a legitimate workflow, please file a GitHub issue.'
@@ -59,10 +63,17 @@ export function isDescendantOrEqual(resolvedTarget: string, resolvedBase: string
 }
 
 export function getAllowedRoots(store: Store): string[] {
-  const roots = getLocalRepos(store).map((repo) => resolve(repo.path))
-  const workspaceDir = store.getSettings().workspaceDir
-  if (workspaceDir) {
-    roots.push(resolve(workspaceDir))
+  const localRepos = getLocalRepos(store)
+  const settings = store.getSettings()
+  const roots = localRepos.map((repo) => resolve(repo.path))
+  if (settings.workspaceDir) {
+    if (localRepos.length === 0) {
+      roots.push(resolve(settings.workspaceDir))
+    } else {
+      for (const repo of localRepos) {
+        roots.push(resolve(computeWorkspaceRoot(repo.path, settings)))
+      }
+    }
   }
   return roots
 }

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -48,4 +48,19 @@ describe('computeWorktreePath WSL layout', () => {
       })
     ).toBe(win32.join('C:\\workspaces', 'feature'))
   })
+
+  it('resolves relative workspace directories against the WSL repo path', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+
+    expect(
+      computeWorktreePath('feature', '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo', {
+        nestWorkspaces: true,
+        workspaceDir: '..\\.worktrees'
+      })
+    ).toBe(win32.join('\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\.worktrees', 'repo', 'feature'))
+  })
 })

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: these worktree path/name tests share a
 single setup-free pure-logic module, and splitting them would make the related
 edge cases harder to audit together. */
-import { join, resolve } from 'path'
+import { join, posix, resolve, win32 } from 'path'
 import { describe, expect, it } from 'vitest'
 import {
   sanitizeWorktreeName,
@@ -15,7 +15,8 @@ import {
   formatWorktreeRemovalError,
   isOrphanCompatiblePreflightError,
   isOrphanedWorktreeError,
-  areWorktreePathsEqual
+  areWorktreePathsEqual,
+  computeRemoteWorktreePath
 } from './worktree-logic'
 
 describe('sanitizeWorktreeName', () => {
@@ -167,6 +168,62 @@ describe('computeWorktreePath', () => {
         workspaceDir: '/workspaces'
       })
     ).toBe(join('/workspaces', 'my-project', 'feature'))
+  })
+
+  it('resolves POSIX relative workspace directories against the repo path', () => {
+    expect(
+      computeWorktreePath('feature', '/repos/my-project', {
+        nestWorkspaces: true,
+        workspaceDir: '../.worktrees'
+      })
+    ).toBe(resolve('/repos/.worktrees/my-project/feature'))
+  })
+
+  it('normalizes relative workspace directory traversal before appending the worktree name', () => {
+    expect(
+      computeWorktreePath('feature', '/repos/my-project', {
+        nestWorkspaces: false,
+        workspaceDir: '../repos/../.worktrees/./nested'
+      })
+    ).toBe(resolve('/repos/.worktrees/nested/feature'))
+  })
+
+  it('keeps absolute workspace directories rooted at their configured path', () => {
+    expect(
+      computeWorktreePath('feature', '/repos/my-project', {
+        nestWorkspaces: false,
+        workspaceDir: '/workspaces'
+      })
+    ).toBe(join('/workspaces', 'feature'))
+  })
+
+  it('resolves Windows relative workspace directories against the repo path', () => {
+    expect(
+      computeWorktreePath('feature', 'C:\\src\\my-project', {
+        nestWorkspaces: true,
+        workspaceDir: '..\\.worktrees'
+      })
+    ).toBe(win32.resolve('C:\\src\\.worktrees\\my-project\\feature'))
+  })
+})
+
+describe('computeRemoteWorktreePath', () => {
+  it('resolves relative workspace directories against the remote repo path', () => {
+    expect(
+      computeRemoteWorktreePath('feature', '/home/user/my-project', {
+        nestWorkspaces: true,
+        workspaceDir: '../.worktrees'
+      })
+    ).toBe(posix.resolve('/home/user/.worktrees/my-project/feature'))
+  })
+
+  it('keeps SSH worktrees repo-sibling when workspaceDir is an absolute local setting', () => {
+    expect(
+      computeRemoteWorktreePath('feature', '/home/user/my-project', {
+        nestWorkspaces: true,
+        workspaceDir: '/Users/local/orca/workspaces'
+      })
+    ).toBe(posix.resolve('/home/user/feature'))
   })
 })
 

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -1,4 +1,4 @@
-import { basename, join, resolve, relative, isAbsolute, posix, win32 } from 'path'
+import { basename, resolve, relative, isAbsolute, posix, win32 } from 'path'
 import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
 import { splitWorktreeId } from '../../shared/worktree-id'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
@@ -97,35 +97,43 @@ export function computeWorktreePath(
   repoPath: string,
   settings: { nestWorkspaces: boolean; workspaceDir: string }
 ): string {
-  const pathOps =
-    looksLikeWindowsPath(repoPath) || looksLikeWindowsPath(settings.workspaceDir)
-      ? win32
-      : { basename, join }
-
-  const wsl = parseWslPath(repoPath)
-  if (wsl) {
-    const wslHome = getWslHome(wsl.distro)
-    if (wslHome) {
-      // Why: WSL UNC paths are still Windows paths from Node's perspective.
-      // On Linux CI, the default path helpers use POSIX semantics and would
-      // treat `\\wsl.localhost\...` as a plain string, producing mixed-separator
-      // paths like `\\wsl.localhost\Ubuntu\home\jin/orca/...`. Use win32 path
-      // operations whenever a Windows/UNC path is involved so behavior matches
-      // the Windows production runtime.
-      const wslWorkspaceDir = win32.join(wslHome, 'orca', 'workspaces')
-      if (settings.nestWorkspaces) {
-        const repoName = win32.basename(repoPath).replace(/\.git$/, '')
-        return win32.join(wslWorkspaceDir, repoName, sanitizedName)
-      }
-      return win32.join(wslWorkspaceDir, sanitizedName)
-    }
-  }
+  const workspaceRoot = computeWorkspaceRoot(repoPath, settings)
+  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
 
   if (settings.nestWorkspaces) {
     const repoName = pathOps.basename(repoPath).replace(/\.git$/, '')
-    return pathOps.join(settings.workspaceDir, repoName, sanitizedName)
+    return pathOps.join(workspaceRoot, repoName, sanitizedName)
   }
-  return pathOps.join(settings.workspaceDir, sanitizedName)
+  return pathOps.join(workspaceRoot, sanitizedName)
+}
+
+export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir: string }): string {
+  const wsl = parseWslPath(repoPath)
+  if (wsl && !isWorkspaceDirRelativeToRepo(repoPath, settings.workspaceDir)) {
+    const wslHome = getWslHome(wsl.distro)
+    if (wslHome) {
+      // Why: WSL UNC paths are still Windows paths from Node's perspective.
+      // Mirror absolute local Windows workspace roots inside the distro so
+      // terminals stay on the WSL filesystem; repo-relative roots can resolve
+      // directly against the WSL repo path.
+      return win32.join(wslHome, 'orca', 'workspaces')
+    }
+  }
+  return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
+}
+
+export function computeRemoteWorktreePath(
+  sanitizedName: string,
+  repoPath: string,
+  settings: { nestWorkspaces: boolean; workspaceDir: string }
+): string {
+  if (isWorkspaceDirRelativeToRepo(repoPath, settings.workspaceDir)) {
+    return computeWorktreePath(sanitizedName, repoPath, settings)
+  }
+  // Why: absolute workspaceDir values are local-desktop settings. SSH worktrees
+  // keep the legacy repo-sibling root unless the user opts into a relative
+  // root that can be resolved on the remote host.
+  return getRuntimePathOps(repoPath, repoPath).join(repoPath, '..', sanitizedName)
 }
 
 export function areWorktreePathsEqual(
@@ -148,7 +156,27 @@ export function areWorktreePathsEqual(
 }
 
 function looksLikeWindowsPath(pathValue: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
+  return (
+    /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\') || pathValue.startsWith('//')
+  )
+}
+
+function getRuntimePathOps(
+  repoPath: string,
+  workspaceDir: string
+): Pick<typeof posix, 'basename' | 'isAbsolute' | 'join' | 'normalize' | 'resolve'> {
+  return looksLikeWindowsPath(repoPath) || looksLikeWindowsPath(workspaceDir) ? win32 : posix
+}
+
+function resolveWorkspaceDirForRepo(repoPath: string, workspaceDir: string): string {
+  const pathOps = getRuntimePathOps(repoPath, workspaceDir)
+  return pathOps.isAbsolute(workspaceDir)
+    ? pathOps.normalize(workspaceDir)
+    : pathOps.resolve(repoPath, workspaceDir)
+}
+
+function isWorkspaceDirRelativeToRepo(repoPath: string, workspaceDir: string): boolean {
+  return !getRuntimePathOps(repoPath, workspaceDir).isAbsolute(workspaceDir)
 }
 
 /**

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -8,7 +8,7 @@
 // cohesive flow would split awkwardly.
 
 import type { BrowserWindow } from 'electron'
-import { join, posix, win32 } from 'path'
+import { posix, win32 } from 'path'
 import { existsSync } from 'fs'
 import { randomUUID } from 'crypto'
 import type { Store } from '../persistence'
@@ -30,7 +30,6 @@ import { gitExecFileAsync } from '../git/runner'
 import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { RemoteFetchResult, RemoteTrackingBase } from '../runtime/orca-runtime'
-import { isWslPath, parseWslPath, getWslHome } from '../wsl'
 import {
   buildPosixRunnerScript,
   buildWindowsRunnerScript,
@@ -53,6 +52,8 @@ import {
   sanitizeWorktreeDisplayName,
   computeBranchName,
   computeWorktreePath,
+  computeRemoteWorktreePath,
+  computeWorkspaceRoot,
   ensurePathWithinWorkspace,
   shouldSetDisplayName,
   mergeWorktree,
@@ -735,8 +736,7 @@ export async function createRemoteWorktree(
     username
   )
 
-  // Compute worktree path relative to the repo's parent on the remote
-  const remotePath = `${repo.path}/../${sanitizedName}`
+  const remotePath = computeRemoteWorktreePath(sanitizedName, repo.path, settings)
 
   // Determine base branch
   // Why: previously fell back to a hardcoded 'origin/main' when
@@ -1113,13 +1113,7 @@ export async function createLocalWorktree(
       .catch(() => undefined)
     emitCreateWorktreeProgress(mainWindow, 'fetching')
   }
-  // Why: WSL worktrees live under ~/orca/workspaces inside the WSL
-  // filesystem. Validate against that root, not the Windows workspace dir.
-  // If WSL home lookup fails, keep using the configured workspace root so
-  // the path traversal guard still runs on the fallback path.
-  const wslInfo = isWslPath(repo.path) ? parseWslPath(repo.path) : null
-  const wslHome = wslInfo ? getWslHome(wslInfo.distro) : null
-  const workspaceRoot = wslHome ? join(wslHome, 'orca', 'workspaces') : settings.workspaceDir
+  const workspaceRoot = computeWorkspaceRoot(repo.path, settings)
 
   // Why: this validation does not depend on remote refs, so it can overlap a
   // required remote-tracking base refresh.

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1387,20 +1387,20 @@ describe('registerWorktreeHandlers', () => {
     expect(provider.addWorktree).toHaveBeenCalledWith(
       '/remote/repo',
       'sparse-dashboard',
-      '/remote/repo/../sparse-dashboard',
+      '/remote/sparse-dashboard',
       { base: 'origin/main', noCheckout: true }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['sparse-checkout', 'init', '--cone'],
-      '/remote/repo/../sparse-dashboard'
+      '/remote/sparse-dashboard'
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['sparse-checkout', 'set', '--', 'apps/mobile', 'packages/shared'],
-      '/remote/repo/../sparse-dashboard'
+      '/remote/sparse-dashboard'
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['checkout', 'sparse-dashboard'],
-      '/remote/repo/../sparse-dashboard'
+      '/remote/sparse-dashboard'
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-ssh::/remote/sparse-dashboard',
@@ -1468,9 +1468,9 @@ describe('registerWorktreeHandlers', () => {
 
     expect(provider.exec).toHaveBeenCalledWith(
       ['config', '--local', '--unset-all', 'branch.sparse-dashboard.base'],
-      '/remote/repo/../sparse-dashboard'
+      '/remote/sparse-dashboard'
     )
-    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo/../sparse-dashboard', true, {
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/sparse-dashboard', true, {
       deleteBranch: true,
       forceBranchDelete: true
     })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1370,7 +1370,7 @@ describe('OrcaRuntimeService', () => {
     expect(provider.addWorktree).toHaveBeenCalledWith(
       '/remote/repo',
       'mobile-feature',
-      '/remote/repo/../mobile-feature',
+      '/remote/mobile-feature',
       { base: 'origin/main' }
     )
     expect(result.worktree).toMatchObject({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15,7 +15,6 @@ import {
   deriveValidatedClonePath,
   getClonePathComparisonKey
 } from '../git/repo-clone-path'
-import { isWslPath, parseWslPath, getWslHome } from '../wsl'
 import { createHash, randomUUID } from 'crypto'
 import { isAbsolute, join } from 'path'
 import { mkdir, readFile, readdir, rm, stat } from 'fs/promises'
@@ -349,6 +348,7 @@ import { AgentDetector } from '../stats/agent-detector'
 import {
   computeBranchName,
   computeWorktreePath,
+  computeWorkspaceRoot,
   ensurePathWithinWorkspace,
   formatWorktreeRemovalError,
   isOrphanCompatiblePreflightError,
@@ -7561,12 +7561,7 @@ export class OrcaRuntimeService {
     }
 
     let worktreePath = computeWorktreePath(sanitizedName, repo.path, settings)
-    // Why: CLI-managed WSL worktrees live under ~/orca/workspaces inside the
-    // distro filesystem. If home lookup fails, still validate against the
-    // configured workspace dir so the traversal guard is never bypassed.
-    const wslInfo = isWslPath(repo.path) ? parseWslPath(repo.path) : null
-    const wslHome = wslInfo ? getWslHome(wslInfo.distro) : null
-    const workspaceRoot = wslHome ? join(wslHome, 'orca', 'workspaces') : settings.workspaceDir
+    const workspaceRoot = computeWorkspaceRoot(repo.path, settings)
     worktreePath = ensurePathWithinWorkspace(worktreePath, workspaceRoot)
     const remoteTrackingBase = await this.resolveRemoteTrackingBase(repo.path, baseBranch)
     if (remoteTrackingBase) {

--- a/src/shared/cross-platform-path.test.ts
+++ b/src/shared/cross-platform-path.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isPathInsideOrEqual, relativePathInsideRoot } from './cross-platform-path'
+import {
+  isPathInsideOrEqual,
+  relativePathInsideRoot,
+  resolveRuntimePath
+} from './cross-platform-path'
 
 describe('cross-platform path containment', () => {
   it('keeps POSIX sibling prefixes outside the root', () => {
@@ -22,5 +26,19 @@ describe('cross-platform path containment', () => {
       'src'
     )
     expect(isPathInsideOrEqual('\\\\Server\\Share\\Repo', '\\\\server\\share\\repo2')).toBe(false)
+  })
+})
+
+describe('resolveRuntimePath', () => {
+  it('resolves POSIX relative paths against the base path', () => {
+    expect(resolveRuntimePath('/repos/app', '../.worktrees')).toBe('/repos/.worktrees')
+  })
+
+  it('normalizes absolute POSIX paths without rebasing them', () => {
+    expect(resolveRuntimePath('/repos/app', '/workspaces/../worktrees')).toBe('/worktrees')
+  })
+
+  it('resolves Windows relative paths with drive semantics', () => {
+    expect(resolveRuntimePath('C:\\repos\\app', '..\\.worktrees')).toBe('C:/repos/.worktrees')
   })
 })

--- a/src/shared/cross-platform-path.ts
+++ b/src/shared/cross-platform-path.ts
@@ -15,6 +15,28 @@ export function normalizeRuntimePathForComparison(value: string): string {
   return isWindowsAbsolutePathLike(value) ? normalized.toLowerCase() : normalized
 }
 
+export function isRuntimePathAbsolute(
+  value: string,
+  pathFlavor: 'posix' | 'windows' = isWindowsPathFlavor(value) ? 'windows' : 'posix'
+): boolean {
+  if (pathFlavor === 'windows') {
+    return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\') || value.startsWith('/')
+  }
+  return value.startsWith('/')
+}
+
+export function resolveRuntimePath(basePath: string, targetPath: string): string {
+  const pathFlavor =
+    isWindowsPathFlavor(basePath) || isWindowsPathFlavor(targetPath) ? 'windows' : 'posix'
+  if (isRuntimePathAbsolute(targetPath, pathFlavor)) {
+    return normalizeRuntimePathDots(targetPath, pathFlavor)
+  }
+  return normalizeRuntimePathDots(
+    `${trimRuntimePathTrailingSlash(normalizeRuntimePathSeparators(basePath))}/${targetPath}`,
+    pathFlavor
+  )
+}
+
 export function getRuntimePathBasename(value: string): string {
   const trimmed = value.replace(/[\\/]+$/g, '')
   if (!trimmed) {
@@ -62,4 +84,60 @@ function trimRuntimePathTrailingSlash(value: string): string {
     return value
   }
   return value.replace(/\/+$/, '')
+}
+
+function isWindowsPathFlavor(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.includes('\\') || value.startsWith('//')
+}
+
+function normalizeRuntimePathDots(value: string, pathFlavor: 'posix' | 'windows'): string {
+  const normalized = normalizeRuntimePathSeparators(value)
+  const { root, rest } = splitRuntimePathRoot(normalized, pathFlavor)
+  const segments: string[] = []
+  for (const segment of rest.split('/')) {
+    if (!segment || segment === '.') {
+      continue
+    }
+    if (segment === '..') {
+      if (segments.length > 0 && segments.at(-1) !== '..') {
+        segments.pop()
+      } else if (!root) {
+        segments.push(segment)
+      }
+      continue
+    }
+    segments.push(segment)
+  }
+  const suffix = segments.join('/')
+  if (!root) {
+    return suffix || '.'
+  }
+  return suffix ? `${root}${suffix}` : trimRuntimePathTrailingSlash(root)
+}
+
+function splitRuntimePathRoot(
+  value: string,
+  pathFlavor: 'posix' | 'windows'
+): { root: string; rest: string } {
+  if (pathFlavor === 'windows') {
+    const drive = value.match(/^([A-Za-z]:)(?:\/|$)/)
+    if (drive) {
+      return { root: `${drive[1]}/`, rest: value.slice(drive[0].length) }
+    }
+    if (value.startsWith('//')) {
+      const parts = value.slice(2).split('/')
+      if (parts.length >= 2 && parts[0] && parts[1]) {
+        const root = `//${parts[0]}/${parts[1]}/`
+        return { root, rest: parts.slice(2).join('/') }
+      }
+      return { root: '//', rest: value.slice(2) }
+    }
+    if (value.startsWith('/')) {
+      return { root: '/', rest: value.slice(1) }
+    }
+  }
+  if (value.startsWith('/')) {
+    return { root: '/', rest: value.slice(1) }
+  }
+  return { root: '', rest: value }
 }

--- a/src/shared/worktree-ownership.test.ts
+++ b/src/shared/worktree-ownership.test.ts
@@ -172,6 +172,19 @@ describe('worktree ownership classification', () => {
     ).toBe('orca-managed')
   })
 
+  it('resolves relative workspace roots against the repo path when matching managed worktrees', () => {
+    const repo = makeRepo({ path: '/repos/app' })
+    const settings = makeSettings({ workspaceDir: '../.worktrees' })
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree({ path: '/repos/.worktrees/app/feature' }),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+      })
+    ).toBe('orca-managed')
+  })
+
   it('handles Windows drive casing and separators', () => {
     const repo = makeRepo({ path: 'C:\\repos\\App' })
     const settings = makeSettings({ workspaceDir: 'C:\\Orca\\Workspaces' })

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -3,7 +3,8 @@ import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators,
-  relativePathInsideRoot
+  relativePathInsideRoot,
+  resolveRuntimePath
 } from './cross-platform-path'
 import { parseWslUncPath } from './wsl-paths'
 import type {
@@ -48,8 +49,16 @@ export function buildKnownOrcaWorkspaceLayouts(
 ): OrcaWorkspaceLayout[] {
   const layouts: OrcaWorkspaceLayout[] = []
   if (!repo?.connectionId && settings.workspaceDir) {
-    layouts.push({ path: settings.workspaceDir, nestWorkspaces: settings.nestWorkspaces })
-    layouts.push(...(settings.workspaceDirHistory ?? []))
+    layouts.push({
+      path: repo ? resolveRuntimePath(repo.path, settings.workspaceDir) : settings.workspaceDir,
+      nestWorkspaces: settings.nestWorkspaces
+    })
+    layouts.push(
+      ...(settings.workspaceDirHistory ?? []).map((layout) => ({
+        ...layout,
+        path: repo ? resolveRuntimePath(repo.path, layout.path) : layout.path
+      }))
+    )
   }
 
   const wslLayouts = repo ? buildWslWorkspaceLayouts(repo.path, settings) : []


### PR DESCRIPTION
Fixes #711.

## Summary
- Resolve relative `workspaceDir` values against the repo path before creating local/runtime worktrees.
- Reuse the resolved root for ownership classification and local filesystem authorization.
- Apply relative workspace roots to SSH worktrees on the remote repo path, while keeping absolute desktop workspace roots on the legacy repo-sibling SSH behavior.

## Validation
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/worktree-logic.test.ts src/main/ipc/worktree-logic-wsl.test.ts src/shared/worktree-ownership.test.ts src/shared/cross-platform-path.test.ts src/main/ipc/filesystem.test.ts src/main/ipc/worktrees.test.ts src/main/ipc/worktrees-windows.test.ts src/main/runtime/orca-runtime.test.ts`
- `pnpm exec oxlint src/main/ipc/worktree-logic.ts src/main/ipc/worktree-logic.test.ts src/main/ipc/worktree-logic-wsl.test.ts src/main/ipc/worktree-remote.ts src/main/runtime/orca-runtime.ts src/main/ipc/filesystem-auth.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts src/shared/cross-platform-path.ts src/shared/cross-platform-path.test.ts src/shared/worktree-ownership.ts src/shared/worktree-ownership.test.ts`
- `pnpm run typecheck`
- `git diff --check HEAD~1 HEAD`
- `git merge-tree --write-tree HEAD origin/main`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.