### PR TITLE
fix: cancel orchestration animation frames

### DIFF
--- a/src/renderer/src/components/feature-wall/agents-orchestration/OrchestrationPage.tsx
+++ b/src/renderer/src/components/feature-wall/agents-orchestration/OrchestrationPage.tsx
@@ -96,8 +96,10 @@ export function OrchestrationPage(props: {
 
   useEffect(() => {
     if (active && displayedChildCount >= 2) {
-      requestAnimationFrame(() => drawArrow())
+      const frameId = requestAnimationFrame(() => drawArrow())
+      return () => cancelAnimationFrame(frameId)
     }
+    return undefined
   }, [active, displayedChildCount, drawArrow])
 
   useEffect(() => {
@@ -129,14 +131,24 @@ export function OrchestrationPage(props: {
       setRowPending({})
       setCreatedChildCount(2)
       pendingMirror.current = {}
-      requestAnimationFrame(() => drawArrow())
-      return
+      const frameId = requestAnimationFrame(() => drawArrow())
+      return () => cancelAnimationFrame(frameId)
     }
 
     let cancelled = false
     const timeouts: number[] = []
+    const frames = new Set<number>()
     const later = (fn: () => void, ms: number): void => {
       timeouts.push(window.setTimeout(() => !cancelled && fn(), ms))
+    }
+    const nextFrame = (fn: () => void): void => {
+      const frameId = requestAnimationFrame(() => {
+        frames.delete(frameId)
+        if (!cancelled) {
+          fn()
+        }
+      })
+      frames.add(frameId)
     }
 
     const clearArrows = (): void => {
@@ -178,7 +190,7 @@ export function OrchestrationPage(props: {
         '<path d="M3 7l9 6 9-6"/></svg>'
       layer.appendChild(bubble)
       void bubble.offsetWidth
-      requestAnimationFrame(() => bubble.classList.add('in-flight'))
+      nextFrame(() => bubble.classList.add('in-flight'))
 
       later(() => {
         // Reveal the recipient agent on landing — that's the moment work
@@ -249,6 +261,8 @@ export function OrchestrationPage(props: {
     return () => {
       cancelled = true
       timeouts.forEach((id) => window.clearTimeout(id))
+      frames.forEach((id) => cancelAnimationFrame(id))
+      frames.clear()
       window.removeEventListener('resize', onResize)
       if (cleanupLayer) {
         cleanupLayer.innerHTML = ''


### PR DESCRIPTION
## Summary
- cancel the deferred arrow redraw frame when the orchestration visual deactivates before it runs
- track bubble launch animation frames and cancel any pending callbacks during effect cleanup

## Merge risk assessment
Risk level: LOW

This only scopes existing requestAnimationFrame callbacks to their owning React effects. It does not change the animation timing, layout calculation, resize listener, or timer sequence. The behavior impact is limited to avoiding stale visual callbacks after the feature-wall page is inactive or unmounted.

## Validation
- pnpm exec oxlint src/renderer/src/components/feature-wall/agents-orchestration/OrchestrationPage.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-wall/feature-wall-rail-navigation.test.ts src/renderer/src/components/feature-wall/use-feature-wall-completion.test.ts src/renderer/src/components/feature-wall/use-feature-wall-tour-telemetry.test.ts
- git diff --check
- pnpm typecheck (fails only on existing local missing modules: @tiptap/extension-details, react-colorful)
