### PR TITLE
fix: guard sidebar dialog async state

### DIFF
--- a/src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -24,6 +24,14 @@ export function ProjectGroupDeleteDialog({
 }: ProjectGroupDeleteDialogProps): React.JSX.Element {
   const [deleting, setDeleting] = useState(false)
   const [wasOpen, setWasOpen] = useState(open)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   // Why: opening the dialog must clear a stale in-flight state before the
   // destructive button renders; an Effect would leave one disabled frame.
@@ -41,11 +49,15 @@ export function ProjectGroupDeleteDialog({
     setDeleting(true)
     try {
       await onConfirm()
-      setDeleting(false)
-      onOpenChange(false)
+      if (mountedRef.current) {
+        setDeleting(false)
+        onOpenChange(false)
+      }
     } catch (error) {
       console.error('Failed to delete project group:', error)
-      setDeleting(false)
+      if (mountedRef.current) {
+        setDeleting(false)
+      }
     }
   }, [deleting, onConfirm, onOpenChange])
 

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useId, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -35,7 +35,15 @@ export function ProjectGroupNameDialog({
   const [name, setName] = useState(initialName)
   const [submitting, setSubmitting] = useState(false)
   const [previousOpenState, setPreviousOpenState] = useState({ open, initialName })
+  const mountedRef = useRef(true)
   const trimmedName = name.trim()
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   // Why: the input should mount already seeded and selectable for the active
   // group; Effect-based hydration shows one frame with the prior draft.
@@ -56,10 +64,14 @@ export function ProjectGroupNameDialog({
       setSubmitting(true)
       try {
         await onSubmit(trimmedName)
-        onOpenChange(false)
+        if (mountedRef.current) {
+          onOpenChange(false)
+        }
       } catch (error) {
         console.error('Failed to save project group name:', error)
-        setSubmitting(false)
+        if (mountedRef.current) {
+          setSubmitting(false)
+        }
       }
     },
     [onOpenChange, onSubmit, submitting, trimmedName]

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
@@ -41,9 +41,17 @@ export function WorktreeTitleInlineRename({
 }: WorktreeTitleInlineRenameProps): React.JSX.Element {
   const editingRef = useRef(false)
   const savingRef = useRef(false)
+  const mountedRef = useRef(true)
   const [editing, setEditing] = useState(false)
   const [value, setValue] = useState(displayName)
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
   const setEditingMode = useCallback(
     (nextEditing: boolean) => {
@@ -104,12 +112,18 @@ export function WorktreeTitleInlineRename({
     setSaving(true)
     try {
       await onRename(commit.displayName)
-      setEditingMode(false)
+      if (mountedRef.current) {
+        setEditingMode(false)
+      }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to rename workspace.')
+      if (mountedRef.current) {
+        toast.error(err instanceof Error ? err.message : 'Failed to rename workspace.')
+      }
     } finally {
       savingRef.current = false
-      setSaving(false)
+      if (mountedRef.current) {
+        setSaving(false)
+      }
     }
   }, [cancelRename, displayName, onRename, setEditingMode, value])
 


### PR DESCRIPTION
## Summary
- Guard project group create/rename/delete dialog state updates after async submit/delete completes.
- Guard inline workspace rename completion and failure toast after async rename resolves.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to post-await UI state updates in sidebar rename/delete surfaces.
- No data model, persistence, IPC, or SSH behavior changed.
- Existing synchronous dialog open/reset behavior is preserved.

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)