### PR TITLE
fix: time out remote hook sftp operations

### DIFF
--- a/src/main/agent-hooks/installer-utils-remote.test.ts
+++ b/src/main/agent-hooks/installer-utils-remote.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SFTPWrapper } from 'ssh2'
 
 import {
@@ -162,6 +162,27 @@ describe('installer-utils-remote', () => {
     await expect(readHooksJsonRemote(sftp, '/home/u/.claude/settings.json')).rejects.toMatchObject({
       code: 3
     })
+  })
+
+  it('times out remote reads that never call back', async () => {
+    vi.useFakeTimers()
+    try {
+      const sftp = {
+        readFile: vi.fn()
+      } as unknown as SFTPWrapper
+      const pending = readHooksJsonRemote(sftp, '/home/u/.claude/settings.json')
+      let rejection: unknown = null
+      pending.catch((error) => {
+        rejection = error
+      })
+
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(rejection).toBeInstanceOf(Error)
+      await expect(pending).rejects.toThrow('Timed out waiting for SFTP readFile')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('atomically writes settings.json via tmp + rename', async () => {

--- a/src/main/agent-hooks/installer-utils-remote.ts
+++ b/src/main/agent-hooks/installer-utils-remote.ts
@@ -17,6 +17,7 @@ import type { SFTPWrapper, FileEntryWithStats } from 'ssh2'
 import { isPlainObject, type HooksConfig } from './installer-utils'
 
 const DEFAULT_REMOTE_CONFIG_MODE = 0o600
+const REMOTE_SFTP_OPERATION_TIMEOUT_MS = 10_000
 
 /** Read+JSON-parse a remote file. Returns `null` on parse failure (caller
  *  surfaces "could not parse" status to the UI), `{}` on missing file
@@ -170,16 +171,51 @@ export async function writeTextFileRemoteAtomic(
 
 // ─── Private SFTP primitives ────────────────────────────────────────
 
-async function readFile(sftp: SFTPWrapper, remotePath: string): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    sftp.readFile(remotePath, 'utf8', (err, data) => {
+function sftpOperation<T>(
+  label: string,
+  run: (callback: (err: unknown, value?: T) => void) => void
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      // Why: remote hook installation must fail open; a wedged SFTP callback
+      // should degrade hook status, not block SSH workspace startup forever.
+      reject(new Error(`Timed out waiting for SFTP ${label}`))
+    }, REMOTE_SFTP_OPERATION_TIMEOUT_MS)
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref()
+    }
+
+    const finish = (err: unknown, value?: T): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
       if (err) {
         reject(err)
         return
       }
-      resolve(typeof data === 'string' ? data : data.toString('utf8'))
-    })
+      resolve(value as T)
+    }
+
+    try {
+      run(finish)
+    } catch (error) {
+      finish(error)
+    }
   })
+}
+
+async function readFile(sftp: SFTPWrapper, remotePath: string): Promise<string> {
+  const data = await sftpOperation<string | Buffer>(`readFile ${remotePath}`, (callback) => {
+    sftp.readFile(remotePath, 'utf8', callback)
+  })
+  return typeof data === 'string' ? data : data.toString('utf8')
 }
 
 async function writeFile(
@@ -188,29 +224,18 @@ async function writeFile(
   content: string,
   mode?: number
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const options =
-      mode === undefined ? { encoding: 'utf8' as const } : { encoding: 'utf8' as const, mode }
-    sftp.writeFile(remotePath, content, options, (err) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve()
-    })
+  const options =
+    mode === undefined ? { encoding: 'utf8' as const } : { encoding: 'utf8' as const, mode }
+  await sftpOperation<void>(`writeFile ${remotePath}`, (callback) => {
+    sftp.writeFile(remotePath, content, options, callback)
   })
 }
 
 async function statMode(sftp: SFTPWrapper, remotePath: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    sftp.stat(remotePath, (err, stats) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve(stats.mode & 0o7777)
-    })
+  const stats = await sftpOperation<{ mode: number }>(`stat ${remotePath}`, (callback) => {
+    sftp.stat(remotePath, callback)
   })
+  return stats.mode & 0o7777
 }
 
 async function getRemoteFileModeOrDefault(
@@ -248,76 +273,38 @@ async function rename(sftp: SFTPWrapper, src: string, dst: string): Promise<void
 }
 
 async function renamePlain(sftp: SFTPWrapper, src: string, dst: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.rename(src, dst, (err) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve()
-    })
+  await sftpOperation<void>(`rename ${src}`, (callback) => {
+    sftp.rename(src, dst, callback)
   })
 }
 
 async function renameOpenSsh(sftp: SFTPWrapper, src: string, dst: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.ext_openssh_rename(src, dst, (err) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve()
-    })
+  await sftpOperation<void>(`openssh_rename ${src}`, (callback) => {
+    sftp.ext_openssh_rename(src, dst, callback)
   })
 }
 
 async function unlink(sftp: SFTPWrapper, remotePath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.unlink(remotePath, (err) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve()
-    })
+  await sftpOperation<void>(`unlink ${remotePath}`, (callback) => {
+    sftp.unlink(remotePath, callback)
   })
 }
 
 async function chmod(sftp: SFTPWrapper, remotePath: string, mode: number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.chmod(remotePath, mode, (err) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve()
-    })
+  await sftpOperation<void>(`chmod ${remotePath}`, (callback) => {
+    sftp.chmod(remotePath, mode, callback)
   })
 }
 
 async function readdir(sftp: SFTPWrapper, remotePath: string): Promise<FileEntryWithStats[]> {
-  return new Promise((resolve, reject) => {
-    sftp.readdir(remotePath, (err, list) => {
-      if (err) {
-        reject(err)
-        return
-      }
-      resolve(list)
-    })
+  return await sftpOperation<FileEntryWithStats[]>(`readdir ${remotePath}`, (callback) => {
+    sftp.readdir(remotePath, callback)
   })
 }
 
 async function mkdir(sftp: SFTPWrapper, remotePath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    sftp.mkdir(remotePath, (err) => {
-      if (err) {
-        // SSH_FX_FAILURE (4) often means "already exists" on OpenSSH; we
-        // probe with stat afterwards rather than parse the error code.
-        reject(err)
-        return
-      }
-      resolve()
-    })
+  await sftpOperation<void>(`mkdir ${remotePath}`, (callback) => {
+    sftp.mkdir(remotePath, callback)
   })
 }
 


### PR DESCRIPTION
## Summary
- Add a 10s deadline around the SFTP callback primitives used by remote managed hook installation.
- Reject wedged read/write/stat/rename/chmod/readdir/mkdir/unlink callbacks so SSH startup can continue through the existing fail-open hook-install status path.
- Add a unit repro for a remote `readFile` callback that never fires.

## Repro Before Fix
- Added `src/main/agent-hooks/installer-utils-remote.test.ts` coverage with an SFTP `readFile` that never invokes its callback.
- Before the fix, `pnpm vitest run --config config/vitest.config.ts src/main/agent-hooks/installer-utils-remote.test.ts -t "times out remote reads that never call back"` failed because the promise was still pending after 30s of fake time.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/agent-hooks/installer-utils-remote.test.ts -t "times out remote reads that never call back"`
- `pnpm vitest run --config config/vitest.config.ts src/main/agent-hooks/installer-utils-remote.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/agent-hooks/installer-utils-remote.ts src/main/agent-hooks/installer-utils-remote.test.ts`
- `git diff --check HEAD`

## Risk
Low. Remote managed hook installation is best-effort; on timeout this uses the existing error-status path instead of blocking SSH workspace startup.
