### PR TITLE
perf: reconcile ssh reset dialog state during render

### DIFF
--- a/src/renderer/src/components/settings/SshTargetDestructiveActions.tsx
+++ b/src/renderer/src/components/settings/SshTargetDestructiveActions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { SshConnectionState } from '../../../../shared/ssh-types'
 import { SshDestructiveActionDialog } from './SshDestructiveActionDialog'
@@ -94,11 +94,12 @@ export function SshTargetDestructiveActions({
   const pendingTerminateIsBusy =
     pendingTerminate !== null && targetActionsInFlight.get(pendingTerminate.id) === 'terminate'
 
-  useEffect(() => {
-    if (pendingResetBlockedByConnection && !pendingResetIsBusy) {
-      setPendingReset(null)
-    }
-  }, [pendingResetBlockedByConnection, pendingResetIsBusy])
+  if (pendingResetBlockedByConnection && !pendingResetIsBusy) {
+    // Why: this is component-local state reconciliation from current SSH
+    // connection props; doing it during render avoids a hidden dialog commit
+    // followed by a cleanup Effect pass.
+    setPendingReset(null)
+  }
 
   const confirmResetRelay = async (): Promise<void> => {
     if (!pendingReset) {


### PR DESCRIPTION
## Summary

Moves the SSH reset-relay dialog blocked-connection repair out of a `useEffect` and into render-time local state reconciliation. This removes a post-commit Effect pass and keeps the dialog hidden immediately when the current SSH connection props say reset is blocked.

## Risk

`risk:medium` because this touches SSH settings dialog timing. It does not change SSH transport, relay operations, paths, shortcuts, or platform-specific behavior.

## Validation

- `pnpm exec oxlint src/renderer/src/components/settings/SshTargetDestructiveActions.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-remove.test.ts src/renderer/src/store/slices/ssh.test.ts src/renderer/src/lib/new-workspace-ssh-gate.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 807 -> 806.

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.