### PR TITLE
fix: guard feature wall usage refresh

### DIFF
--- a/src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
+++ b/src/renderer/src/components/feature-wall/use-feature-wall-completion.ts
@@ -19,6 +19,7 @@ import {
 import { hasFeatureWallUsageTracking } from './feature-wall-usage-tracking'
 import { usePersistedFeatureWallCompletion } from './use-persisted-feature-wall-completion'
 import { useFeatureWallSessionDepth } from './use-feature-wall-session-depth'
+import { useMountedRef } from '@/hooks/useMountedRef'
 
 export type FeatureWallCompletionState = {
   workflowDone: Record<FeatureWallWorkflowId, boolean>
@@ -43,6 +44,7 @@ export function useFeatureWallCompletion(
 ): FeatureWallCompletionState {
   const { onTourDepthSummaryChange } = options
   const settings = useAppStore((s) => s.settings)
+  const mountedRef = useMountedRef()
   const preflightStatus = useAppStore((s) => s.preflightStatus)
   const rateLimits = useAppStore((s) => s.rateLimits)
   const fetchRateLimits = useAppStore((s) => s.fetchRateLimits)
@@ -100,8 +102,11 @@ export function useFeatureWallCompletion(
   }, [rateLimits.claude, rateLimits.codex])
 
   const refreshUsageAccountState = useCallback(async (): Promise<void> => {
-    setHasUsageAccount(await readUsageAccountState())
-  }, [readUsageAccountState])
+    const nextHasUsageAccount = await readUsageAccountState()
+    if (mountedRef.current) {
+      setHasUsageAccount(nextHasUsageAccount)
+    }
+  }, [mountedRef, readUsageAccountState])
 
   const sessionDepth = useFeatureWallSessionDepth({
     isOpen,


### PR DESCRIPTION
## Summary
- Guard the Feature Wall completion usage-account refresh callback before updating local completion state after unmount.
- Leave account/rate-limit reads unchanged.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- Renderer-only hook state cleanup.
- Existing account and rate-limit read behavior is unchanged.
- Mirrors the stale guard already used by the hook's open/focus refresh effect.

## Validation
- `pnpm exec oxlint src/renderer/src/components/feature-wall/use-feature-wall-completion.ts`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)