### PR TITLE
Add E2E coverage for PR and workspace create failures

### DIFF
--- a/tests/e2e/source-control-create-pr.spec.ts
+++ b/tests/e2e/source-control-create-pr.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import type { CreateHostedReviewResult } from '../../src/shared/hosted-review'
 
 type CreatePRPayload = {
   repoPath: string
@@ -71,9 +72,10 @@ async function forceCreatePREligibleStatus(
 }
 
 async function seedCreatePREligibleBranch(
-  page: Page
+  page: Page,
+  options: { createResult?: CreateHostedReviewResult } = {}
 ): Promise<{ branch: string; worktreeId: string }> {
-  return page.evaluate(async () => {
+  return page.evaluate(async ({ createResult }) => {
     const store = window.__store
     if (!store) {
       throw new Error('window.__store is not available')
@@ -158,6 +160,9 @@ async function seedCreatePREligibleBranch(
           repoPath,
           input
         })
+        if (createResult) {
+          return createResult
+        }
         return {
           ok: true as const,
           number: 73,
@@ -169,7 +174,7 @@ async function seedCreatePREligibleBranch(
     state.setRightSidebarOpen(true)
     state.setRightSidebarTab('source-control')
     return { branch, worktreeId: worktree.id }
-  })
+  }, options)
 }
 
 test.describe('Source Control create pull request', () => {
@@ -224,5 +229,39 @@ test.describe('Source Control create pull request', () => {
       body: '- Initial commit for E2E',
       draft: false
     })
+  })
+
+  test('surfaces create failures without clearing the pull request composer', async ({
+    orcaPage
+  }) => {
+    const failureMessage = 'Create PR failed: GitHub API rate limit exceeded'
+    const { branch, worktreeId } = await seedCreatePREligibleBranch(orcaPage, {
+      createResult: {
+        ok: false,
+        code: 'unknown',
+        error: failureMessage
+      }
+    })
+    await openSourceControl(orcaPage, worktreeId)
+    await forceCreatePREligibleStatus(orcaPage, worktreeId, branch)
+
+    const createButton = orcaPage.getByRole('button', { name: 'Create PR' })
+    const titleInput = orcaPage.getByRole('textbox', { name: 'Pull request title' })
+    const descriptionInput = orcaPage.getByRole('textbox', {
+      name: 'Pull request description'
+    })
+    await expect(createButton).toBeVisible({ timeout: 10_000 })
+    await titleInput.fill('Failing PR from E2E')
+    await descriptionInput.fill('This draft should survive a failed create attempt.')
+    await expect(createButton).toBeEnabled()
+    await createButton.click()
+
+    await expect(orcaPage.getByText(failureMessage)).toBeVisible()
+    await expect(titleInput).toHaveValue('Failing PR from E2E')
+    await expect(descriptionInput).toHaveValue('This draft should survive a failed create attempt.')
+    await expect(orcaPage.getByRole('textbox', { name: 'Pull request base branch' })).toHaveValue(
+      'main'
+    )
+    await expect(createButton).toBeEnabled()
   })
 })

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -152,6 +152,69 @@ test.describe('Create Workspace', () => {
     }
   })
 
+  test('keeps the composer open and preserves inputs when worktree creation fails', async ({
+    orcaPage
+  }) => {
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const originalCreateWorktree = store.getState().createWorktree
+      ;(
+        window as unknown as {
+          __restoreCreateWorktree?: () => void
+        }
+      ).__restoreCreateWorktree = () => {
+        store.setState({ createWorktree: originalCreateWorktree })
+      }
+      store.setState({
+        createWorktree: async () => {
+          throw new Error('could not resolve a default base ref for the E2E fixture')
+        }
+      })
+    })
+
+    try {
+      const workspaceName = `e2e-create-failure-${Date.now()}`
+
+      await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+
+      const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByRole('combobox').first()).toBeVisible()
+
+      const nameInput = dialog.getByPlaceholder(/Type a name/i)
+      await expect(nameInput).toBeVisible()
+      await nameInput.fill(workspaceName)
+
+      const createButton = dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })
+      await expect(createButton).toBeEnabled()
+      await createButton.click()
+
+      const alert = dialog.getByRole('alert')
+      await expect(alert).toContainText('No base branch found')
+      await expect(alert).toContainText('Orca could not resolve a usable base ref')
+      await expect(alert).toContainText('Create an initial commit')
+      await expect(dialog).toBeVisible()
+      await expect(nameInput).toHaveValue(workspaceName)
+      await expect(createButton).toBeEnabled()
+    } finally {
+      await orcaPage
+        .evaluate(() => {
+          ;(
+            window as unknown as {
+              __restoreCreateWorktree?: () => void
+            }
+          ).__restoreCreateWorktree?.()
+          window.__store?.getState().closeModal()
+        })
+        .catch(() => {
+          /* page may already be torn down */
+        })
+    }
+  })
+
   test('reuses a resolved pasted GitHub URL when quick create submits', async ({
     electronApp,
     orcaPage


### PR DESCRIPTION
Refs #2321

Summary:
- Adds a Source Control E2E failure case where Create PR returns a GitHub-style error and the composer keeps the title, description, base branch, and enabled retry action visible.
- Adds a Create Workspace E2E failure case where worktree creation reports the missing-base-ref error, keeps the dialog open, preserves the typed workspace name, and re-enables Create.
- Keeps this as a focused P0 slice; no product behavior changes.

Validation:
- `pnpm run test:e2e -- source-control-create-pr.spec.ts worktree.spec.ts` (5 passed)
- `pnpm exec oxfmt --check tests/e2e/source-control-create-pr.spec.ts tests/e2e/worktree.spec.ts`
- `pnpm exec oxlint tests/e2e/source-control-create-pr.spec.ts tests/e2e/worktree.spec.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.