### PR TITLE
fix: guard notification sound async state

### DIFF
--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -16,6 +16,7 @@ import {
 } from '../ui/select'
 import { BellRing, Bot, FileAudio, Siren, Upload, Volume2 } from 'lucide-react'
 import { getNotificationSoundOptions } from '@/components/notification-sound-options'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '@/store'
 export { NOTIFICATIONS_PANE_SEARCH_ENTRIES } from './notifications-search'
 
@@ -142,6 +143,7 @@ export function NotificationsPane({
 }: NotificationsPaneProps): React.JSX.Element {
   const notificationSettings = settings.notifications
   const notificationSettingsRef = useRef(notificationSettings)
+  const mountedRef = useMountedRef()
   const [isPickingSound, setIsPickingSound] = useState(false)
 
   const updateNotificationSettings = async (
@@ -203,7 +205,9 @@ export function NotificationsPane({
         await previewSound('custom')
       }
     } finally {
-      setIsPickingSound(false)
+      if (mountedRef.current) {
+        setIsPickingSound(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard the notification custom-sound picker spinner after async file selection completes.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local settings UI state after the existing sound picker flow resolves.
- Notification settings persistence, sound preview/playback, IPC contracts, platform behavior, and SSH behavior are unchanged.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/NotificationsPane.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)