### PR TITLE
fix: clean up file drop relay listener

### DIFF
--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   onMock,
   removeAllListenersMock,
+  removeListenerMock,
   setPermissionRequestHandlerMock,
   setPermissionCheckHandlerMock,
   setDisplayMediaRequestHandlerMock,
@@ -22,6 +23,7 @@ const {
 } = vi.hoisted(() => ({
   onMock: vi.fn(),
   removeAllListenersMock: vi.fn(),
+  removeListenerMock: vi.fn(),
   setPermissionRequestHandlerMock: vi.fn(),
   setPermissionCheckHandlerMock: vi.fn(),
   setDisplayMediaRequestHandlerMock: vi.fn(),
@@ -52,6 +54,7 @@ vi.mock('electron', () => ({
   ipcMain: {
     on: onMock,
     removeAllListeners: removeAllListenersMock,
+    removeListener: removeListenerMock,
     removeHandler: removeHandlerMock,
     handle: handleMock
   },
@@ -152,6 +155,7 @@ describe('attachMainWindowServices', () => {
   beforeEach(() => {
     onMock.mockReset()
     removeAllListenersMock.mockReset()
+    removeListenerMock.mockReset()
     handleMock.mockReset()
     removeHandlerMock.mockReset()
     setPermissionRequestHandlerMock.mockReset()
@@ -425,6 +429,28 @@ describe('attachMainWindowServices', () => {
     expect(closedHandler).toBeTypeOf('function')
     closedHandler?.()
     expect(browserManagerUnregisterAllMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the native file-drop relay when the main window closes', () => {
+    const mainWindowOnMock = vi.fn()
+    const mainWindow = createMainWindow({ send: vi.fn() })
+    mainWindow.on = mainWindowOnMock
+
+    attachMainWindowServices(mainWindow as never, createStore(), createRuntime() as never)
+
+    const channel = 'terminal:file-dropped-from-preload'
+    const relayHandler = onMock.mock.calls.find(([event]) => event === channel)?.[1]
+    expect(relayHandler).toBeTypeOf('function')
+    expect(removeAllListenersMock).toHaveBeenCalledWith(channel)
+
+    const closedHandlers = mainWindowOnMock.mock.calls
+      .filter(([event]) => event === 'closed')
+      .map(([, handler]) => handler as () => void)
+    for (const handler of closedHandlers) {
+      handler()
+    }
+
+    expect(removeListenerMock).toHaveBeenCalledWith(channel, relayHandler)
   })
 
   it('forwards runtime notifier events to the renderer', () => {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -373,8 +373,9 @@ function registerRuntimeWindowLifecycle(
 }
 
 function registerFileDropRelay(mainWindow: BrowserWindow): void {
-  ipcMain.removeAllListeners('terminal:file-dropped-from-preload')
-  ipcMain.on('terminal:file-dropped-from-preload', (_event, args: NativeFileDropPayload) => {
+  const channel = 'terminal:file-dropped-from-preload'
+  ipcMain.removeAllListeners(channel)
+  const relayFileDrop = (_event: Electron.IpcMainEvent, args: NativeFileDropPayload): void => {
     if (mainWindow.isDestroyed()) {
       return
     }
@@ -382,6 +383,12 @@ function registerFileDropRelay(mainWindow: BrowserWindow): void {
     // Why: relay exactly one IPC event per drop gesture so the renderer
     // receives the full batch of paths without timer-based reconstruction.
     mainWindow.webContents.send('terminal:file-drop', args)
+  }
+  ipcMain.on(channel, relayFileDrop)
+  mainWindow.on('closed', () => {
+    // Why: macOS can keep the app process alive after the window closes; drop
+    // the relay closure so a destroyed BrowserWindow is not retained.
+    ipcMain.removeListener(channel, relayFileDrop)
   })
 }
 


### PR DESCRIPTION
## Summary
- Remove the main-process native file-drop IPC relay when its owning main window closes.
- Add a regression test proving the exact registered relay handler is removed on `closed`.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low: the change only adds lifecycle cleanup for an existing IPC listener and keeps the same relay behavior while the window is alive. The regression exercises the cleanup path directly.

## Validation
- `pnpm exec oxlint src/main/window/attach-main-window-services.ts src/main/window/attach-main-window-services.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/attach-main-window-services.test.ts`
- `git diff --check`
- `pnpm typecheck` failed only on existing missing packages: `@tiptap/extension-details` and `react-colorful`.
