### PR TITLE
perf: handle large ssh config alias lists

### DIFF
--- a/src/main/ssh/ssh-config-parser.test.ts
+++ b/src/main/ssh/ssh-config-parser.test.ts
@@ -6,6 +6,16 @@ vi.mock('os', () => ({
   homedir: () => '/home/testuser'
 }))
 
+const LARGE_HOST_ALIAS_COUNT = 150_000
+
+function buildHostAliases(count: number): string {
+  const aliases: string[] = []
+  for (let index = 0; index < count; index += 1) {
+    aliases.push(`generated-${index}`)
+  }
+  return aliases.join(' ')
+}
+
 describe('parseSshConfig', () => {
   it('parses a basic host block', () => {
     const config = `
@@ -170,6 +180,31 @@ Host staging stage *.example.com
       { host: 'staging', hostname: 'staging.example.com' },
       { host: 'stage', hostname: 'staging.example.com' }
     ])
+  })
+
+  it('parses large concrete alias lists on one Host line', () => {
+    const config = [
+      `Host ${buildHostAliases(LARGE_HOST_ALIAS_COUNT)}`,
+      '  HostName generated.example.com',
+      'Host after',
+      '  HostName after.example.com'
+    ].join('\n')
+
+    const hosts = parseSshConfig(config)
+
+    expect(hosts).toHaveLength(LARGE_HOST_ALIAS_COUNT + 1)
+    expect(hosts[0]).toEqual({
+      host: 'generated-0',
+      hostname: 'generated.example.com'
+    })
+    expect(hosts[LARGE_HOST_ALIAS_COUNT - 1]).toEqual({
+      host: `generated-${LARGE_HOST_ALIAS_COUNT - 1}`,
+      hostname: 'generated.example.com'
+    })
+    expect(hosts.at(-1)).toEqual({
+      host: 'after',
+      hostname: 'after.example.com'
+    })
   })
 
   it('applies identity agent settings to every concrete alias on a multi-pattern Host line', () => {

--- a/src/main/ssh/ssh-config-parser.ts
+++ b/src/main/ssh/ssh-config-parser.ts
@@ -44,7 +44,7 @@ export function parseSshConfig(content: string): SshConfigHost[] {
 
     if (key === 'host') {
       if (current.length > 0) {
-        hosts.push(...current)
+        appendHosts(hosts, current)
       }
 
       const patterns = splitHostPatterns(value)
@@ -62,7 +62,7 @@ export function parseSshConfig(content: string): SshConfigHost[] {
 
     if (key === 'match') {
       if (current.length > 0) {
-        hosts.push(...current)
+        appendHosts(hosts, current)
       }
       current = []
       continue
@@ -122,9 +122,17 @@ export function parseSshConfig(content: string): SshConfigHost[] {
   }
 
   if (current.length > 0) {
-    hosts.push(...current)
+    appendHosts(hosts, current)
   }
   return hosts
+}
+
+function appendHosts(target: SshConfigHost[], entries: SshConfigHost[]): void {
+  // Why: generated SSH configs can put many concrete aliases on one Host line;
+  // spreading that block into push can exceed JavaScript's argument limit.
+  for (const entry of entries) {
+    target.push(entry)
+  }
 }
 
 function splitHostPatterns(input: string): string[] {


### PR DESCRIPTION
## Summary
- Replace spread-based SSH config host flushes with iterative append logic.
- Add a regression test for generated SSH config Host lines with very large concrete alias lists.

## Validation
- pnpm exec oxlint src/main/ssh/ssh-config-parser.ts src/main/ssh/ssh-config-parser.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-config-parser.test.ts src/main/ssh/ssh-config-parser-host-patterns.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low. Parser-only change preserves ordering and avoids JavaScript argument-limit failures for generated SSH configs.
