### PR TITLE
fix: guard onboarding theme async state

### DIFF
--- a/src/renderer/src/components/onboarding/ThemeStep.tsx
+++ b/src/renderer/src/components/onboarding/ThemeStep.tsx
@@ -3,6 +3,7 @@ import { Check, Monitor, Moon, Settings2, Sun } from 'lucide-react'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { track } from '@/lib/telemetry'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import type {
   DiscoveryStatusEmitted,
   GhosttyImportPreview,
@@ -63,6 +64,7 @@ function fieldGroupCountBucket(count: number): '0' | '1-3' | '4-7' | '8+' {
 export function ThemeStep({ theme, onThemeChange, settings, updateSettings }: ThemeStepProps) {
   const [importing, setImporting] = useState(false)
   const [discovery, setDiscovery] = useState<DiscoveryState>({ status: 'idle' })
+  const mountedRef = useMountedRef()
 
   // Why: read-only IPC. Auto-detect on step mount so the user sees a clear
   // "we found your Ghostty config" prompt instead of a buried Import button.
@@ -129,7 +131,9 @@ export function ThemeStep({ theme, onThemeChange, settings, updateSettings }: Th
     try {
       const resolved = preview.found ? preview : await window.api.settings.previewGhosttyImport()
       if (!resolved.found || Object.keys(resolved.diff).length === 0) {
-        toast.info('No Ghostty settings found to import')
+        if (mountedRef.current) {
+          toast.info('No Ghostty settings found to import')
+        }
         track('onboarding_ghostty_import_failed', { reason: 'empty_diff' })
         return
       }
@@ -146,22 +150,28 @@ export function ThemeStep({ theme, onThemeChange, settings, updateSettings }: Th
       })
       // Why: parent controller holds local `theme` state that overwrites
       // settings.theme on Continue; sync it so the import isn't clobbered.
-      if (resolved.diff.theme) {
+      if (resolved.diff.theme && mountedRef.current) {
         onThemeChange(resolved.diff.theme)
       }
       const importedFields = humanFields(resolved.diff)
-      setDiscovery({ status: 'imported', fields: importedFields })
+      if (mountedRef.current) {
+        setDiscovery({ status: 'imported', fields: importedFields })
+      }
       track('onboarding_ghostty_discovered', {
         state: 'imported',
         field_group_count_bucket: fieldGroupCountBucket(importedFields.length)
       })
     } catch (err) {
-      toast.error('Failed to import Ghostty settings', {
-        description: err instanceof Error ? err.message : String(err)
-      })
+      if (mountedRef.current) {
+        toast.error('Failed to import Ghostty settings', {
+          description: err instanceof Error ? err.message : String(err)
+        })
+      }
       track('onboarding_ghostty_import_failed', { reason: 'unknown' })
     } finally {
-      setImporting(false)
+      if (mountedRef.current) {
+        setImporting(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard Ghostty import completion UI updates after the onboarding theme step unmounts.
- Preserve the actual settings import and telemetry while skipping stale local state/toasts.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to onboarding local state and toasts after existing Ghostty import async work resolves.
- Theme persistence, Ghostty import parsing, telemetry event names, IPC contracts, and SSH behavior are unchanged.
- The parent theme sync still happens when the step remains mounted, preserving the Continue-flow behavior.

## Validation
- `pnpm exec oxlint src/renderer/src/components/onboarding/ThemeStep.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)