### PR TITLE
fix: guard comment composer async state

### DIFF
--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -953,6 +953,14 @@ export function LinearIssueCommentFooter({
   const [body, setBody] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const autoGrow = useCallback(() => {
     const el = textareaRef.current
@@ -972,6 +980,9 @@ export function LinearIssueCommentFooter({
     try {
       const result = await linearAddIssueComment(settings, issueId, trimmed, workspaceId)
       const typed = result as { ok: boolean; id?: string; error?: string }
+      if (!mountedRef.current) {
+        return
+      }
       if (typed.ok) {
         setBody('')
         onCommentAdded({
@@ -983,9 +994,13 @@ export function LinearIssueCommentFooter({
         toast.error(typed.error ?? 'Failed to add comment')
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to add comment')
+      if (mountedRef.current) {
+        toast.error(err instanceof Error ? err.message : 'Failed to add comment')
+      }
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }, [body, issueId, onCommentAdded, settings, workspaceId])
 

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1713,6 +1713,14 @@ function MarkdownAnnotationComposer({
   const [body, setBody] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     textareaRef.current?.focus()
@@ -1727,11 +1735,16 @@ function MarkdownAnnotationComposer({
     setSubmitting(true)
     try {
       const ok = await onSubmit(trimmed)
+      if (!mountedRef.current) {
+        return
+      }
       if (ok) {
         setBody('')
       }
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- guard Linear issue comment footer completion before clearing local input/submitting state after unmount
- guard markdown annotation composer completion before clearing local input/submitting state after unmount
- keep existing submit APIs and success/failure behavior unchanged while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- limited to two local comment-composer UI guards
- no changes to Linear, markdown note, or store mutation semantics
- only suppresses stale local UI state writes after the composer is gone

## Validation
- `pnpm exec oxlint src/renderer/src/components/LinearItemDrawer.tsx src/renderer/src/components/editor/MarkdownPreview.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)