### PR TITLE
fix: cancel add repo radio focus frames

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
@@ -5,7 +5,7 @@
  * oxlint limit, following the same pattern as useRemoteRepo.
  */
 
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Folder, GitBranch, Home, Pencil } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -291,18 +291,31 @@ export function CreateStep({
   onCreate
 }: CreateStepProps): React.JSX.Element {
   const radioGroupRef = useRef<HTMLDivElement>(null)
+  const radioFocusFrameRef = useRef<number | null>(null)
+
+  const cancelRadioFocusFrame = useCallback((): void => {
+    if (radioFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(radioFocusFrameRef.current)
+    radioFocusFrameRef.current = null
+  }, [])
+
+  useEffect(() => cancelRadioFocusFrame, [cancelRadioFocusFrame])
 
   // Arrow keys cycle selection within the radiogroup (WAI-ARIA radio pattern).
   const cycleKind = useCallback(() => {
     const next = createKind === 'git' ? 'folder' : 'git'
     onKindChange(next)
-    requestAnimationFrame(() => {
+    cancelRadioFocusFrame()
+    radioFocusFrameRef.current = requestAnimationFrame(() => {
+      radioFocusFrameRef.current = null
       const nextEl = radioGroupRef.current?.querySelector<HTMLButtonElement>(
         `[data-kind="${next}"]`
       )
       nextEl?.focus()
     })
-  }, [createKind, onKindChange])
+  }, [cancelRadioFocusFrame, createKind, onKindChange])
 
   const trimmedName = createName.trim()
   const canSubmit = trimmedName.length > 0 && createParent.trim().length > 0 && !isCreating

--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { GitBranch, GitBranchPlus, Settings } from 'lucide-react'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -143,22 +143,35 @@ export function ProjectAddedContent({
     getInitialProjectAddedChoice(hiddenWorktreeCount, primaryBranchName)
   )
   const radioGroupRef = useRef<HTMLDivElement>(null)
+  const radioFocusFrameRef = useRef<number | null>(null)
   const trimmedName = worktreeName.trim()
   const hasHiddenWorktrees = hiddenWorktreeCount > 0
   const normalizedPrimaryBranchName = primaryBranchName.trim()
   const choices = getProjectAddedChoiceOrder(hiddenWorktreeCount, normalizedPrimaryBranchName)
   const selectedChoice = choices.includes(choice) ? choice : (choices[0] ?? 'create')
 
+  const cancelRadioFocusFrame = useCallback((): void => {
+    if (radioFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(radioFocusFrameRef.current)
+    radioFocusFrameRef.current = null
+  }, [])
+
+  useEffect(() => cancelRadioFocusFrame, [cancelRadioFocusFrame])
+
   const cycleChoice = useCallback(() => {
     const index = choices.indexOf(selectedChoice)
     const nextChoice = choices[(index + 1) % choices.length] ?? 'create'
     setChoice(nextChoice)
-    requestAnimationFrame(() => {
+    cancelRadioFocusFrame()
+    radioFocusFrameRef.current = requestAnimationFrame(() => {
+      radioFocusFrameRef.current = null
       radioGroupRef.current
         ?.querySelector<HTMLButtonElement>(`[data-choice="${nextChoice}"]`)
         ?.focus()
     })
-  }, [choices, selectedChoice])
+  }, [cancelRadioFocusFrame, choices, selectedChoice])
 
   const handlePrimaryAction = (): void => {
     if (selectedChoice === 'primary') {


### PR DESCRIPTION
## Summary
- Track the Add Repo create-step radio focus frame and cancel stale callbacks.
- Track the project-added choice radio focus frame and cancel stale callbacks.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the existing arrow-key radio selection behavior, focus target, and one-frame delay. It only prevents superseded or unmounted Add Repo dialog focus callbacks from firing later.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoSetupStep.tsx src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)