### PR TITLE
fix: cancel floating return focus frame

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -359,6 +359,17 @@ function App(): React.JSX.Element {
   // Why: the floating workspace is a transient overlay; hotkey minimize should
   // return keyboard focus to the surface the user was working in before it.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
+  const floatingTerminalReturnFocusFrameRef = useRef<number | null>(null)
+
+  const cancelFloatingTerminalReturnFocusFrame = useCallback((): void => {
+    if (floatingTerminalReturnFocusFrameRef.current === null) {
+      return
+    }
+    cancelAnimationFrame(floatingTerminalReturnFocusFrameRef.current)
+    floatingTerminalReturnFocusFrameRef.current = null
+  }, [])
+
+  useEffect(() => cancelFloatingTerminalReturnFocusFrame, [cancelFloatingTerminalReturnFocusFrame])
 
   const rememberFloatingTerminalReturnFocus = useCallback((): void => {
     const active = document.activeElement
@@ -381,10 +392,15 @@ function App(): React.JSX.Element {
     if (!target || !document.contains(target)) {
       return
     }
-    requestAnimationFrame(() => {
+    cancelFloatingTerminalReturnFocusFrame()
+    floatingTerminalReturnFocusFrameRef.current = requestAnimationFrame(() => {
+      floatingTerminalReturnFocusFrameRef.current = null
+      if (!document.contains(target)) {
+        return
+      }
       target.focus({ preventScroll: true })
     })
-  }, [])
+  }, [cancelFloatingTerminalReturnFocusFrame])
 
   const setFloatingTerminalOpenWithFocus = useCallback(
     (nextOpen: SetStateAction<boolean>): void => {


### PR DESCRIPTION
## Summary
- Track App's deferred floating-terminal return-focus frame.
- Cancel stale return-focus callbacks and re-check the target is still in the document before focusing.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the same floating-terminal minimize focus restoration behavior and one-frame delay. It only prevents stale focus callbacks from firing after replacement or app cleanup.

## Validation
- pnpm exec oxlint src/renderer/src/App.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.test.ts src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)