### PR TITLE
Focus file search input from ref

### DIFF
--- a/src/renderer/src/components/right-sidebar/Search.tsx
+++ b/src/renderer/src/components/right-sidebar/Search.tsx
@@ -106,9 +106,13 @@ export default function Search(): React.JSX.Element {
     })
   }, [cancelSeededInputSelectionFrame])
 
-  // Focus input on mount
-  useEffect(() => {
-    inputRef.current?.focus()
+  const setSearchInputRef = useCallback((el: HTMLInputElement | null): void => {
+    inputRef.current = el
+    // Why: focusing belongs to the input mount; the object ref still backs
+    // seeded-search selection and result keyboard handlers.
+    if (el) {
+      el.focus()
+    }
   }, [])
 
   // Cleanup debounce timer on unmount
@@ -324,7 +328,7 @@ export default function Search(): React.JSX.Element {
   return (
     <div className="flex flex-col h-full">
       <SearchHeader
-        inputRef={inputRef}
+        inputRef={setSearchInputRef}
         includeInputRef={includeInputRef}
         excludeInputRef={excludeInputRef}
         query={fileSearchQuery}

--- a/src/renderer/src/components/right-sidebar/SearchHeader.tsx
+++ b/src/renderer/src/components/right-sidebar/SearchHeader.tsx
@@ -5,7 +5,7 @@ import { SearchFilters } from './SearchFilters'
 import { ToggleButton } from './SearchResultItems'
 
 type SearchHeaderProps = {
-  inputRef: React.RefObject<HTMLInputElement | null>
+  inputRef: React.Ref<HTMLInputElement>
   includeInputRef: React.RefObject<HTMLInputElement | null>
   excludeInputRef: React.RefObject<HTMLInputElement | null>
   query: string


### PR DESCRIPTION
## Summary
- Move the right-sidebar file search input mount focus from a passive Effect into the input ref callback.
- Keep the existing object ref for seeded-search selection and keyboard behavior.
- Removes 1 Effect hook call site from `Search.tsx`.

## Validation
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/Search.tsx src/renderer/src/components/right-sidebar/SearchHeader.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/lib/file-search-selection.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- Effect hook AST count: `origin/main 912`, `working 911`

## Risk
Low. This is isolated DOM focus for the local file-search input; it does not change runtime search requests, persistence, IPC, SSH, source-control provider behavior, or result handling.
