### PR TITLE
fix: name remote repos from resolved paths

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -549,6 +549,42 @@ describe('repos:addRemote', () => {
     expect(result).toHaveProperty('repo.path', '/home/user/project')
   })
 
+  it('uses the resolved git root basename for the default remote display name', async () => {
+    mockGitProvider.isGitRepoAsync.mockResolvedValueOnce({
+      isRepo: true,
+      rootPath: '/home/user/project'
+    })
+
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-1',
+      remotePath: '/home/user/project/src'
+    })
+
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/home/user/project',
+        displayName: 'project'
+      })
+    )
+    expect(result).toHaveProperty('repo.displayName', 'project')
+  })
+
+  it('derives default remote display names from Windows path separators', async () => {
+    const result = await handlers.get('repos:addRemote')!(null, {
+      connectionId: 'conn-1',
+      remotePath: 'C:\\Users\\alice\\project',
+      kind: 'folder'
+    })
+
+    expect(mockStore.addRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'C:\\Users\\alice\\project',
+        displayName: 'project'
+      })
+    )
+    expect(result).toHaveProperty('repo.displayName', 'project')
+  })
+
   it('notifies renderer when remote repo is added', async () => {
     await handlers.get('repos:addRemote')!(null, {
       connectionId: 'conn-1',

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -84,6 +84,14 @@ function emitRepoAdded(method: RepoMethod, alreadyExisted: boolean): void {
   track('repo_added', { method, ...getCohortAtEmit() })
 }
 
+function getRemoteRepoFolderName(remotePath: string): string {
+  const trimmed = remotePath.replace(/[\\/]+$/, '')
+  if (!trimmed) {
+    return remotePath
+  }
+  return trimmed.split(/[\\/]/).at(-1) || remotePath
+}
+
 type ActiveCloneMetadata = {
   path: string
   pathKey: string
@@ -601,9 +609,6 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         return { repo: existing }
       }
 
-      const pathSegments = resolvedPath.replace(/\/+$/, '').split('/')
-      let folderName = pathSegments.at(-1) || resolvedPath
-
       if (args.kind !== 'folder') {
         // Why: when kind is not explicitly 'folder', verify the remote path is
         // a git repo. Return an error on failure so the renderer can show the "Open as
@@ -626,6 +631,8 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           return { error: `Not a valid git repository: ${args.remotePath}` }
         }
       }
+
+      const folderName = getRemoteRepoFolderName(resolvedPath)
 
       // When folderName is the home directory basename (e.g. 'ubuntu'),
       // use SSH target label for a more descriptive name


### PR DESCRIPTION
## Summary
- derive default SSH repo display names after git root canonicalization
- split remote display-name basenames on both `/` and `\` separators
- add regression coverage for subdirectory git roots and Windows-style remote paths

## Why
`repos:addRemote` computed `folderName` before `isGitRepoAsync` could replace a selected subdirectory with the actual repo root. Adding `/home/user/project/src` could therefore store `/home/user/project` while naming the repo `src`. The same basename logic also only understood `/`, so Windows SSH paths like `C:\Users\alice\project` produced the whole absolute path as the default display name.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/repos-remote.test.ts`
- `pnpm run lint -- src/main/ipc/repos.ts src/main/ipc/repos-remote.test.ts`
- `git diff --check`

Risk: low

Risk assessment: Low. This only changes default display-name derivation for newly added remote repos and adds focused coverage for repo-root and Windows-style path cases.