### PR TITLE
Use external store for activity terminal portals

### DIFF
--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 
 export type ActivityTerminalPortalTarget = {
   slotId: string
@@ -15,7 +15,8 @@ export type ActivityTerminalPortalTarget = {
 }
 
 let currentTargets: ActivityTerminalPortalTarget[] = []
-const subscribers = new Set<(targets: ActivityTerminalPortalTarget[]) => void>()
+const emptyTargets: ActivityTerminalPortalTarget[] = []
+const subscribers = new Set<() => void>()
 
 // Why: the portal target is published with its {worktreeId, tabId} already
 // attached so consumers don't have to derive routing from the global
@@ -30,29 +31,29 @@ export function setActivityTerminalPortals(targets: ActivityTerminalPortalTarget
   }
   currentTargets = targets
   for (const subscriber of subscribers) {
-    subscriber(targets)
+    subscriber()
+  }
+}
+
+function subscribeActivityTerminalPortals(onStoreChange: () => void): () => void {
+  subscribers.add(onStoreChange)
+  return () => {
+    subscribers.delete(onStoreChange)
   }
 }
 
 export function useActivityTerminalPortals(enabled: boolean): ActivityTerminalPortalTarget[] {
-  const [targets, setTargets] = useState<ActivityTerminalPortalTarget[]>(
-    enabled ? currentTargets : []
+  // Why: portal targets live in module state so Terminal can consume them
+  // without routing through the app store; subscribe as an external store.
+  const subscribe = useCallback(
+    (onStoreChange: () => void): (() => void) =>
+      enabled ? subscribeActivityTerminalPortals(onStoreChange) : () => {},
+    [enabled]
   )
 
-  useLayoutEffect(() => {
-    if (!enabled) {
-      setTargets([])
-      return
-    }
-    setTargets(currentTargets)
-    const subscriber = (next: ActivityTerminalPortalTarget[]): void => setTargets(next)
-    subscribers.add(subscriber)
-    return () => {
-      subscribers.delete(subscriber)
-    }
-  }, [enabled])
+  const getSnapshot = useCallback(() => (enabled ? currentTargets : emptyTargets), [enabled])
 
-  return targets
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 }
 
 export function findActivityTerminalPortal(


### PR DESCRIPTION
## Summary
- replaces the activity terminal portal layout Effect/state mirror with `useSyncExternalStore`
- keeps the module-level portal target list as the single external source of truth
- returns a stable empty snapshot while activity terminal portals are disabled

## Risk
High - this changes terminal/activity portal subscription plumbing used to isolate TerminalPane content into Activity. No IPC protocol, provider, SSH, or PTY transport behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/activity/activity-terminal-portal.ts`
- `pnpm exec oxlint src/renderer/src/components/activity/activity-terminal-portal.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/activity/ActivityPrototypePage.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST hook counter: `origin/main 911`, `working 910`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.