### PR TITLE
Guard browser mobile driver action from root ref

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserMobileDriverOverlay.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserMobileDriverOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useCallback, useRef, useState, type ReactElement } from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { BrowserDriverState } from '@/lib/pane-manager/browser-mobile-driver-state'
@@ -10,14 +10,11 @@ type Props = {
 
 export function BrowserMobileDriverOverlay({ driver, onTakeBack }: Props): ReactElement | null {
   const [pending, setPending] = useState(false)
-  const mountedRef = useRef(true)
+  const mountedRef = useRef(false)
 
-  useEffect(
-    () => () => {
-      mountedRef.current = false
-    },
-    []
-  )
+  const setOverlayRef = useCallback((node: HTMLDivElement | null): void => {
+    mountedRef.current = node !== null
+  }, [])
 
   if (driver.kind !== 'mobile') {
     return null
@@ -39,6 +36,7 @@ export function BrowserMobileDriverOverlay({ driver, onTakeBack }: Props): React
 
   return (
     <div
+      ref={setOverlayRef}
       role="dialog"
       aria-live="assertive"
       className={cn(

--- a/src/renderer/src/components/browser-pane/BrowserMobileDriverOverlay.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserMobileDriverOverlay.tsx
@@ -14,6 +14,11 @@ export function BrowserMobileDriverOverlay({ driver, onTakeBack }: Props): React
 
   const setOverlayRef = useCallback((node: HTMLDivElement | null): void => {
     mountedRef.current = node !== null
+    if (node) {
+      // Why: take-back can resolve after the overlay renders null; a later
+      // mobile session must not inherit the stale disabled state.
+      setPending(false)
+    }
   }, [])
 
   if (driver.kind !== 'mobile') {


### PR DESCRIPTION
## Summary\n- move the browser mobile-driver action mounted guard from a cleanup-only Effect to the overlay root ref\n- remove the overlay component's only Effect while preserving async take-back cleanup behavior\n\n## Validation\n- pnpm exec oxfmt --write src/renderer/src/components/browser-pane/BrowserMobileDriverOverlay.tsx\n- pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserMobileDriverOverlay.tsx\n- pnpm run typecheck:web\n- git diff --check\n\nRisk: medium

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
