### PR TITLE
fix: allow dot-dot-prefixed pty session paths

### DIFF
--- a/src/main/daemon/pty-session-id.test.ts
+++ b/src/main/daemon/pty-session-id.test.ts
@@ -75,6 +75,10 @@ describe('isSafePtySessionId', () => {
     // validator must allow that as long as the result stays inside userData.
     expect(isSafePtySessionId('sub/path/ok@@12345678', USER_DATA)).toBe(true)
   })
+
+  it('accepts ids with path segments that merely start with dot-dot', () => {
+    expect(isSafePtySessionId('..sessions/ok@@12345678', USER_DATA)).toBe(true)
+  })
 })
 
 describe('parsePtySessionId', () => {

--- a/src/main/daemon/pty-session-id.ts
+++ b/src/main/daemon/pty-session-id.ts
@@ -61,7 +61,7 @@ export function isSafePtySessionId(id: string, userDataPath: string): boolean {
   // from C:\userdata to D:\evil yields "D:\evil", which does NOT start with
   // ".."). Reject any absolute result — a legitimate subpath under
   // userData always produces a relative result on every platform.
-  if (rel === '' || isAbsolute(rel) || rel.startsWith('..') || rel.includes(`..${sep}`)) {
+  if (rel === '' || isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
     return false
   }
   return true


### PR DESCRIPTION
## Summary
- Fix daemon PTY session-id containment so valid in-userData path segments like `..sessions` are not rejected as parent traversal.
- Add a regression covering a strict userData child path whose segment merely starts with `..`.

## Merge risk assessment
Risk: MEDIUM (`risk:medium`)

Why medium: this is a one-line correction with targeted regression coverage, but it changes the daemon PTY session-id containment check. Because that check protects path traversal boundaries across platforms, it should get another review pass before merge.

## Verification
- Failing before fix: `pnpm test src/main/daemon/pty-session-id.test.ts -- -t "merely start"` returned `false` for `..sessions/ok@@12345678`.
- Passing after fix: `pnpm test src/main/daemon/pty-session-id.test.ts`
- Passing after fix: `pnpm run typecheck:node`
- Passing after fix: `pnpm exec oxlint src/main/daemon/pty-session-id.ts src/main/daemon/pty-session-id.test.ts`

Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.