### PR TITLE
fix: time out wsl cli commands

### DIFF
--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -1,6 +1,13 @@
 import type { CliInstallStatus } from '../../shared/cli-install-types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
+}))
+
 import { WslCliInstaller, _internals } from './wsl-cli-installer'
-import { describe, expect, it, vi } from 'vitest'
 
 function makeHostStatus(launcherPath = 'C:\\Users\\me\\AppData\\Local\\Orca\\bin\\orca.cmd') {
   return {
@@ -80,6 +87,14 @@ function createWslRunner(initialFile: string | null = null, pathIncludesLocalBin
 }
 
 describe('WslCliInstaller', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('installs a WSL launcher that forwards to the Windows Orca launcher', async () => {
     const wsl = createWslRunner()
     const installer = new WslCliInstaller({
@@ -206,6 +221,32 @@ describe('WslCliInstaller', () => {
     expect(wrapped).toContain('set -o pipefail;')
     expect(encoded).toBeTruthy()
     expect(Buffer.from(encoded as string, 'base64').toString('utf8')).toBe(command)
+  })
+
+  it('settles when wsl.exe never reports completion', async () => {
+    vi.useFakeTimers()
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    const installer = new WslCliInstaller({
+      platform: 'win32',
+      distro: 'Ubuntu',
+      hostInstaller: { getStatus: async () => makeHostStatus() }
+    })
+
+    const promise = installer.getStatus()
+    let settled = false
+    void promise
+      .catch(() => undefined)
+      .finally(() => {
+        settled = true
+      })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await Promise.resolve()
+
+    expect(settled).toBe(true)
+    await expect(promise).rejects.toThrow('WSL command timed out')
+    expect(killMock).toHaveBeenCalled()
   })
 
   it('refuses to remove an old managed launcher when the bridge path is user-owned', async () => {

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: WSL CLI status/install/remove share one state machine;
    splitting the installer would separate conflict checks from the operations they guard. */
 import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
 import { getDefaultWslDistro } from '../wsl'
 import { CliInstaller } from './cli-installer'
@@ -18,11 +17,11 @@ import {
   quoteShell
 } from './wsl-cli-scripts'
 
-const execFileAsync = promisify(execFile)
 const MANAGED_MARKER = getWslLauncherMarker()
 const BRIDGE_MANAGED_MARKER = getWslBridgeMarker()
 const WSL_COMMAND_NAME = 'orca-ide'
 const LEGACY_WSL_COMMAND_NAME = 'orca'
+const WSL_COMMAND_TIMEOUT_MS = 10_000
 
 type WslCliInstallerOptions = {
   platform?: NodeJS.Platform
@@ -348,15 +347,46 @@ export class WslCliInstaller {
 }
 
 async function runWslCommand(distro: string, command: string): Promise<string> {
-  const { stdout } = (await execFileAsync(
-    'wsl.exe',
-    ['-d', distro, '--', 'bash', '-lc', buildEncodedWslBashCommand(command)],
-    {
-      encoding: 'utf8',
-      timeout: 10000
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null, stdout = ''): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(stdout)
     }
-  )) as { stdout: string }
-  return stdout
+
+    // Why: WSL CLI status/install/remove backs Settings UI; a wedged wsl.exe
+    // process must not leave the command registration flow pending forever.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(new Error(`WSL command timed out after ${WSL_COMMAND_TIMEOUT_MS}ms.`))
+    }, WSL_COMMAND_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        'wsl.exe',
+        ['-d', distro, '--', 'bash', '-lc', buildEncodedWslBashCommand(command)],
+        {
+          encoding: 'utf8',
+          timeout: WSL_COMMAND_TIMEOUT_MS
+        },
+        (error, stdout) => {
+          finish(error ?? null, stdout)
+        }
+      )
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
 }
 
 function buildEncodedWslBashCommand(command: string): string {


### PR DESCRIPTION
## Summary
- Add a promise-level timeout around the default `wsl.exe` runner used by WSL CLI registration status/install/remove.
- Pass the same timeout to `execFile`, kill the child best-effort, and reject with an explicit timeout error if `wsl.exe` never reports completion.

## Reproduction
- Added a regression test that exercises `WslCliInstaller.getStatus()` with the default runner while mocking `wsl.exe` so `execFile` never invokes its callback.
- Before the fix, the status promise stayed pending after 10 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/cli/wsl-cli-installer.test.ts:245:21`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/cli/wsl-cli-installer.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/cli/wsl-cli-installer.ts src/main/cli/wsl-cli-installer.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; this preserves the existing WSL command arguments and only bounds the stuck-child path.