### PR TITLE
fix: settle relay rg search timeouts

### DIFF
--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -12,6 +12,7 @@ import { EventEmitter } from 'events'
 import type { ChildProcess } from 'child_process'
 import { listFilesWithGit } from './fs-handler-git-fallback'
 import { listFilesWithRg } from './fs-handler-list-files'
+import { searchWithRg } from './fs-handler-utils'
 
 function createMockProcess(): ChildProcess {
   const p = new EventEmitter() as unknown as ChildProcess
@@ -153,6 +154,31 @@ describe('relay quick open ignored file listing', () => {
       expect(outcome).toContain('git ls-files timed out')
       expect(primaryProc.kill).toHaveBeenCalled()
       expect(ignoredProc.kill).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rg search settles and detaches when a timed-out child does not emit close', async () => {
+    vi.useFakeTimers()
+    try {
+      const proc = createMockProcess()
+      spawnMock.mockReturnValue(proc)
+
+      const promise = searchWithRg('/remote/root', 'ok', { maxResults: 100 })
+      const outcomePromise = promise.then((result) =>
+        result.truncated ? `truncated:${result.totalMatches}` : 'not-truncated'
+      )
+
+      await vi.runOnlyPendingTimersAsync()
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toBe('truncated:0')
+      expect(proc.kill).toHaveBeenCalled()
+      expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect(proc.listenerCount('error')).toBe(0)
+      expect(proc.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()
     }

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -116,45 +116,64 @@ export function searchWithRg(
       return
     }
 
-    const resolveOnce = (): void => {
+    let killTimeout: ReturnType<typeof setTimeout>
+
+    function resolveOnce(): void {
       if (resolved) {
         return
       }
       resolved = true
       clearTimeout(killTimeout)
+      // Why: child.kill() is advisory over SSH; detach listeners if the
+      // process ignores timeout kill so old searches cannot retain closures.
+      child.stdout!.off('data', handleStdoutData)
+      child.stderr!.off('data', handleStderrData)
+      child.off('error', handleError)
+      child.off('close', handleClose)
       resolve(finalize(acc))
     }
 
-    const processLine = (line: string): void => {
+    function processLine(line: string): void {
       const verdict = ingestRgJsonLine(line, rootPath, acc, opts.maxResults)
       if (verdict === 'stop') {
         child.kill()
       }
     }
 
-    child.stdout!.setEncoding('utf-8')
-    child.stdout!.on('data', (chunk: string) => {
+    function handleStdoutData(chunk: string): void {
       buffer += chunk
       const lines = buffer.split('\n')
       buffer = lines.pop() ?? ''
       for (const line of lines) {
         processLine(line)
       }
-    })
-    child.stderr!.on('data', () => {
+    }
+
+    function handleStderrData(): void {
       /* drain */
-    })
-    child.once('error', () => resolveOnce())
-    child.once('close', () => {
+    }
+
+    function handleError(): void {
+      resolveOnce()
+    }
+
+    function handleClose(): void {
       if (buffer) {
         processLine(buffer)
       }
       resolveOnce()
-    })
+    }
 
-    const killTimeout = setTimeout(() => {
+    child.stdout!.setEncoding('utf-8')
+    child.stdout!.on('data', handleStdoutData)
+    child.stderr!.on('data', handleStderrData)
+    child.once('error', handleError)
+    child.once('close', handleClose)
+
+    killTimeout = setTimeout(() => {
       acc.truncated = true
       child.kill()
+      resolveOnce()
     }, SEARCH_TIMEOUT_MS)
   })
 }


### PR DESCRIPTION
## Summary
- settle the SSH relay rg search path immediately when the search timeout fires
- detach process listeners after timeout so a child that ignores kill cannot retain old search closures
- add fake-timer coverage for a timed-out rg child that never emits `close`

## Risk
Risk: Low (`risk:low`)

This only changes the SSH relay `rg` search path after the existing timeout has already fired. Successful search behavior is unchanged; the previous failure mode was a retained pending request, and the new behavior is a bounded truncated result.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/relay/fs-handler-list-files-ignored.test.ts` left `searchWithRg()` pending after timeout when the child emitted no `close`
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/relay/fs-handler-list-files-ignored.test.ts src/relay/fs-handler.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/relay/fs-handler-utils.ts src/relay/fs-handler-list-files-ignored.test.ts`