### PR TITLE
perf: keep hidden terminal output off typing path

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2894,6 +2894,158 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('holds background PTY output briefly after foreground input', async () => {
+    vi.useFakeTimers()
+    const activeProc = createMockProc()
+    const backgroundProc = createMockProc()
+    spawnMock.mockReturnValueOnce(activeProc.proc).mockReturnValueOnce(backgroundProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const activeSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const backgroundSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+      mainWindow.webContents.send.mockClear()
+
+      backgroundProc.emitData('background output')
+      writeListener(null, {
+        id: activeSpawn.id,
+        data: 'a'
+      })
+
+      vi.advanceTimersByTime(8)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+
+      activeProc.emitData('\x1b[20;2Hredraw')
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: activeSpawn.id,
+        data: '\x1b[20;2Hredraw'
+      })
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+
+      vi.advanceTimersByTime(41)
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+
+      vi.advanceTimersByTime(1)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not hold foreground PTY batch output behind background output', async () => {
+    vi.useFakeTimers()
+    const activeProc = createMockProc()
+    const backgroundProc = createMockProc()
+    spawnMock.mockReturnValueOnce(activeProc.proc).mockReturnValueOnce(backgroundProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const activeSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const backgroundSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+      mainWindow.webContents.send.mockClear()
+
+      backgroundProc.emitData('background output')
+      writeListener(null, {
+        id: activeSpawn.id,
+        data: 'a'
+      })
+      const foregroundOutput = 'x'.repeat(1025)
+      activeProc.emitData(foregroundOutput)
+
+      vi.advanceTimersByTime(8)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: activeSpawn.id,
+        data: foregroundOutput
+      })
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not starve background PTY output during continuous input', async () => {
+    vi.useFakeTimers()
+    const activeProc = createMockProc()
+    const backgroundProc = createMockProc()
+    spawnMock.mockReturnValueOnce(activeProc.proc).mockReturnValueOnce(backgroundProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const activeSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const backgroundSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writeListener = getPtyWriteListener()
+      mainWindow.webContents.send.mockClear()
+
+      backgroundProc.emitData('background output')
+      for (let index = 0; index < 7; index++) {
+        writeListener(null, {
+          id: activeSpawn.id,
+          data: 'a'
+        })
+        vi.advanceTimersByTime(40)
+      }
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+
+      writeListener(null, {
+        id: activeSpawn.id,
+        data: 'a'
+      })
+      vi.advanceTimersByTime(10)
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: backgroundSpawn.id,
+        data: 'background output'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('ignores PTY input for unknown sessions', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -930,6 +930,11 @@ export function registerPtyHandlers(
   // large output and non-interactive output must still use the batcher.
   const INTERACTIVE_OUTPUT_WINDOW_MS = 100
   const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
+  const BACKGROUND_OUTPUT_INPUT_QUIET_MS = 50
+  const BACKGROUND_OUTPUT_MAX_INPUT_HOLD_MS = 250
+  let lastRendererInputAt = Number.NEGATIVE_INFINITY
+  let lastRendererInputPtyId: string | null = null
+  let backgroundFlushHeldSince: number | null = null
 
   function getChunkStartSeq(endSeq: number | undefined, data: string): number | undefined {
     return typeof endSeq === 'number' ? Math.max(0, endSeq - data.length) : undefined
@@ -972,15 +977,32 @@ export function registerPtyHandlers(
     flushTimer = setTimeout(flushPendingData, delayMs)
   }
 
-  function flushPendingData(): void {
-    flushTimer = null
-    if (mainWindow.isDestroyed()) {
-      pendingData.clear()
-      return
+  function hasRecentRendererInput(now: number): boolean {
+    return now - lastRendererInputAt < BACKGROUND_OUTPUT_INPUT_QUIET_MS
+  }
+
+  function hasPendingDataOutsideRecentInputPty(): boolean {
+    for (const id of pendingData.keys()) {
+      if (id !== lastRendererInputPtyId) {
+        return true
+      }
     }
+    return false
+  }
+
+  function drainPendingDataEntries(
+    maxWrites: number,
+    shouldDrain: (id: string) => boolean = () => true
+  ): number {
     let writes = 0
-    while (pendingData.size > 0 && writes < PTY_BATCH_FLUSH_MAX_WRITES) {
-      const next = pendingData.entries().next().value
+    while (writes < maxWrites) {
+      let next: [string, PendingPtyData] | undefined
+      for (const entry of pendingData.entries()) {
+        if (shouldDrain(entry[0])) {
+          next = entry
+          break
+        }
+      }
       if (!next) {
         break
       }
@@ -998,6 +1020,51 @@ export function registerPtyHandlers(
       }
       mainWindow.webContents.send('pty:data', makePtyDataPayload(id, chunk, pending.startSeq))
       writes++
+    }
+    return writes
+  }
+
+  function shouldHoldBackgroundFlushForInput(now: number): boolean {
+    if (
+      pendingData.size === 0 ||
+      !hasRecentRendererInput(now) ||
+      !hasPendingDataOutsideRecentInputPty()
+    ) {
+      backgroundFlushHeldSince = null
+      return false
+    }
+    backgroundFlushHeldSince ??= now
+    if (now - backgroundFlushHeldSince >= BACKGROUND_OUTPUT_MAX_INPUT_HOLD_MS) {
+      backgroundFlushHeldSince = null
+      return false
+    }
+    return true
+  }
+
+  function flushPendingData(): void {
+    flushTimer = null
+    if (mainWindow.isDestroyed()) {
+      pendingData.clear()
+      return
+    }
+    const now = performance.now()
+    let writes = 0
+    if (hasRecentRendererInput(now) && lastRendererInputPtyId !== null) {
+      writes += drainPendingDataEntries(
+        PTY_BATCH_FLUSH_MAX_WRITES,
+        (id) => id === lastRendererInputPtyId
+      )
+    }
+    if (shouldHoldBackgroundFlushForInput(now)) {
+      // Why: hidden PTYs can keep producing output while the user types in a
+      // foreground TUI. Holding background IPC briefly lets those bytes
+      // coalesce instead of flooding the renderer ahead of key echo frames.
+      const quietDelay = Math.max(1, BACKGROUND_OUTPUT_INPUT_QUIET_MS - (now - lastRendererInputAt))
+      schedulePendingDataFlush(quietDelay)
+      return
+    }
+    if (writes < PTY_BATCH_FLUSH_MAX_WRITES) {
+      writes += drainPendingDataEntries(PTY_BATCH_FLUSH_MAX_WRITES - writes)
     }
     if (pendingData.size > 0) {
       // Why: a background terminal can dump megabytes at once. Yield between
@@ -1093,6 +1160,9 @@ export function registerPtyHandlers(
           pendingData.delete(payload.id)
         }
         lastInputAtByPty.delete(payload.id)
+        if (lastRendererInputPtyId === payload.id) {
+          lastRendererInputPtyId = null
+        }
         mainWindow.webContents.send('pty:exit', payload)
       }
     })
@@ -2065,7 +2135,10 @@ export function registerPtyHandlers(
       return false
     }
     try {
-      lastInputAtByPty.set(args.id, performance.now())
+      const now = performance.now()
+      lastRendererInputAt = now
+      lastRendererInputPtyId = args.id
+      lastInputAtByPty.set(args.id, now)
       provider.write(args.id, args.data)
       return true
     } catch {
@@ -2089,7 +2162,10 @@ export function registerPtyHandlers(
       return false
     }
     try {
-      lastInputAtByPty.set(args.id, performance.now())
+      const now = performance.now()
+      lastRendererInputAt = now
+      lastRendererInputPtyId = args.id
+      lastInputAtByPty.set(args.id, now)
       provider.write(args.id, args.data)
       return true
     } catch {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -2586,18 +2586,42 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('routes visible pane PTY bytes through the background scheduler when the document is hidden', async () => {
-    ;(globalThis as { document?: Pick<Document, 'visibilityState'> }).document = {
-      visibilityState: 'hidden'
+  it('restores visible pane PTY bytes from the main snapshot when the document was hidden', async () => {
+    const visibilityListeners = new Set<() => void>()
+    const documentStub = {
+      visibilityState: 'hidden' as DocumentVisibilityState,
+      addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'visibilitychange' && typeof listener === 'function') {
+          visibilityListeners.add(listener as () => void)
+        }
+      }),
+      removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'visibilitychange' && typeof listener === 'function') {
+          visibilityListeners.delete(listener as () => void)
+        }
+      })
     }
+    ;(globalThis as { document?: Document }).document = documentStub as unknown as Document
     const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport()
-    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
       return 'pty-id'
     })
     transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const backgroundedOutput = 'backgrounded document output\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: backgroundedOutput,
+      cols: 120,
+      rows: 40,
+      seq: backgroundedOutput.length
+    })
 
     const pane = createPane(1)
     const manager = createManager(1)
@@ -2611,15 +2635,73 @@ describe('connectPanePty', () => {
 
     expect(capturedDataCallback.current).not.toBeNull()
     vi.useFakeTimers()
-    capturedDataCallback.current?.('backgrounded document output\r\n')
+    capturedDataCallback.current?.(backgroundedOutput, {
+      seq: backgroundedOutput.length,
+      rawLength: backgroundedOutput.length
+    })
 
-    expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      'backgrounded document output\r\n',
-      expect.any(Function)
-    )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(backgroundedOutput, expect.any(Function))
 
     vi.advanceTimersByTime(50)
-    expect(pane.terminal.write).toHaveBeenCalledWith('backgrounded document output\r\n')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(backgroundedOutput, expect.any(Function))
+
+    documentStub.visibilityState = 'visible'
+    for (const listener of visibilityListeners) {
+      listener()
+    }
+    await flushAsyncTicks(20)
+
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    expect(pane.terminal.write).toHaveBeenCalledWith(backgroundedOutput, expect.any(Function))
+  })
+
+  it('restores ordinary hidden pane output from the main snapshot on foreground output', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'hidden output\r\n'
+    const live = 'visible-after\r\n'
+    getMainBufferSnapshot.mockResolvedValue({
+      data: `${hidden}${live}`,
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + live.length
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    vi.useFakeTimers()
+    vi.advanceTimersByTime(50)
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden, expect.any(Function))
+
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    expect(pane.terminal.write).toHaveBeenCalledWith(`${hidden}${live}`, expect.any(Function))
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden, expect.any(Function))
+    disposable.dispose()
   })
 
   it('restores hidden backlog overflow from the main terminal snapshot on foreground output', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1354,6 +1354,13 @@ export function connectPanePty(
     }
 
     function writePtyOutputToXterm(data: string, foreground: boolean): void {
+      if (!foreground && canUseMainBufferSnapshot(transport.getPtyId())) {
+        // Why: hidden panes do not need live xterm parsing. Main already
+        // retains the PTY buffer, so defer display work until the pane is
+        // visible and restore from that snapshot instead.
+        markHiddenOutputRestoreNeeded()
+        return
+      }
       writeTerminalOutput(pane.terminal, data, {
         foreground,
         beforeWrite: beforeTerminalOutputWrite,


### PR DESCRIPTION
## Summary
- prioritize output from the PTY that just received renderer input, while briefly coalescing other PTY output with a starvation cap
- stop live-writing hidden terminal output into xterm when main-buffer snapshots are available, then restore from the snapshot when the pane becomes visible/foregrounded
- add focused coverage for foreground prioritization, background starvation protection, and hidden-pane snapshot restore behavior

## Risk
Low. The change is scoped to terminal output delivery/rendering, keeps foreground PTY output immediate, caps background holds, and leaves remote runtime PTYs without main-buffer snapshots on the existing background path.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts`
