### PR TITLE
Clear copy feedback timers from refs

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, Check, Copy } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
@@ -75,7 +75,14 @@ function InstallRgGuidance({
     }
   }, [])
 
-  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
+  const setCopyButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node === null) {
+        clearCopiedResetTimer()
+      }
+    },
+    [clearCopiedResetTimer]
+  )
 
   const handleCopy = useCallback(() => {
     if (!command) {
@@ -118,6 +125,7 @@ function InstallRgGuidance({
         <div className="flex items-center gap-2 rounded border border-border bg-muted/50 px-3 py-2 font-mono text-xs text-foreground">
           <span className="flex-1 truncate">{command}</span>
           <button
+            ref={setCopyButtonRef}
             type="button"
             onClick={handleCopy}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"

--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
@@ -19,7 +19,14 @@ export default function CodeBlockCopyButton({
     }
   }, [])
 
-  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
+  const setCopyButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node === null) {
+        clearCopiedResetTimer()
+      }
+    },
+    [clearCopiedResetTimer]
+  )
 
   const handleCopy = useCallback(() => {
     // Extract the text content from the nested <code> element rendered by
@@ -54,6 +61,7 @@ export default function CodeBlockCopyButton({
     <div className="code-block-wrapper">
       <pre {...props}>{children}</pre>
       <button
+        ref={setCopyButtonRef}
         type="button"
         className="code-block-copy-btn"
         onClick={handleCopy}

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
@@ -59,7 +59,14 @@ export function RichMarkdownCodeBlock({
     }
   }, [])
 
-  useEffect(() => clearCopiedResetTimer, [clearCopiedResetTimer])
+  const setCopyButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node === null) {
+        clearCopiedResetTimer()
+      }
+    },
+    [clearCopiedResetTimer]
+  )
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -108,6 +115,7 @@ export function RichMarkdownCodeBlock({
         ) : null}
       </select>
       <button
+        ref={setCopyButtonRef}
         type="button"
         className="code-block-copy-btn"
         contentEditable={false}

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -61,7 +61,14 @@ export function MobilePane(): React.JSX.Element {
     }
   }, [])
 
-  useEffect(() => clearCodeCopiedResetTimer, [clearCodeCopiedResetTimer])
+  const setPairingCodeButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node === null) {
+        clearCodeCopiedResetTimer()
+      }
+    },
+    [clearCodeCopiedResetTimer]
+  )
 
   const loadDevices = useCallback(async () => {
     try {
@@ -206,6 +213,7 @@ export function MobilePane(): React.JSX.Element {
                 Or paste this code in the mobile app:
               </div>
               <Button
+                ref={setPairingCodeButtonRef}
                 variant="outline"
                 size="sm"
                 onClick={() => void copyPairingCode()}

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import type { OrcaHooks, Repo, RepoHookSettings } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { Button } from '../ui/button'
@@ -67,7 +67,14 @@ export function RepositoryPane({
     }
   }, [])
 
-  useEffect(() => clearCopiedTemplateResetTimer, [clearCopiedTemplateResetTimer])
+  const setRepositoryPaneRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node === null) {
+        clearCopiedTemplateResetTimer()
+      }
+    },
+    [clearCopiedTemplateResetTimer]
+  )
 
   const handleRemoveProject = (repoId: string) => {
     if (confirmingRemove === repoId) {
@@ -272,7 +279,7 @@ export function RepositoryPane({
   ].filter(Boolean)
 
   return (
-    <div className="space-y-8">
+    <div ref={setRepositoryPaneRootRef} className="space-y-8">
       {visibleSections.map((section, index) => (
         <div key={index} className="space-y-8">
           {index > 0 ? <Separator /> : null}


### PR DESCRIPTION
## Summary
- Clear copy-feedback reset timers from ref cleanup in quick open, code block copy buttons, mobile pairing, and repository hooks settings
- Remove five cleanup-only React effects added for transient copied states
- Keep copied-state behavior unchanged while lowering the React effect count

## Risk
Low: scoped to transient UI copy feedback timers. No IPC, provider, persistence, or SSH behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/QuickOpen.tsx src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/RepositoryPane.tsx`
- `pnpm exec oxlint src/renderer/src/components/QuickOpen.tsx src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/RepositoryPane.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-search.test.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts src/renderer/src/components/editor/rich-markdown-commands.test.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts src/renderer/src/components/settings/RepositoryPane.test.ts src/renderer/src/components/settings/MobileNetworkInterfaceSection.test.tsx src/renderer/src/components/settings/mobile-network-interface-selection.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- React effect count: 899 -> 894
