### PR TITLE
fix: allow dot-dot-prefixed sftp upload paths

### DIFF
--- a/src/main/ssh/sftp-upload.test.ts
+++ b/src/main/ssh/sftp-upload.test.ts
@@ -50,6 +50,22 @@ describe('sftp-upload', () => {
     })
   })
 
+  it('uploads files from valid dot-dot-prefixed local directories', async () => {
+    const localDir = await mkdtemp(join(tmpdir(), 'orca-sftp-upload-'))
+    await mkdir(join(localDir, '..fixtures'))
+    await writeFile(join(localDir, '..fixtures', 'asset.txt'), 'asset')
+    const sftp = createSftpMock()
+
+    await uploadDirectory(sftp, localDir, '/remote/assets', await realpath(localDir), {
+      exclusive: true
+    })
+
+    expect(sftp.mkdir).toHaveBeenCalledWith('/remote/assets/..fixtures', expect.any(Function))
+    expect(sftp.createWriteStream).toHaveBeenCalledWith('/remote/assets/..fixtures/asset.txt', {
+      flags: 'wx'
+    })
+  })
+
   it('does not create the remote file when the local source is a symlink', async () => {
     const localDir = await mkdtemp(join(tmpdir(), 'orca-sftp-upload-'))
     await writeFile(join(localDir, 'target.txt'), 'secret')

--- a/src/main/ssh/sftp-upload.test.ts
+++ b/src/main/ssh/sftp-upload.test.ts
@@ -66,6 +66,23 @@ describe('sftp-upload', () => {
     })
   })
 
+  it('rejects sibling directories outside the upload root', async () => {
+    const localDir = await mkdtemp(join(tmpdir(), 'orca-sftp-upload-'))
+    const escapedDir = `${localDir}-sibling`
+    await mkdir(escapedDir)
+    await writeFile(join(escapedDir, 'asset.txt'), 'asset')
+    const sftp = createSftpMock()
+
+    await expect(
+      uploadDirectory(sftp, escapedDir, '/remote/assets', await realpath(localDir), {
+        exclusive: true
+      })
+    ).rejects.toThrow('Path escaped upload root')
+
+    expect(sftp.mkdir).not.toHaveBeenCalled()
+    expect(sftp.createWriteStream).not.toHaveBeenCalled()
+  })
+
   it('does not create the remote file when the local source is a symlink', async () => {
     const localDir = await mkdtemp(join(tmpdir(), 'orca-sftp-upload-'))
     await writeFile(join(localDir, 'target.txt'), 'secret')

--- a/src/main/ssh/sftp-upload.ts
+++ b/src/main/ssh/sftp-upload.ts
@@ -1,7 +1,7 @@
 import { constants } from 'fs'
 import type { ReadStream } from 'fs'
 import { lstat, open, readdir, realpath } from 'fs/promises'
-import { isAbsolute, join as pathJoin, relative } from 'path'
+import { isAbsolute, join as pathJoin, relative, sep } from 'path'
 import type { SFTPWrapper } from 'ssh2'
 
 export function mkdirSftp(
@@ -147,7 +147,10 @@ async function assertLocalUploadPathInsideRoot(
 ): Promise<void> {
   const candidateRealPath = await realpath(candidatePath)
   const relativeToRoot = relative(rootRealPath, candidateRealPath)
-  if (relativeToRoot !== '' && (relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot))) {
+  if (
+    relativeToRoot !== '' &&
+    (relativeToRoot === '..' || relativeToRoot.startsWith(`..${sep}`) || isAbsolute(relativeToRoot))
+  ) {
     throw new Error(`Path escaped upload root: ${candidatePath}`)
   }
 }


### PR DESCRIPTION
## Summary
- Fix recursive SFTP upload containment so valid local children like `..fixtures` are not rejected as parent traversal.
- Add a regression covering exclusive directory upload from a dot-dot-prefixed local directory.

## Merge risk assessment
Risk: MEDIUM (`risk:medium`)

Why medium: this is a small, covered correction, but it changes an SFTP upload path-containment guard. Because that guard protects recursive upload traversal boundaries across platforms, it should get another review pass before merge.

## Verification
- Failing before fix: `pnpm test src/main/ssh/sftp-upload.test.ts -- -t "dot-dot-prefixed"` threw `Path escaped upload root` for the local `..fixtures` directory.
- Passing after fix: `pnpm test src/main/ssh/sftp-upload.test.ts`
- Passing after fix: `pnpm run typecheck:node`
- Passing after fix: `pnpm exec oxlint src/main/ssh/sftp-upload.ts src/main/ssh/sftp-upload.test.ts`

Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.