### PR TITLE
Share markdown preview timer cleanup

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -200,6 +200,14 @@ function cancelMarkdownPreviewEditorRevealFrames(frameIds: MutableRefObject<numb
   frameIds.current = []
 }
 
+function clearMarkdownPreviewTimeout(timeoutRef: MutableRefObject<number | null>): void {
+  if (timeoutRef.current === null) {
+    return
+  }
+  window.clearTimeout(timeoutRef.current)
+  timeoutRef.current = null
+}
+
 function requestMarkdownPreviewEditorRevealFrame(
   frameIds: MutableRefObject<number[]>,
   callback: FrameRequestCallback
@@ -551,7 +559,13 @@ export default function MarkdownPreview({
   )
 
   useEffect(() => {
-    return () => cancelMarkdownPreviewEditorRevealFrames(pendingEditorRevealFrameIdsRef)
+    return () => {
+      // Why: review-note reveal/copy timers are event-owned, but the final
+      // cancellation belongs to the preview surface unmount.
+      cancelMarkdownPreviewEditorRevealFrames(pendingEditorRevealFrameIdsRef)
+      clearMarkdownPreviewTimeout(attentionReviewCommentTimeoutRef)
+      clearMarkdownPreviewTimeout(reviewNotesCopiedResetTimerRef)
+    }
   }, [])
 
   // Why: each split pane needs its own markdown preview viewport even when the
@@ -807,14 +821,6 @@ export default function MarkdownPreview({
       // Best-effort clipboard action; failures usually mean the window is not focused.
     }
   }, [clearReviewNotesCopiedResetTimer, markdownReviewNotes.length, markdownReviewPrompt])
-
-  useEffect(() => {
-    return () => {
-      if (attentionReviewCommentTimeoutRef.current !== null) {
-        window.clearTimeout(attentionReviewCommentTimeoutRef.current)
-      }
-    }
-  }, [])
 
   const pulseRenderedMarkdownReviewNote = useCallback((commentId: string): void => {
     if (attentionReviewCommentTimeoutRef.current !== null) {


### PR DESCRIPTION
## Summary
- fold markdown review-note attention timeout cleanup into the existing preview reveal-frame cleanup
- clear the review-notes copy reset timer from the same preview unmount cleanup
- reduce the current React Effect count from 894 to 893 on this branch

## Risk
Medium. This touches editor preview review-note UI cleanup only; no markdown parsing, file IO, source-control provider, SSH, or terminal behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/markdown-preview-search.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts
- pnpm run typecheck:web
- git diff --check
- effect-count script: 893

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
