### PR TITLE
perf: bound rich markdown range calculations

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -75,6 +75,11 @@ import {
   type RichMarkdownAnnotationHighlightRange
 } from './rich-markdown-annotation-highlight'
 import {
+  getRichMarkdownLineRangeFromBlocks,
+  getRichMarkdownRangeBounds,
+  getRichMarkdownRangeStart
+} from './rich-markdown-range-bounds'
+import {
   shouldExpandRichMarkdownReviewRail,
   stackRichMarkdownReviewNotePositions,
   type RichMarkdownReviewNotePosition
@@ -460,10 +465,7 @@ function getRichMarkdownCommentAnchorTop(
     // Why: range notes should sort by the start of the selected text. Anchoring
     // to the end puts overlapping ranges with the same final line in creation
     // order, so a 43-45 card can render above a 41-45 card.
-    const anchorPos =
-      ranges.length > 0
-        ? Math.min(...ranges.map((range) => Math.min(range.from, range.to)))
-        : block.from
+    const anchorPos = getRichMarkdownRangeStart(ranges) ?? block.from
     const coords = editor.view.coordsAtPos(
       Math.max(1, Math.min(anchorPos, editor.state.doc.content.size))
     )
@@ -479,13 +481,8 @@ function getRichMarkdownSelectionRange(editor: Editor): RichMarkdownComposerStat
   const selectedBlocks = empty
     ? blocks.filter((block) => block.from <= from && from <= block.to)
     : blocks.filter((block) => from <= block.to && to >= block.from)
-  const targetBlocks = selectedBlocks.length > 0 ? selectedBlocks : [blocks[0]]
-  const startLine = Math.min(...targetBlocks.map((block) => block.startLine))
-  const lineNumber = Math.max(...targetBlocks.map((block) => block.endLine))
-  return {
-    lineNumber,
-    startLine: startLine === lineNumber ? undefined : startLine
-  }
+  const targetBlocks = selectedBlocks.length > 0 ? selectedBlocks : [blocks[0]!]
+  return getRichMarkdownLineRangeFromBlocks(targetBlocks) ?? { lineNumber: 1 }
 }
 
 function hasRichMarkdownCommentForRange(
@@ -938,8 +935,11 @@ export default function RichMarkdownEditor({
       if (ranges.length === 0) {
         return
       }
-      const from = Math.min(...ranges.map((range) => Math.min(range.from, range.to)))
-      const to = Math.max(...ranges.map((range) => Math.max(range.from, range.to)))
+      const bounds = getRichMarkdownRangeBounds(ranges)
+      if (!bounds) {
+        return
+      }
+      const { from, to } = bounds
       const maxPos = ed.state.doc.content.size
       const startCoords = ed.view.coordsAtPos(Math.max(1, Math.min(from, maxPos)))
       const endCoords = ed.view.coordsAtPos(Math.max(1, Math.min(to, maxPos)))

--- a/src/renderer/src/components/editor/rich-markdown-range-bounds.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-range-bounds.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getRichMarkdownLineRangeFromBlocks,
+  getRichMarkdownRangeBounds,
+  getRichMarkdownRangeStart
+} from './rich-markdown-range-bounds'
+
+describe('rich markdown range bounds', () => {
+  it('finds selected line bounds without spreading block arrays', () => {
+    const blocks = Array.from({ length: 130_000 }, (_, index) => ({
+      startLine: index + 1,
+      endLine: index + 1
+    }))
+
+    expect(getRichMarkdownLineRangeFromBlocks(blocks)).toEqual({
+      startLine: 1,
+      lineNumber: 130_000
+    })
+  })
+
+  it('finds annotation range bounds without spreading range arrays', () => {
+    const ranges = Array.from({ length: 130_000 }, (_, index) => ({
+      from: index + 10,
+      to: index + 11
+    }))
+    ranges.push({ from: 3, to: 2 })
+    ranges.push({ from: 200_000, to: 199_999 })
+
+    expect(getRichMarkdownRangeStart(ranges)).toBe(2)
+    expect(getRichMarkdownRangeBounds(ranges)).toEqual({
+      from: 2,
+      to: 200_000
+    })
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-range-bounds.ts
+++ b/src/renderer/src/components/editor/rich-markdown-range-bounds.ts
@@ -1,0 +1,74 @@
+import type { RichMarkdownAnnotationHighlightRange } from './rich-markdown-annotation-highlight'
+
+export type RichMarkdownLineBlock = {
+  readonly startLine: number
+  readonly endLine: number
+}
+
+export type RichMarkdownLineRange = {
+  lineNumber: number
+  startLine?: number
+}
+
+export function getRichMarkdownLineRangeFromBlocks(
+  blocks: readonly RichMarkdownLineBlock[]
+): RichMarkdownLineRange | null {
+  if (blocks.length === 0) {
+    return null
+  }
+
+  let startLine = Number.POSITIVE_INFINITY
+  let lineNumber = Number.NEGATIVE_INFINITY
+  for (const block of blocks) {
+    if (block.startLine < startLine) {
+      startLine = block.startLine
+    }
+    if (block.endLine > lineNumber) {
+      lineNumber = block.endLine
+    }
+  }
+
+  return {
+    lineNumber,
+    startLine: startLine === lineNumber ? undefined : startLine
+  }
+}
+
+export function getRichMarkdownRangeStart(
+  ranges: readonly RichMarkdownAnnotationHighlightRange[]
+): number | null {
+  if (ranges.length === 0) {
+    return null
+  }
+
+  let start = Number.POSITIVE_INFINITY
+  for (const range of ranges) {
+    const rangeStart = Math.min(range.from, range.to)
+    if (rangeStart < start) {
+      start = rangeStart
+    }
+  }
+  return start
+}
+
+export function getRichMarkdownRangeBounds(
+  ranges: readonly RichMarkdownAnnotationHighlightRange[]
+): RichMarkdownAnnotationHighlightRange | null {
+  if (ranges.length === 0) {
+    return null
+  }
+
+  let from = Number.POSITIVE_INFINITY
+  let to = Number.NEGATIVE_INFINITY
+  for (const range of ranges) {
+    const rangeStart = Math.min(range.from, range.to)
+    const rangeEnd = Math.max(range.from, range.to)
+    if (rangeStart < from) {
+      from = rangeStart
+    }
+    if (rangeEnd > to) {
+      to = rangeEnd
+    }
+  }
+  return { from, to }
+}


### PR DESCRIPTION
## Summary
- compute RichMarkdown annotation/range bounds in one pass instead of mapping large arrays into spread calls
- reuse the helper for review-note anchoring, selected-line ranges, and scroll-to-source bounds
- add 130,000-entry regression coverage for selected blocks and annotation ranges

## Risk
Medium. This is a small mechanical bounds-calculation change, but it touches RichMarkdown review-note anchoring and scroll behavior in the editor.

## Validation
- `pnpm exec oxfmt --write src/renderer/src/components/editor/RichMarkdownEditor.tsx src/renderer/src/components/editor/rich-markdown-range-bounds.ts src/renderer/src/components/editor/rich-markdown-range-bounds.test.ts`
- `pnpm exec oxlint src/renderer/src/components/editor/RichMarkdownEditor.tsx src/renderer/src/components/editor/rich-markdown-range-bounds.ts src/renderer/src/components/editor/rich-markdown-range-bounds.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-range-bounds.test.ts src/renderer/src/components/editor/rich-markdown-key-handler.test.ts src/renderer/src/components/editor/rich-markdown-details-keyboard.test.ts src/renderer/src/components/editor/rich-markdown-list-continuation.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.