### PR TITLE
fix: handle large mobile host name lists

### DIFF
--- a/mobile/src/transport/host-names.test.ts
+++ b/mobile/src/transport/host-names.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getNextHostNameFromHosts } from './host-names'
+
+describe('getNextHostNameFromHosts', () => {
+  it('increments the largest numbered default host name', () => {
+    expect(
+      getNextHostNameFromHosts([
+        { name: 'Host 2' },
+        { name: 'Custom workstation' },
+        { name: 'Host 7' },
+        { name: 'Host 3' }
+      ])
+    ).toBe('Host 8')
+  })
+
+  it('handles very large host lists without spreading number arrays', () => {
+    const hosts = Array.from({ length: 130_000 }, (_, index) => ({
+      name: `Host ${index + 1}`
+    }))
+
+    expect(getNextHostNameFromHosts(hosts)).toBe('Host 130001')
+  })
+})

--- a/mobile/src/transport/host-names.ts
+++ b/mobile/src/transport/host-names.ts
@@ -1,0 +1,21 @@
+type HostNameSource = {
+  readonly name: string
+}
+
+const HOST_NUMBER_PATTERN = /^Host (\d+)$/
+
+export function getNextHostNameFromHosts(hosts: readonly HostNameSource[]): string {
+  let largestHostNumber = 0
+
+  for (const host of hosts) {
+    const match = HOST_NUMBER_PATTERN.exec(host.name)
+    if (!match) continue
+
+    const hostNumber = Number.parseInt(match[1]!, 10)
+    if (hostNumber > largestHostNumber) {
+      largestHostNumber = hostNumber
+    }
+  }
+
+  return `Host ${largestHostNumber + 1}`
+}

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -6,6 +6,7 @@ import {
   type HostProfile,
   type StoredHostProfile
 } from './types'
+import { getNextHostNameFromHosts } from './host-names'
 
 const STORAGE_KEY = 'orca:hosts'
 // Why: SecureStore keys must match [A-Za-z0-9._-]; colons are rejected.
@@ -161,14 +162,7 @@ export async function renameHost(hostId: string, newName: string): Promise<void>
 
 export async function getNextHostName(): Promise<string> {
   const hosts = await loadStoredHosts()
-  const existingNumbers = hosts
-    .map((h) => {
-      const match = h.name.match(/^Host (\d+)$/)
-      return match ? parseInt(match[1]!, 10) : 0
-    })
-    .filter((n) => n > 0)
-  const next = existingNumbers.length > 0 ? Math.max(...existingNumbers) + 1 : 1
-  return `Host ${next}`
+  return getNextHostNameFromHosts(hosts)
 }
 
 export async function updateLastConnected(hostId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- compute the next mobile default host name in one pass instead of building and spreading an array of every saved host number
- add a 130,000-host regression test for the host-name helper

## Risk
Low. This only affects generated display names for newly paired mobile hosts; persisted host metadata, SecureStore tokens, pairing, and connection behavior are unchanged.

## Validation
- `pnpm --dir mobile install --frozen-lockfile`
- `pnpm --dir mobile exec oxfmt --write src/transport/host-store.ts src/transport/host-names.ts src/transport/host-names.test.ts`
- `pnpm --dir mobile exec oxlint src/transport/host-store.ts src/transport/host-names.ts src/transport/host-names.test.ts`
- `pnpm --dir mobile exec vitest run src/transport/host-names.test.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `pnpm --dir mobile test`
- `pnpm --dir mobile lint`
- `git diff --check`