### PR TITLE
fix: guard notice async state

### DIFF
--- a/src/renderer/src/components/FirstLaunchBanner.tsx
+++ b/src/renderer/src/components/FirstLaunchBanner.tsx
@@ -33,7 +33,7 @@
 // off), the notice never returns, because the cohort condition
 // (`optedIn === null`) clears in all three resolving paths.
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
 
 import { Button } from './ui/button'
@@ -57,6 +57,14 @@ export function FirstLaunchBanner({
   // wasted IPC round-trip, but the guard also blocks a Turn-off click
   // arriving mid-flight after an acknowledge (or vice versa).
   const [inFlight, setInFlight] = useState(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const handleAcknowledge = async (): Promise<void> => {
     if (inFlight) {
@@ -74,13 +82,17 @@ export function FirstLaunchBanner({
     try {
       await acknowledgeBanner()
       await fetchSettings()
-      onResolve()
+      if (mountedRef.current) {
+        onResolve()
+      }
     } finally {
       // Why: if `fetchSettings` rejects (IPC error during shutdown,
       // settings file lock, etc.), `onResolve` never runs and the banner
       // stays mounted. Without resetting `inFlight`, every button stays
       // permanently disabled for the rest of the session.
-      setInFlight(false)
+      if (mountedRef.current) {
+        setInFlight(false)
+      }
     }
   }
 
@@ -97,9 +109,13 @@ export function FirstLaunchBanner({
     try {
       await telemetrySetOptIn(false)
       await fetchSettings()
-      onResolve()
+      if (mountedRef.current) {
+        onResolve()
+      }
     } finally {
-      setInFlight(false)
+      if (mountedRef.current) {
+        setInFlight(false)
+      }
     }
   }
 

--- a/src/renderer/src/components/StarNagCard.tsx
+++ b/src/renderer/src/components/StarNagCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Star, X } from 'lucide-react'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
@@ -19,12 +19,20 @@ export function StarNagCard(): React.JSX.Element | null {
   const [visible, setVisible] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(false)
+  const mountedRef = useRef(true)
   // Why: UpdateCard lives at the same bottom-right slot. When it is visible
   // (any non-idle / non-not-available state), stack the star-nag card above
   // it instead of overlapping — we must not cover a pending update prompt
   // because that's a higher-priority action.
   const updateStatus = useAppStore((s) => s.updateStatus)
   const updateCardVisible = updateStatus.state !== 'idle' && updateStatus.state !== 'not-available'
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     return window.api.starNag.onShow(() => {
@@ -67,13 +75,19 @@ export function StarNagCard(): React.JSX.Element | null {
     setBusy(true)
     setError(false)
     const ok = await window.api.gh.starOrca('star_nag')
-    setBusy(false)
+    if (mountedRef.current) {
+      setBusy(false)
+    }
     if (!ok) {
-      setError(true)
+      if (mountedRef.current) {
+        setError(true)
+      }
       return
     }
     await window.api.starNag.complete()
-    setVisible(false)
+    if (mountedRef.current) {
+      setVisible(false)
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- guard first-launch telemetry banner resolution/reset after the banner unmounts
- guard star-nag completion state updates after the card unmounts
- preserve the existing persistence IPC calls; only local React UI writes are suppressed after unmount

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- narrow local React guards in notification-style UI components
- no changes to telemetry opt-in semantics, star persistence, or main-process APIs
- only prevents stale post-await state writes when the originating UI is gone

## Validation
- `pnpm exec oxlint src/renderer/src/components/StarNagCard.tsx src/renderer/src/components/FirstLaunchBanner.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)