### PR TITLE
Fix sidebar scroll lock during workspace delete

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -5,7 +5,8 @@ import {
   shouldUseNativeContextMenu,
   shouldIgnoreNestedWorktreeContextMenuScope,
   shouldRemoveFolderProjectFromContextMenu,
-  shouldSuppressContextMenuFollowUpClick
+  shouldSuppressContextMenuFollowUpClick,
+  shouldContinueDeleteSiblingPositionRestore
 } from './WorktreeContextMenu'
 
 describe('shouldUseNativeContextMenu', () => {
@@ -91,6 +92,17 @@ describe('shouldSuppressContextMenuFollowUpClick', () => {
 
   it('does not suppress clicks that predate the context menu timestamp', () => {
     expect(shouldSuppressContextMenuFollowUpClick(1_000, 999)).toBe(false)
+  })
+})
+
+describe('shouldContinueDeleteSiblingPositionRestore', () => {
+  it('stops once the delete row position has settled even when the row remains mounted', () => {
+    expect(
+      shouldContinueDeleteSiblingPositionRestore({
+        attempts: 6,
+        stableFrames: 6
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -57,6 +57,8 @@ const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 const WORKTREE_CONTEXT_MENU_SCOPE_ATTR = 'data-worktree-context-menu-scope'
 const WORKTREE_NATIVE_CONTEXT_MENU_ATTR = 'data-worktree-native-context-menu'
 const CONTEXT_MENU_CLICK_SUPPRESSION_MS = 500
+const DELETE_POSITION_RESTORE_MAX_FRAMES = 180
+const DELETE_POSITION_RESTORE_STABLE_FRAMES = 6
 
 function shouldUseNativeContextMenu(target: EventTarget | null): boolean {
   const maybeElement = target as {
@@ -127,6 +129,18 @@ function findSidebarVirtualRowByKey(sidebar: Element, rowKey: string): HTMLEleme
   )
 }
 
+export function shouldContinueDeleteSiblingPositionRestore(args: {
+  attempts: number
+  stableFrames: number
+}): boolean {
+  // Why: slow deletes leave the target row mounted; after initial focus/remount
+  // settling, the restore loop must stop so user scrolling wins.
+  return (
+    args.attempts < DELETE_POSITION_RESTORE_MAX_FRAMES &&
+    args.stableFrames < DELETE_POSITION_RESTORE_STABLE_FRAMES
+  )
+}
+
 function preserveDeleteSiblingPosition(scope: HTMLElement | null): () => void {
   const sidebar = scope?.closest('[data-worktree-sidebar]')
   const row = scope?.closest('[data-worktree-virtual-row]')
@@ -173,7 +187,12 @@ function preserveDeleteSiblingPosition(scope: HTMLElement | null): () => void {
         stableFrames = 0
       }
       attempts += 1
-      if (attempts < 180 && (currentTarget || stableFrames < 6)) {
+      if (
+        shouldContinueDeleteSiblingPositionRestore({
+          attempts,
+          stableFrames
+        })
+      ) {
         window.requestAnimationFrame(restore)
       }
     }


### PR DESCRIPTION
## Summary
- Stop the sidebar delete-position restore loop after the row position settles, even if the slow delete keeps the target row mounted.
- Keep the initial focus/remount stabilization behavior while letting user wheel/trackpad scrolling win during deletion.
- Add regression coverage for the still-mounted deleting row case.

## Verification
- Confirmed the new regression failed before the fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeContextMenu.tsx src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts`

## Note
- `pnpm run lint` currently fails on an unrelated pre-existing `max-lines` violation in `src/shared/telemetry-events.test.ts`.