### PR TITLE
Move mobile home client ref sync out of effect

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -301,12 +301,12 @@ export default function HomeScreen() {
     if (hosts.length > 0) primeHosts(hosts)
   }, [hosts, primeHosts])
   const allClientsRef = useRef<Array<{ hostId: string; client: RpcClient }>>([])
-  useEffect(() => {
-    allClientsRef.current = allClients.map((entry) => ({
-      hostId: entry.hostId,
-      client: entry.client
-    }))
-  }, [allClients])
+  // Why: the focus callback stays stable to avoid refetching on every
+  // client-store render, but it still needs the latest host clients.
+  allClientsRef.current = allClients.map((entry) => ({
+    hostId: entry.hostId,
+    client: entry.client
+  }))
 
   // Why: hydrate the home page from a persisted snapshot on cold-start so
   // Resume + Account-usage cards paint immediately with last-known data


### PR DESCRIPTION
## Summary
- move the mobile home `allClientsRef` sync out of a passive Effect
- keep the focus callback stable while giving it the latest shared host clients during render
- preserve the existing focus-time stats/worktree/accounts/task-provider refresh path

## Risk
Medium - mobile home remote-client refresh behavior; no transport protocol, persistence format, or navigation contract changes.

## Validation
- `pnpm exec oxfmt --write mobile/app/index.tsx`
- `pnpm exec oxlint mobile/app/index.tsx`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- AST Effect count: 920 -> 919

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.