### PR TITLE
fix: settle runtime file search timeouts

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -2,9 +2,11 @@
    authorization, and watcher lifecycle fixtures; splitting would duplicate the
    setup that makes cross-command filesystem behavior comparable. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
 import type * as Fs from 'fs'
 import type * as FsPromises from 'fs/promises'
 import type * as FilesystemAuth from '../ipc/filesystem-auth'
+import type * as GitRunner from '../git/runner'
 
 const {
   lstatMock,
@@ -13,14 +15,18 @@ const {
   resolveAuthorizedPathMock,
   statMock,
   subscribeParcelWatcherMock,
+  checkRgAvailableMock,
+  wslAwareSpawnMock,
   watchMock
 } = vi.hoisted(() => ({
+  checkRgAvailableMock: vi.fn(),
   lstatMock: vi.fn(),
   readdirMock: vi.fn(),
   renameMock: vi.fn(),
   resolveAuthorizedPathMock: vi.fn(),
   statMock: vi.fn(),
   subscribeParcelWatcherMock: vi.fn(),
+  wslAwareSpawnMock: vi.fn(),
   watchMock: vi.fn()
 }))
 
@@ -55,6 +61,18 @@ vi.mock('../ipc/filesystem-auth', async () => {
   }
 })
 
+vi.mock('../git/runner', async () => {
+  const actual = await vi.importActual<typeof GitRunner>('../git/runner')
+  return {
+    ...actual,
+    wslAwareSpawn: wslAwareSpawnMock
+  }
+})
+
+vi.mock('../ipc/rg-availability', () => ({
+  checkRgAvailable: checkRgAvailableMock
+}))
+
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   getSshFilesystemProvider: vi.fn(),
   SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE:
@@ -63,6 +81,13 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 
 import { awaitRuntimeFileWatcherUnsubscribes, RuntimeFileCommands } from './orca-runtime-files'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import { SEARCH_TIMEOUT_MS } from '../../shared/text-search'
+
+type MockRuntimeSearchChild = EventEmitter & {
+  stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+  stderr: EventEmitter
+  kill: ReturnType<typeof vi.fn>
+}
 
 function enoent(): Error {
   return Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
@@ -94,6 +119,7 @@ function mockLocalPathStats(entries: Record<string, [number, number]>) {
 function createRuntimeFileCommands(options?: {
   path?: string
   openDiff?: ReturnType<typeof vi.fn>
+  resolveRuntimeGitTarget?: ReturnType<typeof vi.fn>
 }) {
   const store = {
     getRepo: vi.fn((_repoId?: string) => undefined as { connectionId?: string } | undefined)
@@ -107,11 +133,20 @@ function createRuntimeFileCommands(options?: {
       repoId: 'repo-1',
       path
     })),
-    resolveRuntimeGitTarget: vi.fn(),
+    resolveRuntimeGitTarget: options?.resolveRuntimeGitTarget ?? vi.fn(),
     openFile: vi.fn(),
     ...(options?.openDiff ? { openDiff: options.openDiff } : {})
   } as never)
   return { commands, store }
+}
+
+function createRuntimeSearchChild(): MockRuntimeSearchChild {
+  const child = new EventEmitter() as MockRuntimeSearchChild
+  child.stdout = new EventEmitter() as MockRuntimeSearchChild['stdout']
+  child.stdout.setEncoding = vi.fn()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
 }
 
 describe('RuntimeFileCommands', () => {
@@ -126,6 +161,8 @@ describe('RuntimeFileCommands', () => {
     statMock.mockReset()
     subscribeParcelWatcherMock.mockReset()
     watchMock.mockReset()
+    checkRgAvailableMock.mockReset()
+    wslAwareSpawnMock.mockReset()
     readdirMock.mockResolvedValue([])
     lstatMock.mockRejectedValue(enoent())
     renameMock.mockResolvedValue(undefined)
@@ -328,5 +365,38 @@ describe('RuntimeFileCommands', () => {
     resolveUnsubscribe()
     await drainPromise
     expect(drained).toBe(true)
+  })
+
+  it('settles and detaches runtime rg searches when timeout kill is ignored', async () => {
+    const resolveRuntimeGitTarget = vi.fn(async () => ({
+      worktree: {
+        id: 'wt-1',
+        repoId: 'repo-1',
+        path: '/repo'
+      },
+      connectionId: null
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeGitTarget })
+    const child = createRuntimeSearchChild()
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    checkRgAvailableMock.mockResolvedValue(true)
+    wslAwareSpawnMock.mockReturnValue(child)
+
+    const resultPromise = commands.searchRuntimeFiles('id:wt-1', {
+      query: 'needle',
+      maxResults: 10
+    })
+    await vi.advanceTimersByTimeAsync(SEARCH_TIMEOUT_MS)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      files: [],
+      totalMatches: 0,
+      truncated: true
+    })
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.stdout.listenerCount('data')).toBe(0)
+    expect(child.stderr.listenerCount('data')).toBe(0)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
   })
 })

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -717,8 +717,20 @@ export class RuntimeFileCommands {
         if (this.activeRuntimeTextSearches.get(searchKey) === child) {
           this.activeRuntimeTextSearches.delete(searchKey)
         }
-        clearTimeout(killTimeout)
+        cleanupListeners()
         resolvePromise(finalize(acc))
+      }
+
+      let killTimeout: ReturnType<typeof setTimeout> | null = null
+      const cleanupListeners = (): void => {
+        if (killTimeout) {
+          clearTimeout(killTimeout)
+          killTimeout = null
+        }
+        child?.stdout?.off('data', onStdoutData)
+        child?.stderr?.off('data', onStderrData)
+        child?.off('error', onError)
+        child?.off('close', onClose)
       }
 
       const processLine = (line: string): void => {
@@ -742,28 +754,34 @@ export class RuntimeFileCommands {
       this.activeRuntimeTextSearches.set(searchKey, nextChild)
 
       nextChild.stdout!.setEncoding('utf-8')
-      nextChild.stdout!.on('data', (chunk: string) => {
+      const onStdoutData = (chunk: string): void => {
         stdoutBuffer += chunk
         const lines = stdoutBuffer.split('\n')
         stdoutBuffer = lines.pop() ?? ''
         for (const line of lines) {
           processLine(line)
         }
-      })
-      nextChild.stderr!.on('data', () => {
+      }
+      const onStderrData = (): void => {
         // Drain stderr so rg cannot block on a full pipe.
-      })
-      nextChild.once('error', () => resolveOnce())
-      nextChild.once('close', () => {
+      }
+      const onError = (): void => resolveOnce()
+      const onClose = (): void => {
         if (stdoutBuffer) {
           processLine(stdoutBuffer)
         }
         resolveOnce()
-      })
+      }
 
-      const killTimeout = setTimeout(() => {
+      nextChild.stdout!.on('data', onStdoutData)
+      nextChild.stderr!.on('data', onStderrData)
+      nextChild.once('error', onError)
+      nextChild.once('close', onClose)
+
+      killTimeout = setTimeout(() => {
         acc.truncated = true
         child?.kill()
+        resolveOnce()
       }, SEARCH_TIMEOUT_MS)
     })
   }


### PR DESCRIPTION
## Summary
- make local runtime `rg` searches resolve immediately when their timeout fires
- detach stdout/stderr/process listeners during runtime search cleanup
- add a regression for an ignored timeout kill

## Risk
Risk level: LOW

The change is limited to local runtime file-search timeout cleanup. Normal search parsing and SSH provider searches are unchanged.

## Validation
- pnpm vitest run src/main/runtime/orca-runtime-files.test.ts
- pnpm exec oxlint src/main/runtime/orca-runtime-files.ts src/main/runtime/orca-runtime-files.test.ts
- pnpm typecheck:node
- git diff --check