### PR TITLE
fix: cancel untitled rename focus frame

### DIFF
--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { FolderOpen } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -36,6 +36,7 @@ export function UntitledFileRenameDialog({
   const [dir, setDir] = useState(worktreePath)
   const [error, setError] = useState<string | null>(null)
   const nameInputRef = useRef<HTMLInputElement>(null)
+  const focusFrameRef = useRef<number | null>(null)
   const seededOpenStateRef = useRef({ open: false, baseName, worktreePath })
 
   const displayError = externalError ?? error
@@ -53,6 +54,15 @@ export function UntitledFileRenameDialog({
   } else if (seededOpenStateRef.current.open) {
     seededOpenStateRef.current = { open: false, baseName, worktreePath }
   }
+
+  useEffect(() => {
+    return () => {
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current)
+        focusFrameRef.current = null
+      }
+    }
+  }, [])
 
   const handleBrowse = useCallback(async () => {
     const picked = await window.api.shell.pickDirectory({ defaultPath: dir || worktreePath })
@@ -98,7 +108,11 @@ export function UntitledFileRenameDialog({
         className="max-w-[340px]"
         onOpenAutoFocus={(event) => {
           event.preventDefault()
-          requestAnimationFrame(() => {
+          if (focusFrameRef.current !== null) {
+            cancelAnimationFrame(focusFrameRef.current)
+          }
+          focusFrameRef.current = requestAnimationFrame(() => {
+            focusFrameRef.current = null
             nameInputRef.current?.focus()
             nameInputRef.current?.select()
           })


### PR DESCRIPTION
## Summary
- track the UntitledFileRenameDialog auto-focus requestAnimationFrame
- cancel a pending focus frame before scheduling a replacement
- cancel any pending focus frame when the dialog component unmounts

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
- git diff --check HEAD~1..HEAD
- pnpm typecheck (local environment still stops on existing missing packages: @tiptap/extension-details, react-colorful)

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the existing Radix open autofocus override and input focus/select behavior. The change only cancels stale queued focus frames when the dialog unmounts or schedules a newer focus request.