### PR TITLE
fix: guard add repo setup state

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -115,6 +115,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   // Why: server path adds share the same dialog but run against a runtime
   // server; resetState cancels their stale scan/add/fetch continuations.
   const serverAddGenRef = useRef(0)
+  // Why: setup actions can await settings/worktree refreshes; resetState
+  // cancels stale continuations when the setup step is dismissed.
+  const setupActionGenRef = useRef(0)
   // Why: a dropped path is modal data, so ordinary state updates must not
   // re-run the import while the Add Project dialog advances through steps.
   const droppedLocalPathHandledRef = useRef<string | null>(null)
@@ -248,6 +251,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     cloneGenRef.current++
     localAddGenRef.current++
     serverAddGenRef.current++
+    setupActionGenRef.current++
     // Why: kill the git clone process if one is running, so backing out
     // or closing the dialog doesn't leave a clone running on disk.
     void window.api.repos.cloneAbort()
@@ -722,13 +726,20 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     if (!projectId) {
       return
     }
+    const gen = ++setupActionGenRef.current
     trackSetupAction('open_existing')
     if (!otherWorktreesVisible) {
       const updated = await updateRepo(projectId, { externalWorktreeVisibility: 'show' })
+      if (gen !== setupActionGenRef.current) {
+        return
+      }
       if (updated && addedRepo) {
         setAddedRepo({ ...addedRepo, externalWorktreeVisibility: 'show' })
       }
       await fetchWorktrees(projectId)
+      if (gen !== setupActionGenRef.current) {
+        return
+      }
     }
     await finishImportedRepoWithoutOpening()
   }, [


### PR DESCRIPTION
## Summary
- add a reset-invalidated setup action guard for AddRepoDialog's existing-worktrees action
- skip stale repo-local setup state/fetch continuation after the setup step is dismissed
- leave nested import, clone, local add, and server-path add flows unchanged

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- scoped to the setup-step existing-worktrees action only
- preserves the updateRepo/fetch/finalize behavior for the current active action
- follows the same generation-guard pattern used by the other AddRepoDialog low-risk splits

## Validation
- `pnpm exec oxlint src/renderer/src/components/sidebar/AddRepoDialog.tsx`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
