### PR TITLE
fix: cancel file explorer inline focus frame

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type React from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
@@ -40,6 +40,25 @@ export function useFileExplorerInlineInput({
   const toggleDir = useAppStore((s) => s.toggleDir)
   const openFile = useAppStore((s) => s.openFile)
   const [inlineInput, setInlineInput] = useState<InlineInput | null>(null)
+  const scrollFocusFrameRef = useRef<number | null>(null)
+
+  const cancelScrollFocusFrame = useCallback((): void => {
+    if (scrollFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(scrollFocusFrameRef.current)
+    scrollFocusFrameRef.current = null
+  }, [])
+
+  useEffect(() => cancelScrollFocusFrame, [cancelScrollFocusFrame])
+
+  const scheduleScrollFocus = useCallback((): void => {
+    cancelScrollFocusFrame()
+    scrollFocusFrameRef.current = requestAnimationFrame(() => {
+      scrollFocusFrameRef.current = null
+      scrollRef.current?.focus()
+    })
+  }, [cancelScrollFocusFrame, scrollRef])
 
   const inlineInputIndex = useMemo(() => {
     if (!inlineInput || inlineInput.type === 'rename') {
@@ -94,8 +113,8 @@ export function useFileExplorerInlineInput({
 
   const dismissInlineInput = useCallback(() => {
     setInlineInput(null)
-    requestAnimationFrame(() => scrollRef.current?.focus())
-  }, [scrollRef])
+    scheduleScrollFocus()
+  }, [scheduleScrollFocus])
 
   const handleInlineSubmit = useCallback(
     (value: string) => {
@@ -176,9 +195,9 @@ export function useFileExplorerInlineInput({
       }
       void run()
       setInlineInput(null)
-      requestAnimationFrame(() => scrollRef.current?.focus())
+      scheduleScrollFocus()
     },
-    [inlineInput, activeWorktreeId, worktreePath, refreshDir, openFile, scrollRef]
+    [inlineInput, activeWorktreeId, worktreePath, refreshDir, openFile, scheduleScrollFocus]
   )
 
   return {


### PR DESCRIPTION
## Summary
- Track the deferred file-explorer inline-input focus frame in the hook that schedules it.
- Cancel stale focus frames when a newer dismiss/submit focus is scheduled and when the hook unmounts.

## Merge risk assessment
Risk level: LOW

Rationale: this keeps the existing one-frame focus deferral and target unchanged. The only behavior change is preventing stale focus callbacks from firing after replacement or unmount in the file explorer inline create/rename flow.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/useFileExplorerInlineInput.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)