### PR TITLE
perf: reuse mounted ref in resource usage status

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -28,6 +28,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
@@ -695,7 +696,7 @@ export function ResourceUsageStatusSegment({
   // somewhere stable for keyboard users.
   const popoverBodyRef = useRef<HTMLDivElement | null>(null)
   const popoverBodyFocusFrameRef = useRef<number | null>(null)
-  const mountedRef = useRef(true)
+  const mountedRef = useMountedRef()
 
   const cancelPopoverBodyFocusFrame = useCallback((): void => {
     if (popoverBodyFocusFrameRef.current === null) {
@@ -706,13 +707,6 @@ export function ResourceUsageStatusSegment({
   }, [])
 
   useEffect(() => cancelPopoverBodyFocusFrame, [cancelPopoverBodyFocusFrame])
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
 
   const setPopoverBodyNode = useCallback(
     (node: HTMLDivElement | null): void => {
@@ -745,7 +739,7 @@ export function ResourceUsageStatusSegment({
         setSessionsError(true)
       }
     }
-  }, [runtimeEnvironmentActive])
+  }, [mountedRef, runtimeEnvironmentActive])
 
   const daemonActions = useDaemonActions({
     onRestartSettled: () => {
@@ -1096,7 +1090,7 @@ export function ResourceUsageStatusSegment({
         void refreshSessions()
       }
     }
-  }, [cancelPopoverBodyFocusFrame, killConfirm, refreshSessions])
+  }, [cancelPopoverBodyFocusFrame, killConfirm, mountedRef, refreshSessions])
 
   const openSpaceResults = useCallback((): void => {
     setOpen(false)


### PR DESCRIPTION
## Summary
- replace the Resource Usage status segment cleanup-only mounted guard Effect with useMountedRef
- keep post-kill focus cleanup, session refresh, daemon action callbacks, and runtime-environment gating unchanged

## Validation
- pnpm exec oxfmt --write src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm exec oxlint src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts src/renderer/src/components/status-bar/resource-usage-open-slices.test.ts src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
- pnpm run typecheck:web
- git diff --check

## Risk
Low. This is a mechanical replacement of local mount bookkeeping around existing resource/session async guards. It does not change daemon IPC, session kill behavior, focus restoration, polling cadence, or resource merge logic.