### PR TITLE
fix: clear browser reload fallback timer

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -470,6 +470,51 @@ describe('AgentBrowserBridge', () => {
     expect(lifecycleEvents).toEqual(['acquire-100', 'command-snapshot', 'restore-100'])
   })
 
+  it('clears reload fallback timer after the load event settles', async () => {
+    vi.useFakeTimers()
+    try {
+      succeedWith(null)
+      const wc = {
+        ...mockWebContents(100, 'https://reloaded.example', 'Reloaded'),
+        reload: vi.fn(),
+        on: vi.fn(),
+        removeListener: vi.fn()
+      }
+      webContentsFromIdMock.mockReturnValue(wc)
+
+      const result = bridge.reload()
+
+      await vi.waitFor(() => {
+        expect(wc.on).toHaveBeenCalledWith('did-finish-load', expect.any(Function))
+      })
+
+      const finishListener = wc.on.mock.calls.find(([event]) => event === 'did-finish-load')?.[1] as
+        | (() => void)
+        | undefined
+      const failListener = wc.on.mock.calls.find(([event]) => event === 'did-fail-load')?.[1] as
+        | (() => void)
+        | undefined
+      expect(finishListener).toBeDefined()
+      expect(failListener).toBeDefined()
+      expect(vi.getTimerCount()).toBe(1)
+
+      finishListener!()
+
+      await expect(result).resolves.toEqual({
+        url: 'https://reloaded.example',
+        title: 'Reloaded'
+      })
+      expect(wc.removeListener).toHaveBeenCalledWith('did-finish-load', finishListener)
+      expect(wc.removeListener).toHaveBeenCalledWith('did-fail-load', failListener)
+      expect(vi.getTimerCount()).toBe(0)
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(wc.removeListener).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('serializes screenshot visibility prep across sessions', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -1119,19 +1119,33 @@ export class AgentBrowserBridge {
       }
       wc.reload()
       await new Promise<void>((resolve) => {
-        const onFinish = (): void => {
+        let settled = false
+        let fallbackTimer: ReturnType<typeof setTimeout> | null = null
+
+        const finish = (): void => {
+          if (settled) {
+            return
+          }
+          settled = true
           wc.removeListener('did-finish-load', onFinish)
           wc.removeListener('did-fail-load', onFail)
+          if (fallbackTimer) {
+            clearTimeout(fallbackTimer)
+            fallbackTimer = null
+          }
           resolve()
         }
-        const onFail = (): void => {
-          wc.removeListener('did-finish-load', onFinish)
-          wc.removeListener('did-fail-load', onFail)
-          resolve()
-        }
+        const onFinish = (): void => finish()
+        const onFail = (): void => finish()
+
         wc.on('did-finish-load', onFinish)
         wc.on('did-fail-load', onFail)
-        setTimeout(onFinish, 10_000)
+        // Why: successful reloads must clear the fallback timer; otherwise each
+        // reload retains the webContents and listeners until the 10s timeout fires.
+        fallbackTimer = setTimeout(finish, 10_000)
+        if (typeof fallbackTimer.unref === 'function') {
+          fallbackTimer.unref()
+        }
       })
       return { url: wc.getURL(), title: wc.getTitle() }
     })


### PR DESCRIPTION
## Summary
- clear the browser reload fallback timeout when Electron reports did-finish-load or did-fail-load
- guard reload settlement so the timeout fallback cannot run cleanup twice
- add a fake-timer regression test for reload listener/timer cleanup

## Risk Level
LOW - scoped to the main-process browser reload wait path. The 10s fallback remains for missing load events; this only clears it after an earlier successful/failing load event.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts src/main/ipc/notifications.test.ts src/main/computer/permissions.test.ts src/main/ipc/developer-permissions.test.ts
- pnpm exec oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts src/main/computer/permissions.ts src/main/computer/permissions.test.ts src/main/ipc/developer-permissions.ts src/main/ipc/developer-permissions.test.ts
- pnpm run typecheck:node