### PR TITLE
Capture mobile pairing baseline during QR generation

### DIFF
--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -54,6 +54,7 @@ export function MobilePane(): React.JSX.Element {
   const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
   const [deviceCountAtQr, setDeviceCountAtQr] = useState<number | null>(null)
+  const devicesRef = useRef<PairedDevice[]>([])
   const codeCopiedResetTimerRef = useRef<number | null>(null)
   const mountedRef = useMountedRef()
   // Why: clipboard IPC can resolve after settings navigation; avoid starting
@@ -81,6 +82,7 @@ export function MobilePane(): React.JSX.Element {
     try {
       const result = await window.api.mobile.listDevices()
       if (mountedRef.current) {
+        devicesRef.current = result.devices
         setDevices(result.devices)
       }
     } catch {
@@ -129,9 +131,10 @@ export function MobilePane(): React.JSX.Element {
             setQrDataUrl(result.qrDataUrl)
             setPairingUrl(result.pairingUrl)
             setEndpoint(result.endpoint)
-            // Why: polling needs the device count from the moment this QR was minted,
-            // not a later count after `loadDevices` refreshes the paired-device list.
-            setDeviceCountAtQr(devices.length)
+            // Why: async QR generation may overlap a device-list refresh; use
+            // the latest committed list, then keep this baseline ahead of the
+            // post-QR refresh below.
+            setDeviceCountAtQr(devicesRef.current.length)
             clearCodeCopiedResetTimer()
             setCodeCopied(false)
             void loadDevices()
@@ -151,7 +154,7 @@ export function MobilePane(): React.JSX.Element {
         }
       }
     },
-    [clearCodeCopiedResetTimer, devices.length, loadDevices, mountedRef, selectedAddress]
+    [clearCodeCopiedResetTimer, loadDevices, mountedRef, selectedAddress]
   )
 
   useEffect(() => {
@@ -194,7 +197,11 @@ export function MobilePane(): React.JSX.Element {
     try {
       await window.api.mobile.revokeDevice({ deviceId })
       if (mountedRef.current) {
-        setDevices((prev) => prev.filter((d) => d.deviceId !== deviceId))
+        setDevices((prev) => {
+          const nextDevices = prev.filter((d) => d.deviceId !== deviceId)
+          devicesRef.current = nextDevices
+          return nextDevices
+        })
         toast.success('Device revoked')
       }
     } catch {

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -53,6 +53,7 @@ export function MobilePane(): React.JSX.Element {
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined)
   const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
+  const [deviceCountAtQr, setDeviceCountAtQr] = useState<number | null>(null)
   const codeCopiedResetTimerRef = useRef<number | null>(null)
   const mountedRef = useMountedRef()
   // Why: clipboard IPC can resolve after settings navigation; avoid starting
@@ -128,6 +129,9 @@ export function MobilePane(): React.JSX.Element {
             setQrDataUrl(result.qrDataUrl)
             setPairingUrl(result.pairingUrl)
             setEndpoint(result.endpoint)
+            // Why: polling needs the device count from the moment this QR was minted,
+            // not a later count after `loadDevices` refreshes the paired-device list.
+            setDeviceCountAtQr(devices.length)
             clearCodeCopiedResetTimer()
             setCodeCopied(false)
             void loadDevices()
@@ -147,24 +151,13 @@ export function MobilePane(): React.JSX.Element {
         }
       }
     },
-    [clearCodeCopiedResetTimer, loadDevices, mountedRef, selectedAddress]
+    [clearCodeCopiedResetTimer, devices.length, loadDevices, mountedRef, selectedAddress]
   )
 
   useEffect(() => {
     void loadDevices()
     void loadNetworkInterfaces()
   }, [loadDevices, loadNetworkInterfaces])
-
-  // Why: after generating a QR code the device only appears once the phone
-  // actually connects (lastSeenAt > 0). Poll until a new device shows up.
-  const [deviceCountAtQr, setDeviceCountAtQr] = useState<number | null>(null)
-  useEffect(() => {
-    if (!qrDataUrl) {
-      setDeviceCountAtQr(null)
-      return
-    }
-    setDeviceCountAtQr(devices.length)
-  }, [qrDataUrl]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useMobilePairingDevicePolling({
     deviceCountAtQr,


### PR DESCRIPTION
## Summary\n- move the mobile pairing device-count baseline into the QR generation success path\n- remove the follow-up Effect that only mirrored QR generation state into polling state\n\n## Validation\n- pnpm exec oxfmt --write src/renderer/src/components/settings/MobilePane.tsx\n- pnpm exec oxlint src/renderer/src/components/settings/MobilePane.tsx\n- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/mobile-pairing-device-polling.test.ts src/renderer/src/components/settings/MobileNetworkInterfaceSection.test.tsx src/renderer/src/components/settings/mobile-network-interface-selection.test.ts\n- pnpm run typecheck:web\n- git diff --check\n\nRisk: medium

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
