### PR TITLE
Reconnect native macOS provider after socket errors

### DIFF
--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -141,11 +141,16 @@ describe('MacOSNativeProviderClient', () => {
     const firstRejection = expect(firstCall).rejects.toThrow('active helper failed')
     await vi.waitFor(() => expect(sockets).toHaveLength(1))
     const firstSocket = sockets[0]!
+    const firstSocketDirectory = mkdtempSyncMock.mock.results[0]?.value as string
     await vi.waitFor(() => expect(firstSocket.writes).toHaveLength(1))
 
     firstSocket.emit('error', new Error('active helper failed'))
     await firstRejection
     expect(firstSocket.destroyed).toBe(true)
+    expect(rmSyncMock).toHaveBeenCalledWith(firstSocketDirectory, {
+      recursive: true,
+      force: true
+    })
 
     const secondCall = client.capabilities()
     await vi.waitFor(() => expect(sockets).toHaveLength(2))

--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -53,6 +53,11 @@ class FakeSocket extends EventEmitter {
   end(): void {
     this.destroyed = true
   }
+
+  destroy(): this {
+    this.destroyed = true
+    return this
+  }
 }
 
 async function loadClientModule() {
@@ -115,6 +120,38 @@ describe('MacOSNativeProviderClient', () => {
     firstSocket.emit('data', '{"id":999,"ok":false,"error":{"code":"old","message":"old"}}\n')
     firstSocket.emit('error', new Error('old helper failed late'))
     firstSocket.emit('close')
+
+    const capabilities = {
+      protocolVersion: 1,
+      supports: {}
+    }
+    secondSocket.emit(
+      'data',
+      `${JSON.stringify({ id: secondRequest.id, ok: true, result: capabilities })}\n`
+    )
+
+    await expect(secondCall).resolves.toEqual(capabilities)
+  })
+
+  it('starts a replacement socket after the active helper connection errors', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const firstCall = client.capabilities()
+    const firstRejection = expect(firstCall).rejects.toThrow('active helper failed')
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const firstSocket = sockets[0]!
+    await vi.waitFor(() => expect(firstSocket.writes).toHaveLength(1))
+
+    firstSocket.emit('error', new Error('active helper failed'))
+    await firstRejection
+    expect(firstSocket.destroyed).toBe(true)
+
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(sockets).toHaveLength(2))
+    const secondSocket = sockets[1]!
+    await vi.waitFor(() => expect(secondSocket.writes).toHaveLength(1))
+    const secondRequest = JSON.parse(secondSocket.writes[0]!) as { id: number }
 
     const capabilities = {
       protocolVersion: 1,

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -266,6 +266,14 @@ export class MacOSNativeProviderClient {
     if (this.socket !== socket) {
       return
     }
+    // Why: an active transport error makes the helper socket unreliable; the
+    // next request must reconnect instead of reusing a broken socket.
+    this.socket = null
+    this.socketBuffer = ''
+    if (!socket.destroyed) {
+      socket.destroy()
+    }
+    this.cleanupSocketDirectory()
     this.rejectPending(new RuntimeClientError('accessibility_error', error.message))
   }
   private cleanupSocketDirectory(): void {


### PR DESCRIPTION
## Summary
- clear and destroy the cached native macOS helper socket when the active socket emits `error`
- clean the temp socket directory so the next computer-use call reconnects
- add regression coverage for recovery after an active helper socket error

## Failing-before evidence
- `pnpm vitest run --config config/vitest.config.ts src/main/computer/macos-native-provider-client.test.ts -t "starts a replacement socket"` failed because the errored active socket was not destroyed or replaced.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/computer/macos-native-provider-client.test.ts -t "starts a replacement socket"`
- `pnpm vitest run --config config/vitest.config.ts src/main/computer/macos-native-provider-client.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/computer/macos-native-provider-client.ts src/main/computer/macos-native-provider-client.test.ts`
- `git diff --check`

## Risk assessment
Risk: MEDIUM

Historic risk metadata backfill based on the existing `risk:medium` label.
