### PR TITLE
Fix terminal pane resize redraw storm

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -223,6 +223,15 @@ function createMockTransport(initialPtyId: string | null = null): MockTransport 
   return transport
 }
 
+function createPaneContainer(): HTMLElement {
+  const container = new EventTarget() as HTMLElement
+  Object.defineProperty(container, 'dataset', {
+    configurable: true,
+    value: {}
+  })
+  return container
+}
+
 function createPane(paneId: number) {
   const leafId = leafIdForPane(paneId)
   const activeBuffer = {
@@ -272,7 +281,7 @@ function createPane(paneId: number) {
         registerOscHandler: vi.fn(() => ({ dispose: vi.fn() }))
       }
     },
-    container: { dataset: {} },
+    container: createPaneContainer(),
     fitAddon: {
       fit: vi.fn()
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -20,6 +20,11 @@ import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
 import { isPaneReplaying, replayIntoTerminal } from './replay-guard'
 import { terminalOutputPrefersDomRenderer } from '@/lib/pane-manager/terminal-complex-script'
 import {
+  PANE_PTY_RESIZE_HOLD_FLUSH_EVENT,
+  queuePanePtyResizeIfHeld,
+  type PanePtyResizeHoldFlushDetail
+} from '@/lib/pane-manager/pane-pty-resize-hold'
+import {
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
   POST_REPLAY_MODE_RESET,
   POST_REPLAY_REATTACH_RESET,
@@ -1220,7 +1225,14 @@ export function connectPanePty(
     }
   })
 
-  const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
+  const shouldSuppressDesktopPtyResize = (): boolean => {
+    const currentPtyId = transport.getPtyId()
+    return Boolean(
+      currentPtyId && (getFitOverrideForPty(currentPtyId) || isPtyLocked(currentPtyId))
+    )
+  }
+
+  const forwardPtyResize = (cols: number, rows: number): void => {
     // Why: when a mobile-fit override is active OR mobile is currently the
     // driver of this PTY, the PTY is already at phone dims and any desktop
     // resize is wrong. Suppress resize forwarding to avoid spurious SIGWINCH
@@ -1230,8 +1242,26 @@ export function connectPanePty(
     //   transitions where override may not be set (e.g. legacy code paths).
     // The pty:resize IPC has a defense-in-depth twin. See
     // docs/mobile-presence-lock.md.
-    const currentPtyId = transport.getPtyId()
-    if (currentPtyId && (getFitOverrideForPty(currentPtyId) || isPtyLocked(currentPtyId))) {
+    if (shouldSuppressDesktopPtyResize()) {
+      return
+    }
+    transport.resize(cols, rows)
+  }
+
+  const onHeldPtyResizeFlush = (event: Event): void => {
+    const detail = (event as CustomEvent<PanePtyResizeHoldFlushDetail>).detail
+    if (!detail) {
+      return
+    }
+    forwardPtyResize(detail.cols, detail.rows)
+  }
+  pane.container.addEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
+
+  const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
+    if (shouldSuppressDesktopPtyResize()) {
+      return
+    }
+    if (queuePanePtyResizeIfHeld(pane.container, cols, rows)) {
       return
     }
     transport.resize(cols, rows)
@@ -2697,6 +2727,7 @@ export function connectPanePty(
       }
       onDataDisposable.dispose()
       onResizeDisposable.dispose()
+      pane.container.removeEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
       geometryReportObserver?.disconnect()
       if (pendingGeometryReportRaf !== null) {
         cancelAnimationFrame(pendingGeometryReportRaf)

--- a/src/renderer/src/lib/pane-manager/pane-divider.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider.ts
@@ -1,4 +1,5 @@
 import type { PaneStyleOptions, ManagedPaneInternal } from './pane-manager-types'
+import { holdPtyResizesForPaneSubtrees } from './pane-pty-resize-hold'
 
 // ---------------------------------------------------------------------------
 // Divider creation & drag-to-resize
@@ -129,6 +130,7 @@ function attachDividerDrag(
   let prevEl: HTMLElement | null = null
   let nextEl: HTMLElement | null = null
   let activePointerId: number | null = null
+  let releasePtyResizeHold: { flush: () => void; cancel: () => void } | null = null
   const flexScheduler = createDividerFlexFrameScheduler({
     apply: (newPrev, newNext) => {
       if (!prevEl || !nextEl) {
@@ -157,6 +159,9 @@ function attachDividerDrag(
     if (!prevEl || !nextEl) {
       return
     }
+    // Why: shells redraw prompts on every PTY SIGWINCH. During a divider drag
+    // we still fit xterm locally, but forward only the final PTY size on drop.
+    releasePtyResizeHold = holdPtyResizesForPaneSubtrees([prevEl, nextEl])
 
     const prevRect = prevEl.getBoundingClientRect()
     const nextRect = nextEl.getBoundingClientRect()
@@ -214,6 +219,8 @@ function attachDividerDrag(
     if (nextEl) {
       callbacks.refitPanesUnder(nextEl)
     }
+    releasePtyResizeHold?.flush()
+    releasePtyResizeHold = null
     prevEl = null
     nextEl = null
 
@@ -239,12 +246,38 @@ function attachDividerDrag(
     callbacks.onLayoutChanged?.()
   }
 
+  const cancelActiveDrag = (): void => {
+    dragging = false
+    flexScheduler.cancel()
+    releasePtyResizeHold?.cancel()
+    releasePtyResizeHold = null
+    activePointerId = null
+    prevEl = null
+    nextEl = null
+    divider.classList.remove('is-dragging')
+  }
+
+  const onPointerCancel = (): void => {
+    cancelActiveDrag()
+  }
+
+  const onLostPointerCapture = (): void => {
+    if (!dragging) {
+      return
+    }
+    cancelActiveDrag()
+  }
+
   divider.addEventListener('pointerdown', onPointerDown)
   divider.addEventListener('pointermove', onPointerMove)
   divider.addEventListener('pointerup', onPointerUp)
+  divider.addEventListener('pointercancel', onPointerCancel)
+  divider.addEventListener('lostpointercapture', onLostPointerCapture)
   divider.addEventListener('dblclick', onDoubleClick)
   dividerDragCleanups.set(divider, () => {
     flexScheduler.cancel()
+    releasePtyResizeHold?.cancel()
+    releasePtyResizeHold = null
     if (activePointerId !== null) {
       try {
         if (divider.hasPointerCapture(activePointerId)) {
@@ -262,6 +295,8 @@ function attachDividerDrag(
     divider.removeEventListener('pointerdown', onPointerDown)
     divider.removeEventListener('pointermove', onPointerMove)
     divider.removeEventListener('pointerup', onPointerUp)
+    divider.removeEventListener('pointercancel', onPointerCancel)
+    divider.removeEventListener('lostpointercapture', onLostPointerCapture)
     divider.removeEventListener('dblclick', onDoubleClick)
   })
 }

--- a/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  holdPtyResizesForPaneSubtrees,
+  PANE_PTY_RESIZE_HOLD_FLUSH_EVENT,
+  queuePanePtyResizeIfHeld
+} from './pane-pty-resize-hold'
+
+class MockCustomEvent<T> extends Event {
+  detail: T
+
+  constructor(type: string, init: { detail: T }) {
+    super(type)
+    this.detail = init.detail
+  }
+}
+
+class MockElement {
+  classList: { contains: (className: string) => boolean }
+  dispatched: Event[] = []
+
+  constructor(
+    private readonly classNames: string[],
+    private readonly descendants: MockElement[] = []
+  ) {
+    this.classList = {
+      contains: (className: string) => this.classNames.includes(className)
+    }
+  }
+
+  querySelectorAll(): MockElement[] {
+    return this.descendants
+  }
+
+  dispatchEvent(event: Event): boolean {
+    this.dispatched.push(event)
+    return true
+  }
+}
+
+describe('pane PTY resize hold', () => {
+  const originalCustomEvent = globalThis.CustomEvent
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    globalThis.CustomEvent = originalCustomEvent
+  })
+
+  it('queues drag-frame pane resizes and flushes only the final size', () => {
+    globalThis.CustomEvent = MockCustomEvent as unknown as typeof CustomEvent
+    const leftPane = new MockElement(['pane'])
+    const rightPane = new MockElement(['pane'])
+    const split = new MockElement(['pane-split'], [leftPane, rightPane])
+
+    const release = holdPtyResizesForPaneSubtrees([split as unknown as HTMLElement])
+
+    expect(queuePanePtyResizeIfHeld(leftPane as unknown as HTMLElement, 100, 30)).toBe(true)
+    expect(queuePanePtyResizeIfHeld(leftPane as unknown as HTMLElement, 120, 32)).toBe(true)
+    expect(queuePanePtyResizeIfHeld(rightPane as unknown as HTMLElement, 80, 30)).toBe(true)
+
+    release.flush()
+
+    expect(leftPane.dispatched).toHaveLength(1)
+    expect(rightPane.dispatched).toHaveLength(1)
+    expect(leftPane.dispatched[0]?.type).toBe(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT)
+    expect((leftPane.dispatched[0] as CustomEvent).detail).toEqual({ cols: 120, rows: 32 })
+    expect((rightPane.dispatched[0] as CustomEvent).detail).toEqual({ cols: 80, rows: 30 })
+    expect(queuePanePtyResizeIfHeld(leftPane as unknown as HTMLElement, 130, 32)).toBe(false)
+  })
+
+  it('cancels queued resizes without forwarding a stale PTY size', () => {
+    globalThis.CustomEvent = MockCustomEvent as unknown as typeof CustomEvent
+    const pane = new MockElement(['pane'])
+
+    const release = holdPtyResizesForPaneSubtrees([pane as unknown as HTMLElement])
+    expect(queuePanePtyResizeIfHeld(pane as unknown as HTMLElement, 100, 30)).toBe(true)
+
+    release.cancel()
+
+    expect(pane.dispatched).toHaveLength(0)
+    expect(queuePanePtyResizeIfHeld(pane as unknown as HTMLElement, 120, 30)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts
@@ -79,4 +79,24 @@ describe('pane PTY resize hold', () => {
     expect(pane.dispatched).toHaveLength(0)
     expect(queuePanePtyResizeIfHeld(pane as unknown as HTMLElement, 120, 30)).toBe(false)
   })
+
+  it('keeps an outer hold active when an overlapping hold is cancelled', () => {
+    globalThis.CustomEvent = MockCustomEvent as unknown as typeof CustomEvent
+    const pane = new MockElement(['pane'])
+
+    const outer = holdPtyResizesForPaneSubtrees([pane as unknown as HTMLElement])
+    const inner = holdPtyResizesForPaneSubtrees([pane as unknown as HTMLElement])
+    expect(queuePanePtyResizeIfHeld(pane as unknown as HTMLElement, 100, 30)).toBe(true)
+
+    inner.cancel()
+
+    expect(pane.dispatched).toHaveLength(0)
+    expect(queuePanePtyResizeIfHeld(pane as unknown as HTMLElement, 120, 32)).toBe(true)
+
+    outer.flush()
+
+    expect(pane.dispatched).toHaveLength(1)
+    expect((pane.dispatched[0] as CustomEvent).detail).toEqual({ cols: 120, rows: 32 })
+    expect(queuePanePtyResizeIfHeld(pane as unknown as HTMLElement, 130, 32)).toBe(false)
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.ts
@@ -61,7 +61,15 @@ function flushPanePtyResizeHold(paneElement: HTMLElement): void {
 }
 
 function cancelPanePtyResizeHold(paneElement: HTMLElement): void {
-  resizeHolds.delete(paneElement)
+  const state = resizeHolds.get(paneElement)
+  if (!state) {
+    return
+  }
+  state.depth -= 1
+  state.pending = null
+  if (state.depth <= 0) {
+    resizeHolds.delete(paneElement)
+  }
 }
 
 function collectPaneElements(root: HTMLElement | null, panes: Set<HTMLElement>): void {

--- a/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pty-resize-hold.ts
@@ -1,0 +1,114 @@
+export type PanePtyResizeHoldFlushDetail = {
+  cols: number
+  rows: number
+}
+
+export const PANE_PTY_RESIZE_HOLD_FLUSH_EVENT = 'orca-pane-pty-resize-hold-flush'
+
+type ResizeHoldState = {
+  depth: number
+  pending: PanePtyResizeHoldFlushDetail | null
+}
+
+const resizeHolds = new WeakMap<HTMLElement, ResizeHoldState>()
+
+function getOrCreateHoldState(paneElement: HTMLElement): ResizeHoldState {
+  const existing = resizeHolds.get(paneElement)
+  if (existing) {
+    return existing
+  }
+  const next: ResizeHoldState = { depth: 0, pending: null }
+  resizeHolds.set(paneElement, next)
+  return next
+}
+
+function beginPanePtyResizeHold(paneElement: HTMLElement): void {
+  const state = getOrCreateHoldState(paneElement)
+  state.depth += 1
+}
+
+export function queuePanePtyResizeIfHeld(
+  paneElement: HTMLElement,
+  cols: number,
+  rows: number
+): boolean {
+  const state = resizeHolds.get(paneElement)
+  if (!state) {
+    return false
+  }
+  state.pending = { cols, rows }
+  return true
+}
+
+function flushPanePtyResizeHold(paneElement: HTMLElement): void {
+  const state = resizeHolds.get(paneElement)
+  if (!state) {
+    return
+  }
+  state.depth -= 1
+  if (state.depth > 0) {
+    return
+  }
+  resizeHolds.delete(paneElement)
+  if (!state.pending) {
+    return
+  }
+  paneElement.dispatchEvent(
+    new CustomEvent<PanePtyResizeHoldFlushDetail>(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, {
+      detail: state.pending
+    })
+  )
+}
+
+function cancelPanePtyResizeHold(paneElement: HTMLElement): void {
+  resizeHolds.delete(paneElement)
+}
+
+function collectPaneElements(root: HTMLElement | null, panes: Set<HTMLElement>): void {
+  if (!root) {
+    return
+  }
+  if (root.classList.contains('pane')) {
+    panes.add(root)
+    return
+  }
+  for (const pane of root.querySelectorAll<HTMLElement>('.pane[data-pane-id]')) {
+    panes.add(pane)
+  }
+}
+
+export function holdPtyResizesForPaneSubtrees(roots: (HTMLElement | null)[]): {
+  flush: () => void
+  cancel: () => void
+} {
+  const panes = new Set<HTMLElement>()
+  for (const root of roots) {
+    collectPaneElements(root, panes)
+  }
+
+  for (const pane of panes) {
+    beginPanePtyResizeHold(pane)
+  }
+
+  const heldPanes = Array.from(panes)
+  let released = false
+
+  const release = (flush: boolean): void => {
+    if (released) {
+      return
+    }
+    released = true
+    for (const pane of heldPanes) {
+      if (flush) {
+        flushPanePtyResizeHold(pane)
+      } else {
+        cancelPanePtyResizeHold(pane)
+      }
+    }
+  }
+
+  return {
+    flush: () => release(true),
+    cancel: () => release(false)
+  }
+}

--- a/tests/e2e/terminal-panes.spec.ts
+++ b/tests/e2e/terminal-panes.spec.ts
@@ -25,7 +25,8 @@ import {
   waitForActiveTerminalManager,
   waitForTerminalOutput,
   waitForPaneCount,
-  getTerminalContent
+  getTerminalContent,
+  sendToTerminal
 } from './helpers/terminal'
 import {
   waitForSessionReady,
@@ -122,6 +123,18 @@ async function expectSavedLayoutNotToContainTitle(
       { timeout: 3_000 }
     )
     .toBe(false)
+}
+
+async function readVisiblePaneContents(page: Page): Promise<string[]> {
+  const snapshot = await waitForPaneIdentitySnapshot(page, 2)
+  return page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    return (
+      manager
+        ?.getPanes()
+        .map((pane) => pane.serializeAddon?.serialize?.({ scrollback: 200 }) ?? '') ?? []
+    )
+  }, snapshot.tabId)
 }
 
 // Why: only the pointer-drag resize test needs a visible window (pointer
@@ -699,6 +712,54 @@ test.describe('Terminal Panes', () => {
         { timeout: 5_000, message: 'Pane widths did not change after dragging divider' }
       )
       .toBe(true)
+  })
+
+  test('@headful resizing split panes forwards only the settled PTY size', async ({ orcaPage }) => {
+    await splitActiveTerminalPane(orcaPage, 'vertical')
+    const snapshot = await waitForPaneIdentitySnapshot(orcaPage, 2)
+    const ptyIds = snapshot.panes
+      .map((pane) => pane.ptyId)
+      .filter((ptyId): ptyId is string => Boolean(ptyId))
+
+    for (const ptyId of ptyIds) {
+      await sendToTerminal(
+        orcaPage,
+        ptyId,
+        "export PS1='ISSUE2910_PROMPT$ '; export PROMPT=\"$PS1\"; trap 'printf \"\\nISSUE2910_WINCH\\n\"' WINCH; clear; printf 'ISSUE2910_READY\\n'\r"
+      )
+    }
+
+    await expect
+      .poll(
+        async () =>
+          (await readVisiblePaneContents(orcaPage)).every((content) =>
+            content.includes('ISSUE2910_READY')
+          ),
+        { timeout: 10_000, message: 'Split panes did not receive resize-regression prompt setup' }
+      )
+      .toBe(true)
+
+    const divider = orcaPage.locator('.pane-divider.is-vertical').first()
+    await expect(divider).toBeVisible({ timeout: 3_000 })
+    const box = await divider.boundingBox()
+    expect(box).not.toBeNull()
+
+    const startX = box!.x + box!.width / 2
+    const startY = box!.y + box!.height / 2
+    await orcaPage.mouse.move(startX, startY)
+    await orcaPage.mouse.down()
+    await orcaPage.mouse.move(startX - 350, startY, { steps: 40 })
+    await orcaPage.mouse.move(startX + 250, startY, { steps: 40 })
+    await orcaPage.mouse.up()
+    await orcaPage.waitForTimeout(500)
+
+    const paneContents = await readVisiblePaneContents(orcaPage)
+    for (const content of paneContents) {
+      const promptRedraws = content.match(/ISSUE2910_PROMPT/g)?.length ?? 0
+      const winchNotifications = content.match(/ISSUE2910_WINCH/g)?.length ?? 0
+      expect(promptRedraws).toBeLessThanOrEqual(3)
+      expect(winchNotifications).toBeLessThanOrEqual(1)
+    }
   })
 
   test('@headful dragging terminal panes around preserves leaf-keyed PTY bindings', async ({


### PR DESCRIPTION
## Summary
- Holds PTY resize forwarding while an internal terminal pane divider is actively dragged, then flushes only the final settled size.
- Keeps xterm fitting locally during the drag so the visual pane tracks the pointer without sending a SIGWINCH storm to zsh/SSH shells.
- Adds unit coverage for the resize-hold queue and a headful E2E regression that reproduces the split-pane prompt redraw storm.

Fixes #2910

## Evidence
- Reproduced from the Loom sequence: one terminal tab, split into two terminal panes, drag the internal vertical divider repeatedly. Before the fix, the pane buffer filled with repeated prompt redraws; local CDP evidence: /tmp/orca-issue-2910/repro-after-drag.png.
- After the fix, the same repeated drag on a fresh split tab emitted only one WINCH marker per pane; local CDP evidence: /tmp/orca-issue-2910/fix-fresh-after-drag.png.

## Validation
- pnpm run lint
- pnpm run typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-pty-resize-hold.test.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts
- SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-panes.spec.ts --config tests/playwright.config.ts --project=electron-headful -g "settled PTY size" --workers=1
- git diff --check HEAD~1 HEAD
- git merge-tree --write-tree origin/main HEAD -> 270cd4b954205b65459a2665943f19ba1fefbca6

## Notes
- I also accidentally ran all headful specs once; this new resize E2E passed there too, while unrelated dead-terminal specs failed from a shared temp git index.lock collision under parallel execution.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.