### PR TITLE
Focus markdown preview search input from ref

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -344,6 +344,16 @@ export default function MarkdownPreview({
   const rootRef = useRef<HTMLDivElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const setSearchInputElement = useCallback((input: HTMLInputElement | null) => {
+    inputRef.current = input
+    if (!input) {
+      return
+    }
+    // Why: opening preview search should select the query once, while typing
+    // and match-count updates must not keep re-selecting the field.
+    input.focus()
+    input.select()
+  }, [])
   const matchesRef = useRef<HTMLElement[]>([])
   const lastAppliedInitialAnchorRef = useRef<string | null>(null)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
@@ -612,13 +622,6 @@ export default function MarkdownPreview({
     },
     [scrollToAnchor]
   )
-
-  useEffect(() => {
-    if (isSearchOpen) {
-      inputRef.current?.focus()
-      inputRef.current?.select()
-    }
-  }, [isSearchOpen])
 
   useEffect(() => {
     const body = bodyRef.current
@@ -1308,7 +1311,7 @@ export default function MarkdownPreview({
           <div className="markdown-preview-search" onKeyDown={(event) => event.stopPropagation()}>
             <div className="markdown-preview-search-field">
               <Input
-                ref={inputRef}
+                ref={setSearchInputElement}
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 onKeyDown={(event) => {


### PR DESCRIPTION
## Summary
- replace the markdown preview find-bar focus/select Effect with a stable callback ref
- preserve selecting the query once when preview search opens
- remove one visual-only Effect call site from `MarkdownPreview.tsx`

## Risk
Medium. This changes editor preview find UI focus behavior, but does not touch persistence, IPC, SSH, source-control/provider behavior, terminal/browser runtime protocols, or markdown parsing.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/MarkdownPreview.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-preview-url-transform.test.ts src/renderer/src/components/editor/markdown-doc-links.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: `origin/main 912`, working branch 911

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.