### PR TITLE
Clear floating icon menu frame from trigger ref

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { EyeOff, PanelBottom, PanelTop } from 'lucide-react'
 import {
   DropdownMenu,
@@ -28,15 +28,14 @@ export function FloatingTerminalIconContextMenu({
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const reopenFrameRef = useRef<number | null>(null)
 
-  useEffect(
-    () => () => {
+  const setTriggerRef = useCallback((node: HTMLSpanElement | null): void => {
+    if (node === null) {
       if (reopenFrameRef.current !== null) {
         window.cancelAnimationFrame(reopenFrameRef.current)
         reopenFrameRef.current = null
       }
-    },
-    []
-  )
+    }
+  }, [])
 
   const moveAction = useMemo(() => {
     if (currentLocation === 'floating-button') {
@@ -56,6 +55,7 @@ export function FloatingTerminalIconContextMenu({
   return (
     <>
       <span
+        ref={setTriggerRef}
         className={className}
         style={style}
         data-floating-terminal-toggle


### PR DESCRIPTION
## Summary\n- move floating workspace icon context-menu reopen-frame cleanup from a cleanup-only Effect to the trigger ref\n- keep right-click reopen behavior unchanged while removing the component's only Effect\n\n## Validation\n- pnpm exec oxfmt --write src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx\n- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalIconContextMenu.tsx\n- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts\n- pnpm run typecheck:web\n- git diff --check\n\nRisk: low