### PR TITLE
Fix browser address bar paths with spaces

### DIFF
--- a/src/shared/browser-url.test.ts
+++ b/src/shared/browser-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { ORCA_BROWSER_BLANK_URL } from './constants'
 import {
   buildSearchUrl,
+  looksLikeSearchQuery,
   normalizeKagiSessionLink,
   normalizeBrowserNavigationUrl,
   normalizeExternalBrowserUrl,
@@ -39,8 +40,14 @@ describe('browser-url helpers', () => {
     expect(normalizeBrowserNavigationUrl('/Users/me/Downloads/Example.ipynb')).toBe(
       'file:///Users/me/Downloads/Example.ipynb'
     )
+    expect(normalizeBrowserNavigationUrl('/Users/me/Application Support/Example.ipynb')).toBe(
+      'file:///Users/me/Application%20Support/Example.ipynb'
+    )
     expect(normalizeBrowserNavigationUrl('C:\\Users\\me\\Downloads\\Example.ipynb')).toBe(
       'file:///C:/Users/me/Downloads/Example.ipynb'
+    )
+    expect(normalizeBrowserNavigationUrl('C:\\Program Files\\Orca\\Example.ipynb')).toBe(
+      'file:///C:/Program%20Files/Orca/Example.ipynb'
     )
   })
 
@@ -68,6 +75,14 @@ describe('browser-url helpers', () => {
     )
     expect(normalizeBrowserNavigationUrl('singleword', null)).toBe(
       'https://www.google.com/search?q=singleword'
+    )
+  })
+
+  it('does not classify absolute local paths with spaces as search queries', () => {
+    expect(looksLikeSearchQuery('/Users/me/Application Support/Example.ipynb')).toBe(false)
+    expect(looksLikeSearchQuery('C:\\Program Files\\Orca\\Example.ipynb')).toBe(false)
+    expect(normalizeBrowserNavigationUrl('/Users/me/Application Support/Example.ipynb', null)).toBe(
+      'file:///Users/me/Application%20Support/Example.ipynb'
     )
   })
 

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -8,8 +8,10 @@ const LOCAL_ADDRESS_PATTERN =
 // A single-word input containing a dot with a valid TLD-like suffix is treated as
 // a URL attempt, not a search query.
 const LOOKS_LIKE_URL_PATTERN = /^[^\s]+\.[a-z]{2,}(\/.*)?$/i
-const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/][^\s]*$/
-const UNIX_ABSOLUTE_PATH_PATTERN = /^\/[^\s]*$/
+// Why: users often paste paths under "Application Support" or "Program Files".
+// Trim edges, but preserve internal spaces while detecting absolute paths.
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/].*$/
+const UNIX_ABSOLUTE_PATH_PATTERN = /^\/.*$/
 
 export type SearchEngine = 'google' | 'duckduckgo' | 'bing' | 'kagi'
 
@@ -121,13 +123,17 @@ export function buildSearchUrl(
 }
 
 export function looksLikeSearchQuery(input: string): boolean {
-  if (input.includes(' ')) {
-    return true
-  }
-  if (LOOKS_LIKE_URL_PATTERN.test(input)) {
+  const trimmed = input.trim()
+  if (UNIX_ABSOLUTE_PATH_PATTERN.test(trimmed) || WINDOWS_ABSOLUTE_PATH_PATTERN.test(trimmed)) {
     return false
   }
-  if (input.includes('.') || input.includes(':')) {
+  if (trimmed.includes(' ')) {
+    return true
+  }
+  if (LOOKS_LIKE_URL_PATTERN.test(trimmed)) {
+    return false
+  }
+  if (trimmed.includes('.') || trimmed.includes(':')) {
     return false
   }
   return true


### PR DESCRIPTION
## Summary
- Treat absolute POSIX and Windows paths with internal spaces as local file paths instead of search queries.
- Keep address-bar suggestions aligned with the URL normalization path so Enter opens `file://` for pasted local paths.
- Add regression coverage for `Application Support` and `Program Files` style paths.

## Reproduction Evidence
Before the fix, typing `/tmp/orca bug scanner evidence/space path.html` in the in-app browser address bar opened a Google search URL:

`https://www.google.com/search?q=%2Ftmp%2Forca%20bug%20scanner%20evidence%2Fspace%20path.html`

After the fix, the same flow opens:

`file:///tmp/orca%20bug%20scanner%20evidence/space%20path.html`

Screenshot evidence captured locally at `/tmp/orca-browser-space-path-fixed.png` and will be attached in a PR comment.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-url.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/browser-url.ts src/shared/browser-url.test.ts`
- Electron verification via CDP on `nwparker/bug-scanner`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.