### PR TITLE
Share terminal close dialog timer cleanup

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -236,16 +236,6 @@ function Terminal(): React.JSX.Element | null {
     closeDialogDebounceTimersRef.current.add(timer)
   }, [])
 
-  useEffect(() => {
-    const timers = closeDialogDebounceTimersRef.current
-    return () => {
-      for (const timer of timers) {
-        window.clearTimeout(timer)
-      }
-      timers.clear()
-    }
-  }, [])
-
   // Window close confirmation dialog — shown for local terminals with running
   // child processes. SSH terminals detach/persist through the relay lifecycle.
   const [windowCloseDialogOpen, setWindowCloseDialogOpen] = useState(false)
@@ -569,6 +559,7 @@ function Terminal(): React.JSX.Element | null {
   const [, setBackgroundMountRevision] = useState(0)
   useEffect(() => {
     const timers = measurableBackgroundWorktreeTimersRef.current
+    const closeDialogDebounceTimers = closeDialogDebounceTimersRef.current
     const onBackgroundMountTerminalWorktree = (event: Event): void => {
       const customEvent = event as CustomEvent<BackgroundMountTerminalWorktreeDetail>
       const worktreeId = customEvent.detail?.worktreeId
@@ -607,6 +598,12 @@ function Terminal(): React.JSX.Element | null {
         window.clearTimeout(timer)
       }
       timers.clear()
+      // Why: close-dialog debounce timers are Terminal-owned and only need
+      // unmount cleanup; keep them with the existing Terminal lifetime cleanup.
+      for (const timer of closeDialogDebounceTimers) {
+        window.clearTimeout(timer)
+      }
+      closeDialogDebounceTimers.clear()
     }
   }, [])
   // Why: gated on workspaceSessionReady to prevent TerminalPane from mounting


### PR DESCRIPTION
## Summary
- fold the dirty-file close-dialog debounce timer cleanup into the existing Terminal lifetime cleanup
- keep the upstream debounce guard helper and dirty-close behavior unchanged
- reduce the current React Effect count from 894 to 893 on this branch

## Risk
Medium. This touches Terminal dirty-editor close dialog timing, but only consolidates same-lifetime timer cleanup. No PTY protocol, SSH lifecycle, provider, persistence, or tab reconciliation behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/Terminal.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal/background-terminal-worktree-mount.test.ts src/renderer/src/components/terminal/active-terminal-repair.test.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm run typecheck:web
- git diff --check
- effect-count script: 893

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
