### PR TITLE
Ignore local React perf audit ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ docs/**
 !docs/readme/**
 !docs/reference/
 !docs/reference/**
+# Keep generated React perf scan ledgers local; durable docs still use docs/reference.
+docs/reference/react-performance-audit.md
 !docs/STYLEGUIDE.md
 !docs/mobile-terminal-shortcut-bar.md
 


### PR DESCRIPTION
## Summary
- keep the generated React perf audit ledger out of source control with a narrow ignore rule
- preserve the local .context ledger path for ongoing scan state

## Risk
Low - gitignore-only repo hygiene change, no runtime behavior.

## Test
- git diff --check