### PR TITLE
fix: guard resource kill async state

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -1080,19 +1080,21 @@ export function ResourceUsageStatusSegment({
     } catch {
       /* already dead — fall through */
     } finally {
-      setKilling(false)
-      setKillConfirm(null)
-      // Why: after the killed row unmounts, focus would otherwise drop to
-      // <body>. Park focus on the popover body so keyboard users land back
-      // in the list rather than outside the popover.
-      cancelPopoverBodyFocusFrame()
-      if (popoverBodyRef.current) {
-        popoverBodyFocusFrameRef.current = requestAnimationFrame(() => {
-          popoverBodyFocusFrameRef.current = null
-          popoverBodyRef.current?.focus()
-        })
+      if (mountedRef.current) {
+        setKilling(false)
+        setKillConfirm(null)
+        // Why: after the killed row unmounts, focus would otherwise drop to
+        // <body>. Park focus on the popover body so keyboard users land back
+        // in the list rather than outside the popover.
+        cancelPopoverBodyFocusFrame()
+        if (popoverBodyRef.current) {
+          popoverBodyFocusFrameRef.current = requestAnimationFrame(() => {
+            popoverBodyFocusFrameRef.current = null
+            popoverBodyRef.current?.focus()
+          })
+        }
+        void refreshSessions()
       }
-      void refreshSessions()
     }
   }, [cancelPopoverBodyFocusFrame, killConfirm, refreshSessions])
 


### PR DESCRIPTION
## Summary
- guard the confirmed resource-session kill cleanup before clearing local kill UI state
- avoid queuing the post-kill focus frame or session refresh after the status segment unmounts
- keep the existing optimistic row removal and PTY kill behavior unchanged while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- one narrow mounted-state guard in the already guarded resource usage segment
- no change to PTY kill IPC, orphan handling, session sorting, or resource sampling
- only suppresses stale local UI cleanup/focus work after unmount

## Validation
- `pnpm exec oxlint src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)