### PR TITLE
fix: settle relay git grep timeouts

### DIFF
--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -138,51 +138,69 @@ export function searchWithGitGrep(
     const acc = createAccumulator()
     let stdoutBuffer = ''
     let done = false
+    const child = spawn('git', gitArgs, {
+      cwd: rootPath,
+      env: buildRelayCommandEnv(),
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    let killTimeout: ReturnType<typeof setTimeout>
 
-    const resolveOnce = (): void => {
+    function resolveOnce(): void {
       if (done) {
         return
       }
       done = true
       clearTimeout(killTimeout)
+      // Why: child.kill() is advisory over SSH; detach listeners if the
+      // process ignores timeout kill so old searches cannot retain closures.
+      child.stdout!.off('data', handleStdoutData)
+      child.stderr!.off('data', handleStderrData)
+      child.off('error', handleError)
+      child.off('close', handleClose)
       resolve(finalize(acc))
     }
 
-    const processLine = (line: string): void => {
+    function processLine(line: string): void {
       const verdict = ingestGitGrepLine(line, rootPath, matchRegex, acc, opts.maxResults)
       if (verdict === 'stop') {
         child.kill()
       }
     }
 
-    const child = spawn('git', gitArgs, {
-      cwd: rootPath,
-      env: buildRelayCommandEnv(),
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
-    child.stdout!.setEncoding('utf-8')
-    child.stdout!.on('data', (chunk: string) => {
+    function handleStdoutData(chunk: string): void {
       stdoutBuffer += chunk
       const lines = stdoutBuffer.split('\n')
       stdoutBuffer = lines.pop() ?? ''
       for (const l of lines) {
         processLine(l)
       }
-    })
-    child.stderr!.on('data', () => {
+    }
+
+    function handleStderrData(): void {
       /* drain */
-    })
-    child.once('error', () => resolveOnce())
-    child.once('close', () => {
+    }
+
+    function handleError(): void {
+      resolveOnce()
+    }
+
+    function handleClose(): void {
       if (stdoutBuffer) {
         processLine(stdoutBuffer)
       }
       resolveOnce()
-    })
+    }
 
-    const killTimeout = setTimeout(() => {
+    child.stdout!.setEncoding('utf-8')
+    child.stdout!.on('data', handleStdoutData)
+    child.stderr!.on('data', handleStderrData)
+    child.once('error', handleError)
+    child.once('close', handleClose)
+
+    killTimeout = setTimeout(() => {
       acc.truncated = true
       child.kill()
+      resolveOnce()
     }, SEARCH_TIMEOUT_MS)
   })
 }

--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -10,7 +10,7 @@ vi.mock('child_process', () => ({
 
 import { EventEmitter } from 'events'
 import type { ChildProcess } from 'child_process'
-import { listFilesWithGit } from './fs-handler-git-fallback'
+import { listFilesWithGit, searchWithGitGrep } from './fs-handler-git-fallback'
 import { listFilesWithRg } from './fs-handler-list-files'
 
 function createMockProcess(): ChildProcess {
@@ -153,6 +153,32 @@ describe('relay quick open ignored file listing', () => {
       expect(outcome).toContain('git ls-files timed out')
       expect(primaryProc.kill).toHaveBeenCalled()
       expect(ignoredProc.kill).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('git grep fallback settles and detaches when a timed-out child does not emit close', async () => {
+    vi.useFakeTimers()
+    try {
+      const proc = createMockProcess()
+      spawnMock.mockReturnValue(proc)
+
+      const promise = searchWithGitGrep('/remote/root', 'ok', { maxResults: 100 })
+      const outcomePromise = promise.then((result) =>
+        result.truncated ? `truncated:${result.totalMatches}` : 'not-truncated'
+      )
+
+      ;(proc.stdout as unknown as EventEmitter).emit('data', 'src/file.ts\x001:ok\npartial')
+      await vi.runOnlyPendingTimersAsync()
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toBe('truncated:1')
+      expect(proc.kill).toHaveBeenCalled()
+      expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect(proc.listenerCount('error')).toBe(0)
+      expect(proc.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()
     }


### PR DESCRIPTION
## Summary
- settle the SSH relay `git grep` fallback immediately when the search timeout fires
- detach stdout/stderr/close/error listeners after timeout so a child that ignores kill cannot retain old search closures
- add fake-timer coverage for a timed-out child that never emits `close`

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/relay/fs-handler-list-files-ignored.test.ts` left `searchWithGitGrep()` pending after timeout when the child emitted no `close`
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/relay/fs-handler-list-files-ignored.test.ts src/relay/fs-handler.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/relay/fs-handler-git-fallback.ts src/relay/fs-handler-list-files-ignored.test.ts`
