### PR TITLE
fix: settle local agent generation cancellation

### DIFF
--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -1064,6 +1064,70 @@ describe('generateCommitMessageFromContext', () => {
     })
   })
 
+  it('settles local commit-message cancellation even when the killed child does not close', async () => {
+    vi.useFakeTimers()
+    try {
+      const listeners = new Map<string, (value: unknown) => void>()
+      const removeListener = (key: string, callback: (value: unknown) => void): void => {
+        if (listeners.get(key) === callback) {
+          listeners.delete(key)
+        }
+      }
+      const child = {
+        pid: 123,
+        kill: vi.fn(),
+        stdout: {
+          on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)),
+          off: vi.fn((event, callback) => removeListener(`stdout:${event}`, callback))
+        },
+        stderr: {
+          on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)),
+          off: vi.fn((event, callback) => removeListener(`stderr:${event}`, callback))
+        },
+        stdin: { end: vi.fn() },
+        on: vi.fn((event, callback) => listeners.set(event, callback)),
+        off: vi.fn((event, callback) => removeListener(event, callback))
+      }
+      spawnMock.mockReturnValue(child as never)
+
+      const pending = generateCommitMessageFromContext(
+        {
+          branch: 'main',
+          stagedSummary: 'M\tREADME.md',
+          stagedPatch: '+hello'
+        },
+        {
+          agentId: 'custom',
+          model: '',
+          customAgentCommand: 'agent'
+        },
+        {
+          kind: 'local',
+          cwd: '/repo'
+        }
+      )
+      const outcomePromise = pending.then((result) =>
+        !result.success && result.canceled ? 'canceled' : 'other'
+      )
+
+      cancelGenerateCommitMessageLocal('/repo')
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toBe('canceled')
+      expect(listeners.has('stdout:data')).toBe(false)
+      expect(listeners.has('stderr:data')).toBe(false)
+      expect(listeners.has('error')).toBe(false)
+      expect(listeners.has('close')).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('routes Windows batch-script agent commands through cmd.exe', async () => {
     const originalComSpec = process.env.ComSpec
     process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe'

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -491,11 +491,18 @@ async function runLocalPlan(
     let canceledByUser = false
     const laneKey = localLaneKey(operation, cwd)
     let cancelToken: (() => void) | null = null
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let detachChildListeners = (): void => {}
     const finalize = (result: InternalTextGenerationResult): void => {
       if (settled) {
         return
       }
       settled = true
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      detachChildListeners()
       if (cancelToken && cancelTokensByLane.get(laneKey) === cancelToken) {
         cancelTokensByLane.delete(laneKey)
       }
@@ -505,10 +512,13 @@ async function runLocalPlan(
     cancelToken = () => {
       canceledByUser = true
       killProcessTree(child)
+      // Why: cancellation is a user-visible UI command; do not wait for a
+      // wedged agent CLI to emit `close` before the request leaves loading.
+      finalize({ success: false, error: 'Generation canceled.', canceled: true })
     }
     cancelTokensByLane.set(laneKey, cancelToken)
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       killProcessTree(child)
       finalize({
         success: false,
@@ -516,7 +526,7 @@ async function runLocalPlan(
       })
     }, GENERATION_TIMEOUT_MS)
 
-    child.stdout?.on('data', (chunk: Buffer) => {
+    const onStdoutData = (chunk: Buffer): void => {
       stdoutBytes += chunk.byteLength
       if (stdoutBytes > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
@@ -524,8 +534,8 @@ async function runLocalPlan(
         return
       }
       stdout += chunk.toString('utf-8')
-    })
-    child.stderr?.on('data', (chunk: Buffer) => {
+    }
+    const onStderrData = (chunk: Buffer): void => {
       stderrBytes += chunk.byteLength
       if (stderrBytes > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
@@ -533,9 +543,8 @@ async function runLocalPlan(
         return
       }
       stderr += chunk.toString('utf-8')
-    })
-    child.on('error', (error) => {
-      clearTimeout(timer)
+    }
+    const onError = (error: Error): void => {
       const code = (error as NodeJS.ErrnoException).code
       if (code === 'ENOENT') {
         finalize({
@@ -549,9 +558,8 @@ async function runLocalPlan(
         success: false,
         error: `${label} failed to start. Check the agent command in Settings and try again.`
       })
-    })
-    child.on('close', (code) => {
-      clearTimeout(timer)
+    }
+    const onClose = (code: number | null): void => {
       if (canceledByUser) {
         finalize({ success: false, error: 'Generation canceled.', canceled: true })
         return
@@ -561,7 +569,17 @@ async function runLocalPlan(
         return
       }
       finalizeFromAgentOutput({ code, stdout, stderr, label, emptyResultName, finalize })
-    })
+    }
+    child.stdout?.on('data', onStdoutData)
+    child.stderr?.on('data', onStderrData)
+    child.on('error', onError)
+    child.on('close', onClose)
+    detachChildListeners = () => {
+      child.stdout?.off?.('data', onStdoutData)
+      child.stderr?.off?.('data', onStderrData)
+      child.off?.('error', onError)
+      child.off?.('close', onClose)
+    }
 
     child.stdin?.end(stdinPayload ?? undefined)
   })


### PR DESCRIPTION
## Summary
- settle local source-control AI generation immediately when the user cancels
- keep killing the agent process tree, but do not wait forever for a child that never emits close
- clear the timeout and detach child listeners once local generation has settled

## Risk
Risk: Low (`risk:low`)

This only changes the local source-control generation cancellation path after the user has explicitly canceled. Successful generation and remote execution paths are unchanged; the previous failure mode was a retained pending local request after cancellation.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/text-generation/commit-message-text-generation.test.ts -t "settles local commit-message cancellation"` left the local generation promise pending after cancel when the killed child emitted no `close`
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/text-generation/commit-message-text-generation.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/text-generation/commit-message-text-generation.ts src/main/text-generation/commit-message-text-generation.test.ts`