### PR TITLE
Reset add project dialog before commit

### DIFF
--- a/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { FolderPlus, Loader2 } from 'lucide-react'
 import {
@@ -43,6 +43,7 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
   const [error, setError] = useState<string | null>(null)
 
   const isOpen = activeModal === 'confirm-add-project-from-folder'
+  const [previousOpen, setPreviousOpen] = useState(isOpen)
   const folderPath = typeof modalData.folderPath === 'string' ? modalData.folderPath : ''
   const connectionId = typeof modalData.connectionId === 'string' ? modalData.connectionId : ''
   const repoId = addedRepo?.id ?? ''
@@ -77,13 +78,16 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
   )
   const primaryBranchName = getProjectAddedPrimaryBranchName(primaryWorktree)
 
-  useEffect(() => {
+  if (isOpen !== previousOpen) {
+    setPreviousOpen(isOpen)
     if (!isOpen) {
+      // Why: closed modal state is fully local; clear it before commit so the
+      // next open never paints stale progress or errors.
       setAddedRepo(null)
       setIsAdding(false)
       setError(null)
     }
-  }, [isOpen])
+  }
 
   const openNonGitConfirmation = useCallback(() => {
     closeModal()


### PR DESCRIPTION
## Summary
- removes the close-state reset Effect from `AddProjectFromFolderDialog`
- reconciles local modal state during render when the dialog closes, so stale progress/error state is cleared before the next committed frame
- removes 1 renderer `useEffect` site

## Risk
Medium. The change is local UI state only, but it touches the new add-project-from-folder workflow and close/skip transitions.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx`
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/AddProjectFromFolderDialog.test.tsx src/renderer/src/components/right-sidebar/FileExplorerVirtualRowsAddProject.test.tsx src/renderer/src/components/right-sidebar/file-explorer-add-project-action.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- scoped effect count: `794 -> 793`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
