### PR TITLE
fix: clear file row drag expand timers

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { getWorkspaceFileDragPaths, WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 
 const DRAG_EXPAND_DELAY_MS = 500
@@ -51,6 +51,13 @@ export function useFileExplorerRowDrag({
       nativeExpandTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => {
+    return () => {
+      clearExpandTimer()
+      clearNativeExpandTimer()
+    }
+  }, [clearExpandTimer, clearNativeExpandTimer])
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const isInternal = e.dataTransfer.types.includes(WORKSPACE_FILE_PATH_MIME)


### PR DESCRIPTION
## Summary
- clear internal and native file-row drag auto-expand timers when the row hook unmounts
- keep existing drag-enter/leave/drop behavior unchanged

## Merge risk assessment
Risk level: LOW

This is a hook-level cleanup for existing row-owned timers. It does not change drop targets, move/copy behavior, expand delays, or file operations; it only prevents delayed expand callbacks after a row unmounts mid-drag.

## Validation
- pnpm exec oxlint src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)