### PR TITLE
Fix filesystem auth for dotdot-prefixed child paths

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -6,8 +6,10 @@ import { listRepoWorktrees } from '../repo-worktrees'
 import type { GitWorktreeInfo, Repo } from '../../shared/types'
 import {
   invalidateAuthorizedRootsCache,
+  isDescendantOrEqual,
   rebuildAuthorizedRootsCache,
-  resolveRegisteredWorktreePath
+  resolveRegisteredWorktreePath,
+  validateGitRelativeFilePath
 } from './filesystem-auth'
 
 vi.mock('../repo-worktrees', async () => {
@@ -63,5 +65,30 @@ describe('filesystem auth worktree roots', () => {
       resolve(lastWorktreePath)
     )
     expect(listRepoWorktrees).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('filesystem-auth path containment', () => {
+  it('allows descendants whose path segment starts with dotdot characters', () => {
+    const root = resolve('/workspace/repo')
+    const child = resolve('/workspace/repo/..fixtures/file.ts')
+
+    expect(isDescendantOrEqual(child, root)).toBe(true)
+  })
+
+  it('allows git-relative files under dotdot-prefixed child directories', () => {
+    expect(validateGitRelativeFilePath(resolve('/workspace/repo'), '..fixtures/file.ts')).toBe(
+      '..fixtures/file.ts'
+    )
+  })
+
+  it('still rejects parent-directory escapes', () => {
+    const root = resolve('/workspace/repo')
+    const outside = resolve('/workspace/repo/../other/file.ts')
+
+    expect(isDescendantOrEqual(outside, root)).toBe(false)
+    expect(() => validateGitRelativeFilePath(root, '../other/file.ts')).toThrow(
+      'Access denied: git file path escapes the selected worktree'
+    )
   })
 })

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -52,8 +52,7 @@ export function isDescendantOrEqual(resolvedTarget: string, resolvedBase: string
   // where relative('D:\\repo', 'C:\\etc\\passwd') returns absolute path 'C:\\etc\\passwd'
   return (
     rel !== '' &&
-    rel !== '..' &&
-    !rel.startsWith(`..${sep}`) &&
+    !(rel === '..' || rel.startsWith(`..${sep}`)) &&
     !isAbsolute(rel) &&
     resolve(resolvedBase, rel) === resolvedTarget
   )

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -1,4 +1,4 @@
-import { resolve, relative, dirname, basename, isAbsolute } from 'path'
+import { resolve, relative, dirname, basename, isAbsolute, sep } from 'path'
 import { realpathSync } from 'fs'
 import { realpath } from 'fs/promises'
 import type { Store } from '../persistence'
@@ -47,12 +47,13 @@ export function isDescendantOrEqual(resolvedTarget: string, resolvedBase: string
     return true
   }
   const rel = relative(resolvedBase, resolvedTarget)
-  // rel must not start with ".." and must not be an absolute path (e.g. different drive on Windows)
+  // rel must not be ".."/"../..." or an absolute path (e.g. different drive on Windows)
   // [Security Fix]: Added !isAbsolute(rel) to prevent drive traversal bypasses on Windows
   // where relative('D:\\repo', 'C:\\etc\\passwd') returns absolute path 'C:\\etc\\passwd'
   return (
     rel !== '' &&
-    !rel.startsWith('..') &&
+    rel !== '..' &&
+    !rel.startsWith(`..${sep}`) &&
     !isAbsolute(rel) &&
     resolve(resolvedBase, rel) === resolvedTarget
   )


### PR DESCRIPTION
## Summary
- allow legitimate child path segments like `..fixtures` in filesystem authorization containment checks
- keep parent-directory escapes and cross-drive absolute-relative results rejected
- add direct regressions for auth containment and git-relative path validation

## Repro / verification
- Before the fix, `pnpm test src/main/ipc/filesystem-auth.test.ts` failed because `/workspace/repo/..fixtures/file.ts` was treated as outside `/workspace/repo`, and `validateGitRelativeFilePath(..., '..fixtures/file.ts')` threw.
- After the fix: `pnpm test src/main/ipc/filesystem-auth.test.ts src/main/ipc/filesystem.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/filesystem-auth.ts src/main/ipc/filesystem-auth.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.