### PR TITLE
fix: clean up pane container listeners

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { disposePane } from './pane-lifecycle'
+
+function makePane(): ManagedPaneInternal {
+  const leafId = '11111111-1111-4111-8111-111111111111' as never
+  return {
+    id: 1,
+    leafId,
+    stablePaneId: leafId,
+    terminal: { dispose: vi.fn() } as never,
+    container: { removeEventListener: vi.fn() } as never,
+    xtermContainer: {} as never,
+    linkTooltip: {} as never,
+    terminalGpuAcceleration: 'auto',
+    gpuRenderingEnabled: false,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    hasComplexScriptOutput: false,
+    fitAddon: { dispose: vi.fn() } as never,
+    fitResizeObserver: null,
+    pendingObservedFitRafId: null,
+    searchAddon: { dispose: vi.fn() } as never,
+    serializeAddon: { dispose: vi.fn() } as never,
+    unicode11Addon: { dispose: vi.fn() } as never,
+    webLinksAddon: { dispose: vi.fn() } as never,
+    webglAddon: null,
+    ligaturesAddon: null,
+    panePointerDownHandler: vi.fn(),
+    paneMouseEnterHandler: vi.fn(),
+    compositionHandler: null,
+    pendingSplitScrollState: null,
+    debugLabel: null
+  }
+}
+
+describe('disposePane container listener cleanup', () => {
+  it('removes pane container focus listeners', () => {
+    const pane = makePane()
+    const pointerDownHandler = pane.panePointerDownHandler
+    const mouseEnterHandler = pane.paneMouseEnterHandler
+    const panes = new Map([[pane.id, pane]])
+
+    disposePane(pane, panes)
+
+    expect(pane.container.removeEventListener).toHaveBeenCalledWith(
+      'pointerdown',
+      pointerDownHandler
+    )
+    expect(pane.container.removeEventListener).toHaveBeenCalledWith('mouseenter', mouseEnterHandler)
+    expect(pane.panePointerDownHandler).toBeNull()
+    expect(pane.paneMouseEnterHandler).toBeNull()
+    expect(panes.has(pane.id)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -110,6 +110,16 @@ export function createPaneDOM(
 
   const serializeAddon = new SerializeAddon()
 
+  const panePointerDownHandler = (event: PointerEvent): void => {
+    onPointerDown(id, {
+      focusTerminal: shouldFocusTerminalFromPanePointerDown(event.target)
+    })
+  }
+
+  const paneMouseEnterHandler = (event: MouseEvent): void => {
+    onMouseEnter(id, event)
+  }
+
   const pane: ManagedPaneInternal = {
     id,
     leafId,
@@ -134,6 +144,8 @@ export function createPaneDOM(
     webLinksAddon,
     webglAddon: null,
     ligaturesAddon: null,
+    panePointerDownHandler,
+    paneMouseEnterHandler,
     compositionHandler: null,
     pendingSplitScrollState: null,
     pendingSplitScrollRafIds: [],
@@ -146,19 +158,13 @@ export function createPaneDOM(
   // the terminal. We must call focus: true here because after DOM reparenting
   // (e.g. splitPane moves the original pane into a flex container), xterm.js's
   // native click-to-focus on its internal textarea may not fire reliably.
-  container.addEventListener('pointerdown', (event) => {
-    onPointerDown(id, {
-      focusTerminal: shouldFocusTerminalFromPanePointerDown(event.target)
-    })
-  })
+  container.addEventListener('pointerdown', panePointerDownHandler)
 
   // Focus-follows-mouse handler: when the setting is enabled, hovering a
   // pane makes it active. All gating (feature flag, drag-in-progress,
   // window focus, etc.) lives in the PaneManager callback — this layer
   // just forwards the event.
-  container.addEventListener('mouseenter', (event) => {
-    onMouseEnter(id, event)
-  })
+  container.addEventListener('mouseenter', paneMouseEnterHandler)
 
   return pane
 }
@@ -310,6 +316,14 @@ export function disposePane(
   }
   cancelPendingWebglRefresh(pane)
   detachPaneFitResizeObserver(pane)
+  if (pane.panePointerDownHandler) {
+    pane.container.removeEventListener('pointerdown', pane.panePointerDownHandler)
+    pane.panePointerDownHandler = null
+  }
+  if (pane.paneMouseEnterHandler) {
+    pane.container.removeEventListener('mouseenter', pane.paneMouseEnterHandler)
+    pane.paneMouseEnterHandler = null
+  }
   if (pane.compositionHandler) {
     pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)
     pane.compositionHandler = null

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -113,6 +113,9 @@ export type ManagedPaneInternal = {
   serializeAddon: SerializeAddon
   unicode11Addon: Unicode11Addon
   webLinksAddon: WebLinksAddon
+  // Stored so disposePane() can remove pane-local DOM listeners explicitly.
+  panePointerDownHandler?: ((event: PointerEvent) => void) | null
+  paneMouseEnterHandler?: ((event: MouseEvent) => void) | null
   // Stored so disposePane() can remove it and avoid a memory leak.
   compositionHandler: (() => void) | null
   // Why: splitPane reparents DOM; its delayed restore owns scroll until the


### PR DESCRIPTION
## Summary
- store pane container pointer/focus handlers on the pane record
- remove those pane-local DOM listeners when `disposePane` tears down a terminal pane
- add a focused regression for pane container listener cleanup

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low:
- pointerdown and mouseenter handlers keep the same behavior; they are only named so disposal can remove them
- cleanup runs during existing pane disposal alongside composition listener and addon disposal
- focused tests verify the new listener teardown path without changing pane layout or terminal behavior

## Validation
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-manager-types.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts`
- `git diff --check`
- `pnpm typecheck` (fails on existing missing deps: `@tiptap/extension-details`, `react-colorful`)
