### PR TITLE
fix: clean up pane drag listeners

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts
@@ -52,4 +52,16 @@ describe('disposePane container listener cleanup', () => {
     expect(pane.paneMouseEnterHandler).toBeNull()
     expect(panes.has(pane.id)).toBe(false)
   })
+
+  it('runs pane drag cleanup', () => {
+    const pane = makePane()
+    const paneDragCleanup = vi.fn()
+    pane.paneDragCleanup = paneDragCleanup
+    const panes = new Map([[pane.id, pane]])
+
+    disposePane(pane, panes)
+
+    expect(paneDragCleanup).toHaveBeenCalledTimes(1)
+    expect(pane.paneDragCleanup).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts
@@ -60,6 +60,10 @@ class FakeElement {
     this.listeners.get(type)?.delete(listener)
   }
 
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0
+  }
+
   dispatchPointer(type: string, event: Partial<PointerEvent>): void {
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event as PointerEvent)
@@ -217,5 +221,46 @@ describe('attachPaneDrag', () => {
     expect(onDragActiveChange).toHaveBeenLastCalledWith(false)
     expect(detachPaneFromTree).not.toHaveBeenCalled()
     expect(insertPaneNextTo).not.toHaveBeenCalled()
+  })
+
+  it('returns cleanup that removes handle listeners and cancels active drag capture', () => {
+    const handle = new FakeElement()
+    const root = new FakeElement(['pane-manager-root'])
+    const sourceContainer = new FakeElement(['pane'])
+    const targetContainer = new FakeElement(['pane'])
+    const sourcePane = createPane(1, sourceContainer)
+    const targetPane = createPane(2, targetContainer)
+    const panes = new Map<number, ManagedPaneInternal>([
+      [sourcePane.id, sourcePane],
+      [targetPane.id, targetPane]
+    ])
+    const state = createDragReorderState()
+
+    const cleanup = attachPaneDrag(handle as unknown as HTMLElement, sourcePane.id, state, {
+      getPanes: () => panes,
+      getRoot: () => root as unknown as HTMLElement,
+      getStyleOptions: () => ({}),
+      isDestroyed: () => false,
+      safeFit: vi.fn(),
+      applyPaneOpacity: vi.fn(),
+      applyDividerStyles: vi.fn(),
+      refitPanesUnder: vi.fn()
+    })
+
+    expect(handle.listenerCount('pointerdown')).toBe(1)
+    handle.dispatchPointer('pointerdown', pointerEvent({ pointerId: 1 }))
+    expect(state.cleanupActiveDrag).toBeTypeOf('function')
+    expect(handle.hasPointerCapture(1)).toBe(true)
+
+    cleanup()
+
+    expect(handle.listenerCount('pointerdown')).toBe(0)
+    expect(handle.listenerCount('pointermove')).toBe(0)
+    expect(handle.listenerCount('pointerup')).toBe(0)
+    expect(handle.listenerCount('pointercancel')).toBe(0)
+    expect(handle.listenerCount('lostpointercapture')).toBe(0)
+    expect(handle.hasPointerCapture(1)).toBe(false)
+    expect(state.cleanupActiveDrag).toBeNull()
+    expect(window.removeEventListener).toHaveBeenCalledWith('blur', expect.any(Function), true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-drag-reorder.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-reorder.ts
@@ -42,11 +42,12 @@ export function attachPaneDrag(
   paneId: number,
   state: DragReorderState,
   callbacks: DragReorderCallbacks
-): void {
+): () => void {
   let dragging = false
   let startX = 0
   let startY = 0
   let activePointerId: number | null = null
+  let cleanupCurrentDrag: ((commitDrop: boolean) => void) | null = null
   const DRAG_THRESHOLD = 5
 
   const onPointerDown = (e: PointerEvent): void => {
@@ -70,7 +71,12 @@ export function attachPaneDrag(
       handle.removeEventListener('lostpointercapture', onLostPointerCaptureOuter)
       window.removeEventListener('blur', onWindowBlur, true)
       activePointerId = null
-      state.cleanupActiveDrag = null
+      if (state.cleanupActiveDrag === cleanupDrag) {
+        state.cleanupActiveDrag = null
+      }
+      if (cleanupCurrentDrag === cleanupDrag) {
+        cleanupCurrentDrag = null
+      }
       if (pointerId !== null && handle.hasPointerCapture(pointerId)) {
         handle.releasePointerCapture(pointerId)
       }
@@ -157,6 +163,7 @@ export function attachPaneDrag(
       cleanupDrag(false)
     }
 
+    cleanupCurrentDrag = cleanupDrag
     state.cleanupActiveDrag = cleanupDrag
     handle.addEventListener('pointermove', onPointerMoveOuter)
     handle.addEventListener('pointerup', onPointerUpOuter)
@@ -166,6 +173,10 @@ export function attachPaneDrag(
   }
 
   handle.addEventListener('pointerdown', onPointerDown)
+  return () => {
+    cleanupCurrentDrag?.(false)
+    handle.removeEventListener('pointerdown', onPointerDown)
+  }
 }
 
 export function cancelActivePaneDrag(state: DragReorderState): void {

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -91,7 +91,7 @@ export function createPaneDOM(
   const dragHandle = document.createElement('div')
   dragHandle.className = 'pane-drag-handle'
   container.appendChild(dragHandle)
-  attachPaneDrag(dragHandle, id, dragState, dragCallbacks)
+  const paneDragCleanup = attachPaneDrag(dragHandle, id, dragState, dragCallbacks)
 
   const webLinksAddon = new WebLinksAddon(
     options.onLinkClick ? (event, uri) => options.onLinkClick!(event, uri) : undefined,
@@ -146,6 +146,7 @@ export function createPaneDOM(
     ligaturesAddon: null,
     panePointerDownHandler,
     paneMouseEnterHandler,
+    paneDragCleanup,
     compositionHandler: null,
     pendingSplitScrollState: null,
     pendingSplitScrollRafIds: [],
@@ -324,6 +325,8 @@ export function disposePane(
     pane.container.removeEventListener('mouseenter', pane.paneMouseEnterHandler)
     pane.paneMouseEnterHandler = null
   }
+  pane.paneDragCleanup?.()
+  pane.paneDragCleanup = null
   if (pane.compositionHandler) {
     pane.terminal.element?.removeEventListener('compositionstart', pane.compositionHandler, true)
     pane.compositionHandler = null

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -116,6 +116,7 @@ export type ManagedPaneInternal = {
   // Stored so disposePane() can remove pane-local DOM listeners explicitly.
   panePointerDownHandler?: ((event: PointerEvent) => void) | null
   paneMouseEnterHandler?: ((event: MouseEvent) => void) | null
+  paneDragCleanup?: (() => void) | null
   // Stored so disposePane() can remove it and avoid a memory leak.
   compositionHandler: (() => void) | null
   // Why: splitPane reparents DOM; its delayed restore owns scroll until the


### PR DESCRIPTION
## Summary
- Make `attachPaneDrag` return a disposer for the pane-local drag handle listener.
- Run that disposer from `disposePane`, including any active temporary drag listeners and pointer capture.
- Add focused tests for drag cleanup and pane disposal.

## Merge risk assessment
Risk: LOW (`risk:low`)

Why low: this is scoped lifecycle cleanup for pane drag listeners. It preserves existing drag/drop behavior and only removes listeners when a pane is already being disposed or drag setup is explicitly torn down.

## Validation
- `pnpm exec oxlint src/renderer/src/lib/pane-manager/pane-drag-reorder.ts src/renderer/src/lib/pane-manager/pane-lifecycle.ts src/renderer/src/lib/pane-manager/pane-manager-types.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts src/renderer/src/lib/pane-manager/pane-container-listener-lifecycle.test.ts`
- `git diff --check`
- `pnpm typecheck` failed only on existing missing packages: `@tiptap/extension-details` and `react-colorful`.
