### PR TITLE
fix: guard browser profile async state

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Check, Ellipsis, Import, Monitor, Plus, Settings } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -71,6 +71,7 @@ export function BrowserToolbarMenu({
   const [pendingSwitchProfileId, setPendingSwitchProfileId] = useState<string | null | undefined>(
     undefined
   )
+  const mountedRef = useRef(true)
 
   const effectiveProfileId = currentProfileId ?? 'default'
 
@@ -80,6 +81,13 @@ export function BrowserToolbarMenu({
   const allProfiles = defaultProfile
     ? [defaultProfile, ...browserSessionProfiles.filter((p) => p.id !== 'default')]
     : browserSessionProfiles
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const handleSwitchProfile = (profileId: string | null): void => {
     const targetId = profileId ?? 'default'
@@ -114,7 +122,13 @@ export function BrowserToolbarMenu({
     try {
       const profile = await createBrowserSessionProfile('isolated', trimmed)
       if (!profile) {
-        toast.error('Failed to create profile.')
+        if (mountedRef.current) {
+          toast.error('Failed to create profile.')
+        }
+        return
+      }
+
+      if (!mountedRef.current) {
         return
       }
 
@@ -125,7 +139,9 @@ export function BrowserToolbarMenu({
       switchBrowserTabProfile(workspaceId, profile.id)
       toast.success(`Created and switched to ${profile.label} profile`)
     } finally {
-      setIsCreatingProfile(false)
+      if (mountedRef.current) {
+        setIsCreatingProfile(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- guard browser profile creation completion before closing/resetting the new-profile dialog
- avoid switching/destroying the webview from a stale toolbar after the toolbar unmounts
- keep existing profile creation and active-pane switch behavior unchanged when the toolbar is still mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- limited to the Browser toolbar new-profile dialog completion path
- no changes to browser profile schema, cookie import, viewport controls, or webview lifecycle when mounted
- only suppresses stale UI work after the originating toolbar has unmounted

## Validation
- `pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)