### PR TITLE
fix: cap relay startup stdout buffer

### DIFF
--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -131,6 +131,28 @@ describe('waitForSentinel', () => {
     expect(outcome).toContain('Relay startup output exceeded')
     expect(channel.close).toHaveBeenCalledTimes(1)
   })
+
+  it('does not count same-chunk post-sentinel payload against the startup buffer cap', async () => {
+    const channel = createMockChannel()
+    const transportPromise = waitForSentinel(channel)
+    const postSentinelPayload = Buffer.alloc(70 * 1024, 'b')
+
+    channel.emit(
+      'data',
+      Buffer.concat([
+        Buffer.alloc(64 * 1024, 'a'),
+        Buffer.from(RELAY_SENTINEL),
+        postSentinelPayload
+      ])
+    )
+
+    const transport = await transportPromise
+    const chunks: Buffer[] = []
+    transport.onData((chunk) => chunks.push(chunk))
+
+    expect(Buffer.concat(chunks)).toEqual(postSentinelPayload)
+    expect(channel.close).not.toHaveBeenCalled()
+  })
 })
 
 describe('execCommand', () => {

--- a/src/main/ssh/ssh-relay-deploy-helpers.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.test.ts
@@ -109,6 +109,28 @@ describe('waitForSentinel', () => {
       expect(err).not.toBeInstanceOf(RelayVersionMismatchError)
     })
   })
+
+  it('rejects and closes the channel when pre-sentinel stdout exceeds the startup buffer cap', async () => {
+    const channel = createMockChannel()
+    const transportPromise = waitForSentinel(channel)
+
+    channel.emit('data', Buffer.alloc(65 * 1024, 'a'))
+
+    const outcome = await Promise.race([
+      transportPromise.then(
+        () => 'resolved',
+        (err: Error) => `rejected:${err.message}`
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve('pending'), 0))
+    ])
+    if (outcome === 'pending') {
+      channel.emit('close')
+      await transportPromise.catch(() => {})
+    }
+
+    expect(outcome).toContain('Relay startup output exceeded')
+    expect(channel.close).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('execCommand', () => {

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -11,6 +11,8 @@ export { uploadFile, uploadDirectory, mkdirSftp } from './sftp-upload'
 
 // ── Sentinel detection ────────────────────────────────────────────────
 
+const MAX_RELAY_STARTUP_BUFFER_BYTES = 64 * 1024
+
 export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTransport> {
   return new Promise<MultiplexerTransport>((resolve, reject) => {
     let sentinelReceived = false
@@ -65,11 +67,10 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
       }
     })
 
-    const MAX_BUFFER_CAP = 64 * 1024
     channel.stderr.on('data', (data: Buffer) => {
       stderrOutput += data.toString('utf-8')
-      if (stderrOutput.length > MAX_BUFFER_CAP) {
-        stderrOutput = stderrOutput.slice(-MAX_BUFFER_CAP)
+      if (stderrOutput.length > MAX_RELAY_STARTUP_BUFFER_BYTES) {
+        stderrOutput = stderrOutput.slice(-MAX_RELAY_STARTUP_BUFFER_BYTES)
       }
     })
 
@@ -154,6 +155,14 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
             cb(data)
           }
         }
+        return
+      }
+
+      if (bufferedStdout.length + data.length > MAX_RELAY_STARTUP_BUFFER_BYTES) {
+        // Why: before the sentinel, stdout is untrusted startup noise; cap it
+        // like stderr so a broken remote cannot grow memory until timeout.
+        failOrClose(new Error('Relay startup output exceeded 64 KiB before ready sentinel'))
+        channel.close()
         return
       }
 

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -12,13 +12,14 @@ export { uploadFile, uploadDirectory, mkdirSftp } from './sftp-upload'
 // ── Sentinel detection ────────────────────────────────────────────────
 
 const MAX_RELAY_STARTUP_BUFFER_BYTES = 64 * 1024
+const RELAY_SENTINEL_BUFFER = Buffer.from(RELAY_SENTINEL, 'utf-8')
 
 export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTransport> {
   return new Promise<MultiplexerTransport>((resolve, reject) => {
     let sentinelReceived = false
     let settled = false
     let stderrOutput = ''
-    let bufferedStdout = Buffer.alloc(0)
+    let bufferedStdout: Buffer = Buffer.alloc(0)
     let closedAfterSentinel = false
     // Why: ssh2 fires 'exit' BEFORE 'close' with the remote exit code.
     // Capturing it here lets us translate exit-42 (relay handshake mismatch)
@@ -99,6 +100,13 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
       notifyClosed()
     }
 
+    const failStartupOutputCap = (): void => {
+      // Why: before the sentinel, stdout is untrusted startup noise; cap it
+      // like stderr so a broken remote cannot grow memory until timeout.
+      failOrClose(new Error('Relay startup output exceeded 64 KiB before ready sentinel'))
+      channel.close()
+    }
+
     // Why: SSH channel streams emit `error` when the remote host disappears.
     // Unhandled EventEmitter errors are process-fatal, so convert them into
     // startup rejection before the sentinel and transport close after it.
@@ -158,25 +166,31 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
         return
       }
 
-      if (bufferedStdout.length + data.length > MAX_RELAY_STARTUP_BUFFER_BYTES) {
-        // Why: before the sentinel, stdout is untrusted startup noise; cap it
-        // like stderr so a broken remote cannot grow memory until timeout.
-        failOrClose(new Error('Relay startup output exceeded 64 KiB before ready sentinel'))
-        channel.close()
+      const searchableDataLength = Math.max(
+        0,
+        MAX_RELAY_STARTUP_BUFFER_BYTES - bufferedStdout.length + RELAY_SENTINEL_BUFFER.length
+      )
+      const searchableData = data.subarray(0, searchableDataLength)
+      // Why: search only far enough to accept a sentinel at the cap boundary;
+      // bytes after the sentinel are framed relay data and may be large.
+      const startupStdout =
+        bufferedStdout.length === 0
+          ? searchableData
+          : Buffer.concat([bufferedStdout, searchableData])
+      const sentinelIdx = startupStdout.indexOf(RELAY_SENTINEL_BUFFER)
+
+      if (sentinelIdx > MAX_RELAY_STARTUP_BUFFER_BYTES) {
+        failStartupOutputCap()
         return
       }
-
-      bufferedStdout = Buffer.concat([bufferedStdout, data])
-      const text = bufferedStdout.toString('utf-8')
-      const sentinelIdx = text.indexOf(RELAY_SENTINEL)
 
       if (sentinelIdx !== -1) {
         sentinelReceived = true
         cancelTimers()
 
-        const afterSentinel = bufferedStdout.subarray(
-          Buffer.byteLength(text.substring(0, sentinelIdx + RELAY_SENTINEL.length), 'utf-8')
-        )
+        const afterSentinelOffset =
+          sentinelIdx + RELAY_SENTINEL_BUFFER.length - bufferedStdout.length
+        const afterSentinel = data.subarray(Math.max(0, afterSentinelOffset))
 
         if (afterSentinel.length > 0) {
           pendingAfterSentinel = afterSentinel
@@ -209,7 +223,15 @@ export function waitForSentinel(channel: ClientChannel): Promise<MultiplexerTran
         }
 
         resolve(transport)
+        return
       }
+
+      if (bufferedStdout.length + data.length > MAX_RELAY_STARTUP_BUFFER_BYTES) {
+        failStartupOutputCap()
+        return
+      }
+
+      bufferedStdout = bufferedStdout.length === 0 ? data : Buffer.concat([bufferedStdout, data])
     })
   })
 }


### PR DESCRIPTION
## Summary
- cap pre-sentinel relay stdout at 64 KiB during SSH startup
- close the channel and reject startup when a broken remote streams too much output before the ready sentinel
- reuse the same cap for retained stderr diagnostics

## Risk
Risk: Medium (`risk:medium`)

This protects SSH relay startup from unbounded pre-sentinel stdout, but it changes remote startup failure behavior and can close the SSH channel when the cap is exceeded. It should get another SSH-focused pass before merge.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts` left the startup promise pending after a 65 KiB pre-sentinel stdout chunk
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts src/main/ssh/ssh-relay-deploy.test.ts src/main/ssh/ssh-relay-reset.test.ts src/main/ssh/ssh-relay-cross-version-isolation.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/ssh/ssh-relay-deploy-helpers.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.