### PR TITLE
Add mobile new-tab agent presets

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -23,6 +23,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import {
   AlertTriangle,
   ArrowUp,
+  Bot,
   ChevronLeft,
   ChevronRight,
   Eraser,
@@ -98,6 +99,11 @@ import {
   terminalRecordsEqual,
   type TerminalRecord
 } from '../../../../src/session/mobile-terminal-records'
+import {
+  buildMobileNewTabAgentOptions,
+  type MobileNewTabAgentOption,
+  type MobileNewTabAgentSettings
+} from '../../../../src/session/mobile-new-tab-agent-options'
 import { colors, spacing, radii, typography } from '../../../../src/theme/mobile-theme'
 
 type Terminal = TerminalRecord
@@ -292,6 +298,19 @@ function isFileExistsErrorMessage(message: string): boolean {
 
 type TerminalCreateResult = {
   tab: Extract<MobileSessionTab, { type: 'terminal' }>
+}
+
+type MobileNewTabAgentLoadState = 'idle' | 'loading' | 'loaded' | 'error'
+
+type RuntimeWorktreeResult = {
+  worktree?: {
+    repoId?: string
+  }
+}
+
+type RuntimeRepoSummary = {
+  id: string
+  connectionId?: string | null
 }
 
 type MobileDisplayMode = 'auto' | 'phone' | 'desktop'
@@ -703,6 +722,9 @@ export default function SessionScreen() {
   const [createError, setCreateError] = useState('')
   const [createWarning, setCreateWarning] = useState(initialCreateWarning)
   const [showCreateTabDrawer, setShowCreateTabDrawer] = useState(false)
+  const [createTabAgentLoadState, setCreateTabAgentLoadState] =
+    useState<MobileNewTabAgentLoadState>('idle')
+  const [createTabAgentOptions, setCreateTabAgentOptions] = useState<MobileNewTabAgentOption[]>([])
   const [showCreateBrowserModal, setShowCreateBrowserModal] = useState(false)
   const [actionTarget, setActionTarget] = useState<Terminal | null>(null)
   const [markdownActionTarget, setMarkdownActionTarget] = useState<Extract<
@@ -2610,7 +2632,81 @@ export default function SessionScreen() {
     }
   }, [selectModeActive])
 
-  async function handleCreateTerminal() {
+  useEffect(() => {
+    if (!showCreateTabDrawer) {
+      setCreateTabAgentLoadState('idle')
+      setCreateTabAgentOptions([])
+      return
+    }
+    if (!client || connState !== 'connected') {
+      setCreateTabAgentLoadState('idle')
+      setCreateTabAgentOptions([])
+      return
+    }
+
+    let stale = false
+    setCreateTabAgentLoadState('loading')
+    setCreateTabAgentOptions([])
+
+    void (async () => {
+      const [settingsResponse, worktreeResponse] = await Promise.all([
+        client.sendRequest('settings.get'),
+        client.sendRequest('worktree.show', { worktree: `id:${worktreeId}` })
+      ])
+      if (!settingsResponse.ok) {
+        throw new Error(settingsResponse.error.message)
+      }
+      if (!worktreeResponse.ok) {
+        throw new Error(worktreeResponse.error.message)
+      }
+
+      const settings = (
+        (settingsResponse as RpcSuccess).result as {
+          settings?: MobileNewTabAgentSettings
+        }
+      ).settings
+      const worktree = ((worktreeResponse as RpcSuccess).result as RuntimeWorktreeResult).worktree
+      const repoId = worktree?.repoId
+      if (!repoId) {
+        throw new Error('worktree_repo_missing')
+      }
+
+      const repoResponse = await client.sendRequest('repo.list')
+      if (!repoResponse.ok) {
+        throw new Error(repoResponse.error.message)
+      }
+      const repos =
+        ((repoResponse as RpcSuccess).result as { repos?: RuntimeRepoSummary[] }).repos ?? []
+      const repo = repos.find((candidate) => candidate.id === repoId)
+      if (!repo) {
+        throw new Error('worktree_repo_not_found')
+      }
+      const connectionId = repo.connectionId?.trim() || null
+      const detectedResponse = connectionId
+        ? await client.sendRequest('preflight.detectRemoteAgents', { connectionId })
+        : await client.sendRequest('preflight.detectAgents')
+      if (!detectedResponse.ok) {
+        throw new Error(detectedResponse.error.message)
+      }
+      if (stale) {
+        return
+      }
+      const detectedAgentIds = (detectedResponse as RpcSuccess).result as unknown[]
+      setCreateTabAgentOptions(buildMobileNewTabAgentOptions(settings, detectedAgentIds))
+      setCreateTabAgentLoadState('loaded')
+    })().catch(() => {
+      if (!stale) {
+        setCreateTabAgentOptions([])
+        setCreateTabAgentLoadState('error')
+      }
+    })
+
+    return () => {
+      stale = true
+    }
+  }, [client, connState, showCreateTabDrawer, worktreeId])
+
+  async function handleCreateTerminal(agent?: MobileNewTabAgentOption['agent']) {
     if (!client || creating) return
 
     setCreating(true)
@@ -2619,7 +2715,8 @@ export default function SessionScreen() {
     try {
       const response = await client.sendRequest('session.tabs.createTerminal', {
         worktree: `id:${worktreeId}`,
-        afterTabId: activeSessionTabId ?? undefined
+        afterTabId: activeSessionTabId ?? undefined,
+        ...(agent ? { agent } : {})
       })
       if (response.ok) {
         const result = (response as RpcSuccess).result as TerminalCreateResult
@@ -2951,6 +3048,47 @@ export default function SessionScreen() {
     opacity: toastOpacityRef.current,
     transform: [{ translateY: -keyboardLift }]
   }
+  const createTabAgentActions =
+    createTabAgentLoadState === 'loading'
+      ? [
+          {
+            label: 'Detecting Agents',
+            icon: Bot,
+            disabled: true,
+            loading: true,
+            onPress: () => {}
+          }
+        ]
+      : createTabAgentOptions.length > 0
+        ? createTabAgentOptions.map((option) => ({
+            label: option.label,
+            hint: 'Agent preset',
+            icon: Bot,
+            onPress: () => {
+              setShowCreateTabDrawer(false)
+              void handleCreateTerminal(option.agent)
+            }
+          }))
+        : createTabAgentLoadState === 'loaded'
+          ? [
+              {
+                label: 'No Agents Detected',
+                icon: Bot,
+                disabled: true,
+                onPress: () => {}
+              }
+            ]
+          : createTabAgentLoadState === 'error'
+            ? [
+                {
+                  label: 'Agent Presets Unavailable',
+                  hint: 'Check the host connection',
+                  icon: Bot,
+                  disabled: true,
+                  onPress: () => {}
+                }
+              ]
+            : []
 
   return (
     <View style={styles.container}>
@@ -3512,7 +3650,8 @@ export default function SessionScreen() {
               setShowCreateTabDrawer(false)
               void handleCreateMarkdownNote()
             }
-          }
+          },
+          ...createTabAgentActions
         ]}
         onClose={() => setShowCreateTabDrawer(false)}
       />

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -42,6 +42,7 @@ import {
   X
 } from 'lucide-react-native'
 import type { RpcClient } from '../../../../src/transport/rpc-client'
+import { getRepoIdFromWorktreeId } from '../../../../src/shared/worktree-id'
 import { loadHosts } from '../../../../src/transport/host-store'
 import { useHostClient } from '../../../../src/transport/client-context'
 import type { ConnectionState, RpcFailure, RpcSuccess } from '../../../../src/transport/types'
@@ -301,12 +302,6 @@ type TerminalCreateResult = {
 }
 
 type MobileNewTabAgentLoadState = 'idle' | 'loading' | 'loaded' | 'error'
-
-type RuntimeWorktreeResult = {
-  worktree?: {
-    repoId?: string
-  }
-}
 
 type RuntimeRepoSummary = {
   id: string
@@ -2649,31 +2644,24 @@ export default function SessionScreen() {
     setCreateTabAgentOptions([])
 
     void (async () => {
-      const [settingsResponse, worktreeResponse] = await Promise.all([
+      const [settingsResponse, repoResponse] = await Promise.all([
         client.sendRequest('settings.get'),
-        client.sendRequest('worktree.show', { worktree: `id:${worktreeId}` })
+        client.sendRequest('repo.list')
       ])
       if (!settingsResponse.ok) {
         throw new Error(settingsResponse.error.message)
       }
-      if (!worktreeResponse.ok) {
-        throw new Error(worktreeResponse.error.message)
-      }
-
       const settings = (
         (settingsResponse as RpcSuccess).result as {
           settings?: MobileNewTabAgentSettings
         }
       ).settings
-      const worktree = ((worktreeResponse as RpcSuccess).result as RuntimeWorktreeResult).worktree
-      const repoId = worktree?.repoId
-      if (!repoId) {
-        throw new Error('worktree_repo_missing')
-      }
-
-      const repoResponse = await client.sendRequest('repo.list')
       if (!repoResponse.ok) {
         throw new Error(repoResponse.error.message)
+      }
+      const repoId = getRepoIdFromWorktreeId(worktreeId)
+      if (!repoId) {
+        throw new Error('worktree_repo_missing')
       }
       const repos =
         ((repoResponse as RpcSuccess).result as { repos?: RuntimeRepoSummary[] }).repos ?? []
@@ -3072,7 +3060,7 @@ export default function SessionScreen() {
         : createTabAgentLoadState === 'loaded'
           ? [
               {
-                label: 'No Agents Detected',
+                label: 'No Enabled Agents',
                 icon: Bot,
                 disabled: true,
                 onPress: () => {}

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -42,7 +42,6 @@ import {
   X
 } from 'lucide-react-native'
 import type { RpcClient } from '../../../../src/transport/rpc-client'
-import { getRepoIdFromWorktreeId } from '../../../../src/shared/worktree-id'
 import { loadHosts } from '../../../../src/transport/host-store'
 import { useHostClient } from '../../../../src/transport/client-context'
 import type { ConnectionState, RpcFailure, RpcSuccess } from '../../../../src/transport/types'
@@ -306,6 +305,13 @@ type MobileNewTabAgentLoadState = 'idle' | 'loading' | 'loaded' | 'error'
 type RuntimeRepoSummary = {
   id: string
   connectionId?: string | null
+}
+
+function getRepoIdFromMobileWorktreeId(id: string): string {
+  // Why: mobile cannot import desktop shared modules in its standalone tsc run,
+  // but the runtime worktree id wire format is still `${repoId}::${path}`.
+  const separatorIdx = id.indexOf('::')
+  return separatorIdx === -1 ? id : id.slice(0, separatorIdx)
 }
 
 type MobileDisplayMode = 'auto' | 'phone' | 'desktop'
@@ -2659,7 +2665,7 @@ export default function SessionScreen() {
       if (!repoResponse.ok) {
         throw new Error(repoResponse.error.message)
       }
-      const repoId = getRepoIdFromWorktreeId(worktreeId)
+      const repoId = getRepoIdFromMobileWorktreeId(worktreeId)
       if (!repoId) {
         throw new Error('worktree_repo_missing')
       }

--- a/mobile/src/session/mobile-new-tab-agent-options.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-options.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildMobileNewTabAgentOptions,
+  orderMobileNewTabAgents
+} from './mobile-new-tab-agent-options'
+
+describe('mobile new-tab agent options', () => {
+  it('orders the enabled detected default first', () => {
+    expect(orderMobileNewTabAgents('codex', ['gemini', 'codex', 'claude'], ['gemini'])).toEqual([
+      'codex',
+      'claude'
+    ])
+  })
+
+  it('returns labeled options for enabled detected agents only', () => {
+    expect(
+      buildMobileNewTabAgentOptions({ defaultTuiAgent: null, disabledTuiAgents: ['claude'] }, [
+        'claude',
+        'codex',
+        'not-real'
+      ])
+    ).toEqual([{ agent: 'codex', label: 'Codex' }])
+  })
+
+  it('does not show stale presets while detection is pending', () => {
+    expect(buildMobileNewTabAgentOptions({ defaultTuiAgent: 'codex' }, null)).toEqual([])
+  })
+})

--- a/mobile/src/session/mobile-new-tab-agent-options.ts
+++ b/mobile/src/session/mobile-new-tab-agent-options.ts
@@ -1,0 +1,51 @@
+import type { TuiAgent } from '../../../src/shared/types'
+import {
+  filterEnabledMobileTuiAgents,
+  isMobileTuiAgent,
+  MOBILE_TUI_AGENT_AUTO_PICK_ORDER,
+  MOBILE_TUI_AGENT_LABELS
+} from '../tasks/mobile-tui-agents'
+
+export type MobileNewTabAgentSettings = {
+  defaultTuiAgent?: TuiAgent | 'blank' | null
+  disabledTuiAgents?: unknown
+}
+
+export type MobileNewTabAgentOption = {
+  agent: TuiAgent
+  label: string
+}
+
+export function orderMobileNewTabAgents(
+  defaultAgent: TuiAgent | 'blank' | null | undefined,
+  detectedAgents: Iterable<unknown>,
+  disabledAgents?: unknown
+): TuiAgent[] {
+  const detected = new Set([...detectedAgents].filter(isMobileTuiAgent))
+  const enabledDetected = filterEnabledMobileTuiAgents(
+    MOBILE_TUI_AGENT_AUTO_PICK_ORDER,
+    disabledAgents
+  ).filter((agent) => detected.has(agent))
+
+  if (defaultAgent && defaultAgent !== 'blank' && enabledDetected.includes(defaultAgent)) {
+    return [defaultAgent, ...enabledDetected.filter((agent) => agent !== defaultAgent)]
+  }
+  return enabledDetected
+}
+
+export function buildMobileNewTabAgentOptions(
+  settings: MobileNewTabAgentSettings | null | undefined,
+  detectedAgentIds: Iterable<unknown> | null
+): MobileNewTabAgentOption[] {
+  if (!detectedAgentIds) {
+    return []
+  }
+  return orderMobileNewTabAgents(
+    settings?.defaultTuiAgent,
+    detectedAgentIds,
+    settings?.disabledTuiAgents
+  ).map((agent) => ({
+    agent,
+    label: MOBILE_TUI_AGENT_LABELS[agent]
+  }))
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5375,6 +5375,63 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
+  it('builds mobile session agent launch commands on the runtime host', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-agent' })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: { 'command-code': 'command-code --profile mobile' }
+      })
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+
+    await runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+      agent: 'command-code'
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'command-code --profile mobile',
+        cwd: TEST_WORKTREE_PATH,
+        worktreeId: TEST_WORKTREE_ID
+      })
+    )
+  })
+
+  it('rejects disabled mobile session agent launches before spawning', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-agent' })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: ['codex'],
+        agentCmdOverrides: {}
+      })
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+
+    await expect(
+      runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        agent: 'codex'
+      })
+    ).rejects.toThrow('Selected agent is disabled')
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('forwards inactive mobile terminal creation to the renderer without focusing it', async () => {
     const focusTerminal = vi.fn()
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5432,6 +5432,33 @@ describe('OrcaRuntimeService', () => {
     expect(spawn).not.toHaveBeenCalled()
   })
 
+  it('validates mobile terminal insertion anchors before resolving agent launch commands', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-agent' })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: ['codex'],
+        agentCmdOverrides: {}
+      })
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+
+    await expect(
+      runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        afterTabId: 'stale-tab',
+        agent: 'codex'
+      })
+    ).rejects.toThrow('after_tab_not_found')
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('forwards inactive mobile terminal creation to the renderer without focusing it', async () => {
     const focusTerminal = vi.fn()
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9280,10 +9280,18 @@ export class OrcaRuntimeService {
 
   async createMobileSessionTerminal(
     worktreeSelector: string,
-    opts: { afterTabId?: string; targetGroupId?: string; command?: string; activate?: boolean } = {}
+    opts: {
+      afterTabId?: string
+      targetGroupId?: string
+      command?: string
+      agent?: TuiAgent
+      activate?: boolean
+    } = {}
   ): Promise<RuntimeMobileSessionCreateTerminalResult> {
     this.assertGraphReady()
-    const worktreeId = (await this.resolveWorktreeSelector(worktreeSelector)).id
+    const worktree = await this.resolveWorktreeSelector(worktreeSelector)
+    const worktreeId = worktree.id
+    const command = await this.resolveMobileSessionTerminalCommand(worktree, opts)
     let afterDesktopTabId: string | undefined
     if (opts.afterTabId) {
       const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
@@ -9300,7 +9308,7 @@ export class OrcaRuntimeService {
         worktreeId,
         opts.activate !== false,
         opts.afterTabId,
-        opts.command
+        command
       )
     }
     const requestId = randomUUID()
@@ -9331,7 +9339,7 @@ export class OrcaRuntimeService {
         worktreeId,
         afterTabId: afterDesktopTabId,
         targetGroupId: opts.targetGroupId,
-        command: opts.command,
+        command,
         activate: opts.activate
       })
     })
@@ -9340,6 +9348,42 @@ export class OrcaRuntimeService {
       this.notifier?.focusTerminal(reply.tabId, worktreeId, null)
     }
     return await this.waitForMobileTerminalSurface(worktreeId, reply.tabId)
+  }
+
+  private async resolveMobileSessionTerminalCommand(
+    worktree: Worktree,
+    opts: { command?: string; agent?: TuiAgent }
+  ): Promise<string | undefined> {
+    if (opts.command || !opts.agent) {
+      return opts.command
+    }
+    if (!this.store) {
+      throw new Error('runtime_unavailable')
+    }
+    const settings = this.store.getSettings()
+    if (!isTuiAgentEnabled(opts.agent, settings.disabledTuiAgents)) {
+      throw new Error('Selected agent is disabled. Choose an enabled agent before creating.')
+    }
+    const repo = this.store.getRepo(worktree.repoId)
+    // Why: mobile may be running on iOS while the actual terminal shell is
+    // Windows/macOS/Linux or an SSH Linux host; quote for the host shell.
+    const platform: NodeJS.Platform = repo?.connectionId ? 'linux' : process.platform
+    const startupPlan = buildAgentStartupPlan({
+      agent: opts.agent,
+      prompt: '',
+      cmdOverrides: settings.agentCmdOverrides ?? {},
+      platform,
+      allowEmptyPromptLaunch: true
+    })
+    if (!startupPlan) {
+      throw new Error(`Could not build launch command for ${opts.agent}.`)
+    }
+    if (repo?.connectionId) {
+      await this.markRemoteWorkspaceTrustedForAgent(opts.agent, repo.connectionId, worktree.path)
+    } else {
+      this.markLocalWorkspaceTrustedForAgent(opts.agent, worktree.path)
+    }
+    return startupPlan.launchCommand
   }
 
   private async createHeadlessMobileSessionTerminal(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9291,7 +9291,6 @@ export class OrcaRuntimeService {
     this.assertGraphReady()
     const worktree = await this.resolveWorktreeSelector(worktreeSelector)
     const worktreeId = worktree.id
-    const command = await this.resolveMobileSessionTerminalCommand(worktree, opts)
     let afterDesktopTabId: string | undefined
     if (opts.afterTabId) {
       const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
@@ -9301,6 +9300,7 @@ export class OrcaRuntimeService {
       }
       afterDesktopTabId = anchor.type === 'terminal' ? anchor.parentTabId : anchor.id
     }
+    const command = await this.resolveMobileSessionTerminalCommand(worktree, opts)
 
     const win = this.getAvailableAuthoritativeWindow()
     if (!win) {

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -119,7 +119,45 @@ describe('session tab RPC methods', () => {
       afterTabId: undefined,
       targetGroupId: 'group-left',
       command: 'zsh',
+      agent: undefined,
       activate: true
+    })
+  })
+
+  it('dispatches terminal creation with a requested agent preset', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createMobileSessionTerminal: vi.fn().mockResolvedValue({
+        tab: {
+          type: 'terminal',
+          id: 'tab-1::leaf-1',
+          parentTabId: 'tab-1',
+          leafId: 'leaf-1',
+          title: 'Terminal',
+          status: 'ready',
+          terminal: 'pty-1',
+          isActive: true
+        },
+        publicationEpoch: 'epoch-1',
+        snapshotVersion: 1
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('session.tabs.createTerminal', {
+        worktree: 'id:wt-1',
+        agent: 'codex'
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.createMobileSessionTerminal).toHaveBeenCalledWith('id:wt-1', {
+      afterTabId: undefined,
+      targetGroupId: undefined,
+      command: undefined,
+      agent: 'codex',
+      activate: undefined
     })
   })
 

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -161,6 +161,27 @@ describe('session tab RPC methods', () => {
     })
   })
 
+  it('rejects unknown agent presets without creating a terminal', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      createMobileSessionTerminal: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('session.tabs.createTerminal', {
+        worktree: 'id:wt-1',
+        agent: 'not-real'
+      })
+    )
+
+    expect(response.ok).toBe(false)
+    expect(response).toMatchObject({
+      error: { code: 'invalid_argument', message: 'Unknown agent preset' }
+    })
+    expect(runtime.createMobileSessionTerminal).not.toHaveBeenCalled()
+  })
+
   it('streams all known session tab snapshots and later updates', async () => {
     const unsubscribe = vi.fn()
     const listeners: ((snapshot: unknown) => void)[] = []

--- a/src/main/runtime/rpc/methods/session-tabs.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { defineMethod, defineStreamingMethod, type RpcAnyMethod } from '../core'
 
 const WorktreeTabSelector = z.object({
@@ -19,6 +20,10 @@ const CreateTerminalTab = WorktreeTabSelector.extend({
   afterTabId: z.string().optional(),
   targetGroupId: z.string().optional(),
   command: z.string().optional(),
+  agent: z
+    .unknown()
+    .transform((value) => (isTuiAgent(value) ? value : undefined))
+    .optional(),
   activate: z.boolean().optional()
 })
 
@@ -99,6 +104,7 @@ export const SESSION_TAB_METHODS: RpcAnyMethod[] = [
         afterTabId: params.afterTabId,
         targetGroupId: params.targetGroupId,
         command: params.command,
+        agent: params.agent,
         activate: params.activate
       })
   }),

--- a/src/main/runtime/rpc/methods/session-tabs.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import type { TuiAgent } from '../../../../shared/types'
 import { defineMethod, defineStreamingMethod, type RpcAnyMethod } from '../core'
 
 const WorktreeTabSelector = z.object({
@@ -21,8 +22,9 @@ const CreateTerminalTab = WorktreeTabSelector.extend({
   targetGroupId: z.string().optional(),
   command: z.string().optional(),
   agent: z
-    .unknown()
-    .transform((value) => (isTuiAgent(value) ? value : undefined))
+    .custom<TuiAgent>(isTuiAgent, {
+      message: 'Unknown agent preset'
+    })
     .optional(),
   activate: z.boolean().optional()
 })

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -276,6 +276,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'worktree.activate',
   'worktree.create',
   'worktree.ps',
+  'worktree.show',
   'worktree.resolveMrBase',
   'worktree.resolvePrBase',
   'worktree.rm',


### PR DESCRIPTION
## Summary
- Adds enabled agent presets to the iOS/mobile new-tab action sheet alongside Terminal, Browser, and Markdown Note.
- Reuses existing mobile TUI agent labels/order, default-agent preference, disabled-agent filtering, and local/remote preflight detection instead of hardcoding agent names.
- Extends the mobile session terminal RPC launch path so selecting a preset starts the selected agent on the runtime host while preserving SSH/remote semantics.

Closes #3290.

## Product fit / bug reproduction evidence
- This is an enhancement/parity gap, not a reproduced runtime bug: before this change, `mobile/app/h/[hostId]/session/[worktreeId].tsx` only offered Terminal, Browser, and Markdown Note in the new-tab drawer.
- Desktop already appends `QuickLaunchAgentMenuItems` in `src/renderer/src/components/tab-bar/TabBar.tsx`, and `QuickLaunchButton.tsx` maps detected enabled agents into menu entries.
- The mobile implementation now shares the same backing preset data and launches through the existing runtime terminal creation path rather than inventing a mobile-only agent list.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/mobile-rpc-allowlist.test.ts --testNamePattern "session tab RPC methods|mobile session|mobile RPC allowlist"` passed: 3 files, 14 tests.
- `pnpm --dir mobile exec vitest run src/session/mobile-new-tab-agent-options.test.ts` passed: 1 file, 3 tests.
- `pnpm run typecheck:node` passed.
- `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json` passed.
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/methods/session-tabs.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/main/runtime/runtime-rpc.ts mobile/app/h/[hostId]/session/[worktreeId].tsx mobile/src/session/mobile-new-tab-agent-options.ts mobile/src/session/mobile-new-tab-agent-options.test.ts` passed with 0 warnings/errors.
- `pnpm --dir mobile exec oxlint app/h/[hostId]/session/[worktreeId].tsx src/session/mobile-new-tab-agent-options.ts src/session/mobile-new-tab-agent-options.test.ts` passed with 0 warnings/errors.
- `git diff --check` passed.
- `git merge-tree --write-tree HEAD FETCH_HEAD` passed against `origin/main` (`5a55d5828e1ad74d5460e806185f99814d6fafcc`), producing tree `85765c3b9553695b45d1689a20c7eb7bd16ec64d`.

## Simulator evidence
- Simulator screenshot was blocked in this worker: `xcodebuild -version` found Xcode 26.1.1 and `pnpm --dir mobile exec expo --version` found Expo 55.0.29, but `xcrun simctl list devices available --json` reported no available simulator devices registered for any installed runtime.
- Component/unit and runtime RPC tests cover the menu/preset mapping and launch behavior.