### PR TITLE
fix: guard agent skill setup async state

### DIFF
--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -3,6 +3,7 @@ import { RefreshCw, Terminal } from 'lucide-react'
 import { IntegrationStatusPill } from '../integration-status-pill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
 import { Button } from '../ui/button'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
 
@@ -53,6 +54,7 @@ export function AgentSkillSetupPanel({
 }: AgentSkillSetupPanelProps): React.JSX.Element {
   const [terminalOpen, setTerminalOpen] = useState(false)
   const [preInstallNoticeVisible, setPreInstallNoticeVisible] = useState(Boolean(preInstallNotice))
+  const mountedRef = useMountedRef()
 
   useEffect(() => {
     if (!preInstallNotice) {
@@ -88,9 +90,13 @@ export function AgentSkillSetupPanel({
     }
     try {
       const status = await window.api.cli.getInstallStatus()
-      setPreInstallNoticeVisible(!isOrcaCliAvailableOnPath(status))
+      if (mountedRef.current) {
+        setPreInstallNoticeVisible(!isOrcaCliAvailableOnPath(status))
+      }
     } catch {
-      setPreInstallNoticeVisible(true)
+      if (mountedRef.current) {
+        setPreInstallNoticeVisible(true)
+      }
     }
   }
   const actionRow = (
@@ -105,7 +111,9 @@ export function AgentSkillSetupPanel({
               await onBeforeOpenTerminal?.()
               await refreshPreInstallNotice()
             } finally {
-              setTerminalOpen(true)
+              if (mountedRef.current) {
+                setTerminalOpen(true)
+              }
             }
           })()
         }}


### PR DESCRIPTION
## Summary
- Guard AgentSkillSetupPanel local notice and terminal-open state after async prerequisite checks resolve.
- Preserve the CLI prerequisite and install-terminal side effects.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only reusable setup panel state cleanup.
- No change to install commands, skill detection, or CLI prerequisite behavior.
- Only stale local state writes after unmount are skipped.

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/AgentSkillSetupPanel.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)