### PR TITLE
perf: clean settings search reset from effect

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -213,6 +213,18 @@ function Settings(): React.JSX.Element {
   const repoHooksRuntimeIdentityRef = useRef<string>('local')
   const shortcutsEscapeConfirmUntilRef = useRef(0)
 
+  const setSettingsRootNode = useCallback(
+    (node: HTMLDivElement | null): void => {
+      if (node) {
+        return
+      }
+      // Why: the settings search is a transient in-page filter. Leaving it behind makes the next
+      // visit look partially broken because whole sections stay hidden before the user types again.
+      setSettingsSearchQuery('')
+    },
+    [setSettingsSearchQuery]
+  )
+
   const confirmDiscardCommitPromptChanges = useCallback(async (): Promise<boolean> => {
     if (!hasUnsavedCommitPromptChanges) {
       return true
@@ -338,15 +350,6 @@ function Settings(): React.JSX.Element {
     document.addEventListener('keydown', handleFindShortcut)
     return () => document.removeEventListener('keydown', handleFindShortcut)
   }, [keybindings])
-
-  useEffect(
-    () => () => {
-      // Why: the settings search is a transient in-page filter. Leaving it behind makes the next
-      // visit look partially broken because whole sections stay hidden before the user types again.
-      setSettingsSearchQuery('')
-    },
-    [setSettingsSearchQuery]
-  )
 
   useEffect(() => {
     if (!settings || !settingsNavigationTarget) {
@@ -694,8 +697,13 @@ function Settings(): React.JSX.Element {
 
   if (!settings) {
     return (
-      <div className="flex flex-1 items-center justify-center text-muted-foreground">
-        Loading settings...
+      <div
+        ref={setSettingsRootNode}
+        className="settings-view-shell flex min-h-0 flex-1 overflow-hidden bg-background"
+      >
+        <div className="flex flex-1 items-center justify-center text-muted-foreground">
+          Loading settings...
+        </div>
       </div>
     )
   }
@@ -721,7 +729,10 @@ function Settings(): React.JSX.Element {
     activeSectionId === 'shortcuts' && settingsSearchQuery.trim() === ''
 
   return (
-    <div className="settings-view-shell flex min-h-0 flex-1 overflow-hidden bg-background">
+    <div
+      ref={setSettingsRootNode}
+      className="settings-view-shell flex min-h-0 flex-1 overflow-hidden bg-background"
+    >
       <SettingsSidebar
         activeSectionId={activeSectionId}
         generalGroups={generalNavGroups}


### PR DESCRIPTION
## Summary
- move Settings search-query unmount cleanup from a cleanup-only Effect to the stable Settings root ref
- keep the same transient search reset behavior when the Settings view unmounts
- keep the loading and loaded Settings roots on the same shell so the ref cleanup does not fire during settings hydration

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- narrow renderer-only lifecycle cleanup in Settings
- search and navigation behavior are unchanged while Settings is mounted
- removes one cleanup-only Effect and preserves the existing unmount reset intent

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/settings/Settings.tsx`
- `pnpm exec oxlint src/renderer/src/components/settings/Settings.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/Settings.load-performance.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- renderer Effect count: 806 -> 805