### PR TITLE
Fix stalled speech model downloads

### DIFF
--- a/src/main/speech/model-manager.test.ts
+++ b/src/main/speech/model-manager.test.ts
@@ -141,6 +141,57 @@ describe('ModelManager', () => {
     }
   })
 
+  it('times out a model download request that never responds', async () => {
+    vi.useFakeTimers()
+    const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
+    try {
+      const errorHandlers: ((err: Error) => void)[] = []
+      const request = {
+        destroy: vi.fn((err?: Error) => {
+          queueMicrotask(() => {
+            for (const handler of errorHandlers) {
+              handler(err ?? new Error('destroyed'))
+            }
+          })
+          return request
+        }),
+        setTimeout: vi.fn((ms: number, cb: () => void) => {
+          setTimeout(cb, ms)
+          return request
+        }),
+        on: vi.fn((event: string, cb: (err: Error) => void) => {
+          if (event === 'error') {
+            errorHandlers.push(cb)
+          }
+          return request
+        })
+      }
+      httpsGetMock.mockReturnValue(request)
+      const manager = new ModelManager(dir) as unknown as ModelManagerInternals
+
+      const download = manager.downloadFile(
+        'https://example.com/model.tar.bz2',
+        join(dir, 'model.tar.bz2'),
+        1,
+        'm',
+        () => false
+      )
+      const outcomePromise = download.then(
+        () => 'resolved',
+        (error) => (error instanceof Error ? error.message : String(error))
+      )
+
+      await vi.advanceTimersByTimeAsync(120_000)
+      const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
+
+      expect(outcome).toBe('Model download timed out after 120 seconds without network activity')
+      expect(request.destroy).toHaveBeenCalledWith(expect.any(Error))
+    } finally {
+      vi.useRealTimers()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('clears extraction abort polling when the child does not close', async () => {
     vi.useFakeTimers()
     const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))

--- a/src/main/speech/model-manager.ts
+++ b/src/main/speech/model-manager.ts
@@ -22,6 +22,8 @@ type DownloadHandle = {
 
 type ProgressCallback = (modelId: string, progress: number) => void
 
+const DOWNLOAD_IDLE_TIMEOUT_MS = 120_000
+
 export class ModelManager {
   private modelsDir: string
   private activeDownloads = new Map<string, DownloadHandle>()
@@ -336,6 +338,16 @@ export class ModelManager {
         ? httpsGet(parsedUrl, { signal }, onResponse)
         : httpsGet(parsedUrl, onResponse)
 
+      // Why: cancellation only helps after the user presses cancel; a peer
+      // that accepts the socket and goes silent must not leave the model stuck
+      // in "downloading" forever.
+      request.setTimeout(DOWNLOAD_IDLE_TIMEOUT_MS, () => {
+        request.destroy(
+          new Error(
+            `Model download timed out after ${DOWNLOAD_IDLE_TIMEOUT_MS / 1000} seconds without network activity`
+          )
+        )
+      })
       request.on('error', reject)
     })
   }


### PR DESCRIPTION
## Summary
- add a 120s inactivity timeout to HTTPS speech model downloads
- destroy the stalled request with a clear error so download state can leave `downloading`
- add a regression test for a request that accepts the call but never responds

## Bug
Speech model downloads accepted user cancellation, but the HTTPS request itself had no inactivity timeout. If the peer opened the request and then never sent a response or further network activity, `downloadFile()` stayed pending forever and the model could remain stuck in `downloading`.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/speech/model-manager.test.ts
- pnpm exec oxlint src/main/speech/model-manager.ts src/main/speech/model-manager.test.ts
- pnpm typecheck:node
- git diff --check

Risk: low. The timeout is now a conservative 120s network-idle guard, not a total download duration cap, so ordinary slow downloads can continue while truly silent requests no longer leave the model stuck in downloading.