### PR TITLE
fix: time out wsl hook commands

### DIFF
--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -749,6 +749,52 @@ describe('runHook', () => {
       })
     }
   })
+
+  it('settles WSL hooks when wsl.exe never reports completion', async () => {
+    vi.useFakeTimers()
+    execMock.mockReset()
+    execFileMock.mockReset()
+    const killMock = vi.fn()
+    execFileMock.mockImplementation(() => ({ kill: killMock }) as never)
+
+    const fs = await import('fs')
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.readFileSync).mockReturnValue('scripts:\n  setup: |\n    echo hello\n')
+
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    try {
+      const { runHook } = await import('./hooks')
+      const promise = runHook('setup', '\\\\wsl.localhost\\Ubuntu\\home\\jin\\feature', {
+        ...makeRepo(),
+        path: 'C:\\Users\\jinwo\\git\\orca'
+      })
+      let settled = false
+      void promise.finally(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(120_000)
+      await Promise.resolve()
+
+      expect(settled).toBe(true)
+      await expect(promise).resolves.toMatchObject({
+        success: false,
+        output: expect.stringContaining('Hook timed out')
+      })
+      expect(killMock).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
 })
 
 describe('shouldRunSetupForCreate', () => {

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -525,30 +525,53 @@ export function runHook(
     }
 
     return new Promise((resolve) => {
-      execFile(
-        'wsl.exe',
-        ['-d', wslInfo.distro, '--', 'bash', '-c', bashCmd],
-        {
-          timeout: HOOK_TIMEOUT,
-          encoding: 'utf-8',
-          env: { ...process.env, ...wslEnv }
-        },
-        (error, stdout, stderr) => {
-          if (error) {
-            console.error(`[hooks] ${hookName} hook failed in ${cwd}:`, error.message)
-            resolve({
-              success: false,
-              output: `${stdout}\n${stderr}\n${error.message}`.trim()
-            })
-          } else {
-            console.log(`[hooks] ${hookName} hook completed in ${cwd}`)
-            resolve({
-              success: true,
-              output: `${stdout}\n${stderr}`.trim()
-            })
-          }
+      let child: ReturnType<typeof execFile> | null = null
+      let settled = false
+
+      const finish = (error: Error | null, stdout = '', stderr = ''): void => {
+        if (settled) {
+          return
         }
-      )
+        settled = true
+        clearTimeout(timeout)
+        if (error) {
+          console.error(`[hooks] ${hookName} hook failed in ${cwd}:`, error.message)
+          resolve({
+            success: false,
+            output: `${stdout}\n${stderr}\n${error.message}`.trim()
+          })
+        } else {
+          console.log(`[hooks] ${hookName} hook completed in ${cwd}`)
+          resolve({
+            success: true,
+            output: `${stdout}\n${stderr}`.trim()
+          })
+        }
+      }
+
+      // Why: Node's execFile timeout only signals wsl.exe; if no callback
+      // arrives, hook setup/archive must still unblock after HOOK_TIMEOUT.
+      const timeout = setTimeout(() => {
+        child?.kill()
+        finish(new Error(`Hook timed out after ${HOOK_TIMEOUT}ms.`))
+      }, HOOK_TIMEOUT)
+
+      try {
+        child = execFile(
+          'wsl.exe',
+          ['-d', wslInfo.distro, '--', 'bash', '-c', bashCmd],
+          {
+            timeout: HOOK_TIMEOUT,
+            encoding: 'utf-8',
+            env: { ...process.env, ...wslEnv }
+          },
+          (error, stdout, stderr) => {
+            finish(error ?? null, stdout, stderr)
+          }
+        )
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)))
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- Add a promise-level timeout around WSL setup/archive hook execution through `wsl.exe`.
- Kill the child process best-effort and return the existing hook failure result shape when the command never reports completion.

## Reproduction
- Added a regression test that mocks WSL hook `wsl.exe` execution so `execFile` never invokes its callback.
- Before the fix, `runHook()` stayed pending after the 120-second hook timeout elapsed in fake time and failed with `AssertionError: expected false to be true` at `src/main/hooks.test.ts:784:23`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/hooks.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/hooks.ts src/main/hooks.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; this only bounds the stuck WSL child-process path and keeps successful hook output handling unchanged.