### PR TITLE
perf: pause hidden terminal renderer output

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -82,7 +82,8 @@ import {
   getPtyIdForPaneKey,
   registerPaneKeyTeardownListener,
   getLocalPtyProvider,
-  registerHeadlessPtyRuntime
+  registerHeadlessPtyRuntime,
+  isRendererPtyOutputPaused
 } from './ipc/pty'
 import { AgentBrowserBridge } from './browser/agent-browser-bridge'
 import { browserManager } from './browser/browser-manager'
@@ -868,6 +869,9 @@ registerPaneKeyTeardownListener((paneKey) => {
 
 function sendSyntheticTitle(ptyId: string, data: string, options: { force?: boolean } = {}): void {
   if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+  if (options.force !== true && isRendererPtyOutputPaused(ptyId)) {
     return
   }
   // Why: repeated working-spinner frames are decorative and can arrive every

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2860,6 +2860,103 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('does not send renderer PTY data while renderer output is paused', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const pauseCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:pauseOutput')
+      if (!pauseCall) {
+        throw new Error('missing pty:pauseOutput listener')
+      }
+      const pauseRendererOutput = pauseCall[1] as (
+        event: unknown,
+        args: { id: string; paused: boolean }
+      ) => void
+      mainWindow.webContents.send.mockClear()
+
+      pauseRendererOutput(null, { id: spawnResult.id, paused: true })
+      mockProc.emitData('hidden output')
+      vi.advanceTimersByTime(50)
+
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+        id: spawnResult.id,
+        data: 'hidden output'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps 250 paused background PTYs off the renderer input path', async () => {
+    vi.useFakeTimers()
+    const backgroundCount = 250
+    const procs = Array.from({ length: backgroundCount + 1 }, () => createMockProc())
+    let spawnIndex = 0
+    spawnMock.mockImplementation(() => procs[spawnIndex++].proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const activeSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const backgroundSpawns: { id: string }[] = []
+      for (let index = 0; index < backgroundCount; index++) {
+        backgroundSpawns.push(
+          (await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            cwd: '/tmp'
+          })) as { id: string }
+        )
+      }
+      const pauseCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:pauseOutput')
+      if (!pauseCall) {
+        throw new Error('missing pty:pauseOutput listener')
+      }
+      const pauseRendererOutput = pauseCall[1] as (
+        event: unknown,
+        args: { id: string; paused: boolean }
+      ) => void
+      for (const spawn of backgroundSpawns) {
+        pauseRendererOutput(null, { id: spawn.id, paused: true })
+      }
+      mainWindow.webContents.send.mockClear()
+
+      for (let index = 0; index < backgroundCount; index++) {
+        procs[index + 1].emitData(`hidden ${index}\n`)
+      }
+      vi.advanceTimersByTime(100)
+
+      for (let index = 0; index < backgroundCount; index++) {
+        expect(mainWindow.webContents.send).not.toHaveBeenCalledWith('pty:data', {
+          id: backgroundSpawns[index].id,
+          data: `hidden ${index}\n`
+        })
+      }
+
+      const writeListener = getPtyWriteListener()
+      writeListener(null, { id: activeSpawn.id, data: 'a' })
+      procs[0].emitData('redraw')
+
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: activeSpawn.id,
+        data: 'redraw'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('sends small PTY redraws immediately after terminal input', async () => {
     vi.useFakeTimers()
     const mockProc = createMockProc()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -78,6 +78,9 @@ const ptySizes = new Map<string, { cols: number; rows: number }>()
 // is PTY-scoped and must be cleared by every teardown path, including SSH and
 // daemon shutdowns that do not flow through the local provider exit listener.
 const lastInputAtByPty = new Map<string, number>()
+// Why: hidden renderer panes restore from main-owned snapshots, so ordinary
+// PTY bytes do not need to wake the renderer while a pane is hidden.
+const rendererPausedOutputPtys = new Set<string>()
 // Why: the agent-hooks server caches per-paneKey state (last prompt, last
 // tool) that otherwise grows unbounded as panes come and go. Track the
 // spawn-time paneKey so clearProviderPtyState can clear that cache on PTY
@@ -103,6 +106,10 @@ const AGENT_HOOK_RUNTIME_ENV_KEYS = [
 
 export function getPtyIdForPaneKey(paneKey: string): string | undefined {
   return paneKeyPtyId.get(paneKey)
+}
+
+export function isRendererPtyOutputPaused(ptyId: string): boolean {
+  return rendererPausedOutputPtys.has(ptyId)
 }
 
 // Why: consumers (currently the cursor-agent synthesized-spinner loop in
@@ -724,6 +731,7 @@ export function clearProviderPtyState(id: string): void {
   piTitlebarExtensionService.clearPty(id)
   ptySizes.delete(id)
   lastInputAtByPty.delete(id)
+  rendererPausedOutputPtys.delete(id)
   const paneKey = ptyPaneKey.get(id)
   const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY does not keep
@@ -849,6 +857,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:getMainBufferSnapshot')
   ipcMain.removeHandler('pty:writeAccepted')
   ipcMain.removeAllListeners('pty:write')
+  ipcMain.removeAllListeners('pty:pauseOutput')
   ipcMain.removeAllListeners('pty:ackColdRestore')
   ipcMain.removeAllListeners('pty:serializeBuffer:response')
 
@@ -1081,6 +1090,16 @@ export function registerPtyHandlers(
     flushTimer = null
   }
 
+  function setRendererPtyOutputPaused(id: string, paused: boolean): void {
+    if (paused) {
+      rendererPausedOutputPtys.add(id)
+      pendingData.delete(id)
+      clearFlushTimerIfIdle()
+      return
+    }
+    rendererPausedOutputPtys.delete(id)
+  }
+
   // Why: extracted so the "Restart daemon" flow can rebind against the fresh
   // adapter after replaceDaemonProvider runs. Both the startup registration
   // and the post-restart rebind go through the same code path — no risk of
@@ -1111,6 +1130,11 @@ export function registerPtyHandlers(
           flushTimer = null
         }
         pendingData.clear()
+        return
+      }
+      if (rendererPausedOutputPtys.has(payload.id)) {
+        pendingData.delete(payload.id)
+        clearFlushTimerIfIdle()
         return
       }
       const existing = pendingData.get(payload.id)
@@ -1163,6 +1187,7 @@ export function registerPtyHandlers(
         if (lastRendererInputPtyId === payload.id) {
           lastRendererInputPtyId = null
         }
+        rendererPausedOutputPtys.delete(payload.id)
         mainWindow.webContents.send('pty:exit', payload)
       }
     })
@@ -2176,6 +2201,14 @@ export function registerPtyHandlers(
   ipcMain.on('pty:write', (_event, args: { id: string; data: string }) => {
     writePtyInput(args)
   })
+
+  ipcMain.on('pty:pauseOutput', (_event, args: { id?: string; paused?: boolean }) => {
+    if (typeof args?.id !== 'string') {
+      return
+    }
+    setRendererPtyOutputPaused(args.id, args.paused === true)
+  })
+
   ipcMain.handle('pty:writeAccepted', (_event, args: { id: string; data: string }): boolean => {
     return writePtyInputAccepted(args)
   })

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -57,6 +57,7 @@ vi.mock('../ipc/pty', () => ({
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
+  isRendererPtyOutputPaused: vi.fn(() => false),
   setPtyOwnership: vi.fn()
 }))
 

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -68,6 +68,7 @@ vi.mock('../ipc/pty', () => ({
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
+  isRendererPtyOutputPaused: vi.fn(() => false),
   setPtyOwnership: vi.fn()
 }))
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -36,6 +36,7 @@ import {
   clearPtyOwnershipForConnection,
   clearProviderPtyState,
   deletePtyOwnership,
+  isRendererPtyOutputPaused,
   setPtyOwnership
 } from '../ipc/pty'
 import {
@@ -815,7 +816,7 @@ export class SshRelaySession {
     ptyProvider.onData((payload) => {
       const seq = this.runtime?.onPtyData(payload.id, payload.data, Date.now())
       const win = this.getMainWindow()
-      if (win && !win.isDestroyed()) {
+      if (win && !win.isDestroyed() && !isRendererPtyOutputPaused(payload.id)) {
         win.webContents.send('pty:data', {
           ...payload,
           ...(typeof seq === 'number' ? { seq, rawLength: payload.data.length } : {})

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -819,6 +819,7 @@ export type PreloadApi = {
     signal: (id: string, signal: string) => void
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
     ackColdRestore: (id: string) => void
+    pauseOutput: (id: string, paused: boolean) => void
     hasChildProcesses: (id: string) => Promise<boolean>
     getForegroundProcess: (id: string) => Promise<string | null>
     getCwd: (id: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -739,6 +739,10 @@ const api = {
       ipcRenderer.send('pty:ackColdRestore', { id })
     },
 
+    pauseOutput: (id: string, paused: boolean): void => {
+      ipcRenderer.send('pty:pauseOutput', { id, paused })
+    },
+
     kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
       ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
 

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -721,6 +721,7 @@ export default function TerminalPane({
     setupSplit,
     issueCommandSplit,
     isActive,
+    isVisible,
     systemPrefersDark,
     settings,
     settingsRef,

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -449,6 +449,7 @@ describe('connectPanePty', () => {
         },
         pty: {
           signal: vi.fn(),
+          pauseOutput: vi.fn(),
           getMainBufferSnapshot: vi.fn().mockResolvedValue(null),
           getForegroundProcess: vi.fn().mockResolvedValue(null),
           hasChildProcesses: vi.fn().mockResolvedValue(false),
@@ -2702,6 +2703,46 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith(`${hidden}${live}`, expect.any(Function))
     expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden, expect.any(Function))
     disposable.dispose()
+  })
+
+  it('pauses renderer PTY output while hidden and restores from main snapshot on show', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    transport.connect.mockResolvedValue('pty-id')
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const pauseOutput = window.api.pty.pauseOutput as unknown as ReturnType<typeof vi.fn>
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'hidden while paused\r\n',
+      cols: 120,
+      rows: 40,
+      seq: 21
+    })
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      isVisibleRef: { current: false }
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    expect(pauseOutput).toHaveBeenCalledWith('pty-id', true)
+
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    binding.syncRendererOutputVisibility()
+    await flushAsyncTicks(20)
+
+    expect(pauseOutput).toHaveBeenCalledWith('pty-id', false)
+    expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'hidden while paused\r\n',
+      expect.any(Function)
+    )
+
+    binding.dispose()
   })
 
   it('restores hidden backlog overflow from the main terminal snapshot on foreground output', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -82,6 +82,10 @@ let codexRestartNoticePresenceSource: Record<
 > | null = null
 let codexRestartNoticePresence = false
 
+export type PanePtyBinding = IDisposable & {
+  syncRendererOutputVisibility: () => void
+}
+
 function isAgentTaskCompleteNotificationEnabled(): boolean {
   const notifications = useAppStore.getState().settings?.notifications
   return notifications?.enabled !== false && notifications?.agentTaskComplete !== false
@@ -233,7 +237,7 @@ export function connectPanePty(
   pane: ManagedPane,
   manager: PaneManager,
   deps: PtyConnectionDeps
-): IDisposable {
+): PanePtyBinding {
   let disposed = false
   let connectFrame: number | null = null
   let unregisterBacklogRecovery: (() => void) | null = null
@@ -1158,6 +1162,8 @@ export function connectPanePty(
   if (geometryReportObserver && pane.container instanceof Element) {
     geometryReportObserver.observe(pane.container)
   }
+  let rendererOutputPausedPtyId: string | null = null
+  let syncRendererOutputVisibility = (): void => {}
 
   // Defer PTY spawn/attach to next frame so FitAddon has time to calculate
   // the correct terminal dimensions from the laid-out container.
@@ -1276,6 +1282,7 @@ export function connectPanePty(
           if (typeof gen === 'number' && resolvedPtyId) {
             if (!isRemoteRuntimePtyId(resolvedPtyId)) {
               registerPaneSerializerFor(resolvedPtyId)
+              syncRendererOutputVisibility()
               void window.api.pty.settlePaneSerializer(cacheKey, gen).catch(() => {})
             }
           } else if (typeof gen === 'number') {
@@ -1341,6 +1348,38 @@ export function connectPanePty(
 
     function canUseMainBufferSnapshot(ptyId: string | null): ptyId is string {
       return Boolean(ptyId) && !isRemoteRuntimePtyId(ptyId)
+    }
+
+    function canPauseRendererOutput(ptyId: string | null): ptyId is string {
+      return canUseMainBufferSnapshot(ptyId) && typeof window.api.pty.pauseOutput === 'function'
+    }
+
+    function setRendererOutputPaused(ptyId: string, paused: boolean): void {
+      window.api.pty.pauseOutput(ptyId, paused)
+      rendererOutputPausedPtyId = paused ? ptyId : null
+    }
+
+    syncRendererOutputVisibility = (): void => {
+      const ptyId = transport.getPtyId()
+      if (rendererOutputPausedPtyId !== null && rendererOutputPausedPtyId !== ptyId) {
+        setRendererOutputPaused(rendererOutputPausedPtyId, false)
+      }
+      if (!canPauseRendererOutput(ptyId)) {
+        return
+      }
+      const shouldPause = !shouldWritePtyOutputForeground(deps.isVisibleRef.current)
+      if (shouldPause) {
+        if (rendererOutputPausedPtyId !== ptyId) {
+          // Why: main owns the retained terminal buffer for snapshot-capable
+          // PTYs, so hidden panes can stop receiving live bytes entirely.
+          setRendererOutputPaused(ptyId, true)
+        }
+        return
+      }
+      if (rendererOutputPausedPtyId === ptyId) {
+        setRendererOutputPaused(ptyId, false)
+        markHiddenOutputRestoreNeeded()
+      }
     }
 
     function beforeTerminalOutputWrite(chunk: string): void {
@@ -1680,6 +1719,7 @@ export function connectPanePty(
       typeof document.removeEventListener === 'function'
     ) {
       const onDocumentVisibilityChange = (): void => {
+        syncRendererOutputVisibility()
         if (shouldWritePtyOutputForeground(deps.isVisibleRef.current)) {
           requestHiddenOutputRestoreIfNeeded()
         }
@@ -1690,6 +1730,7 @@ export function connectPanePty(
     }
 
     const dataCallback = (data: string, meta?: PtyDataMeta): void => {
+      syncRendererOutputVisibility()
       resetHiddenOutputRestoreIfPtyChanged()
       observeTerminalBracketedPasteModeOutput(pane.terminal, data)
       for (const link of observeTerminalGitHubPRLink(data)) {
@@ -1800,6 +1841,7 @@ export function connectPanePty(
       // serializer and the onTitleChange-driven lastTitle source so the
       // main-process hydration path has full status parity.
       registerPaneSerializerFor(ptyId)
+      syncRendererOutputVisibility()
 
       // Strict precedence: snapshot > replay > coldRestore. Paint exactly
       // one source per reattach. Painting snapshot AND replay produced the
@@ -2266,6 +2308,7 @@ export function connectPanePty(
         deps.syncPanePtyLayoutBinding(pane.id, attachPtyId)
         deps.updateTabPtyId(deps.tabId, attachPtyId)
         agentCompletionCoordinator.startProcessTracking()
+        syncRendererOutputVisibility()
       } catch (err) {
         reportError(err instanceof Error ? err.message : String(err))
         deps.clearTabPtyId(deps.tabId, attachPtyId)
@@ -2316,6 +2359,7 @@ export function connectPanePty(
             // Why: attach sets the transport's PTY id; starting process
             // tracking before this point no-ops because getPtyId() is empty.
             agentCompletionCoordinator.startProcessTracking()
+            syncRendererOutputVisibility()
           })
           .catch((err) => {
             reportError(err instanceof Error ? err.message : String(err))
@@ -2329,6 +2373,9 @@ export function connectPanePty(
   })
 
   return {
+    syncRendererOutputVisibility() {
+      syncRendererOutputVisibility()
+    },
     dispose() {
       disposed = true
       if (terminalKeyTargetSupportsEvents) {
@@ -2357,6 +2404,10 @@ export function connectPanePty(
       unregisterBacklogRecovery = null
       unregisterDocumentVisibilityRecovery?.()
       unregisterDocumentVisibilityRecovery = null
+      if (rendererOutputPausedPtyId !== null) {
+        window.api.pty.pauseOutput(rendererOutputPausedPtyId, false)
+        rendererOutputPausedPtyId = null
+      }
       discardTerminalOutput(pane.terminal)
       if (agentTaskCompleteSettingsUnsubscribe !== null) {
         agentTaskCompleteSettingsUnsubscribe()

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -88,6 +88,7 @@ type UseTerminalPaneLifecycleDeps = {
    *  issue-automation command with the linked issue number interpolated. */
   issueCommandSplit?: { command: string; env?: Record<string, string> } | null
   isActive: boolean
+  isVisible: boolean
   systemPrefersDark: boolean
   settings: GlobalSettings | null | undefined
   settingsRef: React.RefObject<GlobalSettings | null | undefined>
@@ -243,6 +244,7 @@ export function useTerminalPaneLifecycle({
   setupSplit,
   issueCommandSplit,
   isActive,
+  isVisible,
   systemPrefersDark,
   settings,
   settingsRef,
@@ -1182,6 +1184,17 @@ export function useTerminalPaneLifecycle({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabId, cwd])
+
+  useEffect(() => {
+    isVisibleRef.current = isVisible
+    for (const panePtyBinding of panePtyBindingsRef.current.values()) {
+      const bindingWithVisibility = panePtyBinding as IDisposable & {
+        syncRendererOutputVisibility?: () => void
+      }
+      bindingWithVisibility.syncRendererOutputVisibility?.()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Why: visibility flips must notify existing PTY bindings even though the ref object identity is stable.
+  }, [isVisible, isVisibleRef, panePtyBindingsRef])
 
   useEffect(() => {
     const manager = managerRef.current

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1961,6 +1961,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     signal: () => {},
     kill: () => Promise.resolve(),
     ackColdRestore: () => {},
+    pauseOutput: () => {},
     hasChildProcesses: () => Promise.resolve(false),
     getForegroundProcess: () => Promise.resolve(null),
     getCwd: () => Promise.resolve('~'),


### PR DESCRIPTION
## Summary
- Pause renderer `pty:data` delivery for hidden snapshot-capable terminal panes while keeping main/runtime-owned buffers up to date.
- Resume hidden panes on visibility and restore from the main snapshot so visible terminal state stays correct.
- Apply the same pause gate to direct SSH relay output and non-forced synthetic title frames.
- Add regression coverage for 250 paused background PTYs staying off the renderer input path while the active PTY still redraws immediately.

## Risk
Low. Foreground terminal output is unchanged, hidden snapshot-capable panes already restore from main-owned snapshots, remote runtime PTYs keep the existing live path, and forced final/permission title frames still deliver.

## Tests
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/main/index.ts src/main/ipc/pty.ts src/main/ipc/pty.test.ts src/main/ssh/ssh-relay-session.ts src/main/ssh/ssh-relay-session.test.ts src/main/ssh/ssh-relay-session-terminal-error.test.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/web/web-preload-api.ts src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/ssh/ssh-relay-session.test.ts src/main/ssh/ssh-relay-session-terminal-error.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts`
- `pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts`
- `git diff --check`
