### PR TITLE
fix: reject malformed dictation audio chunks

### DIFF
--- a/src/main/runtime/rpc/methods/speech.test.ts
+++ b/src/main/runtime/rpc/methods/speech.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { SPEECH_METHODS } from './speech'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+describe('speech RPC methods', () => {
+  it('feeds valid base64 dictation chunks to the runtime', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      feedMobileDictation: vi.fn().mockReturnValue({ dictationId: 'dict-1' })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SPEECH_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('speech.dictation.chunk', {
+        dictationId: 'dict-1',
+        audioBase64: 'AAAA',
+        sampleRate: 16_000
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true, result: { dictationId: 'dict-1' } })
+    expect(runtime.feedMobileDictation).toHaveBeenCalledWith({
+      dictationId: 'dict-1',
+      audioBase64: 'AAAA',
+      sampleRate: 16_000,
+      clientId: undefined,
+      connectionId: undefined
+    })
+  })
+
+  it('rejects malformed base64 dictation chunks before feeding audio', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      feedMobileDictation: vi.fn().mockReturnValue({ dictationId: 'dict-1' })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SPEECH_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('speech.dictation.chunk', {
+        dictationId: 'dict-1',
+        audioBase64: '!!!!',
+        sampleRate: 16_000
+      })
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(runtime.feedMobileDictation).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/methods/speech.ts
+++ b/src/main/runtime/rpc/methods/speech.ts
@@ -2,6 +2,12 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalString, requiredString } from '../schemas'
 
+const AUDIO_BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/
+
+function isValidAudioBase64(value: string): boolean {
+  return value.length % 4 !== 1 && AUDIO_BASE64_PATTERN.test(value)
+}
+
 const DictationStart = z.object({
   dictationId: requiredString('Missing dictation ID'),
   modelId: OptionalString
@@ -9,7 +15,10 @@ const DictationStart = z.object({
 
 const DictationChunk = z.object({
   dictationId: requiredString('Missing dictation ID'),
-  audioBase64: requiredString('Missing audio chunk'),
+  audioBase64: requiredString('Missing audio chunk')
+    // Why: Buffer.from(..., 'base64') silently drops malformed bytes; reject
+    // bad mobile audio chunks instead of feeding empty/corrupt PCM.
+    .refine(isValidAudioBase64, 'Audio chunk must be base64'),
   sampleRate: z.number().finite().positive()
 })
 


### PR DESCRIPTION
## Summary
- Validate `speech.dictation.chunk` audio payloads as base64 at the RPC boundary.
- Keep valid chunks routing unchanged while rejecting malformed chunks before `Buffer.from(..., 'base64')` can silently drop bytes.

## Evidence
- Reproduced with a dispatcher test sending `audioBase64: "!!!!"`; before the fix, the response was `ok: true` and `feedMobileDictation()` was called.
- Verified malformed chunks now return `ok: false`, the runtime is not called, and valid `AAAA` chunks still route through.

## Checks
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/speech.test.ts -t "rejects malformed base64 dictation chunks"`
- `pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/speech.test.ts`
- `pnpm typecheck:node`
- `pnpm oxlint src/main/runtime/rpc/methods/speech.ts src/main/runtime/rpc/methods/speech.test.ts`
- `git diff --check HEAD`

Risk: low. The change rejects only malformed audio chunks from paired clients; valid mobile PCM chunks keep the same runtime path.
