### PR TITLE
fix: guard async copy feedback timers

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import React, { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, Check, Copy } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
@@ -67,6 +67,9 @@ function InstallRgGuidance({
 }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
   const copiedResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after this guidance unmounts; avoid
+  // starting a reset timer that will outlive the component.
+  const isMountedRef = useRef(false)
 
   const clearCopiedResetTimer = useCallback((): void => {
     if (copiedResetTimerRef.current !== null) {
@@ -84,6 +87,14 @@ function InstallRgGuidance({
     [clearCopiedResetTimer]
   )
 
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCopiedResetTimer()
+    }
+  }, [clearCopiedResetTimer])
+
   const handleCopy = useCallback(() => {
     if (!command) {
       return
@@ -95,6 +106,9 @@ function InstallRgGuidance({
     void window.api.ui
       .writeClipboardText(command)
       .then(() => {
+        if (!isMountedRef.current) {
+          return
+        }
         clearCopiedResetTimer()
         setCopied(true)
         copiedResetTimerRef.current = window.setTimeout(() => {

--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
@@ -11,6 +11,9 @@ export default function CodeBlockCopyButton({
 }: CodeBlockCopyButtonProps): React.JSX.Element {
   const [copied, setCopied] = useState(false)
   const copiedResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after this button unmounts; avoid starting
+  // a reset timer that will outlive the component.
+  const isMountedRef = useRef(false)
 
   const clearCopiedResetTimer = useCallback((): void => {
     if (copiedResetTimerRef.current !== null) {
@@ -27,6 +30,14 @@ export default function CodeBlockCopyButton({
     },
     [clearCopiedResetTimer]
   )
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCopiedResetTimer()
+    }
+  }, [clearCopiedResetTimer])
 
   const handleCopy = useCallback(() => {
     // Extract the text content from the nested <code> element rendered by
@@ -45,6 +56,9 @@ export default function CodeBlockCopyButton({
     void window.api.ui
       .writeClipboardText(text)
       .then(() => {
+        if (!isMountedRef.current) {
+          return
+        }
         clearCopiedResetTimer()
         setCopied(true)
         copiedResetTimerRef.current = window.setTimeout(() => {

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
@@ -45,6 +45,9 @@ export function RichMarkdownCodeBlock({
   const language = (node.attrs.language as string) || ''
   const [copied, setCopied] = useState(false)
   const copiedResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after the node view unmounts; avoid
+  // starting a reset timer that will outlive the component.
+  const isMountedRef = useRef(false)
   const settings = useAppStore((s) => s.settings)
   const isDark =
     settings?.theme === 'dark' ||
@@ -68,6 +71,14 @@ export function RichMarkdownCodeBlock({
     [clearCopiedResetTimer]
   )
 
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCopiedResetTimer()
+    }
+  }, [clearCopiedResetTimer])
+
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       updateAttributes({ language: e.target.value })
@@ -82,6 +93,9 @@ export function RichMarkdownCodeBlock({
       void window.api.ui
         .writeClipboardText(text)
         .then(() => {
+          if (!isMountedRef.current) {
+            return
+          }
           clearCopiedResetTimer()
           setCopied(true)
           copiedResetTimerRef.current = window.setTimeout(() => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: co-locating all checks-panel sub-components (checks list,
 conflict sections, threaded PR comments) keeps the shared icon/color maps in one place. */
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   CircleCheck,
   CircleX,
@@ -357,6 +357,9 @@ export function ChecksList({
 function CopyButton({ text }: { text: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
   const copiedResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after this row action unmounts; avoid
+  // starting a reset timer that will outlive the component.
+  const isMountedRef = useRef(false)
 
   const clearCopiedResetTimer = useCallback((): void => {
     if (copiedResetTimerRef.current !== null) {
@@ -374,10 +377,21 @@ function CopyButton({ text }: { text: string }): React.JSX.Element {
     [clearCopiedResetTimer]
   )
 
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCopiedResetTimer()
+    }
+  }, [clearCopiedResetTimer])
+
   const handleCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
       void window.api.ui.writeClipboardText(text).then(() => {
+        if (!isMountedRef.current) {
+          return
+        }
         clearCopiedResetTimer()
         setCopied(true)
         copiedResetTimerRef.current = window.setTimeout(() => {

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -53,6 +53,9 @@ export function MobilePane(): React.JSX.Element {
   const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
   const codeCopiedResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after settings navigation; avoid starting
+  // a reset timer that will outlive this pane.
+  const isMountedRef = useRef(false)
 
   const clearCodeCopiedResetTimer = useCallback((): void => {
     if (codeCopiedResetTimerRef.current !== null) {
@@ -69,6 +72,14 @@ export function MobilePane(): React.JSX.Element {
     },
     [clearCodeCopiedResetTimer]
   )
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCodeCopiedResetTimer()
+    }
+  }, [clearCodeCopiedResetTimer])
 
   const loadDevices = useCallback(async () => {
     try {
@@ -158,6 +169,9 @@ export function MobilePane(): React.JSX.Element {
       // (no transient activation, non-secure context). Use the main-process
       // IPC clipboard which the rest of the app uses everywhere.
       await window.api.ui.writeClipboardText(pairingUrl)
+      if (!isMountedRef.current) {
+        return
+      }
       clearCodeCopiedResetTimer()
       setCodeCopied(true)
       codeCopiedResetTimerRef.current = window.setTimeout(() => {

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { OrcaHooks, Repo, RepoHookSettings } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { Button } from '../ui/button'
@@ -56,6 +56,9 @@ export function RepositoryPane({
   const [confirmingRemove, setConfirmingRemove] = useState<string | null>(null)
   const [copiedTemplate, setCopiedTemplate] = useState(false)
   const copiedTemplateResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after settings navigation; avoid starting
+  // a reset timer that will outlive this pane.
+  const isMountedRef = useRef(false)
   // Why: searching a project name is navigation to that project, not a
   // request to hide every child row that does not repeat the project name.
   const forceFullPaneForRepoMatch = matchesRepositoryIdentitySearch(searchQuery, repo)
@@ -75,6 +78,14 @@ export function RepositoryPane({
     },
     [clearCopiedTemplateResetTimer]
   )
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCopiedTemplateResetTimer()
+    }
+  }, [clearCopiedTemplateResetTimer])
 
   const handleRemoveProject = (repoId: string) => {
     if (confirmingRemove === repoId) {
@@ -100,6 +111,9 @@ export function RepositoryPane({
     pnpm worktree:setup
   archive: |
     echo "Cleaning up before archive"`)
+    if (!isMountedRef.current) {
+      return
+    }
     clearCopiedTemplateResetTimer()
     setCopiedTemplate(true)
     copiedTemplateResetTimerRef.current = window.setTimeout(() => {

--- a/src/renderer/src/components/stats/ShareUsageButton.tsx
+++ b/src/renderer/src/components/stats/ShareUsageButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toPng } from 'html-to-image'
 import { Check, Copy, Share2 } from 'lucide-react'
 import { Button } from '../ui/button'
@@ -21,6 +21,9 @@ export function ShareUsageButton(props: ShareUsageButtonProps): React.JSX.Elemen
   const [copied, setCopied] = useState(false)
   const [capturing, setCapturing] = useState(false)
   const copiedResetTimerRef = useRef<number | null>(null)
+  // Why: image capture/clipboard IPC can resolve after dialog teardown; avoid
+  // state writes and reset timers after this control unmounts.
+  const isMountedRef = useRef(false)
 
   const clearCopiedResetTimer = useCallback((): void => {
     if (copiedResetTimerRef.current !== null) {
@@ -38,6 +41,14 @@ export function ShareUsageButton(props: ShareUsageButtonProps): React.JSX.Elemen
     [clearCopiedResetTimer]
   )
 
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      clearCopiedResetTimer()
+    }
+  }, [clearCopiedResetTimer])
+
   const captureToClipboard = useCallback(async () => {
     if (!cardRef.current || capturing) {
       return
@@ -51,13 +62,15 @@ export function ShareUsageButton(props: ShareUsageButtonProps): React.JSX.Elemen
       await window.api.ui.writeClipboardImage(dataUrl)
       return true
     } finally {
-      setCapturing(false)
+      if (isMountedRef.current) {
+        setCapturing(false)
+      }
     }
   }, [capturing])
 
   const handleCopy = useCallback(async () => {
     const ok = await captureToClipboard()
-    if (ok) {
+    if (ok && isMountedRef.current) {
       clearCopiedResetTimer()
       setCopied(true)
       copiedResetTimerRef.current = window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- guard async clipboard/image-copy completions before setting copy feedback state
- clear pending copy feedback reset timers when the owning component unmounts

## Merge risk assessment
Risk level: LOW

This only affects transient “Copied” UI feedback after async clipboard operations complete. The clipboard writes, image capture, settings values, and underlying copy payloads are unchanged; the guard only skips follow-up state writes/timers if the control has already unmounted.

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/QuickOpen.tsx src/renderer/src/components/stats/ShareUsageButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx src/renderer/src/components/right-sidebar/checks-panel-content.tsx src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/RepositoryPane.tsx
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryPane.test.ts (blocked by existing local missing module: react-colorful)