### PR TITLE
Add Source Control fast-forward action

### DIFF
--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -8,7 +8,7 @@ vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock
 }))
 
-import { gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from './remote'
+import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from './remote'
 
 describe('git remote operations', () => {
   beforeEach(() => {
@@ -199,6 +199,37 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
       [['pull', 'fork', 'feature/fix'], { cwd: '/repo' }]
+    ])
+  })
+
+  it('fast-forwards with --ff-only using the configured upstream', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'feature\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'origin/feature\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await gitFastForward('/repo')
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['symbolic-ref', '--quiet', '--short', 'HEAD'], { cwd: '/repo' }],
+      [['rev-parse', '--abbrev-ref', 'HEAD@{u}'], { cwd: '/repo' }],
+      [['pull', '--ff-only'], { cwd: '/repo' }]
+    ])
+  })
+
+  it('fast-forwards from the explicit publish target when one is provided', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await gitFastForward('/repo', {
+      remoteName: 'fork',
+      branchName: 'feature/fix'
+    })
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['pull', '--ff-only', 'fork', 'feature/fix'], { cwd: '/repo' }]
     ])
   })
 

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -76,14 +76,15 @@ export async function gitPush(
   }
 }
 
-export async function gitPull(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-  // Why: plain `git pull` uses the user's configured pull strategy (merge by
-  // default) so diverged branches reconcile instead of erroring out. Conflicts
-  // surface through the existing conflict-resolution flow.
+async function gitPullWithArgs(
+  worktreePath: string,
+  pullArgs: string[],
+  pushTarget?: GitPushTarget
+): Promise<void> {
   try {
     if (pushTarget) {
       const target = await validateGitPushTarget(worktreePath, pushTarget)
-      await gitExecFileAsync(['pull', target.remoteName, target.branchName], {
+      await gitExecFileAsync(['pull', ...pullArgs, target.remoteName, target.branchName], {
         cwd: worktreePath
       })
       return
@@ -94,16 +95,30 @@ export async function gitPull(worktreePath: string, pushTarget?: GitPushTarget):
     if (upstream && !upstream.isConfiguredUpstream) {
       // Why: legacy Orca branches may still track origin/main while pushes
       // target origin/<branch>. Pull the same effective branch the UI reports.
-      await gitExecFileAsync(['pull', upstream.remoteName, upstream.branchName], {
+      await gitExecFileAsync(['pull', ...pullArgs, upstream.remoteName, upstream.branchName], {
         cwd: worktreePath
       })
       return
     }
 
-    await gitExecFileAsync(['pull'], { cwd: worktreePath })
+    await gitExecFileAsync(['pull', ...pullArgs], { cwd: worktreePath })
   } catch (error) {
     throw new Error(normalizeGitErrorMessage(error, 'pull'))
   }
+}
+
+export async function gitPull(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
+  // Why: plain `git pull` uses the user's configured pull strategy (merge by
+  // default) so diverged branches reconcile instead of erroring out. Conflicts
+  // surface through the existing conflict-resolution flow.
+  await gitPullWithArgs(worktreePath, [], pushTarget)
+}
+
+export async function gitFastForward(
+  worktreePath: string,
+  pushTarget?: GitPushTarget
+): Promise<void> {
+  await gitPullWithArgs(worktreePath, ['--ff-only'], pushTarget)
 }
 
 export async function gitPullRebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -1294,6 +1294,22 @@ describe('registerFilesystemHandlers', () => {
     expect(bulkDiscardChangesMock).not.toHaveBeenCalled()
   })
 
+  it('routes ssh git:fastForward through the SSH provider', async () => {
+    const sshFastForwardMock = vi.fn().mockResolvedValue(undefined)
+    const pushTarget = { remoteName: 'fork', branchName: 'feature/fix' }
+    getSshGitProviderMock.mockReturnValue({ fastForwardBranch: sshFastForwardMock })
+
+    registerFilesystemHandlers(store as never)
+
+    await handlers.get('git:fastForward')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'conn-1',
+      pushTarget
+    })
+
+    expect(sshFastForwardMock).toHaveBeenCalledWith('/remote/repo', pushTarget)
+  })
+
   it('rejects git:commit with empty message and does not call commitChanges', async () => {
     registerFilesystemHandlers(store as never)
 

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -64,7 +64,7 @@ import {
 } from '../text-generation/commit-message-text-generation'
 import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
 import { getUpstreamStatus } from '../git/upstream'
-import { gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
+import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
 import { checkIgnoredPaths } from '../git/check-ignored-paths'
 import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
 import { getCommitMessageModelDiscoveryHostKey } from '../../shared/commit-message-host-key'
@@ -1166,6 +1166,30 @@ export function registerFilesystemHandlers(
         await validateGitPushTarget(worktreePath, args.pushTarget)
       }
       await gitPull(worktreePath, args.pushTarget)
+    }
+  )
+
+  ipcMain.handle(
+    'git:fastForward',
+    async (
+      _event,
+      args: { worktreePath: string; connectionId?: string; pushTarget?: GitPushTarget }
+    ): Promise<void> => {
+      if (args.connectionId) {
+        if (args.pushTarget) {
+          assertGitPushTargetShape(args.pushTarget)
+        }
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.fastForwardBranch(args.worktreePath, args.pushTarget)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      if (args.pushTarget) {
+        await validateGitPushTarget(worktreePath, args.pushTarget)
+      }
+      await gitFastForward(worktreePath, args.pushTarget)
     }
   )
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -548,6 +548,24 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('fastForwardBranch sends git.fastForward request', async () => {
+    await provider.fastForwardBranch('/home/user/repo')
+    expect(mux.request).toHaveBeenCalledWith('git.fastForward', {
+      worktreePath: '/home/user/repo'
+    })
+  })
+
+  it('fastForwardBranch forwards an explicit push target', async () => {
+    const pushTarget = { remoteName: 'fork', branchName: 'feature' }
+
+    await provider.fastForwardBranch('/home/user/repo', pushTarget)
+
+    expect(mux.request).toHaveBeenCalledWith('git.fastForward', {
+      worktreePath: '/home/user/repo',
+      pushTarget
+    })
+  })
+
   it('rebaseFromBase sends git.rebaseFromBase request', async () => {
     await provider.rebaseFromBase('/home/user/repo', 'upstream/main')
 

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -331,6 +331,13 @@ export class SshGitProvider implements IGitProvider {
     await this.mux.request('git.pull', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
   }
 
+  async fastForwardBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
+    await this.mux.request('git.fastForward', {
+      worktreePath,
+      ...(pushTarget ? { pushTarget } : {})
+    })
+  }
+
   async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
     await this.mux.request('git.rebaseFromBase', { worktreePath, baseRef })
   }

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -185,6 +185,7 @@ export type IGitProvider = {
     options?: { forceWithLease?: boolean }
   ): Promise<void>
   pullBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void>
+  fastForwardBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void>
   rebaseFromBase(worktreePath: string, baseRef: string): Promise<void>
   fetchRemote(worktreePath: string, pushTarget?: GitPushTarget): Promise<void>
   getBranchDiff(

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -40,7 +40,7 @@ import {
 } from '../git/status'
 import { getHistory as getGitHistory } from '../git/history'
 import { getUpstreamStatus } from '../git/upstream'
-import { gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
+import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
 import {
   getSshGitProvider,
   SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
@@ -300,6 +300,23 @@ export class RuntimeGitCommands {
       return { ok: true }
     }
     await gitPull(target.worktree.path, pushTarget)
+    return { ok: true }
+  }
+
+  async fastForwardRuntimeGit(
+    worktreeSelector: string,
+    pushTarget?: GitPushTarget
+  ): Promise<{ ok: true }> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      await provider.fastForwardBranch(target.worktree.path, pushTarget)
+      return { ok: true }
+    }
+    await gitFastForward(target.worktree.path, pushTarget)
     return { ok: true }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2110,6 +2110,8 @@ export class OrcaRuntimeService {
   pullRuntimeGit: RuntimeGitCommands['pullRuntimeGit'] = this.gitCommands.pullRuntimeGit.bind(
     this.gitCommands
   )
+  fastForwardRuntimeGit: RuntimeGitCommands['fastForwardRuntimeGit'] =
+    this.gitCommands.fastForwardRuntimeGit.bind(this.gitCommands)
   rebaseRuntimeGitFromBase: RuntimeGitCommands['rebaseRuntimeGitFromBase'] =
     this.gitCommands.rebaseRuntimeGitFromBase.bind(this.gitCommands)
   pushRuntimeGit: RuntimeGitCommands['pushRuntimeGit'] = this.gitCommands.pushRuntimeGit.bind(

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -304,6 +304,24 @@ describe('git RPC methods', () => {
     expect(runtime.fetchRuntimeGit).toHaveBeenCalledWith('id:wt-1', pushTarget)
   })
 
+  it('forwards fast-forward push target to the runtime', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      fastForwardRuntimeGit: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+    const pushTarget = { remoteName: 'fork', branchName: 'feature' }
+
+    await dispatcher.dispatch(
+      makeRequest('git.fastForward', {
+        worktree: 'id:wt-1',
+        pushTarget
+      })
+    )
+
+    expect(runtime.fastForwardRuntimeGit).toHaveBeenCalledWith('id:wt-1', pushTarget)
+  })
+
   it('forwards commit-message settings to the runtime', async () => {
     const commitMessageAi = {
       enabled: true,

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: this table is the runtime git RPC contract; splitting it would make method coverage harder to audit. */
 import { defineMethod, type RpcMethod } from '../core'
 import type { GlobalSettings } from '../../../../shared/types'
 import {
@@ -107,6 +108,14 @@ export const GIT_METHODS: RpcMethod[] = [
       params.pushTarget === undefined
         ? runtime.pullRuntimeGit(params.worktree)
         : runtime.pullRuntimeGit(params.worktree, params.pushTarget)
+  }),
+  defineMethod({
+    name: 'git.fastForward',
+    params: GitTargetedRemote,
+    handler: async (params, { runtime }) =>
+      params.pushTarget === undefined
+        ? runtime.fastForwardRuntimeGit(params.worktree)
+        : runtime.fastForwardRuntimeGit(params.worktree, params.pushTarget)
   }),
   defineMethod({
     name: 'git.rebaseFromBase',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -153,6 +153,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'git.discard',
   'git.diff',
   'git.fetch',
+  'git.fastForward',
   'git.pull',
   'git.push',
   'git.rebaseFromBase',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1655,6 +1655,11 @@ export type PreloadApi = {
       connectionId?: string
       pushTarget?: GitPushTarget
     }) => Promise<void>
+    fastForward: (args: {
+      worktreePath: string
+      connectionId?: string
+      pushTarget?: GitPushTarget
+    }) => Promise<void>
     rebaseFromBase: (args: {
       worktreePath: string
       baseRef: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2260,6 +2260,11 @@ const api = {
       connectionId?: string
       pushTarget?: GitPushTarget
     }): Promise<void> => ipcRenderer.invoke('git:pull', args),
+    fastForward: (args: {
+      worktreePath: string
+      connectionId?: string
+      pushTarget?: GitPushTarget
+    }): Promise<void> => ipcRenderer.invoke('git:fastForward', args),
     rebaseFromBase: (args: {
       worktreePath: string
       baseRef: string

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -56,6 +56,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.fetchRemoteTrackingRef')
     expect(methods).toContain('git.push')
     expect(methods).toContain('git.pull')
+    expect(methods).toContain('git.fastForward')
     expect(methods).toContain('git.rebaseFromBase')
     expect(methods).toContain('git.branchDiff')
     expect(methods).toContain('git.listWorktrees')
@@ -829,6 +830,54 @@ describe('GitHandler', () => {
         await expect(fs.access(path.join(tmpDir, '.git', 'FETCH_HEAD'))).resolves.toBeUndefined()
       } finally {
         await fs.rm(bareDir, { recursive: true, force: true })
+      }
+    })
+
+    it('fast-forwards the tracked branch with ff-only pull semantics', async () => {
+      const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-bare-'))
+      const producerParent = mkdtempSync(path.join(tmpdir(), 'relay-git-producer-'))
+      const producerDir = path.join(producerParent, 'repo')
+      try {
+        execFileSync('git', ['init', '--bare'], { cwd: bareDir, stdio: 'pipe' })
+
+        gitInit(tmpDir)
+        writeFileSync(path.join(tmpDir, 'base.txt'), 'base')
+        gitCommit(tmpDir, 'initial')
+        const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        }).trim()
+        execFileSync('git', ['remote', 'add', 'origin', bareDir], {
+          cwd: tmpDir,
+          stdio: 'pipe'
+        })
+        execFileSync('git', ['push', '--set-upstream', 'origin', branch], {
+          cwd: tmpDir,
+          stdio: 'pipe'
+        })
+
+        execFileSync('git', ['clone', bareDir, producerDir], { stdio: 'pipe' })
+        execFileSync('git', ['config', 'user.email', 'test@test.com'], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
+        execFileSync('git', ['config', 'user.name', 'Test'], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
+        writeFileSync(path.join(producerDir, 'remote.txt'), 'remote')
+        gitCommit(producerDir, 'remote commit')
+        execFileSync('git', ['push', 'origin', branch], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
+
+        await dispatcher.callRequest('git.fastForward', { worktreePath: tmpDir })
+
+        await expect(fs.readFile(path.join(tmpDir, 'remote.txt'), 'utf-8')).resolves.toBe('remote')
+      } finally {
+        await fs.rm(bareDir, { recursive: true, force: true })
+        await fs.rm(producerParent, { recursive: true, force: true })
       }
     })
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -76,6 +76,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.fetchRemoteTrackingRef', (p) => this.fetchRemoteTrackingRef(p))
     this.dispatcher.onRequest('git.push', (p) => this.push(p))
     this.dispatcher.onRequest('git.pull', (p) => this.pull(p))
+    this.dispatcher.onRequest('git.fastForward', (p) => this.fastForward(p))
     this.dispatcher.onRequest('git.rebaseFromBase', (p) => this.rebaseFromBase(p))
     this.dispatcher.onRequest('git.branchDiff', (p) => this.branchDiff(p))
     this.dispatcher.onRequest('git.commitDiff', (p) => this.commitDiff(p))
@@ -460,31 +461,45 @@ export class GitHandler {
     }
   }
 
-  private async pull(params: Record<string, unknown>) {
+  private async pullWithArgs(params: Record<string, unknown>, pullArgs: string[]) {
     const worktreePath = params.worktreePath as string
-    // Why: plain `git pull` uses the user's configured pull strategy (merge by
-    // default) so diverged branches reconcile instead of erroring out.
     try {
       if (params.pushTarget !== undefined) {
         assertGitPushTargetShape(params.pushTarget)
         const pushTarget = params.pushTarget as GitPushTarget
         await this.git(['check-ref-format', '--branch', pushTarget.branchName], worktreePath)
-        await this.git(['pull', pushTarget.remoteName, pushTarget.branchName], worktreePath)
+        await this.git(
+          ['pull', ...pullArgs, pushTarget.remoteName, pushTarget.branchName],
+          worktreePath
+        )
         return
       }
       const upstream = await resolveEffectiveGitUpstream((args) => this.git(args, worktreePath))
       if (upstream && !upstream.isConfiguredUpstream) {
         // Why: legacy Orca branches may still track origin/main while pushes
         // target origin/<branch>. Pull the same effective branch the UI reports.
-        await this.git(['pull', upstream.remoteName, upstream.branchName], worktreePath)
+        await this.git(
+          ['pull', ...pullArgs, upstream.remoteName, upstream.branchName],
+          worktreePath
+        )
         return
       }
-      await this.git(['pull'], worktreePath)
+      await this.git(['pull', ...pullArgs], worktreePath)
     } catch (error) {
       // Why: mirror the local gitPull normalization so SSH users see the same
       // actionable messages instead of raw git stderr.
       throw new Error(normalizeGitErrorMessage(error, 'pull'))
     }
+  }
+
+  private async pull(params: Record<string, unknown>) {
+    // Why: plain `git pull` uses the user's configured pull strategy (merge by
+    // default) so diverged branches reconcile instead of erroring out.
+    await this.pullWithArgs(params, [])
+  }
+
+  private async fastForward(params: Record<string, unknown>) {
+    await this.pullWithArgs(params, ['--ff-only'])
   }
 
   private async rebaseFromBase(params: Record<string, unknown>) {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -816,6 +816,7 @@ function resolveRemoteActionError(kind: RemoteOpKind, error: unknown): string {
     isPush: kind === 'push',
     isSync: kind === 'sync',
     isFetch: kind === 'fetch',
+    isFastForward: kind === 'fast_forward',
     isRebase: kind === 'rebase'
   })
 }
@@ -954,6 +955,7 @@ function SourceControlInner(): React.JSX.Element {
   const setUpstreamStatus = useAppStore((s) => s.setUpstreamStatus)
   const pushBranch = useAppStore((s) => s.pushBranch)
   const pullBranch = useAppStore((s) => s.pullBranch)
+  const fastForwardBranch = useAppStore((s) => s.fastForwardBranch)
   const syncBranch = useAppStore((s) => s.syncBranch)
   const rebaseFromBase = useAppStore((s) => s.rebaseFromBase)
   const fetchBranch = useAppStore((s) => s.fetchBranch)
@@ -2012,7 +2014,9 @@ function SourceControlInner(): React.JSX.Element {
   // place — store slices already surface actionable toasts, so additional
   // try/catch here would duplicate the notification.
   const runRemoteAction = useCallback(
-    async (kind: 'push' | 'pull' | 'sync' | 'fetch' | 'publish' | 'rebase'): Promise<void> => {
+    async (
+      kind: 'push' | 'pull' | 'fast_forward' | 'sync' | 'fetch' | 'publish' | 'rebase'
+    ): Promise<void> => {
       if (!activeWorktreeId || !worktreePath) {
         return
       }
@@ -2043,6 +2047,15 @@ function SourceControlInner(): React.JSX.Element {
         }
         if (kind === 'pull') {
           await pullBranch(activeWorktreeId, worktreePath, connectionId, activeWorktree?.pushTarget)
+          return
+        }
+        if (kind === 'fast_forward') {
+          await fastForwardBranch(
+            activeWorktreeId,
+            worktreePath,
+            connectionId,
+            activeWorktree?.pushTarget
+          )
           return
         }
         if (kind === 'fetch') {
@@ -2093,6 +2106,7 @@ function SourceControlInner(): React.JSX.Element {
       activeWorktree?.pushTarget,
       activeWorktreeId,
       fetchBranch,
+      fastForwardBranch,
       effectiveBaseRef,
       pullBranch,
       pushBranch,
@@ -2797,6 +2811,7 @@ function SourceControlInner(): React.JSX.Element {
           return
         case 'push':
         case 'pull':
+        case 'fast_forward':
         case 'sync':
         case 'fetch':
         case 'publish':

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -37,6 +37,7 @@ describe('resolveDropdownItems', () => {
       'create_pr',
       'push_create_pr',
       'pull',
+      'fast_forward',
       'sync',
       'rebase_base',
       'fetch',
@@ -173,6 +174,10 @@ describe('resolveDropdownItems', () => {
     expect(byKind.pull.disabled).toBe(true)
     expect(byKind.pull.title).toBe(
       'Nothing new to pull — remote only has older copies of local commits'
+    )
+    expect(byKind.fast_forward.disabled).toBe(true)
+    expect(byKind.fast_forward.title).toBe(
+      'Nothing new to fast-forward — remote only has older copies of local commits'
     )
     expect(byKind.commit_sync.label).toBe('Commit & Sync')
     expect(byKind.commit_sync.disabled).toBe(true)
@@ -322,6 +327,7 @@ describe('resolveDropdownItems', () => {
       'commit_sync',
       'push',
       'pull',
+      'fast_forward',
       'sync',
       'fetch',
       'publish'
@@ -347,6 +353,7 @@ describe('resolveDropdownItems', () => {
     )
     expect(byKind.push.title).toBe('Publish the branch first to push commits')
     expect(byKind.pull.title).toBe('Publish the branch first to pull commits')
+    expect(byKind.fast_forward.title).toBe('Publish the branch first to fast-forward')
     expect(byKind.sync.title).toBe('Publish the branch first to sync commits')
     expect(byKind.fetch.title).toBe('Fetch from remote without merging')
     expect(byKind.fetch.disabled).toBe(false)
@@ -415,6 +422,7 @@ describe('resolveDropdownItems', () => {
     )
     expect(byKind.push.title).toBe('PR is already merged')
     expect(byKind.pull.title).toBe('PR is already merged')
+    expect(byKind.fast_forward.title).toBe('PR is already merged')
     expect(byKind.sync.title).toBe('PR is already merged')
     expect(byKind.publish.label).toBe('PR Status')
     expect(byKind.publish.title).toBe('PR is already merged')
@@ -455,6 +463,27 @@ describe('resolveDropdownItems', () => {
     // Sanity check: plain counterparts still carry counts.
     expect(byKind.push.label).toBe('Push (2)')
     expect(byKind.sync.label).toBe('Sync (↓3 ↑2)')
+  })
+
+  it('enables fast-forward only when the branch is behind with no local commits', () => {
+    const behindOnly = resolveDropdownItems(
+      inputs({ upstreamStatus: { hasUpstream: true, ahead: 0, behind: 2 } })
+    )
+    const diverged = resolveDropdownItems(
+      inputs({ upstreamStatus: { hasUpstream: true, ahead: 1, behind: 2 } })
+    )
+    const behindOnlyByKind = Object.fromEntries(
+      behindOnly.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    const divergedByKind = Object.fromEntries(
+      diverged.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+
+    expect(behindOnlyByKind.fast_forward.label).toBe('Fast-forward (2)')
+    expect(behindOnlyByKind.fast_forward.title).toBe('Fast-forward 2 commits')
+    expect(behindOnlyByKind.fast_forward.disabled).toBe(false)
+    expect(divergedByKind.fast_forward.disabled).toBe(true)
+    expect(divergedByKind.fast_forward.title).toBe('Local commits prevent a fast-forward pull')
   })
 
   it('enables the push-before-PR recovery action when review creation is only blocked by unpushed commits', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -21,6 +21,7 @@ export type DropdownActionKind =
   | 'push_create_pr'
   | 'push'
   | 'pull'
+  | 'fast_forward'
   | 'sync'
   | 'rebase_base'
   | 'fetch'
@@ -45,6 +46,10 @@ function describePushCount(ahead: number): string {
 
 function describePullCount(behind: number): string {
   return `Pull ${behind} commit${behind === 1 ? '' : 's'}`
+}
+
+function describeFastForwardCount(behind: number): string {
+  return `Fast-forward ${behind} commit${behind === 1 ? '' : 's'}`
 }
 
 function describeSyncCounts(ahead: number, behind: number): string {
@@ -267,6 +272,33 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
       globalBusy || upstreamLoading || !hasUpstream || behind === 0 || shouldForcePushWithLease
   }
 
+  const fastForwardItem: DropdownItem = {
+    kind: 'fast_forward',
+    label: formatCountLabel('Fast-forward', behind),
+    title: upstreamLoading
+      ? 'Checking branch status…'
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : !hasUpstream
+            ? 'Publish the branch first to fast-forward'
+            : shouldForcePushWithLease
+              ? 'Nothing new to fast-forward — remote only has older copies of local commits'
+              : behind === 0
+                ? 'Nothing to fast-forward'
+                : ahead > 0
+                  ? 'Local commits prevent a fast-forward pull'
+                  : describeFastForwardCount(behind),
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      !hasUpstream ||
+      behind === 0 ||
+      ahead > 0 ||
+      shouldForcePushWithLease
+  }
+
   const syncItem: DropdownItem = {
     kind: 'sync',
     label: formatSyncLabel('Sync', ahead, behind),
@@ -415,6 +447,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     createPRItem,
     pushCreatePRItem,
     pullItem,
+    fastForwardItem,
     syncItem,
     rebaseItem,
     fetchItem,

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.ts
@@ -31,7 +31,14 @@ export type PrimaryActionKind =
 // because Fetch participates in the busy flag, but it is intentionally NOT
 // in PrimaryActionKind — Fetch is dropdown-only, so when fetch is in flight
 // the primary keeps its natural label and CommitArea suppresses the spinner.
-export type RemoteOpKind = 'push' | 'pull' | 'sync' | 'fetch' | 'publish' | 'rebase'
+export type RemoteOpKind =
+  | 'push'
+  | 'pull'
+  | 'sync'
+  | 'fetch'
+  | 'fast_forward'
+  | 'publish'
+  | 'rebase'
 
 export type PrimaryAction = {
   kind: PrimaryActionKind

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -6,6 +6,7 @@ import {
   cancelRuntimeGenerateCommitMessage,
   commitRuntimeGit,
   discoverRuntimeCommitMessageModels,
+  fastForwardRuntimeGit,
   fetchRuntimeGit,
   generateRuntimeCommitMessage,
   getRuntimeGitDiff,
@@ -29,6 +30,7 @@ const gitBulkStage = vi.fn()
 const gitBulkDiscard = vi.fn()
 const gitCommit = vi.fn()
 const gitFetch = vi.fn()
+const gitFastForward = vi.fn()
 const gitPush = vi.fn()
 const gitRebaseFromBase = vi.fn()
 const gitGenerateCommitMessage = vi.fn()
@@ -48,6 +50,7 @@ beforeEach(() => {
   gitBulkDiscard.mockReset()
   gitCommit.mockReset()
   gitFetch.mockReset()
+  gitFastForward.mockReset()
   gitPush.mockReset()
   gitRebaseFromBase.mockReset()
   gitGenerateCommitMessage.mockReset()
@@ -70,6 +73,7 @@ beforeEach(() => {
         bulkDiscard: gitBulkDiscard,
         commit: gitCommit,
         fetch: gitFetch,
+        fastForward: gitFastForward,
         push: gitPush,
         rebaseFromBase: gitRebaseFromBase,
         generateCommitMessage: gitGenerateCommitMessage,
@@ -307,6 +311,7 @@ describe('runtime git client', () => {
       pushTarget: { remoteName: 'origin', branchName: 'feature' }
     })
     await fetchRuntimeGit(context, { remoteName: 'fork', branchName: 'feature' })
+    await fastForwardRuntimeGit(context, { remoteName: 'fork', branchName: 'feature' })
     await rebaseRuntimeGitFromBase(context, 'origin/main')
 
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
@@ -359,6 +364,15 @@ describe('runtime git client', () => {
       timeoutMs: 30_000
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(8, {
+      selector: 'env-1',
+      method: 'git.fastForward',
+      params: {
+        worktree: 'wt-1',
+        pushTarget: { remoteName: 'fork', branchName: 'feature' }
+      },
+      timeoutMs: 30_000
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(9, {
       selector: 'env-1',
       method: 'git.rebaseFromBase',
       params: { worktree: 'wt-1', baseRef: 'origin/main' },

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -337,6 +337,27 @@ export async function pullRuntimeGit(
   )
 }
 
+export async function fastForwardRuntimeGit(
+  context: RuntimeGitContext,
+  pushTarget?: GitPushTarget
+): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    await window.api.git.fastForward({
+      worktreePath: context.worktreePath,
+      connectionId: context.connectionId,
+      ...(pushTarget ? { pushTarget } : {})
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'git.fastForward',
+    { worktree: context.worktreeId, ...(pushTarget ? { pushTarget } : {}) },
+    { timeoutMs: 30_000 }
+  )
+}
+
 export async function rebaseRuntimeGitFromBase(
   context: RuntimeGitContext,
   baseRef: string

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1506,6 +1506,62 @@ describe('createEditorSlice remote branch actions', () => {
     expect(store.getState().isRemoteOperationActive).toBe(false)
   })
 
+  it('keeps fast-forward wording when normalized pull errors report local changes', async () => {
+    const store = createEditorStore()
+    gitFastForwardMock.mockRejectedValueOnce(
+      new Error(
+        'Pull would overwrite local changes. Commit, stash, or discard them before pulling.'
+      )
+    )
+
+    await expect(store.getState().fastForwardBranch('wt-1', '/repo')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Fast-forward blocked — commit or stash your local changes first.'
+    )
+  })
+
+  it('keeps fast-forward wording when normalized pull errors report untracked files', async () => {
+    const store = createEditorStore()
+    gitFastForwardMock.mockRejectedValueOnce(
+      new Error('Pull would overwrite untracked files. Move, remove, or add them before pulling.')
+    )
+
+    await expect(store.getState().fastForwardBranch('wt-1', '/repo')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Fast-forward blocked — move, remove, or add untracked files first.'
+    )
+  })
+
+  it('keeps rebase wording when normalized pull errors report local changes', async () => {
+    const store = createEditorStore()
+    gitRebaseFromBaseMock.mockRejectedValueOnce(
+      new Error(
+        'Pull would overwrite local changes. Commit, stash, or discard them before pulling.'
+      )
+    )
+
+    await expect(store.getState().rebaseFromBase('wt-1', '/repo', 'origin/main')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Rebase blocked — commit or stash your local changes first.'
+    )
+  })
+
+  it('keeps rebase wording when normalized pull errors report untracked files', async () => {
+    const store = createEditorStore()
+    gitRebaseFromBaseMock.mockRejectedValueOnce(
+      new Error('Pull would overwrite untracked files. Move, remove, or add them before pulling.')
+    )
+
+    await expect(store.getState().rebaseFromBase('wt-1', '/repo', 'origin/main')).rejects.toThrow()
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Rebase blocked — move, remove, or add untracked files first.'
+    )
+  })
+
   it('fetches the explicit push target and refreshes that target status', async () => {
     const store = createEditorStore()
     const pushTarget = { remoteName: 'fork', branchName: 'feature' }

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1332,6 +1332,7 @@ describe('createEditorSlice remote branch actions', () => {
   const gitUpstreamStatusMock = vi.fn()
   const gitPushMock = vi.fn()
   const gitPullMock = vi.fn()
+  const gitFastForwardMock = vi.fn()
   const gitRebaseFromBaseMock = vi.fn()
   const gitFetchMock = vi.fn()
 
@@ -1341,6 +1342,7 @@ describe('createEditorSlice remote branch actions', () => {
     gitUpstreamStatusMock.mockReset()
     gitPushMock.mockReset()
     gitPullMock.mockReset()
+    gitFastForwardMock.mockReset()
     gitRebaseFromBaseMock.mockReset()
     gitFetchMock.mockReset()
 
@@ -1361,6 +1363,7 @@ describe('createEditorSlice remote branch actions', () => {
         upstreamStatus: gitUpstreamStatusMock,
         push: gitPushMock,
         pull: gitPullMock,
+        fastForward: gitFastForwardMock,
         rebaseFromBase: gitRebaseFromBaseMock,
         fetch: gitFetchMock
       }
@@ -1466,6 +1469,41 @@ describe('createEditorSlice remote branch actions', () => {
       pushTarget
     })
     expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('runs fast-forward and refreshes upstream on success', async () => {
+    const store = createEditorStore()
+    const pushTarget = { remoteName: 'fork', branchName: 'feature' }
+
+    await store.getState().fastForwardBranch('wt-1', '/repo', undefined, pushTarget)
+
+    expect(gitFastForwardMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined,
+      pushTarget
+    })
+    expect(gitUpstreamStatusMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      connectionId: undefined,
+      pushTarget
+    })
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(store.getState().isRemoteOperationActive).toBe(false)
+  })
+
+  it('surfaces a fast-forward toast and clears the busy flag when fast-forward fails', async () => {
+    const store = createEditorStore()
+    gitFastForwardMock.mockRejectedValueOnce(new Error('Not possible to fast-forward, aborting.'))
+
+    await expect(store.getState().fastForwardBranch('wt-1', '/repo')).rejects.toThrow(
+      'Not possible to fast-forward'
+    )
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Fast-forward failed. Not possible to fast-forward, aborting.'
+    )
+    expect(gitUpstreamStatusMock).not.toHaveBeenCalled()
+    expect(store.getState().isRemoteOperationActive).toBe(false)
   })
 
   it('fetches the explicit push target and refreshes that target status', async () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -932,6 +932,26 @@ export function resolveRemoteOperationErrorMessage(
     return 'Pull blocked — commit or stash your local changes first.'
   }
 
+  if (/Pull would overwrite local changes/i.test(error.message)) {
+    if (options?.isRebase) {
+      return 'Rebase blocked — commit or stash your local changes first.'
+    }
+    if (options?.isFastForward) {
+      return 'Fast-forward blocked — commit or stash your local changes first.'
+    }
+    return 'Pull blocked — commit or stash your local changes first.'
+  }
+
+  if (/Pull would overwrite untracked files/i.test(error.message)) {
+    if (options?.isRebase) {
+      return 'Rebase blocked — move, remove, or add untracked files first.'
+    }
+    if (options?.isFastForward) {
+      return 'Fast-forward blocked — move, remove, or add untracked files first.'
+    }
+    return 'Pull blocked — move, remove, or add untracked files first.'
+  }
+
   if (options?.publish) {
     // Why: publish failures often bubble up as raw wrapped git/IPC payloads; this
     // keeps the toast human-readable while preserving the actionable fatal reason.

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -33,6 +33,7 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import type { RemoteOpKind } from '@/components/right-sidebar/source-control-primary-action'
 import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
 import {
+  fastForwardRuntimeGit,
   fetchRuntimeGit,
   getRuntimeGitUpstreamStatus,
   pullRuntimeGit,
@@ -430,6 +431,12 @@ export type EditorSlice = {
     options?: { forceWithLease?: boolean }
   ) => Promise<void>
   pullBranch: (
+    worktreeId: string,
+    worktreePath: string,
+    connectionId?: string,
+    pushTarget?: GitPushTarget
+  ) => Promise<void>
+  fastForwardBranch: (
     worktreeId: string,
     worktreePath: string,
     connectionId?: string,
@@ -864,6 +871,7 @@ export function resolveRemoteOperationErrorMessage(
     isPush?: boolean
     isSync?: boolean
     isFetch?: boolean
+    isFastForward?: boolean
     isRebase?: boolean
   }
 ): string {
@@ -918,6 +926,9 @@ export function resolveRemoteOperationErrorMessage(
     if (options?.isRebase) {
       return 'Rebase blocked — commit or stash your local changes first.'
     }
+    if (options?.isFastForward) {
+      return 'Fast-forward blocked — commit or stash your local changes first.'
+    }
     return 'Pull blocked — commit or stash your local changes first.'
   }
 
@@ -958,6 +969,13 @@ export function resolveRemoteOperationErrorMessage(
       extractPublishFailureDetail(error.message) ??
       truncateDetail(stripCredentialsFromMessage(error.message))
     return `Fetch failed. ${detail}`
+  }
+
+  if (options?.isFastForward) {
+    const detail =
+      extractPublishFailureDetail(error.message) ??
+      truncateDetail(stripCredentialsFromMessage(error.message))
+    return `Fast-forward failed. ${detail}`
   }
 
   if (options?.isRebase) {
@@ -2804,6 +2822,25 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       )
     } catch (error) {
       toast.error(resolveRemoteOperationErrorMessage(error))
+      throw error
+    } finally {
+      get().endRemoteOperation()
+    }
+    void get().fetchUpstreamStatus(worktreeId, worktreePath, connectionId, pushTarget)
+    const refreshGitHubForWorktree = get().refreshGitHubForWorktree
+    if (typeof refreshGitHubForWorktree === 'function') {
+      refreshGitHubForWorktree(worktreeId)
+    }
+  },
+  fastForwardBranch: async (worktreeId, worktreePath, connectionId, pushTarget) => {
+    get().beginRemoteOperation('fast_forward')
+    try {
+      await fastForwardRuntimeGit(
+        { settings: get().settings, worktreeId, worktreePath, connectionId },
+        pushTarget
+      )
+    } catch (error) {
+      toast.error(resolveRemoteOperationErrorMessage(error, { isFastForward: true }))
       throw error
     } finally {
       get().endRemoteOperation()

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1111,6 +1111,10 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       await callRuntimeResult('git.pull', { worktree: worktree.id, pushTarget })
     },
+    fastForward: async ({ worktreePath, pushTarget }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      await callRuntimeResult('git.fastForward', { worktree: worktree.id, pushTarget })
+    },
     rebaseFromBase: async ({ worktreePath, baseRef }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       await callRuntimeResult('git.rebaseFromBase', { worktree: worktree.id, baseRef })


### PR DESCRIPTION
## Summary

Adds a focused, provider-neutral Source Control fast-forward action for issue #3001.

- Adds `Fast-forward` to the Source Control split-button dropdown when a branch is behind with no local commits.
- Routes the action through local git, SSH relay/provider, runtime RPC, preload, web preload, and renderer runtime clients.
- Keeps existing Pull behavior unchanged and uses `git pull --ff-only` for the new action.

## Evidence

- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/remote.test.ts src/relay/git-handler.test.ts src/main/providers/ssh-git-provider.test.ts src/main/ipc/filesystem.test.ts src/renderer/src/runtime/runtime-git-client.test.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts` -> 7 files / 302 tests passed
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts` -> 97 tests passed after the final copy tweak
- `pnpm run typecheck:node` -> passed
- `pnpm run typecheck:web` -> passed
- Focused `pnpm exec oxlint ...` -> passed
- `git diff --check` -> passed
- `git merge-tree --write-tree HEAD origin/main` after `git fetch origin main` -> clean (`d61df5e2462362515f8ac230e1784d188e325168`)

## Electron Evidence

Blocked. `pnpm run ensure:electron-runtime` failed because the local disk is critically full while installing the Electron package binary:

```
[electron-package] Failed to install Electron package binary.
[Error: ENOSPC: no space left on device, write]
```

No Electron screenshot/video was captured for that reason.

## Notes

This intentionally does not implement the full issue list. It takes the narrow first slice: generic Git fast-forward, without GitHub-only behavior.
