### PR TITLE
Derive image viewer preview source during render

### DIFF
--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const reactHookRuntime = vi.hoisted(() => ({
+  states: [] as unknown[],
+  index: 0
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    useMemo<T>(factory: () => T) {
+      return factory()
+    },
+    useState<T>(initial: T | (() => T)) {
+      const stateIndex = reactHookRuntime.index++
+      if (!(stateIndex in reactHookRuntime.states)) {
+        reactHookRuntime.states[stateIndex] =
+          typeof initial === 'function' ? (initial as () => T)() : initial
+      }
+      const setState = (next: T | ((previous: T) => T)): void => {
+        reactHookRuntime.states[stateIndex] =
+          typeof next === 'function'
+            ? (next as (previous: T) => T)(reactHookRuntime.states[stateIndex] as T)
+            : next
+      }
+      return [reactHookRuntime.states[stateIndex] as T, setState] as const
+    }
+  }
+})
+
+vi.mock('lucide-react', () => ({
+  Image: function Image(props: Record<string, unknown>) {
+    return { type: 'Image', props }
+  },
+  RotateCcw: function RotateCcw(props: Record<string, unknown>) {
+    return { type: 'RotateCcw', props }
+  },
+  X: function X(props: Record<string, unknown>) {
+    return { type: 'X', props }
+  },
+  ZoomIn: function ZoomIn(props: Record<string, unknown>) {
+    return { type: 'ZoomIn', props }
+  },
+  ZoomOut: function ZoomOut(props: Record<string, unknown>) {
+    return { type: 'ZoomOut', props }
+  }
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: function Dialog(props: { children?: unknown }) {
+    return { type: 'Dialog', props }
+  },
+  DialogContent: function DialogContent(props: { children?: unknown }) {
+    return { type: 'DialogContent', props }
+  },
+  DialogDescription: function DialogDescription(props: { children?: unknown }) {
+    return { type: 'DialogDescription', props }
+  },
+  DialogTitle: function DialogTitle(props: { children?: unknown }) {
+    return { type: 'DialogTitle', props }
+  }
+}))
+
+vi.mock('./PdfViewer', () => ({
+  default: function PdfViewer(props: Record<string, unknown>) {
+    return { type: 'PdfViewer', props }
+  }
+}))
+
+type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+function expandNode(node: unknown): unknown {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return node
+  }
+  if (Array.isArray(node)) {
+    return node.map(expandNode)
+  }
+  const el = node as ReactElementLike
+  if (typeof el.type === 'function') {
+    return expandNode(el.type(el.props))
+  }
+  return {
+    ...el,
+    props: {
+      ...el.props,
+      children: expandNode(el.props?.children)
+    }
+  }
+}
+
+function findElementsByType(node: unknown, typeName: string): ReactElementLike[] {
+  const results: ReactElementLike[] = []
+  const visit = (current: unknown): void => {
+    if (current == null || typeof current === 'string' || typeof current === 'number') {
+      return
+    }
+    if (Array.isArray(current)) {
+      for (const child of current) {
+        visit(child)
+      }
+      return
+    }
+    const el = current as ReactElementLike
+    if (el.type === typeName) {
+      results.push(el)
+    }
+    visit(el.props?.children)
+  }
+  visit(node)
+  return results
+}
+
+function findPreviewImage(node: unknown): ReactElementLike {
+  const image = findElementsByType(node, 'img').find((element) => element.props.onError)
+  if (!image) {
+    throw new Error('preview image not found')
+  }
+  return image
+}
+
+async function renderExpandedImageViewer(content: string): Promise<unknown> {
+  reactHookRuntime.index = 0
+  const module = await import('./ImageViewer')
+  return expandNode(
+    module.default({
+      content,
+      filePath: '/repo/preview.png',
+      mimeType: 'image/png'
+    })
+  )
+}
+
+describe('ImageViewer preview source retry', () => {
+  beforeEach(() => {
+    reactHookRuntime.states = []
+    reactHookRuntime.index = 0
+    vi.clearAllMocks()
+  })
+
+  it('retries an earlier failed source after a later source loads successfully', async () => {
+    const failedContent = 'failed-source'
+    const loadedContent = 'loaded-source'
+
+    const firstRender = await renderExpandedImageViewer(failedContent)
+    const firstImage = findPreviewImage(firstRender)
+    expect(firstImage.props.src).toBe(`data:image/png;base64,${failedContent}`)
+
+    ;(firstImage.props.onError as () => void)()
+    const failedRender = await renderExpandedImageViewer(failedContent)
+    expect(findElementsByType(failedRender, 'Image')).toHaveLength(1)
+    expect(findElementsByType(failedRender, 'img')).toHaveLength(0)
+
+    const loadedRender = await renderExpandedImageViewer(loadedContent)
+    const loadedImage = findPreviewImage(loadedRender)
+    ;(
+      loadedImage.props.onLoad as (event: {
+        currentTarget: { naturalWidth: number; naturalHeight: number }
+      }) => void
+    )({ currentTarget: { naturalWidth: 12, naturalHeight: 10 } })
+
+    const retryRender = await renderExpandedImageViewer(failedContent)
+    const retryImage = findPreviewImage(retryRender)
+    expect(retryImage.props.src).toBe(`data:image/png;base64,${failedContent}`)
+  })
+})

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -1,5 +1,5 @@
 import { Image as ImageIcon, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
-import { type JSX, useEffect, useMemo, useState } from 'react'
+import { type JSX, useMemo, useState } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import PdfViewer from './PdfViewer'
@@ -22,18 +22,22 @@ export default function ImageViewer({
   mimeType = FALLBACK_IMAGE_MIME_TYPE,
   layout = 'fill'
 }: ImageViewerProps): JSX.Element {
-  const [imageError, setImageError] = useState(false)
   const [isPopupOpen, setIsPopupOpen] = useState(false)
   const [zoom, setZoom] = useState(1)
   const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(
     null
   )
+  const [failedPreviewSrc, setFailedPreviewSrc] = useState<string | null>(null)
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const cleanedContent = useMemo(() => content.replace(/\s/g, ''), [content])
   const isPdf = mimeType === 'application/pdf'
   const isIntrinsicLayout = layout === 'intrinsic'
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const previewSrc = useMemo(
+    () => (cleanedContent && !isPdf ? `data:${mimeType};base64,${cleanedContent}` : null),
+    [cleanedContent, isPdf, mimeType]
+  )
+  const imageError = previewSrc !== null && failedPreviewSrc === previewSrc
   const estimatedSize = useMemo(() => {
     const bytes = Math.floor((cleanedContent.length * 3) / 4)
     if (bytes < 1024) {
@@ -45,28 +49,6 @@ export default function ImageViewer({
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
   }, [cleanedContent])
   const zoomPercent = Math.round(zoom * 100)
-
-  useEffect(() => {
-    setImageError(false)
-    if (!cleanedContent || isPdf) {
-      setPreviewUrl(null)
-      return
-    }
-    let binary: string
-    try {
-      binary = window.atob(cleanedContent)
-    } catch {
-      setImageError(true)
-      return
-    }
-    const bytes = new Uint8Array(binary.length)
-    for (let i = 0; i < binary.length; i += 1) {
-      bytes[i] = binary.charCodeAt(i)
-    }
-    const objectUrl = URL.createObjectURL(new Blob([bytes], { type: mimeType }))
-    setPreviewUrl(objectUrl)
-    return () => URL.revokeObjectURL(objectUrl)
-  }, [cleanedContent, mimeType, isPdf])
 
   if (isPdf) {
     return <PdfViewer content={cleanedContent} filePath={filePath} />
@@ -87,7 +69,7 @@ export default function ImageViewer({
     )
   }
 
-  if (!previewUrl) {
+  if (!previewSrc) {
     return (
       <div
         className={cn(
@@ -121,7 +103,7 @@ export default function ImageViewer({
             style={{ transform: `scale(${zoom})`, transformOrigin: 'center center' }}
           >
             <img
-              src={previewUrl}
+              src={previewSrc}
               alt={filename}
               className={cn(
                 'max-w-full object-contain',
@@ -131,7 +113,9 @@ export default function ImageViewer({
                 const img = event.currentTarget
                 setImageDimensions({ width: img.naturalWidth, height: img.naturalHeight })
               }}
-              onError={() => setImageError(true)}
+              // Why: track the failed source identity, not a boolean, so a new
+              // image retries immediately without waiting for an Effect reset.
+              onError={() => setFailedPreviewSrc(previewSrc)}
             />
           </div>
         </div>
@@ -201,7 +185,7 @@ export default function ImageViewer({
               style={{ transform: `scale(${zoom})`, transformOrigin: 'center center' }}
             >
               <img
-                src={previewUrl}
+                src={previewSrc}
                 alt={filename}
                 className="block max-h-full max-w-full object-contain"
               />

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -112,6 +112,7 @@ export default function ImageViewer({
               onLoad={(event) => {
                 const img = event.currentTarget
                 setImageDimensions({ width: img.naturalWidth, height: img.naturalHeight })
+                setFailedPreviewSrc(null)
               }}
               // Why: track the failed source identity, not a boolean, so a new
               // image retries immediately without waiting for an Effect reset.


### PR DESCRIPTION
## Summary
- replace the image preview blob-url Effect with a render-derived data URL source
- track failed image loads by preview source identity so new image content retries immediately
- remove one Effect call site from `ImageViewer.tsx`

## Risk
Medium. This changes editor image preview rendering, but does not touch persistence, IPC, SSH, source-control/provider behavior, terminal/browser runtime protocols, or markdown parsing.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/ImageViewer.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/ImageViewer.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-preview-url-transform.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: `origin/main 912`, working branch 911

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.