### PR TITLE
Avoid double-closing Windows ConPTY handles

### DIFF
--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -371,6 +371,25 @@ describe('LocalPtyProvider', () => {
       expect(onExit).toHaveBeenCalledWith(id, -1)
     })
 
+    it('does not destroy after an intentional Windows shutdown kill', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const killSpy = vi.fn()
+      const destroySpy = vi.fn(() => {
+        killSpy()
+      })
+      spawnMock.mockReturnValue({
+        ...mockProc,
+        kill: killSpy,
+        destroy: destroySpy
+      })
+
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+      await provider.shutdown(id, { immediate: true })
+
+      expect(killSpy).toHaveBeenCalledTimes(1)
+      expect(destroySpy).not.toHaveBeenCalled()
+    })
+
     it('is a no-op for unknown PTY ids', async () => {
       await provider.shutdown('nonexistent', { immediate: true })
       expect(mockProc.kill).not.toHaveBeenCalled()
@@ -509,6 +528,24 @@ describe('LocalPtyProvider', () => {
       expect(mock2Kill).toHaveBeenCalled()
       const list = await provider.listProcesses()
       expect(list).toHaveLength(0)
+    })
+
+    it('does not destroy after intentional Windows orphan kills', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const destroySpy = vi.fn()
+      const killSpy = vi.fn()
+      spawnMock.mockReturnValue({
+        ...mockProc,
+        kill: killSpy,
+        destroy: destroySpy
+      })
+
+      await provider.spawn({ cols: 80, rows: 24 })
+
+      provider.killAll()
+
+      expect(killSpy).toHaveBeenCalledTimes(1)
+      expect(destroySpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -106,7 +106,7 @@ function clearPtyState(id: string): void {
   ptyLoadGeneration.delete(id)
 }
 
-function destroyPtyProcess(proc: pty.IPty): void {
+function destroyPtyProcess(proc: pty.IPty, options: { alreadyKilled?: boolean } = {}): void {
   // Why: node-pty's UnixTerminal.destroy() closes the master socket, which
   // releases the ptmx fd to the OS — without this call the fd leaks until GC
   // (see docs/fix-pty-fd-leak.md). destroy() also registers a close listener
@@ -114,9 +114,11 @@ function destroyPtyProcess(proc: pty.IPty): void {
   // the time that listener runs the child may have exited and its pid been
   // recycled to an unrelated user process — SIGHUP would land on a Chrome tab,
   // editor, etc. Neutralize proc.kill on this instance before calling
-  // destroy() to defuse the hazard. Windows exempt: WindowsTerminal.destroy
-  // IS a kill() call via _deferNoArgs, so neutralizing it would leak the
-  // ConPTY agent.
+  // destroy() to defuse the hazard. On Windows, destroy() is itself kill();
+  // skip it only after we have already killed the ConPTY.
+  if (process.platform === 'win32' && options.alreadyKilled) {
+    return
+  }
   if (process.platform !== 'win32') {
     ;(proc as unknown as { kill: (sig?: string) => void }).kill = () => {}
   }
@@ -134,7 +136,7 @@ function safeKillAndClean(id: string, proc: pty.IPty): void {
   } catch {
     /* Process may already be dead */
   }
-  destroyPtyProcess(proc)
+  destroyPtyProcess(proc, { alreadyKilled: true })
   clearPtyState(id)
 }
 
@@ -501,7 +503,7 @@ export class LocalPtyProvider implements IPtyProvider {
     } catch {
       /* Process may already be dead */
     }
-    destroyPtyProcess(proc)
+    destroyPtyProcess(proc, { alreadyKilled: true })
     ptyProcesses.delete(id)
     ptyShellName.delete(id)
     ptyLoadGeneration.delete(id)

--- a/src/main/rate-limits/hidden-pty-cleanup.test.ts
+++ b/src/main/rate-limits/hidden-pty-cleanup.test.ts
@@ -69,7 +69,7 @@ describe('cleanupHiddenRateLimitPty', () => {
     expect(killMock).toHaveBeenCalledWith()
   })
 
-  it('does not neutralize kill on Windows because destroy closes ConPTY through kill', () => {
+  it('does not destroy after an intentional Windows kill because destroy kills again', () => {
     setPlatform('win32')
     const term = {
       kill: vi.fn(),
@@ -80,7 +80,22 @@ describe('cleanupHiddenRateLimitPty', () => {
 
     cleanupHiddenRateLimitPty(term, [], { kill: true })
 
-    expect(term.kill).toHaveBeenCalledTimes(2)
+    expect(term.kill).toHaveBeenCalledTimes(1)
+    expect(term.destroy).not.toHaveBeenCalled()
+  })
+
+  it('destroys a Windows PTY after natural exit so ConPTY cleanup still runs', () => {
+    setPlatform('win32')
+    const term = {
+      kill: vi.fn(),
+      destroy: vi.fn(() => {
+        term.kill()
+      })
+    }
+
+    cleanupHiddenRateLimitPty(term, [], { kill: false })
+
+    expect(term.kill).toHaveBeenCalledTimes(1)
     expect(term.destroy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/rate-limits/hidden-pty-cleanup.ts
+++ b/src/main/rate-limits/hidden-pty-cleanup.ts
@@ -22,6 +22,12 @@ export function cleanupHiddenRateLimitPty(
     } catch {
       /* already exited */
     }
+
+    // Why: node-pty WindowsTerminal.destroy() calls kill() again, which can
+    // close the same ConPTY handle twice after an intentional termination.
+    if (process.platform === 'win32') {
+      return
+    }
   }
 
   // Why: node-pty destroy releases the master PTY fd; on POSIX, neutralize


### PR DESCRIPTION
## Summary
- avoid calling `destroy()` after an intentional Windows PTY `kill()` because node-pty implements Windows `destroy()` as another kill
- keep natural-exit cleanup intact so Windows ConPTY teardown still runs when no explicit kill happened
- add regression tests for hidden rate-limit PTYs and local PTY shutdown/orphan cleanup

## Evidence
- user-provided `Orca.exe.21960.dmp` confirms `Orca.exe 1.4.35.0` still hit `0xc0000374` heap-corruption termination
- parsed dump showed the crashing thread in `ntdll.dll` with `conpty.node` present in stack memory
- this points at the same native ConPTY cleanup class as the recent Windows startup crashes, but not fully fixed by #3009

## Testing
- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/hidden-pty-cleanup.test.ts src/main/providers/local-pty-provider.test.ts`
- `pnpm run typecheck:node`

## Notes
- `src/main/ipc/pty.test.ts` still has unrelated Windows-host failures from POSIX path/newline expectations; those failures were not introduced by this change.