### PR TITLE
Fix GitLab hosted source links

### DIFF
--- a/src/main/git/hosted-remote-url.test.ts
+++ b/src/main/git/hosted-remote-url.test.ts
@@ -50,7 +50,7 @@ describe('hosted remote URLs', () => {
 
     expect(
       buildHostedRemoteFileUrl('git@gitlab.com:group/sub/repo.git', 'src/a.ts', 'feature/x', 9)
-    ).toBe('https://gitlab.com/group/sub/repo/tree/feature%2Fx/src/a.ts#L9')
+    ).toBe('https://gitlab.com/group/sub/repo/-/blob/feature%2Fx/src/a.ts#L9')
 
     expect(
       buildHostedRemoteFileUrl('git@bitbucket.org:team/repo.git', 'src/a.ts', 'feature/x', 7)

--- a/src/main/git/hosted-remote-url.ts
+++ b/src/main/git/hosted-remote-url.ts
@@ -117,7 +117,7 @@ export function buildHostedRemoteFileUrl(
     return `${baseUrl}/blob/${encodedBranch}${filePathSuffix}#L${line}`
   }
   if (remote.provider === 'gitlab') {
-    return `${baseUrl}/tree/${encodedBranch}${filePathSuffix}#L${line}`
+    return `${baseUrl}/-/blob/${encodedBranch}${filePathSuffix}#L${line}`
   }
   return `${baseUrl}/src/${encodedBranch}${filePathSuffix}#L${line}`
 }


### PR DESCRIPTION
## Summary
- Generate GitLab hosted source links with the file blob route (`/-/blob/...`) instead of the project tree route.
- Keep GitHub and Bitbucket hosted source URL formats unchanged.

## Evidence
- `pnpm test src/main/git/hosted-remote-url.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/git/hosted-remote-url.ts src/main/git/hosted-remote-url.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.