### PR TITLE
Cancel diff comment scroll frame from editor cleanup

### DIFF
--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -144,8 +144,6 @@ export function useDiffCommentDecorator({
     scrollToZoneFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelScrollToZoneFrame, [cancelScrollToZoneFrame])
-
   const commentableLineSet = useMemo(
     () => (commentableLineNumbers ? new Set(commentableLineNumbers) : null),
     [commentableLineNumbers]


### PR DESCRIPTION
## Summary
- remove the cleanup-only mount Effect for the diff-comment scroll-to-zone frame
- keep cancellation in the editor-scoped cleanup and invalid-request paths that already own the resolver lifecycle
- reduce projected React Effect count from 889 to 888 when applied to current main

## Risk
Medium. This touches diff-comment Monaco scroll-to-note timing, but leaves zone creation, scroll math, edit/delete behavior, and persistence unchanged.

## Validation
- pnpm exec oxlint src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts src/renderer/src/lib/diff-comment-compat.test.ts src/renderer/src/lib/diff-comments-format.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.