### PR TITLE
fix: guard linear connect async state

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3170,6 +3170,14 @@ export default function TaskPage(): React.JSX.Element {
     'idle'
   )
   const [linearConnectError, setLinearConnectError] = useState<string | null>(null)
+  const linearConnectMountedRef = useRef(true)
+
+  useEffect(() => {
+    linearConnectMountedRef.current = true
+    return () => {
+      linearConnectMountedRef.current = false
+    }
+  }, [])
 
   const activeGithubTaskKind = getGitHubTaskKind(activeTaskPreset, appliedTaskSearch)
   const selectedGitHubRepoExternalLink = useMemo(() => {
@@ -4259,6 +4267,9 @@ export default function TaskPage(): React.JSX.Element {
     setLinearConnectError(null)
     try {
       const result = await connectLinear(key)
+      if (!linearConnectMountedRef.current) {
+        return
+      }
       if (result.ok) {
         setLinearApiKeyDraft('')
         setLinearConnectState('idle')
@@ -4268,8 +4279,10 @@ export default function TaskPage(): React.JSX.Element {
         setLinearConnectError(result.error)
       }
     } catch (error) {
-      setLinearConnectState('error')
-      setLinearConnectError(error instanceof Error ? error.message : 'Connection failed')
+      if (linearConnectMountedRef.current) {
+        setLinearConnectState('error')
+        setLinearConnectError(error instanceof Error ? error.message : 'Connection failed')
+      }
     }
   }, [connectLinear, linearApiKeyDraft])
 

--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ExternalLink, Github, Loader2, Terminal } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { Button } from '@/components/ui/button'
@@ -123,6 +123,14 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
   const [apiKeyDraft, setApiKeyDraft] = useState('')
   const [connectState, setConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
   const [connectError, setConnectError] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const workspaceCount = linearStatus.workspaces?.length ?? (linearStatus.connected ? 1 : 0)
 
@@ -135,6 +143,9 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
     setConnectError(null)
     try {
       const result = await connectLinear(apiKey)
+      if (!mountedRef.current) {
+        return
+      }
       if (result.ok) {
         setApiKeyDraft('')
         setConnectState('idle')
@@ -144,8 +155,10 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
       setConnectState('error')
       setConnectError(result.error)
     } catch (error) {
-      setConnectState('error')
-      setConnectError(error instanceof Error ? error.message : 'Connection failed')
+      if (mountedRef.current) {
+        setConnectState('error')
+        setConnectError(error instanceof Error ? error.message : 'Connection failed')
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- guard onboarding Linear connect result handling after the row unmounts
- guard Tasks page Linear connect result handling after the page unmounts
- keep the existing `connectLinear` store operation and success/error UI behavior unchanged while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- limited to local UI state guards around the existing Linear connection promise
- no changes to Linear API-key validation, store connection logic, or task/onboarding navigation
- only suppresses stale state writes after the initiating surface is gone

## Validation
- `pnpm exec oxlint src/renderer/src/components/onboarding/IntegrationsStep.tsx src/renderer/src/components/TaskPage.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)