### PR TITLE
Move crash report viewer lookup into open path

### DIFF
--- a/src/renderer/src/components/crash-report/CrashReportDialog.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialog.tsx
@@ -59,6 +59,9 @@ export function CrashReportDialog(): React.JSX.Element {
   const [loading, setLoading] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [viewer, setViewer] = useState<GitHubViewer | null>(null)
+  // Why: account lookup can resolve after the dialog closes or reopens.
+  // Sequence the request so a stale viewer is never used for submission.
+  const viewerRequestIdRef = useRef(0)
   const deferredNotes = useDeferredValue(notes)
   const diagnosticText = useMemo(
     // Why: formatting applies redaction and truncation over the full crash
@@ -67,10 +70,46 @@ export function CrashReportDialog(): React.JSX.Element {
     [deferredNotes, report]
   )
 
-  const openCrashReport = useCallback((nextReport: CrashReportRecord): void => {
-    setReport(nextReport)
-    setOpen(true)
+  const clearViewer = useCallback((): void => {
+    viewerRequestIdRef.current += 1
+    setViewer(null)
   }, [])
+
+  const loadViewerForOpenDialog = useCallback((): void => {
+    const requestId = ++viewerRequestIdRef.current
+    setViewer(null)
+    void window.api.gh
+      .viewer()
+      .then((nextViewer) => {
+        if (mountedRef.current && requestId === viewerRequestIdRef.current) {
+          setViewer(nextViewer)
+        }
+      })
+      .catch((error) => {
+        if (mountedRef.current && requestId === viewerRequestIdRef.current) {
+          setViewer(null)
+          console.error('Failed to load GitHub viewer for crash report:', error)
+        }
+      })
+  }, [mountedRef])
+
+  const openDialog = useCallback((): void => {
+    setOpen(true)
+    loadViewerForOpenDialog()
+  }, [loadViewerForOpenDialog])
+
+  const closeDialog = useCallback((): void => {
+    clearViewer()
+    setOpen(false)
+  }, [clearViewer])
+
+  const openCrashReport = useCallback(
+    (nextReport: CrashReportRecord): void => {
+      setReport(nextReport)
+      openDialog()
+    },
+    [openDialog]
+  )
 
   const loadCrashReport = useCallback(
     async (promptIfPresent: boolean): Promise<void> => {
@@ -95,8 +134,8 @@ export function CrashReportDialog(): React.JSX.Element {
           return
         }
         setReport(displayedReport)
-        if (nextReport && promptIfPresent && mountedRef.current) {
-          setOpen(true)
+        if (nextReport && promptIfPresent) {
+          openDialog()
         }
       } catch (error) {
         console.error('Failed to load crash report:', error)
@@ -106,7 +145,7 @@ export function CrashReportDialog(): React.JSX.Element {
         }
       }
     },
-    [mountedRef]
+    [mountedRef, openDialog]
   )
 
   useEffect(() => {
@@ -121,11 +160,11 @@ export function CrashReportDialog(): React.JSX.Element {
     return window.api.ui.onOpenCrashReport(() => {
       void loadCrashReport(false).then(() => {
         if (mountedRef.current) {
-          setOpen(true)
+          openDialog()
         }
       })
     })
-  }, [loadCrashReport, mountedRef])
+  }, [loadCrashReport, mountedRef, openDialog])
 
   useEffect(() => {
     const pendingReport = takePendingReactErrorBoundaryReport()
@@ -148,32 +187,6 @@ export function CrashReportDialog(): React.JSX.Element {
       )
     }
   }, [openCrashReport])
-
-  useEffect(() => {
-    if (!open) {
-      setViewer(null)
-      return
-    }
-
-    let cancelled = false
-    void window.api.gh
-      .viewer()
-      .then((nextViewer) => {
-        if (!cancelled) {
-          setViewer(nextViewer)
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setViewer(null)
-          console.error('Failed to load GitHub viewer for crash report:', error)
-        }
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [open])
 
   const handleCopy = async (): Promise<void> => {
     const result = await window.api.crashReports.copyLatestDiagnostics(
@@ -198,7 +211,7 @@ export function CrashReportDialog(): React.JSX.Element {
   const handleDismiss = async (): Promise<void> => {
     await dismissReportIfNeeded()
     if (mountedRef.current) {
-      setOpen(false)
+      closeDialog()
     }
   }
 
@@ -226,7 +239,7 @@ export function CrashReportDialog(): React.JSX.Element {
       setReport(result.report)
       setNotes('')
       toast.success('Crash report sent.')
-      setOpen(false)
+      closeDialog()
     } catch (error) {
       toast.error('Failed to send crash report.')
       console.error('Failed to submit crash report:', error)
@@ -245,6 +258,7 @@ export function CrashReportDialog(): React.JSX.Element {
           return
         }
         if (!nextOpen) {
+          clearViewer()
           void dismissReportIfNeeded().finally(() => {
             if (mountedRef.current) {
               setOpen(false)
@@ -252,7 +266,7 @@ export function CrashReportDialog(): React.JSX.Element {
           })
           return
         }
-        setOpen(true)
+        openDialog()
       }}
     >
       <DialogContent className="sm:max-w-xl">

--- a/src/renderer/src/components/crash-report/CrashReportDialog.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialog.tsx
@@ -149,6 +149,12 @@ export function CrashReportDialog(): React.JSX.Element {
   )
 
   useEffect(() => {
+    return () => {
+      viewerRequestIdRef.current += 1
+    }
+  }, [])
+
+  useEffect(() => {
     if (promptedThisLaunch.current) {
       return
     }


### PR DESCRIPTION
## Summary
- move crash-report GitHub viewer lookup into explicit dialog open paths
- clear and sequence viewer requests on close/reopen so stale identity cannot be used for submission
- remove the passive open-state Effect that only fetched/cleared viewer state

## Risk
Medium. This touches crash-report submission identity lookup behavior, but keeps the crash report load, dismiss, copy, and submit IPC paths unchanged.

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/crash-report/CrashReportDialog.tsx
- pnpm exec oxlint src/renderer/src/components/crash-report/CrashReportDialog.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 923 -> 922

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.