### PR TITLE
Guard SSH target row async state without effect

### DIFF
--- a/src/renderer/src/components/sidebar/SshTargetRow.tsx
+++ b/src/renderer/src/components/sidebar/SshTargetRow.tsx
@@ -4,7 +4,7 @@
  * Why extracted: keeps AddRepoSteps.tsx under the 400-line oxlint limit
  * while isolating the inline-connect interaction logic.
  */
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import type { SshTarget, SshConnectionState } from '../../../../shared/ssh-types'
 
@@ -57,15 +57,15 @@ export function SshTargetRow({
     })
   }
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handleRowRootRef = useCallback((node: HTMLDivElement | null): void => {
+    // Why: SSH connects can resolve after this row is removed; the row ref
+    // gives the async completion the same guard without a mount-only Effect.
+    mountedRef.current = node !== null
   }, [])
 
   return (
     <div
+      ref={handleRowRootRef}
       role={isConnected ? 'button' : undefined}
       tabIndex={isConnected ? 0 : undefined}
       className={`w-full flex items-center gap-2 px-3 py-2 rounded-md border text-xs transition-colors ${


### PR DESCRIPTION
## Summary
- move the SSH target row mounted guard from a cleanup-only Effect to the row root ref lifecycle
- keep the async Connect completion from writing local state after the row unmounts
- preserve existing SSH connect/select behavior while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- one narrow UI-only mounted guard in the add-repo SSH target row
- no changes to SSH connection IPC, relay deployment, target selection, or connection state storage
- only suppresses stale local state cleanup after the row unmounts

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/sidebar/SshTargetRow.tsx`
- `pnpm exec oxlint src/renderer/src/components/sidebar/SshTargetRow.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/lib/new-workspace-ssh-gate.test.ts src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 809 -> 808.