### PR TITLE
Cancel file explorer drag scroll in global cleanup

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts
@@ -123,8 +123,6 @@ export function useFileExplorerDragDrop({
     }
   }, [])
 
-  useEffect(() => () => stopDragEdgeScroll(), [stopDragEdgeScroll])
-
   const clearDragState = useCallback(() => {
     rootDragCounterRef.current = 0
     nativeRootDragCounterRef.current = 0
@@ -153,11 +151,12 @@ export function useFileExplorerDragDrop({
     window.addEventListener('blur', handleGlobalDragFinish)
 
     return () => {
+      stopDragEdgeScroll()
       document.removeEventListener('drop', handleGlobalDragFinish, true)
       document.removeEventListener('dragend', handleGlobalDragFinish, true)
       window.removeEventListener('blur', handleGlobalDragFinish)
     }
-  }, [stopAndClearDragState])
+  }, [stopAndClearDragState, stopDragEdgeScroll])
 
   // requestAnimationFrame + small per-frame deltas avoids choppy jumps from irregular dragover events
   const tickDragEdgeScroll = useCallback(() => {


### PR DESCRIPTION
## Summary
- remove the standalone cleanup-only Effect for file explorer drag edge-scroll frames
- cancel the same edge-scroll rAF from the existing document/window drag listener cleanup
- keep drag finish/drop/blur behavior unchanged

## Performance impact
- Effect hook call-site count projects from 892 to 891 on current `origin/main` (`d82f453d17`)
- removes one cleanup-only passive Effect from `useFileExplorerDragDrop`

## Risk
- Medium: touches right-sidebar file explorer drag/drop auto-scroll cleanup, but no persistence, SSH protocol, or provider behavior

## Validation
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.