### PR TITLE
fix: settle git file listing timeouts

### DIFF
--- a/src/main/ipc/filesystem-list-files.test.ts
+++ b/src/main/ipc/filesystem-list-files.test.ts
@@ -279,6 +279,46 @@ describe('filesystem-list-files', () => {
       expect(result).toEqual(['.github/workflows/ci.yml', 'valid.ts'])
     })
 
+    it('settles and detaches git fallback scans that ignore timeout kills', async () => {
+      checkRgAvailableMock.mockResolvedValue(false)
+      vi.useFakeTimers()
+
+      try {
+        const gitP1 = createMockProcess()
+        const gitP2 = createMockProcess()
+        let callIndex = 0
+
+        spawnMock.mockImplementation((cmd: string) => {
+          if (cmd === 'git') {
+            callIndex++
+            return callIndex === 1 ? gitP1 : gitP2
+          }
+          return createMockProcess()
+        })
+
+        const storeMock = {} as unknown as Store
+        const promise = listQuickOpenFiles('/mock/root', storeMock)
+
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        ;(gitP1.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\npartial')
+
+        await vi.advanceTimersByTimeAsync(10000)
+
+        await expect(promise).resolves.toEqual(['src/index.ts'])
+        expect(gitP1.kill).toHaveBeenCalled()
+        expect(gitP2.kill).toHaveBeenCalled()
+        expect((gitP1.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+        expect((gitP1.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+        expect(gitP1.listenerCount('error')).toBe(0)
+        expect(gitP1.listenerCount('close')).toBe(0)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('does not fall back to git when rg is available', async () => {
       checkRgAvailableMock.mockResolvedValue(true)
 

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -185,14 +185,6 @@ function listFilesWithGit(
     return new Promise((resolve) => {
       let buf = ''
       let done = false
-      const finish = (): void => {
-        if (done) {
-          return
-        }
-        done = true
-        clearTimeout(timer)
-        resolve()
-      }
 
       const processLine = (line: string): void => {
         if (line.charCodeAt(line.length - 1) === 13 /* \r */) {
@@ -218,8 +210,8 @@ function listFilesWithGit(
         cwd: rootPath,
         stdio: ['ignore', 'pipe', 'pipe']
       })
-      child.stdout!.setEncoding('utf-8')
-      child.stdout!.on('data', (chunk: string) => {
+      let timer: ReturnType<typeof setTimeout>
+      const handleStdoutData = (chunk: string): void => {
         buf += chunk
         let start = 0
         let newlineIdx = buf.indexOf('\n', start)
@@ -229,23 +221,44 @@ function listFilesWithGit(
           newlineIdx = buf.indexOf('\n', start)
         }
         buf = start < buf.length ? buf.substring(start) : ''
-      })
-      child.stderr!.on('data', () => {
+      }
+      const handleStderrData = (): void => {
         /* drain */
-      })
-      child.once('error', () => {
+      }
+      const handleError = (): void => {
         buf = ''
         finish()
-      })
-      child.once('close', () => {
+      }
+      const handleClose = (): void => {
         if (buf) {
           processLine(buf)
         }
         finish()
-      })
-      const timer = setTimeout(() => {
+      }
+      const finish = (): void => {
+        if (done) {
+          return
+        }
+        done = true
+        clearTimeout(timer)
+        // Why: child.kill() is advisory. If git ignores it, detach our
+        // closures so repeated Quick Open attempts do not retain old scans.
+        child.stdout!.off('data', handleStdoutData)
+        child.stderr!.off('data', handleStderrData)
+        child.off('error', handleError)
+        child.off('close', handleClose)
+        resolve()
+      }
+
+      child.stdout!.setEncoding('utf-8')
+      child.stdout!.on('data', handleStdoutData)
+      child.stderr!.on('data', handleStderrData)
+      child.once('error', handleError)
+      child.once('close', handleClose)
+      timer = setTimeout(() => {
         buf = ''
         child.kill()
+        finish()
       }, 10000)
     })
   }


### PR DESCRIPTION
## Summary
- settle the local `git ls-files` Quick Open fallback when its timeout fires instead of only sending `kill()`
- detach stdout/stderr/process listeners as the fallback settles so a git process that ignores the signal does not retain old scan closures
- add a fake-timer regression test for a hung git fallback that still resolves with complete lines already streamed

## Risk
Risk: Low (`risk:low`)

This only affects the local Quick Open git fallback used when `rg` is unavailable. The normal `rg` path and SSH relay file listing path are unchanged. On timeout the fallback now returns already completed lines and discards the partial buffered line, matching the previous close-path filtering behavior while avoiding indefinite retention.

## Validation
- `pnpm exec oxlint src/main/ipc/filesystem-list-files.ts src/main/ipc/filesystem-list-files.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem-list-files.ts src/main/ipc/filesystem-list-files.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-list-files.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- `git diff --check`

Note: root `pnpm typecheck` still fails on existing missing renderer dependencies: `@tiptap/extension-details` and `react-colorful`.
