### PR TITLE
Cancel keybindings toggle frame from ref cleanup

### DIFF
--- a/src/renderer/src/components/settings/KeybindingsFileActions.tsx
+++ b/src/renderer/src/components/settings/KeybindingsFileActions.tsx
@@ -51,7 +51,15 @@ export function KeybindingsFileActions(): React.JSX.Element {
     floatingTerminalToggleFrameRef.current = null
   }, [])
 
-  React.useEffect(() => cancelFloatingTerminalToggleFrame, [cancelFloatingTerminalToggleFrame])
+  const setActionsRootNode = React.useCallback(
+    (node: HTMLDivElement | null): void => {
+      // Why: the deferred floating-terminal toggle belongs to this settings control.
+      if (!node) {
+        cancelFloatingTerminalToggleFrame()
+      }
+    },
+    [cancelFloatingTerminalToggleFrame]
+  )
 
   const prepareKeybindingsPath = async (): Promise<string | null> => {
     const snapshot = await ensureKeybindingsFile()
@@ -116,7 +124,10 @@ export function KeybindingsFileActions(): React.JSX.Element {
   }
 
   return (
-    <div className="space-y-2 rounded-md border border-border bg-card px-3 py-2 text-card-foreground shadow-xs">
+    <div
+      ref={setActionsRootNode}
+      className="space-y-2 rounded-md border border-border bg-card px-3 py-2 text-card-foreground shadow-xs"
+    >
       <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
         <div className="min-w-0">
           <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">


### PR DESCRIPTION
## Summary
- cancel the deferred floating-terminal toggle frame from the Keybindings JSON actions root ref cleanup
- remove the cleanup-only mount Effect that only disposed that frame
- reduce scoped React Effect count from 883 to 882 on this branch

## Risk
Medium. This touches Settings keybindings and the floating-terminal toggle event after opening keybindings in Orca. It does not change persistence format, provider behavior, SSH, or terminal PTY protocol.

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/KeybindingsFileActions.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.