### PR TITLE
fix: avoid spread limit in usage session scans

### DIFF
--- a/src/main/claude-usage/scanner-large-directory.test.ts
+++ b/src/main/claude-usage/scanner-large-directory.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Dirent } from 'node:fs'
+import type * as FsPromises from 'fs/promises'
+import type * as NodeOs from 'os'
+import { join } from 'path'
+
+const { homedirMock, readdirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>(),
+  readdirMock: vi.fn<(dirPath: string) => Promise<Dirent[]>>()
+}))
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('os')
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('fs/promises')
+  return {
+    ...actual,
+    readdir: readdirMock
+  }
+})
+
+const FILE_COUNT = 125_000
+const FAKE_HOME = join('/', 'tmp', 'orca-large-claude-home')
+const PROJECTS_ROOT = join(FAKE_HOME, '.claude', 'projects')
+const TRANSCRIPTS_ROOT = join(FAKE_HOME, '.claude', 'transcripts')
+const PROJECT_DIR = join(PROJECTS_ROOT, 'large-project')
+
+function dirent(name: string, kind: 'directory' | 'file'): Dirent {
+  return {
+    name,
+    isDirectory: () => kind === 'directory',
+    isFile: () => kind === 'file'
+  } as Dirent
+}
+
+const largeTranscriptEntries = Array.from({ length: FILE_COUNT }, (_, index) =>
+  dirent(`session-${index}.jsonl`, 'file')
+)
+
+describe('listClaudeTranscriptFiles large directories', () => {
+  it('keeps nested transcript scans past the JavaScript spread-argument limit', async () => {
+    homedirMock.mockReturnValue(FAKE_HOME)
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === PROJECTS_ROOT) {
+        return [dirent('large-project', 'directory')]
+      }
+      if (dirPath === PROJECT_DIR) {
+        return largeTranscriptEntries
+      }
+      if (dirPath === TRANSCRIPTS_ROOT) {
+        return []
+      }
+      throw new Error(`Unexpected readdir path: ${dirPath}`)
+    })
+
+    const { listClaudeTranscriptFiles } = await import('./scanner')
+
+    await expect(listClaudeTranscriptFiles()).resolves.toHaveLength(FILE_COUNT)
+  })
+})

--- a/src/main/claude-usage/scanner.ts
+++ b/src/main/claude-usage/scanner.ts
@@ -133,7 +133,7 @@ async function walkJsonlFiles(dirPath: string): Promise<string[]> {
   for (const entry of entries) {
     const fullPath = join(dirPath, entry.name)
     if (entry.isDirectory()) {
-      files.push(...(await walkJsonlFiles(fullPath)))
+      appendDiscoveredFiles(files, await walkJsonlFiles(fullPath))
       continue
     }
     if (entry.isFile() && entry.name.endsWith('.jsonl')) {
@@ -142,6 +142,14 @@ async function walkJsonlFiles(dirPath: string): Promise<string[]> {
   }
 
   return files
+}
+
+function appendDiscoveredFiles(target: string[], source: readonly string[]): void {
+  // Why: long-lived transcript directories can exceed V8's argument limit if
+  // child file arrays are spread into push().
+  for (const filePath of source) {
+    target.push(filePath)
+  }
 }
 
 export async function listClaudeTranscriptFiles(): Promise<string[]> {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -969,7 +969,7 @@ export class CodexRuntimeHomeService {
     for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
       const childPath = join(rootPath, entry.name)
       if (entry.isDirectory()) {
-        files.push(...this.listFilesRecursively(childPath))
+        this.appendListedFiles(files, this.listFilesRecursively(childPath))
         continue
       }
       if (entry.isFile()) {
@@ -977,6 +977,14 @@ export class CodexRuntimeHomeService {
       }
     }
     return files.sort()
+  }
+
+  private appendListedFiles(target: string[], source: readonly string[]): void {
+    // Why: migrating legacy session trees must tolerate directories larger than
+    // V8's argument limit for spread calls.
+    for (const filePath of source) {
+      target.push(filePath)
+    }
   }
 
   private getPreservedLegacySessionPath(runtimeFilePath: string, accountId: string): string {

--- a/src/main/codex-usage/scanner-large-directory.test.ts
+++ b/src/main/codex-usage/scanner-large-directory.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Dirent, Stats } from 'node:fs'
+import type * as FsPromises from 'fs/promises'
+import { join } from 'path'
+
+const { readdirMock, statMock } = vi.hoisted(() => ({
+  readdirMock: vi.fn<(dirPath: string) => Promise<Dirent[]>>(),
+  statMock: vi.fn<(filePath: string) => Promise<Stats>>()
+}))
+
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('fs/promises')
+  return {
+    ...actual,
+    readdir: readdirMock,
+    stat: statMock
+  }
+})
+
+const FILE_COUNT = 125_000
+const FAKE_ROOT = join('/', 'tmp', 'orca-large-codex-home')
+const RUNTIME_SESSIONS_ROOT = join(FAKE_ROOT, 'runtime', 'sessions')
+const SYSTEM_SESSIONS_ROOT = join(FAKE_ROOT, 'system', 'sessions')
+const RUNTIME_BULK_DIR = join(RUNTIME_SESSIONS_ROOT, 'bulk')
+
+vi.mock('../codex/codex-home-paths', () => ({
+  getOrcaManagedCodexHomePath: () => join(FAKE_ROOT, 'runtime'),
+  getSystemCodexHomePath: () => join(FAKE_ROOT, 'system')
+}))
+
+vi.mock('../codex/codex-session-bridge', () => ({
+  getLegacyCopiedCodexSessionBridgeScanPreference: () => null
+}))
+
+function dirent(name: string, kind: 'directory' | 'file'): Dirent {
+  return {
+    name,
+    isDirectory: () => kind === 'directory',
+    isFile: () => kind === 'file'
+  } as Dirent
+}
+
+const largeSessionEntries = Array.from({ length: FILE_COUNT }, (_, index) =>
+  dirent(`session-${index}.jsonl`, 'file')
+)
+
+describe('listCodexSessionFiles large directories', () => {
+  it('keeps nested session scans past the JavaScript spread-argument limit', async () => {
+    readdirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === RUNTIME_SESSIONS_ROOT) {
+        return [dirent('bulk', 'directory')]
+      }
+      if (dirPath === RUNTIME_BULK_DIR) {
+        return largeSessionEntries
+      }
+      if (dirPath === SYSTEM_SESSIONS_ROOT) {
+        return []
+      }
+      throw new Error(`Unexpected readdir path: ${dirPath}`)
+    })
+    statMock.mockImplementation(async (filePath) => {
+      const match = /session-(\d+)\.jsonl$/.exec(filePath.replaceAll('\\', '/'))
+      return {
+        dev: 1,
+        ino: match ? Number(match[1]) + 1 : 0
+      } as Stats
+    })
+
+    const { listCodexSessionFiles } = await import('./scanner')
+
+    await expect(listCodexSessionFiles()).resolves.toHaveLength(FILE_COUNT)
+  })
+})

--- a/src/main/codex-usage/scanner.ts
+++ b/src/main/codex-usage/scanner.ts
@@ -97,7 +97,7 @@ async function walkJsonlFiles(dirPath: string): Promise<string[]> {
   for (const entry of entries) {
     const fullPath = join(dirPath, entry.name)
     if (entry.isDirectory()) {
-      files.push(...(await walkJsonlFiles(fullPath)))
+      appendDiscoveredFiles(files, await walkJsonlFiles(fullPath))
       continue
     }
     if (entry.isFile() && entry.name.endsWith('.jsonl')) {
@@ -106,6 +106,14 @@ async function walkJsonlFiles(dirPath: string): Promise<string[]> {
   }
 
   return files
+}
+
+function appendDiscoveredFiles(target: string[], source: readonly string[]): void {
+  // Why: large session directories can exceed V8's argument limit if child
+  // file arrays are spread into push().
+  for (const filePath of source) {
+    target.push(filePath)
+  }
 }
 
 export function getCodexSessionsDirectory(): string {
@@ -127,7 +135,7 @@ export async function listCodexSessionFiles(): Promise<string[]> {
   const files: string[] = []
   for (const dirPath of getCodexSessionDirectories()) {
     try {
-      files.push(...(await walkJsonlFiles(dirPath)))
+      appendDiscoveredFiles(files, await walkJsonlFiles(dirPath))
     } catch {
       // Missing or unreadable history in one home should not hide the other.
     }

--- a/src/main/codex/codex-session-bridge.ts
+++ b/src/main/codex/codex-session-bridge.ts
@@ -61,7 +61,7 @@ function listCodexSessionJsonlFiles(rootPath: string): string[] {
     for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
       const childPath = join(rootPath, entry.name)
       if (entry.isDirectory()) {
-        files.push(...listCodexSessionJsonlFiles(childPath))
+        appendSessionFilePaths(files, listCodexSessionJsonlFiles(childPath))
         continue
       }
       if (entry.isFile() && entry.name.endsWith('.jsonl')) {
@@ -72,6 +72,14 @@ function listCodexSessionJsonlFiles(rootPath: string): string[] {
     console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
   }
   return files.sort()
+}
+
+function appendSessionFilePaths(target: string[], source: readonly string[]): void {
+  // Why: existing Codex homes can accumulate enough nested sessions to exceed
+  // V8's argument limit if child arrays are spread into push().
+  for (const filePath of source) {
+    target.push(filePath)
+  }
 }
 
 function linkSystemCodexSessionFile(


### PR DESCRIPTION
## Summary
- replace recursive `push(...childFiles)` aggregation in Claude/Codex usage scanners with loop appends so large nested history directories are not dropped
- apply the same spread-limit guard to Codex session bridge and legacy runtime-home session migration walkers
- add mocked large-directory regressions for the public Claude and Codex usage listing paths

## Evidence
- Failing repro before the fix: `pnpm test src/main/claude-usage/scanner-large-directory.test.ts src/main/codex-usage/scanner-large-directory.test.ts` returned `[]` for both scanners when a nested directory exposed 125,000 JSONL entries.
- After the fix: `pnpm test src/main/claude-usage/scanner-large-directory.test.ts src/main/codex-usage/scanner-large-directory.test.ts`
- Adjacent suites: `pnpm test src/main/claude-usage/scanner.test.ts src/main/claude-usage/scanner-scan.test.ts src/main/codex-usage/scanner.test.ts src/main/codex-usage/scanner-paths.test.ts src/main/codex/codex-session-bridge.test.ts src/main/codex-accounts/runtime-home-service.test.ts`
- Typecheck: `pnpm run typecheck:node`
- Lint: `pnpm exec oxlint src/main/claude-usage/scanner.ts src/main/claude-usage/scanner-large-directory.test.ts src/main/codex-usage/scanner.ts src/main/codex-usage/scanner-large-directory.test.ts src/main/codex/codex-session-bridge.ts src/main/codex-accounts/runtime-home-service.ts`

## Risk
Low. The change preserves ordering and filtering while replacing argument-spread array appends with equivalent loops.
