### PR TITLE
fix: guard combined diff notes async state

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -181,6 +181,7 @@ export default function CombinedDiffViewer({
   const [clearNotesDialogOpen, setClearNotesDialogOpen] = useState(false)
   const [isClearingNotes, setIsClearingNotes] = useState(false)
   const [notesCopied, setNotesCopied] = useState(false)
+  const mountedRef = useRef(true)
   // Why: clipboard IPC can resolve after the combined diff unmounts; skip
   // copied feedback instead of starting a reset timer on a stale viewer.
   const notesCopyMountedRef = useRef(false)
@@ -202,6 +203,13 @@ export default function CombinedDiffViewer({
   const setScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
     scrollContainerRef.current = node
     notesCopyMountedRef.current = node !== null
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
   }, [])
   const loadSchedulerRef = useRef(
     createCombinedDiffLoadScheduler({
@@ -906,13 +914,18 @@ export default function CombinedDiffViewer({
     setIsClearingNotes(true)
     try {
       const ok = await clearDiffComments(file.worktreeId)
+      if (!mountedRef.current) {
+        return
+      }
       if (ok) {
         setClearNotesDialogOpen(false)
       } else {
         toast.error('Failed to clear notes.')
       }
     } finally {
-      setIsClearingNotes(false)
+      if (mountedRef.current) {
+        setIsClearingNotes(false)
+      }
     }
   }, [clearDiffComments, diffCommentCount, file.worktreeId, isClearingNotes])
 


### PR DESCRIPTION
## Summary
- guard combined-diff review-note clearing after the viewer unmounts
- avoid stale dialog/loading state writes when `clearDiffComments` completes late
- keep the existing clear action and failure toast behavior unchanged while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- narrow guard beside an existing mounted guard for the same notes popover surface
- does not change diff loading, comment formatting, or store clear semantics
- only suppresses local UI state updates after the viewer is gone

## Validation
- `pnpm exec oxlint src/renderer/src/components/editor/CombinedDiffViewer.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)