### PR TITLE
fix: cancel editor reveal frames

### DIFF
--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -2012,6 +2012,7 @@ describe('createEditorSlice activateMarkdownLink', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.useRealTimers()
   })
 
@@ -2202,6 +2203,52 @@ describe('createEditorSlice activateMarkdownLink', () => {
       filePath: '/repo/docs/guide.md',
       fileId: '/repo/docs/guide.md',
       line: 10,
+      column: 1,
+      matchLength: 0
+    })
+  })
+
+  it('cancels superseded line-anchor reveal frames', async () => {
+    const store = createEditorStore()
+    pathExistsMock.mockResolvedValue(true)
+    let nextFrameId = 1
+    const pendingFrames = new Map<number, FrameRequestCallback>()
+    const canceledFrameIds = new Set<number>()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const frameId = nextFrameId++
+      pendingFrames.set(frameId, callback)
+      return frameId
+    })
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => {
+      canceledFrameIds.add(frameId)
+      pendingFrames.delete(frameId)
+    })
+
+    await store.getState().activateMarkdownLink('./first.md#L3', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+    await store.getState().activateMarkdownLink('./second.md#L9', {
+      sourceFilePath: '/repo/docs/note.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(canceledFrameIds).toContain(1)
+    while (pendingFrames.size > 0) {
+      const nextPendingFrame = pendingFrames.entries().next()
+      if (nextPendingFrame.done) {
+        break
+      }
+      const [frameId, callback] = nextPendingFrame.value
+      pendingFrames.delete(frameId)
+      callback(0)
+    }
+    expect(store.getState().pendingEditorReveal).toEqual({
+      filePath: '/repo/docs/second.md',
+      fileId: '/repo/docs/second.md',
+      line: 9,
       column: 1,
       matchLength: 0
     })

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -205,6 +205,36 @@ export type PendingEditorReveal = {
   matchLength: number
 }
 
+const pendingEditorLineRevealFrameIds = new Set<number>()
+
+function cancelPendingEditorLineRevealFrames(): void {
+  if (typeof cancelAnimationFrame === 'function') {
+    for (const frameId of pendingEditorLineRevealFrameIds) {
+      cancelAnimationFrame(frameId)
+    }
+  }
+  pendingEditorLineRevealFrameIds.clear()
+}
+
+function trackEditorLineRevealFrameId(frameId: number): void {
+  pendingEditorLineRevealFrameIds.add(frameId)
+}
+
+function requestTrackedEditorLineRevealFrame(callback: FrameRequestCallback): void {
+  let completed = false
+  let frameId: number | undefined
+  frameId = requestAnimationFrame((timestamp) => {
+    completed = true
+    if (frameId !== undefined) {
+      pendingEditorLineRevealFrameIds.delete(frameId)
+    }
+    callback(timestamp)
+  })
+  if (!completed) {
+    trackEditorLineRevealFrameId(frameId)
+  }
+}
+
 function scheduleEditorLineReveal(
   get: () => AppState,
   filePath: string,
@@ -214,9 +244,10 @@ function scheduleEditorLineReveal(
 ): void {
   // Why: openFile can replace a preview and remount Monaco asynchronously; the
   // reveal must land after that remount or the old editor can clear it.
+  cancelPendingEditorLineRevealFrames()
   get().setPendingEditorReveal(null)
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
+  requestTrackedEditorLineRevealFrame(() => {
+    requestTrackedEditorLineRevealFrame(() => {
       get().setPendingEditorReveal({
         filePath,
         fileId,


### PR DESCRIPTION
## Summary
- cancel superseded editor line reveal requestAnimationFrame chains before scheduling a new reveal
- keep the existing two-frame Monaco remount delay while ensuring only the latest markdown line-anchor reveal can apply
- add a regression test that cancels the stale frame and drains the latest reveal

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/editor.ts src/renderer/src/store/slices/editor.test.ts
- git diff --check HEAD~1..HEAD

## Merge risk assessment
Risk level: LOW

Rationale: this is a narrowly scoped renderer-store scheduler change. It preserves the existing reveal delay and payload shape, only canceling older queued frames when a newer reveal supersedes them. The focused regression test covers the cancellation path. Impact is limited to markdown/file line-anchor reveals in editor tabs.