### PR TITLE
Focus terminal tab rename input from ref

### DIFF
--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -101,6 +101,7 @@ export default function SortableTab({
   // (e.g. showing the bell without the wash, or vice versa).
   const showActivityAffordance = hasUnreadActivity && !isEditing
   const [renameValue, setRenameValue] = useState('')
+  const renameFocusFrameRef = useRef<number | null>(null)
   // Why: React's synthetic onBlur fires during the Input's unmount when isEditing flips
   // to false. Without this guard, pressing Escape (or committing via Enter) would cause
   // the blur handler to run commitRename a second time and overwrite the title with the
@@ -134,13 +135,20 @@ export default function SortableTab({
   }, [])
 
   const setRenameInputElement = useCallback((input: HTMLInputElement | null) => {
+    if (renameFocusFrameRef.current !== null) {
+      cancelAnimationFrame(renameFocusFrameRef.current)
+      renameFocusFrameRef.current = null
+    }
     if (!input) {
       return
     }
-    // Why: focus/select only when the inline input mounts; terminal title updates
-    // during editing must not re-select the user's in-progress rename text.
-    input.focus()
-    input.select()
+    // Why: defer past Radix menu teardown/focus restore while still keying off
+    // input mount only; terminal title updates must not re-select in-progress text.
+    renameFocusFrameRef.current = requestAnimationFrame(() => {
+      renameFocusFrameRef.current = null
+      input.focus()
+      input.select()
+    })
   }, [])
 
   useEffect(() => {

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -101,7 +101,6 @@ export default function SortableTab({
   // (e.g. showing the bell without the wash, or vice versa).
   const showActivityAffordance = hasUnreadActivity && !isEditing
   const [renameValue, setRenameValue] = useState('')
-  const renameInputRef = useRef<HTMLInputElement>(null)
   // Why: React's synthetic onBlur fires during the Input's unmount when isEditing flips
   // to false. Without this guard, pressing Escape (or committing via Enter) would cause
   // the blur handler to run commitRename a second time and overwrite the title with the
@@ -134,21 +133,15 @@ export default function SortableTab({
     setIsEditing(false)
   }, [])
 
-  // Why: rAF defers focus()+select() until after the Input mounts so the text
-  // is pre-selected (overwriting the old title is the common case). Deps are
-  // intentionally just [isEditing] — we do NOT re-run when tab.title or
-  // tab.customTitle change mid-edit, so external title updates cannot
-  // re-focus/re-select and disrupt the user's typing.
-  useEffect(() => {
-    if (!isEditing) {
+  const setRenameInputElement = useCallback((input: HTMLInputElement | null) => {
+    if (!input) {
       return
     }
-    const frame = requestAnimationFrame(() => {
-      renameInputRef.current?.focus()
-      renameInputRef.current?.select()
-    })
-    return () => cancelAnimationFrame(frame)
-  }, [isEditing])
+    // Why: focus/select only when the inline input mounts; terminal title updates
+    // during editing must not re-select the user's in-progress rename text.
+    input.focus()
+    input.select()
+  }, [])
 
   useEffect(() => {
     const closeMenu = (): void => setMenuOpen(false)
@@ -273,7 +266,7 @@ export default function SortableTab({
       )}
       {isEditing ? (
         <Input
-          ref={renameInputRef}
+          ref={setRenameInputElement}
           data-tab-rename-input="true"
           value={renameValue}
           aria-label={`Rename tab ${tabTitle}`}

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -118,6 +118,35 @@ test.describe('Tab Rename (Inline)', () => {
     await expect(tabLocatorByTitle(orcaPage, 'My Custom Title')).toBeVisible()
   })
 
+  test('context-menu Change Title opens a focused select-all rename input', async ({
+    orcaPage
+  }) => {
+    const worktreeId = (await getActiveWorktreeId(orcaPage))!
+    const originalTitle = await getActiveTabTitle(orcaPage, worktreeId)
+    expect(originalTitle.length).toBeGreaterThan(0)
+
+    await tabLocatorByTitle(orcaPage, originalTitle).click({ button: 'right' })
+    await orcaPage.getByRole('menuitem', { name: 'Change Title', exact: true }).click()
+
+    const renameInput = orcaPage.getByRole('textbox', {
+      name: `Rename tab ${originalTitle}`,
+      exact: true
+    })
+    await expect(renameInput).toBeVisible()
+    await expect(renameInput).toBeFocused()
+
+    // Why: plain keyboard typing exercises the real focused selection. If the
+    // context menu steals focus back or the title is not selected, this will not
+    // replace the original text with the intended custom title.
+    await orcaPage.keyboard.type('Context Menu Title')
+    await renameInput.press('Enter')
+
+    await expect
+      .poll(async () => getActiveCustomTitle(orcaPage, worktreeId), { timeout: 3_000 })
+      .toBe('Context Menu Title')
+    await expect(tabLocatorByTitle(orcaPage, 'Context Menu Title')).toBeVisible()
+  })
+
   test('Escape during inline rename discards the edit', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
     const originalTitle = await getActiveTabTitle(orcaPage, worktreeId)


### PR DESCRIPTION
## Summary
- replace the terminal tab rename focus/select Effect with a stable callback ref
- preserve mount-time select-all behavior when inline rename opens
- remove one visual-only Effect call site from `SortableTab.tsx`

## Risk
Medium. This changes terminal-tab inline rename focus behavior in renderer UI, but does not touch PTY/session/runtime protocols, SSH transport, persistence, or git-provider paths.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/tab-bar/SortableTab.tsx`
- `pnpm exec oxlint src/renderer/src/components/tab-bar/SortableTab.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: `origin/main 912`, working branch 911

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.