### PR TITLE
fix: guard repo combobox add state

### DIFF
--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -13,6 +13,7 @@ import { useAppStore } from '@/store'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { searchRepos } from '@/lib/repo-search'
 import { cn } from '@/lib/utils'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import type { Repo } from '../../../../shared/types'
 import RepoBadgeLabel from './RepoBadgeLabel'
 
@@ -49,6 +50,7 @@ export default function RepoCombobox({
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
   const inputRef = React.useRef<HTMLInputElement | null>(null)
   const focusFrameRef = React.useRef<number | null>(null)
+  const mountedRef = useMountedRef()
 
   const selectedRepo = useMemo(
     () => repos.find((repo) => repo.id === value) ?? null,
@@ -151,14 +153,19 @@ export default function RepoCombobox({
         if (isGitRepoKind(repo)) {
           await fetchWorktrees(repo.id)
         }
+        if (!mountedRef.current) {
+          return
+        }
         onValueChange(repo.id)
         setOpen(false)
         setQuery('')
       }
     } finally {
-      setIsAdding(false)
+      if (mountedRef.current) {
+        setIsAdding(false)
+      }
     }
-  }, [addRepo, fetchWorktrees, isAdding, onValueChange])
+  }, [addRepo, fetchWorktrees, isAdding, mountedRef, onValueChange])
 
   return (
     <div className="flex w-full items-center gap-1.5">


### PR DESCRIPTION
## Summary
- Guard RepoCombobox add-folder completion before selecting/closing local combobox state after unmount.
- Preserve project add and worktree-fetch side effects.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only combobox local state cleanup.
- `addRepo` and `fetchWorktrees` behavior is unchanged.
- Only parent selection and combobox-local open/query/spinner state are skipped after unmount.

## Validation
- `pnpm exec oxlint src/renderer/src/components/repo/RepoCombobox.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)