### PR TITLE
fix: guard sidebar restart state

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -23,6 +23,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { toast } from 'sonner'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import { showOnboardingFromRenderer } from '../onboarding/show-onboarding-event'
 import { SidebarFeedbackDialog } from './SidebarFeedbackDialog'
 import { ScrollToCurrentWorkspaceToolbarButton } from './ScrollToCurrentWorkspaceToolbarButton'
@@ -44,6 +45,7 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
   const [showAdminHelpOptions, setShowAdminHelpOptions] = useState(false)
   const [isRestartingOrca, setIsRestartingOrca] = useState(false)
   const lastShowOnboardingAtRef = React.useRef(0)
+  const mountedRef = useMountedRef()
 
   const handleShowOnboarding = (): void => {
     const now = Date.now()
@@ -75,10 +77,12 @@ const SidebarToolbar = React.memo(function SidebarToolbar() {
     setIsRestartingOrca(true)
     toast.info('Restarting Orca…')
     void window.api.app.restart().catch((error) => {
-      setIsRestartingOrca(false)
-      toast.error('Couldn’t restart Orca.', {
-        description: error instanceof Error ? error.message : undefined
-      })
+      if (mountedRef.current) {
+        setIsRestartingOrca(false)
+        toast.error('Couldn’t restart Orca.', {
+          description: error instanceof Error ? error.message : undefined
+        })
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- guard the sidebar restart failure path before clearing local loading state or showing the failure toast
- leave the restart request and initial restart toast unchanged

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- only changes the async failure continuation for an admin restart action
- mounted toolbar behavior is unchanged
- no persistence, IPC contract, or SSH behavior changes

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/SidebarToolbar.tsx`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
