### PR TITLE
fix: guard ssh status async state

### DIFF
--- a/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
+++ b/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Loader2, Server, ServerOff } from 'lucide-react'
 import {
@@ -41,16 +41,28 @@ export function SshDisconnectedDialog({
   status
 }: SshDisconnectedDialogProps): React.JSX.Element {
   const [connecting, setConnecting] = useState(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const handleReconnect = useCallback(async () => {
     setConnecting(true)
     try {
       await window.api.ssh.connect({ targetId })
-      onOpenChange(false)
+      if (mountedRef.current) {
+        onOpenChange(false)
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Reconnection failed')
     } finally {
-      setConnecting(false)
+      if (mountedRef.current) {
+        setConnecting(false)
+      }
     }
   }, [targetId, onOpenChange])
 

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { AlertTriangle, Cloud, Loader2, MonitorSmartphone, Server, ServerOff } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -113,7 +113,15 @@ function TargetRow({
   syncStatus: RemoteWorkspaceSyncStatus | undefined
 }): React.JSX.Element {
   const [busy, setBusy] = useState(false)
+  const mountedRef = useRef(true)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const handleConnect = useCallback(async () => {
     setBusy(true)
@@ -123,7 +131,9 @@ function TargetRow({
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Connection failed')
     } finally {
-      setBusy(false)
+      if (mountedRef.current) {
+        setBusy(false)
+      }
     }
   }, [recordFeatureInteraction, targetId])
 
@@ -135,7 +145,9 @@ function TargetRow({
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Disconnect failed')
     } finally {
-      setBusy(false)
+      if (mountedRef.current) {
+        setBusy(false)
+      }
     }
   }, [recordFeatureInteraction, targetId])
 


### PR DESCRIPTION
## Summary
- guard SSH status-row connect/disconnect busy resets after the row unmounts
- guard SSH disconnected-dialog reconnect close/reset after the dialog unmounts

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- narrowly scoped to local React mounted-state guards around existing SSH IPC calls
- does not change connect/disconnect request ordering or SSH provider behavior
- only suppresses local UI state writes after the initiating component has unmounted

## Validation
- `pnpm exec oxlint src/renderer/src/components/status-bar/SshStatusSegment.tsx src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)