### PR TITLE
chore: allow shared agent detection length

### DIFF
--- a/src/shared/agent-detection.ts
+++ b/src/shared/agent-detection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Shared agent-title detection keeps related token rules together. */
 /**
  * Shared agent detection utilities — used by both the main process (stats
  * collection) and the renderer (activity indicators, unread badges).
@@ -503,10 +504,8 @@ export function detectAgentStatusFromTitle(title: string): AgentStatus | null {
   return null
 }
 
-// Why: shared between the runtime (dispatch guard, tui-idle fallback) and the
-// renderer (agent-ready-wait, new-workspace). A bare shell is the only process
-// type that garbles injected preambles, so this is the negative signal for
-// "is an agent running".
+// Why: shared runtime/renderer signal for "is an agent running"; bare shells
+// garble injected preambles, so they are treated as the negative signal.
 const SHELL_NAMES = new Set([
   '',
   'bash',


### PR DESCRIPTION
## Summary
- add an explicit max-lines disable to shared agent detection, matching the repo pattern for intentional large files
- compress the nearby shell-signal why comment without changing detection logic

## Merge risk assessment
Risk level: LOW

Lint-only change. It does not alter agent detection data, regexes, control flow, or runtime behavior. This unblocks full-project oxlint after the tab-agent work expanded the shared detector.

## Validation
- pnpm exec oxlint --format github
- pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-kind.test.ts src/shared/agent-detection.test.ts src/renderer/src/lib/agent-title-decoration.test.ts src/renderer/src/lib/tab-agent.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)