### PR TITLE
fix: settle git grep search timeouts

### DIFF
--- a/src/main/ipc/filesystem-search-git.test.ts
+++ b/src/main/ipc/filesystem-search-git.test.ts
@@ -168,6 +168,32 @@ describe('filesystem-search-git', () => {
     expect(result.totalMatches).toBe(0)
   })
 
+  it('settles and detaches when git grep ignores the timeout kill', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const proc = createMockProcess()
+      spawnMock.mockReturnValue(proc)
+
+      const promise = searchWithGitGrep('/mock/root', { query: 'ok', rootPath: '/mock/root' }, 100)
+
+      ;(proc.stdout as unknown as EventEmitter).emit('data', 'valid.ts\x001:ok\npartial')
+
+      await vi.runOnlyPendingTimersAsync()
+
+      const result = await promise
+      expect(result.truncated).toBe(true)
+      expect(result.files).toHaveLength(1)
+      expect(proc.kill).toHaveBeenCalled()
+      expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect(proc.listenerCount('error')).toBe(0)
+      expect(proc.listenerCount('close')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('skips lines without null separator', async () => {
     const proc = createMockProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/ipc/filesystem-search-git.ts
+++ b/src/main/ipc/filesystem-search-git.ts
@@ -28,51 +28,68 @@ export function searchWithGitGrep(
     let stdoutBuffer = ''
     let done = false
 
-    const resolveOnce = (): void => {
+    const child = gitSpawn(gitArgs, {
+      cwd: rootPath,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    let killTimeout: ReturnType<typeof setTimeout>
+
+    function resolveOnce(): void {
       if (done) {
         return
       }
       done = true
       clearTimeout(killTimeout)
+      // Why: child.kill() is advisory. If git ignores it, detach our
+      // closures so repeated fallback searches do not retain old scans.
+      child.stdout!.off('data', handleStdoutData)
+      child.stderr!.off('data', handleStderrData)
+      child.off('error', handleError)
+      child.off('close', handleClose)
       resolve(finalize(acc))
     }
 
-    const processLine = (line: string): void => {
+    function processLine(line: string): void {
       const verdict = ingestGitGrepLine(line, rootPath, matchRegex, acc, maxResults)
       if (verdict === 'stop') {
         child.kill()
       }
     }
 
-    const child = gitSpawn(gitArgs, {
-      cwd: rootPath,
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
-    child.stdout!.setEncoding('utf-8')
-    child.stdout!.on('data', (chunk: string) => {
+    function handleStdoutData(chunk: string): void {
       stdoutBuffer += chunk
       const lines = stdoutBuffer.split('\n')
       stdoutBuffer = lines.pop() ?? ''
       for (const l of lines) {
         processLine(l)
       }
-    })
-    child.stderr!.on('data', () => {
+    }
+
+    function handleStderrData(): void {
       /* drain */
-    })
-    child.once('error', () => {
+    }
+
+    function handleError(): void {
       resolveOnce()
-    })
-    child.once('close', () => {
+    }
+
+    function handleClose(): void {
       if (stdoutBuffer) {
         processLine(stdoutBuffer)
       }
       resolveOnce()
-    })
+    }
 
-    const killTimeout = setTimeout(() => {
+    child.stdout!.setEncoding('utf-8')
+    child.stdout!.on('data', handleStdoutData)
+    child.stderr!.on('data', handleStderrData)
+    child.once('error', handleError)
+    child.once('close', handleClose)
+
+    killTimeout = setTimeout(() => {
       acc.truncated = true
       child.kill()
+      resolveOnce()
     }, SEARCH_TIMEOUT_MS)
   })
 }


### PR DESCRIPTION
## Summary
- settle the local `git grep` fallback search immediately when its timeout fires
- detach stdout/stderr/process listeners when the fallback settles so a git process that ignores `kill()` cannot retain the search accumulator
- add a fake-timer regression test for the hung-timeout path

## Risk
Risk: Low (`risk:low`)

This only affects the local text-search fallback used when `rg` is unavailable. The normal `rg` search path and SSH relay search path are unchanged. Timeout behavior moves from waiting for child `close` to returning a truncated partial result immediately, which matches the existing `truncated` semantics and avoids an indefinite retained search.

## Validation
- `pnpm exec oxlint src/main/ipc/filesystem-search-git.ts src/main/ipc/filesystem-search-git.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem-search-git.ts src/main/ipc/filesystem-search-git.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-search-git.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- `git diff --check`

Note: root `pnpm typecheck` still fails on existing missing renderer dependencies: `@tiptap/extension-details` and `react-colorful`.
