### PR TITLE
fix: handle large manual worktree reorders

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -55,6 +55,16 @@ describe('moveWorktreeIdsWithinGroup', () => {
       'c'
     ])
   })
+
+  it('moves a very large selected batch without overflowing argument limits', () => {
+    const ids = Array.from({ length: 130_000 }, (_, index) => `wt-${index}`)
+
+    const result = moveWorktreeIdsWithinGroup(ids, ids, 0)
+
+    expect(result).toHaveLength(ids.length)
+    expect(result[0]).toBe('wt-0')
+    expect(result.at(-1)).toBe('wt-129999')
+  })
 })
 
 describe('buildWorktreeDragPreviewOffsets', () => {
@@ -184,6 +194,28 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
       ['parent', { manualOrder: 0 }],
       ['child', { manualOrder: -1000 }]
     ])
+  })
+
+  it('reorders a very large visible group without overflowing argument limits', () => {
+    const ids = Array.from({ length: 130_000 }, (_, index) => `wt-${index}`)
+    const rankByWorktreeId = new Map(
+      ids.map((id, index) => [id, (ids.length - index) * 1000] as const)
+    )
+
+    const result = buildManualOrderUpdatesForVisibleGroups({
+      groups: [{ key: 'all', worktreeIds: ids }],
+      sourceGroupKey: 'all',
+      draggedIds: ['wt-0'],
+      dropIndex: ids.length,
+      now: 10_000,
+      rankByWorktreeId
+    })
+
+    expect(result.changed).toBe(true)
+    expect(result.orderedIds).toHaveLength(ids.length)
+    expect(result.orderedIds[0]).toBe('wt-1')
+    expect(result.orderedIds.at(-1)).toBe('wt-0')
+    expect(Array.from(result.updates)).toEqual([['wt-0', { manualOrder: 0 }]])
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-manual-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.ts
@@ -26,6 +26,20 @@ function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((value, index) => value === b[index])
 }
 
+function appendWorktreeIds(target: string[], ids: readonly string[]): void {
+  // Why: generated workspace fleets can exceed V8's argument limit for
+  // `push(...ids)` while manual ordering still needs the full visible order.
+  for (const id of ids) {
+    target.push(id)
+  }
+}
+
+function insertWorktreeIds(target: string[], index: number, ids: readonly string[]): void {
+  const tail = target.splice(index)
+  appendWorktreeIds(target, ids)
+  appendWorktreeIds(target, tail)
+}
+
 export function expandDraggedWorktreeIdsForVisibleLineage(
   rows: readonly WorktreeDragLineageRow[],
   draggedIds: readonly string[]
@@ -101,7 +115,7 @@ export function moveWorktreeIdsWithinGroup(
   const remaining = groupIds.filter((id) => !draggedSet.has(id))
   const insertAt = Math.max(0, Math.min(remaining.length, boundedDropIndex - removedBeforeDrop))
   const next = remaining.slice()
-  next.splice(insertAt, 0, ...orderedDraggedIds)
+  insertWorktreeIds(next, insertAt, orderedDraggedIds)
   return next
 }
 
@@ -128,7 +142,7 @@ export function buildManualOrderUpdatesForVisibleGroups(args: {
     if (group.key === args.sourceGroupKey && !arraysEqual(ids, group.worktreeIds)) {
       changed = true
     }
-    orderedIds.push(...ids)
+    appendWorktreeIds(orderedIds, ids)
   }
 
   if (!changed) {
@@ -194,10 +208,10 @@ export function buildManualOrderUpdatesForGroupDrop(args: {
         }
       }
       ids = group.worktreeIds.filter((id) => !draggedSet.has(id))
-      ids.splice(
+      insertWorktreeIds(
+        ids,
         Math.max(0, Math.min(ids.length, boundedDropIndex - removedBeforeDrop)),
-        0,
-        ...orderedDraggedIds
+        orderedDraggedIds
       )
     } else {
       ids = group.worktreeIds.filter((id) => !draggedSet.has(id))
@@ -206,7 +220,7 @@ export function buildManualOrderUpdatesForGroupDrop(args: {
     if (!arraysEqual(ids, group.worktreeIds)) {
       changed = true
     }
-    orderedIds.push(...ids)
+    appendWorktreeIds(orderedIds, ids)
   }
 
   if (!changed) {


### PR DESCRIPTION
## Summary
- append and insert manual worktree order arrays without argument spreading
- add regressions for a 130,000-row visible group and a 130,000-row multi-select batch

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- replaces spread-based array insertion/appending with equivalent iterative helpers to avoid V8 argument limits
- no ordering policy, persistence contract, or UI surface changes beyond supporting very large worktree lists
- includes focused large-list regression coverage for both affected paths

## Evidence
- Failing before fix: pnpm test src/renderer/src/components/sidebar/worktree-manual-order.test.ts -- -t "very large" failed at next.splice and orderedIds.push with RangeError
- Passing after fix: pnpm test src/renderer/src/components/sidebar/worktree-manual-order.test.ts -- -t "very large"
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/sidebar/worktree-manual-order.ts src/renderer/src/components/sidebar/worktree-manual-order.test.ts