### PR TITLE
Move MCP config confirm timer into handler

### DIFF
--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertCircle, FileCode2, LoaderCircle, Plus, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { Repo, Worktree } from '../../../../shared/types'
@@ -48,6 +48,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
   const [configs, setConfigs] = useState<LoadedMcpConfigInspection[]>([])
   const [loading, setLoading] = useState(true)
   const [createConfirm, setCreateConfirm] = useState(false)
+  const createConfirmResetTimerRef = useRef<number | null>(null)
   const [inspectionUnavailableMessage, setInspectionUnavailableMessage] = useState<string | null>(
     null
   )
@@ -215,13 +216,12 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     void loadConfigs()
   }, [loadConfigs])
 
-  useEffect(() => {
-    if (!createConfirm) {
-      return
+  const clearCreateConfirmResetTimer = useCallback((): void => {
+    if (createConfirmResetTimerRef.current !== null) {
+      window.clearTimeout(createConfirmResetTimerRef.current)
+      createConfirmResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setCreateConfirm(false), 3000)
-    return () => window.clearTimeout(timeout)
-  }, [createConfirm])
+  }, [])
 
   const handleOpen = (config: LoadedMcpConfigInspection): void => {
     setActiveWorktree(targetWorktreeId)
@@ -241,7 +241,12 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
 
   const handleCreateStarter = async (): Promise<void> => {
     if (!createConfirm) {
+      clearCreateConfirmResetTimer()
       setCreateConfirm(true)
+      createConfirmResetTimerRef.current = window.setTimeout(() => {
+        createConfirmResetTimerRef.current = null
+        setCreateConfirm(false)
+      }, 3000)
       return
     }
 
@@ -250,6 +255,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       // Why: v1 only creates the root workspace config so we do not need to
       // guess per-agent directory layouts or mutate agent-specific files.
       await window.api.fs.writeFile({ filePath: target, content: MCP_STARTER_CONFIG, connectionId })
+      clearCreateConfirmResetTimer()
       setCreateConfirm(false)
       await loadConfigs()
       setActiveWorktree(targetWorktreeId)


### PR DESCRIPTION
## Summary
- schedule the MCP config create-confirm reset from the first-click handler
- remove the passive Effect that only watched createConfirm to start the reset timer

## Risk
Low - isolated transient button-confirmation UI state; MCP config inspection and local/SSH file creation paths are unchanged.

## React effect count
- current scoped baseline: 878
- after this PR: 877

## Test
- pnpm exec oxlint src/renderer/src/components/settings/McpConfigSection.tsx
- pnpm run typecheck:web
- git diff --check