### PR TITLE
fix: cancel terminal file reveal frames

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -48,6 +48,33 @@ export function getTerminalFileContext(
 }
 
 let latestOpenDetectedFilePathRequestId = 0
+let pendingEditorRevealFrameIds: number[] = []
+
+function cancelPendingEditorRevealFrames(): void {
+  if (typeof cancelAnimationFrame === 'function') {
+    for (const frameId of pendingEditorRevealFrameIds) {
+      cancelAnimationFrame(frameId)
+    }
+  }
+  pendingEditorRevealFrameIds = []
+}
+
+function schedulePendingEditorReveal(callback: () => void): void {
+  cancelPendingEditorRevealFrames()
+  const firstFrameId = requestAnimationFrame(() => {
+    pendingEditorRevealFrameIds = pendingEditorRevealFrameIds.filter(
+      (frameId) => frameId !== firstFrameId
+    )
+    const secondFrameId = requestAnimationFrame(() => {
+      pendingEditorRevealFrameIds = pendingEditorRevealFrameIds.filter(
+        (frameId) => frameId !== secondFrameId
+      )
+      callback()
+    })
+    pendingEditorRevealFrameIds.push(secondFrameId)
+  })
+  pendingEditorRevealFrameIds.push(firstFrameId)
+}
 
 export function openDetectedFilePath(
   filePath: string,
@@ -57,6 +84,7 @@ export function openDetectedFilePath(
 ): void {
   const { runtimeEnvironmentId, worktreeId, worktreePath } = deps
   const requestId = ++latestOpenDetectedFilePathRequestId
+  cancelPendingEditorRevealFrames()
 
   void (async () => {
     let statResult
@@ -127,17 +155,15 @@ export function openDetectedFilePath(
     if (line !== null) {
       const targetColumn = column ?? 1
       store.setPendingEditorReveal(null)
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (requestId !== latestOpenDetectedFilePathRequestId) {
-            return
-          }
-          store.setPendingEditorReveal({
-            filePath,
-            line,
-            column: targetColumn,
-            matchLength: 0
-          })
+      schedulePendingEditorReveal(() => {
+        if (requestId !== latestOpenDetectedFilePathRequestId) {
+          return
+        }
+        store.setPendingEditorReveal({
+          filePath,
+          line,
+          column: targetColumn,
+          matchLength: 0
         })
       })
     }

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -116,6 +116,9 @@ beforeEach(() => {
   vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
     return setTimeout(() => callback(0), 0) as unknown as number
   })
+  vi.stubGlobal('cancelAnimationFrame', (handle: number): void => {
+    clearTimeout(handle)
+  })
 })
 
 afterEach(() => {
@@ -273,6 +276,24 @@ describe('handleOscLink', () => {
       column: 7,
       matchLength: 0
     })
+  })
+
+  it('cancels a pending Monaco reveal frame when another file open starts', async () => {
+    setPlatform('Macintosh')
+    const cancelAnimationFrame = vi.fn()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 42)
+    )
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+
+    openDetectedFilePath('/tmp/src/main.ts', 42, null, deps)
+    await flushAsyncWork()
+
+    openDetectedFilePath('/tmp/src/other.ts', null, null, deps)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42)
+    expect(setPendingEditorRevealMock).toHaveBeenCalledWith(null)
   })
 
   it('advertises the browser-open behavior in the html hover hint', () => {


### PR DESCRIPTION
## Summary
- track the terminal file-link Monaco reveal double-rAF chain
- cancel pending reveal frames when a newer file-open request starts
- keep latest-request guarding in place for async stat races
- add terminal link coverage for canceling a pending reveal frame

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `git diff --check`

## Merge Risk Assessment
Risk level: LOW

The editor reveal still happens after the same two animation frames for the latest request. Superseded requests now cancel their queued frames instead of leaving stale closures in the browser frame queue.