### PR TITLE
Focus worktree rename input from ref

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -39,7 +39,6 @@ export function WorktreeTitleInlineRename({
   onEditingChange,
   onRename
 }: WorktreeTitleInlineRenameProps): React.JSX.Element {
-  const inputRef = useRef<HTMLInputElement>(null)
   const savingRef = useRef(false)
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(displayName)
@@ -54,15 +53,14 @@ export function WorktreeTitleInlineRename({
     }
   }, [editing, onEditingChange])
 
-  useEffect(() => {
-    if (!editing) {
+  const handleInputRef = useCallback((input: HTMLInputElement | null) => {
+    if (!input) {
       return
     }
-    const input = inputRef.current
-    input?.focus()
+    input.focus()
     // Why: double-click rename should make replacing the workspace title a one-keystroke action.
-    input?.select()
-  }, [editing])
+    input.select()
+  }, [])
 
   const stopCardEvent = useCallback((event: React.SyntheticEvent) => {
     event.stopPropagation()
@@ -142,7 +140,7 @@ export function WorktreeTitleInlineRename({
           {displayName}
         </span>
         <Input
-          ref={inputRef}
+          ref={handleInputRef}
           value={value}
           style={{ font: 'inherit' }}
           disabled={saving}


### PR DESCRIPTION
Summary
- Replace the worktree title rename input focus Effect with a callback ref
- Keep the one-keystroke select-all behavior when rename mode opens
- Remove one visual-only Effect from the inline rename component

Risk: Low

Low because this is isolated local focus/selection behavior with no persistence, IPC, terminal, browser, source-control, SSH, or provider behavior.

Verification
- pnpm exec oxfmt --write src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 913, branch 912