### PR TITLE
Lift feature wall skill installed state

### DIFF
--- a/src/renderer/src/components/feature-wall/BrowserUseSkillSetupCard.tsx
+++ b/src/renderer/src/components/feature-wall/BrowserUseSkillSetupCard.tsx
@@ -1,37 +1,19 @@
-import { useEffect, type JSX } from 'react'
-import {
-  ORCA_CLI_SKILL_INSTALL_COMMAND,
-  ORCA_CLI_SKILL_NAME
-} from '@/lib/agent-feature-install-commands'
+import type { JSX } from 'react'
+import { ORCA_CLI_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
   ensureOrcaCliAvailableForAgentSkillTerminal
 } from '@/lib/agent-skill-cli-prerequisite'
 import { BROWSER_USE_ENABLED_STORAGE_KEY } from '@/lib/browser-use-setup-state'
-import {
-  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
-  useInstalledAgentSkill
-} from '@/hooks/useInstalledAgentSkills'
+import type { InstalledAgentSkillState } from '@/hooks/useInstalledAgentSkills'
 import { AgentSkillSetupPanel } from '@/components/settings/AgentSkillSetupPanel'
 
 export function BrowserUseSkillSetupCard(props: {
   compact?: boolean
   terminalHeightPx?: number
-  onInstalledChange?: (installed: boolean) => void
+  skill: InstalledAgentSkillState
 }): JSX.Element {
-  const { compact, terminalHeightPx, onInstalledChange } = props
-  const {
-    installed: skillInstalled,
-    loading: skillLoading,
-    error: skillError,
-    refresh: refreshSkillInstalled
-  } = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
-    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
-  })
-
-  useEffect(() => {
-    onInstalledChange?.(skillInstalled)
-  }, [onInstalledChange, skillInstalled])
+  const { compact, terminalHeightPx, skill } = props
 
   const handleBeforeOpenTerminal = async (): Promise<void> => {
     await ensureOrcaCliAvailableForAgentSkillTerminal()
@@ -47,14 +29,14 @@ export function BrowserUseSkillSetupCard(props: {
       terminalTitle="Browser Use setup"
       terminalAriaLabel="Browser Use skill install terminal"
       terminalWorktreeId="feature-wall-browser-use-skill-terminal"
-      installed={skillInstalled}
-      loading={skillLoading}
-      error={skillError}
+      installed={skill.installed}
+      loading={skill.loading}
+      error={skill.error}
       terminalHeightPx={terminalHeightPx}
       preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
       onBeforeOpenTerminal={handleBeforeOpenTerminal}
       showRecheckWhenInstalled={false}
-      onRecheck={refreshSkillInstalled}
+      onRecheck={skill.refresh}
     />
   )
 

--- a/src/renderer/src/components/feature-wall/FeatureWallBody.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallBody.tsx
@@ -5,6 +5,7 @@ import type { AgentsStep } from '../../../../shared/agents-orchestration-steps'
 import type { WorkbenchStep } from '../../../../shared/workbench-steps'
 import type { ReviewStep } from '../../../../shared/review-steps'
 import type { GlobalSettings } from '../../../../shared/types'
+import type { InstalledAgentSkillState } from '@/hooks/useInstalledAgentSkills'
 import { cn } from '@/lib/utils'
 import { PreviewMedia, RelatedFeatures } from './FeatureWallPreview'
 import { TasksAnimatedVisual } from './TasksAnimatedVisual'
@@ -31,8 +32,8 @@ export function FeatureWallBody(props: {
   agentsActiveStep: AgentsStep | null
   workbenchActiveStep: WorkbenchStep | null
   reviewActiveStep: ReviewStep | null
-  onOrchestrationSkillInstalledChange: (installed: boolean) => void
-  onBrowserUseSkillInstalledChange: (installed: boolean) => void
+  orchestrationSkill: InstalledAgentSkillState
+  browserUseSkill: InstalledAgentSkillState
   onUsageAccountStateChange: () => void | Promise<void>
   settings: GlobalSettings | null
   updateSettings: (updates: Partial<GlobalSettings>) => void
@@ -47,8 +48,8 @@ export function FeatureWallBody(props: {
     agentsActiveStep,
     workbenchActiveStep,
     reviewActiveStep,
-    onOrchestrationSkillInstalledChange,
-    onBrowserUseSkillInstalledChange,
+    orchestrationSkill,
+    browserUseSkill,
     onUsageAccountStateChange
   } = props
   const isWorkspaces = selected.id === 'workspaces'
@@ -127,17 +128,9 @@ export function FeatureWallBody(props: {
   ) : isAgentsUsage ? (
     <UsageAccountsCard onAccountStateChange={onUsageAccountStateChange} />
   ) : isAgentsOrchestration ? (
-    <OrchestrationSetupCard
-      compact
-      terminalHeightPx={240}
-      onInstalledChange={onOrchestrationSkillInstalledChange}
-    />
+    <OrchestrationSetupCard compact terminalHeightPx={240} skill={orchestrationSkill} />
   ) : isWorkbenchBrowser ? (
-    <BrowserUseSkillSetupCard
-      compact
-      terminalHeightPx={240}
-      onInstalledChange={onBrowserUseSkillInstalledChange}
-    />
+    <BrowserUseSkillSetupCard compact terminalHeightPx={240} skill={browserUseSkill} />
   ) : isReviewPrView ? (
     <GitHubRow compact />
   ) : isReviewShip ? (

--- a/src/renderer/src/components/feature-wall/FeatureWallTourPanel.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallTourPanel.tsx
@@ -8,6 +8,7 @@ import type { ReviewStep, ReviewStepId } from '../../../../shared/review-steps'
 import type { FeatureWallOpenSourceTelemetry } from '../../../../shared/telemetry-events'
 import type { GlobalSettings } from '../../../../shared/types'
 import type { WorkbenchStep, WorkbenchStepId } from '../../../../shared/workbench-steps'
+import type { InstalledAgentSkillState } from '@/hooks/useInstalledAgentSkills'
 import { cn } from '@/lib/utils'
 import type { FeatureWallCompletionState } from './use-feature-wall-completion'
 import { FeatureWallBody } from './FeatureWallBody'
@@ -47,8 +48,8 @@ export function FeatureWallTourPanel(props: {
   showGif: boolean
   prefersReducedMotion: boolean
   source: FeatureWallOpenSourceTelemetry
-  onOrchestrationSkillInstalledChange: (installed: boolean) => void
-  onBrowserUseSkillInstalledChange: (installed: boolean) => void
+  orchestrationSkill: InstalledAgentSkillState
+  browserUseSkill: InstalledAgentSkillState
   settings: GlobalSettings | null
   updateSettings: (updates: Partial<GlobalSettings>) => void
   footerText: string | null
@@ -139,8 +140,8 @@ export function FeatureWallTourPanel(props: {
             agentsActiveStep={props.agentsActiveStep}
             workbenchActiveStep={props.workbenchActiveStep}
             reviewActiveStep={props.reviewActiveStep}
-            onOrchestrationSkillInstalledChange={props.onOrchestrationSkillInstalledChange}
-            onBrowserUseSkillInstalledChange={props.onBrowserUseSkillInstalledChange}
+            orchestrationSkill={props.orchestrationSkill}
+            browserUseSkill={props.browserUseSkill}
             onUsageAccountStateChange={props.completion.refreshUsageAccountState}
             settings={props.settings}
             updateSettings={props.updateSettings}

--- a/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
@@ -15,6 +15,11 @@ import type { FeatureWallOpenSourceTelemetry } from '../../../../shared/telemetr
 import type { FeatureWallTourDepthSummary } from '../../../../shared/feature-wall-tour-depth'
 import { track } from '@/lib/telemetry'
 import { useAppStore } from '@/store'
+import { ORCA_CLI_SKILL_NAME, ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
+import {
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
+  useInstalledAgentSkill
+} from '@/hooks/useInstalledAgentSkills'
 import { usePrefersReducedMotion } from './feature-wall-modal-helpers'
 import {
   getFeatureWallRailNavigationTarget,
@@ -104,14 +109,23 @@ export function FeatureWallTourSurface({
       setReviewStepId(reviewSteps[0]?.id ?? 'notes')
     }
   }
-  const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState(false)
-  const [browserUseSkillInstalled, setBrowserUseSkillInstalled] = useState(false)
+  // Why: the feature-wall completion model owns skill-completion state, so read
+  // installed skills here instead of asking child setup cards to notify upward
+  // from passive Effects.
+  const orchestrationSkill = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
+    enabled: isOpen,
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
+  const browserUseSkill = useInstalledAgentSkill(ORCA_CLI_SKILL_NAME, {
+    enabled: isOpen,
+    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
+  })
   const completion = useFeatureWallCompletion(
     isOpen,
     taskSourcePresentation.hasConnectedTaskSource,
     taskSourcePresentation.isCheckingTaskSources,
-    orchestrationSkillInstalled,
-    browserUseSkillInstalled,
+    orchestrationSkill.installed,
+    browserUseSkill.installed,
     { onTourDepthSummaryChange }
   )
   const { markExitAction } = useFeatureWallTourTelemetry({
@@ -385,8 +399,8 @@ export function FeatureWallTourSurface({
       showGif={showGif}
       prefersReducedMotion={prefersReducedMotion}
       source={source}
-      onOrchestrationSkillInstalledChange={setOrchestrationSkillInstalled}
-      onBrowserUseSkillInstalledChange={setBrowserUseSkillInstalled}
+      orchestrationSkill={orchestrationSkill}
+      browserUseSkill={browserUseSkill}
       settings={settings}
       updateSettings={updateSettings}
       footerText={footerText}

--- a/src/renderer/src/components/settings/OrchestrationSetupCard.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSetupCard.tsx
@@ -1,34 +1,18 @@
-import { useEffect, type JSX } from 'react'
-import { ORCHESTRATION_SKILL_NAME } from '@/lib/agent-feature-install-commands'
+import type { JSX } from 'react'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
   ensureOrcaCliAvailableForAgentSkillTerminal
 } from '@/lib/agent-skill-cli-prerequisite'
 import { ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/orchestration-install-command'
-import {
-  GLOBAL_AGENT_SKILL_SOURCE_KINDS,
-  useInstalledAgentSkill
-} from '@/hooks/useInstalledAgentSkills'
+import type { InstalledAgentSkillState } from '@/hooks/useInstalledAgentSkills'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 
 export function OrchestrationSetupCard(props: {
   compact?: boolean
   terminalHeightPx?: number
-  onInstalledChange?: (installed: boolean) => void
+  skill: InstalledAgentSkillState
 }): JSX.Element {
-  const { compact, terminalHeightPx, onInstalledChange } = props
-  const {
-    installed: skillInstalled,
-    loading: skillLoading,
-    error: skillError,
-    refresh: refreshSkillInstalled
-  } = useInstalledAgentSkill(ORCHESTRATION_SKILL_NAME, {
-    sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
-  })
-
-  useEffect(() => {
-    onInstalledChange?.(skillInstalled)
-  }, [onInstalledChange, skillInstalled])
+  const { compact, terminalHeightPx, skill } = props
 
   const setupPanel = (
     <AgentSkillSetupPanel
@@ -39,16 +23,16 @@ export function OrchestrationSetupCard(props: {
       terminalTitle="Orchestration setup"
       terminalAriaLabel="Orchestration skill install terminal"
       terminalWorktreeId="feature-wall-orchestration-skill-terminal"
-      installed={skillInstalled}
-      loading={skillLoading}
-      error={skillError}
+      installed={skill.installed}
+      loading={skill.loading}
+      error={skill.error}
       terminalHeightPx={terminalHeightPx}
       preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
       onBeforeOpenTerminal={async () => {
         await ensureOrcaCliAvailableForAgentSkillTerminal()
       }}
       showRecheckWhenInstalled={false}
-      onRecheck={refreshSkillInstalled}
+      onRecheck={skill.refresh}
     />
   )
 

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -15,6 +15,13 @@ type InstalledAgentSkillMatchOptions = {
   sourceKinds?: readonly SkillSourceKind[]
 }
 
+export type InstalledAgentSkillState = {
+  installed: boolean
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
 let cachedDiscovery: SkillDiscoveryResult | null = null
 let pendingDiscovery: Promise<SkillDiscoveryResult> | null = null
 let pendingDiscoverySatisfiesForcedRefresh = false
@@ -108,12 +115,7 @@ export const _installedAgentSkillDiscoveryInternalsForTests = {
 export function useInstalledAgentSkill(
   skillName: string,
   options: InstalledAgentSkillOptions = {}
-): {
-  installed: boolean
-  loading: boolean
-  error: string | null
-  refresh: () => Promise<void>
-} {
+): InstalledAgentSkillState {
   const { enabled = true, sourceKinds } = options
   const [result, setResult] = useState<SkillDiscoveryResult | null>(cachedDiscovery)
   const [loading, setLoading] = useState(enabled && !cachedDiscovery)


### PR DESCRIPTION
Summary
- Read orchestration and browser-use installed-skill state in FeatureWallTourSurface, where feature-wall completion is computed
- Pass installed-skill state down to the setup cards instead of callback props
- Remove the child-to-parent passive Effects used only to report installed changes

Risk: Medium

Medium because this changes feature-wall completion timing and installed-skill discovery ownership while preserving the displayed setup-card behavior.

Verification
- pnpm exec oxfmt --write src/renderer/src/hooks/useInstalledAgentSkills.ts src/renderer/src/components/settings/OrchestrationSetupCard.tsx src/renderer/src/components/feature-wall/BrowserUseSkillSetupCard.tsx src/renderer/src/components/feature-wall/FeatureWallBody.tsx src/renderer/src/components/feature-wall/FeatureWallTourPanel.tsx src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
- pnpm exec oxlint src/renderer/src/hooks/useInstalledAgentSkills.ts src/renderer/src/components/settings/OrchestrationSetupCard.tsx src/renderer/src/components/feature-wall/BrowserUseSkillSetupCard.tsx src/renderer/src/components/feature-wall/FeatureWallBody.tsx src/renderer/src/components/feature-wall/FeatureWallTourPanel.tsx src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-completion.test.ts
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 914, branch 912

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.