### PR TITLE
fix: guard settings star async state

### DIFF
--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -38,6 +38,7 @@ import {
   SettingsSwitch,
   SettingsSwitchRow
 } from './SettingsFormControls'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 function createOpenInApplication(): OpenInApplication {
   return {
@@ -83,6 +84,7 @@ type GeneralPaneProps = {
 export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const updateStatus = useAppStore((s) => s.updateStatus)
+  const mountedRef = useMountedRef()
   // Why: the 'error' variant of UpdateStatus does not carry a `version` field.
   // The main process emits `{ state: 'error' }` for both check failures (no
   // version known yet) and download/install failures (version was known from
@@ -163,10 +165,14 @@ export function GeneralPane({ settings, updateSettings }: GeneralPaneProps): Rea
     setStarState('starring')
     const ok = await window.api.gh.starOrca('settings')
     if (!ok) {
-      setStarState('error')
+      if (mountedRef.current) {
+        setStarState('error')
+      }
       return
     }
-    setStarState('starred')
+    if (mountedRef.current) {
+      setStarState('starred')
+    }
     // Why: clicking star anywhere should also permanently mute the
     // threshold-based nag so the user isn't re-prompted via the popup.
     await window.api.starNag.complete()


### PR DESCRIPTION
## Summary
- Guard Settings star-button local state updates after the async GitHub star call resolves.
- Keep the GitHub star and star-nag completion side effects unchanged.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only settings UI state change.
- Existing `gh.starOrca` and `starNag.complete` behavior remains intact.
- Only stale `starState` updates after unmount are skipped.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/GeneralPane.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)