### PR TITLE
fix: reject malformed file upload base64

### DIFF
--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -391,6 +391,10 @@ describe('file RPC methods', () => {
     [
       'non-string content',
       { worktree: 'id:wt-1', relativePath: 'assets/logo.png', contentBase64: 0 }
+    ],
+    [
+      'malformed content',
+      { worktree: 'id:wt-1', relativePath: 'assets/logo.png', contentBase64: '!!!!' }
     ]
   ])('rejects a base64 write with %s', async (_name, params) => {
     const runtime = {
@@ -454,6 +458,15 @@ describe('file RPC methods', () => {
         worktree: 'id:wt-1',
         relativePath: 'assets/video.mov',
         contentBase64: 0,
+        append: true
+      }
+    ],
+    [
+      'malformed content',
+      {
+        worktree: 'id:wt-1',
+        relativePath: 'assets/video.mov',
+        contentBase64: '!!!!',
         append: true
       }
     ]

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -4,6 +4,13 @@ import { defineMethod, defineStreamingMethod, type RpcAnyMethod } from '../core'
 import { createFileWatchEventBatcher } from './file-watch-event-batcher'
 
 let filesWatchSubscriptionSeq = 0
+const RUNTIME_FILE_BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/
+
+function isValidRuntimeFileBase64(value: unknown): value is string {
+  return (
+    typeof value === 'string' && value.length % 4 !== 1 && RUNTIME_FILE_BASE64_PATTERN.test(value)
+  )
+}
 
 const WorktreeSelector = z.object({
   worktree: z
@@ -43,6 +50,9 @@ const FileWriteBase64 = FileOpen.extend({
   contentBase64: z
     .unknown()
     .refine((v): v is string => typeof v === 'string', { message: 'Missing file content' })
+    // Why: Buffer.from(..., 'base64') accepts malformed input by dropping
+    // invalid bytes, which can silently create empty or corrupt uploaded files.
+    .refine(isValidRuntimeFileBase64, 'File content must be base64')
 })
 
 const FileWriteBase64Chunk = FileWriteBase64.extend({


### PR DESCRIPTION
## Summary
- validate `files.writeBase64` and `files.writeBase64Chunk` payloads before dispatching runtime writes
- keep explicit empty base64 content valid for empty-file uploads
- add malformed-content regressions for single-shot and chunked upload RPCs

## Evidence
Failing repro before the fix:
```text
pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/files.test.ts -t "malformed content"

expected { id: 'req-1', ok: true, … } to match object { ok: false }
```

Verified after the fix:
```text
pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/files.test.ts -t "malformed content"
# 2 passed | 31 skipped

pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/files.test.ts
# 33 passed

pnpm typecheck:node
# passed

pnpm oxlint src/main/runtime/rpc/methods/files.ts src/main/runtime/rpc/methods/files.test.ts
# Found 0 warnings and 0 errors.

git diff --check HEAD
# passed
```

## Risk
Low. This tightens input validation at the RPC schema boundary before file writes; valid base64 and explicit empty uploads continue to work.
