### PR TITLE
Refresh PR state when agents complete

### DIFF
--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -5,14 +5,59 @@ import {
   type AgentStatusEntry
 } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/types'
+import type { AppState } from '../types'
 import type { RetainedAgentEntry } from './agent-status'
-import { createTestStore } from './store-test-helpers'
+import { createTestStore, makeTab, makeWorktree } from './store-test-helpers'
 
 // Why: queueMicrotask is used by the agent-status slice to schedule the
 // freshness timer after state updates. In tests we need to flush microtasks
 // before advancing fake timers so the setTimeout gets registered.
 function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => queueMicrotask(resolve))
+}
+
+function stubGitHubPRRefreshApi() {
+  const enqueuePRRefresh = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal('window', {
+    api: {
+      gh: { enqueuePRRefresh }
+    }
+  })
+  return enqueuePRRefresh
+}
+
+function seedAgentPRRefreshFixture(
+  store: ReturnType<typeof createTestStore>,
+  worktreeCardProperties: AppState['worktreeCardProperties']
+): void {
+  store.setState({
+    repos: [
+      {
+        id: 'repo-1',
+        path: '/repo',
+        displayName: 'Repo',
+        badgeColor: '#999999',
+        addedAt: 1,
+        kind: 'git'
+      }
+    ],
+    groupBy: 'repo',
+    rightSidebarOpen: false,
+    worktreeCardProperties,
+    worktreesByRepo: {
+      'repo-1': [
+        makeWorktree({
+          id: 'wt-1',
+          repoId: 'repo-1',
+          path: '/repo/worktrees/pr-from-agent',
+          branch: 'feature/pr-from-agent'
+        })
+      ]
+    },
+    tabsByWorktree: {
+      'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+    }
+  } as Partial<AppState>)
 }
 
 describe('agent status freshness expiry', () => {
@@ -257,6 +302,82 @@ describe('agent status tool + assistant fields', () => {
     // smart-sort attention class, so both freshness and sort epochs must tick.
     expect(store.getState().agentStatusEpoch).toBe(firstEpoch + 1)
     expect(store.getState().sortEpoch).toBe(firstSortEpoch + 1)
+  })
+})
+
+describe('agent status PR refresh handoff', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('enqueues an active PR refresh for the owning worktree when an agent completes', async () => {
+    vi.useFakeTimers()
+    const enqueuePRRefresh = stubGitHubPRRefreshApi()
+    const store = createTestStore()
+    seedAgentPRRefreshFixture(store, ['pr'])
+
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'create a PR', agentType: 'codex' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'done', prompt: 'create a PR', agentType: 'codex' })
+
+    await flushMicrotasks()
+
+    expect(enqueuePRRefresh).toHaveBeenCalledWith({
+      candidate: expect.objectContaining({
+        repoPath: '/repo',
+        branch: 'feature/pr-from-agent',
+        worktreeId: 'wt-1',
+        linkedPRNumber: null
+      }),
+      reason: 'active',
+      priority: 80
+    })
+  })
+
+  it('does not spend a PR refresh when no PR surface is visible', async () => {
+    vi.useFakeTimers()
+    const enqueuePRRefresh = stubGitHubPRRefreshApi()
+    const store = createTestStore()
+    seedAgentPRRefreshFixture(store, ['comment'])
+
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'create a PR', agentType: 'codex' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'done', prompt: 'create a PR', agentType: 'codex' })
+
+    await flushMicrotasks()
+
+    expect(enqueuePRRefresh).not.toHaveBeenCalled()
+  })
+
+  it('does not repeat the refresh for same-state done detail updates', async () => {
+    vi.useFakeTimers()
+    const enqueuePRRefresh = stubGitHubPRRefreshApi()
+    const store = createTestStore()
+    seedAgentPRRefreshFixture(store, ['pr'])
+
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'working', prompt: 'create a PR', agentType: 'codex' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:0', { state: 'done', prompt: 'create a PR', agentType: 'codex' })
+    store.getState().setAgentStatus('tab-1:0', {
+      state: 'done',
+      prompt: 'create a PR',
+      agentType: 'codex',
+      lastAssistantMessage: 'Opened https://github.com/acme/orca/pull/42'
+    })
+
+    await flushMicrotasks()
+
+    expect(enqueuePRRefresh).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -124,6 +124,31 @@ function paneKeyMatchesAnyTabPrefix(paneKey: string, tabPrefixes: string[]): boo
   return false
 }
 
+function isAgentCompletionState(state: ParsedAgentStatusPayload['state']): boolean {
+  return state === 'done' || state === 'waiting' || state === 'blocked'
+}
+
+function getTabIdFromPaneKey(paneKey: string): string | null {
+  const separator = paneKey.indexOf(':')
+  if (separator <= 0 || separator !== paneKey.lastIndexOf(':')) {
+    return null
+  }
+  return paneKey.slice(0, separator)
+}
+
+function findAgentPaneWorktreeId(state: AppState, paneKey: string): string | null {
+  const tabId = getTabIdFromPaneKey(paneKey)
+  if (!tabId) {
+    return null
+  }
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    if (tabs.some((tab) => tab.id === tabId)) {
+      return worktreeId
+    }
+  }
+  return null
+}
+
 function pruneMigrationUnsupportedEntries(
   entries: Record<string, MigrationUnsupportedPtyEntry>,
   predicate: (entry: MigrationUnsupportedPtyEntry) => boolean
@@ -173,6 +198,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
 
     setAgentStatus: (paneKey, payload, terminalTitle, timing) => {
       const updatedAt = timing?.updatedAt ?? Date.now()
+      let completionRefreshWorktreeId: string | null = null
       set((s) => {
         const existing = s.agentStatusByPaneKey[paneKey]
         // Why: snapshots and live pushes share receivedAt from the same main-side
@@ -263,6 +289,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           // it when a new turn starts (working → Stop reprices it).
           interrupted: payload.interrupted
         }
+        if (
+          isAgentCompletionState(entry.state) &&
+          existing !== undefined &&
+          !isAgentCompletionState(existing.state)
+        ) {
+          completionRefreshWorktreeId = findAgentPaneWorktreeId(s, paneKey)
+        }
         // Why: broad freshness-aware subscribers only need a global tick when
         // an entry appears, changes state, crosses stale->fresh, or receives
         // a same-state `done` update that may carry the final assistant
@@ -329,6 +362,12 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       // Why: schedule after set completes so the timer reads the updated map.
       // queueMicrotask avoids re-entry into the zustand store during set.
       queueMicrotask(() => freshness.schedule())
+      if (completionRefreshWorktreeId) {
+        const worktreeId = completionRefreshWorktreeId
+        // Why: agents can create a PR via `gh pr create`, bypassing Orca's
+        // create-PR flow and leaving a fresh "no PR" cache entry in place.
+        queueMicrotask(() => get().refreshGitHubForWorktreeIfStale(worktreeId))
+      }
     },
 
     setMigrationUnsupportedPty: (entry) => {


### PR DESCRIPTION
## Summary
- enqueue an active GitHub PR refresh when an agent transitions into a completion state
- map agent pane keys back to their owning worktree so agent-created PRs are discovered after completion
- avoid repeat refreshes for same-state done detail updates

## Tests
- npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices/agent-status.test.ts
- pnpm run typecheck:web