### PR TITLE
fix: cancel document theme frames

### DIFF
--- a/src/renderer/src/lib/document-theme.test.ts
+++ b/src/renderer/src/lib/document-theme.test.ts
@@ -48,17 +48,30 @@ function createThemeRoot(): { classList: FakeClassList } {
 
 function createFrameQueue(): {
   requestAnimationFrame: (callback: FrameRequestCallback) => number
+  cancelAnimationFrame: (handle: number) => void
   flushNextFrame: () => void
+  pendingCount: () => number
 } {
-  const callbacks: FrameRequestCallback[] = []
+  let nextHandle = 1
+  const callbacks = new Map<number, FrameRequestCallback>()
   return {
     requestAnimationFrame: (callback) => {
-      callbacks.push(callback)
-      return callbacks.length
+      const handle = nextHandle++
+      callbacks.set(handle, callback)
+      return handle
+    },
+    cancelAnimationFrame: (handle) => {
+      callbacks.delete(handle)
     },
     flushNextFrame: () => {
-      callbacks.shift()?.(0)
-    }
+      const [handle, callback] = callbacks.entries().next().value ?? []
+      if (handle === undefined || !callback) {
+        return
+      }
+      callbacks.delete(handle)
+      callback(0)
+    },
+    pendingCount: () => callbacks.size
   }
 }
 
@@ -100,7 +113,8 @@ describe('document theme', () => {
 
     applyDocumentTheme('dark', {
       root,
-      requestAnimationFrame: frames.requestAnimationFrame
+      requestAnimationFrame: frames.requestAnimationFrame,
+      cancelAnimationFrame: frames.cancelAnimationFrame
     })
 
     expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(true)
@@ -110,5 +124,32 @@ describe('document theme', () => {
 
     frames.flushNextFrame()
     expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(false)
+  })
+
+  it('cancels stale transition suppression frames on rapid theme changes', () => {
+    const root = createThemeRoot()
+    const frames = createFrameQueue()
+
+    applyDocumentTheme('dark', {
+      root,
+      requestAnimationFrame: frames.requestAnimationFrame,
+      cancelAnimationFrame: frames.cancelAnimationFrame
+    })
+    expect(frames.pendingCount()).toBe(1)
+
+    applyDocumentTheme('light', {
+      root,
+      requestAnimationFrame: frames.requestAnimationFrame,
+      cancelAnimationFrame: frames.cancelAnimationFrame
+    })
+    expect(frames.pendingCount()).toBe(1)
+
+    frames.flushNextFrame()
+    expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(true)
+    expect(frames.pendingCount()).toBe(1)
+
+    frames.flushNextFrame()
+    expect(root.classList.contains(THEME_TRANSITION_DISABLED_CLASS)).toBe(false)
+    expect(frames.pendingCount()).toBe(0)
   })
 })

--- a/src/renderer/src/lib/document-theme.ts
+++ b/src/renderer/src/lib/document-theme.ts
@@ -18,12 +18,23 @@ type ThemeRoot = {
 
 type ThemeMediaMatcher = (query: string) => Pick<MediaQueryList, 'matches'>
 type ThemeAnimationFrame = (callback: FrameRequestCallback) => number
+type ThemeCancelAnimationFrame = (handle: number) => void
 
 type ApplyDocumentThemeOptions = {
   root?: ThemeRoot
   matchMedia?: ThemeMediaMatcher
   requestAnimationFrame?: ThemeAnimationFrame
+  cancelAnimationFrame?: ThemeCancelAnimationFrame
   disableTransitions?: boolean
+}
+
+let pendingTransitionDisableFrames: number[] = []
+
+function cancelPendingTransitionDisableFrames(cancelFrame: ThemeCancelAnimationFrame): void {
+  for (const frameId of pendingTransitionDisableFrames) {
+    cancelFrame(frameId)
+  }
+  pendingTransitionDisableFrames = []
 }
 
 function systemPrefersDark(
@@ -67,12 +78,22 @@ export function applyDocumentTheme(
   }
 
   const requestFrame = options.requestAnimationFrame ?? window.requestAnimationFrame.bind(window)
+  const cancelFrame = options.cancelAnimationFrame ?? window.cancelAnimationFrame.bind(window)
+  cancelPendingTransitionDisableFrames(cancelFrame)
 
   // Why: two frames lets the root theme class recalculate before restoring
   // normal hover/collapse transitions, preventing staggered color fades.
-  requestFrame(() => {
-    requestFrame(() => {
+  const firstFrame = requestFrame(() => {
+    pendingTransitionDisableFrames = pendingTransitionDisableFrames.filter(
+      (id) => id !== firstFrame
+    )
+    const secondFrame = requestFrame(() => {
+      pendingTransitionDisableFrames = pendingTransitionDisableFrames.filter(
+        (id) => id !== secondFrame
+      )
       root.classList.remove(THEME_TRANSITION_DISABLED_CLASS)
     })
+    pendingTransitionDisableFrames.push(secondFrame)
   })
+  pendingTransitionDisableFrames.push(firstFrame)
 }


### PR DESCRIPTION
## Summary
- Track the two-frame transition-suppression cleanup scheduled by applyDocumentTheme.
- Cancel stale cleanup frames before scheduling a new theme cleanup, so rapid theme changes keep only the latest pending frame chain.
- Add a focused document-theme test that proves stale frames are canceled.

## Merge risk assessment
Risk level: LOW

Rationale: this preserves the existing two-frame transition suppression delay and root class behavior. It only prevents older rapid theme-change frame chains from firing after a newer theme application supersedes them.

## Validation
- pnpm exec oxlint src/renderer/src/lib/document-theme.ts src/renderer/src/lib/document-theme.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/document-theme.test.ts
- git diff --check HEAD~1..HEAD
- pnpm typecheck (fails in this checkout on existing missing local packages: @tiptap/extension-details and react-colorful)