### PR TITLE
Stabilize audio recording store subscription

### DIFF
--- a/mobile/packages/expo-two-way-audio/src/hooks.ts
+++ b/mobile/packages/expo-two-way-audio/src/hooks.ts
@@ -12,15 +12,21 @@ export const useMicrophonePermissions = createPermissionHook({
   requestMethod: requestMicrophonePermissionsAsync
 })
 
-export function useIsRecording() {
-  const subscribe = (cb: () => void) => {
-    const sub = addExpoTwoWayAudioEventListener('onRecordingChange', cb)
-    return () => sub.remove()
-  }
-  const getSnapshot = () => isRecording()
-  const getServerSnapshot = () => false
+// Why: useSyncExternalStore resubscribes when these identities change; keep
+// the native recording listener stable across component re-renders.
+const subscribeToRecordingChanges = (cb: () => void) => {
+  const sub = addExpoTwoWayAudioEventListener('onRecordingChange', cb)
+  return () => sub.remove()
+}
+const getRecordingSnapshot = () => isRecording()
+const getServerRecordingSnapshot = () => false
 
-  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+export function useIsRecording() {
+  return useSyncExternalStore(
+    subscribeToRecordingChanges,
+    getRecordingSnapshot,
+    getServerRecordingSnapshot
+  )
 }
 
 export function useExpoTwoWayAudioEventListener<K extends keyof ExpoTwoWayAudioEventMap>(


### PR DESCRIPTION
## Summary
- hoists the `useIsRecording` `useSyncExternalStore` subscribe/snapshot callbacks to module scope
- avoids native recording listener resubscription churn when components using the hook re-render
- leaves the event-listener Effect for `useExpoTwoWayAudioEventListener` unchanged because it synchronizes with the native event emitter

## Risk
Medium. This is a small hook-level perf cleanup, but it touches the mobile native audio package.

## Validation
- `pnpm exec oxfmt --write mobile/packages/expo-two-way-audio/src/hooks.ts`
- `pnpm exec oxlint mobile/packages/expo-two-way-audio/src/hooks.ts`
- `git diff --check`

## Typecheck
- `pnpm exec tsc --noEmit -p mobile/packages/expo-two-way-audio/tsconfig.json` is blocked in this checkout by missing `expo-modules-core` and `expo-module-scripts/tsconfig.base`, matching the existing mobile package tooling gap.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
