### PR TITLE
Cancel add repo radio focus from ref cleanup

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
@@ -5,7 +5,7 @@
  * oxlint limit, following the same pattern as useRemoteRepo.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Folder, GitBranch, Home, Pencil } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -301,7 +301,16 @@ export function CreateStep({
     radioFocusFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelRadioFocusFrame, [cancelRadioFocusFrame])
+  const setRadioGroupNode = useCallback(
+    (node: HTMLDivElement | null): void => {
+      // Why: the queued arrow-key focus is only valid while this radiogroup is mounted.
+      if (!node) {
+        cancelRadioFocusFrame()
+      }
+      radioGroupRef.current = node
+    },
+    [cancelRadioFocusFrame]
+  )
 
   // Arrow keys cycle selection within the radiogroup (WAI-ARIA radio pattern).
   const cycleKind = useCallback(() => {
@@ -336,7 +345,7 @@ export function CreateStep({
       <div className="space-y-3.5 pt-1 min-w-0">
         {/* Kind toggle. Real radiogroup so screen readers announce it as a choice. */}
         <div
-          ref={radioGroupRef}
+          ref={setRadioGroupNode}
           role="radiogroup"
           aria-label="Project kind"
           className="grid grid-cols-2 gap-2"

--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { GitBranch, GitBranchPlus, Settings } from 'lucide-react'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -158,7 +158,16 @@ export function ProjectAddedContent({
     radioFocusFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelRadioFocusFrame, [cancelRadioFocusFrame])
+  const setRadioGroupNode = useCallback(
+    (node: HTMLDivElement | null): void => {
+      // Why: the queued arrow-key focus is only valid while this radiogroup is mounted.
+      if (!node) {
+        cancelRadioFocusFrame()
+      }
+      radioGroupRef.current = node
+    },
+    [cancelRadioFocusFrame]
+  )
 
   const cycleChoice = useCallback(() => {
     const index = choices.indexOf(selectedChoice)
@@ -198,7 +207,7 @@ export function ProjectAddedContent({
       <div className="space-y-3 pt-1">
         {choices.length > 1 ? (
           <div
-            ref={radioGroupRef}
+            ref={setRadioGroupNode}
             role="radiogroup"
             aria-label="How to start working"
             className="space-y-2"


### PR DESCRIPTION
## Summary
- cancel Add Repo create/setup radio arrow-key focus frames from the radiogroup ref cleanup path
- remove the two cleanup-only mount Effects that only disposed those frames
- reduce scoped React Effect count from 883 to 881 on this branch

## Risk
Low. This is isolated Add Repo dialog focus cleanup state. Arrow-key selection still schedules the same focus move, and unmount now cancels it through the DOM ref that owns the radiogroup. No persistence, IPC, SSH, or provider behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoCreateStep.tsx src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx
- pnpm run typecheck:web
- git diff --check