### PR TITLE
Move mobile pairing copy timer into handler

### DIFF
--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Check, Copy, Maximize2, Smartphone, Trash2 } from 'lucide-react'
 import { Button } from '../ui/button'
@@ -52,14 +52,14 @@ export function MobilePane(): React.JSX.Element {
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined)
   const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
+  const codeCopiedResetTimerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    if (!codeCopied) {
-      return
+  const clearCodeCopiedResetTimer = useCallback((): void => {
+    if (codeCopiedResetTimerRef.current !== null) {
+      window.clearTimeout(codeCopiedResetTimerRef.current)
+      codeCopiedResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setCodeCopied(false), 2000)
-    return () => window.clearTimeout(timeout)
-  }, [codeCopied])
+  }, [])
 
   const loadDevices = useCallback(async () => {
     try {
@@ -103,6 +103,7 @@ export function MobilePane(): React.JSX.Element {
           setQrDataUrl(result.qrDataUrl)
           setPairingUrl(result.pairingUrl)
           setEndpoint(result.endpoint)
+          clearCodeCopiedResetTimer()
           setCodeCopied(false)
           void loadDevices()
         } else {
@@ -114,7 +115,7 @@ export function MobilePane(): React.JSX.Element {
         setLoading(false)
       }
     },
-    [loadDevices, selectedAddress]
+    [clearCodeCopiedResetTimer, loadDevices, selectedAddress]
   )
 
   useEffect(() => {
@@ -148,7 +149,12 @@ export function MobilePane(): React.JSX.Element {
       // (no transient activation, non-secure context). Use the main-process
       // IPC clipboard which the rest of the app uses everywhere.
       await window.api.ui.writeClipboardText(pairingUrl)
+      clearCodeCopiedResetTimer()
       setCodeCopied(true)
+      codeCopiedResetTimerRef.current = window.setTimeout(() => {
+        codeCopiedResetTimerRef.current = null
+        setCodeCopied(false)
+      }, 2000)
     } catch {
       toast.error('Failed to copy pairing code')
     }


### PR DESCRIPTION
## Summary
- move mobile pairing URL copy feedback reset timer into the copy handler
- clear any pending copy reset when regenerating the pairing QR
- remove the passive Effect that existed only to reset copy feedback after render

## Risk
Low. This only affects transient Settings UI copy feedback for the mobile pairing URL; pairing, QR generation, device polling, and IPC behavior are unchanged.

## Verification
- pnpm exec oxfmt --write src/renderer/src/components/settings/MobilePane.tsx
- pnpm exec oxlint src/renderer/src/components/settings/MobilePane.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts src/renderer/src/components/settings/MobileNetworkInterfaceSection.test.tsx
- pnpm run typecheck:web
- git diff --check
- AST Effect count: 924 -> 923
