### PR TITLE
fix: guard add repo clone state

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -542,8 +542,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
       toast.error('Enter a server path for the clone destination.')
       return
     }
+    const gen = cloneGenRef.current
     const dir = await window.api.repos.pickDirectory()
-    if (dir) {
+    if (dir && gen === cloneGenRef.current) {
       setCloneDestination(dir)
       setCloneError(null)
     }
@@ -596,6 +597,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
       setAddedRepo(repo)
       setExistingWorkspaceSource('clone_url')
       await fetchWorktrees(repo.id)
+      if (gen !== cloneGenRef.current) {
+        return
+      }
       setStep('setup')
     } catch (err) {
       if (gen !== cloneGenRef.current) {


### PR DESCRIPTION
## Summary
- reuse AddRepoDialog's clone generation guard for destination-picker results
- re-check the clone generation after worktree fetch before moving to the setup step

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- no change to clone execution, abort behavior, repo upsert, or worktree fetch
- only ignores clone UI continuations after reset/close or after a newer clone supersedes the old one
- follows the existing `cloneGenRef` pattern already present in this path

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoDialog.tsx`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
