### PR TITLE
fix: time out wsl preflight probes

### DIFF
--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -292,6 +292,48 @@ describe('preflight', () => {
     )
   })
 
+  it('times out hung WSL preflight probes', async () => {
+    vi.useFakeTimers()
+    try {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: 'win32'
+      })
+      execFileAsyncMock.mockImplementation((command, args) => {
+        if (command === 'git') {
+          return Promise.resolve({ stdout: 'git version 2.0.0\n' })
+        }
+        if (command === 'gh' || command === 'glab') {
+          return Promise.reject(Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))
+        }
+        if (command === 'wsl.exe' && Array.isArray(args) && args.at(-1) === "'gh' --version") {
+          return new Promise(() => {})
+        }
+        if (command === 'wsl.exe' && Array.isArray(args) && args.at(-1) === "'glab' --version") {
+          return Promise.reject(Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))
+        }
+        throw new Error(`unexpected command ${String(command)}`)
+      })
+
+      const statusPromise = runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+      let settled = false
+      void statusPromise.finally(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(5000)
+      await Promise.resolve()
+
+      expect(settled).toBe(true)
+      await expect(statusPromise).resolves.toMatchObject({
+        gh: { installed: false },
+        glab: { installed: false }
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('re-runs the probe when forced so updated gh auth state is visible without relaunch', async () => {
     execFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -64,15 +64,7 @@ type PreflightCommandResult = { stdout: string; stderr: string }
 
 // Why: a broken PATH shim or auth helper should not keep startup/settings
 // preflight IPC pending forever; WSL probes already use the same deadline.
-async function execLocalPreflightCommand(
-  command: string,
-  args: string[]
-): Promise<PreflightCommandResult> {
-  const commandPromise = execFileAsync(command, args, {
-    encoding: 'utf-8',
-    timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
-  }) as Promise<PreflightCommandResult>
-
+async function withPreflightTimeout<T>(command: string, commandPromise: Promise<T>): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | null = null
   try {
     return await Promise.race([
@@ -96,15 +88,28 @@ async function execLocalPreflightCommand(
   }
 }
 
+async function execLocalPreflightCommand(
+  command: string,
+  args: string[]
+): Promise<PreflightCommandResult> {
+  const commandPromise = execFileAsync(command, args, {
+    encoding: 'utf-8',
+    timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
+  }) as Promise<PreflightCommandResult>
+
+  return withPreflightTimeout(command, commandPromise)
+}
+
 async function execCommandInWsl(
   target: WslPreflightTarget,
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
   const distroArgs = target.distro ? ['-d', target.distro] : []
-  return execFileAsync('wsl.exe', [...distroArgs, '--', 'bash', '-lc', command], {
+  const commandPromise = execFileAsync('wsl.exe', [...distroArgs, '--', 'bash', '-lc', command], {
     encoding: 'utf-8',
     timeout: PREFLIGHT_COMMAND_TIMEOUT_MS
   }) as Promise<{ stdout: string; stderr: string }>
+  return withPreflightTimeout('wsl.exe', commandPromise)
 }
 
 async function isCommandAvailable(


### PR DESCRIPTION
## Summary
- Apply the existing promise-level preflight timeout race to WSL command probes as well as local probes.
- Preserve the existing fallback behavior where a timed-out command is treated as unavailable.

## Reproduction
- Added a regression test that mocks the WSL `gh --version` preflight probe so it never resolves.
- Before the fix, `runPreflightCheck()` stayed pending after 5 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/ipc/preflight.test.ts:327:23`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/preflight.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; this reuses the existing preflight timeout policy and only changes the WSL probe settle path.