### PR TITLE
Show section activity in worktree sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2406,22 +2406,21 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     ) : null}
 
                     <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <div className="truncate text-[13px] font-semibold leading-none">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
                           {row.label}
                         </div>
-                        <div className="rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
+                        <div className="shrink-0 rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
                           {row.count}
                         </div>
+                        <SectionActivityBadges
+                          summary={sectionActivity}
+                          collapsed={isCollapsed}
+                          showStatus={showSectionStatus}
+                          showUnread={showSectionUnread}
+                        />
                       </div>
                     </div>
-
-                    <SectionActivityBadges
-                      summary={sectionActivity}
-                      collapsed={isCollapsed}
-                      showStatus={showSectionStatus}
-                      showUnread={showSectionUnread}
-                    />
 
                     <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
                       <ChevronDown

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -142,7 +142,7 @@ import {
   pruneWorktreeSelection,
   updateWorktreeSelection
 } from './worktree-multi-selection'
-import { branchDisplayName } from './WorktreeCardHelpers'
+import { branchDisplayName, FilledBellIcon } from './WorktreeCardHelpers'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getRepoHeaderCreateState } from './repo-header-create-state'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
@@ -157,6 +157,12 @@ import {
 } from '../../../../shared/worktree-ownership'
 import { RepoIconGlyph } from '@/components/repo/repo-icon'
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
+import {
+  buildWorktreeSectionActivitySummaries,
+  EMPTY_WORKTREE_SECTION_ACTIVITY,
+  type WorktreeSectionActivityState,
+  type WorktreeSectionActivitySummary
+} from './worktree-section-activity'
 
 type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
@@ -369,6 +375,9 @@ type VirtualizedWorktreeViewportProps = {
     dropIndex: number
   }) => void
   showInlineAgentCards: boolean
+  showSectionStatus: boolean
+  showSectionUnread: boolean
+  sectionActivityByGroupKey: ReadonlyMap<string, WorktreeSectionActivitySummary>
   // Why: broad grouping changes still remount the viewport, while add/delete
   // stays mounted for row-key anchoring and layout animation. These refs bridge
   // both paths so the virtualizer never falls back to scrollTop 0.
@@ -377,6 +386,67 @@ type VirtualizedWorktreeViewportProps = {
 }
 
 type WorktreeItemRow = Extract<Row, { type: 'item' }>
+
+function formatSectionActivityLabel(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? '' : 's'}`
+}
+
+function SectionActivityBadges({
+  summary,
+  collapsed,
+  showStatus,
+  showUnread
+}: {
+  summary: WorktreeSectionActivitySummary
+  collapsed: boolean
+  showStatus: boolean
+  showUnread: boolean
+}): React.JSX.Element | null {
+  const runningCount = showStatus ? summary.runningCount : 0
+  const unreadCount = showUnread ? summary.unreadCount : 0
+
+  if (runningCount === 0 && unreadCount === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex shrink-0 items-center gap-1 transition-opacity',
+        !collapsed && 'opacity-70 group-hover:opacity-100 group-focus-within:opacity-100'
+      )}
+    >
+      {runningCount > 0 ? (
+        <span
+          className={cn(
+            'inline-flex h-4 min-w-4 items-center justify-center gap-1 rounded-full border border-amber-500/25 bg-amber-500/10 px-1 text-[10px] font-semibold leading-none text-amber-700 dark:text-amber-300',
+            collapsed && 'border-amber-500/35 bg-amber-500/15'
+          )}
+          title={formatSectionActivityLabel(runningCount, 'running workspace')}
+          aria-label={formatSectionActivityLabel(runningCount, 'running workspace')}
+        >
+          <span className="inline-flex size-3 items-center justify-center" aria-hidden="true">
+            <span className="block size-2.5 rounded-full border-[1.5px] border-amber-500 border-t-transparent animate-spin" />
+          </span>
+          <span>{runningCount}</span>
+        </span>
+      ) : null}
+      {unreadCount > 0 ? (
+        <span
+          className={cn(
+            'inline-flex h-4 min-w-4 items-center justify-center gap-1 rounded-full border border-sidebar-border bg-sidebar-accent px-1 text-[10px] font-semibold leading-none text-muted-foreground',
+            collapsed && 'text-foreground'
+          )}
+          title={formatSectionActivityLabel(unreadCount, 'unread workspace')}
+          aria-label={formatSectionActivityLabel(unreadCount, 'unread workspace')}
+        >
+          <FilledBellIcon className="size-2.5 text-amber-500" />
+          <span>{unreadCount}</span>
+        </span>
+      ) : null}
+    </div>
+  )
+}
 
 type WorktreeRowDragState = {
   draggingWorktreeId: string | null
@@ -618,6 +688,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   onPinWorktrees,
   onReorderWorktrees,
   showInlineAgentCards,
+  showSectionStatus,
+  showSectionUnread,
+  sectionActivityByGroupKey,
   scrollOffsetRef,
   scrollAnchorRef
 }: VirtualizedWorktreeViewportProps) {
@@ -2228,6 +2301,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   })
                 : null
               const projectGroupDepth = row.projectGroupDepth ?? 0
+              const isCollapsed = collapsedGroups.has(row.key)
+              const sectionActivity =
+                sectionActivityByGroupKey.get(row.key) ?? EMPTY_WORKTREE_SECTION_ACTIVITY
               return (
                 <div
                   key={vItem.key}
@@ -2340,11 +2416,18 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                       </div>
                     </div>
 
+                    <SectionActivityBadges
+                      summary={sectionActivity}
+                      collapsed={isCollapsed}
+                      showStatus={showSectionStatus}
+                      showUnread={showSectionUnread}
+                    />
+
                     <div className="flex size-4 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/60 opacity-0 transition-opacity group-hover:opacity-100">
                       <ChevronDown
                         className={cn(
                           'size-3.5 cursor-pointer transition-transform [&_path]:cursor-pointer',
-                          collapsedGroups.has(row.key) && '-rotate-90'
+                          isCollapsed && '-rotate-90'
                         )}
                       />
                     </div>
@@ -2941,6 +3024,15 @@ const WorktreeList = React.memo(function WorktreeList({
     groupBy === 'pr-status' || cardProps.includes('pr') ? s.prCache : null
   )
   const settings = useAppStore((s) => s.settings)
+  const sectionActivityTabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const sectionActivityBrowserTabsByWorktree = useAppStore((s) => s.browserTabsByWorktree)
+  const sectionActivityPtyIdsByTabId = useAppStore((s) => s.ptyIdsByTabId)
+  const sectionActivityRuntimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
+  const sectionActivityAgentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
+  const sectionActivityMigrationUnsupportedByPtyId = useAppStore(
+    (s) => s.migrationUnsupportedByPtyId
+  )
+  const sectionActivityRetainedAgentsByPaneKey = useAppStore((s) => s.retainedAgentsByPaneKey)
 
   const sortEpoch = useAppStore((s) => s.sortEpoch)
 
@@ -3237,6 +3329,59 @@ const WorktreeList = React.memo(function WorktreeList({
   const allRepoIds = useMemo(() => repos.map((r) => r.id), [repos])
   const reorderReposAction = useAppStore((s) => s.reorderRepos)
   const projectGroupOrdering = getProjectGroupOrdering(groupBy, sortBy)
+  const showSectionStatus = cardProps.includes('status')
+  const showSectionUnread = cardProps.includes('unread')
+  const sectionActivityState: WorktreeSectionActivityState = useMemo(() => {
+    const current = useAppStore.getState()
+    return {
+      tabsByWorktree: sectionActivityTabsByWorktree,
+      browserTabsByWorktree: sectionActivityBrowserTabsByWorktree,
+      ptyIdsByTabId: sectionActivityPtyIdsByTabId,
+      runtimePaneTitlesByTabId: sectionActivityRuntimePaneTitlesByTabId,
+      agentStatusEpoch: sectionActivityAgentStatusEpoch,
+      // Why: agentStatusByPaneKey can tick for same-state tool details. The
+      // section counts only need structural status transitions, tracked by
+      // agentStatusEpoch, so read the current map without subscribing to it.
+      agentStatusByPaneKey: current.agentStatusByPaneKey,
+      migrationUnsupportedByPtyId: sectionActivityMigrationUnsupportedByPtyId,
+      retainedAgentsByPaneKey: sectionActivityRetainedAgentsByPaneKey
+    }
+  }, [
+    sectionActivityAgentStatusEpoch,
+    sectionActivityBrowserTabsByWorktree,
+    sectionActivityMigrationUnsupportedByPtyId,
+    sectionActivityPtyIdsByTabId,
+    sectionActivityRetainedAgentsByPaneKey,
+    sectionActivityRuntimePaneTitlesByTabId,
+    sectionActivityTabsByWorktree
+  ])
+  const sectionActivityByGroupKey = useMemo(
+    () =>
+      showSectionStatus || showSectionUnread
+        ? buildWorktreeSectionActivitySummaries({
+            groupBy,
+            worktrees,
+            repoMap,
+            prCache,
+            workspaceStatuses,
+            projectGroups,
+            settings,
+            state: sectionActivityState
+          })
+        : new Map<string, WorktreeSectionActivitySummary>(),
+    [
+      groupBy,
+      prCache,
+      projectGroups,
+      repoMap,
+      sectionActivityState,
+      settings,
+      showSectionStatus,
+      showSectionUnread,
+      workspaceStatuses,
+      worktrees
+    ]
+  )
 
   // Build flat row list for rendering
   const rows: Row[] = useMemo(
@@ -3736,6 +3881,9 @@ const WorktreeList = React.memo(function WorktreeList({
         onPinWorktrees={pinWorktrees}
         onReorderWorktrees={reorderWorktrees}
         showInlineAgentCards={cardProps.includes('inline-agents')}
+        showSectionStatus={showSectionStatus}
+        showSectionUnread={showSectionUnread}
+        sectionActivityByGroupKey={sectionActivityByGroupKey}
         scrollOffsetRef={scrollOffsetRef}
         scrollAnchorRef={scrollAnchorRef}
       />

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -390,21 +390,7 @@ function formatSectionActivityLabel(count: number, label: string): string {
   return `${count} ${label}${count === 1 ? '' : 's'}`
 }
 
-function formatSectionCountBadgeLabel(
-  workspaceCount: number,
-  runningCount: number,
-  showStatus: boolean
-): string {
-  const workspaceLabel = formatSectionActivityLabel(workspaceCount, 'workspace')
-  if (!showStatus) {
-    return workspaceLabel
-  }
-  return runningCount > 0
-    ? `${workspaceLabel}, ${formatSectionActivityLabel(runningCount, 'running workspace')}`
-    : `${workspaceLabel}, none running`
-}
-
-function SectionCountBadge({
+function SectionMetricsBadge({
   count,
   summary,
   showStatus
@@ -415,24 +401,50 @@ function SectionCountBadge({
 }): React.JSX.Element {
   const runningCount = showStatus ? summary.runningCount : 0
   const hasRunning = runningCount > 0
-  const label = formatSectionCountBadgeLabel(count, runningCount, showStatus)
+  const totalLabel = formatSectionActivityLabel(count, 'workspace')
+  const runningLabel = formatSectionActivityLabel(runningCount, 'running workspace')
+  const badgeLabel = showStatus ? `${totalLabel}; ${runningLabel}` : totalLabel
 
   return (
     <span
-      className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center gap-1 rounded-full border border-sidebar-border bg-sidebar-accent px-1.5 text-[9px] font-medium leading-none text-muted-foreground/90"
-      title={label}
-      aria-label={label}
+      className="inline-flex h-4 shrink-0 overflow-hidden rounded-full border border-sidebar-border bg-sidebar-accent text-[9px] font-medium leading-none text-muted-foreground/90"
+      aria-label={badgeLabel}
     >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex h-full min-w-4 items-center justify-center px-1.5">
+            {count}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {totalLabel}
+        </TooltipContent>
+      </Tooltip>
       {showStatus ? (
-        <span className="inline-flex size-2.5 items-center justify-center" aria-hidden="true">
-          {hasRunning ? (
-            <span className="block size-1.5 rounded-full bg-amber-500 animate-pulse" />
-          ) : (
-            <span className="block size-1.5 rounded-full bg-current opacity-40" />
-          )}
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className={cn(
+                'inline-flex h-full min-w-4 items-center justify-center gap-1 border-l border-sidebar-border/80 px-1.5',
+                hasRunning &&
+                  'bg-amber-500/10 text-amber-700 dark:text-amber-300 dark:bg-amber-500/15'
+              )}
+            >
+              <span
+                className={cn(
+                  'block size-1.5 rounded-full',
+                  hasRunning ? 'bg-amber-500 animate-pulse' : 'bg-current opacity-40'
+                )}
+                aria-hidden="true"
+              />
+              <span>{runningCount}</span>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {runningLabel}
+          </TooltipContent>
+        </Tooltip>
       ) : null}
-      <span>{count}</span>
     </span>
   )
 }
@@ -2398,7 +2410,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
                           {row.label}
                         </div>
-                        <SectionCountBadge
+                        <SectionMetricsBadge
                           count={row.count}
                           summary={sectionActivity}
                           showStatus={showSectionStatus}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -402,8 +402,11 @@ function SectionMetricsBadge({
   const runningCount = showStatus ? summary.runningCount : 0
   const hasRunning = runningCount > 0
   const totalLabel = formatSectionActivityLabel(count, 'workspace')
-  const runningLabel = formatSectionActivityLabel(runningCount, 'running workspace')
+  const runningLabel = hasRunning
+    ? formatSectionActivityLabel(runningCount, 'running workspace')
+    : 'no running workspaces'
   const badgeLabel = showStatus ? `${totalLabel}; ${runningLabel}` : totalLabel
+  const totalTooltipLabel = showStatus && !hasRunning ? badgeLabel : totalLabel
 
   return (
     <span
@@ -417,24 +420,15 @@ function SectionMetricsBadge({
           </span>
         </TooltipTrigger>
         <TooltipContent side="bottom" sideOffset={6}>
-          {totalLabel}
+          {totalTooltipLabel}
         </TooltipContent>
       </Tooltip>
-      {showStatus ? (
+      {showStatus && hasRunning ? (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span
-              className={cn(
-                'inline-flex h-full min-w-4 items-center justify-center gap-1 border-l border-sidebar-border/80 px-1.5',
-                hasRunning &&
-                  'bg-amber-500/10 text-amber-700 dark:text-amber-300 dark:bg-amber-500/15'
-              )}
-            >
+            <span className="inline-flex h-full min-w-4 items-center justify-center gap-1 border-l border-sidebar-border/80 bg-amber-500/10 px-1.5 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300">
               <span
-                className={cn(
-                  'block size-1.5 rounded-full',
-                  hasRunning ? 'bg-amber-500 animate-pulse' : 'bg-current opacity-40'
-                )}
+                className="block size-1.5 rounded-full bg-amber-500 animate-pulse"
                 aria-hidden="true"
               />
               <span>{runningCount}</span>

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -142,7 +142,7 @@ import {
   pruneWorktreeSelection,
   updateWorktreeSelection
 } from './worktree-multi-selection'
-import { branchDisplayName, FilledBellIcon } from './WorktreeCardHelpers'
+import { branchDisplayName } from './WorktreeCardHelpers'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getRepoHeaderCreateState } from './repo-header-create-state'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
@@ -376,7 +376,6 @@ type VirtualizedWorktreeViewportProps = {
   }) => void
   showInlineAgentCards: boolean
   showSectionStatus: boolean
-  showSectionUnread: boolean
   sectionActivityByGroupKey: ReadonlyMap<string, WorktreeSectionActivitySummary>
   // Why: broad grouping changes still remount the viewport, while add/delete
   // stays mounted for row-key anchoring and layout animation. These refs bridge
@@ -391,60 +390,50 @@ function formatSectionActivityLabel(count: number, label: string): string {
   return `${count} ${label}${count === 1 ? '' : 's'}`
 }
 
-function SectionActivityBadges({
-  summary,
-  collapsed,
-  showStatus,
-  showUnread
-}: {
-  summary: WorktreeSectionActivitySummary
-  collapsed: boolean
+function formatSectionCountBadgeLabel(
+  workspaceCount: number,
+  runningCount: number,
   showStatus: boolean
-  showUnread: boolean
-}): React.JSX.Element | null {
-  const runningCount = showStatus ? summary.runningCount : 0
-  const unreadCount = showUnread ? summary.unreadCount : 0
-
-  if (runningCount === 0 && unreadCount === 0) {
-    return null
+): string {
+  const workspaceLabel = formatSectionActivityLabel(workspaceCount, 'workspace')
+  if (!showStatus) {
+    return workspaceLabel
   }
+  return runningCount > 0
+    ? `${workspaceLabel}, ${formatSectionActivityLabel(runningCount, 'running workspace')}`
+    : `${workspaceLabel}, none running`
+}
+
+function SectionCountBadge({
+  count,
+  summary,
+  showStatus
+}: {
+  count: number
+  summary: WorktreeSectionActivitySummary
+  showStatus: boolean
+}): React.JSX.Element {
+  const runningCount = showStatus ? summary.runningCount : 0
+  const hasRunning = runningCount > 0
+  const label = formatSectionCountBadgeLabel(count, runningCount, showStatus)
 
   return (
-    <div
-      className={cn(
-        'flex shrink-0 items-center gap-1 transition-opacity',
-        !collapsed && 'opacity-70 group-hover:opacity-100 group-focus-within:opacity-100'
-      )}
+    <span
+      className="inline-flex h-4 min-w-4 shrink-0 items-center justify-center gap-1 rounded-full border border-sidebar-border bg-sidebar-accent px-1.5 text-[9px] font-medium leading-none text-muted-foreground/90"
+      title={label}
+      aria-label={label}
     >
-      {runningCount > 0 ? (
-        <span
-          className={cn(
-            'inline-flex h-4 min-w-4 items-center justify-center gap-1 rounded-full border border-amber-500/25 bg-amber-500/10 px-1 text-[10px] font-semibold leading-none text-amber-700 dark:text-amber-300',
-            collapsed && 'border-amber-500/35 bg-amber-500/15'
+      {showStatus ? (
+        <span className="inline-flex size-2.5 items-center justify-center" aria-hidden="true">
+          {hasRunning ? (
+            <span className="block size-1.5 rounded-full bg-amber-500 animate-pulse" />
+          ) : (
+            <span className="block size-1.5 rounded-full bg-current opacity-40" />
           )}
-          title={formatSectionActivityLabel(runningCount, 'running workspace')}
-          aria-label={formatSectionActivityLabel(runningCount, 'running workspace')}
-        >
-          <span className="inline-flex size-3 items-center justify-center" aria-hidden="true">
-            <span className="block size-2.5 rounded-full border-[1.5px] border-amber-500 border-t-transparent animate-spin" />
-          </span>
-          <span>{runningCount}</span>
         </span>
       ) : null}
-      {unreadCount > 0 ? (
-        <span
-          className={cn(
-            'inline-flex h-4 min-w-4 items-center justify-center gap-1 rounded-full border border-sidebar-border bg-sidebar-accent px-1 text-[10px] font-semibold leading-none text-muted-foreground',
-            collapsed && 'text-foreground'
-          )}
-          title={formatSectionActivityLabel(unreadCount, 'unread workspace')}
-          aria-label={formatSectionActivityLabel(unreadCount, 'unread workspace')}
-        >
-          <FilledBellIcon className="size-2.5 text-amber-500" />
-          <span>{unreadCount}</span>
-        </span>
-      ) : null}
-    </div>
+      <span>{count}</span>
+    </span>
   )
 }
 
@@ -689,7 +678,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   onReorderWorktrees,
   showInlineAgentCards,
   showSectionStatus,
-  showSectionUnread,
   sectionActivityByGroupKey,
   scrollOffsetRef,
   scrollAnchorRef
@@ -2410,14 +2398,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
                           {row.label}
                         </div>
-                        <div className="shrink-0 rounded-full bg-black/12 px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground/90">
-                          {row.count}
-                        </div>
-                        <SectionActivityBadges
+                        <SectionCountBadge
+                          count={row.count}
                           summary={sectionActivity}
-                          collapsed={isCollapsed}
                           showStatus={showSectionStatus}
-                          showUnread={showSectionUnread}
                         />
                       </div>
                     </div>
@@ -3329,7 +3313,6 @@ const WorktreeList = React.memo(function WorktreeList({
   const reorderReposAction = useAppStore((s) => s.reorderRepos)
   const projectGroupOrdering = getProjectGroupOrdering(groupBy, sortBy)
   const showSectionStatus = cardProps.includes('status')
-  const showSectionUnread = cardProps.includes('unread')
   const sectionActivityState: WorktreeSectionActivityState = useMemo(() => {
     const current = useAppStore.getState()
     return {
@@ -3356,7 +3339,7 @@ const WorktreeList = React.memo(function WorktreeList({
   ])
   const sectionActivityByGroupKey = useMemo(
     () =>
-      showSectionStatus || showSectionUnread
+      showSectionStatus
         ? buildWorktreeSectionActivitySummaries({
             groupBy,
             worktrees,
@@ -3376,7 +3359,6 @@ const WorktreeList = React.memo(function WorktreeList({
       sectionActivityState,
       settings,
       showSectionStatus,
-      showSectionUnread,
       workspaceStatuses,
       worktrees
     ]
@@ -3881,7 +3863,6 @@ const WorktreeList = React.memo(function WorktreeList({
         onReorderWorktrees={reorderWorktrees}
         showInlineAgentCards={cardProps.includes('inline-agents')}
         showSectionStatus={showSectionStatus}
-        showSectionUnread={showSectionUnread}
         sectionActivityByGroupKey={sectionActivityByGroupKey}
         scrollOffsetRef={scrollOffsetRef}
         scrollAnchorRef={scrollAnchorRef}

--- a/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
@@ -116,7 +116,7 @@ function buildSummaries({
 }
 
 describe('buildWorktreeSectionActivitySummaries', () => {
-  it('counts running and unread worktrees across repo project-group ancestors', () => {
+  it('counts running worktrees across repo project-group ancestors', () => {
     const parent = makeProjectGroup({ id: 'parent', name: 'Parent' })
     const child = makeProjectGroup({
       id: 'child',
@@ -124,7 +124,7 @@ describe('buildWorktreeSectionActivitySummaries', () => {
       parentGroupId: parent.id
     })
     const repo = makeRepo({ projectGroupId: child.id })
-    const worktree = makeWorktree({ repoId: repo.id, isUnread: true })
+    const worktree = makeWorktree({ repoId: repo.id })
     const state = makeState({
       tabsByWorktree: {
         [worktree.id]: [
@@ -144,22 +144,19 @@ describe('buildWorktreeSectionActivitySummaries', () => {
     })
 
     expect(summaries.get(getProjectGroupHeaderKey(parent.id))).toEqual({
-      runningCount: 1,
-      unreadCount: 1
+      runningCount: 1
     })
     expect(summaries.get(getProjectGroupHeaderKey(child.id))).toEqual({
-      runningCount: 1,
-      unreadCount: 1
+      runningCount: 1
     })
     expect(summaries.get(`repo:${repo.id}`)).toEqual({
-      runningCount: 1,
-      unreadCount: 1
+      runningCount: 1
     })
   })
 
   it('keeps pinned workspace activity on the pinned header only', () => {
     const repo = makeRepo({ projectGroupId: 'group-1' })
-    const worktree = makeWorktree({ repoId: repo.id, isPinned: true, isUnread: true })
+    const worktree = makeWorktree({ repoId: repo.id, isPinned: true })
     const now = Date.now()
     const entry: AgentStatusEntry = {
       state: 'working',
@@ -187,8 +184,7 @@ describe('buildWorktreeSectionActivitySummaries', () => {
     })
 
     expect(summaries.get(PINNED_GROUP_KEY)).toEqual({
-      runningCount: 1,
-      unreadCount: 1
+      runningCount: 1
     })
     expect(summaries.get(`repo:${repo.id}`)).toBeUndefined()
     expect(summaries.get(getProjectGroupHeaderKey('group-1'))).toBeUndefined()

--- a/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { ProjectGroup, Repo, TerminalTab, Worktree } from '../../../../shared/types'
+import {
+  getProjectGroupHeaderKey,
+  PINNED_GROUP_KEY,
+  type WorktreeGroupBy
+} from './worktree-list-groups'
+import {
+  buildWorktreeSectionActivitySummaries,
+  type WorktreeSectionActivityState
+} from './worktree-section-activity'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/tmp/repo-1',
+    displayName: 'repo',
+    badgeColor: '#000000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+function makeProjectGroup(overrides: Partial<ProjectGroup>): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Group',
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/repo-1-feature',
+    branch: 'refs/heads/feature',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    comment: '',
+    displayName: 'feature',
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+function makeTerminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'zsh',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function makeState(
+  overrides: Partial<WorktreeSectionActivityState> = {}
+): WorktreeSectionActivityState {
+  return {
+    tabsByWorktree: {},
+    browserTabsByWorktree: {},
+    ptyIdsByTabId: {},
+    runtimePaneTitlesByTabId: {},
+    agentStatusEpoch: 0,
+    agentStatusByPaneKey: {},
+    migrationUnsupportedByPtyId: {},
+    retainedAgentsByPaneKey: {},
+    ...overrides
+  }
+}
+
+function buildSummaries({
+  groupBy = 'repo',
+  worktrees,
+  repos,
+  projectGroups = [],
+  state
+}: {
+  groupBy?: WorktreeGroupBy
+  worktrees: readonly Worktree[]
+  repos: readonly Repo[]
+  projectGroups?: readonly ProjectGroup[]
+  state: WorktreeSectionActivityState
+}) {
+  return buildWorktreeSectionActivitySummaries({
+    groupBy,
+    worktrees,
+    repoMap: new Map(repos.map((repo) => [repo.id, repo])),
+    prCache: null,
+    workspaceStatuses: [],
+    projectGroups,
+    state
+  })
+}
+
+describe('buildWorktreeSectionActivitySummaries', () => {
+  it('counts running and unread worktrees across repo project-group ancestors', () => {
+    const parent = makeProjectGroup({ id: 'parent', name: 'Parent' })
+    const child = makeProjectGroup({
+      id: 'child',
+      name: 'Child',
+      parentGroupId: parent.id
+    })
+    const repo = makeRepo({ projectGroupId: child.id })
+    const worktree = makeWorktree({ repoId: repo.id, isUnread: true })
+    const state = makeState({
+      tabsByWorktree: {
+        [worktree.id]: [
+          makeTerminalTab({ id: 'tab-1', worktreeId: worktree.id, title: 'Codex working' })
+        ]
+      },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1']
+      }
+    })
+
+    const summaries = buildSummaries({
+      worktrees: [worktree],
+      repos: [repo],
+      projectGroups: [parent, child],
+      state
+    })
+
+    expect(summaries.get(getProjectGroupHeaderKey(parent.id))).toEqual({
+      runningCount: 1,
+      unreadCount: 1
+    })
+    expect(summaries.get(getProjectGroupHeaderKey(child.id))).toEqual({
+      runningCount: 1,
+      unreadCount: 1
+    })
+    expect(summaries.get(`repo:${repo.id}`)).toEqual({
+      runningCount: 1,
+      unreadCount: 1
+    })
+  })
+
+  it('keeps pinned workspace activity on the pinned header only', () => {
+    const repo = makeRepo({ projectGroupId: 'group-1' })
+    const worktree = makeWorktree({ repoId: repo.id, isPinned: true, isUnread: true })
+    const now = Date.now()
+    const entry: AgentStatusEntry = {
+      state: 'working',
+      prompt: '',
+      updatedAt: now,
+      stateStartedAt: now,
+      paneKey: 'tab-1:leaf-1',
+      stateHistory: []
+    }
+    const state = makeState({
+      tabsByWorktree: {
+        [worktree.id]: [makeTerminalTab({ id: 'tab-1', worktreeId: worktree.id })]
+      },
+      agentStatusEpoch: 1,
+      agentStatusByPaneKey: {
+        [entry.paneKey]: entry
+      }
+    })
+
+    const summaries = buildSummaries({
+      worktrees: [worktree],
+      repos: [repo],
+      projectGroups: [makeProjectGroup({ id: 'group-1' })],
+      state
+    })
+
+    expect(summaries.get(PINNED_GROUP_KEY)).toEqual({
+      runningCount: 1,
+      unreadCount: 1
+    })
+    expect(summaries.get(`repo:${repo.id}`)).toBeUndefined()
+    expect(summaries.get(getProjectGroupHeaderKey('group-1'))).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -31,12 +31,10 @@ export type WorktreeSectionActivityState = Pick<
 
 export type WorktreeSectionActivitySummary = {
   runningCount: number
-  unreadCount: number
 }
 
 export const EMPTY_WORKTREE_SECTION_ACTIVITY: WorktreeSectionActivitySummary = {
-  runningCount: 0,
-  unreadCount: 0
+  runningCount: 0
 }
 
 export function buildWorktreeSectionActivitySummaries({
@@ -81,9 +79,6 @@ export function buildWorktreeSectionActivitySummaries({
       const summary = summaries.get(groupKey) ?? { ...EMPTY_WORKTREE_SECTION_ACTIVITY }
       if (status === 'working') {
         summary.runningCount++
-      }
-      if (worktree.isUnread) {
-        summary.unreadCount++
       }
       summaries.set(groupKey, summary)
     }

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -1,0 +1,113 @@
+import type { AppState } from '@/store/types'
+import { resolveWorktreeStatus } from '@/lib/worktree-status'
+import type {
+  ProjectGroup,
+  Repo,
+  Worktree,
+  WorkspaceStatusDefinition
+} from '../../../../shared/types'
+import {
+  getGroupKeysForWorktree,
+  type WorktreeGroupBy,
+  PINNED_GROUP_KEY
+} from './worktree-list-groups'
+import {
+  selectLivePtyIdsForWorktree,
+  selectRuntimePaneTitlesForWorktree
+} from './worktree-card-status-inputs'
+import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+
+export type WorktreeSectionActivityState = Pick<
+  AppState,
+  | 'tabsByWorktree'
+  | 'browserTabsByWorktree'
+  | 'ptyIdsByTabId'
+  | 'runtimePaneTitlesByTabId'
+  | 'agentStatusEpoch'
+  | 'agentStatusByPaneKey'
+  | 'migrationUnsupportedByPtyId'
+  | 'retainedAgentsByPaneKey'
+>
+
+export type WorktreeSectionActivitySummary = {
+  runningCount: number
+  unreadCount: number
+}
+
+export const EMPTY_WORKTREE_SECTION_ACTIVITY: WorktreeSectionActivitySummary = {
+  runningCount: 0,
+  unreadCount: 0
+}
+
+export function buildWorktreeSectionActivitySummaries({
+  groupBy,
+  worktrees,
+  repoMap,
+  prCache,
+  workspaceStatuses,
+  settings,
+  projectGroups,
+  state
+}: {
+  groupBy: WorktreeGroupBy
+  worktrees: readonly Worktree[]
+  repoMap: Map<string, Repo>
+  prCache: Record<string, unknown> | null
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  settings?: AppState['settings']
+  projectGroups: readonly ProjectGroup[]
+  state: WorktreeSectionActivityState
+}): Map<string, WorktreeSectionActivitySummary> {
+  const summaries = new Map<string, WorktreeSectionActivitySummary>()
+
+  for (const worktree of worktrees) {
+    const groupKeys = worktree.isPinned
+      ? [PINNED_GROUP_KEY]
+      : getGroupKeysForWorktree(
+          groupBy,
+          worktree,
+          repoMap,
+          prCache,
+          workspaceStatuses,
+          settings,
+          projectGroups
+        )
+    if (groupKeys.length === 0) {
+      continue
+    }
+
+    const status = getSectionWorktreeStatus(state, worktree.id)
+    for (const groupKey of groupKeys) {
+      const summary = summaries.get(groupKey) ?? { ...EMPTY_WORKTREE_SECTION_ACTIVITY }
+      if (status === 'working') {
+        summary.runningCount++
+      }
+      if (worktree.isUnread) {
+        summary.unreadCount++
+      }
+      summaries.set(groupKey, summary)
+    }
+  }
+
+  return summaries
+}
+
+function getSectionWorktreeStatus(
+  state: WorktreeSectionActivityState,
+  worktreeId: string
+): ReturnType<typeof resolveWorktreeStatus> {
+  const agentSummary = selectWorktreeAgentActivitySummary(state, worktreeId)
+
+  // Why: collapsed headers must mirror the card dot semantics exactly; otherwise
+  // a hidden section can advertise different activity than its visible cards.
+  return resolveWorktreeStatus({
+    tabs: state.tabsByWorktree[worktreeId] ?? [],
+    browserTabs: state.browserTabsByWorktree[worktreeId] ?? [],
+    ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
+    runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
+    hasPermission: agentSummary.hasPermission,
+    hasLiveWorking: agentSummary.hasLiveWorking,
+    hasLiveDone: agentSummary.hasLiveDone,
+    hasRetainedDone: agentSummary.hasRetainedDone
+  })
+}


### PR DESCRIPTION
## Summary
- Add compact running and unread count chips to worktree sidebar section headers.
- Derive section counts from the same worktree status inputs used by cards, including project-group ancestors and pinned sections.
- Respect the existing sidebar status/unread display toggles and avoid subscribing to high-frequency agent status detail updates.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-section-activity.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts
- pnpm run typecheck:web
- pnpm exec oxfmt --check src/renderer/src/components/sidebar/worktree-section-activity.ts src/renderer/src/components/sidebar/worktree-section-activity.test.ts src/renderer/src/components/sidebar/WorktreeList.tsx
- pnpm exec oxlint src/renderer/src/components/sidebar/worktree-section-activity.ts src/renderer/src/components/sidebar/worktree-section-activity.test.ts src/renderer/src/components/sidebar/WorktreeList.tsx
- Electron visual verification on dev instance nwparker/collapsed-progress-indicator; screenshots captured locally for PR comment.