### PR TITLE
Reduce terminal observer hot-path work

### DIFF
--- a/src/renderer/src/components/terminal-pane/bell-detector.test.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { createBellDetector } from './bell-detector'
+
+describe('createBellDetector', () => {
+  it('skips ANSI chunks without losing later real bells', () => {
+    const detector = createBellDetector()
+
+    expect(detector.chunkContainsBell('\x1b[32mbuild\x1b[0m output')).toBe(false)
+    expect(detector.chunkContainsBell('\x07')).toBe(true)
+  })
+
+  it('keeps split OSC state so title terminators are not reported as bells', () => {
+    const detector = createBellDetector()
+
+    expect(detector.chunkContainsBell('\x1b]0;Codex working')).toBe(false)
+    expect(detector.chunkContainsBell('\x07')).toBe(false)
+    expect(detector.chunkContainsBell('\x07')).toBe(true)
+  })
+
+  it('treats BEL after a split non-OSC escape as a real bell', () => {
+    const detector = createBellDetector()
+
+    expect(detector.chunkContainsBell('\x1b')).toBe(false)
+    expect(detector.chunkContainsBell('\x07')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/bell-detector.ts
+++ b/src/renderer/src/components/terminal-pane/bell-detector.ts
@@ -28,6 +28,15 @@ export function createBellDetector(): BellDetector {
 
   return {
     chunkContainsBell(data: string): boolean {
+      if (!inOsc && !pendingEscape && !data.includes('\x07')) {
+        // Why: CSI/plain chunks with no BEL and no OSC start cannot affect
+        // bell state; avoid walking every byte of normal terminal output.
+        if (!data.includes('\x1b]')) {
+          pendingEscape = data.endsWith('\x1b')
+          return false
+        }
+      }
+
       for (let i = 0; i < data.length; i += 1) {
         const char = data[i]
 

--- a/src/renderer/src/components/terminal-pane/command-code-output-status.test.ts
+++ b/src/renderer/src/components/terminal-pane/command-code-output-status.test.ts
@@ -28,6 +28,45 @@ describe('createCommandCodeOutputStatusDetector', () => {
     expect(onWorking).toHaveBeenCalledWith('')
   })
 
+  it('detects the Command Code banner across PTY chunk boundaries', () => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({
+      startupCommand: null,
+      onWorking
+    })
+
+    expect(detector.observe('# Command')).toBe(false)
+    expect(detector.observe(' Code v0.27.2')).toBe(false)
+    expect(detector.observe('⌘ Parsing...')).toBe(true)
+
+    expect(onWorking).toHaveBeenCalledWith('')
+  })
+
+  it('detects the Command Code banner when ANSI styling splits the words', () => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({
+      startupCommand: null,
+      onWorking
+    })
+
+    expect(detector.observe('# C\x1b[35mommand Co\x1b[0mde v0.27.2')).toBe(false)
+    expect(detector.observe('⌘ Parsing...')).toBe(true)
+
+    expect(onWorking).toHaveBeenCalledWith('')
+  })
+
+  it('does not trust near-miss Command Code banner text', () => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({
+      startupCommand: null,
+      onWorking
+    })
+
+    expect(detector.observe('NotCommand CodeX\r\n⌘ Parsing...')).toBe(false)
+
+    expect(onWorking).not.toHaveBeenCalled()
+  })
+
   it.each([
     'Pondering',
     'Contemplating',

--- a/src/renderer/src/components/terminal-pane/command-code-output-status.ts
+++ b/src/renderer/src/components/terminal-pane/command-code-output-status.ts
@@ -107,8 +107,12 @@ const ACTIVE_EXECUTION_STATUS_RE = new RegExp(
   `(?:^|[\\r\\n])\\s*(?:${COMMAND_CODE_STATUS_GLYPH_RE_SOURCE}\\s*)?(?:Executing:\\s+\\S|Running\\s*\\()`
 )
 const IDLE_PROMPT_RE = /(?:^|[\r\n])\s*[❯>]\s+Ask your question\.\.\./
+const COMMAND_CODE_BANNER_RE = /\bCommand Code\b/
 
 function stripTerminalControl(data: string): string {
+  if (!terminalControlMayAffectText(data)) {
+    return data
+  }
   const withoutAnsi = data.replace(ANSI_ESCAPE_RE, '').replace(INCOMPLETE_ANSI_ESCAPE_RE, '')
   let output = ''
   for (let index = 0; index < withoutAnsi.length; index += 1) {
@@ -119,6 +123,21 @@ function stripTerminalControl(data: string): string {
     output += withoutAnsi[index]
   }
   return output
+}
+
+function terminalControlMayAffectText(data: string): boolean {
+  for (let index = 0; index < data.length; index += 1) {
+    const code = data.charCodeAt(index)
+    if (
+      code === 0x0d ||
+      code === 0x1b ||
+      (code <= 0x1f && code !== 0x0a) ||
+      (code >= 0x7f && code <= 0x9f)
+    ) {
+      return true
+    }
+  }
+  return false
 }
 
 function cleanPromptCandidate(value: string): string {
@@ -136,32 +155,55 @@ function isCommandCodeLaunchCommand(command: string | null | undefined): boolean
   return /(?:^|[\s;&|])(?:command-code|commandcode|cmdc)(?:\s|$)/.test(command)
 }
 
-function patternOverlapsCurrentRawText(
+function rawTextMayContainCommandCodeBanner(rawText: string): boolean {
+  // Why: every terminal pane observes this detector, but only Command Code
+  // panes need the ANSI/control stripping path. Use a broad no-false-negative
+  // letter prefilter so ANSI styling inside the banner words still works.
+  return rawText.includes('C') && rawText.includes('o') && rawText.includes('d')
+}
+
+function patternOverlapsSanitizedText(
   pattern: RegExp,
-  previousRawText: string,
-  currentRawText: string
+  previousTextLength: number,
+  combinedText: string
 ): boolean {
-  const previousLength = stripTerminalControl(previousRawText).length
-  const combinedText = stripTerminalControl(previousRawText + currentRawText)
   const re = new RegExp(pattern.source, 'g')
   for (const match of combinedText.matchAll(re)) {
     const start = match.index ?? 0
-    if (start + match[0].length > previousLength) {
+    if (start + match[0].length > previousTextLength) {
       return true
     }
   }
   return false
 }
 
-function isActiveStatusText(currentRawText: string, previousRawText = ''): boolean {
+type StatusScanContext = {
+  combinedText: string
+  previousTextLength: number
+  combinedTextWithChunkBoundary: string
+  previousTextWithChunkBoundaryLength: number
+}
+
+function patternOverlapsStatusContext(pattern: RegExp, context: StatusScanContext): boolean {
   return (
-    patternOverlapsCurrentRawText(ACTIVE_LLM_STATUS_RE, previousRawText, currentRawText) ||
-    patternOverlapsCurrentRawText(ACTIVE_EXECUTION_STATUS_RE, previousRawText, currentRawText)
+    patternOverlapsSanitizedText(pattern, context.previousTextLength, context.combinedText) ||
+    patternOverlapsSanitizedText(
+      pattern,
+      context.previousTextWithChunkBoundaryLength,
+      context.combinedTextWithChunkBoundary
+    )
   )
 }
 
-function isIdlePromptText(currentRawText: string, previousRawText = ''): boolean {
-  return patternOverlapsCurrentRawText(IDLE_PROMPT_RE, previousRawText, currentRawText)
+function isActiveStatusText(context: StatusScanContext): boolean {
+  return (
+    patternOverlapsStatusContext(ACTIVE_LLM_STATUS_RE, context) ||
+    patternOverlapsStatusContext(ACTIVE_EXECUTION_STATUS_RE, context)
+  )
+}
+
+function isIdlePromptText(context: StatusScanContext): boolean {
+  return patternOverlapsStatusContext(IDLE_PROMPT_RE, context)
 }
 
 export function createCommandCodeOutputStatusDetector(args: {
@@ -176,19 +218,39 @@ export function createCommandCodeOutputStatusDetector(args: {
   return {
     observe(data: string): boolean {
       const previousRawText = recentRawText
-      const scanText = stripTerminalControl(previousRawText + data)
-      const scanTextWithChunkBoundary = stripTerminalControl(
-        previousRawText ? `${previousRawText}\n${data}` : data
-      )
-      recentRawText = (previousRawText + data).slice(-RECENT_TEXT_LIMIT)
-      if (
-        !hasSeenCommandCodeUi &&
-        (/\bCommand Code\b/.test(scanText) || /\bCommand Code\b/.test(scanTextWithChunkBoundary))
-      ) {
+      const rawText = previousRawText + data
+      recentRawText = rawText.slice(-RECENT_TEXT_LIMIT)
+
+      if (!hasSeenCommandCodeUi) {
+        if (!rawTextMayContainCommandCodeBanner(rawText)) {
+          return false
+        }
+        const scanText = stripTerminalControl(rawText)
+        const scanTextWithChunkBoundary = previousRawText
+          ? stripTerminalControl(`${previousRawText}\n${data}`)
+          : scanText
+        if (
+          !COMMAND_CODE_BANNER_RE.test(scanText) &&
+          !COMMAND_CODE_BANNER_RE.test(scanTextWithChunkBoundary)
+        ) {
+          return false
+        }
         hasSeenCommandCodeUi = true
       }
-      if (!hasSeenCommandCodeUi) {
-        return false
+
+      const scanText = stripTerminalControl(rawText)
+      const scanTextWithChunkBoundary = previousRawText
+        ? stripTerminalControl(`${previousRawText}\n${data}`)
+        : scanText
+      const previousTextLength = previousRawText ? stripTerminalControl(previousRawText).length : 0
+      const previousTextWithChunkBoundaryLength = previousRawText
+        ? stripTerminalControl(`${previousRawText}\n`).length
+        : 0
+      const statusContext: StatusScanContext = {
+        combinedText: scanText,
+        previousTextLength,
+        combinedTextWithChunkBoundary: scanTextWithChunkBoundary,
+        previousTextWithChunkBoundaryLength
       }
       for (const promptMatch of scanText.matchAll(/(?:^|[\r\n])\s*[❯>]\s+([^\r\n]+)(?=[\r\n])/g)) {
         const prompt = cleanPromptCandidate(promptMatch[1] ?? '')
@@ -199,20 +261,14 @@ export function createCommandCodeOutputStatusDetector(args: {
       // Why: Command Code lacks a prompt-start hook. Its TUI prints these
       // status words while a submitted prompt is actively running, including
       // no-tool turns that would otherwise jump straight from idle to done.
-      if (
-        isActiveStatusText(data, previousRawText) ||
-        isActiveStatusText(data, `${previousRawText}\n`)
-      ) {
+      if (isActiveStatusText(statusContext)) {
         args.onWorking(lastSubmittedPrompt)
         return true
       }
       // Why: Command Code does not reliably emit a Stop hook for no-tool turns.
       // When a submitted prompt has returned to the idle composer, let the pane
       // connection settle-check the current row and mark that turn done.
-      if (
-        lastSubmittedPrompt &&
-        (isIdlePromptText(data, previousRawText) || isIdlePromptText(data, `${previousRawText}\n`))
-      ) {
+      if (lastSubmittedPrompt && isIdlePromptText(statusContext)) {
         args.onDone?.(lastSubmittedPrompt)
         return true
       }


### PR DESCRIPTION
## Summary
- add a fast path for non-Command-Code terminal chunks so the detector avoids ANSI/control stripping until a plausible `Command Code` banner appears
- keep the banner prefilter broad enough to handle PTY chunk boundaries and ANSI styling inside the banner words before running the stripped-text check
- reuse sanitized scan text for active Command Code panes instead of stripping the same chunk repeatedly for each status regex
- add a BEL detector fast path for ordinary chunks with no BEL and no OSC start, while preserving split OSC and split bare-ESC behavior

## Perf
Microbench command: `pnpm exec tsx` script with 300k iterations after 20k warmup, run on this machine.

| Observer case | Before | After |
| --- | ---: | ---: |
| Command Code non-agent plain | 5807.1 ns/chunk | 61.6 ns/chunk |
| Command Code non-agent ANSI | 4606.5 ns/chunk | 59.9 ns/chunk |
| Command Code active plain idle | 26074.9 ns/chunk | 6688.0 ns/chunk |
| BEL detector plain | 228.0 ns/chunk | 19.8 ns/chunk |
| BEL detector ANSI | 339.8 ns/chunk | 85.3 ns/chunk |

## Tests
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/command-code-output-status.test.ts src/renderer/src/components/terminal-pane/bell-detector.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/command-code-output-status.ts src/renderer/src/components/terminal-pane/command-code-output-status.test.ts src/renderer/src/components/terminal-pane/bell-detector.ts src/renderer/src/components/terminal-pane/bell-detector.test.ts`
- `pnpm run typecheck:web`
- `git diff --check HEAD~1..HEAD`