### PR TITLE
fix: include OpenClaude in mobile agent catalog

### DIFF
--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -5,6 +5,7 @@ import type { TuiAgent } from '../../../src/shared/types'
 // mirrored with src/shared/tui-agent-selection.ts and assert parity in tests.
 export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
+  'openclaude',
   'codex',
   'grok',
   'copilot',
@@ -37,6 +38,7 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
 
 export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   claude: 'Claude',
+  openclaude: 'OpenClaude',
   codex: 'Codex',
   grok: 'Grok',
   copilot: 'GitHub Copilot',
@@ -68,6 +70,7 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
 }
 
 export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>> = {
+  openclaude: 'openclaude.gitlawb.com',
   grok: 'x.ai',
   copilot: 'github.com',
   opencode: 'opencode.ai',
@@ -97,6 +100,7 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
 
 export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
   claude: 'claude',
+  openclaude: 'openclaude',
   codex: 'codex',
   grok: 'grok',
   copilot: 'copilot',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -5,6 +5,7 @@ import { isTuiAgent } from './tui-agent-config'
 // automatic fallback priority when the user has not chosen a default agent.
 export const TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
+  'openclaude',
   'codex',
   'grok',
   'copilot',


### PR DESCRIPTION
## Summary
- include OpenClaude in the shared TUI auto-pick order so it matches the desktop agent catalog
- add OpenClaude mobile label, favicon domain, and launch command metadata so the mobile catalog remains exhaustive for `TuiAgent`

## Risk
Low. This completes metadata for an already configured agent id; it does not change hook installation, process detection, terminal startup mechanics, or persisted settings shape.

## Validation
- `pnpm exec oxfmt --write src/shared/tui-agent-selection.ts mobile/src/tasks/mobile-tui-agents.ts`
- `pnpm exec oxlint src/shared/tui-agent-selection.ts mobile/src/tasks/mobile-tui-agents.ts`
- `pnpm --dir mobile exec tsc --noEmit`
- `pnpm --dir mobile exec vitest run src/tasks/mobile-agent-catalog.test.ts src/session/mobile-new-tab-agent-options.test.ts src/tasks/workspace-agent-selection.test.ts`
- `pnpm --dir mobile test`
- `pnpm --dir mobile lint`
- `pnpm run typecheck`
- `git diff --check`
