### PR TITLE
Add compact agent activity layout for worktree cards

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -61,6 +61,7 @@ import {
   getDefaultUIState,
   getDefaultRepoHookSettings,
   getDefaultWorkspaceSession,
+  normalizeAgentActivityDisplayMode,
   normalizeWorktreeCardProperties,
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
@@ -2802,6 +2803,9 @@ export class Store {
       worktreeCardProperties: normalizeWorktreeCardProperties(
         this.state.ui?.worktreeCardProperties
       ),
+      agentActivityDisplayMode: normalizeAgentActivityDisplayMode(
+        this.state.ui?.agentActivityDisplayMode
+      ),
       workspaceStatuses: normalizeWorkspaceStatuses(this.state.ui?.workspaceStatuses),
       workspaceBoardOpacity: clampWorkspaceBoardOpacity(this.state.ui?.workspaceBoardOpacity),
       workspaceBoardCompact: normalizeWorkspaceBoardCompact(this.state.ui?.workspaceBoardCompact),
@@ -2831,6 +2835,10 @@ export class Store {
         updates.worktreeCardProperties !== undefined
           ? normalizeWorktreeCardProperties(updates.worktreeCardProperties)
           : normalizeWorktreeCardProperties(this.state.ui?.worktreeCardProperties),
+      agentActivityDisplayMode:
+        updates.agentActivityDisplayMode !== undefined
+          ? normalizeAgentActivityDisplayMode(updates.agentActivityDisplayMode)
+          : normalizeAgentActivityDisplayMode(this.state.ui?.agentActivityDisplayMode),
       workspaceStatuses:
         updates.workspaceStatuses !== undefined
           ? normalizeWorkspaceStatuses(updates.workspaceStatuses)

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -25,6 +25,7 @@ const WorktreeCardProperty = z.enum([
   'ports',
   'inline-agents'
 ])
+const AgentActivityDisplayMode = z.enum(['compact', 'full'])
 const StatusBarItem = z.enum(['claude', 'codex', 'gemini', 'opencode-go', 'ssh', 'resource-usage'])
 const WorkspaceStatusDefinition = z.object({
   id: z.string(),
@@ -142,6 +143,7 @@ const UiUpdate = z
     uiZoomLevel: z.number().finite().optional(),
     editorFontZoomLevel: z.number().finite().optional(),
     worktreeCardProperties: z.array(WorktreeCardProperty).optional(),
+    agentActivityDisplayMode: AgentActivityDisplayMode.optional(),
     workspaceStatuses: z.array(WorkspaceStatusDefinition).optional(),
     workspaceBoardOpacity: z.number().finite().optional(),
     workspaceBoardCompact: z.boolean().optional(),

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -829,6 +829,39 @@
   background: color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
+/* Why: the virtualized card row is height-measured; animating height would
+   make TanStack reposition sibling cards on every frame. */
+.compact-agent-expansion-grid {
+  display: grid;
+  grid-template-rows: 0fr;
+}
+
+.compact-agent-expansion-grid-expanded {
+  grid-template-rows: 1fr;
+}
+
+/* Why: keyframes run when the content mounts already in its final state. */
+@keyframes compact-agent-expansion-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.compact-agent-expansion-grid-expanded .compact-agent-expansion-content {
+  animation: compact-agent-expansion-reveal 150ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .compact-agent-expansion-grid-expanded .compact-agent-expansion-content {
+    animation-duration: 0ms;
+  }
+}
+
 .scroll-to-current-workspace-reveal-highlight {
   position: relative;
   isolation: isolate;

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import type { WorktreeCardProperty } from '../../../../shared/types'
+import type { AgentActivityDisplayMode, WorktreeCardProperty } from '../../../../shared/types'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
 import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
 import SidebarWorkspaceFilterSection from './SidebarWorkspaceFilterSection'
@@ -46,6 +46,11 @@ const PROPERTY_OPTIONS: { id: WorktreeCardProperty; label: string }[] = [
   { id: 'inline-agents', label: 'Agent activity' }
 ]
 
+const AGENT_ACTIVITY_DISPLAY_OPTIONS: { id: AgentActivityDisplayMode; label: string }[] = [
+  { id: 'compact', label: 'Compact' },
+  { id: 'full', label: 'Full list' }
+]
+
 const SORT_OPTIONS = [
   { id: 'name', label: 'Name', description: null },
   {
@@ -72,6 +77,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const repos = useAppStore((s) => s.repos)
   const worktreeCardProperties = useAppStore((s) => s.worktreeCardProperties)
   const toggleWorktreeCardProperty = useAppStore((s) => s.toggleWorktreeCardProperty)
+  const agentActivityDisplayMode = useAppStore((s) => s.agentActivityDisplayMode)
+  const setAgentActivityDisplayMode = useAppStore((s) => s.setAgentActivityDisplayMode)
   const sortBy = useAppStore((s) => s.sortBy)
   const setSortBy = useAppStore((s) => s.setSortBy)
   const groupBy = useAppStore((s) => s.groupBy)
@@ -256,6 +263,26 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
                 {opt.label}
               </DropdownMenuCheckboxItem>
             ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
+              Agent activity layout
+            </DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={agentActivityDisplayMode}
+              onValueChange={(value) =>
+                setAgentActivityDisplayMode(value as AgentActivityDisplayMode)
+              }
+            >
+              {AGENT_ACTIVITY_DISPLAY_OPTIONS.map((opt) => (
+                <DropdownMenuRadioItem
+                  key={opt.id}
+                  value={opt.id}
+                  onSelect={(e) => e.preventDefault()}
+                >
+                  {opt.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -638,7 +638,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const cardBody = (
     <div
       className={cn(
-        'group relative flex items-start gap-1.5 px-1.5 py-1.5 cursor-pointer transition-all duration-200 outline-none select-none ml-1',
+        'group relative flex items-start gap-1.5 px-1.5 py-1.5 cursor-pointer transition-[background-color,border-color,opacity,box-shadow] duration-200 outline-none select-none ml-1',
         isMultiSelected ? 'rounded-sm' : 'rounded-lg',
         isActiveSurface
           ? 'bg-black/[0.08] shadow-[0_1px_2px_rgba(0,0,0,0.04)] border border-black/[0.015] dark:bg-white/[0.10] dark:border-border/40 dark:shadow-[0_1px_2px_rgba(0,0,0,0.03)]'

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -2,22 +2,59 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-let mockAgents: unknown[] = [
-  {
-    paneKey: 'tab-1:1',
-    tab: { id: 'tab-1' },
-    state: 'working',
-    entry: {
-      stateStartedAt: 1000,
-      orchestration: undefined
-    }
+type MockAgentOptions = {
+  paneKey?: string
+  tabId?: string
+  agentType?: string
+  state?: string
+  startedAt?: number
+  prompt?: string
+  stateStartedAt?: number
+  orchestration?: { parentPaneKey: string }
+  lineage?: {
+    depth: number
+    isFirstSibling: boolean
+    isLastSibling: boolean
+    childCount: number
   }
-]
+}
+
+function mockAgent({
+  paneKey = 'tab-1:1',
+  tabId = paneKey.split(':')[0],
+  agentType,
+  state = 'working',
+  startedAt,
+  prompt,
+  stateStartedAt = 1000,
+  orchestration,
+  lineage
+}: MockAgentOptions = {}): unknown {
+  return {
+    paneKey,
+    tab: { id: tabId },
+    agentType,
+    state,
+    startedAt,
+    entry: {
+      prompt,
+      state,
+      stateStartedAt,
+      stateHistory: prompt === undefined ? undefined : [],
+      orchestration
+    },
+    lineage
+  }
+}
+
+let mockAgents: unknown[] = [mockAgent()]
 let mockFocusedAgentPaneKey: string | null = null
+let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
+      agentActivityDisplayMode: mockAgentActivityDisplayMode,
       acknowledgedAgentsByPaneKey: {},
       dropAgentStatus: vi.fn(),
       dismissRetainedAgent: vi.fn(),
@@ -82,21 +119,13 @@ vi.mock('@/components/ui/tooltip', () => ({
 describe('WorktreeCardAgents', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockAgents = [
-      {
-        paneKey: 'tab-1:1',
-        tab: { id: 'tab-1' },
-        state: 'working',
-        entry: {
-          stateStartedAt: 1000,
-          orchestration: undefined
-        }
-      }
-    ]
+    mockAgents = [mockAgent()]
     mockFocusedAgentPaneKey = null
+    mockAgentActivityDisplayMode = undefined
   })
 
-  it('renders ordinary rows in a labeled group without a child disclosure', async () => {
+  it('renders ordinary rows in full mode without a child disclosure', async () => {
+    mockAgentActivityDisplayMode = 'full'
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
@@ -108,24 +137,22 @@ describe('WorktreeCardAgents', () => {
     expect(markup).not.toContain('aria-expanded')
   })
 
+  it('uses compact mode when the display preference is absent', async () => {
+    mockAgents = [mockAgent({ agentType: 'codex', startedAt: 1000, prompt: 'Run tests' })]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('role="group"')
+    expect(markup).toContain('Run tests')
+    expect(markup).toContain('title="Codex"')
+    expect(markup).not.toContain('data-testid="agent-row"')
+  })
+
   it('marks only the focused agent row', async () => {
+    mockAgentActivityDisplayMode = 'full'
     mockFocusedAgentPaneKey = 'tab-1:2'
-    mockAgents = [
-      {
-        paneKey: 'tab-1:1',
-        tab: { id: 'tab-1' },
-        entry: {
-          stateStartedAt: 1000
-        }
-      },
-      {
-        paneKey: 'tab-1:2',
-        tab: { id: 'tab-1' },
-        entry: {
-          stateStartedAt: 1000
-        }
-      }
-    ]
+    mockAgents = [mockAgent({ paneKey: 'tab-1:1' }), mockAgent({ paneKey: 'tab-1:2' })]
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
@@ -135,39 +162,29 @@ describe('WorktreeCardAgents', () => {
   })
 
   it('collapses orchestration child agent rows behind a parent disclosure by default', async () => {
+    mockAgentActivityDisplayMode = 'full'
     mockAgents = [
-      {
+      mockAgent({
         paneKey: 'tab-parent:1',
-        tab: { id: 'tab-parent' },
-        state: 'working',
-        entry: {
-          stateStartedAt: 1000,
-          orchestration: undefined
-        },
         lineage: {
           depth: 0,
           isFirstSibling: true,
           isLastSibling: true,
           childCount: 1
         }
-      },
-      {
+      }),
+      mockAgent({
         paneKey: 'tab-child:1',
-        tab: { id: 'tab-child' },
         state: 'done',
-        entry: {
-          stateStartedAt: 1500,
-          orchestration: {
-            parentPaneKey: 'tab-parent:1'
-          }
-        },
+        stateStartedAt: 1500,
+        orchestration: { parentPaneKey: 'tab-parent:1' },
         lineage: {
           depth: 1,
           isFirstSibling: true,
           isLastSibling: true,
           childCount: 0
         }
-      }
+      })
     ]
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
@@ -181,50 +198,32 @@ describe('WorktreeCardAgents', () => {
   })
 
   it('keeps partially cyclic orchestration rows visible as flat roots', async () => {
+    mockAgentActivityDisplayMode = 'full'
     mockAgents = [
-      {
-        paneKey: 'tab-root:1',
-        tab: { id: 'tab-root' },
-        state: 'working',
-        entry: {
-          stateStartedAt: 1000,
-          orchestration: undefined
-        }
-      },
-      {
+      mockAgent({ paneKey: 'tab-root:1' }),
+      mockAgent({
         paneKey: 'tab-cycle-a:1',
-        tab: { id: 'tab-cycle-a' },
-        state: 'working',
-        entry: {
-          stateStartedAt: 1200,
-          orchestration: {
-            parentPaneKey: 'tab-cycle-b:1'
-          }
-        },
+        stateStartedAt: 1200,
+        orchestration: { parentPaneKey: 'tab-cycle-b:1' },
         lineage: {
           depth: 0,
           isFirstSibling: true,
           isLastSibling: false,
           childCount: 1
         }
-      },
-      {
+      }),
+      mockAgent({
         paneKey: 'tab-cycle-b:1',
-        tab: { id: 'tab-cycle-b' },
         state: 'done',
-        entry: {
-          stateStartedAt: 1300,
-          orchestration: {
-            parentPaneKey: 'tab-cycle-a:1'
-          }
-        },
+        stateStartedAt: 1300,
+        orchestration: { parentPaneKey: 'tab-cycle-a:1' },
         lineage: {
           depth: 1,
           isFirstSibling: false,
           isLastSibling: true,
           childCount: 1
         }
-      }
+      })
     ]
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
@@ -243,5 +242,103 @@ describe('WorktreeCardAgents', () => {
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
 
     expect(markup).toBe('')
+  })
+
+  it('renders a compact summary affordance for multiple flat agents', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        state: 'waiting',
+        startedAt: 1000,
+        prompt: 'Pick a layout'
+      }),
+      mockAgent({
+        paneKey: 'tab-1:2',
+        agentType: 'claude',
+        startedAt: 1500,
+        stateStartedAt: 1500,
+        prompt: 'Run tests'
+      }),
+      mockAgent({
+        paneKey: 'tab-1:3',
+        agentType: 'gemini',
+        state: 'done',
+        startedAt: 1700,
+        stateStartedAt: 1700,
+        prompt: 'Review spacing'
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('aria-expanded="false"')
+    expect(markup).toContain('3 agents: 1 waiting, 1 working, 1 done')
+    expect(markup).toContain('Expand 3 agents: 1 waiting, 1 working, 1 done')
+    expect(markup).not.toContain('data-testid="agent-row"')
+  })
+  it('prioritizes agent varieties in compact summary icons', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      ['tab-1:1', 'codex', 'One'],
+      ['tab-1:2', 'codex', 'Two'],
+      ['tab-1:3', 'codex', 'Three'],
+      ['tab-1:4', 'gemini', 'Four'],
+      ['tab-1:5', 'claude', 'Five']
+    ].map(([paneKey, agentType, prompt]) =>
+      mockAgent({ paneKey, agentType, startedAt: 1000, prompt })
+    )
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    const iconTitles = [...markup.matchAll(/title="([^"]+)"/g)].map((match) => match[1])
+
+    expect(iconTitles).toEqual(['Codex', 'Gemini', 'Claude'])
+  })
+
+  it('summarizes compact lineage by parent rows before revealing children', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        paneKey: 'tab-parent-a:1',
+        agentType: 'codex',
+        startedAt: 1000,
+        prompt: 'Parent A'
+      }),
+      mockAgent({
+        paneKey: 'tab-child-a:1',
+        agentType: 'claude',
+        state: 'done',
+        startedAt: 1100,
+        stateStartedAt: 1100,
+        prompt: 'Child A',
+        orchestration: { parentPaneKey: 'tab-parent-a:1' }
+      }),
+      mockAgent({
+        paneKey: 'tab-parent-b:1',
+        agentType: 'gemini',
+        state: 'waiting',
+        startedAt: 1200,
+        stateStartedAt: 1200,
+        prompt: 'Parent B'
+      }),
+      mockAgent({
+        paneKey: 'tab-child-b:1',
+        agentType: 'codex',
+        startedAt: 1300,
+        stateStartedAt: 1300,
+        prompt: 'Child B',
+        orchestration: { parentPaneKey: 'tab-parent-b:1' }
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('role="tree"')
+    expect(markup).toContain('2 parents: 1 waiting, 1 working')
+    expect(markup).not.toContain('Parent A')
+    expect(markup).not.toContain('Child A')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
@@ -10,6 +10,29 @@ import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/da
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import { dismissStaleAgentRowByKey } from '../terminal-pane/stale-agent-row'
 import { useFocusedAgentPaneKey } from './focused-agent-row-highlight'
+import {
+  CompactAgentExpansion,
+  CompactAgentRow,
+  CompactAgentSummaryButton
+} from './worktree-card-compact-agents'
+import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
+import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
+
+export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
+  'orca-suppress-worktree-list-scroll-adjustment'
+
+const dispatchSuppressScrollAdjustment = () => {
+  window.dispatchEvent(new CustomEvent(SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT))
+}
+
+function revealCompactAgentCard(agentListRoot: HTMLElement | null): void {
+  const sidebarElement = agentListRoot?.closest('[data-worktree-sidebar]')
+  const worktreeOptionElement = agentListRoot?.closest('[role="option"]')
+  if (!(sidebarElement instanceof HTMLElement) || !worktreeOptionElement) {
+    return
+  }
+  revealElementInScrollContainer(sidebarElement, worktreeOptionElement, 'auto')
+}
 
 type Props = {
   worktreeId: string
@@ -116,9 +139,12 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   agents,
   className
 }: BodyProps) {
+  const agentActivityDisplayMode =
+    useAppStore((s) => s.agentActivityDisplayMode) ?? DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
   const dropAgentStatus = useAppStore((s) => s.dropAgentStatus)
   const dismissRetainedAgent = useAppStore((s) => s.dismissRetainedAgent)
   const focusedAgentPaneKey = useFocusedAgentPaneKey(worktreeId)
+  const compactAgentListRootRef = useRef<HTMLDivElement | null>(null)
 
   // Why: subscribe to the ack map reference (Object.is equality) and derive
   // per-agent unvisited flags locally. Keeps the inline list's bold/mute
@@ -188,15 +214,26 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   // never mount this component (see WorktreeCardAgents), so idle worktrees
   // don't pay any timer cost.
   const now = useNow(30_000)
-  const hasLineage = agents.some((agent) => agent.lineage && agent.lineage.depth > 0)
   const { rootAgents, childrenByParentPaneKey } = useMemo(
     () => buildAgentLineageModel(agents),
     [agents]
   )
+  const hasLineage = childrenByParentPaneKey.size > 0
   const [expandedLineageParents, setExpandedLineageParents] = useState<ReadonlySet<string>>(
     () => new Set()
   )
+  const [compactRootListExpanded, setCompactRootListExpanded] = useState(false)
+
+  useLayoutEffect(() => {
+    if (compactRootListExpanded && agentActivityDisplayMode === 'compact') {
+      dispatchSuppressScrollAdjustment()
+      // Why: keep any needed reveal scroll in the expansion commit; a delayed
+      // store reveal paints the tall card once, then scrolls it on the next turn.
+      revealCompactAgentCard(compactAgentListRootRef.current)
+    }
+  }, [agentActivityDisplayMode, compactRootListExpanded])
   const toggleLineageParent = useCallback((paneKey: string) => {
+    dispatchSuppressScrollAdjustment()
     setExpandedLineageParents((current) => {
       const next = new Set(current)
       if (next.has(paneKey)) {
@@ -283,6 +320,88 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     )
   }
 
+  const renderCompactAgentBranch = (
+    agent: DashboardAgentRowData,
+    ancestorPaneKeys: ReadonlySet<string> = new Set()
+  ): React.ReactNode => {
+    if (ancestorPaneKeys.has(agent.paneKey)) {
+      return null
+    }
+    const childAgents = childrenByParentPaneKey.get(agent.paneKey) ?? []
+    const hasChildAgents = childAgents.length > 0
+    const expanded = expandedLineageParents.has(agent.paneKey)
+    const descendantAncestorPaneKeys = new Set(ancestorPaneKeys)
+    descendantAncestorPaneKeys.add(agent.paneKey)
+    return (
+      <React.Fragment key={agent.paneKey}>
+        <CompactAgentRow
+          agent={agent}
+          now={now}
+          onActivate={handleActivateAgentTab}
+          childAgentCount={hasChildAgents ? childAgents.length : undefined}
+          childAgentsExpanded={expanded}
+          onToggleChildAgents={
+            hasChildAgents ? () => toggleLineageParent(agent.paneKey) : undefined
+          }
+          reserveDisclosureGutter={anyRootHasChildren && !hasChildAgents}
+          isFocusedPane={agent.paneKey === focusedAgentPaneKey}
+        />
+        {hasChildAgents ? (
+          <CompactAgentExpansion expanded={expanded}>
+            {childAgents.map((childAgent) =>
+              renderCompactAgentBranch(childAgent, descendantAncestorPaneKeys)
+            )}
+          </CompactAgentExpansion>
+        ) : null}
+      </React.Fragment>
+    )
+  }
+
+  if (agentActivityDisplayMode === 'compact') {
+    const shouldUseSummaryRow = agents.length > 1
+    const summaryAgents = hasLineage ? rootAgents : agents
+    const subjectLabel = hasLineage
+      ? `${rootAgents.length} ${rootAgents.length === 1 ? 'parent' : 'parents'}`
+      : `${agents.length} agents`
+
+    return (
+      <div
+        ref={compactAgentListRootRef}
+        className={cn('flex flex-col mt-1 mb-1 gap-0.5', className)}
+        onClick={stopBubble}
+        onDoubleClick={stopBubble}
+        onMouseDown={stopBubble}
+        onPointerDown={stopBubble}
+        role={hasLineage ? 'tree' : 'group'}
+        aria-label="Agents"
+      >
+        {shouldUseSummaryRow && (
+          <CompactAgentSummaryButton
+            agents={summaryAgents}
+            subjectLabel={subjectLabel}
+            expanded={compactRootListExpanded}
+            onToggle={() => {
+              dispatchSuppressScrollAdjustment()
+              setCompactRootListExpanded((expanded) => !expanded)
+            }}
+          />
+        )}
+        {!shouldUseSummaryRow ? (
+          <CompactAgentRow
+            agent={agents[0]}
+            now={now}
+            onActivate={handleActivateAgentTab}
+            isFocusedPane={agents[0].paneKey === focusedAgentPaneKey}
+          />
+        ) : shouldUseSummaryRow ? (
+          <CompactAgentExpansion expanded={compactRootListExpanded}>
+            {rootAgents.map((rootAgent) => renderCompactAgentBranch(rootAgent))}
+          </CompactAgentExpansion>
+        ) : null}
+      </div>
+    )
+  }
+
   return (
     // Why: swallow bubbling so clicks on the gutter around the agent rows
     // don't reach WorktreeCard's activate / edit-meta handlers.
@@ -290,6 +409,8 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
       className={cn('flex flex-col mt-1 mb-1', className)}
       onClick={stopBubble}
       onDoubleClick={stopBubble}
+      onMouseDown={stopBubble}
+      onPointerDown={stopBubble}
       role={hasLineage ? 'tree' : 'group'}
       aria-label="Agents"
     >

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -27,7 +27,9 @@ import {
   useWorktreeMap
 } from '@/store/selectors'
 import WorktreeCard from './WorktreeCard'
-import WorktreeCardAgents from './WorktreeCardAgents'
+import WorktreeCardAgents, {
+  SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT
+} from './WorktreeCardAgents'
 import { SshDisconnectedDialog } from './SshDisconnectedDialog'
 import { WorktreeActivityStatusIndicator } from './WorktreeActivityStatusIndicator'
 import { Button } from '@/components/ui/button'
@@ -77,12 +79,15 @@ import {
   getActiveStickyHeaderIndex,
   getActiveStickyHeaderIndexForScroll,
   getPreviousStickyHeaderIndex,
-  GROUP_HEADER_ROW_HEIGHT,
   getStickyHeaderIndexes,
   getVirtualRowTransform,
   shouldUseHeaderTopSpacing,
   type RenderRow
 } from './worktree-list-virtual-rows'
+import {
+  revealElementInScrollContainer,
+  WORKTREE_SIDEBAR_REVEAL_TOP_INSET
+} from './worktree-sidebar-reveal'
 import {
   getWorkspaceStatus,
   getWorkspaceStatusFromGroupKey,
@@ -158,6 +163,11 @@ import {
 import { RepoIconGlyph } from '@/components/repo/repo-icon'
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 
+export {
+  getScrollTopToRevealBounds,
+  WORKTREE_SIDEBAR_REVEAL_TOP_INSET
+} from './worktree-sidebar-reveal'
+
 type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
   | { type: 'rename'; groupId: string; currentName: string }
@@ -172,10 +182,8 @@ type ProjectGroupDeleteDialogState = {
 // terminal title changes) trigger score recalculations.
 const SORT_SETTLE_MS = 3_000
 const USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 500
-const WORKTREE_REVEAL_TOP_CLEARANCE = 6
 const EMPTY_PROJECT_GROUPS: readonly ProjectGroup[] = []
-export const WORKTREE_SIDEBAR_REVEAL_TOP_INSET =
-  GROUP_HEADER_ROW_HEIGHT + WORKTREE_REVEAL_TOP_CLEARANCE
+const EXPANDING_CARD_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 300
 const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
   // Why: TanStack Virtual owns scroll correction. Native browser anchoring can
   // fight virtual row measurement/remounts and produce visible jumps.
@@ -247,59 +255,16 @@ function getWorktreeOptionId(worktreeId: string): string {
   return `worktree-list-option-${encodeURIComponent(worktreeId)}`
 }
 
-function getMountedWorktreeBounds(
-  container: HTMLElement,
-  worktreeId: string
-): VirtualItemBounds | null {
-  const element = document.getElementById(getWorktreeOptionId(worktreeId))
-  if (!element || !container.contains(element)) {
-    return null
-  }
-
-  const containerRect = container.getBoundingClientRect()
-  const elementRect = element.getBoundingClientRect()
-  return {
-    index: -1,
-    start: elementRect.top - containerRect.top + container.scrollTop,
-    end: elementRect.bottom - containerRect.top + container.scrollTop
-  }
-}
-
-export function getScrollTopToRevealBounds(
-  container: HTMLElement,
-  bounds: Pick<VirtualItemBounds, 'start' | 'end'>,
-  topInset = 0
-): number | null {
-  const viewportTopInset = Math.max(0, Math.min(container.clientHeight, topInset))
-  const viewportTop = container.scrollTop + viewportTopInset
-  const viewportBottom = container.scrollTop + container.clientHeight
-  if (bounds.start < viewportTop) {
-    return bounds.start - viewportTopInset
-  }
-  if (bounds.end > viewportBottom) {
-    return bounds.end - container.clientHeight
-  }
-  return null
-}
-
 function revealMountedWorktreeElement(
   container: HTMLElement,
   worktreeId: string,
   behavior: ScrollBehavior
 ): boolean {
-  const bounds = getMountedWorktreeBounds(container, worktreeId)
-  if (!bounds) {
+  const element = document.getElementById(getWorktreeOptionId(worktreeId))
+  if (!element || !container.contains(element)) {
     return false
   }
-  const nextScrollTop = getScrollTopToRevealBounds(
-    container,
-    bounds,
-    WORKTREE_SIDEBAR_REVEAL_TOP_INSET
-  )
-  if (nextScrollTop !== null) {
-    container.scrollTo({ top: Math.max(0, nextScrollTop), behavior })
-  }
-  return true
+  return revealElementInScrollContainer(container, element, behavior)
 }
 
 function getWorktreeVisibilityMenuLabel(repo: Repo): string {
@@ -396,12 +361,6 @@ const WORKTREE_ROW_DRAG_INITIAL_STATE: WorktreeRowDragState = {
   dropIndicatorY: null,
   previewOffsetsByWorktreeId: EMPTY_WORKTREE_DRAG_PREVIEW_OFFSETS,
   pointerY: null
-}
-
-type VirtualItemBounds = {
-  index: number
-  start: number
-  end: number
 }
 
 type WorktreePointerDrag = {
@@ -989,6 +948,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       now: window.performance.now(),
       suppressUntil: suppressMeasurementAdjustmentUntilRef.current
     })
+
+  useEffect(() => {
+    const handleSuppress = () => {
+      // Why: compact agent expansion changes measured row height; let the row
+      // grow in place instead of letting TanStack compensate scrollTop.
+      suppressMeasurementAdjustmentUntilRef.current =
+        window.performance.now() + EXPANDING_CARD_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS
+    }
+    window.addEventListener(SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT, handleSuppress)
+    return () => {
+      window.removeEventListener(SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT, handleSuppress)
+    }
+  }, [])
 
   React.useEffect(() => {
     if (!pendingRevealWorktree) {
@@ -2601,7 +2573,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   data-worktree-drag-group-key={worktreeDragGroupKey}
                   data-worktree-drag-group-index={worktreeDragGroupIndex}
                   className={cn(
-                    'relative transition-[opacity,transform,filter] duration-150 ease-out',
+                    // Why: avoid transitioning 'transform' to prevent browser-side lag and flashing
+                    // when TanStack Virtual programmatically repositions adjacent rows.
+                    'relative transition-[opacity,filter] duration-150 ease-out',
                     highlightedRevealWorktreeId === itemRow.worktree.id &&
                       'scroll-to-current-workspace-reveal-highlight',
                     worktreeDragState.draggingWorktreeId === itemRow.worktree.id &&

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
@@ -1,0 +1,382 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { ChevronRight } from 'lucide-react'
+import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
+import { cn } from '@/lib/utils'
+import type { AgentStatusState } from '../../../../shared/agent-status-types'
+
+function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
+  switch (state) {
+    case 'working':
+    case 'blocked':
+    case 'waiting':
+    case 'done':
+    case 'idle':
+      return state
+    default:
+      return 'idle'
+  }
+}
+
+function getAgentDotState(agent: DashboardAgentRowData): AgentDotState {
+  return agent.entry.interrupted === true ? 'interrupted' : asDotState(agent.state)
+}
+
+function formatShortTimeAgo(ts: number, now: number): string {
+  const delta = now - ts
+  if (delta < 60_000) {
+    return 'now'
+  }
+  const minutes = Math.floor(delta / 60_000)
+  if (minutes < 60) {
+    return `${minutes}m`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h`
+  }
+  return `${Math.floor(hours / 24)}d`
+}
+
+function lastEnteredDoneAt(agent: DashboardAgentRowData): number | null {
+  const entry = agent.entry
+  if (entry.state === 'done') {
+    return entry.stateStartedAt
+  }
+  for (let i = (entry.stateHistory?.length ?? 0) - 1; i >= 0; i--) {
+    if (entry.stateHistory[i].state === 'done') {
+      return entry.stateHistory[i].startedAt
+    }
+  }
+  return null
+}
+
+function getCompactAgentPrimary(agent: DashboardAgentRowData): string {
+  const prompt = agent.entry.prompt?.trim() ?? ''
+  return prompt || agentStateLabel(getAgentDotState(agent))
+}
+
+function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
+  if (agent.entry.interrupted === true) {
+    return 'Interrupted by user'
+  }
+  if (agent.state === 'working') {
+    const toolName = agent.entry.toolName?.trim() ?? ''
+    const toolInput = agent.entry.toolInput?.trim() ?? ''
+    if (toolName && toolInput) {
+      return `${toolName}: ${toolInput}`
+    }
+    if (toolName) {
+      return toolName
+    }
+  }
+  return agent.entry.lastAssistantMessage?.trim() || formatAgentTypeLabel(agent.agentType)
+}
+
+function getCompactAgentTime(agent: DashboardAgentRowData, now: number): string | null {
+  const doneAt = lastEnteredDoneAt(agent)
+  if (doneAt !== null) {
+    return formatShortTimeAgo(doneAt, now)
+  }
+  const startedAt = agent.startedAt > 0 ? agent.startedAt : agent.entry.stateStartedAt
+  return startedAt > 0 ? formatShortTimeAgo(startedAt, now) : null
+}
+
+const SUMMARY_STATE_ORDER: AgentDotState[] = [
+  'waiting',
+  'blocked',
+  'interrupted',
+  'working',
+  'done',
+  'idle'
+]
+
+function stopActivationKeyPropagation(e: React.KeyboardEvent): void {
+  // Why: the surrounding worktree list handles Enter/Space as row activation.
+  // Focused nested buttons need those keys to stay local.
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.stopPropagation()
+  }
+}
+
+function summarizeAgents(agents: DashboardAgentRowData[], subjectLabel: string): string {
+  const counts = new Map<AgentDotState, number>()
+  for (const agent of agents) {
+    const dotState = getAgentDotState(agent)
+    counts.set(dotState, (counts.get(dotState) ?? 0) + 1)
+  }
+  const parts = SUMMARY_STATE_ORDER.flatMap((state) => {
+    const count = counts.get(state) ?? 0
+    if (count === 0) {
+      return []
+    }
+    const label =
+      state === 'waiting'
+        ? 'waiting'
+        : state === 'blocked'
+          ? 'blocked'
+          : state === 'interrupted'
+            ? 'interrupted'
+            : state === 'working'
+              ? 'working'
+              : state === 'done'
+                ? 'done'
+                : 'idle'
+    return `${count} ${label}`
+  })
+  return `${subjectLabel}: ${parts.join(', ')}`
+}
+
+function selectSummaryIconAgents(
+  agents: DashboardAgentRowData[],
+  maxCount: number
+): DashboardAgentRowData[] {
+  const groups = new Map<string, { agents: DashboardAgentRowData[]; firstIndex: number }>()
+  agents.forEach((agent, index) => {
+    const key = agent.agentType ?? 'unknown'
+    const group = groups.get(key)
+    if (group) {
+      group.agents.push(agent)
+    } else {
+      groups.set(key, { agents: [agent], firstIndex: index })
+    }
+  })
+  const sortedGroups = [...groups.values()].sort(
+    (a, b) => b.agents.length - a.agents.length || a.firstIndex - b.firstIndex
+  )
+  const selected: DashboardAgentRowData[] = []
+  for (const group of sortedGroups) {
+    if (selected.length >= maxCount) {
+      break
+    }
+    selected.push(group.agents[0])
+  }
+  // Why: once every visible agent kind is represented, duplicate slots should
+  // reflect the largest groups instead of arbitrary list order.
+  for (const group of sortedGroups) {
+    for (const agent of group.agents.slice(1)) {
+      if (selected.length >= maxCount) {
+        return selected
+      }
+      selected.push(agent)
+    }
+  }
+  return selected
+}
+
+type CompactAgentSummaryButtonProps = {
+  agents: DashboardAgentRowData[]
+  subjectLabel: string
+  expanded: boolean
+  onToggle: () => void
+}
+
+type CompactAgentExpansionProps = {
+  expanded: boolean
+  children: React.ReactNode
+}
+
+export function CompactAgentExpansion({
+  expanded,
+  children
+}: CompactAgentExpansionProps): React.JSX.Element {
+  const [hasRenderedChildren, setHasRenderedChildren] = useState(expanded)
+  useEffect(() => {
+    if (expanded) {
+      setHasRenderedChildren(true)
+    }
+  }, [expanded])
+  const shouldRenderChildren = expanded || hasRenderedChildren
+
+  return (
+    <div
+      className={cn(
+        'compact-agent-expansion-grid',
+        expanded && 'compact-agent-expansion-grid-expanded'
+      )}
+      aria-hidden={!expanded}
+      inert={!expanded}
+    >
+      <div className="min-h-0 overflow-hidden">
+        {shouldRenderChildren && (
+          <div className="compact-agent-expansion-content flex flex-col gap-0.5 pt-0.5">
+            {children}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function CompactAgentSummaryButton({
+  agents,
+  subjectLabel,
+  expanded,
+  onToggle
+}: CompactAgentSummaryButtonProps): React.JSX.Element {
+  const summary = summarizeAgents(agents, subjectLabel)
+  const iconAgents = selectSummaryIconAgents(agents, 3)
+  const stopPointerPropagation = useCallback((e: React.SyntheticEvent) => {
+    e.stopPropagation()
+  }, [])
+  const handleToggle = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      onToggle()
+    },
+    [onToggle]
+  )
+  return (
+    <button
+      type="button"
+      draggable={false}
+      className={cn(
+        'group/agent-summary flex h-6 w-full min-w-0 items-center gap-1.5 rounded-sm border border-sidebar-border/70',
+        'bg-sidebar-accent/35 px-1.5 text-left text-[11px] leading-none text-muted-foreground',
+        'hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring'
+      )}
+      aria-label={`${expanded ? 'Collapse' : 'Expand'} ${summary}`}
+      aria-expanded={expanded}
+      onClick={handleToggle}
+      onKeyDown={stopActivationKeyPropagation}
+      onMouseDown={stopPointerPropagation}
+      onPointerDown={stopPointerPropagation}
+      onDragStart={stopPointerPropagation}
+    >
+      <span className="flex shrink-0 items-center -space-x-1" aria-hidden>
+        {iconAgents.map((agent) => (
+          <span
+            key={agent.paneKey}
+            className="inline-flex size-4 items-center justify-center rounded-full border border-sidebar bg-sidebar"
+            title={formatAgentTypeLabel(agent.agentType)}
+          >
+            <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={12} />
+          </span>
+        ))}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{summary}</span>
+      <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+        +{agents.length}
+      </span>
+      <ChevronRight
+        className={cn('size-3 shrink-0 transition-transform duration-150', expanded && 'rotate-90')}
+        aria-hidden
+      />
+    </button>
+  )
+}
+
+type CompactAgentRowProps = {
+  agent: DashboardAgentRowData
+  now: number
+  onActivate: (tabId: string, paneKey: string) => void
+  childAgentCount?: number
+  childAgentsExpanded?: boolean
+  onToggleChildAgents?: () => void
+  reserveDisclosureGutter?: boolean
+  isFocusedPane?: boolean
+  hideIdentityIcon?: boolean
+}
+
+export const CompactAgentRow = React.memo(function CompactAgentRow({
+  agent,
+  now,
+  onActivate,
+  childAgentCount,
+  childAgentsExpanded = false,
+  onToggleChildAgents,
+  reserveDisclosureGutter = false,
+  isFocusedPane = false,
+  hideIdentityIcon = false
+}: CompactAgentRowProps) {
+  const hasChildDisclosure =
+    typeof childAgentCount === 'number' &&
+    childAgentCount > 0 &&
+    typeof onToggleChildAgents === 'function'
+  const dotState = getAgentDotState(agent)
+  const primary = getCompactAgentPrimary(agent)
+  const secondary = getCompactAgentSecondary(agent)
+  const shortTime = getCompactAgentTime(agent, now)
+
+  const handleActivate = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onActivate(agent.tab.id, agent.paneKey)
+    },
+    [agent.paneKey, agent.tab.id, onActivate]
+  )
+  const handleToggleChildren = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      onToggleChildAgents?.()
+    },
+    [onToggleChildAgents]
+  )
+
+  return (
+    <div
+      draggable={false}
+      className={cn(
+        'group/compact-agent-row flex h-6 min-w-0 cursor-pointer items-center gap-1 rounded-sm px-1 text-[11px] leading-none',
+        'text-muted-foreground worktree-agent-row-hover',
+        isFocusedPane && 'bg-sidebar-accent'
+      )}
+      onClick={handleActivate}
+      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onDragStart={(e) => e.stopPropagation()}
+      data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
+      role={agent.lineage ? 'treeitem' : undefined}
+      aria-level={agent.lineage ? agent.lineage.depth + 1 : undefined}
+      aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}
+      title={`${primary}${secondary ? ` - ${secondary}` : ''}`}
+    >
+      {hasChildDisclosure ? (
+        <button
+          type="button"
+          className="flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring"
+          aria-label={`${childAgentsExpanded ? 'Hide' : 'Show'} ${childAgentCount} child ${
+            childAgentCount === 1 ? 'agent' : 'agents'
+          }`}
+          aria-expanded={childAgentsExpanded}
+          onClick={handleToggleChildren}
+          onKeyDown={stopActivationKeyPropagation}
+        >
+          <ChevronRight
+            className={cn(
+              'size-3 transition-transform duration-150',
+              childAgentsExpanded && 'rotate-90'
+            )}
+            aria-hidden
+          />
+        </button>
+      ) : reserveDisclosureGutter ? (
+        <span className="size-4 shrink-0" aria-hidden />
+      ) : null}
+      <AgentStateDot state={dotState} size="sm" />
+      {!hideIdentityIcon && (
+        <span className="inline-flex shrink-0" title={formatAgentTypeLabel(agent.agentType)}>
+          <AgentIcon agent={agentTypeToIconAgent(agent.agentType)} size={13} />
+        </span>
+      )}
+      <span className="min-w-0 flex-1 truncate">
+        <span className="text-foreground/85">{primary}</span>
+        {secondary && <span className="text-muted-foreground/75"> - {secondary}</span>}
+      </span>
+      {hasChildDisclosure && !childAgentsExpanded && (
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">
+          +{childAgentCount}
+        </span>
+      )}
+      {shortTime && (
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/60">
+          {shortTime}
+        </span>
+      )}
+    </div>
+  )
+})

--- a/src/renderer/src/components/sidebar/worktree-sidebar-reveal.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-reveal.ts
@@ -1,0 +1,55 @@
+import { GROUP_HEADER_ROW_HEIGHT } from './worktree-list-virtual-rows'
+
+const WORKTREE_REVEAL_TOP_CLEARANCE = 6
+export const WORKTREE_SIDEBAR_REVEAL_TOP_INSET =
+  GROUP_HEADER_ROW_HEIGHT + WORKTREE_REVEAL_TOP_CLEARANCE
+
+type SidebarRevealBounds = {
+  start: number
+  end: number
+}
+
+function getElementScrollBounds(container: HTMLElement, element: Element): SidebarRevealBounds {
+  const containerRect = container.getBoundingClientRect()
+  const elementRect = element.getBoundingClientRect()
+  return {
+    start: elementRect.top - containerRect.top + container.scrollTop,
+    end: elementRect.bottom - containerRect.top + container.scrollTop
+  }
+}
+
+export function getScrollTopToRevealBounds(
+  container: HTMLElement,
+  bounds: SidebarRevealBounds,
+  topInset = 0
+): number | null {
+  const viewportTopInset = Math.max(0, Math.min(container.clientHeight, topInset))
+  const viewportTop = container.scrollTop + viewportTopInset
+  const viewportBottom = container.scrollTop + container.clientHeight
+  if (bounds.start < viewportTop) {
+    return bounds.start - viewportTopInset
+  }
+  if (bounds.end > viewportBottom) {
+    return bounds.end - container.clientHeight
+  }
+  return null
+}
+
+export function revealElementInScrollContainer(
+  container: HTMLElement,
+  element: Element,
+  behavior: ScrollBehavior
+): boolean {
+  if (!container.contains(element)) {
+    return false
+  }
+  const nextScrollTop = getScrollTopToRevealBounds(
+    container,
+    getElementScrollBounds(container, element),
+    WORKTREE_SIDEBAR_REVEAL_TOP_INSET
+  )
+  if (nextScrollTop !== null) {
+    container.scrollTo({ top: Math.max(0, nextScrollTop), behavior })
+  }
+  return true
+}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -589,6 +589,29 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().worktreeCardProperties).toEqual(expected)
     expect(setUI).toHaveBeenCalledWith({ worktreeCardProperties: expected })
   })
+
+  it('persists the agent activity display mode', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().setAgentActivityDisplayMode('full')
+
+    expect(store.getState().agentActivityDisplayMode).toBe('full')
+    expect(setUI).toHaveBeenCalledWith({ agentActivityDisplayMode: 'full' })
+  })
+
+  it('normalizes invalid persisted agent activity display modes', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        agentActivityDisplayMode: 'bogus' as PersistedUIState['agentActivityDisplayMode']
+      })
+    )
+
+    expect(store.getState().agentActivityDisplayMode).toBe('compact')
+  })
 })
 
 describe('createUISlice settings navigation', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -19,6 +19,7 @@ import type {
   TuiAgent,
   UpdateStatus,
   WorkspaceStatusDefinition,
+  AgentActivityDisplayMode,
   WorktreeCardProperty
 } from '../../../../shared/types'
 import { PET_SIZE_DEFAULT, PET_SIZE_MAX, PET_SIZE_MIN } from '../../../../shared/types'
@@ -40,9 +41,11 @@ import {
 } from '../../../../shared/task-providers'
 import {
   DEFAULT_HIDE_SLEEPING_WORKSPACES,
+  DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE,
   DEFAULT_SHOW_SLEEPING_WORKSPACES,
   DEFAULT_STATUS_BAR_ITEMS,
   DEFAULT_WORKTREE_CARD_PROPERTIES,
+  normalizeAgentActivityDisplayMode,
   normalizeWorktreeCardProperties
 } from '../../../../shared/constants'
 import {
@@ -526,6 +529,8 @@ export type UISlice = {
   toggleCollapsedGroup: (key: string) => void
   worktreeCardProperties: WorktreeCardProperty[]
   toggleWorktreeCardProperty: (prop: WorktreeCardProperty) => void
+  agentActivityDisplayMode: AgentActivityDisplayMode
+  setAgentActivityDisplayMode: (mode: AgentActivityDisplayMode) => void
   workspaceStatuses: WorkspaceStatusDefinition[]
   setWorkspaceStatuses: (statuses: WorkspaceStatusDefinition[]) => void
   workspaceBoardOpacity: number
@@ -1065,6 +1070,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     }),
 
   worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
+  agentActivityDisplayMode: DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE,
   toggleWorktreeCardProperty: (prop) =>
     set((s) => {
       const current = normalizeWorktreeCardProperties(s.worktreeCardProperties)
@@ -1075,6 +1081,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       window.api.ui.set({ worktreeCardProperties: updated }).catch(console.error)
       return { worktreeCardProperties: updated }
     }),
+  setAgentActivityDisplayMode: (mode) => {
+    const normalized = normalizeAgentActivityDisplayMode(mode)
+    window.api.ui.set({ agentActivityDisplayMode: normalized }).catch(console.error)
+    set({ agentActivityDisplayMode: normalized })
+  },
 
   workspaceStatuses: cloneDefaultWorkspaceStatuses(),
   setWorkspaceStatuses: (statuses) => {
@@ -1269,6 +1280,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         uiZoomLevel: ui.uiZoomLevel ?? 0,
         editorFontZoomLevel: ui.editorFontZoomLevel ?? 0,
         worktreeCardProperties: normalizeWorktreeCardProperties(ui.worktreeCardProperties),
+        agentActivityDisplayMode: normalizeAgentActivityDisplayMode(ui.agentActivityDisplayMode),
         workspaceStatuses: normalizeWorkspaceStatuses(ui.workspaceStatuses),
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardCompact: normalizeWorkspaceBoardCompact(ui.workspaceBoardCompact),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -21,7 +21,8 @@ import {
   getDefaultOnboardingState,
   getDefaultSettings,
   getDefaultUIState,
-  getDefaultWorkspaceSession
+  getDefaultWorkspaceSession,
+  normalizeAgentActivityDisplayMode
 } from '../../../shared/constants'
 import { legacyBaseRefSearchResult } from '../../../shared/base-ref-search-result'
 import { createE2EConfig } from '../../../shared/e2e-config'
@@ -2117,7 +2118,10 @@ function mergeWebUIState(
 ): PersistedUIState {
   return {
     ...base,
-    ...updates
+    ...updates,
+    agentActivityDisplayMode: normalizeAgentActivityDisplayMode(
+      updates.agentActivityDisplayMode ?? base.agentActivityDisplayMode
+    )
   }
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -7,7 +7,8 @@ import type {
   PersistedState,
   PersistedUIState,
   RepoHookSettings,
-  WorkspaceSessionState
+  WorkspaceSessionState,
+  AgentActivityDisplayMode
 } from './types'
 import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
@@ -28,6 +29,11 @@ export const SCHEMA_VERSION = 1
 export const DEFAULT_APP_FONT_FAMILY = 'Geist'
 export const DEFAULT_SHOW_SLEEPING_WORKSPACES = true
 export const DEFAULT_HIDE_SLEEPING_WORKSPACES = false
+export const DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE: AgentActivityDisplayMode = 'compact'
+
+export function normalizeAgentActivityDisplayMode(value: unknown): AgentActivityDisplayMode {
+  return value === 'full' || value === 'compact' ? value : DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
+}
 
 // Why: the onboarding wizard's last step index. Centralized so backfill,
 // clamps, and UI step references all agree on the same upper bound.
@@ -379,6 +385,7 @@ export function getDefaultUIState(): PersistedUIState {
     uiZoomLevel: 0,
     editorFontZoomLevel: 0,
     worktreeCardProperties: [...DEFAULT_WORKTREE_CARD_PROPERTIES],
+    agentActivityDisplayMode: DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE,
     workspaceStatuses: cloneDefaultWorkspaceStatuses(),
     workspaceBoardOpacity: 1,
     workspaceBoardCompact: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2204,6 +2204,8 @@ export type WorktreeCardProperty =
   // view options.
   | 'inline-agents'
 
+export type AgentActivityDisplayMode = 'compact' | 'full'
+
 export type StatusBarItem =
   | 'claude'
   | 'codex'
@@ -2252,6 +2254,7 @@ export type PersistedUIState = {
   uiZoomLevel: number
   editorFontZoomLevel: number
   worktreeCardProperties: WorktreeCardProperty[]
+  agentActivityDisplayMode?: AgentActivityDisplayMode
   workspaceStatuses?: WorkspaceStatusDefinition[]
   workspaceBoardOpacity?: number
   workspaceBoardCompact?: boolean


### PR DESCRIPTION
## Summary
- add a persisted compact/full agent activity display preference
- render compact per-worktree agent summaries with expandable rows
- preserve virtualized sidebar scroll position when compact agent rows expand

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/store/slices/ui.test.ts

Risk: medium

Risk assessment: Medium. This changes persisted UI preference state and virtualized sidebar rendering for worktree agent activity; it should get another review/verification pass before merge.