### PR TITLE
Reduce font autocomplete scroll effect

### DIFF
--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -456,7 +456,6 @@ export function FontAutocomplete({
   const inputRef = useRef<HTMLInputElement | null>(null)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const previewFontFamilyRef = useRef(onPreviewFontFamily)
-  const optionRefs = useRef(new Map<string, HTMLButtonElement>())
   const listboxId = useId()
 
   previewFontFamilyRef.current = onPreviewFontFamily
@@ -522,19 +521,6 @@ export function FontAutocomplete({
       setHighlightedIndex(Math.max(selectedIndex, 0))
     }
   }
-
-  useEffect(() => {
-    if (!open || highlightedIndex < 0) {
-      return
-    }
-
-    const highlightedFont = filteredSuggestions[highlightedIndex]
-    if (!highlightedFont) {
-      return
-    }
-
-    optionRefs.current.get(highlightedFont)?.scrollIntoView({ block: 'nearest' })
-  }, [filteredSuggestions, highlightedIndex, open])
 
   // Why: notify the consumer of the currently-highlighted font so it can
   // render a live preview. Closing the dropdown or moving past all options
@@ -672,11 +658,9 @@ export function FontAutocomplete({
                     role="option"
                     aria-selected={index === highlightedIndex}
                     ref={(element) => {
-                      if (element) {
-                        optionRefs.current.set(font, element)
-                        return
+                      if (element && index === highlightedIndex) {
+                        element.scrollIntoView({ block: 'nearest' })
                       }
-                      optionRefs.current.delete(font)
                     }}
                     onMouseDown={(e) => e.preventDefault()}
                     onMouseEnter={() => setHighlightedIndex(index)}


### PR DESCRIPTION
## Summary
- move FontAutocomplete highlighted-option scrolling from a passive Effect into the option ref callback
- drop the option element map now that the highlighted option can scroll itself on render

## Measurement
- Effect-family AST count: origin/main 911, working branch 910

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/settings/SettingsFormControls.tsx
- pnpm exec oxlint src/renderer/src/components/settings/SettingsFormControls.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx src/renderer/src/components/settings/TerminalPane.pwsh.test.ts src/renderer/src/components/settings/TerminalPane.ghostty.test.ts
- pnpm run typecheck:web
- git diff --check

## Merge risk
Medium: touches settings font autocomplete keyboard/mouse highlight scrolling. No persistence, IPC, SSH, terminal runtime, or provider behavior changes, but settings UI behavior should be reviewed before merge.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.