### PR TITLE
Clear editor copy mounted guards from refs

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -199,6 +199,10 @@ export default function CombinedDiffViewer({
   const sectionsRef = useRef<DiffSection[]>([])
   const generationRef = useRef(0)
   const loadSectionRef = useRef<(index: number) => Promise<void>>(async () => {})
+  const setScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
+    scrollContainerRef.current = node
+    notesCopyMountedRef.current = node !== null
+  }, [])
   const loadSchedulerRef = useRef(
     createCombinedDiffLoadScheduler({
       loadSection: (index) => loadSectionRef.current(index)
@@ -866,13 +870,6 @@ export default function CombinedDiffViewer({
   }, [branchSummary, file, openAllDiffs, openBranchAllDiffs])
 
   useEffect(() => {
-    notesCopyMountedRef.current = true
-    return () => {
-      notesCopyMountedRef.current = false
-    }
-  }, [])
-
-  useEffect(() => {
     if (diffCommentCount === 0 && !isClearingNotes) {
       setClearNotesDialogOpen(false)
     }
@@ -1143,7 +1140,10 @@ export default function CombinedDiffViewer({
             onCollapsedChange={setFileTreeCollapsed}
             onNavigate={handleTreeNavigate}
           />
-          <div ref={scrollContainerRef} className="min-w-0 flex-1 overflow-auto scrollbar-editor">
+          <div
+            ref={setScrollContainerRef}
+            className="min-w-0 flex-1 overflow-auto scrollbar-editor"
+          >
             {skippedConflictNotice}
             <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
               {virtualizer.getVirtualItems().map((virtualItem) => {

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -53,6 +53,10 @@ function EditorPanelInner({
   // Why: clipboard IPC can resolve after the editor panel unmounts; skip path
   // toast feedback instead of starting a reset timer on a stale panel.
   const pathCopyMountedRef = useRef(false)
+  const setPanelRef = useCallback((node: HTMLDivElement | null) => {
+    panelRef.current = node
+    pathCopyMountedRef.current = node !== null
+  }, [])
   const [showMarkdownTableOfContents, setShowMarkdownTableOfContents] = useState(false)
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
@@ -92,12 +96,6 @@ function EditorPanelInner({
   useEffect(() => acquireExportPdfListener(), [])
   useClosedEditorTabCleanup(openFiles)
   useMarkdownPreviewShortcut({ activeFile, panelRef, openMarkdownPreview })
-  useEffect(() => {
-    pathCopyMountedRef.current = true
-    return () => {
-      pathCopyMountedRef.current = false
-    }
-  }, [])
 
   useEffect(() => {
     if (!copiedPathToast) {
@@ -294,7 +292,7 @@ function EditorPanelInner({
 
   return (
     <EditorPanelShell
-      panelRef={panelRef}
+      panelRef={setPanelRef}
       activeFile={activeFile}
       activeViewStateId={activeViewStateId}
       model={model}

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -1,4 +1,4 @@
-import { Suspense, type JSX, type RefObject } from 'react'
+import { Suspense, type JSX, type Ref } from 'react'
 import { useAppStore } from '@/store'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { OpenFile } from '@/store/slices/editor'
@@ -13,7 +13,7 @@ import { getUntitledFileRoot } from './untitled-file-rename-path'
 type EditorPanelRenderModel = ReturnType<typeof getEditorPanelRenderModel>
 
 type EditorPanelShellProps = {
-  panelRef: RefObject<HTMLDivElement | null>
+  panelRef: Ref<HTMLDivElement>
   activeFile: OpenFile
   activeViewStateId: string | null | undefined
   model: EditorPanelRenderModel

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -665,13 +665,16 @@ export default function MarkdownPreview({
     }
   }, [])
 
-  useEffect(() => {
-    reviewNotesCopyMountedRef.current = true
-    return () => {
-      reviewNotesCopyMountedRef.current = false
-      clearReviewNotesCopiedResetTimer()
-    }
-  }, [clearReviewNotesCopiedResetTimer])
+  const setRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      rootRef.current = node
+      reviewNotesCopyMountedRef.current = node !== null
+      if (node === null) {
+        clearReviewNotesCopiedResetTimer()
+      }
+    },
+    [clearReviewNotesCopiedResetTimer]
+  )
 
   const scrollToAnchor = useCallback((rawAnchor: string): boolean => {
     const container = rootRef.current
@@ -1505,7 +1508,7 @@ export default function MarkdownPreview({
   return (
     <div className="markdown-preview-shell">
       <div
-        ref={rootRef}
+        ref={setRootRef}
         tabIndex={0}
         style={{ fontSize: `${editorFontSize}px` }}
         className={`markdown-preview h-full min-h-0 overflow-auto scrollbar-editor ${isDark ? 'markdown-dark' : 'markdown-light'}`}


### PR DESCRIPTION
## Summary
- moves editor/markdown async copy-feedback mounted guards into existing panel/root/scroll-container ref lifecycles
- preserves clipboard IPC calls, copied-state timers, and editor scroll refs
- removes 3 renderer `useEffect` sites

## Risk
Low. This is scoped to local copied-feedback state after async clipboard completion; editor save, diff loading, markdown rendering, and source-control data paths are unchanged.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/EditorPanel.tsx src/renderer/src/components/editor/EditorPanelShell.tsx src/renderer/src/components/editor/CombinedDiffViewer.tsx src/renderer/src/components/editor/MarkdownPreview.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/EditorPanel.tsx src/renderer/src/components/editor/EditorPanelShell.tsx src/renderer/src/components/editor/CombinedDiffViewer.tsx src/renderer/src/components/editor/MarkdownPreview.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/markdown-preview-search.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-preview-controls.test.ts src/renderer/src/components/editor/CombinedDiffFileTree.test.ts src/renderer/src/components/editor/line-copy-path.test.ts src/renderer/src/lib/diff-comments-format.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- scoped effect count: `796 -> 793`