### PR TITLE
perf: clean smart name input focus frame from ref

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -231,16 +231,6 @@ export default function SmartWorkspaceNameField({
     [gitlabAvailable, linearAvailable, textOnly]
   )
 
-  const setInputNode = useCallback(
-    (node: HTMLInputElement | null) => {
-      localInputRef.current = node
-      if (inputRef) {
-        inputRef.current = node
-      }
-    },
-    [inputRef]
-  )
-
   const cancelSelectedSourceFocusFrame = useCallback((): void => {
     if (selectedSourceFocusFrameRef.current === null) {
       return
@@ -257,12 +247,20 @@ export default function SmartWorkspaceNameField({
     localInputFocusFrameRef.current = null
   }, [])
 
-  useEffect(
-    () => () => {
-      cancelSelectedSourceFocusFrame()
-      cancelLocalInputFocusFrame()
+  const setInputNode = useCallback(
+    (node: HTMLInputElement | null) => {
+      if (!node) {
+        // Why: tab-mode changes schedule a deferred input focus. If the input
+        // disappears first, cancel at the input owner boundary instead of
+        // keeping a cleanup-only Effect for this one animation frame.
+        cancelLocalInputFocusFrame()
+      }
+      localInputRef.current = node
+      if (inputRef) {
+        inputRef.current = node
+      }
     },
-    [cancelLocalInputFocusFrame, cancelSelectedSourceFocusFrame]
+    [cancelLocalInputFocusFrame, inputRef]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -916,6 +916,11 @@ export default function SmartWorkspaceNameField({
           setMode(nextMode)
           setOpen(!disabled && nextMode !== 'text')
           cancelLocalInputFocusFrame()
+          if (!localInputRef.current) {
+            return
+          }
+          // Why: selected-source mode keeps tabs visible while the input is
+          // absent, so no input ref would own cancellation for this frame.
           localInputFocusFrameRef.current = requestAnimationFrame(() => {
             localInputFocusFrameRef.current = null
             localInputRef.current?.focus({ preventScroll: true })


### PR DESCRIPTION
## Summary

Moves the SmartWorkspaceNameField tab-mode input focus-frame cleanup from a cleanup-only `useEffect` into the input ref lifecycle. The deferred input focus still gets canceled if the input unmounts before the animation frame runs, while the selected-source focus frame remains covered by the existing selected-source Effect cleanup.

## Risk

`risk:medium` because this touches new-workspace source/input focus timing. It does not change provider querying, repo selection, task-link parsing, paths, SSH behavior, or cross-platform shortcuts.

## Validation

- `pnpm exec oxlint src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/composer-branch-selection.test.ts src/renderer/src/lib/smart-github-submit.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Renderer Effect count: 807 -> 806.

Made with [Orca](https://github.com/stablyai/orca) 🐋

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.