### PR TITLE
fix: settle relay git grep timeouts

### DIFF
--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -139,50 +139,69 @@ export function searchWithGitGrep(
     let stdoutBuffer = ''
     let done = false
 
-    const resolveOnce = (): void => {
+    const child = spawn('git', gitArgs, {
+      cwd: rootPath,
+      env: buildRelayCommandEnv(),
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    let killTimeout: ReturnType<typeof setTimeout>
+
+    function resolveOnce(): void {
       if (done) {
         return
       }
       done = true
       clearTimeout(killTimeout)
+      // Why: child.kill() is advisory. If git ignores it, detach our
+      // closures so repeated relay searches do not retain old scans.
+      child.stdout!.off('data', handleStdoutData)
+      child.stderr!.off('data', handleStderrData)
+      child.off('error', handleError)
+      child.off('close', handleClose)
       resolve(finalize(acc))
     }
 
-    const processLine = (line: string): void => {
+    function processLine(line: string): void {
       const verdict = ingestGitGrepLine(line, rootPath, matchRegex, acc, opts.maxResults)
       if (verdict === 'stop') {
         child.kill()
       }
     }
 
-    const child = spawn('git', gitArgs, {
-      cwd: rootPath,
-      env: buildRelayCommandEnv(),
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
-    child.stdout!.setEncoding('utf-8')
-    child.stdout!.on('data', (chunk: string) => {
+    function handleStdoutData(chunk: string): void {
       stdoutBuffer += chunk
       const lines = stdoutBuffer.split('\n')
       stdoutBuffer = lines.pop() ?? ''
       for (const l of lines) {
         processLine(l)
       }
-    })
-    child.stderr!.on('data', () => {
+    }
+
+    function handleStderrData(): void {
       /* drain */
-    })
-    child.once('error', () => resolveOnce())
-    child.once('close', () => {
+    }
+
+    function handleError(): void {
+      resolveOnce()
+    }
+
+    function handleClose(): void {
       if (stdoutBuffer) {
         processLine(stdoutBuffer)
       }
       resolveOnce()
-    })
+    }
 
-    const killTimeout = setTimeout(() => {
+    child.stdout!.setEncoding('utf-8')
+    child.stdout!.on('data', handleStdoutData)
+    child.stderr!.on('data', handleStderrData)
+    child.once('error', handleError)
+    child.once('close', handleClose)
+
+    killTimeout = setTimeout(() => {
       acc.truncated = true
       child.kill()
+      resolveOnce()
     }, SEARCH_TIMEOUT_MS)
   })
 }

--- a/src/relay/fs-handler-git-search.test.ts
+++ b/src/relay/fs-handler-git-search.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import { searchWithGitGrep } from './fs-handler-git-fallback'
+
+function createMockProcess(): ChildProcess {
+  const p = new EventEmitter() as unknown as ChildProcess
+  ;(p as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(
+    (p as unknown as Record<string, unknown>).stdout as EventEmitter & {
+      setEncoding: () => void
+    }
+  ).setEncoding = vi.fn()
+  ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(p as unknown as Record<string, unknown>).kill = vi.fn()
+  return p
+}
+
+describe('relay git grep fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('settles and detaches when git grep ignores the timeout kill', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const proc = createMockProcess()
+      spawnMock.mockReturnValue(proc)
+
+      const promise = searchWithGitGrep('/remote/root', 'ok', { maxResults: 100 })
+
+      ;(proc.stdout as unknown as EventEmitter).emit('data', 'valid.ts\x001:ok\npartial')
+
+      await vi.runOnlyPendingTimersAsync()
+
+      const result = await promise
+      expect(result.truncated).toBe(true)
+      expect(result.files).toHaveLength(1)
+      expect(proc.kill).toHaveBeenCalled()
+      expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect(proc.listenerCount('error')).toBe(0)
+      expect(proc.listenerCount('close')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- settle the SSH relay `git grep` fallback search immediately when its timeout fires
- detach stdout/stderr/process listeners when the fallback settles so a git process that ignores `kill()` cannot retain the search accumulator
- add fake-timer regression coverage for the hung timeout path

## Risk
Risk: Low (`risk:low`)

This only affects the SSH relay text-search fallback used when `rg` is unavailable and the existing timeout has already fired. Successful search behavior is unchanged; the previous failure mode was a retained pending request, and the new behavior is a bounded truncated result.

## Validation
- `pnpm exec oxlint src/relay/fs-handler-git-fallback.ts src/relay/fs-handler-git-search.test.ts`
- `pnpm exec oxfmt --check src/relay/fs-handler-git-fallback.ts src/relay/fs-handler-git-search.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/relay/fs-handler-git-search.test.ts src/relay/fs-handler-list-files-ignored.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- `git diff --check`

Note: root `pnpm typecheck` still fails on existing missing renderer dependencies: `@tiptap/extension-details` and `react-colorful`.
