### PR TITLE
fix: cancel workspace focus frames

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -252,6 +252,7 @@ export default function NewWorkspaceComposerCard({
   const defaultTuiAgent = useAppStore((s) => s.settings?.defaultTuiAgent ?? null)
   const disabledTuiAgents = useAppStore((s) => s.settings?.disabledTuiAgents ?? [])
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const nameInputFocusFrameRef = React.useRef<number | null>(null)
   const submitShortcutModifierLabel = getScreenSubmitModifierLabel()
   const selectedRepoName = React.useMemo(() => {
     const repo = eligibleRepos.find((candidate) => candidate.id === repoId)
@@ -272,14 +273,26 @@ export default function NewWorkspaceComposerCard({
     [updateSettings]
   )
 
+  const cancelNameInputFocusFrame = React.useCallback((): void => {
+    if (nameInputFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(nameInputFocusFrameRef.current)
+    nameInputFocusFrameRef.current = null
+  }, [])
+
+  React.useEffect(() => cancelNameInputFocusFrame, [cancelNameInputFocusFrame])
+
   const focusNameInput = React.useCallback(() => {
     // Why: after the repo picker commits a choice, moving focus to the name
     // field keeps the keyboard flow progressing through the form instead of
     // trapping the user in the repo popover interaction.
-    requestAnimationFrame(() => {
+    cancelNameInputFocusFrame()
+    nameInputFocusFrameRef.current = requestAnimationFrame(() => {
+      nameInputFocusFrameRef.current = null
       nameInputRef?.current?.focus()
     })
-  }, [nameInputRef])
+  }, [cancelNameInputFocusFrame, nameInputRef])
 
   const visibleQuickAgents = React.useMemo(() => {
     const enabledIds = new Set(

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -198,6 +198,8 @@ export default function SmartWorkspaceNameField({
   const tabsListRef = useRef<HTMLDivElement | null>(null)
   const repoSlugCacheRef = useRef<Map<string, RepoSlug | null>>(new Map())
   const handledCrossRepoUrlRef = useRef<string | null>(null)
+  const selectedSourceFocusFrameRef = useRef<number | null>(null)
+  const localInputFocusFrameRef = useRef<number | null>(null)
   const [crossRepoPrompt, setCrossRepoPrompt] = useState<{
     link: NonNullable<ReturnType<typeof parseGitHubIssueOrPRLink>>
     matchingRepo: RepoOption | null
@@ -237,6 +239,30 @@ export default function SmartWorkspaceNameField({
       }
     },
     [inputRef]
+  )
+
+  const cancelSelectedSourceFocusFrame = useCallback((): void => {
+    if (selectedSourceFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(selectedSourceFocusFrameRef.current)
+    selectedSourceFocusFrameRef.current = null
+  }, [])
+
+  const cancelLocalInputFocusFrame = useCallback((): void => {
+    if (localInputFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(localInputFocusFrameRef.current)
+    localInputFocusFrameRef.current = null
+  }, [])
+
+  useEffect(
+    () => () => {
+      cancelSelectedSourceFocusFrame()
+      cancelLocalInputFocusFrame()
+    },
+    [cancelLocalInputFocusFrame, cancelSelectedSourceFocusFrame]
   )
 
   useEffect(() => {
@@ -308,9 +334,14 @@ export default function SmartWorkspaceNameField({
       setOpen(false)
       // Why: after Enter accepts a PR/issue row, the input unmounts. Keep the
       // keyboard flow on the source field so the next Enter advances to Agent.
-      requestAnimationFrame(() => selectedSourceRef.current?.focus({ preventScroll: true }))
+      cancelSelectedSourceFocusFrame()
+      selectedSourceFocusFrameRef.current = requestAnimationFrame(() => {
+        selectedSourceFocusFrameRef.current = null
+        selectedSourceRef.current?.focus({ preventScroll: true })
+      })
     }
-  }, [selectedSource])
+    return cancelSelectedSourceFocusFrame
+  }, [cancelSelectedSourceFocusFrame, selectedSource])
 
   const normalizedGhQuery = useMemo(
     () => normalizeGitHubLinkQuery(debouncedQuery),
@@ -886,7 +917,11 @@ export default function SmartWorkspaceNameField({
           const nextMode = next as SmartNameMode
           setMode(nextMode)
           setOpen(!disabled && nextMode !== 'text')
-          requestAnimationFrame(() => localInputRef.current?.focus({ preventScroll: true }))
+          cancelLocalInputFocusFrame()
+          localInputFocusFrameRef.current = requestAnimationFrame(() => {
+            localInputFocusFrameRef.current = null
+            localInputRef.current?.focus({ preventScroll: true })
+          })
         }}
         className="gap-0"
       >


### PR DESCRIPTION
## Summary
- Track and cancel the workspace composer repo-selection focus frame when superseded or unmounted.
- Track and cancel smart workspace name field focus frames for selected-source handoff and tab-mode changes.

## Merge risk assessment
Risk level: LOW

Rationale: the change only owns existing requestAnimationFrame focus callbacks. It preserves the same focus targets and timing while preventing stale callbacks from firing after unmount or replacement. Surface area is limited to workspace creation focus flow.

## Validation
- pnpm exec oxlint src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx src/renderer/src/components/NewWorkspaceComposerCard.tsx
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)