### PR TITLE
Notify worktree title rename mode from handlers

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
@@ -39,19 +39,24 @@ export function WorktreeTitleInlineRename({
   onEditingChange,
   onRename
 }: WorktreeTitleInlineRenameProps): React.JSX.Element {
+  const editingRef = useRef(false)
   const savingRef = useRef(false)
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(displayName)
   const [saving, setSaving] = useState(false)
 
-  useEffect(() => {
-    onEditingChange?.(editing)
-    return () => {
-      if (editing) {
-        onEditingChange?.(false)
+  const setEditingMode = useCallback(
+    (nextEditing: boolean) => {
+      if (editingRef.current === nextEditing) {
+        return
       }
-    }
-  }, [editing, onEditingChange])
+      editingRef.current = nextEditing
+      setEditing(nextEditing)
+      // Why: the parent card disables drag while renaming; an Effect leaves one draggable commit.
+      onEditingChange?.(nextEditing)
+    },
+    [onEditingChange]
+  )
 
   const handleInputRef = useCallback((input: HTMLInputElement | null) => {
     if (!input) {
@@ -74,15 +79,15 @@ export function WorktreeTitleInlineRename({
       event.preventDefault()
       event.stopPropagation()
       setValue(displayName)
-      setEditing(true)
+      setEditingMode(true)
     },
-    [disabled, displayName]
+    [disabled, displayName, setEditingMode]
   )
 
   const cancelRename = useCallback(() => {
     setValue(displayName)
-    setEditing(false)
-  }, [displayName])
+    setEditingMode(false)
+  }, [displayName, setEditingMode])
 
   const commitRename = useCallback(async () => {
     if (savingRef.current) {
@@ -99,14 +104,14 @@ export function WorktreeTitleInlineRename({
     setSaving(true)
     try {
       await onRename(commit.displayName)
-      setEditing(false)
+      setEditingMode(false)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to rename workspace.')
     } finally {
       savingRef.current = false
       setSaving(false)
     }
-  }, [cancelRename, displayName, onRename, value])
+  }, [cancelRename, displayName, onRename, setEditingMode, value])
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Summary
- Replace the inline worktree-title editing-change Effect with explicit rename-mode transitions
- Notify the parent card in the same event turn so drag/styling disables without a delayed commit
- Remove one local UI coordination Effect from the sidebar rename control

Risk: Low

Low because this is isolated local card/input UI state. It does not touch persistence, IPC, terminal, browser, source-control, SSH, or provider behavior.

Verification
- pnpm exec oxfmt --write src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 912, branch 911