### PR TITLE
Cancel reviewer picker focus from ref cleanup

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1232,7 +1232,16 @@ function PRReviewCell({
     reviewerInputFocusFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelReviewerInputFocusFrame, [cancelReviewerInputFocusFrame])
+  const setReviewerInputNode = useCallback(
+    (node: HTMLInputElement | null): void => {
+      // Why: the queued picker focus is only valid while this input is mounted.
+      if (!node) {
+        cancelReviewerInputFocusFrame()
+      }
+      reviewerInputRef.current = node
+    },
+    [cancelReviewerInputFocusFrame]
+  )
 
   useEffect(() => {
     setLocalReviewRequests(item.reviewRequests ?? [])
@@ -1509,7 +1518,7 @@ function PRReviewCell({
         </div>
         <div className="border-b border-border/70 p-3">
           <Input
-            ref={reviewerInputRef}
+            ref={setReviewerInputNode}
             value={reviewerInput}
             onChange={(event) => setReviewerInput(event.target.value)}
             placeholder="Type or choose a user"


### PR DESCRIPTION
## Summary
- cancel the PR reviewer picker input focus frame from the input ref cleanup path
- remove the cleanup-only mount Effect that only disposed that frame
- reduce scoped React Effect count from 883 to 882 on this branch

## Risk
Medium. This touches the TaskPage PR reviewer request popover focus flow. It does not change reviewer request persistence, provider RPC/IPC calls, SSH, or transport behavior.

## Validation
- pnpm exec oxlint src/renderer/src/components/TaskPage.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/task-page-cache-selectors.test.ts src/renderer/src/components/task-page-pr-check-summary.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.