### PR TITLE
Fix SSH config parsing for large Host alias lists

### DIFF
--- a/src/main/ssh/ssh-config-parser.test.ts
+++ b/src/main/ssh/ssh-config-parser.test.ts
@@ -172,6 +172,18 @@ Host staging stage *.example.com
     ])
   })
 
+  it('parses generated configs with very large multi-alias Host lines', () => {
+    const aliases = Array.from({ length: 125_000 }, (_, index) => `host-${index}`)
+    const hosts = parseSshConfig(`
+Host ${aliases.join(' ')}
+  HostName shared.example.com
+`)
+
+    expect(hosts).toHaveLength(aliases.length)
+    expect(hosts[0]).toEqual({ host: 'host-0', hostname: 'shared.example.com' })
+    expect(hosts.at(-1)).toEqual({ host: 'host-124999', hostname: 'shared.example.com' })
+  })
+
   it('applies identity agent settings to every concrete alias on a multi-pattern Host line', () => {
     const config = `
 Host staging stage

--- a/src/main/ssh/ssh-config-parser.ts
+++ b/src/main/ssh/ssh-config-parser.ts
@@ -44,7 +44,7 @@ export function parseSshConfig(content: string): SshConfigHost[] {
 
     if (key === 'host') {
       if (current.length > 0) {
-        hosts.push(...current)
+        appendSshConfigHosts(hosts, current)
       }
 
       const patterns = splitHostPatterns(value)
@@ -62,7 +62,7 @@ export function parseSshConfig(content: string): SshConfigHost[] {
 
     if (key === 'match') {
       if (current.length > 0) {
-        hosts.push(...current)
+        appendSshConfigHosts(hosts, current)
       }
       current = []
       continue
@@ -122,9 +122,17 @@ export function parseSshConfig(content: string): SshConfigHost[] {
   }
 
   if (current.length > 0) {
-    hosts.push(...current)
+    appendSshConfigHosts(hosts, current)
   }
   return hosts
+}
+
+function appendSshConfigHosts(target: SshConfigHost[], entries: SshConfigHost[]): void {
+  // Why: generated SSH configs can contain very large Host alias lists; spreading
+  // those entries into push() can exceed V8's argument limit.
+  for (const entry of entries) {
+    target.push(entry)
+  }
 }
 
 function splitHostPatterns(input: string): string[] {


### PR DESCRIPTION
## Summary
- avoid spreading large parsed Host alias blocks into `Array.push`
- add a regression for generated SSH configs with 125,000 concrete aliases on one Host line

## Repro / verification
- Before the fix, `pnpm test src/main/ssh/ssh-config-parser.test.ts` failed with `RangeError: Maximum call stack size exceeded` at `hosts.push(...current)`.
- After the fix: `pnpm test src/main/ssh/ssh-config-parser.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ssh/ssh-config-parser.ts src/main/ssh/ssh-config-parser.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.