### PR TITLE
fix: abort orchestration ask waits on disconnect

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -949,6 +949,38 @@ describe('orchestration RPC methods', () => {
       expect(outbound).toBeTruthy()
     })
 
+    it('returns promptly when the RPC signal aborts while waiting', async () => {
+      setup()
+      vi.useFakeTimers()
+      const controller = new AbortController()
+      const method = findMethod('orchestration.ask')
+      const parsed = method.params!.parse({
+        from: 'term_worker',
+        to: 'term_coord',
+        question: 'still there?',
+        timeoutMs: 60_000
+      })
+
+      try {
+        const promise = method.handler(parsed, {
+          runtime,
+          signal: controller.signal
+        }) as Promise<{ timedOut: boolean }>
+
+        controller.abort()
+        const outcomePromise = Promise.race([
+          promise.then((result) => (result.timedOut ? 'aborted' : 'answered')),
+          new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 0))
+        ])
+        await vi.advanceTimersByTimeAsync(0)
+        const outcome = await outcomePromise
+
+        expect(outcome).toBe('aborted')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('rejects group addresses with a dedicated error (no message persisted)', async () => {
       setup()
       await expect(

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -511,7 +511,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.ask',
     params: AskParams,
-    handler: async (params, { runtime }) => {
+    handler: async (params, { runtime, signal }) => {
       // Why: group addresses have no unambiguous answer semantics (whose
       // reply wins? first? consensus?) and the ~60-LOC scope is not the
       // place to design that. Rejecting here closes the silent-timeout
@@ -566,11 +566,16 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             timedOut: false
           }
         }
+        if (signal?.aborted) {
+          return { answer: null, messageId: null, threadId, timedOut: true }
+        }
         const remainingMs = deadline - Date.now()
         if (remainingMs <= 0) {
           return { answer: null, messageId: null, threadId, timedOut: true }
         }
-        await runtime.waitForMessage(from, { timeoutMs: remainingMs })
+        // Why: if the asking client disconnects, release the waiter immediately
+        // while leaving the already-sent decision gate visible to the recipient.
+        await runtime.waitForMessage(from, { timeoutMs: remainingMs, signal })
       }
     }
   }),


### PR DESCRIPTION
## Summary
- pass the RPC abort signal into `orchestration.ask` wait loops
- return promptly when the asking client disconnects instead of keeping the waiter alive until timeout
- keep the already-sent decision gate visible to the recipient while releasing server-side resources

## Risk
Risk level: LOW

The change is limited to the disconnect/abort path for an existing wait loop. Normal answer delivery and persisted decision-gate visibility are unchanged, and the regression covers the waiter release behavior.

## Evidence
- Failing before fix: `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration.test.ts -t "returns promptly when the RPC signal aborts while waiting"` returned `pending` after abort because `orchestration.ask` did not pass the RPC signal to `waitForMessage`
- Passing after fix: `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/orchestration.test.ts`
- Passing after fix: `pnpm typecheck:node`
- Passing after fix: `pnpm oxlint src/main/runtime/rpc/methods/orchestration.ts src/main/runtime/rpc/methods/orchestration.test.ts`
