### PR TITLE
Cancel mobile browser long press from root ref

### DIFF
--- a/mobile/src/browser/MobileBrowserPane.tsx
+++ b/mobile/src/browser/MobileBrowserPane.tsx
@@ -188,6 +188,17 @@ export function MobileBrowserPane({
     }
   }, [])
 
+  const setRootViewRef = useCallback(
+    (node: View | null) => {
+      // Why: long-press right-click timers belong to this responder surface;
+      // clearing from ref cleanup preserves the same unmount boundary.
+      if (node === null) {
+        clearLongPressTimer()
+      }
+    },
+    [clearLongPressTimer]
+  )
+
   const resetBrowserZoomState = useCallback(() => {
     clearLongPressTimer()
     pinchRef.current = null
@@ -694,8 +705,6 @@ export function MobileBrowserPane({
     [client, flushPendingWheelCommand, pageParams]
   )
 
-  useEffect(() => () => clearLongPressTimer(), [clearLongPressTimer])
-
   const mapTouchPoint = useCallback((locationX: number, locationY: number): BrowserPoint | null => {
     return mapScreenToBrowserPoint(
       locationX,
@@ -1017,7 +1026,7 @@ export function MobileBrowserPane({
   )
 
   return (
-    <View style={styles.root}>
+    <View ref={setRootViewRef} style={styles.root}>
       <View style={styles.toolbar}>
         <ToolbarIconButton
           disabled={controlsDisabled || !tab.canGoBack}


### PR DESCRIPTION
## Summary
- remove the cleanup-only Effect that cleared the mobile browser long-press timer
- clear the timer from the root `View` callback ref when the browser pane unmounts
- preserve existing responder grant/move/release timer behavior

## Performance impact
- Effect hook call-site count projects from 892 to 891 on current `origin/main` (`f9a5c65359`)
- removes one cleanup-only passive Effect from `MobileBrowserPane`

## Risk
- Medium: touches mobile browser gesture cleanup, but no runtime protocol, SSH, persistence, or provider behavior

## Validation
- `pnpm exec oxlint mobile/src/browser/MobileBrowserPane.tsx`
- `node - <<'NODE' ... NODE` source invariant for removal of the cleanup-only Effect and root ref wiring
- `pnpm run typecheck:web`
- `git diff --check`

## Validation note
- `pnpm --dir mobile test -- src/browser/mobile-browser-pane-source.test.ts src/browser/browser-screencast-request.test.ts` is blocked because `mobile/node_modules/.bin/vitest` is not installed in this checkout.
- `pnpm exec vitest run --root mobile src/browser/mobile-browser-pane-source.test.ts src/browser/browser-screencast-request.test.ts` is blocked by missing `expo/tsconfig.base` from `mobile/tsconfig.json`.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
