### PR TITLE
Guard remote runtime PTY id decoding

### DIFF
--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -27,6 +27,13 @@ describe('remote runtime terminal ids', () => {
     expect(getRemoteRuntimePtyEnvironmentId('remote:terminal-1')).toBeNull()
     expect(getRemoteRuntimeTerminalHandle('remote:terminal-1')).toBe('terminal-1')
   })
+
+  it('treats malformed encoded ids as invalid instead of throwing', () => {
+    const malformed = 'remote:%E0%A4%A@@terminal-1'
+
+    expect(getRemoteRuntimePtyEnvironmentId(malformed)).toBeNull()
+    expect(getRemoteRuntimeTerminalHandle(malformed)).toBeNull()
+  })
 })
 
 describe('remote runtime terminal data subscriptions', () => {

--- a/src/renderer/src/runtime/runtime-terminal-stream.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.ts
@@ -46,9 +46,13 @@ export function parseRemoteRuntimePtyId(ptyId: string): RemoteRuntimePtyIdParts 
   if (separatorIndex === -1) {
     return { environmentId: null, handle: rest }
   }
-  return {
-    environmentId: decodeURIComponent(rest.slice(0, separatorIndex)),
-    handle: decodeURIComponent(rest.slice(separatorIndex + REMOTE_PTY_OWNER_SEPARATOR.length))
+  try {
+    return {
+      environmentId: decodeURIComponent(rest.slice(0, separatorIndex)),
+      handle: decodeURIComponent(rest.slice(separatorIndex + REMOTE_PTY_OWNER_SEPARATOR.length))
+    }
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
## Summary
- treat malformed encoded remote runtime PTY ids as invalid instead of throwing
- add a regression around public remote PTY id getters

## Evidence
- Reproduced in unit coverage: `getRemoteRuntimePtyEnvironmentId('remote:%E0%A4%A@@terminal-1')` previously threw `URIError: URI malformed` through `decodeURIComponent`.
- The fixed parser returns `null`, so terminal/session sync callers see an invalid remote PTY id instead of an exception.
- No screenshot attached: this is renderer runtime parsing behavior covered by deterministic tests.

## Verification
- `pnpm test src/renderer/src/runtime/runtime-terminal-stream.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/runtime/runtime-terminal-stream.ts src/renderer/src/runtime/runtime-terminal-stream.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.