### PR TITLE
feat(workspaces): auto-sleep inactive workspaces

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -911,6 +911,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
             | 'worktreeBaseRef'
             | 'kind'
             | 'symlinkPaths'
+            | 'autoSleepInactiveWorkspacesAfterMs'
             | 'issueSourcePreference'
             | 'externalWorktreeVisibility'
             | 'externalWorktreeVisibilityPromptDismissedAt'
@@ -948,6 +949,15 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         if (!Array.isArray(v) || !v.every((e) => typeof e === 'string')) {
           delete updates.symlinkPaths
         }
+      }
+      if (
+        'autoSleepInactiveWorkspacesAfterMs' in updates &&
+        updates.autoSleepInactiveWorkspacesAfterMs !== null &&
+        updates.autoSleepInactiveWorkspacesAfterMs !== undefined &&
+        (typeof updates.autoSleepInactiveWorkspacesAfterMs !== 'number' ||
+          !Number.isFinite(updates.autoSleepInactiveWorkspacesAfterMs))
+      ) {
+        delete updates.autoSleepInactiveWorkspacesAfterMs
       }
       if ('repoIcon' in updates) {
         const repoIcon = sanitizeRepoIcon(updates.repoIcon)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1659,6 +1659,21 @@ describe('Store', () => {
     expect(reloaded.getRepo('r1')!.issueSourcePreference).toBe('upstream')
   })
 
+  it('updateRepo persists auto-sleep inactivity threshold updates', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+
+    const enabled = store.updateRepo('r1', { autoSleepInactiveWorkspacesAfterMs: 30 * 60_000 })
+    expect(enabled!.autoSleepInactiveWorkspacesAfterMs).toBe(30 * 60_000)
+
+    const disabled = store.updateRepo('r1', { autoSleepInactiveWorkspacesAfterMs: null })
+    expect(disabled!.autoSleepInactiveWorkspacesAfterMs).toBeNull()
+
+    store.flush()
+    const reloaded = await createStore()
+    expect(reloaded.getRepo('r1')!.autoSleepInactiveWorkspacesAfterMs).toBeNull()
+  })
+
   it('updateRepo with issueSourcePreference=undefined clears the preference', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ issueSourcePreference: 'origin' }))

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2267,6 +2267,7 @@ export class Store {
         | 'kind'
         | 'symlinkPaths'
         | 'issueSourcePreference'
+        | 'autoSleepInactiveWorkspacesAfterMs'
         | 'externalWorktreeVisibility'
         | 'externalWorktreeVisibilityPromptDismissedAt'
         | 'projectGroupId'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5668,6 +5668,7 @@ export class OrcaRuntimeService {
         | 'worktreeBaseRef'
         | 'kind'
         | 'symlinkPaths'
+        | 'autoSleepInactiveWorkspacesAfterMs'
         | 'issueSourcePreference'
         | 'externalWorktreeVisibility'
         | 'externalWorktreeVisibilityPromptDismissedAt'

--- a/src/main/runtime/rpc/methods/repo-auto-sleep.test.ts
+++ b/src/main/runtime/rpc/methods/repo-auto-sleep.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcRequest } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { REPO_METHODS } from './repo'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+describe('repo auto-sleep RPC methods', () => {
+  it('accepts auto-sleep updates across the runtime boundary', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateRepo: vi.fn().mockResolvedValue({
+        id: 'repo-1',
+        path: '/srv/repo',
+        autoSleepInactiveWorkspacesAfterMs: null
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('repo.update', {
+        repo: 'repo-1',
+        updates: { autoSleepInactiveWorkspacesAfterMs: null }
+      })
+    )
+
+    expect(runtime.updateRepo).toHaveBeenCalledWith('repo-1', {
+      autoSleepInactiveWorkspacesAfterMs: null
+    })
+    expect(response).toMatchObject({
+      ok: true,
+      result: { repo: { id: 'repo-1', autoSleepInactiveWorkspacesAfterMs: null } }
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -56,6 +56,19 @@ const RepoUpdate = RepoSelector.extend({
     worktreeBaseRef: OptionalString,
     kind: z.enum(['git', 'folder']).optional(),
     symlinkPaths: z.array(z.string()).optional(),
+    autoSleepInactiveWorkspacesAfterMs: z
+      .unknown()
+      .transform((value) => {
+        if (value === null) {
+          return null
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          return value
+        }
+        return undefined
+      })
+      .pipe(z.union([z.number(), z.null(), z.undefined()]))
+      .optional(),
     issueSourcePreference: z.enum(['auto', 'upstream', 'origin']).optional(),
     externalWorktreeVisibility: z.enum(['hide', 'show']).optional(),
     externalWorktreeVisibilityPromptDismissedAt: z.number().finite().optional(),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,6 +64,7 @@ import {
 } from '@/lib/floating-workspace-terminal-actions'
 import { DictationController } from './components/dictation/DictationController'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
+import { AutoSleepInactiveWorkspaces } from './components/workspaces/AutoSleepInactiveWorkspaces'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
 import RecentTabSwitcher from './components/tab-bar/RecentTabSwitcher'
@@ -1579,6 +1580,7 @@ function App(): React.JSX.Element {
       <TooltipProvider delayDuration={400}>
         <ConfirmationDialogProvider>
           <WorkspacePortScanner />
+          <AutoSleepInactiveWorkspaces />
           {/* Why: leaf-mounted retention sync keeps agent-status retention
             subscriptions from re-rendering the App tree. */}
           <RetainedAgentsSyncGate />

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -19,6 +19,11 @@ import { useAppStore } from '../../store'
 import { getRepositoryIconSectionId } from './repository-settings-targets'
 import { RepositoryIconPicker } from './RepositoryIconPicker'
 import { getRepositoryPaneSearchEntries } from './repository-search'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import {
+  AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS,
+  autoSleepPresetValueFromMs
+} from '../../../../shared/auto-sleep-inactive-workspaces'
 export { getRepositoryPaneSearchEntries }
 
 type RepositoryPaneProps = {
@@ -117,9 +122,13 @@ export function RepositoryPane({
 
   const allEntries = getRepositoryPaneSearchEntries(repo)
   const identityEntries = allEntries.filter((entry) =>
-    ['Display Name', 'Project Icon', 'Default Worktree Base', 'Remove Project'].includes(
-      entry.title
-    )
+    [
+      'Display Name',
+      'Project Icon',
+      'Default Worktree Base',
+      'Auto-Sleep Inactive Workspaces',
+      'Remove Project'
+    ].includes(entry.title)
   )
   const sparsePresetEntries = allEntries.filter((entry) =>
     ['Sparse Checkout Presets'].includes(entry.title)
@@ -259,6 +268,52 @@ export function RepositoryPane({
             />
           </SearchableSetting>
         ) : null}
+
+        <SearchableSetting
+          title="Auto-Sleep Inactive Workspaces"
+          description="Sleeps workspaces after a period of inactivity. Does not affect the active workspace, pinned workspaces, or workspaces with working agents."
+          keywords={[
+            repo.displayName,
+            'sleep',
+            'inactive',
+            'workspace',
+            'memory',
+            'resource',
+            'auto sleep'
+          ]}
+          className="space-y-2"
+        >
+          <Label className="text-sm font-semibold">Auto-Sleep Inactive Workspaces</Label>
+          <p className="text-xs text-muted-foreground">
+            Sleeps workspaces after a period of inactivity. Does not affect the active workspace,
+            pinned workspaces, or workspaces with working agents.
+          </p>
+          <Select
+            value={autoSleepPresetValueFromMs(repo.autoSleepInactiveWorkspacesAfterMs)}
+            onValueChange={(value) => {
+              const preset = AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS.find(
+                (entry) => entry.value === value
+              )
+              if (!preset) {
+                return
+              }
+              void updateRepo(repo.id, {
+                autoSleepInactiveWorkspacesAfterMs: preset.ms
+              })
+            }}
+          >
+            <SelectTrigger size="sm" className="min-w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </SearchableSetting>
       </section>
     ) : null,
     hooksSection,

--- a/src/renderer/src/components/settings/repository-search.ts
+++ b/src/renderer/src/components/settings/repository-search.ts
@@ -48,6 +48,21 @@ export function getRepositoryPaneSearchEntries(repo: Repo): SettingsSearchEntry[
           }
         ]),
     {
+      title: 'Auto-Sleep Inactive Workspaces',
+      description:
+        'Sleeps workspaces after a period of inactivity. Does not affect the active workspace, pinned workspaces, or workspaces with working agents.',
+      keywords: [
+        repo.displayName,
+        'sleep',
+        'inactive',
+        'workspace',
+        'memory',
+        'resource',
+        'auto sleep',
+        'hibernate'
+      ]
+    },
+    {
       title: 'Remove Project',
       description: 'Remove this project from Orca.',
       keywords: [repo.displayName, 'delete', 'project', 'repository']

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { hasSleepableWorkspaceActivity } from '@/lib/worktree-sleepable-activity'
 import {
-  hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldUseNativeContextMenu,
   shouldIgnoreNestedWorktreeContextMenuScope,

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -37,7 +37,7 @@ import { isFolderRepo } from '../../../../shared/repo-kind'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import { hasSleepableWorkspaceActivity } from '@/lib/worktree-sleepable-activity'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import { getLineageRenderInfo } from './worktree-list-groups'
 import { getWorkspaceStatus, getWorkspaceStatusVisualMeta } from './workspace-status'
@@ -93,18 +93,6 @@ function shouldSuppressContextMenuFollowUpClick(contextMenuOpenedAt: number, now
   return (
     now - contextMenuOpenedAt >= 0 && now - contextMenuOpenedAt <= CONTEXT_MENU_CLICK_SUPPRESSION_MS
   )
-}
-
-function hasSleepableWorkspaceActivity(
-  worktreeId: string,
-  tabsByWorktree: Record<string, { id: string }[]>,
-  ptyIdsByTabId: Record<string, string[]>,
-  browserTabsByWorktree: Record<string, { id: string }[]>
-): boolean {
-  const tabs = tabsByWorktree[worktreeId] ?? []
-  const hasLiveTerminal = tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
-  const hasBrowser = (browserTabsByWorktree[worktreeId] ?? []).length > 0
-  return hasLiveTerminal || hasBrowser
 }
 
 function shouldRemoveFolderProjectFromContextMenu(
@@ -698,11 +686,11 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
 })
 
 export default WorktreeContextMenu
+export { hasSleepableWorkspaceActivity } from '@/lib/worktree-sleepable-activity'
 export {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
   WORKTREE_NATIVE_CONTEXT_MENU_ATTR,
-  hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldRemoveFolderProjectFromContextMenu,
   shouldUseNativeContextMenu,

--- a/src/renderer/src/components/workspaces/AutoSleepInactiveWorkspaces.tsx
+++ b/src/renderer/src/components/workspaces/AutoSleepInactiveWorkspaces.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+import { collectAutoSleepWorktreeIds } from '@/lib/auto-sleep-inactive-workspaces'
+import { runSleepWorktrees } from '@/components/sidebar/sleep-worktree-flow'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
+
+const AUTO_SLEEP_SCAN_INTERVAL_MS = 60_000
+
+function isRuntimeEnvironmentActive(): boolean {
+  return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
+}
+
+function runAutoSleepScan(): void {
+  if (isRuntimeEnvironmentActive()) {
+    return
+  }
+  const state = useAppStore.getState()
+  const worktreeIds = collectAutoSleepWorktreeIds(state)
+  if (worktreeIds.length === 0) {
+    return
+  }
+  void runSleepWorktrees(worktreeIds)
+}
+
+export function AutoSleepInactiveWorkspaces(): null {
+  useEffect(() => {
+    if (isRuntimeEnvironmentActive()) {
+      return
+    }
+    return installWindowVisibilityInterval({
+      run: runAutoSleepScan,
+      intervalMs: AUTO_SLEEP_SCAN_INTERVAL_MS
+    })
+  }, [])
+
+  return null
+}

--- a/src/renderer/src/lib/auto-sleep-inactive-workspaces.test.ts
+++ b/src/renderer/src/lib/auto-sleep-inactive-workspaces.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree } from '../../../shared/types'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../shared/agent-status-types'
+import {
+  collectAutoSleepWorktreeIds,
+  type AutoSleepInactiveWorkspacesState
+} from './auto-sleep-inactive-workspaces'
+
+vi.mock('@/lib/pane-manager/mobile-driver-state', () => ({
+  isPtyLocked: vi.fn(() => false)
+}))
+
+import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
+
+const NOW = 1_700_000_000_000
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'orca',
+    badgeColor: '#000',
+    addedAt: 1,
+    autoSleepInactiveWorkspacesAfterMs: 30 * 60_000,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::wt-a',
+    repoId: 'repo-1',
+    path: '/repo/wt-a',
+    branch: 'feature/a',
+    displayName: 'wt-a',
+    isMainWorktree: false,
+    isPinned: false,
+    isUnread: false,
+    lastActivityAt: NOW,
+    ...overrides
+  } as Worktree
+}
+
+function makeState(
+  overrides: Partial<AutoSleepInactiveWorkspacesState> = {}
+): AutoSleepInactiveWorkspacesState {
+  const worktree = makeWorktree()
+  return {
+    activeWorktreeId: null,
+    worktreesByRepo: { 'repo-1': [worktree] },
+    repos: [makeRepo()],
+    tabsByWorktree: {
+      [worktree.id]: [{ id: 'tab-1', title: 'shell' }]
+    },
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    browserTabsByWorktree: {},
+    lastVisitedAtByWorktreeId: {
+      [worktree.id]: NOW - 31 * 60_000
+    },
+    agentStatusByPaneKey: {},
+    runtimePaneTitlesByTabId: {},
+    openFiles: [],
+    editorDrafts: {},
+    sshConnectionStates: new Map(),
+    ...overrides
+  }
+}
+
+describe('collectAutoSleepWorktreeIds', () => {
+  it('sleeps an eligible background workspace when the repo policy is enabled', () => {
+    const state = makeState()
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual(['repo-1::wt-a'])
+  })
+
+  it('skips repos with auto-sleep disabled', () => {
+    const state = makeState({
+      repos: [makeRepo({ autoSleepInactiveWorkspacesAfterMs: null })]
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips workspaces visited within the inactivity window', () => {
+    const worktree = makeWorktree()
+    const state = makeState({
+      lastVisitedAtByWorktreeId: {
+        [worktree.id]: NOW - 5 * 60_000
+      }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips workspaces that were never visited', () => {
+    const state = makeState({
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips the active workspace', () => {
+    const worktree = makeWorktree()
+    const state = makeState({
+      activeWorktreeId: worktree.id
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips pinned workspaces', () => {
+    const state = makeState({
+      worktreesByRepo: {
+        'repo-1': [makeWorktree({ isPinned: true })]
+      }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips already-slept workspaces without live resources', () => {
+    const worktree = makeWorktree()
+    const state = makeState({
+      tabsByWorktree: { [worktree.id]: [{ id: 'tab-1', title: 'shell' }] },
+      ptyIdsByTabId: { 'tab-1': [] }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips workspaces with a fresh working agent', () => {
+    const entry: AgentStatusEntry = {
+      paneKey: 'tab-1:0',
+      state: 'working',
+      prompt: '',
+      updatedAt: NOW - 1_000,
+      stateStartedAt: NOW - 1_000,
+      stateHistory: [],
+      agentType: 'claude'
+    }
+    const state = makeState({
+      agentStatusByPaneKey: { 'tab-1:0': entry }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips workspaces with title-derived working agents', () => {
+    const worktree = makeWorktree()
+    const state = makeState({
+      tabsByWorktree: {
+        [worktree.id]: [{ id: 'tab-1', title: 'Claude working' }]
+      }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('allows sleep when agent status is stale', () => {
+    const worktree = makeWorktree()
+    const entry: AgentStatusEntry = {
+      paneKey: 'tab-1:0',
+      state: 'working',
+      prompt: '',
+      updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1,
+      stateStartedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1,
+      stateHistory: [],
+      agentType: 'claude'
+    }
+    const state = makeState({
+      agentStatusByPaneKey: { 'tab-1:0': entry }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([worktree.id])
+  })
+
+  it('skips workspaces with dirty editor buffers', () => {
+    const worktree = makeWorktree()
+    const state = makeState({
+      openFiles: [{ id: 'file-1', worktreeId: worktree.id, isDirty: true }]
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips SSH-backed repos when disconnected', () => {
+    const state = makeState({
+      repos: [
+        makeRepo({
+          connectionId: 'ssh-1',
+          autoSleepInactiveWorkspacesAfterMs: 30 * 60_000
+        })
+      ],
+      sshConnectionStates: new Map([
+        [
+          'ssh-1',
+          {
+            targetId: 'ssh-1',
+            status: 'disconnected',
+            error: null,
+            reconnectAttempt: 0
+          }
+        ]
+      ])
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual([])
+  })
+
+  it('skips workspaces with a mobile-locked PTY', () => {
+    vi.mocked(isPtyLocked).mockReturnValueOnce(true)
+    expect(collectAutoSleepWorktreeIds(makeState(), NOW)).toEqual([])
+  })
+
+  it('evaluates repos independently with different policies', () => {
+    const wtA = makeWorktree({ id: 'repo-1::wt-a', repoId: 'repo-1' })
+    const wtB = makeWorktree({ id: 'repo-2::wt-b', repoId: 'repo-2' })
+    const state = makeState({
+      repos: [
+        makeRepo({ id: 'repo-1', autoSleepInactiveWorkspacesAfterMs: 30 * 60_000 }),
+        makeRepo({ id: 'repo-2', autoSleepInactiveWorkspacesAfterMs: null })
+      ],
+      worktreesByRepo: {
+        'repo-1': [wtA],
+        'repo-2': [wtB]
+      },
+      tabsByWorktree: {
+        [wtA.id]: [{ id: 'tab-a', title: 'a' }],
+        [wtB.id]: [{ id: 'tab-b', title: 'b' }]
+      },
+      ptyIdsByTabId: {
+        'tab-a': ['pty-a'],
+        'tab-b': ['pty-b']
+      },
+      lastVisitedAtByWorktreeId: {
+        [wtA.id]: NOW - 31 * 60_000,
+        [wtB.id]: NOW - 31 * 60_000
+      }
+    })
+    expect(collectAutoSleepWorktreeIds(state, NOW)).toEqual(['repo-1::wt-a'])
+  })
+})

--- a/src/renderer/src/lib/auto-sleep-inactive-workspaces.ts
+++ b/src/renderer/src/lib/auto-sleep-inactive-workspaces.ts
@@ -1,0 +1,136 @@
+import type { Repo, Worktree } from '../../../shared/types'
+import type { SshConnectionState } from '../../../shared/ssh-types'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
+import { hasSleepableWorkspaceActivity } from '@/lib/worktree-sleepable-activity'
+import { hasFreshLiveAgent, hasWorkingTitleAgent } from '@/lib/worktree-live-agent-blockers'
+
+export type AutoSleepInactiveWorkspacesState = {
+  activeWorktreeId: string | null
+  worktreesByRepo: Record<string, Worktree[]>
+  repos: Repo[]
+  tabsByWorktree: Record<string, { id: string; title: string }[]>
+  ptyIdsByTabId: Record<string, string[]>
+  browserTabsByWorktree: Record<string, { id: string }[]>
+  lastVisitedAtByWorktreeId: Record<string, number>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  runtimePaneTitlesByTabId: Record<string, Record<string, string>>
+  openFiles: { id: string; worktreeId: string; isDirty?: boolean }[]
+  editorDrafts: Record<string, unknown>
+  sshConnectionStates: Map<string, SshConnectionState>
+}
+
+function isRepoSshDisconnected(
+  repo: Repo,
+  sshConnectionStates: Map<string, SshConnectionState>
+): boolean {
+  if (!repo.connectionId) {
+    return false
+  }
+  return sshConnectionStates.get(repo.connectionId)?.status !== 'connected'
+}
+
+function hasDirtyEditorBuffer(
+  worktreeId: string,
+  openFiles: AutoSleepInactiveWorkspacesState['openFiles'],
+  editorDrafts: AutoSleepInactiveWorkspacesState['editorDrafts']
+): boolean {
+  return openFiles.some(
+    (file) =>
+      file.worktreeId === worktreeId && (file.isDirty || editorDrafts[file.id] !== undefined)
+  )
+}
+
+function hasMobileLockedPty(
+  worktreeId: string,
+  tabsByWorktree: AutoSleepInactiveWorkspacesState['tabsByWorktree'],
+  ptyIdsByTabId: AutoSleepInactiveWorkspacesState['ptyIdsByTabId']
+): boolean {
+  const tabs = tabsByWorktree[worktreeId] ?? []
+  for (const tab of tabs) {
+    for (const ptyId of ptyIdsByTabId[tab.id] ?? []) {
+      if (isPtyLocked(ptyId)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function shouldAutoSleepWorktree(
+  worktree: Worktree,
+  repo: Repo,
+  state: AutoSleepInactiveWorkspacesState,
+  now: number
+): boolean {
+  const inactiveAfterMs = repo.autoSleepInactiveWorkspacesAfterMs
+  if (inactiveAfterMs == null || inactiveAfterMs <= 0) {
+    return false
+  }
+  if (state.activeWorktreeId === worktree.id) {
+    return false
+  }
+  if (worktree.isPinned) {
+    return false
+  }
+  if (isRepoSshDisconnected(repo, state.sshConnectionStates)) {
+    return false
+  }
+  if (
+    !hasSleepableWorkspaceActivity(
+      worktree.id,
+      state.tabsByWorktree,
+      state.ptyIdsByTabId,
+      state.browserTabsByWorktree
+    )
+  ) {
+    return false
+  }
+
+  const lastVisitedAt = state.lastVisitedAtByWorktreeId[worktree.id] ?? 0
+  if (lastVisitedAt <= 0) {
+    return false
+  }
+  if (now - lastVisitedAt < inactiveAfterMs) {
+    return false
+  }
+
+  const tabs = state.tabsByWorktree[worktree.id] ?? []
+  const tabIds = new Set(tabs.map((tab) => tab.id))
+  if (hasDirtyEditorBuffer(worktree.id, state.openFiles, state.editorDrafts)) {
+    return false
+  }
+  if (hasFreshLiveAgent(state.agentStatusByPaneKey, tabIds, now)) {
+    return false
+  }
+  if (hasWorkingTitleAgent(tabs, state.ptyIdsByTabId, state.runtimePaneTitlesByTabId)) {
+    return false
+  }
+  if (hasMobileLockedPty(worktree.id, state.tabsByWorktree, state.ptyIdsByTabId)) {
+    return false
+  }
+
+  return true
+}
+
+export function collectAutoSleepWorktreeIds(
+  state: AutoSleepInactiveWorkspacesState,
+  now: number = Date.now()
+): string[] {
+  const repoById = new Map(state.repos.map((repo) => [repo.id, repo]))
+  const ids: string[] = []
+
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      const repo = repoById.get(worktree.repoId)
+      if (!repo) {
+        continue
+      }
+      if (shouldAutoSleepWorktree(worktree, repo, state, now)) {
+        ids.push(worktree.id)
+      }
+    }
+  }
+
+  return ids
+}

--- a/src/renderer/src/lib/worktree-live-agent-blockers.ts
+++ b/src/renderer/src/lib/worktree-live-agent-blockers.ts
@@ -1,0 +1,45 @@
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../shared/agent-status-types'
+import { detectAgentStatusFromTitle, isExplicitAgentStatusFresh } from '@/lib/agent-status'
+
+function getPaneKeyTabId(paneKey: AgentStatusEntry['paneKey']): string {
+  const separatorIndex = paneKey.lastIndexOf(':')
+  return separatorIndex === -1 ? paneKey : paneKey.slice(0, separatorIndex)
+}
+
+export function hasFreshLiveAgent(
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>,
+  tabIds: Set<string>,
+  now: number
+): boolean {
+  return Object.values(agentStatusByPaneKey).some(
+    (entry) =>
+      tabIds.has(getPaneKeyTabId(entry.paneKey)) &&
+      isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS) &&
+      (entry.state === 'working' || entry.state === 'blocked' || entry.state === 'waiting')
+  )
+}
+
+export function hasWorkingTitleAgent(
+  tabs: { id: string; title: string }[],
+  ptyIdsByTabId: Record<string, string[]>,
+  runtimePaneTitlesByTabId: Record<string, Record<string, string>>
+): boolean {
+  for (const tab of tabs) {
+    if ((ptyIdsByTabId[tab.id]?.length ?? 0) === 0) {
+      continue
+    }
+    const paneTitles = runtimePaneTitlesByTabId[tab.id]
+    const titles =
+      paneTitles && Object.keys(paneTitles).length > 0 ? Object.values(paneTitles) : [tab.title]
+    for (const title of titles) {
+      const status = detectAgentStatusFromTitle(title)
+      if (status === 'working' || status === 'permission') {
+        return true
+      }
+    }
+  }
+  return false
+}

--- a/src/renderer/src/lib/worktree-sleepable-activity.ts
+++ b/src/renderer/src/lib/worktree-sleepable-activity.ts
@@ -1,0 +1,13 @@
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+
+export function hasSleepableWorkspaceActivity(
+  worktreeId: string,
+  tabsByWorktree: Record<string, { id: string }[]>,
+  ptyIdsByTabId: Record<string, string[]>,
+  browserTabsByWorktree: Record<string, { id: string }[]>
+): boolean {
+  const tabs = tabsByWorktree[worktreeId] ?? []
+  const hasLiveTerminal = tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
+  const hasBrowser = (browserTabsByWorktree[worktreeId] ?? []).length > 0
+  return hasLiveTerminal || hasBrowser
+}

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -31,6 +31,7 @@ type RepoUpdate = Partial<
     | 'worktreeBaseRef'
     | 'kind'
     | 'symlinkPaths'
+    | 'autoSleepInactiveWorkspacesAfterMs'
     | 'issueSourcePreference'
     | 'externalWorktreeVisibility'
     | 'externalWorktreeVisibilityPromptDismissedAt'

--- a/src/shared/auto-sleep-inactive-workspaces.test.ts
+++ b/src/shared/auto-sleep-inactive-workspaces.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS,
+  autoSleepMsFromPresetValue,
+  autoSleepPresetValueFromMs
+} from './auto-sleep-inactive-workspaces'
+
+describe('auto-sleep inactive workspace presets', () => {
+  it('maps known millisecond values to preset keys', () => {
+    expect(autoSleepPresetValueFromMs(30 * 60_000)).toBe('30m')
+    expect(autoSleepPresetValueFromMs(60 * 60_000)).toBe('1h')
+    expect(autoSleepPresetValueFromMs(null)).toBe('off')
+    expect(autoSleepPresetValueFromMs(undefined)).toBe('off')
+  })
+
+  it('falls back to off for unknown millisecond values', () => {
+    expect(autoSleepPresetValueFromMs(99_000)).toBe('off')
+  })
+
+  it('maps preset keys back to milliseconds', () => {
+    expect(autoSleepMsFromPresetValue('30m')).toBe(30 * 60_000)
+    expect(autoSleepMsFromPresetValue('off')).toBeNull()
+    expect(autoSleepMsFromPresetValue('unknown')).toBeNull()
+  })
+
+  it('defaults new repos to off', () => {
+    expect(AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS[0]).toEqual({
+      value: 'off',
+      label: 'Off',
+      ms: null
+    })
+  })
+})

--- a/src/shared/auto-sleep-inactive-workspaces.ts
+++ b/src/shared/auto-sleep-inactive-workspaces.ts
@@ -1,0 +1,24 @@
+export const AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS = [
+  { value: 'off', label: 'Off', ms: null },
+  { value: '30m', label: '30 minutes', ms: 30 * 60_000 },
+  { value: '1h', label: '1 hour', ms: 60 * 60_000 },
+  { value: '4h', label: '4 hours', ms: 4 * 60 * 60_000 }
+] as const
+
+export type AutoSleepInactiveWorkspacePresetValue =
+  (typeof AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS)[number]['value']
+
+export function autoSleepPresetValueFromMs(
+  ms: number | null | undefined
+): AutoSleepInactiveWorkspacePresetValue {
+  if (ms == null) {
+    return 'off'
+  }
+  const exact = AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS.find((preset) => preset.ms === ms)
+  return exact ? exact.value : 'off'
+}
+
+export function autoSleepMsFromPresetValue(value: string): number | null {
+  const preset = AUTO_SLEEP_INACTIVE_WORKSPACE_PRESETS.find((entry) => entry.value === value)
+  return preset?.ms ?? null
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -105,6 +105,9 @@ export type Repo = {
    *  "what to link", the global flag is the "whether to link at all" switch.
    *  Undefined/empty means no symlinks are created for this repo. */
   symlinkPaths?: string[]
+  /** When set, background workspaces in this project auto-sleep after this many
+   *  ms without user focus. null/undefined = disabled (default). */
+  autoSleepInactiveWorkspacesAfterMs?: number | null
   /** Durable sidebar-only repo organization. Execution remains repo-scoped. */
   projectGroupId?: string | null
   /** User-authored ordering inside the project group or ungrouped bucket. */


### PR DESCRIPTION
## Summary

- Adds a per-project Auto-Sleep Inactive Workspaces setting with Off, 30 minutes, 1 hour, and 4 hours presets.
- Sleeps eligible background workspaces after inactivity while skipping the active workspace, pinned workspaces, disconnected SSH-backed repos, dirty editor buffers, mobile-locked PTYs, and live/working agents.
- Persists the repo setting through local IPC and runtime RPC so it works for local and SSH/runtime-backed projects.

Closes #3693.

## Screenshots

Screenshot provided for the new Project Settings dropdown:

- Project Settings > gh-tui showing the Auto-Sleep Inactive Workspaces select open with Off, 30 minutes, 1 hour, and 4 hours options.

<img width="884" height="969" alt="autosleep" src="https://github.com/user-attachments/assets/8bc2bf45-6fcc-49da-9506-7060a60fa1bb" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Testing details:

- `pnpm lint` passed after rebasing onto `upstream/main`.
- `pnpm typecheck` passed after rebasing onto `upstream/main` and installing current lockfile dependencies.
- Focused tests passed:
  - `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/auto-sleep-inactive-workspaces.test.ts src/shared/auto-sleep-inactive-workspaces.test.ts src/main/runtime/rpc/methods/repo.test.ts src/main/runtime/rpc/methods/repo-auto-sleep.test.ts src/main/persistence.test.ts`
  - `TMPDIR=/Volumes/EVO/orca-vitest-tmp pnpm vitest run --config config/vitest.config.ts src/main/startup/run-electron-vite-dev-web.test.ts`
  - `pnpm run build:cli && pnpm vitest run --config config/vitest.config.ts src/main/runtime/orchestration-cli-subprocess.test.ts`
- Full `pnpm test` was run and failed locally in unrelated suites with timeout/environment failures. Direct reruns isolated the failures as local load/stale-build/temp-volume issues: `run-electron-vite-dev-web.test.ts` passed with `TMPDIR` on the same volume, and `orchestration-cli-subprocess.test.ts` passed after rebuilding the CLI.
- `pnpm build` was attempted after rebasing. It completed typecheck, relay, native macOS, CLI, main, and preload stages, then `build:electron-vite` stalled in the renderer client bundle phase with the Node process spending time in V8 allocation/GC. The hung local build was stopped rather than reported as passing.

## AI Review Report

Ran structured Codex autoreview against the branch. It initially flagged one P1 issue: the new repo setting was not accepted by the typed repo update API. Fixed by adding `autoSleepInactiveWorkspacesAfterMs` to the renderer store update type, local IPC update type/validation, runtime update type, RPC schema, and persistence update type, with focused persistence and RPC coverage.

Final autoreview command:

`/Users/gannonhall/skiller/autoreview/scripts/autoreview --mode commit --commit 1dec6ea855537a8f63600ce2c00f244e8a9869fb`

Final result: `autoreview clean: no accepted/actionable findings reported`.

Cross-platform review notes: checked macOS/Linux/Windows concerns touched by this change. No keyboard shortcuts or platform-specific labels were introduced. New behavior avoids path manipulation and shell commands. SSH/runtime compatibility was explicitly reviewed by persisting the setting through runtime RPC and by skipping auto-sleep when an SSH-backed repo is disconnected.

## Security Audit

Reviewed input handling and trust boundaries for the new persisted setting. The local IPC boundary strips non-finite/non-number values while preserving `null` for disabled, and the runtime RPC schema accepts only finite numbers, `null`, or omitted values. No new command execution, filesystem path handling, auth, secrets, dependency, or browser injection surfaces were introduced. Auto-sleep only invokes the existing sleep-worktree flow after eligibility checks.

## Notes

- X handle: `@_gannon_`
- Platform-specific behavior: SSH-backed repos are intentionally skipped when disconnected so auto-sleep does not assume local-only execution.
- Local full-suite and build issues noted above appear environmental/unrelated to this change, but are not hidden from the checklist.

Risk: medium. This is a broad user-facing auto-sleep feature spanning renderer settings, persisted repo config, runtime RPC, and workspace sleep eligibility, so it should remain open for review.

## ELI5

Projects can auto-sleep inactive workspaces after 30m/1h/4h. Active, pinned, dirty, or busy agent workspaces are left alone to free resources.
