### PR TITLE
fix: guard terminal window relaunch state

### DIFF
--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -6,6 +6,7 @@ import { Label } from '../ui/label'
 import { ColorField, NumberField } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { clampNumber } from '@/lib/terminal-theme'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 type TerminalWindowSectionProps = {
   settings: GlobalSettings
@@ -85,6 +86,7 @@ export function TerminalWindowSection({
   const blurAtMountRef = useRef<boolean>(settings.windowBackgroundBlur ?? false)
   const blurPendingRestart = (settings.windowBackgroundBlur ?? false) !== blurAtMountRef.current
   const [relaunchingBlur, setRelaunchingBlur] = useState(false)
+  const mountedRef = useMountedRef()
 
   // Why: the mount-time snapshot captures local state, not main-process state.
   // If the setting is persisted and read correctly on next boot we never need
@@ -104,7 +106,9 @@ export function TerminalWindowSection({
     try {
       await window.api.app.relaunch()
     } catch {
-      setRelaunchingBlur(false)
+      if (mountedRef.current) {
+        setRelaunchingBlur(false)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Guard the terminal window blur restart error path before clearing local relaunch state after unmount.
- Leave the app relaunch IPC call unchanged.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only settings section change.
- Only skips local button spinner cleanup when the component is already unmounted.
- No change to settings persistence or relaunch behavior.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/TerminalWindowSection.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)