### PR TITLE
fix: guard workspace cleanup async state

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -1,4 +1,6 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines -- Why: cleanup scanning, safety review, and
+   confirmation stay together so destructive workspace deletion remains
+   auditable. */
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   AlertTriangle,
@@ -24,6 +26,7 @@ import { Button } from '@/components/ui/button'
 import RepoMultiCombobox from '@/components/ui/repo-multi-combobox'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -187,6 +190,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
   const [removing, setRemoving] = useState(false)
   const [rowFailures, setRowFailures] = useState<Record<string, string>>({})
   const [repoSelection, setRepoSelection] = useState<ReadonlySet<string>>(() => new Set())
+  const mountedRef = useMountedRef()
   const eligibleRepos = useMemo(() => repos.filter((repo) => isGitRepoKind(repo)), [repos])
   const eligibleRepoIds = useMemo(() => eligibleRepos.map((repo) => repo.id), [eligibleRepos])
 
@@ -195,12 +199,14 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       setRowFailures({})
       setActiveView('ready')
       void scanWorkspaceCleanup().catch((err: unknown) => {
-        toast.error('Workspace cleanup scan failed', {
-          description: err instanceof Error ? err.message : String(err)
-        })
+        if (mountedRef.current) {
+          toast.error('Workspace cleanup scan failed', {
+            description: err instanceof Error ? err.message : String(err)
+          })
+        }
       })
     }
-  }, [open, scanWorkspaceCleanup])
+  }, [mountedRef, open, scanWorkspaceCleanup])
 
   useEffect(() => {
     if (!open) {
@@ -346,11 +352,13 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
   const refresh = useCallback(() => {
     setRowFailures({})
     void scanWorkspaceCleanup().catch((err: unknown) => {
-      toast.error('Workspace cleanup scan failed', {
-        description: err instanceof Error ? err.message : String(err)
-      })
+      if (mountedRef.current) {
+        toast.error('Workspace cleanup scan failed', {
+          description: err instanceof Error ? err.message : String(err)
+        })
+      }
     })
-  }, [scanWorkspaceCleanup])
+  }, [mountedRef, scanWorkspaceCleanup])
 
   const toggleActiveSelection = useCallback(() => {
     if (activeQueueableRows.length === 0) {
@@ -375,19 +383,23 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     (candidate: WorkspaceCleanupCandidate) => {
       void dismissCandidates([candidate])
         .then(() => {
-          setSelectedIds((current) => {
-            const next = new Set(current)
-            next.delete(candidate.worktreeId)
-            return next
-          })
+          if (mountedRef.current) {
+            setSelectedIds((current) => {
+              const next = new Set(current)
+              next.delete(candidate.worktreeId)
+              return next
+            })
+          }
         })
         .catch((err: unknown) => {
-          toast.error('Could not ignore cleanup suggestion', {
-            description: err instanceof Error ? err.message : String(err)
-          })
+          if (mountedRef.current) {
+            toast.error('Could not ignore cleanup suggestion', {
+              description: err instanceof Error ? err.message : String(err)
+            })
+          }
         })
     },
-    [dismissCandidates]
+    [dismissCandidates, mountedRef]
   )
 
   const confirmRemove = useCallback(async () => {
@@ -404,30 +416,40 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       for (const failure of result.failures) {
         nextFailures[failure.worktreeId] = failure.message
       }
-      setRowFailures(nextFailures)
-      setSelectedIds((current) => {
-        const next = new Set(current)
-        for (const id of result.removedIds) {
-          next.delete(id)
-        }
-        return next
-      })
+      if (mountedRef.current) {
+        setRowFailures(nextFailures)
+        setSelectedIds((current) => {
+          const next = new Set(current)
+          for (const id of result.removedIds) {
+            next.delete(id)
+          }
+          return next
+        })
+      }
       if (result.removedIds.length > 0) {
-        toast.success(
-          `Removed ${result.removedIds.length} workspace${result.removedIds.length === 1 ? '' : 's'}`
-        )
+        if (mountedRef.current) {
+          toast.success(
+            `Removed ${result.removedIds.length} workspace${result.removedIds.length === 1 ? '' : 's'}`
+          )
+        }
       }
       if (result.failures.length > 0) {
-        toast.error(
-          `${result.failures.length} workspace${result.failures.length === 1 ? '' : 's'} could not be removed`
-        )
+        if (mountedRef.current) {
+          toast.error(
+            `${result.failures.length} workspace${result.failures.length === 1 ? '' : 's'} could not be removed`
+          )
+        }
       } else {
-        setConfirming(false)
+        if (mountedRef.current) {
+          setConfirming(false)
+        }
       }
     } finally {
-      setRemoving(false)
+      if (mountedRef.current) {
+        setRemoving(false)
+      }
     }
-  }, [removeCandidates, selectedCandidates])
+  }, [mountedRef, removeCandidates, selectedCandidates])
 
   const selectedCount = selectedCandidates.length
 


### PR DESCRIPTION
## Summary
- guard workspace cleanup scan, ignore, and removal UI updates after the dialog unmounts
- leave workspace cleanup candidate computation and `removeWorkspaceCleanupCandidates` behavior unchanged
- replace the generic max-lines disable with a short destructive-flow rationale

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- renderer-only dialog change
- deletion/store action semantics are untouched; removed IDs and failures are handled exactly after the existing call returns
- only stale local selection, failure, confirmation state, and toasts are skipped after unmount

## Validation
- `pnpm exec oxlint src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)