### PR TITLE
Guard markdown file URL decoding

### DIFF
--- a/src/renderer/src/components/editor/markdown-internal-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.test.ts
@@ -123,6 +123,10 @@ describe('resolveMarkdownLinkTarget', () => {
     })
   })
 
+  it('returns null for malformed file URL escapes', () => {
+    expect(resolveMarkdownLinkTarget('file:///repo/docs/%E0%A4%A.md', SOURCE, ROOT)).toBeNull()
+  })
+
   it('returns null for empty href', () => {
     expect(resolveMarkdownLinkTarget('', SOURCE, ROOT)).toBeNull()
     expect(resolveMarkdownLinkTarget(undefined, SOURCE, ROOT)).toBeNull()

--- a/src/renderer/src/components/editor/markdown-internal-links.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.ts
@@ -51,8 +51,13 @@ function toFileUrl(filePath: string): string {
   return `file:///${segments.join('/')}`
 }
 
-function fileUrlToAbsolutePath(url: URL): string {
-  let absolutePath = decodeURIComponent(url.pathname)
+function fileUrlToAbsolutePath(url: URL): string | null {
+  let absolutePath: string
+  try {
+    absolutePath = decodeURIComponent(url.pathname)
+  } catch {
+    return null
+  }
   // Windows: "/C:/foo" → "C:/foo"
   if (/^\/[A-Za-z]:\//.test(absolutePath)) {
     absolutePath = absolutePath.slice(1)
@@ -175,6 +180,9 @@ export function resolveMarkdownLinkTarget(
   }
 
   const rawAbsolutePath = fileUrlToAbsolutePath(resolved)
+  if (!rawAbsolutePath) {
+    return null
+  }
 
   // Why: hash-based line anchor takes precedence; fall back to trailing
   // `:line:col` syntax only if no hash anchor was found.

--- a/src/renderer/src/components/editor/markdown-preview-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.test.ts
@@ -115,6 +115,10 @@ describe('resolveImageAbsolutePath', () => {
     expect(resolveImageAbsolutePath('data:image/png;base64,abc', '/repo/README.md')).toBeNull()
   })
 
+  it('returns null for malformed file URL escapes', () => {
+    expect(resolveImageAbsolutePath('file:///repo/docs/%E0%A4%A.png', '/repo/README.md')).toBeNull()
+  })
+
   it('returns null for undefined src', () => {
     expect(resolveImageAbsolutePath(undefined, '/repo/README.md')).toBeNull()
   })
@@ -135,5 +139,9 @@ describe('fileUrlToAbsolutePath', () => {
 
   it('returns null for non-file URLs', () => {
     expect(fileUrlToAbsolutePath(new URL('https://example.com/readme.md'))).toBeNull()
+  })
+
+  it('returns null for malformed file URL escapes', () => {
+    expect(fileUrlToAbsolutePath(new URL('file:///repo/docs/%E0%A4%A.md'))).toBeNull()
   })
 })

--- a/src/renderer/src/components/editor/markdown-preview-links.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.ts
@@ -125,7 +125,12 @@ export function resolveImageAbsolutePath(
 
   // Convert file:///path/to/file → /path/to/file (Unix)
   // Convert file:///C:/path/to/file → C:/path/to/file (Windows)
-  let absolutePath = decodeURIComponent(resolved.pathname)
+  let absolutePath: string
+  try {
+    absolutePath = decodeURIComponent(resolved.pathname)
+  } catch {
+    return null
+  }
   if (/^\/[A-Za-z]:\//.test(absolutePath)) {
     absolutePath = absolutePath.slice(1)
   }
@@ -138,7 +143,12 @@ export function fileUrlToAbsolutePath(fileUrl: URL): string | null {
     return null
   }
 
-  let absolutePath = decodeURIComponent(fileUrl.pathname)
+  let absolutePath: string
+  try {
+    absolutePath = decodeURIComponent(fileUrl.pathname)
+  } catch {
+    return null
+  }
   if (/^\/[A-Za-z]:\//.test(absolutePath)) {
     absolutePath = absolutePath.slice(1)
   }


### PR DESCRIPTION
## Summary
- treat malformed `file:` URL path escapes as invalid markdown link/image targets
- add regressions for markdown internal-link classification and preview file URL path conversion

## Evidence
- Reproduced in unit coverage: `resolveMarkdownLinkTarget('file:///repo/docs/%E0%A4%A.md', ...)` and `fileUrlToAbsolutePath(new URL('file:///repo/docs/%E0%A4%A.md'))` previously threw `URIError: URI malformed`.
- The fixed paths return `null`, so preview/rich-editor link handling ignores malformed local file targets instead of throwing.
- No screenshot attached: this is renderer link-classification behavior covered by deterministic tests.

## Verification
- `pnpm test src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/editor/markdown-internal-links.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-preview-links.ts src/renderer/src/components/editor/markdown-preview-links.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.