### PR TITLE
fix: time out process cwd lsof lookup

### DIFF
--- a/src/main/providers/process-cwd.test.ts
+++ b/src/main/providers/process-cwd.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileMock, readlinkMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
@@ -26,6 +26,10 @@ describe('resolveProcessCwd', () => {
     })
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('bounds cached cwd results across unique process ids', async () => {
     const { resolveProcessCwd } = await import('./process-cwd')
 
@@ -40,5 +44,33 @@ describe('resolveProcessCwd', () => {
 
     await expect(resolveProcessCwd(1)).resolves.toBe('/cwd/1')
     expect(readlinkMock).toHaveBeenCalledTimes(258)
+  })
+
+  it('falls back when lsof never reports completion', async () => {
+    vi.useFakeTimers()
+    readlinkMock.mockRejectedValue(new Error('proc unavailable'))
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    const { resolveProcessCwd } = await import('./process-cwd')
+
+    let settled = false
+    const cwdPromise = resolveProcessCwd(42).then((cwd) => {
+      settled = true
+      return cwd
+    })
+
+    await vi.waitFor(() =>
+      expect(execFileMock).toHaveBeenCalledWith(
+        'lsof',
+        ['-a', '-p', '42', '-d', 'cwd', '-Fn'],
+        { encoding: 'utf-8', timeout: 1500 },
+        expect.any(Function)
+      )
+    )
+    await vi.advanceTimersByTimeAsync(1500)
+
+    expect(settled).toBe(true)
+    await expect(cwdPromise).resolves.toBe('')
+    expect(killMock).toHaveBeenCalled()
   })
 })

--- a/src/main/providers/process-cwd.ts
+++ b/src/main/providers/process-cwd.ts
@@ -1,8 +1,5 @@
 import { execFile as execFileCb } from 'child_process'
 import { readlink } from 'fs/promises'
-import { promisify } from 'util'
-
-const execFile = promisify(execFileCb)
 
 /**
  * Resolve the current working directory of a local process by pid.
@@ -92,10 +89,7 @@ async function doResolve(pid: number): Promise<string> {
     // and emits cwd records for every process on the system, so the n-line
     // scan below picks up the first unrelated process (often pid ~391 with
     // cwd `/`) and returns `/` regardless of the target pid's real cwd.
-    const { stdout } = await execFile('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'], {
-      encoding: 'utf-8',
-      timeout: LSOF_TIMEOUT_MS
-    })
+    const stdout = await readCwdWithLsof(pid)
     for (const line of stdout.split('\n')) {
       if (line.startsWith('n') && line.includes('/')) {
         // Why: lsof -d cwd is authoritative — don't second-guess it with
@@ -110,4 +104,50 @@ async function doResolve(pid: number): Promise<string> {
   }
 
   return ''
+}
+
+function readCwdWithLsof(pid: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let child: ReturnType<typeof execFileCb> | undefined
+    const timer = setTimeout(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      child?.kill()
+      reject(new Error(`lsof timed out after ${LSOF_TIMEOUT_MS}ms`))
+    }, LSOF_TIMEOUT_MS)
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      callback()
+    }
+
+    // Why: execFile's timeout only signals lsof; a missing callback would
+    // otherwise leave the shared per-pid cwd lookup promise cached forever.
+    try {
+      child = execFileCb(
+        'lsof',
+        ['-a', '-p', String(pid), '-d', 'cwd', '-Fn'],
+        {
+          encoding: 'utf-8',
+          timeout: LSOF_TIMEOUT_MS
+        },
+        (error, stdout) => {
+          if (error) {
+            settle(() => reject(error))
+            return
+          }
+          settle(() => resolve(String(stdout)))
+        }
+      )
+    } catch (error) {
+      settle(() => reject(error))
+    }
+  })
 }


### PR DESCRIPTION
## Summary
- add a promise-level timeout around the macOS `lsof` cwd fallback
- kill wedged `lsof` children best-effort when they never invoke the callback
- release the per-PID in-flight cwd lookup so callers get the existing empty-cwd fallback

## Repro Evidence
Before the fix, the new regression test failed because `resolveProcessCwd()` stayed pending after the 1.5s fake timeout window:

```
AssertionError: expected false to be true
src/main/providers/process-cwd.test.ts:72:21
```

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/providers/process-cwd.test.ts -t "falls back when lsof never reports completion"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/providers/process-cwd.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/providers/process-cwd.ts src/main/providers/process-cwd.test.ts`
- `git diff --check`

Risk: low. The existing fallback already returns an empty cwd when `lsof` fails; this makes a wedged `lsof` reach the same fallback instead of leaving the shared lookup pending.