### PR TITLE
Fix worktree removal path boundary for dotdot-prefixed children

### DIFF
--- a/src/main/worktree-orphan-gitdir-proof.ts
+++ b/src/main/worktree-orphan-gitdir-proof.ts
@@ -192,9 +192,13 @@ async function adminGitdirPointsAtCandidate(
 
 function containsPath(parentPath: string, childPath: string, pathOps: PathOps): boolean {
   const relativePath = pathOps.relative(parentPath, childPath)
+  // Why: `..name` is a valid child name; only `..` and `../...` escape.
   return (
     relativePath === '' ||
-    (!!relativePath && !relativePath.startsWith('..') && !pathOps.isAbsolute(relativePath))
+    (!!relativePath &&
+      relativePath !== '..' &&
+      !relativePath.startsWith(`..${pathOps.sep}`) &&
+      !pathOps.isAbsolute(relativePath))
   )
 }
 

--- a/src/main/worktree-removal-safety.test.ts
+++ b/src/main/worktree-removal-safety.test.ts
@@ -80,6 +80,18 @@ describe('getRegisteredDeletableWorktree', () => {
       ])
     ).toMatchObject({ path: '/workspaces/parent' })
   })
+
+  it('rejects deleting a worktree that contains another registered worktree in a dotdot-prefixed child', () => {
+    expect(() =>
+      getRegisteredDeletableWorktree('/repo', '/workspaces/parent', [
+        makeGitWorktree('/repo', true),
+        makeGitWorktree('/workspaces/parent'),
+        makeGitWorktree('/workspaces/parent/..child')
+      ])
+    ).toThrow(
+      'Refusing to delete worktree because it contains another registered worktree: /workspaces/parent/..child'
+    )
+  })
 })
 
 describe('canSafelyRemoveOrphanedWorktreeDirectory', () => {
@@ -92,6 +104,20 @@ describe('canSafelyRemoveOrphanedWorktreeDirectory', () => {
         makeReadPath([
           ['/workspaces/orphan/.git', 'gitdir: /repo/.git/worktrees/orphan\n'],
           ['/repo/.git/worktrees/orphan/gitdir', '/workspaces/orphan/.git\n']
+        ])
+      )
+    ).resolves.toBe(true)
+  })
+
+  it('accepts repo worktree admin entries with dotdot-prefixed directory names', async () => {
+    await expect(
+      canSafelyRemoveOrphanedWorktreeDirectory(
+        '/workspaces/orphan',
+        '/repo',
+        makeStatPath(['/workspaces/orphan/.git'], ['/repo/.git']),
+        makeReadPath([
+          ['/workspaces/orphan/.git', 'gitdir: /repo/.git/worktrees/..orphan\n'],
+          ['/repo/.git/worktrees/..orphan/gitdir', '/workspaces/orphan/.git\n']
         ])
       )
     ).resolves.toBe(true)

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -46,9 +46,13 @@ function getPathOps(...paths: string[]): PathOps {
 
 function containsPath(parentPath: string, childPath: string, pathOps: PathOps): boolean {
   const relativePath = pathOps.relative(parentPath, childPath)
+  // Why: `..name` is a valid child name; only `..` and `../...` escape.
   return (
     relativePath === '' ||
-    (!!relativePath && !relativePath.startsWith('..') && !pathOps.isAbsolute(relativePath))
+    (!!relativePath &&
+      relativePath !== '..' &&
+      !relativePath.startsWith(`..${pathOps.sep}`) &&
+      !pathOps.isAbsolute(relativePath))
   )
 }
 


### PR DESCRIPTION
## Summary
- treat child path names like `..child` as valid descendants instead of parent escapes
- apply the same boundary rule to orphaned-worktree gitdir proof checks
- add regressions for registered nested worktree deletion guards and orphan admin entries named `..*`

## Repro / verification
- Before the fix, `pnpm test src/main/worktree-removal-safety.test.ts` failed: the registered child worktree under `/workspaces/parent/..child` was not detected, and an admin entry under `/repo/.git/worktrees/..orphan` was rejected.
- After the fix: `pnpm test src/main/worktree-removal-safety.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/worktree-removal-safety.ts src/main/worktree-orphan-gitdir-proof.ts src/main/worktree-removal-safety.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.