### PR TITLE
Detect GitHub URL-style SSH remotes

### DIFF
--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -47,6 +47,14 @@ describe('github owner/repo resolution', () => {
       owner: 'TheBoredTeam',
       repo: 'boring.notch'
     })
+    expect(parseGitHubOwnerRepo('ssh://git@github.com/stablyai/orca.git')).toEqual({
+      owner: 'stablyai',
+      repo: 'orca'
+    })
+    expect(parseGitHubOwnerRepo('ssh://git@ssh.github.com:443/stablyai/orca.git')).toEqual({
+      owner: 'stablyai',
+      repo: 'orca'
+    })
     expect(parseGitHubOwnerRepo('git@example.com:stablyai/orca.git')).toBeNull()
   })
 

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -159,17 +159,49 @@ export function parseGitHubOwnerRepo(remoteUrl: string): OwnerRepo | null {
   return { owner: identity.owner, repo: identity.repo }
 }
 
+function normalizeGitHubRemoteHost(host: string): string {
+  // Why: GitHub documents ssh.github.com:443 as SSH-over-HTTPS for github.com repos.
+  return host.toLowerCase() === 'ssh.github.com' ? 'github.com' : host
+}
+
+function parseGitHubRemotePath(path: string): Pick<GitHubRemoteIdentity, 'owner' | 'repo'> | null {
+  const parts = path.replace(/^\/+/, '').replace(/\/+$/, '').split('/')
+  if (parts.length !== 2) {
+    return null
+  }
+  const [owner, repoWithSuffix] = parts
+  const repo = repoWithSuffix.replace(/\.git$/i, '')
+  if (!owner || !repo) {
+    return null
+  }
+  return { owner, repo }
+}
+
 export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdentity | null {
   const trimmed = remoteUrl.trim()
   const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i)
   if (httpsMatch) {
-    return { host: httpsMatch[1], owner: httpsMatch[2], repo: httpsMatch[3] }
+    return {
+      host: normalizeGitHubRemoteHost(httpsMatch[1]),
+      owner: httpsMatch[2],
+      repo: httpsMatch[3]
+    }
   }
   const sshMatch = trimmed.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/i)
   if (sshMatch) {
-    return { host: sshMatch[1], owner: sshMatch[2], repo: sshMatch[3] }
+    return { host: normalizeGitHubRemoteHost(sshMatch[1]), owner: sshMatch[2], repo: sshMatch[3] }
   }
-  return null
+
+  try {
+    const url = new URL(trimmed)
+    if (!['git:', 'git+ssh:', 'ssh:'].includes(url.protocol.toLowerCase())) {
+      return null
+    }
+    const path = parseGitHubRemotePath(url.pathname)
+    return path ? { host: normalizeGitHubRemoteHost(url.hostname), ...path } : null
+  } catch {
+    return null
+  }
 }
 
 export async function getRemoteUrlForRepo(


### PR DESCRIPTION
## Summary

- Parse URL-style GitHub SSH remotes in owner/repo detection.
- Map GitHub's documented `ssh.github.com:443` transport host back to `github.com`.
- Add regression coverage for both `ssh://git@github.com/...` and `ssh://git@ssh.github.com:443/...`.

## Repro / Evidence

Before the fix, `gh-utils.test.ts` failed because:

- `parseGitHubOwnerRepo('ssh://git@github.com/stablyai/orca.git')` returned `null`.

That parser feeds `getOwnerRepo()` from the configured `origin` remote, so users with valid URL-style SSH GitHub remotes were treated as non-GitHub repositories by source-control features.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/gh-utils.test.ts`
- `pnpm exec oxlint src/main/github/gh-utils.ts src/main/github/gh-utils.test.ts`
- `pnpm run typecheck:node`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.