### PR TITLE
fix: clean up shell path timeout listeners

### DIFF
--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import type { ChildProcessWithoutNullStreams } from 'child_process'
 import {
   _resetHydrateShellPathCache,
   hydrateShellPath,
@@ -6,13 +8,33 @@ import {
   type HydrationResult
 } from './hydrate-shell-path'
 
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
+
 type HydrationSpawner = (shell: string) => Promise<HydrationResult>
+
+function createMockShellProcess(): ChildProcessWithoutNullStreams {
+  const proc = new EventEmitter() as ChildProcessWithoutNullStreams
+  Object.assign(proc, {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: new EventEmitter(),
+    kill: vi.fn()
+  })
+  return proc
+}
 
 describe('hydrateShellPath', () => {
   const originalPath = process.env.PATH
 
   beforeEach(() => {
     _resetHydrateShellPathCache()
+    spawnMock.mockReset()
   })
 
   afterEach(() => {
@@ -108,6 +130,31 @@ describe('hydrateShellPath', () => {
       spawner: async () => ({ segments: [], ok: false, failureReason: 'empty_path' })
     })
     expect(result).toEqual({ segments: [], ok: false, failureReason: 'empty_path' })
+  })
+
+  it('cleans up shell listeners when hydration times out', async () => {
+    vi.useFakeTimers()
+    const proc = createMockShellProcess()
+    spawnMock.mockReturnValue(proc)
+
+    try {
+      const resultPromise = hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+      const assertion = expect(resultPromise).resolves.toEqual({
+        segments: [],
+        ok: false,
+        failureReason: 'timeout'
+      })
+
+      await vi.advanceTimersByTimeAsync(5000)
+
+      await assertion
+      expect(proc.kill).toHaveBeenCalledWith('SIGKILL')
+      expect(proc.stdout.listenerCount('data')).toBe(0)
+      expect(proc.listenerCount('error')).toBe(0)
+      expect(proc.listenerCount('close')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -86,6 +86,7 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
     const command = `printf '%s' '${DELIMITER}'; printf '%s' "$PATH"; printf '%s' '${DELIMITER}'`
     let finished = false
     let stdout = ''
+    let timer: ReturnType<typeof setTimeout> | null = null
 
     const child = spawn(shell, ['-ilc', command], {
       // Why: inherit current env so the shell sees the same baseline, then let
@@ -97,11 +98,25 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
       detached: false
     })
 
-    const timer = setTimeout(() => {
+    const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      child.stdout.off('data', onStdoutData)
+      child.off('error', onError)
+      child.off('close', onClose)
+    }
+    const finish = (result: HydrationResult): void => {
       if (finished) {
         return
       }
       finished = true
+      cleanup()
+      resolve(result)
+    }
+
+    timer = setTimeout(() => {
       // Why: slow rc files (corporate env setup, nvm eager init) can exceed
       // our budget. Kill the shell and fall back to process.env rather than
       // blocking the Agents pane indefinitely.
@@ -110,35 +125,29 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
       } catch {
         // ignore
       }
-      resolve({ segments: [], ok: false, failureReason: 'timeout' })
+      finish({ segments: [], ok: false, failureReason: 'timeout' })
     }, SPAWN_TIMEOUT_MS)
 
-    child.stdout.on('data', (chunk: Buffer) => {
+    const onStdoutData = (chunk: Buffer): void => {
       stdout += chunk.toString('utf8')
-    })
+    }
 
-    child.on('error', () => {
-      if (finished) {
-        return
-      }
-      finished = true
-      clearTimeout(timer)
-      resolve({ segments: [], ok: false, failureReason: 'spawn_error' })
-    })
+    const onError = (): void => {
+      finish({ segments: [], ok: false, failureReason: 'spawn_error' })
+    }
 
-    child.on('close', () => {
-      if (finished) {
-        return
-      }
-      finished = true
-      clearTimeout(timer)
+    const onClose = (): void => {
       const segments = parseCapturedPath(stdout)
       if (segments.length === 0) {
-        resolve({ segments: [], ok: false, failureReason: 'empty_path' })
+        finish({ segments: [], ok: false, failureReason: 'empty_path' })
         return
       }
-      resolve({ segments, ok: true, failureReason: 'none' })
-    })
+      finish({ segments, ok: true, failureReason: 'none' })
+    }
+
+    child.stdout.on('data', onStdoutData)
+    child.on('error', onError)
+    child.on('close', onClose)
   })
 }
 


### PR DESCRIPTION
## Summary
- detach shell PATH hydration stdout/error/close listeners when hydration settles
- keep timeout fallback and SIGKILL behavior unchanged
- add a timeout regression that asserts listener cleanup

## Risk
Risk level: LOW

The change is limited to GUI startup shell PATH hydration cleanup. It preserves timeout, spawn-error, empty-path, and successful parse result behavior.

## Validation
- pnpm vitest run src/main/startup/hydrate-shell-path.test.ts
- pnpm exec oxlint src/main/startup/hydrate-shell-path.ts src/main/startup/hydrate-shell-path.test.ts
- pnpm typecheck:node
- git diff --check