### PR TITLE
perf: classify relay bulk discard paths safely

### DIFF
--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -20,14 +20,14 @@ import {
 
 describe('GitHandler', () => {
   let dispatcher: MockDispatcher
+  let handler: GitHandler
   let tmpDir: string
 
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-git-'))
     dispatcher = createMockDispatcher()
     const ctx = new RelayContext()
-    // eslint-disable-next-line no-new
-    new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
+    handler = new GitHandler(dispatcher as unknown as RelayDispatcher, ctx)
   })
 
   afterEach(async () => {
@@ -496,6 +496,32 @@ describe('GitHandler', () => {
       await expect(fs.readFile(path.join(tmpDir, 'a.txt'), 'utf-8')).resolves.toBe('a')
       await expect(fs.readFile(path.join(tmpDir, 'b.txt'), 'utf-8')).resolves.toBe('b')
       await expect(fs.access(path.join(tmpDir, 'new.txt'))).rejects.toThrow()
+    })
+
+    it('handles large tracked path lists during bulk discard classification', async () => {
+      const trackedStdout = Array.from({ length: 150_000 }, (_, index) => `docs/file-${index}.ts`)
+        .join('\0')
+        .concat('\0')
+      const gitMock = vi
+        .spyOn(
+          handler as unknown as {
+            git: (args: string[], cwd: string) => Promise<{ stdout: string; stderr: string }>
+          },
+          'git'
+        )
+        .mockResolvedValueOnce({ stdout: trackedStdout, stderr: '' })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+      await dispatcher.callRequest('git.bulkDiscard', {
+        worktreePath: tmpDir,
+        filePaths: ['docs']
+      })
+
+      expect(gitMock).toHaveBeenNthCalledWith(
+        2,
+        ['restore', '--worktree', '--source=HEAD', '--', ':(literal)docs'],
+        tmpDir
+      )
     })
 
     it('rejects path traversal', async () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -276,7 +276,13 @@ export class GitHandler {
         ['ls-files', '-z', '--', ...chunk.map((p) => this.literalPathspec(p))],
         worktreePath
       )
-      trackedPathSpecs.push(...stdout.split('\0').filter(Boolean))
+      // Why: selecting a tracked directory can make `ls-files -z` return
+      // enough descendants for push(...split) to exceed the argument limit.
+      for (const trackedPathSpec of stdout.split('\0')) {
+        if (trackedPathSpec) {
+          trackedPathSpecs.push(trackedPathSpec)
+        }
+      }
     }
 
     const trackedPaths = filePaths.filter((filePath) =>


### PR DESCRIPTION
## Summary
- Avoid spreading relay git ls-files -z results when classifying bulk-discard paths
- Add a regression for a 150k-path tracked subtree during relay bulk discard

## Validation
- pnpm exec oxlint src/relay/git-handler.ts src/relay/git-handler.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/relay/git-handler.test.ts src/relay/git-handler-staging.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low. This preserves relay restore/clean classification and only avoids a JavaScript argument-limit failure for very large tracked path lists.