### PR TITLE
fix: guard add project folder state

### DIFF
--- a/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { track } from '@/lib/telemetry'
@@ -41,6 +42,7 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
   const [addedRepo, setAddedRepo] = useState<Repo | null>(null)
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const mountedRef = useMountedRef()
 
   const isOpen = activeModal === 'confirm-add-project-from-folder'
   const folderPath = typeof modalData.folderPath === 'string' ? modalData.folderPath : ''
@@ -120,11 +122,17 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
         } else {
           useAppStore.setState({ repos: [...state.repos, repo] })
         }
+        if (!mountedRef.current) {
+          return
+        }
         toast.success('Remote project added', { description: repo.displayName })
       } else {
         repo = await addRepoPath(folderPath)
       }
 
+      if (!mountedRef.current) {
+        return
+      }
       if (!repo) {
         return
       }
@@ -137,14 +145,28 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       if (message.includes(NON_GIT_REPO_ERROR)) {
-        openNonGitConfirmation()
+        if (mountedRef.current) {
+          openNonGitConfirmation()
+        }
         return
       }
-      setError(message)
+      if (mountedRef.current) {
+        setError(message)
+      }
     } finally {
-      setIsAdding(false)
+      if (mountedRef.current) {
+        setIsAdding(false)
+      }
     }
-  }, [addRepoPath, connectionId, fetchWorktrees, folderPath, isAdding, openNonGitConfirmation])
+  }, [
+    addRepoPath,
+    connectionId,
+    fetchWorktrees,
+    folderPath,
+    isAdding,
+    mountedRef,
+    openNonGitConfirmation
+  ])
 
   const handleStartPrimaryWorktree = useCallback(() => {
     if (!primaryWorktree) {
@@ -165,14 +187,14 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
     track('add_repo_setup_step_action', { action: 'open_existing' })
     if (!otherWorktreesVisible) {
       const updated = await updateRepo(repoId, { externalWorktreeVisibility: 'show' })
-      if (updated && addedRepo) {
+      if (updated && addedRepo && mountedRef.current) {
         setAddedRepo({ ...addedRepo, externalWorktreeVisibility: 'show' })
       }
     }
     closeModal()
     await fetchWorktrees(repoId)
     finalizeImportedRepoAfterSkip(useAppStore.getState(), repoId)
-  }, [addedRepo, closeModal, fetchWorktrees, otherWorktreesVisible, repoId, updateRepo])
+  }, [addedRepo, closeModal, fetchWorktrees, mountedRef, otherWorktreesVisible, repoId, updateRepo])
 
   const handleCreateWorktree = useCallback(
     (name?: string) => {


### PR DESCRIPTION
## Summary
- guard add-project-from-folder async follow-up state when the dialog component unmounts
- keep local and SSH project import mutations intact while skipping stale dialog-local state, toast, and non-Git modal follow-up after teardown
- guard the existing-worktrees visibility update before refreshing dialog-local repo state

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- repo creation, SSH remote import, store updates, and worktree fetches are unchanged for mounted dialogs
- new behavior only skips UI-local follow-up after the component has unmounted
- focused existing tests cover local Git, local non-Git, SSH Git, and SSH non-Git paths

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx src/renderer/src/components/sidebar/AddProjectFromFolderDialog.test.tsx`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/AddProjectFromFolderDialog.test.tsx`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
