### PR TITLE
fix: guard forwarded port remove state

### DIFF
--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -34,6 +34,7 @@ import {
   advertisedBrowserUrlForForwardedRow,
   browserUrlForPortForwardEntry
 } from '@/lib/workspace-port-urls'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   Dialog,
   DialogContent,
@@ -863,6 +864,7 @@ function ForwardedPortRow({
   onOpenInBrowser: () => void
 }): React.JSX.Element {
   const [removing, setRemoving] = useState(false)
+  const mountedRef = useMountedRef()
   const forwardedAddress = addressForPortForwardEntry(entry)
 
   const handleRemove = useCallback(async () => {
@@ -872,8 +874,10 @@ function ForwardedPortRow({
     } catch {
       // broadcast will update state
     }
-    setRemoving(false)
-  }, [entry.id])
+    if (mountedRef.current) {
+      setRemoving(false)
+    }
+  }, [entry.id, mountedRef])
 
   const handleCopy = useCallback(() => {
     void window.api.ui.writeClipboardText(forwardedAddress)


### PR DESCRIPTION
## Summary
- Guard ForwardedPortRow local removing state after async SSH port-forward removal resolves.
- Leave the remove IPC and broadcast-driven list update behavior unchanged.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only row-local spinner cleanup.
- No change to SSH port-forward removal semantics.
- Existing broadcast refresh remains the source of truth for row/list state.

## Validation
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/PortsPanel.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)