### PR TITLE
Fix Windows filesystem auth path casing

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -1,3 +1,4 @@
+import type * as NodePath from 'node:path'
 import { resolve } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
@@ -90,5 +91,35 @@ describe('filesystem-auth path containment', () => {
     expect(() => validateGitRelativeFilePath(root, '../other/file.ts')).toThrow(
       'Access denied: git file path escapes the selected worktree'
     )
+  })
+
+  it('accepts Windows descendants when drive and root casing differ', async () => {
+    vi.resetModules()
+    vi.doMock('../repo-worktrees', () => ({
+      isRepoRoot: vi.fn(),
+      listRepoWorktrees: vi.fn()
+    }))
+    vi.doMock('path', async () => {
+      const path = await vi.importActual<typeof NodePath>('node:path')
+      return {
+        ...path.win32,
+        default: path.win32
+      }
+    })
+
+    try {
+      const { isDescendantOrEqual: isDescendantOrEqualWithWinPath } = await import(
+        './filesystem-auth'
+      )
+
+      expect(isDescendantOrEqualWithWinPath(String.raw`c:\repo\src\app.ts`, String.raw`C:\Repo`))
+        .toBe(true)
+      expect(isDescendantOrEqualWithWinPath(String.raw`D:\repo\src\app.ts`, String.raw`C:\Repo`))
+        .toBe(false)
+    } finally {
+      vi.doUnmock('path')
+      vi.doUnmock('../repo-worktrees')
+      vi.resetModules()
+    }
   })
 })

--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -108,14 +108,15 @@ describe('filesystem-auth path containment', () => {
     })
 
     try {
-      const { isDescendantOrEqual: isDescendantOrEqualWithWinPath } = await import(
-        './filesystem-auth'
-      )
+      const { isDescendantOrEqual: isDescendantOrEqualWithWinPath } =
+        await import('./filesystem-auth')
 
-      expect(isDescendantOrEqualWithWinPath(String.raw`c:\repo\src\app.ts`, String.raw`C:\Repo`))
-        .toBe(true)
-      expect(isDescendantOrEqualWithWinPath(String.raw`D:\repo\src\app.ts`, String.raw`C:\Repo`))
-        .toBe(false)
+      expect(
+        isDescendantOrEqualWithWinPath(String.raw`c:\repo\src\app.ts`, String.raw`C:\Repo`)
+      ).toBe(true)
+      expect(
+        isDescendantOrEqualWithWinPath(String.raw`D:\repo\src\app.ts`, String.raw`C:\Repo`)
+      ).toBe(false)
     } finally {
       vi.doUnmock('path')
       vi.doUnmock('../repo-worktrees')

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -50,12 +50,9 @@ export function isDescendantOrEqual(resolvedTarget: string, resolvedBase: string
   // rel must not be ".."/"../..." or an absolute path (e.g. different drive on Windows)
   // [Security Fix]: Added !isAbsolute(rel) to prevent drive traversal bypasses on Windows
   // where relative('D:\\repo', 'C:\\etc\\passwd') returns absolute path 'C:\\etc\\passwd'
-  return (
-    rel !== '' &&
-    !(rel === '..' || rel.startsWith(`..${sep}`)) &&
-    !isAbsolute(rel) &&
-    resolve(resolvedBase, rel) === resolvedTarget
-  )
+  // Why: Windows path.relative() already treats drive/root casing as equivalent;
+  // rejoining and comparing strings would deny valid `c:\repo` descendants of `C:\Repo`.
+  return rel !== '' && !(rel === '..' || rel.startsWith(`..${sep}`)) && !isAbsolute(rel)
 }
 
 export function getAllowedRoots(store: Store): string[] {

--- a/src/main/repo-worktrees.test.ts
+++ b/src/main/repo-worktrees.test.ts
@@ -8,7 +8,7 @@ vi.mock('./git/worktree', () => ({
   listWorktrees: listWorktreesMock
 }))
 
-import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
+import { createFolderWorktree, isRepoRoot, listRepoWorktrees } from './repo-worktrees'
 
 describe('repo-worktrees', () => {
   beforeEach(() => {
@@ -72,5 +72,20 @@ describe('repo-worktrees', () => {
 
     expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo')
     expect(result).toHaveLength(1)
+  })
+
+  it('treats Windows repo root casing differences as the same local root', () => {
+    const repos = [
+      {
+        id: 'repo-1',
+        path: String.raw`C:\Repo`,
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        kind: 'git' as const
+      }
+    ]
+
+    expect(isRepoRoot(repos, String.raw`c:\repo`)).toBe(true)
   })
 })

--- a/src/main/repo-worktrees.ts
+++ b/src/main/repo-worktrees.ts
@@ -1,11 +1,13 @@
 import type { GitWorktreeInfo, Repo } from '../shared/types'
-import { resolve } from 'path'
 import { listWorktrees } from './git/worktree'
 import { isFolderRepo } from '../shared/repo-kind'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import { areWorktreePathsEqual } from './ipc/worktree-logic'
 
 export function isRepoRoot(repos: Repo[], resolvedTarget: string): boolean {
-  return repos.some((repo) => !repo.connectionId && resolve(repo.path) === resolvedTarget)
+  return repos.some(
+    (repo) => !repo.connectionId && areWorktreePathsEqual(repo.path, resolvedTarget)
+  )
 }
 
 export function createFolderWorktree(repo: Repo): GitWorktreeInfo {


### PR DESCRIPTION
## Summary
- fix filesystem authorization for Windows descendants whose drive/root casing differs from the registered repo root
- use the existing Windows-aware worktree path comparator for repo-root detection
- keep the existing `path.relative()` escape checks for `..` and different-drive absolute results
- add deterministic `path.win32` and repo-root casing regression tests

## Evidence
- Reproduced in a unit test by loading `filesystem-auth` with `path.win32`: `c:\repo\src\app.ts` should be authorized under `C:\Repo`, while `D:\repo\src\app.ts` must still be rejected.
- The old helper failed the valid same-root case because it rejoined the relative path as `C:\Repo\src\app.ts` and compared strings case-sensitively.
- Added a second regression showing `isRepoRoot()` must treat `C:\Repo` and `c:\repo` as the same local repo root. The old exact `resolve(...) === ...` comparison rejected that case.
- No screenshot attached: this is main-process path authorization behavior covered by deterministic tests.

## Verification
- `pnpm test src/main/repo-worktrees.test.ts src/main/ipc/filesystem-auth.test.ts src/main/ipc/filesystem.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/repo-worktrees.ts src/main/repo-worktrees.test.ts src/main/ipc/filesystem-auth.ts src/main/ipc/filesystem-auth.test.ts`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.