### PR TITLE
Resolve mobile browser address sync before commit

### DIFF
--- a/mobile/src/browser/MobileBrowserPane.tsx
+++ b/mobile/src/browser/MobileBrowserPane.tsx
@@ -39,6 +39,7 @@ import {
   type BrowserZoomState
 } from './browser-touch-geometry'
 import { displayBrowserUrl, normalizeBrowserUrl } from './browser-url'
+import { resolveMobileBrowserAddressSync } from './mobile-browser-address-sync'
 
 export type MobileBrowserTab = {
   type: 'browser'
@@ -127,6 +128,10 @@ export function MobileBrowserPane({
   const cachedInitialFrame = peekCachedBrowserFrame(cacheKey)
   const [addressValue, setAddressValue] = useState(displayBrowserUrl(tab.url))
   const [addressFocused, setAddressFocused] = useState(false)
+  const [addressSyncState, setAddressSyncState] = useState({
+    focused: false,
+    url: tab.url
+  })
   const [keyboardValue, setKeyboardValue] = useState('')
   const [frameUri, setFrameUri] = useState<string | null>(cachedInitialFrame?.uri ?? null)
   const [frameMetadata, setFrameMetadata] = useState<BrowserScreencastFrameMetadata | null>(
@@ -203,11 +208,18 @@ export function MobileBrowserPane({
     }
   }, [worktreeId])
 
-  useEffect(() => {
-    if (!addressFocused) {
+  const addressSync = resolveMobileBrowserAddressSync(addressSyncState, {
+    focused: addressFocused,
+    url: tab.url
+  })
+  if (addressSync.nextState !== addressSyncState) {
+    setAddressSyncState(addressSync.nextState)
+    if (addressSync.shouldSyncValue) {
+      // Why: keep browser stream/goto address updates intact, but avoid a
+      // stale post-blur paint when the tab URL is the source of truth.
       setAddressValue(displayBrowserUrl(tab.url))
     }
-  }, [addressFocused, tab.url])
+  }
 
   useEffect(() => {
     frameMetadataRef.current = frameMetadata

--- a/mobile/src/browser/mobile-browser-address-sync.test.ts
+++ b/mobile/src/browser/mobile-browser-address-sync.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveMobileBrowserAddressSync } from './mobile-browser-address-sync'
+
+describe('resolveMobileBrowserAddressSync', () => {
+  it('syncs the tab URL when the input is not focused', () => {
+    const result = resolveMobileBrowserAddressSync(
+      { focused: false, url: 'https://old.example/' },
+      { focused: false, url: 'https://new.example/' }
+    )
+
+    expect(result).toEqual({
+      nextState: { focused: false, url: 'https://new.example/' },
+      shouldSyncValue: true
+    })
+  })
+
+  it('defers tab URL sync while the user is editing', () => {
+    const result = resolveMobileBrowserAddressSync(
+      { focused: false, url: 'https://old.example/' },
+      { focused: true, url: 'https://new.example/' }
+    )
+
+    expect(result).toEqual({
+      nextState: { focused: true, url: 'https://new.example/' },
+      shouldSyncValue: false
+    })
+  })
+
+  it('syncs the latest tab URL when editing ends', () => {
+    const result = resolveMobileBrowserAddressSync(
+      { focused: true, url: 'https://new.example/' },
+      { focused: false, url: 'https://new.example/' }
+    )
+
+    expect(result).toEqual({
+      nextState: { focused: false, url: 'https://new.example/' },
+      shouldSyncValue: true
+    })
+  })
+
+  it('preserves externally updated address text when focus and tab URL are unchanged', () => {
+    const previous = { focused: false, url: 'https://new.example/' }
+    const result = resolveMobileBrowserAddressSync(previous, {
+      focused: false,
+      url: 'https://new.example/'
+    })
+
+    expect(result).toEqual({
+      nextState: previous,
+      shouldSyncValue: false
+    })
+  })
+})

--- a/mobile/src/browser/mobile-browser-address-sync.ts
+++ b/mobile/src/browser/mobile-browser-address-sync.ts
@@ -1,0 +1,20 @@
+export type MobileBrowserAddressSyncState = {
+  focused: boolean
+  url: string
+}
+
+export type MobileBrowserAddressSyncResult = {
+  nextState: MobileBrowserAddressSyncState
+  shouldSyncValue: boolean
+}
+
+export function resolveMobileBrowserAddressSync(
+  previous: MobileBrowserAddressSyncState,
+  next: MobileBrowserAddressSyncState
+): MobileBrowserAddressSyncResult {
+  const changed = previous.focused !== next.focused || previous.url !== next.url
+  return {
+    nextState: changed ? next : previous,
+    shouldSyncValue: changed && !next.focused
+  }
+}


### PR DESCRIPTION
## Summary
- move MobileBrowserPane tab-URL address sync out of a passive Effect
- preserve immediate browser stream/goto address updates when focus and tab URL are unchanged
- add a pure address-sync helper with focused state-transition coverage

## Risk
Risk: Medium

This touches mobile browser address-bar state in a remote browser surface. It does not change RPC requests, streaming, touch handling, or URL normalization, but it affects when the visible address field reconciles after tab URL/focus changes.

## Validation
- `pnpm exec oxlint mobile/src/browser/MobileBrowserPane.tsx mobile/src/browser/mobile-browser-address-sync.ts mobile/src/browser/mobile-browser-address-sync.test.ts`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- `pnpm exec tsx -e "import { strict as assert } from 'node:assert'; import { resolveMobileBrowserAddressSync } from './mobile/src/browser/mobile-browser-address-sync.ts'; assert.deepEqual(resolveMobileBrowserAddressSync({ focused: false, url: 'https://old.example/' }, { focused: false, url: 'https://new.example/' }), { nextState: { focused: false, url: 'https://new.example/' }, shouldSyncValue: true }); assert.deepEqual(resolveMobileBrowserAddressSync({ focused: false, url: 'https://old.example/' }, { focused: true, url: 'https://new.example/' }), { nextState: { focused: true, url: 'https://new.example/' }, shouldSyncValue: false }); assert.deepEqual(resolveMobileBrowserAddressSync({ focused: true, url: 'https://new.example/' }, { focused: false, url: 'https://new.example/' }), { nextState: { focused: false, url: 'https://new.example/' }, shouldSyncValue: true }); const previous = { focused: false, url: 'https://new.example/' }; assert.deepEqual(resolveMobileBrowserAddressSync(previous, { focused: false, url: 'https://new.example/' }), { nextState: previous, shouldSyncValue: false }); console.log('mobile-browser-address-sync ok')"`
- AST Effect count: 921 -> 920

## Validation gap
- `pnpm exec vitest run --root mobile src/browser/mobile-browser-address-sync.test.ts` is blocked in this checkout because `mobile/tsconfig.json` extends missing `expo/tsconfig.base`.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.