### PR TITLE
fix: guard remote file browser unmount

### DIFF
--- a/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
+++ b/src/renderer/src/components/sidebar/RemoteFileBrowser.tsx
@@ -81,8 +81,14 @@ export function RemoteFileBrowser({
     setFileHint(false)
   }, [])
 
+  const invalidateBrowseRequests = useCallback(() => {
+    genRef.current++
+    previewGenRef.current++
+  }, [])
+
   useEffect(() => {
     return () => {
+      invalidateBrowseRequests()
       if (fileHintTimerRef.current) {
         clearTimeout(fileHintTimerRef.current)
         fileHintTimerRef.current = null
@@ -96,7 +102,7 @@ export function RemoteFileBrowser({
         pasteResolveTimerRef.current = null
       }
     }
-  }, [])
+  }, [invalidateBrowseRequests])
 
   const fetchListing = useCallback(
     async (dirPath: string): Promise<BrowseResult> => {


### PR DESCRIPTION
## Summary
- Invalidate RemoteFileBrowser browse and preview generations during unmount cleanup.
- Reuse the existing stale-request guards so in-flight SSH browse results cannot update picker state after close.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Read-only SSH directory browsing UI cleanup.
- No change to browse RPCs, path parsing, cache semantics, or selection behavior while mounted.
- Existing generation guards already drop superseded requests; this extends them to unmount.

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/RemoteFileBrowser.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)