### PR TITLE
fix: time out ssh channel opens

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -11,6 +11,7 @@ let connectBehavior: 'ready' | 'error' = 'ready'
 let connectErrorMessage = ''
 let destroyErrorMessage = ''
 let connectSequence: ('ready' | Error)[] = []
+let execBehavior: 'callback' | 'pending' = 'callback'
 
 type MockSshClient = {
   setNoDelay: ReturnType<typeof vi.fn>
@@ -83,6 +84,9 @@ vi.mock('ssh2', () => {
     }
     exec(cmd: string, cb: (err: Error | undefined, channel: unknown) => void) {
       this.lastExecCommand = cmd
+      if (execBehavior === 'pending') {
+        return
+      }
       cb(undefined, {})
     }
     sftp() {}
@@ -173,6 +177,7 @@ describe('SshConnection', () => {
     connectErrorMessage = ''
     destroyErrorMessage = ''
     connectSequence = []
+    execBehavior = 'callback'
     clientInstances = []
     spawnSystemSshCommandMock.mockReset()
     spawnSystemSshCommandMock.mockImplementation(() => createSystemCommandChannel())
@@ -542,6 +547,27 @@ describe('SshConnection', () => {
     expect(clientInstances[0].lastExecCommand).toBe(
       "exec /bin/sh -c 'cd '\\''/tmp'\\'' && ('\\''/usr/bin/node'\\'' -e '\\''console.log(1)'\\'' || echo MISSING)'"
     )
+  })
+
+  it('times out when ssh2 never opens an exec channel', async () => {
+    const conn = new SshConnection(createTarget(), createCallbacks())
+    await conn.connect()
+    execBehavior = 'pending'
+
+    vi.useFakeTimers()
+    try {
+      const outcomePromise = conn
+        .exec('printf ready')
+        .then(() => 'opened')
+        .catch((error: Error) => error.message)
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toBe('SSH exec channel timed out')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses system SSH transport when ProxyUseFdpass is resolved by OpenSSH', async () => {

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -12,6 +12,8 @@ let connectErrorMessage = ''
 let destroyErrorMessage = ''
 let connectSequence: ('ready' | Error)[] = []
 let execBehavior: 'callback' | 'pending' = 'callback'
+let pendingExecCallback: ((err: Error | undefined, channel: unknown) => void) | null = null
+let sftpBehavior: 'callback' | 'pending' = 'callback'
 
 type MockSshClient = {
   setNoDelay: ReturnType<typeof vi.fn>
@@ -85,11 +87,17 @@ vi.mock('ssh2', () => {
     exec(cmd: string, cb: (err: Error | undefined, channel: unknown) => void) {
       this.lastExecCommand = cmd
       if (execBehavior === 'pending') {
+        pendingExecCallback = cb
         return
       }
       cb(undefined, {})
     }
-    sftp() {}
+    sftp(cb: (err: Error | undefined, channel: unknown) => void) {
+      if (sftpBehavior === 'pending') {
+        return
+      }
+      cb(undefined, {})
+    }
   }
   return {
     BaseAgent: MockBaseAgent,
@@ -178,6 +186,8 @@ describe('SshConnection', () => {
     destroyErrorMessage = ''
     connectSequence = []
     execBehavior = 'callback'
+    pendingExecCallback = null
+    sftpBehavior = 'callback'
     clientInstances = []
     spawnSystemSshCommandMock.mockReset()
     spawnSystemSshCommandMock.mockImplementation(() => createSystemCommandChannel())
@@ -565,6 +575,48 @@ describe('SshConnection', () => {
       const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
 
       expect(outcome).toBe('SSH exec channel timed out')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a late exec callback after the channel-open timeout settles', async () => {
+    const conn = new SshConnection(createTarget(), createCallbacks())
+    await conn.connect()
+    execBehavior = 'pending'
+
+    vi.useFakeTimers()
+    try {
+      const outcomePromise = conn
+        .exec('printf ready')
+        .then(() => 'opened')
+        .catch((error: Error) => error.message)
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      pendingExecCallback?.(undefined, {})
+
+      await expect(outcomePromise).resolves.toBe('SSH exec channel timed out')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('times out when ssh2 never opens an SFTP channel', async () => {
+    const conn = new SshConnection(createTarget(), createCallbacks())
+    await conn.connect()
+    sftpBehavior = 'pending'
+
+    vi.useFakeTimers()
+    try {
+      const outcomePromise = conn
+        .sftp()
+        .then(() => 'opened')
+        .catch((error: Error) => error.message)
+
+      await vi.advanceTimersByTimeAsync(30_000)
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toBe('SSH SFTP channel timed out')
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -94,8 +94,9 @@ export class SshConnection {
     if (!this.client) {
       throw new Error('Not connected')
     }
-    return new Promise((res, rej) =>
-      this.client!.exec(wrapRemoteCommandForPosixShell(cmd), (e, ch) => (e ? rej(e) : res(ch)))
+    const client = this.client
+    return this.waitForSshCallback('SSH exec channel timed out', (callback) =>
+      client.exec(wrapRemoteCommandForPosixShell(cmd), callback)
     )
   }
 
@@ -106,7 +107,43 @@ export class SshConnection {
     if (!this.client) {
       throw new Error('Not connected')
     }
-    return new Promise((res, rej) => this.client!.sftp((e, s) => (e ? rej(e) : res(s))))
+    const client = this.client
+    return this.waitForSshCallback('SSH SFTP channel timed out', (callback) =>
+      client.sftp(callback)
+    )
+  }
+
+  private waitForSshCallback<T>(
+    timeoutMessage: string,
+    register: (callback: (error: Error | undefined, value: T) => void) => void
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      let settled = false
+      const timer = setTimeout(() => {
+        settled = true
+        reject(new Error(timeoutMessage))
+      }, CONNECT_TIMEOUT_MS)
+      const finish = (error: Error | undefined, value?: T): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        clearTimeout(timer)
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(value as T)
+      }
+
+      try {
+        // Why: higher-level channel timers start only after ssh2 invokes its
+        // open callback. A stale SSH socket can otherwise keep exec/sftp stuck.
+        register(finish)
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
   }
 
   async uploadDirectory(localDir: string, remoteDir: string): Promise<void> {


### PR DESCRIPTION
## Summary
- add a timeout around ssh2 exec/sftp channel-open callbacks
- keep remote operations from hanging before their higher-level channel timers can start
- ignore late channel callbacks after the timeout has settled the request

## Risk
Risk: Medium (`risk:medium`)

This changes core SSH exec/SFTP channel-open behavior. The change is timeout-scoped and covered by a regression test, but SSH transport behavior is broad enough that it should get another focused pass before merge.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts -t "times out when ssh2 never opens an exec channel"` left `SshConnection.exec()` pending when ssh2 never invoked the exec callback
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/ssh/ssh-connection.ts src/main/ssh/ssh-connection.test.ts`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.


Risk: medium

Historic risk metadata backfill based on the existing `risk:medium` label.