### PR TITLE
perf: scan large cleanup diff notes safely

### DIFF
--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -344,6 +344,33 @@ describe('workspace cleanup scan', () => {
     })
   })
 
+  it('summarizes large diff-note lists without hitting argument limits', async () => {
+    const diffComments = Array.from(
+      { length: 150_000 },
+      (_, index): DiffComment => ({
+        id: `comment-${index}`,
+        worktreeId: 'repo-1::/repo-feature',
+        filePath: 'src/file.ts',
+        lineNumber: 12,
+        body: 'Follow up before deleting',
+        createdAt: NOW - index,
+        side: 'modified'
+      })
+    )
+
+    const result = await scanWorkspaceCleanup(
+      makeStore({
+        baseRef: undefined,
+        diffComments
+      })
+    )
+
+    expect(result.candidates[0]?.localContext).toMatchObject({
+      diffCommentCount: 150_000,
+      newestDiffCommentAt: NOW
+    })
+  })
+
   it('does not expose PR cache state in inactivity cleanup results', async () => {
     const result = await scanWorkspaceCleanup(
       makeStore({

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -582,7 +582,16 @@ function getNewestDiffCommentAt(diffComments: Worktree['diffComments'] | undefin
   if (!diffComments || diffComments.length === 0) {
     return null
   }
-  return Math.max(...diffComments.map((comment) => comment.createdAt))
+  // Why: persisted diff notes can grow large enough for spread-based Math.max
+  // to exceed the JavaScript argument limit during cleanup scans.
+  let newest = diffComments[0]?.createdAt ?? null
+  for (let index = 1; index < diffComments.length; index += 1) {
+    const createdAt = diffComments[index]?.createdAt
+    if (createdAt !== undefined && (newest === null || createdAt > newest)) {
+      newest = createdAt
+    }
+  }
+  return newest
 }
 
 function createEmptyGitEvidence(): GitEvidence {


### PR DESCRIPTION
## Summary
- Replace the spread-based newest diff-note timestamp calculation in workspace cleanup with a single-pass scan
- Add a regression covering 150k persisted diff notes during cleanup scanning

## Validation
- pnpm exec oxlint src/main/ipc/workspace-cleanup.ts src/main/ipc/workspace-cleanup.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/workspace-cleanup.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low. This preserves cleanup result fields and only avoids a JavaScript argument-limit failure for very large diff-note lists.