### PR TITLE
Track app-origin GitHub stars

### DIFF
--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -8,6 +8,10 @@ const {
   listWorkItemsMock,
   getAuthenticatedViewerMock,
   mergePRMock,
+  checkOrcaStarredMock,
+  starOrcaMock,
+  trackMock,
+  getCohortAtEmitMock,
   getAllWebContentsMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -17,6 +21,10 @@ const {
   listWorkItemsMock: vi.fn(),
   getAuthenticatedViewerMock: vi.fn(),
   mergePRMock: vi.fn(),
+  checkOrcaStarredMock: vi.fn(),
+  starOrcaMock: vi.fn(),
+  trackMock: vi.fn(),
+  getCohortAtEmitMock: vi.fn(),
   getAllWebContentsMock: vi.fn()
 }))
 
@@ -35,7 +43,17 @@ vi.mock('../github/client', () => ({
   listIssues: listIssuesMock,
   listWorkItems: listWorkItemsMock,
   getAuthenticatedViewer: getAuthenticatedViewerMock,
-  mergePR: mergePRMock
+  mergePR: mergePRMock,
+  checkOrcaStarred: checkOrcaStarredMock,
+  starOrca: starOrcaMock
+}))
+
+vi.mock('../telemetry/client', () => ({
+  track: trackMock
+}))
+
+vi.mock('../telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: getCohortAtEmitMock
 }))
 
 import { registerGitHubHandlers } from './github'
@@ -70,6 +88,11 @@ describe('registerGitHubHandlers', () => {
     listWorkItemsMock.mockReset()
     getAuthenticatedViewerMock.mockReset()
     mergePRMock.mockReset()
+    checkOrcaStarredMock.mockReset()
+    starOrcaMock.mockReset()
+    trackMock.mockReset()
+    getCohortAtEmitMock.mockReset()
+    getCohortAtEmitMock.mockReturnValue({ nth_repo_added: undefined })
     getAllWebContentsMock.mockReset()
     getAllWebContentsMock.mockReturnValue([])
     for (const key of Object.keys(handlers)) {
@@ -269,5 +292,74 @@ describe('registerGitHubHandlers', () => {
       email: 'octocat@example.com'
     })
     expect(getAuthenticatedViewerMock).toHaveBeenCalled()
+  })
+
+  it('emits app_starred_orca once after a successful star with cohort context', async () => {
+    starOrcaMock.mockResolvedValue(true)
+    getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 3 })
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    await expect(handlers['gh:starOrca'](null, 'settings')).resolves.toBe(true)
+
+    expect(starOrcaMock).toHaveBeenCalledTimes(1)
+    expect(getCohortAtEmitMock).toHaveBeenCalledTimes(1)
+    expect(trackMock).toHaveBeenCalledTimes(1)
+    expect(trackMock).toHaveBeenCalledWith('app_starred_orca', {
+      source: 'settings',
+      nth_repo_added: 3
+    })
+  })
+
+  it('accepts every app star source for success telemetry', async () => {
+    starOrcaMock.mockResolvedValue(true)
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    for (const source of ['star_nag', 'settings', 'landing'] as const) {
+      await expect(handlers['gh:starOrca'](null, source)).resolves.toBe(true)
+    }
+
+    expect(trackMock).toHaveBeenCalledTimes(3)
+    expect(trackMock.mock.calls.map(([, props]) => props)).toEqual([
+      { source: 'star_nag', nth_repo_added: undefined },
+      { source: 'settings', nth_repo_added: undefined },
+      { source: 'landing', nth_repo_added: undefined }
+    ])
+  })
+
+  it('does not emit app_starred_orca when the star action returns false', async () => {
+    starOrcaMock.mockResolvedValue(false)
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    await expect(handlers['gh:starOrca'](null, 'landing')).resolves.toBe(false)
+
+    expect(starOrcaMock).toHaveBeenCalledTimes(1)
+    expect(trackMock).not.toHaveBeenCalled()
+    expect(getCohortAtEmitMock).not.toHaveBeenCalled()
+  })
+
+  it('does not emit app_starred_orca when the star action throws', async () => {
+    starOrcaMock.mockRejectedValue(new Error('gh failed'))
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    await expect(handlers['gh:starOrca'](null, 'star_nag')).rejects.toThrow('gh failed')
+
+    expect(trackMock).not.toHaveBeenCalled()
+    expect(getCohortAtEmitMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves star result but skips telemetry for an invalid IPC source', async () => {
+    starOrcaMock.mockResolvedValue(true)
+
+    registerGitHubHandlers(store as never, stats as never)
+
+    await expect(handlers['gh:starOrca'](null, 'github_website')).resolves.toBe(true)
+
+    expect(starOrcaMock).toHaveBeenCalledTimes(1)
+    expect(trackMock).not.toHaveBeenCalled()
+    expect(getCohortAtEmitMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -92,6 +92,9 @@ import type {
   UpdateProjectItemFieldArgs,
   UpdatePullRequestBySlugArgs
 } from '../../shared/github-project-types'
+import { appStarSourceSchema } from '../../shared/gh-star-source'
+import { track } from '../telemetry/client'
+import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 
 // Why: notify every renderer (each window has its own SWR cache instance)
 // that a work item was mutated locally so they can drop their cached entry
@@ -844,7 +847,19 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
   // Star operations target the Orca repo itself — no repoPath validation needed
   ipcMain.handle('gh:viewer', () => getAuthenticatedViewer())
   ipcMain.handle('gh:checkOrcaStarred', () => checkOrcaStarred())
-  ipcMain.handle('gh:starOrca', () => starOrca())
+  ipcMain.handle('gh:starOrca', async (_event, source: unknown) => {
+    const sourceParse = appStarSourceSchema.safeParse(source)
+    const starred = await starOrca()
+    if (starred && sourceParse.success) {
+      // Why: this main-owned event bypasses renderer telemetry IPC, so cohort
+      // context must be attached here on the successful star path.
+      track('app_starred_orca', {
+        source: sourceParse.data,
+        ...getCohortAtEmit()
+      })
+    }
+    return starred
+  })
 
   // Why: `rate_limit` is exempt from GitHub's rate-limit accounting, so
   // polling is cheap. A 30s in-process cache still avoids the gh subprocess

--- a/src/main/ipc/telemetry.test.ts
+++ b/src/main/ipc/telemetry.test.ts
@@ -156,6 +156,14 @@ describe('telemetry IPC handlers', () => {
     })
   })
 
+  it('drops main-owned events from renderer telemetry IPC', () => {
+    registerWith({ installId: 'x', existedBeforeTelemetryRelease: false, optedIn: true })
+    const handler = handlers.get('telemetry:track')!
+    handler({}, 'app_starred_orca', { source: 'settings' })
+    expect(trackMock).not.toHaveBeenCalled()
+    expect(getCohortAtEmitMock).not.toHaveBeenCalled()
+  })
+
   it('injects cohort for setup script prompt events', () => {
     registerWith({ installId: 'x', existedBeforeTelemetryRelease: false, optedIn: true })
     getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 3 })

--- a/src/main/ipc/telemetry.ts
+++ b/src/main/ipc/telemetry.ts
@@ -53,6 +53,8 @@ import type { OptInVia } from '../../shared/telemetry-events'
 // mirrors how other core-handlers accept the store explicitly.
 let storeRef: Store | null = null
 
+const MAIN_OWNED_TELEMETRY_EVENTS = new Set<EventName>(['app_starred_orca'])
+
 /**
  * Derive the `via` discriminator for a `telemetry:setOptIn` call from
  * main-owned state. Called BEFORE any state mutation so the cohort + opt-in
@@ -117,6 +119,13 @@ export function registerTelemetryHandlers(store: Store): void {
     if (props !== null && props !== undefined && typeof props !== 'object') {
       return
     }
+    const eventName = name as EventName
+    // Why: some event schemas are registered for main-owned emissions only.
+    // Letting renderer IPC emit them would let compromised content spoof
+    // product outcomes that must be tied to a successful main-side action.
+    if (MAIN_OWNED_TELEMETRY_EVENTS.has(eventName)) {
+      return
+    }
     // Inject cohort here, at the IPC entry, only for events whose schemas
     // declare `nth_repo_added` (see `COHORT_EXTENDED` in telemetry-events.ts).
     // The selectivity is load-bearing: schemas are `.strict()`, so adding
@@ -130,7 +139,6 @@ export function registerTelemetryHandlers(store: Store): void {
     // The two injection sets are disjoint by construction today — no schema
     // declares both `nth_repo_added` and `cohort` — but combining them via
     // spread keeps that an additive change rather than a structural one.
-    const eventName = name as EventName
     const baseProps = (props ?? {}) as Record<string, unknown>
     const withRepoCohort = isCohortExtendedEvent(eventName)
       ? { ...baseProps, ...getCohortAtEmit() }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -272,6 +272,7 @@ import type {
 } from '../shared/opencode-usage-types'
 import type { TelemetryConsentState } from '../shared/telemetry-consent-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
+import type { AppStarSource } from '../shared/gh-star-source'
 import type {
   RemoteWorkspaceChangedEvent,
   RemoteWorkspaceConnectedClient,
@@ -1065,7 +1066,7 @@ export type PreloadApi = {
       }) => void
     ) => () => void
     checkOrcaStarred: () => Promise<boolean | null>
-    starOrca: () => Promise<boolean>
+    starOrca: (source: AppStarSource) => Promise<boolean>
     /**
      * GitHub API rate-limit snapshot. Does NOT consume quota (the
      * `rate_limit` endpoint is exempt). Cached 30s server-side — pass

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -120,6 +120,7 @@ import type {
 import type { TelemetryConsentState } from '../shared/telemetry-consent-types'
 import type { RefreshAgentsResult } from './api-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
+import type { AppStarSource } from '../shared/gh-star-source'
 import type {
   Automation,
   AutomationCreateInput,
@@ -1163,7 +1164,8 @@ const api = {
     },
 
     checkOrcaStarred: (): Promise<boolean | null> => ipcRenderer.invoke('gh:checkOrcaStarred'),
-    starOrca: (): Promise<boolean> => ipcRenderer.invoke('gh:starOrca'),
+    starOrca: (source: AppStarSource): Promise<boolean> =>
+      ipcRenderer.invoke('gh:starOrca', source),
 
     // Why: rate_limit is exempt from rate-limit accounting, but we still pass
     // `force` through so callers can bust the 30s in-process cache after a

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -104,7 +104,7 @@ function GitHubStarButton({ hasRepos }: { hasRepos: boolean }): React.JSX.Elemen
       return
     }
     setState('starred') // optimistic
-    const ok = await window.api.gh.starOrca()
+    const ok = await window.api.gh.starOrca('landing')
     if (!ok) {
       setState('not-starred')
       return

--- a/src/renderer/src/components/StarNagCard.tsx
+++ b/src/renderer/src/components/StarNagCard.tsx
@@ -66,7 +66,7 @@ export function StarNagCard(): React.JSX.Element | null {
     }
     setBusy(true)
     setError(false)
-    const ok = await window.api.gh.starOrca()
+    const ok = await window.api.gh.starOrca('star_nag')
     setBusy(false)
     if (!ok) {
       setError(true)

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -153,7 +153,7 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
       return
     }
     setStarState('starring')
-    const ok = await window.api.gh.starOrca()
+    const ok = await window.api.gh.starOrca('settings')
     if (!ok) {
       setStarState('error')
       return

--- a/src/shared/gh-star-source.ts
+++ b/src/shared/gh-star-source.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const APP_STAR_SOURCE_VALUES = ['star_nag', 'settings', 'landing'] as const
+
+// Why: renderer-originated IPC is untrusted, so main validates against this
+// closed enum before attaching source context to successful star telemetry.
+export const appStarSourceSchema = z.enum(APP_STAR_SOURCE_VALUES)
+export type AppStarSource = z.infer<typeof appStarSourceSchema>

--- a/src/shared/telemetry-events.test.ts
+++ b/src/shared/telemetry-events.test.ts
@@ -14,6 +14,39 @@ import {
   SETTINGS_CHANGED_WHITELIST,
   settingsChangedKeySchema
 } from './telemetry-events'
+import { appStarSourceSchema } from './gh-star-source'
+
+describe('app_starred_orca schema', () => {
+  it('accepts every declared app star source', () => {
+    for (const source of appStarSourceSchema.options) {
+      const parsed = eventSchemas.app_starred_orca.safeParse({ source })
+      expect(parsed.success).toBe(true)
+    }
+  })
+
+  it('accepts cohort context on successful app star telemetry', () => {
+    const parsed = eventSchemas.app_starred_orca.safeParse({
+      source: 'settings',
+      nth_repo_added: 2
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects unknown app star source values', () => {
+    const parsed = eventSchemas.app_starred_orca.safeParse({
+      source: 'github_website'
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects extra keys via .strict()', () => {
+    const parsed = eventSchemas.app_starred_orca.safeParse({
+      source: 'landing',
+      repo: 'stablyai/orca'
+    })
+    expect(parsed.success).toBe(false)
+  })
+})
 
 describe('agent_error schema', () => {
   it('round-trips a minimal {error_class, agent_kind} payload', () => {

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -18,6 +18,7 @@ import { FEATURE_WALL_MAX_DWELL_MS } from './feature-wall-telemetry'
 import { FEATURE_WALL_EXIT_ACTIONS, FEATURE_WALL_TOUR_DEPTH_STEPS } from './feature-wall-tour-depth'
 import { SETUP_SCRIPT_IMPORT_PROVIDERS } from './setup-script-import-providers'
 import { WORKSPACE_SOURCE_VALUES, type WorkspaceSource } from './workspace-source'
+import { appStarSourceSchema } from './gh-star-source'
 import {
   NESTED_REPO_COUNT_BUCKETS,
   NESTED_REPO_IMPORT_ACTIONS,
@@ -263,6 +264,13 @@ const appOpenedSchema = z.object({ nth_repo_added: nthRepoAddedSchema }).strict(
 
 const repoAddedSchema = z
   .object({ method: repoMethodSchema, nth_repo_added: nthRepoAddedSchema })
+  .strict()
+
+const appStarredOrcaSchema = z
+  .object({
+    source: appStarSourceSchema,
+    nth_repo_added: nthRepoAddedSchema
+  })
   .strict()
 
 const workspaceCreatedSchema = z
@@ -1012,6 +1020,7 @@ const onboardingFeatureSetupTerminalInteractedSchema = z
 // which cannot be unmixed after the fact.
 export const eventSchemas = {
   app_opened: appOpenedSchema,
+  app_starred_orca: appStarredOrcaSchema,
 
   repo_added: repoAddedSchema,
   add_repo_setup_step_action: addRepoSetupStepActionEventSchema,
@@ -1105,6 +1114,7 @@ export const COHORT_EXTENDED: readonly EventName[] = Array.from(COHORT_EXTENDED_
 // injection set against silent schema drift.
 type _CohortExtendedRoster =
   | 'app_opened'
+  | 'app_starred_orca'
   | 'repo_added'
   | 'add_repo_setup_step_action'
   | 'add_repo_existing_workspaces_detected'


### PR DESCRIPTION
## Summary

Adds success telemetry for users who star `stablyai/orca` from Orca surfaces. The app now threads a closed `source` enum from the Landing star button, Settings > General, and the star nag into `gh:starOrca`; main emits `app_starred_orca` only after the GitHub star action succeeds.

The event payload is intentionally low-cardinality and privacy-safe: `source` plus optional `nth_repo_added`. No GitHub login, repo path, URL, command output, or error text is emitted.

## Design Review

Created a scratch design doc before implementation. The design-review subagent ran `auto-design-review-fix`; iteration 1 found issues around renderer-owned emission and attribution semantics, then the doc was revised to make `gh:starOrca` the main-owned emission point. Iteration 2 returned clean with no unresolved actionable findings.

## Implementation

Implemented the reviewed main-owned design:

- Added `src/shared/gh-star-source.ts` for the shared `star_nag | settings | landing` enum/schema.
- Added strict `app_starred_orca` telemetry schema and cohort roster inclusion.
- Updated renderer star call sites to pass their source.
- Updated preload/API typing for `gh.starOrca(source)`.
- Updated `gh:starOrca` to validate source, call `starOrca()`, and emit only on successful star.
- Added a main-owned telemetry denylist in `telemetry:track` so renderer IPC cannot spoof `app_starred_orca`.

Deviation from initial design draft: the reviewed design moved emission from renderer success handlers to main after the actual `starOrca()` result, which is stricter and avoids duplicate/missed renderer instrumentation.

## Completeness Verification

Read-only completeness verification compared the implementation against the reviewed design and found no omissions. It confirmed source threading, success-only emission, invalid-source behavior, cohort injection, privacy/cardinality constraints, SSH/cross-platform neutrality, and test coverage.

## Code Review Loop

Round 1:
- Reviewer A found the new shared source module was untracked.
- Reviewer B found renderer `telemetry:track` could spoof `app_starred_orca` because the event was in the shared schema registry.

Fixes:
- Added `src/shared/gh-star-source.ts` to the branch diff.
- Added `MAIN_OWNED_TELEMETRY_EVENTS` filtering in `src/main/ipc/telemetry.ts` plus a regression test.

Round 2:
- Reviewers still flagged the shared module as untracked because it was not visible in the diff yet.

Round 3:
- Both fresh reviewers returned no actionable findings.

## Brennan Test Changes

`brennan-test-changes` verdict: land.

Validated behavior:
- `gh:starOrca(source)` emits `app_starred_orca` only after `starOrca()` resolves `true`.
- Event includes validated `source` and `nth_repo_added`.
- No telemetry on false result or thrown star action.
- Invalid source preserves star result but emits no telemetry.
- Renderer `telemetry:track` cannot spoof `app_starred_orca`.
- No console-log telemetry substitution remains in the diff.

Product surface validation:
- Launched the exact worktree with Electron dev server.
- Verified Settings > General renders the `Support Orca` / `Star Orca on GitHub` surface.
- Forced the star nag and verified the `Enjoying Orca?` card and `Star on GitHub` action render.
- Did not click the real GitHub star buttons in Electron because that would target the live Orca repo; source behavior is covered by focused tests and static call-site verification.

## Checks

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/telemetry.test.ts src/main/ipc/github.test.ts src/shared/telemetry-events.test.ts` passed: 78 tests.
- `pnpm exec oxlint src/main/ipc/telemetry.ts src/main/ipc/telemetry.test.ts src/main/ipc/github.ts src/main/ipc/github.test.ts src/shared/telemetry-events.ts src/shared/telemetry-events.test.ts src/shared/gh-star-source.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/components/StarNagCard.tsx src/renderer/src/components/settings/GeneralPane.tsx src/renderer/src/components/Landing.tsx` passed.
- `pnpm run typecheck:web` passed.
- `pnpm run typecheck:node` passed.
- `pnpm run typecheck` passed in Brennan test pass.
- `pnpm run lint` passed in Brennan test pass.
- `git diff --check` passed.

## Gaps / Risks

- `node config/scripts/verify-telemetry-constants.mjs` could not run locally because this checkout has no packaged `dist/` directory. This verifier is release-artifact dependent rather than source-level.
- Electron validation intentionally avoided clicking the live GitHub star action.

Made with [Orca](https://github.com/stablyai/orca) 🐋
