### PR TITLE
Derive mobile session create warning before paint

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -121,6 +121,11 @@ import {
   type MobileNewTabAgentOption,
   type MobileNewTabAgentSettings
 } from '../../../../src/session/mobile-new-tab-agent-options'
+import {
+  createMobileSessionCreateWarningState,
+  dismissMobileSessionCreateWarningState,
+  reconcileMobileSessionCreateWarningState
+} from '../../../../src/session/mobile-session-create-warning-state'
 import { colors, spacing, radii, typography } from '../../../../src/theme/mobile-theme'
 import type { DiffComment } from '../../../../../src/shared/types'
 
@@ -981,7 +986,9 @@ export default function SessionScreen() {
   const [creatingBrowser, setCreatingBrowser] = useState(false)
   const [creatingMarkdown, setCreatingMarkdown] = useState(false)
   const [createError, setCreateError] = useState('')
-  const [createWarning, setCreateWarning] = useState(initialCreateWarning)
+  const [createWarningState, setCreateWarningState] = useState(() =>
+    createMobileSessionCreateWarningState(initialCreateWarning)
+  )
   const [showCreateTabDrawer, setShowCreateTabDrawer] = useState(false)
   const [createTabAgentLoadState, setCreateTabAgentLoadState] =
     useState<MobileNewTabAgentLoadState>('idle')
@@ -1089,10 +1096,16 @@ export default function SessionScreen() {
     activeSessionTab?.type !== 'browser'
   const liveInputEnabled = activeHandle ? liveInputTerminalHandles.has(activeHandle) : false
   const [browserScreencastSupported, setBrowserScreencastSupported] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    setCreateWarning(initialCreateWarning)
-  }, [initialCreateWarning])
+  const reconciledCreateWarningState = reconcileMobileSessionCreateWarningState(
+    createWarningState,
+    initialCreateWarning
+  )
+  // Why: Expo can reuse this screen for a new route. Reconcile before paint
+  // so a dismissed old creation warning never flashes for the next session.
+  if (reconciledCreateWarningState !== createWarningState) {
+    setCreateWarningState(reconciledCreateWarningState)
+  }
+  const createWarning = reconciledCreateWarningState.visible
 
   const clearToastHideTimer = useCallback(() => {
     if (!toastHideTimerRef.current) return
@@ -3782,7 +3795,7 @@ export default function SessionScreen() {
             <Text style={styles.createWarningText}>{createWarning}</Text>
             <Pressable
               style={styles.createWarningDismiss}
-              onPress={() => setCreateWarning('')}
+              onPress={() => setCreateWarningState(dismissMobileSessionCreateWarningState)}
               accessibilityLabel="Dismiss workspace creation warning"
               hitSlop={8}
             >

--- a/mobile/src/session/mobile-session-create-warning-state.test.ts
+++ b/mobile/src/session/mobile-session-create-warning-state.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createMobileSessionCreateWarningState,
+  dismissMobileSessionCreateWarningState,
+  reconcileMobileSessionCreateWarningState
+} from './mobile-session-create-warning-state'
+
+describe('mobile session create warning state', () => {
+  it('preserves a dismissed warning while the route warning is unchanged', () => {
+    const dismissed = dismissMobileSessionCreateWarningState(
+      createMobileSessionCreateWarningState('Created, but setup failed')
+    )
+
+    expect(reconcileMobileSessionCreateWarningState(dismissed, 'Created, but setup failed')).toBe(
+      dismissed
+    )
+  })
+
+  it('shows a new warning when the route warning changes', () => {
+    const dismissed = dismissMobileSessionCreateWarningState(
+      createMobileSessionCreateWarningState('Old warning')
+    )
+
+    expect(reconcileMobileSessionCreateWarningState(dismissed, 'New warning')).toEqual({
+      source: 'New warning',
+      visible: 'New warning'
+    })
+  })
+})

--- a/mobile/src/session/mobile-session-create-warning-state.ts
+++ b/mobile/src/session/mobile-session-create-warning-state.ts
@@ -1,0 +1,29 @@
+export type MobileSessionCreateWarningState = {
+  source: string
+  visible: string
+}
+
+export function createMobileSessionCreateWarningState(
+  source: string
+): MobileSessionCreateWarningState {
+  return { source, visible: source }
+}
+
+export function reconcileMobileSessionCreateWarningState(
+  current: MobileSessionCreateWarningState,
+  source: string
+): MobileSessionCreateWarningState {
+  if (current.source === source) {
+    return current
+  }
+  return createMobileSessionCreateWarningState(source)
+}
+
+export function dismissMobileSessionCreateWarningState(
+  current: MobileSessionCreateWarningState
+): MobileSessionCreateWarningState {
+  if (!current.visible) {
+    return current
+  }
+  return { ...current, visible: '' }
+}


### PR DESCRIPTION
## Summary
- move mobile session creation-warning route-param reconciliation out of a passive Effect
- preserve local dismiss state for the same warning while showing a new banner when the route warning changes
- add a focused helper and test for the warning-state transition

## Risk
Medium. This touches the mobile session route banner state, but does not change terminal/session transport, tab hydration, or RPC behavior.

## Verification
- pnpm exec oxfmt --write mobile/app/h/[hostId]/session/[worktreeId].tsx mobile/src/session/mobile-session-create-warning-state.ts mobile/src/session/mobile-session-create-warning-state.test.ts
- pnpm exec oxlint mobile/app/h/[hostId]/session/[worktreeId].tsx mobile/src/session/mobile-session-create-warning-state.ts mobile/src/session/mobile-session-create-warning-state.test.ts
- pnpm exec tsx -e "import assert from 'node:assert/strict'; import { createMobileSessionCreateWarningState, dismissMobileSessionCreateWarningState, reconcileMobileSessionCreateWarningState } from './mobile/src/session/mobile-session-create-warning-state.ts'; const dismissed = dismissMobileSessionCreateWarningState(createMobileSessionCreateWarningState('Old warning')); assert.equal(reconcileMobileSessionCreateWarningState(dismissed, 'Old warning'), dismissed); assert.deepEqual(reconcileMobileSessionCreateWarningState(dismissed, 'New warning'), { source: 'New warning', visible: 'New warning' });"
- git diff --check
- AST Effect count: 923 -> 922

## Verification gap
- pnpm --dir mobile test -- src/session/mobile-session-create-warning-state.test.ts src/session/mobile-session-startup-source.test.ts is blocked in this checkout because the mobile-local vitest binary is unavailable.
- pnpm exec vitest run --dir mobile src/session/mobile-session-create-warning-state.test.ts src/session/mobile-session-startup-source.test.ts is blocked by the existing missing expo/tsconfig.base resolution in mobile/tsconfig.json.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.