### PR TITLE
fix: cancel follow-output frames

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 const reactRefState = vi.hoisted(() => ({
+  effectCleanups: [] as (() => void)[],
   slots: [] as { current: unknown }[],
   index: 0
 }))
@@ -24,8 +25,15 @@ function beginHookRender(): void {
 }
 
 function resetHookRefs(): void {
+  reactRefState.effectCleanups = []
   reactRefState.slots = []
   reactRefState.index = 0
+}
+
+function runEffectCleanups(): void {
+  for (const cleanup of reactRefState.effectCleanups.splice(0)) {
+    cleanup()
+  }
 }
 
 vi.mock('react', async (importOriginal) => {
@@ -34,7 +42,10 @@ vi.mock('react', async (importOriginal) => {
     ...actual,
     useCallback: <T extends (...args: never[]) => unknown>(callback: T) => callback,
     useEffect: (effect: () => void | (() => void)) => {
-      effect()
+      const cleanup = effect()
+      if (typeof cleanup === 'function') {
+        reactRefState.effectCleanups.push(cleanup)
+      }
     },
     useRef: <T>(value: T) => {
       const index = reactRefState.index
@@ -59,6 +70,7 @@ vi.mock('@/lib/pane-manager/pane-scroll', () => ({
 
 describe('useTerminalScrollVisibilityMemory', () => {
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame
 
   beforeEach(() => {
     resetHookRefs()
@@ -66,10 +78,16 @@ describe('useTerminalScrollVisibilityMemory', () => {
   })
 
   afterEach(() => {
+    runEffectCleanups()
     if (originalRequestAnimationFrame) {
       globalThis.requestAnimationFrame = originalRequestAnimationFrame
     } else {
       delete (globalThis as unknown as { requestAnimationFrame?: unknown }).requestAnimationFrame
+    }
+    if (originalCancelAnimationFrame) {
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+    } else {
+      delete (globalThis as unknown as { cancelAnimationFrame?: unknown }).cancelAnimationFrame
     }
   })
 
@@ -103,5 +121,32 @@ describe('useTerminalScrollVisibilityMemory', () => {
       maxChars: 256 * 1024
     })
     expect(terminal.scrollToBottom).toHaveBeenCalled()
+  })
+
+  it('cancels pending follow-output frames on cleanup', () => {
+    const terminal = {
+      onScroll: vi.fn(() => ({ dispose: vi.fn() })),
+      scrollToBottom: vi.fn()
+    }
+    const manager = {
+      getPanes: vi.fn(() => [{ id: 1, terminal }])
+    }
+    const cancelAnimationFrame = vi.fn()
+    globalThis.requestAnimationFrame = vi.fn(() => 7)
+    globalThis.cancelAnimationFrame = cancelAnimationFrame
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    visibilityMemory.scheduleFollowOutputIfNeeded(1)
+    runEffectCleanups()
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(7)
+    expect(mocks.flushTerminalOutput).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -40,6 +40,7 @@ export function useTerminalScrollVisibilityMemory({
   const scrollDisposablesRef = useRef<Map<number, IDisposable>>(new Map())
   const suppressScrollTrackingRef = useRef(false)
   const pendingFollowOutputPaneIdsRef = useRef<Set<number>>(new Set())
+  const followOutputFrameIdsRef = useRef<number[]>([])
 
   const captureVisibleScrollSnapshot = useCallback(
     (terminal: Terminal): VisibleScrollSnapshot => ({
@@ -126,15 +127,37 @@ export function useTerminalScrollVisibilityMemory({
     return didScroll
   }, [isVisibleRef, managerRef, rememberVisibleScrollSnapshot, visibleResumeCompleteRef])
 
+  const cancelPendingFollowOutputFrames = useCallback((): void => {
+    for (const frameId of followOutputFrameIdsRef.current) {
+      cancelAnimationFrame(frameId)
+    }
+    followOutputFrameIdsRef.current = []
+  }, [])
+
   const scheduleFollowOutputIfNeeded = useCallback(
     (paneId: number): void => {
       pendingFollowOutputPaneIdsRef.current.add(paneId)
-      requestAnimationFrame(() => {
-        requestAnimationFrame(applyPendingFollowOutputRequests)
+      if (followOutputFrameIdsRef.current.length > 0) {
+        return
+      }
+      const firstFrameId = requestAnimationFrame(() => {
+        followOutputFrameIdsRef.current = followOutputFrameIdsRef.current.filter(
+          (frameId) => frameId !== firstFrameId
+        )
+        const secondFrameId = requestAnimationFrame(() => {
+          followOutputFrameIdsRef.current = followOutputFrameIdsRef.current.filter(
+            (frameId) => frameId !== secondFrameId
+          )
+          applyPendingFollowOutputRequests()
+        })
+        followOutputFrameIdsRef.current.push(secondFrameId)
       })
+      followOutputFrameIdsRef.current.push(firstFrameId)
     },
     [applyPendingFollowOutputRequests]
   )
+
+  useEffect(() => cancelPendingFollowOutputFrames, [cancelPendingFollowOutputFrames])
 
   useEffect(() => {
     const manager = managerRef.current


### PR DESCRIPTION
## Summary
- track the double-rAF follow-output scheduler in terminal scroll visibility memory
- coalesce duplicate pending follow-output frame chains
- cancel pending follow-output frames on hook cleanup
- add focused coverage for cleanup cancellation

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts`
- `git diff --check`

## Merge Risk Assessment
Risk level: LOW

The follow-output behavior still runs after the same two animation frames while mounted. The change owns those frame IDs, avoids stacking duplicate frame chains for the same pending set, and cancels retained closures when the hook unmounts.