### PR TITLE
Fold browser find debounce into search effect

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserFind.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserFind.tsx
@@ -14,19 +14,10 @@ export default function BrowserFind({
   webviewRef
 }: BrowserFindProps): React.JSX.Element | null {
   const inputRef = useRef<HTMLInputElement>(null)
+  const wasOpenRef = useRef(isOpen)
   const [query, setQuery] = useState('')
-  const [debouncedQuery, setDebouncedQuery] = useState('')
   const [activeMatch, setActiveMatch] = useState(0)
   const [totalMatches, setTotalMatches] = useState(0)
-
-  // Why: findInPage re-highlights the active match on every call, which causes
-  // a visible flash as the user types. Debounce to only re-run once typing
-  // settles. Enter (findNext/findPrevious) still uses the live `query` so
-  // explicit navigation is immediate.
-  useEffect(() => {
-    const id = setTimeout(() => setDebouncedQuery(query), 200)
-    return () => clearTimeout(id)
-  }, [query])
 
   const safeFindInPage = useCallback(
     (text: string, opts?: Electron.FindInPageOptions): void => {
@@ -80,16 +71,29 @@ export default function BrowserFind({
   }, [isOpen, safeStopFindInPage])
 
   useEffect(() => {
-    if (!debouncedQuery) {
+    const wasOpen = wasOpenRef.current
+    wasOpenRef.current = isOpen
+    if (!isOpen) {
+      return
+    }
+    if (!query) {
       safeStopFindInPage()
       setActiveMatch(0)
       setTotalMatches(0)
       return
     }
-    if (isOpen) {
-      safeFindInPage(debouncedQuery)
+
+    const runFind = (): void => safeFindInPage(query)
+    if (!wasOpen) {
+      runFind()
+      return
     }
-  }, [debouncedQuery, isOpen, safeFindInPage, safeStopFindInPage])
+    // Why: findInPage re-highlights the active match on every call, which can
+    // flash while typing. Debounce typing changes, while reopen and Enter
+    // navigation still use the live query immediately.
+    const id = window.setTimeout(runFind, 200)
+    return () => window.clearTimeout(id)
+  }, [isOpen, query, safeFindInPage, safeStopFindInPage])
 
   // Why: this effect captures `webviewRef.current` into a local variable, so
   // if the webview element were replaced while `isOpen` stays true the listener


### PR DESCRIPTION
## Summary
- Remove BrowserFind debounced-query state and its separate Effect
- Keep typing searches debounced while preserving immediate search when reopening the find bar with an existing query
- Continue using live query for Enter/Shift+Enter navigation

Risk: Medium

## Verification
- pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserFind.tsx
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 914, branch 913

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.