### PR TITLE
fix: cancel input focus frames

### DIFF
--- a/src/renderer/src/components/settings/SshPassphraseDialog.tsx
+++ b/src/renderer/src/components/settings/SshPassphraseDialog.tsx
@@ -38,9 +38,11 @@ export function SshPassphraseDialog(): React.JSX.Element | null {
 
   // DOM focus is a side effect that must remain in useEffect.
   useEffect(() => {
-    if (requestId) {
-      requestAnimationFrame(() => inputRef.current?.focus())
+    if (!requestId) {
+      return undefined
     }
+    const focusFrame = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => cancelAnimationFrame(focusFrame)
   }, [requestId])
 
   const handleSubmit = useCallback(async () => {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
@@ -50,9 +50,10 @@ export default function TabBarCreateEntry({
       setPending(false)
       setError(null)
       setSelectedIndex(0)
-      return
+      return undefined
     }
-    requestAnimationFrame(() => inputRef.current?.focus())
+    const focusFrame = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => cancelAnimationFrame(focusFrame)
   }, [menuOpen])
 
   const options = useMemo(() => getTabEntryOptions(query, fileList), [fileList, query])


### PR DESCRIPTION
## Summary
- cancel the SSH credential dialog focus frame when the active request changes or the dialog unmounts
- cancel the tab-create entry focus frame when the menu closes before the frame fires

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/SshPassphraseDialog.tsx src/renderer/src/components/tab-bar/TabBarCreateEntry.tsx
- git diff --check HEAD~1..HEAD

## Merge risk assessment
Risk level: LOW

Rationale: this only adds cleanup for existing one-frame focus scheduling. It does not change when focus is requested while the components remain mounted/open, and the blast radius is limited to transient input focus after SSH credential prompts and the tab-create menu open.