### PR TITLE
fix: clear copy feedback timers

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import React, { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, Check, Copy } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
@@ -74,6 +74,8 @@ function InstallRgGuidance({
       copiedResetTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
 
   const handleCopy = useCallback(() => {
     if (!command) {

--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
@@ -18,6 +18,8 @@ export default function CodeBlockCopyButton({
       copiedResetTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
 
   const handleCopy = useCallback(() => {
     // Extract the text content from the nested <code> element rendered by

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
@@ -58,6 +58,8 @@ export function RichMarkdownCodeBlock({
       copiedResetTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -61,6 +61,8 @@ export function MobilePane(): React.JSX.Element {
     }
   }, [])
 
+  useEffect(() => clearCodeCopiedResetTimer, [clearCodeCopiedResetTimer])
+
   const loadDevices = useCallback(async () => {
     try {
       const result = await window.api.mobile.listDevices()

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { OrcaHooks, Repo, RepoHookSettings } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { Button } from '../ui/button'
@@ -60,12 +60,14 @@ export function RepositoryPane({
   // request to hide every child row that does not repeat the project name.
   const forceFullPaneForRepoMatch = matchesRepositoryIdentitySearch(searchQuery, repo)
 
-  const clearCopiedTemplateResetTimer = (): void => {
+  const clearCopiedTemplateResetTimer = useCallback((): void => {
     if (copiedTemplateResetTimerRef.current !== null) {
       window.clearTimeout(copiedTemplateResetTimerRef.current)
       copiedTemplateResetTimerRef.current = null
     }
-  }
+  }, [])
+
+  useEffect(() => clearCopiedTemplateResetTimer, [clearCopiedTemplateResetTimer])
 
   const handleRemoveProject = (repoId: string) => {
     if (confirmingRemove === repoId) {


### PR DESCRIPTION
## Summary
- add unmount cleanup for copy-feedback reset timers in transient copy UI components
- keep existing copy behavior and reset timing unchanged

## Merge risk assessment
Risk level: LOW

The change only clears already-owned timer refs when their component unmounts. It does not alter copied text, clipboard IPC calls, button rendering, or timer durations. The affected UI surfaces are independent copy affordances.

## Validation
- pnpm exec oxlint src/renderer/src/components/QuickOpen.tsx src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/RepositoryPane.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryPane.test.tsx src/renderer/src/components/quick-open-search.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)