### PR TITLE
fix(status-bar): hide footer usage bars for unconfigured providers

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -37,6 +37,7 @@ import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { ResourceUsageStatusSegment } from './ResourceUsageStatusSegment'
 import { PortsStatusSegment } from './PortsStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+import { isProviderConfigured } from './status-bar-provider-visibility'
 import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy'
 import { PetStatusSegment } from './PetStatusSegment'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
@@ -804,31 +805,27 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
 
   const { claude, codex, gemini, opencodeGo } = rateLimits
 
-  // Why: hiding `unavailable` providers makes the status bar appear to lose a
-  // provider at random after refreshes or wake/resume. Keeping the slot visible
-  // preserves layout stability and makes it obvious that the provider is still
-  // configured but currently unavailable. Detection-gating (see
-  // status-bar-agent-gating) hides the per-CLI bars when the agent isn't
-  // installed on PATH — this is what stops a fresh install from showing
-  // "Gemini Usage" when Gemini isn't installed.
+  // Why: a provider only earns a bar once it's configured (isProviderConfigured
+  // drops the `unavailable` state — Gemini OAuth off, OpenCode Go cookie unset,
+  // Claude on API-key billing). A configured provider that fails transiently
+  // (`error`) keeps its slot so the bar doesn't flap on refresh hiccups.
+  // Detection-gating (see status-bar-agent-gating) additionally hides per-CLI
+  // bars when the agent isn't installed on PATH.
   const showClaude =
-    !!claude &&
+    isProviderConfigured(claude) &&
     statusBarItems.includes('claude') &&
     isStatusBarItemAvailable('claude', detectedAgentIds)
   const showCodex =
-    !!codex &&
+    isProviderConfigured(codex) &&
     statusBarItems.includes('codex') &&
     isStatusBarItemAvailable('codex', detectedAgentIds)
-  // Why: hide only when the state hasn't loaded yet (null), not when unavailable.
-  // Gemini shows if credentials exist; OpenCode Go shows always so users can see
-  // the provider and know to configure the cookie in Settings.
   const showGemini =
-    gemini !== null &&
+    isProviderConfigured(gemini) &&
     statusBarItems.includes('gemini') &&
     isStatusBarItemAvailable('gemini', detectedAgentIds)
   // Why: OpenCode Go is a web/cookie-auth provider, not a CLI on PATH, so
   // detection-gating doesn't apply.
-  const showOpencodeGo = opencodeGo !== null && statusBarItems.includes('opencode-go')
+  const showOpencodeGo = isProviderConfigured(opencodeGo) && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitStatus
+} from '../../../../shared/rate-limit-types'
+import { isProviderConfigured } from './status-bar-provider-visibility'
+
+function provider(status: ProviderRateLimitStatus): ProviderRateLimits {
+  return {
+    provider: 'gemini',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status
+  }
+}
+
+describe('isProviderConfigured', () => {
+  it('hides a provider whose state has not loaded yet', () => {
+    expect(isProviderConfigured(null)).toBe(false)
+  })
+
+  it('hides an unconfigured (unavailable) provider', () => {
+    // The bug: Gemini OAuth off / OpenCode Go cookie unset returns a non-null
+    // `unavailable` object, which previously slipped past the `!== null` gate
+    // and rendered a "--" bar for a provider the user never configured.
+    expect(isProviderConfigured(provider('unavailable'))).toBe(false)
+  })
+
+  it('shows configured providers, including ones failing transiently', () => {
+    expect(isProviderConfigured(provider('ok'))).toBe(true)
+    expect(isProviderConfigured(provider('error'))).toBe(true)
+    expect(isProviderConfigured(provider('fetching'))).toBe(true)
+    expect(isProviderConfigured(provider('idle'))).toBe(true)
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -1,0 +1,13 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+
+// Why: a provider that returns `unavailable` is explicitly not configured
+// (Gemini OAuth off, OpenCode Go cookie unset, Claude on API-key billing). Its
+// fetch object is non-null, so a bare `!== null` check still renders a "--"
+// bar for a provider the user never set up. `error` is kept visible on purpose
+// — that's a *configured* provider failing transiently, and hiding it would
+// make the bar flap on every refresh hiccup.
+export function isProviderConfigured(
+  provider: ProviderRateLimits | null
+): provider is ProviderRateLimits {
+  return provider !== null && provider.status !== 'unavailable'
+}


### PR DESCRIPTION
## Summary

Before, the status bar footer showed greyed-out `--` usage bars for Gemini and OpenCode Go even when you'd never set them up — a user with only Claude Code and Codex configured still saw four providers cluttering the footer. Now the footer only shows a provider once it's actually configured.

## Change
The show-gates hid a provider only when its usage state was still `null`. But an unconfigured provider doesn't return `null` — it returns a non-null object with status `unavailable` (Gemini OAuth off, OpenCode Go cookie unset, Claude on API-key billing), which slipped straight through. A new `isProviderConfigured` type-guard treats `unavailable` as not-configured while keeping a *configured* provider that's failing transiently (`error`) visible, so a bar doesn't flap to hidden on a single refresh hiccup. Applying it uniformly also fixes the latent case where Claude on API-key billing rendered an empty bar.

## Evidence

I only have Claude Code and Codex setup.

### Before
<img width="600" alt="CleanShot 2026-05-29 at 17 07 45@2x" src="https://github.com/user-attachments/assets/1b72a306-c6bf-42a3-bab6-e21a576f8360" />


### After
<img width="650" alt="CleanShot 2026-05-29 at 17 08 24@2x" src="https://github.com/user-attachments/assets/bf9e6936-6b59-489b-ba0d-b05db9646a54" />


## Tests
Covered by a new unit test (`status-bar-provider-visibility.test.ts`) asserting `unavailable`/`null` hide while `ok`/`error`/`fetching` show; the prior gap was that the show-logic lived inline in the component with no test.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
