### PR TITLE
Fix usage attribution for dotdot-prefixed child paths

### DIFF
--- a/src/main/codex-usage/scanner.test.ts
+++ b/src/main/codex-usage/scanner.test.ts
@@ -258,6 +258,35 @@ describe('attributeCodexUsageEvent', () => {
     expect(attributed?.worktreeId).toBe('repo-1::/workspace/repo')
   })
 
+  it('does not attribute true parent-directory escapes to the worktree', async () => {
+    const attributed = await attributeCodexUsageEvent(
+      {
+        sessionId: 'session-1',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        cwd: '/workspace/repo/../other/session',
+        model: 'gpt-5.2-codex',
+        hasInferredPricing: false,
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 25,
+        reasoningOutputTokens: 10,
+        totalTokens: 125
+      },
+      [
+        {
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          path: '/workspace/repo',
+          displayName: 'Repo',
+          canonicalPath: '/workspace/repo'
+        }
+      ]
+    )
+
+    expect(attributed?.projectKey).toBe('cwd:/workspace/repo/../other/session')
+    expect(attributed?.worktreeId).toBeNull()
+  })
+
   it('does not treat different Windows drives as containing paths', async () => {
     const attributed = await attributeCodexUsageEvent(
       {

--- a/src/main/codex-usage/scanner.test.ts
+++ b/src/main/codex-usage/scanner.test.ts
@@ -228,6 +228,36 @@ describe('attributeCodexUsageEvent', () => {
     expect(attributed?.worktreeId).toBe('repo-2::/workspace/repo/app2')
   })
 
+  it('attributes cwd paths under dotdot-prefixed child directories to the worktree', async () => {
+    const attributed = await attributeCodexUsageEvent(
+      {
+        sessionId: 'session-1',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        cwd: '/workspace/repo/..fixtures/session',
+        model: 'gpt-5.2-codex',
+        hasInferredPricing: false,
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 25,
+        reasoningOutputTokens: 10,
+        totalTokens: 125
+      },
+      [
+        {
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo',
+          path: '/workspace/repo',
+          displayName: 'Repo',
+          canonicalPath: '/workspace/repo'
+        }
+      ]
+    )
+
+    expect(attributed?.projectKey).toBe('worktree:repo-1::/workspace/repo')
+    expect(attributed?.projectLabel).toBe('Repo')
+    expect(attributed?.worktreeId).toBe('repo-1::/workspace/repo')
+  })
+
   it('does not treat different Windows drives as containing paths', async () => {
     const attributed = await attributeCodexUsageEvent(
       {

--- a/src/main/codex-usage/scanner.ts
+++ b/src/main/codex-usage/scanner.ts
@@ -454,7 +454,14 @@ function isContainingPath(candidatePath: string, targetPath: string): boolean {
   const isAbsoluteRelative = useWin32
     ? win32.isAbsolute(relativePath)
     : posix.isAbsolute(relativePath)
-  return !isAbsoluteRelative && !relativePath.startsWith('..') && relativePath !== '.'
+  const parentPrefix = useWin32 ? `..${win32.sep}` : `..${posix.sep}`
+  // Why: `..name` is a valid child path; only `..` and `../...` escape.
+  return (
+    !isAbsoluteRelative &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(parentPrefix) &&
+    relativePath !== '.'
+  )
 }
 
 function findContainingWorktree(

--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: OpenCode scanner tests cover multiple DB schema generations and attribution boundaries together so parser regressions stay auditable. */
 import Database from 'better-sqlite3'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
@@ -30,6 +31,21 @@ function worktrees() {
       canonicalPath: WORKTREE
     }
   ]
+}
+
+function usageEvent(cwd: string) {
+  return {
+    sessionId: 'session-1',
+    timestamp: '2026-04-09T10:00:00.000Z',
+    cwd,
+    model: 'anthropic/claude-sonnet-4-5',
+    estimatedCostUsd: 0.012,
+    inputTokens: 100,
+    cachedInputTokens: 10,
+    outputTokens: 25,
+    reasoningOutputTokens: 10,
+    totalTokens: 125
+  }
 }
 
 describe('parseOpenCodeUsageRow', () => {
@@ -79,24 +95,38 @@ describe('parseOpenCodeUsageRow', () => {
 describe('attributeOpenCodeUsageEvent', () => {
   it('attributes cwd paths under dotdot-prefixed child directories to the worktree', async () => {
     const attributed = await attributeOpenCodeUsageEvent(
-      {
-        sessionId: 'session-1',
-        timestamp: '2026-04-09T10:00:00.000Z',
-        cwd: `${WORKTREE}/..fixtures/session`,
-        model: 'anthropic/claude-sonnet-4-5',
-        estimatedCostUsd: 0.012,
-        inputTokens: 100,
-        cachedInputTokens: 10,
-        outputTokens: 25,
-        reasoningOutputTokens: 10,
-        totalTokens: 125
-      },
+      usageEvent(`${WORKTREE}/..fixtures/session`),
       worktrees()
     )
 
     expect(attributed?.projectKey).toBe('worktree:repo-1::/workspace/repo')
     expect(attributed?.projectLabel).toBe('Repo')
     expect(attributed?.worktreeId).toBe('repo-1::/workspace/repo')
+  })
+
+  it('does not attribute true parent-directory escapes to the worktree', async () => {
+    const attributed = await attributeOpenCodeUsageEvent(
+      usageEvent(`${WORKTREE}/../other/session`),
+      worktrees()
+    )
+
+    expect(attributed?.projectKey).toBe('cwd:/workspace/repo/../other/session')
+    expect(attributed?.worktreeId).toBeNull()
+  })
+
+  it('does not treat different Windows drives as containing paths', async () => {
+    const attributed = await attributeOpenCodeUsageEvent(usageEvent('D:\\other\\repo'), [
+      {
+        repoId: 'repo-1',
+        worktreeId: 'repo-1::C:\\repo',
+        path: 'C:\\repo',
+        displayName: 'Repo',
+        canonicalPath: 'C:\\repo'
+      }
+    ])
+
+    expect(attributed?.projectKey).toBe('cwd:d:/other/repo')
+    expect(attributed?.worktreeId).toBeNull()
   })
 })
 

--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { parseOpenCodeUsageDatabase, parseOpenCodeUsageRow } from './scanner'
+import {
+  attributeOpenCodeUsageEvent,
+  parseOpenCodeUsageDatabase,
+  parseOpenCodeUsageRow
+} from './scanner'
 
 const WORKTREE = '/workspace/repo'
 
@@ -69,6 +73,30 @@ describe('parseOpenCodeUsageRow', () => {
       reasoningOutputTokens: 100,
       totalTokens: 1350
     })
+  })
+})
+
+describe('attributeOpenCodeUsageEvent', () => {
+  it('attributes cwd paths under dotdot-prefixed child directories to the worktree', async () => {
+    const attributed = await attributeOpenCodeUsageEvent(
+      {
+        sessionId: 'session-1',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        cwd: `${WORKTREE}/..fixtures/session`,
+        model: 'anthropic/claude-sonnet-4-5',
+        estimatedCostUsd: 0.012,
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 25,
+        reasoningOutputTokens: 10,
+        totalTokens: 125
+      },
+      worktrees()
+    )
+
+    expect(attributed?.projectKey).toBe('worktree:repo-1::/workspace/repo')
+    expect(attributed?.projectLabel).toBe('Repo')
+    expect(attributed?.worktreeId).toBe('repo-1::/workspace/repo')
   })
 })
 

--- a/src/main/opencode-usage/scanner.ts
+++ b/src/main/opencode-usage/scanner.ts
@@ -428,7 +428,14 @@ function isContainingPath(candidatePath: string, targetPath: string): boolean {
   const isAbsoluteRelative = useWin32
     ? win32.isAbsolute(relativePath)
     : posix.isAbsolute(relativePath)
-  return !isAbsoluteRelative && !relativePath.startsWith('..') && relativePath !== '.'
+  const parentPrefix = useWin32 ? `..${win32.sep}` : `..${posix.sep}`
+  // Why: `..name` is a valid child path; only `..` and `../...` escape.
+  return (
+    !isAbsoluteRelative &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(parentPrefix) &&
+    relativePath !== '.'
+  )
 }
 
 async function buildWorktreesWithCanonicalPaths(


### PR DESCRIPTION
## Summary
- attribute Codex usage cwd paths under directories like `..fixtures` to the containing worktree
- apply the same containment boundary fix to OpenCode usage attribution
- keep different-drive and true parent escapes outside the worktree

## Repro / verification
- Before the fix, `pnpm test src/main/codex-usage/scanner.test.ts src/main/opencode-usage/scanner.test.ts` failed because `/workspace/repo/..fixtures/session` was categorized as `cwd:/workspace/repo/..fixtures/session` instead of the containing worktree.
- After the fix: `pnpm test src/main/codex-usage/scanner.test.ts src/main/opencode-usage/scanner.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/codex-usage/scanner.ts src/main/codex-usage/scanner.test.ts src/main/opencode-usage/scanner.ts src/main/opencode-usage/scanner.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.