### PR TITLE
fix: guard developer permissions async state

### DIFF
--- a/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
+++ b/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import {
   Accessibility,
   Bluetooth,
@@ -130,20 +130,39 @@ export function DeveloperPermissionsPane(): React.JSX.Element {
   const [states, setStates] = useState<DeveloperPermissionState[]>([])
   const [loading, setLoading] = useState(true)
   const [pendingId, setPendingId] = useState<DeveloperPermissionId | null>(null)
+  const mountedRef = useRef(true)
+  const refreshSequenceRef = useRef(0)
 
   const stateById = useMemo(
     () => new Map(states.map((state) => [state.id, state.status] as const)),
     [states]
   )
 
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      refreshSequenceRef.current += 1
+    }
+  }, [])
+
   const refresh = useCallback(async (): Promise<void> => {
+    const refreshId = refreshSequenceRef.current + 1
+    refreshSequenceRef.current = refreshId
     setLoading(true)
     try {
-      setStates(await window.api.developerPermissions.getStatus())
+      const nextStates = await window.api.developerPermissions.getStatus()
+      if (mountedRef.current && refreshId === refreshSequenceRef.current) {
+        setStates(nextStates)
+      }
     } catch {
-      toast.error('Could not load developer permissions')
+      if (mountedRef.current && refreshId === refreshSequenceRef.current) {
+        toast.error('Could not load developer permissions')
+      }
     } finally {
-      setLoading(false)
+      if (mountedRef.current && refreshId === refreshSequenceRef.current) {
+        setLoading(false)
+      }
     }
   }, [])
 
@@ -167,7 +186,13 @@ export function DeveloperPermissionsPane(): React.JSX.Element {
     setPendingId(id)
     try {
       const result = await window.api.developerPermissions.request({ id })
+      if (!mountedRef.current) {
+        return
+      }
       await refresh()
+      if (!mountedRef.current) {
+        return
+      }
       if (result.status === 'granted') {
         toast.success('Permission granted')
       } else if (result.openedSystemSettings) {
@@ -176,9 +201,13 @@ export function DeveloperPermissionsPane(): React.JSX.Element {
         toast.message('Permission request sent')
       }
     } catch {
-      toast.error('Could not request permission')
+      if (mountedRef.current) {
+        toast.error('Could not request permission')
+      }
     } finally {
-      setPendingId(null)
+      if (mountedRef.current) {
+        setPendingId(null)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard Developer Permissions refresh results after the settings pane unmounts.
- Sequence overlapping refreshes so stale permission status cannot replace newer data.
- Guard request completion toasts and pending state after navigation away.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local settings UI state and toasts after existing developer-permission IPC calls.
- Permission request behavior, macOS settings launch behavior, IPC contracts, SSH behavior, and platform support logic are unchanged.
- The added sequence only prevents stale refresh results from applying after a newer refresh or unmount.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/DeveloperPermissionsPane.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)