### PR TITLE
fix: clean up daemon socket probe listeners

### DIFF
--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -54,6 +54,10 @@ const {
         }
         return this
       },
+      removeListener(event: string, cb: () => void) {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+        return this
+      },
       destroy() {}
     }
   })
@@ -450,6 +454,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
           }
           return this
         },
+        removeListener(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return this
+        },
         destroy() {}
       }
     })
@@ -577,6 +585,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
           }
           return this
         },
+        removeListener(event: string, cb: () => void) {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return this
+        },
         destroy() {}
       }
     })
@@ -588,6 +600,48 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(requestMock).toHaveBeenCalledWith('shutdown', { killSessions: true })
     // The fallback killStaleDaemon must NOT fire when the RPC path worked.
     expect(killStaleDaemonMock).not.toHaveBeenCalled()
+  })
+
+  it('cleans up daemon socket probe listeners when the probe times out', async () => {
+    vi.useFakeTimers()
+    try {
+      const handlers: Record<string, Set<() => void>> = {
+        connect: new Set(),
+        error: new Set()
+      }
+      const socket = {
+        on(event: string, cb: () => void) {
+          handlers[event]?.add(cb)
+          return this
+        },
+        removeListener(event: string, cb: () => void) {
+          handlers[event]?.delete(cb)
+          return this
+        },
+        destroy: vi.fn(),
+        listenerCount(event: string) {
+          return handlers[event]?.size ?? 0
+        }
+      }
+      probeSocketExistsMock.mockReturnValue(true)
+      netConnectMock.mockReturnValueOnce(socket)
+      const mod = await importFresh()
+
+      const cleanup = mod.cleanupDaemonForProtocol('/fake/daemon', PROTOCOL_VERSION)
+      await Promise.resolve()
+
+      expect(socket.listenerCount('connect')).toBe(1)
+      expect(socket.listenerCount('error')).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(1000)
+
+      await expect(cleanup).resolves.toEqual({ cleaned: false, killedCount: 0 })
+      expect(socket.destroy).toHaveBeenCalledTimes(1)
+      expect(socket.listenerCount('connect')).toBe(0)
+      expect(socket.listenerCount('error')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('coalesces concurrent restartDaemon() calls so the 7-step sequence runs exactly once', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -83,19 +83,35 @@ function probeSocket(socketPath: string): Promise<boolean> {
       return
     }
     const sock = connect({ path: socketPath })
-    const timer = setTimeout(() => {
-      sock.destroy()
-      resolve(false)
+    let settled = false
+    let timer: ReturnType<typeof setTimeout>
+    function finish(alive: boolean, options?: { destroy?: boolean }): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      sock.removeListener('connect', onConnect)
+      sock.removeListener('error', onError)
+      if (options?.destroy) {
+        sock.destroy()
+      }
+      resolve(alive)
+    }
+
+    function onConnect(): void {
+      finish(true, { destroy: true })
+    }
+
+    function onError(): void {
+      finish(false)
+    }
+
+    timer = setTimeout(() => {
+      finish(false, { destroy: true })
     }, 1000)
-    sock.on('connect', () => {
-      clearTimeout(timer)
-      sock.destroy()
-      resolve(true)
-    })
-    sock.on('error', () => {
-      clearTimeout(timer)
-      resolve(false)
-    })
+    sock.on('connect', onConnect)
+    sock.on('error', onError)
   })
 }
 


### PR DESCRIPTION
## Summary
- route daemon socket probe connect/error/timeout outcomes through one guarded finish path
- clear the probe timer and unregister socket listeners when the probe settles
- cover timeout cleanup for a socket probe that never connects or errors

## Validation
- pnpm vitest run src/main/daemon/daemon-init.test.ts
- pnpm exec oxlint src/main/daemon/daemon-init.ts src/main/daemon/daemon-init.test.ts
- pnpm typecheck:node
- git diff --check

## Risk assessment
Risk: LOW

This only cleans up listeners after the daemon socket liveness probe has already settled. The existing true/false probe outcomes, stale-daemon cleanup path, and respawn sequencing are unchanged.