### PR TITLE
Resolve host new-worktree route action before commit

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -61,6 +61,11 @@ import {
   loadPreferences,
   savePreferences
 } from '../../../src/storage/preferences'
+import {
+  createInitialHostRouteActionState,
+  resolveHostRouteActionState,
+  setHostRouteNewWorktreeVisible
+} from '../../../src/host-route-action-state'
 
 // Why: locally-typed subset of the desktop's RuntimeStatus we read from
 // `status.get`. Only the version fields matter to mobile today; everything
@@ -336,7 +341,9 @@ export default function HostScreen() {
   const [actionTarget, setActionTarget] = useState<Worktree | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<Worktree | null>(null)
   const [confirmRemoveHost, setConfirmRemoveHost] = useState(false)
-  const [showNewWorktree, setShowNewWorktree] = useState(false)
+  const [routeActionState, setRouteActionState] = useState(() =>
+    createInitialHostRouteActionState(action)
+  )
   const [sleptIds, setSleptIds] = useState<Set<string>>(new Set())
 
   // Persisted pin state
@@ -344,9 +351,16 @@ export default function HostScreen() {
   const [_prefsLoaded, setPrefsLoaded] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
 
-  useEffect(() => {
-    if (action === 'newWorktree') setShowNewWorktree(true)
-  }, [action])
+  const resolvedRouteActionState = resolveHostRouteActionState(routeActionState, action)
+  // Why: `action=newWorktree` is a route-derived open edge. Resolve it before
+  // commit, but don't reopen after the user closes while the same URL remains.
+  if (resolvedRouteActionState !== routeActionState) {
+    setRouteActionState(resolvedRouteActionState)
+  }
+  const showNewWorktree = resolvedRouteActionState.showNewWorktree
+  const setShowNewWorktreeVisible = useCallback((visible: boolean) => {
+    setRouteActionState((current) => setHostRouteNewWorktreeVisible(current, visible))
+  }, [])
 
   // Load persisted pins and preferences
   useEffect(() => {
@@ -867,7 +881,7 @@ export default function HostScreen() {
 
           <Pressable
             style={styles.newButton}
-            onPress={() => setShowNewWorktree(true)}
+            onPress={() => setShowNewWorktreeVisible(true)}
             disabled={connState !== 'connected'}
           >
             <Plus
@@ -1238,7 +1252,7 @@ export default function HostScreen() {
           const params = new URLSearchParams({ name: worktreeName, created: '1' })
           router.push(`/h/${hostId}/session/${encodeURIComponent(worktreeId)}?${params.toString()}`)
         }}
-        onClose={() => setShowNewWorktree(false)}
+        onClose={() => setShowNewWorktreeVisible(false)}
       />
     </SafeAreaView>
   )

--- a/mobile/src/host-route-action-state.test.ts
+++ b/mobile/src/host-route-action-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createInitialHostRouteActionState,
+  resolveHostRouteActionState,
+  setHostRouteNewWorktreeVisible
+} from './host-route-action-state'
+
+describe('host route action state', () => {
+  it('opens new worktree modal on an initial newWorktree action', () => {
+    expect(createInitialHostRouteActionState('newWorktree')).toEqual({
+      routeAction: 'newWorktree',
+      showNewWorktree: true
+    })
+  })
+
+  it('keeps initial non-action routes closed', () => {
+    expect(createInitialHostRouteActionState(undefined)).toEqual({
+      routeAction: undefined,
+      showNewWorktree: false
+    })
+  })
+
+  it('opens once when route action changes to newWorktree', () => {
+    expect(
+      resolveHostRouteActionState({ routeAction: undefined, showNewWorktree: false }, 'newWorktree')
+    ).toEqual({
+      routeAction: 'newWorktree',
+      showNewWorktree: true
+    })
+  })
+
+  it('does not reopen after user closes while route action is unchanged', () => {
+    const closed = setHostRouteNewWorktreeVisible(
+      { routeAction: 'newWorktree', showNewWorktree: true },
+      false
+    )
+
+    expect(resolveHostRouteActionState(closed, 'newWorktree')).toBe(closed)
+  })
+
+  it('preserves an already-open modal when route action changes away', () => {
+    expect(
+      resolveHostRouteActionState({ routeAction: 'newWorktree', showNewWorktree: true }, undefined)
+    ).toEqual({
+      routeAction: undefined,
+      showNewWorktree: true
+    })
+  })
+})

--- a/mobile/src/host-route-action-state.ts
+++ b/mobile/src/host-route-action-state.ts
@@ -1,0 +1,36 @@
+export type HostRouteActionState = {
+  routeAction: string | undefined
+  showNewWorktree: boolean
+}
+
+export function createInitialHostRouteActionState(
+  routeAction: string | undefined
+): HostRouteActionState {
+  return {
+    routeAction,
+    showNewWorktree: routeAction === 'newWorktree'
+  }
+}
+
+export function resolveHostRouteActionState(
+  current: HostRouteActionState,
+  routeAction: string | undefined
+): HostRouteActionState {
+  if (current.routeAction === routeAction) {
+    return current
+  }
+  return {
+    routeAction,
+    showNewWorktree: current.showNewWorktree || routeAction === 'newWorktree'
+  }
+}
+
+export function setHostRouteNewWorktreeVisible(
+  current: HostRouteActionState,
+  showNewWorktree: boolean
+): HostRouteActionState {
+  if (current.showNewWorktree === showNewWorktree) {
+    return current
+  }
+  return { ...current, showNewWorktree }
+}


### PR DESCRIPTION
## Summary
- remove the passive `action=newWorktree` Effect from the mobile host home route
- resolve the route-action open edge during render while preserving close-while-same-url behavior
- add focused state helper coverage for initial open, route changes, and user close behavior

## Risk
Medium - mobile host home workspace creation entry point, local route/modal state only.

## Validation
- `pnpm exec oxfmt --write mobile/app/h/[hostId]/index.tsx mobile/src/host-route-action-state.ts mobile/src/host-route-action-state.test.ts`
- `pnpm exec oxlint mobile/app/h/[hostId]/index.tsx mobile/src/host-route-action-state.ts mobile/src/host-route-action-state.test.ts`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- direct `tsx` assertions for `host-route-action-state`
- AST Effect count: 921 -> 920

## Mobile test constraints
- `pnpm exec vitest run mobile/src/host-route-action-state.test.ts` is blocked in this checkout by missing `expo/tsconfig.base` from the mobile TypeScript config.
- `pnpm --dir mobile test src/host-route-action-state.test.ts` is blocked because `vitest` is not installed in the mobile package context.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.