### PR TITLE
fix: guard worktree meta dialog state

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -15,6 +15,7 @@ import { parseGitHubIssueOrPRLink, parseGitHubIssueOrPRNumber } from '@/lib/gith
 import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { ExternalLink, LoaderCircle } from 'lucide-react'
 import type { WorktreeMeta } from '../../../../shared/types'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 function parseExplicitGitHubIssueUrl(input: string): string | null {
   const trimmed = input.trim()
@@ -64,6 +65,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const prevIsOpenRef = useRef(false)
   const displayNameInputRef = useRef<HTMLInputElement>(null)
+  const mountedRef = useMountedRef()
   if (isOpen && !prevIsOpenRef.current) {
     setDisplayNameInput(currentDisplayName)
     setIssueInput(currentIssue)
@@ -166,7 +168,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
       await updateWorktreeMeta(worktreeId, updates)
       closeModal()
     } finally {
-      setSaving(false)
+      if (mountedRef.current) {
+        setSaving(false)
+      }
     }
   }, [
     worktreeId,
@@ -177,7 +181,8 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     prInput,
     commentInput,
     updateWorktreeMeta,
-    closeModal
+    closeModal,
+    mountedRef
   ])
 
   const handleCommentKeyDown = useCallback(
@@ -232,7 +237,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
         void window.api.shell.openUrl(issue.url)
       }
     } finally {
-      setOpeningIssue(false)
+      if (mountedRef.current) {
+        setOpeningIssue(false)
+      }
     }
   }, [
     cachedIssueUrl,
@@ -241,6 +248,7 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
     issueNumber,
     issueRepo,
     issueUrlFromInput,
+    mountedRef,
     openingIssue
   ])
 


### PR DESCRIPTION
## Summary
- Guard WorktreeMetaDialog async spinner cleanup after metadata save and issue open fetches resolve.
- Preserve metadata updates, modal close behavior, and issue URL opening side effects.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only dialog-local loading state cleanup.
- No change to worktree metadata persistence or issue lookup/open behavior.
- Only stale `saving`/`openingIssue` resets are skipped after unmount.

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)