### PR TITLE
Guard SSH target card async state without effect

### DIFF
--- a/src/renderer/src/components/settings/SshTargetCard.tsx
+++ b/src/renderer/src/components/settings/SshTargetCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import {
   CircleStop,
   Loader2,
@@ -87,11 +87,10 @@ export function SshTargetCard({
   const removeInFlight = busyAction === 'remove'
   const mountedRef = useRef(true)
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handleCardRef = useCallback((node: HTMLDivElement | null): void => {
+    // Why: SSH target actions can resolve after the card is removed; the root
+    // ref gives async completions the same stale-write guard without an Effect.
+    mountedRef.current = node !== null
   }, [])
 
   const clearActionInFlight = (): void => {
@@ -226,7 +225,10 @@ export function SshTargetCard({
   )
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-card/40 px-4 py-3">
+    <div
+      ref={handleCardRef}
+      className="flex items-center gap-3 rounded-lg border border-border/50 bg-card/40 px-4 py-3"
+    >
       <Server className="size-4 shrink-0 text-muted-foreground" />
 
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- move the SSH target card mounted guard from a cleanup-only Effect to the card root ref lifecycle
- keep async Connect/Disconnect/Terminate/Reset completions from clearing local action state after the card unmounts
- preserve existing SSH target action behavior while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- one narrow UI-only mounted guard in the SSH settings target card
- no changes to SSH action IPC, relay reset/termination semantics, target editing, or stored connection state
- only suppresses stale local action-state cleanup after the card unmounts

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/settings/SshTargetCard.tsx`
- `pnpm exec oxlint src/renderer/src/components/settings/SshTargetCard.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-remove.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/lib/new-workspace-ssh-gate.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 812 -> 811.