### PR TITLE
fix: guard onboarding notification async state

### DIFF
--- a/src/renderer/src/components/onboarding/NotificationStep.tsx
+++ b/src/renderer/src/components/onboarding/NotificationStep.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/select'
 import { sendNotificationSettingsTestNotification } from '@/components/settings/NotificationsPane'
 import { getNotificationSoundOptions } from '@/components/notification-sound-options'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import logo from '../../../../../resources/logo.svg'
 
 export type NotificationDraft = {
@@ -51,6 +52,7 @@ export function NotificationStep({
   const [showMacSettingsPreview, setShowMacSettingsPreview] = useState(false)
   const [selectPortalRoot, setSelectPortalRoot] = useState<HTMLElement | null>(null)
   const syncedNotificationSettingsRef = useRef(notificationSettings)
+  const mountedRef = useMountedRef()
 
   if (syncedNotificationSettingsRef.current !== notificationSettings) {
     syncedNotificationSettingsRef.current = notificationSettings
@@ -100,7 +102,9 @@ export function NotificationStep({
   const handleMacPermission = async (): Promise<void> => {
     setShowMacSettingsPreview(true)
     const status = await window.api.notifications.requestPermission()
-    setPermissionStatus(status)
+    if (mountedRef.current) {
+      setPermissionStatus(status)
+    }
     await window.api.notifications.openSystemSettings()
   }
 
@@ -115,7 +119,9 @@ export function NotificationStep({
       volume: getCustomSoundVolume()
     })
     if (!result.played) {
-      toast.error('Notification sound could not be played')
+      if (mountedRef.current) {
+        toast.error('Notification sound could not be played')
+      }
     }
   }
 
@@ -128,7 +134,9 @@ export function NotificationStep({
         await previewSound('custom')
       }
     } finally {
-      setIsPickingSound(false)
+      if (mountedRef.current) {
+        setIsPickingSound(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard onboarding notification permission status after the permission request resolves.
- Guard custom sound picker state and preview error toast after the onboarding step unmounts.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local onboarding notification UI state/toasts after existing async calls resolve.
- Notification settings persistence, sound playback, OS settings launch behavior, IPC contracts, and SSH behavior are unchanged.

## Validation
- `pnpm exec oxlint src/renderer/src/components/onboarding/NotificationStep.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)