### PR TITLE
fix: preserve Windows UNC OSC-7 cwd

### DIFF
--- a/src/renderer/src/components/terminal-pane/parse-osc7.test.ts
+++ b/src/renderer/src/components/terminal-pane/parse-osc7.test.ts
@@ -19,9 +19,13 @@ describe('parseOsc7', () => {
   })
 
   it('preserves Windows UNC cwd paths', () => {
-    expect(parseOsc7('file://server/share/project', { preserveHostAsUnc: true })).toBe(
+    expect(parseOsc7('file://server/share/project', { uncHost: 'server' })).toBe(
       '\\\\server\\share\\project'
     )
+  })
+
+  it('does not treat unrelated OSC-7 hosts as UNC servers', () => {
+    expect(parseOsc7('file://remote/home/jin/repo', { uncHost: 'server' })).toBe('/home/jin/repo')
   })
 
   it('keeps POSIX host-prefixed paths unchanged by default', () => {

--- a/src/renderer/src/components/terminal-pane/parse-osc7.test.ts
+++ b/src/renderer/src/components/terminal-pane/parse-osc7.test.ts
@@ -18,6 +18,16 @@ describe('parseOsc7', () => {
     expect(parseOsc7('file:///C:/Users/jin/repo')).toBe('C:/Users/jin/repo')
   })
 
+  it('preserves Windows UNC cwd paths', () => {
+    expect(parseOsc7('file://server/share/project', { preserveHostAsUnc: true })).toBe(
+      '\\\\server\\share\\project'
+    )
+  })
+
+  it('keeps POSIX host-prefixed paths unchanged by default', () => {
+    expect(parseOsc7('file://server/share/project')).toBe('/share/project')
+  })
+
   it('returns null for non-file URIs', () => {
     expect(parseOsc7('http://example.com/')).toBeNull()
   })

--- a/src/renderer/src/components/terminal-pane/parse-osc7.ts
+++ b/src/renderer/src/components/terminal-pane/parse-osc7.ts
@@ -10,7 +10,7 @@
 const OSC7_URI = /^file:\/\/([^/]*)(\/.*)$/
 
 type ParseOsc7Options = {
-  preserveHostAsUnc?: boolean
+  uncHost?: string | null
 }
 
 /**
@@ -33,9 +33,11 @@ export function parseOsc7(data: string, options: ParseOsc7Options = {}): string 
   if (!path) {
     return null
   }
-  if (options.preserveHostAsUnc) {
-    // Why: Windows UNC OSC-7 payloads use the URI host as the server name.
-    if (host && host.toLowerCase() !== 'localhost') {
+  const isWindowsDrivePath = /^\/[A-Za-z]:/.test(path)
+  if (options.uncHost && !isWindowsDrivePath) {
+    // Why: only the launch UNC server is known to be a Windows file host.
+    // Other OSC-7 hosts can come from SSH/Linux shells and must stay POSIX.
+    if (host.toLowerCase() === options.uncHost.toLowerCase()) {
       return `\\\\${host}${path.replace(/\//g, '\\')}`
     }
   }
@@ -44,7 +46,7 @@ export function parseOsc7(data: string, options: ParseOsc7Options = {}): string 
   // leading slash before the drive letter so we hand back `C:/Users/...`.
   // Renderer runs with sandbox + contextIsolation so process.platform is
   // unavailable; detect Windows paths by shape instead.
-  if (/^\/[A-Za-z]:/.test(path)) {
+  if (isWindowsDrivePath) {
     path = path.slice(1)
   }
   return path

--- a/src/renderer/src/components/terminal-pane/parse-osc7.ts
+++ b/src/renderer/src/components/terminal-pane/parse-osc7.ts
@@ -7,28 +7,39 @@
 // parser strips the leading `\x1b]7;` and trailing BEL/ST before handing us
 // the payload, so `data` here is just the `file://...` URI.
 
-const OSC7_URI = /^file:\/\/[^/]*(\/.*)$/
+const OSC7_URI = /^file:\/\/([^/]*)(\/.*)$/
+
+type ParseOsc7Options = {
+  preserveHostAsUnc?: boolean
+}
 
 /**
  * Parse an OSC 7 payload and return the decoded path, or null if the payload
  * is not a file URI we recognize. Returns the path a `cwd` option of
  * `child_process.spawn` / `node-pty` would accept on the current platform.
  */
-export function parseOsc7(data: string): string | null {
+export function parseOsc7(data: string, options: ParseOsc7Options = {}): string | null {
   const match = OSC7_URI.exec(data)
   if (!match) {
     return null
   }
+  const host = match[1]
   let path: string
   try {
-    path = decodeURIComponent(match[1])
+    path = decodeURIComponent(match[2])
   } catch {
     return null
   }
   if (!path) {
     return null
   }
-  // Why: on Windows the URI looks like file:///C:/Users/... — match[1] is
+  if (options.preserveHostAsUnc) {
+    // Why: Windows UNC OSC-7 payloads use the URI host as the server name.
+    if (host && host.toLowerCase() !== 'localhost') {
+      return `\\\\${host}${path.replace(/\//g, '\\')}`
+    }
+  }
+  // Why: on Windows the URI looks like file:///C:/Users/... — the path is
   // `/C:/Users/...`, which `spawn`'s cwd option does not accept. Strip the
   // leading slash before the drive letter so we hand back `C:/Users/...`.
   // Renderer runs with sandbox + contextIsolation so process.platform is

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -72,8 +72,9 @@ import {
 } from '@/constants/terminal'
 import { acquireWebviewsDragPassthrough } from '../browser-pane/webview-registry'
 
-function isUncPathLike(value: string | undefined): boolean {
-  return value?.startsWith('\\\\') === true || value?.startsWith('//') === true
+function extractUncHost(value: string | undefined): string | null {
+  const match = /^(?:\\\\|\/\/)([^\\/]+)/.exec(value ?? '')
+  return match?.[1] || null
 }
 
 type UseTerminalPaneLifecycleDeps = {
@@ -481,7 +482,7 @@ export function useTerminalPaneLifecycle({
 
     const fileOpenLinkHint = getTerminalFileOpenHint()
     const urlOpenLinkHint = getTerminalUrlOpenHint()
-    const preserveOsc7HostAsUnc = isUncPathLike(cwd)
+    const osc7UncHost = extractUncHost(cwd)
 
     let releaseWebviewDragPassthrough: (() => void) | null = null
 
@@ -535,7 +536,7 @@ export function useTerminalPaneLifecycle({
         // consumer registers on code 7, registration order decides who sees
         // each sequence.
         const osc7Disposable = pane.terminal.parser.registerOscHandler(7, (data) => {
-          const parsedCwd = parseOsc7(data, { preserveHostAsUnc: preserveOsc7HostAsUnc })
+          const parsedCwd = parseOsc7(data, { uncHost: osc7UncHost })
           if (parsedCwd) {
             const confirmed = !isPaneReplaying(replayingPanesRef, pane.id)
             paneCwdRef.current.set(pane.id, { cwd: parsedCwd, confirmed })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -72,6 +72,10 @@ import {
 } from '@/constants/terminal'
 import { acquireWebviewsDragPassthrough } from '../browser-pane/webview-registry'
 
+function isUncPathLike(value: string | undefined): boolean {
+  return value?.startsWith('\\\\') === true || value?.startsWith('//') === true
+}
+
 type UseTerminalPaneLifecycleDeps = {
   tabId: string
   worktreeId: string
@@ -477,6 +481,7 @@ export function useTerminalPaneLifecycle({
 
     const fileOpenLinkHint = getTerminalFileOpenHint()
     const urlOpenLinkHint = getTerminalUrlOpenHint()
+    const preserveOsc7HostAsUnc = isUncPathLike(cwd)
 
     let releaseWebviewDragPassthrough: (() => void) | null = null
 
@@ -530,10 +535,10 @@ export function useTerminalPaneLifecycle({
         // consumer registers on code 7, registration order decides who sees
         // each sequence.
         const osc7Disposable = pane.terminal.parser.registerOscHandler(7, (data) => {
-          const cwd = parseOsc7(data)
-          if (cwd) {
+          const parsedCwd = parseOsc7(data, { preserveHostAsUnc: preserveOsc7HostAsUnc })
+          if (parsedCwd) {
             const confirmed = !isPaneReplaying(replayingPanesRef, pane.id)
-            paneCwdRef.current.set(pane.id, { cwd, confirmed })
+            paneCwdRef.current.set(pane.id, { cwd: parsedCwd, confirmed })
           }
           return true
         })


### PR DESCRIPTION
## Summary
- Preserve OSC-7 file URI hosts as UNC server names when a terminal was launched from a UNC cwd.
- Keep default POSIX host-prefixed OSC-7 behavior unchanged for SSH/Linux-style payloads.
- Add parser regressions for both paths.

## Evidence
- Before the fix, `pnpm test src/renderer/src/components/terminal-pane/parse-osc7.test.ts` failed because `file://server/share/project` parsed as `/share/project` with UNC preservation enabled.
- `pnpm test src/renderer/src/components/terminal-pane/parse-osc7.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/parse-osc7.ts src/renderer/src/components/terminal-pane/parse-osc7.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.