### PR TITLE
fix: allow dot-prefixed nested worktree paths

### DIFF
--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -111,6 +111,12 @@ describe('ensurePathWithinWorkspace', () => {
       'Invalid worktree path'
     )
   })
+
+  it('allows workspace children whose names start with dot-dot text', () => {
+    const result = ensurePathWithinWorkspace('/workspace/..repo/feature', '/workspace')
+
+    expect(result).toBe(resolve('/workspace/..repo/feature'))
+  })
 })
 
 describe('computeBranchName', () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -1,4 +1,4 @@
-import { basename, join, resolve, relative, isAbsolute, posix, win32 } from 'path'
+import { basename, join, resolve, relative, isAbsolute, posix, sep, win32 } from 'path'
 import type { GitWorktreeInfo, Worktree, WorktreeMeta } from '../../shared/types'
 import { splitWorktreeId } from '../../shared/worktree-id'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
@@ -57,7 +57,7 @@ export function ensurePathWithinWorkspace(targetPath: string, workspaceDir: stri
   const resolvedTargetPath = resolve(targetPath)
   const rel = relative(resolvedWorkspaceDir, resolvedTargetPath)
 
-  if (isAbsolute(rel) || rel.startsWith('..')) {
+  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
     throw new Error('Invalid worktree path')
   }
 


### PR DESCRIPTION
## Summary
- tighten worktree path containment so only real parent escapes (`..` or `../...`) are rejected
- preserve valid workspace children whose directory names start with dot-dot text, such as nested worktrees for repos named `..repo`
- add a regression test for the valid nested path case

## Evidence
- Before the fix, `pnpm test src/main/ipc/worktree-logic.test.ts -- -t "allows workspace children whose names start with dot-dot text"` failed with `Error: Invalid worktree path` at `ensurePathWithinWorkspace`.
- `pnpm test src/main/ipc/worktree-logic.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/worktree-logic.ts src/main/ipc/worktree-logic.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.