### PR TITLE
fix: allow dot-dot-prefixed relay diff paths

### DIFF
--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -425,6 +425,24 @@ describe('GitHandler', () => {
       expect(result.originalContent).toBe('original')
       expect(result.modifiedContent).toBe('staged-content')
     })
+
+    it('returns diff for tracked files in valid dot-dot-prefixed directories', async () => {
+      gitInit(tmpDir)
+      mkdirSync(path.join(tmpDir, '..fixtures'))
+      writeFileSync(path.join(tmpDir, '..fixtures', 'file.txt'), 'original')
+      gitCommit(tmpDir, 'initial')
+      writeFileSync(path.join(tmpDir, '..fixtures', 'file.txt'), 'modified')
+
+      const result = (await dispatcher.callRequest('git.diff', {
+        worktreePath: tmpDir,
+        filePath: '..fixtures/file.txt',
+        staged: false
+      })) as { kind: string; originalContent: string; modifiedContent: string }
+
+      expect(result.kind).toBe('text')
+      expect(result.originalContent).toBe('original')
+      expect(result.modifiedContent).toBe('modified')
+    })
   })
 
   describe('discard', () => {

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -443,6 +443,18 @@ describe('GitHandler', () => {
       expect(result.originalContent).toBe('original')
       expect(result.modifiedContent).toBe('modified')
     })
+
+    it('rejects diff paths that traverse outside the worktree', async () => {
+      gitInit(tmpDir)
+
+      await expect(
+        dispatcher.callRequest('git.diff', {
+          worktreePath: tmpDir,
+          filePath: '../outside.txt',
+          staged: false
+        })
+      ).rejects.toThrow('outside the worktree')
+    })
   })
 
   describe('discard', () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -139,7 +139,7 @@ export class GitHandler {
     // path.join. Without validation, ../../etc/passwd traverses outside the worktree.
     const resolved = path.resolve(worktreePath, filePath)
     const rel = path.relative(path.resolve(worktreePath), resolved)
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
       throw new Error(`Path "${filePath}" resolves outside the worktree`)
     }
     return computeDiff(


### PR DESCRIPTION
## Summary
- Fix the SSH relay `git.diff` containment check so valid in-worktree paths like `..fixtures/file.txt` are not rejected as parent traversal.
- Add a relay regression covering a tracked modified file inside a dot-dot-prefixed directory.

## Merge risk assessment
Risk: HIGH (`risk:high`)

Why high:
- touches SSH relay path-containment logic, which is a security boundary for remote file access
- the intended behavior is a false-positive fix, but containment changes need review for traversal regressions across platforms
- includes a focused regression, but should get relay/security review before merge

## Verification
- Failing before fix: `pnpm test src/relay/git-handler.test.ts -- -t "dot-dot-prefixed"` rejected `..fixtures/file.txt` with `Path "..fixtures/file.txt" resolves outside the worktree`.
- Passing after fix: `pnpm test src/relay/git-handler.test.ts`
- Passing after fix: `pnpm run typecheck:node`
- Passing after fix: `pnpm exec oxlint src/relay/git-handler.ts src/relay/git-handler.test.ts`

Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.