### PR TITLE
Restart computer sidecar after active child errors

### DIFF
--- a/src/main/computer/sidecar-client.test.ts
+++ b/src/main/computer/sidecar-client.test.ts
@@ -79,4 +79,28 @@ describe('computer sidecar client', () => {
 
     await expect(secondCall).resolves.toEqual({ supports: { screenshots: true } })
   })
+
+  it('starts a replacement sidecar after the active child errors', async () => {
+    const firstCall = callComputerSidecarCapabilities()
+    const firstRejection = expect(firstCall).rejects.toThrow('active sidecar failed')
+    const firstChild = children[0]!
+
+    firstChild.emit('error', new Error('active sidecar failed'))
+    await firstRejection
+    expect(firstChild.killed).toBe(true)
+
+    const secondCall = callComputerSidecarCapabilities()
+    void secondCall.catch(() => undefined)
+    expect(children).toHaveLength(2)
+    const secondChild = children[1]!
+    const secondRequest = secondChild.sent[0]!
+
+    secondChild.emit('message', {
+      id: secondRequest.id,
+      ok: true,
+      result: { supports: { screenshots: true } }
+    })
+
+    await expect(secondCall).resolves.toEqual({ supports: { screenshots: true } })
+  })
 })

--- a/src/main/computer/sidecar-client.ts
+++ b/src/main/computer/sidecar-client.ts
@@ -222,6 +222,10 @@ class ComputerSidecarProcess {
     if (this.child !== child) {
       return
     }
+    // Why: an active process error makes the IPC sidecar unreliable; restart
+    // on the next call instead of reusing a broken helper.
+    this.child = null
+    child.kill('SIGTERM')
     const wrapped = new RuntimeClientError('accessibility_error', error.message)
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer)


### PR DESCRIPTION
## Summary
- clear the cached computer sidecar when the active child emits `error`
- terminate the failed helper so the next computer-use call forks a replacement
- add regression coverage for restart-after-error behavior

## Failing-before evidence
- `pnpm vitest run --config config/vitest.config.ts src/main/computer/sidecar-client.test.ts -t "starts a replacement"` failed because the second call reused the first errored child (`children` length stayed 1).

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/computer/sidecar-client.test.ts -t "starts a replacement"`
- `pnpm vitest run --config config/vitest.config.ts src/main/computer/sidecar-client.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/computer/sidecar-client.ts src/main/computer/sidecar-client.test.ts`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
