### PR TITLE
fix: clean up production daemon shutdown listener

### DIFF
--- a/src/main/daemon/production-launcher.test.ts
+++ b/src/main/daemon/production-launcher.test.ts
@@ -125,6 +125,57 @@ describe('createProductionLauncher', () => {
     expect(child.disconnect).toHaveBeenCalled()
     expect(child.unref).toHaveBeenCalled()
   })
+
+  it('removes shutdown exit listener when force-kill timeout settles first', async () => {
+    vi.useFakeTimers()
+    try {
+      const handlers: Record<string, ((arg?: unknown) => void)[]> = {
+        message: [],
+        error: [],
+        exit: []
+      }
+      const child = {
+        pid: 12345,
+        killed: false,
+        on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+          handlers[event]?.push(cb)
+          return child
+        }),
+        once: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+          handlers[event]?.push(cb)
+          return child
+        }),
+        off: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return child
+        }),
+        kill: vi.fn(),
+        disconnect: vi.fn(),
+        unref: vi.fn()
+      }
+      forkMock.mockReturnValueOnce(child)
+
+      const launcher = createProductionLauncher({
+        getDaemonEntryPath: () => join(dir, 'daemon-entry.js')
+      })
+
+      const launch = launcher(socketPathFor(dir), tokenPathFor(dir))
+      handlers.message[0]?.({ type: 'ready' })
+      const handle = await launch
+
+      const shutdown = handle.shutdown()
+      expect(handlers.exit).toHaveLength(1)
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await shutdown
+
+      expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
+      expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
+      expect(handlers.exit).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })
 
 function socketPathFor(dir: string): string {

--- a/src/main/daemon/production-launcher.ts
+++ b/src/main/daemon/production-launcher.ts
@@ -89,16 +89,28 @@ function shutdownChild(child: ChildProcess): Promise<void> {
       return
     }
 
-    const timeout = setTimeout(() => {
-      child.kill('SIGKILL')
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout>
+    function finish(): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      child.off('exit', onExit)
       resolve()
+    }
+
+    function onExit(): void {
+      finish()
+    }
+
+    timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      finish()
     }, 5000)
 
-    child.once('exit', () => {
-      clearTimeout(timeout)
-      resolve()
-    })
-
+    child.once('exit', onExit)
     child.kill('SIGTERM')
   })
 }


### PR DESCRIPTION
## Summary
- route production daemon shutdown completion through one guarded finish path
- remove the shutdown `exit` listener when the force-kill timeout settles first
- cover the timeout-first shutdown path with fake timers

## Validation
- pnpm vitest run src/main/daemon/production-launcher.test.ts
- pnpm exec oxlint src/main/daemon/production-launcher.ts src/main/daemon/production-launcher.test.ts
- pnpm typecheck:node
- git diff --check

## Risk assessment
Risk: LOW

This only detaches the shutdown `exit` listener after the production daemon shutdown promise has already settled. Startup readiness, detached daemon behavior, and SIGTERM/SIGKILL sequencing are unchanged.