### PR TITLE
Cancel popover wheel frames from content ref

### DIFF
--- a/src/renderer/src/components/ui/popover-content-ref.ts
+++ b/src/renderer/src/components/ui/popover-content-ref.ts
@@ -1,0 +1,44 @@
+import * as React from 'react'
+import type { Popover as PopoverPrimitive } from 'radix-ui'
+
+type PopoverContentRef = React.ComponentProps<typeof PopoverPrimitive.Content>['ref']
+
+export function updatePopoverContentRef(
+  forwardedRef: PopoverContentRef | undefined,
+  node: HTMLDivElement | null,
+  cancelWheelFrames: () => void
+): (() => void) | undefined {
+  if (node === null) {
+    cancelWheelFrames()
+    if (typeof forwardedRef === 'function') {
+      forwardedRef(null)
+    } else if (forwardedRef) {
+      forwardedRef.current = null
+    }
+    return undefined
+  }
+
+  if (typeof forwardedRef === 'function') {
+    const cleanup = forwardedRef(node)
+    // Why: React callback refs may return cleanup; wrapping the Radix ref must
+    // preserve that cleanup instead of replacing it with a null callback.
+    return () => {
+      cancelWheelFrames()
+      if (typeof cleanup === 'function') {
+        cleanup()
+      } else {
+        forwardedRef(null)
+      }
+    }
+  }
+
+  if (forwardedRef) {
+    forwardedRef.current = node
+  }
+  return () => {
+    cancelWheelFrames()
+    if (forwardedRef) {
+      forwardedRef.current = null
+    }
+  }
+}

--- a/src/renderer/src/components/ui/popover.test.tsx
+++ b/src/renderer/src/components/ui/popover.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { updatePopoverContentRef } from './popover-content-ref'
+
+describe('updatePopoverContentRef', () => {
+  it('preserves callback ref cleanup when content detaches', () => {
+    const node = {} as HTMLDivElement
+    const cancelWheelFrames = vi.fn()
+    const cleanup = vi.fn()
+    const ref = vi.fn(() => cleanup)
+
+    const detach = updatePopoverContentRef(ref, node, cancelWheelFrames)
+    detach?.()
+
+    expect(ref).toHaveBeenCalledTimes(1)
+    expect(ref).toHaveBeenCalledWith(node)
+    expect(cancelWheelFrames).toHaveBeenCalledTimes(1)
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears callback refs that do not return cleanup', () => {
+    const node = {} as HTMLDivElement
+    const cancelWheelFrames = vi.fn()
+    const ref = vi.fn()
+
+    const detach = updatePopoverContentRef(ref, node, cancelWheelFrames)
+    detach?.()
+
+    expect(ref).toHaveBeenNthCalledWith(1, node)
+    expect(ref).toHaveBeenNthCalledWith(2, null)
+    expect(cancelWheelFrames).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears object refs when content detaches', () => {
+    const node = {} as HTMLDivElement
+    const cancelWheelFrames = vi.fn()
+    const ref: { current: HTMLDivElement | null } = { current: null }
+
+    const detach = updatePopoverContentRef(ref, node, cancelWheelFrames)
+    expect(ref.current).toBe(node)
+
+    detach?.()
+
+    expect(ref.current).toBeNull()
+    expect(cancelWheelFrames).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels pending frames when React supplies a null node', () => {
+    const cancelWheelFrames = vi.fn()
+    const ref: { current: HTMLDivElement | null } = { current: {} as HTMLDivElement }
+
+    updatePopoverContentRef(ref, null, cancelWheelFrames)
+
+    expect(ref.current).toBeNull()
+    expect(cancelWheelFrames).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/ui/popover.tsx
+++ b/src/renderer/src/components/ui/popover.tsx
@@ -24,20 +24,34 @@ function PopoverContent({
   portalContainer,
   style,
   onWheel,
+  ref: forwardedRef,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content> & {
   portalContainer?: HTMLElement | null
 }) {
   const wheelFrameIdsRef = React.useRef<Set<number>>(new Set())
 
-  React.useEffect(
-    () => () => {
-      for (const frameId of wheelFrameIdsRef.current) {
-        cancelAnimationFrame(frameId)
+  const cancelWheelFrames = React.useCallback(() => {
+    for (const frameId of wheelFrameIdsRef.current) {
+      cancelAnimationFrame(frameId)
+    }
+    wheelFrameIdsRef.current.clear()
+  }, [])
+
+  const setContentRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      // Why: the wheel shim schedules frames against the content node; cancel
+      // them when Radix removes that node instead of from a passive Effect.
+      if (node === null) {
+        cancelWheelFrames()
       }
-      wheelFrameIdsRef.current.clear()
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(node)
+      } else if (forwardedRef) {
+        forwardedRef.current = node
+      }
     },
-    []
+    [cancelWheelFrames, forwardedRef]
   )
 
   const handleWheel = React.useCallback(
@@ -89,6 +103,7 @@ function PopoverContent({
           'z-[60] overflow-hidden rounded-md border border-border/50 bg-popover text-popover-foreground shadow-md outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className
         )}
+        ref={setContentRef}
         // Why: Electron's -webkit-app-region: drag on the titlebar captures
         // clicks at the OS level regardless of z-index. Without no-drag,
         // popovers that visually overlap the titlebar are unclickable.

--- a/src/renderer/src/components/ui/popover.tsx
+++ b/src/renderer/src/components/ui/popover.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { Popover as PopoverPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
+import { updatePopoverContentRef } from './popover-content-ref'
 
 function Popover(props: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
@@ -42,14 +43,7 @@ function PopoverContent({
     (node: HTMLDivElement | null) => {
       // Why: the wheel shim schedules frames against the content node; cancel
       // them when Radix removes that node instead of from a passive Effect.
-      if (node === null) {
-        cancelWheelFrames()
-      }
-      if (typeof forwardedRef === 'function') {
-        forwardedRef(node)
-      } else if (forwardedRef) {
-        forwardedRef.current = node
-      }
+      return updatePopoverContentRef(forwardedRef, node, cancelWheelFrames)
     },
     [cancelWheelFrames, forwardedRef]
   )


### PR DESCRIPTION
## Summary
- remove the cleanup-only Effect that cancelled popover wheel shim animation frames
- cancel pending wheel frames from the Radix content callback ref when the content node unmounts
- preserve any forwarded Radix content ref while keeping the wheel-scroll behavior unchanged

## Performance impact
- Effect hook call-site count projects from 890 to 889 on current `origin/main` (`388bc59a58`)
- removes one cleanup-only passive Effect from the shared `PopoverContent` primitive

## Risk
- Medium: `PopoverContent` is shared across issue, PR, browser, settings, and picker UI surfaces

## Validation
- `pnpm exec oxlint src/renderer/src/components/ui/popover.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/ui/color-picker.test.tsx src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.