### PR TITLE
Move runtime pairing copy timer into handler

### DIFF
--- a/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
@@ -112,6 +112,7 @@ export function RuntimePairingUrlGenerator({
   const [isGeneratingPairing, setIsGeneratingPairing] = useState(false)
   const networkInterfaceLoadIdRef = useRef(0)
   const accessGrantLoadIdRef = useRef(0)
+  const containerRef = useRef<HTMLDivElement | null>(null)
   const copiedTargetResetTimerRef = useRef<number | null>(null)
 
   const clearCopiedTargetResetTimer = useCallback((): void => {
@@ -250,6 +251,10 @@ export function RuntimePairingUrlGenerator({
       setCopiedTarget(target)
       copiedTargetResetTimerRef.current = window.setTimeout(() => {
         copiedTargetResetTimerRef.current = null
+        // Why: this timer is event-owned, so Settings may close before it fires.
+        if (!containerRef.current?.isConnected) {
+          return
+        }
         setCopiedTarget((current) => (current === target ? null : current))
       }, 1400)
       toast.success(target === 'web' ? 'Copied web client URL.' : 'Copied pairing URL.')
@@ -274,7 +279,7 @@ export function RuntimePairingUrlGenerator({
   }
 
   return (
-    <div className={containerClassName}>
+    <div ref={containerRef} className={containerClassName}>
       {showHeader ? (
         <div className="space-y-1">
           <Label id="runtime-share-server-label">Share this Orca server</Label>

--- a/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
@@ -112,17 +112,14 @@ export function RuntimePairingUrlGenerator({
   const [isGeneratingPairing, setIsGeneratingPairing] = useState(false)
   const networkInterfaceLoadIdRef = useRef(0)
   const accessGrantLoadIdRef = useRef(0)
+  const copiedTargetResetTimerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    if (copiedTarget === null) {
-      return
+  const clearCopiedTargetResetTimer = useCallback((): void => {
+    if (copiedTargetResetTimerRef.current !== null) {
+      window.clearTimeout(copiedTargetResetTimerRef.current)
+      copiedTargetResetTimerRef.current = null
     }
-    const target = copiedTarget
-    const timeout = window.setTimeout(() => {
-      setCopiedTarget((current) => (current === target ? null : current))
-    }, 1400)
-    return () => window.clearTimeout(timeout)
-  }, [copiedTarget])
+  }, [])
 
   const loadRuntimeAccessGrants = useCallback(
     async (options: { showToastOnError?: boolean } = {}): Promise<void> => {
@@ -249,7 +246,12 @@ export function RuntimePairingUrlGenerator({
   const copyGeneratedUrl = async (target: 'web' | 'pairing', value: string): Promise<void> => {
     try {
       await window.api.ui.writeClipboardText(value)
+      clearCopiedTargetResetTimer()
       setCopiedTarget(target)
+      copiedTargetResetTimerRef.current = window.setTimeout(() => {
+        copiedTargetResetTimerRef.current = null
+        setCopiedTarget((current) => (current === target ? null : current))
+      }, 1400)
       toast.success(target === 'web' ? 'Copied web client URL.' : 'Copied pairing URL.')
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to copy URL.')


### PR DESCRIPTION
## Summary
- move generated runtime/web URL copy feedback reset into the successful copy handler
- preserve the per-target guard so a later copy is not cleared by an older timer
- reduce renderer React effect hook sites from 922 to 921

## Risk
Medium. This is limited to transient copied-state UI in the runtime sharing settings surface, but the screen manages runtime/web pairing grants. It does not change URL generation, access grants, revocation, network interface loading, SSH/runtime transport, persistence, or copied URL values.

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
- pnpm exec oxlint src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
- pnpm run typecheck:web
- git diff --check
- AST React effect hook count: 922 -> 921

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.