### PR TITLE
fix: replace workspace port advertised listener

### DIFF
--- a/src/main/ipc/workspace-ports.test.ts
+++ b/src/main/ipc/workspace-ports.test.ts
@@ -258,6 +258,26 @@ describe('registerWorkspacePortHandlers', () => {
       port: 3002
     })
   })
+
+  it('unsubscribes the previous advertised URL listener when handlers are registered again', () => {
+    const store = makeStore()
+    const firstUnsubscribe = vi.fn()
+    const secondUnsubscribe = vi.fn()
+    const onDidChange = vi
+      .fn()
+      .mockReturnValueOnce(firstUnsubscribe)
+      .mockReturnValueOnce(secondUnsubscribe)
+
+    registerWorkspacePortHandlers(store as never, {
+      advertisedUrlEvents: { onDidChange }
+    })
+    registerWorkspacePortHandlers(store as never, {
+      advertisedUrlEvents: { onDidChange }
+    })
+
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(secondUnsubscribe).not.toHaveBeenCalled()
+  })
 })
 
 function workspacePort({ pid, port }: { pid: number; port: number }): WorkspacePort {

--- a/src/main/ipc/workspace-ports.ts
+++ b/src/main/ipc/workspace-ports.ts
@@ -19,6 +19,8 @@ type WorkspacePortHandlersOptions = {
   getWindows?: () => BrowserWindow[]
 }
 
+let unsubscribeAdvertisedUrlChanges: (() => void) | null = null
+
 export function registerWorkspacePortHandlers(
   store: Store,
   options: WorkspacePortHandlersOptions = {}
@@ -27,7 +29,8 @@ export function registerWorkspacePortHandlers(
   const advertisedUrlEvents = options.advertisedUrlEvents ?? advertisedUrlWatcher
   const getWindows = options.getWindows ?? (() => BrowserWindow.getAllWindows())
 
-  advertisedUrlEvents.onDidChange((event) => {
+  unsubscribeAdvertisedUrlChanges?.()
+  unsubscribeAdvertisedUrlChanges = advertisedUrlEvents.onDidChange((event) => {
     const localWorktrees = getStoreWorkspacePortProbes(store)
     if (!localWorktrees.some((worktree) => worktree.id === event.worktreeId)) {
       return


### PR DESCRIPTION
## Summary
- retain the workspace port advertised-URL unsubscribe handle
- dispose the previous advertised URL listener before registering a replacement
- add focused coverage for repeated handler registration

## Merge risk assessment
Risk: LOW

Production registers these handlers once, and this only affects repeated registration by preventing stacked advertised-URL listeners. IPC channel handling and port scan/kill behavior are unchanged.

## Validation
- pnpm exec oxlint src/main/ipc/workspace-ports.ts src/main/ipc/workspace-ports.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/workspace-ports.test.ts
- pnpm typecheck (blocked by existing missing modules: @tiptap/extension-details, react-colorful)