### PR TITLE
perf: handle large daemon pty reconciliation lists

### DIFF
--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -8,6 +8,16 @@ type AdapterMock = DaemonPtyAdapter & {
   emitExit: (id: string, code: number) => void
 }
 
+const LARGE_RECONCILE_SESSION_COUNT = 150_000
+
+function buildSessionIds(prefix: string, count: number): string[] {
+  const ids: string[] = []
+  for (let index = 0; index < count; index += 1) {
+    ids.push(`${prefix}-${index}`)
+  }
+  return ids
+}
+
 function createAdapter(
   label: string,
   sessions: string[] = [],
@@ -156,6 +166,22 @@ describe('DaemonPtyRouter', () => {
     })
     expect(legacy.write).toHaveBeenCalledWith('legacy-alive', 'old\n')
     expect(current.write).toHaveBeenCalledWith('current-alive', 'new\n')
+  })
+
+  it('merges large startup reconciliation results', async () => {
+    const alive = buildSessionIds('alive', LARGE_RECONCILE_SESSION_COUNT)
+    const killed = buildSessionIds('killed', LARGE_RECONCILE_SESSION_COUNT)
+    const current = createAdapter('current', [], { alive, killed })
+    const router = new DaemonPtyRouter({ current, legacy: [] })
+
+    const result = await router.reconcileOnStartup(new Set(['wt']))
+
+    expect(result.alive).toHaveLength(LARGE_RECONCILE_SESSION_COUNT)
+    expect(result.killed).toHaveLength(LARGE_RECONCILE_SESSION_COUNT)
+    expect(result.alive.at(-1)).toBe(`alive-${LARGE_RECONCILE_SESSION_COUNT - 1}`)
+    expect(result.killed.at(-1)).toBe(`killed-${LARGE_RECONCILE_SESSION_COUNT - 1}`)
+    router.write('alive-0', 'restored\n')
+    expect(current.write).toHaveBeenCalledWith('alive-0', 'restored\n')
   })
 
   it('disposes current and legacy adapters', () => {

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -175,8 +175,14 @@ export class DaemonPtyRouter implements IPtyProvider {
     const killed: string[] = []
     for (const adapter of this.allAdapters()) {
       const result = await adapter.reconcileOnStartup(validWorktreeIds)
-      alive.push(...result.alive)
-      killed.push(...result.killed)
+      // Why: daemon startup can reconcile many restored sessions; spreading
+      // those arrays into push can exceed JavaScript's argument limit.
+      for (const id of result.alive) {
+        alive.push(id)
+      }
+      for (const id of result.killed) {
+        killed.push(id)
+      }
       for (const id of result.alive) {
         this.sessionAdapters.set(id, adapter)
       }


### PR DESCRIPTION
## Summary
- append daemon PTY startup reconciliation results iteratively instead of spreading large session arrays
- add a 150k alive/killed session regression test for reconciliation merging

## Validation
- pnpm exec oxlint src/main/daemon/daemon-pty-router.ts src/main/daemon/daemon-pty-router.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-router.test.ts
- pnpm run typecheck:node
- git diff --check