### PR TITLE
Fix SSH remote workspace stale sync conflicts

### DIFF
--- a/src/main/ipc/remote-workspace-patch-queue.test.ts
+++ b/src/main/ipc/remote-workspace-patch-queue.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- Why: queue/cache regression cases share one mocked IPC harness so stale revision sequencing stays visible. */
 import { ipcMain } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
@@ -250,5 +251,75 @@ describe('remoteWorkspace:setForConnectedTargets patch queue', () => {
       })
     ).resolves.toMatchObject([{ targetId: 'target-reset', result: { ok: true } }])
     expect(patchBaseRevisions).toEqual([7, 0])
+  })
+
+  it('does not retry stale writes when the relay reports a newer revision', async () => {
+    const newerTarget: SshTarget = {
+      id: 'target-newer',
+      label: 'Newer Target',
+      host: 'newer.example.com',
+      port: 22,
+      username: 'alice'
+    }
+    getSshConnectionStoreMock.mockReturnValue({
+      listTargets: () => [newerTarget]
+    })
+    getRepoMock.mockImplementation((repoId: string) =>
+      repoId === 'repo-newer'
+        ? ({
+            id: 'repo-newer',
+            path: '/remote/repo',
+            displayName: 'Repo',
+            badgeColor: 'blue',
+            addedAt: 1,
+            connectionId: 'target-newer'
+          } as never)
+        : undefined
+    )
+
+    const patchBaseRevisions: number[] = []
+    const request = vi
+      .fn()
+      .mockImplementation(async (method: string, params: Record<string, unknown>) => {
+        if (method === 'workspace.get') {
+          return snapshot(
+            {
+              activeWorktreePath: '/previous',
+              activeTabId: null,
+              tabsByWorktreePath: {},
+              terminalLayoutsByTabId: {}
+            },
+            7
+          )
+        }
+        if (method === 'workspace.patch') {
+          patchBaseRevisions.push(params.baseRevision as number)
+          return {
+            ok: false,
+            reason: 'stale-revision',
+            snapshot: snapshot(
+              {
+                activeWorktreePath: '/other-device',
+                activeTabId: null,
+                tabsByWorktreePath: {},
+                terminalLayoutsByTabId: {}
+              },
+              8
+            )
+          }
+        }
+        throw new Error(`Unexpected method ${method}`)
+      })
+    muxByTargetId.set('target-newer', { request })
+
+    await expect(
+      callSetForConnectedTargets({
+        session: sessionWithTab('repo-newer::/remote/workspace', 'tab-local'),
+        hydratedTargetIds: ['target-newer']
+      })
+    ).resolves.toMatchObject([
+      { targetId: 'target-newer', result: { ok: false, reason: 'stale-revision' } }
+    ])
+    expect(patchBaseRevisions).toEqual([7])
   })
 })

--- a/src/main/ipc/remote-workspace-patch-queue.test.ts
+++ b/src/main/ipc/remote-workspace-patch-queue.test.ts
@@ -1,0 +1,254 @@
+import { ipcMain } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type {
+  RemoteWorkspaceSession,
+  RemoteWorkspaceSnapshot
+} from '../../shared/remote-workspace-types'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { WorkspaceSessionState } from '../../shared/types'
+
+const {
+  getActiveMultiplexerMock,
+  getSshConnectionStoreMock,
+  registerRemoteWorkspaceNotificationHandlerMock
+} = vi.hoisted(() => ({
+  getActiveMultiplexerMock: vi.fn(),
+  getSshConnectionStoreMock: vi.fn(),
+  registerRemoteWorkspaceNotificationHandlerMock: vi.fn(() => vi.fn())
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn()
+  }
+}))
+
+vi.mock('./ssh', () => ({
+  getActiveMultiplexer: getActiveMultiplexerMock,
+  getSshConnectionStore: getSshConnectionStoreMock
+}))
+
+vi.mock('./remote-workspace-events', () => ({
+  registerRemoteWorkspaceNotificationHandler: registerRemoteWorkspaceNotificationHandlerMock
+}))
+
+import { registerRemoteWorkspaceHandlers } from './remote-workspace'
+
+function snapshot(session: RemoteWorkspaceSession, revision = 7): RemoteWorkspaceSnapshot {
+  return {
+    namespace: 'target',
+    revision,
+    updatedAt: 123,
+    schemaVersion: 1,
+    session
+  }
+}
+
+function sessionWithTab(worktreeId: string, tabId: string): WorkspaceSessionState {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: worktreeId,
+    activeTabId: tabId,
+    tabsByWorktree: {
+      [worktreeId]: [{ id: tabId, type: 'terminal', title: 'Shell', worktreeId } as never]
+    },
+    terminalLayoutsByTabId: {}
+  }
+}
+
+function patchSession(params: Record<string, unknown>): RemoteWorkspaceSession {
+  return (params.patch as { session: RemoteWorkspaceSession }).session
+}
+
+describe('remoteWorkspace:setForConnectedTargets patch queue', () => {
+  const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
+  const muxByTargetId = new Map<string, { request: ReturnType<typeof vi.fn> }>()
+  const getRepoMock = vi.fn<Store['getRepo']>()
+  const store = {
+    getRepo: getRepoMock
+  } as unknown as Store
+
+  const target: SshTarget = {
+    id: 'target-1',
+    label: 'Target 1',
+    host: 'one.example.com',
+    port: 22,
+    username: 'alice'
+  }
+
+  beforeEach(() => {
+    handlers.clear()
+    muxByTargetId.clear()
+    vi.mocked(ipcMain.handle).mockReset()
+    vi.mocked(ipcMain.handle).mockImplementation((channel, handler) => {
+      handlers.set(channel, handler as (event: unknown, args: unknown) => unknown)
+    })
+    vi.mocked(ipcMain.removeHandler).mockReset()
+    getSshConnectionStoreMock.mockReset()
+    getSshConnectionStoreMock.mockReturnValue({
+      listTargets: () => [target]
+    })
+    getRepoMock.mockReset()
+    getRepoMock.mockImplementation((repoId: string) =>
+      repoId === 'repo-target-1'
+        ? ({
+            id: 'repo-target-1',
+            path: '/remote/repo',
+            displayName: 'Repo',
+            badgeColor: 'blue',
+            addedAt: 1,
+            connectionId: 'target-1'
+          } as never)
+        : undefined
+    )
+    getActiveMultiplexerMock.mockReset()
+    getActiveMultiplexerMock.mockImplementation((targetId: string) => muxByTargetId.get(targetId))
+    registerRemoteWorkspaceNotificationHandlerMock.mockClear()
+
+    registerRemoteWorkspaceHandlers(store, () => null)
+  })
+
+  async function callSetForConnectedTargets(args: {
+    session: WorkspaceSessionState
+    hydratedTargetIds?: unknown
+  }): Promise<unknown> {
+    const handler = handlers.get('remoteWorkspace:setForConnectedTargets')
+    if (!handler) {
+      throw new Error('remoteWorkspace:setForConnectedTargets handler was never registered')
+    }
+    return handler(null, args)
+  }
+
+  it('serializes overlapping writes for the same target so they use fresh base revisions', async () => {
+    let currentRevision = 7
+    let releaseFirstPatch!: () => void
+    const firstPatchCanFinish = new Promise<void>((resolve) => {
+      releaseFirstPatch = resolve
+    })
+    const patchBaseRevisions: number[] = []
+    const request = vi
+      .fn()
+      .mockImplementation(async (method: string, params: Record<string, unknown>) => {
+        if (method === 'workspace.get') {
+          return snapshot(
+            {
+              activeWorktreePath: '/previous',
+              activeTabId: null,
+              tabsByWorktreePath: {},
+              terminalLayoutsByTabId: {}
+            },
+            currentRevision
+          )
+        }
+        if (method === 'workspace.patch') {
+          patchBaseRevisions.push(params.baseRevision as number)
+          if (patchBaseRevisions.length === 1) {
+            await firstPatchCanFinish
+          }
+          currentRevision += 1
+          return {
+            ok: true,
+            snapshot: snapshot(patchSession(params), currentRevision)
+          }
+        }
+        throw new Error(`Unexpected method ${method}`)
+      })
+    muxByTargetId.set('target-1', { request })
+
+    const first = callSetForConnectedTargets({
+      session: sessionWithTab('repo-target-1::/remote/workspace-a', 'tab-a'),
+      hydratedTargetIds: ['target-1']
+    })
+    await vi.waitFor(() => expect(patchBaseRevisions).toEqual([7]))
+
+    const second = callSetForConnectedTargets({
+      session: sessionWithTab('repo-target-1::/remote/workspace-b', 'tab-b'),
+      hydratedTargetIds: ['target-1']
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(patchBaseRevisions).toEqual([7])
+
+    releaseFirstPatch()
+    await expect(Promise.all([first, second])).resolves.toMatchObject([
+      [{ targetId: 'target-1', result: { ok: true } }],
+      [{ targetId: 'target-1', result: { ok: true } }]
+    ])
+    expect(patchBaseRevisions).toEqual([7, 8])
+  })
+
+  it('retries once when a reset relay reports a lower revision than the cached base', async () => {
+    const resetTarget: SshTarget = {
+      id: 'target-reset',
+      label: 'Reset Target',
+      host: 'reset.example.com',
+      port: 22,
+      username: 'alice'
+    }
+    getSshConnectionStoreMock.mockReturnValue({
+      listTargets: () => [resetTarget]
+    })
+    getRepoMock.mockImplementation((repoId: string) =>
+      repoId === 'repo-reset'
+        ? ({
+            id: 'repo-reset',
+            path: '/remote/repo',
+            displayName: 'Repo',
+            badgeColor: 'blue',
+            addedAt: 1,
+            connectionId: 'target-reset'
+          } as never)
+        : undefined
+    )
+
+    const patchBaseRevisions: number[] = []
+    const request = vi
+      .fn()
+      .mockImplementation(async (method: string, params: Record<string, unknown>) => {
+        if (method === 'workspace.get') {
+          return snapshot(
+            {
+              activeWorktreePath: '/previous',
+              activeTabId: null,
+              tabsByWorktreePath: {},
+              terminalLayoutsByTabId: {}
+            },
+            7
+          )
+        }
+        if (method === 'workspace.patch') {
+          patchBaseRevisions.push(params.baseRevision as number)
+          if (patchBaseRevisions.length === 1) {
+            return {
+              ok: false,
+              reason: 'stale-revision',
+              snapshot: snapshot(
+                {
+                  activeWorktreePath: null,
+                  activeTabId: null,
+                  tabsByWorktreePath: {},
+                  terminalLayoutsByTabId: {}
+                },
+                0
+              )
+            }
+          }
+          return {
+            ok: true,
+            snapshot: snapshot(patchSession(params), 1)
+          }
+        }
+        throw new Error(`Unexpected method ${method}`)
+      })
+    muxByTargetId.set('target-reset', { request })
+
+    await expect(
+      callSetForConnectedTargets({
+        session: sessionWithTab('repo-reset::/remote/workspace', 'tab-reset'),
+        hydratedTargetIds: ['target-reset']
+      })
+    ).resolves.toMatchObject([{ targetId: 'target-reset', result: { ok: true } }])
+    expect(patchBaseRevisions).toEqual([7, 0])
+  })
+})

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -39,10 +39,10 @@ import {
   remoteWorkspaceSessionMatchesSnapshot
 } from './remote-workspace'
 
-function snapshot(session: RemoteWorkspaceSession): RemoteWorkspaceSnapshot {
+function snapshot(session: RemoteWorkspaceSession, revision = 7): RemoteWorkspaceSnapshot {
   return {
     namespace: 'target',
-    revision: 7,
+    revision,
     updatedAt: 123,
     schemaVersion: 1,
     session
@@ -50,6 +50,7 @@ function snapshot(session: RemoteWorkspaceSession): RemoteWorkspaceSnapshot {
 }
 
 const baseSession = {
+  activeRepoId: null,
   activeWorktreeId: null,
   activeTabId: null,
   tabsByWorktree: {},
@@ -148,8 +149,9 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
   const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
   const requestByTargetId = new Map<string, ReturnType<typeof vi.fn>>()
   const muxByTargetId = new Map<string, { request: ReturnType<typeof vi.fn> }>()
+  const getRepoMock = vi.fn<Store['getRepo']>()
   const store = {
-    getRepo: vi.fn()
+    getRepo: getRepoMock
   } as unknown as Store
 
   beforeEach(() => {
@@ -165,6 +167,19 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
     getSshConnectionStoreMock.mockReturnValue({
       listTargets: () => targets
     })
+    getRepoMock.mockReset()
+    getRepoMock.mockImplementation((repoId: string) =>
+      repoId === 'repo-target-1'
+        ? ({
+            id: 'repo-target-1',
+            path: '/remote/repo',
+            displayName: 'Repo',
+            badgeColor: 'blue',
+            addedAt: 1,
+            connectionId: 'target-1'
+          } as never)
+        : undefined
+    )
     getActiveMultiplexerMock.mockReset()
     getActiveMultiplexerMock.mockImplementation((targetId: string) => {
       let mux = muxByTargetId.get(targetId)

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -28,6 +28,7 @@ const SNAPSHOT_SCHEMA_VERSION = 1
 
 let mainWindowGetter: (() => BrowserWindow | null) | null = null
 const latestSnapshotByTargetId = new Map<string, RemoteWorkspaceSnapshot>()
+const remoteWorkspacePatchTailByTargetId = new Map<string, Promise<void>>()
 let unregisterRemoteWorkspaceNotifications: (() => void) | null = null
 
 function emptyRemoteSession(): RemoteWorkspaceSession {
@@ -220,6 +221,106 @@ async function getRemoteSnapshot(target: SshTarget): Promise<RemoteWorkspaceSnap
   }
 }
 
+async function queueRemoteWorkspacePatch<T>(
+  targetId: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = remoteWorkspacePatchTailByTargetId.get(targetId) ?? Promise.resolve()
+  let release!: () => void
+  const tail = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const queued = previous.catch(() => {}).then(() => tail)
+  remoteWorkspacePatchTailByTargetId.set(targetId, queued)
+
+  await previous.catch(() => {})
+  try {
+    return await operation()
+  } finally {
+    release()
+    if (remoteWorkspacePatchTailByTargetId.get(targetId) === queued) {
+      remoteWorkspacePatchTailByTargetId.delete(targetId)
+    }
+  }
+}
+
+async function patchRemoteWorkspaceSession(
+  target: SshTarget,
+  session: RemoteWorkspaceSession
+): Promise<RemoteWorkspacePatchResult | null> {
+  const mux = getActiveMultiplexer(target.id)
+  if (!mux) {
+    return null
+  }
+  const namespace = getRemoteWorkspaceNamespace(target)
+  const current =
+    latestSnapshotByTargetId.get(target.id) ?? (await getRemoteSnapshot(target)) ?? undefined
+  if (current && remoteWorkspaceSessionMatchesSnapshot(current, session)) {
+    // Why: a pulled workspace snapshot rehydrates local state and can trigger
+    // session persistence. Identical target sessions must stay a local no-op or
+    // two clients will echo revisions indefinitely.
+    return { ok: true, snapshot: current }
+  }
+
+  const requestPatch = async (
+    baseRevision: number | undefined
+  ): Promise<RemoteWorkspacePatchResult> => {
+    try {
+      return (await mux.request('workspace.patch', {
+        namespace,
+        baseRevision: baseRevision ?? 0,
+        clientId: CLIENT_ID,
+        patch: { kind: 'replace-session', session }
+      })) as RemoteWorkspacePatchResult
+    } catch (err) {
+      return (err as { code?: unknown })?.code === -32601
+        ? {
+            ok: false,
+            reason: 'unavailable',
+            message: 'Remote workspace sync is unavailable on this relay'
+          }
+        : {
+            ok: false,
+            reason: 'unavailable',
+            message: err instanceof Error ? err.message : 'Remote workspace sync failed'
+          }
+    }
+  }
+
+  const result = await requestPatch(current?.revision)
+  if (result.ok) {
+    latestSnapshotByTargetId.set(target.id, result.snapshot)
+    return result
+  }
+  if (result.snapshot) {
+    latestSnapshotByTargetId.set(target.id, result.snapshot)
+  }
+
+  if (
+    result.reason === 'stale-revision' &&
+    current &&
+    result.snapshot &&
+    result.snapshot.revision < current.revision
+  ) {
+    if (remoteWorkspaceSessionMatchesSnapshot(result.snapshot, session)) {
+      return { ok: true, snapshot: result.snapshot }
+    }
+    // Why: a relay reset can legitimately move the remote snapshot revision
+    // backwards while this process still has the old cached revision. Retrying
+    // only for backwards revisions restores the blank-slate target without
+    // overwriting a newer snapshot from another device.
+    const retry = await requestPatch(result.snapshot.revision)
+    if (retry.ok) {
+      latestSnapshotByTargetId.set(target.id, retry.snapshot)
+    } else if (retry.snapshot) {
+      latestSnapshotByTargetId.set(target.id, retry.snapshot)
+    }
+    return retry
+  }
+
+  return result
+}
+
 export function handleRemoteWorkspaceNotification(
   targetId: string,
   method: string,
@@ -287,48 +388,13 @@ export function registerRemoteWorkspaceHandlers(
 
       const results: { targetId: string; result: RemoteWorkspacePatchResult }[] = []
       for (const target of targets) {
-        const mux = getActiveMultiplexer(target.id)
-        if (!mux) {
-          continue
-        }
-        const namespace = getRemoteWorkspaceNamespace(target)
-        const current =
-          latestSnapshotByTargetId.get(target.id) ?? (await getRemoteSnapshot(target)) ?? undefined
         const session = exportSessionForTarget(store, target.id, args.session)
-        let result: RemoteWorkspacePatchResult
-        if (current && remoteWorkspaceSessionMatchesSnapshot(current, session)) {
-          // Why: a pulled workspace snapshot rehydrates local state and can
-          // trigger session persistence. Identical target sessions must be a
-          // local no-op or two clients will echo revisions indefinitely.
-          result = { ok: true, snapshot: current }
+        const result = await queueRemoteWorkspacePatch(target.id, () =>
+          patchRemoteWorkspaceSession(target, session)
+        )
+        if (result) {
           results.push({ targetId: target.id, result })
-          continue
         }
-        try {
-          result = (await mux.request('workspace.patch', {
-            namespace,
-            baseRevision: current?.revision ?? 0,
-            clientId: CLIENT_ID,
-            patch: { kind: 'replace-session', session }
-          })) as RemoteWorkspacePatchResult
-        } catch (err) {
-          result =
-            (err as { code?: unknown })?.code === -32601
-              ? {
-                  ok: false,
-                  reason: 'unavailable',
-                  message: 'Remote workspace sync is unavailable on this relay'
-                }
-              : {
-                  ok: false,
-                  reason: 'unavailable',
-                  message: err instanceof Error ? err.message : 'Remote workspace sync failed'
-                }
-        }
-        if (result.ok) {
-          latestSnapshotByTargetId.set(target.id, result.snapshot)
-        }
-        results.push({ targetId: target.id, result })
       }
       return results
     }


### PR DESCRIPTION
Fixes #2902.

## Summary
- Serializes remote workspace session patch writes per SSH target so overlapping local persistence events cannot both patch from the same cached base revision.
- Retries `stale-revision` once only when the relay reports a lower revision than the cached snapshot, which matches relay/profile reset behavior rather than a true newer remote workspace.
- Adds focused regression coverage for same-target write serialization and reset-relay stale revision recovery.

## Diagnosis
The status bar "Workspace conflict" maps to `RemoteWorkspaceSyncStatus.phase === 'conflict'`, which is produced when `remoteWorkspace:setForConnectedTargets` receives a `stale-revision` result from the remote relay. I did not reproduce the conflict on a clean first-create SSH flow, but I did reproduce the underlying stale-revision failure mode in a minimized handler test: two overlapping writes for the same SSH target could both read revision 7 and both patch with base revision 7. The first succeeds and advances the snapshot; the second can then become a self-originated stale write and leave the target in conflict, after which the renderer suppresses future uploads for that target.

There was a second compatible lifecycle path: after SSH target/relay reset, the main process can hold a cached snapshot revision ahead of the reset relay's blank workspace. Previously that lower returned revision was treated as a conflict; the fix retries once from the returned lower revision so a reset blank-slate target can accept the current local session without suppressing future uploads.

## SSH Evidence
- Built relay with `pnpm run build:relay`.
- Started throwaway Docker SSH host `orca-ssh-issue2902` from `node:24-bookworm`, user `coder`, port `127.0.0.1:22222`.
- Isolated Orca profile and CDP port for the before run: `ORCA_DEV_USER_DATA_PATH=/tmp/orca-dev-issue2902-ssh-workspace-conflict REMOTE_DEBUGGING_PORT=39417 pnpm dev`.
- Before fix, clean remote workspace creation did not naturally reproduce the conflict: sync status was `synced`, direction `push`, revision `1`.
- After fix, reset the remote/profile and ran with `ORCA_DEV_USER_DATA_PATH=/tmp/orca-dev-issue2902-ssh-workspace-conflict-fixed REMOTE_DEBUGGING_PORT=39418 pnpm dev`.
- After fix, created remote worktree `/home/coder/issue2902-fixed`; sync status was `synced`, direction `push`, revision `1`; remote snapshot active path was `/home/coder/issue2902-fixed`.
- Dirty delete path after fix: non-force delete returned `Worktree has uncommitted or untracked changes.` with `canForceDelete: true`; force delete returned `{ ok: true }`; store no longer contained the worktree; sync status advanced to revision `2` with an empty remote session.
- Remote verification after force delete: `test ! -e ~/issue2902-fixed` printed `fixed-folder-removed`; `git -C ~/issue2902-repo worktree list --porcelain` listed only the main worktree.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/remote-workspace.test.ts src/main/ipc/remote-workspace-patch-queue.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build:relay`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

Did not merge.
