### PR TITLE
fix: time out desktop script bridge

### DIFF
--- a/src/main/computer/desktop-script-provider-client.test.ts
+++ b/src/main/computer/desktop-script-provider-client.test.ts
@@ -1,14 +1,40 @@
 /* eslint-disable max-lines -- Why: desktop provider contract coverage shares one mocked bridge harness. */
 import { execFile } from 'child_process'
-import { readFileSync } from 'fs'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DesktopScriptProviderClient } from './desktop-script-provider-client'
+
+const { operationFiles, mkdtempMock, rmMock, writeFileMock } = vi.hoisted(() => {
+  const files = new Map<string, string>()
+  return {
+    operationFiles: files,
+    mkdtempMock: vi.fn(async (prefix: string) => `${prefix}${files.size}`),
+    rmMock: vi.fn(async () => undefined),
+    writeFileMock: vi.fn(async (filePath: string, data: string | Buffer) => {
+      files.set(filePath, Buffer.isBuffer(data) ? data.toString('utf8') : data)
+    })
+  }
+})
 
 vi.mock('child_process', () => ({
   execFile: vi.fn()
 }))
 
+vi.mock('fs/promises', () => ({
+  mkdtemp: mkdtempMock,
+  rm: rmMock,
+  writeFile: writeFileMock
+}))
+
 describe('DesktopScriptProviderClient', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.mocked(execFile).mockReset()
+    operationFiles.clear()
+    mkdtempMock.mockClear()
+    rmMock.mockClear()
+    writeFileMock.mockClear()
+  })
+
   it('normalizes list-apps responses', async () => {
     mockBridgeResponse({
       ok: true,
@@ -291,6 +317,27 @@ describe('DesktopScriptProviderClient', () => {
     })
   })
 
+  it('rejects when the desktop provider subprocess ignores the exec timeout', async () => {
+    vi.useFakeTimers()
+    const kill = vi.fn()
+    vi.mocked(execFile).mockImplementationOnce(() => ({ kill }) as never)
+
+    const client = new DesktopScriptProviderClient('linux', '/tmp/runtime.py')
+    const promise = client.listApps()
+    let settled = false
+    void promise.catch(() => {
+      settled = true
+    })
+
+    await vi.waitFor(() => expect(execFile).toHaveBeenCalled(), { timeout: 1_000 })
+    await vi.advanceTimersByTimeAsync(30_001)
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(settled).toBe(true)
+    expect(kill).toHaveBeenCalled()
+    await expect(promise).rejects.toMatchObject({ code: 'action_timeout' })
+  })
+
   it('maps action-specific bridge errors to actionable codes', async () => {
     mockBridgeResponse({ ok: false, error: 'element value is not settable' })
     mockBridgeResponse({ ok: false, error: 'Raise is not a valid secondary action' })
@@ -375,7 +422,11 @@ function mockBridgeResponse(
   vi.mocked(execFile).mockImplementationOnce((_command, _args, _options, callback) => {
     const operationPath = _args?.at(-1)
     if (inspectOperation && typeof operationPath === 'string') {
-      inspectOperation(JSON.parse(readFileSync(operationPath, 'utf8')) as Record<string, unknown>)
+      const operation = operationFiles.get(operationPath)
+      if (!operation) {
+        throw new Error(`Missing mocked operation file: ${operationPath}`)
+      }
+      inspectOperation(JSON.parse(operation) as Record<string, unknown>)
     }
     const done = callback as (error: Error | null, stdout: string, stderr: string) => void
     done(null, JSON.stringify(response), '')

--- a/src/main/computer/desktop-script-provider-client.ts
+++ b/src/main/computer/desktop-script-provider-client.ts
@@ -428,28 +428,60 @@ function execBridge(
         ]
       : [scriptPath, operationPath]
   return new Promise((resolve, reject) => {
-    execFile(
-      command,
-      args,
-      {
-        env: process.env,
-        maxBuffer: 20 * 1024 * 1024,
-        timeout: REQUEST_TIMEOUT_MS,
-        windowsHide: true
-      },
-      (error, stdout, stderr) => {
-        if (error) {
-          const message = stderr.trim() || stdout.trim() || error.message
-          reject(
-            error.killed
-              ? new RuntimeClientError('action_timeout', message)
-              : mapBridgeError(message)
-          )
-          return
-        }
-        resolve({ stdout, stderr })
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null, result?: { stdout: string; stderr: string }): void => {
+      if (settled) {
+        return
       }
-    )
+      settled = true
+      clearTimeout(timeout)
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(result ?? { stdout: '', stderr: '' })
+    }
+
+    // Why: Node's execFile timeout only sends a signal; a provider process that
+    // ignores it can still leave the computer-use action promise pending.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(
+        new RuntimeClientError(
+          'action_timeout',
+          `desktop provider timed out after ${REQUEST_TIMEOUT_MS}ms`
+        )
+      )
+    }, REQUEST_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        command,
+        args,
+        {
+          env: process.env,
+          maxBuffer: 20 * 1024 * 1024,
+          timeout: REQUEST_TIMEOUT_MS,
+          windowsHide: true
+        },
+        (error, stdout, stderr) => {
+          if (error) {
+            const message = stderr.trim() || stdout.trim() || error.message
+            finish(
+              error.killed
+                ? new RuntimeClientError('action_timeout', message)
+                : mapBridgeError(message)
+            )
+            return
+          }
+          finish(null, { stdout, stderr })
+        }
+      )
+    } catch (error) {
+      finish(mapBridgeError(error instanceof Error ? error.message : String(error)))
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- add a promise-level timeout around the desktop script provider bridge subprocess
- reject with `action_timeout` and kill the child best-effort even if the `execFile` callback never arrives
- make the desktop provider bridge test harness deterministic by keeping operation JSON in memory

## Evidence
- Pre-fix repro: `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/desktop-script-provider-client.test.ts -t "ignores the exec timeout"` failed with `expected false to be true` after advancing 30 seconds of fake time because `DesktopScriptProviderClient.listApps()` was still pending.
- Post-fix: the same targeted repro passes.
- Full validation: `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/desktop-script-provider-client.test.ts`
- Full validation: `pnpm run typecheck:node`
- Full validation: `pnpm exec oxlint src/main/computer/desktop-script-provider-client.ts src/main/computer/desktop-script-provider-client.test.ts`
- Full validation: `git diff --check HEAD~1..HEAD`

Risk: low

Risk assessment: Low. This only bounds desktop computer-use bridge subprocesses that have already exceeded the existing 30s timeout window.