### PR TITLE
fix: cancel split scroll restore handles

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   attachPaneFitResizeObserver,
   detachPaneFitResizeObserver
 } from './pane-fit-resize-observer'
+import { clearPendingSplitScrollRestore } from './pane-split-scroll'
 import { buildDefaultTerminalOptions } from './pane-terminal-options'
 import {
   ENABLE_WEBGL_RENDERER,
@@ -135,6 +136,8 @@ export function createPaneDOM(
     ligaturesAddon: null,
     compositionHandler: null,
     pendingSplitScrollState: null,
+    pendingSplitScrollRafIds: [],
+    pendingSplitScrollTimerId: null,
     pendingSplitScrollBufferDisposable: null,
     debugLabel: options.debugLabel ?? null
   }
@@ -312,8 +315,7 @@ export function disposePane(
     pane.compositionHandler = null
   }
   try {
-    pane.pendingSplitScrollBufferDisposable?.dispose()
-    pane.pendingSplitScrollBufferDisposable = null
+    clearPendingSplitScrollRestore(pane)
   } catch {
     /* ignore */
   }

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -118,6 +118,10 @@ export type ManagedPaneInternal = {
   // Why: splitPane reparents DOM; its delayed restore owns scroll until the
   // browser settles, so intermediate fits must not compete with it.
   pendingSplitScrollState: ScrollState | null
+  // Stored so repeated split restores and disposePane() can cancel deferred
+  // restore handles instead of leaving stale pane closures alive.
+  pendingSplitScrollRafIds?: number[]
+  pendingSplitScrollTimerId?: ReturnType<typeof setTimeout> | null
   // Stored so repeated split restores and disposePane() can remove the
   // deferred alt-screen buffer listener instead of stacking callbacks.
   pendingSplitScrollBufferDisposable?: IDisposable | null

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -164,7 +164,7 @@ function safeScrollCall(fn: () => void): boolean {
   }
 }
 
-function releaseScrollStateMarker(state: ScrollState): void {
+export function releaseScrollStateMarker(state: ScrollState): void {
   state.firstVisibleLineMarker?.dispose()
   state.firstVisibleLineMarker = undefined
 }

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -6,6 +6,7 @@ const captureScrollState = vi.hoisted(() => vi.fn())
 const wrapInSplit = vi.hoisted(() => vi.fn())
 const openTerminal = vi.hoisted(() => vi.fn())
 const disposeWebgl = vi.hoisted(() => vi.fn())
+const clearPendingSplitScrollRestore = vi.hoisted(() => vi.fn())
 const scheduleSplitScrollRestore = vi.hoisted(() => vi.fn())
 const updateMultiPaneState = vi.hoisted(() => vi.fn())
 const applyPaneOpacity = vi.hoisted(() => vi.fn())
@@ -30,6 +31,7 @@ vi.mock('./pane-webgl-renderer', () => ({
 }))
 
 vi.mock('./pane-split-scroll', () => ({
+  clearPendingSplitScrollRestore,
   scheduleSplitScrollRestore
 }))
 
@@ -159,6 +161,8 @@ describe('splitManagedPane', () => {
     expect(result?.id).toBe(newPane.id)
     expect(captureScrollState).toHaveBeenCalledWith(fallbackPane.terminal)
     expect(captureScrollState).toHaveBeenCalledWith(siblingPane.terminal)
+    expect(clearPendingSplitScrollRestore).toHaveBeenCalledWith(fallbackPane)
+    expect(clearPendingSplitScrollRestore).toHaveBeenCalledWith(siblingPane)
     expect(fallbackPane.pendingSplitScrollState).toBe(fallbackScrollState)
     expect(siblingPane.pendingSplitScrollState).toBe(siblingScrollState)
     expect(disposeWebgl).toHaveBeenCalledWith(fallbackPane)

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -17,7 +17,7 @@ import {
 import { applyDividerStyles, applyPaneOpacity } from './pane-divider'
 import { disposePane, openTerminal } from './pane-lifecycle'
 import { disposeWebgl } from './pane-webgl-renderer'
-import { scheduleSplitScrollRestore } from './pane-split-scroll'
+import { clearPendingSplitScrollRestore, scheduleSplitScrollRestore } from './pane-split-scroll'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 import { toPublicPane } from './pane-public-view'
 
@@ -91,6 +91,7 @@ function prepareMovedPanesForSplit(
   }
 
   return movedPanes.map((pane) => {
+    clearPendingSplitScrollRestore(pane)
     // Why: wrapInSplit reparents moved containers, resetting browser scrollTop.
     const scrollState = captureScrollState(pane.terminal)
     // Why: lock prevents safeFit/fitAllPanes from restoring scroll during the

--- a/src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts
@@ -3,12 +3,14 @@ import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 
 const restoreScrollState = vi.hoisted(() => vi.fn())
+const releaseScrollStateMarker = vi.hoisted(() => vi.fn())
 
 vi.mock('./pane-scroll', () => ({
+  releaseScrollStateMarker,
   restoreScrollState
 }))
 
-import { scheduleSplitScrollRestore } from './pane-split-scroll'
+import { clearPendingSplitScrollRestore, scheduleSplitScrollRestore } from './pane-split-scroll'
 
 const scrollState = {
   bufferType: 'normal',
@@ -93,6 +95,7 @@ describe('scheduleSplitScrollRestore', () => {
       return 1
     })
     restoreScrollState.mockClear()
+    releaseScrollStateMarker.mockClear()
   })
 
   afterEach(() => {
@@ -222,5 +225,36 @@ describe('scheduleSplitScrollRestore', () => {
     expect(bufferChangeDisposables[1].dispose).toHaveBeenCalledTimes(1)
     expect(pane.pendingSplitScrollBufferDisposable).toBeNull()
     expect(reattachWebgl).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels pending split restore handles and releases captured state', () => {
+    let nextFrameId = 10
+    const cancelAnimationFrame = vi.fn()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => nextFrameId++)
+    )
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+    const { pane } = createPane('normal')
+
+    scheduleSplitScrollRestore(
+      () => pane,
+      pane.id,
+      scrollState,
+      () => false
+    )
+
+    expect(pane.pendingSplitScrollRafIds).toEqual([10])
+    expect(pane.pendingSplitScrollTimerId).not.toBeNull()
+    expect(vi.getTimerCount()).toBe(1)
+
+    clearPendingSplitScrollRestore(pane)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(10)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(pane.pendingSplitScrollRafIds).toEqual([])
+    expect(pane.pendingSplitScrollTimerId).toBeNull()
+    expect(pane.pendingSplitScrollState).toBeNull()
+    expect(releaseScrollStateMarker).toHaveBeenCalledWith(scrollState)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-split-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-scroll.ts
@@ -1,6 +1,6 @@
 import type { IBuffer, IDisposable } from '@xterm/xterm'
 import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
-import { restoreScrollState } from './pane-scroll'
+import { releaseScrollStateMarker, restoreScrollState } from './pane-scroll'
 
 function refreshAfterReparent(pane: ManagedPaneInternal): void {
   try {
@@ -13,6 +13,28 @@ function refreshAfterReparent(pane: ManagedPaneInternal): void {
 function clearPendingSplitScrollBufferDisposable(pane: ManagedPaneInternal): void {
   pane.pendingSplitScrollBufferDisposable?.dispose()
   pane.pendingSplitScrollBufferDisposable = null
+}
+
+function cancelPendingSplitScrollHandles(pane: ManagedPaneInternal): void {
+  clearPendingSplitScrollBufferDisposable(pane)
+  if (typeof cancelAnimationFrame === 'function') {
+    for (const rafId of pane.pendingSplitScrollRafIds ?? []) {
+      cancelAnimationFrame(rafId)
+    }
+  }
+  pane.pendingSplitScrollRafIds = []
+  if (pane.pendingSplitScrollTimerId != null) {
+    clearTimeout(pane.pendingSplitScrollTimerId)
+    pane.pendingSplitScrollTimerId = null
+  }
+}
+
+export function clearPendingSplitScrollRestore(pane: ManagedPaneInternal): void {
+  cancelPendingSplitScrollHandles(pane)
+  if (pane.pendingSplitScrollState) {
+    releaseScrollStateMarker(pane.pendingSplitScrollState)
+    pane.pendingSplitScrollState = null
+  }
 }
 
 function runAfterNormalBuffer(
@@ -76,12 +98,21 @@ export function scheduleSplitScrollRestore(
   isDestroyed: () => boolean,
   reattachWebgl?: (pane: ManagedPaneInternal) => void
 ): void {
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
+  const scheduledPane = getPaneById(paneId)
+  if (scheduledPane) {
+    cancelPendingSplitScrollHandles(scheduledPane)
+  }
+
+  const firstRafId = requestAnimationFrame(() => {
+    const liveAfterFirstFrame = getPaneById(paneId)
+    const secondRafId = requestAnimationFrame(() => {
+      const live = getPaneById(paneId)
+      if (live) {
+        live.pendingSplitScrollRafIds = []
+      }
       if (isDestroyed()) {
         return
       }
-      const live = getPaneById(paneId)
       if (!live?.pendingSplitScrollState) {
         return
       }
@@ -96,13 +127,26 @@ export function scheduleSplitScrollRestore(
       restoreScrollState(live.terminal, scrollState)
       refreshAfterReparent(live)
     })
+    if (liveAfterFirstFrame) {
+      liveAfterFirstFrame.pendingSplitScrollRafIds = [
+        ...(liveAfterFirstFrame.pendingSplitScrollRafIds ?? []),
+        secondRafId
+      ]
+    }
   })
+  if (scheduledPane) {
+    scheduledPane.pendingSplitScrollRafIds = [firstRafId]
+  }
 
-  setTimeout(() => {
+  const settleTimerId = setTimeout(() => {
+    const live = getPaneById(paneId)
+    if (live?.pendingSplitScrollTimerId === settleTimerId) {
+      live.pendingSplitScrollTimerId = null
+      live.pendingSplitScrollRafIds = []
+    }
     if (isDestroyed()) {
       return
     }
-    const live = getPaneById(paneId)
     if (!live) {
       return
     }
@@ -134,4 +178,7 @@ export function scheduleSplitScrollRestore(
     }
     restoreCapturedScrollState(live, scrollState, reattachWebgl)
   }, 200)
+  if (scheduledPane) {
+    scheduledPane.pendingSplitScrollTimerId = settleTimerId
+  }
 }


### PR DESCRIPTION
## Summary
- track split-scroll restore rAFs and the 200ms settle timer on the pane
- clear stale split-scroll handles, buffer listeners, and captured scroll markers when a restore is replaced or a pane is disposed
- add split-scroll coverage for cancellation and keep split-close expectations aligned

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager`
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-scroll.ts src/renderer/src/lib/pane-manager/pane-split-scroll.ts src/renderer/src/lib/pane-manager/pane-split-close.ts src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-manager-types.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts`
- `git diff --check`

## Merge Risk Assessment
Risk level: LOW

This touches terminal split-pane scroll restoration, so I did an extra pass before PR creation: all pane-manager tests passed (20 files / 151 tests). The mounted behavior remains the same; the change adds ownership and cancellation for deferred handles and releases the captured marker when a restore is canceled.