### PR TITLE
Move mobile connection log scroll into content handler

### DIFF
--- a/mobile/src/components/ConnectionLog.tsx
+++ b/mobile/src/components/ConnectionLog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import type { ConnectionLogEntry } from '../transport/types'
 import { colors, radii, spacing, typography } from '../theme/mobile-theme'
@@ -36,14 +36,6 @@ function formatTime(ts: number, baseTs: number): string {
 export function ConnectionLog({ entries, title }: Props) {
   const scrollRef = useRef<ScrollView | null>(null)
 
-  // Why: keep the latest entry visible while logs grow during a slow
-  // connect. Skip on empty so the title row doesn't jump.
-  useEffect(() => {
-    if (entries.length === 0) return
-    const id = setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 16)
-    return () => clearTimeout(id)
-  }, [entries.length])
-
   if (entries.length === 0) return null
   const baseTs = entries[0]!.ts
 
@@ -55,6 +47,7 @@ export function ConnectionLog({ entries, title }: Props) {
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: true })}
       >
         {entries.map((entry) => (
           <View key={entry.id} style={styles.row}>


### PR DESCRIPTION
## Summary
- replace the mobile connection log's post-render timer effect with `ScrollView.onContentSizeChange`
- keep the latest pairing/reconnect log entry visible when log content grows
- reduce React effect hook sites from 923 to 922

## Risk
Medium. This is local mobile UI behavior only, but it sits in the pairing/reconnect log surface. It does not change pairing transport, RPC, host storage, copied data, or desktop behavior.

## Verification
- pnpm exec oxfmt --write mobile/src/components/ConnectionLog.tsx
- pnpm exec oxlint mobile/src/components/ConnectionLog.tsx
- git diff --check
- AST React effect hook count: 923 -> 922

## Verification gaps
- `pnpm --dir mobile exec tsc --noEmit` is not usable in this checkout: mobile Expo/React Native dependencies and `expo/tsconfig.base` are not resolved, producing pre-existing project-wide module/JSX errors.
- `pnpm --dir mobile test -- --runInBand mobile/src/components/ConnectionLog.test.tsx` is not usable because `vitest` is not installed in the mobile package context, and there is no existing ConnectionLog test file.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.