### PR TITLE
Reduce SSH passphrase focus effect

### DIFF
--- a/src/renderer/src/components/settings/SshPassphraseDialog.tsx
+++ b/src/renderer/src/components/settings/SshPassphraseDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -19,6 +19,7 @@ export function SshPassphraseDialog(): React.JSX.Element | null {
   const [value, setValue] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  const focusFrameRef = useRef<number | null>(null)
 
   const open = request !== null
 
@@ -36,14 +37,27 @@ export function SshPassphraseDialog(): React.JSX.Element | null {
     }
   }
 
-  // DOM focus is a side effect that must remain in useEffect.
-  useEffect(() => {
-    if (!requestId) {
-      return undefined
-    }
-    const focusFrame = requestAnimationFrame(() => inputRef.current?.focus())
-    return () => cancelAnimationFrame(focusFrame)
-  }, [requestId])
+  // Why: focusing from the ref callback avoids a passive request-id Effect while
+  // still canceling stale frames when the request or mounted input changes.
+  const setInputRef = useCallback(
+    (input: HTMLInputElement | null): void => {
+      inputRef.current = input
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current)
+        focusFrameRef.current = null
+      }
+      if (!input || !requestId) {
+        return
+      }
+      focusFrameRef.current = requestAnimationFrame(() => {
+        focusFrameRef.current = null
+        if (inputRef.current === input) {
+          input.focus()
+        }
+      })
+    },
+    [requestId]
+  )
 
   const handleSubmit = useCallback(async () => {
     if (!request || !value) {
@@ -107,7 +121,7 @@ export function SshPassphraseDialog(): React.JSX.Element | null {
           </label>
           <Input
             id="ssh-credential-input"
-            ref={inputRef}
+            ref={setInputRef}
             type="password"
             value={value}
             onChange={(e) => setValue(e.target.value)}


### PR DESCRIPTION
## Summary
- move SSH credential dialog input focus from a passive request-id Effect to the input ref callback
- cancel stale focus animation frames when the input ref detaches or a new SSH credential request takes over

## Measurement
- Effect-family AST count: origin/main 911, working branch 910

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/settings/SshPassphraseDialog.tsx
- pnpm exec oxlint src/renderer/src/components/settings/SshPassphraseDialog.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/hooks/useIpcEvents.test.ts
- pnpm run typecheck:web
- git diff --check

## Merge risk
High: touches SSH credential prompt focus behavior. No SSH transport, relay, persistence, or credential IPC semantics changed, but passphrase/password prompting is on the SSH critical path and should be reviewed before merge.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.