### PR TITLE
fix: tolerate literal percent in bitbucket remotes

### DIFF
--- a/src/main/bitbucket/repository-ref.test.ts
+++ b/src/main/bitbucket/repository-ref.test.ts
@@ -36,6 +36,23 @@ describe('Bitbucket repository refs', () => {
     expect(parseBitbucketRepoRef('https://github.com/team/project.git')).toBeNull()
   })
 
+  it('keeps malformed percent sequences as literal repo path text', async () => {
+    expect(parseBitbucketRepoRef('git@bitbucket.org:team/project%zz.git')).toEqual({
+      workspace: 'team',
+      repoSlug: 'project%zz'
+    })
+
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git@bitbucket.org:team/project%zz.git\n',
+      stderr: ''
+    })
+
+    await expect(getBitbucketRepoRef('/repo')).resolves.toEqual({
+      workspace: 'team',
+      repoSlug: 'project%zz'
+    })
+  })
+
   it('resolves origin through the WSL-aware git runner and caches the result', async () => {
     gitExecFileAsyncMock.mockResolvedValue({
       stdout: 'git@bitbucket.org:team/project.git\n',

--- a/src/main/bitbucket/repository-ref.ts
+++ b/src/main/bitbucket/repository-ref.ts
@@ -12,6 +12,14 @@ export function _resetBitbucketRepoRefCache(): void {
   repoRefCache.clear()
 }
 
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 function parseBitbucketPath(pathname: string): BitbucketRepoRef | null {
   const withoutSuffix = pathname.replace(/\.git$/i, '')
   const parts = withoutSuffix
@@ -27,8 +35,8 @@ function parseBitbucketPath(pathname: string): BitbucketRepoRef | null {
     return null
   }
   return {
-    workspace: decodeURIComponent(workspace),
-    repoSlug: decodeURIComponent(repoSlug)
+    workspace: decodeSegment(workspace),
+    repoSlug: decodeSegment(repoSlug)
   }
 }
 


### PR DESCRIPTION
## Summary
- make Bitbucket remote path segment decoding tolerant of literal malformed percent sequences
- keep the raw segment text when decoding fails, matching the Gitea/hosted-remote parser behavior
- add a regression for SSH-style Bitbucket remotes with a literal `%zz` in the repo slug

## Evidence
- Before the fix, `pnpm test src/main/bitbucket/repository-ref.test.ts -- -t "keeps malformed percent sequences as literal repo path text"` failed with `URIError: URI malformed` at `decodeURIComponent(repoSlug)`.
- `pnpm test src/main/bitbucket/repository-ref.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/bitbucket/repository-ref.ts src/main/bitbucket/repository-ref.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.