### PR TITLE
Focus diff comment popover from ref

### DIFF
--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { CornerDownLeft, User } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -45,7 +45,6 @@ export function DiffCommentPopover({
   // reflect the in-flight status to the user.
   const [submitting, setSubmitting] = useState(false)
   const mountedRef = useMountedRef()
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const popoverRef = useRef<HTMLDivElement | null>(null)
   // Why: stash onCancel in a ref so the document mousedown listener below can
   // read the freshest callback without listing `onCancel` in its dependency
@@ -61,8 +60,10 @@ export function DiffCommentPopover({
   // "Line N" label as the dialog's accessible name.
   const labelId = useId()
 
-  useEffect(() => {
-    textareaRef.current?.focus()
+  const focusTextareaRef = useCallback((textarea: HTMLTextAreaElement | null): void => {
+    // Why: the draft field should receive focus as soon as the popover mounts;
+    // no external system needs a post-render Effect for this.
+    textarea?.focus()
   }, [])
 
   // Why: Monaco's editor area does not bubble a synthetic React click up to
@@ -129,7 +130,6 @@ export function DiffCommentPopover({
           <User className="size-3" />
         </span>
       </div>
-
       {/* Right Column: Content */}
       <div className="orca-diff-comment-content-col" style={{ gap: '8px' }}>
         <div id={labelId} className="orca-diff-comment-popover-label">
@@ -139,7 +139,7 @@ export function DiffCommentPopover({
               : `Line ${lineNumber}`)}
         </div>
         <textarea
-          ref={textareaRef}
+          ref={focusTextareaRef}
           className="orca-diff-comment-popover-textarea"
           placeholder={placeholder}
           value={body}


### PR DESCRIPTION
## Summary
- Move the diff-comment popover textarea mount focus from a passive Effect into the textarea ref callback.
- Keep the document mousedown outside-click subscription in an Effect because that is real external DOM synchronization.
- Removes 1 Effect hook call site from `DiffCommentPopover.tsx`.

## Validation
- `pnpm exec oxlint src/renderer/src/components/diff-comments/DiffCommentPopover.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- Effect hook AST count: `origin/main 911`, `working 910`

## Risk
Medium. This changes editor/review-note popover focus timing only; it does not change note persistence, diff comment submission, IPC, SSH, runtime ownership, or git-provider behavior.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.