### PR TITLE
Move mobile dictation ref mirrors out of effect

### DIFF
--- a/mobile/src/hooks/use-mobile-dictation-source.test.ts
+++ b/mobile/src/hooks/use-mobile-dictation-source.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('./use-mobile-dictation.ts', import.meta.url), 'utf8')
+
+function sliceBetween(startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('useMobileDictation source invariants', () => {
+  it('publishes live option refs from committed renders before passive Effects flush', () => {
+    const refDeclarations = sliceBetween(
+      'const clientRef = useRef(client)',
+      'useLayoutEffect(() => {'
+    )
+    expect(refDeclarations).not.toContain('.current =')
+
+    const mirrorEffect = sliceBetween('useLayoutEffect(() => {', 'const reportError =')
+    expect(mirrorEffect).toContain('clientRef.current = client')
+    expect(mirrorEffect).toContain('enabledRef.current = enabled')
+    expect(mirrorEffect).toContain('onTranscriptRef.current = onTranscript')
+    expect(mirrorEffect).toContain('onErrorRef.current = onError')
+    expect(mirrorEffect).toContain('}, [client, enabled, onTranscript, onError])')
+  })
+})

--- a/mobile/src/hooks/use-mobile-dictation.ts
+++ b/mobile/src/hooks/use-mobile-dictation.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines -- Why: mobile dictation keeps permission, recording,
  * chunk upload, completion, and cancellation in one hook so native audio state
  * cannot drift from the runtime RPC lifecycle. */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Buffer } from 'buffer'
 import {
   addExpoTwoWayAudioEventListener,
@@ -57,12 +57,14 @@ export function useMobileDictation(options: UseMobileDictationOptions): UseMobil
   const generationRef = useRef(0)
   const finishingIdRef = useRef<string | null>(null)
 
-  // Native audio events and stable start/stop callbacks read these before
-  // passive Effects flush, so keep the live options current during render.
-  clientRef.current = client
-  enabledRef.current = enabled
-  onTranscriptRef.current = onTranscript
-  onErrorRef.current = onError
+  useLayoutEffect(() => {
+    // Native audio events can arrive before passive Effects flush, but refs
+    // should only expose options from a committed render.
+    clientRef.current = client
+    enabledRef.current = enabled
+    onTranscriptRef.current = onTranscript
+    onErrorRef.current = onError
+  }, [client, enabled, onTranscript, onError])
 
   const reportError = useCallback((err: unknown) => {
     const normalized = err instanceof Error ? err : new Error(String(err))

--- a/mobile/src/hooks/use-mobile-dictation.ts
+++ b/mobile/src/hooks/use-mobile-dictation.ts
@@ -57,12 +57,12 @@ export function useMobileDictation(options: UseMobileDictationOptions): UseMobil
   const generationRef = useRef(0)
   const finishingIdRef = useRef<string | null>(null)
 
-  useEffect(() => {
-    clientRef.current = client
-    enabledRef.current = enabled
-    onTranscriptRef.current = onTranscript
-    onErrorRef.current = onError
-  }, [client, enabled, onTranscript, onError])
+  // Native audio events and stable start/stop callbacks read these before
+  // passive Effects flush, so keep the live options current during render.
+  clientRef.current = client
+  enabledRef.current = enabled
+  onTranscriptRef.current = onTranscript
+  onErrorRef.current = onError
 
   const reportError = useCallback((err: unknown) => {
     const normalized = err instanceof Error ? err : new Error(String(err))


### PR DESCRIPTION
## Summary
- replace the passive ref-mirror Effect in useMobileDictation with render-time ref assignments
- keep native audio event subscriptions, enabled cancellation, and unmount cleanup Effects unchanged

## Risk
Medium - touches the mobile native audio/RPC dictation path, though the behavior change is limited to keeping existing refs current without a passive Effect.

## Validation
- pnpm exec oxlint mobile/src/hooks/use-mobile-dictation.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count: 921 -> 920

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.