### PR TITLE
fix: map openclaude on mobile

### DIFF
--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -5,6 +5,7 @@ import type { TuiAgent } from '../../../src/shared/types'
 // mirrored with src/shared/tui-agent-selection.ts and assert parity in tests.
 export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
+  'openclaude',
   'codex',
   'grok',
   'copilot',
@@ -37,6 +38,7 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
 
 export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   claude: 'Claude',
+  openclaude: 'OpenClaude',
   codex: 'Codex',
   grok: 'Grok',
   copilot: 'GitHub Copilot',
@@ -97,6 +99,7 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
 
 export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
   claude: 'claude',
+  openclaude: 'openclaude',
   codex: 'codex',
   grok: 'grok',
   copilot: 'copilot',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -5,6 +5,7 @@ import { isTuiAgent } from './tui-agent-config'
 // automatic fallback priority when the user has not chosen a default agent.
 export const TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
+  'openclaude',
   'codex',
   'grok',
   'copilot',


### PR DESCRIPTION
## Summary
- add `openclaude` to the shared TUI auto-pick order so it is covered by the mobile parity test
- add the mobile `openclaude` label and launch-command mappings required by `Record<TuiAgent, string>`

## Risk
Risk: Low (`risk:low`)

This only registers an already-defined TUI agent in mobile picker/catalog metadata. Existing agent behavior is unchanged except that OpenClaude can now be selected/launched where it was already part of the shared agent union and config.

## Validation
- `pnpm exec oxlint src/shared/tui-agent-selection.ts mobile/src/tasks/mobile-tui-agents.ts`
- `pnpm --dir mobile exec oxlint src/tasks/mobile-tui-agents.ts`
- `pnpm exec oxlint src/shared/tui-agent-selection.ts`
- `pnpm --dir mobile exec oxfmt --check src/tasks/mobile-tui-agents.ts`
- `pnpm exec oxfmt --check src/shared/tui-agent-selection.ts`
- `pnpm --dir mobile exec vitest run src/tasks/mobile-agent-catalog.test.ts src/session/mobile-new-tab-agent-options.test.ts src/tasks/workspace-agent-selection.test.ts`
- `pnpm --dir mobile exec tsc --noEmit -p tsconfig.json --composite false`
- `git diff --check`

Note: root `pnpm typecheck` still fails on existing missing renderer dependencies: `@tiptap/extension-details` and `react-colorful`.
