### PR TITLE
Cancel file explorer flash timeout from reveal cleanup

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -111,13 +111,6 @@ function FileExplorerInner(): React.JSX.Element {
     copyPathsForNode
   } = useFileExplorerSelection(visibleFlatRows, isMac)
 
-  const clearFlashTimeout = useCallback(() => {
-    if (flashTimeoutRef.current !== null) {
-      window.clearTimeout(flashTimeoutRef.current)
-      flashTimeoutRef.current = null
-    }
-  }, [])
-
   const entries = useMemo(
     () => (activeWorktreeId ? (gitStatusByWorktree[activeWorktreeId] ?? []) : []),
     [activeWorktreeId, gitStatusByWorktree]
@@ -193,8 +186,6 @@ function FileExplorerInner(): React.JSX.Element {
       }
     }
   }, [sshConnectedGeneration, visibleWorktreePath]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => clearFlashTimeout, [clearFlashTimeout])
 
   useEffect(() => {
     if (!visibleWorktreePath) {

--- a/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts
@@ -57,7 +57,18 @@ export function useFileExplorerReveal({
     }
   }, [])
 
-  useEffect(() => cancelRevealScroll, [cancelRevealScroll])
+  // Why: reveal owns the flash and scroll timers it schedules; keep cleanup on
+  // hook unmount so no-worktree renders preserve the existing timeout behavior.
+  useEffect(
+    () => () => {
+      cancelRevealScroll()
+      if (flashTimeoutRef.current !== null) {
+        window.clearTimeout(flashTimeoutRef.current)
+        flashTimeoutRef.current = null
+      }
+    },
+    [cancelRevealScroll, flashTimeoutRef]
+  )
 
   const pendingRevealAncestorDirs = useMemo(() => {
     if (


### PR DESCRIPTION
## Summary
- remove the file explorer's parent-level cleanup-only flash timeout Effect
- fold that timeout cancellation into `useFileExplorerReveal`'s existing reveal cleanup
- keep cleanup scoped to hook unmount so no-worktree renders preserve the current timeout behavior

## Performance impact
- Effect hook call-site count projects from 889 to 888 on current `origin/main` (`64dd35ecf4`)
- removes one cleanup-only passive Effect from the file explorer surface

## Risk
- Medium: touches right-sidebar file explorer reveal/flash cleanup behavior

## Validation
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/FileExplorer.tsx src/renderer/src/components/right-sidebar/useFileExplorerReveal.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.