### PR TITLE
fix: cancel ipynb structural frames

### DIFF
--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -2,7 +2,15 @@
 controls share one parsed document/update path for this first notebook editor
 slice; splitting before the model stabilizes would make save/run mutations
 harder to audit. */
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject
+} from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import DOMPurify from 'dompurify'
 import Markdown from 'react-markdown'
@@ -69,6 +77,31 @@ type IpynbViewerProps = {
 }
 
 const NOTEBOOK_SOURCE_COMMIT_DELAY_MS = 400
+
+function cancelIpynbStructuralContentFrames(frameIds: MutableRefObject<number[]>): void {
+  for (const frameId of frameIds.current) {
+    cancelAnimationFrame(frameId)
+  }
+  frameIds.current = []
+}
+
+function requestIpynbStructuralContentFrame(
+  frameIds: MutableRefObject<number[]>,
+  callback: FrameRequestCallback
+): void {
+  let completed = false
+  let frameId: number | undefined
+  frameId = requestAnimationFrame((timestamp) => {
+    completed = true
+    if (frameId !== undefined) {
+      frameIds.current = frameIds.current.filter((pendingFrameId) => pendingFrameId !== frameId)
+    }
+    callback(timestamp)
+  })
+  if (!completed) {
+    frameIds.current.push(frameId)
+  }
+}
 
 function valueToText(value: unknown): string {
   if (Array.isArray(value)) {
@@ -486,6 +519,7 @@ export default function IpynbViewer({
   const onContentChangeRef = useRef(onContentChange)
   const onDirtyStateHintRef = useRef(onDirtyStateHint)
   const sourceCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const structuralContentFrameIdsRef = useRef<number[]>([])
   const fontSize = computeEditorFontSize(13, editorFontZoomLevel)
   const parsed = useMemo(() => {
     try {
@@ -551,6 +585,7 @@ export default function IpynbViewer({
   useEffect(() => {
     return () => {
       void flushSourceDrafts()
+      cancelIpynbStructuralContentFrames(structuralContentFrameIdsRef)
     }
   }, [flushSourceDrafts])
 
@@ -680,7 +715,7 @@ export default function IpynbViewer({
     // Exit edit mode first, then reorder/replace cells on the next frame so
     // structural notebook actions do not dispose an editor mid-render.
     setEditingCellKey(null)
-    requestAnimationFrame(() => {
+    requestIpynbStructuralContentFrame(structuralContentFrameIdsRef, () => {
       applyContent(getNextContent(latestContent))
     })
   }


### PR DESCRIPTION
## Summary
- track requestAnimationFrame callbacks used to apply structural notebook cell edits after Monaco exits edit mode
- preserve multiple queued structural edits while the notebook stays mounted
- cancel any remaining queued structural edit frames when IpynbViewer unmounts

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/ipynb-parse.test.ts
- pnpm exec oxlint src/renderer/src/components/editor/IpynbViewer.tsx src/renderer/src/components/editor/ipynb-parse.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (local environment still stops on existing missing packages: @tiptap/extension-details, react-colorful)

## Merge risk assessment
Risk level: LOW

Rationale: the next-frame delay for structural notebook edits is preserved, and queued edits are not coalesced or superseded while mounted. The change only cancels still-pending structural edit frames during component teardown.