### PR TITLE
Share remote file browser timer cleanup

### DIFF
--- a/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
+++ b/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
@@ -61,6 +61,7 @@ export function RemoteFileBrowser({
   // Why: paste resolution intentionally runs next tick; closing the picker
   // before then should cancel stale preview work.
   const pasteResolveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Cache directory listings by absolute resolved path for the lifetime of
   // the picker so ordinary typing issues at most one remote call per newly
   // committed segment. targetId does not change within a picker instance.
@@ -100,6 +101,10 @@ export function RemoteFileBrowser({
       if (pasteResolveTimerRef.current) {
         clearTimeout(pasteResolveTimerRef.current)
         pasteResolveTimerRef.current = null
+      }
+      if (clickTimerRef.current) {
+        clearTimeout(clickTimerRef.current)
+        clickTimerRef.current = null
       }
     }
   }, [invalidateBrowseRequests])
@@ -423,15 +428,6 @@ export function RemoteFileBrowser({
   }, [resolvedPath, onSelect])
 
   // Single-click navigates; double-click on a folder selects it.
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => {
-    return () => {
-      if (clickTimerRef.current) {
-        clearTimeout(clickTimerRef.current)
-      }
-    }
-  }, [])
-
   // When preview is active, row clicks must be relative to the preview path,
   // not the committed `resolvedPath`.
   const listParentPath = preview?.resolvedPath ?? resolvedPath


### PR DESCRIPTION
## Summary
- move the remote file browser click timer ref beside the other pending timer refs
- clear the click timer from the existing picker unmount cleanup
- remove the second cleanup-only Effect and reduce the current React Effect count from 893 to 892 on this branch

## Risk
Medium. This is SSH picker UI, but the change only consolidates same-lifetime timer cleanup and does not alter browse requests, path parsing, selection, or transport behavior.

## Validation
- pnpm exec oxlint src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/remote-file-browser-helpers.test.ts
- pnpm run typecheck:web
- git diff --check
- effect-count script: 892

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.