### PR TITLE
Handle browser grab cancellation before payload validation

### DIFF
--- a/src/main/browser/browser-grab-session-controller.ts
+++ b/src/main/browser/browser-grab-session-controller.ts
@@ -26,7 +26,28 @@ function isGuestCancellationPayload(rawPayload: unknown): boolean {
     return false
   }
   const payload = rawPayload as Record<string, unknown>
-  return payload.__orcaCancelled === true || payload.message === 'cancelled'
+  if (payload.__orcaCancelled === true) {
+    return true
+  }
+  // Why: old guest/Electron paths can serialize cancellation as a plain error
+  // object, but valid grab payloads may also carry page-authored fields.
+  if (payload.message !== 'cancelled') {
+    return false
+  }
+  return !('page' in payload) && !('target' in payload) && !('payload' in payload)
+}
+
+function getGuestErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message
+  }
+  if (err && typeof err === 'object') {
+    const message = (err as Record<string, unknown>).message
+    if (typeof message === 'string') {
+      return message
+    }
+  }
+  return 'Selection failed'
 }
 
 export class BrowserGrabSessionController {
@@ -138,7 +159,7 @@ export class BrowserGrabSessionController {
             payload
           })
         } catch (err) {
-          const message = err instanceof Error ? err.message : 'Selection failed'
+          const message = getGuestErrorMessage(err)
           if (message.includes('cancelled')) {
             settleOnce({ opId, kind: 'cancelled', reason: 'user' })
           } else {

--- a/src/main/browser/browser-grab-session-controller.ts
+++ b/src/main/browser/browser-grab-session-controller.ts
@@ -21,6 +21,14 @@ type ActiveGrabOp = {
 /** Hard timeout for an armed grab operation to prevent indefinite hangs. */
 const GRAB_OP_TIMEOUT_MS = 120_000
 
+function isGuestCancellationPayload(rawPayload: unknown): boolean {
+  if (!rawPayload || typeof rawPayload !== 'object') {
+    return false
+  }
+  const payload = rawPayload as Record<string, unknown>
+  return payload.__orcaCancelled === true || payload.message === 'cancelled'
+}
+
 export class BrowserGrabSessionController {
   private readonly activeGrabOps = new Map<string, ActiveGrabOp>()
 
@@ -102,6 +110,12 @@ export class BrowserGrabSessionController {
         try {
           const rawPayload = await guest.executeJavaScript(buildGuestOverlayScript('awaitClick'))
           if (!rawPayload || typeof rawPayload !== 'object') {
+            settleOnce({ opId, kind: 'cancelled', reason: 'user' })
+            return
+          }
+          // Why: teardown cancellation is an expected user path. Classify it
+          // before payload validation so it cannot surface as an invalid grab.
+          if (isGuestCancellationPayload(rawPayload)) {
             settleOnce({ opId, kind: 'cancelled', reason: 'user' })
             return
           }

--- a/src/main/browser/browser-manager-grab.test.ts
+++ b/src/main/browser/browser-manager-grab.test.ts
@@ -4,6 +4,7 @@ main-side payload validation. Splitting across files would scatter the shared
 mock setup and make it harder to verify the grab contract holistically. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GRAB_BUDGET } from '../../shared/browser-grab-types'
+import type { BrowserGrabPayload } from '../../shared/browser-grab-types'
 
 const {
   webContentsFromIdMock,
@@ -60,6 +61,57 @@ function makeGuest(id: number) {
     capturePage: guestCapturePageMock,
     getURL: vi.fn(() => 'https://example.com/')
   } as unknown as Electron.WebContents
+}
+
+function makeValidGrabPayload(): BrowserGrabPayload {
+  return {
+    page: {
+      sanitizedUrl: 'https://example.com/',
+      title: 'Example',
+      viewportWidth: 1280,
+      viewportHeight: 720,
+      scrollX: 0,
+      scrollY: 0,
+      devicePixelRatio: 2,
+      capturedAt: '2026-04-10T00:00:00.000Z'
+    },
+    target: {
+      tagName: 'button',
+      selector: 'button',
+      textSnippet: 'Click me',
+      htmlSnippet: '<button>Click me</button>',
+      attributes: {},
+      accessibility: {
+        role: 'button',
+        accessibleName: 'Click me',
+        ariaLabel: null,
+        ariaLabelledBy: null
+      },
+      rectViewport: { x: 0, y: 0, width: 100, height: 40 },
+      rectPage: { x: 0, y: 0, width: 100, height: 40 },
+      computedStyles: {
+        display: 'block',
+        position: 'static',
+        width: '100px',
+        height: '40px',
+        margin: '0',
+        padding: '0',
+        color: '#000',
+        backgroundColor: '#fff',
+        border: 'none',
+        borderRadius: '0',
+        fontFamily: 'sans-serif',
+        fontSize: '14px',
+        fontWeight: '400',
+        lineHeight: '20px',
+        textAlign: 'left',
+        zIndex: 'auto'
+      }
+    },
+    nearbyText: [],
+    ancestorPath: ['div', 'body'],
+    screenshot: null
+  }
 }
 
 describe('browserManager grab operations', () => {
@@ -353,6 +405,26 @@ describe('browserManager grab operations', () => {
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
+    })
+
+    it('resolves with cancelled when executeJavaScript rejects a serialized cancelled error', async () => {
+      guestExecuteJavaScriptMock.mockRejectedValueOnce({ message: 'cancelled' })
+
+      const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
+      expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
+    })
+
+    it('does not treat a valid payload message field as cancellation', async () => {
+      guestExecuteJavaScriptMock.mockResolvedValueOnce({
+        ...makeValidGrabPayload(),
+        message: 'cancelled'
+      })
+
+      const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
+      expect(result.kind).toBe('selected')
+      if (result.kind === 'selected') {
+        expect(result.payload.target.tagName).toBe('button')
+      }
     })
 
     it('resolves with error when executeJavaScript throws', async () => {

--- a/src/main/browser/browser-manager-grab.test.ts
+++ b/src/main/browser/browser-manager-grab.test.ts
@@ -341,6 +341,20 @@ describe('browserManager grab operations', () => {
       expect(result.kind).toBe('cancelled')
     })
 
+    it('resolves with cancelled when guest returns teardown cancellation marker', async () => {
+      guestExecuteJavaScriptMock.mockResolvedValueOnce({ __orcaCancelled: true })
+
+      const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
+      expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
+    })
+
+    it('resolves with cancelled when guest returns a serialized cancelled error', async () => {
+      guestExecuteJavaScriptMock.mockResolvedValueOnce({ message: 'cancelled' })
+
+      const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
+      expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
+    })
+
     it('resolves with error when executeJavaScript throws', async () => {
       guestExecuteJavaScriptMock.mockRejectedValueOnce(new Error('Script failed'))
 

--- a/src/main/browser/grab-guest-script.test.ts
+++ b/src/main/browser/grab-guest-script.test.ts
@@ -97,6 +97,7 @@ describe('buildGuestOverlayScript', () => {
   it('teardown script cancels pending awaitClick', () => {
     const script = buildGuestOverlayScript('teardown')
     expect(script).toContain('cancelAwait')
+    expect(buildGuestOverlayScript('awaitClick')).toContain('__orcaCancelled')
   })
 
   it('arm script uses full-viewport overlay as click catcher', () => {

--- a/src/main/browser/grab-guest-script.ts
+++ b/src/main/browser/grab-guest-script.ts
@@ -838,12 +838,14 @@ const AWAIT_CLICK_SCRIPT = `new Promise(function(resolve, reject) {
   grab.host.addEventListener('click', onClick, true);
   grab.host.addEventListener('contextmenu', onContext, true);
 
-  // Store cancel hook so teardown can reject the Promise
+  // Store cancel hook so teardown can settle the Promise
   grab.cancelAwait = function() {
     grab.host.removeEventListener('click', onClick, true);
     grab.host.removeEventListener('contextmenu', onContext, true);
     grab.cleanup();
-    reject(new Error('cancelled'));
+    // Why: teardown cancellation is a normal user flow; resolving a marker
+    // avoids a noisy guest-console Error while main still treats it as cancel.
+    resolve({ __orcaCancelled: true });
   };
 })`
 


### PR DESCRIPTION
## Summary

Refs #2783.

This fixes the cancellation path visible in the issue screenshot: guest teardown no longer rejects the pending picker promise with `Error: cancelled`; it resolves an explicit `__orcaCancelled` marker instead. Main now classifies that marker, and a serialized `{ message: 'cancelled' }` error shape, before payload validation so expected cancellation cannot surface as `Guest returned invalid payload structure`.

## Repro / Diagnosis

The issue did not include a target URL, so I built a local matrix for the grab guest runtime:

- normal element: valid payload (`page` + `target`)
- iframe element: valid payload, selected as the iframe element
- open shadow DOM: valid payload, selected as the host
- detached-after-hover element: valid payload
- SVG element: valid payload
- stale document/navigation before click: raw guest promise times out; main already has navigation cancellation coverage

I also downloaded and inspected the issue screenshot. The screenshot shows `Error: cancelled at grab.cancelAwait`, which matches the teardown cancellation path changed here.

## Before / After Evidence

Before the patch, teardown cancellation used `reject(new Error('cancelled'))`, producing the guest-console error shown in the issue screenshot. After the patch, the same teardown check returns:

```json
{ "__orcaCancelled": true }
```

After the patch, Playwright matrix output showed valid payloads for normal, iframe, shadow host, detached, and SVG cases; stale navigation remained a no-payload timeout only at the raw guest seam. The same patched scripts driven through Orca's Electron browser/CDP page returned valid payloads for normal, iframe, shadow host, and SVG cases, plus `{ "__orcaCancelled": true }` for teardown cancellation.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/grab-guest-script.test.ts src/main/browser/browser-manager-grab.test.ts src/main/browser/browser-grab-payload.test.ts`
- `pnpm exec oxlint src/main/browser/browser-grab-session-controller.ts src/main/browser/grab-guest-script.ts src/main/browser/grab-guest-script.test.ts src/main/browser/browser-manager-grab.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` (no conflicts)

## Notes

I still could not reproduce a non-cancellation invalid payload with the local matrix. If the reporter still sees `Guest returned invalid payload structure` after this fix, we need the exact target URL or a reduced HTML snippet from that page to distinguish target-page mutation from another guest serialization edge case.
