### PR TITLE
Log packaged single-instance lock early exits

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,7 +55,10 @@ import {
 import { startFirstWindowStartupServices } from './startup/first-window-startup-services'
 import { getDevInstanceIdentity } from './startup/dev-instance-identity'
 import { hydrateShellPath, mergePathSegments } from './startup/hydrate-shell-path'
-import { acquireSingleInstanceLock } from './startup/single-instance-lock'
+import {
+  acquireSingleInstanceLock,
+  logSingleInstanceLockFailure
+} from './startup/single-instance-lock'
 import { RateLimitService } from './rate-limits/service'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
@@ -273,14 +276,9 @@ function getExpectedTeardownScope(webContentsId?: number): ExpectedTeardownScope
 const hasSingleInstanceLock =
   is.dev && !isServeMode ? true : acquireSingleInstanceLock(app, focusExistingWindow)
 if (!hasSingleInstanceLock) {
-  if (is.dev) {
-    // Why: packaged runs have no attached console, but dev runs do. Emit a
-    // single line so a `pnpm dev` operator does not mistake a silent exit
-    // for a broken launcher.
-    console.log(
-      '[single-instance] Another Orca instance is already running against this userData path — focusing existing window.'
-    )
-  }
+  // Why: if Electron returns a false negative here, packaged macOS launches
+  // otherwise look like silent crashes. `open --stderr` can capture this line.
+  logSingleInstanceLockFailure()
   app.quit()
 }
 

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -1,6 +1,10 @@
 import type { App } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
-import { acquireSingleInstanceLock } from './single-instance-lock'
+import {
+  acquireSingleInstanceLock,
+  logSingleInstanceLockFailure,
+  SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE
+} from './single-instance-lock'
 
 type Listener = (...args: unknown[]) => void
 
@@ -63,5 +67,16 @@ describe('acquireSingleInstanceLock', () => {
     registered?.()
 
     expect(onSecondInstance).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('logSingleInstanceLockFailure', () => {
+  it('emits a production-visible diagnostic for the early quit path', () => {
+    const logger = { error: vi.fn() }
+
+    logSingleInstanceLockFailure(logger)
+
+    expect(logger.error).toHaveBeenCalledWith(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE)
+    expect(logger.error.mock.calls[0]?.[0]).toContain('Electron/macOS single-instance lock failure')
   })
 })

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -1,5 +1,8 @@
 import type { App } from 'electron'
 
+export const SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE =
+  '[single-instance] Another Orca instance is already running for this userData profile; exiting this launch after requesting the existing window. If no Orca process is running, this may be an Electron/macOS single-instance lock failure.'
+
 /**
  * Why: Orca writes two canonical discovery files into `<userData>/`:
  * `orca-runtime.json` (RPC endpoint + authToken for the bundled CLI) and
@@ -24,4 +27,8 @@ export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void
   }
   app.on('second-instance', onSecondInstance)
   return true
+}
+
+export function logSingleInstanceLockFailure(logger: Pick<Console, 'error'> = console): void {
+  logger.error(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE)
 }


### PR DESCRIPTION
Refs #3464.\n\nThis adds a production-visible stderr diagnostic when a packaged launch loses Electron's single-instance lock and exits before startup side effects. The exact Tahoe beta false-negative from #3464 did not reproduce on my macOS 26.3.1 build 25D2128, but the affected branch was silent in production, which made the reporter's launch look like a clean no-op.\n\nEvidence:\n- Downloaded and ran v1.4.35 arm64 release from /tmp with isolated ORCA_E2E_USER_DATA_DIR on macOS 26.3.1 build 25D2128; it stayed alive after 3s and created userData, so the false-negative appears build/environment specific.\n- Installed 1.4.36-rc.3 also stayed alive after 3s with isolated userData.\n- pnpm exec vitest run --config config/vitest.config.ts src/main/startup/single-instance-lock.test.ts: 1 file / 4 tests passed.\n- pnpm run typecheck:node passed.\n- pnpm run lint passed.\n- git diff --check HEAD^..HEAD passed.\n- git merge-tree --write-tree origin/main HEAD passed: 50feea51b7e66bd3f1cec9c4b7c0aac74c51866c.\n\nNo merge performed.