### PR TITLE
fix: cancel drag selection guard frame

### DIFF
--- a/src/renderer/src/components/editor/drag-selection-guard.ts
+++ b/src/renderer/src/components/editor/drag-selection-guard.ts
@@ -77,6 +77,7 @@ export const DragSelectionGuard = Extension.create({
           const doc = editorView.dom.ownerDocument
 
           const originalOnSelectionChange: () => void = observer.onSelectionChange
+          let mouseUpFrameId: number | null = null
 
           // Remove the listener registered by ProseMirror's DOMObserver constructor
           doc.removeEventListener('selectionchange', originalOnSelectionChange)
@@ -110,7 +111,11 @@ export const DragSelectionGuard = Extension.create({
               return
             }
             suppressedDuringDrag = false
-            requestAnimationFrame(() => {
+            if (mouseUpFrameId !== null) {
+              cancelAnimationFrame(mouseUpFrameId)
+            }
+            mouseUpFrameId = requestAnimationFrame(() => {
+              mouseUpFrameId = null
               // Why: if the plugin was destroyed between mouseup and this
               // rAF callback, viewRef is null — bail out to avoid a
               // TypeError on viewRef.domSelectionRange().
@@ -172,6 +177,10 @@ export const DragSelectionGuard = Extension.create({
 
           return {
             destroy() {
+              if (mouseUpFrameId !== null) {
+                cancelAnimationFrame(mouseUpFrameId)
+                mouseUpFrameId = null
+              }
               doc.removeEventListener('mouseup', handleMouseUp)
               doc.removeEventListener('selectionchange', patchedOnSelectionChange)
               observer.onSelectionChange = originalOnSelectionChange


### PR DESCRIPTION
## Summary
- track the drag-selection guard mouseup requestAnimationFrame
- cancel a pending mouseup restore frame before scheduling a replacement
- cancel any pending mouseup restore frame when the ProseMirror plugin view is destroyed

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/drag-selection-guard.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (local environment still stops on existing missing packages: @tiptap/extension-details, react-colorful)

## Merge risk assessment
Risk level: LOW

Rationale: this is a lifecycle cleanup for a single-frame mouseup restore in the rich markdown drag-selection guard. The existing restore logic is unchanged when the frame fires; the change only prevents stale queued callbacks from outliving the plugin view.