### PR TITLE
fix: clean up pane divider listeners

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-divider.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it, vi } from 'vitest'
-import { createDividerFlexFrameScheduler } from './pane-divider'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDivider, createDividerFlexFrameScheduler, disposeDivider } from './pane-divider'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('createDividerFlexFrameScheduler', () => {
   it('coalesces repeated drag updates into one flex write per animation frame', () => {
@@ -39,5 +43,56 @@ describe('createDividerFlexFrameScheduler', () => {
     expect(cancelFrame).toHaveBeenCalledWith(7)
     expect(apply).toHaveBeenCalledTimes(1)
     expect(apply).toHaveBeenCalledWith(180, 220)
+  })
+})
+
+describe('disposeDivider', () => {
+  it('removes divider-local drag listeners and releases active pointer capture', () => {
+    const listeners = new Map<string, EventListener>()
+    const divider = {
+      style: {
+        setProperty: vi.fn()
+      },
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn()
+      },
+      addEventListener: vi.fn((event: string, listener: EventListener) => {
+        listeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn((event: string, listener: EventListener) => {
+        if (listeners.get(event) === listener) {
+          listeners.delete(event)
+        }
+      }),
+      setPointerCapture: vi.fn(),
+      hasPointerCapture: vi.fn(() => true),
+      releasePointerCapture: vi.fn(),
+      previousElementSibling: null,
+      nextElementSibling: null
+    } as unknown as HTMLElement
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => divider)
+    })
+    vi.stubGlobal('requestAnimationFrame', vi.fn())
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    const created = createDivider(true, {}, { refitPanesUnder: vi.fn() })
+    const pointerDown = listeners.get('pointerdown')
+    expect(pointerDown).toBeTypeOf('function')
+
+    pointerDown?.({
+      preventDefault: vi.fn(),
+      pointerId: 7,
+      clientX: 10
+    } as unknown as PointerEvent)
+    disposeDivider(created)
+
+    expect(divider.removeEventListener).toHaveBeenCalledWith('pointerdown', pointerDown)
+    expect(divider.removeEventListener).toHaveBeenCalledWith('pointermove', expect.any(Function))
+    expect(divider.removeEventListener).toHaveBeenCalledWith('pointerup', expect.any(Function))
+    expect(divider.removeEventListener).toHaveBeenCalledWith('dblclick', expect.any(Function))
+    expect(divider.releasePointerCapture).toHaveBeenCalledWith(7)
+    expect(divider.classList.remove).toHaveBeenCalledWith('is-dragging')
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-divider.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider.ts
@@ -22,6 +22,8 @@ type DividerFlexFrameScheduler = {
   cancel: () => void
 }
 
+const dividerDragCleanups = new WeakMap<HTMLElement, () => void>()
+
 export function createDividerFlexFrameScheduler({
   apply,
   requestFrame = requestAnimationFrame,
@@ -95,6 +97,22 @@ export function createDivider(
   return divider
 }
 
+export function disposeDivider(divider: HTMLElement): void {
+  const cleanup = dividerDragCleanups.get(divider)
+  if (!cleanup) {
+    return
+  }
+  cleanup()
+  dividerDragCleanups.delete(divider)
+}
+
+export function disposeDividersIn(root: HTMLElement): void {
+  const dividers = root.querySelectorAll('.pane-divider')
+  for (const divider of dividers) {
+    disposeDivider(divider as HTMLElement)
+  }
+}
+
 function attachDividerDrag(
   divider: HTMLElement,
   isVertical: boolean,
@@ -110,6 +128,7 @@ function attachDividerDrag(
   let totalSize = 0
   let prevEl: HTMLElement | null = null
   let nextEl: HTMLElement | null = null
+  let activePointerId: number | null = null
   const flexScheduler = createDividerFlexFrameScheduler({
     apply: (newPrev, newNext) => {
       if (!prevEl || !nextEl) {
@@ -124,6 +143,7 @@ function attachDividerDrag(
     e.preventDefault()
     flexScheduler.cancel()
     divider.setPointerCapture(e.pointerId)
+    activePointerId = e.pointerId
     divider.classList.add('is-dragging')
     dragging = true
     didMove = false
@@ -182,7 +202,10 @@ function attachDividerDrag(
     }
     dragging = false
     flexScheduler.flush()
-    divider.releasePointerCapture(e.pointerId)
+    activePointerId = null
+    if (divider.hasPointerCapture(e.pointerId)) {
+      divider.releasePointerCapture(e.pointerId)
+    }
     divider.classList.remove('is-dragging')
     // Final refit at the exact drop position.
     if (prevEl) {
@@ -220,6 +243,27 @@ function attachDividerDrag(
   divider.addEventListener('pointermove', onPointerMove)
   divider.addEventListener('pointerup', onPointerUp)
   divider.addEventListener('dblclick', onDoubleClick)
+  dividerDragCleanups.set(divider, () => {
+    flexScheduler.cancel()
+    if (activePointerId !== null) {
+      try {
+        if (divider.hasPointerCapture(activePointerId)) {
+          divider.releasePointerCapture(activePointerId)
+        }
+      } catch {
+        // Best effort: the captured pointer may already be gone during teardown.
+      }
+    }
+    activePointerId = null
+    dragging = false
+    prevEl = null
+    nextEl = null
+    divider.classList.remove('is-dragging')
+    divider.removeEventListener('pointerdown', onPointerDown)
+    divider.removeEventListener('pointermove', onPointerMove)
+    divider.removeEventListener('pointerup', onPointerUp)
+    divider.removeEventListener('dblclick', onDoubleClick)
+  })
 }
 
 export function applyDividerStyles(root: HTMLElement, styleOptions: PaneStyleOptions): void {

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -11,7 +11,8 @@ import {
   createDivider,
   applyDividerStyles,
   applyPaneOpacity,
-  applyRootBackground
+  applyRootBackground,
+  disposeDividersIn
 } from './pane-divider'
 import { cancelActivePaneDrag, createDragReorderState, handlePaneDrop } from './pane-drag-reorder'
 import { createPaneDOM, openTerminal, setLigaturesEnabled, disposePane } from './pane-lifecycle'
@@ -265,6 +266,7 @@ export class PaneManager {
       disposePane(pane, this.panes)
     }
     this.identities.clear()
+    disposeDividersIn(this.root)
     this.root.innerHTML = ''
     this.activePaneId = null
   }

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -6,7 +6,7 @@ import type {
   PaneStyleOptions,
   ScrollState
 } from './pane-manager-types'
-import { createDivider } from './pane-divider'
+import { createDivider, disposeDivider } from './pane-divider'
 import { getFitOverrideForPty } from './mobile-fit-overrides'
 import { disposeWebgl, attachWebgl } from './pane-webgl-renderer'
 import { captureScrollState, restoreScrollStateAfterLayout } from './pane-scroll'
@@ -290,6 +290,7 @@ export function removeDividers(parent: HTMLElement): void {
       child instanceof HTMLElement && child.classList.contains('pane-divider')
   )
   for (const d of dividers) {
+    disposeDivider(d)
     d.remove()
   }
 }


### PR DESCRIPTION
## Summary
- Add explicit cleanup for pane divider drag listeners and pending divider resize frames.
- Dispose divider listeners when split dividers are removed and before pane manager root teardown clears the DOM.
- Add a unit test covering listener removal and active pointer capture release.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low: this is lifecycle cleanup around existing divider behavior. It does not change split layout calculations or user-facing drag behavior; it removes listeners and cancels pending frame work when the divider is already being torn down.

## Validation
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-divider.ts src/renderer/src/lib/pane-manager/pane-tree-ops.ts src/renderer/src/lib/pane-manager/pane-manager.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-divider.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/lib/pane-manager/pane-tree-reparent-frame.test.ts`
- `git diff --check`
- `pnpm typecheck` failed only on existing missing packages: `@tiptap/extension-details` and `react-colorful`.
