### PR TITLE
Take over PR #3384 provider usage bar visibility

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -37,6 +37,7 @@ import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { ResourceUsageStatusSegment } from './ResourceUsageStatusSegment'
 import { PortsStatusSegment } from './PortsStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+import { isProviderConfigured } from './status-bar-provider-visibility'
 import { shouldOpenStatusBarContextMenu } from './status-bar-context-menu-policy'
 import { PetStatusSegment } from './PetStatusSegment'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
@@ -804,31 +805,27 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
 
   const { claude, codex, gemini, opencodeGo } = rateLimits
 
-  // Why: hiding `unavailable` providers makes the status bar appear to lose a
-  // provider at random after refreshes or wake/resume. Keeping the slot visible
-  // preserves layout stability and makes it obvious that the provider is still
-  // configured but currently unavailable. Detection-gating (see
-  // status-bar-agent-gating) hides the per-CLI bars when the agent isn't
-  // installed on PATH — this is what stops a fresh install from showing
-  // "Gemini Usage" when Gemini isn't installed.
+  // Why: a provider only earns a bar once it's configured (isProviderConfigured
+  // drops the `unavailable` state — Gemini OAuth off, OpenCode Go cookie unset,
+  // Claude on API-key billing). A configured provider that fails transiently
+  // (`error`) keeps its slot so the bar doesn't flap on refresh hiccups.
+  // Detection-gating (see status-bar-agent-gating) additionally hides per-CLI
+  // bars when the agent isn't installed on PATH.
   const showClaude =
-    !!claude &&
+    isProviderConfigured(claude) &&
     statusBarItems.includes('claude') &&
     isStatusBarItemAvailable('claude', detectedAgentIds)
   const showCodex =
-    !!codex &&
+    isProviderConfigured(codex) &&
     statusBarItems.includes('codex') &&
     isStatusBarItemAvailable('codex', detectedAgentIds)
-  // Why: hide only when the state hasn't loaded yet (null), not when unavailable.
-  // Gemini shows if credentials exist; OpenCode Go shows always so users can see
-  // the provider and know to configure the cookie in Settings.
   const showGemini =
-    gemini !== null &&
+    isProviderConfigured(gemini) &&
     statusBarItems.includes('gemini') &&
     isStatusBarItemAvailable('gemini', detectedAgentIds)
   // Why: OpenCode Go is a web/cookie-auth provider, not a CLI on PATH, so
   // detection-gating doesn't apply.
-  const showOpencodeGo = opencodeGo !== null && statusBarItems.includes('opencode-go')
+  const showOpencodeGo = isProviderConfigured(opencodeGo) && statusBarItems.includes('opencode-go')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -5,14 +5,18 @@ import type {
 } from '../../../../shared/rate-limit-types'
 import { isProviderConfigured } from './status-bar-provider-visibility'
 
-function provider(status: ProviderRateLimitStatus): ProviderRateLimits {
+function provider(
+  status: ProviderRateLimitStatus,
+  overrides: Partial<ProviderRateLimits> = {}
+): ProviderRateLimits {
   return {
     provider: 'gemini',
     session: null,
     weekly: null,
     updatedAt: 0,
     error: null,
-    status
+    status,
+    ...overrides
   }
 }
 
@@ -28,10 +32,27 @@ describe('isProviderConfigured', () => {
     expect(isProviderConfigured(provider('unavailable'))).toBe(false)
   })
 
+  it('hides a first-load fetching provider until it has proven usage data', () => {
+    // The initial fetch marks every provider as `fetching`; without prior data
+    // that state is not proof the user configured Gemini or OpenCode Go.
+    expect(isProviderConfigured(provider('fetching'))).toBe(false)
+  })
+
   it('shows configured providers, including ones failing transiently', () => {
     expect(isProviderConfigured(provider('ok'))).toBe(true)
     expect(isProviderConfigured(provider('error'))).toBe(true)
-    expect(isProviderConfigured(provider('fetching'))).toBe(true)
+    expect(
+      isProviderConfigured(
+        provider('fetching', {
+          session: {
+            usedPercent: 25,
+            windowMinutes: 300,
+            resetsAt: null,
+            resetDescription: null
+          }
+        })
+      )
+    ).toBe(true)
     expect(isProviderConfigured(provider('idle'))).toBe(true)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitStatus
+} from '../../../../shared/rate-limit-types'
+import { isProviderConfigured } from './status-bar-provider-visibility'
+
+function provider(status: ProviderRateLimitStatus): ProviderRateLimits {
+  return {
+    provider: 'gemini',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status
+  }
+}
+
+describe('isProviderConfigured', () => {
+  it('hides a provider whose state has not loaded yet', () => {
+    expect(isProviderConfigured(null)).toBe(false)
+  })
+
+  it('hides an unconfigured (unavailable) provider', () => {
+    // The bug: Gemini OAuth off / OpenCode Go cookie unset returns a non-null
+    // `unavailable` object, which previously slipped past the `!== null` gate
+    // and rendered a "--" bar for a provider the user never configured.
+    expect(isProviderConfigured(provider('unavailable'))).toBe(false)
+  })
+
+  it('shows configured providers, including ones failing transiently', () => {
+    expect(isProviderConfigured(provider('ok'))).toBe(true)
+    expect(isProviderConfigured(provider('error'))).toBe(true)
+    expect(isProviderConfigured(provider('fetching'))).toBe(true)
+    expect(isProviderConfigured(provider('idle'))).toBe(true)
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -1,5 +1,14 @@
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 
+function hasUsageData(provider: ProviderRateLimits): boolean {
+  return Boolean(
+    provider.session ||
+    provider.weekly ||
+    provider.monthly ||
+    (provider.buckets && provider.buckets.length > 0)
+  )
+}
+
 // Why: a provider that returns `unavailable` is explicitly not configured
 // (Gemini OAuth off, OpenCode Go cookie unset, Claude on API-key billing). Its
 // fetch object is non-null, so a bare `!== null` check still renders a "--"
@@ -9,5 +18,11 @@ import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 export function isProviderConfigured(
   provider: ProviderRateLimits | null
 ): provider is ProviderRateLimits {
-  return provider !== null && provider.status !== 'unavailable'
+  if (provider === null || provider.status === 'unavailable') {
+    return false
+  }
+  if (provider.status === 'fetching' && !hasUsageData(provider)) {
+    return false
+  }
+  return true
 }

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -1,0 +1,13 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+
+// Why: a provider that returns `unavailable` is explicitly not configured
+// (Gemini OAuth off, OpenCode Go cookie unset, Claude on API-key billing). Its
+// fetch object is non-null, so a bare `!== null` check still renders a "--"
+// bar for a provider the user never set up. `error` is kept visible on purpose
+// — that's a *configured* provider failing transiently, and hiding it would
+// make the bar flap on every refresh hiccup.
+export function isProviderConfigured(
+  provider: ProviderRateLimits | null
+): provider is ProviderRateLimits {
+  return provider !== null && provider.status !== 'unavailable'
+}


### PR DESCRIPTION
Takeover follow-up for #3384 because the contributor fork rejected a maintainer push (`permission denied`) even though the PR reports `maintainerCanModify: true`.

## Summary

This includes the original #3384 behavior and a review fix found during visible verification:

- hide provider usage bars for explicit `unavailable` states, which cover unconfigured Gemini OAuth, unset OpenCode Go cookies, and Claude API-key billing
- also hide first-load `fetching` provider states when there is no previous usage data yet, so Gemini/OpenCode Go do not briefly render placeholder `...` bars before the fetch resolves
- keep providers visible when they are configured but transiently failing (`error`) or when a refresh is `fetching` with stale usage data

## Evidence

- `pnpm exec vitest run src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts src/renderer/src/components/status-bar/tooltip.test.ts` -> 3 files / 13 tests passed
- `pnpm run typecheck:web` passed
- `pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx src/renderer/src/components/status-bar/status-bar-provider-visibility.ts src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts` passed
- `git diff --check origin/main...HEAD` passed
- `git merge-tree --write-tree origin/main HEAD` passed
- Electron/CDP attached to `pr-3384-provider-usage-bars @ tmchow/filter-unconfigured-providers`; visible proof:
  - `unavailable` Gemini/OpenCode Go: no `Open Gemini usage details`, no `Open OpenCode Go usage details`, no `--` placeholder in the footer
  - first-load `fetching` with no usage data: no Gemini/OpenCode buttons and no placeholder bars
  - transient `error`: Gemini and OpenCode Go buttons remain visible as `Unavailable`, preserving the configured-provider failure affordance

No merge performed.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.