### PR TITLE
fix: guard crash report async state

### DIFF
--- a/src/renderer/src/components/crash-report/CrashReportDialog.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialog.tsx
@@ -21,6 +21,7 @@ function formatSummary(report: CrashReportRecord): string {
 
 export function CrashReportDialog(): React.JSX.Element {
   const promptedThisLaunch = useRef(false)
+  const mountedRef = useRef(true)
   const [open, setOpen] = useState(false)
   const [report, setReport] = useState<CrashReportRecord | null>(null)
   const [notes, setNotes] = useState('')
@@ -53,16 +54,28 @@ export function CrashReportDialog(): React.JSX.Element {
           console.error('Failed to dismiss crash report after startup prompt:', error)
         }
       }
+      if (!mountedRef.current) {
+        return
+      }
       setReport(displayedReport)
-      if (nextReport && promptIfPresent) {
+      if (nextReport && promptIfPresent && mountedRef.current) {
         setOpen(true)
       }
     } catch (error) {
       console.error('Failed to load crash report:', error)
     } finally {
-      setLoading(false)
+      if (mountedRef.current) {
+        setLoading(false)
+      }
     }
   }
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     if (promptedThisLaunch.current) {
@@ -74,7 +87,11 @@ export function CrashReportDialog(): React.JSX.Element {
 
   useEffect(() => {
     return window.api.ui.onOpenCrashReport(() => {
-      void loadCrashReport(false).then(() => setOpen(true))
+      void loadCrashReport(false).then(() => {
+        if (mountedRef.current) {
+          setOpen(true)
+        }
+      })
     })
   }, [])
 
@@ -118,13 +135,17 @@ export function CrashReportDialog(): React.JSX.Element {
   const dismissReportIfNeeded = async (): Promise<void> => {
     if (report?.status === 'pending') {
       await window.api.crashReports.dismiss({ reportId: report.id })
-      setReport({ ...report, status: 'dismissed' })
+      if (mountedRef.current) {
+        setReport({ ...report, status: 'dismissed' })
+      }
     }
   }
 
   const handleDismiss = async (): Promise<void> => {
     await dismissReportIfNeeded()
-    setOpen(false)
+    if (mountedRef.current) {
+      setOpen(false)
+    }
   }
 
   const handleSubmit = async (): Promise<void> => {
@@ -145,6 +166,9 @@ export function CrashReportDialog(): React.JSX.Element {
       if (!result.ok) {
         throw new Error(result.error)
       }
+      if (!mountedRef.current) {
+        return
+      }
       setReport(result.report)
       setNotes('')
       toast.success('Crash report sent.')
@@ -153,7 +177,9 @@ export function CrashReportDialog(): React.JSX.Element {
       toast.error('Failed to send crash report.')
       console.error('Failed to submit crash report:', error)
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }
 
@@ -165,7 +191,11 @@ export function CrashReportDialog(): React.JSX.Element {
           return
         }
         if (!nextOpen) {
-          void dismissReportIfNeeded().finally(() => setOpen(false))
+          void dismissReportIfNeeded().finally(() => {
+            if (mountedRef.current) {
+              setOpen(false)
+            }
+          })
           return
         }
         setOpen(true)


### PR DESCRIPTION
## Summary
- guard crash report load, dismiss, and submit completions before writing dialog state after unmount
- keep the existing crash-report dismiss/submit API calls and viewer lookup behavior unchanged

## Merge risk assessment
Risk: LOW

This only skips local React state writes when async crash-report work finishes after the dialog component has unmounted. The persisted crash-report status changes still run before the guard.

## Validation
- pnpm exec oxlint src/renderer/src/components/crash-report/CrashReportDialog.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/shared/crash-reporting.test.ts
- pnpm typecheck (blocked by existing missing modules: @tiptap/extension-details, react-colorful)