### PR TITLE
Suppress recoverable child process crash prompts

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -146,6 +146,24 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'child',
+        processType: 'GPU',
+        reason: 'abnormal-exit',
+        exitCode: 512,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'abnormal-exit',
+        exitCode: 8704,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
         processType: 'Utility',
         serviceName: 'network.mojom.NetworkService',
         reason: 'killed',
@@ -158,6 +176,26 @@ describe('shouldRecordProcessGoneCrash', () => {
         source: 'child',
         processType: 'Utility',
         serviceName: 'network.mojom.NetworkService',
+        reason: 'crashed',
+        exitCode: -1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'audio.mojom.AudioService',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'none'
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'audio.mojom.AudioService',
         reason: 'crashed',
         exitCode: -1,
         expectedTeardown: 'none'

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -3,8 +3,11 @@ export type ExpectedTeardownScope = 'none' | 'renderer-reload' | 'app-shutdown'
 
 const WINDOWS_CONTROL_TERMINATION_EXIT_CODES = new Set([0xc000013a, 0x40010004])
 const RECOVERABLE_CHILD_PROCESS_TYPES = new Set(['gpu'])
-const RECOVERABLE_UTILITY_SERVICE_NAMES = new Set(['network.mojom.NetworkService'])
-const RECOVERABLE_CHILD_PROCESS_REASONS = new Set(['crashed', 'killed'])
+const RECOVERABLE_UTILITY_SERVICE_NAMES = new Set([
+  'audio.mojom.AudioService',
+  'network.mojom.NetworkService'
+])
+const RECOVERABLE_CHILD_PROCESS_REASONS = new Set(['abnormal-exit', 'crashed', 'killed'])
 
 function isWindowsControlTerminationExitCode(exitCode: number | null): boolean {
   if (exitCode === null) {
@@ -56,8 +59,8 @@ export function shouldRecordProcessGoneCrash({
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
 }): boolean {
-  // Why: GPU and Network Service exits are recoverable Chromium child-process
-  // churn; treating them as app crashes creates noisy user prompts.
+  // Why: GPU, Network Service, and Audio Service exits are recoverable Chromium
+  // child-process churn; treating them as app crashes creates noisy user prompts.
   if (isRecoverableChromiumChildProcess({ source, processType, serviceName, reason })) {
     return false
   }


### PR DESCRIPTION
## Summary
- suppress recoverable Chromium Audio Service utility exits in process-gone crash reporting
- suppress recoverable GPU `abnormal-exit` child-process exits, matching the recent Slack crash-report cluster
- keep unknown child crashes, severe child failures, and renderer crashes reportable

## Crash scan context
- scanned 92 Slack uploads from 2026-05-23 through 2026-05-30 in C0B4PDCMPPT; ledger is local only under `tmp/` and intentionally not committed
- current code/PR #2762 already covers recoverable GPU crashed/killed and Network Service exits
- this PR covers the remaining low-risk child-process false positives: Audio Service `killed/1` / `crashed/-1`, and GPU `abnormal-exit` exits (`512`, `8704`)

## Risk
Low. This only expands the existing recoverable Chromium child-process suppression list. Renderer crashes and unknown/severe child-process failures still record crash reports.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/crash-reporting/crash-report-store.test.ts src/main/crash-reporting/crash-breadcrumb-store.test.ts src/shared/crash-reporting.test.ts src/main/ipc/crash-reporting.test.ts`
- `pnpm run typecheck:node`
- Electron CDP best-effort repro: terminal Ctrl+C/new terminal, Settings > AI Provider Accounts, and Orca Mobile page stayed up with 0 console errors
