### PR TITLE
Fix mobile terminal tap mouse reports

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -327,6 +327,10 @@ function isWheelMouseTrackingMode(mode: TerminalModes['mouseTrackingMode'] | und
   return mode === 'vt200' || mode === 'drag' || mode === 'any'
 }
 
+function isGestureMouseTrackingMode(mode: TerminalModes['mouseTrackingMode'] | undefined): boolean {
+  return mode === 'x10' || isWheelMouseTrackingMode(mode)
+}
+
 function TerminalPaneView({
   handle,
   active,
@@ -2401,9 +2405,9 @@ export default function SessionScreen() {
       if (handle !== activeHandleRef.current || activeSessionTabTypeRef.current !== 'terminal')
         return
       const modes = ptyModesRef.current.get(handle)
-      // Why: WebView messages can become PTY input here. Only TUI scroll paths
-      // generate gesture input, and the bridge is rate-limited for SSH safety.
-      if (!modes?.altScreen && !isWheelMouseTrackingMode(modes?.mouseTrackingMode)) return
+      // Why: WebView messages can become PTY input here. Only TUI gesture paths
+      // generate these bounded reports, and the bridge is rate-limited for SSH safety.
+      if (!modes?.altScreen && !isGestureMouseTrackingMode(modes?.mouseTrackingMode)) return
       const sequenceCount = countTerminalGestureInputSequences(bytes)
       if (sequenceCount == null) return
       if (!allowTerminalGestureInput(handle, sequenceCount)) return

--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -1090,6 +1090,36 @@ const XTERM_HTML = `<!DOCTYPE html>
     return ESC + '[M' + String.fromCharCode(button) + String.fromCharCode(col) + String.fromCharCode(row);
   }
 
+  function isClickMouseTrackingMode(mouseTrackingMode) {
+    return mouseTrackingMode !== 'none';
+  }
+
+  function buildMouseClickInput(clientX, clientY) {
+    var mouseTrackingMode = getMouseTrackingMode();
+    if (!isClickMouseTrackingMode(mouseTrackingMode)) return '';
+    var cell = viewportToMouseReportCell(clientX, clientY);
+    if (!cell) return '';
+    if (sgrMousePixelsMode) {
+      return ESC + '[<0;' + cell.x + ';' + cell.y + 'M' + ESC + '[<0;' + cell.x + ';' + cell.y + 'm';
+    }
+    if (sgrMouseMode) {
+      // Why: xterm increments zero-based mouse cells before encoding reports.
+      var sgrCol = cell.col + 1;
+      var sgrRow = cell.row + 1;
+      return ESC + '[<0;' + sgrCol + ';' + sgrRow + 'M' + ESC + '[<0;' + sgrCol + ';' + sgrRow + 'm';
+    }
+    // Why: default mouse reports use ASCII-offset cell coordinates and code 3
+    // for release; wide coordinates cannot survive the mobile string bridge.
+    var pressButton = 32;
+    var releaseButton = 35;
+    var col = cell.col + 1 + 32;
+    var row = cell.row + 1 + 32;
+    if (pressButton > 126 || releaseButton > 126 || col > 126 || row > 126) return '';
+    var press = ESC + '[M' + String.fromCharCode(pressButton) + String.fromCharCode(col) + String.fromCharCode(row);
+    if (mouseTrackingMode === 'x10') return press;
+    return press + ESC + '[M' + String.fromCharCode(releaseButton) + String.fromCharCode(col) + String.fromCharCode(row);
+  }
+
   function isWheelMouseTrackingMode(mode) {
     return mode !== 'none' && mode !== 'x10';
   }
@@ -1540,7 +1570,12 @@ const XTERM_HTML = `<!DOCTYPE html>
     }
     if (dispatch.mode === 'surface') {
       if (e.touches.length === 0 && longPressOrigin && selMode !== 'select') {
-        notify({ type: 'terminal-tap' });
+        var clickInput = buildMouseClickInput(longPressOrigin.x, longPressOrigin.y);
+        if (clickInput) {
+          notify({ type: 'terminal-input', bytes: clickInput });
+        } else {
+          notify({ type: 'terminal-tap' });
+        }
       }
       clearLongPress();
       if (e.touches.length === 0) {

--- a/mobile/src/terminal/terminal-gesture-input.test.ts
+++ b/mobile/src/terminal/terminal-gesture-input.test.ts
@@ -19,10 +19,23 @@ describe('isTerminalGestureInput', () => {
     expect(isTerminalGestureInput(`${ESC}[<64;0;0M`)).toBe(true)
   })
 
+  it('accepts SGR left-click press and release sequences', () => {
+    expect(isTerminalGestureInput(`${ESC}[<0;38;20M${ESC}[<0;38;20m`)).toBe(true)
+    expect(countTerminalGestureInputSequences(`${ESC}[<0;38;20M${ESC}[<0;38;20m`)).toBe(2)
+  })
+
   it('accepts repeated default mouse wheel sequences', () => {
     expect(
       isTerminalGestureInput(
         `${ESC}[M${String.fromCharCode(96, 97, 33)}${ESC}[M${String.fromCharCode(97, 126, 126)}`
+      )
+    ).toBe(true)
+  })
+
+  it('accepts default left-click press and release sequences', () => {
+    expect(
+      isTerminalGestureInput(
+        `${ESC}[M${String.fromCharCode(32, 70, 52)}${ESC}[M${String.fromCharCode(35, 70, 52)}`
       )
     ).toBe(true)
   })

--- a/mobile/src/terminal/terminal-gesture-input.ts
+++ b/mobile/src/terminal/terminal-gesture-input.ts
@@ -1,31 +1,47 @@
 const ESC = '\x1b'
 const MAX_TERMINAL_GESTURE_INPUT_LENGTH = 2048
 const MAX_TERMINAL_GESTURE_INPUT_SEQUENCES = 32
-const SGR_MOUSE_WHEEL_SEQUENCE_RE = new RegExp(`^${ESC}\\[<(64|65);[0-9]{1,4};[0-9]{1,4}M$`)
+const SGR_MOUSE_GESTURE_SEQUENCE_RE = new RegExp(
+  `^${ESC}\\[<(0|64|65);[0-9]{1,4};[0-9]{1,4}([Mm])$`
+)
 
-function isDefaultMouseWheelSequence(bytes: string, offset: number): number | null {
+function isDefaultMouseGestureSequence(bytes: string, offset: number): number | null {
   if (!bytes.startsWith(`${ESC}[M`, offset) || offset + 6 > bytes.length) {
     return null
   }
   const button = bytes.charCodeAt(offset + 3)
   const col = bytes.charCodeAt(offset + 4)
   const row = bytes.charCodeAt(offset + 5)
-  if ((button === 96 || button === 97) && col >= 33 && col <= 126 && row >= 33 && row <= 126) {
+  if (
+    (button === 32 || button === 35 || button === 96 || button === 97) &&
+    col >= 33 &&
+    col <= 126 &&
+    row >= 33 &&
+    row <= 126
+  ) {
     return offset + 6
   }
   return null
 }
 
-function isSgrMouseWheelSequence(bytes: string, offset: number): number | null {
+function isSgrMouseGestureSequence(bytes: string, offset: number): number | null {
   if (!bytes.startsWith(`${ESC}[<`, offset)) {
     return null
   }
-  const end = bytes.indexOf('M', offset)
+  const pressEnd = bytes.indexOf('M', offset)
+  const releaseEnd = bytes.indexOf('m', offset)
+  const end =
+    pressEnd === -1 ? releaseEnd : releaseEnd === -1 ? pressEnd : Math.min(pressEnd, releaseEnd)
   if (end === -1) {
     return null
   }
   const sequence = bytes.slice(offset, end + 1)
-  return SGR_MOUSE_WHEEL_SEQUENCE_RE.test(sequence) ? end + 1 : null
+  const match = SGR_MOUSE_GESTURE_SEQUENCE_RE.exec(sequence)
+  if (!match) return null
+  const button = match[1]
+  const final = match[2]
+  if ((button === '64' || button === '65') && final !== 'M') return null
+  return end + 1
 }
 
 function isArrowScrollSequence(bytes: string, offset: number): number | null {
@@ -51,8 +67,8 @@ export function countTerminalGestureInputSequences(bytes: string): number | null
   while (offset < bytes.length) {
     const next =
       isArrowScrollSequence(bytes, offset) ??
-      isSgrMouseWheelSequence(bytes, offset) ??
-      isDefaultMouseWheelSequence(bytes, offset)
+      isSgrMouseGestureSequence(bytes, offset) ??
+      isDefaultMouseGestureSequence(bytes, offset)
 
     if (next == null) {
       return null

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -33,6 +33,20 @@ describe('TerminalWebView scroll routing', () => {
     expect(momentumBlock).toContain('routeScrollLines(lines, ts.lastX, ts.lastY);')
   })
 
+  it('routes taps as terminal mouse clicks before focusing live input', () => {
+    expect(source).toContain('function buildMouseClickInput(clientX, clientY)')
+    expect(source).toContain("return mouseTrackingMode !== 'none';")
+
+    const touchEndBlock = sliceBetween(
+      "document.addEventListener('touchend'",
+      '}, { capture: true, passive: true });'
+    )
+    expect(touchEndBlock.indexOf('var clickInput = buildMouseClickInput')).toBeLessThan(
+      touchEndBlock.indexOf("notify({ type: 'terminal-tap' });")
+    )
+    expect(touchEndBlock).toContain("notify({ type: 'terminal-input', bytes: clickInput });")
+  })
+
   it('does not rubber-band normal scroll at scrollback edges', () => {
     expect(source).toContain('function canScrollNormalBufferDelta(deltaY)')
     const smoothScrollBlock = sliceBetween(


### PR DESCRIPTION
## Summary
- synthesize left-button terminal mouse press/release reports from mobile taps when terminal mouse tracking is active
- allow only bounded SGR/default left-click reports through the existing mobile terminal gesture-input validator
- keep ordinary non-mouse terminal taps focused on live input

Fixes #3371

## Reproduction and Evidence
- Reproduced the current bridge rejection before the fix with a direct `tsx` probe: reporter sequence `\x1b[<0;38;20M\x1b[<0;38;20m` returned `accepted:false,count:null`.
- After the fix, the same direct probe returned `sgrAccepted:true,sgrCount:2`; default left-click reports are accepted and invalid wheel-release reports remain rejected.
- Static WebView route check returned `hasMouseClickBuilder:true,clickBeforeTap:true,terminalInputClick:true`.
- `pnpm exec oxlint mobile/src/terminal/TerminalWebView.tsx mobile/src/terminal/terminal-gesture-input.ts mobile/src/terminal/terminal-gesture-input.test.ts mobile/src/terminal/terminal-webview-scroll-routing.test.ts mobile/app/h/[hostId]/session/[worktreeId].tsx`: 0 warnings, 0 errors.
- `git diff --check HEAD~1..HEAD`: passed.
- Focused Vitest command was attempted but blocked before tests ran because local `mobile/node_modules/expo` is missing and Vite cannot resolve `expo/tsconfig.base` from `mobile/tsconfig.json`.