### PR TITLE
Resolve Project dialog state before commit

### DIFF
--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -49,6 +49,10 @@ import ProjectViewList from './ProjectViewList'
 import ProjectItemSlugDialog from './ProjectItemSlugDialog'
 import { filterProjectTableRowsByOpenRepos } from './project-row-filtering'
 import {
+  resolveMissingRepoProjectDialogState,
+  resolveRepoBackedProjectDialogState
+} from './project-dialog-state'
+import {
   getNextVisibleProjectTableCache,
   getVisibleProjectTable,
   type CachedVisibleProjectTable
@@ -376,26 +380,27 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
   } | null>(null)
   const liveRepoIds = useMemo(() => new Set(repos.map((repo) => repo.id)), [repos])
 
-  useEffect(() => {
-    if (dialogRepoItem && !liveRepoIds.has(dialogRepoItem.repoId)) {
-      setDialogRepoItem(null)
-    }
-  }, [dialogRepoItem, liveRepoIds])
+  const resolvedDialogRepoItem = resolveRepoBackedProjectDialogState(dialogRepoItem, liveRepoIds)
+  if (resolvedDialogRepoItem !== dialogRepoItem) {
+    // Why: repo-backed Project dialogs cannot edit after their repo leaves
+    // Orca; clear them before the modal tree receives stale repo ids.
+    setDialogRepoItem(resolvedDialogRepoItem)
+  }
 
-  useEffect(() => {
-    if (!slugIndexReady) {
-      return
-    }
-    if (
-      slugDialog &&
-      lookupSlug(`${slugDialog.origin.owner}/${slugDialog.origin.repo}`).length > 0
-    ) {
-      setSlugDialog(null)
-    }
-    if (repoNotInOrca && lookupSlug(`${repoNotInOrca.owner}/${repoNotInOrca.repo}`).length > 0) {
-      setRepoNotInOrca(null)
-    }
-  }, [slugIndexReady, lookupSlug, slugDialog, repoNotInOrca])
+  const resolvedMissingRepoDialogs = resolveMissingRepoProjectDialogState({
+    slugIndexReady,
+    slugDialog,
+    repoNotInOrca,
+    lookupSlug
+  })
+  if (resolvedMissingRepoDialogs.slugDialog !== slugDialog) {
+    // Why: once a previously missing repo is registered, Project rows should
+    // use the full repo-backed dialog instead of the slug fallback.
+    setSlugDialog(resolvedMissingRepoDialogs.slugDialog)
+  }
+  if (resolvedMissingRepoDialogs.repoNotInOrca !== repoNotInOrca) {
+    setRepoNotInOrca(resolvedMissingRepoDialogs.repoNotInOrca)
+  }
 
   const buildWorkItem = useCallback(
     (row: GitHubProjectRow, repoId: string): GitHubWorkItem | null => {
@@ -762,12 +767,12 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
           707) so a row from another repo cannot accidentally edit the active
           workspace. */}
       <GitHubItemDialog
-        workItem={dialogRepoItem?.workItem ?? null}
-        repoPath={dialogRepoItem?.repoPath ?? null}
-        repoId={dialogRepoItem?.repoId ?? null}
-        projectOrigin={dialogRepoItem?.origin}
+        workItem={resolvedDialogRepoItem?.workItem ?? null}
+        repoPath={resolvedDialogRepoItem?.repoPath ?? null}
+        repoId={resolvedDialogRepoItem?.repoId ?? null}
+        projectOrigin={resolvedDialogRepoItem?.origin}
         onUse={(item) => {
-          const current = dialogRepoItem
+          const current = resolvedDialogRepoItem
           setDialogRepoItem(null)
           if (!current) {
             return
@@ -793,21 +798,21 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
           having a duplicate (always-disabled or always-routing-to-fallback)
           button here would only confuse the user. */}
       <ProjectItemSlugDialog
-        projectOrigin={slugDialog?.origin ?? null}
+        projectOrigin={resolvedMissingRepoDialogs.slugDialog?.origin ?? null}
         onClose={() => setSlugDialog(null)}
       />
 
       {/* repo-not-in-orca prompt: see design doc Interaction States. */}
       <Dialog
-        open={repoNotInOrca !== null}
+        open={resolvedMissingRepoDialogs.repoNotInOrca !== null}
         onOpenChange={(open) => !open && setRepoNotInOrca(null)}
       >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Repository not in Orca</DialogTitle>
             <DialogDescription>
-              {repoNotInOrca
-                ? `${repoNotInOrca.owner}/${repoNotInOrca.repo} isn't added to Orca. Add it to start work, or open in GitHub.`
+              {resolvedMissingRepoDialogs.repoNotInOrca
+                ? `${resolvedMissingRepoDialogs.repoNotInOrca.owner}/${resolvedMissingRepoDialogs.repoNotInOrca.repo} isn't added to Orca. Add it to start work, or open in GitHub.`
                 : null}
             </DialogDescription>
           </DialogHeader>
@@ -815,12 +820,12 @@ export default function ProjectViewWrapper(_props: Props = {} as Props): React.J
             <Button variant="ghost" onClick={() => setRepoNotInOrca(null)}>
               Cancel
             </Button>
-            {repoNotInOrca?.url ? (
+            {resolvedMissingRepoDialogs.repoNotInOrca?.url ? (
               <Button
                 variant="outline"
                 onClick={() => {
-                  if (repoNotInOrca.url) {
-                    void window.api.shell.openUrl(repoNotInOrca.url)
+                  if (resolvedMissingRepoDialogs.repoNotInOrca?.url) {
+                    void window.api.shell.openUrl(resolvedMissingRepoDialogs.repoNotInOrca.url)
                   }
                   setRepoNotInOrca(null)
                 }}

--- a/src/renderer/src/components/github-project/project-dialog-state.test.ts
+++ b/src/renderer/src/components/github-project/project-dialog-state.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveMissingRepoProjectDialogState,
+  resolveRepoBackedProjectDialogState
+} from './project-dialog-state'
+
+describe('resolveRepoBackedProjectDialogState', () => {
+  it('keeps a repo-backed dialog when the repo still exists', () => {
+    const dialog = { repoId: 'repo-1', label: 'Issue 1' }
+
+    expect(resolveRepoBackedProjectDialogState(dialog, new Set(['repo-1']))).toBe(dialog)
+  })
+
+  it('clears a repo-backed dialog when its repo is removed', () => {
+    expect(
+      resolveRepoBackedProjectDialogState({ repoId: 'repo-1' }, new Set(['repo-2']))
+    ).toBeNull()
+  })
+})
+
+describe('resolveMissingRepoProjectDialogState', () => {
+  it('waits for the slug index before closing missing-repo dialogs', () => {
+    const slugDialog = { origin: { owner: 'stablyai', repo: 'orca' } }
+    const repoNotInOrca = { owner: 'stablyai', repo: 'orca', url: null }
+
+    expect(
+      resolveMissingRepoProjectDialogState({
+        slugIndexReady: false,
+        slugDialog,
+        repoNotInOrca,
+        lookupSlug: () => ['repo-1']
+      })
+    ).toEqual({ slugDialog, repoNotInOrca })
+  })
+
+  it('clears slug fallback dialogs once the repo slug resolves', () => {
+    const slugDialog = { origin: { owner: 'stablyai', repo: 'orca' } }
+    const repoNotInOrca = { owner: 'other', repo: 'tool', url: null }
+    const result = resolveMissingRepoProjectDialogState({
+      slugIndexReady: true,
+      slugDialog,
+      repoNotInOrca,
+      lookupSlug: (slug) => (slug === 'stablyai/orca' ? ['repo-1'] : [])
+    })
+
+    expect(result.slugDialog).toBeNull()
+    expect(result.repoNotInOrca).toBe(repoNotInOrca)
+  })
+
+  it('clears repo-not-in-orca dialogs once the repo slug resolves', () => {
+    const slugDialog = { origin: { owner: 'other', repo: 'tool' } }
+    const repoNotInOrca = { owner: 'stablyai', repo: 'orca', url: null }
+    const result = resolveMissingRepoProjectDialogState({
+      slugIndexReady: true,
+      slugDialog,
+      repoNotInOrca,
+      lookupSlug: (slug) => (slug === 'stablyai/orca' ? ['repo-1'] : [])
+    })
+
+    expect(result.slugDialog).toBe(slugDialog)
+    expect(result.repoNotInOrca).toBeNull()
+  })
+})

--- a/src/renderer/src/components/github-project/project-dialog-state.ts
+++ b/src/renderer/src/components/github-project/project-dialog-state.ts
@@ -1,0 +1,59 @@
+type RepoBackedProjectDialogState = {
+  repoId: string
+}
+
+type SlugProjectDialogState = {
+  origin: {
+    owner: string
+    repo: string
+  }
+}
+
+type RepoNotInOrcaDialogState = {
+  owner: string
+  repo: string
+}
+
+type LookupSlug = (slug: string) => readonly unknown[]
+
+function hasRepoMatch(lookupSlug: LookupSlug, owner: string, repo: string): boolean {
+  return lookupSlug(`${owner}/${repo}`).length > 0
+}
+
+export function resolveRepoBackedProjectDialogState<T extends RepoBackedProjectDialogState>(
+  dialog: T | null,
+  liveRepoIds: ReadonlySet<string>
+): T | null {
+  if (dialog && !liveRepoIds.has(dialog.repoId)) {
+    return null
+  }
+  return dialog
+}
+
+export function resolveMissingRepoProjectDialogState<
+  TSlugDialog extends SlugProjectDialogState,
+  TRepoNotInOrca extends RepoNotInOrcaDialogState
+>(args: {
+  slugIndexReady: boolean
+  slugDialog: TSlugDialog | null
+  repoNotInOrca: TRepoNotInOrca | null
+  lookupSlug: LookupSlug
+}): {
+  slugDialog: TSlugDialog | null
+  repoNotInOrca: TRepoNotInOrca | null
+} {
+  const { lookupSlug, repoNotInOrca, slugDialog, slugIndexReady } = args
+  if (!slugIndexReady) {
+    return { slugDialog, repoNotInOrca }
+  }
+  return {
+    slugDialog:
+      slugDialog && hasRepoMatch(lookupSlug, slugDialog.origin.owner, slugDialog.origin.repo)
+        ? null
+        : slugDialog,
+    repoNotInOrca:
+      repoNotInOrca && hasRepoMatch(lookupSlug, repoNotInOrca.owner, repoNotInOrca.repo)
+        ? null
+        : repoNotInOrca
+  }
+}


### PR DESCRIPTION
Summary:
- moves GitHub Project repo-backed dialog stale-repo cleanup out of a passive Effect
- moves slug fallback / repo-not-in-Orca dialog cleanup out of a passive Effect once the repo slug resolves
- adds a focused resolver helper with unit coverage for the dialog-state transitions

Risk: Medium
- GitHub Project dialog UI state only; no GitHub mutation/provider behavior changes

Validation:
- pnpm exec oxlint src/renderer/src/components/github-project/ProjectViewWrapper.tsx src/renderer/src/components/github-project/project-dialog-state.ts src/renderer/src/components/github-project/project-dialog-state.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/github-project/project-dialog-state.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count: 923 -> 921

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.