### PR TITLE
fix: handle large worktree auth caches

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -1,0 +1,49 @@
+import { resolve } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import { listRepoWorktrees } from '../repo-worktrees'
+import {
+  invalidateAuthorizedRootsCache,
+  rebuildAuthorizedRootsCache,
+  resolveRegisteredWorktreePath
+} from './filesystem-auth'
+
+vi.mock('../repo-worktrees', () => ({
+  isRepoRoot: vi.fn(() => false),
+  listRepoWorktrees: vi.fn()
+}))
+
+const listRepoWorktreesMock = vi.mocked(listRepoWorktrees)
+
+function createStore(repoPath: string): Store {
+  return {
+    getRepos: () => [{ id: 'repo-1', path: repoPath }],
+    getSettings: () => ({ workspaceDir: '' })
+  } as unknown as Store
+}
+
+afterEach(() => {
+  invalidateAuthorizedRootsCache()
+  listRepoWorktreesMock.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('filesystem auth registered worktree roots', () => {
+  it('registers very large worktree lists during cache rebuild', async () => {
+    const repoPath = '/repo/main'
+    const targetWorktreePath = '/linked-worktrees/worktree-129999'
+    const worktrees = Array.from({ length: 130_000 }, (_, index) => ({
+      path: `/linked-worktrees/worktree-${index}`
+    }))
+    listRepoWorktreesMock.mockResolvedValue(
+      worktrees as Awaited<ReturnType<typeof listRepoWorktrees>>
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await rebuildAuthorizedRootsCache(createStore(repoPath))
+
+    await expect(
+      resolveRegisteredWorktreePath(targetWorktreePath, createStore(repoPath))
+    ).resolves.toBe(resolve(targetWorktreePath))
+  })
+})

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- Why: filesystem authorization shares module-local
+ * root caches with the path validation entrypoints that consume them. */
 import { resolve, relative, dirname, basename, isAbsolute } from 'path'
 import { realpathSync } from 'fs'
 import { realpath } from 'fs/promises'
@@ -102,7 +104,9 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
 
         const worktrees = await listRepoWorktrees(repo)
         const worktreeRoots = worktrees.map((wt) => resolve(wt.path))
-        roots.push(...worktreeRoots)
+        for (const worktreeRoot of worktreeRoots) {
+          roots.push(worktreeRoot)
+        }
       } catch (error) {
         // Why: a single inaccessible repo (EACCES, EIO, etc.) must not break
         // the entire cache rebuild — that would disable File Explorer and

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -103,9 +103,8 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
         roots.push(resolve(repo.path))
 
         const worktrees = await listRepoWorktrees(repo)
-        const worktreeRoots = worktrees.map((wt) => resolve(wt.path))
-        for (const worktreeRoot of worktreeRoots) {
-          roots.push(worktreeRoot)
+        for (const worktree of worktrees) {
+          roots.push(resolve(worktree.path))
         }
       } catch (error) {
         // Why: a single inaccessible repo (EACCES, EIO, etc.) must not break


### PR DESCRIPTION
## Summary
- avoid spreading large linked-worktree root lists while rebuilding filesystem authorization caches
- keep the existing per-repo failure isolation, but no longer treat an oversized valid worktree list as a skipped repo
- add a regression test covering 130,000 registered worktree roots

## Evidence
- Before the fix, `pnpm test src/main/ipc/filesystem-auth.test.ts -- -t "registers very large worktree lists during cache rebuild"` failed because `resolveRegisteredWorktreePath()` rejected the last linked worktree after the rebuild caught the spread failure.
- `pnpm test src/main/ipc/filesystem-auth.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/filesystem-auth.ts src/main/ipc/filesystem-auth.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.