### PR TITLE
fix: preserve large relay status results

### DIFF
--- a/src/relay/git-handler-status-ops.test.ts
+++ b/src/relay/git-handler-status-ops.test.ts
@@ -1,0 +1,35 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { getStatusOp } from './git-handler-status-ops'
+
+function modifiedStatusLine(path: string): string {
+  return `1 .M N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ${path}`
+}
+
+describe('getStatusOp', () => {
+  it('preserves very large status result sets from the SSH relay', async () => {
+    const fileCount = 130_000
+    const stdout = Array.from({ length: fileCount }, (_, index) =>
+      modifiedStatusLine(`src/generated/file-${index}.ts`)
+    ).join('\n')
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args.includes('status')) {
+        return { stdout, stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await getStatusOp(git, {
+      worktreePath: join(tmpdir(), 'orca-relay-status-large')
+    })
+
+    expect(result.entries).toHaveLength(fileCount)
+    expect(result.entries.at(-1)).toMatchObject({
+      path: 'src/generated/file-129999.ts',
+      status: 'modified',
+      area: 'unstaged'
+    })
+  })
+})

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -99,7 +99,11 @@ export async function getStatusOp(
       disableOptionalLocks: true
     })
     const parsed = parseStatusOutput(stdout)
-    entries.push(...parsed.entries)
+    // Why: SSH worktrees can report huge status sets; spreading into push can
+    // throw before entries reach the renderer.
+    for (const entry of parsed.entries) {
+      entries.push(entry)
+    }
     head = parsed.head
     branch = parsed.branch
     upstreamStatus = parsed.upstreamStatus


### PR DESCRIPTION
## Summary
- append parsed SSH relay status entries iteratively instead of spreading a huge array into push
- add a regression test for 130,000 modified files from the relay status path

## Evidence
- Failing before fix: pnpm test src/relay/git-handler-status-ops.test.ts -- -t "preserves very large status result sets from the SSH relay" returned 0 entries instead of 130000
- Passing after fix: pnpm test src/relay/git-handler-status-ops.test.ts -- -t "preserves very large status result sets from the SSH relay"
- pnpm run typecheck:node
- pnpm exec oxlint src/relay/git-handler-status-ops.ts src/relay/git-handler-status-ops.test.ts

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.