### PR TITLE
fix: ignore malformed markdown file links

### DIFF
--- a/src/renderer/src/components/editor/markdown-internal-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.test.ts
@@ -123,6 +123,10 @@ describe('resolveMarkdownLinkTarget', () => {
     })
   })
 
+  it('returns null for malformed percent-encoded file URL paths', () => {
+    expect(resolveMarkdownLinkTarget('file:///repo/docs/%zz.md', SOURCE, ROOT)).toBeNull()
+  })
+
   it('returns null for empty href', () => {
     expect(resolveMarkdownLinkTarget('', SOURCE, ROOT)).toBeNull()
     expect(resolveMarkdownLinkTarget(undefined, SOURCE, ROOT)).toBeNull()

--- a/src/renderer/src/components/editor/markdown-internal-links.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.ts
@@ -51,8 +51,13 @@ function toFileUrl(filePath: string): string {
   return `file:///${segments.join('/')}`
 }
 
-function fileUrlToAbsolutePath(url: URL): string {
-  let absolutePath = decodeURIComponent(url.pathname)
+function fileUrlToAbsolutePath(url: URL): string | null {
+  let absolutePath: string
+  try {
+    absolutePath = decodeURIComponent(url.pathname)
+  } catch {
+    return null
+  }
   // Windows: "/C:/foo" → "C:/foo"
   if (/^\/[A-Za-z]:\//.test(absolutePath)) {
     absolutePath = absolutePath.slice(1)
@@ -175,6 +180,9 @@ export function resolveMarkdownLinkTarget(
   }
 
   const rawAbsolutePath = fileUrlToAbsolutePath(resolved)
+  if (rawAbsolutePath === null) {
+    return null
+  }
 
   // Why: hash-based line anchor takes precedence; fall back to trailing
   // `:line:col` syntax only if no hash anchor was found.


### PR DESCRIPTION
## Summary
- guard markdown internal file URL decoding against malformed percent sequences
- return null for malformed file link targets instead of throwing out of link activation
- add a regression for file:///repo/docs/%zz.md

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- only changes malformed file-link handling from throw to no target
- valid markdown file links continue through the existing decode/resolve path
- includes a focused regression for the malformed percent-encoding case

## Evidence
- Failing before fix: pnpm test src/renderer/src/components/editor/markdown-internal-links.test.ts -- -t "malformed percent-encoded file URL paths" threw URIError
- Passing after fix: pnpm test src/renderer/src/components/editor/markdown-internal-links.test.ts -- -t "malformed percent-encoded file URL paths"
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/editor/markdown-internal-links.ts src/renderer/src/components/editor/markdown-internal-links.test.ts