### PR TITLE
feat(sidebar): show worktree comment inline on card face

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -214,7 +214,10 @@ describe('WorktreeCard linked PR display', () => {
     expect(markup).not.toContain('data-slot="badge"')
     expect(markup).not.toContain('Loading issue')
     expect(markup).not.toContain('Loading PR')
-    expect(markup).not.toContain('Reviewer handoff note')
+    // The comment now renders as a single truncated line on the card face
+    // (previously hover-only); the meta badges stay icon-only.
+    expect(markup).toContain('Reviewer handoff note')
+    expect(markup.indexOf('Workspace notes')).toBeLessThan(markup.indexOf('Linked issue #123'))
   })
 
   it('keeps issue, Linear issue, PR, and notes metadata out of compact cards', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -269,6 +269,39 @@ describe('WorktreeCard linked PR display', () => {
     expect(markup).not.toContain('Reviewer handoff note')
   })
 
+  it('normalizes multi-line comments into one inline preview row', async () => {
+    worktreeCardProperties = ['comment']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ comment: '  First line\n\n  second\tline  ' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('First line second line')
+    expect(markup).toContain('class="min-w-0 truncate"')
+    expect(markup).not.toContain('First line\n')
+  })
+
+  it('does not render a blank inline comment row for whitespace-only notes', async () => {
+    worktreeCardProperties = ['comment']
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ comment: ' \n\t ' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('Workspace notes')
+    expect(markup).not.toContain('class="min-w-0 truncate"')
+  })
+
   it('hides live port metadata when the Ports card property is disabled', async () => {
     const worktree = makeWorktree()
     workspacePortScan = {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -734,6 +734,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const metaLinearIssue = showLinearIssue ? linearIssueDisplay : null
   const metaReview = showPR ? prDisplay : null
   const metaComment = showComment ? worktree.comment : null
+  const inlineCommentPreview = metaComment?.trim().replace(/\s+/g, ' ') ?? ''
   const handleOpenGitHubIssueInOrca = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -1330,12 +1331,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
         {/* Why: surface the worktree comment inline on the card face for
              at-a-glance context (previously visible only on hover). One
              truncated line keeps the row a fixed height regardless of
-             comment length — avoiding the variable-height virtualizer jank
-             that led to the revert of #431 (commit 474db0ef). */}
-        {metaComment && metaComment.trim().length > 0 && (
+             comment length, avoiding the variable-height virtualizer jank
+             that led to the revert of #431 (commit 474db0ef). Compact cards
+             suppress all meta, so the inline note follows that mode too. */}
+        {showDetailedCardProperties && inlineCommentPreview.length > 0 && (
           <div className="flex min-w-0 items-center gap-1 text-[11px] leading-none text-muted-foreground">
-            <StickyNote className="size-2.5 shrink-0 text-muted-foreground/70" />
-            <span className="min-w-0 truncate">{metaComment.trim().replace(/\s+/g, ' ')}</span>
+            <StickyNote aria-hidden="true" className="size-2.5 shrink-0 text-muted-foreground/70" />
+            <span className="min-w-0 truncate">{inlineCommentPreview}</span>
           </div>
         )}
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -16,6 +16,7 @@ import {
   ServerOff,
   Sparkles,
   Star,
+  StickyNote,
   Trash2,
   Workflow
 } from 'lucide-react'
@@ -1323,6 +1324,18 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 {detailsAndPorts}
               </div>
             )}
+          </div>
+        )}
+
+        {/* Why: surface the worktree comment inline on the card face for
+             at-a-glance context (previously visible only on hover). One
+             truncated line keeps the row a fixed height regardless of
+             comment length — avoiding the variable-height virtualizer jank
+             that led to the revert of #431 (commit 474db0ef). */}
+        {metaComment && metaComment.trim().length > 0 && (
+          <div className="flex min-w-0 items-center gap-1 text-[11px] leading-none text-muted-foreground">
+            <StickyNote className="size-2.5 shrink-0 text-muted-foreground/70" />
+            <span className="min-w-0 truncate">{metaComment.trim().replace(/\s+/g, ' ')}</span>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Render the worktree comment as a **single truncated (`text-ellipsis`) line** on the `WorktreeCard` body. Previously the comment was visible only on hover (via `WorktreeCardMeta` / the details hover). This surfaces it at a glance on the card face.

- One line, fixed height — `truncate` + internal whitespace normalized to single spaces so multi-line comments preview cleanly.
- Gated on a non-empty comment **and** the existing `'comment'` card property (`metaComment`), so users who hide notes are unaffected.
- Uses existing STYLEGUIDE tokens only (`text-[11px]`, `text-muted-foreground`, `truncate`, `leading-none` — already used by the branch row); a small `StickyNote` icon matches the hover's note treatment. No new colors/sizes.
- The hover details (full text + edit) are left untouched; this is purely additive.

## Relationship to the reverted #431

This area was attempted before: **#431 "feat: display worktree comments with line wrapping instead of hover card"** was merged then reverted (commit `474db0ef`, no stated reason). #431's approach **wrapped multi-line comments and computed a dynamic, content-dependent virtualizer row height** (`estimateRowHeight` keyed on content length / newline count) — variable-height rows in the virtualized list are the likely jank/revert cause.

This PR deliberately avoids that: the comment is **one fixed-height truncated line regardless of comment length**, so the list virtualizer row height stays stable. It does not modify the virtualizer's measurement strategy.

## Test plan

- `pnpm typecheck:web` — passes
- `oxlint` on touched files — 0 warnings / 0 errors
- `vitest run src/renderer/src/components/sidebar` — 58 files / 461 tests pass
- Updated `WorktreeCard.pr-display.test.tsx`: the comment text now renders inline on the closed card (assertion flipped), while the meta badges remain icon-only.

## Notes

🤖 Agent-authored (Claude Opus 4.8) for **@BorjaLL**'s review — opened as a **draft**. Flagging the #431 history explicitly so a human can confirm there's no undocumented product objection to inline comments before this is taken out of draft.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.