### PR TITLE
Move checks panel copy timer into handler

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: co-locating all checks-panel sub-components (checks list,
 conflict sections, threaded PR comments) keeps the shared icon/color maps in one place. */
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   CircleCheck,
   CircleX,
@@ -356,23 +356,28 @@ export function ChecksList({
 
 function CopyButton({ text }: { text: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
+  const copiedResetTimerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    if (!copied) {
-      return
+  const clearCopiedResetTimer = useCallback((): void => {
+    if (copiedResetTimerRef.current !== null) {
+      window.clearTimeout(copiedResetTimerRef.current)
+      copiedResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setCopied(false), 1500)
-    return () => window.clearTimeout(timeout)
-  }, [copied])
+  }, [])
 
   const handleCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
       void window.api.ui.writeClipboardText(text).then(() => {
+        clearCopiedResetTimer()
         setCopied(true)
+        copiedResetTimerRef.current = window.setTimeout(() => {
+          copiedResetTimerRef.current = null
+          setCopied(false)
+        }, 1500)
       })
     },
-    [text]
+    [clearCopiedResetTimer, text]
   )
 
   return (


### PR DESCRIPTION
## Summary
- move the checks panel comment copy reset timer into the copy handler
- keep the one-shot copied indicator behavior without a render-triggered effect
- reduce renderer React effect hook sites from 928 to 927

## Risk
Low. This is limited to the transient copy icon state for PR check/comment copy buttons in the right sidebar. It does not touch data loading, persistence, git provider APIs, SSH/runtime behavior, or destructive actions.

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/right-sidebar/checks-panel-content.tsx
- pnpm exec oxlint src/renderer/src/components/right-sidebar/checks-panel-content.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/right-sidebar/checks-panel-empty-state.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count: 928 -> 927
