### PR TITLE
fix: dispose contextual copy listeners

### DIFF
--- a/src/renderer/src/components/editor/setup-contextual-copy.ts
+++ b/src/renderer/src/components/editor/setup-contextual-copy.ts
@@ -255,7 +255,7 @@ export function setupContextualCopy({
     return true
   }
 
-  editorInstance.onDidChangeCursorSelection((event) => {
+  const selectionListener = editorInstance.onDidChangeCursorSelection((event) => {
     if (event.source !== 'restoreState') {
       schedulePrimarySelectionBufferUpdate()
     }
@@ -264,13 +264,13 @@ export function setupContextualCopy({
     }
     updateCopyHint()
   })
-  editorInstance.onDidScrollChange(() => {
+  const scrollListener = editorInstance.onDidScrollChange(() => {
     updateCopyHint()
   })
-  editorInstance.onDidFocusEditorText(() => {
+  const focusListener = editorInstance.onDidFocusEditorText(() => {
     startCopyHintPolling()
   })
-  editorInstance.onDidBlurEditorText(() => {
+  const blurListener = editorInstance.onDidBlurEditorText(() => {
     stopCopyHintPolling()
     copyHintNode.style.display = 'none'
     copyHintWidgetPosition = null
@@ -294,6 +294,12 @@ export function setupContextualCopy({
   editorDomNode.addEventListener('mouseup', updateCopyHint, true)
   editorDomNode.addEventListener('keyup', updateCopyHint, true)
   editorInstance.onDidDispose(() => {
+    // Why: Monaco owns these emitters, but disposing explicitly keeps this
+    // feature's lifecycle symmetrical with the DOM listener cleanup below.
+    selectionListener.dispose()
+    scrollListener.dispose()
+    focusListener.dispose()
+    blurListener.dispose()
     if (primarySelectionTimer !== null) {
       window.clearTimeout(primarySelectionTimer)
       primarySelectionTimer = null


### PR DESCRIPTION
## Summary
- retain Monaco contextual-copy event subscriptions as disposables
- dispose those subscriptions during the existing editor dispose cleanup

## Merge risk assessment
Risk level: LOW

This does not change contextual-copy behavior, shortcut handling, primary-selection updates, or copy text formatting. It only makes the listener lifecycle explicit alongside the DOM listener and timer cleanup that already runs when the editor is disposed.

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/setup-contextual-copy.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/selection-copy.test.ts src/renderer/src/components/editor/editor-shortcuts.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)