### PR TITLE
fix: guard add repo parent picker state

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
@@ -55,8 +55,9 @@ export function useCreateRepo(
       toast.error('Enter a server parent path.')
       return
     }
+    const gen = createGenRef.current
     const dir = await window.api.repos.pickDirectory()
-    if (dir) {
+    if (dir && gen === createGenRef.current) {
       setCreateParent(dir)
       setCreateError(null)
     }


### PR DESCRIPTION
## Summary
- Guard the Add Project create-step parent folder picker against stale dialog state updates.
- Reuse the existing create generation counter that is bumped when the create flow resets.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only create-step draft state cleanup.
- No change to project creation, runtime RPCs, or repository store updates.
- Uses the existing stale-callback invalidation pattern in this hook.

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoCreateStep.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)