### PR TITLE
fix: time out ssh config resolution

### DIFF
--- a/src/main/ssh/ssh-config-parser.ts
+++ b/src/main/ssh/ssh-config-parser.ts
@@ -261,15 +261,41 @@ const SSH_G_TIMEOUT_MS = 5000
 // resolution without reimplementing OpenSSH's complex matching logic.
 export function resolveWithSshG(host: string): Promise<SshResolvedConfig | null> {
   return new Promise((resolve) => {
-    // Why: '--' prevents a host label starting with '-' from being interpreted
-    // as an SSH flag (classic argument injection vector).
-    execFile('ssh', ['-G', '--', host], { timeout: SSH_G_TIMEOUT_MS }, (err, stdout) => {
-      if (err) {
-        resolve(null)
+    let settled = false
+    let child: ReturnType<typeof execFile> | undefined
+    const timer = setTimeout(() => {
+      if (settled) {
         return
       }
-      resolve(parseSshGOutput(stdout))
-    })
+      settled = true
+      child?.kill()
+      resolve(null)
+    }, SSH_G_TIMEOUT_MS)
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      callback()
+    }
+
+    // Why: '--' prevents a host label starting with '-' from being interpreted
+    // as an SSH flag (classic argument injection vector).
+    // Why: execFile's timeout only signals ssh; a stuck callback must still
+    // release SSH import/connection resolution with the existing null fallback.
+    try {
+      child = execFile('ssh', ['-G', '--', host], { timeout: SSH_G_TIMEOUT_MS }, (err, stdout) => {
+        if (err) {
+          settle(() => resolve(null))
+          return
+        }
+        settle(() => resolve(parseSshGOutput(stdout)))
+      })
+    } catch {
+      settle(() => resolve(null))
+    }
   })
 }
 

--- a/src/main/ssh/ssh-config-resolver.test.ts
+++ b/src/main/ssh/ssh-config-resolver.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveWithSshG } from './ssh-config-parser'
 
 vi.mock('os', () => ({
@@ -10,6 +10,15 @@ vi.mock('child_process', () => ({
 }))
 
 describe('resolveWithSshG', () => {
+  beforeEach(async () => {
+    const { execFile } = await import('child_process')
+    vi.mocked(execFile).mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns parsed config on success', async () => {
     const { execFile } = await import('child_process')
     const mockExecFile = vi.mocked(execFile)
@@ -60,5 +69,25 @@ describe('resolveWithSshG', () => {
 
     const result = await resolveWithSshG('myhost')
     expect(result).toBeNull()
+  })
+
+  it('returns null when ssh -G never reports completion', async () => {
+    vi.useFakeTimers()
+    const { execFile } = await import('child_process')
+    const mockExecFile = vi.mocked(execFile)
+    const killMock = vi.fn()
+    mockExecFile.mockImplementation(() => ({ kill: killMock }) as never)
+
+    let settled = false
+    const resultPromise = resolveWithSshG('stuck-host').then((result) => {
+      settled = true
+      return result
+    })
+
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(settled).toBe(true)
+    await expect(resultPromise).resolves.toBeNull()
+    expect(killMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Add a promise-level timeout around `ssh -G` config resolution so Orca does not wait forever if the OpenSSH command wedges.
- Kill the child process best-effort and keep the existing `null` fallback for failed config resolution.

## Reproduction
- Added a regression test that mocks `ssh -G -- stuck-host` to never invoke the `execFile` callback.
- Before the fix, the promise stayed pending after 5 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/ssh/ssh-config-resolver.test.ts:89:21`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-config-resolver.test.ts src/main/ssh/ssh-config-parser.test.ts src/main/ssh/ssh-connection-utils.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ssh/ssh-config-parser.ts src/main/ssh/ssh-config-resolver.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; this preserves the existing `null` fallback and only resolves a stuck command path.