### PR TITLE
fix: cancel floating panel focus frame

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -139,6 +139,8 @@ export function FloatingTerminalPanel({
   const pendingEditorCloseQueueRef = useRef<string[]>([])
   const saveDialogFileIdRef = useRef<string | null>(null)
   const panelRef = useRef<HTMLDivElement>(null)
+  const shortcutFocusFrameRef = useRef<number | null>(null)
+  const shortcutFocusTimeoutRef = useRef<number | null>(null)
   const dragRef = useRef<{
     pointerId: number
     startX: number
@@ -690,17 +692,35 @@ export function FloatingTerminalPanel({
     panelRef.current?.focus({ preventScroll: true })
   }, [])
 
+  const cancelShortcutFocusFrame = useCallback((): void => {
+    if (shortcutFocusFrameRef.current !== null) {
+      cancelAnimationFrame(shortcutFocusFrameRef.current)
+      shortcutFocusFrameRef.current = null
+    }
+    if (shortcutFocusTimeoutRef.current !== null) {
+      window.clearTimeout(shortcutFocusTimeoutRef.current)
+      shortcutFocusTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => cancelShortcutFocusFrame, [cancelShortcutFocusFrame])
+
   const focusPanelForShortcutsAfterClose = useCallback(() => {
     if (typeof window === 'undefined') {
       return
     }
-    const focusPanel = (): void => focusPanelForShortcuts(false)
+    cancelShortcutFocusFrame()
+    const focusPanel = (): void => {
+      shortcutFocusFrameRef.current = null
+      shortcutFocusTimeoutRef.current = null
+      focusPanelForShortcuts(false)
+    }
     if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(focusPanel)
+      shortcutFocusFrameRef.current = window.requestAnimationFrame(focusPanel)
       return
     }
-    globalThis.setTimeout(focusPanel, 0)
-  }, [focusPanelForShortcuts])
+    shortcutFocusTimeoutRef.current = window.setTimeout(focusPanel, 0)
+  }, [cancelShortcutFocusFrame, focusPanelForShortcuts])
 
   const setFloatingTerminalInputFocused = useCallback((target: EventTarget | null): void => {
     window.api.ui.setFloatingTerminalInputFocused(isFloatingWorkspaceTerminalInputTarget(target))


### PR DESCRIPTION
## Summary
- Track the floating terminal panel's deferred shortcut focus rAF.
- Track and clear the zero-delay timeout fallback on environments without rAF.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the same close-action shortcut focus recovery and defer timing. It only prevents stale focus callbacks from firing after replacement or panel cleanup.

## Validation
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/components/floating-terminal/floating-terminal-panel-bounds.test.ts src/renderer/src/components/floating-terminal/floating-terminal-trigger-position.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)