### PR TITLE
fix: guard nested add repo import state

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -115,6 +115,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   // Why: server path adds share the same dialog but run against a runtime
   // server; resetState cancels their stale scan/add/fetch continuations.
   const serverAddGenRef = useRef(0)
+  // Why: nested group import can create many repos; resetState must prevent
+  // stale import completions from reopening setup UI after Back/close.
+  const nestedImportGenRef = useRef(0)
   // Why: a dropped path is modal data, so ordinary state updates must not
   // re-run the import while the Add Project dialog advances through steps.
   const droppedLocalPathHandledRef = useRef<string | null>(null)
@@ -248,6 +251,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     cloneGenRef.current++
     localAddGenRef.current++
     serverAddGenRef.current++
+    nestedImportGenRef.current++
     // Why: kill the git clone process if one is running, so backing out
     // or closing the dialog doesn't leave a clone running on disk.
     void window.api.repos.cloneAbort()
@@ -390,6 +394,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
       const foundCount = nestedScan.repos.length
       const selectedCount = nestedSelectedPaths.size
       const runtimeKind = nestedRuntimeKind ?? getNestedRepoRuntimeKind(nestedConnectionId)
+      const gen = ++nestedImportGenRef.current
       setIsAdding(true)
       track(
         'add_repo_nested_import_action',
@@ -433,13 +438,18 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
         const firstRepoId = importedRepoIds[0]
         if (!firstRepoId) {
           const firstFailure = result.projects.find((entry) => entry.status === 'failed')?.error
-          toast.error('No repositories imported', {
-            description: firstFailure ?? undefined
-          })
+          if (gen === nestedImportGenRef.current) {
+            toast.error('No repositories imported', {
+              description: firstFailure ?? undefined
+            })
+          }
           return
         }
         for (const projectId of importedRepoIds) {
           await fetchWorktrees(projectId)
+        }
+        if (gen !== nestedImportGenRef.current) {
+          return
         }
         const repo = useAppStore.getState().repos.find((entry) => entry.id === firstRepoId)
         if (repo) {
@@ -454,9 +464,11 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
           setStep('setup')
         }
         if (result.failedCount > 0) {
-          toast.warning('Some repositories could not be imported', {
-            description: `${result.failedCount} failed`
-          })
+          if (gen === nestedImportGenRef.current) {
+            toast.warning('Some repositories could not be imported', {
+              description: `${result.failedCount} failed`
+            })
+          }
         }
       } finally {
         if (!resultTracked) {
@@ -473,7 +485,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
             })
           )
         }
-        setIsAdding(false)
+        if (gen === nestedImportGenRef.current) {
+          setIsAdding(false)
+        }
       }
     },
     [


### PR DESCRIPTION
## Summary
- add a reset-invalidated generation guard for AddRepoDialog nested group imports
- prevent stale nested import completions from reopening setup UI or clearing loading state after Back/close
- keep import execution and result telemetry intact while guarding user-visible follow-up

## Merge risk assessment
Risk: MEDIUM (`risk:medium`)

Why medium:
- this path can import multiple projects and spans local, SSH, and runtime nested repo flows
- the change intentionally skips stale setup/toast follow-up after reset, but the import itself may already have completed
- focused validation covers lint/format/type surface, but this path benefits from manual nested-import verification before merge

Risk reduction already done:
- split out local folder add, clone, and server-path guards into separate low-risk PRs
- scoped this PR to nested import submit only; no local/clone/server-path behavior changes are included
- preserved result telemetry even when UI follow-up is stale

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoDialog.tsx`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.