### PR TITLE
Clear SSH reset prompt during render

### DIFF
--- a/src/renderer/src/components/settings/SshTargetDestructiveActions.tsx
+++ b/src/renderer/src/components/settings/SshTargetDestructiveActions.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { SshConnectionState } from '../../../../shared/ssh-types'
 import { SshDestructiveActionDialog } from './SshDestructiveActionDialog'
-import { isSshTargetConnecting, type SshTargetBusyAction } from './ssh-target-action-state'
+import {
+  isSshTargetConnecting,
+  shouldClearPendingSshReset,
+  type SshTargetBusyAction
+} from './ssh-target-action-state'
 
 type PendingTargetAction = { id: string; label: string }
 
@@ -93,12 +97,17 @@ export function SshTargetDestructiveActions({
     pendingReset !== null && isSshTargetConnecting(pendingResetStatus)
   const pendingTerminateIsBusy =
     pendingTerminate !== null && targetActionsInFlight.get(pendingTerminate.id) === 'terminate'
-
-  useEffect(() => {
-    if (pendingResetBlockedByConnection && !pendingResetIsBusy) {
-      setPendingReset(null)
-    }
-  }, [pendingResetBlockedByConnection, pendingResetIsBusy])
+  const shouldClearReset = shouldClearPendingSshReset({
+    pendingTargetId: pendingReset?.id ?? null,
+    pendingResetIsBusy,
+    connectionStatus: pendingResetStatus
+  })
+  if (shouldClearReset) {
+    // Why: a reconnecting target cannot safely reset its relay; clear the
+    // pending dialog before it paints stale destructive UI.
+    setPendingReset(null)
+  }
+  const dialogPendingReset = shouldClearReset ? null : pendingReset
 
   const confirmResetRelay = async (): Promise<void> => {
     if (!pendingReset) {
@@ -160,10 +169,10 @@ export function SshTargetDestructiveActions({
       />
 
       <SshDestructiveActionDialog
-        open={!!pendingReset && (!pendingResetBlockedByConnection || pendingResetIsBusy)}
+        open={!!dialogPendingReset && (!pendingResetBlockedByConnection || pendingResetIsBusy)}
         title="Reset Remote Relay?"
         description="This force-stops the remote relay for this SSH target. Active remote terminals and port forwards for this target will end."
-        targetLabel={pendingReset?.label}
+        targetLabel={dialogPendingReset?.label}
         actionLabel="Reset Relay"
         busyLabel="Resetting"
         isBusy={pendingResetIsBusy}

--- a/src/renderer/src/components/settings/ssh-target-action-state.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-action-state.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { isSshTargetConnecting, shouldClearPendingSshReset } from './ssh-target-action-state'
+
+describe('ssh target action state', () => {
+  it('classifies connecting statuses as busy connection states', () => {
+    expect(isSshTargetConnecting('connecting')).toBe(true)
+    expect(isSshTargetConnecting('deploying-relay')).toBe(true)
+    expect(isSshTargetConnecting('reconnecting')).toBe(true)
+    expect(isSshTargetConnecting('connected')).toBe(false)
+    expect(isSshTargetConnecting('disconnected')).toBe(false)
+  })
+
+  it('clears pending reset only when a non-busy target starts connecting', () => {
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: 'target-1',
+        pendingResetIsBusy: false,
+        connectionStatus: 'reconnecting'
+      })
+    ).toBe(true)
+
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: 'target-1',
+        pendingResetIsBusy: true,
+        connectionStatus: 'reconnecting'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: null,
+        pendingResetIsBusy: false,
+        connectionStatus: 'reconnecting'
+      })
+    ).toBe(false)
+
+    expect(
+      shouldClearPendingSshReset({
+        pendingTargetId: 'target-1',
+        pendingResetIsBusy: false,
+        connectionStatus: 'connected'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/ssh-target-action-state.ts
+++ b/src/renderer/src/components/settings/ssh-target-action-state.ts
@@ -11,3 +11,15 @@ const SSH_TARGET_CONNECTING_STATUSES: ReadonlySet<SshConnectionStatus> = new Set
 export function isSshTargetConnecting(status: SshConnectionStatus): boolean {
   return SSH_TARGET_CONNECTING_STATUSES.has(status)
 }
+
+export function shouldClearPendingSshReset({
+  pendingTargetId,
+  pendingResetIsBusy,
+  connectionStatus
+}: {
+  pendingTargetId: string | null
+  pendingResetIsBusy: boolean
+  connectionStatus: SshConnectionStatus
+}): boolean {
+  return pendingTargetId !== null && !pendingResetIsBusy && isSshTargetConnecting(connectionStatus)
+}


### PR DESCRIPTION
## Summary
- replace the SSH reset prompt cleanup Effect with render-time pending-reset reconciliation
- keep the destructive reset dialog hidden as soon as a target enters a connecting/reconnecting state
- add focused tests for the SSH target action-state helper

## Risk
Medium. This is a small UI-state repair, but it touches SSH destructive action flow, so it should stay open for review rather than auto-merge.

## Verification
- `pnpm exec oxfmt --write src/renderer/src/components/settings/SshTargetDestructiveActions.tsx src/renderer/src/components/settings/ssh-target-action-state.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts`
- `pnpm exec oxlint src/renderer/src/components/settings/SshTargetDestructiveActions.tsx src/renderer/src/components/settings/ssh-target-action-state.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/hooks/useIpcEvents.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: `926 -> 925`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.