### PR TITLE
perf: handle large workspace cleanup results

### DIFF
--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
-import type { DiffComment, GitStatusResult, Repo } from '../../shared/types'
+import type { DiffComment, GitStatusResult, GitWorktreeInfo, Repo } from '../../shared/types'
 
 const {
   listRepoWorktreesMock,
@@ -62,6 +62,29 @@ const REPO: Repo = {
   displayName: 'Repo',
   badgeColor: '#000',
   addedAt: NOW
+}
+const LARGE_WORKTREE_COUNT = 150_000
+
+function buildGitWorktrees(count: number): GitWorktreeInfo[] {
+  const worktrees: GitWorktreeInfo[] = []
+  for (let index = 0; index < count; index += 1) {
+    worktrees.push({
+      path: `/repo-feature-${index}`,
+      head: `abc${index}`,
+      branch: `refs/heads/feature-${index}`,
+      isBare: false,
+      isMainWorktree: false
+    })
+  }
+  return worktrees
+}
+
+function buildWorktreeIds(repoId: string, count: number): string[] {
+  const worktreeIds: string[] = []
+  for (let index = 0; index < count; index += 1) {
+    worktreeIds.push(`${repoId}::/repo-feature-${index}`)
+  }
+  return worktreeIds
 }
 
 function makeStore(
@@ -368,6 +391,33 @@ describe('workspace cleanup scan', () => {
     expect(result.candidates[0]?.localContext).toMatchObject({
       diffCommentCount: 150_000,
       newestDiffCommentAt: NOW
+    })
+  })
+
+  it('aggregates large cleanup candidate batches without hitting argument limits', async () => {
+    listRepoWorktreesMock.mockResolvedValue(buildGitWorktrees(LARGE_WORKTREE_COUNT))
+
+    const result = await scanWorkspaceCleanup(makeStore(), {
+      skipGitWorktreeIds: buildWorktreeIds(REPO.id, LARGE_WORKTREE_COUNT)
+    })
+
+    expect(getStatusMock).not.toHaveBeenCalled()
+    expect(result.errors).toEqual([])
+    expect(result.candidates).toHaveLength(LARGE_WORKTREE_COUNT)
+    expect(result.candidates[0]).toMatchObject({
+      worktreeId: 'repo-1::/repo-feature-0',
+      path: '/repo-feature-0',
+      branch: 'feature-0',
+      tier: 'review',
+      git: {
+        clean: null,
+        checkedAt: null
+      }
+    })
+    expect(result.candidates[LARGE_WORKTREE_COUNT - 1]).toMatchObject({
+      worktreeId: `repo-1::/repo-feature-${LARGE_WORKTREE_COUNT - 1}`,
+      path: `/repo-feature-${LARGE_WORKTREE_COUNT - 1}`,
+      branch: `feature-${LARGE_WORKTREE_COUNT - 1}`
     })
   })
 

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -199,8 +199,8 @@ export async function scanWorkspaceCleanup(
       targetWorktreeId: args.worktreeId,
       skipGitWorktreeIds: new Set(args.skipGitWorktreeIds ?? [])
     })
-    candidates.push(...result.candidates)
-    errors.push(...result.errors)
+    appendListItems(candidates, result.candidates)
+    appendListItems(errors, result.errors)
   }
 
   return { scannedAt, candidates, errors }
@@ -327,7 +327,7 @@ async function buildCandidate(args: {
   const gitEvidence = !shouldReadGit
     ? createEmptyGitEvidence()
     : await readGitEvidence(worktree, repo, provider)
-  blockers.push(...gitEvidence.blockers)
+  appendListItems(blockers, gitEvidence.blockers)
 
   const candidateWithoutFingerprint: WorkspaceCleanupCandidate = {
     worktreeId: worktree.id,
@@ -390,6 +390,14 @@ function shouldReadGitEvidence(args: {
   // Why: inactivity is the only recommendation signal now. Git is read only
   // to keep the destructive path from deleting dirty or local-only branch work.
   return true
+}
+
+function appendListItems<T>(target: T[], entries: readonly T[]): void {
+  // Why: cleanup can aggregate generated-size worktree batches; spreading
+  // those batches into push can exceed JavaScript's argument limit.
+  for (const entry of entries) {
+    target.push(entry)
+  }
 }
 
 async function readGitEvidence(


### PR DESCRIPTION
## Summary
- Replace spread-based workspace cleanup result aggregation with iterative append logic.
- Cover generated-size cleanup candidate batches so scans do not hit JavaScript argument limits.

## Validation
- pnpm exec oxlint src/main/ipc/workspace-cleanup.ts src/main/ipc/workspace-cleanup.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/workspace-cleanup.test.ts
- pnpm run typecheck:node
- git diff --check / git diff --check origin/main...HEAD

Risk: low. This preserves ordering and result shape while avoiding argument-limit crashes during broad cleanup scans.
