### PR TITLE
Record Space page interaction on open

### DIFF
--- a/src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx
+++ b/src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx
@@ -7,11 +7,6 @@ import { useAppStore } from '../../store'
 
 export default function WorkspaceSpacePage(): React.JSX.Element {
   const closeSpacePage = useAppStore((state) => state.closeSpacePage)
-  const recordFeatureInteraction = useAppStore((state) => state.recordFeatureInteraction)
-
-  useEffect(() => {
-    recordFeatureInteraction('workspace-cleanup')
-  }, [recordFeatureInteraction])
 
   useEffect(() => {
     const hasVisibleOverlay = (): boolean =>

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -960,6 +960,36 @@ describe('createUISlice feature interactions', () => {
 })
 
 describe('createUISlice space navigation', () => {
+  it('records Space page opens as workspace cleanup interactions', () => {
+    const setMock = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          set: setMock
+        }
+      }
+    })
+    const now = 1_700_000_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    try {
+      const store = createUIStore()
+      store.getState().hydratePersistedUI(makePersistedUI())
+      setMock.mockClear()
+
+      store.getState().openSpacePage()
+
+      const expected: FeatureInteractionState = {
+        'workspace-cleanup': { firstInteractedAt: now, interactionCount: 1 }
+      }
+      expect(store.getState().featureInteractions).toEqual(expected)
+      expect(setMock).toHaveBeenCalledWith({ featureInteractions: expected })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('returns to the tasks page after opening Space from an in-progress draft', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -856,12 +856,14 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         worktreeNavHistoryIndex: nextHistoryIndex
       }
     }),
-  openSpacePage: () =>
+  openSpacePage: () => {
+    get().recordFeatureInteraction?.('workspace-cleanup')
     set((state) => ({
       activeView: 'space',
       previousViewBeforeSpace:
         state.activeView === 'space' ? state.previousViewBeforeSpace : state.activeView
-    })),
+    }))
+  },
   closeSpacePage: () =>
     set((state) => ({
       activeView: state.previousViewBeforeSpace


### PR DESCRIPTION
## Summary
- moves the Space page workspace-cleanup interaction recording into `openSpacePage`
- removes the Space page mount-only bookkeeping Effect
- adds a UI slice regression test for the recorded Space page open interaction

## Risk
Medium - this changes persisted feature interaction bookkeeping for Space page opens. No SSH, terminal, browser, source-control provider, or transport behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/store/slices/ui.test.ts`
- `pnpm exec oxlint src/renderer/src/components/workspace-space/WorkspaceSpacePage.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/store/slices/ui.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ui.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST hook counter: `origin/main 911`, `working 910`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.