### PR TITLE
Clear browser address timers from ref

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -71,16 +71,25 @@ export default function BrowserAddressBar({
   const blurCloseTimerRef = useRef<number | null>(null)
   const closingResetTimerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    return () => {
-      if (blurCloseTimerRef.current !== null) {
-        window.clearTimeout(blurCloseTimerRef.current)
-      }
-      if (closingResetTimerRef.current !== null) {
-        window.clearTimeout(closingResetTimerRef.current)
-      }
+  const clearAddressBarTimers = useCallback((): void => {
+    if (blurCloseTimerRef.current !== null) {
+      window.clearTimeout(blurCloseTimerRef.current)
+      blurCloseTimerRef.current = null
+    }
+    if (closingResetTimerRef.current !== null) {
+      window.clearTimeout(closingResetTimerRef.current)
+      closingResetTimerRef.current = null
     }
   }, [])
+
+  const setAddressBarFormRef = useCallback(
+    (node: HTMLFormElement | null) => {
+      if (node === null) {
+        clearAddressBarTimers()
+      }
+    },
+    [clearAddressBarTimers]
+  )
 
   const searchEngine: SearchEngine =
     (browserDefaultSearchEngine as SearchEngine | null) ?? DEFAULT_SEARCH_ENGINE
@@ -279,6 +288,7 @@ export default function BrowserAddressBar({
     >
       <PopoverTrigger asChild>
         <form
+          ref={setAddressBarFormRef}
           className="flex min-w-0 flex-1 items-center gap-2 rounded-xl border border-border bg-background px-3 py-1 shadow-sm"
           onSubmit={(event) => {
             event.preventDefault()


### PR DESCRIPTION
## Summary
- moves BrowserAddressBar blur/closing timer cleanup from a cleanup-only Effect to the address form ref lifecycle
- preserves the popover/focus coordination Effect that depends on suggestion state
- removes 1 renderer `useEffect` site

## Risk
Low. This is scoped to clearing local UI timers on address bar unmount; navigation, history suggestions, and webview behavior are unchanged.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/browser-pane/BrowserAddressBar.tsx`
- `pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserAddressBar.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-focus.test.ts src/renderer/src/components/browser-pane/browser-keyboard.test.ts src/renderer/src/components/browser-pane/browser-pane-page-selection.test.ts src/renderer/src/components/browser-pane/context-menu-positioning.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- scoped renderer effect count: `794 -> 793`