### PR TITLE
fix: clear close dialog debounce timers

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -227,6 +227,24 @@ function Terminal(): React.JSX.Element | null {
   // so the stray click from the previous dialog is absorbed while a genuine
   // new click on the next dialog still works.
   const isClosingRef = useRef(false)
+  const closeDialogDebounceTimersRef = useRef<Set<number>>(new Set())
+  const releaseCloseDialogGuardAfterDebounce = useCallback(() => {
+    const timer = window.setTimeout(() => {
+      closeDialogDebounceTimersRef.current.delete(timer)
+      isClosingRef.current = false
+    }, CLOSE_DIALOG_DEBOUNCE_MS)
+    closeDialogDebounceTimersRef.current.add(timer)
+  }, [])
+
+  useEffect(() => {
+    const timers = closeDialogDebounceTimersRef.current
+    return () => {
+      for (const timer of timers) {
+        window.clearTimeout(timer)
+      }
+      timers.clear()
+    }
+  }, [])
 
   // Window close confirmation dialog — shown for local terminals with running
   // child processes. SSH terminals detach/persist through the relay lifecycle.
@@ -399,9 +417,7 @@ function Terminal(): React.JSX.Element | null {
         (id) => id !== fileId
       )
       advanceEditorCloseQueue()
-      setTimeout(() => {
-        isClosingRef.current = false
-      }, CLOSE_DIALOG_DEBOUNCE_MS)
+      releaseCloseDialogGuardAfterDebounce()
       return
     }
 
@@ -433,9 +449,7 @@ function Terminal(): React.JSX.Element | null {
           (id) => id !== fileId
         )
         advanceEditorCloseQueue()
-        setTimeout(() => {
-          isClosingRef.current = false
-        }, CLOSE_DIALOG_DEBOUNCE_MS)
+        releaseCloseDialogGuardAfterDebounce()
         return
       }
       toast.error('Save timed out or failed. Fix errors before closing.')
@@ -450,10 +464,13 @@ function Terminal(): React.JSX.Element | null {
       (id) => id !== fileId
     )
     advanceEditorCloseQueue()
-    setTimeout(() => {
-      isClosingRef.current = false
-    }, CLOSE_DIALOG_DEBOUNCE_MS)
-  }, [advanceEditorCloseQueue, saveDialogFileId, waitForFileClosed])
+    releaseCloseDialogGuardAfterDebounce()
+  }, [
+    advanceEditorCloseQueue,
+    releaseCloseDialogGuardAfterDebounce,
+    saveDialogFileId,
+    waitForFileClosed
+  ])
 
   const handleSaveDialogDiscard = useCallback(async () => {
     if (isClosingRef.current) {
@@ -488,10 +505,14 @@ function Terminal(): React.JSX.Element | null {
       (id) => id !== fileId
     )
     advanceEditorCloseQueue()
-    setTimeout(() => {
-      isClosingRef.current = false
-    }, CLOSE_DIALOG_DEBOUNCE_MS)
-  }, [advanceEditorCloseQueue, closeFile, markFileDirty, saveDialogFileId])
+    releaseCloseDialogGuardAfterDebounce()
+  }, [
+    advanceEditorCloseQueue,
+    closeFile,
+    markFileDirty,
+    releaseCloseDialogGuardAfterDebounce,
+    saveDialogFileId
+  ])
 
   const handleSaveDialogCancel = useCallback(() => {
     if (isClosingRef.current) {
@@ -501,10 +522,8 @@ function Terminal(): React.JSX.Element | null {
     pendingEditorCloseQueueRef.current = []
     windowCloseAfterDirtyRef.current = null
     setSaveDialogFileId(null)
-    setTimeout(() => {
-      isClosingRef.current = false
-    }, CLOSE_DIALOG_DEBOUNCE_MS)
-  }, [])
+    releaseCloseDialogGuardAfterDebounce()
+  }, [releaseCloseDialogGuardAfterDebounce])
 
   useEffect(() => {
     const onRequestEditorClose = (event: Event): void => {


### PR DESCRIPTION
## Summary
- route dirty-editor close-dialog debounce releases through one tracked helper
- clear any pending close-dialog debounce timers when Terminal unmounts

## Merge risk assessment
Risk level: LOW

The debounce duration and guard behavior are unchanged. This only records the existing 200ms timers in a Set and clears them during component cleanup, preventing stale timer callbacks from retaining Terminal state after unmount.

## Validation
- pnpm exec oxlint src/renderer/src/components/Terminal.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/editor-autosave-controller.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
- git diff --check
- pnpm typecheck (fails only on existing local missing modules: @tiptap/extension-details, react-colorful)
