### PR TITLE
Show existing worktrees on Tasks issues

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -100,9 +100,9 @@ import {
 import PRFilterDropdowns, { type PRFilterChange } from '@/components/github/PRFilterDropdowns'
 import { buildGitHubRepoUrl, parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import {
-  findGithubPrWorkspaceAttachment,
-  getGithubPrWorkspaceAttachmentLabel
-} from '@/lib/github-pr-workspace-attachment'
+  findWorkItemWorkspaceAttachment,
+  getWorkItemWorkspaceAttachmentLabel
+} from '@/lib/work-item-workspace-attachment'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
@@ -3805,12 +3805,16 @@ export default function TaskPage(): React.JSX.Element {
     [openComposerForItem]
   )
 
-  const handleOpenOrUseGitHubPR = useCallback(
+  const handleOpenOrUseGitHubItem = useCallback(
     (item: GitHubWorkItem): void => {
-      const currentAttached = findGithubPrWorkspaceAttachment(
+      const currentAttached = findWorkItemWorkspaceAttachment(
         useAppStore.getState().allWorktrees(),
-        item.repoId,
-        item.number
+        {
+          provider: 'github',
+          type: item.type,
+          repoId: item.repoId,
+          number: item.number
+        }
       )
       if (!currentAttached) {
         handleUseWorkItem(item)
@@ -3819,7 +3823,9 @@ export default function TaskPage(): React.JSX.Element {
 
       const result = activateAndRevealWorktree(currentAttached.id)
       if (result === false) {
-        toast.error('Unable to open the workspace attached to this pull request.')
+        toast.error(
+          `Unable to open the workspace attached to this ${item.type === 'pr' ? 'pull request' : 'issue'}.`
+        )
       }
     },
     [handleUseWorkItem]
@@ -5172,13 +5178,16 @@ export default function TaskPage(): React.JSX.Element {
                   {!showGitHubTaskSkeletons &&
                     filteredWorkItems.map((item) => {
                       const itemRepo = repoMap.get(item.repoId) ?? null
-                      const attachedWorkspace =
-                        item.type === 'pr'
-                          ? findGithubPrWorkspaceAttachment(allWorktrees, item.repoId, item.number)
-                          : null
+                      const attachedWorkspace = findWorkItemWorkspaceAttachment(allWorktrees, {
+                        provider: 'github',
+                        type: item.type,
+                        repoId: item.repoId,
+                        number: item.number
+                      })
                       const attachedWorkspaceLabel = attachedWorkspace
-                        ? getGithubPrWorkspaceAttachmentLabel(attachedWorkspace)
+                        ? getWorkItemWorkspaceAttachmentLabel(attachedWorkspace)
                         : null
+                      const itemKindLabel = item.type === 'pr' ? 'PR' : 'issue'
                       return (
                         // Why: the row is a clickable container rather than a
                         // <button> because it holds nested interactive elements
@@ -5262,9 +5271,12 @@ export default function TaskPage(): React.JSX.Element {
                                 </span>
                               ) : null}
                               {attachedWorkspaceLabel ? (
-                                <span className="inline-flex min-w-0 items-center gap-1">
+                                <span className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-full border border-border/50 bg-background/80 px-1.5 py-0.5 text-[10px] font-medium text-foreground">
                                   <FolderKanban className="size-3 shrink-0" />
-                                  <span className="truncate">{attachedWorkspaceLabel}</span>
+                                  <span className="shrink-0">In progress</span>
+                                  <span className="min-w-0 truncate text-muted-foreground">
+                                    {attachedWorkspaceLabel}
+                                  </span>
                                 </span>
                               ) : null}
                               {item.labels.slice(0, 3).map((label) => (
@@ -5324,7 +5336,7 @@ export default function TaskPage(): React.JSX.Element {
                           </Tooltip>
 
                           <div className="flex items-center justify-start gap-1 lg:justify-end">
-                            {item.type === 'pr' ? (
+                            {item.type === 'pr' || attachedWorkspace ? (
                               <DropdownMenu modal={false}>
                                 <ButtonGroup>
                                   <Button
@@ -5333,13 +5345,13 @@ export default function TaskPage(): React.JSX.Element {
                                     size="xs"
                                     onClick={(event) => {
                                       event.stopPropagation()
-                                      handleOpenOrUseGitHubPR(item)
+                                      handleOpenOrUseGitHubItem(item)
                                     }}
                                     className="bg-background/80"
                                     aria-label={
                                       attachedWorkspace
-                                        ? 'Open workspace attached to PR'
-                                        : 'Start workspace from PR'
+                                        ? `Open workspace attached to ${itemKindLabel}`
+                                        : `Start workspace from ${itemKindLabel}`
                                     }
                                   >
                                     {attachedWorkspace ? 'Open' : 'Start'}
@@ -5352,7 +5364,7 @@ export default function TaskPage(): React.JSX.Element {
                                       size="icon-xs"
                                       onClick={(event) => event.stopPropagation()}
                                       className="bg-background/80"
-                                      aria-label="More PR actions"
+                                      aria-label={`More ${itemKindLabel} workspace actions`}
                                     >
                                       <ChevronDown className="size-3" />
                                     </Button>
@@ -5381,15 +5393,16 @@ export default function TaskPage(): React.JSX.Element {
                                 type="button"
                                 onClick={(event) => {
                                   event.stopPropagation()
-                                  handleUseWorkItem(item)
+                                  handleOpenOrUseGitHubItem(item)
                                 }}
                                 className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-background/80 px-2 py-1 text-[11px] text-foreground transition hover:bg-muted/60"
+                                aria-label={`Start workspace from ${itemKindLabel}`}
                               >
                                 Start
                                 <ArrowRight className="size-3" />
                               </button>
                             )}
-                            {item.type !== 'pr' ? (
+                            {item.type !== 'pr' && !attachedWorkspace ? (
                               <DropdownMenu modal={false}>
                                 <DropdownMenuTrigger asChild>
                                   <button

--- a/src/renderer/src/lib/github-pr-workspace-attachment.ts
+++ b/src/renderer/src/lib/github-pr-workspace-attachment.ts
@@ -1,46 +1,22 @@
 import type { Worktree } from '../../../shared/types'
-import { basename } from './path'
+import {
+  findWorkItemWorkspaceAttachment,
+  getWorkItemWorkspaceAttachmentLabel
+} from './work-item-workspace-attachment'
 
 export function findGithubPrWorkspaceAttachment(
   worktrees: readonly Worktree[],
   repoId: string | null | undefined,
   prNumber: number
 ): Worktree | null {
-  if (!repoId) {
-    return null
-  }
-
-  return (
-    worktrees.find(
-      (worktree) =>
-        worktree.repoId === repoId && worktree.linkedPR === prNumber && !worktree.isArchived
-    ) ?? null
-  )
+  return findWorkItemWorkspaceAttachment(worktrees, {
+    provider: 'github',
+    type: 'pr',
+    repoId,
+    number: prNumber
+  })
 }
 
 export function getGithubPrWorkspaceAttachmentLabel(worktree: Worktree): string {
-  const displayName = worktree.displayName.trim()
-  if (displayName) {
-    return displayName
-  }
-
-  const branch = getBranchLabel(worktree.branch)
-  if (branch) {
-    return branch
-  }
-
-  return basename(worktree.path) || worktree.path
-}
-
-function getBranchLabel(branch: string | null | undefined): string | null {
-  const trimmed = branch?.trim()
-  if (!trimmed) {
-    return null
-  }
-
-  if (trimmed.startsWith('refs/heads/')) {
-    return trimmed.slice('refs/heads/'.length)
-  }
-
-  return trimmed
+  return getWorkItemWorkspaceAttachmentLabel(worktree)
 }

--- a/src/renderer/src/lib/work-item-workspace-attachment.test.ts
+++ b/src/renderer/src/lib/work-item-workspace-attachment.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  findWorkItemWorkspaceAttachment,
+  getWorkItemWorkspaceAttachmentLabel
+} from './work-item-workspace-attachment'
+import type { Worktree } from '../../../shared/types'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: overrides.id ?? 'wt-1',
+    repoId: overrides.repoId ?? 'repo-1',
+    path: overrides.path ?? '/tmp/repo-1/wt-1',
+    head: 'abc123',
+    branch: overrides.branch ?? 'refs/heads/feature/work-item',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: overrides.displayName ?? 'Work item workspace',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('work item workspace attachment', () => {
+  it('finds non-archived GitHub issue workspaces by repo and number', () => {
+    const attached = worktree({ linkedIssue: 3346 })
+
+    expect(
+      findWorkItemWorkspaceAttachment([attached], {
+        provider: 'github',
+        type: 'issue',
+        repoId: 'repo-1',
+        number: 3346
+      })
+    ).toBe(attached)
+  })
+
+  it('keeps GitHub issue and GitLab issue metadata separate', () => {
+    const gitlabOnly = worktree({ linkedGitLabIssue: 3346 })
+
+    expect(
+      findWorkItemWorkspaceAttachment([gitlabOnly], {
+        provider: 'github',
+        type: 'issue',
+        repoId: 'repo-1',
+        number: 3346
+      })
+    ).toBeNull()
+    expect(
+      findWorkItemWorkspaceAttachment([gitlabOnly], {
+        provider: 'gitlab',
+        type: 'issue',
+        repoId: 'repo-1',
+        number: 3346
+      })
+    ).toBe(gitlabOnly)
+  })
+
+  it('ignores archived and cross-repo workspaces', () => {
+    const archived = worktree({ linkedIssue: 3346, isArchived: true })
+    const otherRepo = worktree({ repoId: 'repo-2', linkedIssue: 3346 })
+
+    expect(
+      findWorkItemWorkspaceAttachment([archived, otherRepo], {
+        provider: 'github',
+        type: 'issue',
+        repoId: 'repo-1',
+        number: 3346
+      })
+    ).toBeNull()
+  })
+
+  it('finds Linear workspaces by identifier without requiring a git repo', () => {
+    const attached = worktree({ linkedLinearIssue: 'ENG-123' })
+
+    expect(
+      findWorkItemWorkspaceAttachment([attached], {
+        provider: 'linear',
+        identifier: 'ENG-123'
+      })
+    ).toBe(attached)
+  })
+
+  it('labels attachments without exposing a full path when display or branch is available', () => {
+    expect(getWorkItemWorkspaceAttachmentLabel(worktree({ displayName: '  Named issue  ' }))).toBe(
+      'Named issue'
+    )
+    expect(
+      getWorkItemWorkspaceAttachmentLabel(
+        worktree({ displayName: '', branch: 'refs/heads/fix-ci' })
+      )
+    ).toBe('fix-ci')
+    expect(
+      getWorkItemWorkspaceAttachmentLabel(
+        worktree({ displayName: '', branch: '', path: 'C:\\repo\\workspace-tail' })
+      )
+    ).toBe('workspace-tail')
+  })
+})

--- a/src/renderer/src/lib/work-item-workspace-attachment.ts
+++ b/src/renderer/src/lib/work-item-workspace-attachment.ts
@@ -1,0 +1,79 @@
+import type { Worktree } from '../../../shared/types'
+import { basename } from './path'
+
+export type WorkItemWorkspaceAttachmentRef =
+  | {
+      provider: 'github'
+      type: 'issue' | 'pr'
+      repoId: string | null | undefined
+      number: number
+    }
+  | {
+      provider: 'gitlab'
+      type: 'issue' | 'mr'
+      repoId: string | null | undefined
+      number: number
+    }
+  | {
+      provider: 'linear'
+      identifier: string | null | undefined
+    }
+
+export function findWorkItemWorkspaceAttachment(
+  worktrees: readonly Worktree[],
+  ref: WorkItemWorkspaceAttachmentRef
+): Worktree | null {
+  return worktrees.find((worktree) => isAttachedToWorkItem(worktree, ref)) ?? null
+}
+
+export function getWorkItemWorkspaceAttachmentLabel(worktree: Worktree): string {
+  const displayName = worktree.displayName.trim()
+  if (displayName) {
+    return displayName
+  }
+
+  const branch = getBranchLabel(worktree.branch)
+  if (branch) {
+    return branch
+  }
+
+  return basename(worktree.path) || worktree.path
+}
+
+function isAttachedToWorkItem(worktree: Worktree, ref: WorkItemWorkspaceAttachmentRef): boolean {
+  if (worktree.isArchived) {
+    return false
+  }
+
+  switch (ref.provider) {
+    case 'github':
+      return (
+        Boolean(ref.repoId) &&
+        worktree.repoId === ref.repoId &&
+        (ref.type === 'pr' ? worktree.linkedPR === ref.number : worktree.linkedIssue === ref.number)
+      )
+    case 'gitlab':
+      return (
+        Boolean(ref.repoId) &&
+        worktree.repoId === ref.repoId &&
+        (ref.type === 'mr'
+          ? worktree.linkedGitLabMR === ref.number
+          : worktree.linkedGitLabIssue === ref.number)
+      )
+    case 'linear':
+      return Boolean(ref.identifier) && worktree.linkedLinearIssue === ref.identifier
+  }
+}
+
+function getBranchLabel(branch: string | null | undefined): string | null {
+  const trimmed = branch?.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  if (trimmed.startsWith('refs/heads/')) {
+    return trimmed.slice('refs/heads/'.length)
+  }
+
+  return trimmed
+}


### PR DESCRIPTION
## Summary
- Triage: #3346 is valid; GitHub issue rows on Tasks did not surface existing linked Orca worktrees, so starting from the row could create duplicate workspaces.
- Added a provider-aware work-item workspace attachment helper for GitHub, GitLab, and Linear metadata, while keeping the existing GitHub PR wrapper API.
- Updated Tasks issue/PR rows to show an `In progress` workspace chip and make attached rows open the existing workspace, with `Start new workspace` still available from the overflow menu.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/work-item-workspace-attachment.test.ts src/renderer/src/lib/github-pr-workspace-attachment.test.ts`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `git diff --check HEAD~1..HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> `4d21f80b2ac3eec1fed5e37c8b8cc95dfc6f5456`
- Electron dev app evidence: seeded issue #3346 on Tasks with the existing worktree linked, confirmed the visible row shows `In progress nwparker/issue-3346-tasks-existing-worktree` and the primary action is `Open`; local screenshot saved at `.playwright-cli/issue-3346-tasks-existing-worktree-attached.png` (not committed).

Fixes #3346

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.