### PR TITLE
fix: guard work item link copy feedback

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -5440,6 +5440,16 @@ export default function GitHubItemDialog({
   const files = details?.files ?? []
   const checks = details?.checks ?? []
   const [pendingViewedPaths, setPendingViewedPaths] = useState<Set<string>>(() => new Set())
+  // Why: clipboard IPC can resolve after the dialog unmounts; skip copied-state
+  // feedback instead of starting its reset timer on a stale surface.
+  const linkCopyMountedRef = useRef(false)
+
+  useEffect(() => {
+    linkCopyMountedRef.current = true
+    return () => {
+      linkCopyMountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     setLinkCopied(false)
@@ -5461,6 +5471,9 @@ export default function GitHubItemDialog({
       // Why: Electron's clipboard IPC is reliable even when browser clipboard
       // APIs lose focus/activation inside nested overlay surfaces.
       await window.api.ui.writeClipboardText(workItem.url)
+      if (!linkCopyMountedRef.current) {
+        return
+      }
       setLinkCopied(true)
       toast.success('GitHub link copied')
     } catch {

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -5325,6 +5325,16 @@ export default function PullRequestPage({
   const files = details?.files ?? []
   const checks = details?.checks ?? []
   const [pendingViewedPaths, setPendingViewedPaths] = useState<Set<string>>(() => new Set())
+  // Why: clipboard IPC can resolve after the page unmounts; skip copied-state
+  // feedback instead of starting its reset timer on a stale surface.
+  const linkCopyMountedRef = useRef(false)
+
+  useEffect(() => {
+    linkCopyMountedRef.current = true
+    return () => {
+      linkCopyMountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     setLinkCopied(false)
@@ -5346,6 +5356,9 @@ export default function PullRequestPage({
       // Why: Electron's clipboard IPC is reliable even when browser clipboard
       // APIs lose focus/activation inside nested overlay surfaces.
       await window.api.ui.writeClipboardText(workItem.url)
+      if (!linkCopyMountedRef.current) {
+        return
+      }
       setLinkCopied(true)
       toast.success('GitHub link copied')
     } catch {


### PR DESCRIPTION
## Summary
- guard PR page GitHub-link copy feedback after async clipboard completion
- apply the same stale-surface guard to the GitHub item dialog copy action

## Merge risk assessment
Risk level: LOW

The copied URL, clipboard IPC call, and success/error toast behavior are unchanged while the surface is still mounted. The only skipped work is the transient copied-state update and its reset timer if the page/dialog has already unmounted.

## Validation
- pnpm exec oxlint src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/GitHubItemDialog.tsx
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)