### PR TITLE
fix: clean up notification display listeners

### DIFF
--- a/src/main/ipc/notifications.test.ts
+++ b/src/main/ipc/notifications.test.ts
@@ -992,10 +992,14 @@ describe('registerNotificationHandlers', () => {
     const handler = getDispatchHandler()
 
     const result = handler({}, { source: 'test', requireDisplayConfirmation: true })
-    getNotificationOnceEventHandler('show')()
+    const showHandler = getNotificationOnceEventHandler('show')
+    const failedHandler = getNotificationOnceEventHandler('failed')
+    showHandler()
 
     await expect(result).resolves.toEqual({ delivered: true })
     expect(notificationShowMock).toHaveBeenCalledTimes(1)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('show', showHandler)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('failed', failedHandler)
   })
 
   it('reports not-displayed when explicit test notifications never show', async () => {
@@ -1013,10 +1017,14 @@ describe('registerNotificationHandlers', () => {
     const handler = getDispatchHandler()
 
     const result = handler({}, { source: 'test', requireDisplayConfirmation: true })
+    const showHandler = getNotificationOnceEventHandler('show')
+    const failedHandler = getNotificationOnceEventHandler('failed')
     await vi.advanceTimersByTimeAsync(2501)
 
     await expect(result).resolves.toEqual({ delivered: false, reason: 'not-displayed' })
     expect(notificationShowMock).toHaveBeenCalledTimes(1)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('show', showHandler)
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('failed', failedHandler)
   })
 
   it('loads allowed custom sound files for preload playback', async () => {

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -136,19 +136,35 @@ function waitForNotificationDisplay(notification: Notification): Promise<boolean
   return new Promise((resolve) => {
     let settled = false
     let timer: ReturnType<typeof setTimeout> | null = null
-    const settle = (displayed: boolean): void => {
+
+    function cleanup(): void {
+      notification.removeListener('show', onShow)
+      notification.removeListener('failed', onFailed)
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    function settle(displayed: boolean): void {
       if (settled) {
         return
       }
       settled = true
-      if (timer) {
-        clearTimeout(timer)
-      }
+      cleanup()
       resolve(displayed)
     }
 
-    notification.once('show', () => settle(true))
-    notification.once('failed', () => settle(false))
+    function onShow(): void {
+      settle(true)
+    }
+
+    function onFailed(): void {
+      settle(false)
+    }
+
+    notification.once('show', onShow)
+    notification.once('failed', onFailed)
     timer = setTimeout(() => settle(false), NOTIFICATION_DISPLAY_CONFIRMATION_TIMEOUT_MS)
   })
 }


### PR DESCRIPTION
## Summary
- remove notification display-confirmation `show`/`failed` listeners whenever the confirmation promise settles
- keep the existing show, failed, and timeout delivery behavior unchanged
- cover listener cleanup on both native show and timeout paths

## Validation
- pnpm vitest run src/main/ipc/notifications.test.ts
- pnpm exec oxlint src/main/ipc/notifications.ts src/main/ipc/notifications.test.ts
- pnpm typecheck:node
- git diff --check

## Risk assessment
Risk: LOW

This is scoped to listener cleanup for explicit notification display confirmation. It does not change notification construction, click handling, retention, cooldown, or the delivered/not-displayed contract.