### PR TITLE
Open terminal UNC file URLs

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
+
+describe('resolveTerminalFileUrlTarget', () => {
+  it('resolves UNC file URLs with line and column anchors', () => {
+    expect(
+      resolveTerminalFileUrlTarget(new URL('file://Server/Share/Repo/src/app.ts#L12C3'))
+    ).toEqual({
+      filePath: '//server/Share/Repo/src/app.ts',
+      line: 12,
+      column: 3
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts
@@ -11,4 +11,8 @@ describe('resolveTerminalFileUrlTarget', () => {
       column: 3
     })
   })
+
+  it('returns null for malformed file URL escapes', () => {
+    expect(resolveTerminalFileUrlTarget(new URL('file:///tmp/%E0%A4%A.txt'))).toBeNull()
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts
@@ -4,7 +4,9 @@ import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
 describe('resolveTerminalFileUrlTarget', () => {
   it('resolves UNC file URLs with line and column anchors', () => {
     expect(
-      resolveTerminalFileUrlTarget(new URL('file://Server/Share/Repo/src/app.ts#L12C3'))
+      resolveTerminalFileUrlTarget(new URL('file://Server/Share/Repo/src/app.ts#L12C3'), {
+        allowUncHost: true
+      })
     ).toEqual({
       filePath: '//server/Share/Repo/src/app.ts',
       line: 12,

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -501,6 +501,38 @@ describe('handleOscLink', () => {
     })
   })
 
+  it('opens UNC file URL links with line and column anchors', async () => {
+    setPlatform('Windows')
+
+    handleOscLink(
+      'file://Server/Share/Repo/src/app.ts#L12C3',
+      { metaKey: false, ctrlKey: true },
+      {
+        ...deps,
+        worktreePath: '//Server/Share/Repo'
+      }
+    )
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({
+      targetPath: '//server/Share/Repo/src/app.ts'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '//server/Share/Repo/src/app.ts',
+        relativePath: 'src/app.ts'
+      })
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(1, null)
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: '//server/Share/Repo/src/app.ts',
+      line: 12,
+      column: 3,
+      matchLength: 0
+    })
+  })
+
   it('opens relative OSC file links against the terminal cwd', async () => {
     setPlatform('Macintosh')
 

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -20,6 +20,13 @@ describe('terminal path helpers', () => {
     expect(
       toWorktreeRelativePath('//server/share/repo/src/file.ts', '\\\\server\\share\\repo')
     ).toBe('src/file.ts')
+
+    expect(isPathInsideWorktree('//server/share/repo/src/file.ts', '//Server/Share/Repo')).toBe(
+      true
+    )
+    expect(toWorktreeRelativePath('//server/share/repo/src/file.ts', '//Server/Share/Repo')).toBe(
+      'src/file.ts'
+    )
   })
 
   describe('extractTerminalFileLinks bare-filename tokens', () => {


### PR DESCRIPTION
## Summary
- support `file://server/share/...` terminal links by translating them to UNC-style paths
- preserve line/column anchors while routing UNC file URLs through Orca's file opener
- treat malformed `file:` URL path escapes as invalid instead of throwing through terminal link handling

## Evidence
- Reproduced in unit coverage: `resolveTerminalFileUrlTarget(new URL('file://Server/Share/Repo/src/app.ts#L12C3'))` previously returned `null`, so modifier-clicking a UNC `file:` link did nothing.
- Added a malformed escape regression: `resolveTerminalFileUrlTarget(new URL('file:///tmp/%E0%A4%A.txt'))` now returns `null` instead of throwing `URIError: URI malformed`.
- No screenshot attached: this is terminal link parser/routing behavior covered by deterministic tests.

## Verification
- `pnpm test src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-file-url-target.ts src/renderer/src/components/terminal-pane/terminal-file-url-target.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.