### PR TITLE
Clear settings search when opening settings

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -329,15 +329,6 @@ function Settings(): React.JSX.Element {
     return () => document.removeEventListener('keydown', handleFindShortcut)
   }, [keybindings])
 
-  useEffect(
-    () => () => {
-      // Why: the settings search is a transient in-page filter. Leaving it behind makes the next
-      // visit look partially broken because whole sections stay hidden before the user types again.
-      setSettingsSearchQuery('')
-    },
-    [setSettingsSearchQuery]
-  )
-
   useEffect(() => {
     if (!settings || !settingsNavigationTarget) {
       return

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../shared/types'
 import { createUISlice } from './ui'
 import { createWorktreeNavHistorySlice } from './worktree-nav-history'
+import { createSettingsSearchState } from './settings-search-state'
 import type { AppState } from '../types'
 import type { FeatureInteractionState } from '../../../../shared/feature-interactions'
 
@@ -28,6 +29,7 @@ function createUIStore(): StoreApi<AppState> {
     worktreesByRepo: {},
     rightSidebarOpen: false,
     rightSidebarWidth: 280,
+    ...createSettingsSearchState(args[0]),
     ...createWorktreeNavHistorySlice(...(args as Parameters<typeof createWorktreeNavHistorySlice>)),
     ...createUISlice(...(args as Parameters<typeof createUISlice>))
   })) as unknown as StoreApi<AppState>
@@ -656,6 +658,17 @@ describe('createUISlice settings navigation', () => {
     store.getState().closeSettingsPage()
 
     expect(store.getState().activeView).toBe('tasks')
+  })
+
+  it('clears transient settings search when opening settings', () => {
+    const store = createUIStore()
+
+    store.setState({ settingsSearchInputQuery: 'terminal', settingsSearchQuery: 'terminal' })
+    store.getState().openSettingsPage()
+
+    expect(store.getState().activeView).toBe('settings')
+    expect(store.getState().settingsSearchInputQuery).toBe('')
+    expect(store.getState().settingsSearchQuery).toBe('')
   })
 })
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -888,7 +888,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     })),
   setNewWorkspaceDraft: (draft) => set({ newWorkspaceDraft: draft }),
   clearNewWorkspaceDraft: () => set({ newWorkspaceDraft: null }),
-  openSettingsPage: () =>
+  openSettingsPage: () => {
+    // Why: settings search is a transient page filter; opening Settings
+    // should never inherit hidden sections from the previous visit.
+    get().setSettingsSearchQuery('')
     set((state) => ({
       activeView: 'settings',
       // Why: Settings is a temporary detour from either terminal or the
@@ -897,7 +900,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       // dumping the user into terminal.
       previousViewBeforeSettings:
         state.activeView === 'settings' ? state.previousViewBeforeSettings : state.activeView
-    })),
+    }))
+  },
   closeSettingsPage: () =>
     set((state) => {
       const previousView =


### PR DESCRIPTION
## Summary
- remove Settings' cleanup-only Effect for clearing transient search state
- clear settings search from the store action that opens Settings instead
- add UI slice coverage so reopened Settings starts with no stale filter

## Risk
Medium. This touches Settings navigation/search state, but does not change persistence, IPC, SSH, or provider behavior.

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/settings/Settings.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/store/slices/ui.test.ts
- pnpm exec oxlint src/renderer/src/components/settings/Settings.tsx src/renderer/src/store/slices/ui.ts src/renderer/src/store/slices/ui.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/store/slices/settings-search-state.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- AST Effect count: origin/main 917, working 916

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.