### PR TITLE
Fix usage overview crash on very large daily histories

### DIFF
--- a/src/renderer/src/components/stats/usage-overview-model.test.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.test.ts
@@ -253,6 +253,34 @@ describe('usage overview model', () => {
     expect(overview.cacheShare).toBeNull()
   })
 
+  it('aggregates very large daily histories without spreading every day into Math.max', () => {
+    const codexDaily: CodexUsageDailyPoint[] = Array.from({ length: 130_000 }, (_, index) => {
+      const date = new Date(Date.UTC(2026, 0, 1 + index))
+      return {
+        day: date.toISOString().slice(0, 10),
+        inputTokens: index + 1,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+        totalTokens: index + 1
+      }
+    })
+
+    const overview = buildUsageOverview({
+      claude: { scanState: null, summary: null, daily: [] },
+      codex: {
+        scanState: enabledCodexScanState(),
+        summary: null,
+        daily: codexDaily
+      },
+      opencode: { scanState: null, summary: null, daily: [] }
+    })
+
+    expect(overview.daily).toHaveLength(130_000)
+    expect(overview.bestDay?.totalTokens).toBe(130_000)
+    expect(overview.daily.at(-1)?.intensity).toBe(4)
+  })
+
   it('formats token and cost values for compact UI labels', () => {
     expect(formatUsageTokens(999)).toBe('999')
     expect(formatUsageTokens(1_200)).toBe('1.2k')

--- a/src/renderer/src/components/stats/usage-overview-model.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.ts
@@ -260,7 +260,12 @@ function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[
     byDay.set(entry.day, current)
   }
 
-  const maxTokens = Math.max(0, ...[...byDay.values()].map((entry) => entry.totalTokens))
+  let maxTokens = 0
+  // Why: usage history can be large enough to exceed V8's argument limit if
+  // every day is spread into Math.max.
+  for (const entry of byDay.values()) {
+    maxTokens = Math.max(maxTokens, entry.totalTokens)
+  }
   return [...byDay.values()]
     .sort((left, right) => left.day.localeCompare(right.day))
     .map((entry) => ({


### PR DESCRIPTION
## Summary
- Replace the usage overview daily-token max spread with an iterative max so large scan histories do not exceed V8 argument limits.
- Add a regression covering 130,000 Codex daily points through `buildUsageOverview`.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low: this preserves the same max calculation while avoiding a stack-sensitive spread over page-sized usage histories. The change is localized to usage overview model calculation and includes a large-input regression.

## Failing before fix
- `pnpm test src/renderer/src/components/stats/usage-overview-model.test.ts -- --runInBand` failed with `RangeError: Maximum call stack size exceeded` at `usage-overview-model.ts:263`.

## Verification
- `pnpm test src/renderer/src/components/stats/usage-overview-model.test.ts -- --runInBand`
- `pnpm typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/stats/usage-overview-model.ts src/renderer/src/components/stats/usage-overview-model.test.ts`