### PR TITLE
fix: avoid spread limit in bulk discard

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -210,6 +210,24 @@ describe('bulk git helpers', () => {
     expect(rmMock).not.toHaveBeenCalled()
   })
 
+  it('handles bulk discard directories with many tracked descendants', async () => {
+    const trackedDescendants = Array.from({ length: 125_000 }, (_, index) => `src/file-${index}.ts`)
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: `${trackedDescendants.join('\0')}\0` })
+      .mockResolvedValueOnce({ stdout: '' })
+
+    await bulkDiscardChanges('/repo', ['src'])
+
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      ['restore', '--worktree', '--source=HEAD', '--', ':(literal)src'],
+      {
+        cwd: '/repo'
+      }
+    )
+    expect(rmMock).not.toHaveBeenCalled()
+  })
+
   it('rejects bulk discard paths that traverse outside the worktree', async () => {
     await expect(bulkDiscardChanges('/repo', ['src/file.ts', '../outside.txt'])).rejects.toThrow(
       'resolves outside the worktree'

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1158,7 +1158,13 @@ async function listTrackedPathSpecs(
         cwd: worktreePath
       }
     )
-    trackedPaths.push(...stdout.split('\0').filter(Boolean))
+    // Why: a selected directory can expand to more tracked descendants than
+    // V8 allows as spread arguments.
+    for (const trackedPath of stdout.split('\0')) {
+      if (trackedPath) {
+        trackedPaths.push(trackedPath)
+      }
+    }
   }
   return trackedPaths
 }


### PR DESCRIPTION
## Summary
- avoid spreading the full `git ls-files -z` result into `trackedPaths.push(...)` during bulk discard
- add a regression for selecting a tracked directory with 125,000 tracked descendants

## Evidence
- Failing repro before the fix: `pnpm test src/main/git/status.test.ts -- -t "many tracked descendants"` threw `RangeError: Maximum call stack size exceeded` at `trackedPaths.push(...stdout.split(...))`.
- After the fix: `pnpm test src/main/git/status.test.ts`
- Typecheck: `pnpm run typecheck:node`
- Lint: `pnpm exec oxlint src/main/git/status.ts src/main/git/status.test.ts`

## Risk
Low. The collector preserves the same NUL-delimited filtering and ordering, but appends entries with a loop instead of a spread call.

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.