### PR TITLE
Reset mobile modal drafts before opening paint

### DIFF
--- a/mobile/src/components/CustomKeyModal.tsx
+++ b/mobile/src/components/CustomKeyModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { View, Text, Pressable, TextInput, StyleSheet, Switch } from 'react-native'
 import { ChevronLeft } from 'lucide-react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -83,8 +83,12 @@ export function CustomKeyModal({ visible, onClose, onKeysChanged }: Props) {
   const [macroLabel, setMacroLabel] = useState('')
   const [macroText, setMacroText] = useState('')
   const [macroEnter, setMacroEnter] = useState(true)
+  const [previousVisible, setPreviousVisible] = useState(visible)
 
-  useEffect(() => {
+  // Why: reset before the opening commit so the drawer does not flash the last
+  // custom-key draft; keep close state unchanged for the slide-out animation.
+  if (visible !== previousVisible) {
+    setPreviousVisible(visible)
     if (visible) {
       setStep('choose-type')
       setShortcutKey('c')
@@ -93,7 +97,7 @@ export function CustomKeyModal({ visible, onClose, onKeysChanged }: Props) {
       setMacroText('')
       setMacroEnter(true)
     }
-  }, [visible])
+  }
 
   const addKey = useCallback(
     async (key: Omit<CustomKey, 'id'>) => {

--- a/mobile/src/components/TextInputModal.tsx
+++ b/mobile/src/components/TextInputModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import {
   View,
   Text,
@@ -39,10 +39,19 @@ export function TextInputModal({
   onCancel
 }: Props) {
   const [value, setValue] = useState(defaultValue)
+  const [previousVisible, setPreviousVisible] = useState(visible)
+  const [previousDefaultValue, setPreviousDefaultValue] = useState(defaultValue)
 
-  useEffect(() => {
-    if (visible) setValue(defaultValue)
-  }, [visible, defaultValue])
+  // Why: reset before the opening commit so the drawer never paints the
+  // previous modal value while preserving the existing close animation state.
+  const shouldResetValue = visible && (!previousVisible || defaultValue !== previousDefaultValue)
+  if (visible !== previousVisible || shouldResetValue) {
+    setPreviousVisible(visible)
+    if (shouldResetValue) {
+      setPreviousDefaultValue(defaultValue)
+      setValue(defaultValue)
+    }
+  }
 
   function handleSubmit() {
     const trimmed = value.trim()


### PR DESCRIPTION
## Summary
- move TextInputModal default-value reset out of useEffect and into the local render-time reset path
- move CustomKeyModal open reset out of useEffect while preserving the existing slide-out close state
- remove two passive Effect passes from mobile modal open flows

## Risk
Risk: Low

This only changes local React Native modal draft state seeding. It does not touch RPC, terminal byte generation, persistence, SSH, provider calls, or platform-specific behavior. The close animation keeps the previous draft state exactly as before; opening now resets before the first committed paint instead of after it.

## Validation
- pnpm exec oxlint mobile/src/components/TextInputModal.tsx mobile/src/components/CustomKeyModal.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count: 923 -> 921

## Validation gap
- pnpm --dir mobile exec tsc --noEmit -p tsconfig.json is not usable in this checkout: mobile-local dependencies/config are unresolved before checking this change (for example missing expo/tsconfig.base, react-native, expo-router).