### PR TITLE
perf: reuse mounted ref in browser toolbar menu

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { Check, Ellipsis, Import, Monitor, Plus, Settings } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -25,6 +25,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useAppStore } from '@/store'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { BROWSER_FAMILY_LABELS } from '../../../../shared/constants'
 import type { BrowserViewportPresetId } from '../../../../shared/types'
 import {
@@ -71,7 +72,7 @@ export function BrowserToolbarMenu({
   const [pendingSwitchProfileId, setPendingSwitchProfileId] = useState<string | null | undefined>(
     undefined
   )
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
 
   const effectiveProfileId = currentProfileId ?? 'default'
 
@@ -81,13 +82,6 @@ export function BrowserToolbarMenu({
   const allProfiles = defaultProfile
     ? [defaultProfile, ...browserSessionProfiles.filter((p) => p.id !== 'default')]
     : browserSessionProfiles
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const handleSwitchProfile = (profileId: string | null): void => {
     const targetId = profileId ?? 'default'


### PR DESCRIPTION
## Summary
- replace the browser toolbar profile menu cleanup-only mounted guard Effect with useMountedRef
- keep profile creation, import, viewport preset, and webview destruction behavior unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
- pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/browser.test.ts src/renderer/src/runtime/web-runtime-session.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This is a mechanical replacement of local mount bookkeeping around existing browser-profile async guards. It does not change profile creation/switching, cookie import, viewport overrides, or webview lifecycle semantics.