### PR TITLE
Clear copy feedback mounted guards from refs

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -5443,12 +5443,8 @@ export default function GitHubItemDialog({
   // Why: clipboard IPC can resolve after the dialog unmounts; skip copied-state
   // feedback instead of starting its reset timer on a stale surface.
   const linkCopyMountedRef = useRef(false)
-
-  useEffect(() => {
-    linkCopyMountedRef.current = true
-    return () => {
-      linkCopyMountedRef.current = false
-    }
+  const setLinkCopyButtonRef = useCallback((node: HTMLButtonElement | null) => {
+    linkCopyMountedRef.current = node !== null
   }, [])
 
   useEffect(() => {
@@ -5593,6 +5589,7 @@ export default function GitHubItemDialog({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
+                      ref={setLinkCopyButtonRef}
                       type="button"
                       variant="ghost"
                       size="icon-sm"
@@ -5735,6 +5732,7 @@ export default function GitHubItemDialog({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
+                    ref={setLinkCopyButtonRef}
                     type="button"
                     variant="ghost"
                     size="icon-sm"

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -5328,12 +5328,8 @@ export default function PullRequestPage({
   // Why: clipboard IPC can resolve after the page unmounts; skip copied-state
   // feedback instead of starting its reset timer on a stale surface.
   const linkCopyMountedRef = useRef(false)
-
-  useEffect(() => {
-    linkCopyMountedRef.current = true
-    return () => {
-      linkCopyMountedRef.current = false
-    }
+  const setLinkCopyButtonRef = useCallback((node: HTMLButtonElement | null) => {
+    linkCopyMountedRef.current = node !== null
   }, [])
 
   useEffect(() => {
@@ -5484,6 +5480,7 @@ export default function PullRequestPage({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
+                  ref={setLinkCopyButtonRef}
                   type="button"
                   variant="ghost"
                   size="icon-sm"

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, Check, Copy } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
@@ -80,20 +80,13 @@ function InstallRgGuidance({
 
   const setCopyButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCopiedResetTimer()
       }
     },
     [clearCopiedResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCopiedResetTimer()
-    }
-  }, [clearCopiedResetTimer])
 
   const handleCopy = useCallback(() => {
     if (!command) {

--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
@@ -24,20 +24,13 @@ export default function CodeBlockCopyButton({
 
   const setCopyButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCopiedResetTimer()
       }
     },
     [clearCopiedResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCopiedResetTimer()
-    }
-  }, [clearCopiedResetTimer])
 
   const handleCopy = useCallback(() => {
     // Extract the text content from the nested <code> element rendered by

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
@@ -64,20 +64,13 @@ export function RichMarkdownCodeBlock({
 
   const setCopyButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCopiedResetTimer()
       }
     },
     [clearCopiedResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCopiedResetTimer()
-    }
-  }, [clearCopiedResetTimer])
 
   const onChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: co-locating all checks-panel sub-components (checks list,
 conflict sections, threaded PR comments) keeps the shared icon/color maps in one place. */
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import {
   CircleCheck,
   CircleX,
@@ -370,20 +370,13 @@ function CopyButton({ text }: { text: string }): React.JSX.Element {
 
   const setCopyButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCopiedResetTimer()
       }
     },
     [clearCopiedResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCopiedResetTimer()
-    }
-  }, [clearCopiedResetTimer])
 
   const handleCopy = useCallback(
     (e: React.MouseEvent) => {

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -66,20 +66,13 @@ export function MobilePane(): React.JSX.Element {
 
   const setPairingCodeButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCodeCopiedResetTimer()
       }
     },
     [clearCodeCopiedResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCodeCopiedResetTimer()
-    }
-  }, [clearCodeCopiedResetTimer])
 
   const loadDevices = useCallback(async () => {
     try {

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import type { OrcaHooks, Repo, RepoHookSettings } from '../../../../shared/types'
 import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
 import { Button } from '../ui/button'
@@ -72,20 +72,13 @@ export function RepositoryPane({
 
   const setRepositoryPaneRootRef = useCallback(
     (node: HTMLDivElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCopiedTemplateResetTimer()
       }
     },
     [clearCopiedTemplateResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCopiedTemplateResetTimer()
-    }
-  }, [clearCopiedTemplateResetTimer])
 
   const handleRemoveProject = (repoId: string) => {
     if (confirmingRemove === repoId) {

--- a/src/renderer/src/components/stats/ShareUsageButton.tsx
+++ b/src/renderer/src/components/stats/ShareUsageButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { toPng } from 'html-to-image'
 import { Check, Copy, Share2 } from 'lucide-react'
 import { Button } from '../ui/button'
@@ -34,20 +34,13 @@ export function ShareUsageButton(props: ShareUsageButtonProps): React.JSX.Elemen
 
   const setShareButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
+      isMountedRef.current = node !== null
       if (node === null) {
         clearCopiedResetTimer()
       }
     },
     [clearCopiedResetTimer]
   )
-
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-      clearCopiedResetTimer()
-    }
-  }, [clearCopiedResetTimer])
 
   const captureToClipboard = useCallback(async () => {
     if (!cardRef.current || capturing) {


### PR DESCRIPTION
## Summary
- moves async copy/share feedback mounted guards from cleanup-only Effects into the existing button/root ref lifecycle
- applies the same ref-mounted guard to GitHub/PR header copy-link buttons
- removes 9 renderer `useEffect` sites without changing copy IPC behavior

## Risk
Low. The change is scoped to transient copied/capturing feedback after async clipboard/image-copy completions; existing success paths and timers are preserved.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/QuickOpen.tsx src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx src/renderer/src/components/right-sidebar/checks-panel-content.tsx src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/RepositoryPane.tsx src/renderer/src/components/stats/ShareUsageButton.tsx src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx`
- `pnpm exec oxlint src/renderer/src/components/QuickOpen.tsx src/renderer/src/components/editor/CodeBlockCopyButton.tsx src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx src/renderer/src/components/right-sidebar/checks-panel-content.tsx src/renderer/src/components/settings/MobilePane.tsx src/renderer/src/components/settings/RepositoryPane.tsx src/renderer/src/components/stats/ShareUsageButton.tsx src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-search.test.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts src/renderer/src/components/editor/rich-markdown-commands.test.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/right-sidebar/checks-panel-empty-state.test.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts src/renderer/src/components/settings/RepositoryPane.test.ts src/renderer/src/components/settings/MobileNetworkInterfaceSection.test.tsx src/renderer/src/components/settings/mobile-network-interface-selection.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- scoped effect count: `801 -> 792`