### PR TITLE
Add explicit proxy settings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -111,6 +111,7 @@ import {
 import { shouldSendSyntheticTitleFrame } from './synthetic-title-visibility'
 import { isCrashReportReason } from '../shared/crash-reporting'
 import { KeybindingService } from './keybindings/keybinding-service'
+import { applyElectronProxySettings } from './network/proxy-settings'
 
 let mainWindow: BrowserWindow | null = null
 /** Whether a manual app.quit() (Cmd+Q, etc.) is in progress. Shared with the
@@ -1060,6 +1061,13 @@ app.whenReady().then(async () => {
   }
 
   store = new Store()
+  try {
+    // Why: Dock/Launchpad launches do not inherit shell proxy env vars, so the
+    // persisted proxy must be applied before any app-owned network fetchers run.
+    await applyElectronProxySettings(store.getSettings())
+  } catch {
+    console.warn('[proxy] Failed to apply network proxy settings')
+  }
   agentAwakeService = new AgentAwakeService()
   agentAwakeService.setEnabled(store.getSettings().keepComputerAwakeWhileAgentsRun)
   // Why: disk-hydrated status rows are UI continuity only. The service starts

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -381,7 +381,12 @@ describe('registerPtyHandlers', () => {
     argsEnv?: Record<string, string>,
     processEnvOverrides?: Record<string, string | undefined>,
     getSelectedCodexHomePath?: () => string | null,
-    getSettings?: () => { enableGitHubAttribution?: boolean; agentStatusHooksEnabled?: boolean },
+    getSettings?: () => {
+      enableGitHubAttribution?: boolean
+      agentStatusHooksEnabled?: boolean
+      httpProxyUrl?: string
+      httpProxyBypassRules?: string
+    },
     // Why: PR #2662 finding 2 — the threading from IPC `args.command` through
     // buildPtyHostEnv to piTitlebarExtensionService.buildPtyEnv was untested
     // for the OMP case because this helper never forwarded a command. Accept
@@ -858,6 +863,18 @@ describe('registerPtyHandlers', () => {
       expect(env.ORCA_CODEX_HOME).toBe('/tmp/orca-codex-home')
     })
 
+    it('injects explicit proxy settings into local PTY env', async () => {
+      const env = await spawnAndGetEnv(undefined, undefined, undefined, () => ({
+        httpProxyUrl: 'http://proxy.example:8080',
+        httpProxyBypassRules: 'localhost,*.internal'
+      }))
+
+      expect(env.HTTP_PROXY).toBe('http://proxy.example:8080')
+      expect(env.HTTPS_PROXY).toBe('http://proxy.example:8080')
+      expect(env.ALL_PROXY).toBe('http://proxy.example:8080')
+      expect(env.NO_PROXY).toBe('localhost,*.internal')
+    })
+
     describe('daemon-active provider (parity with LocalPtyProvider)', () => {
       // Why: these tests guard the regression the daemon-parity refactor was
       // written to fix — under the daemon, LocalPtyProvider.buildSpawnEnv is
@@ -900,7 +917,11 @@ describe('registerPtyHandlers', () => {
       async function daemonSpawnAndGetOptions(
         argsEnv?: Record<string, string>,
         getSelectedCodexHomePath?: () => string | null,
-        getSettings?: () => { enableGitHubAttribution: boolean },
+        getSettings?: () => {
+          enableGitHubAttribution?: boolean
+          httpProxyUrl?: string
+          httpProxyBypassRules?: string
+        },
         processEnvOverrides?: Record<string, string | undefined>,
         // Why: daemon spawn tests need to exercise both WSL launch metadata
         // from main and PR #2662 command threading for OMP overlay selection.
@@ -947,7 +968,11 @@ describe('registerPtyHandlers', () => {
       async function daemonSpawnAndGetEnv(
         argsEnv?: Record<string, string>,
         getSelectedCodexHomePath?: () => string | null,
-        getSettings?: () => { enableGitHubAttribution: boolean },
+        getSettings?: () => {
+          enableGitHubAttribution?: boolean
+          httpProxyUrl?: string
+          httpProxyBypassRules?: string
+        },
         processEnvOverrides?: Record<string, string | undefined>,
         spawnArgs?: { cwd?: string; shellOverride?: string; command?: string }
       ): Promise<Record<string, string>> {
@@ -1044,6 +1069,17 @@ describe('registerPtyHandlers', () => {
         const env = await daemonSpawnAndGetEnv({}, () => '/tmp/orca-codex-home')
         expect(env.CODEX_HOME).toBe('/tmp/orca-codex-home')
         expect(env.ORCA_CODEX_HOME).toBe('/tmp/orca-codex-home')
+      })
+
+      it('injects explicit proxy settings on the daemon path', async () => {
+        const env = await daemonSpawnAndGetEnv({}, undefined, () => ({
+          httpProxyUrl: 'http://proxy.example:8080',
+          httpProxyBypassRules: 'localhost;*.internal'
+        }))
+
+        expect(env.HTTP_PROXY).toBe('http://proxy.example:8080')
+        expect(env.HTTPS_PROXY).toBe('http://proxy.example:8080')
+        expect(env.NO_PROXY).toBe('localhost,*.internal')
       })
 
       it('skips host Codex home when a daemon-backed Windows spawn targets a WSL cwd', async () => {
@@ -1432,7 +1468,10 @@ describe('registerPtyHandlers', () => {
           mainWindow as never,
           undefined,
           undefined,
-          undefined,
+          (() => ({
+            httpProxyUrl: 'http://proxy.example:8080',
+            httpProxyBypassRules: 'localhost'
+          })) as never,
           undefined,
           store as never
         )
@@ -1462,6 +1501,9 @@ describe('registerPtyHandlers', () => {
         expect(env.ORCA_PI_CODING_AGENT_DIR).toBeUndefined()
         expect(env.ORCA_PI_SOURCE_AGENT_DIR).toBeUndefined()
         expect(env.CODEX_HOME).toBeUndefined()
+        expect(env.HTTP_PROXY).toBeUndefined()
+        expect(env.HTTPS_PROXY).toBeUndefined()
+        expect(env.NO_PROXY).toBeUndefined()
         expect(env.FOO).toBe('bar')
         expect(openCodeBuildPtyEnvMock).not.toHaveBeenCalled()
         expect(piBuildPtyEnvMock).not.toHaveBeenCalled()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -64,6 +64,7 @@ import { parseWslPath } from '../wsl'
 import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
+import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared/network-proxy'
 
 // ─── Provider Registry ──────────────────────────────────────────────
 // Routes PTY operations by connectionId. null = local provider.
@@ -303,6 +304,7 @@ export type BuildPtyHostEnvOptions = {
    *  the bug this option fixes (cross-agent shadowing when both dirs exist). */
   launchCommand?: string
   agentStatusHooksEnabled: boolean
+  networkProxySettings?: NetworkProxySettings
 }
 
 function readInheritedPath(baseEnv: Record<string, string>): string {
@@ -502,6 +504,7 @@ export function buildPtyHostEnv(
   opts: BuildPtyHostEnvOptions
 ): Record<string, string> {
   mergePersistedWindowsPath(baseEnv)
+  Object.assign(baseEnv, buildConfiguredProxyEnv(opts.networkProxySettings))
 
   // Why: the Local path passes a baseEnv that already includes process.env
   // (LocalPtyProvider.spawn merges it before calling buildSpawnEnv). The
@@ -919,7 +922,8 @@ export function registerPtyHandlers(
           skipCodexHomeEnv: ctx?.isWsl === true && !selectedCodexHomePath,
           githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false,
           launchCommand: ctx?.command,
-          agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.())
+          agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+          networkProxySettings: getSettings?.()
         })
         // Why: agents need their own terminal handle at process start so they
         // can self-identify in orchestration messages without an extra RPC.
@@ -1449,7 +1453,8 @@ export function registerPtyHandlers(
           skipCodexHomeEnv,
           githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false,
           launchCommand: args.command,
-          agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.())
+          agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+          networkProxySettings: getSettings?.()
         })
       }
 
@@ -1893,7 +1898,8 @@ export function registerPtyHandlers(
             skipCodexHomeEnv,
             githubAttributionEnabled: getSettings?.()?.enableGitHubAttribution ?? false,
             launchCommand: args.command,
-            agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.())
+            agentStatusHooksEnabled: isAgentStatusHooksEnabled(getSettings?.()),
+            networkProxySettings: getSettings?.()
           })
         } catch (err) {
           // Why: buildPtyHostEnv has filesystem side-effects (Pi overlay

--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
-const { browserWindowGetAllWindowsMock, handleMock, previewGhosttyImportMock } = vi.hoisted(() => ({
+const {
+  applyElectronProxySettingsMock,
+  browserWindowGetAllWindowsMock,
+  handleMock,
+  previewGhosttyImportMock
+} = vi.hoisted(() => ({
+  applyElectronProxySettingsMock: vi.fn(),
   browserWindowGetAllWindowsMock: vi.fn(),
   handleMock: vi.fn(),
   previewGhosttyImportMock: vi.fn()
@@ -14,6 +20,10 @@ vi.mock('electron', () => ({
 
 vi.mock('../ghostty/index', () => ({
   previewGhosttyImport: previewGhosttyImportMock
+}))
+
+vi.mock('../network/proxy-settings', () => ({
+  applyElectronProxySettings: applyElectronProxySettingsMock
 }))
 
 import { registerSettingsHandlers } from './settings'
@@ -36,6 +46,8 @@ const store = {
 describe('registerSettingsHandlers', () => {
   beforeEach(() => {
     handleMock.mockClear()
+    applyElectronProxySettingsMock.mockClear()
+    applyElectronProxySettingsMock.mockResolvedValue({ source: 'settings' })
     previewGhosttyImportMock.mockClear()
     browserWindowGetAllWindowsMock.mockReset()
     store.getSettings.mockReset()
@@ -153,5 +165,55 @@ describe('registerSettingsHandlers', () => {
       {},
       { notifyListeners: true, originWebContentsId: 1 }
     )
+  })
+
+  it('sanitizes and applies proxy settings from renderer settings IPC', async () => {
+    store.getSettings.mockReturnValue({ httpProxyUrl: '' })
+    store.updateSettings.mockReturnValue({
+      httpProxyUrl: 'http://proxy.example:8080',
+      httpProxyBypassRules: 'localhost;*.internal'
+    })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, {
+      httpProxyUrl: ' http://proxy.example:8080/path#frag ',
+      httpProxyBypassRules: 'localhost, *.internal'
+    })
+
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      {
+        httpProxyUrl: 'http://proxy.example:8080',
+        httpProxyBypassRules: 'localhost;*.internal'
+      },
+      { notifyListeners: true, originWebContentsId: 1 }
+    )
+    expect(applyElectronProxySettingsMock).toHaveBeenCalledWith({
+      httpProxyUrl: 'http://proxy.example:8080',
+      httpProxyBypassRules: 'localhost;*.internal'
+    })
+  })
+
+  it('drops invalid proxy URLs at the settings boundary', async () => {
+    store.getSettings.mockReturnValue({ httpProxyUrl: 'http://proxy.example:8080' })
+    store.updateSettings.mockReturnValue({ httpProxyUrl: '' })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      _event: unknown,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, { httpProxyUrl: 'ftp://proxy.example:2121' })
+
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      { httpProxyUrl: '' },
+      { notifyListeners: true, originWebContentsId: 1 }
+    )
+    expect(applyElectronProxySettingsMock).toHaveBeenCalledWith({ httpProxyUrl: '' })
   })
 })

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -9,6 +9,8 @@ import { SETTINGS_CHANGED_WHITELIST, type SettingsChangedKey } from '../../share
 import type { AgentAwakeService } from '../agent-awake-service'
 import { sanitizeFloatingWorkspaceDirectorySetting } from './floating-workspace-directory'
 import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
+import { applyElectronProxySettings } from '../network/proxy-settings'
+import { normalizeProxyBypassRules, normalizeProxyUrl } from '../../shared/network-proxy'
 
 // Why: the whitelist is the source-of-truth for which keys we emit on. Casting
 // to a Set once at module load lets the IPC handler's per-key membership
@@ -54,6 +56,13 @@ export function registerSettingsHandlers(
         args.floatingTerminalCwd
       )
     }
+    if ('httpProxyUrl' in args) {
+      const proxyUrl = normalizeProxyUrl(args.httpProxyUrl)
+      sanitizedArgs.httpProxyUrl = proxyUrl.ok ? proxyUrl.value : ''
+    }
+    if ('httpProxyBypassRules' in args) {
+      sanitizedArgs.httpProxyBypassRules = normalizeProxyBypassRules(args.httpProxyBypassRules)
+    }
     if (args.theme) {
       nativeTheme.themeSource = args.theme
     }
@@ -81,6 +90,13 @@ export function registerSettingsHandlers(
     }
     if (APPEARANCE_MENU_KEYS.some((key) => key in sanitizedArgs)) {
       rebuildAppMenu()
+    }
+    if ('httpProxyUrl' in sanitizedArgs || 'httpProxyBypassRules' in sanitizedArgs) {
+      try {
+        await applyElectronProxySettings(result)
+      } catch {
+        console.warn('[settings] failed to apply network proxy settings')
+      }
     }
 
     // Why: telemetry-plan.md§Settings — fire `settings_changed` only for

--- a/src/main/network/proxy-settings.test.ts
+++ b/src/main/network/proxy-settings.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { defaultSessionMock } = vi.hoisted(() => ({
+  defaultSessionMock: {
+    resolveProxy: vi.fn(async () => 'DIRECT'),
+    setProxy: vi.fn(async () => {})
+  }
+}))
+
+vi.mock('electron', () => ({
+  session: {
+    defaultSession: defaultSessionMock
+  }
+}))
+
+import {
+  applyElectronProxySettings,
+  ensureElectronProxyFromEnvironment,
+  resetProxyApplicationForTests
+} from './proxy-settings'
+
+function createProxySession(resolveProxy = 'DIRECT') {
+  return {
+    resolveProxy: vi.fn(async () => resolveProxy),
+    setProxy: vi.fn(async () => {}),
+    closeAllConnections: vi.fn(async () => {})
+  }
+}
+
+describe('Electron proxy settings', () => {
+  beforeEach(() => {
+    resetProxyApplicationForTests()
+  })
+
+  it('applies explicit settings before env fallback', async () => {
+    const proxySession = createProxySession()
+
+    await expect(
+      applyElectronProxySettings(
+        {
+          httpProxyUrl: ' http://user:pass@proxy.example:8080/path#token ',
+          httpProxyBypassRules: 'localhost, *.internal'
+        },
+        {
+          proxySession,
+          env: { HTTPS_PROXY: 'http://env.example:8080' }
+        }
+      )
+    ).resolves.toEqual({
+      source: 'settings',
+      proxyRules: 'http://user:pass@proxy.example:8080',
+      proxyBypassRules: 'localhost;*.internal'
+    })
+
+    expect(proxySession.setProxy).toHaveBeenCalledWith({
+      mode: 'fixed_servers',
+      proxyRules: 'http://user:pass@proxy.example:8080',
+      proxyBypassRules: 'localhost;*.internal'
+    })
+    expect(proxySession.resolveProxy).not.toHaveBeenCalled()
+    expect(proxySession.closeAllConnections).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves system proxy settings when no explicit or env proxy is configured', async () => {
+    const proxySession = createProxySession('PROXY system.example:8080')
+
+    await expect(applyElectronProxySettings({}, { proxySession, env: {} })).resolves.toEqual({
+      source: 'system'
+    })
+
+    expect(proxySession.setProxy).not.toHaveBeenCalled()
+  })
+
+  it('bridges env proxy vars only when Chromium would otherwise go direct', async () => {
+    const proxySession = createProxySession('DIRECT')
+
+    await expect(
+      applyElectronProxySettings(
+        {},
+        {
+          proxySession,
+          env: {
+            HTTPS_PROXY: 'https://env.example:8443',
+            HTTP_PROXY: 'http://lower-priority.example:8080',
+            NO_PROXY: 'localhost,*.internal'
+          }
+        }
+      )
+    ).resolves.toEqual({
+      source: 'env',
+      proxyRules: 'https://env.example:8443',
+      proxyBypassRules: 'localhost;*.internal'
+    })
+
+    expect(proxySession.setProxy).toHaveBeenCalledWith({
+      mode: 'fixed_servers',
+      proxyRules: 'https://env.example:8443',
+      proxyBypassRules: 'localhost;*.internal'
+    })
+  })
+
+  it('clears a previous app proxy before returning to system/env behavior', async () => {
+    const proxySession = createProxySession('DIRECT')
+
+    await applyElectronProxySettings(
+      { httpProxyUrl: 'http://proxy.example:8080' },
+      { proxySession }
+    )
+    await applyElectronProxySettings(
+      { httpProxyUrl: '' },
+      { proxySession, env: { HTTP_PROXY: 'http://env.example:8080' } }
+    )
+
+    expect(proxySession.setProxy).toHaveBeenNthCalledWith(2, { mode: 'system' })
+    expect(proxySession.setProxy).toHaveBeenNthCalledWith(3, {
+      mode: 'fixed_servers',
+      proxyRules: 'http://env.example:8080'
+    })
+  })
+
+  it('does not let env fallback override an already-applied explicit setting', async () => {
+    const proxySession = createProxySession('DIRECT')
+
+    await applyElectronProxySettings(
+      { httpProxyUrl: 'http://proxy.example:8080' },
+      { proxySession }
+    )
+    await ensureElectronProxyFromEnvironment({
+      proxySession,
+      env: { HTTP_PROXY: 'http://env.example:8080' }
+    })
+
+    expect(proxySession.setProxy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/network/proxy-settings.ts
+++ b/src/main/network/proxy-settings.ts
@@ -1,0 +1,125 @@
+import { session } from 'electron'
+import {
+  getProxyBypassRulesFromEnvironment,
+  getProxyUrlFromEnvironment,
+  normalizeProxyBypassRules,
+  normalizeProxyUrl,
+  type NetworkProxySettings
+} from '../../shared/network-proxy'
+
+type ProxySession = {
+  resolveProxy(url: string): Promise<string>
+  setProxy(config: {
+    mode?: 'system' | 'fixed_servers'
+    proxyRules?: string
+    proxyBypassRules?: string
+  }): Promise<void>
+  closeAllConnections?: () => Promise<void>
+}
+
+export type ProxyApplyResult =
+  | { source: 'settings'; proxyRules: string; proxyBypassRules?: string }
+  | { source: 'env'; proxyRules: string; proxyBypassRules?: string }
+  | { source: 'system' | 'none' | 'invalid-settings' | 'invalid-env' }
+
+const PROXY_PROBE_URL = 'https://api.anthropic.com/'
+
+let lastAppliedProxyConfig: Extract<ProxyApplyResult, { source: 'settings' | 'env' }> | null = null
+
+async function setSessionProxy(
+  proxySession: ProxySession,
+  config: Parameters<ProxySession['setProxy']>[0]
+): Promise<void> {
+  await proxySession.setProxy(config)
+  await proxySession.closeAllConnections?.()
+}
+
+export function resetProxyApplicationForTests(): void {
+  lastAppliedProxyConfig = null
+}
+
+export async function ensureElectronProxyFromEnvironment(
+  options: {
+    proxySession?: ProxySession
+    env?: Record<string, string | undefined>
+    force?: boolean
+    probeUrl?: string
+  } = {}
+): Promise<ProxyApplyResult> {
+  if (!options.force && lastAppliedProxyConfig !== null) {
+    return lastAppliedProxyConfig
+  }
+
+  const proxySession = options.proxySession ?? session.defaultSession
+  const resolved = await proxySession.resolveProxy(options.probeUrl ?? PROXY_PROBE_URL)
+  if (resolved !== 'DIRECT') {
+    return { source: 'system' }
+  }
+
+  const proxy = getProxyUrlFromEnvironment(options.env ?? process.env)
+  if (!proxy.ok) {
+    return { source: 'invalid-env' }
+  }
+  if (!proxy.value) {
+    return { source: 'none' }
+  }
+
+  const bypassRules = getProxyBypassRulesFromEnvironment(options.env ?? process.env)
+  await setSessionProxy(proxySession, {
+    mode: 'fixed_servers',
+    proxyRules: proxy.value,
+    ...(bypassRules ? { proxyBypassRules: bypassRules } : {})
+  })
+  lastAppliedProxyConfig = {
+    source: 'env',
+    proxyRules: proxy.value,
+    ...(bypassRules ? { proxyBypassRules: bypassRules } : {})
+  }
+  return lastAppliedProxyConfig
+}
+
+export async function applyElectronProxySettings(
+  settings: NetworkProxySettings,
+  options: {
+    proxySession?: ProxySession
+    env?: Record<string, string | undefined>
+    probeUrl?: string
+  } = {}
+): Promise<ProxyApplyResult> {
+  const proxySession = options.proxySession ?? session.defaultSession
+  const proxy = normalizeProxyUrl(settings.httpProxyUrl)
+  if (!proxy.ok) {
+    return ensureElectronProxyFromEnvironment({
+      proxySession,
+      env: options.env,
+      force: lastAppliedProxyConfig !== null,
+      probeUrl: options.probeUrl
+    }).then((result) => (result.source === 'none' ? { source: 'invalid-settings' } : result))
+  }
+
+  if (proxy.value) {
+    const bypassRules = normalizeProxyBypassRules(settings.httpProxyBypassRules)
+    await setSessionProxy(proxySession, {
+      mode: 'fixed_servers',
+      proxyRules: proxy.value,
+      ...(bypassRules ? { proxyBypassRules: bypassRules } : {})
+    })
+    lastAppliedProxyConfig = {
+      source: 'settings',
+      proxyRules: proxy.value,
+      ...(bypassRules ? { proxyBypassRules: bypassRules } : {})
+    }
+    return lastAppliedProxyConfig
+  }
+
+  if (lastAppliedProxyConfig !== null) {
+    await setSessionProxy(proxySession, { mode: 'system' })
+    lastAppliedProxyConfig = null
+  }
+  return ensureElectronProxyFromEnvironment({
+    proxySession,
+    env: options.env,
+    force: true,
+    probeUrl: options.probeUrl
+  })
+}

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1534,10 +1534,13 @@ export class Store {
         const raw = readFileSync(dataFile, 'utf-8')
         const parsed = JSON.parse(raw) as PersistedState
 
-        // Why: opencodeSessionCookie is stored encrypted on disk via safeStorage.
+        // Why: secret settings are stored encrypted on disk via safeStorage.
         // Decrypt at the load boundary so the rest of the app sees plaintext.
         if (parsed.settings?.opencodeSessionCookie) {
           parsed.settings.opencodeSessionCookie = decrypt(parsed.settings.opencodeSessionCookie)
+        }
+        if (parsed.settings?.httpProxyUrl) {
+          parsed.settings.httpProxyUrl = decrypt(parsed.settings.httpProxyUrl)
         }
         if (parsed.ui?.browserKagiSessionLink) {
           parsed.ui.browserKagiSessionLink = decryptOptionalSecret(parsed.ui.browserKagiSessionLink)
@@ -2069,13 +2072,14 @@ export class Store {
     await mkdir(dir, { recursive: true }).catch(() => {})
     const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
 
-    // Why: opencodeSessionCookie must be encrypted on disk. Clone state so
-    // the in-memory this.state stays plaintext for the rest of the app.
+    // Why: secrets must be encrypted on disk. Clone state so the in-memory
+    // this.state stays plaintext for the rest of the app.
     const stateToSave = {
       ...this.state,
       settings: {
         ...this.state.settings,
-        opencodeSessionCookie: encrypt(this.state.settings.opencodeSessionCookie)
+        opencodeSessionCookie: encrypt(this.state.settings.opencodeSessionCookie),
+        httpProxyUrl: encrypt(this.state.settings.httpProxyUrl ?? '')
       },
       ui: {
         ...this.state.ui,
@@ -2123,13 +2127,14 @@ export class Store {
     }
     const tmpFile = `${dataFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
 
-    // Why: opencodeSessionCookie must be encrypted on disk. Clone state so
-    // the in-memory this.state stays plaintext for the rest of the app.
+    // Why: secrets must be encrypted on disk. Clone state so the in-memory
+    // this.state stays plaintext for the rest of the app.
     const stateToSave = {
       ...this.state,
       settings: {
         ...this.state.settings,
-        opencodeSessionCookie: encrypt(this.state.settings.opencodeSessionCookie)
+        opencodeSessionCookie: encrypt(this.state.settings.opencodeSessionCookie),
+        httpProxyUrl: encrypt(this.state.settings.httpProxyUrl ?? '')
       },
       ui: {
         ...this.state.ui,

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -21,13 +21,12 @@ import {
 } from '../claude-accounts/managed-auth-path'
 import { createOAuthUsageError, OAuthUsageError } from './claude-oauth-usage-error'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
+import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
 const CLAUDE_CODE_USER_AGENT = 'claude-code/2.1.0'
 const API_TIMEOUT_MS = 10_000
-
-let proxyConfigured = false
 
 /**
  * Bridge standard HTTP proxy env vars into Electron's session proxy config.
@@ -40,36 +39,10 @@ let proxyConfigured = false
  * Anthropic from an unexpected IP, risking rate-limit signals on the account.
  */
 async function ensureProxyFromEnv(): Promise<void> {
-  if (proxyConfigured) {
-    return
-  }
-  proxyConfigured = true
-
-  // Why: app.resolveProxy does NOT reflect session-level proxy config —
-  // only session.defaultSession.resolveProxy does.
-  const resolved = await session.defaultSession.resolveProxy(OAUTH_USAGE_URL)
-  if (resolved !== 'DIRECT') {
-    return
-  }
-
-  const proxyUrl =
-    process.env.HTTPS_PROXY ??
-    process.env.https_proxy ??
-    process.env.ALL_PROXY ??
-    process.env.all_proxy ??
-    process.env.HTTP_PROXY ??
-    process.env.http_proxy
-  if (!proxyUrl) {
-    return
-  }
-
-  try {
-    new URL(proxyUrl)
-    await session.defaultSession.setProxy({ proxyRules: proxyUrl })
-  } catch {
-    // Invalid proxy URL — degrade to direct connection rather than crashing.
-    // The usage bar is cosmetic; a typo'd envvar should not break polling.
-  }
+  await ensureElectronProxyFromEnvironment({
+    proxySession: session.defaultSession,
+    probeUrl: OAUTH_USAGE_URL
+  }).catch(() => {})
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -23,6 +23,7 @@ import {
   GENERAL_CLI_SEARCH_ENTRIES,
   GENERAL_EDITOR_SEARCH_ENTRIES,
   GENERAL_NAVIGATION_SEARCH_ENTRIES,
+  GENERAL_NETWORK_SEARCH_ENTRIES,
   GENERAL_PANE_SEARCH_ENTRIES,
   GENERAL_SUPPORT_SEARCH_ENTRIES,
   GENERAL_UPDATE_SEARCH_ENTRIES,
@@ -39,6 +40,7 @@ import {
   SettingsSwitchRow
 } from './SettingsFormControls'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { normalizeProxyBypassRules, normalizeProxyUrl } from '../../../../shared/network-proxy'
 
 function createOpenInApplication(): OpenInApplication {
   return {
@@ -172,6 +174,11 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   const [autoSaveDelayDraftState, setAutoSaveDelayDraftState] = useState(() =>
     createAutoSaveDelayDraftState(settings.editorAutoSaveDelayMs)
   )
+  const [httpProxyUrlDraft, setHttpProxyUrlDraft] = useState(settings.httpProxyUrl ?? '')
+  const [httpProxyUrlError, setHttpProxyUrlError] = useState<string | null>(null)
+  const [httpProxyBypassRulesDraft, setHttpProxyBypassRulesDraft] = useState(
+    settings.httpProxyBypassRules ?? ''
+  )
   const [openInApplicationsDraftState, setOpenInApplicationsDraftState] = useState(() =>
     createOpenInApplicationsDraftState(settings.openInApplications)
   )
@@ -270,6 +277,15 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     }))
   }
 
+  useEffect(() => {
+    setHttpProxyUrlDraft(settings.httpProxyUrl ?? '')
+    setHttpProxyUrlError(null)
+  }, [settings.httpProxyUrl])
+
+  useEffect(() => {
+    setHttpProxyBypassRulesDraft(settings.httpProxyBypassRules ?? '')
+  }, [settings.httpProxyBypassRules])
+
   const commitOpenInApplications = (applications: OpenInApplication[]): void => {
     if (!shouldCommitOpenInApplicationsDraft(applications)) {
       return
@@ -311,6 +327,27 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     setAutoSaveDelayDraftState((current) =>
       updateAutoSaveDelayDraftState(current, settings.editorAutoSaveDelayMs, String(next))
     )
+  }
+
+  const commitHttpProxyUrl = (): void => {
+    const normalized = normalizeProxyUrl(httpProxyUrlDraft)
+    if (!normalized.ok) {
+      setHttpProxyUrlError(normalized.message)
+      return
+    }
+    setHttpProxyUrlError(null)
+    setHttpProxyUrlDraft(normalized.value)
+    if (normalized.value !== (settings.httpProxyUrl ?? '')) {
+      updateSettings({ httpProxyUrl: normalized.value })
+    }
+  }
+
+  const commitHttpProxyBypassRules = (): void => {
+    const normalized = normalizeProxyBypassRules(httpProxyBypassRulesDraft)
+    setHttpProxyBypassRulesDraft(normalized)
+    if (normalized !== (settings.httpProxyBypassRules ?? '')) {
+      updateSettings({ httpProxyBypassRules: normalized })
+    }
   }
 
   const handleRestartToUpdate = (): void => {
@@ -525,6 +562,89 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
           >
             Add Custom Launcher
           </Button>
+        </SearchableSetting>
+      </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, GENERAL_NETWORK_SEARCH_ENTRIES) ? (
+      <section key="network" className="space-y-4">
+        <SettingsSubsectionHeader
+          title="Network"
+          description="Configure app-level network routing."
+        />
+
+        <SearchableSetting
+          title="HTTP Proxy"
+          description="Proxy URL for Orca network requests and local terminal children."
+          keywords={['proxy', 'http_proxy', 'https_proxy', 'network', 'dock', 'launchpad']}
+          className="space-y-3"
+        >
+          <div className="space-y-1">
+            <Label htmlFor="settings-http-proxy-url">HTTP Proxy</Label>
+            <p className="text-xs text-muted-foreground">
+              Leave empty to use system proxy settings and inherited proxy environment variables.
+            </p>
+          </div>
+          <Input
+            id="settings-http-proxy-url"
+            value={httpProxyUrlDraft}
+            onChange={(e) => {
+              setHttpProxyUrlDraft(e.target.value)
+              if (httpProxyUrlError) {
+                setHttpProxyUrlError(null)
+              }
+            }}
+            onBlur={commitHttpProxyUrl}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.currentTarget.blur()
+              }
+            }}
+            placeholder="http://proxy.example.com:8080"
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
+            aria-invalid={httpProxyUrlError ? true : undefined}
+            className="font-mono text-xs"
+          />
+          {httpProxyUrlError ? (
+            <p className="text-xs text-destructive">{httpProxyUrlError}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Supports http, https, socks, socks4, and socks5 URLs.
+            </p>
+          )}
+        </SearchableSetting>
+
+        <SearchableSetting
+          title="Proxy Bypass Rules"
+          description="Hosts that should bypass the configured HTTP proxy."
+          keywords={['proxy', 'bypass', 'no_proxy', 'localhost', 'network']}
+          className="space-y-3"
+        >
+          <div className="space-y-1">
+            <Label htmlFor="settings-http-proxy-bypass-rules">Proxy Bypass Rules</Label>
+            <p className="text-xs text-muted-foreground">
+              Optional. Separate hosts with commas, semicolons, or new lines.
+            </p>
+          </div>
+          <Input
+            id="settings-http-proxy-bypass-rules"
+            value={httpProxyBypassRulesDraft}
+            onChange={(e) => setHttpProxyBypassRulesDraft(e.target.value)}
+            onBlur={commitHttpProxyBypassRules}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.currentTarget.blur()
+              }
+            }}
+            placeholder="localhost, 127.0.0.1, *.internal"
+            autoCapitalize="none"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
+            className="font-mono text-xs"
+          />
         </SearchableSetting>
       </section>
     ) : null,

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -28,6 +28,19 @@ export const GENERAL_WORKSPACE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const GENERAL_NETWORK_SEARCH_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'HTTP Proxy',
+    description: 'Proxy URL for Orca network requests and local terminal children.',
+    keywords: ['proxy', 'http_proxy', 'https_proxy', 'network', 'dock', 'launchpad']
+  },
+  {
+    title: 'Proxy Bypass Rules',
+    description: 'Hosts that should bypass the configured HTTP proxy.',
+    keywords: ['proxy', 'bypass', 'no_proxy', 'localhost', 'network']
+  }
+]
+
 export const GENERAL_EDITOR_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Auto Save Files',
@@ -141,6 +154,7 @@ export const GENERAL_SUPPORT_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 
 export const GENERAL_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...GENERAL_WORKSPACE_SEARCH_ENTRIES,
+  ...GENERAL_NETWORK_SEARCH_ENTRIES,
   ...GENERAL_NAVIGATION_SEARCH_ENTRIES,
   ...GENERAL_EDITOR_SEARCH_ENTRIES,
   ...GENERAL_CLI_SEARCH_ENTRIES,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -230,6 +230,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalAllowOsc52Clipboard: false,
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackBytes: 10_000_000,
+    httpProxyUrl: '',
+    httpProxyBypassRules: '',
     openLinksInApp: true,
     openInApplications: [],
     rightSidebarOpenByDefault: true,

--- a/src/shared/network-proxy.test.ts
+++ b/src/shared/network-proxy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConfiguredProxyEnv,
+  getProxyBypassRulesFromEnvironment,
+  getProxyUrlFromEnvironment,
+  normalizeProxyBypassRules,
+  normalizeProxyUrl,
+  redactProxyUrl
+} from './network-proxy'
+
+describe('network proxy settings', () => {
+  it('normalizes supported proxy URLs without path, query, or fragment', () => {
+    expect(normalizeProxyUrl(' https://user:pass@proxy.example.com:8443/path?q=1#secret ')).toEqual(
+      {
+        ok: true,
+        value: 'https://user:pass@proxy.example.com:8443'
+      }
+    )
+  })
+
+  it('rejects unsupported or malformed proxy URLs', () => {
+    expect(normalizeProxyUrl('file:///tmp/proxy').ok).toBe(false)
+    expect(normalizeProxyUrl('http://').ok).toBe(false)
+    expect(normalizeProxyUrl('not-a-url').ok).toBe(false)
+  })
+
+  it('normalizes bypass rules from common separator styles', () => {
+    expect(normalizeProxyBypassRules('localhost, 127.0.0.1; *.internal\n<local>')).toBe(
+      'localhost;127.0.0.1;*.internal;<local>'
+    )
+  })
+
+  it('uses standard proxy environment precedence', () => {
+    expect(
+      getProxyUrlFromEnvironment({
+        HTTP_PROXY: 'http://plain.example:8080',
+        HTTPS_PROXY: 'https://secure.example:8443'
+      })
+    ).toEqual({ ok: true, value: 'https://secure.example:8443' })
+    expect(
+      getProxyBypassRulesFromEnvironment({
+        no_proxy: 'localhost,*.internal'
+      })
+    ).toBe('localhost;*.internal')
+  })
+
+  it('builds local PTY proxy env only from explicit settings', () => {
+    expect(
+      buildConfiguredProxyEnv({
+        httpProxyUrl: 'http://proxy.example:8080',
+        httpProxyBypassRules: 'localhost;*.internal'
+      })
+    ).toEqual({
+      HTTP_PROXY: 'http://proxy.example:8080',
+      HTTPS_PROXY: 'http://proxy.example:8080',
+      ALL_PROXY: 'http://proxy.example:8080',
+      http_proxy: 'http://proxy.example:8080',
+      https_proxy: 'http://proxy.example:8080',
+      all_proxy: 'http://proxy.example:8080',
+      NO_PROXY: 'localhost,*.internal',
+      no_proxy: 'localhost,*.internal'
+    })
+    expect(buildConfiguredProxyEnv({ httpProxyUrl: '' })).toEqual({})
+  })
+
+  it('redacts credentials for diagnostics', () => {
+    expect(redactProxyUrl('http://user:pass@proxy.example:8080')).toBe(
+      'http://***:***@proxy.example:8080'
+    )
+  })
+})

--- a/src/shared/network-proxy.ts
+++ b/src/shared/network-proxy.ts
@@ -1,0 +1,130 @@
+export type NetworkProxySettings = {
+  httpProxyUrl?: string | null
+  httpProxyBypassRules?: string | null
+}
+
+export type ProxyUrlValidationResult =
+  | { ok: true; value: string; message?: undefined }
+  | { ok: false; value: ''; message: string }
+
+const PROXY_URL_MAX_LENGTH = 2048
+const PROXY_BYPASS_RULES_MAX_LENGTH = 4096
+const PROXY_PROTOCOLS = new Set(['http:', 'https:', 'socks:', 'socks4:', 'socks5:'])
+const PROXY_ENV_KEYS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'HTTP_PROXY',
+  'http_proxy'
+] as const
+const NO_PROXY_ENV_KEYS = ['NO_PROXY', 'no_proxy'] as const
+
+function formatProxyUrl(url: URL): string {
+  const auth =
+    url.username || url.password ? `${url.username}${url.password ? `:${url.password}` : ''}@` : ''
+  return `${url.protocol}//${auth}${url.host}`
+}
+
+export function normalizeProxyUrl(value: unknown): ProxyUrlValidationResult {
+  if (typeof value !== 'string') {
+    return { ok: true, value: '' }
+  }
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return { ok: true, value: '' }
+  }
+  if (trimmed.length > PROXY_URL_MAX_LENGTH) {
+    return { ok: false, value: '', message: 'Proxy URL is too long.' }
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return { ok: false, value: '', message: 'Enter a valid proxy URL.' }
+  }
+  if (!PROXY_PROTOCOLS.has(parsed.protocol)) {
+    return {
+      ok: false,
+      value: '',
+      message: 'Use an http, https, socks, socks4, or socks5 proxy URL.'
+    }
+  }
+  if (!parsed.hostname) {
+    return { ok: false, value: '', message: 'Proxy URL must include a host.' }
+  }
+  return { ok: true, value: formatProxyUrl(parsed) }
+}
+
+export function normalizeProxyBypassRules(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  return value
+    .slice(0, PROXY_BYPASS_RULES_MAX_LENGTH)
+    .split(/[;,\n]/)
+    .map((rule) => rule.trim())
+    .filter(Boolean)
+    .join(';')
+}
+
+export function getProxyUrlFromEnvironment(
+  env: Record<string, string | undefined>
+): ProxyUrlValidationResult {
+  for (const key of PROXY_ENV_KEYS) {
+    if (env[key]) {
+      return normalizeProxyUrl(env[key])
+    }
+  }
+  return { ok: true, value: '' }
+}
+
+export function getProxyBypassRulesFromEnvironment(
+  env: Record<string, string | undefined>
+): string {
+  for (const key of NO_PROXY_ENV_KEYS) {
+    if (env[key]) {
+      return normalizeProxyBypassRules(env[key])
+    }
+  }
+  return ''
+}
+
+export function buildConfiguredProxyEnv(
+  settings: NetworkProxySettings | null | undefined
+): Record<string, string> {
+  const proxy = normalizeProxyUrl(settings?.httpProxyUrl)
+  if (!proxy.ok || !proxy.value) {
+    return {}
+  }
+  const env: Record<string, string> = {
+    HTTP_PROXY: proxy.value,
+    HTTPS_PROXY: proxy.value,
+    ALL_PROXY: proxy.value,
+    http_proxy: proxy.value,
+    https_proxy: proxy.value,
+    all_proxy: proxy.value
+  }
+  const bypassRules = normalizeProxyBypassRules(settings?.httpProxyBypassRules)
+  // Why: explicit Orca proxy settings should not accidentally inherit a
+  // parent shell's NO_PROXY. The bypass field above is the single source for
+  // local child process bypass behavior when a configured proxy is present.
+  const noProxy = bypassRules ? bypassRules.replaceAll(';', ',') : ''
+  env.NO_PROXY = noProxy
+  env.no_proxy = noProxy
+  return env
+}
+
+export function redactProxyUrl(value: string): string {
+  const parsed = normalizeProxyUrl(value)
+  if (!parsed.ok || !parsed.value) {
+    return parsed.value
+  }
+  const url = new URL(parsed.value)
+  if (url.username || url.password) {
+    url.username = '***'
+    url.password = url.password ? '***' : ''
+  }
+  return formatProxyUrl(url)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1987,6 +1987,11 @@ export type GlobalSettings = {
    *  usable without the setup output crowding the initial pane. */
   setupScriptLaunchMode: SetupScriptLaunchMode
   terminalScrollbackBytes: number
+  /** Optional app-level proxy for Electron networking and locally spawned PTYs.
+   *  Empty preserves system proxy settings plus inherited proxy env behavior. */
+  httpProxyUrl?: string
+  /** Optional semicolon/comma/newline-separated bypass rules for httpProxyUrl. */
+  httpProxyBypassRules?: string
   /** Why: opening arbitrary links inside Orca uses an isolated guest browser surface.
    *  The setting stays opt-in so existing workflows continue to use the system browser
    *  until the user explicitly wants worktree-scoped in-app browsing. */


### PR DESCRIPTION
## Summary
- Adds explicit Settings > General > Network fields for an HTTP proxy URL and bypass rules.
- Applies the sanitized proxy at Electron startup and on settings updates, preserving system/env behavior when the setting is empty.
- Injects explicit proxy env vars only into local PTY children so bundled CLIs can use the configured proxy without implying SSH remote configuration.

Fixes #1378

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/network-proxy.test.ts src/main/network/proxy-settings.test.ts src/main/ipc/settings.test.ts src/main/ipc/pty.test.ts src/main/rate-limits/claude-fetcher.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `git merge-tree --write-tree HEAD origin/main`

## Evidence
- Verified the dev app identity for this worktree via Playwright CDP.
- Captured Settings > General > Network UI with the proxy URL and bypass fields at `/tmp/orca-issue-1378-proxy-settings.png` (not committed).

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.