### PR TITLE
fix: terminate websocket clients during shutdown

### DIFF
--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -316,6 +316,27 @@ describe('WebSocketTransport', () => {
     await transport.stop()
   })
 
+  it('does not wait for an unresponsive client close handshake during stop', async () => {
+    const { transport } = await createTransport()
+    await transport.start()
+    const ws = await connectWs(transport)
+    const underlying = (ws as unknown as { _socket: { pause: () => void } })._socket
+    underlying.pause()
+
+    const stopPromise = transport.stop()
+    const outcome = await Promise.race([
+      stopPromise.then(() => 'stopped' as const),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 100))
+    ])
+
+    if (outcome === 'pending') {
+      ws.terminate()
+      await stopPromise
+    }
+
+    expect(outcome).toBe('stopped')
+  })
+
   it('falls back to OS-assigned port when preferred port is in use', async () => {
     const { transport: first } = await createTransport()
     await first.start()

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -251,7 +251,9 @@ export class WebSocketTransport implements RpcTransport {
 
     if (wss) {
       for (const client of wss.clients) {
-        client.close(1001, 'Server shutting down')
+        // Why: stop() is a teardown path. A half-open mobile socket may never
+        // answer a graceful close frame, which keeps httpServer.close pending.
+        client.terminate()
       }
       wss.close()
     }


### PR DESCRIPTION
## Summary
- terminate owned WebSocket clients during `WebSocketTransport.stop()` instead of waiting on a graceful close handshake
- add a regression test where a paused/half-open client previously kept `stop()` pending

## Evidence
Failing repro before the fix:
```text
pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/ws-transport.test.ts -t "does not wait for an unresponsive client close handshake during stop"

AssertionError: expected 'pending' to be 'stopped'
```

Verified after the fix:
```text
pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/ws-transport.test.ts -t "does not wait for an unresponsive client close handshake during stop"
# 1 passed | 14 skipped

pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/ws-transport.test.ts
# 15 passed

pnpm typecheck:node
# passed

pnpm oxlint src/main/runtime/rpc/ws-transport.ts src/main/runtime/rpc/ws-transport.test.ts
# Found 0 warnings and 0 errors.

git diff --check HEAD
# passed
```

## Risk
Low. This is scoped to the transport shutdown path; active connections are already being torn down, and terminating avoids a known half-open close-handshake hang.

Risk: low. This only changes WebSocket transport shutdown teardown, where clients are already being closed, and avoids waiting forever on half-open close handshakes.