### PR TITLE
Move editor path copy timer into handler

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -50,9 +50,17 @@ function EditorPanelInner({
   const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
     null
   )
+  const copiedPathToastTimerRef = useRef<number | null>(null)
   const [showMarkdownTableOfContents, setShowMarkdownTableOfContents] = useState(false)
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
+  const clearCopiedPathToastTimer = useCallback((): void => {
+    if (copiedPathToastTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(copiedPathToastTimerRef.current)
+    copiedPathToastTimerRef.current = null
+  }, [])
 
   if (settings?.diffDefaultView !== prevDiffView) {
     setPrevDiffView(settings?.diffDefaultView)
@@ -86,16 +94,17 @@ function EditorPanelInner({
     handleRenameConfirm
   } = useUntitledFileRename({ openFiles, closeFile, openFile, clearUntitled })
 
-  useEffect(() => acquireExportPdfListener(), [])
+  useEffect(() => {
+    const releaseExportPdfListener = acquireExportPdfListener()
+    return () => {
+      releaseExportPdfListener()
+      // Why: the copy-toast timeout is started by the copy event; clear it
+      // with the existing mount cleanup so it cannot update after unmount.
+      clearCopiedPathToastTimer()
+    }
+  }, [clearCopiedPathToastTimer])
   useClosedEditorTabCleanup(openFiles)
   useMarkdownPreviewShortcut({ activeFile, panelRef, openMarkdownPreview })
-  useEffect(() => {
-    if (!copiedPathToast) {
-      return
-    }
-    const timeout = window.setTimeout(() => setCopiedPathToast(null), 1500)
-    return () => window.clearTimeout(timeout)
-  }, [copiedPathToast])
 
   const handleContentChangeForFile = useCallback(
     (file: typeof activeFile, content: string) => {
@@ -181,11 +190,17 @@ function EditorPanelInner({
     }
     try {
       await window.api.ui.writeClipboardText(copyState.copyText)
+      clearCopiedPathToastTimer()
       setCopiedPathToast({ fileId: activeFile.id, token: Date.now() })
+      copiedPathToastTimerRef.current = window.setTimeout(() => {
+        copiedPathToastTimerRef.current = null
+        setCopiedPathToast(null)
+      }, 1500)
     } catch {
+      clearCopiedPathToastTimer()
       setCopiedPathToast(null)
     }
-  }, [activeFile])
+  }, [activeFile, clearCopiedPathToastTimer])
 
   if (!activeFile) {
     return null


### PR DESCRIPTION
## Summary
- Start the editor path-copy toast timeout directly after a successful copy event
- Reuse the existing EditorPanel mount cleanup to clear any pending copy-toast timeout on unmount
- Remove the passive Effect that watched copiedPathToast only to start the timeout

Risk: Medium

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/editor/EditorPanel.tsx
- pnpm exec oxlint src/renderer/src/components/editor/EditorPanel.tsx
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 914, branch 913

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.