### PR TITLE
fix: cancel keybindings toggle frame

### DIFF
--- a/src/renderer/src/components/settings/KeybindingsFileActions.tsx
+++ b/src/renderer/src/components/settings/KeybindingsFileActions.tsx
@@ -41,6 +41,17 @@ export function KeybindingsFileActions(): React.JSX.Element {
   const floatingTerminalEnabled = useAppStore(
     (state) => state.settings?.floatingTerminalEnabled === true
   )
+  const floatingTerminalToggleFrameRef = React.useRef<number | null>(null)
+
+  const cancelFloatingTerminalToggleFrame = React.useCallback((): void => {
+    if (floatingTerminalToggleFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(floatingTerminalToggleFrameRef.current)
+    floatingTerminalToggleFrameRef.current = null
+  }, [])
+
+  React.useEffect(() => cancelFloatingTerminalToggleFrame, [cancelFloatingTerminalToggleFrame])
 
   const prepareKeybindingsPath = async (): Promise<string | null> => {
     const snapshot = await ensureKeybindingsFile()
@@ -76,7 +87,9 @@ export function KeybindingsFileActions(): React.JSX.Element {
       if (!floatingTerminalEnabled) {
         await updateSettings({ floatingTerminalEnabled: true })
       }
-      requestAnimationFrame(() => {
+      cancelFloatingTerminalToggleFrame()
+      floatingTerminalToggleFrameRef.current = requestAnimationFrame(() => {
+        floatingTerminalToggleFrameRef.current = null
         if (!isFloatingWorkspacePanelVisible()) {
           window.dispatchEvent(new CustomEvent(TOGGLE_FLOATING_TERMINAL_EVENT))
         }


### PR DESCRIPTION
## Summary
- Track the deferred floating-terminal toggle frame from the keybindings editor action.
- Cancel any pending toggle frame when a newer one is scheduled or the settings action component unmounts.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the existing async keybindings file-open/settings flow and the same one-frame delayed toggle. It only prevents duplicate or stale scheduled toggle callbacks from firing after replacement or component cleanup.

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/KeybindingsFileActions.tsx
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)