### PR TITLE
Fix concurrent browser tab registration waits

### DIFF
--- a/src/main/ipc/browser.test.ts
+++ b/src/main/ipc/browser.test.ts
@@ -57,7 +57,11 @@ vi.mock('../browser/browser-manager', () => ({
   }
 }))
 
-import { registerBrowserHandlers, setAgentBrowserBridgeRef } from './browser'
+import {
+  registerBrowserHandlers,
+  setAgentBrowserBridgeRef,
+  waitForTabRegistration
+} from './browser'
 
 describe('registerBrowserHandlers', () => {
   beforeEach(() => {
@@ -163,6 +167,56 @@ describe('registerBrowserHandlers', () => {
 
     expect(result).toBe(true)
     expect(onTabChangedMock).toHaveBeenCalledWith(4242, 'wt-browser')
+  })
+
+  it('resolves concurrent tab registration waiters for the same page', async () => {
+    vi.useFakeTimers()
+    try {
+      getGuestWebContentsIdMock.mockReturnValue(null)
+      const first = waitForTabRegistration('page-1', 1000)
+      const second = waitForTabRegistration('page-1', 1000)
+      const settled = Promise.allSettled([first, second])
+
+      registerBrowserHandlers()
+
+      const registerHandler = handleMock.mock.calls.find(
+        ([channel]) => channel === 'browser:registerGuest'
+      )?.[1] as (
+        event: { sender: Electron.WebContents },
+        args: {
+          browserPageId: string
+          workspaceId: string
+          worktreeId: string
+          webContentsId: number
+        }
+      ) => boolean
+
+      const result = registerHandler(
+        {
+          sender: {
+            id: 91,
+            isDestroyed: () => false,
+            getType: () => 'window',
+            getURL: () => 'file:///renderer/index.html'
+          } as Electron.WebContents
+        },
+        {
+          browserPageId: 'page-1',
+          workspaceId: 'workspace-1',
+          worktreeId: 'worktree-1',
+          webContentsId: 123
+        }
+      )
+
+      expect(result).toBe(true)
+      await vi.advanceTimersByTimeAsync(1001)
+      expect(await settled).toEqual([
+        { status: 'fulfilled', value: undefined },
+        { status: 'fulfilled', value: undefined }
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('validates annotation viewport bridge requests before syncing to the guest', async () => {

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -39,22 +39,32 @@ let agentBrowserBridgeRef: AgentBrowserBridge | null = null
 
 // Why: CLI-driven tab creation must wait until the renderer mounts the webview
 // and calls registerGuest, so the tab has a webContentsId and is operable by
-// subsequent commands. This map holds one-shot resolvers keyed by browserPageId.
-const pendingTabRegistrations = new Map<string, () => void>()
+// subsequent commands. Multiple commands can wait for the same page during
+// startup, so keep all one-shot resolvers keyed by browserPageId.
+const pendingTabRegistrations = new Map<string, Set<() => void>>()
 
 export function waitForTabRegistration(browserPageId: string, timeoutMs = 8_000): Promise<void> {
   if (browserManager.getGuestWebContentsId(browserPageId) !== null) {
     return Promise.resolve()
   }
   return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      pendingTabRegistrations.delete(browserPageId)
-      reject(new Error('Tab registration timed out'))
-    }, timeoutMs)
-    pendingTabRegistrations.set(browserPageId, () => {
+    let registrationResolvers = pendingTabRegistrations.get(browserPageId)
+    if (!registrationResolvers) {
+      registrationResolvers = new Set()
+      pendingTabRegistrations.set(browserPageId, registrationResolvers)
+    }
+    const resolveRegistration = (): void => {
       clearTimeout(timer)
       resolve()
-    })
+    }
+    const timer = setTimeout(() => {
+      registrationResolvers.delete(resolveRegistration)
+      if (registrationResolvers.size === 0) {
+        pendingTabRegistrations.delete(browserPageId)
+      }
+      reject(new Error('Tab registration timed out'))
+    }, timeoutMs)
+    registrationResolvers.add(resolveRegistration)
   })
 }
 
@@ -128,10 +138,12 @@ export function registerBrowserHandlers(): void {
       if (agentBrowserBridgeRef && previousWcId !== null && previousWcId !== args.webContentsId) {
         agentBrowserBridgeRef.onProcessSwap(args.browserPageId, args.webContentsId, previousWcId)
       }
-      const pendingResolve = pendingTabRegistrations.get(args.browserPageId)
-      if (pendingResolve) {
+      const pendingResolves = pendingTabRegistrations.get(args.browserPageId)
+      if (pendingResolves) {
         pendingTabRegistrations.delete(args.browserPageId)
-        pendingResolve()
+        for (const pendingResolve of pendingResolves) {
+          pendingResolve()
+        }
       }
       return true
     }


### PR DESCRIPTION
## Summary
- keep all pending `waitForTabRegistration()` resolvers for a browser page instead of overwriting the first waiter
- clean up each waiter on timeout while preserving later waiters for the same page
- add browser IPC coverage for concurrent waiters resolving from one renderer `browser:registerGuest` call

## Risk
Risk level: LOW

The change is limited to pending registration wait bookkeeping for one browser page, with focused coverage for the concurrent waiter case and unchanged already-registered behavior.

## Failing-before evidence
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/browser.test.ts -t "resolves concurrent tab registration waiters"` failed before the fix: the first waiter rejected with `Tab registration timed out` while the second waiter fulfilled.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/browser.test.ts -t "resolves concurrent tab registration waiters"`
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/browser.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/ipc/browser.ts src/main/ipc/browser.test.ts`
- `git diff --check`
