### PR TITLE
fix: guard cli setup async state

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Check, Clipboard, Copy, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -40,17 +40,35 @@ export function FloatingTerminalOrchestrationDialog({
   const [cliLoading, setCliLoading] = useState(false)
   const [cliBusy, setCliBusy] = useState(false)
   const [skillBusy, setSkillBusy] = useState(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const setCliStatusIfMounted = useCallback((status: CliInstallStatus | null): void => {
+    if (mountedRef.current) {
+      setCliStatus(status)
+    }
+  }, [])
 
   const refreshCliStatus = useCallback(async (): Promise<void> => {
     setCliLoading(true)
     try {
-      setCliStatus(await window.api.cli.getInstallStatus())
+      setCliStatusIfMounted(await window.api.cli.getInstallStatus())
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+      if (mountedRef.current) {
+        toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+      }
     } finally {
-      setCliLoading(false)
+      if (mountedRef.current) {
+        setCliLoading(false)
+      }
     }
-  }, [])
+  }, [setCliStatusIfMounted])
 
   useEffect(() => {
     if (open) {
@@ -70,8 +88,11 @@ export function FloatingTerminalOrchestrationDialog({
     setCliBusy(true)
     try {
       const next = await ensureOrcaCliAvailableForAgentSkillTerminal({
-        onStatusChange: setCliStatus
+        onStatusChange: setCliStatusIfMounted
       })
+      if (!mountedRef.current) {
+        return
+      }
       if (next) {
         notifyOrchestrationSetupStateChanged()
         onSetupStateChange()
@@ -80,7 +101,9 @@ export function FloatingTerminalOrchestrationDialog({
         toast.success('Registered the Orca CLI in PATH.')
       }
     } finally {
-      setCliBusy(false)
+      if (mountedRef.current) {
+        setCliBusy(false)
+      }
     }
   }
 
@@ -88,8 +111,11 @@ export function FloatingTerminalOrchestrationDialog({
     setSkillBusy(true)
     try {
       const nextCliStatus = await ensureOrcaCliAvailableForAgentSkillTerminal({
-        onStatusChange: setCliStatus
+        onStatusChange: setCliStatusIfMounted
       })
+      if (!mountedRef.current) {
+        return
+      }
       localStorage.setItem(ORCHESTRATION_ENABLED_STORAGE_KEY, '1')
       localStorage.removeItem(ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY)
       notifyOrchestrationSetupStateChanged()
@@ -112,9 +138,13 @@ export function FloatingTerminalOrchestrationDialog({
         onOpenChange(false)
       }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
+      if (mountedRef.current) {
+        toast.error(error instanceof Error ? error.message : 'Failed to copy skill command.')
+      }
     } finally {
-      setSkillBusy(false)
+      if (mountedRef.current) {
+        setSkillBusy(false)
+      }
     }
   }
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -141,6 +141,7 @@ export function FloatingTerminalPanel({
   const panelRef = useRef<HTMLDivElement>(null)
   const shortcutFocusFrameRef = useRef<number | null>(null)
   const shortcutFocusTimeoutRef = useRef<number | null>(null)
+  const mountedRef = useRef(true)
   const dragRef = useRef<{
     pointerId: number
     startX: number
@@ -345,6 +346,13 @@ export function FloatingTerminalPanel({
   }, [handleSaveDialogCancel])
 
   useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
     if (!open || normalizedInitialBoundsRef.current || typeof window === 'undefined') {
       return
     }
@@ -410,9 +418,13 @@ export function FloatingTerminalPanel({
     }
     try {
       const status = await window.api.cli.getInstallStatus()
-      setShowOrchestrationSetup(!isOrcaCliAvailableOnPath(status))
+      if (mountedRef.current) {
+        setShowOrchestrationSetup(!isOrcaCliAvailableOnPath(status))
+      }
     } catch {
-      setShowOrchestrationSetup(true)
+      if (mountedRef.current) {
+        setShowOrchestrationSetup(true)
+      }
     }
   }, [])
 

--- a/src/renderer/src/components/settings/WslCliRegistration.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
@@ -26,17 +26,32 @@ export function WslCliRegistration({
   const [loading, setLoading] = useState(false)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  const mountedRef = useRef(true)
   const { wslAvailable } = useWindowsTerminalCapabilities(currentPlatform === 'win32')
   const showWslCli = currentPlatform === 'win32' && wslAvailable
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const refreshStatus = async (): Promise<void> => {
     setLoading(true)
     try {
-      setStatus(await window.api.cli.getWslInstallStatus())
+      const next = await window.api.cli.getWslInstallStatus()
+      if (mountedRef.current) {
+        setStatus(next)
+      }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to load WSL CLI status.')
+      if (mountedRef.current) {
+        toast.error(error instanceof Error ? error.message : 'Failed to load WSL CLI status.')
+      }
     } finally {
-      setLoading(false)
+      if (mountedRef.current) {
+        setLoading(false)
+      }
     }
   }
 
@@ -58,15 +73,22 @@ export function WslCliRegistration({
     setBusyAction('install')
     try {
       const next = await window.api.cli.installWsl()
+      if (!mountedRef.current) {
+        return
+      }
       setStatus(next)
       setDialogOpen(false)
       toast.success(`Registered \`${next.commandName}\` in WSL.`)
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : `Failed to register \`${commandName}\` in WSL.`
-      )
+      if (mountedRef.current) {
+        toast.error(
+          error instanceof Error ? error.message : `Failed to register \`${commandName}\` in WSL.`
+        )
+      }
     } finally {
-      setBusyAction(null)
+      if (mountedRef.current) {
+        setBusyAction(null)
+      }
     }
   }
 
@@ -74,15 +96,22 @@ export function WslCliRegistration({
     setBusyAction('remove')
     try {
       const next = await window.api.cli.removeWsl()
+      if (!mountedRef.current) {
+        return
+      }
       setStatus(next)
       setDialogOpen(false)
       toast.success(`Removed \`${next.commandName}\` from WSL.`)
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : `Failed to remove \`${commandName}\` from WSL.`
-      )
+      if (mountedRef.current) {
+        toast.error(
+          error instanceof Error ? error.message : `Failed to remove \`${commandName}\` from WSL.`
+        )
+      }
     } finally {
-      setBusyAction(null)
+      if (mountedRef.current) {
+        setBusyAction(null)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- guard floating terminal orchestration setup status refreshes after the panel unmounts
- guard orchestration setup dialog CLI status/install/paste flows after the dialog unmounts
- guard WSL CLI registration status/install/remove flows after the settings pane unmounts

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- scoped to local CLI setup UI state/callback guards
- preserves the underlying CLI install/status IPC calls and orchestration setup storage updates while mounted
- does not change terminal paste command content, WSL command registration behavior, or CLI detection semantics

## Validation
- `pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx src/renderer/src/components/settings/WslCliRegistration.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)