### PR TITLE
fix: avoid project group order spread crash

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -16,6 +16,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import type {
   PersistedState,
+  ProjectGroup,
   Repo,
   TerminalTab,
   WorktreeLineage,
@@ -1502,6 +1503,35 @@ describe('Store', () => {
     expect(store.getRepo('direct')?.projectGroupId).toBeNull()
     expect(store.getRepo('nested')?.projectGroupId).toBeNull()
     expect(store.getRepo('sibling')?.projectGroupId).toBe(sibling.id)
+  })
+
+  it('creates a project group when persisted group history is very large', async () => {
+    const projectGroups: ProjectGroup[] = Array.from({ length: 130_000 }, (_, index) => ({
+      id: `group-${index}`,
+      name: `Group ${index}`,
+      parentPath: null,
+      parentGroupId: null,
+      createdFrom: 'manual',
+      tabOrder: index,
+      isCollapsed: false,
+      color: null,
+      createdAt: index,
+      updatedAt: index
+    }))
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      projectGroups
+    })
+    const store = await createStore()
+
+    const group = store.createProjectGroup({ name: 'New group', createdFrom: 'manual' })
+
+    expect(group.tabOrder).toBe(projectGroups.length)
   })
 
   it('sanitizes invalid project group updates before persisting a repo', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2120,10 +2120,11 @@ export class Store {
     parentGroupId?: string | null
     createdFrom: ProjectGroup['createdFrom']
   }): ProjectGroup {
-    const maxOrder = Math.max(
-      -1,
-      ...(this.state.projectGroups ?? []).map((group) => group.tabOrder)
-    )
+    let maxOrder = -1
+    // Why: persisted group lists can be large enough to exceed spread limits.
+    for (const existingGroup of this.state.projectGroups ?? []) {
+      maxOrder = Math.max(maxOrder, existingGroup.tabOrder)
+    }
     const group = createProjectGroup({
       ...input,
       tabOrder: maxOrder + 1


### PR DESCRIPTION
## Summary
- Replace project group tab-order spread max with a loop.
- Add a regression for creating a group after loading a very large persisted project-group list.

## Evidence
- Before the fix, `pnpm test src/main/persistence.test.ts -- -t "creates a project group when persisted group history is very large"` failed with `RangeError: Maximum call stack size exceeded` at `Math.max(...projectGroups.map(...))`.
- `pnpm test src/main/persistence.test.ts -- -t "creates a project group when persisted group history is very large"`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/persistence.ts src/main/persistence.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.