### PR TITLE
fix: clear native notification fallback timers

### DIFF
--- a/src/main/computer/permissions.test.ts
+++ b/src/main/computer/permissions.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  notificationCtorMock,
+  notificationIsSupportedMock,
+  notificationOnMock,
+  notificationRemoveListenerMock,
+  notificationShowMock,
+  shellOpenExternalMock,
+  isTrustedAccessibilityClientMock
+} = vi.hoisted(() => {
+  const notificationOnMock = vi.fn()
+  const notificationRemoveListenerMock = vi.fn()
+  const notificationShowMock = vi.fn()
+  const notificationCtorMock = vi.fn(function () {
+    return {
+      on: notificationOnMock,
+      removeListener: notificationRemoveListenerMock,
+      show: notificationShowMock
+    }
+  })
+  return {
+    notificationCtorMock,
+    notificationIsSupportedMock: vi.fn(() => true),
+    notificationOnMock,
+    notificationRemoveListenerMock,
+    notificationShowMock,
+    shellOpenExternalMock: vi.fn(),
+    isTrustedAccessibilityClientMock: vi.fn(() => false)
+  }
+})
+
+vi.mock('electron', () => ({
+  Notification: Object.assign(notificationCtorMock, {
+    isSupported: notificationIsSupportedMock
+  }),
+  shell: {
+    openExternal: shellOpenExternalMock
+  },
+  systemPreferences: {
+    isTrustedAccessibilityClient: isTrustedAccessibilityClientMock
+  }
+}))
+
+import { notifyPermissionRequired } from './permissions'
+
+describe('notifyPermissionRequired', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllTimers()
+    notificationCtorMock.mockClear()
+    notificationIsSupportedMock.mockReset()
+    notificationIsSupportedMock.mockReturnValue(true)
+    notificationOnMock.mockClear()
+    notificationRemoveListenerMock.mockClear()
+    notificationShowMock.mockClear()
+    shellOpenExternalMock.mockClear()
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  })
+
+  function getNotificationEventHandler(eventName: string): () => void {
+    const call = notificationOnMock.mock.calls.find((c: unknown[]) => c[0] === eventName)
+    if (!call) {
+      throw new Error(`Notification ${eventName} handler not registered`)
+    }
+    return call[1] as () => void
+  }
+
+  it('clears the retained notification fallback timer when the notification closes', () => {
+    notifyPermissionRequired('Enable accessibility')
+
+    expect(notificationShowMock).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(1)
+
+    const closeHandler = getNotificationEventHandler('close')
+    closeHandler()
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('close', closeHandler)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  it('opens macOS Accessibility settings on click after releasing notification state', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    notifyPermissionRequired('Enable accessibility')
+
+    getNotificationEventHandler('click')()
+
+    expect(shellOpenExternalMock).toHaveBeenCalledWith(
+      expect.stringContaining('Privacy_Accessibility')
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/computer/permissions.ts
+++ b/src/main/computer/permissions.ts
@@ -36,16 +36,32 @@ export function notifyPermissionRequired(instructions: string): void {
   })
   activePermissionNotifications.add(notification)
 
-  const release = (): void => {
+  let releaseTimer: ReturnType<typeof setTimeout> | null = null
+  let released = false
+  function release(): void {
+    if (released) {
+      return
+    }
+    released = true
     activePermissionNotifications.delete(notification)
+    notification.removeListener('close', release)
+    notification.removeListener('click', onClick)
+    if (releaseTimer) {
+      clearTimeout(releaseTimer)
+      releaseTimer = null
+    }
   }
-  notification.on('close', release)
-  notification.on('click', () => {
+  function onClick(): void {
     release()
     if (process.platform === 'darwin') {
       void shell.openExternal(ACCESSIBILITY_SETTINGS_URL)
     }
-  })
-  setTimeout(release, 5 * 60 * 1000)
+  }
+  notification.on('close', release)
+  notification.on('click', onClick)
+  releaseTimer = setTimeout(release, 5 * 60 * 1000)
+  if (typeof releaseTimer.unref === 'function') {
+    releaseTimer.unref()
+  }
   notification.show()
 }

--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -11,6 +11,7 @@ const {
   notificationCloseMock,
   notificationOnMock,
   notificationOnceMock,
+  notificationRemoveListenerMock,
   notificationCtorMock,
   notificationIsSupportedMock,
   getAllWindowsMock,
@@ -22,12 +23,14 @@ const {
   const notificationCloseMock = vi.fn()
   const notificationOnMock = vi.fn()
   const notificationOnceMock = vi.fn()
+  const notificationRemoveListenerMock = vi.fn()
   const notificationCtorMock = vi.fn(function () {
     return {
       show: notificationShowMock,
       close: notificationCloseMock,
       on: notificationOnMock,
-      once: notificationOnceMock
+      once: notificationOnceMock,
+      removeListener: notificationRemoveListenerMock
     }
   })
   const notificationIsSupportedMock = vi.fn(() => true)
@@ -40,6 +43,7 @@ const {
     notificationCloseMock,
     notificationOnMock,
     notificationOnceMock,
+    notificationRemoveListenerMock,
     notificationCtorMock,
     notificationIsSupportedMock,
     getAllWindowsMock,
@@ -91,6 +95,7 @@ describe('registerNotificationHandlers', () => {
     notificationCloseMock.mockClear()
     notificationOnMock.mockClear()
     notificationOnceMock.mockClear()
+    notificationRemoveListenerMock.mockClear()
     notificationIsSupportedMock.mockReset()
     notificationIsSupportedMock.mockReturnValue(true)
     getAllWindowsMock.mockReset()
@@ -385,11 +390,14 @@ describe('registerNotificationHandlers', () => {
     expect(
       handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', paneKey })
     ).toEqual({ delivered: true })
+    expect(vi.getTimerCount()).toBe(1)
 
     getNotificationEventHandler('click')()
 
     expect(restore).toHaveBeenCalledTimes(1)
     expect(focus).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('click', expect.any(Function))
     expect(webContentsSend).toHaveBeenCalledWith('ui:activateWorktree', {
       repoId: 'repo',
       worktreeId: 'repo::wt1'
@@ -402,6 +410,29 @@ describe('registerNotificationHandlers', () => {
       flashFocusedPane: true,
       scrollToBottomIfOutputSinceLastView: true
     })
+  })
+
+  it('clears the retained notification fallback timer when the native notification closes', () => {
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: true
+        }
+      })
+    } as never)
+
+    const handler = getDispatchHandler()
+    expect(handler({}, { source: 'agent-task-complete' })).toEqual({ delivered: true })
+    expect(vi.getTimerCount()).toBe(1)
+
+    const closeHandler = getNotificationEventHandler('close')
+    closeHandler()
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('close', closeHandler)
   })
 
   it('formats agent-task-complete with the agent response when a status snapshot is present', () => {
@@ -1073,11 +1104,22 @@ describe('registerNotificationHandlers', () => {
 describe('triggerStartupNotificationRegistration', () => {
   const originalPlatform = process.platform
 
+  function getStartupNotificationEventHandler(eventName: string): () => void {
+    const call = notificationOnMock.mock.calls.find((c: unknown[]) => c[0] === eventName)
+    if (!call) {
+      throw new Error(`Startup notification ${eventName} handler not registered`)
+    }
+    return call[1] as () => void
+  }
+
   beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllTimers()
     notificationCtorMock.mockClear()
     notificationShowMock.mockClear()
     notificationCloseMock.mockClear()
     notificationOnMock.mockClear()
+    notificationRemoveListenerMock.mockClear()
     notificationIsSupportedMock.mockReset()
     notificationIsSupportedMock.mockReturnValue(true)
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
@@ -1124,5 +1166,23 @@ describe('triggerStartupNotificationRegistration', () => {
     triggerStartupNotificationRegistration(store as never)
 
     expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
+  it('clears startup notification timers when the notification is clicked', () => {
+    const store = {
+      getUI: () => ({ notificationPermissionRequested: undefined }),
+      updateUI: vi.fn()
+    }
+
+    triggerStartupNotificationRegistration(store as never)
+    expect(vi.getTimerCount()).toBe(1)
+
+    getStartupNotificationEventHandler('click')()
+
+    expect(notificationCloseMock).toHaveBeenCalledTimes(1)
+    expect(shellOpenExternalMock).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('click', expect.any(Function))
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('show', expect.any(Function))
   })
 })

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -26,6 +26,7 @@ import { parsePaneKey } from '../../shared/stable-pane-id'
 
 const NOTIFICATION_COOLDOWN_MS = 5000
 const NOTIFICATION_DISPLAY_CONFIRMATION_TIMEOUT_MS = 2500
+const NOTIFICATION_RELEASE_FALLBACK_MS = 5 * 60 * 1000
 const MAX_NOTIFICATION_SOUND_BYTES = 10 * 1024 * 1024
 const MACOS_PACKAGED_BUNDLE_ID = 'com.stablyai.orca'
 const MACOS_NOTIFICATION_SETTINGS_URL =
@@ -57,6 +58,37 @@ type NotificationSoundId = NotificationSettings['customSoundId']
 // the notification in macOS Notification Center. Prevent this by keeping a
 // strong reference until the notification is clicked or closed.
 const activeNotifications = new Set<Notification>()
+
+function retainNotificationUntilRelease(
+  notification: Notification,
+  onRelease?: () => void
+): () => void {
+  activeNotifications.add(notification)
+  let released = false
+  let releaseTimer: ReturnType<typeof setTimeout> | null = null
+
+  function release(): void {
+    if (released) {
+      return
+    }
+    released = true
+    activeNotifications.delete(notification)
+    notification.removeListener('close', release)
+    if (releaseTimer) {
+      clearTimeout(releaseTimer)
+      releaseTimer = null
+    }
+    onRelease?.()
+  }
+
+  notification.on('close', release)
+  releaseTimer = setTimeout(release, NOTIFICATION_RELEASE_FALLBACK_MS)
+  if (typeof releaseTimer.unref === 'function') {
+    releaseTimer.unref()
+  }
+
+  return release
+}
 
 function getMacNotificationSettingsUrl(): string {
   const bundleId = process.env.ORCA_DEV_MACOS_BUNDLE_ID ?? MACOS_PACKAGED_BUNDLE_ID
@@ -232,15 +264,13 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
 
       // Why: prevent GC from collecting the notification (and its click
       // handler) while it's still visible in macOS Notification Center.
-      activeNotifications.add(notification)
-      const release = (): void => {
-        activeNotifications.delete(notification)
-      }
-      notification.on('close', release)
-      // Why: on macOS the 'close' event may never fire if the OS silently
-      // discards the notification (e.g. DND, Notification Center cleared).
-      // A timeout fallback guarantees the reference is eventually freed.
-      setTimeout(release, 5 * 60 * 1000)
+      let clickHandler: (() => void) | null = null
+      const release = retainNotificationUntilRelease(notification, () => {
+        if (clickHandler) {
+          notification.removeListener('click', clickHandler)
+          clickHandler = null
+        }
+      })
 
       // Why: clicking a notification should bring Orca to the foreground and
       // switch to the worktree/pane that triggered it. Worktree activation owns
@@ -252,7 +282,7 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       // clicking it will not attempt to switch to an unknown worktree.
       if (args.worktreeId && args.worktreeId.includes('::')) {
         const repoId = getRepoIdFromWorktreeId(args.worktreeId)
-        notification.on('click', () => {
+        clickHandler = () => {
           release()
           const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed())
           if (!win) {
@@ -280,7 +310,8 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
               scrollToBottomIfOutputSinceLastView: true
             })
           }
-        })
+        }
+        notification.on('click', clickHandler)
       }
 
       const displayConfirmation = args.requireDisplayConfirmation
@@ -386,12 +417,29 @@ export function triggerStartupNotificationRegistration(store: Store): void {
   activeNotifications.add(notification)
 
   let handled = false
-  const cleanup = (): void => {
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+  let fallbackTimer: ReturnType<typeof setTimeout> | null = null
+
+  function clearStartupTimers(): void {
+    if (closeTimer) {
+      clearTimeout(closeTimer)
+      closeTimer = null
+    }
+    if (fallbackTimer) {
+      clearTimeout(fallbackTimer)
+      fallbackTimer = null
+    }
+  }
+
+  function cleanup(): void {
     if (handled) {
       return
     }
     handled = true
+    clearStartupTimers()
     activeNotifications.delete(notification)
+    notification.removeListener('click', onClick)
+    notification.removeListener('show', onShow)
     notification.close()
   }
 
@@ -399,20 +447,29 @@ export function triggerStartupNotificationRegistration(store: Store): void {
   // Notification Settings so they can verify/enable notifications for Orca.
   // Without this, the notification reads like an actionable prompt ("Allow
   // notifications…") but clicking it does nothing, which is confusing.
-  notification.on('click', () => {
+  function onClick(): void {
     cleanup()
     openNotificationSystemSettings()
-  })
+  }
 
-  notification.on('show', () => {
+  function onShow(): void {
     // Why: close after a short delay so the notification doesn't linger in
     // Notification Center. The macOS permission dialog is a system-level sheet
     // that appears independently and is not dismissed by closing this notification.
-    setTimeout(cleanup, 8000)
-  })
+    closeTimer = setTimeout(cleanup, 8000)
+    if (typeof closeTimer.unref === 'function') {
+      closeTimer.unref()
+    }
+  }
+
+  notification.on('click', onClick)
+  notification.on('show', onShow)
 
   // Fallback in case macOS doesn't fire the 'show' event (e.g. user denies).
-  setTimeout(cleanup, 10_000)
+  fallbackTimer = setTimeout(cleanup, 10_000)
+  if (typeof fallbackTimer.unref === 'function') {
+    fallbackTimer.unref()
+  }
 
   notification.show()
 }


### PR DESCRIPTION
## Summary
- clear notification retention fallback timers when native notifications close or are clicked
- detach notification close/click/show listeners during cleanup
- add tests for app notification dispatch, startup notification registration, and accessibility permission notifications

## Risk Level
LOW - scoped to cleanup after notification release. Existing notification retention and fallback behavior remains; released notifications now clear their timers/listeners immediately.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/notifications.test.ts src/main/computer/permissions.test.ts
- pnpm exec oxlint src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts src/main/computer/permissions.ts src/main/computer/permissions.test.ts
- pnpm run typecheck:node