### PR TITLE
fix: guard diff comment async state

### DIFF
--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -2,6 +2,7 @@ import { CornerDownLeft, Pencil, Trash, FileText } from 'lucide-react'
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 // Why: the saved-note card lives inside a Monaco view zone's DOM node.
 // useDiffCommentDecorator creates a React root per zone and renders this
@@ -51,6 +52,7 @@ export function DiffCommentCard({
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(body)
   const [submitting, setSubmitting] = useState(false)
+  const mountedRef = useMountedRef()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   // Why: stash `onContentResize` in a ref so the layout/resize effects only
@@ -119,7 +121,7 @@ export function DiffCommentCard({
     setSubmitting(true)
     try {
       const ok = await onSubmitEdit(trimmedDraft)
-      if (ok) {
+      if (ok && mountedRef.current) {
         setEditing(false)
       }
     } catch (err) {
@@ -129,7 +131,9 @@ export function DiffCommentCard({
       // (`void handleSubmit()`).
       console.error('Failed to submit diff comment edit:', err)
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }
 

--- a/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentPopover.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState } from 'react'
 import { CornerDownLeft, User } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 // Why: rendered as a DOM sibling overlay inside the editor container rather
 // than as a Monaco content widget because it owns a React textarea with
@@ -43,6 +44,7 @@ export function DiffCommentPopover({
   // fresh id/createdAt. Tracked in React state (not a ref) so the button can
   // reflect the in-flight status to the user.
   const [submitting, setSubmitting] = useState(false)
+  const mountedRef = useMountedRef()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const popoverRef = useRef<HTMLDivElement | null>(null)
   // Why: stash onCancel in a ref so the document mousedown listener below can
@@ -104,7 +106,9 @@ export function DiffCommentPopover({
     try {
       await onSubmit(trimmed)
     } finally {
-      setSubmitting(false)
+      if (mountedRef.current) {
+        setSubmitting(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard diff note popover submit completion after the popover unmounts.
- Guard diff note card edit completion after the card unmounts.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local diff-comment UI state after existing submit/edit callbacks resolve.
- Comment creation/edit behavior, persistence, Monaco view-zone layout logic, IPC contracts, and SSH behavior are unchanged.
- Existing failure behavior stays the same while stale completion updates are skipped.

## Validation
- `pnpm exec oxlint src/renderer/src/components/diff-comments/DiffCommentPopover.tsx src/renderer/src/components/diff-comments/DiffCommentCard.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)