### PR TITLE
fix: guard mcp config async state

### DIFF
--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { AlertCircle, FileCode2, LoaderCircle, Plus, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import type { Repo, Worktree } from '../../../../shared/types'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 import {
@@ -49,6 +50,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
   const [loading, setLoading] = useState(true)
   const [createConfirm, setCreateConfirm] = useState(false)
   const createConfirmResetTimerRef = useRef<number | null>(null)
+  const mountedRef = useMountedRef()
   const [inspectionUnavailableMessage, setInspectionUnavailableMessage] = useState<string | null>(
     null
   )
@@ -104,25 +106,34 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
   const canCreateStarter = detectedCount === 0 && !inspectionUnavailable
 
   const loadConfigs = useCallback(async (): Promise<void> => {
+    if (!mountedRef.current) {
+      return
+    }
     setLoading(true)
     setInspectionUnavailableMessage(null)
 
     try {
       if (connectionId && sshConnectionStatus !== 'connected') {
-        setConfigs(missingInspections)
-        setInspectionUnavailableMessage('Connect this SSH repo to inspect or add MCP configs.')
+        if (mountedRef.current) {
+          setConfigs(missingInspections)
+          setInspectionUnavailableMessage('Connect this SSH repo to inspect or add MCP configs.')
+        }
         return
       }
 
       if (!connectionId && !canInspectLocalMcpConfigRoot(targetRootPath, isWindows)) {
-        setConfigs(missingInspections)
-        setInspectionUnavailableMessage('This workspace path is not available from this host.')
+        if (mountedRef.current) {
+          setConfigs(missingInspections)
+          setInspectionUnavailableMessage('This workspace path is not available from this host.')
+        }
         return
       }
 
       if (!connectionId && !(await window.api.shell.pathExists(targetRootPath))) {
-        setConfigs(missingInspections)
-        setInspectionUnavailableMessage('This workspace path is not available on disk.')
+        if (mountedRef.current) {
+          setConfigs(missingInspections)
+          setInspectionUnavailableMessage('This workspace path is not available on disk.')
+        }
         return
       }
 
@@ -201,16 +212,22 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
           }
         })
       )
-      setConfigs(next)
+      if (mountedRef.current) {
+        setConfigs(next)
+      }
     } catch (error) {
-      setConfigs(missingInspections)
-      setInspectionUnavailableMessage(
-        extractIpcErrorMessage(error, 'Unable to inspect MCP configs.')
-      )
+      if (mountedRef.current) {
+        setConfigs(missingInspections)
+        setInspectionUnavailableMessage(
+          extractIpcErrorMessage(error, 'Unable to inspect MCP configs.')
+        )
+      }
     } finally {
-      setLoading(false)
+      if (mountedRef.current) {
+        setLoading(false)
+      }
     }
-  }, [connectionId, isWindows, missingInspections, sshConnectionStatus, targetRootPath])
+  }, [connectionId, isWindows, missingInspections, mountedRef, sshConnectionStatus, targetRootPath])
 
   const clearCreateConfirmResetTimer = useCallback((): void => {
     if (createConfirmResetTimerRef.current !== null) {
@@ -246,7 +263,9 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       setCreateConfirm(true)
       createConfirmResetTimerRef.current = window.setTimeout(() => {
         createConfirmResetTimerRef.current = null
-        setCreateConfirm(false)
+        if (mountedRef.current) {
+          setCreateConfirm(false)
+        }
       }, 3000)
       return
     }
@@ -257,7 +276,9 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       // guess per-agent directory layouts or mutate agent-specific files.
       await window.api.fs.writeFile({ filePath: target, content: MCP_STARTER_CONFIG, connectionId })
       clearCreateConfirmResetTimer()
-      setCreateConfirm(false)
+      if (mountedRef.current) {
+        setCreateConfirm(false)
+      }
       await loadConfigs()
       setActiveWorktree(targetWorktreeId)
       const targetGroupId = ensureWorktreeRootGroup(targetWorktreeId)


### PR DESCRIPTION
## Summary
- guard MCP config inspection state updates after the settings section unmounts
- guard the add-config confirmation timer and post-create local confirmation reset
- leave MCP file reads/writes, SSH/local inspection checks, and the post-create file-open flow unchanged

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- renderer-only settings section change
- only component-local loading/config/confirmation state is skipped after unmount
- no filesystem write behavior, SSH path handling, or editor navigation behavior changed

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/McpConfigSection.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)