### PR TITLE
perf: reuse mounted ref in ssh status row

### DIFF
--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { AlertTriangle, Cloud, Loader2, MonitorSmartphone, Server, ServerOff } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '../../store'
 import { STATUS_LABELS, statusColor } from '../settings/SshTargetCard'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
@@ -113,15 +114,8 @@ function TargetRow({
   syncStatus: RemoteWorkspaceSyncStatus | undefined
 }): React.JSX.Element {
   const [busy, setBusy] = useState(false)
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const handleConnect = useCallback(async () => {
     setBusy(true)
@@ -135,7 +129,7 @@ function TargetRow({
         setBusy(false)
       }
     }
-  }, [recordFeatureInteraction, targetId])
+  }, [mountedRef, recordFeatureInteraction, targetId])
 
   const handleDisconnect = useCallback(async () => {
     setBusy(true)
@@ -149,7 +143,7 @@ function TargetRow({
         setBusy(false)
       }
     }
-  }, [recordFeatureInteraction, targetId])
+  }, [mountedRef, recordFeatureInteraction, targetId])
 
   return (
     <div className="flex items-center gap-2.5 px-2 py-1.5">


### PR DESCRIPTION
## Summary
- replace the SSH status target row cleanup-only mounted guard Effect with useMountedRef
- keep connect/disconnect IPC, busy state, and SSH feature interaction tracking unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/status-bar/SshStatusSegment.tsx
- pnpm exec oxlint src/renderer/src/components/status-bar/SshStatusSegment.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This is a mechanical replacement of local mount bookkeeping around existing SSH connect/disconnect async guards. It does not change SSH IPC calls, status rendering, or feature-interaction telemetry.