### PR TITLE
fix: clear mcp confirm reset timer

### DIFF
--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -212,10 +212,6 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     }
   }, [connectionId, isWindows, missingInspections, sshConnectionStatus, targetRootPath])
 
-  useEffect(() => {
-    void loadConfigs()
-  }, [loadConfigs])
-
   const clearCreateConfirmResetTimer = useCallback((): void => {
     if (createConfirmResetTimerRef.current !== null) {
       window.clearTimeout(createConfirmResetTimerRef.current)
@@ -223,7 +219,10 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     }
   }, [])
 
-  useEffect(() => clearCreateConfirmResetTimer, [clearCreateConfirmResetTimer])
+  useEffect(() => {
+    void loadConfigs()
+    return clearCreateConfirmResetTimer
+  }, [clearCreateConfirmResetTimer, loadConfigs])
 
   const handleOpen = (config: LoadedMcpConfigInspection): void => {
     setActiveWorktree(targetWorktreeId)

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -223,6 +223,8 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     }
   }, [])
 
+  useEffect(() => clearCreateConfirmResetTimer, [clearCreateConfirmResetTimer])
+
   const handleOpen = (config: LoadedMcpConfigInspection): void => {
     setActiveWorktree(targetWorktreeId)
     const targetGroupId = ensureWorktreeRootGroup(targetWorktreeId)


### PR DESCRIPTION
## Summary
- clear the MCP starter confirmation reset timer when the settings section unmounts
- keep the existing 3s confirm/reset behavior unchanged

## Merge risk assessment
Risk level: LOW

This only adds unmount cleanup for an already-owned timer ref. It does not change MCP config creation, file writes, SSH behavior, or settings state beyond preventing a stale reset callback after unmount.

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/McpConfigSection.tsx
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)

No direct MCP settings component test exists.