### PR TITLE
Normalize floating workspace bounds before commit

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -413,18 +413,19 @@ function App(): React.JSX.Element {
 
   const setFloatingTerminalOpenWithFocus = useCallback(
     (nextOpen: SetStateAction<boolean>): void => {
-      setFloatingTerminalOpen((currentOpen) => {
-        const resolvedOpen = typeof nextOpen === 'function' ? nextOpen(currentOpen) : nextOpen
-        if (resolvedOpen && !currentOpen) {
-          useAppStore.getState().recordFeatureInteraction('floating-workspace')
-          rememberFloatingTerminalReturnFocus()
-        } else if (!resolvedOpen && currentOpen) {
-          restoreFloatingTerminalReturnFocus()
-        }
-        return resolvedOpen
-      })
+      const resolvedOpen =
+        typeof nextOpen === 'function' ? nextOpen(floatingTerminalOpen) : nextOpen
+      // Why: recordFeatureInteraction updates Zustand subscribers; doing it
+      // inside React's state updater logs a render-phase update warning.
+      if (resolvedOpen && !floatingTerminalOpen) {
+        useAppStore.getState().recordFeatureInteraction('floating-workspace')
+        rememberFloatingTerminalReturnFocus()
+      } else if (!resolvedOpen && floatingTerminalOpen) {
+        restoreFloatingTerminalReturnFocus()
+      }
+      setFloatingTerminalOpen(resolvedOpen)
     },
-    [rememberFloatingTerminalReturnFocus, restoreFloatingTerminalReturnFocus]
+    [floatingTerminalOpen, rememberFloatingTerminalReturnFocus, restoreFloatingTerminalReturnFocus]
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- move first-open floating workspace bounds normalization out of a passive Effect
- normalize before the first open paint when the panel mounted before final Electron window dimensions
- keep resize/maximize and terminal/browser/editor pane behavior unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- git diff --check
- AST Effect count 920 -> 919

Risk: Medium. This changes floating workspace panel positioning timing only; no terminal transport, persistence format, browser webview, or source-control behavior changes.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.