### PR TITLE
Resolve diff comments clear dialog before commit

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -107,6 +107,12 @@ import { formatDiffComment, formatDiffComments } from '@/lib/diff-comments-forma
 import { getDiffCommentLineLabel, getDiffCommentSource } from '@/lib/diff-comment-compat'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { DiffNotesSendMenu } from '@/components/editor/DiffNotesSendMenu'
+import {
+  countPendingDiffCommentsClear,
+  formatPendingDiffCommentsClearDescription,
+  resolvePendingDiffCommentsClear,
+  type PendingDiffCommentsClear
+} from './diff-comments-clear-dialog-state'
 import { QuickLaunchAgentMenuItems } from '@/components/tab-bar/QuickLaunchButton'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
@@ -368,10 +374,6 @@ function getSourceControlDirectoryActionPaths(
         : []
   }
 }
-
-type PendingDiffCommentsClear =
-  | { kind: 'all'; worktreeId: string }
-  | { kind: 'file'; worktreeId: string; filePath: string }
 
 type HostedReviewCreationState = {
   repoId: string
@@ -1027,41 +1029,32 @@ function SourceControlInner(): React.JSX.Element {
   }, [diffCommentsCopied])
 
   const pendingDiffCommentsClearCount = useMemo(() => {
-    if (!pendingDiffCommentsClear || pendingDiffCommentsClear.worktreeId !== activeWorktreeId) {
-      return 0
-    }
-    if (pendingDiffCommentsClear.kind === 'all') {
-      return diffCommentsForActive.length
-    }
-    return diffCommentsForActive.filter((c) => c.filePath === pendingDiffCommentsClear.filePath)
-      .length
+    return countPendingDiffCommentsClear(
+      pendingDiffCommentsClear,
+      activeWorktreeId,
+      diffCommentsForActive
+    )
   }, [activeWorktreeId, diffCommentsForActive, pendingDiffCommentsClear])
 
-  const pendingDiffCommentsClearDescription = pendingDiffCommentsClear
-    ? pendingDiffCommentsClear.kind === 'all'
-      ? `Clear ${pendingDiffCommentsClearCount} ${pendingDiffCommentsClearCount === 1 ? 'note' : 'notes'} from this workspace?`
-      : `Clear ${pendingDiffCommentsClearCount} ${pendingDiffCommentsClearCount === 1 ? 'note' : 'notes'} from ${pendingDiffCommentsClear.filePath}?`
-    : ''
-
-  useEffect(() => {
-    if (!pendingDiffCommentsClear || isClearingDiffComments) {
-      return
-    }
-    if (
-      pendingDiffCommentsClear.worktreeId !== activeWorktreeId ||
-      pendingDiffCommentsClearCount === 0
-    ) {
-      setPendingDiffCommentsClear(null)
-    }
-  }, [
+  const resolvedPendingDiffCommentsClear = resolvePendingDiffCommentsClear({
     activeWorktreeId,
-    isClearingDiffComments,
-    pendingDiffCommentsClear,
+    isClearing: isClearingDiffComments,
+    pending: pendingDiffCommentsClear,
+    pendingCount: pendingDiffCommentsClearCount
+  })
+  if (resolvedPendingDiffCommentsClear !== pendingDiffCommentsClear) {
+    // Why: the confirmation is purely local UI state; clear impossible
+    // confirmations before children observe a stale open dialog.
+    setPendingDiffCommentsClear(resolvedPendingDiffCommentsClear)
+  }
+
+  const pendingDiffCommentsClearDescription = formatPendingDiffCommentsClearDescription(
+    resolvedPendingDiffCommentsClear,
     pendingDiffCommentsClearCount
-  ])
+  )
 
   const handleConfirmDiffCommentsClear = useCallback(async (): Promise<void> => {
-    const pending = pendingDiffCommentsClear
+    const pending = resolvedPendingDiffCommentsClear
     if (!pending || isClearingDiffComments || pending.worktreeId !== activeWorktreeId) {
       return
     }
@@ -1088,7 +1081,7 @@ function SourceControlInner(): React.JSX.Element {
     clearDiffComments,
     clearDiffCommentsForFile,
     isClearingDiffComments,
-    pendingDiffCommentsClear,
+    resolvedPendingDiffCommentsClear,
     pendingDiffCommentsClearCount
   ])
 
@@ -4538,7 +4531,7 @@ function SourceControlInner(): React.JSX.Element {
       </div>
 
       <Dialog
-        open={pendingDiffCommentsClear !== null}
+        open={resolvedPendingDiffCommentsClear !== null}
         onOpenChange={(open) => {
           if (!open && !isClearingDiffComments) {
             setPendingDiffCommentsClear(null)

--- a/src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  countPendingDiffCommentsClear,
+  formatPendingDiffCommentsClearDescription,
+  resolvePendingDiffCommentsClear,
+  type PendingDiffCommentsClear
+} from './diff-comments-clear-dialog-state'
+
+const allPending: PendingDiffCommentsClear = { kind: 'all', worktreeId: 'wt-1' }
+const filePending: PendingDiffCommentsClear = {
+  kind: 'file',
+  worktreeId: 'wt-1',
+  filePath: 'src/app.tsx'
+}
+
+describe('diff comments clear dialog state', () => {
+  it('counts all or per-file pending notes for the active worktree', () => {
+    const comments = [
+      { filePath: 'src/app.tsx' },
+      { filePath: 'src/app.tsx' },
+      { filePath: 'src/other.ts' }
+    ]
+
+    expect(countPendingDiffCommentsClear(allPending, 'wt-1', comments)).toBe(3)
+    expect(countPendingDiffCommentsClear(filePending, 'wt-1', comments)).toBe(2)
+  })
+
+  it('returns zero when the pending confirmation belongs to another worktree', () => {
+    expect(countPendingDiffCommentsClear(allPending, 'wt-2', [{ filePath: 'src/app.tsx' }])).toBe(0)
+  })
+
+  it('clears stale confirmations before rendering the dialog', () => {
+    expect(
+      resolvePendingDiffCommentsClear({
+        pending: allPending,
+        activeWorktreeId: 'wt-2',
+        pendingCount: 1,
+        isClearing: false
+      })
+    ).toBeNull()
+    expect(
+      resolvePendingDiffCommentsClear({
+        pending: filePending,
+        activeWorktreeId: 'wt-1',
+        pendingCount: 0,
+        isClearing: false
+      })
+    ).toBeNull()
+  })
+
+  it('keeps the confirmation stable while a clear request is in flight', () => {
+    expect(
+      resolvePendingDiffCommentsClear({
+        pending: filePending,
+        activeWorktreeId: 'wt-2',
+        pendingCount: 0,
+        isClearing: true
+      })
+    ).toBe(filePending)
+  })
+
+  it('formats confirmation copy from the resolved pending state', () => {
+    expect(formatPendingDiffCommentsClearDescription(allPending, 1)).toBe(
+      'Clear 1 note from this workspace?'
+    )
+    expect(formatPendingDiffCommentsClearDescription(filePending, 2)).toBe(
+      'Clear 2 notes from src/app.tsx?'
+    )
+    expect(formatPendingDiffCommentsClearDescription(null, 0)).toBe('')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.ts
+++ b/src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.ts
@@ -1,0 +1,51 @@
+export type PendingDiffCommentsClear =
+  | { kind: 'all'; worktreeId: string }
+  | { kind: 'file'; worktreeId: string; filePath: string }
+
+type DiffCommentWithPath = {
+  filePath: string
+}
+
+export function countPendingDiffCommentsClear(
+  pending: PendingDiffCommentsClear | null,
+  activeWorktreeId: string | null | undefined,
+  comments: readonly DiffCommentWithPath[]
+): number {
+  if (!pending || pending.worktreeId !== activeWorktreeId) {
+    return 0
+  }
+  if (pending.kind === 'all') {
+    return comments.length
+  }
+  return comments.filter((comment) => comment.filePath === pending.filePath).length
+}
+
+export function resolvePendingDiffCommentsClear(args: {
+  pending: PendingDiffCommentsClear | null
+  activeWorktreeId: string | null | undefined
+  pendingCount: number
+  isClearing: boolean
+}): PendingDiffCommentsClear | null {
+  const { activeWorktreeId, isClearing, pending, pendingCount } = args
+  if (!pending || isClearing) {
+    return pending
+  }
+  if (pending.worktreeId !== activeWorktreeId || pendingCount === 0) {
+    return null
+  }
+  return pending
+}
+
+export function formatPendingDiffCommentsClearDescription(
+  pending: PendingDiffCommentsClear | null,
+  count: number
+): string {
+  if (!pending) {
+    return ''
+  }
+  const noun = count === 1 ? 'note' : 'notes'
+  if (pending.kind === 'all') {
+    return `Clear ${count} ${noun} from this workspace?`
+  }
+  return `Clear ${count} ${noun} from ${pending.filePath}?`
+}


### PR DESCRIPTION
Summary:
- moves the Source Control diff-comments clear confirmation stale-state repair out of a passive Effect
- adds a small domain helper for counting, resolving, and formatting the pending clear dialog state
- renders against the resolved pending state so impossible confirmations close before child dialog content observes them

Risk: Medium
- touches Source Control's destructive note-clear confirmation UI; behavior is intentionally unchanged for in-flight clear requests and scoped to local dialog state

Validation:
- pnpm exec oxlint src/renderer/src/components/right-sidebar/SourceControl.tsx src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.ts src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/diff-comments-clear-dialog-state.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count: 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.