### PR TITLE
Skip malformed daemon history session dirs

### DIFF
--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -271,5 +271,12 @@ describe('HistoryReader', () => {
 
       expect(reader.listRestorable()).toEqual([sessionId])
     })
+
+    it('skips malformed encoded session directories', () => {
+      mkdirSync(join(dir, '%E0%A4%A'), { recursive: true })
+      writeSessionWithScrollback(dir, 'alive', makeMeta(), 'data')
+
+      expect(reader.listRestorable()).toEqual(['alive'])
+    })
   })
 })

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -90,7 +90,12 @@ export class HistoryReader {
       if (!entry.isDirectory()) {
         continue
       }
-      const sessionId = decodeURIComponent(entry.name)
+      let sessionId: string
+      try {
+        sessionId = decodeURIComponent(entry.name)
+      } catch {
+        continue
+      }
       const meta = this.readMeta(sessionId)
       if (meta && meta.endedAt === null) {
         restorable.push(sessionId)


### PR DESCRIPTION
## Summary
- skip malformed percent-encoded daemon history directory names during restorable-session listing
- add regression coverage for corrupt history directory names alongside valid live sessions

## Evidence
- Reproduced in unit coverage: a history directory named `%E0%A4%A` previously made `HistoryReader.listRestorable()` throw through `decodeURIComponent(entry.name)`.
- The fixed reader skips that malformed directory and still returns valid restorable sessions.
- No screenshot attached: this is daemon cold-restore history parsing covered by deterministic tests.

## Verification
- `pnpm test src/main/daemon/history-reader.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/daemon/history-reader.ts src/main/daemon/history-reader.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.