### PR TITLE
Clear file row drag expand timers from ref

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -309,17 +309,18 @@ export function FileExplorerRow({
   const findInFolderShortcutLabel = useShortcutLabel('sidebar.search.toggle')
   const FileIcon = getFileTypeIcon(node.relativePath || node.name)
   const rowDropDir = node.isDirectory ? node.path : targetDir
-  const { handleDragOver, handleDragEnter, handleDragLeave, handleDrop } = useFileExplorerRowDrag({
-    rowDropDir,
-    isDirectory: node.isDirectory,
-    nodePath: node.path,
-    isExpanded,
-    onDragTargetChange,
-    onDragExpandDir,
-    onNativeDragTargetChange,
-    onNativeDragExpandDir,
-    onMoveDrop
-  })
+  const { setRowDragNode, handleDragOver, handleDragEnter, handleDragLeave, handleDrop } =
+    useFileExplorerRowDrag({
+      rowDropDir,
+      isDirectory: node.isDirectory,
+      nodePath: node.path,
+      isExpanded,
+      onDragTargetChange,
+      onDragExpandDir,
+      onNativeDragTargetChange,
+      onNativeDragExpandDir,
+      onMoveDrop
+    })
   const handleOpenInOrcaBrowser = useCallback(() => {
     if (!activeWorktreeId) {
       return
@@ -340,6 +341,7 @@ export function FileExplorerRow({
             isFlashing && 'bg-amber-400/20 ring-1 ring-inset ring-amber-400/70'
           )}
           style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
+          ref={setRowDragNode}
           data-native-file-drop-dir={rowDropDir}
           draggable
           onDragStart={(event) => {

--- a/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { getWorkspaceFileDragPaths, WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 
 const DRAG_EXPAND_DELAY_MS = 500
@@ -16,6 +16,7 @@ type UseFileExplorerRowDragParams = {
 }
 
 type RowDragHandlers = {
+  setRowDragNode: (node: HTMLButtonElement | null) => void
   handleDragOver: (e: React.DragEvent) => void
   handleDragEnter: (e: React.DragEvent) => void
   handleDragLeave: (e: React.DragEvent) => void
@@ -52,12 +53,17 @@ export function useFileExplorerRowDrag({
     }
   }, [])
 
-  useEffect(() => {
-    return () => {
-      clearExpandTimer()
-      clearNativeExpandTimer()
-    }
-  }, [clearExpandTimer, clearNativeExpandTimer])
+  const setRowDragNode = useCallback(
+    (node: HTMLButtonElement | null): void => {
+      // Why: delayed drag-expand timers target this row; unmounting the row
+      // makes those timers stale even if the browser skips dragleave.
+      if (node === null) {
+        clearExpandTimer()
+        clearNativeExpandTimer()
+      }
+    },
+    [clearExpandTimer, clearNativeExpandTimer]
+  )
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const isInternal = e.dataTransfer.types.includes(WORKSPACE_FILE_PATH_MIME)
@@ -171,5 +177,5 @@ export function useFileExplorerRowDrag({
     ]
   )
 
-  return { handleDragOver, handleDragEnter, handleDragLeave, handleDrop }
+  return { setRowDragNode, handleDragOver, handleDragEnter, handleDragLeave, handleDrop }
 }


### PR DESCRIPTION
## Summary
- Move File Explorer row drag-expand timer cleanup from a cleanup-only React effect to the row button ref cleanup
- Keep existing drag leave/drop paths responsible for clearing drag counters and visual targets
- Remove one cleanup-only effect from file row drag behavior

## Risk
Medium: touches File Explorer internal/native drag row behavior and auto-expand cleanup. No filesystem mutation, provider, IPC, SSH, or persistence behavior changes.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts src/renderer/src/components/right-sidebar/FileExplorerRow.tsx`
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.ts src/renderer/src/components/right-sidebar/FileExplorerRow.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/useFileExplorerRowDrag.test.ts src/renderer/src/components/right-sidebar/useFileExplorerDragDrop.test.ts src/renderer/src/components/right-sidebar/FileExplorer.test.tsx src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- React effect count: 906 -> 905

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
