### PR TITLE
docs: update final memory leak comb after rebase

### DIFF
--- a/docs/reference/memory-leak-audit-final-comb.md
+++ b/docs/reference/memory-leak-audit-final-comb.md
@@ -2,7 +2,7 @@
 
 Started: 2026-05-29 PDT
 
-Final tracker branch: `nwparker/mem-leak-final-comb-tracker`, based on `origin/main` at `869661cbba` after the final-comb fix PRs merged.
+Current tracker branch: `nwparker/mem-leak-final-comb-current`, based on `origin/main` at `a99c376f3b` after rebasing over later mainline changes.
 
 Objective: run one more complete pass across the current Orca tree for missed listener, timer, observer, worker, socket, watcher, subscription, abort, and disposable leaks; open scoped PRs for confirmed stranglers; include risk level and merge low-risk PRs.
 
@@ -12,9 +12,9 @@ Tracked code files, from `git ls-files`:
 
 | Bucket            | Files | Status  |
 | ----------------- | ----: | ------- |
-| `src/renderer`    |  1584 | Checked |
-| `src/main`        |   856 | Checked |
-| `src/shared`      |   245 | Checked |
+| `src/renderer`    |  1592 | Checked |
+| `src/main`        |   867 | Checked |
+| `src/shared`      |   246 | Checked |
 | `mobile/src`      |   100 | Checked |
 | `tests/e2e`       |    72 | Checked |
 | `src/relay`       |    65 | Checked |
@@ -24,7 +24,7 @@ Tracked code files, from `git ls-files`:
 | `other-code`      |     5 | Checked |
 | `src/preload`     |     6 | Checked |
 | `mobile/packages` |     5 | Checked |
-| Total             |  3052 | Checked |
+| Total             |  3072 | Checked |
 
 ## Scan Log
 
@@ -40,6 +40,17 @@ Tracked code files, from `git ls-files`:
   - Abort controllers without `abort`: 1 test-only controller passed through the abortable API under test.
   - Watchers without close/unwatch: no production misses; remaining heuristic hits are provider type/comment references.
 - 2026-05-29: Re-ran React effect scan and spot-checked candidates. Remaining hits had cleanup returns (`clearTimeout`, `clearInterval`, `removeEventListener`, IPC unsubscribe) or were short one-shot UI focus/open delays.
+- 2026-05-29: Rebased the final comb over current `origin/main` at `a99c376f3b` after additional mainline merges.
+- 2026-05-29: Counted 3345 broad risk-pattern hits across `src`, `mobile`, `tests`, `config`, and `native` on the current tree.
+- 2026-05-29: Re-ran heuristic buckets on the current tree:
+  - `addEventListener` without same-file `removeEventListener`: 37 remaining, same reviewed categories as the previous final-comb pass.
+  - `setInterval` without `clearInterval`: 1 remaining, a test comment string.
+  - `setTimeout` without same-file `clearTimeout`: 235 remaining. New changed-file production hits were intentional app relaunch/restart delays before process exit and a zero-delay floating-terminal focus handoff. Other changed timer candidates had explicit cleanup.
+  - Observers without `disconnect`: 0.
+  - Workers without `terminate`: 0.
+  - Abort controllers without `abort`: 1 test-only controller passed through the abortable API under test.
+  - Watchers without close/unwatch: no production misses; remaining heuristic hits are provider type/comment references.
+- 2026-05-29: Focus-reviewed code changed since the previous tracker merge (`ca15aeb466..a99c376f3b`), including WSL runtime/account selection, daemon PTY checkpointing, main-window/rate-limit listeners, preload IPC subscriptions, feature-tip/settings/status-bar UI, feature-wall animation effects, FileExplorer reset effects, and renderer IPC subscriptions. No new confirmed leak needed a code PR.
 
 ## Findings
 
@@ -51,6 +62,8 @@ Tracked code files, from `git ls-files`:
 
 No higher-risk findings remained after the final pass, so no second higher-risk mitigation pass was needed.
 
+Current rebase verification found no additional confirmed findings beyond the already merged low-risk PRs above.
+
 ## Validation
 
 - `pnpm vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts`
@@ -59,3 +72,8 @@ No higher-risk findings remained after the final pass, so no second higher-risk 
 - `pnpm vitest run --config config/vitest.config.ts src/main/ipc/developer-permissions.test.ts`
 - `pnpm exec oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts src/main/computer/permissions.ts src/main/computer/permissions.test.ts src/main/ipc/developer-permissions.ts src/main/ipc/developer-permissions.test.ts`
 - `pnpm run typecheck:node`
+- Current rebase pass:
+  - `git ls-files 'src/**/*.ts' 'src/**/*.tsx' 'mobile/**/*.ts' 'mobile/**/*.tsx' 'tests/**/*.ts' 'tests/**/*.tsx' 'config/**/*.js' 'config/**/*.mjs' 'native/**/*.ts'`
+  - broad `rg` risk-pattern count across `src`, `mobile`, `tests`, `config`, and `native`
+  - heuristic scans for unmatched listeners, intervals, timers, observers, workers, abort controllers, watchers, React effects, changed-file subscriptions, and changed-file timers
+  - manual changed-file review from `ca15aeb466` to `a99c376f3b`


### PR DESCRIPTION
## Summary
- update the final memory-leak comb tracker after rebasing over current origin/main
- record the current inventory, broad risk-pattern count, heuristic buckets, and changed-file review through a99c376f3b
- note that no new confirmed leak finding was found beyond already merged LOW-risk PRs #3305, #3306, and #3307

## Risk Level
LOW - docs-only audit record. No runtime behavior changes.

## Validation
- current tree inventory across src, mobile, tests, config, native
- broad rg risk-pattern count across src, mobile, tests, config, native
- heuristic scans for unmatched listeners, timers, observers, workers, abort controllers, watchers, React effects, changed-file subscriptions, and changed-file timers
- manual changed-file review from ca15aeb466 to a99c376f3b
- git diff --check