### PR TITLE
Reject invalid browser check state

### DIFF
--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -195,7 +195,7 @@ export const Check = BrowserTarget.extend({
   checked: z
     .unknown()
     .optional()
-    .transform((v) => v !== false)
+    .transform((v) => (v === undefined ? true : v))
     .pipe(z.boolean())
 })
 

--- a/src/main/runtime/rpc/methods/browser.test.ts
+++ b/src/main/runtime/rpc/methods/browser.test.ts
@@ -213,4 +213,26 @@ describe('browser RPC methods', () => {
       value: 'enabled'
     })
   })
+
+  it('rejects non-boolean browser check states instead of coercing them to true', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      browserCheck: vi.fn().mockResolvedValue({ ok: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: BROWSER_CORE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('browser.check', {
+        page: 'page-1',
+        element: 'ref-1',
+        checked: 'false'
+      })
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_argument' }
+    })
+    expect(runtime.browserCheck).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- keep omitted `browser.check.checked` defaulting to `true`
- reject present non-boolean `checked` values instead of coercing them to `true`
- add dispatcher coverage for a malformed string payload

## Risk
Risk level: LOW

The change is limited to RPC schema validation for `browser.check.checked`, preserving the omitted-value default and adding direct malformed-payload coverage.

## Failing-before evidence
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/browser.test.ts -t "rejects non-boolean browser check states"` failed before the fix because `{ checked: "false" }` produced an `ok: true` response and called `runtime.browserCheck`.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/browser.test.ts -t "rejects non-boolean browser check states"`
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/browser.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/runtime/rpc/methods/browser-schemas.ts src/main/runtime/rpc/methods/browser.test.ts`
- `git diff --check`
