### PR TITLE
fix: cancel onboarding enter frames

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -82,7 +82,7 @@ export function OnboardingInlineCommandTerminal({
 
   useEffect(() => {
     if (!autoScrollIntoView) {
-      return
+      return undefined
     }
     if (prefersReducedMotion) {
       const scrollFrame = window.requestAnimationFrame(() => {
@@ -93,20 +93,32 @@ export function OnboardingInlineCommandTerminal({
     // Why: double rAF guarantees the browser commits the initial collapsed
     // styles before we flip to `entered`, so the height/opacity transition
     // actually plays instead of snapping straight to the final state.
+    let enteredFrame: number | null = null
     const enterFrame = window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => setEntered(true))
+      enteredFrame = window.requestAnimationFrame(() => setEntered(true))
     })
-    return () => window.cancelAnimationFrame(enterFrame)
+    return () => {
+      window.cancelAnimationFrame(enterFrame)
+      if (enteredFrame !== null) {
+        window.cancelAnimationFrame(enteredFrame)
+      }
+    }
   }, [autoScrollIntoView, prefersReducedMotion])
 
   useEffect(() => {
     if (autoScrollIntoView) {
-      return
+      return undefined
     }
+    let enteredFrame: number | null = null
     const enterFrame = window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => setEntered(true))
+      enteredFrame = window.requestAnimationFrame(() => setEntered(true))
     })
-    return () => window.cancelAnimationFrame(enterFrame)
+    return () => {
+      window.cancelAnimationFrame(enterFrame)
+      if (enteredFrame !== null) {
+        window.cancelAnimationFrame(enteredFrame)
+      }
+    }
   }, [autoScrollIntoView])
 
   // Why: tracking scroll *during* the height transition is unavoidably


### PR DESCRIPTION
## Summary
- track the inner requestAnimationFrame used by the onboarding inline terminal enter transition
- cancel both outer and inner enter frames when the component unmounts or the auto-scroll mode changes
- preserve the existing double-rAF timing used to start the CSS transition after the initial paint

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/onboarding/OnboardingFlow.test.tsx
- pnpm exec oxlint src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx src/renderer/src/components/onboarding/OnboardingFlow.test.tsx
- git diff --check HEAD~1..HEAD

## Merge risk assessment
Risk level: LOW

Rationale: this is a single-component cleanup change. It keeps the same transition delay and state update when the component remains mounted, and only prevents the queued inner frame from firing after cleanup.