### PR TITLE
fix: time out windows cli path commands

### DIFF
--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -1,7 +1,9 @@
 import { lstat, mkdtemp, mkdir, readFile, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execFileMock = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => ({
   app: {
@@ -9,6 +11,10 @@ vi.mock('electron', () => ({
     getPath: () => tmpdir(),
     getAppPath: () => tmpdir()
   }
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
 }))
 
 import { CliInstaller } from './cli-installer'
@@ -28,7 +34,12 @@ async function makeFixture(): Promise<{
 }
 
 describe('CliInstaller', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -155,6 +166,38 @@ describe('CliInstaller', () => {
     const removed = await installer.remove()
     expect(removed.state).toBe('not_installed')
     expect(userPath).not.toContain(join(fixture.root, 'Programs', 'Orca', 'bin'))
+  })
+
+  it('settles when the Windows PATH query hangs', async () => {
+    vi.useFakeTimers()
+    const fixture = await makeFixture()
+    const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    const installer = new CliInstaller({
+      platform: 'win32',
+      isPackaged: false,
+      userDataPath: fixture.userDataPath,
+      execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
+      appPath: fixture.appPath,
+      commandPathOverride: installPath
+    })
+
+    const promise = installer.getStatus()
+    let settled = false
+    void promise
+      .catch(() => undefined)
+      .finally(() => {
+        settled = true
+      })
+
+    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalled())
+    await vi.advanceTimersByTimeAsync(5_000)
+    await Promise.resolve()
+
+    expect(settled).toBe(true)
+    await expect(promise).rejects.toThrow('Windows PATH command timed out')
+    expect(killMock).toHaveBeenCalled()
   })
 
   // Why: this test creates a Unix symlink to /tmp/not-orca, which only applies on macOS/Linux.

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -13,6 +13,7 @@ const DEFAULT_MAC_COMMAND_PATH = '/usr/local/bin/orca'
 const LINUX_COMMAND_NAME = 'orca-ide'
 const LEGACY_LINUX_COMMAND_NAME = 'orca'
 const DEV_LAUNCHER_DIR = ['cli', 'bin']
+const WINDOWS_PATH_COMMAND_TIMEOUT_MS = 5_000
 
 type CliInstallerOptions = {
   platform?: NodeJS.Platform
@@ -639,7 +640,7 @@ function isAbsoluteForPlatform(platform: NodeJS.Platform, value: string): boolea
 }
 
 async function readWindowsUserPath(): Promise<string | null> {
-  const { stdout } = await execFileAsync('powershell', [
+  const stdout = await runWindowsPathCommand([
     '-NoProfile',
     '-Command',
     "[Environment]::GetEnvironmentVariable('Path','User')"
@@ -648,7 +649,7 @@ async function readWindowsUserPath(): Promise<string | null> {
 }
 
 async function writeWindowsUserPath(value: string): Promise<void> {
-  await execFileAsync('powershell', [
+  await runWindowsPathCommand([
     '-NoProfile',
     '-Command',
     // Why: PATH registration must stay user-scoped on Windows so the Orca
@@ -656,6 +657,48 @@ async function writeWindowsUserPath(value: string): Promise<void> {
     // elevation or mutating machine-wide environment state.
     `[Environment]::SetEnvironmentVariable('Path', ${quotePowerShell(value)}, 'User')`
   ])
+}
+
+function runWindowsPathCommand(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null, stdout = ''): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(stdout)
+    }
+
+    // Why: Windows PATH reads/writes back CLI Settings; wedged PowerShell must
+    // not keep command registration status or install/remove pending forever.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(
+        new Error(`Windows PATH command timed out after ${WINDOWS_PATH_COMMAND_TIMEOUT_MS}ms.`)
+      )
+    }, WINDOWS_PATH_COMMAND_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        'powershell',
+        args,
+        { encoding: 'utf8', timeout: WINDOWS_PATH_COMMAND_TIMEOUT_MS },
+        (error, stdout) => {
+          finish(error ?? null, stdout)
+        }
+      )
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
 }
 
 function quotePowerShell(value: string): string {


### PR DESCRIPTION
## Summary
- Add a promise-level timeout around the default Windows user PATH PowerShell reader/writer used by CLI registration.
- Pass the same timeout to `execFile`, kill PowerShell best-effort, and reject with an explicit timeout error when it never reports completion.

## Reproduction
- Added a regression test that exercises `CliInstaller.getStatus()` on Windows with the default PATH reader while mocking `powershell` so `execFile` never invokes its callback.
- Before the fix, the status promise stayed pending after 5 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/cli/cli-installer.test.ts:195:21`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/cli/cli-installer.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/cli/cli-installer.ts src/main/cli/cli-installer.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; this only bounds the default Windows PATH PowerShell helper and leaves injected installer hooks unchanged.