### PR TITLE
fix: clear local network prompt fallback timer

### DIFF
--- a/src/main/ipc/developer-permissions.test.ts
+++ b/src/main/ipc/developer-permissions.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  handleMock,
+  shellOpenExternalMock,
+  askForMediaAccessMock,
+  getMediaAccessStatusMock,
+  isTrustedAccessibilityClientMock,
+  createSocketMock,
+  socketMock,
+  socketState
+} = vi.hoisted(() => {
+  const handleMock = vi.fn()
+  const socketState = {
+    sendCallback: null as (() => void) | null
+  }
+  const socketMock = {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    bind: vi.fn(),
+    send: vi.fn(),
+    close: vi.fn()
+  }
+  return {
+    handleMock,
+    shellOpenExternalMock: vi.fn(),
+    askForMediaAccessMock: vi.fn(),
+    getMediaAccessStatusMock: vi.fn(),
+    isTrustedAccessibilityClientMock: vi.fn(),
+    createSocketMock: vi.fn(() => socketMock),
+    socketMock,
+    socketState
+  }
+})
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  },
+  shell: {
+    openExternal: shellOpenExternalMock
+  },
+  systemPreferences: {
+    askForMediaAccess: askForMediaAccessMock,
+    getMediaAccessStatus: getMediaAccessStatusMock,
+    isTrustedAccessibilityClient: isTrustedAccessibilityClientMock
+  }
+}))
+
+vi.mock('node:dgram', () => ({
+  default: {
+    createSocket: createSocketMock
+  }
+}))
+
+import { registerDeveloperPermissionHandlers } from './developer-permissions'
+
+describe('registerDeveloperPermissionHandlers', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllTimers()
+    handleMock.mockClear()
+    shellOpenExternalMock.mockClear()
+    askForMediaAccessMock.mockReset()
+    getMediaAccessStatusMock.mockReset()
+    isTrustedAccessibilityClientMock.mockReset()
+    createSocketMock.mockClear()
+    socketState.sendCallback = null
+    socketMock.on.mockClear()
+    socketMock.removeListener.mockClear()
+    socketMock.bind.mockReset()
+    socketMock.bind.mockImplementation((callback: () => void) => callback())
+    socketMock.send.mockReset()
+    socketMock.send.mockImplementation(
+      (
+        _message: Buffer,
+        _offset: number,
+        _length: number,
+        _port: number,
+        _address: string,
+        callback: () => void
+      ) => {
+        socketState.sendCallback = callback
+      }
+    )
+    socketMock.close.mockClear()
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+  })
+
+  function getRequestHandler(): (_event: unknown, args: { id: string }) => Promise<unknown> {
+    const call = handleMock.mock.calls.find(
+      (c: unknown[]) => c[0] === 'developerPermissions:request'
+    )
+    if (!call) {
+      throw new Error('developerPermissions:request handler not registered')
+    }
+    return call[1] as (_event: unknown, args: { id: string }) => Promise<unknown>
+  }
+
+  it('clears the local-network prompt fallback timer when UDP send settles first', async () => {
+    registerDeveloperPermissionHandlers()
+
+    const result = getRequestHandler()({}, { id: 'local-network' })
+    expect(socketMock.send).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(1)
+
+    socketState.sendCallback?.()
+
+    await expect(result).resolves.toEqual({
+      id: 'local-network',
+      status: 'unknown',
+      openedSystemSettings: false
+    })
+    expect(vi.getTimerCount()).toBe(0)
+    expect(socketMock.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
+    expect(socketMock.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/developer-permissions.ts
+++ b/src/main/ipc/developer-permissions.ts
@@ -99,11 +99,17 @@ function triggerLocalNetworkPrompt(): Promise<void> {
   return new Promise((resolve) => {
     const socket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
     let settled = false
-    const finish = (): void => {
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    function finish(): void {
       if (settled) {
         return
       }
       settled = true
+      socket.removeListener('error', finish)
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
       try {
         socket.close()
       } catch {
@@ -116,7 +122,10 @@ function triggerLocalNetworkPrompt(): Promise<void> {
       const message = Buffer.from([0])
       socket.send(message, 0, message.length, 5353, '224.0.0.251', finish)
     })
-    setTimeout(finish, 1000)
+    timeout = setTimeout(finish, 1000)
+    if (typeof timeout.unref === 'function') {
+      timeout.unref()
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- clear the local-network UDP prompt fallback timeout when the socket settles first
- detach the socket error listener during prompt cleanup
- add a focused regression test for the local-network permission request path

## Risk Level
LOW - scoped to cleanup after the local-network permission prompt settles. The 1s fallback remains for stalled socket operations; it is only cleared after early completion.

## Validation
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/developer-permissions.test.ts
- pnpm exec oxlint src/main/ipc/developer-permissions.ts src/main/ipc/developer-permissions.test.ts
- pnpm run typecheck:node