### PR TITLE
fix: guard sparse preset async state

### DIFF
--- a/src/renderer/src/components/settings/SparsePresetSettingsSection.tsx
+++ b/src/renderer/src/components/settings/SparsePresetSettingsSection.tsx
@@ -4,6 +4,7 @@ import type { SparsePreset } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { cn } from '@/lib/utils'
 import { parseSparsePresetDirectories } from '@/lib/sparse-preset-draft'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -59,6 +60,7 @@ export function SparsePresetSettingsSection({
   const [draft, setDraft] = useState<SparsePresetDraft | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null)
+  const mountedRef = useMountedRef()
 
   useEffect(() => {
     if (presets === undefined) {
@@ -119,11 +121,13 @@ export function SparsePresetSettingsSection({
         name: trimmedName,
         directories: parsedDirectories.directories
       })
-      if (saved) {
+      if (saved && mountedRef.current) {
         setDraft(null)
       }
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }
 

--- a/src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
+++ b/src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { parseSparsePresetDirectories } from '@/lib/sparse-preset-draft'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import type { SparsePreset } from '../../../../shared/types'
 
 type SparseCheckoutPresetSelectProps = {
@@ -41,6 +42,7 @@ export default function SparseCheckoutPresetSelect({
   const [submitting, setSubmitting] = useState(false)
   const nameInputRef = useRef<HTMLInputElement>(null)
   const nameInputFocusFrameRef = useRef<number | null>(null)
+  const mountedRef = useMountedRef()
 
   const visiblePresets = presetsForRepo ?? presets
   const presetsLoaded = presetsForRepo !== undefined
@@ -147,7 +149,7 @@ export default function SparseCheckoutPresetSelect({
         name: trimmedName,
         directories: parsedDirectories.directories
       })
-      if (saved) {
+      if (saved && mountedRef.current) {
         if (draft.mode === 'new' || selectedPresetId === saved.id) {
           onSelectPreset(saved)
         }
@@ -155,11 +157,14 @@ export default function SparseCheckoutPresetSelect({
         setOpen(false)
       }
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }, [
     canSave,
     draft,
+    mountedRef,
     onSelectPreset,
     parsedDirectories,
     repoId,

--- a/src/renderer/src/hooks/useMountedRef.ts
+++ b/src/renderer/src/hooks/useMountedRef.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+
+export function useMountedRef(): MutableRefObject<boolean> {
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  return mountedRef
+}


### PR DESCRIPTION
## Summary
- Add a tiny mounted-ref hook for components that need to skip post-await local state after unmount.
- Guard sparse preset save completion in both the checkout selector and repo settings editor.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local sparse preset editor/selector state after existing save calls resolve.
- Save behavior, sparse preset parsing, store actions, IPC contracts, and SSH behavior are unchanged.
- The new hook only tracks component mount state and is used by this PR's two guarded call sites.

## Validation
- `pnpm exec oxlint src/renderer/src/hooks/useMountedRef.ts src/renderer/src/components/sparse/SparseCheckoutPresetSelect.tsx src/renderer/src/components/settings/SparsePresetSettingsSection.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)