### PR TITLE
fix: guard editor copy feedback

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -181,6 +181,9 @@ export default function CombinedDiffViewer({
   const [clearNotesDialogOpen, setClearNotesDialogOpen] = useState(false)
   const [isClearingNotes, setIsClearingNotes] = useState(false)
   const [notesCopied, setNotesCopied] = useState(false)
+  // Why: clipboard IPC can resolve after the combined diff unmounts; skip
+  // copied feedback instead of starting a reset timer on a stale viewer.
+  const notesCopyMountedRef = useRef(false)
   const [fileTreeCollapsed, setFileTreeCollapsedState] = useState(() =>
     getInitialCombinedDiffFileTreeCollapsed(settings?.combinedDiffFileTreeVisibleByDefault)
   )
@@ -863,6 +866,13 @@ export default function CombinedDiffViewer({
   }, [branchSummary, file, openAllDiffs, openBranchAllDiffs])
 
   useEffect(() => {
+    notesCopyMountedRef.current = true
+    return () => {
+      notesCopyMountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
     if (diffCommentCount === 0 && !isClearingNotes) {
       setClearNotesDialogOpen(false)
     }
@@ -882,6 +892,9 @@ export default function CombinedDiffViewer({
     }
     try {
       await window.api.ui.writeClipboardText(diffCommentsPrompt)
+      if (!notesCopyMountedRef.current) {
+        return
+      }
       setNotesCopied(true)
     } catch {
       // Why: clipboard writes can fail while the app is not focused; this

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -50,6 +50,9 @@ function EditorPanelInner({
   const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
     null
   )
+  // Why: clipboard IPC can resolve after the editor panel unmounts; skip path
+  // toast feedback instead of starting a reset timer on a stale panel.
+  const pathCopyMountedRef = useRef(false)
   const [showMarkdownTableOfContents, setShowMarkdownTableOfContents] = useState(false)
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
@@ -89,6 +92,13 @@ function EditorPanelInner({
   useEffect(() => acquireExportPdfListener(), [])
   useClosedEditorTabCleanup(openFiles)
   useMarkdownPreviewShortcut({ activeFile, panelRef, openMarkdownPreview })
+  useEffect(() => {
+    pathCopyMountedRef.current = true
+    return () => {
+      pathCopyMountedRef.current = false
+    }
+  }, [])
+
   useEffect(() => {
     if (!copiedPathToast) {
       return
@@ -181,8 +191,14 @@ function EditorPanelInner({
     }
     try {
       await window.api.ui.writeClipboardText(copyState.copyText)
+      if (!pathCopyMountedRef.current) {
+        return
+      }
       setCopiedPathToast({ fileId: activeFile.id, token: Date.now() })
     } catch {
+      if (!pathCopyMountedRef.current) {
+        return
+      }
       setCopiedPathToast(null)
     }
   }, [activeFile])

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -527,6 +527,9 @@ export default function MarkdownPreview({
   const [activeAnnotationBlockKey, setActiveAnnotationBlockKey] = useState<string | null>(null)
   const [reviewNotesCopied, setReviewNotesCopied] = useState(false)
   const reviewNotesCopiedResetTimerRef = useRef<number | null>(null)
+  // Why: clipboard IPC can resolve after the preview unmounts; skip copied
+  // feedback instead of starting a reset timer on a stale preview.
+  const reviewNotesCopyMountedRef = useRef(false)
   const [activeReviewCommentId, setActiveReviewCommentId] = useState<string | null>(null)
   const [attentionReviewCommentId, setAttentionReviewCommentId] = useState<string | null>(null)
   const attentionReviewCommentTimeoutRef = useRef<number | null>(null)
@@ -661,6 +664,14 @@ export default function MarkdownPreview({
       reviewNotesCopiedResetTimerRef.current = null
     }
   }, [])
+
+  useEffect(() => {
+    reviewNotesCopyMountedRef.current = true
+    return () => {
+      reviewNotesCopyMountedRef.current = false
+      clearReviewNotesCopiedResetTimer()
+    }
+  }, [clearReviewNotesCopiedResetTimer])
 
   const scrollToAnchor = useCallback((rawAnchor: string): boolean => {
     const container = rootRef.current
@@ -797,6 +808,9 @@ export default function MarkdownPreview({
     }
     try {
       await window.api.ui.writeClipboardText(markdownReviewPrompt)
+      if (!reviewNotesCopyMountedRef.current) {
+        return
+      }
       clearReviewNotesCopiedResetTimer()
       setReviewNotesCopied(true)
       reviewNotesCopiedResetTimerRef.current = window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- guard MarkdownPreview review-note copy feedback after async clipboard completion
- guard CombinedDiffViewer note copy feedback after async clipboard completion
- guard EditorPanel path copy toast feedback after async clipboard completion

## Merge risk assessment
Risk level: LOW

The copied text, clipboard calls, and visible feedback behavior are unchanged while the editor surface is mounted. This only skips transient copied/toast state and reset timers if the owning editor view has already unmounted.

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/CombinedDiffViewer.tsx src/renderer/src/components/editor/EditorPanel.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-preview-search.test.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)