### PR TITLE
fix: dispose monaco editor state listeners

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -377,7 +377,7 @@ export default function MonacoEditor({
       if (pos) {
         setEditorCursorLine(filePath, pos.lineNumber)
       }
-      editorInstance.onDidChangeCursorPosition((e) => {
+      const cursorPositionSub = editorInstance.onDidChangeCursorPosition((e) => {
         setEditorCursorLine(filePath, e.position.lineNumber)
         setWithLRU(cursorPositionCache, viewStateKey, {
           lineNumber: e.position.lineNumber,
@@ -385,25 +385,11 @@ export default function MonacoEditor({
         })
       })
 
-      editorInstance.onDidDispose(() => {
-        cleanupSaveShortcut()
-        autoHeightSub?.dispose()
-        if (autoHeightFrame !== null) {
-          window.cancelAnimationFrame(autoHeightFrame)
-          autoHeightFrame = null
-        }
-        conflictDecorationsRef.current?.clear()
-        conflictDecorationsRef.current = null
-        editorRef.current = null
-        setMountedEditor(null)
-        setCommentPopover(null)
-      })
-
       // Why: Writing to the Map at 60fps (every scroll frame) is unnecessary since
       // we only need the final position when the user stops scrolling or switches
       // tabs. A trailing throttle of ~150ms captures the resting position while
       // avoiding excessive writes.
-      editorInstance.onDidScrollChange((e) => {
+      const scrollStateSub = editorInstance.onDidScrollChange((e) => {
         if (scrollThrottleTimerRef.current !== null) {
           clearTimeout(scrollThrottleTimerRef.current)
         }
@@ -415,7 +401,7 @@ export default function MonacoEditor({
 
       // Intercept right-click on line number gutter to show Radix context menu
       // (same approach as VSCode: custom menu instead of Monaco's built-in one)
-      editorInstance.onMouseDown((e) => {
+      const gutterMouseDownSub = editorInstance.onMouseDown((e) => {
         if (
           e.event.rightButton &&
           e.target.type === monaco.editor.MouseTargetType.GUTTER_LINE_NUMBERS
@@ -428,6 +414,25 @@ export default function MonacoEditor({
           setGutterMenuPoint({ x: e.event.posx, y: e.event.posy })
           setGutterMenuOpen(true)
         }
+      })
+
+      editorInstance.onDidDispose(() => {
+        // Why: keep editor-owned UI subscriptions symmetrical with the
+        // shortcut/decorator cleanup when Monaco tears this instance down.
+        cursorPositionSub.dispose()
+        scrollStateSub.dispose()
+        gutterMouseDownSub.dispose()
+        cleanupSaveShortcut()
+        autoHeightSub?.dispose()
+        if (autoHeightFrame !== null) {
+          window.cancelAnimationFrame(autoHeightFrame)
+          autoHeightFrame = null
+        }
+        conflictDecorationsRef.current?.clear()
+        conflictDecorationsRef.current = null
+        editorRef.current = null
+        setMountedEditor(null)
+        setCommentPopover(null)
       })
 
       // If there's a pending reveal at mount time, execute it now


### PR DESCRIPTION
## Summary
- retain Monaco editor cursor/scroll/gutter subscriptions as disposables
- dispose those subscriptions during the existing editor dispose cleanup

## Merge risk assessment
Risk level: LOW

This preserves the cursor-line tracking, scroll throttling, and gutter context-menu behavior. It only makes the editor-instance subscriptions explicit disposables alongside the shortcut, decoration, and frame cleanup that already runs when Monaco disposes the editor.

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/MonacoEditor.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/monaco-reveal-range.test.ts src/renderer/src/components/editor/editor-shortcuts.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)