### PR TITLE
fix: time out daemon hello handshakes

### DIFF
--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -48,6 +48,8 @@ describe('DaemonClient', () => {
   })
 
   function startMockDaemon(opts?: {
+    closeOnConnect?: boolean
+    closeOnHello?: boolean
     onControlMessage?: (msg: unknown) => string | null
     onHello?: (msg: HelloMessage) => void
     onStreamHello?: (msg: HelloMessage) => void
@@ -56,6 +58,11 @@ describe('DaemonClient', () => {
   }): Promise<void> {
     return new Promise((resolve) => {
       server = createServer((socket) => {
+        if (opts?.closeOnConnect) {
+          socket.destroy()
+          return
+        }
+
         let buffer = ''
         socket.on('data', (chunk) => {
           buffer += chunk.toString()
@@ -72,6 +79,10 @@ describe('DaemonClient', () => {
             if (msg.type === 'hello') {
               const hello = msg as HelloMessage
               opts?.onHello?.(hello)
+              if (opts?.closeOnHello) {
+                socket.destroy()
+                return
+              }
               if (opts?.suppressHelloResponse) {
                 return
               }
@@ -163,6 +174,22 @@ describe('DaemonClient', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+
+    it('rejects when the daemon closes before hello completes', async () => {
+      await startMockDaemon({ closeOnHello: true })
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await expect(client.ensureConnected()).rejects.toThrow(
+        'Connection closed before hello response'
+      )
+    })
+
+    it('rejects when the daemon closes immediately after connect', async () => {
+      await startMockDaemon({ closeOnConnect: true })
+
+      client = new DaemonClient({ socketPath, tokenPath })
+      await expect(client.ensureConnected()).rejects.toThrow()
     })
   })
 

--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -49,8 +49,10 @@ describe('DaemonClient', () => {
 
   function startMockDaemon(opts?: {
     onControlMessage?: (msg: unknown) => string | null
+    onHello?: (msg: HelloMessage) => void
     onStreamHello?: (msg: HelloMessage) => void
     rejectVersion?: boolean
+    suppressHelloResponse?: boolean
   }): Promise<void> {
     return new Promise((resolve) => {
       server = createServer((socket) => {
@@ -69,6 +71,10 @@ describe('DaemonClient', () => {
 
             if (msg.type === 'hello') {
               const hello = msg as HelloMessage
+              opts?.onHello?.(hello)
+              if (opts?.suppressHelloResponse) {
+                return
+              }
               if (opts?.rejectVersion) {
                 socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Version mismatch' }))
                 return
@@ -129,6 +135,34 @@ describe('DaemonClient', () => {
 
       client = new DaemonClient({ socketPath, tokenPath })
       await expect(client.ensureConnected()).rejects.toThrow()
+    })
+
+    it('times out when the daemon never answers hello', async () => {
+      let resolveHello: () => void = () => {}
+      const helloReceived = new Promise<void>((resolve) => {
+        resolveHello = resolve
+      })
+      await startMockDaemon({
+        suppressHelloResponse: true,
+        onHello: resolveHello
+      })
+
+      vi.useFakeTimers()
+      try {
+        client = new DaemonClient({ socketPath, tokenPath })
+        const outcomePromise = client
+          .ensureConnected()
+          .then(() => 'connected')
+          .catch((error: Error) => error.message)
+
+        await helloReceived
+        await vi.advanceTimersByTimeAsync(5000)
+        const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+        expect(outcome).toBe('Hello response timed out')
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -214,6 +214,29 @@ export class DaemonClient {
       }
 
       let buffer = ''
+      let settled = false
+      let timer: ReturnType<typeof setTimeout> | null = null
+      const cleanup = (): void => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        socket.removeListener('data', onData)
+        socket.removeListener('error', onError)
+        socket.removeListener('close', onClose)
+      }
+      const finish = (error?: Error): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanup()
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve()
+      }
       const onData = (chunk: Buffer): void => {
         buffer += chunk.toString()
         const newlineIdx = buffer.indexOf('\n')
@@ -221,23 +244,33 @@ export class DaemonClient {
           return
         }
 
-        socket.removeListener('data', onData)
         const line = buffer.slice(0, newlineIdx)
         try {
           const response = JSON.parse(line) as HelloResponse
           if (response.ok) {
-            resolve()
+            finish()
           } else {
-            reject(
+            finish(
               new DaemonProtocolError(addNodePtyRecoveryHint(response.error ?? 'Hello rejected'))
             )
           }
         } catch {
-          reject(new DaemonProtocolError('Invalid hello response'))
+          finish(new DaemonProtocolError('Invalid hello response'))
         }
       }
+      const onError = (error: Error): void => finish(error)
+      const onClose = (): void =>
+        finish(new DaemonProtocolError('Connection closed before hello response'))
 
+      timer = setTimeout(() => {
+        // Why: a stale daemon can accept the socket but never answer hello;
+        // without a handshake timeout, startup waits forever on ensureConnected().
+        finish(new DaemonProtocolError('Hello response timed out'))
+        socket.destroy()
+      }, CONNECT_TIMEOUT_MS)
       socket.on('data', onData)
+      socket.on('error', onError)
+      socket.on('close', onClose)
       socket.write(encodeNdjson(hello))
     })
   }


### PR DESCRIPTION
## Summary
- add a timeout to daemon client hello handshakes after the socket connects
- reject if the daemon closes or errors before answering hello
- remove hello listeners on every settlement path

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/daemon/client.test.ts -t "times out when the daemon never answers hello"` left `ensureConnected()` pending when the daemon accepted the socket but never wrote a hello response
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/daemon/client.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/daemon/client.ts src/main/daemon/client.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.