### PR TITLE
perf: reuse mounted ref in settings async panes

### DIFF
--- a/src/renderer/src/components/settings/RepositoryIconPicker.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Github, Image, Link2, RotateCcw } from 'lucide-react'
 import type { Repo } from '../../../../shared/types'
@@ -15,6 +15,7 @@ import { RepoIconGlyph, REPO_LUCIDE_ICON_OPTIONS } from '../repo/repo-icon'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 const EMOJI_OPTIONS = ['🚀', '✨', '💻', '🧠', '📦', '🔧', '🎨', '🌐', '📊', '🔒', '⚡', '✅']
 
@@ -27,7 +28,7 @@ export function RepositoryIconPicker({
 }): React.JSX.Element {
   const [website, setWebsite] = useState('')
   const [loadingGitHub, setLoadingGitHub] = useState(false)
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
   const activeRuntimeEnvironmentId = useAppStore(
     (state) => state.settings?.activeRuntimeEnvironmentId ?? null
   )
@@ -58,13 +59,6 @@ export function RepositoryIconPicker({
 
   const setIcon = (repoIcon: RepoIcon | null) => updateRepo(repo.id, { repoIcon })
   const setBadgeColor = (badgeColor: string) => updateRepo(repo.id, { badgeColor })
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const handleUploadImage = async () => {
     try {

--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Plus, Upload } from 'lucide-react'
 import {
@@ -9,6 +9,7 @@ import {
 } from '../../../../shared/ssh-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../../../shared/constants'
 import { useAppStore } from '@/store'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { Button } from '../ui/button'
 import { removeSshTargetWithBestEffortCleanup } from './ssh-target-remove'
 import { SshTargetCard } from './SshTargetCard'
@@ -29,7 +30,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [form, setForm] = useState<EditingTarget>(EMPTY_FORM)
   const [testingIds, setTestingIds] = useState<Set<string>>(new Set())
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
 
   const setSshTargetsMetadata = useAppStore((s) => s.setSshTargetsMetadata)
   const clearRemovedSshTargetState = useAppStore((s) => s.clearRemovedSshTargetState)
@@ -49,15 +50,8 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
         }
       }
     },
-    [setSshTargetsMetadata]
+    [mountedRef, setSshTargetsMetadata]
   )
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   useEffect(() => {
     const abortController = new AbortController()


### PR DESCRIPTION
## Summary
- replace duplicated cleanup-only mounted guard Effects in RepositoryIconPicker and SshPane with the shared useMountedRef hook
- keep the SSH target-list abort-controller Effect and async guard behavior intact

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/settings/RepositoryIconPicker.tsx src/renderer/src/components/settings/SshPane.tsx
- pnpm exec oxlint src/renderer/src/components/settings/RepositoryIconPicker.tsx src/renderer/src/components/settings/SshPane.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-remove.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/lib/new-workspace-ssh-gate.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This removes duplicated local mount bookkeeping and reuses the existing mounted-ref hook. It does not change SSH IPC calls, target cleanup behavior, runtime provider selection, or repo icon update semantics.