### PR TITLE
Share reduced motion media query hook

### DIFF
--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -2,6 +2,7 @@
    renderer surface. Keeping the state machine and its presentation variants together avoids
    scattering tightly coupled update behavior across multiple files. */
 import { useEffect, useRef, useState } from 'react'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { useAppStore } from '../store'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
@@ -195,14 +196,7 @@ export function UpdateCard() {
   }, [status.state])
 
   // ── Prefers-reduced-motion ──────────────────────────────────────────
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setPrefersReducedMotion(mq.matches)
-    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches)
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+  const prefersReducedMotion = usePrefersReducedMotion()
 
   // ── Visibility gates ──────────────────────────────────────────────
 

--- a/src/renderer/src/components/feature-wall/feature-wall-modal-helpers.ts
+++ b/src/renderer/src/components/feature-wall/feature-wall-modal-helpers.ts
@@ -1,7 +1,5 @@
-import { useEffect, useState } from 'react'
 import type { FeatureWallOpenSourceTelemetry } from '../../../../shared/telemetry-events'
-
-const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+export { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 
 export function getFeatureWallOpenSource(
   modalData: Record<string, unknown>
@@ -10,28 +8,4 @@ export function getFeatureWallOpenSource(
   return source === 'help_menu' || source === 'popup' || source === 'onboarding'
     ? source
     : 'unknown'
-}
-
-export function usePrefersReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) {
-      return false
-    }
-    return window.matchMedia(REDUCED_MOTION_QUERY).matches
-  })
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) {
-      return
-    }
-    const media = window.matchMedia(REDUCED_MOTION_QUERY)
-    setPrefersReducedMotion(media.matches)
-    const onChange = (event: MediaQueryListEvent): void => {
-      setPrefersReducedMotion(event.matches)
-    }
-    media.addEventListener('change', onChange)
-    return () => media.removeEventListener('change', onChange)
-  }, [])
-
-  return prefersReducedMotion
 }

--- a/src/renderer/src/components/pet/PetOverlay.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from 'react'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { usePetUrl } from './usePetUrl'
 import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
 import type { CustomPet } from '../../../../shared/types'
@@ -174,25 +175,6 @@ function useDocumentVisible(): boolean {
     return () => document.removeEventListener('visibilitychange', onChange)
   }, [])
   return visible
-}
-
-function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return false
-    }
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  })
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return
-    }
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const onChange = (event: MediaQueryListEvent): void => setReduced(event.matches)
-    mq.addEventListener('change', onChange)
-    return () => mq.removeEventListener('change', onChange)
-  }, [])
-  return reduced
 }
 
 // Why: keep a default for the cached helpers below; the live size now comes

--- a/src/renderer/src/hooks/usePrefersReducedMotion.ts
+++ b/src/renderer/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+function readPrefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches
+}
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(readPrefersReducedMotion)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+    const media = window.matchMedia(REDUCED_MOTION_QUERY)
+    setPrefersReducedMotion(media.matches)
+    const onChange = (event: MediaQueryListEvent): void => {
+      setPrefersReducedMotion(event.matches)
+    }
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }, [])
+
+  return prefersReducedMotion
+}


### PR DESCRIPTION
Summary
- Add a shared reduced-motion media-query hook
- Reuse it from UpdateCard, PetOverlay, and feature-wall/onboarding helpers
- Remove duplicate media-query subscription Effect definitions

Risk: Medium

Medium because this touches reduced-motion handling across multiple user-facing renderer surfaces, even though behavior stays the same.

Verification
- pnpm exec oxfmt --write src/renderer/src/hooks/usePrefersReducedMotion.ts src/renderer/src/components/feature-wall/feature-wall-modal-helpers.ts src/renderer/src/components/UpdateCard.tsx src/renderer/src/components/pet/PetOverlay.tsx
- pnpm exec oxlint src/renderer/src/hooks/usePrefersReducedMotion.ts src/renderer/src/components/feature-wall/feature-wall-modal-helpers.ts src/renderer/src/components/UpdateCard.tsx src/renderer/src/components/pet/PetOverlay.tsx
- pnpm run typecheck:web
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/UpdateCard.test.ts src/renderer/src/components/pet/pet-overlay-visibility.test.ts
- git diff --check
- React Effect AST count: origin/main 914, branch 912

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.