### PR TITLE
fix: guard computer use async state

### DIFF
--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -81,6 +81,7 @@ export function ComputerUsePane(): React.JSX.Element {
   // Why: reset changes OS permission state, so older status probes must not overwrite it.
   const resettingRef = useRef(false)
   const permissionOperationSequence = useRef(0)
+  const mountedRef = useRef(true)
   const [helperUnavailableReason, setHelperUnavailableReason] = useState<string | null>(null)
   const {
     installed: computerUseSkillDetected,
@@ -120,6 +121,14 @@ export function ComputerUsePane(): React.JSX.Element {
             PERMISSIONS.length - grantedCount === 1 ? '' : 's'
           } required before agents can operate app windows.`
 
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      permissionOperationSequence.current += 1
+    }
+  }, [])
+
   const refresh = useCallback(async (): Promise<void> => {
     if (resettingRef.current) {
       return
@@ -132,18 +141,21 @@ export function ComputerUsePane(): React.JSX.Element {
       if (operationId !== permissionOperationSequence.current) {
         return
       }
+      if (!mountedRef.current) {
+        return
+      }
       setPlatform(result.platform)
       setStates(result.permissions)
       setHelperUnavailableReason(result.helperUnavailableReason)
     } catch (error) {
-      if (operationId !== permissionOperationSequence.current) {
+      if (operationId !== permissionOperationSequence.current || !mountedRef.current) {
         return
       }
       toast.error(
         error instanceof Error ? error.message : 'Could not load Computer Use permissions'
       )
     } finally {
-      if (operationId === permissionOperationSequence.current) {
+      if (operationId === permissionOperationSequence.current && mountedRef.current) {
         setLoading(false)
       }
     }
@@ -168,6 +180,9 @@ export function ComputerUsePane(): React.JSX.Element {
     setPendingId(id)
     try {
       const result = await window.api.computerUsePermissions.openSetup({ id })
+      if (!mountedRef.current) {
+        return
+      }
       if (result.launchedHelper) {
         toast.message('Opened macOS Privacy & Security')
       } else {
@@ -178,11 +193,15 @@ export function ComputerUsePane(): React.JSX.Element {
         )
       }
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : 'Could not open Computer Use permissions'
-      )
+      if (mountedRef.current) {
+        toast.error(
+          error instanceof Error ? error.message : 'Could not open Computer Use permissions'
+        )
+      }
     } finally {
-      setPendingId(null)
+      if (mountedRef.current) {
+        setPendingId(null)
+      }
     }
   }
 
@@ -199,19 +218,22 @@ export function ComputerUsePane(): React.JSX.Element {
       if (operationId !== permissionOperationSequence.current) {
         return
       }
+      if (!mountedRef.current) {
+        return
+      }
       setPlatform(result.platform)
       setStates(result.permissions)
       setHelperUnavailableReason(result.helperUnavailableReason)
       toast.message('Reset Computer Use access')
     } catch (error) {
-      if (operationId !== permissionOperationSequence.current) {
+      if (operationId !== permissionOperationSequence.current || !mountedRef.current) {
         return
       }
       toast.error(
         error instanceof Error ? error.message : 'Could not reset Computer Use permissions'
       )
     } finally {
-      if (operationId === permissionOperationSequence.current) {
+      if (operationId === permissionOperationSequence.current && mountedRef.current) {
         resettingRef.current = false
         setResetting(false)
         setLoading(false)


### PR DESCRIPTION
## Summary
- Invalidate Computer Use permission status/reset requests when the pane unmounts.
- Guard permission-open completion toasts and pending state after settings navigation closes the pane.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local settings UI state and toasts after existing Computer Use permission IPC calls.
- The OS permission/reset operations, helper launch path, skill install flow, IPC contracts, and SSH behavior are unchanged.
- Existing operation sequencing is preserved and extended to unmount cleanup.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/ComputerUsePane.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)