### PR TITLE
fix: discard oversized relay frames early

### DIFF
--- a/src/main/ssh/relay-protocol.test.ts
+++ b/src/main/ssh/relay-protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   HEADER_LENGTH,
+  MAX_MESSAGE_SIZE,
   MessageType,
   encodeFrame,
   encodeJsonRpcFrame,
@@ -144,6 +145,32 @@ describe('FrameDecoder', () => {
     expect(frames).toHaveLength(0)
     expect(errors).toHaveLength(1)
     expect(errors[0].message).toContain('discarded')
+  })
+
+  it('reports an oversized frame after the header without buffering the full payload', () => {
+    const errors: Error[] = []
+    const frames: DecodedFrame[] = []
+    const decoder = new FrameDecoder(
+      (f) => frames.push(f),
+      (err) => errors.push(err)
+    )
+    const oversizedLength = MAX_MESSAGE_SIZE + 1
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(1, 1)
+    header.writeUInt32BE(0, 5)
+    header.writeUInt32BE(oversizedLength, 9)
+
+    decoder.feed(header)
+
+    expect(frames).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('discarded')
+
+    decoder.feed(Buffer.concat([Buffer.alloc(oversizedLength), encodeKeepAliveFrame(2, 1)]))
+
+    expect(frames).toHaveLength(1)
+    expect(frames[0].type).toBe(MessageType.KeepAlive)
   })
 
   it('reset clears internal buffer', () => {

--- a/src/main/ssh/relay-protocol.test.ts
+++ b/src/main/ssh/relay-protocol.test.ts
@@ -173,6 +173,37 @@ describe('FrameDecoder', () => {
     expect(frames[0].type).toBe(MessageType.KeepAlive)
   })
 
+  it('copies trailing partial-frame bytes after discarding an oversized payload chunk', () => {
+    const errors: Error[] = []
+    const frames: DecodedFrame[] = []
+    const decoder = new FrameDecoder(
+      (f) => frames.push(f),
+      (err) => errors.push(err)
+    )
+    const oversizedLength = MAX_MESSAGE_SIZE + 1
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(1, 1)
+    header.writeUInt32BE(0, 5)
+    header.writeUInt32BE(oversizedLength, 9)
+    const keepAlive = encodeKeepAliveFrame(2, 1)
+
+    decoder.feed(header)
+
+    const payloadWithTrailingHeaderPrefix = Buffer.concat([
+      Buffer.alloc(oversizedLength),
+      keepAlive.subarray(0, 5)
+    ])
+    decoder.feed(payloadWithTrailingHeaderPrefix)
+    payloadWithTrailingHeaderPrefix.fill(0, oversizedLength)
+    decoder.feed(keepAlive.subarray(5))
+
+    expect(errors).toHaveLength(1)
+    expect(frames).toHaveLength(1)
+    expect(frames[0].type).toBe(MessageType.KeepAlive)
+    expect(frames[0].id).toBe(2)
+  })
+
   it('reset clears internal buffer', () => {
     const frames: DecodedFrame[] = []
     const decoder = new FrameDecoder((f) => frames.push(f))

--- a/src/main/ssh/relay-protocol.ts
+++ b/src/main/ssh/relay-protocol.ts
@@ -125,7 +125,8 @@ export type DecodedFrame = {
  * Incremental frame parser. Feed it chunks of data; it emits complete frames.
  */
 export class FrameDecoder {
-  private buffer = Buffer.alloc(0)
+  private buffer: Buffer = Buffer.alloc(0)
+  private discardBytesRemaining = 0
   private onFrame: (frame: DecodedFrame) => void
   private onError: ((err: Error) => void) | null
 
@@ -135,7 +136,17 @@ export class FrameDecoder {
   }
 
   feed(chunk: Buffer | Uint8Array): void {
-    this.buffer = Buffer.concat([this.buffer, chunk])
+    let incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    if (this.discardBytesRemaining > 0) {
+      const bytesToDiscard = Math.min(this.discardBytesRemaining, incoming.length)
+      this.discardBytesRemaining -= bytesToDiscard
+      incoming = incoming.subarray(bytesToDiscard)
+      if (incoming.length === 0) {
+        return
+      }
+    }
+
+    this.buffer = this.buffer.length === 0 ? incoming : Buffer.concat([this.buffer, incoming])
 
     while (this.buffer.length >= HEADER_LENGTH) {
       const length = this.buffer.readUInt32BE(9)
@@ -146,14 +157,11 @@ export class FrameDecoder {
       // bytes as a new header, corrupting every future frame. Instead we
       // skip the entire oversized frame so the decoder stays synchronized.
       if (length > MAX_MESSAGE_SIZE) {
-        if (this.buffer.length < totalLength) {
-          break
-        }
-        this.buffer = this.buffer.subarray(totalLength)
-        const err = new Error(`Frame payload too large: ${length} bytes — discarded`)
-        if (this.onError) {
-          this.onError(err)
-        }
+        const bufferedPayloadBytes = this.buffer.length - HEADER_LENGTH
+        const bytesToDiscard = Math.min(bufferedPayloadBytes, length)
+        this.buffer = this.buffer.subarray(HEADER_LENGTH + bytesToDiscard)
+        this.discardBytesRemaining = length - bytesToDiscard
+        this.reportOversizedFrame(length)
         continue
       }
 
@@ -173,8 +181,16 @@ export class FrameDecoder {
     }
   }
 
+  private reportOversizedFrame(length: number): void {
+    const err = new Error(`Frame payload too large: ${length} bytes — discarded`)
+    if (this.onError) {
+      this.onError(err)
+    }
+  }
+
   reset(): void {
     this.buffer = Buffer.alloc(0)
+    this.discardBytesRemaining = 0
   }
 }
 

--- a/src/main/ssh/relay-protocol.ts
+++ b/src/main/ssh/relay-protocol.ts
@@ -144,9 +144,12 @@ export class FrameDecoder {
       if (incoming.length === 0) {
         return
       }
+      // Why: the retained suffix may be a tiny partial frame after a hostile
+      // oversized payload; copy it so the discarded prefix is not kept alive.
+      incoming = Buffer.from(incoming)
     }
 
-    this.buffer = this.buffer.length === 0 ? incoming : Buffer.concat([this.buffer, incoming])
+    this.buffer = Buffer.concat([this.buffer, incoming])
 
     while (this.buffer.length >= HEADER_LENGTH) {
       const length = this.buffer.readUInt32BE(9)
@@ -159,7 +162,8 @@ export class FrameDecoder {
       if (length > MAX_MESSAGE_SIZE) {
         const bufferedPayloadBytes = this.buffer.length - HEADER_LENGTH
         const bytesToDiscard = Math.min(bufferedPayloadBytes, length)
-        this.buffer = this.buffer.subarray(HEADER_LENGTH + bytesToDiscard)
+        const remaining = this.buffer.subarray(HEADER_LENGTH + bytesToDiscard)
+        this.buffer = remaining.length === 0 ? Buffer.alloc(0) : Buffer.from(remaining)
         this.discardBytesRemaining = length - bytesToDiscard
         this.reportOversizedFrame(length)
         continue

--- a/src/relay/protocol.test.ts
+++ b/src/relay/protocol.test.ts
@@ -34,4 +34,35 @@ describe('relay FrameDecoder', () => {
     expect(frames).toHaveLength(1)
     expect(frames[0].type).toBe(MessageType.KeepAlive)
   })
+
+  it('copies trailing partial-frame bytes after discarding an oversized payload chunk', () => {
+    const errors: Error[] = []
+    const frames: DecodedFrame[] = []
+    const decoder = new FrameDecoder(
+      (f) => frames.push(f),
+      (err) => errors.push(err)
+    )
+    const oversizedLength = MAX_MESSAGE_SIZE + 1
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(1, 1)
+    header.writeUInt32BE(0, 5)
+    header.writeUInt32BE(oversizedLength, 9)
+    const keepAlive = encodeKeepAliveFrame(2, 1)
+
+    decoder.feed(header)
+
+    const payloadWithTrailingHeaderPrefix = Buffer.concat([
+      Buffer.alloc(oversizedLength),
+      keepAlive.subarray(0, 5)
+    ])
+    decoder.feed(payloadWithTrailingHeaderPrefix)
+    payloadWithTrailingHeaderPrefix.fill(0, oversizedLength)
+    decoder.feed(keepAlive.subarray(5))
+
+    expect(errors).toHaveLength(1)
+    expect(frames).toHaveLength(1)
+    expect(frames[0].type).toBe(MessageType.KeepAlive)
+    expect(frames[0].id).toBe(2)
+  })
 })

--- a/src/relay/protocol.test.ts
+++ b/src/relay/protocol.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FrameDecoder,
+  HEADER_LENGTH,
+  MAX_MESSAGE_SIZE,
+  MessageType,
+  encodeKeepAliveFrame,
+  type DecodedFrame
+} from './protocol'
+
+describe('relay FrameDecoder', () => {
+  it('reports an oversized frame after the header without buffering the full payload', () => {
+    const errors: Error[] = []
+    const frames: DecodedFrame[] = []
+    const decoder = new FrameDecoder(
+      (f) => frames.push(f),
+      (err) => errors.push(err)
+    )
+    const oversizedLength = MAX_MESSAGE_SIZE + 1
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(1, 1)
+    header.writeUInt32BE(0, 5)
+    header.writeUInt32BE(oversizedLength, 9)
+
+    decoder.feed(header)
+
+    expect(frames).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('discarded')
+
+    decoder.feed(Buffer.concat([Buffer.alloc(oversizedLength), encodeKeepAliveFrame(2, 1)]))
+
+    expect(frames).toHaveLength(1)
+    expect(frames[0].type).toBe(MessageType.KeepAlive)
+  })
+})

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -109,7 +109,8 @@ export function encodeKeepAliveFrame(id: number, ack: number): Buffer {
 }
 
 export class FrameDecoder {
-  private buffer = Buffer.alloc(0)
+  private buffer: Buffer = Buffer.alloc(0)
+  private discardBytesRemaining = 0
   private onFrame: (frame: DecodedFrame) => void
   private onError: ((err: Error) => void) | null
 
@@ -119,7 +120,17 @@ export class FrameDecoder {
   }
 
   feed(chunk: Buffer | Uint8Array): void {
-    this.buffer = Buffer.concat([this.buffer, chunk])
+    let incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    if (this.discardBytesRemaining > 0) {
+      const bytesToDiscard = Math.min(this.discardBytesRemaining, incoming.length)
+      this.discardBytesRemaining -= bytesToDiscard
+      incoming = incoming.subarray(bytesToDiscard)
+      if (incoming.length === 0) {
+        return
+      }
+    }
+
+    this.buffer = this.buffer.length === 0 ? incoming : Buffer.concat([this.buffer, incoming])
 
     while (this.buffer.length >= HEADER_LENGTH) {
       const length = this.buffer.readUInt32BE(9)
@@ -131,17 +142,11 @@ export class FrameDecoder {
         // payload bytes as a new header, corrupting every future frame.
         // Instead we skip the entire oversized frame so the decoder stays
         // synchronized with the stream.
-        if (this.buffer.length < totalLength) {
-          // Haven't received the full oversized payload yet; wait for more data.
-          break
-        }
-        this.buffer = this.buffer.subarray(totalLength)
-        const err = new Error(`Frame payload too large: ${length} bytes — discarded`)
-        if (this.onError) {
-          this.onError(err)
-        } else {
-          process.stderr.write(`[relay] ${err.message}\n`)
-        }
+        const bufferedPayloadBytes = this.buffer.length - HEADER_LENGTH
+        const bytesToDiscard = Math.min(bufferedPayloadBytes, length)
+        this.buffer = this.buffer.subarray(HEADER_LENGTH + bytesToDiscard)
+        this.discardBytesRemaining = length - bytesToDiscard
+        this.reportOversizedFrame(length)
         continue
       }
 
@@ -160,8 +165,18 @@ export class FrameDecoder {
     }
   }
 
+  private reportOversizedFrame(length: number): void {
+    const err = new Error(`Frame payload too large: ${length} bytes — discarded`)
+    if (this.onError) {
+      this.onError(err)
+    } else {
+      process.stderr.write(`[relay] ${err.message}\n`)
+    }
+  }
+
   reset(): void {
     this.buffer = Buffer.alloc(0)
+    this.discardBytesRemaining = 0
   }
 
   // Why: at the handshake → dispatcher transition, the next consumer must
@@ -171,6 +186,7 @@ export class FrameDecoder {
   drain(): Buffer {
     const out = this.buffer
     this.buffer = Buffer.alloc(0)
+    this.discardBytesRemaining = 0
     return out
   }
 }

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -128,9 +128,12 @@ export class FrameDecoder {
       if (incoming.length === 0) {
         return
       }
+      // Why: the retained suffix may be a tiny partial frame after a hostile
+      // oversized payload; copy it so the discarded prefix is not kept alive.
+      incoming = Buffer.from(incoming)
     }
 
-    this.buffer = this.buffer.length === 0 ? incoming : Buffer.concat([this.buffer, incoming])
+    this.buffer = Buffer.concat([this.buffer, incoming])
 
     while (this.buffer.length >= HEADER_LENGTH) {
       const length = this.buffer.readUInt32BE(9)
@@ -144,7 +147,8 @@ export class FrameDecoder {
         // synchronized with the stream.
         const bufferedPayloadBytes = this.buffer.length - HEADER_LENGTH
         const bytesToDiscard = Math.min(bufferedPayloadBytes, length)
-        this.buffer = this.buffer.subarray(HEADER_LENGTH + bytesToDiscard)
+        const remaining = this.buffer.subarray(HEADER_LENGTH + bytesToDiscard)
+        this.buffer = remaining.length === 0 ? Buffer.alloc(0) : Buffer.from(remaining)
         this.discardBytesRemaining = length - bytesToDiscard
         this.reportOversizedFrame(length)
         continue


### PR DESCRIPTION
## Summary
- report oversized relay frame payloads as soon as the header is parsed
- discard oversized payload bytes across later chunks without buffering the full payload
- apply the same decoder behavior to the embedded SSH protocol and deployed relay protocol copies

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/ssh/relay-protocol.test.ts src/relay/protocol.test.ts` reported 0 oversized-frame errors after feeding only the header
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/ssh/relay-protocol.test.ts src/relay/protocol.test.ts src/relay/protocol-handshake.test.ts src/relay/relay-handshake-roundtrip.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/ssh/relay-protocol.ts src/main/ssh/relay-protocol.test.ts src/relay/protocol.ts src/relay/protocol.test.ts`

## Risk assessment
Risk: HIGH

Historic risk metadata backfill based on the existing `risk:high` label.


Risk: high

Historic risk metadata backfill based on the existing `risk:high` label.