### PR TITLE
Fix mobile terminal selection autoscroll

### DIFF
--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -882,6 +882,8 @@ const XTERM_HTML = `<!DOCTYPE html>
   var longPressOrigin = null; // {x,y, identifier}
   var edgeScrollTimer = null;
   var edgeScrollDir = 0;
+  var edgeScrollClientX = 0;
+  var edgeScrollClientY = 0;
 
   // Eviction watchdog: linesEverWritten counts onLineFeed since last init.
   // Once buffer is full, every onLineFeed evicts the top row in xterm and
@@ -1370,10 +1372,30 @@ const XTERM_HTML = `<!DOCTYPE html>
     selMenu.style.left = clampedLeft + 'px';
   }
 
+  function syncSelectionHandleToViewportPoint(handle, clientX, clientY) {
+    var c = viewportToCell(clientX, clientY);
+    if (!c || !sel) return false;
+    if (handle === 'start') sel.anchor = c;
+    else sel.focus = c;
+    applyXtermSelection();
+    return true;
+  }
+
+  function syncEdgeScrollSelectionEndpoint() {
+    if (!sel || !sel.activeHandle) return false;
+    // Why: WebView may not emit new touchmove events while a handle is held
+    // at the edge; resample the stored finger point after each viewport scroll.
+    return syncSelectionHandleToViewportPoint(
+      sel.activeHandle,
+      edgeScrollClientX,
+      edgeScrollClientY
+    );
+  }
+
   function startEdgeScroll(dir) {
     if (edgeScrollDir === dir) return;
-    edgeScrollDir = dir;
     stopEdgeScroll();
+    edgeScrollDir = dir;
     edgeScrollTimer = setInterval(function() {
       if (!term || edgeScrollDir === 0) return;
       var beforeY = term.buffer.active.viewportY;
@@ -1384,6 +1406,7 @@ const XTERM_HTML = `<!DOCTYPE html>
         stopEdgeScroll();
         return;
       }
+      syncEdgeScrollSelectionEndpoint();
       repositionOverlay();
     }, EDGE_SCROLL_INTERVAL);
   }
@@ -1397,11 +1420,9 @@ const XTERM_HTML = `<!DOCTYPE html>
   }
 
   function handleDragMove(handle, clientX, clientY) {
-    var c = viewportToCell(clientX, clientY);
-    if (!c || !sel) return;
-    if (handle === 'start') sel.anchor = c;
-    else sel.focus = c;
-    applyXtermSelection();
+    edgeScrollClientX = clientX;
+    edgeScrollClientY = clientY;
+    if (!syncSelectionHandleToViewportPoint(handle, clientX, clientY)) return;
     repositionOverlay();
     if (clientY < EDGE_SCROLL_PX) startEdgeScroll(-1);
     else if (clientY > window.innerHeight - EDGE_SCROLL_PX) startEdgeScroll(1);

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -107,4 +107,22 @@ describe('TerminalWebView scroll routing', () => {
     expect(source).toContain('var FRICTION = 0.972;')
     expect(source).toContain('var MIN_VEL = 0.012;')
   })
+
+  it('keeps selection edge autoscroll active and extends the dragged endpoint', () => {
+    const startBlock = sliceBetween('function startEdgeScroll(dir)', 'function stopEdgeScroll()')
+    expect(startBlock.indexOf('stopEdgeScroll();')).toBeLessThan(
+      startBlock.indexOf('edgeScrollDir = dir;')
+    )
+    expect(startBlock.indexOf('term.scrollLines(edgeScrollDir);')).toBeLessThan(
+      startBlock.indexOf('syncEdgeScrollSelectionEndpoint();')
+    )
+
+    const dragMoveBlock = sliceBetween(
+      'function handleDragMove(handle, clientX, clientY)',
+      '  // ============================================================\n  // LATCHING TOUCH DISPATCHER'
+    )
+    expect(dragMoveBlock).toContain('edgeScrollClientX = clientX;')
+    expect(dragMoveBlock).toContain('edgeScrollClientY = clientY;')
+    expect(dragMoveBlock).toContain('syncSelectionHandleToViewportPoint(handle, clientX, clientY)')
+  })
 })


### PR DESCRIPTION
## Summary
- Fix mobile terminal text selection edge autoscroll so dragging a selection handle to the top or bottom keeps scrolling and expanding the selected range.
- Keep the held handle synced to the finger point after each xterm viewport scroll tick.
- Add a focused WebView source regression test for the edge-scroll direction and endpoint sync behavior.

Fixes #3335

## Reproduction / Diagnosis
- The issue reports long-press selection handles in the mobile app can select visible AI response text only; dragging toward the bottom does not continue selecting below the viewport.
- The failing path is Orca mobile terminal WebView code, not React Native selectable Text or an Expo/native limitation: terminal selection is implemented by the embedded xterm overlay in `mobile/src/terminal/TerminalWebView.tsx`.
- Static reproduction found `startEdgeScroll(dir)` set `edgeScrollDir` before calling `stopEdgeScroll()`, which reset it to `0`, so the interval could not scroll. The timer also only repositioned overlay handles after viewport movement and did not resample the active handle, so selection could not grow while the finger stayed at the edge.

## Tests
- `pnpm --dir mobile install --frozen-lockfile`
- `pnpm --dir mobile exec vitest run src/terminal/terminal-webview-scroll-routing.test.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `pnpm --dir mobile lint`
- `git diff --check HEAD~1..HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Device / Simulator Evidence
- Native simulator/device validation was blocked locally: `xcrun simctl list devices available --json` returned no available iOS simulator devices, `adb devices -l` returned an empty device list, and `agent-device` is not installed.
- No merge performed.