### PR TITLE
fix: ignore stale macos provider socket events

### DIFF
--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -1,0 +1,130 @@
+import { EventEmitter } from 'events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  chmodSyncMock,
+  connectMacOSProviderSocketMock,
+  mkdtempSyncMock,
+  resolveMacOSComputerUseExecutablePathMock,
+  rmSyncMock,
+  spawnMock,
+  writeFileSyncMock
+} = vi.hoisted(() => ({
+  chmodSyncMock: vi.fn(),
+  connectMacOSProviderSocketMock: vi.fn(),
+  mkdtempSyncMock: vi.fn(),
+  resolveMacOSComputerUseExecutablePathMock: vi.fn(),
+  rmSyncMock: vi.fn(),
+  spawnMock: vi.fn(),
+  writeFileSyncMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('fs', () => ({
+  chmodSync: chmodSyncMock,
+  mkdtempSync: mkdtempSyncMock,
+  rmSync: rmSyncMock,
+  writeFileSync: writeFileSyncMock
+}))
+
+vi.mock('./macos-native-provider-paths', () => ({
+  resolveMacOSComputerUseExecutablePath: resolveMacOSComputerUseExecutablePathMock
+}))
+
+vi.mock('./macos-native-provider-socket', () => ({
+  connectMacOSProviderSocket: connectMacOSProviderSocketMock
+}))
+
+class FakeSocket extends EventEmitter {
+  destroyed = false
+  writes: string[] = []
+
+  setEncoding(): void {}
+
+  write(line: string, callback?: (error?: Error | null) => void): boolean {
+    this.writes.push(line)
+    callback?.(null)
+    return true
+  }
+
+  end(): void {
+    this.destroyed = true
+  }
+}
+
+async function loadClientModule() {
+  vi.resetModules()
+  return await import('./macos-native-provider-client')
+}
+
+describe('MacOSNativeProviderClient', () => {
+  const sockets: FakeSocket[] = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sockets.length = 0
+    mkdtempSyncMock.mockImplementation((prefix: string) => `${prefix}${sockets.length}`)
+    resolveMacOSComputerUseExecutablePathMock.mockReturnValue(
+      '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos'
+    )
+    spawnMock.mockReturnValue({ unref: vi.fn() })
+    connectMacOSProviderSocketMock.mockImplementation(async () => {
+      const socket = new FakeSocket()
+      sockets.push(socket)
+      return socket
+    })
+  })
+
+  afterEach(() => {
+    chmodSyncMock.mockReset()
+    connectMacOSProviderSocketMock.mockReset()
+    mkdtempSyncMock.mockReset()
+    resolveMacOSComputerUseExecutablePathMock.mockReset()
+    rmSyncMock.mockReset()
+    spawnMock.mockReset()
+    writeFileSyncMock.mockReset()
+    vi.useRealTimers()
+  })
+
+  it('ignores stale socket data, close, and error after a replacement socket starts', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const firstCall = client.capabilities()
+    const firstRejection = expect(firstCall).rejects.toThrow(
+      'native macOS provider handshake timed out'
+    )
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const firstSocket = sockets[0]!
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    await firstRejection
+    expect(firstSocket.destroyed).toBe(true)
+
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(sockets).toHaveLength(2))
+    const secondSocket = sockets[1]!
+    await vi.waitFor(() => expect(secondSocket.writes).toHaveLength(1))
+    const secondRequest = JSON.parse(secondSocket.writes[0]!) as { id: number }
+
+    // Why: a timed-out helper socket can flush events after restart. Those
+    // stale events must not clear/reject the active replacement request.
+    firstSocket.emit('data', '{"id":999,"ok":false,"error":{"code":"old","message":"old"}}\n')
+    firstSocket.emit('error', new Error('old helper failed late'))
+    firstSocket.emit('close')
+
+    const capabilities = {
+      protocolVersion: 1,
+      supports: {}
+    }
+    secondSocket.emit(
+      'data',
+      `${JSON.stringify({ id: secondRequest.id, ok: true, result: capabilities })}\n`
+    )
+
+    await expect(secondCall).resolves.toEqual(capabilities)
+  })
+})

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -192,9 +192,10 @@ export class MacOSNativeProviderClient {
     try {
       const socket = await connectMacOSProviderSocket(this.socketPath, HELPER_CONNECT_TIMEOUT_MS)
       socket.setEncoding('utf8')
-      socket.on('data', (chunk: string) => this.handleSocketData(chunk))
-      socket.on('close', () => this.handleSocketClose())
-      socket.on('error', (error) => this.handleTransportError(error))
+      this.socketBuffer = ''
+      socket.on('data', (chunk: string) => this.handleSocketData(socket, chunk))
+      socket.on('close', () => this.handleSocketClose(socket))
+      socket.on('error', (error) => this.handleTransportError(socket, error))
       this.socket = socket
       return socket
     } catch (error) {
@@ -205,7 +206,12 @@ export class MacOSNativeProviderClient {
       throw error
     }
   }
-  private handleSocketData(chunk: string): void {
+  private handleSocketData(socket: net.Socket, chunk: string): void {
+    // Why: a timed-out helper socket can emit after a replacement starts.
+    // Stale data must not corrupt the replacement socket's line buffer.
+    if (this.socket !== socket) {
+      return
+    }
     this.socketBuffer += chunk
     this.socketBuffer = this.consumeLines(this.socketBuffer)
   }
@@ -242,14 +248,24 @@ export class MacOSNativeProviderClient {
     }
     pending.reject(new RuntimeClientError(response.error.code, response.error.message))
   }
-  private handleSocketClose(): void {
+  private handleSocketClose(socket: net.Socket): void {
+    // Why: late close from a prior helper socket must not tear down the active
+    // replacement socket or reject its in-flight requests.
+    if (this.socket !== socket) {
+      return
+    }
     this.socket = null
+    this.socketBuffer = ''
     this.cleanupSocketDirectory()
     this.rejectPending(
       new RuntimeClientError('accessibility_error', 'native macOS helper app connection closed')
     )
   }
-  private handleTransportError(error: Error): void {
+  private handleTransportError(socket: net.Socket, error: Error): void {
+    // Why: stale socket errors can arrive after shutdown/restart.
+    if (this.socket !== socket) {
+      return
+    }
     this.rejectPending(new RuntimeClientError('accessibility_error', error.message))
   }
   private cleanupSocketDirectory(): void {


### PR DESCRIPTION
## Summary
- Guard macOS native computer-use socket `data`, `close`, and `error` handlers by socket identity.
- Prevent late events from a timed-out helper socket from clearing the replacement socket or rejecting replacement requests.
- Reset the line buffer when a new helper socket becomes active.
- Add a regression test covering timeout, socket replacement, stale old-socket events, and successful replacement handshake.

## Risk assessment
Risk: LOW (`risk:low`)

This only changes behavior for events from a socket that is no longer active. Current-socket data, close, error handling, request IDs, helper launch args, and protocol messages remain unchanged. The behavior is covered by a focused unit test.

## Validation
- `pnpm exec oxlint src/main/computer/macos-native-provider-client.ts src/main/computer/macos-native-provider-client.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/macos-native-provider-client.test.ts`
- `git diff --check`
- `pnpm typecheck` fails only on existing missing dependencies:
  - `@tiptap/extension-details`
  - `react-colorful`
