### PR TITLE
perf: handle large workspace space size scales

### DIFF
--- a/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
+++ b/src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx
@@ -66,6 +66,8 @@ import { buildTreemapLayout, type TreemapRect } from './workspace-space-layout'
 import {
   filterWorkspaceSpaceRows,
   countWorkspaceSpaceActiveAgents,
+  getLargestWorkspaceSpaceItemSize,
+  getLargestWorkspaceSpaceRowSize,
   getSelectedDeletableWorkspaceIds,
   getVisibleDeletableWorkspaceIds,
   getWorkspaceSpaceGitStatusRefreshCandidates,
@@ -831,7 +833,7 @@ function BreakdownList({
     )
   }
 
-  const maxChildSize = Math.max(...worktree.topLevelItems.map((item) => item.sizeBytes), 0)
+  const maxChildSize = getLargestWorkspaceSpaceItemSize(worktree.topLevelItems)
   const topLevelItemCount = worktree.topLevelItems.length + worktree.omittedTopLevelItemCount
   return (
     <div className="min-h-72 rounded-lg border border-border/70 bg-background/35">
@@ -1276,7 +1278,7 @@ export function WorkspaceSpaceManagerPanel(): React.JSX.Element {
   const zoomedWorktree =
     sourceRows.find((row) => row.worktreeId === treemapZoomWorktreeId && row.status === 'ok') ??
     null
-  const maxSize = Math.max(...rows.map((row) => row.sizeBytes), 0)
+  const maxSize = getLargestWorkspaceSpaceRowSize(rows)
   const selectedDeletableIds = useMemo(
     () => getSelectedDeletableWorkspaceIds(rows, selectedIds, isWorktreeUnavailableForDelete),
     [isWorktreeUnavailableForDelete, rows, selectedIds]

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
@@ -3,6 +3,8 @@ import type { WorkspaceSpaceWorktree } from '../../../../shared/workspace-space-
 import {
   countWorkspaceSpaceActiveAgents,
   filterWorkspaceSpaceRows,
+  getLargestWorkspaceSpaceItemSize,
+  getLargestWorkspaceSpaceRowSize,
   getSelectedDeletableWorkspaceIds,
   getVisibleDeletableWorkspaceIds,
   getWorkspaceSpaceGitStatusRefreshCandidates,
@@ -97,6 +99,23 @@ describe('workspace space presentation helpers', () => {
       'a'
     ])
     expect(filterWorkspaceSpaceRows(rows, '', true).map((item) => item.worktreeId)).toEqual(['a'])
+  })
+
+  it('finds largest sizes without spreading large workspace arrays', () => {
+    const rows = Array.from({ length: 130_000 }, (_, index) =>
+      row({ worktreeId: `wt-${index}`, sizeBytes: index === 87_654 ? 999_999 : index })
+    )
+    const items = Array.from({ length: 130_000 }, (_, index) => ({
+      name: `item-${index}`,
+      path: `/repo/item-${index}`,
+      kind: 'directory' as const,
+      sizeBytes: index === 12_345 ? 888_888 : index
+    }))
+
+    expect(getLargestWorkspaceSpaceRowSize(rows)).toBe(999_999)
+    expect(getLargestWorkspaceSpaceItemSize(items)).toBe(888_888)
+    expect(getLargestWorkspaceSpaceRowSize([])).toBe(0)
+    expect(getLargestWorkspaceSpaceItemSize([])).toBe(0)
   })
 
   it('returns only selected worktrees that can be deleted', () => {

--- a/src/renderer/src/components/status-bar/workspace-space-presentation.ts
+++ b/src/renderer/src/components/status-bar/workspace-space-presentation.ts
@@ -7,7 +7,10 @@ import {
 } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/types'
-import type { WorkspaceSpaceWorktree } from '../../../../shared/workspace-space-types'
+import type {
+  WorkspaceSpaceItem,
+  WorkspaceSpaceWorktree
+} from '../../../../shared/workspace-space-types'
 
 export type WorkspaceSpaceSortKey = 'size' | 'name' | 'repo' | 'activity'
 export type WorkspaceSpaceSortDirection = 'asc' | 'desc'
@@ -138,6 +141,30 @@ export function getWorkspaceSpaceSearchText(worktree: WorkspaceSpaceWorktree): s
   ]
     .join(' ')
     .toLowerCase()
+}
+
+export function getLargestWorkspaceSpaceItemSize(
+  items: readonly Pick<WorkspaceSpaceItem, 'sizeBytes'>[]
+): number {
+  let maxSize = 0
+  for (const item of items) {
+    if (item.sizeBytes > maxSize) {
+      maxSize = item.sizeBytes
+    }
+  }
+  return maxSize
+}
+
+export function getLargestWorkspaceSpaceRowSize(
+  rows: readonly Pick<WorkspaceSpaceWorktree, 'sizeBytes'>[]
+): number {
+  let maxSize = 0
+  for (const row of rows) {
+    if (row.sizeBytes > maxSize) {
+      maxSize = row.sizeBytes
+    }
+  }
+  return maxSize
 }
 
 function compareRows(


### PR DESCRIPTION
## Summary
- replace Workspace Space size scale `Math.max(...array.map(...))` calls with iterative max helpers
- keep the rendered size bars and breakdown behavior unchanged
- add 130,000-row/item regressions for workspace and top-level item scales

## Risk
- risk:low
- Local stats/cleanup rendering only. No IPC, persistence, terminal, SSH, browser, provider, or deletion behavior changes.

## Validation
- pnpm exec oxlint src/renderer/src/components/status-bar/WorkspaceSpaceManagerPanel.tsx src/renderer/src/components/status-bar/workspace-space-presentation.ts src/renderer/src/components/status-bar/workspace-space-presentation.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/workspace-space-presentation.test.ts src/renderer/src/components/status-bar/workspace-space-layout.test.ts src/renderer/src/components/status-bar/workspace-space-format.test.ts
- pnpm run typecheck:web
- git diff --check
