### PR TITLE
Fix reset countdown copy

### DIFF
--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
-import { getWindowSections } from './tooltip'
+import { formatResetCountdown, getWindowSections } from './tooltip'
+
+describe('formatResetCountdown', () => {
+  it('uses natural copy when the reset time has arrived', () => {
+    expect(formatResetCountdown(0)).toBe('Resets now')
+    expect(formatResetCountdown(-1)).toBe('Resets now')
+  })
+
+  it('keeps the "in" preposition for future reset times', () => {
+    expect(formatResetCountdown(12 * 60 * 60_000 + 41 * 60_000)).toBe('Resets in 12h 41m')
+  })
+})
 
 describe('getWindowSections', () => {
   it('returns buckets as sections when present', () => {

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -36,6 +36,11 @@ function formatDuration(ms: number): string {
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
 }
 
+export function formatResetCountdown(ms: number): string {
+  const duration = formatDuration(ms)
+  return duration === 'now' ? 'Resets now' : `Resets in ${duration}`
+}
+
 // ---------------------------------------------------------------------------
 // Shared icon component
 // ---------------------------------------------------------------------------
@@ -129,7 +134,7 @@ function TooltipWindowSection({
     return null
   }
   const leftPct = Math.max(0, Math.round(100 - w.usedPercent))
-  const resetIn = w.resetsAt ? formatDuration(w.resetsAt - Date.now()) : null
+  const resetLabel = w.resetsAt ? formatResetCountdown(w.resetsAt - Date.now()) : null
 
   return (
     <div className="space-y-1">
@@ -142,7 +147,7 @@ function TooltipWindowSection({
       </div>
       <div className="flex justify-between text-background/60">
         <span>{leftPct}% left</span>
-        {resetIn && <span>Resets in {resetIn}</span>}
+        {resetLabel && <span>{resetLabel}</span>}
       </div>
     </div>
   )
@@ -289,7 +294,7 @@ export function ProviderPanel({
       return null
     }
     const leftPct = Math.max(0, Math.round(100 - w.usedPercent))
-    const resetIn = w.resetsAt ? formatDuration(w.resetsAt - Date.now()) : null
+    const resetLabel = w.resetsAt ? formatResetCountdown(w.resetsAt - Date.now()) : null
 
     return (
       <div className="space-y-1">
@@ -302,7 +307,7 @@ export function ProviderPanel({
         </div>
         <div className={`flex justify-between ${mutedClass}`}>
           <span>{leftPct}% left</span>
-          {resetIn && <span>Resets in {resetIn}</span>}
+          {resetLabel && <span>{resetLabel}</span>}
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary
- render elapsed usage reset timers as `Resets now` instead of `Resets in now`
- add focused coverage for reset countdown copy

## Test Plan
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/tooltip.test.ts`
- `pnpm run typecheck:web`

Made with [Orca](https://github.com/stablyai/orca) 🐋
