### PR TITLE
fix: clean up macos provider socket listeners

### DIFF
--- a/src/main/computer/macos-native-provider-socket.test.ts
+++ b/src/main/computer/macos-native-provider-socket.test.ts
@@ -1,0 +1,47 @@
+import { EventEmitter } from 'events'
+import { describe, expect, it, vi } from 'vitest'
+
+const { createConnectionMock } = vi.hoisted(() => ({
+  createConnectionMock: vi.fn()
+}))
+
+vi.mock('net', () => ({
+  default: {
+    createConnection: createConnectionMock
+  }
+}))
+
+import { connectMacOSProviderSocket } from './macos-native-provider-socket'
+
+class FakeSocket extends EventEmitter {
+  destroy = vi.fn()
+}
+
+describe('connectMacOSProviderSocket', () => {
+  it('removes socket listeners after a connection error', async () => {
+    vi.useFakeTimers()
+    try {
+      const socket = new FakeSocket()
+      createConnectionMock.mockReturnValueOnce(socket)
+
+      const promise = connectMacOSProviderSocket('/tmp/orca-computer.sock', 50)
+      await Promise.resolve()
+
+      expect(socket.listenerCount('error')).toBe(1)
+      expect(socket.listenerCount('connect')).toBe(1)
+
+      const rejection = expect(promise).rejects.toThrow(
+        'native macOS helper app did not open its socket'
+      )
+      socket.emit('error', new Error('ECONNREFUSED'))
+      await vi.advanceTimersByTimeAsync(100)
+
+      await rejection
+      expect(socket.destroy).toHaveBeenCalledTimes(1)
+      expect(socket.listenerCount('error')).toBe(0)
+      expect(socket.listenerCount('connect')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/computer/macos-native-provider-socket.ts
+++ b/src/main/computer/macos-native-provider-socket.ts
@@ -24,14 +24,20 @@ export async function connectMacOSProviderSocket(
 function connectSocket(socketPath: string): Promise<net.Socket> {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection(socketPath)
-    const onError = (error: Error) => {
+    const cleanup = (): void => {
+      socket.off('error', onError)
+      socket.off('connect', onConnect)
+    }
+    const onError = (error: Error): void => {
+      cleanup()
       socket.destroy()
       reject(error)
     }
-    socket.once('error', onError)
-    socket.once('connect', () => {
-      socket.off('error', onError)
+    const onConnect = (): void => {
+      cleanup()
       resolve(socket)
-    })
+    }
+    socket.once('error', onError)
+    socket.once('connect', onConnect)
   })
 }


### PR DESCRIPTION
## Summary
- route macOS native provider socket connect/error through named listeners
- remove both socket listeners when either path settles
- add regression coverage for connection-error cleanup in the retry wrapper

## Validation
- pnpm vitest run src/main/computer/macos-native-provider-socket.test.ts
- pnpm exec oxlint src/main/computer/macos-native-provider-socket.ts src/main/computer/macos-native-provider-socket.test.ts
- pnpm typecheck:node
- git diff --check

## Risk assessment
Risk: LOW

This only cleans up one-shot listeners after a native-provider socket attempt has already succeeded or failed. The retry cadence, timeout message, socket destruction on error, and successful socket return behavior are unchanged.