### PR TITLE
fix: guard mobile pane async state

### DIFF
--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { useAppStore } from '../../store'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { useMobilePairingDevicePolling } from './mobile-pairing-device-polling'
 import {
   selectRefreshedNetworkAddress,
@@ -53,9 +54,10 @@ export function MobilePane(): React.JSX.Element {
   const [refreshingNetworkInterfaces, setRefreshingNetworkInterfaces] = useState(false)
   const [codeCopied, setCodeCopied] = useState(false)
   const codeCopiedResetTimerRef = useRef<number | null>(null)
+  const mountedRef = useMountedRef()
   // Why: clipboard IPC can resolve after settings navigation; avoid starting
   // a reset timer that will outlive this pane.
-  const isMountedRef = useRef(false)
+  const pairingCodeButtonMountedRef = useRef(false)
 
   const clearCodeCopiedResetTimer = useCallback((): void => {
     if (codeCopiedResetTimerRef.current !== null) {
@@ -66,7 +68,7 @@ export function MobilePane(): React.JSX.Element {
 
   const setPairingCodeButtonRef = useCallback(
     (node: HTMLButtonElement | null) => {
-      isMountedRef.current = node !== null
+      pairingCodeButtonMountedRef.current = node !== null
       if (node === null) {
         clearCodeCopiedResetTimer()
       }
@@ -77,28 +79,37 @@ export function MobilePane(): React.JSX.Element {
   const loadDevices = useCallback(async () => {
     try {
       const result = await window.api.mobile.listDevices()
-      setDevices(result.devices)
+      if (mountedRef.current) {
+        setDevices(result.devices)
+      }
     } catch {
       // Silently fail — device list is non-critical
     }
-  }, [])
+  }, [mountedRef])
 
-  const loadNetworkInterfaces = useCallback(async (opts: { notifyOnError?: boolean } = {}) => {
-    setRefreshingNetworkInterfaces(true)
-    try {
-      const result = await window.api.mobile.listNetworkInterfaces()
-      setNetworkInterfaces(result.interfaces)
-      setSelectedAddress((currentAddress) =>
-        selectRefreshedNetworkAddress(currentAddress, result.interfaces)
-      )
-    } catch {
-      if (opts.notifyOnError) {
-        toast.error('Failed to refresh network interfaces')
+  const loadNetworkInterfaces = useCallback(
+    async (opts: { notifyOnError?: boolean } = {}) => {
+      setRefreshingNetworkInterfaces(true)
+      try {
+        const result = await window.api.mobile.listNetworkInterfaces()
+        if (mountedRef.current) {
+          setNetworkInterfaces(result.interfaces)
+          setSelectedAddress((currentAddress) =>
+            selectRefreshedNetworkAddress(currentAddress, result.interfaces)
+          )
+        }
+      } catch {
+        if (opts.notifyOnError && mountedRef.current) {
+          toast.error('Failed to refresh network interfaces')
+        }
+      } finally {
+        if (mountedRef.current) {
+          setRefreshingNetworkInterfaces(false)
+        }
       }
-    } finally {
-      setRefreshingNetworkInterfaces(false)
-    }
-  }, [])
+    },
+    [mountedRef]
+  )
 
   const generateQR = useCallback(
     async (opts: { rotate?: boolean } = {}) => {
@@ -113,22 +124,30 @@ export function MobilePane(): React.JSX.Element {
         })
         if (result.available) {
           useAppStore.getState().recordFeatureInteraction('mobile-pairing')
-          setQrDataUrl(result.qrDataUrl)
-          setPairingUrl(result.pairingUrl)
-          setEndpoint(result.endpoint)
-          clearCodeCopiedResetTimer()
-          setCodeCopied(false)
-          void loadDevices()
+          if (mountedRef.current) {
+            setQrDataUrl(result.qrDataUrl)
+            setPairingUrl(result.pairingUrl)
+            setEndpoint(result.endpoint)
+            clearCodeCopiedResetTimer()
+            setCodeCopied(false)
+            void loadDevices()
+          }
         } else {
-          toast.error('WebSocket transport is not running')
+          if (mountedRef.current) {
+            toast.error('WebSocket transport is not running')
+          }
         }
       } catch {
-        toast.error('Failed to generate QR code')
+        if (mountedRef.current) {
+          toast.error('Failed to generate QR code')
+        }
       } finally {
-        setLoading(false)
+        if (mountedRef.current) {
+          setLoading(false)
+        }
       }
     },
-    [clearCodeCopiedResetTimer, loadDevices, selectedAddress]
+    [clearCodeCopiedResetTimer, loadDevices, mountedRef, selectedAddress]
   )
 
   useEffect(() => {
@@ -162,7 +181,7 @@ export function MobilePane(): React.JSX.Element {
       // (no transient activation, non-secure context). Use the main-process
       // IPC clipboard which the rest of the app uses everywhere.
       await window.api.ui.writeClipboardText(pairingUrl)
-      if (!isMountedRef.current) {
+      if (!pairingCodeButtonMountedRef.current) {
         return
       }
       clearCodeCopiedResetTimer()
@@ -172,17 +191,23 @@ export function MobilePane(): React.JSX.Element {
         setCodeCopied(false)
       }, 2000)
     } catch {
-      toast.error('Failed to copy pairing code')
+      if (mountedRef.current) {
+        toast.error('Failed to copy pairing code')
+      }
     }
   }
 
   async function revokeDevice(deviceId: string) {
     try {
       await window.api.mobile.revokeDevice({ deviceId })
-      setDevices((prev) => prev.filter((d) => d.deviceId !== deviceId))
-      toast.success('Device revoked')
+      if (mountedRef.current) {
+        setDevices((prev) => prev.filter((d) => d.deviceId !== deviceId))
+        toast.success('Device revoked')
+      }
     } catch {
-      toast.error('Failed to revoke device')
+      if (mountedRef.current) {
+        toast.error('Failed to revoke device')
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard Mobile settings device/network/QR completion state after settings navigation unmounts the pane.
- Keep pairing-code copy timer tied to the mounted copy button while guarding copy/revoke toasts.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Scope is limited to local Mobile settings pane state and toasts after existing mobile IPC calls resolve.
- Pairing QR/token creation, device revoke behavior, network selection logic, IPC contracts, and SSH behavior are unchanged.
- Existing timers are still cleared when the pairing-code button unmounts.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/MobilePane.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)