### PR TITLE
fix: time out developer automation prompt

### DIFF
--- a/src/main/ipc/developer-permissions.test.ts
+++ b/src/main/ipc/developer-permissions.test.ts
@@ -6,6 +6,7 @@ const {
   askForMediaAccessMock,
   getMediaAccessStatusMock,
   isTrustedAccessibilityClientMock,
+  execFileMock,
   createSocketMock,
   socketMock,
   socketState
@@ -27,6 +28,7 @@ const {
     askForMediaAccessMock: vi.fn(),
     getMediaAccessStatusMock: vi.fn(),
     isTrustedAccessibilityClientMock: vi.fn(),
+    execFileMock: vi.fn(),
     createSocketMock: vi.fn(() => socketMock),
     socketMock,
     socketState
@@ -53,6 +55,10 @@ vi.mock('node:dgram', () => ({
   }
 }))
 
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
+}))
+
 import { registerDeveloperPermissionHandlers } from './developer-permissions'
 
 describe('registerDeveloperPermissionHandlers', () => {
@@ -66,6 +72,15 @@ describe('registerDeveloperPermissionHandlers', () => {
     askForMediaAccessMock.mockReset()
     getMediaAccessStatusMock.mockReset()
     isTrustedAccessibilityClientMock.mockReset()
+    execFileMock.mockReset()
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1)
+      if (typeof callback === 'function') {
+        const execCallback = callback as () => void
+        execCallback()
+      }
+      return { kill: vi.fn() }
+    })
     createSocketMock.mockClear()
     socketState.sendCallback = null
     socketMock.on.mockClear()
@@ -121,5 +136,28 @@ describe('registerDeveloperPermissionHandlers', () => {
     expect(vi.getTimerCount()).toBe(0)
     expect(socketMock.removeListener).toHaveBeenCalledWith('error', expect.any(Function))
     expect(socketMock.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles the automation prompt when osascript hangs', async () => {
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    registerDeveloperPermissionHandlers()
+
+    const result = getRequestHandler()({}, { id: 'automation' })
+    let settled = false
+    void result.finally(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    await Promise.resolve()
+
+    expect(settled).toBe(true)
+    await expect(result).resolves.toEqual({
+      id: 'automation',
+      status: 'unknown',
+      openedSystemSettings: false
+    })
+    expect(killMock).toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/developer-permissions.ts
+++ b/src/main/ipc/developer-permissions.ts
@@ -32,6 +32,7 @@ const DEVELOPER_PERMISSION_IDS: DeveloperPermissionId[] = [
   'usb',
   'bluetooth'
 ]
+const APPLE_EVENTS_PROMPT_TIMEOUT_MS = 3_000
 
 function unsupportedOffMac(): DeveloperPermissionStatus | null {
   return process.platform === 'darwin' ? null : 'unsupported'
@@ -86,12 +87,38 @@ async function openPrivacyPane(id: DeveloperPermissionId): Promise<boolean> {
 
 function triggerAppleEventsPrompt(): Promise<void> {
   return new Promise((resolve) => {
-    execFile(
-      'osascript',
-      ['-e', 'tell application "System Events" to return 1'],
-      { timeout: 3000 },
-      () => resolve()
-    )
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      resolve()
+    }
+
+    // Why: this request only nudges macOS to show the Automation prompt; a
+    // stuck osascript process should not keep the permission IPC pending.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish()
+    }, APPLE_EVENTS_PROMPT_TIMEOUT_MS)
+    if (typeof timeout.unref === 'function') {
+      timeout.unref()
+    }
+
+    try {
+      child = execFile(
+        'osascript',
+        ['-e', 'tell application "System Events" to return 1'],
+        { timeout: APPLE_EVENTS_PROMPT_TIMEOUT_MS },
+        finish
+      )
+    } catch {
+      finish()
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- Add an explicit settle timeout around the macOS Automation permission `osascript` prompt trigger.
- Kill the child process best-effort and keep the existing fallback response for the permission request.

## Reproduction
- Added a regression test that mocks the Apple Events prompt `osascript` call so `execFile` never invokes its callback.
- Before the fix, `developerPermissions:request` for `automation` stayed pending after 3 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/ipc/developer-permissions.test.ts:154:21`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/developer-permissions.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/developer-permissions.ts src/main/ipc/developer-permissions.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; this only bounds a best-effort macOS prompt trigger and preserves the existing unknown-status response.