### PR TITLE
Reduce terminal search focus effect

### DIFF
--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { ChevronUp, ChevronDown, X, CaseSensitive, Regex } from 'lucide-react'
 import type { SearchAddon } from '@xterm/addon-search'
 import { Button } from '@/components/ui/button'
@@ -17,7 +17,6 @@ export default function TerminalSearch({
   searchAddon,
   searchStateRef
 }: TerminalSearchProps): React.JSX.Element | null {
-  const inputRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState('')
   const [caseSensitive, setCaseSensitive] = useState(false)
   const [regex, setRegex] = useState(false)
@@ -57,24 +56,24 @@ export default function TerminalSearch({
     }
   }, [searchAddon, query, searchOptions])
 
-  useEffect(() => {
-    if (isOpen) {
-      inputRef.current?.focus()
-    } else {
-      searchAddon?.clearDecorations()
-    }
-  }, [isOpen, searchAddon])
+  const handleInputRef = useCallback((input: HTMLInputElement | null): void => {
+    input?.focus()
+  }, [])
 
   useEffect(() => {
     // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
     // can read the current search state without lifting it to parent state.
     searchStateRef.current = { query, caseSensitive, regex }
 
+    if (!isOpen) {
+      searchAddon?.clearDecorations()
+      return
+    }
     if (!query) {
       searchAddon?.clearDecorations()
       return
     }
-    if (searchAddon && isOpen) {
+    if (searchAddon) {
       searchAddon.findNext(query, searchOptions(true))
     }
   }, [query, searchAddon, isOpen, caseSensitive, regex, searchStateRef, searchOptions])
@@ -106,7 +105,7 @@ export default function TerminalSearch({
       onKeyDown={handleKeyDown}
     >
       <input
-        ref={inputRef}
+        ref={handleInputRef}
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}


### PR DESCRIPTION
## Summary
- move terminal search input focus from a passive open-state Effect to the input ref callback
- keep close-time SearchAddon decoration cleanup in the remaining search-sync Effect

## Measurement
- Effect-family AST count: origin/main 911, working branch 910

## Validation
- pnpm exec oxlint src/renderer/src/components/TerminalSearch.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
- pnpm run typecheck:web
- git diff --check

## Merge risk
Medium: touches terminal search focus and xterm SearchAddon decoration cleanup. No PTY protocol or persistence changes, but terminal focus/search behavior is user-facing and should be reviewed before merge.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.