### PR TITLE
Move mobile tasks client ref sync out of effect

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   ActivityIndicator,
@@ -2020,9 +2020,6 @@ export default function MobileTasksScreen() {
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
   const clientRef = useRef<RpcClient | null>(null)
-  // Why: async task loads use this ref as a stale-client guard; update it
-  // before commit so a just-rendered load path does not see the old client.
-  clientRef.current = client
   const reposRef = useRef<RepoSummary[]>([])
   const loadGenerationRef = useRef(0)
   const taskResumeRef = useRef<TaskResumeState>({})
@@ -2536,6 +2533,12 @@ export default function MobileTasksScreen() {
     }
     return [...logins].sort().join(',')
   }, [projectRowDetail, projectRowItem?.content.assignees])
+
+  // Why: task-loading effects use this as a stale-client guard, so the ref
+  // must be current before those passive effects can run after commit.
+  useLayoutEffect(() => {
+    clientRef.current = client
+  }, [client])
 
   const persistTaskResumeState = useCallback(
     (updates: Partial<TaskResumeState>) => {

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -2020,6 +2020,9 @@ export default function MobileTasksScreen() {
   const reconnectAttempts = useReconnectAttempt(hostId)
   const lastConnectedAt = useLastConnectedAt(hostId)
   const clientRef = useRef<RpcClient | null>(null)
+  // Why: async task loads use this ref as a stale-client guard; update it
+  // before commit so a just-rendered load path does not see the old client.
+  clientRef.current = client
   const reposRef = useRef<RepoSummary[]>([])
   const loadGenerationRef = useRef(0)
   const taskResumeRef = useRef<TaskResumeState>({})
@@ -2533,10 +2536,6 @@ export default function MobileTasksScreen() {
     }
     return [...logins].sort().join(',')
   }, [projectRowDetail, projectRowItem?.content.assignees])
-
-  useEffect(() => {
-    clientRef.current = client
-  }, [client])
 
   const persistTaskResumeState = useCallback(
     (updates: Partial<TaskResumeState>) => {


### PR DESCRIPTION
## Summary
- move the mobile Tasks shared-client ref sync out of a passive Effect
- keep async task-loading stale-client guards reading the latest client before commit
- leave task fetching, provider persistence, and route hydration behavior unchanged

## Risk
High - mobile task/provider RPC behavior and remote-client stale request guards; no transport protocol or persisted format changes.

## Validation
- `pnpm exec oxfmt --write mobile/app/h/[hostId]/tasks.tsx`
- `pnpm exec oxlint mobile/app/h/[hostId]/tasks.tsx`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- AST Effect count: 920 -> 919