### PR TITLE
Guard overlay cleanup across Windows drives

### DIFF
--- a/src/main/pty/overlay-mirror.test.ts
+++ b/src/main/pty/overlay-mirror.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+import type * as NodePath from 'node:path'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { safeRemoveOverlay } from './overlay-mirror'
@@ -8,7 +9,10 @@ import { safeRemoveOverlay } from './overlay-mirror'
 const tempRoots: string[] = []
 
 afterEach(() => {
+  vi.doUnmock('fs')
+  vi.doUnmock('path')
   vi.restoreAllMocks()
+  vi.resetModules()
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
   }
@@ -57,5 +61,39 @@ describe('safeRemoveOverlay', () => {
 
     expect(existsSync(marker)).toBe(true)
     expect(warnSpy).toHaveBeenCalledOnce()
+  })
+
+  it('refuses Windows overlay targets on a different drive than the root', async () => {
+    const lstatSyncMock = vi.fn(() => ({
+      isSymbolicLink: () => false,
+      isDirectory: () => false
+    }))
+    const unlinkSyncMock = vi.fn()
+    vi.doMock('fs', () => ({
+      cpSync: vi.fn(),
+      linkSync: vi.fn(),
+      lstatSync: lstatSyncMock,
+      readdirSync: vi.fn(),
+      rmdirSync: vi.fn(),
+      symlinkSync: vi.fn(),
+      unlinkSync: unlinkSyncMock
+    }))
+    vi.doMock('path', async () => {
+      const path = await vi.importActual<typeof NodePath>('node:path')
+      return {
+        ...path.win32,
+        default: path.win32
+      }
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const { safeRemoveOverlay: safeRemoveOverlayWithWinPath } = await import('./overlay-mirror')
+    safeRemoveOverlayWithWinPath(String.raw`D:\users\me\config`, String.raw`C:\orca\overlays`)
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[overlay-mirror] refusing to remove overlay outside root: target=D:\\users\\me\\config root=C:\\orca\\overlays'
+    )
+    expect(lstatSyncMock).not.toHaveBeenCalled()
+    expect(unlinkSyncMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- reject absolute `path.relative()` results in `safeRemoveOverlay()`
- add a Windows-path regression test that proves different-drive overlay targets are refused before filesystem removal starts

## Evidence
- Reproduced with `path.win32` and mocked filesystem calls: target `D:\users\me\config` with root `C:\orca\overlays` previously bypassed the guard because the relative path was absolute rather than `..`-prefixed.
- The fixed test asserts the warning is emitted and no teardown filesystem call is made.
- No screenshot attached: this is main-process deletion guard behavior covered by deterministic tests.

## Verification
- `pnpm test src/main/pty/overlay-mirror.test.ts src/main/opencode/hook-service.test.ts src/main/pi/titlebar-extension-service.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/pty/overlay-mirror.ts src/main/pty/overlay-mirror.test.ts`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.