### PR TITLE
fix: settle relay git file list timeouts

### DIFF
--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -108,8 +108,13 @@ export function listFilesWithGit(
         resolve()
       })
       const timer = setTimeout(() => {
+        if (done) {
+          return
+        }
+        done = true
         buf = ''
         child.kill()
+        reject(new Error('git ls-files timed out'))
       }, 10_000)
     })
   }

--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -128,4 +128,33 @@ describe('relay quick open ignored file listing', () => {
 
     await expect(promise).rejects.toThrow('git ls-files killed by SIGTERM')
   })
+
+  it('git fallback rejects when a timed-out child does not emit close', async () => {
+    vi.useFakeTimers()
+    try {
+      const primaryProc = createMockProcess()
+      const ignoredProc = createMockProcess()
+      let callIndex = 0
+
+      spawnMock.mockImplementation(() => {
+        callIndex++
+        return callIndex === 1 ? primaryProc : ignoredProc
+      })
+
+      const promise = listFilesWithGit('/remote/root')
+      const outcomePromise = promise.then(
+        () => 'resolved',
+        (err: Error) => `rejected:${err.message}`
+      )
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toContain('git ls-files timed out')
+      expect(primaryProc.kill).toHaveBeenCalled()
+      expect(ignoredProc.kill).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- reject the SSH relay `git ls-files` fallback immediately when its timeout fires
- still kill the timed-out child, but no longer wait forever for a `close` event that may never arrive
- add fake-timer coverage for a timed-out child that ignores the kill/close path

## Risk
Risk: Low (`risk:low`)

This only changes the SSH relay Quick Open git fallback after its existing timeout has already fired. Successful `rg` and `git ls-files` paths are unchanged; the previous failure mode was a retained pending request, and the new behavior is a bounded timeout error.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/relay/fs-handler-list-files-ignored.test.ts` left `listFilesWithGit()` pending after the timeout when the child emitted no `close`
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/relay/fs-handler-list-files-ignored.test.ts src/relay/fs-handler.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/relay/fs-handler-git-fallback.ts src/relay/fs-handler-list-files-ignored.test.ts`