### PR TITLE
fix: guard landing async state

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../store'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { ShortcutKeyCombo } from './ShortcutKeyCombo'
 import { useShortcutKeys } from '@/hooks/useShortcutLabel'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import logo from '../../../../resources/logo.svg'
 
 type ShortcutItem = {
@@ -64,6 +65,7 @@ function GitHubStarButton({ hasRepos }: { hasRepos: boolean }): React.JSX.Elemen
   const [state, setState] = useState<StarState>('loading')
   const [menuOpen, setMenuOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const mountedRef = useMountedRef()
 
   useEffect(() => {
     let cancelled = false
@@ -106,7 +108,9 @@ function GitHubStarButton({ hasRepos }: { hasRepos: boolean }): React.JSX.Elemen
     setState('starred') // optimistic
     const ok = await window.api.gh.starOrca('landing')
     if (!ok) {
-      setState('not-starred')
+      if (mountedRef.current) {
+        setState('not-starred')
+      }
       return
     }
     // Why: starring from any entry point mutes the threshold-based nag.
@@ -235,15 +239,22 @@ export default function Landing(): React.JSX.Element {
       return
     }
 
+    let cancelled = false
     // Why: some users complete `gh auth login` without ever leaving the Orca
     // window. Poll only while a warning is visible so the banner self-clears.
     const intervalId = window.setInterval(() => {
       void window.api.preflight.check({ force: true }).then((status) => {
+        if (cancelled) {
+          return
+        }
         setPreflightIssues(getPreflightIssues(status))
       })
     }, 30000)
 
-    return () => window.clearInterval(intervalId)
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+    }
   }, [preflightIssues.length])
 
   const createWorktreeKeys = useShortcutKeys('workspace.create')


### PR DESCRIPTION
## Summary
- Guard the Landing star-button rollback before updating local state after unmount.
- Cancel stale Landing preflight polling completions after the interval effect cleans up.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only Landing page local UI state change.
- Existing GitHub star, star-nag, and preflight IPC calls remain unchanged.
- Only stale state updates after unmount/effect cleanup are skipped.

## Validation
- `pnpm exec oxlint src/renderer/src/components/Landing.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)