### PR TITLE
Focus markdown link bubble input from ref

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import type { Editor } from '@tiptap/react'
 import { ExternalLink, Pencil, Unlink } from 'lucide-react'
 
@@ -38,16 +38,20 @@ function LinkEditInput({
   onCancel: () => void
 }): React.JSX.Element {
   const [value, setValue] = useState(initialHref)
-  const ref = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    ref.current?.focus()
-    ref.current?.select()
+  const setInputElement = useCallback((input: HTMLInputElement | null) => {
+    if (!input) {
+      return
+    }
+    // Why: edit mode should start with the current URL selected, but typing
+    // changes must not re-select the field on every value update.
+    input.focus()
+    input.select()
   }, [])
 
   return (
     <input
-      ref={ref}
+      ref={setInputElement}
       value={value}
       onChange={(e) => setValue(e.target.value)}
       onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- replace the rich markdown link-edit input focus/select Effect with a stable callback ref
- preserve selecting the current URL when link edit mode mounts
- remove one visual-only Effect call site from `RichMarkdownLinkBubble.tsx`

## Risk
Medium. This changes editor UI focus behavior, but does not touch persistence, IPC, SSH, source-control/provider behavior, terminal/browser runtime protocols, or markdown parsing.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/RichMarkdownLinkBubble.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: `origin/main 912`, working branch 911

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.