### PR TITLE
Fix SSH config include expansion for many-line files

### DIFF
--- a/src/main/ssh/ssh-config-include-expander.ts
+++ b/src/main/ssh/ssh-config-include-expander.ts
@@ -64,12 +64,20 @@ function expandSshConfigFile(
 
     for (const includeArg of includeArgs) {
       for (const matchedPath of resolveIncludePaths(includeArg, context)) {
-        expandedLines.push(...expandSshConfigFile(matchedPath, context, nextStack))
+        appendExpandedLines(expandedLines, expandSshConfigFile(matchedPath, context, nextStack))
       }
     }
   }
 
   return expandedLines
+}
+
+function appendExpandedLines(target: string[], source: string[]): void {
+  // Why: valid include files can stay under the byte cap while still exceeding
+  // V8's argument limit if appended with `push(...source)`.
+  for (const line of source) {
+    target.push(line)
+  }
 }
 
 function readCachedFile(filePath: string, context: IncludeExpansionContext): string | null {

--- a/src/main/ssh/ssh-config-loader.test.ts
+++ b/src/main/ssh/ssh-config-loader.test.ts
@@ -100,6 +100,19 @@ describe('loadUserSshConfig', () => {
     expect(loadUserSshConfig().map((host) => host.host)).toEqual(['first', 'second'])
   })
 
+  it('loads an include file with more lines than the JavaScript argument limit', () => {
+    const home = makeHome()
+    const manyCommentLines = Array.from({ length: 130_000 }, () => '#').join('\n')
+    writeFile(
+      home,
+      '.ssh/config',
+      'Include many-comments.conf\nHost after\n  HostName after.example.com\n'
+    )
+    writeFile(home, '.ssh/many-comments.conf', manyCommentLines)
+
+    expect(loadUserSshConfig().map((host) => host.host)).toEqual(['after'])
+  })
+
   it('supports relative includes, ${VAR}, and local % tokens', () => {
     const home = makeHome()
     process.env.ORCA_SSH_INCLUDE = 'from-env.conf'


### PR DESCRIPTION
## Summary
- avoid spreading included SSH config line arrays into Array.push
- add a regression test for an include file with 130,000 lines under the existing byte cap

## Evidence
- Failing before fix: `pnpm test src/main/ssh/ssh-config-loader.test.ts` returned no hosts after logging `[ssh] Failed to read SSH config` for the many-line include case.
- Passing after fix: `pnpm test src/main/ssh/ssh-config-loader.test.ts`
- `pnpm test src/main/ssh/ssh-config-loader.test.ts src/main/ssh/ssh-config-loader-regression.test.ts src/main/ssh/ssh-config-parser.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ssh/ssh-config-include-expander.ts src/main/ssh/ssh-config-loader.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.