### PR TITLE
perf: clean diff section model cleanup from effect

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -148,14 +148,23 @@ export function DiffSectionItem({
       }
     }, 0)
   }, [modelPathBase])
+  const disposeDiffModelsRef = useRef(disposeDiffModels)
+  disposeDiffModelsRef.current = disposeDiffModels
+
+  const setSectionRootNode = useCallback((node: HTMLDivElement | null): void => {
+    if (node) {
+      return
+    }
+    // Why: virtualized diff rows remount as their keyed section/collapse state
+    // changes; the row root is the owner of the detached Monaco models.
+    disposeDiffModelsRef.current()
+  }, [])
 
   useEffect(() => {
     if (section.collapsed) {
       disposeDiffModels()
     }
   }, [disposeDiffModels, section.collapsed])
-
-  useEffect(() => () => disposeDiffModels(), [disposeDiffModels])
 
   // Why: only forward the pending scroll id when it matches a comment in this
   // section so unrelated sections don't keep re-rendering their decorator
@@ -418,7 +427,7 @@ export function DiffSectionItem({
   }, [index, loadSection])
 
   return (
-    <div className="border-b border-border">
+    <div ref={setSectionRootNode} className="border-b border-border">
       <DiffSectionHeader
         path={section.path}
         dirty={section.dirty}


### PR DESCRIPTION
## Summary
- move DiffSectionItem model-disposal unmount cleanup from a cleanup-only Effect to the keyed row root ref
- keep the existing collapsed-section disposal Effect for active collapsed-state synchronization
- use a latest-disposer ref so the root cleanup disposes the current Monaco model pair when a virtualized row unmounts

## Merge risk assessment
Risk: MEDIUM (`risk:medium`)

Why medium:
- touches Monaco diff model lifecycle in the combined diff/editor surface
- behavior is intended to be equivalent on keyed section/collapse/generation unmounts, but stale model cleanup is editor resource ownership
- focused tests cover combined-diff scheduling/layout and diff-comment positioning; no dedicated Monaco model-disposal test exists

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/DiffSectionItem.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/DiffSectionItem.tsx`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/combined-diff-load-scheduler.test.ts src/renderer/src/components/editor/combined-diff-initial-section-load.test.ts src/renderer/src/components/editor/diff-section-layout.test.ts src/renderer/src/components/diff-comments/diff-comment-popover-position.test.ts src/renderer/src/lib/diff-comment-compat.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- renderer Effect count: 805 -> 804

Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.