### PR TITLE
Reset tab entry selection during render

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -41,6 +41,7 @@ export default function TabBarCreateEntry({
   const [pending, setPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
+  const [selectedIndexQuery, setSelectedIndexQuery] = useState(query)
   const inputRef = useRef<HTMLInputElement>(null)
   const fileList = useRuntimeFileListForWorktree({ enabled: menuOpen, worktreeId })
 
@@ -61,9 +62,13 @@ export default function TabBarCreateEntry({
     [agentOptions, query]
   )
 
-  useEffect(() => {
-    setSelectedIndex(0)
-  }, [query])
+  if (selectedIndexQuery !== query) {
+    setSelectedIndexQuery(query)
+    if (selectedIndex !== 0) {
+      // Why: the first filtered action should be highlighted on the same paint as the new query.
+      setSelectedIndex(0)
+    }
+  }
 
   const disabled = !onOpenEntry
   const hasQuery = query.trim().length > 0


### PR DESCRIPTION
Summary
- Replace the tab-entry selected-index reset Effect with render-time reconciliation
- Keep the first filtered action highlighted on the same paint as query changes
- Remove one local selection-repair Effect from the new tab entry surface

Risk: Medium

Medium because this touches the tab-entry keyboard/selection interaction for opening URLs/files/agents. It does not change persistence, IPC implementation, terminal/browser runtime protocols, SSH, or provider behavior.

Verification
- pnpm exec oxfmt --write src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
- pnpm exec oxlint src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/tab-create-entry-action.test.ts src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts src/renderer/src/components/tab-bar/tab-agent-launch-options.test.ts
- pnpm run typecheck:web
- git diff --check
- React Effect AST count: origin/main 912, branch 911

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.