### PR TITLE
fix: preserve UNC hosts in markdown file links

### DIFF
--- a/src/renderer/src/components/editor/markdown-internal-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.test.ts
@@ -19,6 +19,19 @@ describe('resolveMarkdownLinkTarget', () => {
     })
   })
 
+  it('classifies relative .md inside a UNC worktree as markdown', () => {
+    const r = resolveMarkdownLinkTarget(
+      './guide.md',
+      '\\\\server\\share\\repo\\docs\\note.md',
+      '\\\\server\\share\\repo'
+    )
+    expect(r).toEqual({
+      kind: 'markdown',
+      absolutePath: '//server/share/repo/docs/guide.md',
+      relativePath: 'docs/guide.md'
+    })
+  })
+
   it('classifies relative .md outside worktree as file', () => {
     const r = resolveMarkdownLinkTarget('../../other/guide.md', SOURCE, ROOT)
     expect(r?.kind).toBe('file')
@@ -96,6 +109,20 @@ describe('resolveMarkdownLinkTarget', () => {
       kind: 'file',
       uri: 'file:///repo/docs/image.png',
       absolutePath: '/repo/docs/image.png',
+      relativePath: 'docs/image.png'
+    })
+  })
+
+  it('classifies explicit UNC file URLs without losing the server name', () => {
+    const r = resolveMarkdownLinkTarget(
+      'file://server/share/repo/docs/image.png',
+      '\\\\server\\share\\repo\\docs\\note.md',
+      '\\\\server\\share\\repo'
+    )
+    expect(r).toMatchObject({
+      kind: 'file',
+      uri: 'file://server/share/repo/docs/image.png',
+      absolutePath: '//server/share/repo/docs/image.png',
       relativePath: 'docs/image.png'
     })
   })

--- a/src/renderer/src/components/editor/markdown-internal-links.ts
+++ b/src/renderer/src/components/editor/markdown-internal-links.ts
@@ -1,3 +1,5 @@
+import { filesystemPathToFileUri, fileUriToFilesystemPath } from '../../../../shared/file-uri-path'
+
 // Pure classifier for markdown link targets. Called by the link-activation
 // dispatcher (activateMarkdownLink slice action) from three call sites —
 // MarkdownPreview, RichMarkdownEditor Cmd-click, RichMarkdownLinkBubble open —
@@ -38,31 +40,11 @@ export function absolutePathToFileUri(filePath: string): string {
 }
 
 function toFileUrl(filePath: string): string {
-  const normalizedPath = filePath.replaceAll('\\', '/')
-  const segments = normalizedPath.split('/').map((segment, index) => {
-    if (index === 0 && /^[A-Za-z]:$/.test(segment)) {
-      return segment
-    }
-    return encodeURIComponent(segment)
-  })
-  if (normalizedPath.startsWith('/')) {
-    return `file://${segments.join('/')}`
-  }
-  return `file:///${segments.join('/')}`
+  return filesystemPathToFileUri(filePath)
 }
 
 function fileUrlToAbsolutePath(url: URL): string | null {
-  let absolutePath: string
-  try {
-    absolutePath = decodeURIComponent(url.pathname)
-  } catch {
-    return null
-  }
-  // Windows: "/C:/foo" → "C:/foo"
-  if (/^\/[A-Za-z]:\//.test(absolutePath)) {
-    absolutePath = absolutePath.slice(1)
-  }
-  return absolutePath
+  return fileUriToFilesystemPath(url)
 }
 
 function normalizePathForCompare(p: string): string {

--- a/src/renderer/src/components/editor/markdown-preview-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.test.ts
@@ -48,6 +48,12 @@ describe('getMarkdownPreviewImageSrc', () => {
     )
   })
 
+  it('resolves relative paths for Windows UNC markdown files', () => {
+    expect(
+      getMarkdownPreviewImageSrc('./diagram.png', '\\\\server\\share\\repo\\docs\\README.md')
+    ).toBe('file://server/share/repo/docs/diagram.png')
+  })
+
   it('leaves unsupported schemes unchanged', () => {
     expect(getMarkdownPreviewImageSrc('data:image/png;base64,abc', '/repo/docs/README.md')).toBe(
       'data:image/png;base64,abc'
@@ -107,6 +113,12 @@ describe('resolveImageAbsolutePath', () => {
     )
   })
 
+  it('resolves Windows UNC paths without dropping the server name', () => {
+    expect(
+      resolveImageAbsolutePath('./diagram.png', '\\\\server\\share\\repo\\docs\\README.md')
+    ).toBe('//server/share/repo/docs/diagram.png')
+  })
+
   it('returns null for http URLs', () => {
     expect(resolveImageAbsolutePath('https://example.com/img.png', '/repo/README.md')).toBeNull()
   })
@@ -129,6 +141,18 @@ describe('fileUrlToAbsolutePath', () => {
 
   it('converts windows file URLs to absolute paths', () => {
     expect(fileUrlToAbsolutePath(new URL('file:///C:/repo/docs/README.md'))).toBe(
+      'C:/repo/docs/README.md'
+    )
+  })
+
+  it('converts UNC file URLs to absolute paths with the server name', () => {
+    expect(fileUrlToAbsolutePath(new URL('file://server/share/repo/docs/README.md'))).toBe(
+      '//server/share/repo/docs/README.md'
+    )
+  })
+
+  it('treats localhost file URLs as local paths', () => {
+    expect(fileUrlToAbsolutePath(new URL('file://localhost/C:/repo/docs/README.md'))).toBe(
       'C:/repo/docs/README.md'
     )
   })

--- a/src/renderer/src/components/editor/markdown-preview-links.ts
+++ b/src/renderer/src/components/editor/markdown-preview-links.ts
@@ -1,17 +1,7 @@
+import { filesystemPathToFileUri, fileUriToFilesystemPath } from '../../../../shared/file-uri-path'
+
 function toFileUrl(filePath: string): string {
-  const normalizedPath = filePath.replaceAll('\\', '/')
-  const segments = normalizedPath.split('/').map((segment, index) => {
-    if (index === 0 && /^[A-Za-z]:$/.test(segment)) {
-      return segment
-    }
-    return encodeURIComponent(segment)
-  })
-
-  if (normalizedPath.startsWith('/')) {
-    return `file://${segments.join('/')}`
-  }
-
-  return `file:///${segments.join('/')}`
+  return filesystemPathToFileUri(filePath)
 }
 
 export function resolveMarkdownPreviewHref(rawUrl: string, filePath: string): URL | null {
@@ -123,14 +113,7 @@ export function resolveImageAbsolutePath(
     return null
   }
 
-  // Convert file:///path/to/file → /path/to/file (Unix)
-  // Convert file:///C:/path/to/file → C:/path/to/file (Windows)
-  let absolutePath = decodeURIComponent(resolved.pathname)
-  if (/^\/[A-Za-z]:\//.test(absolutePath)) {
-    absolutePath = absolutePath.slice(1)
-  }
-
-  return absolutePath
+  return fileUriToFilesystemPath(resolved)
 }
 
 export function fileUrlToAbsolutePath(fileUrl: URL): string | null {
@@ -138,10 +121,5 @@ export function fileUrlToAbsolutePath(fileUrl: URL): string | null {
     return null
   }
 
-  let absolutePath = decodeURIComponent(fileUrl.pathname)
-  if (/^\/[A-Za-z]:\//.test(absolutePath)) {
-    absolutePath = absolutePath.slice(1)
-  }
-
-  return absolutePath
+  return fileUriToFilesystemPath(fileUrl)
 }

--- a/src/shared/file-uri-path.ts
+++ b/src/shared/file-uri-path.ts
@@ -1,0 +1,52 @@
+const WINDOWS_DRIVE_PATH_PREFIX = /^\/[A-Za-z]:\//
+const UNC_PATH_PREFIX = /^(?:\\\\|\/\/)([^\\/]+)[\\/]+([^\\/]+)(?:[\\/](.*))?$/
+
+function encodePathSegments(path: string): string {
+  return path
+    .split('/')
+    .map((segment, index) => {
+      if (index === 0 && /^[A-Za-z]:$/.test(segment)) {
+        return segment
+      }
+      return encodeURIComponent(segment)
+    })
+    .join('/')
+}
+
+export function filesystemPathToFileUri(filePath: string): string {
+  const uncMatch = UNC_PATH_PREFIX.exec(filePath)
+  if (uncMatch) {
+    const [, host, share, rest = ''] = uncMatch
+    const pathSegments = [share, ...rest.replaceAll('\\', '/').split('/').filter(Boolean)]
+    // Why: UNC hosts belong in the file URI authority; putting them in the
+    // pathname produces file:////server/share and loses the host on decode.
+    return `file://${encodeURIComponent(host)}/${pathSegments.map(encodeURIComponent).join('/')}`
+  }
+
+  const normalizedPath = filePath.replaceAll('\\', '/')
+  const encodedPath = encodePathSegments(normalizedPath)
+  return normalizedPath.startsWith('/') ? `file://${encodedPath}` : `file:///${encodedPath}`
+}
+
+export function fileUriToFilesystemPath(url: URL): string | null {
+  if (url.protocol !== 'file:') {
+    return null
+  }
+
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(url.pathname)
+  } catch {
+    return null
+  }
+
+  if (url.hostname && url.hostname !== 'localhost') {
+    return `//${url.hostname}${decodedPath}`
+  }
+
+  if (WINDOWS_DRIVE_PATH_PREFIX.test(decodedPath)) {
+    return decodedPath.slice(1)
+  }
+
+  return decodedPath
+}


### PR DESCRIPTION
## Summary
- add a shared file URI/path helper that keeps UNC hosts in the `file://` authority
- use it for Markdown preview image/link resolution and Markdown link activation
- cover relative UNC Markdown links, images, explicit `file://server/...` links, and localhost file URLs

## Why
Markdown files opened from Windows network shares were converted through `file:////server/share/...`. That puts the server name in the pathname instead of the URI authority, so later file URL decoding can drop the server component and resolve linked files against the wrong path.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts`
- `pnpm run lint -- src/shared/file-uri-path.ts src/renderer/src/components/editor/markdown-preview-links.ts src/renderer/src/components/editor/markdown-internal-links.ts src/renderer/src/components/editor/markdown-preview-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `git diff --check HEAD~1..HEAD`

Risk: medium

Risk assessment: Medium. This changes shared file URI/path conversion and Markdown link activation for Windows UNC paths; it should get another cross-platform review before merge.