### PR TITLE
fix: guard settings async state updates

### DIFF
--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -128,7 +128,15 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
   >('loading')
 
   useEffect(() => {
-    window.api.updater.getVersion().then(setAppVersion)
+    let cancelled = false
+    void window.api.updater.getVersion().then((version) => {
+      if (!cancelled) {
+        setAppVersion(version)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { getDefaultVoiceSettings } from '../../../../shared/constants'
 import type { SpeechModelManifest, SpeechModelState } from '../../../../shared/speech-types'
@@ -32,13 +32,29 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   const shortcutLabel = useShortcutLabel('voice.dictation')
   const [catalog, setCatalog] = useState<SpeechModelManifest[]>([])
   const [permissionPending, setPermissionPending] = useState(false)
+  const mountedRef = useRef(true)
 
   useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
     refreshModelStates()
-    window.api.speech
+    void window.api.speech
       .getCatalog()
-      .then(setCatalog)
+      .then((nextCatalog) => {
+        if (!cancelled) {
+          setCatalog(nextCatalog)
+        }
+      })
       .catch(() => {})
+    return () => {
+      cancelled = true
+    }
   }, [refreshModelStates])
 
   useEffect(() => {
@@ -84,7 +100,9 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
     } catch {
       toast.error('Could not request microphone permission. Voice dictation was not enabled.')
     } finally {
-      setPermissionPending(false)
+      if (mountedRef.current) {
+        setPermissionPending(false)
+      }
     }
   }
 

--- a/src/renderer/src/lib/windows-terminal-capabilities.ts
+++ b/src/renderer/src/lib/windows-terminal-capabilities.ts
@@ -96,12 +96,20 @@ export function useWindowsTerminalCapabilities(
       return
     }
 
+    let cancelled = false
     const cached = getCachedWindowsTerminalCapabilities()
     setCapabilities(cachedCapabilities ? cached : { ...cached, isLoading: true })
     subscribers.add(setCapabilities)
-    void loadWindowsTerminalCapabilities({ force: forceRefreshOnMount }).then(setCapabilities)
+    void loadWindowsTerminalCapabilities({ force: forceRefreshOnMount }).then(
+      (nextCapabilities) => {
+        if (!cancelled) {
+          setCapabilities(nextCapabilities)
+        }
+      }
+    )
 
     return () => {
+      cancelled = true
       subscribers.delete(setCapabilities)
     }
   }, [enabled, forceRefreshOnMount])


### PR DESCRIPTION
## Summary
- guard Settings app-version and speech-catalog async completions before writing panel state
- guard Windows terminal capability hook completions after unsubscribe
- guard VoicePane permission pending reset after unmount

## Merge risk assessment
Risk: LOW

This only prevents stale local React state writes after settings panels/hooks unmount. Shared capability cache publishing and settings mutation behavior are unchanged.

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/GeneralPane.tsx src/renderer/src/components/settings/VoicePane.tsx src/renderer/src/lib/windows-terminal-capabilities.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/windows-terminal-capabilities.test.ts src/renderer/src/components/settings/GeneralPane.test.ts
- pnpm typecheck (blocked by existing missing modules: @tiptap/extension-details, react-colorful)