### PR TITLE
Allow sidebar workspaces to drop onto Kanban

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -330,6 +330,16 @@ export default function WorkspaceKanbanDrawer({
   const handleWorktreeActivate = useCallback(() => {
     onOpenChange(false)
   }, [onOpenChange])
+  const handleSheetOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      // Why: Radix treats any outside pointer release as a dismiss request.
+      // The board has custom right-side/sidebar rules, so only those paths close it.
+      if (nextOpen) {
+        onOpenChange(true)
+      }
+    },
+    [onOpenChange]
+  )
 
   const handleRenameStatus = useCallback(
     (statusId: string, label: string) => {
@@ -464,7 +474,7 @@ export default function WorkspaceKanbanDrawer({
     : '0px'
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
+    <Sheet open={open} onOpenChange={handleSheetOpenChange} modal={false}>
       <SheetContent
         side="left"
         showCloseButton={false}
@@ -486,6 +496,29 @@ export default function WorkspaceKanbanDrawer({
           // its tooltip without hover and makes the drawer feel noisy.
           event.preventDefault()
         }}
+        onPointerDownOutside={(event) => {
+          const originalEvent = event.detail.originalEvent
+          const target = originalEvent.target
+          if (preserveOpenForMenu) {
+            event.preventDefault()
+            return
+          }
+          if (isWorkspaceBoardKeepOpenTarget(target)) {
+            event.preventDefault()
+            return
+          }
+          const liveDrawerLeft =
+            boardRef.current
+              ?.closest<HTMLElement>('[data-slot="sheet-content"]')
+              ?.getBoundingClientRect().left ?? drawerLeft
+          const pointerX =
+            'clientX' in originalEvent && typeof originalEvent.clientX === 'number'
+              ? originalEvent.clientX
+              : null
+          if (pointerX !== null && pointerX < liveDrawerLeft) {
+            event.preventDefault()
+          }
+        }}
         onInteractOutside={(event) => {
           const originalEvent = event.detail.originalEvent
           const target = originalEvent.target
@@ -503,7 +536,11 @@ export default function WorkspaceKanbanDrawer({
             boardRef.current
               ?.closest<HTMLElement>('[data-slot="sheet-content"]')
               ?.getBoundingClientRect().left ?? drawerLeft
-          if (originalEvent instanceof PointerEvent && originalEvent.clientX < liveDrawerLeft) {
+          const pointerX =
+            'clientX' in originalEvent && typeof originalEvent.clientX === 'number'
+              ? originalEvent.clientX
+              : null
+          if (pointerX !== null && pointerX < liveDrawerLeft) {
             // Why: keep the workspace sidebar interactive while the companion board stays open.
             event.preventDefault()
           }

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanPinDropTarget.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanPinDropTarget.tsx
@@ -18,7 +18,8 @@ export default function WorkspaceKanbanPinDropTarget({
       data-workspace-pin-drop-target=""
       className={cn(
         'mb-3 flex h-8 shrink-0 items-center gap-2 rounded-md border border-dashed border-sidebar-border bg-background/45 px-3 text-[12px] text-muted-foreground transition-colors',
-        isDragOver && 'border-sidebar-ring bg-sidebar-accent text-foreground'
+        isDragOver && 'border-sidebar-ring bg-sidebar-accent text-foreground',
+        'data-[workspace-board-external-drag-target=true]:border-sidebar-ring data-[workspace-board-external-drag-target=true]:bg-sidebar-accent data-[workspace-board-external-drag-target=true]:text-foreground'
       )}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx
@@ -88,7 +88,8 @@ export default function WorkspaceKanbanStatusLane({
         'relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-t-2 border-sidebar-border transition-colors',
         meta.border,
         meta.laneTint,
-        isDragTarget && 'border-sidebar-ring bg-sidebar-accent/70'
+        isDragTarget && 'border-sidebar-ring bg-sidebar-accent/70',
+        'data-[workspace-board-external-drag-target=true]:border-sidebar-ring data-[workspace-board-external-drag-target=true]:bg-sidebar-accent/70'
       )}
       onDragOver={(event) => onDragOver(event, status.id)}
       onDragLeave={onDragLeave}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -114,8 +114,17 @@ import {
   buildWorktreeDragPreviewOffsets,
   buildManualOrderUpdatesForVisibleGroups,
   expandDraggedWorktreeIdsForVisibleLineage,
+  shouldWriteManualOrderForGroupDrop,
   type WorktreeDragGroup
 } from './worktree-manual-order'
+import {
+  buildWorkspaceKanbanSidebarDropUpdates,
+  clearWorkspaceKanbanSidebarDropTargetVisual,
+  getWorkspaceKanbanSidebarDropGroups,
+  getWorkspaceKanbanSidebarDropTarget,
+  hasWorkspaceKanbanSidebarDropBoard,
+  updateWorkspaceKanbanSidebarDropTargetVisual
+} from './workspace-kanban-sidebar-drop'
 import {
   getFullDropIndexForWorktreeDragUnit,
   getWorktreeDragUnitGroups
@@ -362,6 +371,16 @@ type VirtualizedWorktreeViewportProps = {
   onMoveWorktreesToStatus: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
   onPinWorktree: (worktreeId: string) => void
   onPinWorktrees: (worktreeIds: readonly string[]) => void
+  onDropWorktreesOnWorkspaceBoard: (args: {
+    worktreeIds: readonly string[]
+    status: WorkspaceStatus
+    dropIndex: number
+    groups: readonly WorktreeDragGroup[]
+  }) => void
+  shouldShowWorkspaceBoardDropIndicator: (
+    worktreeIds: readonly string[],
+    status: WorkspaceStatus
+  ) => boolean
   onReorderWorktrees: (args: {
     groups: readonly WorktreeDragGroup[]
     sourceGroupKey: string
@@ -616,6 +635,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   onMoveWorktreesToStatus,
   onPinWorktree,
   onPinWorktrees,
+  onDropWorktreesOnWorkspaceBoard,
+  shouldShowWorkspaceBoardDropIndicator,
   onReorderWorktrees,
   showInlineAgentCards,
   scrollOffsetRef,
@@ -1398,6 +1419,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     setSidebarPointerDragDocumentStyles(false)
     setDragOverStatus(null)
     setPinDragOver(false)
+    clearWorkspaceKanbanSidebarDropTargetVisual()
   }, [cancelWorktreePointerAutoscroll])
 
   const clearWorktreeDrag = useCallback(() => {
@@ -1427,6 +1449,34 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       clearWorktreeDrag()
       return
     }
+    const boardTarget = updateWorkspaceKanbanSidebarDropTargetVisual({
+      x: drag.currentX,
+      y: drag.currentY,
+      shouldShowDropIndicator: (target) =>
+        Boolean(
+          target.status && shouldShowWorkspaceBoardDropIndicator(drag.draggedIds, target.status)
+        )
+    })
+    if (boardTarget.status || boardTarget.isPinDrop) {
+      setDragOverStatus(null)
+      setPinDragOver(false)
+      setWorktreeDragState((prev) =>
+        prev.dropIndex === null &&
+        prev.dropIndicatorY === null &&
+        prev.pointerY === drag.currentY &&
+        prev.previewOffsetsByWorktreeId.size === 0
+          ? prev
+          : {
+              ...prev,
+              dropIndex: null,
+              dropIndicatorY: null,
+              previewOffsetsByWorktreeId: EMPTY_WORKTREE_DRAG_PREVIEW_OFFSETS,
+              pointerY: drag.currentY
+            }
+      )
+      return
+    }
+
     const drop = computeWorktreeDrop(drag.currentY)
     const sidebarContainer = scrollRef.current
     if (!drop) {
@@ -1455,6 +1505,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       )
       return
     }
+    clearWorkspaceKanbanSidebarDropTargetVisual()
     setDragOverStatus(null)
     setPinDragOver(false)
     setWorktreeDragState((prev) =>
@@ -1468,7 +1519,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         ? prev
         : { ...prev, ...drop, pointerY: drag.currentY }
     )
-  }, [clearWorktreeDrag, computeWorktreeDrop, refreshWorktreeDragSession])
+  }, [
+    clearWorktreeDrag,
+    computeWorktreeDrop,
+    refreshWorktreeDragSession,
+    shouldShowWorkspaceBoardDropIndicator
+  ])
 
   const scheduleWorktreePointerDragFrame = useCallback(
     (drag: WorktreePointerDrag) => {
@@ -1585,7 +1641,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         return
       }
       const rects = getWorktreeSidebarDragRectsForGroup(container, sourceGroupKey)
-      if (rects.length <= 1) {
+      if (rects.length <= 1 && !hasWorkspaceKanbanSidebarDropBoard()) {
         return
       }
       const draggedIds =
@@ -1668,29 +1724,41 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         clearWorktreeDrag()
         return
       }
-      const drop = computeWorktreeDrop(event.clientY)
-      const container = scrollRef.current
-      if (drop) {
-        onReorderWorktrees({
-          groups: worktreeDragGroups,
-          sourceGroupKey: drag.sourceGroupKey,
-          draggedIds: drag.reorderDraggedIds,
-          dropIndex: getFullDropIndexForWorktreeDragUnit({
-            groups: worktreeDragUnitGroups,
+      const boardDropTarget = getWorkspaceKanbanSidebarDropTarget(event.clientX, event.clientY)
+      if (boardDropTarget.isPinDrop) {
+        onPinWorktrees(drag.draggedIds)
+      } else if (boardDropTarget.status) {
+        onDropWorktreesOnWorkspaceBoard({
+          worktreeIds: drag.draggedIds,
+          status: boardDropTarget.status,
+          dropIndex: boardDropTarget.dropIndex,
+          groups: getWorkspaceKanbanSidebarDropGroups()
+        })
+      } else {
+        const drop = computeWorktreeDrop(event.clientY)
+        if (drop) {
+          onReorderWorktrees({
+            groups: worktreeDragGroups,
             sourceGroupKey: drag.sourceGroupKey,
-            dropIndex: drop.dropIndex
+            draggedIds: drag.reorderDraggedIds,
+            dropIndex: getFullDropIndexForWorktreeDragUnit({
+              groups: worktreeDragUnitGroups,
+              sourceGroupKey: drag.sourceGroupKey,
+              dropIndex: drop.dropIndex
+            })
           })
-        })
-      } else if (container) {
-        const target = getPointerDropStatusTarget({
-          container,
-          x: event.clientX,
-          y: event.clientY
-        })
-        if (target.isPinDrop) {
-          onPinWorktrees(drag.draggedIds)
-        } else if (target.status) {
-          onMoveWorktreesToStatus(drag.draggedIds, target.status)
+        } else if (scrollRef.current) {
+          const container = scrollRef.current
+          const target = getPointerDropStatusTarget({
+            container,
+            x: event.clientX,
+            y: event.clientY
+          })
+          if (target.isPinDrop) {
+            onPinWorktrees(drag.draggedIds)
+          } else if (target.status) {
+            onMoveWorktreesToStatus(drag.draggedIds, target.status)
+          }
         }
       }
       clearWorktreeDrag()
@@ -1717,13 +1785,29 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     clearWorktreeDrag,
     computeWorktreeDrop,
     onMoveWorktreesToStatus,
+    onDropWorktreesOnWorkspaceBoard,
     onPinWorktrees,
     onReorderWorktrees,
     refreshWorktreeDragSession,
     scheduleWorktreePointerDragFrame,
+    shouldShowWorkspaceBoardDropIndicator,
     worktreeDragGroups,
     worktreeDragUnitGroups
   ])
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent): void => {
+      if (window.performance.now() >= suppressWorktreeClickUntilRef.current) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      event.stopImmediatePropagation()
+    }
+
+    document.addEventListener('click', handleClick, true)
+    return () => document.removeEventListener('click', handleClick, true)
+  }, [])
 
   const runWorktreeNativeAutoscrollFrame = useCallback(
     (frameTime: number) => {
@@ -1896,6 +1980,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         return
       }
       if (!refreshWorktreeDragSession()) {
+        clearWorktreeDrag()
+        return
+      }
+      const boardDropTarget = getWorkspaceKanbanSidebarDropTarget(event.clientX, event.clientY)
+      if (boardDropTarget.status || boardDropTarget.isPinDrop) {
         clearWorktreeDrag()
         return
       }
@@ -3576,6 +3665,49 @@ const WorktreeList = React.memo(function WorktreeList({
     [setSortBy, updateWorktreesMeta, worktreeMap]
   )
 
+  const shouldShowWorkspaceBoardDropIndicator = useCallback(
+    (worktreeIds: readonly string[], status: WorkspaceStatus) => {
+      const sourceGroupKeys = worktreeIds.flatMap((worktreeId) => {
+        const worktree = worktreeMap.get(worktreeId)
+        return worktree ? [getWorkspaceStatus(worktree, workspaceStatuses)] : []
+      })
+      return shouldWriteManualOrderForGroupDrop({
+        sortBy,
+        sourceGroupKeys,
+        targetGroupKey: status
+      })
+    },
+    [sortBy, worktreeMap, workspaceStatuses]
+  )
+
+  const dropWorktreesOnWorkspaceBoard = useCallback(
+    (args: {
+      worktreeIds: readonly string[]
+      status: WorkspaceStatus
+      dropIndex: number
+      groups: readonly WorktreeDragGroup[]
+    }) => {
+      const result = buildWorkspaceKanbanSidebarDropUpdates({
+        ...args,
+        worktreeById: worktreeMap,
+        workspaceStatuses,
+        sortBy,
+        now: Date.now()
+      })
+      if (result.updates.size === 0) {
+        return
+      }
+      // Why: when the drop changes visual order, the board/sidebar must both
+      // switch to Manual so the committed placement remains visible.
+      if (result.shouldSwitchToManual) {
+        setSortBy('manual')
+      }
+      useAppStore.getState().recordFeatureInteraction('workspace-board-actions')
+      void updateWorktreesMeta(result.updates)
+    },
+    [setSortBy, sortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
+  )
+
   // Why: hideDefaultBranchWorkspace is counted as a filter here so the
   // empty-sidebar escape hatch (Clear Filters button below) is reachable when
   // it's the only reason the list is empty — otherwise a user whose only
@@ -3734,6 +3866,8 @@ const WorktreeList = React.memo(function WorktreeList({
         onMoveWorktreesToStatus={moveWorktreesToStatus}
         onPinWorktree={pinWorktree}
         onPinWorktrees={pinWorktrees}
+        onDropWorktreesOnWorkspaceBoard={dropWorktreesOnWorkspaceBoard}
+        shouldShowWorkspaceBoardDropIndicator={shouldShowWorkspaceBoardDropIndicator}
         onReorderWorktrees={reorderWorktrees}
         showInlineAgentCards={cardProps.includes('inline-agents')}
         scrollOffsetRef={scrollOffsetRef}

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceStatusDefinition, Worktree } from '../../../../shared/types'
+import {
+  buildWorkspaceKanbanSidebarDropUpdates,
+  clearWorkspaceKanbanSidebarDropTargetVisual,
+  getWorkspaceKanbanSidebarDropGroups,
+  getWorkspaceKanbanSidebarDropTarget,
+  updateWorkspaceKanbanSidebarDropTargetVisual
+} from './workspace-kanban-sidebar-drop'
+
+const workspaceStatuses: WorkspaceStatusDefinition[] = [
+  { id: 'todo', label: 'Todo' },
+  { id: 'doing', label: 'Doing' }
+]
+
+class FakeNode {
+  parentElement: FakeElement | null = null
+}
+
+class FakeElement extends FakeNode {
+  readonly children: FakeElement[] = []
+  readonly dataset: Record<string, string> = {}
+  readonly style = {
+    setProperty: (name: string, value: string) => {
+      this.styleValues.set(name, value)
+    }
+  }
+  offsetParent: FakeElement | null = null
+  private readonly attributes = new Map<string, string>()
+  private rect: Pick<DOMRect, 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'> = {
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0
+  }
+  private readonly styleValues = new Map<string, string>()
+
+  append(...elements: FakeElement[]): void {
+    for (const element of elements) {
+      element.parentElement = this
+      this.children.push(element)
+    }
+  }
+
+  appendChild(element: FakeElement): FakeElement {
+    this.append(element)
+    return element
+  }
+
+  remove(): void {
+    if (!this.parentElement) {
+      return
+    }
+    const siblings = this.parentElement.children
+    const index = siblings.indexOf(this)
+    if (index !== -1) {
+      siblings.splice(index, 1)
+    }
+    this.parentElement = null
+  }
+
+  contains(target: FakeNode): boolean {
+    return target === this || this.children.some((child) => child.contains(target))
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value)
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name)
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name)
+  }
+
+  closest(selector: string): FakeElement | null {
+    if (this.matches(selector)) {
+      return this
+    }
+    return this.parentElement?.closest(selector) ?? null
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.querySelectorAll(selector)[0] ?? null
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const results: FakeElement[] = []
+    for (const child of this.children) {
+      if (child.matches(selector)) {
+        results.push(child)
+      }
+      results.push(...child.querySelectorAll(selector))
+    }
+    return results
+  }
+
+  getBoundingClientRect(): DOMRect {
+    return this.rect as DOMRect
+  }
+
+  setRect(rect: Pick<DOMRect, 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'>): void {
+    this.rect = rect
+  }
+
+  matches(selector: string): boolean {
+    return selector
+      .split(',')
+      .map((part) => part.trim())
+      .some((part) => {
+        if (!part.startsWith('[') || !part.endsWith(']')) {
+          return false
+        }
+        const attribute = part.slice(1, -1)
+        return this.attributes.has(attribute)
+      })
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement()
+  private pointTarget: FakeElement = this.body
+
+  createElement(): FakeElement {
+    return new FakeElement()
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    if (this.body.matches(selector)) {
+      return this.body
+    }
+    return this.body.querySelector(selector)
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const results = this.body.matches(selector) ? [this.body] : []
+    results.push(...this.body.querySelectorAll(selector))
+    return results
+  }
+
+  elementFromPoint(): FakeElement {
+    return this.pointTarget
+  }
+
+  setElementFromPoint(element: FakeElement): void {
+    this.pointTarget = element
+  }
+}
+
+let fakeDocument: FakeDocument
+
+function setRect(
+  element: HTMLElement,
+  rect: Pick<DOMRect, 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'>
+): void {
+  ;(element as unknown as FakeElement).setRect(rect)
+}
+
+function setVisible(element: HTMLElement): void {
+  Object.defineProperty(element, 'offsetParent', {
+    configurable: true,
+    get: () => document.body
+  })
+}
+
+function setElementFromPoint(element: Element): void {
+  fakeDocument.setElementFromPoint(element as unknown as FakeElement)
+}
+
+function appendBoard(): { board: HTMLElement; lane: HTMLElement; firstCard: HTMLElement } {
+  const board = document.createElement('div')
+  board.setAttribute('data-workspace-board-selection-surface', '')
+  setRect(board, { left: 0, top: 0, right: 320, bottom: 240, width: 320, height: 240 })
+
+  const lane = document.createElement('section')
+  lane.setAttribute('data-workspace-status-drop-target', '')
+  lane.dataset.workspaceStatus = 'doing'
+  setRect(lane, { left: 0, top: 0, right: 200, bottom: 220, width: 200, height: 220 })
+
+  const firstCard = document.createElement('div')
+  firstCard.setAttribute('data-workspace-board-card-id', 'doing-a')
+  firstCard.dataset.workspaceBoardCardId = 'doing-a'
+  setRect(firstCard, { left: 8, top: 8, right: 192, bottom: 48, width: 184, height: 40 })
+  setVisible(firstCard)
+
+  const secondCard = document.createElement('div')
+  secondCard.setAttribute('data-workspace-board-card-id', 'doing-b')
+  secondCard.dataset.workspaceBoardCardId = 'doing-b'
+  setRect(secondCard, { left: 8, top: 56, right: 192, bottom: 96, width: 184, height: 40 })
+  setVisible(secondCard)
+
+  lane.append(firstCard, secondCard)
+  board.append(lane)
+  document.body.append(board)
+  return { board, lane, firstCard }
+}
+
+function worktree(args: {
+  id: string
+  workspaceStatus: string
+  sortOrder: number
+  manualOrder?: number
+}): Worktree {
+  return {
+    id: args.id,
+    workspaceStatus: args.workspaceStatus,
+    sortOrder: args.sortOrder,
+    manualOrder: args.manualOrder
+  } as Worktree
+}
+
+afterEach(() => {
+  clearWorkspaceKanbanSidebarDropTargetVisual()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+beforeEach(() => {
+  fakeDocument = new FakeDocument()
+  vi.stubGlobal('Node', FakeNode)
+  vi.stubGlobal('Element', FakeElement)
+  vi.stubGlobal('HTMLElement', FakeElement)
+  vi.stubGlobal('document', fakeDocument)
+})
+
+describe('workspace kanban sidebar drop DOM bridge', () => {
+  it('resolves the board lane and rendered card index under a sidebar pointer drag', () => {
+    const { lane } = appendBoard()
+    setElementFromPoint(lane)
+
+    expect(getWorkspaceKanbanSidebarDropTarget(24, 60)).toMatchObject({
+      status: 'doing',
+      isPinDrop: false,
+      dropIndex: 1
+    })
+    expect(getWorkspaceKanbanSidebarDropGroups()).toEqual([
+      { key: 'doing', worktreeIds: ['doing-a', 'doing-b'] }
+    ])
+  })
+
+  it('marks and clears the external board hover target', () => {
+    const { lane } = appendBoard()
+    setElementFromPoint(lane)
+
+    updateWorkspaceKanbanSidebarDropTargetVisual({
+      x: 24,
+      y: 60,
+      shouldShowDropIndicator: () => true
+    })
+
+    expect(lane.getAttribute('data-workspace-board-external-drag-target')).toBe('true')
+    expect(document.querySelector('[data-workspace-board-card-drop-indicator]')).not.toBeNull()
+
+    clearWorkspaceKanbanSidebarDropTargetVisual()
+
+    expect(lane.hasAttribute('data-workspace-board-external-drag-target')).toBe(false)
+    expect(document.querySelector('[data-workspace-board-card-drop-indicator]')).toBeNull()
+  })
+})
+
+describe('workspace kanban sidebar drop updates', () => {
+  it('writes a status-only update for cross-lane drops outside Manual sort', () => {
+    const worktreeById = new Map([
+      ['todo-a', worktree({ id: 'todo-a', workspaceStatus: 'todo', sortOrder: 3000 })],
+      ['doing-a', worktree({ id: 'doing-a', workspaceStatus: 'doing', sortOrder: 2000 })]
+    ])
+
+    const result = buildWorkspaceKanbanSidebarDropUpdates({
+      worktreeIds: ['todo-a'],
+      status: 'doing',
+      dropIndex: 1,
+      groups: [
+        { key: 'todo', worktreeIds: ['todo-a'] },
+        { key: 'doing', worktreeIds: ['doing-a'] }
+      ],
+      worktreeById,
+      workspaceStatuses,
+      sortBy: 'recent',
+      now: 10_000
+    })
+
+    expect(result.shouldSwitchToManual).toBe(false)
+    expect(Array.from(result.updates)).toEqual([['todo-a', { workspaceStatus: 'doing' }]])
+  })
+
+  it('keeps the dropped board position when Manual sort is active', () => {
+    const worktreeById = new Map([
+      ['todo-a', worktree({ id: 'todo-a', workspaceStatus: 'todo', sortOrder: 3000 })],
+      ['doing-a', worktree({ id: 'doing-a', workspaceStatus: 'doing', sortOrder: 2000 })],
+      ['doing-b', worktree({ id: 'doing-b', workspaceStatus: 'doing', sortOrder: 1000 })]
+    ])
+
+    const result = buildWorkspaceKanbanSidebarDropUpdates({
+      worktreeIds: ['todo-a'],
+      status: 'doing',
+      dropIndex: 1,
+      groups: [
+        { key: 'todo', worktreeIds: ['todo-a'] },
+        { key: 'doing', worktreeIds: ['doing-a', 'doing-b'] }
+      ],
+      worktreeById,
+      workspaceStatuses,
+      sortBy: 'manual',
+      now: 10_000
+    })
+
+    expect(result.shouldSwitchToManual).toBe(true)
+    expect(result.updates.get('todo-a')).toEqual({
+      workspaceStatus: 'doing',
+      manualOrder: 1500
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
@@ -1,0 +1,190 @@
+import type {
+  WorkspaceStatus,
+  WorkspaceStatusDefinition,
+  Worktree,
+  WorktreeMeta
+} from '../../../../shared/types'
+import { getWorkspaceStatus } from './workspace-status'
+import {
+  buildManualOrderUpdatesForGroupDrop,
+  shouldWriteManualOrderForGroupDrop,
+  type WorktreeDragGroup
+} from './worktree-manual-order'
+import {
+  CARD_SELECTOR,
+  getCardDropTarget,
+  PIN_DROP_TARGET,
+  removeCardDropIndicator,
+  STATUS_DROP_TARGET,
+  updateCardDropIndicator,
+  type WorkspaceKanbanCardDropTarget
+} from './workspace-kanban-card-pointer-drag-dom'
+
+const BOARD_SELECTOR = '[data-workspace-board-selection-surface]'
+const EXTERNAL_DRAG_TARGET_ATTR = 'data-workspace-board-external-drag-target'
+
+let externalDragTargetElement: HTMLElement | null = null
+
+function getWorkspaceKanbanBoardElement(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(BOARD_SELECTOR)
+}
+
+export function hasWorkspaceKanbanSidebarDropBoard(): boolean {
+  return getWorkspaceKanbanBoardElement() !== null
+}
+
+function getStatusDropTargetElement(
+  board: HTMLElement,
+  status: WorkspaceStatus
+): HTMLElement | null {
+  return (
+    Array.from(board.querySelectorAll<HTMLElement>(STATUS_DROP_TARGET)).find(
+      (element) => element.dataset.workspaceStatus === status
+    ) ?? null
+  )
+}
+
+function setExternalDragTargetElement(element: HTMLElement | null): void {
+  if (externalDragTargetElement === element) {
+    return
+  }
+  externalDragTargetElement?.removeAttribute(EXTERNAL_DRAG_TARGET_ATTR)
+  externalDragTargetElement = element
+  externalDragTargetElement?.setAttribute(EXTERNAL_DRAG_TARGET_ATTR, 'true')
+}
+
+export function clearWorkspaceKanbanSidebarDropTargetVisual(): void {
+  setExternalDragTargetElement(null)
+  removeCardDropIndicator()
+}
+
+export function getWorkspaceKanbanSidebarDropGroups(): WorktreeDragGroup[] {
+  const board = getWorkspaceKanbanBoardElement()
+  if (!board) {
+    return []
+  }
+
+  return Array.from(board.querySelectorAll<HTMLElement>(STATUS_DROP_TARGET)).flatMap((lane) => {
+    const status = lane.dataset.workspaceStatus
+    if (!status) {
+      return []
+    }
+    return [
+      {
+        key: status,
+        worktreeIds: Array.from(lane.querySelectorAll<HTMLElement>(CARD_SELECTOR)).flatMap(
+          (card) => card.dataset.workspaceBoardCardId ?? []
+        )
+      }
+    ]
+  })
+}
+
+export function getWorkspaceKanbanSidebarDropTarget(
+  x: number,
+  y: number
+): WorkspaceKanbanCardDropTarget {
+  const board = getWorkspaceKanbanBoardElement()
+  if (!board) {
+    return { status: null, isPinDrop: false, dropIndex: 0 }
+  }
+  return getCardDropTarget(board, x, y)
+}
+
+export function updateWorkspaceKanbanSidebarDropTargetVisual(args: {
+  x: number
+  y: number
+  shouldShowDropIndicator: (target: WorkspaceKanbanCardDropTarget) => boolean
+}): WorkspaceKanbanCardDropTarget {
+  const board = getWorkspaceKanbanBoardElement()
+  if (!board) {
+    clearWorkspaceKanbanSidebarDropTargetVisual()
+    return { status: null, isPinDrop: false, dropIndex: 0 }
+  }
+
+  const target = getCardDropTarget(board, args.x, args.y)
+  const targetElement = target.isPinDrop
+    ? board.querySelector<HTMLElement>(PIN_DROP_TARGET)
+    : target.status
+      ? getStatusDropTargetElement(board, target.status)
+      : null
+  setExternalDragTargetElement(targetElement)
+
+  if (target.status && args.shouldShowDropIndicator(target)) {
+    updateCardDropIndicator(board, target)
+  } else {
+    removeCardDropIndicator()
+  }
+
+  return target
+}
+
+export function buildWorkspaceKanbanSidebarDropUpdates(args: {
+  worktreeIds: readonly string[]
+  status: WorkspaceStatus
+  dropIndex: number
+  groups: readonly WorktreeDragGroup[]
+  worktreeById: ReadonlyMap<string, Worktree>
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  sortBy: string
+  now: number
+}): {
+  updates: Map<string, Partial<WorktreeMeta>>
+  shouldSwitchToManual: boolean
+} {
+  const sourceGroupKeys = args.worktreeIds.flatMap((worktreeId) => {
+    const worktree = args.worktreeById.get(worktreeId)
+    return worktree ? [getWorkspaceStatus(worktree, args.workspaceStatuses)] : []
+  })
+  const writeManualOrder = shouldWriteManualOrderForGroupDrop({
+    sortBy: args.sortBy,
+    sourceGroupKeys,
+    targetGroupKey: args.status
+  })
+  const rankByWorktreeId = writeManualOrder
+    ? (() => {
+        const ranks = new Map<string, number>()
+        for (const group of args.groups) {
+          for (const worktreeId of group.worktreeIds) {
+            const worktree = args.worktreeById.get(worktreeId)
+            if (worktree) {
+              ranks.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+            }
+          }
+        }
+        return ranks
+      })()
+    : undefined
+  const order = writeManualOrder
+    ? buildManualOrderUpdatesForGroupDrop({
+        groups: args.groups,
+        targetGroupKey: args.status,
+        draggedIds: args.worktreeIds,
+        dropIndex: args.dropIndex,
+        now: args.now,
+        rankByWorktreeId
+      })
+    : { changed: false, updates: new Map<string, { manualOrder: number }>() }
+
+  const updates = new Map<string, Partial<WorktreeMeta>>()
+  for (const worktreeId of args.worktreeIds) {
+    const current = args.worktreeById.get(worktreeId)
+    if (!current) {
+      continue
+    }
+    if (getWorkspaceStatus(current, args.workspaceStatuses) !== args.status) {
+      updates.set(worktreeId, { workspaceStatus: args.status })
+    }
+  }
+
+  if (writeManualOrder) {
+    for (const [worktreeId, manualOrder] of order.updates) {
+      updates.set(worktreeId, { ...updates.get(worktreeId), ...manualOrder })
+    }
+  }
+
+  return {
+    updates,
+    shouldSwitchToManual: writeManualOrder && order.changed
+  }
+}


### PR DESCRIPTION
## Summary
- route sidebar workspace pointer drags through the open workspace board so drops can move cards into Kanban columns
- keep the board open during sidebar interactions and suppress the post-drag click that used to close it
- add board drop hover visuals plus unit coverage for sidebar-to-Kanban hit testing and status/manual-order updates

## Verification
- `./node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts src/renderer/src/components/sidebar/workspace-kanban-card-pointer-drag-dom.test.ts src/renderer/src/components/sidebar/use-workspace-kanban-card-pointer-drag.test.ts src/renderer/src/components/sidebar/use-workspace-status-drop.test.ts src/renderer/src/components/sidebar/use-workspace-kanban-outside-dismiss.test.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts src/renderer/src/components/sidebar/workspace-status.test.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts src/renderer/src/components/sidebar/worktree-drag-units.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p config/tsconfig.tc.web.json`
- `./node_modules/.bin/oxlint src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx src/renderer/src/components/sidebar/WorkspaceKanbanPinDropTarget.tsx src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx src/renderer/src/components/sidebar/WorktreeList.tsx`
- Electron CDP verification against `Orca: nwparker/left-to-kanban`: dragged `feat/terminal-link-reveal-in-finder` from the left workspace sidebar into the `In review` Kanban lane; the board stayed open during drag/drop, the target lane highlighted, the worktree status became `in-review`, the card appeared in that lane, and the original status was restored afterward.