### PR TITLE
fix: detect exact filenames in windows paths

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -13,4 +13,9 @@ describe('detectLanguage', () => {
   it('maps .astro files to the custom astro language id', () => {
     expect(detectLanguage('src/routes/index.astro')).toBe('astro')
   })
+
+  it('maps exact filenames from Windows paths', () => {
+    expect(detectLanguage('C:\\Users\\alice\\repo\\Dockerfile')).toBe('dockerfile')
+    expect(detectLanguage('C:\\Users\\alice\\repo\\CMakeLists.txt')).toBe('cmake')
+  })
 })

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -100,7 +100,7 @@ const FILENAME_TO_LANGUAGE: Record<string, string> = {
 
 export function detectLanguage(filePath: string): string {
   // Check exact filename first
-  const parts = filePath.split('/')
+  const parts = filePath.split(/[\\/]/)
   const filename = parts.at(-1)!
   if (FILENAME_TO_LANGUAGE[filename]) {
     return FILENAME_TO_LANGUAGE[filename]


### PR DESCRIPTION
## Summary
- split language-detection basenames on both POSIX and Windows path separators
- add regression coverage for exact filename mappings from Windows paths

## Why
`detectLanguage` already handled Windows separators for extensions, but exact filename mappings still used `filePath.split('/')`. Windows paths like `C:\Users\alice\repo\Dockerfile` therefore missed the `Dockerfile` mapping and opened as plaintext.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/language-detect.test.ts`
- `pnpm run lint -- src/renderer/src/lib/language-detect.ts src/renderer/src/lib/language-detect.test.ts`
- `git diff --check`

Risk: low. This only changes basename splitting for language detection so exact filename mappings work with Windows path separators.