### PR TITLE
Add file tree dotfile visibility toggle

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2258,6 +2258,23 @@ describe('Store', () => {
     expect(ui.dismissedUpdateVersion).toBeNull()
   })
 
+  it('updateUI persists sanitized per-worktree dotfile visibility', async () => {
+    const store = await createStore()
+    store.updateUI({
+      showDotfilesByWorktree: {
+        'repo-1::/repo': false,
+        'repo-2::/repo': true,
+        'repo-3::/repo': 'bad',
+        constructor: false
+      } as never
+    })
+
+    expect(store.getUI().showDotfilesByWorktree).toEqual({
+      'repo-1::/repo': false,
+      'repo-2::/repo': true
+    })
+  })
+
   it('migrates missing rightSidebarOpen from the legacy default setting', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -255,6 +255,26 @@ function normalizeGroupBy(groupBy: unknown): PersistedState['ui']['groupBy'] {
   return getDefaultUIState().groupBy
 }
 
+function normalizeShowDotfilesByWorktree(value: unknown): Record<string, boolean> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  const out: Record<string, boolean> = {}
+  for (const [worktreeId, showDotfiles] of Object.entries(value as Record<string, unknown>)) {
+    if (
+      !worktreeId ||
+      worktreeId === '__proto__' ||
+      worktreeId === 'constructor' ||
+      worktreeId === 'prototype' ||
+      typeof showDotfiles !== 'boolean'
+    ) {
+      continue
+    }
+    out[worktreeId] = showDotfiles
+  }
+  return out
+}
+
 function mergeFeatureInteractions(
   current: PersistedState['ui']['featureInteractions'],
   incoming: PersistedState['ui']['featureInteractions']
@@ -1827,6 +1847,9 @@ export class Store {
               rightSidebarOpen,
               rightSidebarTab: normalizeRightSidebarTab(parsed.ui?.rightSidebarTab),
               sortBy: migrate ? ('smart' as const) : sort,
+              showDotfilesByWorktree: normalizeShowDotfilesByWorktree(
+                parsed.ui?.showDotfilesByWorktree
+              ),
               workspaceStatuses,
               _workspaceStatusesDefaultOrderMigrated: true,
               _workspaceStatusesDefaultWorkflowMigrated: true,
@@ -2892,6 +2915,9 @@ export class Store {
       workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(
         this.state.ui?.workspaceBoardColumnWidth
       ),
+      showDotfilesByWorktree: normalizeShowDotfilesByWorktree(
+        this.state.ui?.showDotfilesByWorktree
+      ),
       featureTipsSeenIds: normalizeFeatureTipIds(this.state.ui?.featureTipsSeenIds),
       featureInteractions: normalizeFeatureInteractions(this.state.ui?.featureInteractions)
     }
@@ -2932,6 +2958,10 @@ export class Store {
       workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(
         updates.workspaceBoardColumnWidth ?? this.state.ui?.workspaceBoardColumnWidth
       ),
+      showDotfilesByWorktree:
+        updates.showDotfilesByWorktree !== undefined
+          ? normalizeShowDotfilesByWorktree(updates.showDotfilesByWorktree)
+          : normalizeShowDotfilesByWorktree(this.state.ui?.showDotfilesByWorktree),
       featureTipsSeenIds:
         updates.featureTipsSeenIds !== undefined
           ? normalizeFeatureTipIds(updates.featureTipsSeenIds)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -449,6 +449,7 @@ function App(): React.JSX.Element {
   const sortBy = useAppStore((s) => s.sortBy)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const hideDefaultBranchWorkspace = useAppStore((s) => s.hideDefaultBranchWorkspace)
+  const showDotfilesByWorktree = useAppStore((s) => s.showDotfilesByWorktree)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
@@ -1017,6 +1018,7 @@ function App(): React.JSX.Element {
         hideSleepingWorkspaces: !showSleepingWorkspaces,
         showSleepingWorkspaces,
         hideDefaultBranchWorkspace,
+        showDotfilesByWorktree,
         filterRepoIds,
         // Why: rides the same debounced save so dashboard auto-acks (which fire
         // on focus/visibility) and the in-memory ack cleanup paths in
@@ -1038,6 +1040,7 @@ function App(): React.JSX.Element {
     sortBy,
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,
+    showDotfilesByWorktree,
     filterRepoIds,
     acknowledgedAgentsByPaneKey
   ])

--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- File Explorer toolbar and row tests share element-walking fixtures. */
 import { describe, expect, it, vi } from 'vitest'
 import { Ellipsis, ListCollapse, Loader2, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -93,6 +94,19 @@ function findGitIgnoredMenuItem(node: unknown): ReactElementLike {
   })
   if (!found) {
     throw new Error('git ignored menu item not found')
+  }
+  return found
+}
+
+function findDotfilesMenuItem(node: unknown): ReactElementLike {
+  let found: ReactElementLike | null = null
+  visit(node, (entry) => {
+    if (entry.type === DropdownMenuCheckboxItem && entry.props.children === 'Show Dotfiles') {
+      found = entry
+    }
+  })
+  if (!found) {
+    throw new Error('dotfiles menu item not found')
   }
   return found
 }
@@ -195,6 +209,8 @@ function makeToolbar(overrides: Partial<Parameters<typeof FileExplorerToolbar>[0
     showGitIgnoredFilesToggle: true,
     showGitIgnoredFiles: true,
     onToggleGitIgnoredFiles: vi.fn(),
+    showDotfiles: true,
+    onToggleDotfiles: vi.fn(),
     ...overrides
   })
 }
@@ -271,6 +287,17 @@ describe('FileExplorerToolbar', () => {
     expect(onToggleGitIgnoredFiles).toHaveBeenCalledTimes(1)
     expect(hasIcon(button, Ellipsis)).toBe(true)
     expect(menuItem.props.checked).toBe(true)
+  })
+
+  it('puts the dotfile visibility toggle in the overflow menu', () => {
+    const onToggleDotfiles = vi.fn()
+    const element = makeToolbar({ onToggleDotfiles, showDotfiles: false })
+
+    const menuItem = findDotfilesMenuItem(element)
+    ;(menuItem.props.onCheckedChange as () => void)()
+
+    expect(onToggleDotfiles).toHaveBeenCalledTimes(1)
+    expect(menuItem.props.checked).toBe(false)
   })
 
   it('adds open-in launchers to the overflow menu', () => {

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -35,6 +35,7 @@ import {
 import type { TreeNode } from './file-explorer-types'
 import { useFileExplorerSelection } from './useFileExplorerSelection'
 import { useFileExplorerGitIgnoredRows } from './useFileExplorerGitIgnoredRows'
+import { getDotfileVisibleFileExplorerRows } from './file-explorer-entries'
 
 function FileExplorerInner(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
@@ -55,6 +56,10 @@ function FileExplorerInner(): React.JSX.Element {
   const closeFile = useAppStore((s) => s.closeFile)
   const openModal = useAppStore((s) => s.openModal)
   const rightSidebarOpen = useAppStore((s) => s.rightSidebarOpen)
+  const showDotfiles = useAppStore((s) =>
+    activeWorktreeId ? (s.showDotfilesByWorktree[activeWorktreeId] ?? true) : true
+  )
+  const toggleShowDotfilesForWorktree = useAppStore((s) => s.toggleShowDotfilesForWorktree)
 
   const worktreePath = activeWorktree?.path ?? null
   const visibleWorktreePath = rightSidebarOpen ? worktreePath : null
@@ -80,13 +85,22 @@ function FileExplorerInner(): React.JSX.Element {
     refreshDir,
     resetAndLoad
   } = useFileExplorerTree(worktreePath, expanded, activeWorktreeId)
+  const dotfileVisibleFlatRows = useMemo(
+    () => getDotfileVisibleFileExplorerRows(flatRows, showDotfiles),
+    [flatRows, showDotfiles]
+  )
   const {
     visibleFlatRows,
     rowsByPath,
     ignoredByRelativePath,
     showGitIgnoredFiles,
     toggleGitIgnoredFiles
-  } = useFileExplorerGitIgnoredRows(activeWorktreeId, worktreePath, flatRows, activeRepoSupportsGit)
+  } = useFileExplorerGitIgnoredRows(
+    activeWorktreeId,
+    worktreePath,
+    dotfileVisibleFlatRows,
+    activeRepoSupportsGit
+  )
   const manualRefresh = useFileExplorerManualRefresh(refreshTree)
   const canCollapseAll = expanded.size > 0
   const handleCollapseAll = useCallback(() => {
@@ -95,6 +109,11 @@ function FileExplorerInner(): React.JSX.Element {
     }
     collapseAllDirs(activeWorktreeId)
   }, [activeWorktreeId, collapseAllDirs])
+  const handleToggleDotfiles = useCallback(() => {
+    if (activeWorktreeId) {
+      toggleShowDotfilesForWorktree(activeWorktreeId)
+    }
+  }, [activeWorktreeId, toggleShowDotfilesForWorktree])
 
   const [flashingPath, setFlashingPath] = useState<string | null>(null)
   const [bgMenuOpen, setBgMenuOpen] = useState(false)
@@ -422,6 +441,8 @@ function FileExplorerInner(): React.JSX.Element {
           showGitIgnoredFilesToggle={activeRepoSupportsGit}
           showGitIgnoredFiles={showGitIgnoredFiles}
           onToggleGitIgnoredFiles={toggleGitIgnoredFiles}
+          showDotfiles={showDotfiles}
+          onToggleDotfiles={handleToggleDotfiles}
         />
         <ScrollArea
           className={cn(

--- a/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
@@ -25,6 +25,8 @@ type FileExplorerToolbarProps = {
   showGitIgnoredFilesToggle: boolean
   showGitIgnoredFiles: boolean
   onToggleGitIgnoredFiles: () => void
+  showDotfiles: boolean
+  onToggleDotfiles: () => void
 }
 
 export function FileExplorerToolbar({
@@ -36,7 +38,9 @@ export function FileExplorerToolbar({
   onCollapseAll,
   showGitIgnoredFilesToggle,
   showGitIgnoredFiles,
-  onToggleGitIgnoredFiles
+  onToggleGitIgnoredFiles,
+  showDotfiles,
+  onToggleDotfiles
 }: FileExplorerToolbarProps): React.JSX.Element {
   return (
     <div className="flex h-8 min-h-8 items-center gap-2 border-b border-border px-2">
@@ -106,6 +110,9 @@ export function FileExplorerToolbar({
           </TooltipContent>
         </Tooltip>
         <DropdownMenuContent align="end" className="min-w-[12rem]">
+          <DropdownMenuCheckboxItem checked={showDotfiles} onCheckedChange={onToggleDotfiles}>
+            Show Dotfiles
+          </DropdownMenuCheckboxItem>
           {showGitIgnoredFilesToggle ? (
             <DropdownMenuCheckboxItem
               checked={showGitIgnoredFiles}
@@ -114,7 +121,7 @@ export function FileExplorerToolbar({
               Show Git Ignored Files
             </DropdownMenuCheckboxItem>
           ) : null}
-          {showGitIgnoredFilesToggle ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuSeparator />
           <WorktreeOpenInMenuItems
             worktreePath={worktreePath}
             connectionId={connectionId}

--- a/src/renderer/src/components/right-sidebar/file-explorer-entries.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-entries.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { shouldIncludeFileExplorerEntry } from './file-explorer-entries'
+import {
+  getDotfileVisibleFileExplorerRows,
+  isDotfileRelativePath,
+  shouldIncludeFileExplorerEntry
+} from './file-explorer-entries'
 
 describe('shouldIncludeFileExplorerEntry', () => {
-  it('keeps hidden files and folders visible in the explorer', () => {
+  it('keeps dotfiles loadable so visibility can be toggled client-side', () => {
     expect(
       shouldIncludeFileExplorerEntry({
         name: '.env',
@@ -36,5 +40,38 @@ describe('shouldIncludeFileExplorerEntry', () => {
         isSymlink: false
       })
     ).toBe(false)
+  })
+})
+
+describe('isDotfileRelativePath', () => {
+  it('matches dotfiles and descendants of dot folders across path separators', () => {
+    expect(isDotfileRelativePath('.env')).toBe(true)
+    expect(isDotfileRelativePath('.config/settings.json')).toBe(true)
+    expect(isDotfileRelativePath('src/.cache/result.json')).toBe(true)
+    expect(isDotfileRelativePath('src\\.cache\\result.json')).toBe(true)
+  })
+
+  it('does not match ordinary paths', () => {
+    expect(isDotfileRelativePath('src/index.ts')).toBe(false)
+    expect(isDotfileRelativePath('config/settings.json')).toBe(false)
+  })
+})
+
+describe('getDotfileVisibleFileExplorerRows', () => {
+  const rows = [
+    { relativePath: 'src/index.ts' },
+    { relativePath: '.env' },
+    { relativePath: '.config/settings.json' },
+    { relativePath: 'src/.cache/result.json' }
+  ]
+
+  it('returns the original row array when dotfiles are visible', () => {
+    expect(getDotfileVisibleFileExplorerRows(rows, true)).toBe(rows)
+  })
+
+  it('filters dotfiles and descendants when dotfiles are hidden', () => {
+    expect(getDotfileVisibleFileExplorerRows(rows, false).map((row) => row.relativePath)).toEqual([
+      'src/index.ts'
+    ])
   })
 })

--- a/src/renderer/src/components/right-sidebar/file-explorer-entries.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-entries.ts
@@ -3,3 +3,21 @@ import type { DirEntry } from '../../../../shared/types'
 export function shouldIncludeFileExplorerEntry(entry: DirEntry): boolean {
   return entry.name !== '.git' && entry.name !== 'node_modules'
 }
+
+function isDotfileSegment(segment: string): boolean {
+  return segment.length > 1 && segment !== '..' && segment.startsWith('.')
+}
+
+export function isDotfileRelativePath(relativePath: string): boolean {
+  return relativePath
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .some(isDotfileSegment)
+}
+
+export function getDotfileVisibleFileExplorerRows<T extends { relativePath: string }>(
+  rows: T[],
+  showDotfiles: boolean
+): T[] {
+  return showDotfiles ? rows : rows.filter((row) => !isDotfileRelativePath(row.relativePath))
+}

--- a/src/renderer/src/store/slices/settings.test.ts
+++ b/src/renderer/src/store/slices/settings.test.ts
@@ -202,6 +202,7 @@ describe('createSettingsSlice runtime switching', () => {
       markdownViewMode: { '/env-1/repo/stale.md': 'rich' },
       editorViewMode: { '/env-1/repo/stale.md': 'changes' },
       editorCursorLine: { '/env-1/repo/stale.md': 4 },
+      showDotfilesByWorktree: { 'repo-env-1::/env-1/repo': false },
       gitIgnoredPathsByWorktree: { 'repo-env-1::/env-1/repo': ['dist/'] },
       prCache: { '/env-1/repo::main': { data: null, fetchedAt: Date.now() } },
       linearIssueCache: { 'LIN-1': { data: { id: 'LIN-1' } as never, fetchedAt: Date.now() } }
@@ -254,6 +255,7 @@ describe('createSettingsSlice runtime switching', () => {
     expect(store.getState().markdownViewMode).toEqual({})
     expect(store.getState().editorViewMode).toEqual({})
     expect(store.getState().editorCursorLine).toEqual({})
+    expect(store.getState().showDotfilesByWorktree).toEqual({})
     expect(store.getState().gitIgnoredPathsByWorktree).toEqual({})
     expect(store.getState().ptyIdsByTabId).toEqual({})
     expect(store.getState().browserTabsByWorktree).toEqual({})

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -83,6 +83,7 @@ function runtimeScopedStateReset(): Partial<AppState> {
     deferredSshSessionIdsByTabId: {},
     cacheTimerByKey: {},
     recentQuickCommandIdByGroup: {},
+    showDotfilesByWorktree: {},
     expandedDirs: {},
     pendingExplorerReveal: null,
     openFiles: [],

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -441,6 +441,60 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().rightSidebarTab).toBe('checks')
   })
 
+  it('hydrates persisted per-worktree dotfile visibility', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        showDotfilesByWorktree: {
+          'repo-1::/repo': false,
+          'repo-2::/repo': true
+        }
+      })
+    )
+
+    expect(store.getState().showDotfilesByWorktree).toEqual({
+      'repo-1::/repo': false,
+      'repo-2::/repo': true
+    })
+  })
+
+  it('drops invalid persisted per-worktree dotfile visibility entries', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        showDotfilesByWorktree: {
+          'repo-1::/repo': false,
+          'repo-2::/repo': 'nope',
+          constructor: false
+        } as never
+      })
+    )
+
+    expect(store.getState().showDotfilesByWorktree).toEqual({ 'repo-1::/repo': false })
+  })
+
+  it('stores only per-worktree dotfile visibility opt-outs', () => {
+    const store = createUIStore()
+
+    store.getState().setShowDotfilesForWorktree('repo-1::/repo', false)
+    expect(store.getState().showDotfilesByWorktree).toEqual({ 'repo-1::/repo': false })
+
+    store.getState().setShowDotfilesForWorktree('repo-1::/repo', true)
+    expect(store.getState().showDotfilesByWorktree).toEqual({})
+  })
+
+  it('toggles per-worktree dotfile visibility independently', () => {
+    const store = createUIStore()
+
+    store.getState().toggleShowDotfilesForWorktree('repo-1::/repo')
+    store.getState().toggleShowDotfilesForWorktree('repo-2::/repo')
+    store.getState().toggleShowDotfilesForWorktree('repo-2::/repo')
+
+    expect(store.getState().showDotfilesByWorktree).toEqual({ 'repo-1::/repo': false })
+  })
+
   it('falls back to explorer for invalid persisted right sidebar tabs', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -239,6 +239,24 @@ function filterTrustedOrcaHooksToValidRepos(
   return next
 }
 
+function isSafePersistedRecordKey(key: string): boolean {
+  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype'
+}
+
+function sanitizeShowDotfilesByWorktree(value: unknown): Record<string, boolean> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  const out: Record<string, boolean> = {}
+  for (const [worktreeId, showDotfiles] of Object.entries(value as Record<string, unknown>)) {
+    if (!worktreeId || !isSafePersistedRecordKey(worktreeId) || typeof showDotfiles !== 'boolean') {
+      continue
+    }
+    out[worktreeId] = showDotfiles
+  }
+  return out
+}
+
 function sanitizePersistedSidebarWidth(width: unknown, fallback: number, maxWidth: number): number {
   if (typeof width !== 'number' || !Number.isFinite(width)) {
     return fallback
@@ -257,10 +275,7 @@ function sanitizeAcknowledgedAgentsByPaneKey(value: unknown): Record<string, num
   const cutoff = Date.now() - HYDRATE_MAX_AGE_MS
   const out: Record<string, number> = {}
   for (const [key, ackAt] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof key !== 'string') {
-      continue
-    }
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    if (typeof key !== 'string' || !isSafePersistedRecordKey(key)) {
       continue
     }
     if (typeof ackAt !== 'number' || !Number.isFinite(ackAt) || ackAt <= 0) {
@@ -600,6 +615,9 @@ export type UISlice = {
   setShowSleepingWorkspaces: (v: boolean) => void
   hideDefaultBranchWorkspace: boolean
   setHideDefaultBranchWorkspace: (v: boolean) => void
+  showDotfilesByWorktree: Record<string, boolean>
+  setShowDotfilesForWorktree: (worktreeId: string, showDotfiles: boolean) => void
+  toggleShowDotfilesForWorktree: (worktreeId: string) => void
   filterRepoIds: string[]
   setFilterRepoIds: (ids: string[]) => void
   collapsedGroups: Set<string>
@@ -1247,6 +1265,40 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   hideDefaultBranchWorkspace: false,
   setHideDefaultBranchWorkspace: (v) => set({ hideDefaultBranchWorkspace: v }),
 
+  showDotfilesByWorktree: {},
+  setShowDotfilesForWorktree: (worktreeId, showDotfiles) =>
+    set((s) => {
+      if (!worktreeId) {
+        return s
+      }
+      const current = s.showDotfilesByWorktree[worktreeId] ?? true
+      if (current === showDotfiles) {
+        return s
+      }
+      const next = { ...s.showDotfilesByWorktree }
+      // Why: showing dotfiles is the default; only persist worktree-level opt-outs.
+      if (showDotfiles) {
+        delete next[worktreeId]
+      } else {
+        next[worktreeId] = false
+      }
+      return { showDotfilesByWorktree: next }
+    }),
+  toggleShowDotfilesForWorktree: (worktreeId) =>
+    set((s) => {
+      if (!worktreeId) {
+        return s
+      }
+      const nextShowDotfiles = !(s.showDotfilesByWorktree[worktreeId] ?? true)
+      const next = { ...s.showDotfilesByWorktree }
+      if (nextShowDotfiles) {
+        delete next[worktreeId]
+      } else {
+        next[worktreeId] = false
+      }
+      return { showDotfilesByWorktree: next }
+    }),
+
   filterRepoIds: [],
   setFilterRepoIds: (ids) => set({ filterRepoIds: ids }),
 
@@ -1469,6 +1521,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         // start from the new default: sleeping workspaces visible.
         showSleepingWorkspaces: !(ui.hideSleepingWorkspaces ?? DEFAULT_HIDE_SLEEPING_WORKSPACES),
         hideDefaultBranchWorkspace: ui.hideDefaultBranchWorkspace ?? false,
+        showDotfilesByWorktree: sanitizeShowDotfilesByWorktree(ui.showDotfilesByWorktree),
         filterRepoIds: (ui.filterRepoIds ?? []).filter((repoId) => validRepoIds.has(repoId)),
         collapsedGroups: new Set(ui.collapsedGroups ?? []),
         uiZoomLevel: ui.uiZoomLevel ?? 0,

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -116,6 +116,7 @@ function createTestStore() {
         editorDrafts: {},
         markdownViewMode: {},
         editorViewMode: {},
+        showDotfilesByWorktree: {},
         expandedDirs: {},
         gitStatusByWorktree: {},
         gitIgnoredPathsByWorktree: {},
@@ -1477,6 +1478,25 @@ describe('removeWorktree state cleanup', () => {
 
     expect(store.getState().expandedDirs).toEqual({
       'repo1::/path/wt2': new Set(['test'])
+    })
+  })
+
+  it('cleans up dotfile visibility for the removed worktree', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      showDotfilesByWorktree: {
+        'repo1::/path/wt1': false,
+        'repo1::/path/wt2': false
+      }
+    } as Partial<AppState>)
+
+    await store.getState().removeWorktree('repo1::/path/wt1')
+
+    expect(store.getState().showDotfilesByWorktree).toEqual({
+      'repo1::/path/wt2': false
     })
   })
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -715,6 +715,7 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     gitBranchChangesByWorktree: omitByWorktree(s.gitBranchChangesByWorktree),
     gitBranchCompareSummaryByWorktree: omitByWorktree(s.gitBranchCompareSummaryByWorktree),
     gitBranchCompareRequestKeyByWorktree: omitByWorktree(s.gitBranchCompareRequestKeyByWorktree),
+    showDotfilesByWorktree: omitByWorktree(s.showDotfilesByWorktree),
     expandedDirs: omitByWorktree(s.expandedDirs),
     // Per-file editor state for removed files
     editorDrafts: omitByFileId(s.editorDrafts),
@@ -1317,6 +1318,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         }
         const nextExpandedDirs = { ...s.expandedDirs }
         delete nextExpandedDirs[worktreeId]
+        const nextShowDotfilesByWorktree = { ...s.showDotfilesByWorktree }
+        delete nextShowDotfilesByWorktree[worktreeId]
         // If the active file belonged to the removed worktree, clear it
         const activeFileCleared = s.activeFileId
           ? s.openFiles.some((f) => f.id === s.activeFileId && f.worktreeId === worktreeId)
@@ -1377,6 +1380,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           editorDrafts: nextEditorDrafts,
           markdownViewMode: nextMarkdownViewMode,
           editorViewMode: nextEditorViewMode,
+          showDotfilesByWorktree: nextShowDotfilesByWorktree,
           expandedDirs: nextExpandedDirs,
           gitStatusByWorktree: nextGitStatusByWorktree,
           gitIgnoredPathsByWorktree: nextGitIgnoredPathsByWorktree,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -390,6 +390,7 @@ export function getDefaultUIState(): PersistedUIState {
     hideSleepingWorkspaces: DEFAULT_HIDE_SLEEPING_WORKSPACES,
     showSleepingWorkspaces: DEFAULT_SHOW_SLEEPING_WORKSPACES,
     hideDefaultBranchWorkspace: false,
+    showDotfilesByWorktree: {},
     filterRepoIds: [],
     collapsedGroups: [],
     uiZoomLevel: 0,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2458,6 +2458,8 @@ export type PersistedUIState = {
    *  the predicate in visible-worktrees.ts excludes worktrees with an empty
    *  branch. */
   hideDefaultBranchWorkspace: boolean
+  /** Per-worktree Explorer dotfile visibility. Missing entries inherit the default: show. */
+  showDotfilesByWorktree?: Record<string, boolean>
   filterRepoIds: string[]
   collapsedGroups: string[]
   uiZoomLevel: number


### PR DESCRIPTION
## Summary
- Add a per-worktree Show Dotfiles checkbox to the File Explorer overflow menu, defaulting to visible so existing projects do not silently lose files.
- Filter dotfile rows in the renderer from provider-neutral tree relative paths before git-ignored filtering, preserving SSH/remote worktrees.
- Persist only per-worktree opt-outs in UI state and clean them up when worktrees are removed or runtime switches reset workspace state.

Closes #1113

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/file-explorer-entries.test.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/store/slices/ui.test.ts src/main/persistence.test.ts src/renderer/src/store/slices/settings.test.ts src/renderer/src/store/slices/worktrees.test.ts
- pnpm run typecheck:web
- pnpm run typecheck:node
- pnpm run typecheck:cli
- pnpm exec oxlint <touched files>
- git diff --check

## UI Evidence
- Electron dev build on CDP port 9334: proof folder initially showed `.config`, `src`, and `.env`; toggling Show Dotfiles off hid `.config` and `.env` while leaving `src`.
- Screenshots captured locally at `/tmp/issue-1113-dotfiles-hidden.png` and `/tmp/issue-1113-dotfiles-menu-unchecked.png`; not committed.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.