### PR TITLE
fix: cancel file explorer reveal scroll frame

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { Dispatch, RefObject, SetStateAction } from 'react'
 import type { Virtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
@@ -43,6 +43,22 @@ export function useFileExplorerReveal({
   flashTimeoutRef,
   virtualizer
 }: UseFileExplorerRevealParams): void {
+  const revealScrollFrameRef = useRef<number | null>(null)
+  const revealScrollTimeoutRef = useRef<number | null>(null)
+
+  const cancelRevealScroll = useCallback((): void => {
+    if (revealScrollFrameRef.current !== null) {
+      cancelAnimationFrame(revealScrollFrameRef.current)
+      revealScrollFrameRef.current = null
+    }
+    if (revealScrollTimeoutRef.current !== null) {
+      window.clearTimeout(revealScrollTimeoutRef.current)
+      revealScrollTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => cancelRevealScroll, [cancelRevealScroll])
+
   const pendingRevealAncestorDirs = useMemo(() => {
     if (
       !pendingExplorerReveal ||
@@ -170,8 +186,11 @@ export function useFileExplorerReveal({
       }, 2000)
     }
 
-    requestAnimationFrame(() => {
-      window.setTimeout(() => {
+    cancelRevealScroll()
+    revealScrollFrameRef.current = requestAnimationFrame(() => {
+      revealScrollFrameRef.current = null
+      revealScrollTimeoutRef.current = window.setTimeout(() => {
+        revealScrollTimeoutRef.current = null
         const targetIndex = flatRows.findIndex((row) => row.path === revealPath)
         if (targetIndex !== -1) {
           virtualizer.scrollToIndex(targetIndex, { align: 'center' })
@@ -180,6 +199,7 @@ export function useFileExplorerReveal({
     })
   }, [
     activeWorktreeId,
+    cancelRevealScroll,
     clearPendingExplorerReveal,
     dirCache,
     expanded,


### PR DESCRIPTION
## Summary
- Track the manual file-explorer reveal scroll animation frame and inner timeout together.
- Cancel stale reveal scroll deferrals when a newer reveal schedules scrolling or the hook unmounts.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the same reveal selection, flash behavior, centered virtualizer scroll, and defer timing. It only prevents old reveal scroll callbacks from firing after replacement or unmount.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/editor.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)