### PR TITLE
Add Homebrew RC cask channel

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -6,9 +6,9 @@ name: Homebrew Cask Bump
 #   - workflow_dispatch → manual backfill for a specific tag
 #
 # The job computes the sha256 of orca-macos-arm64.dmg + orca-macos-x64.dmg
-# from the release, templates Casks/orca.rb in this repo with the new
-# version and hashes, then PRs the result into stablyai/homebrew-orca. It
-# does NOT run for -rc.* tags: the stable cask should only track GA.
+# from the release, templates the channel-specific cask in this repo with the
+# new version and hashes, then PRs the result into stablyai/homebrew-orca.
+# Stable tags update Casks/orca.rb; RC tags update Casks/orca@rc.rb.
 #
 # Why no `release.published` trigger: other products shipped from this repo
 # (e.g. mobile under `mobile-v*`) also publish GitHub Releases. A blanket
@@ -35,14 +35,10 @@ on:
 jobs:
   bump-cask:
     runs-on: ubuntu-latest
-    # Why: defense in depth. The desktop release pipeline already refuses
-    # to invoke this workflow for `-rc.*` tags, but a manual backfill could
-    # still pass one in — reject it here so the stable cask can never point
-    # at an RC. Also requires the desktop tag shape `v<digit>...` so a
-    # mis-typed mobile tag like `mobile-v0.0.1` is rejected up front.
+    # Why: only desktop tags have the macOS DMGs this workflow downloads.
+    # A mobile tag such as `mobile-v0.0.1` must never rewrite either cask.
     if: >
       inputs.tag != '' &&
-      !contains(inputs.tag, '-rc.') &&
       startsWith(inputs.tag, 'v')
     permissions:
       contents: read
@@ -65,6 +61,35 @@ jobs:
           version="${tag#v}"
           echo "tag=$tag" >>"$GITHUB_OUTPUT"
           echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Resolve cask target
+        id: cask
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            token="orca@rc"
+            branch_token="orca-rc"
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            token="orca"
+            branch_token="orca"
+          else
+            echo "::error::Unsupported desktop tag shape: $TAG" >&2
+            exit 1
+          fi
+
+          path="Casks/${token}.rb"
+          if [[ ! -f "$path" ]]; then
+            echo "::error::Missing cask template: $path" >&2
+            exit 1
+          fi
+
+          echo "token=$token" >>"$GITHUB_OUTPUT"
+          echo "path=$path" >>"$GITHUB_OUTPUT"
+          echo "branch=bump/${branch_token}-${VERSION}" >>"$GITHUB_OUTPUT"
+          echo "title=${token} ${VERSION}" >>"$GITHUB_OUTPUT"
 
       - name: Download DMGs and compute sha256
         id: hash
@@ -89,11 +114,12 @@ jobs:
           VERSION: ${{ steps.tag.outputs.version }}
           ARM_SHA: ${{ steps.hash.outputs.arm }}
           INTEL_SHA: ${{ steps.hash.outputs.intel }}
+          CASK_PATH: ${{ steps.cask.outputs.path }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
           import os, re, pathlib
-          p = pathlib.Path("Casks/orca.rb")
+          p = pathlib.Path(os.environ["CASK_PATH"])
           src = p.read_text()
           src = re.sub(r'version "[^"]+"',
                        f'version "{os.environ["VERSION"]}"', src, count=1)
@@ -132,10 +158,13 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.tag.outputs.version }}
           TAG: ${{ steps.tag.outputs.tag }}
+          CASK_PATH: ${{ steps.cask.outputs.path }}
+          BRANCH: ${{ steps.cask.outputs.branch }}
+          TITLE: ${{ steps.cask.outputs.title }}
         run: |
           set -euo pipefail
-          mkdir -p tap/Casks
-          cp Casks/orca.rb tap/Casks/orca.rb
+          mkdir -p "tap/$(dirname "$CASK_PATH")"
+          cp "$CASK_PATH" "tap/$CASK_PATH"
 
           cd tap
           # Why: commit author must match the buf0-bot app so commits are
@@ -148,20 +177,20 @@ jobs:
             exit 0
           fi
 
-          branch="bump/orca-$VERSION"
+          branch="$BRANCH"
           git checkout -b "$branch"
-          git add Casks/orca.rb
-          git commit -m "orca $VERSION"
+          git add "$CASK_PATH"
+          git commit -m "$TITLE"
           git push -u origin "$branch" --force
 
-          # Why: prefer --fill so the PR body matches the commit; fall back
-          # to a brief body if the PR already exists for this branch.
+          # Why: repeated backfills can race an existing PR branch, so edit
+          # the PR title if creation reports that one already exists.
           gh pr create \
-            --title "orca $VERSION" \
-            --body "Automated bump from stablyai/orca release $TAG." \
+            --title "$TITLE" \
+            --body "Automated bump of $CASK_PATH from stablyai/orca release $TAG." \
             --base main \
             --head "$branch" \
-            || gh pr edit "$branch" --title "orca $VERSION"
+            || gh pr edit "$branch" --title "$TITLE"
 
           # Why: squash-merge immediately rather than --auto. The tap has no
           # required checks or branch protection, and `gh pr merge --auto`

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -62,6 +62,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag || steps.version.outputs.recovered_tag }}
       should_release: ${{ steps.tag.outputs.tag != '' || steps.version.outputs.recovered_tag != '' }}
+      latest_published_rc_tag: ${{ steps.publish_drafts.outputs.latest_published_tag }}
     steps:
       - name: Checkout ref
         uses: actions/checkout@v6
@@ -766,11 +767,22 @@ jobs:
             --prerelease="$prerelease" \
             --repo "$GITHUB_REPOSITORY"
 
+  homebrew-bump-published-rc-draft:
+    needs:
+      - cut
+    # Why: publish-complete-draft-releases can expose a recovered RC without
+    # running the build/publish jobs; still advance the RC cask to that tag.
+    if: ${{ needs.cut.outputs.latest_published_rc_tag != '' }}
+    uses: ./.github/workflows/homebrew-bump.yml
+    with:
+      tag: ${{ needs.cut.outputs.latest_published_rc_tag }}
+    secrets: inherit
+
   homebrew-bump:
     needs:
       - cut
       - publish-release
-    if: ${{ !contains(needs.cut.outputs.tag, '-rc.') }}
+    if: ${{ needs.cut.outputs.tag != '' && startsWith(needs.cut.outputs.tag, 'v') }}
     uses: ./.github/workflows/homebrew-bump.yml
     with:
       tag: ${{ needs.cut.outputs.tag }}

--- a/Casks/orca@rc.rb
+++ b/Casks/orca@rc.rb
@@ -1,28 +1,36 @@
-cask "orca" do
+cask "orca@rc" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.3.24"
-  sha256 arm:   "fc707f290ff3b631b7b7947bf339885b61a43d2e89475997c125b61268ed4966",
-         intel: "5f677c13a08f7a5740442e29d388285a86488c8c1f7aa5f10a8721a2c6ede8e4"
+  version "1.4.36-rc.3"
+  sha256 arm:   "563b6b14323fc9d5489299c82442d514bc12cabffc9d06d3964ed572af4b3955",
+         intel: "457088c7021f07de1a419197f7b2bd00092741ad4727d4fef3d86af38a6831e7"
 
   url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
       verified: "github.com/stablyai/orca/"
-  name "Orca"
+  name "Orca RC"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://github.com/stablyai/orca"
+    regex(/^v?(\d+(?:\.\d+)+-rc\.\d+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+        next unless release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
-  # Why: electron-updater (src/main/updater.ts) handles in-place updates by
-  # writing a new Orca.app into /Applications. Marking the cask auto_updates
-  # tells Homebrew not to compete with the in-app updater — `brew upgrade`
-  # becomes a no-op unless the user passes --greedy, and brew's version
-  # metadata stays aligned with whatever the app has swapped itself to.
+  # Why: RC installs should follow Orca's prerelease-aware updater instead of
+  # waiting for Homebrew metadata churn between frequent release candidates.
   auto_updates true
-  conflicts_with cask: "orca@rc"
+  conflicts_with cask: "orca"
   depends_on macos: :big_sur
 
   app "Orca.app"

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,19 @@
+# Developing
+
+## Release Channels
+
+The public Homebrew cask tracks stable desktop releases:
+
+```bash
+brew install --cask stablyai/orca/orca
+```
+
+Release candidates use a separate cask token:
+
+```bash
+brew install --cask stablyai/orca/orca@rc
+```
+
+The two casks conflict because both install `Orca.app`. Switch channels with a
+normal `brew uninstall --cask` followed by the install for the other channel.
+Do not use `--zap` unless you intentionally want to remove local Orca state.

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -75,6 +75,39 @@ describe('Electron runtime package contract', () => {
     expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
   })
 
+  it('bumps separate Homebrew casks for stable and RC desktop tags', () => {
+    const releaseWorkflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+    )
+    const homebrewWorkflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/homebrew-bump.yml'), 'utf8')
+    )
+
+    expect(releaseWorkflow.jobs['homebrew-bump'].if).toContain(
+      "startsWith(needs.cut.outputs.tag, 'v')"
+    )
+    expect(releaseWorkflow.jobs['homebrew-bump'].if).not.toContain("-rc.")
+    expect(releaseWorkflow.jobs['homebrew-bump-published-rc-draft'].with.tag).toBe(
+      '${{ needs.cut.outputs.latest_published_rc_tag }}'
+    )
+
+    const resolveCaskStep = homebrewWorkflow.jobs['bump-cask'].steps.find(
+      (step) => step.name === 'Resolve cask target'
+    )
+    const renderStep = homebrewWorkflow.jobs['bump-cask'].steps.find(
+      (step) => step.name === 'Render updated cask file'
+    )
+    const copyStep = homebrewWorkflow.jobs['bump-cask'].steps.find(
+      (step) => step.name === 'Copy cask into tap and open PR'
+    )
+
+    expect(resolveCaskStep.run).toContain('token="orca@rc"')
+    expect(resolveCaskStep.run).toContain('token="orca"')
+    expect(renderStep.env.CASK_PATH).toBe('${{ steps.cask.outputs.path }}')
+    expect(copyStep.run).toContain('cp "$CASK_PATH" "tap/$CASK_PATH"')
+    expect(copyStep.run).toContain('git add "$CASK_PATH"')
+  })
+
   it('installs the Electron package binary in PR checks without changing native module ABI', () => {
     const prWorkflow = readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8')
     const parsedWorkflow = parse(prWorkflow)

--- a/config/scripts/publish-complete-draft-releases.mjs
+++ b/config/scripts/publish-complete-draft-releases.mjs
@@ -112,6 +112,7 @@ export function writeGithubOutputs({ published, skipped }, outputPath = process.
     `${[
       `published_count=${published.length}`,
       `skipped_count=${skipped.length}`,
+      `latest_published_tag=${published.at(-1) ?? ''}`,
       `published_tags=${published.join(',')}`,
       `skipped_tags=${skipped.map((item) => item.tag).join(',')}`
     ].join('\n')}\n`

--- a/config/scripts/publish-complete-draft-releases.test.mjs
+++ b/config/scripts/publish-complete-draft-releases.test.mjs
@@ -125,6 +125,7 @@ describe('writeGithubOutputs', () => {
         `${[
           'published_count=1',
           'skipped_count=1',
+          'latest_published_tag=v1.4.2-rc.7',
           'published_tags=v1.4.2-rc.7',
           'skipped_tags=v1.4.2-rc.8'
         ].join('\n')}\n`


### PR DESCRIPTION
## Summary

Adds a Homebrew release-candidate cask channel using the conventional cask token `orca@rc`.

- Adds `Casks/orca@rc.rb`, seeded from the latest published desktop RC (`v1.4.36-rc.3`) with verified macOS DMG hashes.
- Makes `homebrew-bump.yml` select `orca` for stable tags and `orca@rc` for `vX.Y.Z-rc.N` tags.
- Lets `release-cut.yml` bump Homebrew for RC releases, including recovered complete RC drafts published by the draft-recovery step.
- Documents the developer-facing install/switching command in `DEVELOPING.md`.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional targeted validation run:

- `pnpm vitest run --config config/vitest.config.ts config/scripts/package-electron-runtime-contract.test.mjs config/scripts/publish-complete-draft-releases.test.mjs`
- `pnpm exec oxlint config/scripts/publish-complete-draft-releases.mjs config/scripts/publish-complete-draft-releases.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`
- `brew style Casks/orca.rb 'Casks/orca@rc.rb'`
- Temporary local tap validation: `brew audit --cask --strict --tap=...`, `brew livecheck --cask .../orca@rc`, and `brew info --cask .../orca@rc`
- `git diff --check`

## AI Review Report

Reviewed the release flow for channel separation, mobile-release exclusion, recovered RC draft handling, and tap PR branch naming. The main issue found during implementation was token shape: Homebrew fully qualified cask names are `user/repo/token`, and Homebrew's alternate-channel convention is `@beta`/`@nightly` style tokens, so this PR uses `stablyai/orca/orca@rc` instead of a four-segment `/rc` command. Cross-platform review: runtime app behavior is unchanged; workflow shell changes are Linux GitHub Actions-only and path handling remains under Homebrew cask conventions.

## Security Audit

Reviewed release automation inputs and auth boundaries. `homebrew-bump.yml` now rejects unsupported desktop tag shapes before downloading assets, continues to exclude non-desktop `mobile-v*` tags, and still uses the existing short-lived buf0-bot GitHub App token only for the tap checkout/push. No new secrets, IPC, renderer, or user-input surfaces are added.

## Notes

The stable and RC casks conflict because both install `Orca.app` with the same bundle identity. Users should uninstall one channel before installing the other.