### PR TITLE
Remove mobile accounts dead client ref

### DIFF
--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import {
   View,
   Text,
@@ -12,7 +12,6 @@ import {
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { ChevronLeft, Check, RefreshCw, User } from 'lucide-react-native'
-import type { RpcClient } from '../../../src/transport/rpc-client'
 import { loadHosts } from '../../../src/transport/host-store'
 import { useHostClient } from '../../../src/transport/client-context'
 import type { RpcSuccess } from '../../../src/transport/types'
@@ -38,11 +37,6 @@ export default function AccountsScreen() {
   const [error, setError] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null)
-  const clientRef = useRef<RpcClient | null>(null)
-
-  useEffect(() => {
-    clientRef.current = client
-  }, [client])
 
   useEffect(() => {
     if (!hostId) return


### PR DESCRIPTION
## Summary
- remove an unused `clientRef` from the mobile Accounts screen
- delete the passive Effect that only mirrored `client` into that unread ref
- drop the now-unused `RpcClient` type and `useRef` imports

## Risk
Low - dead local ref cleanup only; no RPC requests, subscriptions, persistence, or navigation behavior changes.

## Validation
- `pnpm exec oxfmt --write mobile/app/h/[hostId]/accounts.tsx`
- `pnpm exec oxlint mobile/app/h/[hostId]/accounts.tsx`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- AST Effect count: 921 -> 920