### PR TITLE
perf: reuse mounted ref in daemon actions

### DIFF
--- a/src/renderer/src/components/shared/useDaemonActions.tsx
+++ b/src/renderer/src/components/shared/useDaemonActions.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { toast } from 'sonner'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -39,14 +40,7 @@ export type DaemonActionsApi = {
 export function useDaemonActions(callbacks?: DaemonActionCallbacks): DaemonActionsApi {
   const [pending, setPending] = useState<PendingConfirm>(null)
   const [busyKind, setBusyKind] = useState<DaemonActionKind | null>(null)
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
+  const mountedRef = useMountedRef()
 
   const clearPendingAction = useCallback((): void => {
     if (!mountedRef.current) {
@@ -54,7 +48,7 @@ export function useDaemonActions(callbacks?: DaemonActionCallbacks): DaemonActio
     }
     setBusyKind(null)
     setPending(null)
-  }, [])
+  }, [mountedRef])
 
   const runRestart = useCallback(async () => {
     setBusyKind('restart')
@@ -75,7 +69,7 @@ export function useDaemonActions(callbacks?: DaemonActionCallbacks): DaemonActio
         callbacks?.onRestartSettled?.()
       }
     }
-  }, [callbacks, clearPendingAction])
+  }, [callbacks, clearPendingAction, mountedRef])
 
   const runKillAll = useCallback(async () => {
     setBusyKind('killAll')
@@ -106,7 +100,7 @@ export function useDaemonActions(callbacks?: DaemonActionCallbacks): DaemonActio
         callbacks?.onKillAllSettled?.()
       }
     }
-  }, [callbacks, clearPendingAction])
+  }, [callbacks, clearPendingAction, mountedRef])
 
   const runConfirmed = useCallback(() => {
     if (pending === 'restart') {


### PR DESCRIPTION
## Summary
- replace the duplicated cleanup-only mounted guard Effect in useDaemonActions with useMountedRef
- keep restart/kill-all callbacks, toasts, and caller lifecycle hooks unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/shared/useDaemonActions.tsx
- pnpm exec oxlint src/renderer/src/components/shared/useDaemonActions.tsx
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This is a mechanical replacement of local mount bookkeeping around existing daemon action async guards. It does not change daemon IPC calls, confirm dialog state, or caller rollback/settled callbacks.