### PR TITLE
fix: guard browser context menu state

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2111,7 +2111,7 @@ function RemoteBrowserPagePane({
           { timeoutMs: 15_000, suppressFeatureInteraction: true }
         )
         const parsed = readRemoteContextMenuResult(result)
-        if (parsed) {
+        if (parsed && mountedRef.current && isCurrentRemoteOperationToken(operationToken)) {
           setContextMenu((current) =>
             current
               ? {


### PR DESCRIPTION
## Summary
- guard remote browser context-menu enrichment after async element inspection
- keep the basic menu and missing-page cleanup behavior intact while skipping stale menu state when the pane unmounts or a newer remote operation supersedes it

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- one-line guard around remote context-menu state enrichment only
- preserves the RPC call, fallback basic menu, and existing missing-page handling

## Validation
- `pnpm exec oxlint src/renderer/src/components/browser-pane/BrowserPane.tsx`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
