### PR TITLE
Add Markdown document templates

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -51,6 +51,7 @@ import { onOnboardingReopened } from './components/onboarding/show-onboarding-ev
 import { shouldShowOnboarding } from './components/onboarding/should-show-onboarding'
 import { SshPassphraseDialog } from './components/settings/SshPassphraseDialog'
 import DeleteWorktreeDialog from './components/sidebar/DeleteWorktreeDialog'
+import { MarkdownTemplatePicker } from './components/editor/MarkdownTemplatePicker'
 import {
   FloatingTerminalPanel,
   FloatingTerminalToggleButton
@@ -1982,6 +1983,14 @@ function App(): React.JSX.Element {
             compact
           >
             <DeleteWorktreeDialog />
+          </RecoverableRenderErrorBoundary>
+          <RecoverableRenderErrorBoundary
+            boundaryId="modal.markdown-template-picker"
+            surface="modal"
+            resetKey={activeModal}
+            compact
+          >
+            <MarkdownTemplatePicker />
           </RecoverableRenderErrorBoundary>
           <RecoverableRenderErrorBoundary
             boundaryId="modal.crash-report"

--- a/src/renderer/src/components/editor/MarkdownTemplatePicker.tsx
+++ b/src/renderer/src/components/editor/MarkdownTemplatePicker.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from 'react'
+import { FileText } from 'lucide-react'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import type {
+  MarkdownTemplatePickerRequest,
+  MarkdownTemplateSelection
+} from '@/lib/markdown-template-picker-request'
+import { subscribeMarkdownTemplatePicker } from '@/lib/markdown-template-picker-request'
+
+export function MarkdownTemplatePicker(): JSX.Element {
+  const [activeRequest, setActiveRequest] = useState<MarkdownTemplatePickerRequest | null>(null)
+  const activeRequestRef = useRef<MarkdownTemplatePickerRequest | null>(null)
+
+  useEffect(() => {
+    activeRequestRef.current = activeRequest
+  }, [activeRequest])
+
+  const resolveRequest = useCallback((selection: MarkdownTemplateSelection): void => {
+    const request = activeRequestRef.current
+    if (!request) {
+      return
+    }
+
+    activeRequestRef.current = null
+    request.resolve(selection)
+    setActiveRequest(null)
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = subscribeMarkdownTemplatePicker((request) => {
+      activeRequestRef.current?.resolve({ type: 'cancel' })
+      activeRequestRef.current = request
+      setActiveRequest(request)
+    })
+
+    return () => {
+      activeRequestRef.current?.resolve({ type: 'cancel' })
+      activeRequestRef.current = null
+      unsubscribe()
+    }
+  }, [])
+
+  return (
+    <CommandDialog
+      open={activeRequest !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          resolveRequest({ type: 'cancel' })
+        }
+      }}
+      title="New Markdown"
+      description="Choose a Markdown template."
+      contentClassName="w-[520px]"
+    >
+      <CommandInput placeholder="Search templates..." />
+      <CommandList>
+        <CommandEmpty>No matching templates.</CommandEmpty>
+        <CommandGroup heading="New Document">
+          <CommandItem
+            value="blank markdown document"
+            className="items-start gap-3"
+            onSelect={() => resolveRequest({ type: 'blank' })}
+          >
+            <FileText className="mt-0.5 size-4 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium">Blank Markdown</span>
+              <span className="block truncate text-xs text-muted-foreground">untitled.md</span>
+            </span>
+          </CommandItem>
+        </CommandGroup>
+        {activeRequest && (
+          <CommandGroup heading="Templates">
+            {activeRequest.templates.map((template) => (
+              <CommandItem
+                key={template.id}
+                value={`${template.name} ${template.templateRelativePath}`}
+                className="items-start gap-3"
+                onSelect={() => resolveRequest({ type: 'template', template })}
+              >
+                <FileText className="mt-0.5 size-4 text-muted-foreground" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">{template.name}</span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {template.templateRelativePath}
+                  </span>
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { BrowserTab, Tab, TabGroup, TerminalTab } from '../../../../shared/types'
 import type { OpenFile } from '@/store/slices/editor'
-import { createUntitledMarkdownFile } from '@/lib/create-untitled-markdown'
+import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
 import {
   FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
   clampFloatingTerminalBounds,
@@ -252,7 +252,7 @@ vi.mock('@/lib/connection-context', () => ({
 }))
 
 vi.mock('@/lib/create-untitled-markdown', () => ({
-  createUntitledMarkdownFile: vi.fn()
+  createUntitledMarkdownFileWithTemplateSelection: vi.fn()
 }))
 
 vi.mock('@/lib/ipc-error', () => ({
@@ -1146,7 +1146,7 @@ describe('FloatingTerminalPanel close behavior', () => {
 
   it('creates floating markdown files in local filesystem mode', async () => {
     setFloatingTabs([makeTab({ id: 'tab-1' })])
-    vi.mocked(createUntitledMarkdownFile).mockResolvedValue({
+    vi.mocked(createUntitledMarkdownFileWithTemplateSelection).mockResolvedValue({
       filePath: '/tmp/orca/floating-notes/untitled.md',
       relativePath: 'untitled.md',
       worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
@@ -1163,7 +1163,7 @@ describe('FloatingTerminalPanel close behavior', () => {
     ;(tabBar.props.onNewFileTab as () => void)()
     await flushAsyncWork()
 
-    expect(createUntitledMarkdownFile).toHaveBeenCalledWith(
+    expect(createUntitledMarkdownFileWithTemplateSelection).toHaveBeenCalledWith(
       '/tmp/orca/floating-notes',
       FLOATING_TERMINAL_WORKTREE_ID,
       undefined,

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -33,7 +33,7 @@ import {
 import { useTerminalSaveDialog } from '@/components/terminal/useTerminalSaveDialog'
 import { appendUniqueOpenFileIds } from '@/components/terminal/unsaved-close-queue'
 import { getConnectionId } from '@/lib/connection-context'
-import { createUntitledMarkdownFile } from '@/lib/create-untitled-markdown'
+import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
 import { detectLanguage } from '@/lib/language-detect'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
@@ -645,12 +645,15 @@ export function FloatingTerminalPanel({
     }
     void (async () => {
       try {
-        const fileInfo = await createUntitledMarkdownFile(
+        const fileInfo = await createUntitledMarkdownFileWithTemplateSelection(
           markdownCwd,
           FLOATING_TERMINAL_WORKTREE_ID,
           getConnectionId(FLOATING_TERMINAL_WORKTREE_ID) ?? undefined,
           LOCAL_RUNTIME_SETTINGS
         )
+        if (!fileInfo) {
+          return
+        }
         openFile(fileInfo, {
           preview: false,
           targetGroupId: activeGroup?.id,

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -77,7 +77,7 @@ vi.mock('../../store/slices/browser-webview-cleanup', () => ({
 }))
 
 vi.mock('../../lib/create-untitled-markdown', () => ({
-  createUntitledMarkdownFile: vi.fn()
+  createUntitledMarkdownFileWithTemplateSelection: vi.fn()
 }))
 
 vi.mock('../../lib/ipc-error', () => ({

--- a/src/renderer/src/lib/create-untitled-markdown.test.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.test.ts
@@ -128,7 +128,8 @@ describe('createUntitledMarkdownFile', () => {
       })
     ).resolves.toMatchObject({
       filePath: '/repo/untitled.md',
-      relativePath: 'untitled.md'
+      relativePath: 'untitled.md',
+      deleteUntouchedOnClose: false
     })
 
     expect(readFile).toHaveBeenCalledWith(
@@ -177,7 +178,8 @@ describe('createUntitledMarkdownFile', () => {
         createUntitledMarkdownFileWithTemplateSelection('/repo', 'wt-1')
       ).resolves.toMatchObject({
         filePath: '/repo/untitled.md',
-        relativePath: 'untitled.md'
+        relativePath: 'untitled.md',
+        deleteUntouchedOnClose: false
       })
     } finally {
       unsubscribe()

--- a/src/renderer/src/lib/create-untitled-markdown.test.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createUntitledMarkdownFile } from './create-untitled-markdown'
+import {
+  createUntitledMarkdownFile,
+  createUntitledMarkdownFileWithTemplateSelection
+} from './create-untitled-markdown'
+import { subscribeMarkdownTemplatePicker } from './markdown-template-picker-request'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
@@ -92,6 +96,99 @@ describe('createUntitledMarkdownFile', () => {
       filePath: '/repo/untitled.md',
       connectionId: 'conn-1'
     })
+  })
+
+  it('writes selected template content with placeholders after creating the untitled file', async () => {
+    const stat = vi.fn().mockRejectedValue(new Error('ENOENT: no such file'))
+    const createFile = vi.fn().mockResolvedValueOnce(undefined)
+    const readFile = vi.fn().mockResolvedValueOnce({
+      content: '# {{ title }}\n{{date}}\n{{filename}}\n',
+      isBinary: false
+    })
+    const writeFile = vi.fn().mockResolvedValueOnce(undefined)
+
+    vi.stubGlobal('window', {
+      api: {
+        shell: { pathExists: vi.fn() },
+        fs: { createFile, readFile, stat, writeFile }
+      }
+    })
+
+    await expect(
+      createUntitledMarkdownFile('/repo', 'wt-1', undefined, undefined, {
+        now: new Date(2026, 4, 29, 7, 5),
+        template: {
+          id: '.orca/templates/daily.md',
+          name: 'Daily',
+          filePath: '/repo/.orca/templates/daily.md',
+          relativePath: '.orca/templates/daily.md',
+          templateRelativePath: 'daily.md',
+          basename: 'daily.md'
+        }
+      })
+    ).resolves.toMatchObject({
+      filePath: '/repo/untitled.md',
+      relativePath: 'untitled.md'
+    })
+
+    expect(readFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/repo/.orca/templates/daily.md' })
+    )
+    expect(createFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/repo/untitled.md' })
+    )
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/repo/untitled.md',
+        content: '# Untitled\n2026-05-29\nuntitled.md\n'
+      })
+    )
+  })
+
+  it('discovers templates before creating a new markdown file and applies the selected template', async () => {
+    const readDir = vi.fn().mockResolvedValueOnce([
+      { name: 'daily.md', isDirectory: false, isSymlink: false },
+      { name: 'draft.txt', isDirectory: false, isSymlink: false }
+    ])
+    const stat = vi.fn().mockRejectedValue(new Error('ENOENT: no such file'))
+    const createFile = vi.fn().mockResolvedValueOnce(undefined)
+    const readFile = vi.fn().mockResolvedValueOnce({
+      content: '# {{title}}\n',
+      isBinary: false
+    })
+    const writeFile = vi.fn().mockResolvedValueOnce(undefined)
+    const unsubscribe = subscribeMarkdownTemplatePicker((request) => {
+      const template = request.templates[0]
+      if (!template) {
+        throw new Error('Expected a discovered template')
+      }
+      request.resolve({ type: 'template', template })
+    })
+
+    vi.stubGlobal('window', {
+      api: {
+        shell: { pathExists: vi.fn() },
+        fs: { createFile, readDir, readFile, stat, writeFile }
+      }
+    })
+
+    try {
+      await expect(
+        createUntitledMarkdownFileWithTemplateSelection('/repo', 'wt-1')
+      ).resolves.toMatchObject({
+        filePath: '/repo/untitled.md',
+        relativePath: 'untitled.md'
+      })
+    } finally {
+      unsubscribe()
+    }
+
+    expect(readDir).toHaveBeenCalledWith(
+      expect.objectContaining({ dirPath: '/repo/.orca/templates' })
+    )
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/repo/untitled.md', content: '# Untitled\n' })
+    )
   })
 
   it('creates untitled files through the selected runtime environment', async () => {

--- a/src/renderer/src/lib/create-untitled-markdown.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.ts
@@ -22,6 +22,7 @@ export type UntitledMarkdownFileInfo = {
   worktreeId: string
   language: string
   isUntitled: true
+  deleteUntouchedOnClose?: boolean
   mode: 'edit'
 }
 
@@ -93,6 +94,7 @@ export async function createUntitledMarkdownFile(
         worktreeId,
         language: detectLanguage(fileName),
         isUntitled: true,
+        deleteUntouchedOnClose: templateContent === null ? undefined : false,
         mode: 'edit'
       }
     } catch (err) {

--- a/src/renderer/src/lib/create-untitled-markdown.ts
+++ b/src/renderer/src/lib/create-untitled-markdown.ts
@@ -1,7 +1,34 @@
 import type { GlobalSettings } from '../../../shared/types'
-import { createRuntimePath, runtimePathExists } from '../runtime/runtime-file-client'
+import {
+  createRuntimePath,
+  deleteRuntimePath,
+  runtimePathExists,
+  writeRuntimeFile
+} from '../runtime/runtime-file-client'
 import { detectLanguage } from './language-detect'
+import {
+  applyMarkdownTemplatePlaceholders,
+  getMarkdownTemplateTitleForFileName,
+  listMarkdownDocumentTemplates,
+  readMarkdownDocumentTemplateContent,
+  type MarkdownDocumentTemplate
+} from './markdown-document-templates'
+import { requestMarkdownTemplateSelection } from './markdown-template-picker-request'
 import { joinPath } from './path'
+
+export type UntitledMarkdownFileInfo = {
+  filePath: string
+  relativePath: string
+  worktreeId: string
+  language: string
+  isUntitled: true
+  mode: 'edit'
+}
+
+type CreateUntitledMarkdownOptions = {
+  template?: MarkdownDocumentTemplate
+  now?: Date
+}
 
 /**
  * Creates an untitled markdown file on disk and returns the metadata
@@ -14,18 +41,16 @@ export async function createUntitledMarkdownFile(
   worktreePath: string,
   worktreeId: string,
   connectionId?: string,
-  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
-): Promise<{
-  filePath: string
-  relativePath: string
-  worktreeId: string
-  language: string
-  isUntitled: true
-  mode: 'edit'
-}> {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null,
+  options: CreateUntitledMarkdownOptions = {}
+): Promise<UntitledMarkdownFileInfo> {
   const baseName = 'untitled'
   const ext = '.md'
   const MAX_ATTEMPTS = 100
+  const context = { settings, worktreeId, worktreePath, connectionId }
+  const templateContent = options.template
+    ? await readMarkdownDocumentTemplateContent(context, options.template)
+    : null
 
   // Why: createFile uses the 'wx' flag, so pathExists is only a hint. Another
   // create can still win the race after our last probe, especially when the
@@ -38,7 +63,6 @@ export async function createUntitledMarkdownFile(
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     const fileName = attempt === 1 ? `${baseName}${ext}` : `${baseName}-${attempt}${ext}`
     const filePath = joinPath(worktreePath, fileName)
-    const context = { settings, worktreeId, worktreePath, connectionId }
 
     if (await runtimePathExists(context, filePath)) {
       continue
@@ -46,6 +70,22 @@ export async function createUntitledMarkdownFile(
 
     try {
       await createRuntimePath(context, filePath, 'file')
+      if (templateContent !== null) {
+        try {
+          await writeRuntimeFile(
+            context,
+            filePath,
+            applyMarkdownTemplatePlaceholders(templateContent, {
+              title: getMarkdownTemplateTitleForFileName(fileName),
+              filename: fileName,
+              now: options.now
+            })
+          )
+        } catch (error) {
+          await deleteRuntimePath(context, filePath).catch(() => undefined)
+          throw error
+        }
+      }
 
       return {
         filePath,
@@ -66,4 +106,23 @@ export async function createUntitledMarkdownFile(
   }
 
   throw new Error(`Unable to create untitled markdown file after ${MAX_ATTEMPTS} attempts.`)
+}
+
+export async function createUntitledMarkdownFileWithTemplateSelection(
+  worktreePath: string,
+  worktreeId: string,
+  connectionId?: string,
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+): Promise<UntitledMarkdownFileInfo | null> {
+  const context = { settings, worktreeId, worktreePath, connectionId }
+  const templates = await listMarkdownDocumentTemplates(context, worktreePath)
+  const selection = await requestMarkdownTemplateSelection(templates)
+
+  if (selection.type === 'cancel') {
+    return null
+  }
+
+  return createUntitledMarkdownFile(worktreePath, worktreeId, connectionId, settings, {
+    template: selection.type === 'template' ? selection.template : undefined
+  })
 }

--- a/src/renderer/src/lib/floating-workspace-tab-creation.ts
+++ b/src/renderer/src/lib/floating-workspace-tab-creation.ts
@@ -1,6 +1,6 @@
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { BrowserTab, TerminalTab } from '../../../shared/types'
-import { createUntitledMarkdownFile } from './create-untitled-markdown'
+import { createUntitledMarkdownFileWithTemplateSelection } from './create-untitled-markdown'
 import { getConnectionId } from './connection-context'
 import { detectLanguage } from './language-detect'
 import type { AppState } from '@/store/types'
@@ -84,12 +84,15 @@ export async function createFloatingWorkspaceMarkdownTab(
   if (!floatingMarkdownDirectory) {
     return
   }
-  const fileInfo = await createUntitledMarkdownFile(
+  const fileInfo = await createUntitledMarkdownFileWithTemplateSelection(
     floatingMarkdownDirectory,
     FLOATING_TERMINAL_WORKTREE_ID,
     getConnectionId(FLOATING_TERMINAL_WORKTREE_ID) ?? undefined,
     { activeRuntimeEnvironmentId: null }
   )
+  if (!fileInfo) {
+    return
+  }
   store.openFile(
     {
       ...fileInfo,

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -21,7 +21,7 @@ import {
 const activateWebRuntimeSessionTabMock = vi.hoisted(() => vi.fn())
 const createWebRuntimeSessionBrowserTabMock = vi.hoisted(() => vi.fn())
 const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
-const createUntitledMarkdownFileMock = vi.hoisted(() => vi.fn())
+const createUntitledMarkdownFileWithTemplateSelectionMock = vi.hoisted(() => vi.fn())
 const focusTerminalTabSurfaceMock = vi.hoisted(() => vi.fn())
 const isWebRuntimeSessionActiveMock = vi.hoisted(() => vi.fn())
 
@@ -33,7 +33,8 @@ vi.mock('@/runtime/web-runtime-session', () => ({
 }))
 
 vi.mock('./create-untitled-markdown', () => ({
-  createUntitledMarkdownFile: createUntitledMarkdownFileMock
+  createUntitledMarkdownFileWithTemplateSelection:
+    createUntitledMarkdownFileWithTemplateSelectionMock
 }))
 
 vi.mock('./connection-context', () => ({
@@ -423,7 +424,7 @@ describe('createFloatingWorkspaceBrowserTab', () => {
 
 describe('createFloatingWorkspaceMarkdownTab', () => {
   beforeEach(() => {
-    createUntitledMarkdownFileMock.mockReset()
+    createUntitledMarkdownFileWithTemplateSelectionMock.mockReset()
   })
 
   it('creates floating markdown tabs without activating the main workspace', async () => {
@@ -439,11 +440,11 @@ describe('createFloatingWorkspaceMarkdownTab', () => {
       activeGroupIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: 'floating-group' },
       openFile: vi.fn()
     }
-    createUntitledMarkdownFileMock.mockResolvedValue(fileInfo)
+    createUntitledMarkdownFileWithTemplateSelectionMock.mockResolvedValue(fileInfo)
 
     await createFloatingWorkspaceMarkdownTab(store as never, '/tmp/orca/floating-workspace')
 
-    expect(createUntitledMarkdownFileMock).toHaveBeenCalledWith(
+    expect(createUntitledMarkdownFileWithTemplateSelectionMock).toHaveBeenCalledWith(
       '/tmp/orca/floating-workspace',
       FLOATING_TERMINAL_WORKTREE_ID,
       undefined,
@@ -454,6 +455,24 @@ describe('createFloatingWorkspaceMarkdownTab', () => {
       targetGroupId: 'floating-group',
       suppressActiveRuntimeFallback: true
     })
+  })
+
+  it('does not open a floating markdown tab when template selection is cancelled', async () => {
+    const store = {
+      activeGroupIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: 'floating-group' },
+      openFile: vi.fn()
+    }
+    createUntitledMarkdownFileWithTemplateSelectionMock.mockResolvedValue(null)
+
+    await createFloatingWorkspaceMarkdownTab(store as never, '/tmp/orca/floating-workspace')
+
+    expect(createUntitledMarkdownFileWithTemplateSelectionMock).toHaveBeenCalledWith(
+      '/tmp/orca/floating-workspace',
+      FLOATING_TERMINAL_WORKTREE_ID,
+      undefined,
+      { activeRuntimeEnvironmentId: null }
+    )
+    expect(store.openFile).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/lib/markdown-document-templates.test.ts
+++ b/src/renderer/src/lib/markdown-document-templates.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DirEntry } from '../../../shared/types'
+import {
+  applyMarkdownTemplatePlaceholders,
+  listMarkdownDocumentTemplates
+} from './markdown-document-templates'
+
+function entry(name: string, isDirectory = false, isSymlink = false): DirEntry {
+  return { name, isDirectory, isSymlink }
+}
+
+function stubReadDir(entriesByPath: Record<string, DirEntry[]>): ReturnType<typeof vi.fn> {
+  const readDir = vi.fn(async ({ dirPath }: { dirPath: string }) => {
+    const entries = entriesByPath[dirPath]
+    if (!entries) {
+      throw new Error(`ENOENT: no such file or directory, scandir '${dirPath}'`)
+    }
+    return entries
+  })
+
+  vi.stubGlobal('window', {
+    api: {
+      fs: { readDir }
+    }
+  })
+
+  return readDir
+}
+
+describe('markdown document templates', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('substitutes deterministic placeholders and leaves unknown placeholders intact', () => {
+    const content = [
+      '# {{ title }}',
+      'Date: {{date}}',
+      'Time: {{ time }}',
+      'Date/time: {{datetime}}',
+      'File: {{filename}}',
+      'Unknown: {{owner}}'
+    ].join('\n')
+
+    expect(
+      applyMarkdownTemplatePlaceholders(content, {
+        title: 'Daily Note',
+        filename: 'daily-note.md',
+        now: new Date(2026, 4, 29, 7, 5)
+      })
+    ).toBe(
+      [
+        '# Daily Note',
+        'Date: 2026-05-29',
+        'Time: 07:05',
+        'Date/time: 2026-05-29 07:05',
+        'File: daily-note.md',
+        'Unknown: {{owner}}'
+      ].join('\n')
+    )
+  })
+
+  it('discovers markdown files under .orca/templates and skips unsafe entries', async () => {
+    const readDir = stubReadDir({
+      '/repo/.orca/templates': [
+        entry('daily-note.md'),
+        entry('scratch.txt'),
+        entry('linked.md', false, true),
+        entry('nested', true),
+        entry('node_modules', true)
+      ],
+      '/repo/.orca/templates/nested': [entry('meeting.markdown'), entry('brief.mdx')]
+    })
+
+    await expect(
+      listMarkdownDocumentTemplates(
+        {
+          settings: null,
+          worktreeId: 'wt-1',
+          worktreePath: '/repo',
+          connectionId: 'conn-1'
+        },
+        '/repo'
+      )
+    ).resolves.toEqual([
+      {
+        id: '.orca/templates/nested/brief.mdx',
+        name: 'Brief',
+        filePath: '/repo/.orca/templates/nested/brief.mdx',
+        relativePath: '.orca/templates/nested/brief.mdx',
+        templateRelativePath: 'nested/brief.mdx',
+        basename: 'brief.mdx'
+      },
+      {
+        id: '.orca/templates/daily-note.md',
+        name: 'Daily note',
+        filePath: '/repo/.orca/templates/daily-note.md',
+        relativePath: '.orca/templates/daily-note.md',
+        templateRelativePath: 'daily-note.md',
+        basename: 'daily-note.md'
+      },
+      {
+        id: '.orca/templates/nested/meeting.markdown',
+        name: 'Meeting',
+        filePath: '/repo/.orca/templates/nested/meeting.markdown',
+        relativePath: '.orca/templates/nested/meeting.markdown',
+        templateRelativePath: 'nested/meeting.markdown',
+        basename: 'meeting.markdown'
+      }
+    ])
+
+    expect(readDir).toHaveBeenCalledWith({
+      dirPath: '/repo/.orca/templates',
+      connectionId: 'conn-1'
+    })
+  })
+
+  it('returns an empty list when the template directory is missing', async () => {
+    stubReadDir({})
+
+    await expect(
+      listMarkdownDocumentTemplates(
+        { settings: null, worktreeId: 'wt-1', worktreePath: '/repo' },
+        '/repo'
+      )
+    ).resolves.toEqual([])
+  })
+
+  it('keeps Windows file paths native while exposing root-relative template paths', async () => {
+    stubReadDir({
+      'C:\\repo\\.orca\\templates': [entry('daily.md')]
+    })
+
+    await expect(
+      listMarkdownDocumentTemplates(
+        { settings: null, worktreeId: 'wt-1', worktreePath: 'C:\\repo' },
+        'C:\\repo'
+      )
+    ).resolves.toEqual([
+      {
+        id: '.orca/templates/daily.md',
+        name: 'Daily',
+        filePath: 'C:\\repo\\.orca\\templates\\daily.md',
+        relativePath: '.orca/templates/daily.md',
+        templateRelativePath: 'daily.md',
+        basename: 'daily.md'
+      }
+    ])
+  })
+})

--- a/src/renderer/src/lib/markdown-document-templates.ts
+++ b/src/renderer/src/lib/markdown-document-templates.ts
@@ -1,0 +1,184 @@
+import type { DirEntry, GlobalSettings } from '../../../shared/types'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import { readRuntimeDirectory, readRuntimeFileContent } from '@/runtime/runtime-file-client'
+import { basename, joinPath, normalizeRelativePath } from './path'
+
+const MARKDOWN_TEMPLATE_ROOT = '.orca/templates'
+const MARKDOWN_TEMPLATE_MAX_DEPTH = 8
+const MARKDOWN_TEMPLATE_MAX_COUNT = 100
+
+export type MarkdownDocumentTemplate = {
+  id: string
+  name: string
+  filePath: string
+  relativePath: string
+  templateRelativePath: string
+  basename: string
+}
+
+export type MarkdownTemplatePlaceholderValues = {
+  title: string
+  filename: string
+  now?: Date
+}
+
+function isMarkdownTemplateName(name: string): boolean {
+  const lowerName = name.toLowerCase()
+  return lowerName.endsWith('.md') || lowerName.endsWith('.mdx') || lowerName.endsWith('.markdown')
+}
+
+function stripMarkdownExtension(name: string): string {
+  return name.replace(/\.(markdown|mdx|md)$/i, '')
+}
+
+function titleFromName(name: string): string {
+  const stem = stripMarkdownExtension(name).replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim()
+
+  if (!stem) {
+    return 'Untitled'
+  }
+
+  return stem.charAt(0).toUpperCase() + stem.slice(1)
+}
+
+function padDatePart(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+function formatDate(now: Date): string {
+  return `${now.getFullYear()}-${padDatePart(now.getMonth() + 1)}-${padDatePart(now.getDate())}`
+}
+
+function formatTime(now: Date): string {
+  return `${padDatePart(now.getHours())}:${padDatePart(now.getMinutes())}`
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return /ENOENT|not found|no such file/i.test(error.message)
+}
+
+function shouldSkipTemplateDirectory(entry: DirEntry): boolean {
+  return entry.isSymlink || entry.name === '.git' || entry.name === 'node_modules'
+}
+
+export function getMarkdownTemplateTitleForFileName(fileName: string): string {
+  return titleFromName(fileName)
+}
+
+export function applyMarkdownTemplatePlaceholders(
+  content: string,
+  values: MarkdownTemplatePlaceholderValues
+): string {
+  const now = values.now ?? new Date()
+  const date = formatDate(now)
+  const time = formatTime(now)
+  const replacements: Record<string, string> = {
+    title: values.title,
+    filename: values.filename,
+    date,
+    time,
+    datetime: `${date} ${time}`
+  }
+
+  return content.replace(/\{\{\s*([a-zA-Z][a-zA-Z0-9_-]*)\s*\}\}/g, (match, key: string) => {
+    return Object.prototype.hasOwnProperty.call(replacements, key) ? replacements[key] : match
+  })
+}
+
+export async function listMarkdownDocumentTemplates(
+  context: RuntimeFileOperationArgs,
+  worktreePath: string
+): Promise<MarkdownDocumentTemplate[]> {
+  const templates: MarkdownDocumentTemplate[] = []
+  const rootPath = joinPath(worktreePath, MARKDOWN_TEMPLATE_ROOT)
+
+  async function visitDirectory(
+    dirPath: string,
+    relativeDir: string,
+    depth: number
+  ): Promise<void> {
+    if (depth > MARKDOWN_TEMPLATE_MAX_DEPTH || templates.length >= MARKDOWN_TEMPLATE_MAX_COUNT) {
+      return
+    }
+
+    let entries: DirEntry[]
+    try {
+      entries = await readRuntimeDirectory(context, dirPath)
+    } catch (error) {
+      if (relativeDir === '' && isMissingPathError(error)) {
+        return
+      }
+      throw error
+    }
+
+    for (const entry of entries) {
+      if (templates.length >= MARKDOWN_TEMPLATE_MAX_COUNT) {
+        return
+      }
+
+      const entryRelativePath = normalizeRelativePath(
+        relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+      )
+      const entryPath = joinPath(rootPath, entryRelativePath)
+
+      if (entry.isDirectory) {
+        if (!shouldSkipTemplateDirectory(entry)) {
+          await visitDirectory(entryPath, entryRelativePath, depth + 1)
+        }
+        continue
+      }
+
+      if (entry.isSymlink || !isMarkdownTemplateName(entry.name)) {
+        continue
+      }
+
+      const templateRelativePath = entryRelativePath
+      const rootRelativePath = normalizeRelativePath(
+        `${MARKDOWN_TEMPLATE_ROOT}/${templateRelativePath}`
+      )
+      templates.push({
+        id: rootRelativePath,
+        name: titleFromName(entry.name),
+        filePath: joinPath(worktreePath, rootRelativePath),
+        relativePath: rootRelativePath,
+        templateRelativePath,
+        basename: basename(entry.name)
+      })
+    }
+  }
+
+  await visitDirectory(rootPath, '', 0)
+
+  return templates.sort((a, b) => {
+    const nameCompare = a.name.localeCompare(b.name)
+    return nameCompare === 0
+      ? a.templateRelativePath.localeCompare(b.templateRelativePath)
+      : nameCompare
+  })
+}
+
+export async function readMarkdownDocumentTemplateContent(
+  context: {
+    settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+    worktreeId: string
+    connectionId?: string
+  },
+  template: MarkdownDocumentTemplate
+): Promise<string> {
+  const result = await readRuntimeFileContent({
+    settings: context.settings,
+    filePath: template.filePath,
+    relativePath: template.relativePath,
+    worktreeId: context.worktreeId,
+    connectionId: context.connectionId
+  })
+
+  if (result.isBinary) {
+    throw new Error(`Markdown template "${template.templateRelativePath}" is not a text file.`)
+  }
+
+  return result.content
+}

--- a/src/renderer/src/lib/markdown-template-picker-request.ts
+++ b/src/renderer/src/lib/markdown-template-picker-request.ts
@@ -1,0 +1,56 @@
+import type { MarkdownDocumentTemplate } from './markdown-document-templates'
+
+export type MarkdownTemplateSelection =
+  | { type: 'blank' }
+  | { type: 'template'; template: MarkdownDocumentTemplate }
+  | { type: 'cancel' }
+
+export type MarkdownTemplatePickerRequest = {
+  id: string
+  templates: MarkdownDocumentTemplate[]
+  resolve: (selection: MarkdownTemplateSelection) => void
+}
+
+type MarkdownTemplatePickerListener = (request: MarkdownTemplatePickerRequest) => void
+
+let listener: MarkdownTemplatePickerListener | null = null
+let nextRequestId = 0
+
+function once<T extends unknown[]>(fn: (...args: T) => void): (...args: T) => void {
+  let called = false
+  return (...args: T) => {
+    if (called) {
+      return
+    }
+    called = true
+    fn(...args)
+  }
+}
+
+export function subscribeMarkdownTemplatePicker(
+  nextListener: MarkdownTemplatePickerListener
+): () => void {
+  listener = nextListener
+  return () => {
+    if (listener === nextListener) {
+      listener = null
+    }
+  }
+}
+
+export function requestMarkdownTemplateSelection(
+  templates: MarkdownDocumentTemplate[]
+): Promise<MarkdownTemplateSelection> {
+  if (templates.length === 0 || !listener) {
+    return Promise.resolve({ type: 'blank' })
+  }
+
+  return new Promise((resolve) => {
+    listener?.({
+      id: `markdown-template-${nextRequestId}`,
+      templates,
+      resolve: once(resolve)
+    })
+    nextRequestId += 1
+  })
+}

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -384,6 +384,7 @@ function buildRuntimeMobileOpenFilesProjection(openFiles: AppState['openFiles'])
       diffSource: file.diffSource,
       isDirty: file.isDirty,
       isUntitled: file.isUntitled,
+      deleteUntouchedOnClose: file.deleteUntouchedOnClose,
       markdownPreviewSourceFileId: file.markdownPreviewSourceFileId
     }))
   )

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1255,6 +1255,7 @@ function openFileEqual(a: OpenFile, b: OpenFile): boolean {
     a.markdownPreviewAnchor === b.markdownPreviewAnchor &&
     a.isPreview === b.isPreview &&
     a.isUntitled === b.isUntitled &&
+    a.deleteUntouchedOnClose === b.deleteUntouchedOnClose &&
     a.externalMutation === b.externalMutation &&
     a.mode === b.mode
   )

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -737,6 +737,54 @@ describe('createEditorSlice untitled cleanup routing', () => {
     })
     expect(localDeletePathMock).not.toHaveBeenCalled()
   })
+
+  it('closeFile keeps untouched templated untitled files on disk', async () => {
+    const store = createEditorStore()
+    seedRemoteWorktree(store)
+    store.getState().openFile({
+      filePath: '/remote/wt/untitled.md',
+      relativePath: 'untitled.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      isUntitled: true,
+      deleteUntouchedOnClose: false,
+      mode: 'edit'
+    })
+
+    store.getState().closeFile('/remote/wt/untitled.md')
+    await flushAsyncRemoteRefresh()
+
+    expect(runtimeEnvironmentCallMock).not.toHaveBeenCalled()
+    expect(localDeletePathMock).not.toHaveBeenCalled()
+    expect(store.getState().recentlyClosedEditorTabsByWorktree['wt-1']?.[0]).toMatchObject({
+      filePath: '/remote/wt/untitled.md',
+      deleteUntouchedOnClose: false
+    })
+  })
+
+  it('closeAllFiles keeps untouched templated untitled files on disk', async () => {
+    const store = createEditorStore()
+    seedRemoteWorktree(store)
+    store.getState().openFile({
+      filePath: '/remote/wt/untitled.md',
+      relativePath: 'untitled.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      isUntitled: true,
+      deleteUntouchedOnClose: false,
+      mode: 'edit'
+    })
+
+    store.getState().closeAllFiles()
+    await flushAsyncRemoteRefresh()
+
+    expect(runtimeEnvironmentCallMock).not.toHaveBeenCalled()
+    expect(localDeletePathMock).not.toHaveBeenCalled()
+    expect(store.getState().recentlyClosedEditorTabsByWorktree['wt-1']?.[0]).toMatchObject({
+      filePath: '/remote/wt/untitled.md',
+      deleteUntouchedOnClose: false
+    })
+  })
 })
 
 describe('createEditorSlice markdown view state', () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -173,6 +173,9 @@ export type OpenFile = {
   conflictReview?: ConflictReviewState
   isPreview?: boolean // preview tabs are replaced when another file is single-clicked
   isUntitled?: boolean // true for files created via "New Markdown" that haven't been renamed yet
+  // Why: templated New Markdown files contain real user-visible content at
+  // creation time, unlike blank placeholder files that can be discarded.
+  deleteUntouchedOnClose?: boolean
   // Why: when an external process (e.g. `git mv`, `rm`) removes the file on
   // disk while it's open, we keep the tab around so the user can still see
   // (and potentially save) their in-memory content. The tab surfaces this as
@@ -1143,6 +1146,12 @@ function deleteUntouchedUntitledFile(state: AppState, file: OpenFile): void {
     .catch(() => {})
 }
 
+function shouldDeleteUntouchedUntitledFile(file: OpenFile | undefined, hasDraft: boolean): boolean {
+  return (
+    file?.isUntitled === true && !file.isDirty && !hasDraft && file.deleteUntouchedOnClose !== false
+  )
+}
+
 function getWorktreeConnectionId(state: AppState, worktreeId: string): string | undefined {
   const worktree = findWorktreeById(state.worktreesByRepo ?? {}, worktreeId)
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
@@ -1671,7 +1680,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     // content exists but isDirty hasn't flushed yet. A draft means the user
     // typed something, so the file should be kept.
     const hasDraft = !!get().editorDrafts[fileId]
-    const shouldDeleteFromDisk = preClose?.isUntitled === true && !preClose.isDirty && !hasDraft
+    const shouldDeleteFromDisk = shouldDeleteUntouchedUntitledFile(preClose, hasDraft)
 
     set((s) => {
       const closedFile = s.openFiles.find((f) => f.id === fileId)
@@ -1868,9 +1877,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     // are empty placeholders that should not survive a "close all" operation.
     const untitledToDelete = state.openFiles.filter(
       (f) =>
-        f.isUntitled === true &&
-        !f.isDirty &&
-        !state.editorDrafts[f.id] &&
+        shouldDeleteUntouchedUntitledFile(f, !!state.editorDrafts[f.id]) &&
         (!activeWorktreeId || f.worktreeId === activeWorktreeId)
     )
 
@@ -1943,7 +1950,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         // Why: untitled non-dirty files are deleted from disk after close —
         // skip them so the reopen stack doesn't reference vanished paths.
         // Preview tabs are ephemeral views that shouldn't pollute the stack.
-        if ((f.isUntitled && !f.isDirty) || f.mode === 'markdown-preview') {
+        if (
+          shouldDeleteUntouchedUntitledFile(f, !!s.editorDrafts[f.id]) ||
+          f.mode === 'markdown-preview'
+        ) {
           continue
         }
         const { id: _id, isDirty: _dirty, ...snap } = f

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -47,7 +47,7 @@ import {
 } from '@/runtime/runtime-file-client'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
-import { createUntitledMarkdownFile } from '@/lib/create-untitled-markdown'
+import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 
 export type { RightSidebarTab } from '../../../../shared/types'
@@ -1536,12 +1536,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     try {
       const connectionId =
         state.repos.find((entry) => entry.id === worktree.repoId)?.connectionId ?? undefined
-      const fileInfo = await createUntitledMarkdownFile(
+      const fileInfo = await createUntitledMarkdownFileWithTemplateSelection(
         worktree.path,
         worktreeId,
         connectionId,
         get().settings
       )
+      if (!fileInfo) {
+        return
+      }
       get().openFile(fileInfo, { preview: false, targetGroupId: groupId })
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))


### PR DESCRIPTION
## Summary

- Add repository-local Markdown templates from `.orca/templates/**/*.md|mdx|markdown` to the New Markdown flow.
- Show a small command-style picker when templates exist, with a blank-document escape hatch.
- Substitute deterministic placeholders on creation: `{{date}}`, `{{time}}`, `{{datetime}}`, `{{title}}`, and `{{filename}}`.

## Scope notes

- This is a bounded first slice for #1222, not a full template-management UI.
- Template discovery, reads, creates, and writes go through the existing runtime-aware file client so local, SSH, and active runtime environments use the same path as file creation.
- File Explorer `New File` remains generic; the picker is limited to the explicit New Markdown document flow.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/markdown-document-templates.test.ts src/renderer/src/lib/create-untitled-markdown.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/lib/markdown-document-templates.ts src/renderer/src/lib/markdown-document-templates.test.ts src/renderer/src/lib/markdown-template-picker-request.ts src/renderer/src/lib/create-untitled-markdown.ts src/renderer/src/lib/create-untitled-markdown.test.ts src/renderer/src/components/editor/MarkdownTemplatePicker.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts src/renderer/src/store/slices/editor.ts src/renderer/src/App.tsx`
- `git diff --check HEAD~1 HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## UI evidence

- Launched the dev Electron app for this worktree on CDP port 9335 and verified the identity was `nwparker/issue-1222-markdown-document-templates`.
- Created a temporary floating-workspace template at `.orca/templates/daily-note.md`, opened New Markdown, and saw the picker with `Blank Markdown` and `Daily note`.
- Selected `Daily note` and verified the created `untitled.md` rendered `# Untitled` and `Date: 2026-05-29` from placeholder substitution.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.