### PR TITLE
fix: clear transient feedback timers

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: co-locating all checks-panel sub-components (checks list,
 conflict sections, threaded PR comments) keeps the shared icon/color maps in one place. */
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   CircleCheck,
   CircleX,
@@ -365,6 +365,8 @@ function CopyButton({ text }: { text: string }): React.JSX.Element {
     }
   }, [])
 
+  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
+
   const handleCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -409,6 +411,8 @@ function ResolveButton({
       loadingResetTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => clearLoadingResetTimer, [clearLoadingResetTimer])
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {

--- a/src/renderer/src/components/stats/ShareUsageButton.tsx
+++ b/src/renderer/src/components/stats/ShareUsageButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toPng } from 'html-to-image'
 import { Check, Copy, Share2 } from 'lucide-react'
 import { Button } from '../ui/button'
@@ -28,6 +28,8 @@ export function ShareUsageButton(props: ShareUsageButtonProps): React.JSX.Elemen
       copiedResetTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
 
   const captureToClipboard = useCallback(async () => {
     if (!cardRef.current || capturing) {


### PR DESCRIPTION
## Summary
- clear checks-panel copy and resolve feedback timers when their buttons unmount
- clear share-usage copy feedback timers when the share button unmounts

## Merge risk assessment
Risk level: LOW

This only adds unmount cleanup for existing short-lived UI feedback timers. The timer durations, state transitions, and click behavior are unchanged; stale timer callbacks can no longer retain component state after unmount.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/checks-panel-content.tsx src/renderer/src/components/stats/ShareUsageButton.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/stats/ShareUsageButton.test.tsx (one matching suite exists and passed)
- git diff --check
- pnpm typecheck (fails only on existing local missing modules: @tiptap/extension-details, react-colorful)
