### PR TITLE
fix: keep repo icon hrefs inside worktree

### DIFF
--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -69,6 +69,16 @@ describe('detectRepoIcon', () => {
     })
   })
 
+  it('does not resolve declared icon hrefs outside the repo', async () => {
+    const parentPath = await makeTempRepoDir()
+    const repoPath = join(parentPath, 'repo')
+    await mkdir(repoPath)
+    await writeFile(join(parentPath, 'outside.png'), Buffer.from(PNG_1X1_BASE64, 'base64'))
+    await writeFile(join(repoPath, 'index.html'), '<link rel="icon" href="../outside.png">')
+
+    await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toBeUndefined()
+  })
+
   it('falls back to the GitHub owner avatar for GitHub repos', async () => {
     const repoPath = await makeTempRepoDir()
     await gitExecFileAsync(['init'], { cwd: repoPath })

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -75,9 +75,25 @@ function extractIconHref(source: string): string | null {
   return source.match(LINK_ICON_HTML_RE)?.[1] ?? source.match(LINK_ICON_OBJECT_RE)?.[1] ?? null
 }
 
+function normalizeIconHrefPath(href: string): string | null {
+  const trimmed = href.trim()
+  if (!trimmed || trimmed.startsWith('//') || /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) {
+    return null
+  }
+
+  const pathOnly = (trimmed.split(/[?#]/)[0] ?? '').replace(/^\/+/, '').replace(/\\/g, '/')
+  const parts = pathOnly.split('/').filter((part) => part && part !== '.')
+  // Why: declared icon hrefs are repo content. Never let a best-effort icon
+  // probe resolve outside the worktree through `../` path segments.
+  if (parts.length === 0 || parts.some((part) => part === '..')) {
+    return null
+  }
+  return parts.join('/')
+}
+
 function iconHrefCandidates(href: string): string[] {
-  const clean = href.replace(/^\/+/, '')
-  return [`public/${clean}`, clean]
+  const clean = normalizeIconHrefPath(href)
+  return clean ? [`public/${clean}`, clean] : []
 }
 
 async function readLocalPngIcon(repoPath: string, relativePath: string): Promise<RepoIcon | null> {


### PR DESCRIPTION
## Summary
- reject href-derived repo icon candidates that contain schemes, protocol-relative URLs, drive-like prefixes, or `..` segments
- preserve normal root-relative repo icon discovery such as `/brand/icon.png`
- add a regression test proving a declared `../outside.png` is not read from the parent directory

## Evidence
Failing repro before the fix:
```text
pnpm vitest run --config config/vitest.config.ts src/main/repo-icon-autodetect.test.ts -t "does not resolve declared icon hrefs outside the repo"

AssertionError: expected { type: 'image', … } to be undefined
Received label: "../outside.png"
```

Verified after the fix:
```text
pnpm vitest run --config config/vitest.config.ts src/main/repo-icon-autodetect.test.ts -t "does not resolve declared icon hrefs outside the repo"
# 1 passed | 5 skipped

pnpm vitest run --config config/vitest.config.ts src/main/repo-icon-autodetect.test.ts
# 6 passed

pnpm typecheck:node
# passed

pnpm oxlint src/main/repo-icon-autodetect.ts src/main/repo-icon-autodetect.test.ts
# Found 0 warnings and 0 errors.

git diff --check HEAD
# passed
```

## Risk
Medium. The patch is small and covered by focused tests, but the bug crosses a worktree path/privacy boundary and the fix affects both local and SSH repo icon autodetection.

Risk: medium. This is a small, tested path-boundary fix, but it changes repo icon autodetection for local and SSH worktrees and should stay open for review.