### PR TITLE
fix: collect wide project group subtrees

### DIFF
--- a/src/shared/project-groups.test.ts
+++ b/src/shared/project-groups.test.ts
@@ -112,4 +112,20 @@ describe('project-groups', () => {
       ].sort()
     ).toEqual(['child', 'grandchild', 'root'])
   })
+
+  it('collects wide descendant groups without overflowing argument limits', () => {
+    const groups = [
+      { id: 'root', parentGroupId: null },
+      ...Array.from({ length: 130_000 }, (_, index) => ({
+        id: `child-${index}`,
+        parentGroupId: 'root'
+      }))
+    ]
+
+    const subtreeIds = getProjectGroupSubtreeIds(groups, 'root')
+
+    expect(subtreeIds.size).toBe(130_001)
+    expect(subtreeIds.has('root')).toBe(true)
+    expect(subtreeIds.has('child-129999')).toBe(true)
+  })
 })

--- a/src/shared/project-groups.ts
+++ b/src/shared/project-groups.ts
@@ -105,10 +105,9 @@ export function getProjectGroupSubtreeIds(
     if (!group.parentGroupId) {
       continue
     }
-    childGroupsByParentId.set(group.parentGroupId, [
-      ...(childGroupsByParentId.get(group.parentGroupId) ?? []),
-      group.id
-    ])
+    const children = childGroupsByParentId.get(group.parentGroupId) ?? []
+    children.push(group.id)
+    childGroupsByParentId.set(group.parentGroupId, children)
   }
 
   const subtreeIds = new Set<string>()
@@ -119,7 +118,11 @@ export function getProjectGroupSubtreeIds(
       continue
     }
     subtreeIds.add(groupId)
-    pending.push(...(childGroupsByParentId.get(groupId) ?? []))
+    // Why: imported project-group trees can be very wide; `push(...children)`
+    // can exceed V8's argument limit while collecting descendants.
+    for (const childGroupId of childGroupsByParentId.get(groupId) ?? []) {
+      pending.push(childGroupId)
+    }
   }
   return subtreeIds
 }


### PR DESCRIPTION
## Summary
- build project-group child indexes by mutating child arrays instead of recreating them
- append pending subtree IDs iteratively so wide imported group trees do not exceed V8 argument limits
- add a regression for a root group with 130,000 direct child groups

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- replaces spread/rebuild-heavy collection with equivalent iterative mutation to avoid V8 argument limits
- no project-group semantics, persistence format, or provider behavior changes
- includes focused wide-tree regression coverage for the affected path

## Evidence
- Failing before fix: pnpm test src/shared/project-groups.test.ts -- -t "wide descendant groups" failed with RangeError at pending.push
- Passing after fix: pnpm test src/shared/project-groups.test.ts -- -t "wide descendant groups"
- pnpm run typecheck:node
- pnpm run typecheck:web
- pnpm exec oxlint src/shared/project-groups.ts src/shared/project-groups.test.ts