### PR TITLE
fix: time out local automation commands

### DIFF
--- a/src/main/automations/external-manager.test.ts
+++ b/src/main/automations/external-manager.test.ts
@@ -224,9 +224,38 @@ describe('createExternalAutomation', () => {
         '--workdir',
         '/repo'
       ],
-      { encoding: 'utf-8' },
+      { encoding: 'utf-8', timeout: 30_000 },
       expect.any(Function)
     )
+  })
+
+  it('settles when local Hermes cron creation hangs', async () => {
+    vi.useFakeTimers()
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+
+    const promise = createExternalAutomation({
+      managerId: 'hermes:local',
+      provider: 'hermes',
+      target: { type: 'local' },
+      name: 'Nightly audit',
+      prompt: 'Audit the repo',
+      schedule: '0 9 * * 1-5',
+      workdir: null
+    })
+    let settled = false
+    void promise
+      .catch(() => undefined)
+      .finally(() => {
+        settled = true
+      })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await Promise.resolve()
+
+    expect(settled).toBe(true)
+    await expect(promise).rejects.toThrow('Local automation command timed out')
+    expect(killMock).toHaveBeenCalled()
   })
 
   it('updates local Hermes cron jobs through the CLI', async () => {
@@ -256,7 +285,7 @@ describe('createExternalAutomation', () => {
         '--workdir',
         '/repo'
       ],
-      { encoding: 'utf-8' },
+      { encoding: 'utf-8', timeout: 30_000 },
       expect.any(Function)
     )
   })
@@ -275,7 +304,7 @@ describe('runExternalAutomationAction', () => {
     expect(execFileMock).toHaveBeenCalledWith(
       'hermes',
       ['cron', 'run', 'job-1'],
-      { encoding: 'utf-8' },
+      { encoding: 'utf-8', timeout: 30_000 },
       expect.any(Function)
     )
   })
@@ -306,7 +335,7 @@ describe('runExternalAutomationAction', () => {
     expect(execFileMock).toHaveBeenCalledWith(
       'openclaw',
       ['cron', 'disable', 'job-1'],
-      { encoding: 'utf-8' },
+      { encoding: 'utf-8', timeout: 30_000 },
       expect.any(Function)
     )
   })

--- a/src/main/automations/external-manager.ts
+++ b/src/main/automations/external-manager.ts
@@ -5,7 +5,6 @@ import { existsSync } from 'fs'
 import { readFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
-import { promisify } from 'util'
 import type {
   ExternalAutomationAction,
   ExternalAutomationActionInput,
@@ -25,13 +24,13 @@ import {
   readHermesCronOutputRunsPage
 } from './hermes-cron-output'
 
-const execFileAsync = promisify(execFile)
 const HERMES_HOME = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
 const HERMES_CRON_DIR = join(HERMES_HOME, 'cron')
 const HERMES_JOBS_FILE = join(HERMES_CRON_DIR, 'jobs.json')
 const OPENCLAW_JOBS_FILE = join(homedir(), '.openclaw', 'cron', 'jobs.json')
 const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
 const LOCAL_COMMAND_LOOKUP_TIMEOUT_MS = 5_000
+const LOCAL_AUTOMATION_COMMAND_TIMEOUT_MS = 30_000
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -76,6 +75,50 @@ function runLocalCommandLookup(command: string, args: string[]): Promise<void> {
       child = execFile(command, args, { encoding: 'utf-8' }, (error) => {
         finish(error ?? null)
       })
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+}
+
+function runLocalAutomationCommand(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    }
+
+    // Why: local automation mutations back UI actions; a wedged CLI must not
+    // keep create/edit/run/delete pending after Node signals a timeout.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(
+        new Error(
+          `Local automation command timed out after ${LOCAL_AUTOMATION_COMMAND_TIMEOUT_MS}ms.`
+        )
+      )
+    }, LOCAL_AUTOMATION_COMMAND_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        command,
+        args,
+        { encoding: 'utf-8', timeout: LOCAL_AUTOMATION_COMMAND_TIMEOUT_MS },
+        (error) => {
+          finish(error ?? null)
+        }
+      )
     } catch (error) {
       finish(error instanceof Error ? error : new Error(String(error)))
     }
@@ -436,7 +479,7 @@ export async function createExternalAutomation(
 ): Promise<void> {
   const normalized = normalizeHermesCronMutationInput(input)
   if (input.target.type === 'local') {
-    await execFileAsync('hermes', hermesCronCreateArgs(normalized), { encoding: 'utf-8' })
+    await runLocalAutomationCommand('hermes', hermesCronCreateArgs(normalized))
     clearHermesCronOutputRunCountCache()
     return
   }
@@ -458,9 +501,7 @@ export async function updateExternalAutomation(
   }
   const normalized = normalizeHermesCronMutationInput(input)
   if (input.target.type === 'local') {
-    await execFileAsync('hermes', hermesCronEditArgs(input.jobId, normalized), {
-      encoding: 'utf-8'
-    })
+    await runLocalAutomationCommand('hermes', hermesCronEditArgs(input.jobId, normalized))
     clearHermesCronOutputRunCountCache(input.jobId)
     return
   }
@@ -486,7 +527,7 @@ export async function runExternalAutomationAction(
       ? hermesCommandForAction(input.action)
       : openClawCommandForAction(input.action)
   if (input.target.type === 'local') {
-    await execFileAsync(input.provider, ['cron', command, input.jobId], { encoding: 'utf-8' })
+    await runLocalAutomationCommand(input.provider, ['cron', command, input.jobId])
     if (input.provider === 'hermes') {
       clearHermesCronOutputRunCountCache(input.jobId)
     }


### PR DESCRIPTION
## Summary
- Add a bounded local automation command runner for Hermes/OpenClaw create, edit, and lifecycle actions.
- Pass the timeout to `execFile`, independently settle the promise when the child never calls back, and kill the child best-effort.

## Reproduction
- Added a regression test that mocks local `hermes cron create ...` so `execFile` never invokes its callback.
- Before the fix, the promise stayed pending after 30 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/automations/external-manager.test.ts:253:21`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/automations/external-manager.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/automations/external-manager.ts src/main/automations/external-manager.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; local automation mutations already depended on these short-lived CLI calls completing, and remote SSH automation paths are unchanged.