### PR TITLE
fix: settle model discovery timeouts

### DIFF
--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -3,6 +3,7 @@
    cross-path invariants these tests protect. */
 import { spawn } from 'child_process'
 import type * as ChildProcess from 'child_process'
+import { EventEmitter } from 'events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../shared/constants'
 import { sourceControlAiSettingsFromLegacy } from '../../shared/source-control-ai'
@@ -28,6 +29,24 @@ vi.mock('child_process', async (importOriginal) => {
 })
 
 const spawnMock = vi.mocked(spawn)
+
+type MockDiscoveryChild = EventEmitter & {
+  pid: number
+  kill: ReturnType<typeof vi.fn>
+  stdout: EventEmitter
+  stderr: EventEmitter
+  stdin: { end: ReturnType<typeof vi.fn> }
+}
+
+function createMockDiscoveryChild(): MockDiscoveryChild {
+  const child = new EventEmitter() as MockDiscoveryChild
+  child.pid = 123
+  child.kill = vi.fn()
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = { end: vi.fn() }
+  return child
+}
 
 function syncSourceControlAiFromLegacy(settings: GlobalSettings): void {
   settings.sourceControlAi = sourceControlAiSettingsFromLegacy(settings.commitMessageAi)
@@ -391,6 +410,50 @@ describe('discoverCommitMessageModelsLocal', () => {
       defaultModelId: 'github-copilot/gpt-5.4-mini',
       models: [{ id: 'github-copilot/gpt-5.4-mini' }, { id: 'openai-codex/gpt-5.5' }]
     })
+  })
+
+  it('settles and detaches model discovery when timeout kill is ignored', async () => {
+    vi.useFakeTimers()
+    const child = createMockDiscoveryChild()
+    spawnMock.mockReturnValue(child as never)
+
+    try {
+      const pending = discoverCommitMessageModelsLocal('cursor', undefined)
+      const assertion = expect(pending).resolves.toMatchObject({
+        success: false,
+        error: 'Cursor model discovery timed out after 60s.'
+      })
+
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await assertion
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+      expect(child.stdout.listenerCount('data')).toBe(0)
+      expect(child.stderr.listenerCount('data')).toBe(0)
+      expect(child.listenerCount('error')).toBe(0)
+      expect(child.listenerCount('close')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('settles and detaches model discovery when output exceeds the limit', async () => {
+    const child = createMockDiscoveryChild()
+    spawnMock.mockReturnValue(child as never)
+
+    const pending = discoverCommitMessageModelsLocal('cursor', undefined)
+
+    child.stdout.emit('data', Buffer.alloc(4 * 1024 * 1024 + 1))
+
+    await expect(pending).resolves.toMatchObject({
+      success: false,
+      error: 'Cursor returned too much model data.'
+    })
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(child.stdout.listenerCount('data')).toBe(0)
+    expect(child.stderr.listenerCount('data')).toBe(0)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
   })
 })
 

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -293,14 +293,21 @@ export async function discoverCommitMessageModelsLocal(
     let stderr = ''
     let outputLimitExceeded = false
     let settled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let detachChildListeners = (): void => {}
     const finish = (result: DiscoverCommitMessageModelsResult): void => {
       if (settled) {
         return
       }
       settled = true
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      detachChildListeners()
       resolve(result)
     }
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       killProcessTree(child)
       finish({
         success: false,
@@ -312,15 +319,15 @@ export async function discoverCommitMessageModelsLocal(
       if (stdout.length + stderr.length + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
         killProcessTree(child)
+        finish({ success: false, error: `${spec.label} returned too much model data.` })
         return
       }
       append(chunk.toString('utf-8'))
     }
 
-    child.stdout?.on('data', (chunk: Buffer) => onData(chunk, (text) => (stdout += text)))
-    child.stderr?.on('data', (chunk: Buffer) => onData(chunk, (text) => (stderr += text)))
-    child.on('error', (error) => {
-      clearTimeout(timer)
+    const onStdoutData = (chunk: Buffer): void => onData(chunk, (text) => (stdout += text))
+    const onStderrData = (chunk: Buffer): void => onData(chunk, (text) => (stderr += text))
+    const onError = (error: Error): void => {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         finish({
           success: false,
@@ -332,9 +339,8 @@ export async function discoverCommitMessageModelsLocal(
         success: false,
         error: `${spec.label} model discovery failed to start. Check the agent CLI configuration and try again.`
       })
-    })
-    child.on('close', (code) => {
-      clearTimeout(timer)
+    }
+    const onClose = (code: number | null): void => {
       if (outputLimitExceeded) {
         finish({ success: false, error: `${spec.label} returned too much model data.` })
         return
@@ -344,7 +350,18 @@ export async function discoverCommitMessageModelsLocal(
         return
       }
       finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
-    })
+    }
+
+    child.stdout?.on('data', onStdoutData)
+    child.stderr?.on('data', onStderrData)
+    child.on('error', onError)
+    child.on('close', onClose)
+    detachChildListeners = () => {
+      child.stdout?.off?.('data', onStdoutData)
+      child.stderr?.off?.('data', onStderrData)
+      child.off?.('error', onError)
+      child.off?.('close', onClose)
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- make local dynamic model discovery settle immediately on timeout
- make output-limit failures settle immediately after killing the discovery child
- detach model discovery stdout/stderr/process listeners on every finish path

## Risk
Risk level: LOW

The change is limited to local dynamic model-discovery timeout and output-limit cleanup. Successful model parsing and remote discovery are unchanged.

## Validation
- pnpm vitest run src/main/text-generation/commit-message-text-generation.test.ts
- pnpm exec oxlint src/main/text-generation/commit-message-text-generation.ts src/main/text-generation/commit-message-text-generation.test.ts
- pnpm typecheck:node
- git diff --check