### PR TITLE
fix: generate runtime tls certs without openssl

### DIFF
--- a/src/main/runtime/tls-certificate.test.ts
+++ b/src/main/runtime/tls-certificate.test.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { loadOrCreateTlsCertificate } from './tls-certificate'
+
+const tempRoots: string[] = []
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-tls-certificate-test-'))
+  tempRoots.push(root)
+  return root
+}
+
+describe('loadOrCreateTlsCertificate', () => {
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('generates certificates without requiring an openssl executable', () => {
+    const root = makeTempRoot()
+    const result = loadOrCreateTlsCertificate(root)
+
+    expect(result.cert).toContain('-----BEGIN CERTIFICATE-----')
+    expect(result.key).toContain('-----BEGIN PRIVATE KEY-----')
+    expect(result.fingerprint).toMatch(/^sha256:/)
+    expect(existsSync(join(root, 'orca-tls-cert.pem'))).toBe(true)
+    expect(existsSync(join(root, 'orca-tls-key.pem'))).toBe(true)
+  })
+})

--- a/src/main/runtime/tls-certificate.ts
+++ b/src/main/runtime/tls-certificate.ts
@@ -3,8 +3,8 @@
 // cert is generated once on first run and reused across restarts. The mobile
 // app pins the certificate fingerprint received during QR pairing.
 import { createHash } from 'crypto'
-import { execSync } from 'child_process'
-import { existsSync, readFileSync, chmodSync } from 'fs'
+import { generateKeyPairSync, randomBytes, sign } from 'crypto'
+import { existsSync, readFileSync, chmodSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 const TLS_CERT_FILENAME = 'orca-tls-cert.pem'
@@ -34,13 +34,9 @@ export function loadOrCreateTlsCertificate(userDataPath: string): TlsCertificate
   const keyPath_ = join(userDataPath, TLS_KEY_FILENAME)
   const certPath_ = join(userDataPath, TLS_CERT_FILENAME)
 
-  // Why: openssl is available on macOS, Linux, and Windows (via Git Bash).
-  // Using it avoids hand-rolling ASN.1 DER encoding which is error-prone.
-  execSync(
-    `openssl req -new -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 ` +
-      `-nodes -days 3650 -subj "/CN=Orca Runtime" ` +
-      `-keyout "${keyPath_}" -out "${certPath_}" 2>/dev/null`
-  )
+  const generated = generateSelfSignedCertificate()
+  writeFileSync(keyPath_, generated.key)
+  writeFileSync(certPath_, generated.cert)
 
   chmodSync(keyPath_, 0o600)
   chmodSync(certPath_, 0o600)
@@ -48,6 +44,114 @@ export function loadOrCreateTlsCertificate(userDataPath: string): TlsCertificate
   const cert = readFileSync(certPath_, 'utf-8')
   const key = readFileSync(keyPath_, 'utf-8')
   return { cert, key, fingerprint: computeFingerprint(cert)! }
+}
+
+function generateSelfSignedCertificate(): { cert: string; key: string } {
+  // Why: packaged Windows installs cannot assume openssl or POSIX shell
+  // redirection exists, so first-run pairing must generate PEMs in-process.
+  const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048
+  })
+  const key = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString()
+  const publicKeyInfo = publicKey.export({ type: 'spki', format: 'der' }) as Buffer
+  const algorithm = sequence(
+    objectIdentifier('1.2.840.113549.1.1.11'),
+    tagged(0x05, Buffer.alloc(0))
+  )
+  const subject = name('Orca Runtime')
+  const tbsCertificate = sequence(
+    integer(randomBytes(16)),
+    algorithm,
+    subject,
+    sequence(generalizedTime(new Date(Date.now() - 60_000)), generalizedTime(daysFromNow(3650))),
+    subject,
+    publicKeyInfo
+  )
+  const signature = sign('sha256', tbsCertificate, privateKey)
+  const cert = sequence(tbsCertificate, algorithm, bitString(signature))
+  return { cert: toPem('CERTIFICATE', cert), key }
+}
+
+function daysFromNow(days: number): Date {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000)
+}
+
+function toPem(label: string, der: Buffer): string {
+  const body =
+    der
+      .toString('base64')
+      .match(/.{1,64}/g)
+      ?.join('\n') ?? ''
+  return `-----BEGIN ${label}-----\n${body}\n-----END ${label}-----\n`
+}
+
+function name(commonName: string): Buffer {
+  return sequence(
+    set(sequence(objectIdentifier('2.5.4.3'), tagged(0x0c, Buffer.from(commonName, 'utf8'))))
+  )
+}
+
+function generalizedTime(date: Date): Buffer {
+  const value = [
+    date.getUTCFullYear(),
+    `${date.getUTCMonth() + 1}`.padStart(2, '0'),
+    `${date.getUTCDate()}`.padStart(2, '0'),
+    `${date.getUTCHours()}`.padStart(2, '0'),
+    `${date.getUTCMinutes()}`.padStart(2, '0'),
+    `${date.getUTCSeconds()}`.padStart(2, '0'),
+    'Z'
+  ].join('')
+  return tagged(0x18, Buffer.from(value, 'ascii'))
+}
+
+function sequence(...items: Buffer[]): Buffer {
+  return tagged(0x30, Buffer.concat(items))
+}
+
+function set(...items: Buffer[]): Buffer {
+  return tagged(0x31, Buffer.concat(items))
+}
+
+function integer(value: Buffer): Buffer {
+  const firstNonZero = value.findIndex((byte) => byte !== 0)
+  const trimmed = firstNonZero === -1 ? Buffer.from([0]) : value.subarray(firstNonZero)
+  return tagged(0x02, trimmed[0]! & 0x80 ? Buffer.concat([Buffer.from([0]), trimmed]) : trimmed)
+}
+
+function bitString(value: Buffer): Buffer {
+  return tagged(0x03, Buffer.concat([Buffer.from([0]), value]))
+}
+
+function objectIdentifier(value: string): Buffer {
+  const parts = value.split('.').map((part) => Number(part))
+  const bytes = [parts[0]! * 40 + parts[1]!]
+  for (const part of parts.slice(2)) {
+    const encoded = [part & 0x7f]
+    let remaining = part >> 7
+    while (remaining > 0) {
+      encoded.unshift((remaining & 0x7f) | 0x80)
+      remaining >>= 7
+    }
+    bytes.push(...encoded)
+  }
+  return tagged(0x06, Buffer.from(bytes))
+}
+
+function tagged(tag: number, content: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([tag]), lengthBytes(content.length), content])
+}
+
+function lengthBytes(length: number): Buffer {
+  if (length < 0x80) {
+    return Buffer.from([length])
+  }
+  const bytes: number[] = []
+  let remaining = length
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff)
+    remaining >>= 8
+  }
+  return Buffer.from([0x80 | bytes.length, ...bytes])
 }
 
 function computeFingerprint(certPem: string): string | null {


### PR DESCRIPTION
## Summary
- remove the runtime/mobile-pairing TLS certificate dependency on an external `openssl` executable
- generate the self-signed PEM certificate/key in-process with Node crypto
- add regression coverage for first-run cert generation without OpenSSL

## Why
On native Windows, `src/main/runtime/tls-certificate.ts` used `execSync` with a POSIX shell redirection (`2>/dev/null`). This host also does not have `openssl` on PATH, which made the existing WebSocket transport tests fail at first-run certificate generation with `spawnSync openssl ENOENT`. Packaged Windows installs should not require Git Bash/OpenSSL just to start the runtime pairing transport.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/tls-certificate.test.ts src/main/runtime/rpc/ws-transport.test.ts`
- `pnpm run lint -- src/main/runtime/tls-certificate.ts src/main/runtime/tls-certificate.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`

Risk: medium

Risk assessment: Medium. This removes an external OpenSSL dependency from runtime/mobile-pairing TLS certificate generation and changes crypto material generation; it should get another security/runtime review before merge.