### PR TITLE
Fix worktree ownership layout history append for large histories

### DIFF
--- a/src/shared/worktree-ownership-large-history.test.ts
+++ b/src/shared/worktree-ownership-large-history.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings, Repo } from './types'
+import { buildKnownOrcaWorkspaceLayouts } from './worktree-ownership'
+
+describe('buildKnownOrcaWorkspaceLayouts', () => {
+  it('handles workspace directory history larger than the JavaScript argument limit', () => {
+    const workspaceDirHistory = Array.from({ length: 130_000 }, (_, index) => ({
+      path: `/old/workspaces/${index}`,
+      nestWorkspaces: index % 2 === 0
+    }))
+    const settings = {
+      workspaceDir: '/orca/workspaces',
+      nestWorkspaces: true,
+      workspaceDirHistory
+    } satisfies Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces' | 'workspaceDirHistory'>
+    const repo = {
+      path: '/repos/app'
+    } satisfies Pick<Repo, 'path' | 'connectionId'>
+
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+
+    expect(layouts).toHaveLength(workspaceDirHistory.length + 1)
+    expect(layouts.at(-1)).toEqual({ path: '/old/workspaces/129999', nestWorkspaces: false })
+  })
+})

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -49,11 +49,11 @@ export function buildKnownOrcaWorkspaceLayouts(
   const layouts: OrcaWorkspaceLayout[] = []
   if (!repo?.connectionId && settings.workspaceDir) {
     layouts.push({ path: settings.workspaceDir, nestWorkspaces: settings.nestWorkspaces })
-    layouts.push(...(settings.workspaceDirHistory ?? []))
+    appendWorkspaceLayouts(layouts, settings.workspaceDirHistory ?? [])
   }
 
   const wslLayouts = repo ? buildWslWorkspaceLayouts(repo.path, settings) : []
-  layouts.push(...wslLayouts)
+  appendWorkspaceLayouts(layouts, wslLayouts)
 
   const seen = new Set<string>()
   return layouts.filter((layout) => {
@@ -64,6 +64,17 @@ export function buildKnownOrcaWorkspaceLayouts(
     seen.add(key)
     return Boolean(layout.path)
   })
+}
+
+function appendWorkspaceLayouts(
+  target: OrcaWorkspaceLayout[],
+  source: readonly OrcaWorkspaceLayout[]
+): void {
+  // Why: persisted workspace history is unbounded; using push(...source) can
+  // exceed V8's argument limit before ownership classification can recover.
+  for (const layout of source) {
+    target.push(layout)
+  }
 }
 
 function buildWslWorkspaceLayouts(


### PR DESCRIPTION
## Summary
- avoid spreading persisted `workspaceDirHistory` entries into `Array.push` during worktree ownership layout construction
- add a focused regression test for a 130,000-entry workspace history

## Evidence
- Failing before fix: `pnpm test src/shared/worktree-ownership-large-history.test.ts` threw `RangeError: Maximum call stack size exceeded` at `layouts.push(...workspaceDirHistory)`.
- Passing after fix: `pnpm test src/shared/worktree-ownership-large-history.test.ts src/shared/worktree-ownership.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/worktree-ownership.ts src/shared/worktree-ownership-large-history.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.