### PR TITLE
fix: cancel pane initial fit on dispose

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-initial-fit-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-initial-fit-lifecycle.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { disposePane } from './pane-lifecycle'
+
+function createPane(pendingInitialFitRafId: number | null): ManagedPaneInternal {
+  const leafId = '11111111-1111-4111-8111-111111111111' as never
+  return {
+    id: 1,
+    leafId,
+    stablePaneId: leafId,
+    terminal: {
+      element: null,
+      dispose: vi.fn()
+    } as never,
+    container: {} as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'off',
+    gpuRenderingEnabled: false,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    fitAddon: { dispose: vi.fn() } as never,
+    fitResizeObserver: null,
+    pendingInitialFitRafId,
+    pendingObservedFitRafId: null,
+    searchAddon: { dispose: vi.fn() } as never,
+    serializeAddon: { dispose: vi.fn() } as never,
+    unicode11Addon: { dispose: vi.fn() } as never,
+    webLinksAddon: { dispose: vi.fn() } as never,
+    webglAddon: null,
+    ligaturesAddon: null,
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    pendingSplitScrollBufferDisposable: null,
+    debugLabel: null
+  }
+}
+
+describe('pane initial fit lifecycle', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('cancels pending initial fit when the pane is disposed before paint', () => {
+    const cancelAnimationFrame = vi.fn()
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+    const pane = createPane(17)
+    const panes = new Map([[pane.id, pane]])
+
+    disposePane(pane, panes)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(17)
+    expect(pane.pendingInitialFitRafId).toBeNull()
+    expect(panes.has(pane.id)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -119,6 +119,7 @@ export function createPaneDOM(
     hasComplexScriptOutput: false,
     fitAddon,
     fitResizeObserver: null,
+    pendingInitialFitRafId: null,
     pendingObservedFitRafId: null,
     searchAddon,
     serializeAddon,
@@ -230,7 +231,11 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   attachPaneFitResizeObserver(pane)
 
   // Initial fit (deferred to ensure layout has settled)
-  requestAnimationFrame(() => {
+  if (pane.pendingInitialFitRafId != null) {
+    cancelAnimationFrame(pane.pendingInitialFitRafId)
+  }
+  pane.pendingInitialFitRafId = requestAnimationFrame(() => {
+    pane.pendingInitialFitRafId = null
     safeFit(pane)
   })
 }
@@ -290,6 +295,10 @@ export function disposePane(
   pane: ManagedPaneInternal,
   panes: Map<number, ManagedPaneInternal>
 ): void {
+  if (pane.pendingInitialFitRafId != null) {
+    cancelAnimationFrame(pane.pendingInitialFitRafId)
+    pane.pendingInitialFitRafId = null
+  }
   detachPaneFitResizeObserver(pane)
   if (pane.compositionHandler) {
     pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -105,6 +105,8 @@ export type ManagedPaneInternal = {
   // value means "currently disabled".
   ligaturesAddon: LigaturesAddon | null
   fitResizeObserver: ResizeObserver | null
+  // Stored so disposePane() can cancel the first post-open fit if a pane closes before paint.
+  pendingInitialFitRafId?: number | null
   pendingObservedFitRafId: number | null
   serializeAddon: SerializeAddon
   unicode11Addon: Unicode11Addon


### PR DESCRIPTION
## Summary
- track each pane's deferred initial fit frame after `openTerminal`
- cancel that pending frame in `disposePane` before disposing terminal resources
- add a focused regression test for disposing a pane before the first fit frame fires

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-initial-fit-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-manager-types.ts src/renderer/src/lib/pane-manager/pane-initial-fit-lifecycle.test.ts`
- `git diff --check`

## Merge Risk Assessment
Risk level: LOW

The change only records and cancels a one-shot frame that already belongs to the pane lifecycle. Mounted-pane behavior is unchanged; the new path only runs when a pane is disposed before its deferred initial fit executes.