### PR TITLE
fix: guard terminal cwd async updates

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -356,15 +356,31 @@ export function FloatingTerminalPanel({
   }, [bounds.left, bounds.width, open])
 
   useEffect(() => {
+    let cancelled = false
     void window.api.app
       .getFloatingTerminalCwd({
         path: floatingTerminalCwd
       })
-      .then(setCwd)
+      .then((nextCwd) => {
+        if (!cancelled) {
+          setCwd(nextCwd)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
   }, [floatingTerminalCwd])
 
   useEffect(() => {
-    void window.api.app.getFloatingMarkdownDirectory().then(setMarkdownCwd)
+    let cancelled = false
+    void window.api.app.getFloatingMarkdownDirectory().then((nextMarkdownCwd) => {
+      if (!cancelled) {
+        setMarkdownCwd(nextMarkdownCwd)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -62,7 +62,15 @@ export function OnboardingInlineCommandTerminal({
   }, [onOpened])
 
   useEffect(() => {
-    void window.api.app.getFloatingTerminalCwd({ path: '~' }).then(setCwd)
+    let cancelled = false
+    void window.api.app.getFloatingTerminalCwd({ path: '~' }).then((nextCwd) => {
+      if (!cancelled) {
+        setCwd(nextCwd)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- guard floating terminal cwd and markdown-directory IPC completions before writing React state
- guard onboarding inline terminal cwd resolution before writing React state after unmount

## Merge risk assessment
Risk: LOW

This only ignores stale async completions after unmount or dependency replacement. It does not change the requested cwd paths, tab creation, terminal focus, or markdown picker behavior.

## Validation
- pnpm exec oxlint src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm typecheck (blocked by existing missing modules: @tiptap/extension-details, react-colorful)