### PR TITLE
perf: handle large pty registry hydration lists

### DIFF
--- a/src/main/memory/hydrate-local-pty-registry.test.ts
+++ b/src/main/memory/hydrate-local-pty-registry.test.ts
@@ -22,6 +22,8 @@ import type {
   unregisterPty as UnregisterFn
 } from './pty-registry'
 
+const LARGE_SESSION_COUNT = 150_000
+
 // Why: the hydrator pulls the daemon provider through this module-level
 // getter. Stubbing it lets us drive the offline / throwing / live paths
 // without spinning up real sockets.
@@ -62,6 +64,19 @@ function makeProvider(sessions: SessionInfo[]): Pick<DaemonPtyAdapter, 'listSess
   return {
     listSessions: vi.fn().mockResolvedValue(sessions)
   }
+}
+
+function makeLocalSessions(repoId: string, worktreePath: string, count: number): SessionInfo[] {
+  const sessions: SessionInfo[] = []
+  for (let index = 0; index < count; index += 1) {
+    const suffix = index.toString(16).padStart(8, '0')
+    sessions.push({
+      sessionId: `${repoId}::${worktreePath}@@${suffix}`,
+      pid: 1000 + index,
+      cwd: worktreePath
+    } as unknown as SessionInfo)
+  }
+  return sessions
 }
 
 // Why: the module under test memoizes `hasHydrated` at module scope so it
@@ -205,5 +220,25 @@ describe('hydrateLocalPtyRegistryAtBoot', () => {
     expect(entry).toBeDefined()
     expect(entry!.pid).toBe(4242)
     expect(entry!.worktreeId).toBe('repo-a::/local/Triton')
+  })
+
+  it('hydrates large daemon session lists', async () => {
+    const { hydrate, listRegisteredPtys } = await loadFresh()
+
+    const sessions = makeLocalSessions('repo-a', '/local/Triton', LARGE_SESSION_COUNT)
+    const provider = makeProvider(sessions)
+    getDaemonProviderMock.mockReturnValue(provider)
+    listRepoWorktreesMock.mockResolvedValue([
+      { path: '/local/Triton', head: '', branch: '', isBare: false, isMainWorktree: true }
+    ])
+
+    await hydrate(makeStore([{ id: 'repo-a', connectionId: null }]))
+
+    const registered = listRegisteredPtys()
+    expect(registered).toHaveLength(LARGE_SESSION_COUNT)
+    expect(registered[0]?.ptyId).toBe('repo-a::/local/Triton@@00000000')
+    expect(registered.at(-1)?.ptyId).toBe(
+      `repo-a::/local/Triton@@${(LARGE_SESSION_COUNT - 1).toString(16).padStart(8, '0')}`
+    )
   })
 })

--- a/src/main/memory/hydrate-local-pty-registry.ts
+++ b/src/main/memory/hydrate-local-pty-registry.ts
@@ -146,7 +146,11 @@ async function collectSessionInfos(
   for (const adapter of adapters) {
     try {
       const sessions = await adapter.listSessions()
-      out.push(...sessions)
+      // Why: warm reattach can discover many daemon sessions at once; spreading
+      // listSessions() into push can exceed JavaScript's argument limit.
+      for (const session of sessions) {
+        out.push(session)
+      }
     } catch (err) {
       // Why: a single adapter failing should not abort hydration of the
       // others — the current adapter and any legacy daemons each have


### PR DESCRIPTION
## Summary
- append daemon listSessions() hydration results iteratively instead of spreading large restored-session arrays
- add a 150k-session boot hydration regression test

## Validation
- pnpm exec oxlint src/main/memory/hydrate-local-pty-registry.ts src/main/memory/hydrate-local-pty-registry.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/memory/hydrate-local-pty-registry.test.ts
- pnpm run typecheck:node
- git diff --check