### PR TITLE
Fix Windows file explorer path matching

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-paths.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-paths.test.ts
@@ -35,4 +35,11 @@ describe('file explorer path helpers', () => {
     ])
     expect(getRevealAncestorDirs('/repo', '/Repo/Src/File.ts')).toBeNull()
   })
+
+  it('builds reveal ancestors for Windows drive-root worktrees', () => {
+    expect(getRevealAncestorDirs('C:\\', 'c:\\repo\\src\\app.ts')).toEqual([
+      'C:\\repo',
+      'C:\\repo\\src'
+    ])
+  })
 })

--- a/src/renderer/src/lib/path.test.ts
+++ b/src/renderer/src/lib/path.test.ts
@@ -26,6 +26,10 @@ describe('getRelativePathInsideRoot', () => {
     expect(getRelativePathInsideRoot('C:\\Repo\\Docs\\Plan.md', 'c:\\repo')).toBe('Docs/Plan.md')
   })
 
+  it('matches Windows drive-root paths without adding an extra separator', () => {
+    expect(getRelativePathInsideRoot('C:\\Repo\\Docs\\Plan.md', 'c:\\')).toBe('Repo/Docs/Plan.md')
+  })
+
   it('matches Windows UNC paths case-insensitively', () => {
     expect(
       getRelativePathInsideRoot('\\\\Server\\Share\\Repo\\Docs\\Plan.md', '\\\\server\\share\\repo')

--- a/src/renderer/src/lib/path.ts
+++ b/src/renderer/src/lib/path.ts
@@ -24,6 +24,9 @@ function stripTrailingAbsoluteSeparators(path: string): string {
   if (path === '/') {
     return path
   }
+  if (/^[A-Za-z]:\/$/.test(path)) {
+    return path
+  }
   return path.replace(/\/+$/, '')
 }
 
@@ -52,12 +55,14 @@ export function getRelativePathInsideRoot(
     return ''
   }
 
-  const rootPrefix = normalizedRoot === '/' ? '/' : `${comparisonRoot}/`
+  // Why: POSIX and Windows drive roots already include their trailing separator.
+  const isRootPath = normalizedRoot === '/' || /^[A-Za-z]:\/$/.test(normalizedRoot)
+  const rootPrefix = isRootPath ? comparisonRoot : `${comparisonRoot}/`
   if (!comparisonFilePath.startsWith(rootPrefix)) {
     return null
   }
 
-  const sliceStart = normalizedRoot === '/' ? 1 : normalizedRoot.length + 1
+  const sliceStart = isRootPath ? normalizedRoot.length : normalizedRoot.length + 1
   return normalizeRelativePath(normalizedFilePath.slice(sliceStart))
 }
 


### PR DESCRIPTION
## Summary

- Preserve Windows UNC roots when normalizing file explorer paths.
- Compare Windows drive and UNC paths case-insensitively while keeping POSIX paths case-sensitive.
- Use the existing Windows-aware root-relative helper when computing reveal ancestors.

## Repro / Evidence

Before the fix, the new regression test failed these deterministic cases:

- `normalizeAbsolutePath('\\\\Server\\Share\\Repo\\')` returned `/Server/Share/Repo` instead of `//Server/Share/Repo`.
- `isPathEqualOrDescendant('C:\\Repo\\src\\app.ts', 'c:\\repo')` returned `false`.
- `isPathEqualOrDescendant('\\\\Server\\Share\\Repo\\src\\app.ts', '\\\\server\\share\\repo')` returned `false`.
- `getRevealAncestorDirs('C:\\Repo', 'c:\\repo\\src\\app.ts')` returned `null`.

This is Windows-specific path behavior, so the evidence is a deterministic regression test rather than a macOS Electron screenshot.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/file-explorer-paths.test.ts src/renderer/src/components/right-sidebar/file-explorer-watcher-reconcile.test.ts`
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/file-explorer-paths.ts src/renderer/src/components/right-sidebar/file-explorer-paths.test.ts`
- `pnpm run typecheck:web`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.