### PR TITLE
Resolve PDF find open reset before commit

### DIFF
--- a/src/renderer/src/components/editor/PdfFind.tsx
+++ b/src/renderer/src/components/editor/PdfFind.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ChevronUp, ChevronDown, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import type { EventBus } from 'pdfjs-dist/web/pdf_viewer.mjs'
@@ -14,7 +14,6 @@ export default function PdfFind({
   onClose,
   eventBusRef
 }: PdfFindProps): React.JSX.Element | null {
-  const inputRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState('')
   const [activeMatch, setActiveMatch] = useState(0)
   const [totalMatches, setTotalMatches] = useState(0)
@@ -50,21 +49,18 @@ export default function PdfFind({
     }
   }, [query, dispatchFind])
 
-  useEffect(() => {
-    if (isOpen) {
-      inputRef.current?.focus()
-      inputRef.current?.select()
-    } else {
-      const eventBus = eventBusRef.current
-      if (eventBus) {
-        eventBus.dispatch('findbarclose', { source: null })
-      }
-      setActiveMatch(0)
-      setTotalMatches(0)
+  const handleInputRef = useCallback((input: HTMLInputElement | null) => {
+    if (!input) {
+      return
     }
-  }, [isOpen, eventBusRef])
+    input.focus()
+    input.select()
+  }, [])
 
   useEffect(() => {
+    if (!isOpen) {
+      return
+    }
     if (!query) {
       const eventBus = eventBusRef.current
       if (eventBus) {
@@ -74,9 +70,7 @@ export default function PdfFind({
       setTotalMatches(0)
       return
     }
-    if (isOpen) {
-      dispatchFind('')
-    }
+    dispatchFind('')
   }, [query, isOpen, dispatchFind, eventBusRef])
 
   useEffect(() => {
@@ -110,6 +104,13 @@ export default function PdfFind({
     [onClose, findNext, findPrevious]
   )
 
+  // Why: close hides the bar immediately; reset counters before the next commit
+  // so reopening with the same query never paints stale match totals.
+  if (!isOpen && (activeMatch !== 0 || totalMatches !== 0)) {
+    setActiveMatch(0)
+    setTotalMatches(0)
+  }
+
   if (!isOpen) {
     return null
   }
@@ -121,7 +122,7 @@ export default function PdfFind({
       onKeyDown={handleKeyDown}
     >
       <input
-        ref={inputRef}
+        ref={handleInputRef}
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -139,6 +139,10 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
   }, [cleanedContent])
 
   const closeFindBar = useCallback(() => {
+    const eventBus = eventBusRef.current
+    if (eventBus) {
+      eventBus.dispatch('findbarclose', { source: null })
+    }
     setFindOpen(false)
   }, [])
 


### PR DESCRIPTION
Summary
- Move PDF find close cleanup into the explicit close path
- Focus/select the PDF find input from its callback ref when the bar opens
- Reset match counters before the closed render commits instead of from a passive open-state Effect

Risk: Medium

Medium because this touches editor PDF find behavior and pdf.js EventBus close handling, even though the UI flow and search dispatch semantics are preserved.

Verification
- pnpm exec oxfmt --write src/renderer/src/components/editor/PdfFind.tsx src/renderer/src/components/editor/PdfViewer.tsx
- pnpm exec oxlint src/renderer/src/components/editor/PdfFind.tsx src/renderer/src/components/editor/PdfViewer.tsx
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 914, branch 913

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.