### PR TITLE
fix: open terminal UNC file links on Windows

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-url-target.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-url-target.ts
@@ -1,7 +1,13 @@
+import { fileUriToFilesystemPath } from '../../../../shared/file-uri-path'
+
 export type TerminalFileUrlTarget = {
   filePath: string
   line: number | null
   column: number | null
+}
+
+export type TerminalFileUrlTargetOptions = {
+  allowUncHost?: boolean
 }
 
 function parseFileUrlLineHash(hash: string): { line: number; column: number | null } | null {
@@ -28,16 +34,17 @@ function parseFilePathTrailingLineTarget(filePath: string): TerminalFileUrlTarge
   }
 }
 
-export function resolveTerminalFileUrlTarget(parsed: URL): TerminalFileUrlTarget | null {
-  if (parsed.hostname && parsed.hostname !== 'localhost') {
+export function resolveTerminalFileUrlTarget(
+  parsed: URL,
+  options: TerminalFileUrlTargetOptions = {}
+): TerminalFileUrlTarget | null {
+  if (parsed.hostname && parsed.hostname !== 'localhost' && !options.allowUncHost) {
     return null
   }
 
-  let filePath = decodeURIComponent(parsed.pathname)
-  // Why: on Windows, file:///C:/foo yields pathname "/C:/foo". The leading
-  // slash must be stripped to produce a valid Windows path ("C:/foo").
-  if (/^\/[A-Za-z]:/.test(filePath)) {
-    filePath = filePath.slice(1)
+  const filePath = fileUriToFilesystemPath(parsed)
+  if (!filePath) {
+    return null
   }
 
   const hashTarget = parseFileUrlLineHash(parsed.hash)

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -325,6 +325,44 @@ describe('handleOscLink', () => {
     )
   })
 
+  it('opens Windows UNC file URL links from Windows worktrees', async () => {
+    setPlatform('Windows')
+
+    handleOscLink(
+      'file://server/share/repo/test.txt',
+      { metaKey: false, ctrlKey: true },
+      {
+        ...deps,
+        worktreePath: '\\\\server\\share\\repo'
+      }
+    )
+    await flushAsyncWork()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({
+      targetPath: '//server/share/repo/test.txt'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '//server/share/repo/test.txt' })
+    )
+  })
+
+  it('rejects hosted file URL links when the active worktree is not Windows-local', async () => {
+    setPlatform('Windows')
+
+    handleOscLink(
+      'file://server/share/repo/test.txt',
+      { metaKey: false, ctrlKey: true },
+      {
+        ...deps,
+        worktreePath: '/home/user/repo'
+      }
+    )
+    await flushAsyncWork()
+
+    expect(authorizeExternalPathMock).not.toHaveBeenCalled()
+    expect(openFileMock).not.toHaveBeenCalled()
+  })
+
   it('preserves #L line anchors from file URL links', async () => {
     setPlatform('Macintosh')
 

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -1,5 +1,6 @@
 import { resolveTerminalFileLinkText } from '@/lib/terminal-links'
 import { openHttpLink } from '@/lib/http-link-routing'
+import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { isTerminalLinkActivation } from './terminal-link-handlers'
 import { resolveTerminalFileUrlTarget } from './terminal-file-url-target'
@@ -56,9 +57,13 @@ export function handleOscLink(
     // Why: file:// URIs should open inside Orca, not via the OS default editor
     // (shell.openPath). We extract the path from the URI and route it through
     // the same openDetectedFilePath logic used for detected file-path links.
-    // Only local files are supported — remote hosts (file://remote/...) are rejected
-    // because we cannot open them as local paths.
-    const resolved = resolveTerminalFileUrlTarget(parsed)
+    // Remote file hosts stay rejected; Windows local network shares are the
+    // exception because their standard URI form is file://server/share/path.
+    const allowUncHost =
+      navigator.userAgent.includes('Windows') &&
+      isWindowsAbsolutePathLike(deps.worktreePath) &&
+      !deps.runtimeEnvironmentId
+    const resolved = resolveTerminalFileUrlTarget(parsed, { allowUncHost })
     if (!resolved) {
       return
     }


### PR DESCRIPTION
## Summary
- allow terminal `file://server/share/...` links when Orca is running on Windows from a Windows-local worktree
- keep hosted `file://...` links rejected for POSIX/remote worktrees so SSH/runtime output is not mistaken for local UNC paths
- reuse the shared file URI decoder and add coverage for the Windows UNC allow/reject paths

## Why
Windows network-share file links use the hosted file URI form (`file://server/share/path`). The terminal link router rejected every non-localhost file host, so Ctrl-clicking a UNC file link from a Windows-local terminal did nothing even though the path is local from Windows' point of view.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm run lint -- src/renderer/src/components/terminal-pane/terminal-file-url-target.ts src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm run typecheck:web`
- `git diff --check HEAD~1..HEAD`

Risk: medium

Risk assessment: Medium. This changes terminal file-link routing for Windows UNC file URLs and should get another cross-platform terminal/link review before merge.