### PR TITLE
Remove sidebar menu cleanup effects

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Check, FolderPlus, GitBranch, ListFilter, Moon, Server } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -57,12 +57,6 @@ const SidebarFilter = React.memo(function SidebarFilter({
     },
     [onMenuOpenChange]
   )
-
-  useEffect(() => {
-    return () => {
-      onMenuOpenChange?.(false)
-    }
-  }, [onMenuOpenChange])
 
   const handleToggleRepo = useCallback(
     (repoId: string) => {

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { SlidersHorizontal } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -86,12 +86,6 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     },
     [onMenuOpenChange]
   )
-
-  useEffect(() => {
-    return () => {
-      onMenuOpenChange?.(false)
-    }
-  }, [onMenuOpenChange])
 
   // Why: derive from current repos so stale ids (e.g. lingering after a repo
   // is removed) don't inflate counts or falsely signal an applied filter.


### PR DESCRIPTION
## Summary
- remove unmount-only parent notification Effects from the sidebar filter and workspace options menus
- keep menu state updates on the existing explicit Radix open-change paths and board close path
- reduce scoped React Effect count from 879 to 877 on this branch

## Risk
Low. This removes redundant cleanup notifications; normal menu close still reports through onOpenChange, and the workspace board close handler already clears the preserve-open state.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/SidebarFilter.tsx src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
- pnpm run typecheck:web
- git diff --check