### PR TITLE
fix: time out workspace port commands

### DIFF
--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   attributePortToWorkspace,
   isContainerProcess,
   parseLsofListeningOutput,
   parseNetstatListeningOutput,
-  parseProcNetTcp
+  parseProcNetTcp,
+  scanWorkspacePorts
 } from './local-workspace-port-scanner'
+
+const execFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
 
 const worktrees = [
   {
@@ -132,5 +139,39 @@ describe('container process classification', () => {
       true
     )
     expect(isContainerProcess({ processName: 'node', commandLine: 'node server.js' })).toBe(false)
+  })
+})
+
+describe('scanWorkspacePorts command timeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    execFileMock.mockReset()
+  })
+
+  it('returns an unavailable scan when lsof never reports completion', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+
+    let settled = false
+    const scanPromise = scanWorkspacePorts([], {
+      lookup: () => undefined,
+      reconcileScan: vi.fn()
+    }).then((scan) => {
+      settled = true
+      return scan
+    })
+
+    await vi.advanceTimersByTimeAsync(4_000)
+
+    expect(settled).toBe(true)
+    await expect(scanPromise).resolves.toMatchObject({
+      platform: 'darwin',
+      ports: [],
+      unavailableReason: 'Port scanning is unavailable on darwin.'
+    })
+    expect(killMock).toHaveBeenCalled()
   })
 })

--- a/src/main/ports/local-workspace-port-scanner.ts
+++ b/src/main/ports/local-workspace-port-scanner.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: the platform-specific scan paths share parsing,
 attribution, and normalization rules that must stay in lockstep. */
 import { execFile } from 'child_process'
-import { promisify } from 'util'
 import { readFile, readdir, readlink } from 'fs/promises'
 import path from 'path'
 import type {
@@ -11,8 +10,6 @@ import type {
   WorkspacePortScanResult
 } from '../../shared/workspace-ports'
 import { advertisedUrlWatcher, type AdvertisedUrlWatcher } from './advertised-url-watcher'
-
-const execFileAsync = promisify(execFile)
 
 const COMMAND_TIMEOUT_MS = 4_000
 const MAX_PORTS = 200
@@ -340,12 +337,50 @@ async function loadWindowsProcessMetadata(
 }
 
 async function runCommand(command: string, args: string[]): Promise<{ stdout: string }> {
-  const { stdout } = await execFileAsync(command, args, {
-    timeout: COMMAND_TIMEOUT_MS,
-    maxBuffer: 2 * 1024 * 1024,
-    windowsHide: true
+  return await new Promise((resolve, reject) => {
+    let settled = false
+    let child: ReturnType<typeof execFile> | undefined
+    const timer = setTimeout(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      child?.kill()
+      reject(new Error(`${command} timed out after ${COMMAND_TIMEOUT_MS}ms`))
+    }, COMMAND_TIMEOUT_MS)
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      callback()
+    }
+
+    // Why: Node's execFile timeout only signals the child; if the callback
+    // never arrives, the workspace port scan would otherwise hang forever.
+    try {
+      child = execFile(
+        command,
+        args,
+        {
+          timeout: COMMAND_TIMEOUT_MS,
+          maxBuffer: 2 * 1024 * 1024,
+          windowsHide: true
+        },
+        (error, stdout) => {
+          if (error) {
+            settle(() => reject(error))
+            return
+          }
+          settle(() => resolve({ stdout: String(stdout) }))
+        }
+      )
+    } catch (error) {
+      settle(() => reject(error))
+    }
   })
-  return { stdout: String(stdout) }
 }
 
 async function readTextIfAvailable(filePath: string): Promise<string | undefined> {


### PR DESCRIPTION
## Summary
- add a promise-level timeout around local workspace port scanner platform commands
- kill wedged `lsof`/`netstat`/PowerShell children best-effort when they never invoke the `execFile` callback
- cover the wedged macOS `lsof` path with a fake-timer regression test

## Repro Evidence
Before the fix, the new regression test failed because `scanWorkspacePorts()` stayed pending after the 4s timeout window:

```
AssertionError: expected false to be true
src/main/ports/local-workspace-port-scanner.test.ts:169:21
```

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ports/local-workspace-port-scanner.test.ts -t "returns an unavailable scan when lsof never reports completion"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ports/local-workspace-port-scanner.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ports/local-workspace-port-scanner.ts src/main/ports/local-workspace-port-scanner.test.ts`
- `git diff --check`

Risk: low. The existing scanner fallback already returns an unavailable scan on command failure; this just makes the timeout reliable when the child never reports completion.