### PR TITLE
Fix upload guards for dotdot-prefixed child paths

### DIFF
--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -524,6 +524,87 @@ describe('fs:importExternalPaths', () => {
     expect(closeMock).toHaveBeenCalled()
   })
 
+  it('stages runtime upload directories whose child names start with dotdot characters', async () => {
+    const sourcePath = '/tmp/dropped/project'
+    const resolvedPath = path.resolve(sourcePath)
+    const childDir = path.join(resolvedPath, '..assets')
+    const childFile = path.join(childDir, 'icon.txt')
+    lstatMock.mockImplementation(async (p: string) => {
+      if (p === resolvedPath || p === childDir) {
+        return {
+          size: 0,
+          ino: 1,
+          dev: 1,
+          isFile: () => false,
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }
+      }
+      if (p === childFile) {
+        return {
+          size: 4,
+          ino: 2,
+          dev: 1,
+          isFile: () => true,
+          isDirectory: () => false,
+          isSymbolicLink: () => false
+        }
+      }
+      throw enoent()
+    })
+    readdirMock.mockImplementation(async (p: string) => {
+      if (p === resolvedPath) {
+        return [
+          {
+            name: '..assets',
+            isDirectory: () => true,
+            isSymbolicLink: () => false,
+            isFile: () => false
+          }
+        ]
+      }
+      if (p === childDir) {
+        return [
+          {
+            name: 'icon.txt',
+            isDirectory: () => false,
+            isSymbolicLink: () => false,
+            isFile: () => true
+          }
+        ]
+      }
+      return []
+    })
+    openMock.mockResolvedValue({
+      stat: vi.fn().mockResolvedValue({
+        size: 4,
+        ino: 2,
+        dev: 1,
+        isFile: () => true
+      }),
+      readFile: vi.fn().mockResolvedValue(Buffer.from('icon')),
+      close: vi.fn().mockResolvedValue(undefined)
+    })
+
+    const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
+      sourcePaths: [sourcePath]
+    })) as { sources: unknown[] }
+
+    expect(result.sources).toEqual([
+      {
+        sourcePath,
+        status: 'staged',
+        name: 'project',
+        kind: 'directory',
+        entries: [
+          { relativePath: '', kind: 'directory' },
+          { relativePath: '..assets', kind: 'directory' },
+          { relativePath: '..assets/icon.txt', kind: 'file', contentBase64: 'aWNvbg==' }
+        ]
+      }
+    ])
+  })
+
   it('fails runtime upload staging when a file changes between lstat and open', async () => {
     const sourcePath = '/tmp/dropped/logo.png'
     const resolvedPath = path.resolve(sourcePath)

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -14,7 +14,7 @@ import {
   unlink,
   writeFile
 } from 'fs/promises'
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'path'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path'
 import { pipeline } from 'stream/promises'
 import type { Store } from '../persistence'
 import { authorizeExternalPath, resolveAuthorizedPath, isENOENT } from './filesystem-auth'
@@ -554,7 +554,11 @@ async function assertRealPathInsideRoot(
 ): Promise<void> {
   const candidateRealPath = await realpath(candidatePath)
   const relativeToRoot = relative(rootRealPath, candidateRealPath)
-  if (relativeToRoot !== '' && (relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot))) {
+  // Why: `..name` is a valid child path; only `..` and `../...` escape.
+  if (
+    relativeToRoot !== '' &&
+    (relativeToRoot === '..' || relativeToRoot.startsWith(`..${sep}`) || isAbsolute(relativeToRoot))
+  ) {
     throw new Error(`Path escaped upload root during staging: '${displayPath}'`)
   }
 }


### PR DESCRIPTION
## Summary
- allow runtime upload staging to include valid child directories like `..assets`
- allow SFTP directory uploads to traverse the same valid child names
- keep true parent escapes and cross-drive absolute-relative results rejected

## Repro / verification
- Before the fix, `pnpm test src/main/ipc/filesystem-import.test.ts src/main/ssh/sftp-upload.test.ts` failed: runtime staging returned `Path escaped upload root during staging: '..assets'`, and SFTP upload threw `Path escaped upload root` for a local `..assets` child.
- After the fix: `pnpm test src/main/ipc/filesystem-import.test.ts src/main/ssh/sftp-upload.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/filesystem-mutations.ts src/main/ipc/filesystem-import.test.ts src/main/ssh/sftp-upload.ts src/main/ssh/sftp-upload.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.