### PR TITLE
Fix unread badge for background selected chats

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { dispatchTerminalNotification } from './use-notification-dispatch'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
@@ -61,6 +61,19 @@ function makeAgentStatus(paneKey: string): AgentStatusEntry {
   }
 }
 
+function stubDocumentFocus({
+  visibilityState,
+  focused
+}: {
+  visibilityState: DocumentVisibilityState
+  focused: boolean
+}): void {
+  vi.stubGlobal('document', {
+    visibilityState,
+    hasFocus: vi.fn(() => focused)
+  })
+}
+
 describe('dispatchTerminalNotification', () => {
   const liveLeafId = '11111111-1111-4111-8111-111111111111'
   const staleLeafId = '22222222-2222-4222-8222-222222222222'
@@ -112,13 +125,17 @@ describe('dispatchTerminalNotification', () => {
       markTerminalTabUnread: vi.fn(),
       markTerminalPaneUnread: vi.fn()
     }
-    ;(globalThis as unknown as { window: unknown }).window = {
+    vi.stubGlobal('window', {
       api: {
         notifications: {
           dispatch: vi.fn().mockResolvedValue({ delivered: true })
         }
       }
-    }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('uses a live pane key when marking inactive worktree attention', () => {
@@ -205,9 +222,10 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })
 
-  it('does not mark the visible worktree unread when terminal attention is disabled', () => {
+  it('does not mark the visible focused worktree unread when terminal attention is disabled', () => {
     mockState.settings.experimentalTerminalAttention = false
     mockState.activeWorktreeId = 'wt-primary'
+    stubDocumentFocus({ visibilityState: 'visible', focused: true })
 
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
@@ -217,6 +235,23 @@ describe('dispatchTerminalNotification', () => {
 
     expect(window.api.notifications.dispatch).toHaveBeenCalled()
     expect(mockState.markWorktreeUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
+    expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('marks the selected worktree unread when the app is not focused', () => {
+    mockState.settings.experimentalTerminalAttention = false
+    mockState.activeWorktreeId = 'wt-primary'
+    stubDocumentFocus({ visibilityState: 'visible', focused: false })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -186,6 +186,13 @@ function countReposNeedingNotificationDisambiguation(
   return Math.max(activeRepoIds.size, countReposWithWorktrees(state))
 }
 
+function isOrcaWindowForegroundFocused(): boolean {
+  if (typeof document === 'undefined') {
+    return true
+  }
+  return document.visibilityState === 'visible' && document.hasFocus()
+}
+
 /**
  * Returns a stable dispatch function for terminal notifications.
  * Reads repo/worktree labels from the store at dispatch time rather
@@ -227,9 +234,9 @@ export function dispatchTerminalNotification(
       state.markWorktreeUnread(worktreeId)
       state.markTerminalTabUnread(tabId)
       state.markTerminalPaneUnread(event.paneKey)
-    } else if (state.activeWorktreeId !== worktreeId) {
-      // Why: when pane attention is disabled, agent completion still preserves
-      // the existing background-workspace unread signal for Dock/sidebar state.
+    } else if (state.activeWorktreeId !== worktreeId || !isOrcaWindowForegroundFocused()) {
+      // Why: activeWorktreeId is only in-app selection. If Orca is backgrounded,
+      // a selected chat finishing still needs unread/Dock attention.
       state.markWorktreeUnread(worktreeId)
     }
   }


### PR DESCRIPTION
## Summary
- Treat active worktree selection separately from foreground focus when agent completion marks unread.
- Keep suppressing unread for the selected chat while Orca is visible and focused.
- Add a regression test for a selected chat finishing while the renderer window is blurred.

## Proof
- Reproduced pre-fix failure with the new regression: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts` failed because `markWorktreeUnread` was not called for the selected blurred worktree.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts src/renderer/src/lib/unread-badge-count.test.ts src/main/dock/unread-badge.test.ts` -> 3 files, 14 tests passed.
- `pnpm run typecheck:web` -> passed.
- Electron/CDP proof on `Orca: nwparker/orca-focus`: imported the real `dispatchTerminalNotification`, injected a temporary selected live worktree, and toggled `document.hasFocus()`. Result: `focusedCalls: []`, `blurredCalls: [selectedWorktreeId]`, `tabCalls: []`, `paneCalls: []`. Temporary store state was restored and Dock badge cleared afterward.
