### PR TITLE
Fix Quick Open filtering for dotdot-prefixed child paths

### DIFF
--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -75,6 +75,12 @@ describe('buildExcludePathPrefixes', () => {
   it('strips trailing slashes', () => {
     expect(buildExcludePathPrefixes('/r', ['/r/a/', '/r/b///'])).toEqual(['a', 'b'])
   })
+
+  it('keeps valid child prefixes whose segment starts with dotdot characters', () => {
+    expect(buildExcludePathPrefixes('/home/u/repo', ['/home/u/repo/..fixtures'])).toEqual([
+      '..fixtures'
+    ])
+  })
 })
 
 describe('shouldExcludeQuickOpenRelPath', () => {
@@ -179,6 +185,12 @@ describe('normalizeQuickOpenRgLine', () => {
     expect(normalizeQuickOpenRgLine('./src/a.ts', { kind: 'cwd-relative' })).toBe('src/a.ts')
   })
 
+  it('keeps cwd-relative files under dotdot-prefixed child directories', () => {
+    expect(normalizeQuickOpenRgLine('./..fixtures/a.ts', { kind: 'cwd-relative' })).toBe(
+      '..fixtures/a.ts'
+    )
+  })
+
   it('strips CRLF', () => {
     expect(normalizeQuickOpenRgLine('/root/a.ts\r', { kind: 'absolute', rootPath: '/root' })).toBe(
       'a.ts'
@@ -194,6 +206,11 @@ describe('normalizeQuickOpenRgLine', () => {
   it('returns null for empty or root-equal lines', () => {
     expect(normalizeQuickOpenRgLine('', { kind: 'cwd-relative' })).toBeNull()
     expect(normalizeQuickOpenRgLine('.', { kind: 'cwd-relative' })).toBeNull()
+  })
+
+  it('returns null for cwd-relative parent-directory escapes', () => {
+    expect(normalizeQuickOpenRgLine('../outside/a.ts', { kind: 'cwd-relative' })).toBeNull()
+    expect(normalizeQuickOpenRgLine('./../outside/a.ts', { kind: 'cwd-relative' })).toBeNull()
   })
 })
 

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -132,7 +132,7 @@ export function buildExcludePathPrefixes(rootPath: string, excludePaths?: unknow
       : // Fall back to path-flavor relative so we do not accidentally use the
         // local OS's semantics on remote paths.
         flavor.relative(trimmedRoot, raw).replace(/\\/g, '/')
-    if (!rel || rel.startsWith('..') || rel.startsWith('/')) {
+    if (!rel || isParentRelativePath(rel) || rel.startsWith('/')) {
       continue
     }
     // Strip any trailing slash so boundary checks are unambiguous.
@@ -187,6 +187,11 @@ function escapeGlob(segment: string): string {
 function escapeGlobPath(relPath: string): string {
   // Split on '/' so the separators are not themselves escaped.
   return relPath.split('/').map(escapeGlob).join('/')
+}
+
+function isParentRelativePath(relPath: string): boolean {
+  // Why: `..name` is a valid child path; only `..` and `../...` escape.
+  return relPath === '..' || relPath.startsWith('../')
 }
 
 // ─── rg traversal-pruning globs ──────────────────────────────────────
@@ -305,7 +310,7 @@ export function normalizeQuickOpenRgLine(rawLine: string, outputMode: RgOutputMo
     } else if (rel === '.') {
       return null
     }
-    if (!rel || rel.startsWith('/') || rel.startsWith('..')) {
+    if (!rel || rel.startsWith('/') || isParentRelativePath(rel)) {
       return null
     }
     return rel


### PR DESCRIPTION
## Summary
- keep valid cwd-relative files under directories like `..fixtures` in Quick Open results
- keep nested-worktree exclude prefixes when the child directory starts with `..`
- continue rejecting actual parent escapes like `../outside` and `./../outside`

## Repro / verification
- Before the fix, `pnpm test src/shared/quick-open-filter.test.ts` failed because `./..fixtures/a.ts` normalized to `null`, and `/home/u/repo/..fixtures` was dropped from exclude prefixes.
- After the fix: `pnpm test src/shared/quick-open-filter.test.ts src/main/ipc/filesystem-list-files.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/shared/quick-open-filter.ts src/shared/quick-open-filter.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.