### PR TITLE
Reset diff viewer autoscroll before commit

### DIFF
--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -184,13 +184,13 @@ export default function DiffViewer({
   // one-shot per mount.
   const didAutoScrollFirstDiffRef = useRef(false)
   const didAutoScrollModelKeyRef = useRef(modelKey)
-  if (didAutoScrollModelKeyRef.current !== modelKey) {
-    didAutoScrollModelKeyRef.current = modelKey
-    // Why: the one-shot above is intentionally per-modelKey. Reset before
-    // commit so the auto-scroll Effect can run immediately for a new file.
-    didAutoScrollFirstDiffRef.current = false
-  }
   useEffect(() => {
+    if (didAutoScrollModelKeyRef.current !== modelKey) {
+      didAutoScrollModelKeyRef.current = modelKey
+      // Why: the one-shot above is intentionally per-modelKey. Reset inside
+      // this Effect before its first-diff guard runs for the new file.
+      didAutoScrollFirstDiffRef.current = false
+    }
     const diffEditor = diffEditorRef.current
     if (!diffEditor || !modifiedEditor) {
       return

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -183,15 +183,13 @@ export default function DiffViewer({
   // added in this render pass. The didScroll guard makes this strictly
   // one-shot per mount.
   const didAutoScrollFirstDiffRef = useRef(false)
-  // Why: the one-shot above is intentionally per-modelKey. Today every call
-  // site uses `key={viewStateScopeId}` so the component remounts on model
-  // change and the ref is fresh, but the auto-scroll effect lists modelKey in
-  // its deps — make that contract honest by resetting the flag when modelKey
-  // flips, so a future call site without a remount key still gets a fresh
-  // first-diff scroll per file.
-  useLayoutEffect(() => {
+  const didAutoScrollModelKeyRef = useRef(modelKey)
+  if (didAutoScrollModelKeyRef.current !== modelKey) {
+    didAutoScrollModelKeyRef.current = modelKey
+    // Why: the one-shot above is intentionally per-modelKey. Reset before
+    // commit so the auto-scroll Effect can run immediately for a new file.
     didAutoScrollFirstDiffRef.current = false
-  }, [modelKey])
+  }
   useEffect(() => {
     const diffEditor = diffEditorRef.current
     if (!diffEditor || !modifiedEditor) {


### PR DESCRIPTION
## Summary
- reset the DiffViewer first-diff auto-scroll guard during render when `modelKey` changes
- remove the dedicated layout Effect that only reset that ref
- keep the existing auto-scroll Effect and diff view-state cleanup behavior unchanged

## Risk
Medium - editor diff initial-scroll behavior only; no persistence format, terminal, browser, source-control provider, or IPC contract changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/DiffViewer.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/DiffViewer.tsx`
- `pnpm run typecheck:web`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- AST Effect count: 920 -> 919

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.