### PR TITLE
fix: guard cli section async state

### DIFF
--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { FolderOpen, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
@@ -64,6 +64,7 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
   const [loading, setLoading] = useState(true)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<'install' | 'remove' | null>(null)
+  const mountedRef = useRef(true)
   const {
     installed: cliSkillDetected,
     loading: cliSkillLoading,
@@ -73,20 +74,37 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
 
-  const refreshStatus = async (): Promise<void> => {
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const handleStatusChange = useCallback((nextStatus: CliInstallStatus): void => {
+    if (mountedRef.current) {
+      setStatus(nextStatus)
+    }
+  }, [])
+
+  const refreshStatus = useCallback(async (): Promise<void> => {
     setLoading(true)
     try {
-      setStatus(await window.api.cli.getInstallStatus())
+      handleStatusChange(await window.api.cli.getInstallStatus())
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+      if (mountedRef.current) {
+        toast.error(error instanceof Error ? error.message : 'Failed to load CLI status.')
+      }
     } finally {
-      setLoading(false)
+      if (mountedRef.current) {
+        setLoading(false)
+      }
     }
-  }
+  }, [handleStatusChange])
 
   useEffect(() => {
     void refreshStatus()
-  }, [])
+  }, [refreshStatus])
 
   const isEnabled = status?.state === 'installed'
   const isSupported = status?.supported ?? false
@@ -100,15 +118,21 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
     setBusyAction('install')
     try {
       const next = await window.api.cli.install()
-      setStatus(next)
-      setDialogOpen(false)
-      toast.success(`Registered \`${next.commandName}\` in PATH.`)
+      if (mountedRef.current) {
+        setStatus(next)
+        setDialogOpen(false)
+        toast.success(`Registered \`${next.commandName}\` in PATH.`)
+      }
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : `Failed to register \`${commandName}\` in PATH.`
-      )
+      if (mountedRef.current) {
+        toast.error(
+          error instanceof Error ? error.message : `Failed to register \`${commandName}\` in PATH.`
+        )
+      }
     } finally {
-      setBusyAction(null)
+      if (mountedRef.current) {
+        setBusyAction(null)
+      }
     }
   }
 
@@ -116,15 +140,21 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
     setBusyAction('remove')
     try {
       const next = await window.api.cli.remove()
-      setStatus(next)
-      setDialogOpen(false)
-      toast.success(`Removed \`${next.commandName}\` from PATH.`)
+      if (mountedRef.current) {
+        setStatus(next)
+        setDialogOpen(false)
+        toast.success(`Removed \`${next.commandName}\` from PATH.`)
+      }
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : `Failed to remove \`${commandName}\` from PATH.`
-      )
+      if (mountedRef.current) {
+        toast.error(
+          error instanceof Error ? error.message : `Failed to remove \`${commandName}\` from PATH.`
+        )
+      }
     } finally {
-      setBusyAction(null)
+      if (mountedRef.current) {
+        setBusyAction(null)
+      }
     }
   }
 
@@ -248,7 +278,9 @@ export function CliSection({ currentPlatform }: CliSectionProps): React.JSX.Elem
               error={cliSkillError}
               preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
               onBeforeOpenTerminal={async () => {
-                await ensureOrcaCliAvailableForAgentSkillTerminal({ onStatusChange: setStatus })
+                await ensureOrcaCliAvailableForAgentSkillTerminal({
+                  onStatusChange: handleStatusChange
+                })
               }}
               onRecheck={refreshCliSkill}
             />


### PR DESCRIPTION
## Summary
- Guard CLI settings status updates after async status/install/remove calls resolve.
- Guard setup-terminal status callbacks plus loading/busy state and completion toasts after settings navigation unmounts the section.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local settings UI state after existing CLI IPC calls.
- No CLI install/remove implementation, persistence format, IPC contract, SSH behavior, or platform-specific path logic changed.
- Existing refresh, install, remove, and skill setup flows remain the same while avoiding stale completion updates.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/CliSection.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)