### PR TITLE
fix: clean up codex rate limit rpc listeners

### DIFF
--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -127,6 +127,28 @@ describe('fetchCodexRateLimits', () => {
     expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
+  it('removes RPC listeners when the app-server timeout settles', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      status: 'error',
+      error: 'RPC timeout'
+    })
+    expect(rpcChild.kill).toHaveBeenCalledTimes(1)
+    expect(rpcChild.stdout.listenerCount('data')).toBe(0)
+    expect(rpcChild.stderr.listenerCount('data')).toBe(0)
+    expect(rpcChild.listenerCount('error')).toBe(0)
+    expect(rpcChild.listenerCount('close')).toBe(0)
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
   it('normalizes Codex RPC remaining-minute windows to fixed display durations', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -160,19 +160,43 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
     })
 
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    function cleanupListeners(): void {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      child.stdout.off('data', onStdoutData)
+      child.stderr.off('data', onStderrData)
+      child.off('error', onError)
+      child.off('close', onClose)
+    }
+
+    function settle(result: ProviderRateLimits, options?: { kill?: boolean }): void {
+      if (resolved) {
+        return
+      }
+      resolved = true
+      cleanupListeners()
+      if (options?.kill) {
         child.kill()
-        resolve({
+      }
+      resolve(result)
+    }
+
+    timeout = setTimeout(() => {
+      settle(
+        {
           provider: 'codex',
           session: null,
           weekly: null,
           updatedAt: Date.now(),
           error: 'RPC timeout',
           status: 'error'
-        })
-      }
+        },
+        { kill: true }
+      )
     }, rpcTimeoutMs)
 
     function sendRpc(method: string, params?: unknown): number {
@@ -196,7 +220,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params: {} })}\n`)
     }
 
-    child.stdout.on('data', (chunk: Buffer) => {
+    function onStdoutData(chunk: Buffer): void {
       buffer += chunk.toString()
 
       // JSON-RPC messages are newline-delimited
@@ -228,19 +252,19 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
             if (resolved) {
               return
             }
-            resolved = true
-            clearTimeout(timeout)
-            child.kill()
 
             if (msg.error) {
-              resolve({
-                provider: 'codex',
-                session: null,
-                weekly: null,
-                updatedAt: Date.now(),
-                error: withMacTailscaleDnsHint(msg.error.message, stderr),
-                status: 'error'
-              })
+              settle(
+                {
+                  provider: 'codex',
+                  session: null,
+                  weekly: null,
+                  updatedAt: Date.now(),
+                  error: withMacTailscaleDnsHint(msg.error.message, stderr),
+                  status: 'error'
+                },
+                { kill: true }
+              )
               return
             }
 
@@ -249,64 +273,64 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
             const session = mapRpcWindow(result?.primary, 300)
             const weekly = mapRpcWindow(result?.secondary, 10080)
 
-            resolve({
-              provider: 'codex',
-              session,
-              weekly,
-              updatedAt: Date.now(),
-              error: null,
-              status: 'ok'
-            })
+            settle(
+              {
+                provider: 'codex',
+                session,
+                weekly,
+                updatedAt: Date.now(),
+                error: null,
+                status: 'ok'
+              },
+              { kill: true }
+            )
           }
         } catch {
           // Non-JSON line from the RPC server — ignore
         }
       }
-    })
+    }
 
-    child.stderr.on('data', (chunk: Buffer) => {
+    function onStderrData(chunk: Buffer): void {
       stderr += chunk.toString()
       // Why: this background poll only needs recent failure context for hints.
       if (stderr.length > MAX_DIAGNOSTIC_OUTPUT_LENGTH) {
         stderr = stderr.slice(-MAX_DIAGNOSTIC_OUTPUT_LENGTH)
       }
-    })
+    }
 
-    child.on('error', (err) => {
-      if (!resolved) {
-        resolved = true
-        clearTimeout(timeout)
-        const isEnoent = (err as NodeJS.ErrnoException).code === 'ENOENT'
-        const isBareCommand = codexCommand === 'codex'
-        resolve({
-          provider: 'codex',
-          session: null,
-          weekly: null,
-          updatedAt: Date.now(),
-          error: isEnoent
-            ? isBareCommand
-              ? 'Codex CLI not found'
-              : 'Codex CLI found but could not run — Node.js may not be in your PATH'
-            : withMacTailscaleDnsHint(err.message, stderr),
-          status: isEnoent && isBareCommand ? 'unavailable' : 'error'
-        })
-      }
-    })
+    function onError(err: Error): void {
+      const isEnoent = (err as NodeJS.ErrnoException).code === 'ENOENT'
+      const isBareCommand = codexCommand === 'codex'
+      settle({
+        provider: 'codex',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: isEnoent
+          ? isBareCommand
+            ? 'Codex CLI not found'
+            : 'Codex CLI found but could not run — Node.js may not be in your PATH'
+          : withMacTailscaleDnsHint(err.message, stderr),
+        status: isEnoent && isBareCommand ? 'unavailable' : 'error'
+      })
+    }
 
-    child.on('close', () => {
-      if (!resolved) {
-        resolved = true
-        clearTimeout(timeout)
-        resolve({
-          provider: 'codex',
-          session: null,
-          weekly: null,
-          updatedAt: Date.now(),
-          error: withMacTailscaleDnsHint('RPC process exited unexpectedly', stderr),
-          status: 'error'
-        })
-      }
-    })
+    function onClose(): void {
+      settle({
+        provider: 'codex',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: withMacTailscaleDnsHint('RPC process exited unexpectedly', stderr),
+        status: 'error'
+      })
+    }
+
+    child.stdout.on('data', onStdoutData)
+    child.stderr.on('data', onStderrData)
+    child.on('error', onError)
+    child.on('close', onClose)
   })
 }
 


### PR DESCRIPTION
## Summary
- route Codex rate-limit RPC timeout, success, error, and close through a shared settle path
- detach stdout/stderr/process listeners once the RPC child has settled
- add a timeout regression with PTY fallback disabled

## Risk
Risk level: LOW

This only changes cleanup after the Codex rate-limit RPC subprocess has already produced a terminal result or timed out. User-visible rate-limit parsing and PTY fallback behavior are preserved.

## Validation
- pnpm vitest run src/main/rate-limits/codex-fetcher.test.ts src/main/rate-limits/codex-fetcher-auth-errors.test.ts
- pnpm exec oxlint src/main/rate-limits/codex-fetcher.ts src/main/rate-limits/codex-fetcher.test.ts
- pnpm typecheck:node
- git diff --check