### PR TITLE
test: mock PTY pause state in SSH IPC tests

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -151,7 +151,8 @@ vi.mock('./pty', () => ({
   deletePtyOwnership: vi.fn(),
   setPtyOwnership: vi.fn(),
   getSshPtyProvider: vi.fn(),
-  getPtyIdsForConnection: vi.fn().mockReturnValue([])
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  isRendererPtyOutputPaused: vi.fn().mockReturnValue(false)
 }))
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({


### PR DESCRIPTION
## Summary
- add the missing `isRendererPtyOutputPaused` export to the `./pty` mock in `src/main/ipc/ssh.test.ts`

## Why
`ssh-relay-session.ts` now imports `isRendererPtyOutputPaused` from `src/main/ipc/pty.ts`. The SSH IPC test suite mocks that module, but the mock did not expose the new export, so the full verify job failed before the tested SSH event forwarding assertions could run.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/ssh.test.ts`
- `pnpm run lint -- src/main/ipc/ssh.test.ts`
- `git diff --check`