### PR TITLE
Move checks resolve spinner timer into handler

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: co-locating all checks-panel sub-components (checks list,
 conflict sections, threaded PR comments) keeps the shared icon/color maps in one place. */
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import {
   CircleCheck,
   CircleX,
@@ -401,22 +401,27 @@ function ResolveButton({
   onResolve: (threadId: string, resolve: boolean) => void
 }): React.JSX.Element {
   const [loading, setLoading] = useState(false)
+  const loadingResetTimerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    if (!loading) {
-      return
+  const clearLoadingResetTimer = useCallback((): void => {
+    if (loadingResetTimerRef.current !== null) {
+      window.clearTimeout(loadingResetTimerRef.current)
+      loadingResetTimerRef.current = null
     }
-    const timeout = window.setTimeout(() => setLoading(false), 300)
-    return () => window.clearTimeout(timeout)
-  }, [loading])
+  }, [])
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
+      clearLoadingResetTimer()
       setLoading(true)
+      loadingResetTimerRef.current = window.setTimeout(() => {
+        loadingResetTimerRef.current = null
+        setLoading(false)
+      }, 300)
       onResolve(threadId, !isResolved)
     },
-    [threadId, isResolved, onResolve]
+    [clearLoadingResetTimer, threadId, isResolved, onResolve]
   )
 
   if (loading) {


### PR DESCRIPTION
## Summary
- schedule the PR comment Resolve/Unresolve spinner reset directly from the click handler
- remove the passive Effect that only watched loading state to start the 300ms reset timer

## Risk
Low - isolated transient loading indicator in the checks panel; comment resolve callback and PR/check data flows are unchanged.

## React effect count
- current scoped baseline: 878
- after this PR: 877

## Test
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/right-sidebar/checks-panel-empty-state.test.ts
- pnpm exec oxlint src/renderer/src/components/right-sidebar/checks-panel-content.tsx src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/right-sidebar/checks-panel-empty-state.test.ts
- pnpm run typecheck:web
- git diff --check