### PR TITLE
Cancel rich markdown attention timers from root ref

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -737,6 +737,29 @@ export default function RichMarkdownEditor({
     return registerPendingEditorFlush(fileId, flushPendingSerialization)
   }, [fileId, flushPendingSerialization])
 
+  const clearAttentionTimers = useCallback(() => {
+    if (attentionReviewCommentTimeoutRef.current !== null) {
+      window.clearTimeout(attentionReviewCommentTimeoutRef.current)
+      attentionReviewCommentTimeoutRef.current = null
+    }
+    if (sourceAttentionTimeoutRef.current !== null) {
+      window.clearTimeout(sourceAttentionTimeoutRef.current)
+      sourceAttentionTimeoutRef.current = null
+    }
+  }, [])
+
+  const setRootElement = useCallback(
+    (node: HTMLDivElement | null) => {
+      // Why: review-note pulses are tied to this editor root; ref cleanup
+      // keeps the existing unmount boundary without a passive Effect.
+      if (node === null) {
+        clearAttentionTimers()
+      }
+      rootRef.current = node
+    },
+    [clearAttentionTimers]
+  )
+
   const syncAnnotationTarget = useCallback((nextEditor: Editor): void => {
     if (annotationTargetFrameRef.current !== null) {
       window.cancelAnimationFrame(annotationTargetFrameRef.current)
@@ -762,17 +785,6 @@ export default function RichMarkdownEditor({
       }
       setAnnotationTarget(target)
     })
-  }, [])
-
-  useEffect(() => {
-    return () => {
-      if (attentionReviewCommentTimeoutRef.current !== null) {
-        window.clearTimeout(attentionReviewCommentTimeoutRef.current)
-      }
-      if (sourceAttentionTimeoutRef.current !== null) {
-        window.clearTimeout(sourceAttentionTimeoutRef.current)
-      }
-    }
   }, [])
 
   const pulseRichMarkdownReviewNote = useCallback((commentId: string): void => {
@@ -1689,7 +1701,7 @@ export default function RichMarkdownEditor({
   return (
     <div className="rich-markdown-editor-layout">
       <div
-        ref={rootRef}
+        ref={setRootElement}
         className={`rich-markdown-editor-shell ${
           reviewRailExpanded ? 'has-rich-markdown-review-notes' : ''
         }`.trim()}


### PR DESCRIPTION
## Summary
- remove the cleanup-only Effect that cleared rich markdown review-note attention timers
- clear those timers from the editor root callback ref when the root unmounts
- preserve the existing pulse scheduling and unmount cleanup boundary

## Performance impact
- Effect hook call-site count projects from 892 to 891 on current `origin/main` (`f9a5c65359`)
- removes one cleanup-only passive Effect from `RichMarkdownEditor`

## Risk
- Medium: touches rich markdown editor review-note attention/active highlight cleanup, but no persistence, transport, SSH, or provider behavior

## Validation
- `pnpm exec oxlint src/renderer/src/components/editor/RichMarkdownEditor.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-review-note-layout.test.ts src/renderer/src/lib/markdown-review-notes.test.ts src/renderer/src/components/editor/RichMarkdownEditor.test.tsx src/renderer/src/components/editor/markdown-preview-search.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
