### PR TITLE
Minimize empty floating workspace on close shortcut

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -313,9 +313,28 @@ function App(): React.JSX.Element {
   const worktreeSidebarScrollOffsetRef = useRef(0)
   const worktreeSidebarScrollAnchorRef = useRef<VirtualizedScrollAnchor>(null)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
-  const floatingUnifiedTabCount = useAppStore(
-    (s) => s.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]?.length ?? 0
-  )
+  const floatingVisibleTabCount = useAppStore((s) => {
+    const terminalIds = new Set(
+      (s.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).map((tab) => tab.id)
+    )
+    const browserIds = new Set(
+      (s.browserTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).map((tab) => tab.id)
+    )
+    const editorIds = new Set(
+      s.openFiles
+        .filter((file) => file.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)
+        .map((file) => file.id)
+    )
+    return (s.unifiedTabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).filter((tab) => {
+      if (tab.contentType === 'terminal') {
+        return terminalIds.has(tab.entityId)
+      }
+      if (tab.contentType === 'browser') {
+        return browserIds.has(tab.entityId)
+      }
+      return editorIds.has(tab.entityId)
+    }).length
+  })
   const activeTabId = useAppStore((s) => s.activeTabId)
   const expandedPaneByTabId = useAppStore((s) => s.expandedPaneByTabId)
   const canExpandPaneByTabId = useAppStore((s) => s.canExpandPaneByTabId)
@@ -1134,6 +1153,22 @@ function App(): React.JSX.Element {
         }
       }
 
+      // Why: an empty floating workspace has no tab to close; Cmd/Ctrl+W
+      // should hide that transient overlay before underlying app surfaces act.
+      if (
+        keybindingMatchesAction('tab.close', e, shortcutPlatform, keybindings, {
+          context: 'app'
+        }) &&
+        shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
+          floatingTerminalOpen,
+          floatingVisibleTabCount
+        })
+      ) {
+        e.preventDefault()
+        setFloatingTerminalOpenWithFocus(false)
+        return
+      }
+
       // Why: keep this guard. TipTap's Cmd+B bold binding depends on the
       // window-level handler *not* toggling the sidebar when focus lives in an
       // editable surface. The main-process before-input-event already carves out
@@ -1184,22 +1219,6 @@ function App(): React.JSX.Element {
         ) {
           return
         }
-      }
-
-      // Why: after the last floating tab is closed, the empty overlay has no
-      // pane-level handler; Cmd/Ctrl+W should minimize only that landing state.
-      if (
-        matchShortcut('tab.close') &&
-        shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
-          activeView,
-          activeWorktreeId,
-          floatingTerminalOpen,
-          floatingUnifiedTabCount
-        })
-      ) {
-        e.preventDefault()
-        setFloatingTerminalOpenWithFocus(false)
-        return
       }
 
       // Cmd/Ctrl+B — toggle left sidebar
@@ -1299,7 +1318,7 @@ function App(): React.JSX.Element {
     activeWorktreeId,
     actions,
     floatingTerminalOpen,
-    floatingUnifiedTabCount,
+    floatingVisibleTabCount,
     keybindings,
     settings?.terminalShortcutPolicy,
     setFloatingTerminalOpenWithFocus

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -75,6 +75,7 @@ import {
 } from '@/runtime/web-runtime-session'
 import {
   createFloatingWorkspaceTerminalTab,
+  handleEmptyFloatingWorkspacePanelCloseShortcut,
   isFloatingWorkspacePanelFocused,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
@@ -1189,6 +1190,10 @@ function Terminal(): React.JSX.Element | null {
         e.preventDefault()
         notifyTerminalCapture('tab.newMarkdown')
         void handleNewFile()
+        return
+      }
+
+      if (handleEmptyFloatingWorkspacePanelCloseShortcut(e, shortcutPlatform, keybindings)) {
         return
       }
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1307,6 +1307,7 @@ function FloatingTerminalEmptyState({
   return (
     <div
       className="absolute inset-0 flex items-center justify-center"
+      data-floating-terminal-empty-state
       data-floating-terminal-shortcut-surface
       onPointerDown={onFocusPanel}
     >

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -16,6 +16,7 @@ import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
 import { keyboardEventBelongsToScope } from './terminal-keyboard-scope'
 import { normalizeSelectedTextForFileSearch } from '@/lib/file-search-selection'
 import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
+import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -208,6 +209,10 @@ export function useTerminalKeyboardShortcuts({
       }
 
       if (isEditableTarget(e.target)) {
+        return
+      }
+
+      if (handleEmptyFloatingWorkspacePanelCloseShortcut(e, shortcutPlatform, keybindings)) {
         return
       }
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1039,6 +1039,7 @@ describe('useIpcEvents updater integration', () => {
     }))
     vi.doMock('@/lib/floating-workspace-terminal-actions', () => ({
       createFloatingWorkspaceTerminalTab,
+      isEmptyFloatingWorkspacePanelVisible: () => false,
       isFloatingWorkspacePanelFocused: () => floatingPanelFocused
     }))
     vi.doMock('@/runtime/web-runtime-session', () => ({

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -76,6 +76,7 @@ import {
 } from '@/runtime/web-runtime-session'
 import {
   createFloatingWorkspaceTerminalTab,
+  isEmptyFloatingWorkspacePanelVisible,
   isFloatingWorkspacePanelFocused,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
@@ -1650,6 +1651,10 @@ export function useIpcEvents(): void {
 
     unsubs.push(
       window.api.ui.onCloseActiveTab(() => {
+        if (isEmptyFloatingWorkspacePanelVisible()) {
+          window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
+          return
+        }
         const store = useAppStore.getState()
         if (store.activeTabType === 'browser' && store.activeBrowserTabId) {
           if (isRuntimeEnvironmentActive() && store.activeWorktreeId) {

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -5,6 +5,8 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import type { Tab, TerminalTab } from '../../../shared/types'
 import {
   createFloatingWorkspaceTerminalTab,
+  handleEmptyFloatingWorkspacePanelCloseShortcut,
+  isEmptyFloatingWorkspacePanelVisible,
   isFloatingWorkspacePanelFocused,
   isFloatingWorkspacePanelShortcut,
   isFloatingWorkspacePanelShortcutTarget,
@@ -121,6 +123,25 @@ describe('isFloatingWorkspacePanelVisible', () => {
     expect(isFloatingWorkspacePanelVisible({ querySelector: vi.fn().mockReturnValue(null) })).toBe(
       false
     )
+  })
+})
+
+describe('isEmptyFloatingWorkspacePanelVisible', () => {
+  it('detects the visible empty floating workspace panel', () => {
+    const doc = {
+      querySelector: vi.fn().mockReturnValue({})
+    }
+
+    expect(isEmptyFloatingWorkspacePanelVisible(doc as never)).toBe(true)
+    expect(doc.querySelector).toHaveBeenCalledWith(
+      '[data-floating-terminal-panel][aria-hidden="false"] [data-floating-terminal-empty-state]'
+    )
+  })
+
+  it('returns false when the empty state is absent', () => {
+    expect(
+      isEmptyFloatingWorkspacePanelVisible({ querySelector: vi.fn().mockReturnValue(null) })
+    ).toBe(false)
   })
 })
 
@@ -401,33 +422,19 @@ describe('switchFloatingWorkspaceTab', () => {
 
 describe('shouldMinimizeFloatingWorkspacePanelOnCloseShortcut', () => {
   const base = {
-    activeView: 'terminal',
-    activeWorktreeId: null,
     floatingTerminalOpen: true,
-    floatingUnifiedTabCount: 0
+    floatingVisibleTabCount: 0
   }
 
-  it('allows Cmd/Ctrl+W to minimize the empty floating panel from landing', () => {
+  it('allows Cmd/Ctrl+W to minimize any empty floating panel', () => {
     expect(shouldMinimizeFloatingWorkspacePanelOnCloseShortcut(base)).toBe(true)
   })
 
-  it('does not minimize outside the empty floating-panel landing state', () => {
+  it('does not minimize when the floating panel is hidden or has tabs', () => {
     expect(
       shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
         ...base,
-        floatingUnifiedTabCount: 1
-      })
-    ).toBe(false)
-    expect(
-      shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
-        ...base,
-        activeWorktreeId: 'worktree-1'
-      })
-    ).toBe(false)
-    expect(
-      shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
-        ...base,
-        activeView: 'settings'
+        floatingVisibleTabCount: 1
       })
     ).toBe(false)
     expect(
@@ -436,5 +443,78 @@ describe('shouldMinimizeFloatingWorkspacePanelOnCloseShortcut', () => {
         floatingTerminalOpen: false
       })
     ).toBe(false)
+  })
+})
+
+describe('handleEmptyFloatingWorkspacePanelCloseShortcut', () => {
+  it('minimizes the visible empty floating workspace on Cmd/Ctrl+W', () => {
+    installFakeHTMLElement()
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('window', { dispatchEvent })
+    vi.stubGlobal('document', {
+      querySelector: vi.fn().mockReturnValue({})
+    })
+    const event = {
+      altKey: false,
+      code: 'KeyW',
+      ctrlKey: false,
+      key: 'w',
+      metaKey: true,
+      preventDefault: vi.fn(),
+      repeat: false,
+      shiftKey: false,
+      stopImmediatePropagation: vi.fn(),
+      stopPropagation: vi.fn()
+    } as unknown as KeyboardEvent
+
+    expect(handleEmptyFloatingWorkspacePanelCloseShortcut(event, 'darwin')).toBe(true)
+
+    expect(event.preventDefault).toHaveBeenCalledWith()
+    expect(event.stopPropagation).toHaveBeenCalledWith()
+    expect(event.stopImmediatePropagation).toHaveBeenCalledWith()
+    expect(dispatchEvent).toHaveBeenCalledWith(expect.any(Event))
+    const dispatchedEvent = dispatchEvent.mock.calls[0][0] as Event
+    expect(dispatchedEvent.type).toBe('orca-toggle-floating-terminal')
+  })
+
+  it('ignores non-close shortcuts and non-empty floating workspaces', () => {
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() })
+    vi.stubGlobal('document', {
+      querySelector: vi.fn().mockReturnValue({})
+    })
+    const nonCloseEvent = {
+      altKey: false,
+      code: 'KeyT',
+      ctrlKey: false,
+      key: 't',
+      metaKey: true,
+      preventDefault: vi.fn(),
+      repeat: false,
+      shiftKey: false,
+      stopImmediatePropagation: vi.fn(),
+      stopPropagation: vi.fn()
+    } as unknown as KeyboardEvent
+
+    expect(handleEmptyFloatingWorkspacePanelCloseShortcut(nonCloseEvent, 'darwin')).toBe(false)
+    expect(nonCloseEvent.preventDefault).not.toHaveBeenCalled()
+
+    vi.stubGlobal('document', {
+      querySelector: vi.fn().mockReturnValue(null)
+    })
+    const event = {
+      altKey: false,
+      code: 'KeyW',
+      ctrlKey: false,
+      key: 'w',
+      metaKey: true,
+      preventDefault: vi.fn(),
+      repeat: false,
+      shiftKey: false,
+      stopImmediatePropagation: vi.fn(),
+      stopPropagation: vi.fn()
+    } as unknown as KeyboardEvent
+
+    expect(handleEmptyFloatingWorkspacePanelCloseShortcut(event, 'darwin')).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -8,12 +8,14 @@ import {
   type TypeCyclableTab
 } from '@/components/terminal/tab-type-cycle'
 import type { AppState } from '@/store/types'
+import { TOGGLE_FLOATING_TERMINAL_EVENT } from './floating-terminal'
 import {
   activateWebRuntimeSessionTab,
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '@/runtime/web-runtime-session'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
+import { keybindingMatchesAction, type KeybindingOverrides } from '../../../shared/keybindings'
 export {
   isFloatingWorkspacePanelShortcut,
   isFloatingWorkspacePanelShortcutTarget
@@ -40,6 +42,22 @@ type FloatingWorkspaceTabSwitchStore = Pick<
 >
 
 const FLOATING_WORKSPACE_PANEL_SELECTOR = '[data-floating-terminal-panel]'
+const EMPTY_FLOATING_WORKSPACE_PANEL_SELECTOR =
+  '[data-floating-terminal-panel][aria-hidden="false"] [data-floating-terminal-empty-state]'
+
+type EmptyFloatingWorkspaceCloseShortcutEvent = Pick<
+  KeyboardEvent,
+  | 'altKey'
+  | 'code'
+  | 'ctrlKey'
+  | 'key'
+  | 'metaKey'
+  | 'preventDefault'
+  | 'repeat'
+  | 'shiftKey'
+  | 'stopImmediatePropagation'
+  | 'stopPropagation'
+>
 
 function getActiveFloatingWorkspaceGroup(store: FloatingWorkspaceTabSwitchStore): TabGroup | null {
   const groups = store.groupsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []
@@ -174,6 +192,12 @@ export function isFloatingWorkspacePanelVisible(
   return Boolean(doc.querySelector('[data-floating-terminal-panel][aria-hidden="false"]'))
 }
 
+export function isEmptyFloatingWorkspacePanelVisible(
+  doc: Pick<Document, 'querySelector'> | null = typeof document === 'undefined' ? null : document
+): boolean {
+  return Boolean(doc?.querySelector(EMPTY_FLOATING_WORKSPACE_PANEL_SELECTOR))
+}
+
 export function isFloatingWorkspacePanelFocused(
   doc: Pick<Document, 'activeElement'> = document
 ): boolean {
@@ -195,22 +219,33 @@ export function isFloatingWorkspaceTerminalInputTarget(target: EventTarget | nul
 }
 
 export function shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
-  activeView,
-  activeWorktreeId,
   floatingTerminalOpen,
-  floatingUnifiedTabCount
+  floatingVisibleTabCount
 }: {
-  activeView: string
-  activeWorktreeId: string | null
   floatingTerminalOpen: boolean
-  floatingUnifiedTabCount: number
+  floatingVisibleTabCount: number
 }): boolean {
-  return (
-    floatingTerminalOpen &&
-    floatingUnifiedTabCount === 0 &&
-    activeView === 'terminal' &&
-    activeWorktreeId === null
-  )
+  return floatingTerminalOpen && floatingVisibleTabCount === 0
+}
+
+export function handleEmptyFloatingWorkspacePanelCloseShortcut(
+  event: EmptyFloatingWorkspaceCloseShortcutEvent,
+  platform: NodeJS.Platform,
+  keybindings?: KeybindingOverrides
+): boolean {
+  if (
+    event.repeat ||
+    !isEmptyFloatingWorkspacePanelVisible() ||
+    !keybindingMatchesAction('tab.close', event, platform, keybindings, { context: 'app' })
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation()
+  window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
+  return true
 }
 
 export function switchFloatingWorkspaceTab(


### PR DESCRIPTION
## Summary
- Minimize the floating workspace on Cmd/Ctrl+W whenever it has no visible tabs
- Guard terminal, browser, and IPC close paths so the underlying workspace is not closed instead
- Add empty floating workspace detection coverage

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/floating-workspace-terminal-actions.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/lib/floating-workspace-terminal-actions.ts src/renderer/src/lib/floating-workspace-terminal-actions.test.ts src/renderer/src/App.tsx src/renderer/src/components/Terminal.tsx src/renderer/src/components/terminal-pane/keyboard-handlers.ts src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- git diff --check