### PR TITLE
Collapse feature wall session depth publishing Effect

### DIFF
--- a/src/renderer/src/components/feature-wall/use-feature-wall-session-depth.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-session-depth.ts
@@ -94,27 +94,24 @@ export function useFeatureWallSessionDepth(
 
   const wasOpenRef = useRef(false)
   useEffect(() => {
-    const openedNow = isOpen && !wasOpenRef.current
-    wasOpenRef.current = isOpen
-    if (!openedNow) {
+    if (!isOpen) {
+      wasOpenRef.current = false
       return
     }
-    // Why: depth telemetry is per explicit tour session; persisted completion
-    // can color the UI but must not leak into current-session depth fields.
-    sessionDepthRef.current = {
-      visitedWorkflows: new Set(),
-      visitedAgentSteps: new Set(),
-      visitedWorkbenchSteps: new Set(),
-      visitedReviewSteps: new Set(),
-      lastGroupId: null
+    const openedNow = !wasOpenRef.current
+    wasOpenRef.current = true
+    if (openedNow) {
+      // Why: depth telemetry is per explicit tour session; persisted completion
+      // can color the UI but must not leak into current-session depth fields.
+      sessionDepthRef.current = {
+        visitedWorkflows: new Set(),
+        visitedAgentSteps: new Set(),
+        visitedWorkbenchSteps: new Set(),
+        visitedReviewSteps: new Set(),
+        lastGroupId: null
+      }
     }
     publishTourDepthSummary()
-  }, [isOpen, publishTourDepthSummary])
-
-  useEffect(() => {
-    if (isOpen) {
-      publishTourDepthSummary()
-    }
   }, [isOpen, publishTourDepthSummary])
 
   const markWorkflowVisitedForSession = useCallback(


### PR DESCRIPTION
Summary
- Collapse the feature-wall session-depth open-edge reset and summary-publish Effects into one Effect
- Preserve per-open session reset semantics while publishing the summary once on open and on later progress-input changes
- Remove the duplicate summary publication that happened when the tour opened

Risk: Medium

Medium because this touches feature-wall telemetry/session-depth publication timing, even though it narrows duplicate work rather than changing the depth model.

Verification
- pnpm exec oxfmt --write src/renderer/src/components/feature-wall/use-feature-wall-session-depth.ts
- pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-session-depth.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/use-feature-wall-completion.test.ts
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 914, branch 913

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.