### PR TITLE
fix: cancel terminal focus frames

### DIFF
--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -11,6 +11,7 @@ describe('focusTerminalTabSurface', () => {
       callback(0)
       return 1
     })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
   }
 
   it('focuses the scoped xterm helper textarea', () => {
@@ -44,5 +45,22 @@ describe('focusTerminalTabSurface', () => {
     focusTerminalTabSurface('tab-1')
 
     expect(textarea.focus).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending focus frame when a newer focus request starts', () => {
+    const cancelAnimationFrame = vi.fn()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 9)
+    )
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+    vi.stubGlobal('document', {
+      querySelector: vi.fn(() => null)
+    })
+
+    focusTerminalTabSurface('tab-1')
+    focusTerminalTabSurface('tab-2')
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(9)
   })
 })

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -9,9 +9,23 @@ function cssAttributeString(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
+let pendingFocusFrameIds: number[] = []
+
+function cancelPendingFocusFrames(): void {
+  if (typeof cancelAnimationFrame === 'function') {
+    for (const frameId of pendingFocusFrameIds) {
+      cancelAnimationFrame(frameId)
+    }
+  }
+  pendingFocusFrameIds = []
+}
+
 export function focusTerminalTabSurface(tabId: string, leafId?: string | null): void {
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
+  cancelPendingFocusFrames()
+  const firstFrameId = requestAnimationFrame(() => {
+    pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== firstFrameId)
+    const secondFrameId = requestAnimationFrame(() => {
+      pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== secondFrameId)
       // Why: this can be queued before inline tab rename mounts. If it runs
       // afterward, focusing xterm blurs the rename input and commits it closed.
       if (document.querySelector('[data-tab-rename-input="true"]')) {
@@ -34,5 +48,7 @@ export function focusTerminalTabSurface(tabId: string, leafId?: string | null): 
       const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
       fallback?.focus()
     })
+    pendingFocusFrameIds.push(secondFrameId)
   })
+  pendingFocusFrameIds.push(firstFrameId)
 }


### PR DESCRIPTION
## Summary
- track the terminal tab focus double-rAF chain
- cancel pending focus frames when a newer focus request supersedes them
- add coverage for superseded focus-frame cancellation

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/focus-terminal-tab-surface.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/focus-terminal-tab-surface.ts src/renderer/src/lib/focus-terminal-tab-surface.test.ts`
- `git diff --check`

## Merge Risk Assessment
Risk level: LOW

Terminal focus still waits for the same two animation frames before focusing. The only behavioral tightening is latest-request-wins cancellation, which prevents stale queued focus closures from lingering or focusing an older terminal after a newer request.