### PR TITLE
fix: cancel worktree palette focus frames

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -257,6 +257,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const wasVisibleRef = useRef(false)
   const skipRestoreFocusRef = useRef(false)
   const listRef = useRef<HTMLDivElement>(null)
+  const fallbackFocusOuterFrameRef = useRef<number | null>(null)
+  const fallbackFocusInnerFrameRef = useRef<number | null>(null)
   const createLookupGuard = useMemo(() => createWorktreePaletteRequestGuard(), [])
   const preserveCreateLookupOnCloseRef = useRef(false)
 
@@ -727,9 +729,25 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     listRef.current?.scrollTo(0, 0)
   }, [])
 
+  const cancelFallbackFocusFrames = useCallback((): void => {
+    if (fallbackFocusOuterFrameRef.current !== null) {
+      cancelAnimationFrame(fallbackFocusOuterFrameRef.current)
+      fallbackFocusOuterFrameRef.current = null
+    }
+    if (fallbackFocusInnerFrameRef.current !== null) {
+      cancelAnimationFrame(fallbackFocusInnerFrameRef.current)
+      fallbackFocusInnerFrameRef.current = null
+    }
+  }, [])
+
+  useEffect(() => cancelFallbackFocusFrames, [cancelFallbackFocusFrames])
+
   const focusFallbackSurface = useCallback(() => {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
+    cancelFallbackFocusFrames()
+    fallbackFocusOuterFrameRef.current = requestAnimationFrame(() => {
+      fallbackFocusOuterFrameRef.current = null
+      fallbackFocusInnerFrameRef.current = requestAnimationFrame(() => {
+        fallbackFocusInnerFrameRef.current = null
         const xterm = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
         if (xterm) {
           xterm.focus()
@@ -741,7 +759,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         }
       })
     })
-  }, [])
+  }, [cancelFallbackFocusFrames])
 
   const requestBrowserFocus = useCallback(
     (detail: { pageId: string; target: 'webview' | 'address-bar' }) => {


### PR DESCRIPTION
## Summary
- Track both deferred fallback-focus frames used after the Worktree Jump palette closes.
- Cancel stale fallback focus chains when a newer close schedules focus or the palette unmounts.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the same double-rAF delay and fallback focus targets (terminal first, Monaco second). It only prevents old palette-close focus callbacks from firing after replacement or unmount.

## Validation
- pnpm exec oxlint src/renderer/src/components/WorktreeJumpPalette.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-palette-search.test.ts src/renderer/src/lib/worktree-palette-create-action.test.ts src/renderer/src/components/cmd-j/palette-results.test.ts src/renderer/src/components/cmd-j/quick-action-context.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)