### PR TITLE
Fetch inactive account usage on expand

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -157,11 +157,17 @@ function ClaudeSwitcherMenu({
     }
   }, [])
 
-  useEffect(() => {
-    if (accountsExpanded) {
-      void fetchInactiveClaudeAccountUsage()
-    }
-  }, [accountsExpanded, fetchInactiveClaudeAccountUsage])
+  // Why: inactive-account usage is needed only for the explicit switcher
+  // expansion, so fetch it on that event instead of one render later.
+  const handleAccountsExpandedToggle = useCallback((): void => {
+    setAccountsExpanded((current) => {
+      const nextExpanded = !current
+      if (nextExpanded) {
+        void fetchInactiveClaudeAccountUsage()
+      }
+      return nextExpanded
+    })
+  }, [fetchInactiveClaudeAccountUsage])
 
   const handleSelectAccount = async (accountId: string | null): Promise<void> => {
     if (isSwitching) {
@@ -208,7 +214,7 @@ function ClaudeSwitcherMenu({
       <DropdownMenuItem
         onSelect={(event) => {
           event.preventDefault()
-          setAccountsExpanded((prev) => !prev)
+          handleAccountsExpandedToggle()
         }}
       >
         <span className="max-w-[180px] truncate text-[12px] text-foreground">

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -160,14 +160,12 @@ function ClaudeSwitcherMenu({
   // Why: inactive-account usage is needed only for the explicit switcher
   // expansion, so fetch it on that event instead of one render later.
   const handleAccountsExpandedToggle = useCallback((): void => {
-    setAccountsExpanded((current) => {
-      const nextExpanded = !current
-      if (nextExpanded) {
-        void fetchInactiveClaudeAccountUsage()
-      }
-      return nextExpanded
-    })
-  }, [fetchInactiveClaudeAccountUsage])
+    const nextExpanded = !accountsExpanded
+    setAccountsExpanded(nextExpanded)
+    if (nextExpanded) {
+      void fetchInactiveClaudeAccountUsage()
+    }
+  }, [accountsExpanded, fetchInactiveClaudeAccountUsage])
 
   const handleSelectAccount = async (accountId: string | null): Promise<void> => {
     if (isSwitching) {


### PR DESCRIPTION
## Summary
- Move inactive Claude account usage fetch from a passive Effect into the account switcher expansion handler.
- Keep the existing account-list refresh Effect for account/settings synchronization.
- Removes 1 Effect hook call site from `StatusBar.tsx`.

## Validation
- `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- Effect hook AST count: `origin/main 911`, `working 910`

## Risk
Medium. This changes when the status-bar Claude account switcher asks the rate-limit IPC path for inactive-account usage. It does not change account selection, persistence, terminal/SSH behavior, source control, or provider-specific data shapes.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.