### PR TITLE
fix: load large legacy pane alias migrations

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from 'os'
 import type {
   PersistedState,
   Repo,
+  TerminalPaneLayoutNode,
   TerminalTab,
   WorktreeLineage,
   WorkspaceSessionState
@@ -216,6 +217,19 @@ function makeSessionWithBrowserHistory(count: number): WorkspaceSessionState {
       lastVisitedAt: 1_700_000_000_000 - index,
       visitCount: 1
     }))
+  }
+}
+
+function makeBalancedLegacyPaneLayout(start: number, end: number): TerminalPaneLayoutNode {
+  if (end - start === 1) {
+    return { type: 'leaf', leafId: `pane:${start + 1}` }
+  }
+  const midpoint = Math.floor((start + end) / 2)
+  return {
+    type: 'split',
+    direction: 'horizontal',
+    first: makeBalancedLegacyPaneLayout(start, midpoint),
+    second: makeBalancedLegacyPaneLayout(midpoint, end)
   }
 }
 
@@ -3607,6 +3621,46 @@ describe('Store', () => {
         ])
       })
     )
+  })
+
+  it('loads legacy pane aliases from very large persisted split layouts', async () => {
+    const leafCount = 130_000
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {
+        activeRepoId: 'r1',
+        activeWorktreeId: 'wt1',
+        activeTabId: 'tab1',
+        tabsByWorktree: {
+          wt1: [
+            {
+              id: 'tab1',
+              worktreeId: 'wt1',
+              title: 'Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              ptyId: 'large-pty'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          tab1: {
+            root: makeBalancedLegacyPaneLayout(0, leafCount),
+            activeLeafId: 'pane:1',
+            expandedLeafId: null
+          }
+        }
+      }
+    })
+
+    await expect(createStore()).resolves.toBeDefined()
   })
 
   it('converts unambiguous dev migration rows into persisted aliases', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3660,7 +3660,23 @@ describe('Store', () => {
       }
     })
 
-    await expect(createStore()).resolves.toBeDefined()
+    const store = await createStore()
+    store.flush()
+
+    const persisted = readDataFile() as PersistedState
+    const aliasEntries = persisted.legacyPaneKeyAliasEntries
+    expect(aliasEntries).toHaveLength(leafCount + 1)
+    expect(
+      aliasEntries.some((entry) => entry.ptyId === 'large-pty' && entry.legacyPaneKey === 'tab1:0')
+    ).toBe(true)
+    expect(
+      aliasEntries.some((entry) => entry.ptyId === 'large-pty' && entry.legacyPaneKey === 'tab1:1')
+    ).toBe(true)
+    expect(
+      aliasEntries.some(
+        (entry) => entry.ptyId === 'large-pty' && entry.legacyPaneKey === `tab1:${leafCount}`
+      )
+    ).toBe(true)
   })
 
   it('converts unambiguous dev migration rows into persisted aliases', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1013,8 +1013,14 @@ function normalizeWorkspaceSessionPaneIdentities(
       normalizedLayout: normalized.snapshot,
       leafIdByInputLeafId: normalized.leafIdByInputLeafId
     })
-    migrationUnsupportedEntries.push(...migrationEntries.migrationUnsupportedEntries)
-    legacyPaneKeyAliasEntries.push(...migrationEntries.legacyPaneKeyAliasEntries)
+    // Why: old persisted split layouts can generate enough alias rows to
+    // exceed V8's argument limit if the arrays are spread into push().
+    for (const entry of migrationEntries.migrationUnsupportedEntries) {
+      migrationUnsupportedEntries.push(entry)
+    }
+    for (const entry of migrationEntries.legacyPaneKeyAliasEntries) {
+      legacyPaneKeyAliasEntries.push(entry)
+    }
     const leafIdByPtyId = new Map<string, string>()
     const duplicatePtyIds = new Set<string>()
     for (const [leafId, ptyId] of Object.entries(normalized.snapshot.ptyIdsByLeafId ?? {})) {


### PR DESCRIPTION
## Summary
- avoid spreading per-tab pane migration rows while normalizing persisted workspace sessions
- preserve alias registration for very large legacy split layouts without tripping the V8 argument limit
- add a regression covering 130,000 legacy numeric pane leaves

## Evidence
- Before the fix, `pnpm test src/main/persistence.test.ts -- -t "loads legacy pane aliases from very large persisted split layouts"` failed with `RangeError: Maximum call stack size exceeded` at `normalizeWorkspaceSessionPaneIdentities`.
- `pnpm test src/main/persistence.test.ts -- -t "loads legacy pane aliases from very large persisted split layouts"`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/persistence.ts src/main/persistence.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.