### PR TITLE
perf: reuse mounted ref in connect dialogs

### DIFF
--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ExternalLink, Github, Loader2, Terminal } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { Button } from '@/components/ui/button'
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
 import { IntegrationStatusPill } from '@/components/integration-status-pill'
 import { cn } from '@/lib/utils'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { OnboardingInlineCommandTerminal } from './OnboardingInlineCommandTerminal'
 
 type GitHubSetupState = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
@@ -123,14 +124,7 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
   const [apiKeyDraft, setApiKeyDraft] = useState('')
   const [connectState, setConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
   const [connectError, setConnectError] = useState<string | null>(null)
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
+  const mountedRef = useMountedRef()
 
   const workspaceCount = linearStatus.workspaces?.length ?? (linearStatus.connected ? 1 : 0)
 

--- a/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
+++ b/src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Loader2, Server, ServerOff } from 'lucide-react'
 import {
@@ -10,6 +10,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { statusColor } from '@/components/settings/SshTargetCard'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
 
@@ -41,14 +42,7 @@ export function SshDisconnectedDialog({
   status
 }: SshDisconnectedDialogProps): React.JSX.Element {
   const [connecting, setConnecting] = useState(false)
-  const mountedRef = useRef(true)
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
+  const mountedRef = useMountedRef()
 
   const handleReconnect = useCallback(async () => {
     setConnecting(true)
@@ -64,7 +58,7 @@ export function SshDisconnectedDialog({
         setConnecting(false)
       }
     }
-  }, [targetId, onOpenChange])
+  }, [mountedRef, targetId, onOpenChange])
 
   const isConnecting =
     connecting ||


### PR DESCRIPTION
## Summary
- replace cleanup-only mounted guard Effects in the Linear onboarding row and SSH disconnected dialog with useMountedRef
- keep the SSH dialog Enter-key listener Effect and reconnect behavior unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/onboarding/IntegrationsStep.tsx src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
- pnpm exec oxlint src/renderer/src/components/onboarding/IntegrationsStep.tsx src/renderer/src/components/sidebar/SshDisconnectedDialog.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/linear.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/lib/new-workspace-ssh-gate.test.ts src/renderer/src/components/sidebar/AddRepoSetupStep.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This is a mechanical replacement of local mount bookkeeping around existing async guards. It does not change Linear connection state handling, SSH reconnect IPC, or the dialog-level keyboard listener.