### PR TITLE
Guard sidebar dialog async state without effects

### DIFF
--- a/src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -26,11 +26,10 @@ export function ProjectGroupDeleteDialog({
   const [wasOpen, setWasOpen] = useState(open)
   const mountedRef = useRef(true)
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handleDialogContentRef = useCallback((node: HTMLDivElement | null): void => {
+    // Why: deleting can resolve after the dialog closes; the content ref keeps
+    // late completions from mutating stale dialog state without an Effect.
+    mountedRef.current = node !== null
   }, [])
 
   // Why: opening the dialog must clear a stale in-flight state before the
@@ -71,7 +70,11 @@ export function ProjectGroupDeleteDialog({
         onOpenChange(nextOpen)
       }}
     >
-      <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
+      <DialogContent
+        ref={handleDialogContentRef}
+        className="max-w-sm sm:max-w-sm"
+        showCloseButton={false}
+      >
         <DialogHeader>
           <DialogTitle className="text-sm">Delete Project Group</DialogTitle>
           <DialogDescription className="text-xs">

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
+import React, { useCallback, useId, useRef, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -38,11 +38,10 @@ export function ProjectGroupNameDialog({
   const mountedRef = useRef(true)
   const trimmedName = name.trim()
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handleDialogContentRef = useCallback((node: HTMLDivElement | null): void => {
+    // Why: save can finish after the dialog closes; the content ref keeps late
+    // completions from mutating stale dialog state without an Effect.
+    mountedRef.current = node !== null
   }, [])
 
   // Why: the input should mount already seeded and selectable for the active
@@ -80,6 +79,7 @@ export function ProjectGroupNameDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        ref={handleDialogContentRef}
         className="max-w-sm sm:max-w-sm"
         onOpenAutoFocus={(event) => {
           event.preventDefault()

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
@@ -46,11 +46,10 @@ export function WorktreeTitleInlineRename({
   const [value, setValue] = useState(displayName)
   const [saving, setSaving] = useState(false)
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
+  const handleRootRef = useCallback((node: HTMLSpanElement | null): void => {
+    // Why: rename can resolve after this inline title unmounts; the rendered
+    // root owns that stale-write guard without a mount-only Effect.
+    mountedRef.current = node !== null
   }, [])
 
   const setEditingMode = useCallback(
@@ -144,6 +143,7 @@ export function WorktreeTitleInlineRename({
   if (editing) {
     return (
       <span
+        ref={handleRootRef}
         className={cn(
           'relative grid min-w-0 truncate leading-tight text-foreground',
           showUnreadEmphasis ? 'font-semibold' : 'font-normal',
@@ -187,6 +187,7 @@ export function WorktreeTitleInlineRename({
 
   const title = (
     <span
+      ref={handleRootRef}
       className={cn(
         'block min-w-0 truncate leading-tight text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring',
         showUnreadEmphasis ? 'font-semibold' : 'font-normal',


### PR DESCRIPTION
## Summary
- move project group delete and name dialog mounted guards from cleanup-only Effects to DialogContent refs
- move inline workspace rename mounted guard from a cleanup-only Effect to the rendered title root ref
- keep async delete/save/rename completions from mutating stale local UI state after the originating surface closes

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- scoped to local mounted guards in sidebar rename/delete UI surfaces
- no changes to project group persistence, workspace rename persistence, IPC, or SSH behavior
- only changes where late async completions read their stale-write guard

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx`
- `pnpm exec oxlint src/renderer/src/components/sidebar/ProjectGroupDeleteDialog.tsx src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeTitleInlineRename.test.tsx src/renderer/src/store/slices/repos-project-groups.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 823 -> 820.