### PR TITLE
Timeout rg availability probes

### DIFF
--- a/src/main/ipc/rg-availability.test.ts
+++ b/src/main/ipc/rg-availability.test.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'events'
+import type { ChildProcess } from 'child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { wslAwareSpawnMock } = vi.hoisted(() => ({
+  wslAwareSpawnMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  wslAwareSpawn: wslAwareSpawnMock
+}))
+
+import { checkRgAvailable } from './rg-availability'
+
+function createMockProcess(): ChildProcess {
+  const child = new EventEmitter() as unknown as ChildProcess
+  ;(child as unknown as { kill: () => boolean }).kill = vi.fn(() => true)
+  return child
+}
+
+describe('checkRgAvailable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns true when rg exits successfully', async () => {
+    const child = createMockProcess()
+    wslAwareSpawnMock.mockReturnValue(child)
+
+    const promise = checkRgAvailable('/repo')
+    child.emit('close', 0)
+
+    await expect(promise).resolves.toBe(true)
+    expect(wslAwareSpawnMock).toHaveBeenCalledWith('rg', ['--version'], {
+      cwd: '/repo',
+      stdio: 'ignore'
+    })
+  })
+
+  it('settles and detaches when rg availability check ignores timeout kills', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const child = createMockProcess()
+      wslAwareSpawnMock.mockReturnValue(child)
+
+      const promise = checkRgAvailable('/repo')
+      await Promise.resolve()
+
+      await vi.advanceTimersByTimeAsync(5000)
+
+      await expect(Promise.race([promise, Promise.resolve('pending')])).resolves.toBe(false)
+      expect(child.kill).toHaveBeenCalled()
+      expect(child.listenerCount('error')).toBe(0)
+      expect(child.listenerCount('close')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/ipc/rg-availability.ts
+++ b/src/main/ipc/rg-availability.ts
@@ -1,5 +1,7 @@
 import { wslAwareSpawn } from '../git/runner'
 
+const RG_AVAILABILITY_TIMEOUT_MS = 5000
+
 // Why the `settled` flag: when rg is not installed, spawn emits both 'error'
 // and 'close' with non-deterministic ordering across Node versions/platforms.
 // Without guarding, a late 'error' after 'close' would double-resolve (or a
@@ -22,19 +24,34 @@ export function checkRgAvailable(searchPath?: string): Promise<boolean> {
       ...(searchPath ? { cwd: searchPath } : {}),
       stdio: 'ignore'
     })
-    child.once('error', () => {
+    let timeout: ReturnType<typeof setTimeout>
+
+    const cleanup = (): void => {
+      clearTimeout(timeout)
+      child.off('error', onError)
+      child.off('close', onClose)
+    }
+
+    const settle = (available: boolean, options?: { kill?: boolean }): void => {
       if (settled) {
         return
       }
       settled = true
-      resolve(false)
-    })
-    child.once('close', (code) => {
-      if (settled) {
-        return
+      cleanup()
+      if (options?.kill) {
+        child.kill()
       }
-      settled = true
-      resolve(code === 0)
-    })
+      resolve(available)
+    }
+
+    const onError = (): void => settle(false)
+    const onClose = (code: number | null): void => settle(code === 0)
+
+    child.once('error', onError)
+    child.once('close', onClose)
+    timeout = setTimeout(() => settle(false, { kill: true }), RG_AVAILABILITY_TIMEOUT_MS)
+    if (typeof timeout.unref === 'function') {
+      timeout.unref()
+    }
   })
 }


### PR DESCRIPTION
## Summary
- add a 5s timeout to local `rg --version` availability probes
- kill and detach listeners when the probe wedges
- cover successful probes plus wedged probes that ignore the timeout kill

## Failing-before evidence
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/rg-availability.test.ts -t "settles and detaches"` failed because the availability promise stayed `pending` after the timeout window.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/rg-availability.test.ts -t "settles and detaches"`
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/rg-availability.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/ipc/rg-availability.ts src/main/ipc/rg-availability.test.ts`
- `git diff --check`
## Risk assessment
Risk: LOW

This is scoped to the local `rg --version` availability probe used before Quick Open scans. It only adds timeout settlement and listener cleanup for wedged probes; successful and failed availability results keep the same boolean contract.