### PR TITLE
fix: remove dotdot-prefixed overlay children

### DIFF
--- a/src/main/pty/overlay-mirror.test.ts
+++ b/src/main/pty/overlay-mirror.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { safeRemoveOverlay } from './overlay-mirror'
+
+const tempRoots: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('safeRemoveOverlay', () => {
+  it('removes valid overlay children whose names start with dot-dot', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-overlay-root-'))
+    tempRoots.push(root)
+    const overlayDir = join(root, '..session-overlay')
+    mkdirSync(overlayDir, { recursive: true })
+    writeFileSync(join(overlayDir, 'marker.txt'), 'overlay')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    safeRemoveOverlay(overlayDir, root)
+
+    expect(existsSync(overlayDir)).toBe(false)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/pty/overlay-mirror.test.ts
+++ b/src/main/pty/overlay-mirror.test.ts
@@ -28,4 +28,34 @@ describe('safeRemoveOverlay', () => {
     expect(existsSync(overlayDir)).toBe(false)
     expect(warnSpy).not.toHaveBeenCalled()
   })
+
+  it('refuses to remove the overlay root itself', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-overlay-root-'))
+    tempRoots.push(root)
+    const marker = join(root, 'marker.txt')
+    writeFileSync(marker, 'root')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    safeRemoveOverlay(root, root)
+
+    expect(existsSync(marker)).toBe(true)
+    expect(warnSpy).toHaveBeenCalledOnce()
+  })
+
+  it('refuses parent traversal outside the overlay root', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'orca-overlay-parent-'))
+    tempRoots.push(parent)
+    const root = join(parent, 'root')
+    const outside = join(parent, 'outside')
+    mkdirSync(root)
+    mkdirSync(outside)
+    const marker = join(outside, 'marker.txt')
+    writeFileSync(marker, 'outside')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    safeRemoveOverlay(join(root, '..', 'outside'), root)
+
+    expect(existsSync(marker)).toBe(true)
+    expect(warnSpy).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/pty/overlay-mirror.ts
+++ b/src/main/pty/overlay-mirror.ts
@@ -8,7 +8,7 @@
 // consumer cannot accidentally diverge from the audited cleanup behavior.
 
 import { cpSync, linkSync, lstatSync, readdirSync, rmdirSync, symlinkSync, unlinkSync } from 'fs'
-import { join, relative, resolve, sep } from 'path'
+import { isAbsolute, join, relative, resolve, sep } from 'path'
 
 export function mirrorEntry(sourcePath: string, targetPath: string): void {
   // Why: lstatSync (not statSync) so that if the user's source dir contains
@@ -118,7 +118,7 @@ export function safeRemoveOverlay(overlayDir: string, overlayRoot: string): void
   const resolvedRoot = resolve(overlayRoot)
   const resolvedTarget = resolve(overlayDir)
   const rel = relative(resolvedRoot, resolvedTarget)
-  if (rel === '' || rel.startsWith('..') || rel.includes(`..${sep}`)) {
+  if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
     console.warn(
       `[overlay-mirror] refusing to remove overlay outside root: target=${resolvedTarget} root=${resolvedRoot}`
     )


### PR DESCRIPTION
## Summary
- allow PTY overlay cleanup to remove valid child directories whose names start with `..`
- keep refusing the overlay root itself, real parent traversal, and cross-drive absolute relative paths
- add direct coverage for cleanup of a `..session-overlay` child

## Risk
Risk: Medium (`risk:medium`)

This touches a filesystem deletion guard in PTY overlay cleanup. The patch is small and keeps root, parent traversal, and cross-drive protections, but deletion-boundary logic deserves another review pass before merge.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/pty/overlay-mirror.test.ts` left `..session-overlay` on disk after cleanup
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/pty/overlay-mirror.test.ts src/main/opencode/hook-service.test.ts src/main/pi/titlebar-extension-service.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/pty/overlay-mirror.ts src/main/pty/overlay-mirror.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.