### PR TITLE
fix: cancel floating context menu frame

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { EyeOff, PanelBottom, PanelTop } from 'lucide-react'
 import {
   DropdownMenu,
@@ -26,6 +26,17 @@ export function FloatingTerminalIconContextMenu({
   const updateSettings = useAppStore((s) => s.updateSettings)
   const [open, setOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
+  const reopenFrameRef = useRef<number | null>(null)
+
+  useEffect(
+    () => () => {
+      if (reopenFrameRef.current !== null) {
+        window.cancelAnimationFrame(reopenFrameRef.current)
+        reopenFrameRef.current = null
+      }
+    },
+    []
+  )
 
   const moveAction = useMemo(() => {
     if (currentLocation === 'floating-button') {
@@ -55,7 +66,13 @@ export function FloatingTerminalIconContextMenu({
           event.stopPropagation()
           setMenuPoint({ x: event.clientX, y: event.clientY })
           setOpen(false)
-          window.requestAnimationFrame(() => setOpen(true))
+          if (reopenFrameRef.current !== null) {
+            window.cancelAnimationFrame(reopenFrameRef.current)
+          }
+          reopenFrameRef.current = window.requestAnimationFrame(() => {
+            reopenFrameRef.current = null
+            setOpen(true)
+          })
         }}
         onContextMenu={(event) => {
           event.preventDefault()


### PR DESCRIPTION
## Summary
- track the floating terminal context-menu reopen rAF
- cancel superseded reopen frames and the pending frame on unmount

## Validation
- `pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx`
- `git diff --check`

## Merge Risk Assessment
Risk level: LOW

The menu still reopens on the next animation frame after right-click positioning. Cleanup now cancels stale reopen frames so unmounted or superseded triggers do not retain `setOpen` closures.