### PR TITLE
Clear add repo focus frames from refs

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
@@ -5,7 +5,7 @@
  * oxlint limit, following the same pattern as useRemoteRepo.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Folder, GitBranch, Home, Pencil } from 'lucide-react'
 import { useAppStore } from '@/store'
@@ -300,8 +300,6 @@ export function CreateStep({
     cancelAnimationFrame(radioFocusFrameRef.current)
     radioFocusFrameRef.current = null
   }, [])
-
-  useEffect(() => cancelRadioFocusFrame, [cancelRadioFocusFrame])
 
   const setRadioGroupNode = useCallback(
     (node: HTMLDivElement | null): void => {

--- a/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSetupStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { GitBranch, GitBranchPlus, Settings } from 'lucide-react'
 import { DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -157,8 +157,6 @@ export function ProjectAddedContent({
     cancelAnimationFrame(radioFocusFrameRef.current)
     radioFocusFrameRef.current = null
   }, [])
-
-  useEffect(() => cancelRadioFocusFrame, [cancelRadioFocusFrame])
 
   const setRadioGroupNode = useCallback(
     (node: HTMLDivElement | null): void => {

--- a/src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
+++ b/src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { Check, ChevronsUpDown, LoaderCircle, Pencil, Plus, RefreshCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -83,8 +83,6 @@ export default function SparseCheckoutPresetSelect({
     cancelAnimationFrame(nameInputFocusFrameRef.current)
     nameInputFocusFrameRef.current = null
   }, [])
-
-  useEffect(() => cancelNameInputFocusFrame, [cancelNameInputFocusFrame])
 
   const setNameInputNode = useCallback(
     (node: HTMLInputElement | null): void => {


### PR DESCRIPTION
## Summary
- Remove cleanup-only effects for Add Repo create/setup radiogroup focus frames
- Remove the cleanup-only effect for sparse preset name-input focus frames
- Keep the existing radiogroup/input ref cleanup paths as the owner of those queued frames

## Risk
Low: isolated keyboard/focus cleanup for local dialog controls. No persistence, IPC, SSH, repo mutation, or sparse-checkout behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/sidebar/AddRepoCreateStep.tsx src/renderer/src/components/sidebar/AddRepoSetupStep.tsx src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx`
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoCreateStep.tsx src/renderer/src/components/sidebar/AddRepoSetupStep.tsx src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts src/renderer/src/components/sidebar/ProjectAddedDialog.test.tsx src/renderer/src/lib/sparse-preset-draft.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- React effect count: 908 -> 905
