### PR TITLE
Guard Linear comment footer async state without effect

### DIFF
--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -955,11 +955,10 @@ export function LinearIssueCommentFooter({
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const mountedRef = useRef(true)
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handleFooterRef = useCallback((node: HTMLDivElement | null): void => {
+    // Why: comment submission can resolve after the footer unmounts; the root
+    // ref keeps that completion from writing stale local state without an Effect.
+    mountedRef.current = node !== null
   }, [])
 
   const autoGrow = useCallback(() => {
@@ -1016,7 +1015,10 @@ export function LinearIssueCommentFooter({
 
   if (variant === 'linear-page') {
     return (
-      <div className="rounded-xl border border-border/70 bg-background shadow-xs">
+      <div
+        ref={handleFooterRef}
+        className="rounded-xl border border-border/70 bg-background shadow-xs"
+      >
         <textarea
           ref={textareaRef}
           value={body}
@@ -1051,7 +1053,10 @@ export function LinearIssueCommentFooter({
   }
 
   return (
-    <div className="flex items-end gap-2 border-t border-border/60 bg-background/40 px-4 py-3">
+    <div
+      ref={handleFooterRef}
+      className="flex items-end gap-2 border-t border-border/60 bg-background/40 px-4 py-3"
+    >
       <textarea
         ref={textareaRef}
         value={body}


### PR DESCRIPTION
## Summary
- move the Linear issue comment footer mounted guard from a cleanup-only Effect to the footer root ref lifecycle
- keep async comment submission from clearing local body/submitting state after the footer unmounts
- preserve both compact and Linear-page footer variants while mounted

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- one narrow UI-only mounted guard in the Linear comment footer
- no changes to Linear comment payloads, provider calls, optimistic comment insertion, or keyboard shortcuts
- only suppresses stale local footer state after the originating footer unmounts

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/LinearItemDrawer.tsx`
- `pnpm exec oxlint src/renderer/src/components/LinearItemDrawer.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/linear.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 819 -> 818.