### PR TITLE
fix: cancel rich markdown autofocus frame

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -542,6 +542,7 @@ export default function RichMarkdownEditor({
   // Why: ProseMirror keeps the initial handleKeyDown closure, so `editor` stays
   // stuck at the first-render null value unless we read the live instance here.
   const editorRef = useRef<Editor | null>(null)
+  const cancelAutoFocusRef = useRef<(() => void) | null>(null)
   const serializeTimerRef = useRef<number | null>(null)
   // Why: normalizeSoftBreaks dispatches a ProseMirror transaction inside onCreate
   // which triggers onUpdate. Without this guard the editor immediately marks the
@@ -888,7 +889,8 @@ export default function RichMarkdownEditor({
       // otherwise opening a new markdown file (Cmd+Shift+N) or switching to
       // an existing markdown tab leaves the cursor outside the editing
       // surface and the user has to click before typing.
-      autoFocusRichEditor(nextEditor, rootRef.current)
+      cancelAutoFocusRef.current?.()
+      cancelAutoFocusRef.current = autoFocusRichEditor(nextEditor, rootRef.current)
     },
     onUpdate: ({ editor: nextEditor }) => {
       syncSlashMenu(nextEditor, rootRef.current, setSlashMenu)
@@ -1045,6 +1047,8 @@ export default function RichMarkdownEditor({
       if (notePositionsFrameRef.current !== null) {
         window.cancelAnimationFrame(notePositionsFrameRef.current)
       }
+      cancelAutoFocusRef.current?.()
+      cancelAutoFocusRef.current = null
     }
   }, [])
 

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
@@ -1,0 +1,50 @@
+import type { Editor } from '@tiptap/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { autoFocusRichEditor } from './rich-markdown-auto-focus'
+
+function createEditor(focus = vi.fn()): Editor {
+  return {
+    isDestroyed: false,
+    commands: { focus }
+  } as unknown as Editor
+}
+
+describe('autoFocusRichEditor', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns cleanup that cancels the pending focus frame', () => {
+    const cancelAnimationFrameMock = vi.fn()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 42)
+    )
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock)
+
+    const cleanup = autoFocusRichEditor(createEditor(), null)
+    cleanup()
+    cleanup()
+
+    expect(cancelAnimationFrameMock).toHaveBeenCalledTimes(1)
+    expect(cancelAnimationFrameMock).toHaveBeenCalledWith(42)
+  })
+
+  it('focuses the editor when the frame fires with neutral focus', () => {
+    let pendingFrame: FrameRequestCallback = () => {
+      throw new Error('expected focus frame to be scheduled')
+    }
+    const focus = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      pendingFrame = callback
+      return 7
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('document', { activeElement: null, body: {} })
+
+    autoFocusRichEditor(createEditor(focus), null)
+    pendingFrame(0)
+
+    expect(focus).toHaveBeenCalledWith('start', { scrollIntoView: false })
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
+++ b/src/renderer/src/components/editor/rich-markdown-auto-focus.ts
@@ -6,8 +6,9 @@ import type { Editor } from '@tiptap/react'
  * from modals/dialogs and skips scrollIntoView to avoid racing with
  * useEditorScrollRestore.
  */
-export function autoFocusRichEditor(nextEditor: Editor, rootEl: HTMLElement | null): void {
-  requestAnimationFrame(() => {
+export function autoFocusRichEditor(nextEditor: Editor, rootEl: HTMLElement | null): () => void {
+  let frameId: number | null = requestAnimationFrame(() => {
+    frameId = null
     if (nextEditor.isDestroyed) {
       return
     }
@@ -32,4 +33,10 @@ export function autoFocusRichEditor(nextEditor: Editor, rootEl: HTMLElement | nu
     // scroll position on every tab switch.
     nextEditor.commands.focus('start', { scrollIntoView: false })
   })
+  return () => {
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId)
+      frameId = null
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- make autoFocusRichEditor return a cleanup function for its pending requestAnimationFrame
- store and clear that cleanup from RichMarkdownEditor on replacement/unmount
- add a unit test covering frame cancellation and the neutral-focus path

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts
- pnpm exec oxlint src/renderer/src/components/editor/rich-markdown-auto-focus.ts src/renderer/src/components/editor/rich-markdown-auto-focus.test.ts src/renderer/src/components/editor/RichMarkdownEditor.tsx
- git diff --check HEAD~1..HEAD

## Merge risk assessment
Risk level: LOW

Rationale: the editor still auto-focuses on the same next frame when mounted. The only behavior change is that a pending mount-focus frame is canceled if RichMarkdownEditor replaces the editor instance or unmounts first.