### PR TITLE
Move code block copy timers into handlers

### DIFF
--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
@@ -10,14 +10,14 @@ export default function CodeBlockCopyButton({
   ...props
 }: CodeBlockCopyButtonProps): React.JSX.Element {
   const [copied, setCopied] = useState(false)
+  const copiedResetTimerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    if (!copied) {
-      return
+  const clearCopiedResetTimer = useCallback((): void => {
+    if (copiedResetTimerRef.current !== null) {
+      window.clearTimeout(copiedResetTimerRef.current)
+      copiedResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setCopied(false), 1500)
-    return () => window.clearTimeout(timeout)
-  }, [copied])
+  }, [])
 
   const handleCopy = useCallback(() => {
     // Extract the text content from the nested <code> element rendered by
@@ -36,12 +36,17 @@ export default function CodeBlockCopyButton({
     void window.api.ui
       .writeClipboardText(text)
       .then(() => {
+        clearCopiedResetTimer()
         setCopied(true)
+        copiedResetTimerRef.current = window.setTimeout(() => {
+          copiedResetTimerRef.current = null
+          setCopied(false)
+        }, 1500)
       })
       .catch(() => {
         // Silently swallow clipboard write failures (e.g. permission denied).
       })
-  }, [children])
+  }, [children, clearCopiedResetTimer])
 
   return (
     <div className="code-block-wrapper">

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
@@ -44,6 +44,7 @@ export function RichMarkdownCodeBlock({
 }: NodeViewProps): React.JSX.Element {
   const language = (node.attrs.language as string) || ''
   const [copied, setCopied] = useState(false)
+  const copiedResetTimerRef = useRef<number | null>(null)
   const settings = useAppStore((s) => s.settings)
   const isDark =
     settings?.theme === 'dark' ||
@@ -51,13 +52,12 @@ export function RichMarkdownCodeBlock({
 
   const isMermaid = language === 'mermaid'
 
-  useEffect(() => {
-    if (!copied) {
-      return
+  const clearCopiedResetTimer = useCallback((): void => {
+    if (copiedResetTimerRef.current !== null) {
+      window.clearTimeout(copiedResetTimerRef.current)
+      copiedResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setCopied(false), 1500)
-    return () => window.clearTimeout(timeout)
-  }, [copied])
+  }, [])
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -73,13 +73,18 @@ export function RichMarkdownCodeBlock({
       void window.api.ui
         .writeClipboardText(text)
         .then(() => {
+          clearCopiedResetTimer()
           setCopied(true)
+          copiedResetTimerRef.current = window.setTimeout(() => {
+            copiedResetTimerRef.current = null
+            setCopied(false)
+          }, 1500)
         })
         .catch(() => {
           // Silently swallow clipboard write failures (e.g. permission denied).
         })
     },
-    [node]
+    [clearCopiedResetTimer, node]
   )
 
   return (


### PR DESCRIPTION
## Summary
- move markdown preview code-block copy feedback timers into successful copy handlers
- move rich markdown code-block copy feedback timers into successful copy handlers
- reduce renderer React effect hook sites from 926 to 924

## Risk
Low. This is limited to transient copied-label state for code-block copy buttons after clipboard writes already succeed. It does not change copied text extraction, markdown data, persistence, provider APIs, SSH/runtime behavior, or destructive actions.

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
- pnpm exec oxlint src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts src/renderer/src/components/editor/rich-markdown-commands.test.ts
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count: 926 -> 924
