### PR TITLE
Clarify terminal access in onboarding

### DIFF
--- a/src/renderer/src/components/feature-wall/FeatureTourPreview.test.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureTourPreview.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FEATURE_TOUR_PREVIEW_COPY, FeatureTourPreview } from './FeatureTourPreview'
+
+describe('FeatureTourPreview first-run copy', () => {
+  it('teaches that workspaces keep terminal and agent activity together', () => {
+    const workspaceFrame = FEATURE_TOUR_PREVIEW_COPY.find((frame) => frame.id === 1)
+
+    expect(workspaceFrame?.caption).toContain('terminal')
+    expect(workspaceFrame?.caption).toContain('agent activity')
+  })
+
+  it('teaches that opening a workspace returns to its terminal', () => {
+    const terminalFrame = FEATURE_TOUR_PREVIEW_COPY.find((frame) => frame.id === 4)
+
+    expect(terminalFrame?.caption).toContain('Open any workspace')
+    expect(terminalFrame?.caption).toContain('return to its terminal')
+  })
+
+  it('renders the cycling captions into the first-run preview', () => {
+    const html = renderToStaticMarkup(<FeatureTourPreview />)
+
+    expect(html).toContain(
+      'Each workspace keeps its branch, terminal, and agent activity together.'
+    )
+    expect(html).toContain('Open any workspace to return to its terminal')
+  })
+})

--- a/src/renderer/src/components/feature-wall/FeatureTourPreview.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureTourPreview.tsx
@@ -22,7 +22,7 @@ export const FEATURE_TOUR_PREVIEW_COPY: readonly FeatureTourPreviewFrameCopy[] =
     id: 1,
     title: 'Isolated workspaces',
     caption:
-      'Ship several things at once. Each task runs in its own branch, terminal, and agent — no cross-talk.'
+      'Ship several things at once. Each workspace keeps its branch, terminal, and agent activity together.'
   },
   {
     id: 2,
@@ -39,7 +39,7 @@ export const FEATURE_TOUR_PREVIEW_COPY: readonly FeatureTourPreviewFrameCopy[] =
     id: 4,
     title: 'Splittable terminal',
     caption:
-      'Run tests, dev servers, and agents side by side — your shell and profile in every workspace.'
+      'Open any workspace to return to its terminal, then split panes for tests, logs, and agents.'
   }
 ]
 
@@ -401,7 +401,23 @@ export function FeatureTourPreview(props: { className?: string }): JSX.Element {
       <div className="feature-tour-frame" data-frame="4">
         <TerminalFrame />
       </div>
-      <div className="absolute inset-x-0 bottom-1.5 z-[5] flex items-center justify-center gap-1.5">
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[6] h-[66px] border-t border-border/70 bg-card/95">
+        {FEATURE_TOUR_PREVIEW_COPY.map((frame) => (
+          <div
+            key={frame.id}
+            className="feature-tour-copy-slide justify-center px-4 py-2.5 pr-20"
+            data-frame={frame.id}
+          >
+            <div className="truncate text-[13px] font-semibold leading-tight text-foreground">
+              {frame.title}
+            </div>
+            <div className="line-clamp-2 text-[12px] leading-snug text-muted-foreground">
+              {frame.caption}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="absolute bottom-3 right-4 z-[7] flex items-center justify-center gap-1.5">
         <span className="feature-tour-dot" data-frame="1" />
         <span className="feature-tour-dot" data-frame="2" />
         <span className="feature-tour-dot" data-frame="3" />

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -65,6 +65,10 @@ import {
   resolveResourceUsageSpaceScanReady,
   type ResourceUsageSpaceScanSnapshot
 } from './resource-usage-space-scan-ready'
+import {
+  getResourceManagerAriaLabel,
+  getResourceManagerTooltipLines
+} from './resource-manager-terminal-copy'
 
 const POLL_MS = 2_000
 const SESSIONS_POLL_MS = 10_000
@@ -940,6 +944,17 @@ export function ResourceUsageStatusSegment({
   // empty/stale even though the resource numbers look fine.
   const sessionsOnlyError =
     !runtimeEnvironmentActive && sessionsError && memorySnapshotError === null
+  const resourceManagerTooltipLines = getResourceManagerTooltipLines({
+    memoryLabel: memBadgeLabel,
+    sessionCount: sessions.length,
+    runtimeEnvironmentActive,
+    spaceScanReady
+  })
+  const resourceManagerAriaLabel = getResourceManagerAriaLabel({
+    sessionCount: sessions.length,
+    runtimeEnvironmentActive,
+    spaceScanReady
+  })
 
   const toggleRepo = useCallback((repoId: string): void => {
     setCollapsedRepos((prev) => {
@@ -1108,9 +1123,9 @@ export function ResourceUsageStatusSegment({
               {...STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS}
               className="relative inline-flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 hover:bg-accent/70"
               aria-label={
-                spaceScanReady && !runtimeEnvironmentActive
-                  ? 'Resource manager, Space scan ready'
-                  : 'Resource manager'
+                daemonUnreachable
+                  ? `${resourceManagerAriaLabel}, daemon unreachable`
+                  : resourceManagerAriaLabel
               }
             >
               {spaceScanReady && !runtimeEnvironmentActive ? (
@@ -1148,13 +1163,14 @@ export function ResourceUsageStatusSegment({
         </TooltipTrigger>
         <TooltipContent side="top" sideOffset={6}>
           <div className="space-y-0.5">
-            <div>
-              Resource Manager — {memBadgeLabel} · {sessions.length} session
-              {sessions.length === 1 ? '' : 's'}
-            </div>
-            {spaceScanReady && !runtimeEnvironmentActive ? (
-              <div className="text-primary">Space scan ready</div>
-            ) : null}
+            {resourceManagerTooltipLines.map((line, index) => (
+              <div
+                key={`${index}:${line}`}
+                className={line === 'Space scan ready' ? 'text-primary' : ''}
+              >
+                {line}
+              </div>
+            ))}
           </div>
         </TooltipContent>
       </Tooltip>
@@ -1176,7 +1192,9 @@ export function ResourceUsageStatusSegment({
         <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-1.5">
           <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium text-foreground">
             <MemoryStick className="size-3 shrink-0 text-muted-foreground" />
-            <span className="truncate">Resource Manager</span>
+            <span className="truncate">
+              {runtimeEnvironmentActive ? 'Resource Manager' : 'Resource Manager - Terminals'}
+            </span>
           </div>
 
           <div className="flex items-center gap-0.5">

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatTerminalSessionCount,
+  getResourceManagerAriaLabel,
+  getResourceManagerTooltipLines
+} from './resource-manager-terminal-copy'
+
+describe('resource manager terminal copy', () => {
+  it('formats terminal session counts with the terminal noun visible', () => {
+    expect(formatTerminalSessionCount(1)).toBe('1 terminal session')
+    expect(formatTerminalSessionCount(3)).toBe('3 terminal sessions')
+  })
+
+  it('points users from the status-bar count back to workspace terminals', () => {
+    expect(
+      getResourceManagerTooltipLines({
+        memoryLabel: '512 MB',
+        sessionCount: 2,
+        runtimeEnvironmentActive: false,
+        spaceScanReady: false
+      })
+    ).toEqual([
+      'Resource Manager - 512 MB - 2 terminal sessions',
+      'Terminal sessions are grouped by workspace.'
+    ])
+  })
+
+  it('does not advertise local session navigation for runtime servers', () => {
+    expect(
+      getResourceManagerTooltipLines({
+        memoryLabel: '-',
+        sessionCount: 0,
+        runtimeEnvironmentActive: true,
+        spaceScanReady: true
+      })
+    ).toEqual([
+      'Resource Manager - memory unavailable - 0 terminal sessions',
+      'Local terminal sessions are hidden for runtime servers.'
+    ])
+  })
+
+  it('keeps the trigger label descriptive for screen readers', () => {
+    expect(
+      getResourceManagerAriaLabel({
+        sessionCount: 1,
+        runtimeEnvironmentActive: false,
+        spaceScanReady: true
+      })
+    ).toBe('Resource Manager, 1 terminal session, Space scan ready')
+  })
+})

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
@@ -1,0 +1,51 @@
+export function formatTerminalSessionCount(count: number): string {
+  return `${count} terminal session${count === 1 ? '' : 's'}`
+}
+
+export function getResourceManagerTooltipLines(args: {
+  memoryLabel: string
+  sessionCount: number
+  runtimeEnvironmentActive: boolean
+  spaceScanReady: boolean
+}): string[] {
+  const rawMemoryLabel = args.memoryLabel.trim()
+  const memoryLabel =
+    rawMemoryLabel === '' || rawMemoryLabel === '-' || rawMemoryLabel === '—'
+      ? 'memory unavailable'
+      : rawMemoryLabel
+  const lines = [
+    `Resource Manager - ${memoryLabel} - ${formatTerminalSessionCount(args.sessionCount)}`
+  ]
+
+  if (args.spaceScanReady && !args.runtimeEnvironmentActive) {
+    lines.push('Space scan ready')
+  }
+
+  if (args.runtimeEnvironmentActive) {
+    lines.push('Local terminal sessions are hidden for runtime servers.')
+  } else if (args.sessionCount > 0) {
+    lines.push('Terminal sessions are grouped by workspace.')
+  } else {
+    lines.push('No terminal sessions yet.')
+  }
+
+  return lines
+}
+
+export function getResourceManagerAriaLabel(args: {
+  sessionCount: number
+  runtimeEnvironmentActive: boolean
+  spaceScanReady: boolean
+}): string {
+  const parts = ['Resource Manager', formatTerminalSessionCount(args.sessionCount)]
+
+  if (args.spaceScanReady && !args.runtimeEnvironmentActive) {
+    parts.push('Space scan ready')
+  }
+
+  if (args.runtimeEnvironmentActive) {
+    parts.push('local sessions hidden for runtime server')
+  }
+
+  return parts.join(', ')
+}


### PR DESCRIPTION
## Summary
- Update first-run tour copy and its preview captions so workspaces are described as the place to return to terminal and agent activity.
- Clarify Resource Manager status-bar terminal session copy, tooltip, aria label, and local-session popover title.
- Add focused tests for onboarding copy and Resource Manager terminal-session wording.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/FeatureTourPreview.test.tsx src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
- pnpm run lint
- pnpm run typecheck
- git diff --check HEAD~1 HEAD
- git merge-tree --write-tree HEAD origin/main
- Electron CDP proof captured locally: onboarding terminal preview and Resource Manager terminals popover

Refs #1544

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.