### PR TITLE
perf: reuse mounted ref in floating terminal setup

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Check, Clipboard, Copy, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -21,6 +21,7 @@ import {
   ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY,
   notifyOrchestrationSetupStateChanged
 } from '@/lib/orchestration-setup-state'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
 
 type FloatingTerminalOrchestrationDialogProps = {
@@ -40,20 +41,16 @@ export function FloatingTerminalOrchestrationDialog({
   const [cliLoading, setCliLoading] = useState(false)
   const [cliBusy, setCliBusy] = useState(false)
   const [skillBusy, setSkillBusy] = useState(false)
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
 
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
-
-  const setCliStatusIfMounted = useCallback((status: CliInstallStatus | null): void => {
-    if (mountedRef.current) {
-      setCliStatus(status)
-    }
-  }, [])
+  const setCliStatusIfMounted = useCallback(
+    (status: CliInstallStatus | null): void => {
+      if (mountedRef.current) {
+        setCliStatus(status)
+      }
+    },
+    [mountedRef]
+  )
 
   const refreshCliStatus = useCallback(async (): Promise<void> => {
     setCliLoading(true)
@@ -68,7 +65,7 @@ export function FloatingTerminalOrchestrationDialog({
         setCliLoading(false)
       }
     }
-  }, [setCliStatusIfMounted])
+  }, [mountedRef, setCliStatusIfMounted])
 
   useEffect(() => {
     if (open) {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -11,6 +11,7 @@ import TabBar from '@/components/tab-bar/TabBar'
 import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
 import { Button } from '@/components/ui/button'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { useShortcutKeys } from '@/hooks/useShortcutLabel'
 import {
   Dialog,
@@ -141,7 +142,7 @@ export function FloatingTerminalPanel({
   const panelRef = useRef<HTMLDivElement>(null)
   const shortcutFocusFrameRef = useRef<number | null>(null)
   const shortcutFocusTimeoutRef = useRef<number | null>(null)
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
   const dragRef = useRef<{
     pointerId: number
     startX: number
@@ -346,13 +347,6 @@ export function FloatingTerminalPanel({
   }, [handleSaveDialogCancel])
 
   useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
-
-  useEffect(() => {
     if (!open || normalizedInitialBoundsRef.current || typeof window === 'undefined') {
       return
     }
@@ -426,7 +420,7 @@ export function FloatingTerminalPanel({
         setShowOrchestrationSetup(true)
       }
     }
-  }, [])
+  }, [mountedRef])
 
   useEffect(() => {
     if (open) {


### PR DESCRIPTION
## Summary
- replace duplicated cleanup-only mounted guard Effects in the floating terminal panel and orchestration setup dialog with useMountedRef
- keep orchestration setup refresh, CLI status checks, shortcut cleanup, and mixed tab behavior unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
- pnpm exec oxlint src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This reuses existing mount guard behavior in two floating-terminal setup surfaces. It does not change terminal/browser/editor tab operations, orchestration setup markers, shortcut handling, or CLI IPC semantics.