### PR TITLE
Clear worktree drag from sidebar root cleanup

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1429,6 +1429,18 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     setWorktreeDragState(WORKTREE_ROW_DRAG_INITIAL_STATE)
   }, [cancelWorktreeNativeAutoscroll, cleanupWorktreePointerDrag])
 
+  const setScrollRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node === null && scrollRef.current !== null) {
+        // Why: sidebar drag previews and autoscroll frames are tied to the
+        // scroll root surface; clear them before that DOM owner disappears.
+        clearWorktreeDrag()
+      }
+      scrollRef.current = node
+    },
+    [clearWorktreeDrag]
+  )
+
   const flushWorktreePointerDrag = useCallback(() => {
     const drag = worktreePointerDragRef.current
     if (!drag) {
@@ -2195,8 +2207,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
   }, [clearWorktreeDrag])
 
-  useEffect(() => () => clearWorktreeDrag(), [clearWorktreeDrag])
-
   useWorkspaceStatusDocumentDrop(
     scrollRef,
     onMoveWorktreeToStatus,
@@ -2212,7 +2222,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   return (
     <div data-worktree-sidebar-container className="relative min-h-0 flex-1">
       <div
-        ref={scrollRef}
+        ref={setScrollRootRef}
         data-worktree-sidebar
         tabIndex={0}
         role="listbox"


### PR DESCRIPTION
## Summary
- move the WorktreeList cleanup-only drag reset effect onto the sidebar scroll root callback ref
- keep document/window drag listener effects unchanged
- reduce the current React Effect count from 893 to 892 on this branch

## Risk
Medium. This touches sidebar worktree drag cleanup, including preview/autoscroll frame cleanup, but keeps the same unmount lifetime by tying cleanup to the scroll root DOM owner. No source-control provider, SSH transport, terminal, or persistence behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeList.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-sidebar-drag-autoscroll.test.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts src/renderer/src/components/sidebar/worktree-list-scroll-adjustment.test.ts
- pnpm run typecheck:web
- git diff --check
- effect-count script: 892

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
