### PR TITLE
fix: guard untitled rename picker state

### DIFF
--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { getRelativePathInsideRoot } from '@/lib/path'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 type UntitledFileRenameDialogProps = {
   open: boolean
@@ -38,6 +39,7 @@ export function UntitledFileRenameDialog({
   const nameInputRef = useRef<HTMLInputElement>(null)
   const focusFrameRef = useRef<number | null>(null)
   const seededOpenStateRef = useRef({ open: false, baseName, worktreePath })
+  const mountedRef = useMountedRef()
 
   const displayError = externalError ?? error
 
@@ -79,9 +81,12 @@ export function UntitledFileRenameDialog({
     if (!picked) {
       return
     }
+    if (!mountedRef.current) {
+      return
+    }
     setDir(picked)
     setError(null)
-  }, [dir, worktreePath])
+  }, [dir, mountedRef, worktreePath])
 
   const handleSubmit = useCallback(() => {
     const trimmedName = name.trim().replace(/\.md$/, '')


### PR DESCRIPTION
## Summary
- Guard UntitledFileRenameDialog folder picker results before updating dialog-local path/error state after unmount.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only dialog-local state cleanup.
- No change to save/rename validation or file write behavior.
- Native folder picker behavior remains unchanged.

## Validation
- `pnpm exec oxlint src/renderer/src/components/editor/UntitledFileRenameDialog.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)