### PR TITLE
Use GitHub merge method metadata for PR actions

### DIFF
--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -58,7 +58,12 @@ vi.mock('./rate-limit', () => ({
   noteRateLimitSpend: noteRateLimitSpendMock
 }))
 
-import { countWorkItems, listWorkItems, _resetOwnerRepoCache } from './client'
+import {
+  countWorkItems,
+  listWorkItems,
+  _resetMergeQueueCacheForTests,
+  _resetOwnerRepoCache
+} from './client'
 
 describe('listWorkItems', () => {
   beforeEach(() => {
@@ -84,6 +89,7 @@ describe('listWorkItems', () => {
     }))
     getOwnerRepoForRemoteMock.mockResolvedValue(null)
     _resetOwnerRepoCache()
+    _resetMergeQueueCacheForTests()
   })
 
   it('runs both issue and PR GitHub searches for a mixed query and merges the results by recency', async () => {
@@ -221,6 +227,58 @@ describe('listWorkItems', () => {
     ])
   })
 
+  it('hydrates PR list rows with repository merge method settings', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 42,
+            title: 'Add feature',
+            state: 'OPEN',
+            url: 'https://github.com/acme/widgets/pull/42',
+            labels: [],
+            updatedAt: '2026-03-28T00:00:00Z',
+            author: { login: 'octocat' },
+            isDraft: false,
+            headRefName: 'feature/add-feature',
+            headRefOid: 'head-42',
+            baseRefName: 'main'
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              viewerDefaultMergeMethod: 'REBASE',
+              mergeCommitAllowed: false,
+              rebaseMergeAllowed: true,
+              squashMergeAllowed: true
+            }
+          }
+        })
+      })
+
+    const { items } = await listWorkItems('/repo-root', 10, 'is:pr')
+
+    expect(items).toHaveLength(1)
+    expect(items[0]?.mergeMethodSettings).toEqual({
+      defaultMethod: 'rebase',
+      allowedMethods: {
+        squash: true,
+        merge: false,
+        rebase: true
+      }
+    })
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining(['api', 'graphql', '-f', 'owner=acme', '-f', 'repo=widgets']),
+      { cwd: '/repo-root' }
+    )
+  })
+
   it('routes draft queries to PR search only', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
@@ -242,7 +300,7 @@ describe('listWorkItems', () => {
       ])
     })
     const { items } = await listWorkItems('/repo-root', 10, 'is:pr is:draft')
-    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'pr',
@@ -301,7 +359,7 @@ describe('listWorkItems', () => {
 
     const { items } = await listWorkItems('/repo-root', 10, 'is:merged')
 
-    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'pr',

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -305,6 +305,69 @@ describe('getPRForBranch', () => {
     })
   })
 
+  it('hydrates repository merge method settings for exact PR lookups', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 99,
+          title: 'Linked PR',
+          state: 'OPEN',
+          url: 'https://github.com/acme/widgets/pull/99',
+          statusCheckRollup: [],
+          updatedAt: '2026-03-28T00:00:00Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          reviewDecision: 'APPROVED',
+          mergeStateStatus: 'CLEAN',
+          autoMergeRequest: null,
+          baseRefName: 'main',
+          headRefName: 'someone/fix',
+          baseRefOid: 'base-oid',
+          headRefOid: 'linked-head-oid'
+        })
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              viewerDefaultMergeMethod: 'REBASE',
+              mergeCommitAllowed: false,
+              rebaseMergeAllowed: true,
+              squashMergeAllowed: true,
+              mergeQueue: null
+            }
+          }
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'feature/local-worktree', 99)
+
+    expect(pr?.mergeMethodSettings).toEqual({
+      defaultMethod: 'rebase',
+      allowedMethods: {
+        squash: true,
+        merge: false,
+        rebase: true
+      }
+    })
+    expect(pr?.mergeQueueRequired).toBe(false)
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([
+        'api',
+        'graphql',
+        '-f',
+        'owner=acme',
+        '-f',
+        'repo=widgets',
+        '-f',
+        'branch=main'
+      ]),
+      { cwd: '/repo-root' }
+    )
+  })
+
   it('treats linked PR metadata as authoritative even when the branch head differs', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'current-worktree-head\n', stderr: '' })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -361,9 +361,9 @@ const WORK_ITEM_PR_LIST_JSON_FIELDS =
   'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRefOid,headRepositoryOwner,reviewRequests'
 
 // Why: these fields are intentionally excluded from `gh pr list` because
-// statusCheckRollup/review decision/merge metadata fan out into expensive
-// GraphQL work across every row. Requested reviewers are kept in the list
-// payload because the Tasks table renders that column on first paint.
+// statusCheckRollup/review decision/PR-specific merge metadata fan out into
+// expensive GraphQL work across every row. Requested reviewers are kept in the
+// list payload because the Tasks table renders that column on first paint.
 const WORK_ITEM_PR_DETAIL_JSON_FIELDS =
   'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRefOid,headRepositoryOwner,additions,deletions,changedFiles,reviewDecision,reviewRequests,latestReviews,assignees,statusCheckRollup,mergeable,mergeStateStatus,autoMergeRequest,maintainerCanModify'
 
@@ -694,6 +694,26 @@ function mapPullRequestWorkItem(
   }
 }
 
+async function hydrateWorkItemMergeMethodSettings(
+  items: MainWorkItem[],
+  ownerRepo: OwnerRepo | null,
+  ghOptions: GhExecOptions
+): Promise<MainWorkItem[]> {
+  const hasPullRequest = items.some((item) => item.type === 'pr')
+  if (!ownerRepo || !hasPullRequest) {
+    return items
+  }
+  // Why: merge method settings are repository-level, so one cached metadata
+  // probe can keep Tasks rows accurate without per-PR GraphQL fan-out.
+  const mergeMetadata = await detectRepositoryMergeMetadata(ownerRepo, undefined, ghOptions)
+  if (!mergeMetadata.mergeMethodSettings) {
+    return items
+  }
+  return items.map((item) =>
+    item.type === 'pr' ? { ...item, mergeMethodSettings: mergeMetadata.mergeMethodSettings } : item
+  )
+}
+
 async function fetchIssueWorkItem(
   repoPath: string,
   ownerRepo: OwnerRepo | null,
@@ -947,6 +967,7 @@ async function listRecentWorkItems(
       prs = (JSON.parse(prsSettled.value.stdout) as Record<string, unknown>[]).map((item) =>
         mapPullRequestWorkItem(item, prOwnerRepo)
       )
+      prs = await hydrateWorkItemMergeMethodSettings(prs, prOwnerRepo, ghOptions)
     } else {
       // Why: PR-side failures must preserve the pre-diff behavior of
       // Promise.all by re-throwing so the rejection propagates up through
@@ -1088,10 +1109,11 @@ async function listQueriedWorkItems(
       const mapped = (JSON.parse(stdout) as Record<string, unknown>[]).map((item) =>
         mapPullRequestWorkItem(item, prOwnerRepo)
       )
+      const hydrated = await hydrateWorkItemMergeMethodSettings(mapped, prOwnerRepo, ghOptions)
       if (query.state === 'closed') {
-        return mapped.filter((item) => item.state !== 'merged')
+        return hydrated.filter((item) => item.state !== 'merged')
       }
-      return mapped
+      return hydrated
     } catch (err) {
       console.warn('listQueriedWorkItems PRs partial failure:', err)
       return []

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -18,13 +18,15 @@ import type {
   GitHubViewer,
   GitHubWorkItem,
   GitHubPullRequestStateUpdate,
-  GitHubRerunPRChecksResult
+  GitHubRerunPRChecksResult,
+  GitHubPRMergeMethodSettings
 } from '../../shared/types'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
   normalizeHostedReviewBaseRef,
   normalizeHostedReviewHeadRef
 } from '../../shared/hosted-review-refs'
+import { normalizeGitHubPRMergeMethodSettings } from '../../shared/github-pr-merge-methods'
 import { parseTaskQuery, type ParsedTaskQuery } from '../../shared/task-query'
 import {
   GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE,
@@ -88,10 +90,17 @@ type GhExecOptions = ReturnType<typeof ghRepoExecOptions>
 const ORCA_REPO = 'stablyai/orca'
 const MERGE_QUEUE_CACHE_TTL_MS = 10 * 60 * 1000
 const MERGE_QUEUE_UNKNOWN_CACHE_TTL_MS = 60 * 1000
-const mergeQueueRequiredCache = new Map<string, { value: boolean | null; expiresAt: number }>()
+type GitHubRepositoryMergeMetadata = {
+  mergeQueueRequired: boolean | null
+  mergeMethodSettings?: GitHubPRMergeMethodSettings
+}
+const repositoryMergeMetadataCache = new Map<
+  string,
+  { value: GitHubRepositoryMergeMetadata; expiresAt: number }
+>()
 
 export function _resetMergeQueueCacheForTests(): void {
-  mergeQueueRequiredCache.clear()
+  repositoryMergeMetadataCache.clear()
 }
 
 async function assertRateLimitBudget(bucket: RateLimitBucketKind): Promise<void> {
@@ -735,8 +744,14 @@ async function fetchPullRequestWorkItem(
       const item = JSON.parse(stdout) as Record<string, unknown>
       const mapped = mapPullRequestWorkItem(item, ownerRepo)
       const baseRefName = typeof item.baseRefName === 'string' ? item.baseRefName : undefined
-      const mergeQueueRequired = await detectMergeQueueRequired(ownerRepo, baseRefName, ghOptions)
-      return { ...mapped, mergeQueueRequired }
+      const mergeMetadata = await detectRepositoryMergeMetadata(ownerRepo, baseRefName, ghOptions)
+      return {
+        ...mapped,
+        mergeQueueRequired: mergeMetadata.mergeQueueRequired,
+        ...(mergeMetadata.mergeMethodSettings
+          ? { mergeMethodSettings: mergeMetadata.mergeMethodSettings }
+          : {})
+      }
     } catch {
       const { stdout } = await ghExecFileAsync(
         ['api', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${number}`],
@@ -1694,6 +1709,7 @@ type PullRequestLookupData = {
   autoMergeRequest?: unknown
   autoMergeEnabled?: boolean
   mergeQueueRequired?: boolean | null
+  mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
   baseRefName?: string
   headRefName?: string
@@ -1760,63 +1776,99 @@ function normalizePullRequestLookupData(data: PullRequestLookupData): PullReques
   }
 }
 
-function cacheMergeQueueRequired(cacheKey: string, value: boolean | null, ttlMs: number): void {
-  mergeQueueRequiredCache.set(cacheKey, {
+function cacheRepositoryMergeMetadata(
+  cacheKey: string,
+  value: GitHubRepositoryMergeMetadata,
+  ttlMs: number
+): void {
+  repositoryMergeMetadataCache.set(cacheKey, {
     value,
     expiresAt: Date.now() + ttlMs
   })
 }
 
-async function detectMergeQueueRequired(
+async function detectRepositoryMergeMetadata(
   ownerRepo: OwnerRepo,
   branchName: string | undefined,
   ghOptions: GhExecOptions
-): Promise<boolean | null> {
-  if (!branchName) {
-    return null
-  }
-  const cacheKey = `${ownerRepo.owner.toLowerCase()}/${ownerRepo.repo.toLowerCase()}:${branchName}`
-  const cached = mergeQueueRequiredCache.get(cacheKey)
+): Promise<GitHubRepositoryMergeMetadata> {
+  const cacheKey = `${ownerRepo.owner.toLowerCase()}/${ownerRepo.repo.toLowerCase()}:${
+    branchName ?? '__repo__'
+  }`
+  const cached = repositoryMergeMetadataCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
     return cached.value
   }
   const guard = rateLimitGuard('graphql')
   if (guard.blocked) {
-    return null
+    return { mergeQueueRequired: null }
   }
-  const query = `query($owner: String!, $repo: String!, $branch: String!) {
+  const query = branchName
+    ? `query($owner: String!, $repo: String!, $branch: String!) {
     repository(owner: $owner, name: $repo) {
+      viewerDefaultMergeMethod
+      mergeCommitAllowed
+      rebaseMergeAllowed
+      squashMergeAllowed
       mergeQueue(branch: $branch) { id }
+    }
+  }`
+    : `query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      viewerDefaultMergeMethod
+      mergeCommitAllowed
+      rebaseMergeAllowed
+      squashMergeAllowed
     }
   }`
   try {
     noteRateLimitSpend('graphql')
-    const { stdout } = await ghExecFileAsync(
-      [
-        'api',
-        'graphql',
-        '-f',
-        `query=${query}`,
-        '-f',
-        `owner=${ownerRepo.owner}`,
-        '-f',
-        `repo=${ownerRepo.repo}`,
-        '-f',
-        `branch=${branchName}`
-      ],
-      ghOptions
-    )
-    const parsed = JSON.parse(stdout) as {
-      data?: { repository?: { mergeQueue?: { id?: unknown } | null } | null }
+    const args = [
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${ownerRepo.owner}`,
+      '-f',
+      `repo=${ownerRepo.repo}`
+    ]
+    if (branchName) {
+      args.push('-f', `branch=${branchName}`)
     }
-    const value = Boolean(parsed.data?.repository?.mergeQueue)
-    cacheMergeQueueRequired(cacheKey, value, MERGE_QUEUE_CACHE_TTL_MS)
+    const { stdout } = await ghExecFileAsync(args, ghOptions)
+    const parsed = JSON.parse(stdout) as {
+      data?: {
+        repository?: {
+          viewerDefaultMergeMethod?: unknown
+          mergeCommitAllowed?: unknown
+          rebaseMergeAllowed?: unknown
+          squashMergeAllowed?: unknown
+          mergeQueue?: { id?: unknown } | null
+        } | null
+      }
+    }
+    const repository = parsed.data?.repository
+    const mergeMethodSettings = repository
+      ? normalizeGitHubPRMergeMethodSettings({
+          defaultMethod: repository.viewerDefaultMergeMethod,
+          mergeCommitAllowed: repository.mergeCommitAllowed,
+          rebaseMergeAllowed: repository.rebaseMergeAllowed,
+          squashMergeAllowed: repository.squashMergeAllowed
+        })
+      : undefined
+    const value: GitHubRepositoryMergeMetadata = {
+      mergeQueueRequired: branchName ? Boolean(repository?.mergeQueue) : null,
+      ...(mergeMethodSettings ? { mergeMethodSettings } : {})
+    }
+    cacheRepositoryMergeMetadata(cacheKey, value, MERGE_QUEUE_CACHE_TTL_MS)
     return value
   } catch {
     // Why: failed merge-queue probes should stay conservative without
     // retrying GraphQL on every status poll while GitHub/network is unhappy.
-    cacheMergeQueueRequired(cacheKey, null, MERGE_QUEUE_UNKNOWN_CACHE_TTL_MS)
-    return null
+    const value: GitHubRepositoryMergeMetadata = { mergeQueueRequired: null }
+    cacheRepositoryMergeMetadata(cacheKey, value, MERGE_QUEUE_UNKNOWN_CACHE_TTL_MS)
+    return value
   }
 }
 
@@ -1828,11 +1880,15 @@ async function hydratePullRequestLookupData(
   const normalized = normalizePullRequestLookupData(data)
   const hasRichMergeFields =
     'reviewDecision' in data || 'mergeStateStatus' in data || 'autoMergeRequest' in data
+  const mergeMetadata = hasRichMergeFields
+    ? await detectRepositoryMergeMetadata(ownerRepo, normalized.baseRefName, ghOptions)
+    : undefined
   return {
     ...normalized,
-    mergeQueueRequired: hasRichMergeFields
-      ? await detectMergeQueueRequired(ownerRepo, normalized.baseRefName, ghOptions)
-      : undefined
+    ...(mergeMetadata ? { mergeQueueRequired: mergeMetadata.mergeQueueRequired } : {}),
+    ...(mergeMetadata?.mergeMethodSettings
+      ? { mergeMethodSettings: mergeMetadata.mergeMethodSettings }
+      : {})
   }
 }
 
@@ -2225,6 +2281,9 @@ export async function getPRForBranchOutcome(
         ...(data.autoMergeEnabled !== undefined ? { autoMergeEnabled: data.autoMergeEnabled } : {}),
         ...(data.mergeQueueRequired !== undefined
           ? { mergeQueueRequired: data.mergeQueueRequired }
+          : {}),
+        ...(data.mergeMethodSettings !== undefined
+          ? { mergeMethodSettings: data.mergeMethodSettings }
           : {}),
         ...(data.mergeStateStatus !== undefined ? { mergeStateStatus: data.mergeStateStatus } : {}),
         headSha: data.headRefOid,

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -114,6 +114,10 @@ import {
   normalizeGitHubReviewerLogins
 } from '@/components/github-pr-reviewer-display'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
+import {
+  GITHUB_PR_MERGE_METHOD_LABELS,
+  resolveGitHubPRMergeMethods
+} from '../../../shared/github-pr-merge-methods'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { filterEnabledTuiAgents } from '../../../shared/tui-agent-selection'
 import { getConnectionId } from '@/lib/connection-context'
@@ -135,6 +139,7 @@ import type {
   GitHubWorkItemDetails,
   GitHubAssignableUser,
   GitHubReaction,
+  GitHubPRMergeMethod,
   GitBranchChangeEntry,
   GitDiffResult,
   PRCheckDetail,
@@ -2771,6 +2776,7 @@ function PRActionsPanel({
   const confirm = useConfirmationDialog()
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
+  const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
   const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
   const mergeDisabled = !repoPath || mergePending || !mergePresentation.directMergeAvailable
@@ -2832,12 +2838,11 @@ function PRActionsPanel({
     }
   }
 
-  const handleMerge = async (method: 'merge' | 'squash' | 'rebase'): Promise<void> => {
+  const handleMerge = async (method: GitHubPRMergeMethod): Promise<void> => {
     if (!repoPath || mergeDisabled) {
       return
     }
-    const label =
-      method === 'squash' ? 'Squash and merge' : method === 'rebase' ? 'Rebase and merge' : 'Merge'
+    const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
     const confirmed = await confirm({
       title: `${label} PR #${item.number}?`,
       description: 'This will update the pull request on GitHub.',
@@ -2925,7 +2930,9 @@ function PRActionsPanel({
                     <GitMerge className="size-3.5" />
                   )}
                   {mergePresentation.autoMergeAction?.label ??
-                    (mergePresentation.directMergeAvailable ? 'Merge' : mergePresentation.label)}
+                    (mergePresentation.directMergeAvailable
+                      ? mergeMethods.defaultLabel
+                      : mergePresentation.label)}
                   <ChevronDown className="size-3 opacity-60" />
                 </Button>
               </DropdownMenuTrigger>
@@ -2945,18 +2952,16 @@ function PRActionsPanel({
               </DropdownMenuItem>
             )}
             {mergePresentation.autoMergeAction && <DropdownMenuSeparator />}
-            <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('squash')}>
-              <GitMerge className="size-4" />
-              Squash and merge
-            </DropdownMenuItem>
-            <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('merge')}>
-              <GitMerge className="size-4" />
-              Create merge commit
-            </DropdownMenuItem>
-            <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('rebase')}>
-              <GitMerge className="size-4" />
-              Rebase and merge
-            </DropdownMenuItem>
+            {mergeMethods.methods.map(({ method, label }) => (
+              <DropdownMenuItem
+                key={method}
+                disabled={mergeDisabled}
+                onSelect={() => void handleMerge(method)}
+              >
+                <GitMerge className="size-4" />
+                {label}
+              </DropdownMenuItem>
+            ))}
             <DropdownMenuItem onSelect={() => window.api.shell.openUrl(item.url)}>
               <ExternalLink className="size-4" />
               Open GitHub merge box

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -112,6 +112,10 @@ import {
   normalizeGitHubReviewerLogins
 } from '@/components/github-pr-reviewer-display'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
+import {
+  GITHUB_PR_MERGE_METHOD_LABELS,
+  resolveGitHubPRMergeMethods
+} from '../../../shared/github-pr-merge-methods'
 import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { filterEnabledTuiAgents } from '../../../shared/tui-agent-selection'
 import { getConnectionId } from '@/lib/connection-context'
@@ -132,6 +136,7 @@ import type {
   GitHubWorkItemDetails,
   GitHubAssignableUser,
   GitHubReaction,
+  GitHubPRMergeMethod,
   GitBranchChangeEntry,
   GitDiffResult,
   PRCheckDetail,
@@ -3029,6 +3034,7 @@ function PRActionsPanel({
   const confirm = useConfirmationDialog()
   const actionItem = { ...item, state: localState }
   const mergePresentation = presentGitHubPRMergeState(actionItem)
+  const mergeMethods = resolveGitHubPRMergeMethods(actionItem.mergeMethodSettings)
   const canMutateState = localState !== 'merged' && (!!repoPath || !!projectOrigin)
   const nextState: 'open' | 'closed' = localState === 'closed' ? 'open' : 'closed'
   const mergeDisabled = !repoPath || mergePending || !mergePresentation.directMergeAvailable
@@ -3090,12 +3096,11 @@ function PRActionsPanel({
     }
   }
 
-  const handleMerge = async (method: 'merge' | 'squash' | 'rebase'): Promise<void> => {
+  const handleMerge = async (method: GitHubPRMergeMethod): Promise<void> => {
     if (!repoPath || mergeDisabled) {
       return
     }
-    const label =
-      method === 'squash' ? 'Squash and merge' : method === 'rebase' ? 'Rebase and merge' : 'Merge'
+    const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
     const confirmed = await confirm({
       title: `${label} PR #${item.number}?`,
       description: 'This will update the pull request on GitHub.',
@@ -3183,7 +3188,9 @@ function PRActionsPanel({
                     <GitMerge className="size-3.5" />
                   )}
                   {mergePresentation.autoMergeAction?.label ??
-                    (mergePresentation.directMergeAvailable ? 'Merge' : mergePresentation.label)}
+                    (mergePresentation.directMergeAvailable
+                      ? mergeMethods.defaultLabel
+                      : mergePresentation.label)}
                   <ChevronDown className="size-3 opacity-60" />
                 </Button>
               </DropdownMenuTrigger>
@@ -3203,18 +3210,16 @@ function PRActionsPanel({
               </DropdownMenuItem>
             )}
             {mergePresentation.autoMergeAction && <DropdownMenuSeparator />}
-            <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('squash')}>
-              <GitMerge className="size-4" />
-              Squash and merge
-            </DropdownMenuItem>
-            <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('merge')}>
-              <GitMerge className="size-4" />
-              Create merge commit
-            </DropdownMenuItem>
-            <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('rebase')}>
-              <GitMerge className="size-4" />
-              Rebase and merge
-            </DropdownMenuItem>
+            {mergeMethods.methods.map(({ method, label }) => (
+              <DropdownMenuItem
+                key={method}
+                disabled={mergeDisabled}
+                onSelect={() => void handleMerge(method)}
+              >
+                <GitMerge className="size-4" />
+                {label}
+              </DropdownMenuItem>
+            ))}
             <DropdownMenuItem onSelect={() => window.api.shell.openUrl(item.url)}>
               <ExternalLink className="size-4" />
               Open GitHub merge box

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -142,9 +142,14 @@ import {
 } from '@/components/task-page-cache-selectors'
 import { deriveTaskPagePRCheckSummary } from '@/components/task-page-pr-check-summary'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
+import {
+  GITHUB_PR_MERGE_METHOD_LABELS,
+  resolveGitHubPRMergeMethods
+} from '../../../shared/github-pr-merge-methods'
 import type {
   GitHubOwnerRepo,
   GitHubAssignableUser,
+  GitHubPRMergeMethod,
   GitHubWorkItem,
   GitLabTodo,
   GitLabWorkItem,
@@ -1935,14 +1940,14 @@ function PRMergeCell({
     return <span className="text-[11px] text-muted-foreground">Issue</span>
   }
   const mergePresentation = presentGitHubPRMergeState(item)
+  const mergeMethods = resolveGitHubPRMergeMethods(item.mergeMethodSettings)
   const mergeDisabled = !repo || merging || !mergePresentation.directMergeAvailable
 
-  const handleMerge = async (method: 'merge' | 'squash' | 'rebase'): Promise<void> => {
+  const handleMerge = async (method: GitHubPRMergeMethod): Promise<void> => {
     if (!repo || mergeDisabled) {
       return
     }
-    const label =
-      method === 'squash' ? 'Squash and merge' : method === 'rebase' ? 'Rebase and merge' : 'Merge'
+    const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
     const confirmed = await confirm({
       title: `${label} PR #${item.number}?`,
       description: 'This will update the pull request on GitHub.',
@@ -2035,18 +2040,16 @@ function PRMergeCell({
           </DropdownMenuItem>
         )}
         {mergePresentation.autoMergeAction && <DropdownMenuSeparator />}
-        <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('squash')}>
-          <GitMerge className="size-4" />
-          Squash and merge
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('merge')}>
-          <GitMerge className="size-4" />
-          Create merge commit
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={mergeDisabled} onSelect={() => void handleMerge('rebase')}>
-          <GitMerge className="size-4" />
-          Rebase and merge
-        </DropdownMenuItem>
+        {mergeMethods.methods.map(({ method, label }) => (
+          <DropdownMenuItem
+            key={method}
+            disabled={mergeDisabled}
+            onSelect={() => void handleMerge(method)}
+          >
+            <GitMerge className="size-4" />
+            {label}
+          </DropdownMenuItem>
+        ))}
         <DropdownMenuItem onSelect={() => window.api.shell.openUrl(item.url)}>
           <ExternalLink className="size-4" />
           Open GitHub merge box

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -136,8 +136,7 @@ export default function HostedReviewActions({
     })
   }, [githubPR, isGitLab, review])
   const mergeMethods = useMemo(
-    () =>
-      resolveGitHubPRMergeMethods(isGitLab ? null : (githubPR?.mergeMethodSettings ?? null)),
+    () => resolveGitHubPRMergeMethods(isGitLab ? null : (githubPR?.mergeMethodSettings ?? null)),
     [githubPR?.mergeMethodSettings, isGitLab]
   )
   const isUpdatingReviewState = stateUpdating !== null

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -24,15 +24,9 @@ import { useConfirmationDialog } from '@/components/confirmation-dialog'
 import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { PRInfo, Repo, Worktree } from '../../../../shared/types'
+import type { GitHubPRMergeMethod } from '../../../../shared/types'
+import { resolveGitHubPRMergeMethods } from '../../../../shared/github-pr-merge-methods'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
-
-const MERGE_METHODS = ['squash', 'merge', 'rebase'] as const
-
-const MERGE_LABELS: Record<(typeof MERGE_METHODS)[number], string> = {
-  squash: 'Squash and merge',
-  merge: 'Create a merge commit',
-  rebase: 'Rebase and merge'
-}
 
 type HostedReviewActionInfo = Pick<
   HostedReviewInfo,
@@ -141,6 +135,11 @@ export default function HostedReviewActions({
       mergeQueueRequired: review.mergeQueueRequired
     })
   }, [githubPR, isGitLab, review])
+  const mergeMethods = useMemo(
+    () =>
+      resolveGitHubPRMergeMethods(isGitLab ? null : (githubPR?.mergeMethodSettings ?? null)),
+    [githubPR?.mergeMethodSettings, isGitLab]
+  )
   const isUpdatingReviewState = stateUpdating !== null
   const primaryMergeDisabled =
     merging ||
@@ -151,7 +150,7 @@ export default function HostedReviewActions({
   const menuDisabled = merging || isUpdatingReviewState
 
   const handleMerge = useCallback(
-    async (method: 'merge' | 'squash' | 'rebase' = 'squash') => {
+    async (method: GitHubPRMergeMethod = mergeMethods.defaultMethod) => {
       setMerging(true)
       setActionError(null)
       try {
@@ -179,7 +178,15 @@ export default function HostedReviewActions({
         setMerging(false)
       }
     },
-    [githubPR?.prRepo, isGitLab, onRefreshReview, repo.id, repo.path, review.number]
+    [
+      githubPR?.prRepo,
+      isGitLab,
+      mergeMethods.defaultMethod,
+      onRefreshReview,
+      repo.id,
+      repo.path,
+      review.number
+    ]
   )
 
   const handleAutoMerge = useCallback(async () => {
@@ -312,7 +319,7 @@ export default function HostedReviewActions({
                     onClick={() =>
                       mergePresentation.autoMergeAction && !mergePresentation.directMergeAvailable
                         ? void handleAutoMerge()
-                        : void handleMerge('squash')
+                        : void handleMerge(mergeMethods.defaultMethod)
                     }
                     disabled={primaryMergeDisabled}
                   >
@@ -324,7 +331,7 @@ export default function HostedReviewActions({
                     {merging
                       ? 'Working...'
                       : mergePresentation.directMergeAvailable
-                        ? 'Squash and merge'
+                        ? mergeMethods.defaultLabel
                         : (mergePresentation.autoMergeAction?.label ?? mergePresentation.label)}
                   </Button>
                 </span>
@@ -369,14 +376,14 @@ export default function HostedReviewActions({
                     <DropdownMenuSeparator />
                   </>
                 )}
-                {MERGE_METHODS.map((method) => (
+                {mergeMethods.methods.map(({ method, label }) => (
                   <DropdownMenuItem
                     key={method}
                     disabled={directMergeDisabled}
                     onSelect={() => void handleMerge(method)}
                   >
                     <GitMerge className="size-3.5" />
-                    {MERGE_LABELS[method]}
+                    {label}
                   </DropdownMenuItem>
                 ))}
                 <DropdownMenuSeparator />

--- a/src/shared/github-pr-merge-methods.test.ts
+++ b/src/shared/github-pr-merge-methods.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeGitHubPRMergeMethodSettings,
+  resolveGitHubPRMergeMethods
+} from './github-pr-merge-methods'
+
+describe('GitHub PR merge methods', () => {
+  it('keeps the historical squash-first fallback when repository metadata is missing', () => {
+    expect(resolveGitHubPRMergeMethods()).toEqual({
+      defaultMethod: 'squash',
+      defaultLabel: 'Squash and merge',
+      methods: [
+        { method: 'squash', label: 'Squash and merge' },
+        { method: 'merge', label: 'Create merge commit' },
+        { method: 'rebase', label: 'Rebase and merge' }
+      ]
+    })
+  })
+
+  it('uses GitHub viewer defaults and hides methods disabled by the repository', () => {
+    const settings = normalizeGitHubPRMergeMethodSettings({
+      defaultMethod: 'REBASE',
+      mergeCommitAllowed: false,
+      rebaseMergeAllowed: true,
+      squashMergeAllowed: true
+    })
+
+    expect(resolveGitHubPRMergeMethods(settings)).toEqual({
+      defaultMethod: 'rebase',
+      defaultLabel: 'Rebase and merge',
+      methods: [
+        { method: 'rebase', label: 'Rebase and merge' },
+        { method: 'squash', label: 'Squash and merge' }
+      ]
+    })
+  })
+
+  it('falls back to an allowed method when GitHub returns a disabled default', () => {
+    const settings = normalizeGitHubPRMergeMethodSettings({
+      defaultMethod: 'SQUASH',
+      mergeCommitAllowed: true,
+      rebaseMergeAllowed: false,
+      squashMergeAllowed: false
+    })
+
+    expect(settings?.defaultMethod).toBe('merge')
+    expect(resolveGitHubPRMergeMethods(settings).methods).toEqual([
+      { method: 'merge', label: 'Create merge commit' }
+    ])
+  })
+})

--- a/src/shared/github-pr-merge-methods.ts
+++ b/src/shared/github-pr-merge-methods.ts
@@ -1,0 +1,93 @@
+import type { GitHubPRMergeMethod, GitHubPRMergeMethodSettings } from './types'
+
+export const GITHUB_PR_MERGE_METHODS = ['squash', 'merge', 'rebase'] as const
+
+export const GITHUB_PR_MERGE_METHOD_LABELS: Record<GitHubPRMergeMethod, string> = {
+  squash: 'Squash and merge',
+  merge: 'Create merge commit',
+  rebase: 'Rebase and merge'
+}
+
+export type GitHubPRMergeMethodOption = {
+  method: GitHubPRMergeMethod
+  label: string
+}
+
+export type GitHubPRMergeMethodPresentation = {
+  defaultMethod: GitHubPRMergeMethod
+  defaultLabel: string
+  methods: GitHubPRMergeMethodOption[]
+}
+
+function allMethodsAllowed(): Record<GitHubPRMergeMethod, boolean> {
+  return {
+    squash: true,
+    merge: true,
+    rebase: true
+  }
+}
+
+export function mapGitHubDefaultMergeMethod(value: unknown): GitHubPRMergeMethod | null {
+  switch (typeof value === 'string' ? value.toUpperCase() : '') {
+    case 'MERGE':
+      return 'merge'
+    case 'SQUASH':
+      return 'squash'
+    case 'REBASE':
+      return 'rebase'
+    default:
+      return null
+  }
+}
+
+export function normalizeGitHubPRMergeMethodSettings(args: {
+  defaultMethod: unknown
+  mergeCommitAllowed: unknown
+  rebaseMergeAllowed: unknown
+  squashMergeAllowed: unknown
+}): GitHubPRMergeMethodSettings | undefined {
+  const allowedMethods = {
+    squash: args.squashMergeAllowed === true,
+    merge: args.mergeCommitAllowed === true,
+    rebase: args.rebaseMergeAllowed === true
+  }
+  const defaultMethod = mapGitHubDefaultMergeMethod(args.defaultMethod)
+  const firstAllowedMethod = GITHUB_PR_MERGE_METHODS.find((method) => allowedMethods[method])
+  const resolvedDefault =
+    defaultMethod && allowedMethods[defaultMethod]
+      ? defaultMethod
+      : (firstAllowedMethod ?? defaultMethod)
+  if (!resolvedDefault) {
+    return undefined
+  }
+  return {
+    defaultMethod: resolvedDefault,
+    allowedMethods
+  }
+}
+
+export function resolveGitHubPRMergeMethods(
+  settings?: GitHubPRMergeMethodSettings | null
+): GitHubPRMergeMethodPresentation {
+  const allowedMethods = settings?.allowedMethods ?? allMethodsAllowed()
+  const firstAllowedMethod = GITHUB_PR_MERGE_METHODS.find((method) => allowedMethods[method])
+  const defaultMethod =
+    settings?.defaultMethod && allowedMethods[settings.defaultMethod]
+      ? settings.defaultMethod
+      : (firstAllowedMethod ?? 'squash')
+  const orderedMethods = [
+    defaultMethod,
+    ...GITHUB_PR_MERGE_METHODS.filter((method) => method !== defaultMethod)
+  ].filter((method) => allowedMethods[method])
+  const methods = (orderedMethods.length > 0 ? orderedMethods : GITHUB_PR_MERGE_METHODS).map(
+    (method) => ({
+      method,
+      label: GITHUB_PR_MERGE_METHOD_LABELS[method]
+    })
+  )
+  return {
+    defaultMethod,
+    defaultLabel: GITHUB_PR_MERGE_METHOD_LABELS[defaultMethod],
+    methods
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -719,6 +719,13 @@ export type PRConflictSummary = {
 
 export type GitHubRepositoryIdentity = { owner: string; repo: string }
 
+export type GitHubPRMergeMethod = 'merge' | 'squash' | 'rebase'
+
+export type GitHubPRMergeMethodSettings = {
+  defaultMethod: GitHubPRMergeMethod
+  allowedMethods: Record<GitHubPRMergeMethod, boolean>
+}
+
 export type PRInfo = {
   number: number
   title: string
@@ -730,6 +737,7 @@ export type PRInfo = {
   reviewDecision?: PRReviewDecision | null
   autoMergeEnabled?: boolean
   mergeQueueRequired?: boolean | null
+  mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
   // Why: check-runs are keyed by the PR head commit, not the mutable branch name.
   // Keeping the head SHA in cached PR metadata lets the checks panel poll the
@@ -998,6 +1006,7 @@ export type GitHubWorkItem = {
   mergeable?: PRMergeableState
   autoMergeEnabled?: boolean
   mergeQueueRequired?: boolean | null
+  mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
   maintainerCanModify?: boolean
   // Why: true when a PR's head lives on a fork (headRepositoryOwner !== selected repo owner).


### PR DESCRIPTION
Closes #3537.

## Summary
- fetch GitHub repository merge metadata alongside the existing merge-queue GraphQL probe
- carry `viewerDefaultMergeMethod` plus allowed merge-method flags into PR/work-item metadata
- use that metadata in the PR sidebar, PR page, GitHub item dialog, and Tasks PR merge dropdowns so the primary/default action follows GitHub and disabled methods are omitted
- preserve the old squash-first fallback when metadata is unavailable or rate-limited

## Reproduction
- On `origin/main`, the PR merge surfaces are hardcoded squash-first:
  - `git grep -n -E "handleMerge\\('squash'\\)|Squash and merge|Create merge commit|Rebase and merge" origin/main -- src/renderer/src/components/right-sidebar/PRActions.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/TaskPage.tsx`
- On `origin/main`, there is no metadata path for GitHub merge methods:
  - `git grep -n -E "viewerDefaultMergeMethod|mergeCommitAllowed|rebaseMergeAllowed|squashMergeAllowed|mergeMethodSettings" origin/main -- src/main src/shared src/renderer/src/components` returns no matches.
- Live GitHub metadata for `stablyai/orca` is available via GraphQL:
  - `viewerDefaultMergeMethod=SQUASH`, `mergeCommitAllowed=false`, `rebaseMergeAllowed=true`, `squashMergeAllowed=true`, `mergeQueue=null`.

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/github-pr-merge-methods.test.ts src/renderer/src/components/github-pr-merge-state.test.ts src/main/github/client.test.ts` passed: 3 files / 47 tests.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed with 0 warnings and 0 errors.
- `git diff --check HEAD^..HEAD` passed.
- `git merge-tree --write-tree origin/main HEAD` passed with tree `77d3d97312627ff4d593e87c8743eb4e1555a396`.

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.