### PR TITLE
Cancel sparse preset focus from ref cleanup

### DIFF
--- a/src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
+++ b/src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { Check, ChevronsUpDown, LoaderCircle, Pencil, Plus, RefreshCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -84,7 +84,16 @@ export default function SparseCheckoutPresetSelect({
     nameInputFocusFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelNameInputFocusFrame, [cancelNameInputFocusFrame])
+  const setNameInputNode = useCallback(
+    (node: HTMLInputElement | null): void => {
+      // Why: the queued draft focus is only valid while this input is mounted.
+      if (!node) {
+        cancelNameInputFocusFrame()
+      }
+      nameInputRef.current = node
+    },
+    [cancelNameInputFocusFrame]
+  )
 
   const startDraft = useCallback(
     (nextDraft: PresetDraft): void => {
@@ -251,7 +260,7 @@ export default function SparseCheckoutPresetSelect({
                 <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 shadow-xs transition focus-within:border-ring/70 focus-within:ring-1 focus-within:ring-ring/30">
                   <input
                     id="sparse-preset-name"
-                    ref={nameInputRef}
+                    ref={setNameInputNode}
                     value={draft.name}
                     onChange={(event) => setDraft({ ...draft, name: event.target.value })}
                     placeholder="Renderer UI"


### PR DESCRIPTION
## Summary
- cancel the sparse preset name-input focus frame from the input ref cleanup path
- remove the cleanup-only mount Effect that only disposed that frame
- reduce scoped React Effect count from 882 to 881 on this branch

## Risk
Low. This is isolated sparse-preset popover focus cleanup. The create/edit handlers still schedule the same input focus/select behavior, and unmount now cancels it through the input ref. No persistence, IPC, SSH, or provider behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/sparse-preset-draft.test.ts
- pnpm run typecheck:web
- git diff --check