### PR TITLE
fix: cancel popover wheel frames

### DIFF
--- a/src/renderer/src/components/ui/popover.tsx
+++ b/src/renderer/src/components/ui/popover.tsx
@@ -28,6 +28,18 @@ function PopoverContent({
 }: React.ComponentProps<typeof PopoverPrimitive.Content> & {
   portalContainer?: HTMLElement | null
 }) {
+  const wheelFrameIdsRef = React.useRef<Set<number>>(new Set())
+
+  React.useEffect(
+    () => () => {
+      for (const frameId of wheelFrameIdsRef.current) {
+        cancelAnimationFrame(frameId)
+      }
+      wheelFrameIdsRef.current.clear()
+    },
+    []
+  )
+
   const handleWheel = React.useCallback(
     (event: React.WheelEvent<HTMLDivElement>) => {
       onWheel?.(event)
@@ -55,11 +67,13 @@ function PopoverContent({
       if (nextScrollTop !== el.scrollTop) {
         const previousScrollTop = el.scrollTop
         event.stopPropagation()
-        requestAnimationFrame(() => {
+        const frameId = requestAnimationFrame(() => {
+          wheelFrameIdsRef.current.delete(frameId)
           if (el.scrollTop === previousScrollTop) {
             el.scrollTop = nextScrollTop
           }
         })
+        wheelFrameIdsRef.current.add(frameId)
       }
     },
     [onWheel]


### PR DESCRIPTION
## Summary
- Track deferred wheel-scroll frames inside the shared PopoverContent workaround.
- Cancel any still-pending wheel frames when the popover content unmounts, while preserving independent queued wheel callbacks.

## Merge risk assessment
Risk level: LOW

Rationale: this keeps the existing Radix-dialog wheel workaround behavior intact and does not coalesce wheel events. It only owns scheduled frames so unmounted popovers do not keep stale scroll callbacks alive.

## Validation
- pnpm exec oxlint src/renderer/src/components/ui/popover.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts src/renderer/src/components/status-bar/resource-usage-open-slices.test.ts src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)