### PR TITLE
Focus editor tab rename input from ref

### DIFF
--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -287,6 +287,11 @@ describe('EditorFileTab rename menu', () => {
     vi.clearAllMocks()
     vi.resetModules()
     vi.stubGlobal('navigator', { userAgent: 'Mac' })
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
   })
 
   it('turns the tab filename into an inline input from the Rename context-menu item', async () => {
@@ -307,6 +312,17 @@ describe('EditorFileTab rename menu', () => {
     expect(inputs[0].props.defaultValue).toBe('untitled-5.md')
     expect(inputs[0].props['data-tab-rename-input']).toBe('true')
     expect(onActivate).toHaveBeenCalledTimes(1)
+
+    const focus = vi.fn()
+    const select = vi.fn()
+    const setSelectionRange = vi.fn()
+    const setInputRef = inputs[0].props.ref as (input: HTMLInputElement | null) => void
+
+    setInputRef({ focus, select, setSelectionRange } as unknown as HTMLInputElement)
+
+    expect(focus).toHaveBeenCalledTimes(1)
+    expect(setSelectionRange).toHaveBeenCalledWith(0, 'untitled-5'.length)
+    expect(select).not.toHaveBeenCalled()
   })
 
   it('disables Rename for diff tabs that do not map to one writable file', async () => {

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -18,6 +18,9 @@ vi.mock('react', async () => {
   return {
     ...actual,
     useEffect: () => {},
+    useCallback<T extends (...args: never[]) => unknown>(callback: T) {
+      return callback
+    },
     useRef<T>(initial: T) {
       return { current: initial }
     },

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -113,6 +113,7 @@ export default function EditorFileTab({
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const [isRenaming, setIsRenaming] = useState(false)
   const renameInputRef = useRef<HTMLInputElement>(null)
+  const renameFocusFrameRef = useRef<number | null>(null)
   const skipMenuFocusRestoreRef = useRef(false)
   // Escape fires setIsRenaming(false), which unmounts the input. The browser
   // still fires focusout as the focused node is removed, so onBlur can invoke
@@ -162,19 +163,30 @@ export default function EditorFileTab({
 
   const setRenameInputElement = useCallback(
     (input: HTMLInputElement | null) => {
+      if (renameFocusFrameRef.current !== null) {
+        cancelAnimationFrame(renameFocusFrameRef.current)
+        renameFocusFrameRef.current = null
+      }
       renameInputRef.current = input
       if (!input) {
         return
       }
-      // Why: rename should open with the basename selected before the user types.
-      input.focus()
-      const name = basename(file.filePath)
-      const dotIndex = name.lastIndexOf('.')
-      if (dotIndex > 0) {
-        input.setSelectionRange(0, dotIndex)
-      } else {
-        input.select()
-      }
+      // Why: Radix closes the context menu after onSelect; defer focus so its
+      // teardown cannot steal focus back or blur-commit the newly mounted input.
+      renameFocusFrameRef.current = requestAnimationFrame(() => {
+        renameFocusFrameRef.current = null
+        if (renameInputRef.current !== input) {
+          return
+        }
+        input.focus()
+        const name = basename(file.filePath)
+        const dotIndex = name.lastIndexOf('.')
+        if (dotIndex > 0) {
+          input.setSelectionRange(0, dotIndex)
+        } else {
+          input.select()
+        }
+      })
     },
     [file.filePath]
   )

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: editor tab rendering, drag behavior, rename handling, and its context menu share one tightly-coupled tab surface. */
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import {
   X,
@@ -160,26 +160,24 @@ export default function EditorFileTab({
     })
   }
 
-  useEffect(() => {
-    if (!isRenaming) {
-      return
-    }
-    const raf = requestAnimationFrame(() => {
-      const el = renameInputRef.current
-      if (!el) {
+  const setRenameInputElement = useCallback(
+    (input: HTMLInputElement | null) => {
+      renameInputRef.current = input
+      if (!input) {
         return
       }
-      el.focus()
+      // Why: rename should open with the basename selected before the user types.
+      input.focus()
       const name = basename(file.filePath)
       const dotIndex = name.lastIndexOf('.')
       if (dotIndex > 0) {
-        el.setSelectionRange(0, dotIndex)
+        input.setSelectionRange(0, dotIndex)
       } else {
-        el.select()
+        input.select()
       }
-    })
-    return () => cancelAnimationFrame(raf)
-  }, [isRenaming, file.filePath])
+    },
+    [file.filePath]
+  )
 
   const tabStatus =
     file.relativePath === 'All Changes'
@@ -263,7 +261,7 @@ export default function EditorFileTab({
       <span className="mr-1 flex min-w-0 items-baseline gap-1">
         {isRenaming ? (
           <Input
-            ref={renameInputRef}
+            ref={setRenameInputElement}
             data-tab-rename-input="true"
             aria-label={`Rename file ${basename(file.filePath)}`}
             defaultValue={basename(file.filePath)}


### PR DESCRIPTION
Summary
- Replace the editor file-tab rename focus Effect with a callback ref
- Preserve basename-without-extension selection when inline rename opens
- Update the focused EditorFileTab test React mock for useCallback

Risk: Medium

Medium because this is editor tab UI. It does not change file rename persistence, IPC, terminal, browser, SSH, or provider behavior, but it does touch the editor tab rename interaction.

Verification
- pnpm exec oxfmt --write src/renderer/src/components/tab-bar/EditorFileTab.tsx src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
- pnpm exec oxlint src/renderer/src/components/tab-bar/EditorFileTab.tsx src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 910, branch 909

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.