### PR TITLE
Fix workspace cleanup scan for large diff comment lists

### DIFF
--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -344,6 +344,34 @@ describe('workspace cleanup scan', () => {
     })
   })
 
+  it('handles persisted diff note lists larger than the JavaScript argument limit', async () => {
+    const diffComments = Array.from({ length: 130_000 }, (_, index): DiffComment => {
+      return {
+        id: `comment-${index}`,
+        worktreeId: 'repo-1::/repo-feature',
+        filePath: 'src/file.ts',
+        lineNumber: 12,
+        body: 'Follow up before deleting',
+        createdAt: NOW - index,
+        side: 'modified'
+      }
+    })
+
+    const result = await scanWorkspaceCleanup(
+      makeStore({
+        baseRef: undefined,
+        diffComments
+      })
+    )
+
+    expect(result.candidates[0]).toMatchObject({
+      localContext: {
+        diffCommentCount: diffComments.length,
+        newestDiffCommentAt: NOW
+      }
+    })
+  })
+
   it('does not expose PR cache state in inactivity cleanup results', async () => {
     const result = await scanWorkspaceCleanup(
       makeStore({

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -582,7 +582,15 @@ function getNewestDiffCommentAt(diffComments: Worktree['diffComments'] | undefin
   if (!diffComments || diffComments.length === 0) {
     return null
   }
-  return Math.max(...diffComments.map((comment) => comment.createdAt))
+  // Why: persisted review notes can exceed V8's argument limit if expanded
+  // into Math.max(), and cleanup must still show the workspace safely.
+  let newest = Number.NEGATIVE_INFINITY
+  for (const comment of diffComments) {
+    if (comment.createdAt > newest) {
+      newest = comment.createdAt
+    }
+  }
+  return newest
 }
 
 function createEmptyGitEvidence(): GitEvidence {


### PR DESCRIPTION
## Summary
- compute the newest persisted diff-comment timestamp without spreading into `Math.max`
- add a regression test for cleanup scans with 130,000 stored diff notes

## Evidence
- Failing before fix: `pnpm test src/main/ipc/workspace-cleanup.test.ts` rejected with `RangeError: Maximum call stack size exceeded` in `getNewestDiffCommentAt`.
- Passing after fix: `pnpm test src/main/ipc/workspace-cleanup.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/workspace-cleanup.ts src/main/ipc/workspace-cleanup.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.