### PR TITLE
Clear untitled rename focus frame from ref

### DIFF
--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { FolderOpen } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -47,8 +47,6 @@ export function UntitledFileRenameDialog({
       focusFrameRef.current = null
     }
   }, [])
-
-  useEffect(() => cancelFocusFrame, [cancelFocusFrame])
 
   const setNameInputNode = useCallback(
     (node: HTMLInputElement | null): void => {


### PR DESCRIPTION
## Summary
- Remove the cleanup-only effect for the untitled-file rename focus frame
- Keep the existing input callback ref cleanup as the owner of the deferred focus frame

## Risk
Low: isolated dialog focus cleanup. No file operations, persistence, IPC, SSH, or editor model behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/UntitledFileRenameDialog.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/UntitledFileRenameDialog.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/untitled-file-rename-path.test.ts src/renderer/src/store/slices/new-markdown.test.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/lib/create-untitled-markdown.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- React effect count: 909 -> 908
