### PR TITLE
fix: dispose editable editor listeners

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -381,8 +381,7 @@ export function DiffSectionItem({
     const cleanupSaveShortcut = installEditorSaveShortcut(modified.getContainerDomNode(), () =>
       handleSectionSaveRef.current(index)
     )
-    modified.onDidDispose(() => cleanupSaveShortcut())
-    modified.onDidChangeModelContent(() => {
+    const modelContentSub = modified.onDidChangeModelContent(() => {
       const current = modified.getValue()
       setSections((prev) => {
         let changed = false
@@ -405,6 +404,12 @@ export function DiffSectionItem({
         })
         return changed ? next : prev
       })
+    })
+    modified.onDidDispose(() => {
+      // Why: editable diff sections own both the save shortcut and model-change
+      // subscription for this Monaco editor instance.
+      cleanupSaveShortcut()
+      modelContentSub.dispose()
     })
   }
 

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -337,11 +337,15 @@ export default function DiffViewer({
           }
         )
 
-        modifiedEditor.onDidDispose(() => cleanupSaveShortcut())
-
         // Track changes
-        modifiedEditor.onDidChangeModelContent(() => {
+        const modelContentSub = modifiedEditor.onDidChangeModelContent(() => {
           onContentChangeRef.current?.(modifiedEditor.getValue())
+        })
+        modifiedEditor.onDidDispose(() => {
+          // Why: editable diff views own both the save shortcut and
+          // model-change subscription for this Monaco editor instance.
+          cleanupSaveShortcut()
+          modelContentSub.dispose()
         })
 
         modifiedEditor.focus()

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -297,11 +297,16 @@ function CodeCell({
         void onSaveRequestRef.current()
       }
     )
-    editorInstance.onDidDispose(() => cleanupSaveShortcut())
-    editorInstance.addCommand(monacoInstance.KeyCode.Escape, () => {
+    const blurSub = editorInstance.onDidBlurEditorWidget(() => {
       onDeactivateRef.current()
     })
-    editorInstance.onDidBlurEditorWidget(() => {
+    editorInstance.onDidDispose(() => {
+      // Why: the inline source editor owns both the save shortcut and blur
+      // subscription for this Monaco editor instance.
+      cleanupSaveShortcut()
+      blurSub.dispose()
+    })
+    editorInstance.addCommand(monacoInstance.KeyCode.Escape, () => {
       onDeactivateRef.current()
     })
   }, [])


### PR DESCRIPTION
## Summary
- dispose editable diff model-change subscriptions with their Monaco editor instances
- dispose the notebook inline editor blur subscription during editor disposal

## Merge risk assessment
Risk level: LOW

This keeps save shortcuts, editable diff content tracking, and notebook blur deactivation behavior unchanged while the editors are alive. It only makes the listener cleanup explicit when Monaco disposes those editor instances.

## Validation
- pnpm exec oxlint src/renderer/src/components/editor/DiffSectionItem.tsx src/renderer/src/components/editor/DiffViewer.tsx src/renderer/src/components/editor/IpynbViewer.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/editor-autosave-controller.test.ts
- git diff --check
- pnpm typecheck (fails on existing local missing modules: @tiptap/extension-details, react-colorful)