### PR TITLE
Fix boot PTY hydration for large daemon session lists

### DIFF
--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -206,4 +206,24 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry!.pid).toBe(4242)
     expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
   })
+
+  it('registers daemon session lists larger than the JavaScript argument limit', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+
+    const sessions = Array.from({ length: 130_000 }, (_, index) => {
+      const ptyId = `repo-a::/local/Triton@@session-${index}`
+      return { sessionId: ptyId, pid: index + 1, cwd: '/local/Triton' } as unknown as SessionInfo
+    })
+    const provider = makeProvider(sessions)
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockResolvedValue([
+      { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
+    warnSpy.mockRestore()
+
+    expect(listRegisteredPtys()).toHaveLength(sessions.length)
+  })
 })

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -146,7 +146,7 @@ async function collectSessionInfos(
   for (const adapter of adapters) {
     try {
       const sessions = await adapter.listSessions()
-      out.push(...sessions)
+      appendSessionInfos(out, sessions)
     } catch (err) {
       // Why: a single adapter failing should not abort hydration of the
       // others — the current adapter and any legacy daemons each have
@@ -158,4 +158,12 @@ async function collectSessionInfos(
     }
   }
   return out
+}
+
+function appendSessionInfos(target: SessionInfo[], source: readonly SessionInfo[]): void {
+  // Why: a daemon can return an unexpectedly large live-session list; spreading
+  // it into push would look like an adapter failure and drop every session.
+  for (const session of source) {
+    target.push(session)
+  }
 }


### PR DESCRIPTION
## Summary
- append daemon `listSessions()` results without spreading into `Array.push`
- add a regression test for a daemon adapter returning 130,000 live sessions

## Evidence
- Failing before fix: `pnpm test src/main/memory/hydrate-local-pty-registry.test.ts` registered 0 of 130,000 sessions because `out.push(...sessions)` was caught as an adapter failure.
- Passing after fix: `pnpm test src/main/memory/hydrate-local-pty-registry.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/memory/hydrate-local-pty-registry.ts src/main/memory/hydrate-local-pty-registry.test.ts`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.