### PR TITLE
fix: clean up daemon socket startup listeners

### DIFF
--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -106,6 +106,24 @@ describe('DaemonClient', () => {
       await waitFor(() => hellos.length > 0)
     })
 
+    it('removes socket startup listeners after connecting', async () => {
+      await startMockDaemon()
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await client.ensureConnected()
+
+      const connectedClient = client as unknown as {
+        controlSocket: Socket | null
+        streamSocket: Socket | null
+      }
+      for (const socket of [connectedClient.controlSocket, connectedClient.streamSocket]) {
+        expect(socket?.listenerCount('connect')).toBe(0)
+        // One live error listener remains: the disconnect handler installed
+        // after the daemon hello handshake succeeds.
+        expect(socket?.listenerCount('error')).toBe(1)
+      }
+    })
+
     it('rejects on version mismatch', async () => {
       await startMockDaemon({ rejectVersion: true })
 

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -179,20 +179,27 @@ export class DaemonClient {
   private connectSocket(): Promise<Socket> {
     return new Promise((resolve, reject) => {
       const socket = connect(this.socketPath)
+      const cleanup = (): void => {
+        clearTimeout(timer)
+        socket.removeListener('connect', onConnect)
+        socket.removeListener('error', onError)
+      }
+      const onConnect = (): void => {
+        cleanup()
+        resolve(socket)
+      }
+      const onError = (err: Error): void => {
+        cleanup()
+        reject(err)
+      }
       const timer = setTimeout(() => {
+        cleanup()
         socket.destroy()
         reject(new DaemonProtocolError('Connection timed out'))
       }, CONNECT_TIMEOUT_MS)
 
-      socket.on('connect', () => {
-        clearTimeout(timer)
-        resolve(socket)
-      })
-
-      socket.on('error', (err) => {
-        clearTimeout(timer)
-        reject(err)
-      })
+      socket.on('connect', onConnect)
+      socket.on('error', onError)
     })
   }
 


### PR DESCRIPTION
## Summary
- Remove daemon socket connect/error startup listeners once either path settles.
- Keep only the steady-state disconnect error listener on connected daemon sockets.
- Add a regression test that verifies connected control/stream sockets do not retain startup listeners.

## Risk assessment
Risk: LOW (`risk:low`)

This is a local cleanup inside daemon socket connection setup. It does not change the daemon protocol, request flow, reconnect generation handling, SSH relay behavior, or renderer IPC. The only behavior change is removing no-longer-needed startup listeners after connect/error/timeout settles.

## Validation
- `pnpm exec oxlint src/main/daemon/client.ts src/main/daemon/client.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/client.test.ts`
- `git diff --check`
- `pnpm typecheck` fails only on existing missing dependencies:
  - `@tiptap/extension-details`
  - `react-colorful`
