### PR TITLE
Record workspace board opens in handlers

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Kanban, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -11,22 +11,49 @@ const SidebarHeader = React.memo(function SidebarHeader() {
   const newWorktreeShortcutLabel = useShortcutLabel('workspace.create')
   const [workspaceBoardOpen, setWorkspaceBoardOpen] = useState(false)
   const [workspaceBoardMenuOpen, setWorkspaceBoardMenuOpen] = useState(false)
+  const workspaceBoardOpenRef = useRef(workspaceBoardOpen)
   const openModal = useAppStore((s) => s.openModal)
   const repos = useAppStore((s) => s.repos)
   const groupBy = useAppStore((s) => s.groupBy)
   const canCreateWorkspace = repos.length > 0
   const sidebarTitle = groupBy === 'repo' ? 'Projects' : 'Workspaces'
+  workspaceBoardOpenRef.current = workspaceBoardOpen
 
-  const handleWorkspaceBoardOpenChange = useCallback((open: boolean) => {
-    setWorkspaceBoardOpen(open)
-    if (!open) {
-      setWorkspaceBoardMenuOpen(false)
+  const openWorkspaceBoard = useCallback(() => {
+    if (workspaceBoardOpenRef.current) {
+      return
     }
+    workspaceBoardOpenRef.current = true
+    // Why: opening the board is the user action; recording here avoids a
+    // post-render bookkeeping Effect in the drawer.
+    useAppStore.getState().recordFeatureInteraction('workspace-board')
+    setWorkspaceBoardOpen(true)
   }, [])
+
+  const closeWorkspaceBoard = useCallback(() => {
+    workspaceBoardOpenRef.current = false
+    setWorkspaceBoardOpen(false)
+    setWorkspaceBoardMenuOpen(false)
+  }, [])
+
+  const handleWorkspaceBoardOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        openWorkspaceBoard()
+        return
+      }
+      closeWorkspaceBoard()
+    },
+    [closeWorkspaceBoard, openWorkspaceBoard]
+  )
 
   const handleWorkspaceBoardToggle = useCallback(() => {
-    setWorkspaceBoardOpen((open) => !open)
-  }, [])
+    if (workspaceBoardOpen) {
+      closeWorkspaceBoard()
+      return
+    }
+    openWorkspaceBoard()
+  }, [closeWorkspaceBoard, openWorkspaceBoard, workspaceBoardOpen])
 
   useEffect(() => {
     if (!workspaceBoardOpen) {
@@ -54,14 +81,14 @@ const SidebarHeader = React.memo(function SidebarHeader() {
         return
       }
       event.preventDefault()
-      setWorkspaceBoardOpen(false)
+      closeWorkspaceBoard()
     }
 
     // Why: the workspace board is a non-modal companion panel, so focus may
     // be outside the sheet when Escape should still dismiss it.
     document.addEventListener('keydown', handleKeyDown, true)
     return () => document.removeEventListener('keydown', handleKeyDown, true)
-  }, [workspaceBoardMenuOpen, workspaceBoardOpen])
+  }, [closeWorkspaceBoard, workspaceBoardMenuOpen, workspaceBoardOpen])
 
   return (
     <>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -430,12 +430,6 @@ export default function WorkspaceKanbanDrawer({
   useWorkspaceKanbanOutsideDismiss({ open, boardRef, preserveOpenForMenu, onOpenChange })
 
   useEffect(() => {
-    if (open) {
-      useAppStore.getState().recordFeatureInteraction('workspace-board')
-    }
-  }, [open])
-
-  useEffect(() => {
     if (!open || selectedWorktreeIds.size === 0) {
       return
     }


### PR DESCRIPTION
## Summary
- moves workspace board feature-interaction recording from the drawer open Effect into the open handlers
- guards duplicate open requests with a ref so one visible open records once
- keeps the Escape/outside-close behavior clearing board menu state

## Risk
Medium - changes persisted feature interaction bookkeeping and workspace board open/close handler plumbing. No SSH, terminal, browser, source-control provider, or transport behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/sidebar/SidebarHeader.tsx src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx`
- `pnpm exec oxlint src/renderer/src/components/sidebar/SidebarHeader.tsx src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx`
- `pnpm run typecheck:web`
- `git diff --check`
- AST hook counter: `origin/main 911`, `working 910`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.