### PR TITLE
Fetch Codex account usage on expand

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1091,16 +1091,14 @@ function CodexSwitcherMenu({
   }, [])
 
   const handleAccountsExpandedToggle = useCallback((): void => {
-    setAccountsExpanded((current) => {
-      const nextExpanded = !current
-      if (nextExpanded) {
-        // Why: inactive-account usage is needed only for the explicit switcher
-        // expansion, so fetch it on that event instead of one render later.
-        void fetchInactiveCodexAccountUsage()
-      }
-      return nextExpanded
-    })
-  }, [fetchInactiveCodexAccountUsage])
+    const nextExpanded = !accountsExpanded
+    setAccountsExpanded(nextExpanded)
+    if (nextExpanded) {
+      // Why: inactive-account usage is needed only for the explicit switcher
+      // expansion, so fetch it on that event instead of one render later.
+      void fetchInactiveCodexAccountUsage()
+    }
+  }, [accountsExpanded, fetchInactiveCodexAccountUsage])
 
   const selectedRuntimeKey = getCodexStatusRuntimeKey(
     normalizeCodexStatusRuntimeTarget(accountState, toCodexStatusRuntimeTarget(codexTarget))

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1090,11 +1090,17 @@ function CodexSwitcherMenu({
     }
   }, [])
 
-  useEffect(() => {
-    if (accountsExpanded) {
-      void fetchInactiveCodexAccountUsage()
-    }
-  }, [accountsExpanded, fetchInactiveCodexAccountUsage])
+  const handleAccountsExpandedToggle = useCallback((): void => {
+    setAccountsExpanded((current) => {
+      const nextExpanded = !current
+      if (nextExpanded) {
+        // Why: inactive-account usage is needed only for the explicit switcher
+        // expansion, so fetch it on that event instead of one render later.
+        void fetchInactiveCodexAccountUsage()
+      }
+      return nextExpanded
+    })
+  }, [fetchInactiveCodexAccountUsage])
 
   const selectedRuntimeKey = getCodexStatusRuntimeKey(
     normalizeCodexStatusRuntimeTarget(accountState, toCodexStatusRuntimeTarget(codexTarget))
@@ -1136,7 +1142,7 @@ function CodexSwitcherMenu({
       <DropdownMenuItem
         onSelect={(event) => {
           event.preventDefault()
-          setAccountsExpanded((prev) => !prev)
+          handleAccountsExpandedToggle()
         }}
       >
         <div className="flex min-w-0 flex-1 flex-col gap-0.5 py-0.5 text-[12px]">


### PR DESCRIPTION
## Summary
- move inactive Codex account usage loading into the explicit switcher expand toggle
- remove the passive Effect that fetched usage one render after accountsExpanded changed

## Verification
- pnpm exec oxlint src/renderer/src/components/status-bar/StatusBar.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
- pnpm run typecheck:web
- git diff --check
- scoped Effect count: 879 -> 878 on branch

## Merge risk
Medium: touches status-bar Codex account usage loading behavior. No terminal protocol, SSH transport, persistence schema, or provider API contract changes.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.