### PR TITLE
fix: guard browser profile create state

### DIFF
--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -22,6 +22,7 @@ import { BROWSER_PANE_SEARCH_ENTRIES } from './browser-pane-search'
 import { BrowserProfileRow } from './BrowserProfileRow'
 import { BrowserUseSetup } from './BrowserUsePane'
 import { KagiSessionLinkForm } from './KagiSessionLinkForm'
+import { useMountedRef } from '@/hooks/useMountedRef'
 export { BROWSER_PANE_SEARCH_ENTRIES }
 
 type BrowserPaneProps = {
@@ -54,6 +55,7 @@ export function BrowserPane({
   const setDefaultBrowserSessionProfileId = useAppStore((s) => s.setDefaultBrowserSessionProfileId)
   const defaultProfile = browserSessionProfiles.find((p) => p.id === 'default')
   const nonDefaultProfiles = browserSessionProfiles.filter((p) => p.scope !== 'default')
+  const mountedRef = useMountedRef()
   const [homePageDraft, setHomePageDraft] = useState(browserDefaultUrl ?? '')
   const [newProfileDialogOpen, setNewProfileDialogOpen] = useState(false)
   const [newProfileName, setNewProfileName] = useState('')
@@ -354,6 +356,9 @@ export function BrowserPane({
                 const profile = await useAppStore
                   .getState()
                   .createBrowserSessionProfile('isolated', trimmed)
+                if (!mountedRef.current) {
+                  return
+                }
                 if (profile) {
                   setNewProfileDialogOpen(false)
                   setNewProfileName('')
@@ -362,7 +367,9 @@ export function BrowserPane({
                   toast.error('Failed to create profile.')
                 }
               } finally {
-                setIsCreatingProfile(false)
+                if (mountedRef.current) {
+                  setIsCreatingProfile(false)
+                }
               }
             }}
           >


### PR DESCRIPTION
## Summary
- guard browser settings new-profile dialog state after async profile creation
- preserve profile creation while skipping stale dialog/toast/spinner updates after unmount

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- leaves browser profile creation unchanged
- only gates local dialog state, toast feedback, and spinner cleanup after the pane is gone

## Validation
- `pnpm exec oxlint src/renderer/src/components/settings/BrowserPane.tsx`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
