### PR TITLE
Cancel source comment reveal frames from root ref

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1086,7 +1086,7 @@ export function HostedReviewHeaderLink({
 }
 
 function SourceControlInner(): React.JSX.Element {
-  const sourceControlRef = useRef<HTMLDivElement>(null)
+  const sourceControlRef = useRef<HTMLDivElement | null>(null)
   const isMac = useMemo(() => navigator.userAgent.includes('Mac'), [])
   const pendingCommentEditorRevealFrameIdsRef = useRef<number[]>([])
   // Why: React setState is async, so a rapid double-click on the Commit
@@ -1201,12 +1201,13 @@ function SourceControlInner(): React.JSX.Element {
   const [pendingDiffCommentsClear, setPendingDiffCommentsClear] =
     useState<PendingDiffCommentsClear | null>(null)
   const [isClearingDiffComments, setIsClearingDiffComments] = useState(false)
-  const setSourceControlRootRef = useCallback((node: HTMLDivElement | null) => {
+  const setSourceControlRoot = useCallback((node: HTMLDivElement | null) => {
+    // Why: markdown-note reveal frames target the Source Control surface; cancel
+    // them when that surface unmounts instead of from a passive Effect.
+    if (node === null) {
+      cancelSourceControlEditorRevealFrames(pendingCommentEditorRevealFrameIdsRef)
+    }
     sourceControlRef.current = node
-  }, [])
-
-  useEffect(() => {
-    return () => cancelSourceControlEditorRevealFrames(pendingCommentEditorRevealFrameIdsRef)
   }, [])
 
   const handleCopyDiffComments = useCallback(async (): Promise<void> => {
@@ -4156,7 +4157,7 @@ function SourceControlInner(): React.JSX.Element {
 
   return (
     <>
-      <div ref={setSourceControlRootRef} className="relative flex h-full flex-col overflow-hidden">
+      <div ref={setSourceControlRoot} className="relative flex h-full flex-col overflow-hidden">
         <div className="flex items-center px-3 pt-2 border-b border-border">
           {(['all', 'uncommitted'] as const).map((value) => (
             <button


### PR DESCRIPTION
## Summary
- remove the cleanup-only Effect added for Source Control markdown-note editor reveal frames
- cancel pending reveal frames from the Source Control root callback ref when that surface unmounts
- keep the click path and double-rAF reveal timing unchanged

## Performance impact
- Effect hook call-site count projects from 893 to 892 on current `origin/main` (`e45440c545`)
- removes one cleanup-only passive Effect from `SourceControl`

## Risk
- Medium: touches Source Control note navigation cleanup, but no git/provider IPC behavior changes

## Validation
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/SourceControl.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/source-control-primary-action.test.ts src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts src/renderer/src/components/right-sidebar/source-control-discard-confirmation.test.ts src/renderer/src/lib/diff-comments-format.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.