### PR TITLE
Guard voice pane permission state without effect

### DIFF
--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { getDefaultVoiceSettings } from '../../../../shared/constants'
 import type { SpeechModelManifest, SpeechModelState } from '../../../../shared/speech-types'
@@ -34,11 +34,10 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   const [permissionPending, setPermissionPending] = useState(false)
   const mountedRef = useRef(true)
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handlePaneRef = useCallback((node: HTMLDivElement | null): void => {
+    // Why: the microphone permission prompt can resolve after Settings closes;
+    // the pane ref gives that completion a stale-write guard without an Effect.
+    mountedRef.current = node !== null
   }, [])
 
   useEffect(() => {
@@ -116,7 +115,7 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
   const selectedIsReady = selectedModelState?.status === 'ready'
 
   return (
-    <div className="space-y-1">
+    <div ref={handlePaneRef} className="space-y-1">
       <div className="flex items-center justify-between gap-4 py-2">
         <div className="space-y-0.5">
           <Label>Enable Voice Dictation</Label>


### PR DESCRIPTION
## Summary
- move the VoicePane mounted guard from a cleanup-only Effect to the pane root ref lifecycle
- keep the microphone permission completion from clearing local pending state after Settings closes
- preserve existing catalog loading, download progress, and voice settings behavior

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- one narrow UI-only mounted guard in the voice settings pane
- no changes to speech model catalog loading, model downloads, shortcut labels, or persisted voice settings
- only suppresses stale local permission-pending cleanup after the pane unmounts

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/settings/VoicePane.tsx`
- `pnpm exec oxlint src/renderer/src/components/settings/VoicePane.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts src/renderer/src/components/feature-tips/feature-tip-modal-state.test.ts src/renderer/src/store/slices/ui.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 817 -> 816.