### PR TITLE
fix: time out computer permission helper launch

### DIFF
--- a/src/main/computer/macos-computer-use-permissions.test.ts
+++ b/src/main/computer/macos-computer-use-permissions.test.ts
@@ -66,6 +66,7 @@ describe('openComputerUsePermissions', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     setPlatform(originalPlatform)
   })
 
@@ -258,6 +259,48 @@ describe('openComputerUsePermissions', () => {
     expect(child.stderr.off).toHaveBeenCalledWith('data', expect.any(Function))
     expect(child.off).toHaveBeenCalledWith('error', expect.any(Function))
     expect(child.off).toHaveBeenCalledWith('close', expect.any(Function))
+  })
+
+  it('times out when the permission status helper launch never closes', async () => {
+    vi.useFakeTimers()
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
+    const child = {
+      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
+      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
+      on: vi.fn(() => child),
+      off: vi.fn(() => child),
+      kill: vi.fn(),
+      unref: vi.fn()
+    }
+    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
+
+    let settled = false
+    const statusPromise = getComputerUsePermissionStatus().then(
+      (status) => {
+        settled = true
+        return status
+      },
+      (error: unknown) => {
+        settled = true
+        throw error
+      }
+    )
+    const rejection = expect(statusPromise).rejects.toMatchObject({
+      name: 'RuntimeClientError',
+      code: 'accessibility_error',
+      message: 'Timed out launching permission helper'
+    })
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(settled).toBe(true)
+    await rejection
+    expect(child.kill).toHaveBeenCalled()
+    expect(rm).toHaveBeenCalledWith('/tmp/orca-computer-use-permissions-test', {
+      recursive: true,
+      force: true
+    })
   })
 
   it('reads permission status through the helper app identity', async () => {

--- a/src/main/computer/macos-computer-use-permissions.ts
+++ b/src/main/computer/macos-computer-use-permissions.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../shared/computer-use-permissions-types'
 
 const DEFAULT_COMPUTER_USE_BUNDLE_ID = 'com.stablyai.orca.computer-use'
+const PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS = 5_000
 
 export function openComputerUsePermissions(
   permissionId?: ComputerUsePermissionId
@@ -242,11 +243,16 @@ function launchPermissionStatusHelper(helperAppPath: string, statusPath: string)
       stderr += chunk
     }
     let settled = false
+    let launchTimeout: ReturnType<typeof setTimeout> | null = null
     const removeListeners = (): void => {
       launch.stdout?.off('data', onStdoutData)
       launch.stderr?.off('data', onStderrData)
       launch.off('error', onError)
       launch.off('close', onClose)
+      if (launchTimeout) {
+        clearTimeout(launchTimeout)
+        launchTimeout = null
+      }
     }
     const settleResolve = (): void => {
       if (settled) {
@@ -281,6 +287,18 @@ function launchPermissionStatusHelper(helperAppPath: string, statusPath: string)
       settleReject(
         new RuntimeClientError('accessibility_error', `Could not check permissions: ${detail}`)
       )
+    }
+    const onTimeout = (): void => {
+      launch.kill()
+      settleReject(
+        new RuntimeClientError('accessibility_error', 'Timed out launching permission helper')
+      )
+    }
+    // Why: the status-file polling timeout only starts after `open` exits; if
+    // `open` wedges first, permission checks would otherwise stay pending.
+    launchTimeout = setTimeout(onTimeout, PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS)
+    if (typeof launchTimeout.unref === 'function') {
+      launchTimeout.unref()
     }
     launch.stdout?.on('data', onStdoutData)
     launch.stderr?.on('data', onStderrData)


### PR DESCRIPTION
## Summary
- add a 5s deadline around the macOS computer-use permission-status helper launch
- kill the `/usr/bin/open` child best-effort if it never emits `close` or `error`
- clean up listeners and the temp status directory through the existing error path

## Repro Evidence
Before the fix, the new regression test failed because `getComputerUsePermissionStatus()` stayed pending after the 5s fake timeout window:

```
AssertionError: expected false to be true
src/main/computer/macos-computer-use-permissions.test.ts:292:21
```

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/macos-computer-use-permissions.test.ts -t "times out when the permission status helper launch never closes"`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/macos-computer-use-permissions.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/computer/macos-computer-use-permissions.ts src/main/computer/macos-computer-use-permissions.test.ts`
- `git diff --check`

Risk: low. This only bounds the helper launch phase before the existing status-file polling timeout can start.