### PR TITLE
test: update quick workspace agent fallback order

### DIFF
--- a/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
+++ b/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
@@ -4,7 +4,8 @@ import { pickQuickWorkspaceAgent } from './quick-workspace-agent-selection'
 describe('pickQuickWorkspaceAgent', () => {
   it('uses the first enabled catalog agent while detection is pending', () => {
     expect(pickQuickWorkspaceAgent(null, null, [])).toBe('claude')
-    expect(pickQuickWorkspaceAgent(null, null, ['claude'])).toBe('codex')
+    expect(pickQuickWorkspaceAgent(null, null, ['claude'])).toBe('openclaude')
+    expect(pickQuickWorkspaceAgent(null, null, ['claude', 'openclaude'])).toBe('codex')
   })
 
   it('respects blank and disabled preferred agents', () => {


### PR DESCRIPTION
## Summary
- Update quick workspace agent fallback expectations for the OpenClaude catalog order
- Cover the Codex fallback when both Claude and OpenClaude are disabled

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/quick-workspace-agent-selection.test.ts src/renderer/src/components/agent/AgentCombobox.test.tsx src/renderer/src/lib/agent-status.test.ts
- pnpm exec oxlint src/renderer/src/lib/quick-workspace-agent-selection.test.ts
- pnpm run typecheck:web
- git diff --check

Risk: low. Test-only update matching the merged catalog order.