### PR TITLE
test: allow slower windows e2e builds

### DIFF
--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -18,6 +18,7 @@ import os from 'os'
 
 /** Temp file where the test repo path is stored for the fixture to read. */
 export const TEST_REPO_PATH_FILE = path.join(os.tmpdir(), 'orca-e2e-test-repo-path.txt')
+const ELECTRON_E2E_BUILD_TIMEOUT_MS = 300_000
 
 export default function globalSetup(): void {
   const root = process.cwd()
@@ -34,7 +35,9 @@ export default function globalSetup(): void {
     execSync('npx electron-vite build --mode e2e', {
       cwd: root,
       stdio: 'inherit',
-      timeout: 120_000
+      // Why: Windows renderer builds can exceed 120s on local/CI hosts even
+      // when healthy; global setup should not fail before specs can run.
+      timeout: ELECTRON_E2E_BUILD_TIMEOUT_MS
     })
     console.log('[e2e] Build complete.')
   }


### PR DESCRIPTION
## Summary
- increase the Electron E2E global setup build timeout from 120s to 300s
- keep the longer timeout scoped to the main `electron-vite build --mode e2e` step

## Why
On Windows, the renderer E2E build can exceed 120 seconds while still completing successfully. This causes Playwright global setup to fail with `spawnSync ... ETIMEDOUT` before any Windows-specific specs can run.

## Validation
- `pnpm exec playwright test tests/e2e/windows-terminal-env-icons.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1 --reporter=line` (2 passed; build completed in ~2m29s)
- `$env:SKIP_BUILD='1'; pnpm exec playwright test tests/e2e/right-sidebar-windows-titlebar.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1 --reporter=line; Remove-Item Env:SKIP_BUILD` (1 passed)
- `pnpm run lint -- tests/e2e/global-setup.ts`
- `git diff --check`