### PR TITLE
perf: reuse mounted ref in notice cards

### DIFF
--- a/src/renderer/src/components/FirstLaunchBanner.tsx
+++ b/src/renderer/src/components/FirstLaunchBanner.tsx
@@ -33,11 +33,12 @@
 // off), the notice never returns, because the cohort condition
 // (`optedIn === null`) clears in all three resolving paths.
 
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { X } from 'lucide-react'
 
 import { Button } from './ui/button'
 import { acknowledgeBanner, PRIVACY_URL, setOptIn as telemetrySetOptIn } from '../lib/telemetry'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 type FirstLaunchBannerProps = {
   onResolve: () => void
@@ -57,14 +58,7 @@ export function FirstLaunchBanner({
   // wasted IPC round-trip, but the guard also blocks a Turn-off click
   // arriving mid-flight after an acknowledge (or vice versa).
   const [inFlight, setInFlight] = useState(false)
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
+  const mountedRef = useMountedRef()
 
   const handleAcknowledge = async (): Promise<void> => {
     if (inFlight) {

--- a/src/renderer/src/components/StarNagCard.tsx
+++ b/src/renderer/src/components/StarNagCard.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Star, X } from 'lucide-react'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
 import { useAppStore } from '../store'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 /**
  * Persistent "star Orca on GitHub" notification card.
@@ -19,20 +20,13 @@ export function StarNagCard(): React.JSX.Element | null {
   const [visible, setVisible] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(false)
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
   // Why: UpdateCard lives at the same bottom-right slot. When it is visible
   // (any non-idle / non-not-available state), stack the star-nag card above
   // it instead of overlapping — we must not cover a pending update prompt
   // because that's a higher-priority action.
   const updateStatus = useAppStore((s) => s.updateStatus)
   const updateCardVisible = updateStatus.state !== 'idle' && updateStatus.state !== 'not-available'
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   useEffect(() => {
     return window.api.starNag.onShow(() => {


### PR DESCRIPTION
## Summary
- replace duplicated cleanup-only mounted guard Effects in FirstLaunchBanner and StarNagCard with the shared useMountedRef hook
- keep telemetry acknowledge/opt-out and star-nag IPC behavior unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/FirstLaunchBanner.tsx src/renderer/src/components/StarNagCard.tsx
- pnpm exec oxlint src/renderer/src/components/FirstLaunchBanner.tsx src/renderer/src/components/StarNagCard.tsx
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This removes duplicated mount bookkeeping around existing async guards in two notice components. It does not change telemetry persistence, opt-out event routing, GitHub star behavior, or notification visibility rules.