### PR TITLE
fix: clean large legacy codex hook lists

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -687,12 +687,16 @@ describe('CodexHookService', () => {
     )
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    expect(new CodexHookService().install().state).toBe('installed')
+    try {
+      expect(new CodexHookService().install().state).toBe('installed')
 
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      '[codex-hook-service] failed to clean legacy Codex hooks',
-      expect.anything()
-    )
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        '[codex-hook-service] failed to clean legacy Codex hooks',
+        expect.anything()
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
     const systemHooks = JSON.parse(readFileSync(systemHooksPath, 'utf-8')) as {
       hooks: Record<string, unknown>
     }

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -662,6 +662,43 @@ describe('CodexHookService', () => {
     expect(systemToml).not.toContain(':session_start:0:0')
   })
 
+  it('removes very large legacy Orca-managed hook lists from system ~/.codex', () => {
+    const systemCodexHome = join(tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    const legacyScriptPath = join(
+      tmpHome,
+      '.orca',
+      'agent-hooks',
+      process.platform === 'win32' ? 'codex-hook.cmd' : 'codex-hook.sh'
+    )
+    const legacyCommand =
+      process.platform === 'win32' ? legacyScriptPath : wrapPosixHookCommand(legacyScriptPath)
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify({
+        hooks: {
+          Stop: Array.from({ length: 130_000 }, () => ({
+            hooks: [{ type: 'command', command: legacyCommand }]
+          }))
+        }
+      })}\n`,
+      'utf-8'
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(new CodexHookService().install().state).toBe('installed')
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      '[codex-hook-service] failed to clean legacy Codex hooks',
+      expect.anything()
+    )
+    const systemHooks = JSON.parse(readFileSync(systemHooksPath, 'utf-8')) as {
+      hooks: Record<string, unknown>
+    }
+    expect(systemHooks.hooks.Stop).toBeUndefined()
+  })
+
   it('removes the legacy Orca Codex profile file when it only contains managed hooks', () => {
     const systemCodexHome = join(tmpHome, '.codex')
     const profilePath = join(systemCodexHome, 'orca-agent-status.config.toml')


### PR DESCRIPTION
## Summary
- avoid spreading legacy Codex managed-hook trust rows during cleanup
- keep install cleanup working for generated or oversized system `~/.codex/hooks.json` files
- add a regression covering 130,000 legacy managed hook definitions

## Evidence
- Before the fix, `pnpm test src/main/codex/hook-service.test.ts -- -t "removes very large legacy Orca-managed hook lists from system ~/.codex"` failed because cleanup logged `RangeError: Maximum call stack size exceeded` and left the legacy `Stop` hooks in place.
- `pnpm test src/main/codex/hook-service.test.ts -- -t "removes very large legacy Orca-managed hook lists from system ~/.codex"`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/codex/hook-service.ts src/main/codex/hook-service.test.ts`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.