### PR TITLE
Move repository template copy timer into handler

### DIFF
--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useRef, useState } from 'react'
 import type { OrcaHooks, Repo, RepoHookSettings } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { Button } from '../ui/button'
@@ -55,17 +55,17 @@ export function RepositoryPane({
   const symlinksEnabled = useAppStore((state) => state.settings?.experimentalWorktreeSymlinks)
   const [confirmingRemove, setConfirmingRemove] = useState<string | null>(null)
   const [copiedTemplate, setCopiedTemplate] = useState(false)
+  const copiedTemplateResetTimerRef = useRef<number | null>(null)
   // Why: searching a project name is navigation to that project, not a
   // request to hide every child row that does not repeat the project name.
   const forceFullPaneForRepoMatch = matchesRepositoryIdentitySearch(searchQuery, repo)
 
-  useEffect(() => {
-    if (!copiedTemplate) {
-      return
+  const clearCopiedTemplateResetTimer = (): void => {
+    if (copiedTemplateResetTimerRef.current !== null) {
+      window.clearTimeout(copiedTemplateResetTimerRef.current)
+      copiedTemplateResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setCopiedTemplate(false), 1500)
-    return () => window.clearTimeout(timeout)
-  }, [copiedTemplate])
+  }
 
   const handleRemoveProject = (repoId: string) => {
     if (confirmingRemove === repoId) {
@@ -91,7 +91,12 @@ export function RepositoryPane({
     pnpm worktree:setup
   archive: |
     echo "Cleaning up before archive"`)
+    clearCopiedTemplateResetTimer()
     setCopiedTemplate(true)
+    copiedTemplateResetTimerRef.current = window.setTimeout(() => {
+      copiedTemplateResetTimerRef.current = null
+      setCopiedTemplate(false)
+    }, 1500)
   }
 
   const allEntries = getRepositoryPaneSearchEntries(repo)


### PR DESCRIPTION
## Summary
- move the missing-orca.yaml template copy feedback timer into the copy handler
- clear any existing feedback timer before starting a new one
- remove one React Effect hook site from `RepositoryPane`

## Risk
Low. This only changes a short-lived Settings copy-feedback indicator after the template text is copied; no persistence, SSH, provider, or destructive behavior changes.

## Verification
- `pnpm exec oxfmt --write src/renderer/src/components/settings/RepositoryPane.tsx`
- `pnpm exec oxlint src/renderer/src/components/settings/RepositoryPane.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryPane.test.ts src/renderer/src/components/settings/repository-search.test.ts src/renderer/src/components/settings/MobileNetworkInterfaceSection.test.tsx`
- `pnpm run typecheck:web`
- `git diff --check`
- AST Effect count: `929 -> 928`
