### PR TITLE
fix: build large repo-group row lists

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -405,6 +405,22 @@ describe('buildRows project grouping order', () => {
     const headerKeys = rows.filter((r) => r.type === 'header').map((r) => r.key)
     expect(headerKeys).toEqual(['repo:repo-b', 'repo:repo-a', 'repo:repo-c'])
   })
+
+  it('builds rows for a very large repo-group list', () => {
+    const count = 130_000
+    const repos = new Map<string, Repo>()
+    const worktrees = Array.from({ length: count }, (_, index) => {
+      const repoId = `repo-${index}`
+      repos.set(repoId, { ...repo, id: repoId, displayName: `repo ${index}` })
+      return { ...worktree, id: `wt-${index}`, repoId, displayName: `workspace ${index}` }
+    })
+
+    const rows = buildRows('repo', worktrees, repos, null, new Set())
+
+    expect(rows).toHaveLength(count * 2)
+    expect(rows[0]).toMatchObject({ type: 'header', key: 'repo:repo-0' })
+    expect(rows.at(-1)).toMatchObject({ type: 'item', worktree: { id: 'wt-129999' } })
+  })
 })
 
 describe('getProjectGroupOrdering', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -473,7 +473,11 @@ export function buildRows(
         return a[1].label.localeCompare(b[1].label)
       })
     }
-    orderedGroups.push(...entries)
+    // Why: large imported repo sets can have one group per repo; spreading
+    // those entries into push can exceed V8's argument limit.
+    for (const entry of entries) {
+      orderedGroups.push(entry)
+    }
   }
 
   const appendOrderedGroups = (


### PR DESCRIPTION
## Summary
- append ordered repo groups iteratively in the sidebar row builder
- add a regression for 130,000 repo groups feeding the virtualized worktree list

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- swaps argument-spread appending for equivalent iterative appending to avoid V8 limits
- row ordering behavior and virtualized-list contracts are unchanged
- includes focused large-list regression coverage for the affected builder

## Evidence
- Failing before fix: pnpm test src/renderer/src/components/sidebar/worktree-list-groups.test.ts -- -t "very large repo-group list" failed with RangeError at orderedGroups.push
- Passing after fix: pnpm test src/renderer/src/components/sidebar/worktree-list-groups.test.ts -- -t "very large repo-group list"
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/sidebar/worktree-list-groups.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts