### PR TITLE
Clean up speech download request listeners

### DIFF
--- a/src/main/speech/model-manager.test.ts
+++ b/src/main/speech/model-manager.test.ts
@@ -98,6 +98,7 @@ describe('ModelManager', () => {
     try {
       const manifest = SPEECH_MODEL_CATALOG[0]
       const errorHandlers: ((err: Error) => void)[] = []
+      const timeoutHandlers: (() => void)[] = []
       const request = {
         destroy: vi.fn((err?: Error) => {
           queueMicrotask(() => {
@@ -107,9 +108,28 @@ describe('ModelManager', () => {
           })
           return request
         }),
+        setTimeout: vi.fn((_ms: number, cb: () => void) => {
+          timeoutHandlers.push(cb)
+          return request
+        }),
         on: vi.fn((event: string, cb: (err: Error) => void) => {
           if (event === 'error') {
             errorHandlers.push(cb)
+          }
+          return request
+        }),
+        off: vi.fn((event: string, cb: ((err: Error) => void) | (() => void)) => {
+          if (event === 'error') {
+            const index = errorHandlers.indexOf(cb as (err: Error) => void)
+            if (index !== -1) {
+              errorHandlers.splice(index, 1)
+            }
+          }
+          if (event === 'timeout') {
+            const index = timeoutHandlers.indexOf(cb as () => void)
+            if (index !== -1) {
+              timeoutHandlers.splice(index, 1)
+            }
           }
           return request
         })
@@ -135,6 +155,10 @@ describe('ModelManager', () => {
       await expect(download).resolves.toBeUndefined()
 
       expect(request.destroy).toHaveBeenCalledWith(expect.any(Error))
+      expect(request.off).toHaveBeenCalledWith('error', expect.any(Function))
+      expect(request.off).toHaveBeenCalledWith('timeout', expect.any(Function))
+      expect(errorHandlers).toHaveLength(0)
+      expect(timeoutHandlers).toHaveLength(0)
       expect((await manager.getModelState(manifest.id)).status).toBe('not-downloaded')
     } finally {
       rmSync(dir, { recursive: true, force: true })
@@ -146,22 +170,45 @@ describe('ModelManager', () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
     try {
       const errorHandlers: ((err: Error) => void)[] = []
+      const timeoutHandlers: (() => void)[] = []
       const request = {
         destroy: vi.fn((err?: Error) => {
-          queueMicrotask(() => {
-            for (const handler of errorHandlers) {
-              handler(err ?? new Error('destroyed'))
-            }
-          })
+          if (err) {
+            queueMicrotask(() => {
+              for (const handler of errorHandlers) {
+                handler(err)
+              }
+            })
+          }
           return request
         }),
         setTimeout: vi.fn((ms: number, cb: () => void) => {
-          setTimeout(cb, ms)
+          timeoutHandlers.push(cb)
+          setTimeout(() => {
+            for (const handler of timeoutHandlers) {
+              handler()
+            }
+          }, ms)
           return request
         }),
         on: vi.fn((event: string, cb: (err: Error) => void) => {
           if (event === 'error') {
             errorHandlers.push(cb)
+          }
+          return request
+        }),
+        off: vi.fn((event: string, cb: ((err: Error) => void) | (() => void)) => {
+          if (event === 'error') {
+            const index = errorHandlers.indexOf(cb as (err: Error) => void)
+            if (index !== -1) {
+              errorHandlers.splice(index, 1)
+            }
+          }
+          if (event === 'timeout') {
+            const index = timeoutHandlers.indexOf(cb as () => void)
+            if (index !== -1) {
+              timeoutHandlers.splice(index, 1)
+            }
           }
           return request
         })
@@ -185,7 +232,11 @@ describe('ModelManager', () => {
       const outcome = await Promise.race([outcomePromise, Promise.resolve('pending')])
 
       expect(outcome).toBe('Model download timed out after 120 seconds without network activity')
-      expect(request.destroy).toHaveBeenCalledWith(expect.any(Error))
+      expect(request.destroy).toHaveBeenCalledWith()
+      expect(request.off).toHaveBeenCalledWith('error', expect.any(Function))
+      expect(request.off).toHaveBeenCalledWith('timeout', expect.any(Function))
+      expect(errorHandlers).toHaveLength(0)
+      expect(timeoutHandlers).toHaveLength(0)
     } finally {
       vi.useRealTimers()
       rmSync(dir, { recursive: true, force: true })

--- a/src/main/speech/model-manager.ts
+++ b/src/main/speech/model-manager.ts
@@ -252,7 +252,43 @@ export class ModelManager {
         return
       }
 
-      let request: ReturnType<typeof httpsGet>
+      let settled = false
+      let request: ReturnType<typeof httpsGet> | null = null
+      const cleanupRequestListeners = (): void => {
+        const activeRequest = request
+        if (!activeRequest) {
+          return
+        }
+        activeRequest.off('error', onRequestError)
+        activeRequest.off('timeout', onRequestTimeout)
+        request = null
+      }
+      const resolveOnce = (): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanupRequestListeners()
+        resolve()
+      }
+      const rejectOnce = (error: Error): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        cleanupRequestListeners()
+        reject(error)
+      }
+      const onRequestError = (error: Error): void => rejectOnce(error)
+      const onRequestTimeout = (): void => {
+        const activeRequest = request
+        rejectOnce(
+          new Error(
+            `Model download timed out after ${DOWNLOAD_IDLE_TIMEOUT_MS / 1000} seconds without network activity`
+          )
+        )
+        activeRequest?.destroy()
+      }
       const onResponse = (response: IncomingMessage): void => {
         if (
           response.statusCode === 301 ||
@@ -264,12 +300,12 @@ export class ModelManager {
           const redirectUrl = response.headers.location
           if (!redirectUrl) {
             response.resume()
-            reject(new Error('Redirect without location'))
+            rejectOnce(new Error('Redirect without location'))
             return
           }
           if (redirectCount >= 5) {
             response.resume()
-            reject(new Error('Too many redirects'))
+            rejectOnce(new Error('Too many redirects'))
             return
           }
           let resolvedRedirect: URL
@@ -277,12 +313,12 @@ export class ModelManager {
             resolvedRedirect = new URL(redirectUrl, parsedUrl)
           } catch {
             response.resume()
-            reject(new Error('Invalid redirect URL'))
+            rejectOnce(new Error('Invalid redirect URL'))
             return
           }
           if (resolvedRedirect.protocol !== 'https:') {
             response.resume()
-            reject(new Error('Model download redirect must use HTTPS'))
+            rejectOnce(new Error('Model download redirect must use HTTPS'))
             return
           }
           response.resume()
@@ -295,14 +331,14 @@ export class ModelManager {
             signal,
             redirectCount + 1
           )
-            .then(resolve)
-            .catch(reject)
+            .then(resolveOnce)
+            .catch(rejectOnce)
           return
         }
 
         if (response.statusCode !== 200) {
           response.resume()
-          reject(new Error(`HTTP ${response.statusCode}`))
+          rejectOnce(new Error(`HTTP ${response.statusCode}`))
           return
         }
 
@@ -313,7 +349,7 @@ export class ModelManager {
 
         response.on('data', (chunk: Buffer) => {
           if (isAborted()) {
-            request.destroy(new Error('Aborted'))
+            request?.destroy(new Error('Aborted'))
             response.destroy()
             fileStream.destroy()
             return
@@ -326,12 +362,12 @@ export class ModelManager {
         pipeline(response, fileStream)
           .then(() => {
             if (isAborted()) {
-              reject(new Error('Aborted'))
+              rejectOnce(new Error('Aborted'))
             } else {
-              resolve()
+              resolveOnce()
             }
           })
-          .catch(reject)
+          .catch(rejectOnce)
       }
 
       request = signal
@@ -341,14 +377,8 @@ export class ModelManager {
       // Why: cancellation only helps after the user presses cancel; a peer
       // that accepts the socket and goes silent must not leave the model stuck
       // in "downloading" forever.
-      request.setTimeout(DOWNLOAD_IDLE_TIMEOUT_MS, () => {
-        request.destroy(
-          new Error(
-            `Model download timed out after ${DOWNLOAD_IDLE_TIMEOUT_MS / 1000} seconds without network activity`
-          )
-        )
-      })
-      request.on('error', reject)
+      request.setTimeout(DOWNLOAD_IDLE_TIMEOUT_MS, onRequestTimeout)
+      request.on('error', onRequestError)
     })
   }
 


### PR DESCRIPTION
## Summary
- remove speech model download request error and timeout listeners once a download promise settles
- keep the existing idle timeout behavior while rejecting directly on timeout and destroying the request without a synthetic second error
- assert request listener cleanup in cancellation and timeout tests

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/speech/model-manager.test.ts
- pnpm exec oxlint src/main/speech/model-manager.ts src/main/speech/model-manager.test.ts
- pnpm typecheck:node
- git diff --check

Risk: low

Risk assessment: Low. This is scoped to cleanup of listeners attached by one speech-model HTTPS request, preserves the user-facing timeout error and cancellation flow, and is covered by focused regression tests.