### PR TITLE
Move mobile session ref mirrors out of effects

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1099,6 +1099,14 @@ export default function SessionScreen() {
     activeSessionTab?.type !== 'browser'
   const liveInputEnabled = activeHandle ? liveInputTerminalHandles.has(activeHandle) : false
   const [browserScreencastSupported, setBrowserScreencastSupported] = useState<boolean | null>(null)
+  // Why: terminal gesture/input callbacks are intentionally stable and
+  // imperative; keep their refs current before commit instead of one effect later.
+  clientRef.current = client
+  connStateRef.current = connState
+  activeSessionTabTypeRef.current = activeSessionTab?.type ?? null
+  sessionTabsRef.current = sessionTabs
+  activeSessionTabIdRef.current = activeSessionTabId
+  markdownDocsRef.current = markdownDocs
   const reconciledCreateWarningState = reconcileMobileSessionCreateWarningState(
     createWarningState,
     initialCreateWarning
@@ -1188,22 +1196,6 @@ export default function SessionScreen() {
       showToast(err.message)
     }
   })
-
-  useEffect(() => {
-    activeSessionTabTypeRef.current = activeSessionTab?.type ?? null
-  }, [activeSessionTab])
-
-  useEffect(() => {
-    sessionTabsRef.current = sessionTabs
-  }, [sessionTabs])
-
-  useEffect(() => {
-    activeSessionTabIdRef.current = activeSessionTabId
-  }, [activeSessionTabId])
-
-  useEffect(() => {
-    markdownDocsRef.current = markdownDocs
-  }, [markdownDocs])
 
   useEffect(() => {
     diffCommentsRef.current = diffComments
@@ -2133,15 +2125,7 @@ export default function SessionScreen() {
     }
   }, [applySessionTabs, client, worktreeId])
 
-  // Why: keep clientRef in sync with the shared client from
-  // useHostClient() so the existing imperative call sites
-  // (clientRef.current.sendRequest...) keep working without churn.
   useEffect(() => {
-    clientRef.current = client
-  }, [client])
-
-  useEffect(() => {
-    connStateRef.current = connState
     if (connState === 'connected') return
     for (const queued of terminalGestureInputQueuesRef.current.values()) {
       if (queued.timer) clearTimeout(queued.timer)


### PR DESCRIPTION
## Summary
- move mobile session terminal/tab ref mirrors from passive Effects into render-time ref assignments
- keep stable imperative terminal input and session callbacks reading current client, connection state, active tab, tabs, and markdown docs
- leave lifecycle cleanup/subscription Effects intact

## Risk
High - mobile session and terminal input behavior, including remote-client/SSH-adjacent terminal paths. No transport protocol or persisted format changes.

## Validation
- `pnpm exec oxfmt --write mobile/app/h/[hostId]/session/[worktreeId].tsx`
- `pnpm exec oxlint mobile/app/h/[hostId]/session/[worktreeId].tsx`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- AST Effect count: 920 -> 915

## Mobile test constraints
- `pnpm exec vitest run mobile/src/session/mobile-session-startup-source.test.ts mobile/src/session/mobile-terminal-records.test.ts` is blocked in this checkout by missing `expo/tsconfig.base` from the mobile TypeScript config.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.