### PR TITLE
fix: cancel reviewer picker focus frame

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1222,6 +1222,17 @@ function PRReviewCell({
   const [submitting, setSubmitting] = useState(false)
   const settings = useAppStore((s) => s.settings)
   const reviewerInputRef = useRef<HTMLInputElement | null>(null)
+  const reviewerInputFocusFrameRef = useRef<number | null>(null)
+
+  const cancelReviewerInputFocusFrame = useCallback((): void => {
+    if (reviewerInputFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(reviewerInputFocusFrameRef.current)
+    reviewerInputFocusFrameRef.current = null
+  }, [])
+
+  useEffect(() => cancelReviewerInputFocusFrame, [cancelReviewerInputFocusFrame])
 
   useEffect(() => {
     setLocalReviewRequests(item.reviewRequests ?? [])
@@ -1412,9 +1423,14 @@ function PRReviewCell({
   const handleReviewerPickerOpenChange = (nextOpen: boolean): void => {
     setOpen(nextOpen)
     if (nextOpen) {
-      requestAnimationFrame(() => reviewerInputRef.current?.focus())
+      cancelReviewerInputFocusFrame()
+      reviewerInputFocusFrameRef.current = requestAnimationFrame(() => {
+        reviewerInputFocusFrameRef.current = null
+        reviewerInputRef.current?.focus()
+      })
       return
     }
+    cancelReviewerInputFocusFrame()
     setReviewerInput('')
   }
 


### PR DESCRIPTION
## Summary
- Track the TaskPage PR reviewer picker input focus frame.
- Cancel stale focus frames when the picker closes, a newer open schedules focus, or the cell unmounts.

## Merge risk assessment
Risk level: LOW

Rationale: the change preserves the same reviewer picker open behavior, focus target, and one-frame delay. It only prevents stale scheduled focus callbacks from firing after close/replacement/unmount.

## Validation
- pnpm exec oxlint src/renderer/src/components/TaskPage.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/github-pr-reviewer-display.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)