### PR TITLE
fix: expect openclaude workspace fallback

### DIFF
--- a/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
+++ b/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
@@ -4,7 +4,7 @@ import { pickQuickWorkspaceAgent } from './quick-workspace-agent-selection'
 describe('pickQuickWorkspaceAgent', () => {
   it('uses the first enabled catalog agent while detection is pending', () => {
     expect(pickQuickWorkspaceAgent(null, null, [])).toBe('claude')
-    expect(pickQuickWorkspaceAgent(null, null, ['claude'])).toBe('codex')
+    expect(pickQuickWorkspaceAgent(null, null, ['claude'])).toBe('openclaude')
   })
 
   it('respects blank and disabled preferred agents', () => {


### PR DESCRIPTION
## Summary
- update the quick-workspace fallback test now that OpenClaude is in the shared auto-pick order immediately after Claude
- keep the test asserting that disabled agents are skipped while detection is pending

## Risk
Risk: Low (`risk:low`)

Test-only change. It aligns the assertion with the already-merged OpenClaude catalog ordering and does not alter runtime behavior.

## Validation
- `pnpm exec oxlint src/renderer/src/lib/quick-workspace-agent-selection.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/quick-workspace-agent-selection.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/quick-workspace-agent-selection.test.ts`
- `git diff --check`

Note: root `pnpm typecheck` still fails on existing missing renderer dependencies: `@tiptap/extension-details` and `react-colorful`.
