### PR TITLE
Fix light terminal ANSI white contrast

### DIFF
--- a/src/renderer/src/lib/terminal-theme.test.ts
+++ b/src/renderer/src/lib/terminal-theme.test.ts
@@ -93,6 +93,38 @@ describe('resolveEffectiveTerminalAppearance', () => {
   })
 })
 
+function hexChannelToLinear(value: string): number {
+  const channel = parseInt(value, 16) / 255
+  return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4)
+}
+
+function relativeLuminance(hex: string): number {
+  const clean = hex.replace('#', '')
+  const r = hexChannelToLinear(clean.slice(0, 2))
+  const g = hexChannelToLinear(clean.slice(2, 4))
+  const b = hexChannelToLinear(clean.slice(4, 6))
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const fg = relativeLuminance(foreground)
+  const bg = relativeLuminance(background)
+  const lighter = Math.max(fg, bg)
+  const darker = Math.min(fg, bg)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+describe('default light terminal theme contrast', () => {
+  it('keeps ANSI white text readable on its white background', () => {
+    const theme = getTerminalThemePreview(DEFAULT_TERMINAL_THEME_LIGHT)
+
+    // Why: agent TUIs commonly use ANSI white/bright-white for dim code and
+    // diff metadata; near-white values disappear in Orca light mode.
+    expect(contrastRatio(theme!.white!, theme!.background!)).toBeGreaterThanOrEqual(4.5)
+    expect(contrastRatio(theme!.brightWhite!, theme!.background!)).toBeGreaterThanOrEqual(4.5)
+  })
+})
+
 describe('isTerminalBackgroundLight', () => {
   it('classifies common terminal background color formats by luminance', () => {
     expect(isTerminalBackgroundLight('#ffffff')).toBe(true)

--- a/src/renderer/src/lib/terminal-themes/defaults.ts
+++ b/src/renderer/src/lib/terminal-themes/defaults.ts
@@ -41,7 +41,9 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
     blue: '#3465a4',
     magenta: '#75507b',
     cyan: '#06989a',
-    white: '#d3d7cf',
+    // Why: many agent TUIs use ANSI white for code/diff metadata; Tango's
+    // pale aluminium values disappear against Orca's white light theme.
+    white: '#555753',
     brightBlack: '#555753',
     brightRed: '#ef2929',
     brightGreen: '#8ae234',
@@ -49,6 +51,6 @@ export const DEFAULT_TERMINAL_THEMES: TerminalThemeMap = {
     brightBlue: '#729fcf',
     brightMagenta: '#ad7fa8',
     brightCyan: '#34e2e2',
-    brightWhite: '#eeeeec'
+    brightWhite: '#2e3436'
   }
 }


### PR DESCRIPTION
Fixes #2830.

## Summary
- Darken the built-in Tango Light ANSI `white` and `brightWhite` values using the existing Tango gray tokens so agent/diff metadata stays readable on the white terminal background.
- Add a contrast regression for the default light terminal theme so ANSI white and bright-white remain at least 4.5:1 against the background.

## Reproduction / Evidence
- Reproduced from the issue screenshots: low-contrast agent/code/diff text was visible only when selected in light mode.
- Confirmed the pre-fix palette problem numerically: `#d3d7cf` on `#ffffff` was `1.46:1`; `#eeeeec` on `#ffffff` was `1.16:1`.
- Verified the fixed palette: `#555753` on `#ffffff` is `7.31:1`; `#2e3436` on `#ffffff` is `12.65:1`.
- Electron evidence: launched the dev app from this branch (`nwparker/issue-2830-terminal-light-contrast`) on CDP port 9336, set theme to Light + Builtin Tango Light, opened a real terminal in this worktree, and wrote ANSI 37/97 samples through `window.api.pty.writeAccepted`.
- PTY buffer proof contained `\u001b[37mANSI white fixed sample`, `\u001b[97mANSI bright-white fixed sample`, and `\u001b[37;2mDim ANSI white fixed sample`; the viewport screenshot was captured locally at `.playwright-cli/issue-2830-light-terminal-ansi-white-fixed.png` and is intentionally not committed.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-theme.test.ts`
- `pnpm run typecheck:web`
- `pnpm run lint`
- `git diff --check`
- `git diff --check HEAD^..HEAD`
