### PR TITLE
Detect agent-created PR links from terminal output

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -73,6 +73,7 @@ type StoreState = {
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
   agentStatusByPaneKey: Record<string, unknown>
   markWorktreeUnread: ReturnType<typeof vi.fn>
+  observeTerminalGitHubPullRequestLink: ReturnType<typeof vi.fn>
   setAgentStatus: ReturnType<typeof vi.fn>
   removeAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
@@ -425,6 +426,7 @@ describe('connectPanePty', () => {
       runtimePaneTitlesByTabId: {},
       agentStatusByPaneKey: {},
       markWorktreeUnread: vi.fn(),
+      observeTerminalGitHubPullRequestLink: vi.fn(),
       setAgentStatus: vi.fn((paneKey: string, payload: Record<string, unknown>) => {
         mockStoreState.agentStatusByPaneKey[paneKey] = {
           ...payload,
@@ -513,6 +515,31 @@ describe('connectPanePty', () => {
     expect((globalThis as Record<string, unknown>).__ptyConnectDiag).toBeUndefined()
     expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('[pty-connect]'))
     logSpy.mockRestore()
+  })
+
+  it('observes live terminal GitHub PR URLs before agent completion', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+
+    capturedDataCallback.current?.('Created https://github.com/acme/orca/pull/42\r\n')
+
+    expect(mockStoreState.observeTerminalGitHubPullRequestLink).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        url: 'https://github.com/acme/orca/pull/42',
+        slug: { owner: 'acme', repo: 'orca' },
+        number: 42
+      })
+    )
   })
 
   it('keeps the surviving split pane mounted when an intentional pane-close PTY exit arrives', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -60,6 +60,7 @@ import {
 } from './terminal-bracketed-paste'
 import { createCommandCodeOutputStatusDetector } from './command-code-output-status'
 import type { PtyDataMeta } from './pty-dispatcher'
+import { createTerminalGitHubPRLinkDetector } from '@/lib/terminal-github-pr-link-detector'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -689,6 +690,7 @@ export function connectPanePty(
     onWorking: seedCommandCodeOutputWorkingStatus,
     onDone: scheduleCommandCodeOutputDoneStatus
   })
+  const observeTerminalGitHubPRLink = createTerminalGitHubPRLinkDetector()
 
   const onPtySpawn = (ptyId: string): void => {
     bindPanePtyId(pane.id, ptyId, deps.tabId)
@@ -1683,6 +1685,9 @@ export function connectPanePty(
     const dataCallback = (data: string, meta?: PtyDataMeta): void => {
       resetHiddenOutputRestoreIfPtyChanged()
       observeTerminalBracketedPasteModeOutput(pane.terminal, data)
+      for (const link of observeTerminalGitHubPRLink(data)) {
+        useAppStore.getState().observeTerminalGitHubPullRequestLink(deps.worktreeId, link)
+      }
       commandCodeOutputStatusDetector.observe(data)
       commandLifecycle.handlePtyData(data)
       // Why: split-pane layouts have multiple visible-but-inactive panes whose

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { createTerminalGitHubPRLinkDetector } from './terminal-github-pr-link-detector'
+
+describe('createTerminalGitHubPRLinkDetector', () => {
+  it('extracts GitHub pull request URLs from terminal output', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('Created https://github.com/acme/orca/pull/42\r\n')).toEqual([
+      {
+        url: 'https://github.com/acme/orca/pull/42',
+        slug: { owner: 'acme', repo: 'orca' },
+        number: 42
+      }
+    ])
+  })
+
+  it('waits for a boundary when the URL is split across PTY chunks', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('https://github.com/acme/orca/pull/4')).toEqual([])
+    expect(observe('2\r\n')).toEqual([
+      {
+        url: 'https://github.com/acme/orca/pull/42',
+        slug: { owner: 'acme', repo: 'orca' },
+        number: 42
+      }
+    ])
+  })
+
+  it('detects a URL split inside the GitHub prefix', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('created https://gith')).toEqual([])
+    expect(observe('ub.com/acme/orca/pull/42\n')).toEqual([
+      {
+        url: 'https://github.com/acme/orca/pull/42',
+        slug: { owner: 'acme', repo: 'orca' },
+        number: 42
+      }
+    ])
+  })
+
+  it('trims terminal punctuation around printed URLs', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('Opened (https://github.com/acme/orca/pull/42).\n')[0]?.url).toBe(
+      'https://github.com/acme/orca/pull/42'
+    )
+  })
+
+  it('does not repeat the same PR URL from overlapping carry text', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(observe('https://github.com/acme/orca/pull/42\n')).toHaveLength(1)
+    expect(observe('more output\n')).toEqual([])
+  })
+
+  it('ignores non-PR and non-GitHub links', () => {
+    const observe = createTerminalGitHubPRLinkDetector()
+
+    expect(
+      observe(
+        'https://github.com/acme/orca/issues/42 https://github.example.com/acme/orca/pull/42\n'
+      )
+    ).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/terminal-github-pr-link-detector.ts
+++ b/src/renderer/src/lib/terminal-github-pr-link-detector.ts
@@ -1,0 +1,101 @@
+import type { RepoSlug } from './github-links'
+import { parseGitHubIssueOrPRLink } from './github-links'
+
+const GITHUB_PR_URL_RE =
+  /\bhttps:\/\/(?:www\.)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:[/?#][^\s"'<>]*)?/gi
+const GITHUB_HOST_MARKER = 'github.com/'
+const GITHUB_PR_PATH_MARKER = '/pull/'
+const HTTPS_SCHEME_PREFIX = 'https://'
+const HTTPS_SCHEME_FRAGMENT_LAST_CHARS = new Set('https:/'.split(''))
+const TRAILING_TERMINAL_PUNCTUATION_RE = /[),.;\]}]+$/
+const MAX_CARRY_LENGTH = 512
+
+export type TerminalGitHubPRLink = {
+  url: string
+  slug: RepoSlug
+  number: number
+}
+
+function trimTerminalUrl(candidate: string): string {
+  return candidate.replace(TRAILING_TERMINAL_PUNCTUATION_RE, '')
+}
+
+function parseTerminalGitHubPRUrl(candidate: string): TerminalGitHubPRLink | null {
+  const url = trimTerminalUrl(candidate)
+  const parsed = parseGitHubIssueOrPRLink(url)
+  if (!parsed || parsed.type !== 'pr') {
+    return null
+  }
+  return { url, slug: parsed.slug, number: parsed.number }
+}
+
+function endsWithHttpsSchemePrefixFragment(value: string): string {
+  for (let length = Math.min(HTTPS_SCHEME_PREFIX.length - 1, value.length); length > 0; length--) {
+    if (value.endsWith(HTTPS_SCHEME_PREFIX.slice(0, length))) {
+      return value.slice(value.length - length)
+    }
+  }
+  return ''
+}
+
+function getPotentialGitHubPRCarry(value: string, hasGitHubHost: boolean): string {
+  if (hasGitHubHost) {
+    const hostIndex = value.lastIndexOf(GITHUB_HOST_MARKER)
+    const schemeIndex = value.lastIndexOf('https://', hostIndex)
+    if (schemeIndex === -1) {
+      return ''
+    }
+
+    const tail = value.slice(schemeIndex)
+    return /\s/.test(tail) ? '' : tail.slice(-MAX_CARRY_LENGTH)
+  }
+
+  const schemeIndex = value.lastIndexOf('https://')
+  if (schemeIndex !== -1) {
+    const tail = value.slice(schemeIndex)
+    return /\s/.test(tail) ? '' : tail.slice(-MAX_CARRY_LENGTH)
+  }
+
+  const lastChar = value.at(-1)
+  if (!lastChar || !HTTPS_SCHEME_FRAGMENT_LAST_CHARS.has(lastChar)) {
+    return ''
+  }
+
+  return endsWithHttpsSchemePrefixFragment(value)
+}
+
+export function createTerminalGitHubPRLinkDetector(): (data: string) => TerminalGitHubPRLink[] {
+  let carry = ''
+  const seenUrls = new Set<string>()
+
+  return (data: string): TerminalGitHubPRLink[] => {
+    const combined = carry ? carry + data : data
+    const hasGitHubHost = combined.includes(GITHUB_HOST_MARKER)
+
+    if (!hasGitHubHost || !combined.includes(GITHUB_PR_PATH_MARKER)) {
+      carry = getPotentialGitHubPRCarry(combined, hasGitHubHost)
+      return []
+    }
+
+    const links: TerminalGitHubPRLink[] = []
+    for (const match of combined.matchAll(GITHUB_PR_URL_RE)) {
+      const rawUrl = match[0]
+      const matchEnd = (match.index ?? 0) + rawUrl.length
+      // Why: PTY chunks can split the PR number; wait for a boundary before
+      // treating a URL at chunk-end as complete.
+      if (matchEnd === combined.length) {
+        continue
+      }
+
+      const parsed = parseTerminalGitHubPRUrl(rawUrl)
+      if (!parsed || seenUrls.has(parsed.url)) {
+        continue
+      }
+      seenUrls.add(parsed.url)
+      links.push(parsed)
+    }
+
+    carry = getPotentialGitHubPRCarry(combined, true)
+    return links
+  }
+}

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -14,6 +14,7 @@ import type {
   WorktreeRemoteBranchConflictEvent,
   WorktreeMeta
 } from '../../../../shared/types'
+import type { TerminalGitHubPRLink } from '@/lib/terminal-github-pr-link-detector'
 export { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 
 export type WorktreeDeleteState = {
@@ -106,6 +107,7 @@ export type WorktreeSlice = {
     updatesByWorktreeId: ReadonlyMap<string, Partial<WorktreeMeta>>
   ) => Promise<void>
   markWorktreeUnread: (worktreeId: string) => void
+  observeTerminalGitHubPullRequestLink: (worktreeId: string, link: TerminalGitHubPRLink) => void
   /** Clear the worktree's unread dot. Called on user interaction with any
    *  terminal pane inside the worktree (keystroke, click) — matches
    *  ghostty's "show until interact" model. Persists isUnread=false. */

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1858,6 +1858,99 @@ describe('worktree remote runtime mutations', () => {
     })
   })
 
+  it('optimistically links a terminal-observed GitHub PR for the same repo', () => {
+    const store = createTestStore()
+    const fetchPRForBranch = vi.fn().mockResolvedValue(null)
+    const fetchHostedReviewForBranch = vi.fn().mockResolvedValue(null)
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/worktrees/orca',
+      branch: 'refs/heads/feature/pr-link'
+    })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repos/orca', displayName: 'orca', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] },
+      fetchPRForBranch,
+      fetchHostedReviewForBranch
+    } as unknown as Partial<AppState>)
+
+    store.getState().observeTerminalGitHubPullRequestLink(wt.id, {
+      url: 'https://github.com/acme/orca/pull/42',
+      slug: { owner: 'acme', repo: 'orca' },
+      number: 42
+    })
+
+    expect(store.getState().worktreesByRepo.repo1[0]?.linkedPR).toBe(42)
+    expect(mockApi.worktrees.resolvePrBase).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { linkedPR: 42 }
+    })
+    expect(fetchPRForBranch).toHaveBeenCalledWith('/repos/orca', 'feature/pr-link', {
+      force: true,
+      repoId: 'repo1',
+      linkedPRNumber: 42,
+      fallbackPRNumber: null,
+      fallbackPRSource: null
+    })
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledWith(
+      '/repos/orca',
+      'feature/pr-link',
+      expect.objectContaining({
+        force: true,
+        repoId: 'repo1',
+        linkedGitHubPR: 42,
+        linkedGitLabMR: null
+      })
+    )
+  })
+
+  it('waits for exact lookup before linking a terminal PR URL for a differently named repo', async () => {
+    const store = createTestStore()
+    const fetchPRForBranch = vi.fn().mockResolvedValue({ number: 42 })
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/worktrees/orca',
+      branch: 'refs/heads/feature/pr-link'
+    })
+    mockApi.worktrees.resolvePrBase.mockResolvedValueOnce({ baseBranch: 'main' })
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repos/orca', displayName: 'orca', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: { repo1: [wt] },
+      fetchPRForBranch
+    } as unknown as Partial<AppState>)
+
+    store.getState().observeTerminalGitHubPullRequestLink(wt.id, {
+      url: 'https://github.com/acme/docs/pull/42',
+      slug: { owner: 'acme', repo: 'docs' },
+      number: 42
+    })
+
+    expect(store.getState().worktreesByRepo.repo1[0]?.linkedPR).toBeNull()
+    expect(fetchPRForBranch).toHaveBeenCalledWith('/repos/orca', 'feature/pr-link', {
+      force: true,
+      repoId: 'repo1',
+      linkedPRNumber: null,
+      fallbackPRNumber: 42,
+      fallbackPRSource: 'explicit'
+    })
+
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve()
+    }
+
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId: wt.id,
+      updates: { linkedPR: 42 }
+    })
+  })
+
   it('does not surface remote selector misses while persisting activity timestamps', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const store = createTestStore()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -6,12 +6,14 @@ import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
   LocalBaseRefRefreshResult,
+  Repo,
   Worktree,
   WorkspaceVisibleTabType,
   GitPushTarget,
   WorktreeLineage,
   WorktreeMeta
 } from '../../../../shared/types'
+import type { TerminalGitHubPRLink } from '@/lib/terminal-github-pr-link-detector'
 import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types'
 import {
   findWorktreeById,
@@ -26,12 +28,13 @@ import {
   getActiveRuntimeTarget,
   RuntimeRpcCallError
 } from '../../runtime/runtime-rpc-client'
-import { getHostedReviewCacheKey } from './hosted-review'
+import { getHostedReviewCacheKey, refreshHostedReviewCard } from './hosted-review'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-key'
 import { moveFocusToRendererBeforeFocusedWebviewHidden } from './browser-webview-cleanup'
 import { toast } from 'sonner'
 import { requestVirtualizedScrollAnchorRecord } from '@/hooks/requestVirtualizedScrollAnchorRecord'
 import { branchName } from '@/lib/git-utils'
+import { basename } from '@/lib/path'
 export type { WorktreeSlice, WorktreeDeleteState } from './worktree-helpers'
 
 // Why: old runtime servers only have `worktree.list`; preserve the large-list
@@ -91,6 +94,63 @@ function arraysShallowEqual(a: string[] | undefined, b: string[] | undefined): b
     return !a?.length && !b?.length
   }
   return a.every((v, i) => v === b[i])
+}
+
+function normalizeGitHubRepoName(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return null
+  }
+  return trimmed.replace(/\.git$/i, '').toLowerCase()
+}
+
+function parseGitHubRemoteSlug(
+  remoteUrl: string | null | undefined
+): { owner: string; repo: string } | null {
+  const trimmed = remoteUrl?.trim()
+  if (!trimmed) {
+    return null
+  }
+  const withoutGitSuffix = trimmed.replace(/\.git(?:[?#].*)?$/i, '')
+  const match =
+    /^git@github\.com:([^/]+)\/([^/?#]+)$/i.exec(withoutGitSuffix) ??
+    /^ssh:\/\/(?:[^@/]+@)?github\.com[:/]+([^/]+)\/([^/?#]+)$/i.exec(withoutGitSuffix) ??
+    /^https?:\/\/(?:[^@/]+@)?github\.com\/([^/]+)\/([^/?#]+)$/i.exec(withoutGitSuffix)
+  if (!match) {
+    return null
+  }
+  return { owner: match[1], repo: match[2] }
+}
+
+function githubSlugsEqual(
+  left: { owner: string; repo: string } | null,
+  right: { owner: string; repo: string }
+): boolean {
+  return (
+    left !== null &&
+    left.owner.toLowerCase() === right.owner.toLowerCase() &&
+    left.repo.toLowerCase() === right.repo.toLowerCase()
+  )
+}
+
+function shouldOptimisticallyLinkTerminalGitHubPR(
+  repo: Repo,
+  worktree: Pick<Worktree, 'path' | 'pushTarget'>,
+  link: TerminalGitHubPRLink
+): boolean {
+  if (githubSlugsEqual(parseGitHubRemoteSlug(worktree.pushTarget?.remoteUrl), link.slug)) {
+    return true
+  }
+
+  const observedRepo = normalizeGitHubRepoName(link.slug.repo)
+  if (!observedRepo) {
+    return false
+  }
+  const localRepoNames = [repo.displayName, basename(repo.path), basename(worktree.path)]
+    .map(normalizeGitHubRepoName)
+    .filter((name): name is string => name !== null)
+
+  return localRepoNames.includes(observedRepo)
 }
 
 function areLineageRecordsEqual(
@@ -1560,6 +1620,78 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       console.error('Failed to persist unread worktree state:', err)
       void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
     })
+  },
+
+  observeTerminalGitHubPullRequestLink: (worktreeId, link) => {
+    const state = get()
+    const worktree = findKnownWorktreeById(state, worktreeId)
+    if (!worktree || worktree.isBare || worktree.isArchived) {
+      return
+    }
+    const repo = state.repos.find((candidate) => candidate.id === worktree.repoId)
+    if (!repo || (repo.kind && repo.kind !== 'git')) {
+      return
+    }
+    if (typeof worktree.linkedPR === 'number' && worktree.linkedPR !== link.number) {
+      return
+    }
+
+    const branch = branchName(worktree.branch)
+    const shouldLinkNow =
+      worktree.linkedPR === link.number ||
+      shouldOptimisticallyLinkTerminalGitHubPR(repo, worktree, link)
+
+    if (shouldLinkNow && worktree.linkedPR !== link.number) {
+      set((s) => {
+        const nextWorktrees = applyWorktreeUpdates(s.worktreesByRepo, worktreeId, {
+          linkedPR: link.number
+        })
+        const nextDetectedWorktrees = applyDetectedWorktreeUpdates(
+          s.detectedWorktreesByRepo,
+          worktreeId,
+          { linkedPR: link.number }
+        )
+        return {
+          ...(nextWorktrees !== s.worktreesByRepo
+            ? { worktreesByRepo: nextWorktrees, sortEpoch: s.sortEpoch + 1 }
+            : {}),
+          ...(nextDetectedWorktrees !== s.detectedWorktreesByRepo
+            ? { detectedWorktreesByRepo: nextDetectedWorktrees }
+            : {})
+        }
+      })
+      // Why: `gh pr create` prints the canonical PR URL before the agent is
+      // done. Persist the exact number immediately so the workspace card can
+      // show it without waiting for the completion-time GitHub refresh.
+      void get().updateWorktreeMeta(worktreeId, { linkedPR: link.number })
+    }
+
+    const fetchPRForBranch = get().fetchPRForBranch
+    if (typeof fetchPRForBranch === 'function') {
+      void fetchPRForBranch(repo.path, branch, {
+        force: true,
+        repoId: repo.id,
+        linkedPRNumber: shouldLinkNow ? link.number : null,
+        fallbackPRNumber: shouldLinkNow ? null : link.number,
+        fallbackPRSource: shouldLinkNow ? null : 'explicit'
+      }).then((pr) => {
+        if (!shouldLinkNow && pr?.number === link.number) {
+          void get().updateWorktreeMeta(worktreeId, { linkedPR: link.number })
+        }
+      })
+    }
+
+    const fetchHostedReviewForBranch = get().fetchHostedReviewForBranch
+    if (typeof fetchHostedReviewForBranch === 'function') {
+      void refreshHostedReviewCard(fetchHostedReviewForBranch, {
+        repoPath: repo.path,
+        repoId: repo.id,
+        branch,
+        linkedGitHubPR: shouldLinkNow ? link.number : null,
+        fallbackGitHubPR: shouldLinkNow ? null : link.number,
+        linkedGitLabMR: worktree.linkedGitLabMR ?? null
+      })
+    }
   },
 
   clearWorktreeUnread: (worktreeId) => {


### PR DESCRIPTION
## Summary
- watch live PTY output for GitHub PR URLs so agent-created PRs can appear before agent completion
- optimistically link same-repo PR URLs and fall back to exact lookup before linking mismatched repo slugs
- keep the detector hot path gated to cheap string checks before regex/URL parsing

## Perf notes
Measured via local `pnpm exec tsx` microbench against `createTerminalGitHubPRLinkDetector`:
- no-url newline 120B chunks: ~58 ns/chunk
- no-url suffix-char 120B chunks: ~55 ns/chunk
- no-url scheme-fragment 120B chunks: ~119 ns/chunk
- PR URL chunks: ~645 ns/chunk

Ordinary no-URL output does not touch Zustand, regex, or URL parsing.

## Tests
- `npx vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-github-pr-link-detector.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/store/slices/worktrees.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/terminal-github-pr-link-detector.ts src/renderer/src/lib/terminal-github-pr-link-detector.test.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/store/slices/worktrees.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/store/slices/worktree-helpers.ts`
- `pnpm run typecheck:web`
- `git diff --check`
