### PR TITLE
fix: handle large comment markdown references

### DIFF
--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import CommentMarkdown from './CommentMarkdown'
+import CommentMarkdown, { remarkGitHubReferences } from './CommentMarkdown'
 
 describe('CommentMarkdown', () => {
   it('autolinks same-repo GitHub issue references when repo context is provided', () => {
@@ -40,6 +40,33 @@ describe('CommentMarkdown', () => {
     expect(markup).toContain('href="https://example.com/already-linked"')
     expect(markup).not.toContain('href="https://github.com/stablyai/orca/issues/2316"')
     expect(markup).not.toContain('href="https://github.com/stablyai/orca/issues/2317"')
+  })
+
+  it('autolinks very large generated GitHub reference comments', () => {
+    const referenceCount = 130_000
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: Array.from({ length: referenceCount }, (_, index) => `#${index + 1}`).join(' ')
+            }
+          ]
+        }
+      ]
+    }
+
+    const transform = remarkGitHubReferences({ owner: 'stablyai', repo: 'orca' })()
+
+    expect(() => transform(tree)).not.toThrow()
+    expect(tree.children[0]?.children).toHaveLength(referenceCount * 2 - 1)
+    expect(tree.children[0]?.children[0]).toMatchObject({
+      type: 'link',
+      url: 'https://github.com/stablyai/orca/issues/1'
+    })
   })
 
   it('contains long PR body markdown inside its available width', () => {

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -265,7 +265,11 @@ function transformGitHubReferenceChildren(
   const nextChildren: MarkdownNode[] = []
   for (const child of node.children) {
     if (child.type === 'text' && child.value !== undefined) {
-      nextChildren.push(...splitGitHubReferenceText(child.value, defaultRepo))
+      // Why: generated agent comments can contain thousands of issue refs;
+      // appending iteratively avoids V8's argument-list limit.
+      for (const part of splitGitHubReferenceText(child.value, defaultRepo)) {
+        nextChildren.push(part)
+      }
     } else {
       transformGitHubReferenceChildren(child, defaultRepo)
       nextChildren.push(child)


### PR DESCRIPTION
## Summary
- Avoid argument-list spread when sidebar comment markdown expands one text node into many GitHub reference links.
- Add a plugin-level regression with 130,000 generated issue references.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- replaces one array spread append with equivalent iterative appending inside markdown reference transformation
- rendered output and link generation semantics are unchanged for ordinary comments
- includes focused high-volume regression coverage for the affected transformation

## Verification
- Failing before fix: `pnpm test src/renderer/src/components/sidebar/CommentMarkdown.test.tsx -- -t "very large generated"` raised `RangeError: Maximum call stack size exceeded`.
- Passing after fix: `pnpm test src/renderer/src/components/sidebar/CommentMarkdown.test.tsx`
- Passing after fix: `pnpm run typecheck:web`
- Passing after fix: `pnpm exec oxlint src/renderer/src/components/sidebar/CommentMarkdown.tsx src/renderer/src/components/sidebar/CommentMarkdown.test.tsx`