### PR TITLE
test: make clipboard temp path expectation platform-aware

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
 
 const {
   removeHandlerMock,
@@ -131,6 +132,10 @@ describe('registerClipboardHandlers', () => {
 
   it('saves clipboard images to a local temp file when no connection is provided', async () => {
     const png = Buffer.from([0, 1, 2, 3])
+    const expectedPath = join(
+      '/tmp',
+      'orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png'
+    )
     clipboardReadImageMock.mockReturnValue({
       isEmpty: () => false,
       toPNG: () => png
@@ -140,12 +145,9 @@ describe('registerClipboardHandlers', () => {
 
     const handlers = getRegisteredHandlers()
     await expect(handlers.get('clipboard:saveImageAsTempFile')?.({}, undefined)).resolves.toBe(
-      '/tmp/orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png'
+      expectedPath
     )
-    expect(fsWriteFileMock).toHaveBeenCalledWith(
-      '/tmp/orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png',
-      png
-    )
+    expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary
- make the clipboard temp-file unit test derive the local temp path with Node path joining
- keep remote SSH path expectations explicit for POSIX and Windows hosts

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/window/clipboard-ipc-handlers.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktrees-windows.test.ts src/main/ipc/worktree-logic-wsl.test.ts src/main/providers/windows-shell-args.test.ts src/main/providers/windows-powershell.test.ts src/main/daemon/pty-subprocess.test.ts src/main/window/clipboard-ipc-handlers.test.ts src/main/cli/cli-installer.test.ts src/cli/runtime/launch.test.ts
- pnpm run lint -- src/main/window/clipboard-ipc-handlers.test.ts
- git diff --check HEAD~1 HEAD

Risk: low. Test-only cross-platform expectation fix.