### PR TITLE
fix: time out workspace space du scan

### DIFF
--- a/src/main/workspace-space-analysis-du-timeout.test.ts
+++ b/src/main/workspace-space-analysis-du-timeout.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeProcess from 'node:process'
+import type { Repo } from '../shared/types'
+import type { Store } from './persistence'
+
+const { execFileMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  listRepoWorktreesMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
+}))
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'darwin' }
+})
+
+vi.mock('./repo-worktrees', () => ({
+  createFolderWorktree: (repo: Repo) => ({
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: true
+  }),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn()
+}))
+
+import { analyzeWorkspaceSpace } from './workspace-space-analysis'
+
+function createStore(repos: Repo[]): Store {
+  return {
+    getRepos: () => repos,
+    getWorktreeMeta: () => undefined
+  } as unknown as Store
+}
+
+describe('analyzeWorkspaceSpace local du timeout', () => {
+  let tempDir: string | null = null
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-space-du-timeout-'))
+    execFileMock.mockReset()
+    listRepoWorktreesMock.mockReset()
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('falls back when du never reports completion', async () => {
+    const repoPath = join(tempDir!, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await writeFile(join(repoPath, 'app.ts'), 'console.log("ok")\n')
+
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: repoPath,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+
+    vi.useFakeTimers()
+    let settled = false
+    const scanPromise = analyzeWorkspaceSpace(createStore([repo])).then((scan) => {
+      settled = true
+      return scan
+    })
+
+    await vi.waitFor(() =>
+      expect(execFileMock).toHaveBeenCalledWith(
+        'du',
+        ['-k', '-d', '1', repoPath],
+        expect.any(Object),
+        expect.any(Function)
+      )
+    )
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    await vi.waitFor(() => expect(settled).toBe(true))
+    await expect(scanPromise).resolves.toMatchObject({
+      scannedWorktreeCount: 1,
+      unavailableWorktreeCount: 0,
+      worktrees: [expect.objectContaining({ status: 'ok', path: repoPath })]
+    })
+    expect(killMock).toHaveBeenCalled()
+  })
+})

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -4,7 +4,6 @@ import { lstat, readdir } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import { posix, win32 } from 'node:path'
 import { platform } from 'node:process'
-import { promisify } from 'node:util'
 import type { Dirent } from 'node:fs'
 import type { Store } from './persistence'
 import { isFolderRepo } from '../shared/repo-kind'
@@ -31,7 +30,6 @@ const LOCAL_FS_CONCURRENCY = 48
 const REMOTE_FS_CONCURRENCY = 10
 const DU_TIMEOUT_MS = 120_000
 const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
-const execFileAsync = promisify(execFile)
 
 type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
 
@@ -191,11 +189,65 @@ async function readLocalDuDepthOne(
   rootPath: string,
   signal?: AbortSignal
 ): Promise<Map<string, number>> {
-  const { stdout } = await execFileAsync('du', ['-k', '-d', '1', rootPath], {
-    encoding: 'utf8',
-    maxBuffer: DU_MAX_BUFFER_BYTES,
-    signal,
-    timeout: DU_TIMEOUT_MS
+  const stdout = await new Promise<string>((resolve, reject) => {
+    let settled = false
+    let child: ReturnType<typeof execFile> | undefined
+    let onAbort: (() => void) | null = null
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      if (onAbort) {
+        signal?.removeEventListener('abort', onAbort)
+      }
+      callback()
+    }
+    timer = setTimeout(() => {
+      settle(() => {
+        child?.kill()
+        reject(new Error(`du timed out after ${DU_TIMEOUT_MS}ms`))
+      })
+    }, DU_TIMEOUT_MS)
+    onAbort = () => {
+      settle(() => {
+        child?.kill()
+        reject(new Error('Workspace space scan cancelled'))
+      })
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+
+    // Why: execFile's timeout only signals `du`; a wedged child that never
+    // calls back must not block the Space scan or its portable fallback.
+    try {
+      child = execFile(
+        'du',
+        ['-k', '-d', '1', rootPath],
+        {
+          encoding: 'utf8',
+          maxBuffer: DU_MAX_BUFFER_BYTES,
+          signal,
+          timeout: DU_TIMEOUT_MS
+        },
+        (error, stdout) => {
+          if (error) {
+            settle(() => reject(error))
+            return
+          }
+          settle(() => resolve(String(stdout)))
+        }
+      )
+    } catch (error) {
+      settle(() => reject(error))
+    }
   })
   return parseDuDepthOneOutput(stdout)
 }


### PR DESCRIPTION
## Summary
- add a promise-level timeout around the Resource Manager Space local `du` fast path
- kill wedged `du` children best-effort when they never invoke the `execFile` callback
- preserve the existing portable filesystem-walk fallback after `du` fails or times out

## Repro Evidence
Before the fix, the new regression test failed because `analyzeWorkspaceSpace()` stayed pending after the 120s fake timeout window:

```
AssertionError: expected false to be true
src/main/workspace-space-analysis-du-timeout.test.ts:100:21
```

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/workspace-space-analysis-du-timeout.test.ts -t "falls back when du never reports completion"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/workspace-space-analysis-du-timeout.test.ts src/main/workspace-space-analysis.test.ts src/main/ipc/workspace-space.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/workspace-space-analysis.ts src/main/workspace-space-analysis-du-timeout.test.ts`
- `git diff --check`

Risk: low. The existing code already falls back when `du` errors; this only makes a wedged command produce that same fallback instead of blocking the scan.