### PR TITLE
Make workspace resume actions more obvious

### DIFF
--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -5583,12 +5583,14 @@ export default function PullRequestPage({
                   type="button"
                   size="sm"
                   onClick={handleOpenOrUsePR}
-                  className="gap-1.5 whitespace-nowrap"
+                  className="gap-1.5 whitespace-nowrap font-semibold"
                   aria-label={
-                    attachedWorkspace ? 'Open workspace attached to PR' : 'Start workspace from PR'
+                    attachedWorkspace
+                      ? 'Resume workspace attached to PR'
+                      : 'Start workspace from PR'
                   }
                 >
-                  {attachedWorkspace ? 'Open workspace' : 'Start workspace from PR'}
+                  {attachedWorkspace ? 'Resume workspace' : 'Start workspace from PR'}
                   <ArrowRight className="size-3.5" />
                 </Button>
                 <DropdownMenuTrigger asChild>

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -5321,29 +5321,34 @@ export default function TaskPage(): React.JSX.Element {
                                 <ButtonGroup>
                                   <Button
                                     type="button"
-                                    variant="outline"
+                                    variant={attachedWorkspace ? 'default' : 'outline'}
                                     size="xs"
                                     onClick={(event) => {
                                       event.stopPropagation()
                                       handleOpenOrUseGitHubPR(item)
                                     }}
-                                    className="bg-background/80"
+                                    className={cn(
+                                      'min-w-[72px] gap-1 font-semibold',
+                                      attachedWorkspace ? 'shadow-xs' : 'bg-background/80'
+                                    )}
                                     aria-label={
                                       attachedWorkspace
-                                        ? 'Open workspace attached to PR'
+                                        ? 'Resume workspace attached to PR'
                                         : 'Start workspace from PR'
                                     }
                                   >
-                                    {attachedWorkspace ? 'Open' : 'Start'}
+                                    {attachedWorkspace ? 'Resume' : 'Start'}
                                     <ArrowRight className="size-3" />
                                   </Button>
                                   <DropdownMenuTrigger asChild>
                                     <Button
                                       type="button"
-                                      variant="outline"
+                                      variant={attachedWorkspace ? 'default' : 'outline'}
                                       size="icon-xs"
                                       onClick={(event) => event.stopPropagation()}
-                                      className="bg-background/80"
+                                      className={cn(
+                                        attachedWorkspace ? 'shadow-xs' : 'bg-background/80'
+                                      )}
                                       aria-label="More PR actions"
                                     >
                                       <ChevronDown className="size-3" />

--- a/src/renderer/src/components/automations/automation-run-view-state.test.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.test.ts
@@ -72,7 +72,7 @@ describe('automation run view state', () => {
     })
   })
 
-  it('falls back to opening the workspace when terminal history is gone', () => {
+  it('falls back to resuming the workspace when terminal history is gone', () => {
     expect(
       getAutomationRunViewState({
         run: makeRun(),
@@ -81,8 +81,8 @@ describe('automation run view state', () => {
       })
     ).toMatchObject({
       availability: 'workspace',
-      actionLabel: 'Open workspace',
-      statusLabel: 'Opened workspace; original terminal is closed.',
+      actionLabel: 'Resume workspace',
+      statusLabel: 'Workspace is available; original terminal is closed.',
       canOpen: true
     })
   })

--- a/src/renderer/src/components/automations/automation-run-view-state.ts
+++ b/src/renderer/src/components/automations/automation-run-view-state.ts
@@ -59,10 +59,10 @@ export function getAutomationRunViewState({
   if (run.workspaceId && workspaceExists) {
     return {
       availability: 'workspace',
-      actionLabel: 'Open workspace',
+      actionLabel: 'Resume workspace',
       statusLabel: run.terminalSessionId
-        ? 'Opened workspace; original terminal is closed.'
-        : 'Opened workspace.',
+        ? 'Workspace is available; original terminal is closed.'
+        : 'Workspace is available.',
       canOpen: true
     }
   }

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -453,7 +453,7 @@ function WorktreeRow({
         <button
           type="button"
           onClick={onNavigate}
-          aria-label={`Open workspace ${rowLabel}`}
+          aria-label={`Resume workspace ${rowLabel}`}
           className="flex-1 min-w-0 py-2 pr-2 pl-1 text-left flex items-center gap-1.5"
           disabled={!isNavigable}
         >


### PR DESCRIPTION
## Summary
- Rename attached-workspace actions from Open to Resume
- Make attached PR workspace actions visually stronger
- Update automation fallback copy and tests

## Test plan
- pnpm typecheck
- pnpm test -- src/renderer/src/components/automations/automation-run-view-state.test.ts (ran full Vitest suite: 1060 passed, 1 skipped)

Risk: medium

Risk assessment: Medium. This changes user-facing workspace action copy and emphasis across attached workspace flows; it should stay open for another UI/product pass before merge.