### PR TITLE
fix: settle local rg search timeouts

### DIFF
--- a/src/main/ipc/filesystem-search-rg-timeout.test.ts
+++ b/src/main/ipc/filesystem-search-rg-timeout.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, resolveAuthorizedPathMock, checkRgAvailableMock, wslAwareSpawnMock } =
+  vi.hoisted(() => ({
+    handleMock: vi.fn(),
+    resolveAuthorizedPathMock: vi.fn(),
+    checkRgAvailableMock: vi.fn(),
+    wslAwareSpawnMock: vi.fn()
+  }))
+
+const handlers = new Map<string, (event: unknown, args: unknown) => Promise<unknown> | unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  },
+  shell: {
+    trashItem: vi.fn()
+  }
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: vi.fn(),
+  wslAwareSpawn: wslAwareSpawnMock
+}))
+
+vi.mock('../wsl', () => ({
+  parseWslPath: vi.fn(() => null),
+  toWindowsWslPath: vi.fn((value: string) => value)
+}))
+
+vi.mock('./filesystem-auth', () => ({
+  authorizeExternalPath: vi.fn(async (value: string) => value),
+  isENOENT: vi.fn(() => false),
+  resolveAuthorizedPath: resolveAuthorizedPathMock,
+  resolveRegisteredWorktreePath: vi.fn(async (value: string) => value),
+  validateGitRelativeFilePath: vi.fn((value: string) => value)
+}))
+
+vi.mock('./filesystem-list-files', () => ({
+  listQuickOpenFiles: vi.fn()
+}))
+
+vi.mock('./filesystem-mutations', () => ({
+  registerFilesystemMutationHandlers: vi.fn()
+}))
+
+vi.mock('./filesystem-search-git', () => ({
+  searchWithGitGrep: vi.fn()
+}))
+
+vi.mock('./markdown-documents', () => ({
+  listMarkdownDocuments: vi.fn(),
+  markdownDocumentsFromRelativePaths: vi.fn()
+}))
+
+vi.mock('./rg-availability', () => ({
+  checkRgAvailable: checkRgAvailableMock
+}))
+
+import { registerFilesystemHandlers } from './filesystem'
+
+function createMockProcess(): ChildProcess {
+  const p = new EventEmitter() as unknown as ChildProcess
+  ;(p as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(
+    (p as unknown as Record<string, unknown>).stdout as EventEmitter & {
+      setEncoding: () => void
+    }
+  ).setEncoding = vi.fn()
+  ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(p as unknown as Record<string, unknown>).kill = vi.fn()
+  return p
+}
+
+describe('filesystem rg search timeout', () => {
+  beforeEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+    handleMock.mockImplementation((channel, handler) => {
+      handlers.set(channel, handler)
+    })
+    resolveAuthorizedPathMock.mockImplementation(async (value: string) => value)
+    checkRgAvailableMock.mockResolvedValue(true)
+  })
+
+  it('settles and detaches when rg ignores the timeout kill', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const child = createMockProcess()
+      wslAwareSpawnMock.mockReturnValue(child)
+      registerFilesystemHandlers({} as never)
+
+      const promise = handlers.get('fs:search')!(
+        { sender: { id: 7 } },
+        { rootPath: '/repo', query: 'ok' }
+      ) as Promise<{ truncated: boolean }>
+
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      await vi.runOnlyPendingTimersAsync()
+
+      const result = await promise
+      expect(result.truncated).toBe(true)
+      expect(child.kill).toHaveBeenCalled()
+      expect((child.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect((child.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+      expect(child.listenerCount('error')).toBe(0)
+      expect(child.listenerCount('close')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -523,6 +523,7 @@ export function registerFilesystemHandlers(
         let stdoutBuffer = ''
         let resolved = false
         let child: ChildProcess | null = null
+        let killTimeout: ReturnType<typeof setTimeout>
 
         // Why: when rg runs inside WSL, output paths are Linux-native
         // (e.g. /home/user/repo/src/file.ts). Translate them back to
@@ -541,6 +542,12 @@ export function registerFilesystemHandlers(
             activeTextSearches.delete(searchKey)
           }
           clearTimeout(killTimeout)
+          // Why: child.kill() is advisory. If rg ignores it, detach our
+          // closures so repeated local searches do not retain old scans.
+          child?.stdout?.off('data', handleStdoutData)
+          child?.stderr?.off('data', handleStderrData)
+          child?.off('error', handleError)
+          child?.off('close', handleClose)
           resolvePromise(finalize(acc))
         }
 
@@ -558,35 +565,39 @@ export function registerFilesystemHandlers(
         child = nextChild
         activeTextSearches.set(searchKey, nextChild)
 
-        nextChild.stdout!.setEncoding('utf-8')
-        nextChild.stdout!.on('data', (chunk: string) => {
+        const handleStdoutData = (chunk: string): void => {
           stdoutBuffer += chunk
           const lines = stdoutBuffer.split('\n')
           stdoutBuffer = lines.pop() ?? ''
           for (const line of lines) {
             processLine(line)
           }
-        })
-        nextChild.stderr!.on('data', () => {
+        }
+        const handleStderrData = (): void => {
           // Drain stderr so rg cannot block on a full pipe.
-        })
-
-        nextChild.once('error', () => {
+        }
+        const handleError = (): void => {
           resolveOnce()
-        })
-
-        nextChild.once('close', () => {
+        }
+        const handleClose = (): void => {
           if (stdoutBuffer) {
             processLine(stdoutBuffer)
           }
           resolveOnce()
-        })
+        }
+
+        nextChild.stdout!.setEncoding('utf-8')
+        nextChild.stdout!.on('data', handleStdoutData)
+        nextChild.stderr!.on('data', handleStderrData)
+        nextChild.once('error', handleError)
+        nextChild.once('close', handleClose)
 
         // Why: if the timeout fires, the child is killed and results are partial.
         // We must mark them as truncated so the UI can indicate incomplete results.
-        const killTimeout = setTimeout(() => {
+        killTimeout = setTimeout(() => {
           acc.truncated = true
           child?.kill()
+          resolveOnce()
         }, SEARCH_TIMEOUT_MS)
       })
     }


### PR DESCRIPTION
## Summary
- settle local filesystem `rg` search immediately when the search timeout fires
- detach stdout/stderr/process listeners when the search settles so an rg process that ignores `kill()` cannot retain old scan closures
- add focused fake-timer coverage for a timed-out local rg child that never emits `close`

## Risk
Risk: Low (`risk:low`)

This only changes the local filesystem text-search path after the existing timeout has fired. Successful search behavior is unchanged; the previous failure mode was a retained pending search, and the new behavior returns the existing truncated result.

## Validation
- `pnpm exec oxlint src/main/ipc/filesystem.ts src/main/ipc/filesystem-search-rg-timeout.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem.ts src/main/ipc/filesystem-search-rg-timeout.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-search-rg-timeout.test.ts`
- `pnpm exec tsgo --noEmit -p config/tsconfig.node.json`
- `git diff --check`

Note: root `pnpm typecheck` still fails on existing missing renderer dependencies: `@tiptap/extension-details` and `react-colorful`.
