### PR TITLE
fix: cancel inline input refocus frames

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -97,10 +97,27 @@ export function InlineInputRow({
   // of auto-submitting, which would dismiss the empty input.
   const focusSettled = useRef(false)
   const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const refocusFrame = useRef<number | null>(null)
+
+  const cancelRefocusFrame = useCallback((): void => {
+    if (refocusFrame.current !== null) {
+      cancelAnimationFrame(refocusFrame.current)
+      refocusFrame.current = null
+    }
+  }, [])
+
+  const scheduleInputRefocus = useCallback((): void => {
+    cancelRefocusFrame()
+    refocusFrame.current = requestAnimationFrame(() => {
+      refocusFrame.current = null
+      inputRef.current?.focus()
+    })
+  }, [cancelRefocusFrame])
 
   useEffect(() => {
     submitted.current = false
     focusSettled.current = false
+    cancelRefocusFrame()
 
     // Schedule focus after any pending focus-restore from menu close
     const raf = requestAnimationFrame(() => {
@@ -126,6 +143,7 @@ export function InlineInputRow({
     })
     return () => {
       cancelAnimationFrame(raf)
+      cancelRefocusFrame()
       if (blurTimeout.current) {
         clearTimeout(blurTimeout.current)
       }
@@ -133,7 +151,7 @@ export function InlineInputRow({
         clearTimeout(settleTimer.current)
       }
     }
-  }, [inlineInput])
+  }, [cancelRefocusFrame, inlineInput])
 
   const clearBlurTimeout = useCallback(() => {
     if (blurTimeout.current) {
@@ -190,14 +208,14 @@ export function InlineInputRow({
             (e.relatedTarget.closest('[data-slot="context-menu-trigger"]') ||
               e.relatedTarget.closest('[data-slot="dropdown-menu-trigger"]'))
           ) {
-            requestAnimationFrame(() => inputRef.current?.focus())
+            scheduleInputRefocus()
             return
           }
           // During the grace period after mount, menu close focus management
           // may shift focus away (often relatedTarget is null). Re-focus
           // instead of dismissing the still-empty input.
           if (!focusSettled.current) {
-            requestAnimationFrame(() => inputRef.current?.focus())
+            scheduleInputRefocus()
             return
           }
           const value = e.currentTarget.value


### PR DESCRIPTION
## Summary
- route InlineInputRow blur recovery refocus requests through a row-owned animation-frame ref
- cancel any pending refocus frame when inline input state changes or the row unmounts

## Merge risk assessment
Risk level: LOW

This is a narrow cleanup for transient file-explorer inline inputs. It preserves the existing refocus timing and only adds cancellation for a stale frame after replacement or unmount. The user-visible flow remains the same for create/rename inputs.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)