### PR TITLE
fix: guard skills page async state

### DIFF
--- a/src/renderer/src/components/skills/SkillsPage.tsx
+++ b/src/renderer/src/components/skills/SkillsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowLeft, BookOpen, Clock, FolderOpen, Loader2, RefreshCw, Search } from 'lucide-react'
 import { toast } from 'sonner'
 import { Badge } from '@/components/ui/badge'
@@ -15,6 +15,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import type {
   DiscoveredSkill,
   SkillDiscoveryResult,
@@ -181,22 +182,30 @@ export default function SkillsPage(): React.JSX.Element {
     sourceKind: 'all',
     provider: 'all'
   })
+  const mountedRef = useMountedRef()
 
-  const loadSkills = async (): Promise<void> => {
+  const loadSkills = useCallback(async (): Promise<void> => {
     setLoading(true)
     try {
-      setResult(await window.api.skills.discover())
+      const nextResult = await window.api.skills.discover()
+      if (mountedRef.current) {
+        setResult(nextResult)
+      }
     } catch (error) {
       console.error('Failed to discover skills:', error)
-      toast.error('Could not scan local skills')
+      if (mountedRef.current) {
+        toast.error('Could not scan local skills')
+      }
     } finally {
-      setLoading(false)
+      if (mountedRef.current) {
+        setLoading(false)
+      }
     }
-  }
+  }, [mountedRef])
 
   useEffect(() => {
     void loadSkills()
-  }, [])
+  }, [loadSkills])
 
   useEffect(() => {
     const hasVisibleOverlay = (): boolean =>


### PR DESCRIPTION
## Summary
- Guard the Skills page discovery result, loading state, and error toast after the page unmounts.
- Stabilize the discovery callback used by initial load and manual refresh.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local Skills page UI state after the existing discovery IPC resolves.
- Skill discovery behavior, filtering, file reveal actions, IPC contracts, and SSH behavior are unchanged.

## Validation
- `pnpm exec oxlint src/renderer/src/components/skills/SkillsPage.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)