### PR TITLE
Move markdown review copy timer into handler

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -459,6 +459,7 @@ export default function MarkdownPreview({
   const [activeAnnotationBlockKey, setActiveAnnotationBlockKey] = useState<string | null>(null)
   const [reviewPanelOpen, setReviewPanelOpen] = useState(false)
   const [reviewNotesCopied, setReviewNotesCopied] = useState(false)
+  const reviewNotesCopiedResetTimerRef = useRef<number | null>(null)
   const [activeReviewCommentId, setActiveReviewCommentId] = useState<string | null>(null)
   const markdownReviewNotes = useMemo(
     () => sortMarkdownReviewNotes(markdownComments as MarkdownReviewNote[]),
@@ -579,6 +580,13 @@ export default function MarkdownPreview({
     setIsSearchOpen(false)
     setQuery('')
     setActiveMatchIndex(-1)
+  }, [])
+
+  const clearReviewNotesCopiedResetTimer = useCallback((): void => {
+    if (reviewNotesCopiedResetTimerRef.current !== null) {
+      window.clearTimeout(reviewNotesCopiedResetTimerRef.current)
+      reviewNotesCopiedResetTimerRef.current = null
+    }
   }, [])
 
   const scrollToAnchor = useCallback((rawAnchor: string): boolean => {
@@ -716,19 +724,16 @@ export default function MarkdownPreview({
     }
     try {
       await window.api.ui.writeClipboardText(markdownReviewPrompt)
+      clearReviewNotesCopiedResetTimer()
       setReviewNotesCopied(true)
+      reviewNotesCopiedResetTimerRef.current = window.setTimeout(() => {
+        reviewNotesCopiedResetTimerRef.current = null
+        setReviewNotesCopied(false)
+      }, 1600)
     } catch {
       // Best-effort clipboard action; failures usually mean the window is not focused.
     }
-  }, [markdownReviewNotes.length, markdownReviewPrompt])
-
-  useEffect(() => {
-    if (!reviewNotesCopied) {
-      return
-    }
-    const timeout = window.setTimeout(() => setReviewNotesCopied(false), 1600)
-    return () => window.clearTimeout(timeout)
-  }, [reviewNotesCopied])
+  }, [clearReviewNotesCopiedResetTimer, markdownReviewNotes.length, markdownReviewPrompt])
 
   const scrollToReviewNote = useCallback((comment: DiffComment): void => {
     setActiveReviewCommentId(comment.id)


### PR DESCRIPTION
## Summary
- schedule markdown review-notes copied-state reset directly after successful copy
- remove the passive Effect that only watched copied state to start the timer

## Risk
Low - isolated copy-feedback UI state in MarkdownPreview; no persistence, source-control, terminal, or browser runtime behavior changes.

## React effect count
- current baseline: 764
- after this PR: 763

## Test
- pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/markdown-preview-search.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts
- pnpm run typecheck:web
- git diff --check