### PR TITLE
Fold terminal pane frame cleanup into unmount effect

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -902,11 +902,8 @@ export default function TerminalPane({
     const snapshots = activityIsolationSnapshotRef.current
     return () => {
       restoreExpandedLayoutFrom(snapshots)
+      cancelPendingPaneSizeRefreshFrames({ pendingPaneSizeRefreshFrameIdsRef })
     }
-  }, [])
-
-  useEffect(() => {
-    return () => cancelPendingPaneSizeRefreshFrames({ pendingPaneSizeRefreshFrameIdsRef })
   }, [])
 
   const handleRestartCodexPane = useCallback(


### PR DESCRIPTION
## Summary
- fold the terminal pane-size refresh frame cleanup into the existing TerminalPane unmount cleanup
- keep the upstream expand/collapse frame cancellation helper and tests intact
- restore React Effect count to 893 after #3474 raised it to 894

## Risk
Low. This keeps the same component-unmount lifetime and only consolidates two adjacent cleanup-only passive Effects into one cleanup boundary. No terminal layout, PTY, SSH, or provider behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/expand-collapse.ts src/renderer/src/components/terminal-pane/expand-collapse.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/expand-collapse.test.ts
- pnpm run typecheck:web
- git diff --check
- effect-count script: 893
