### PR TITLE
fix: time out agent-browser stale close

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -157,6 +157,40 @@ describe('AgentBrowserBridge', () => {
     expect(clickCall![1]).not.toContain('--cdp')
   })
 
+  it('continues when stale agent-browser session close hangs during session creation', async () => {
+    vi.useFakeTimers()
+    try {
+      const closeKill = vi.fn()
+      execFileMock.mockImplementation(
+        (_bin: string, args: string[], _opts: unknown, cb: Function) => {
+          if (args.includes('close')) {
+            return { kill: closeKill }
+          }
+          if (args.includes('snapshot')) {
+            cb(null, JSON.stringify({ success: true, data: { snapshot: 'ready' } }), '')
+            return { kill: vi.fn() }
+          }
+          throw new Error(`unexpected agent-browser args ${args.join(' ')}`)
+        }
+      )
+
+      const promise = bridge.snapshot()
+      let settled = false
+      void promise.finally(() => {
+        settled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(3_000)
+      await Promise.resolve()
+
+      expect(settled).toBe(true)
+      await expect(promise).resolves.toEqual({ browserPageId: 'tab-1', snapshot: 'ready' })
+      expect(closeKill).toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // ── --json always appended ──
 
   it('always appends --json to commands', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -54,6 +54,7 @@ import type {
 const EXEC_TIMEOUT_MS = 90_000
 const CONSECUTIVE_TIMEOUT_LIMIT = 3
 const WAIT_PROCESS_TIMEOUT_GRACE_MS = 1_000
+const STALE_SESSION_CLOSE_TIMEOUT_MS = 3_000
 
 type SessionState = {
   proxy: CdpWsProxy
@@ -1917,11 +1918,7 @@ export class AgentBrowserBridge {
       // across Orca restarts. A stale session ignores --cdp (already initialized) and
       // connects to the dead port. Must await close so the daemon forgets the session
       // before we pass --cdp with the new port.
-      await new Promise<void>((resolve) => {
-        execFile(this.agentBrowserBin, ['--session', sessionName, 'close'], { timeout: 3000 }, () =>
-          resolve()
-        )
-      })
+      await this.closeStaleAgentBrowserSession(sessionName)
 
       const proxy = new CdpWsProxy(wc)
       const cdpEndpoint = await proxy.start()
@@ -2095,6 +2092,40 @@ export class AgentBrowserBridge {
 
   private createPageUnavailableError(sessionName: string): BrowserError {
     return new BrowserError('browser_tab_not_found', pageUnavailableMessageForSession(sessionName))
+  }
+
+  private closeStaleAgentBrowserSession(sessionName: string): Promise<void> {
+    return new Promise((resolve) => {
+      let child: ReturnType<typeof execFile> | null = null
+      let settled = false
+
+      const finish = (): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        clearTimeout(timeout)
+        resolve()
+      }
+
+      // Why: this is best-effort daemon cleanup before creating a fresh session;
+      // a wedged close command must not block the real browser action.
+      const timeout = setTimeout(() => {
+        child?.kill()
+        finish()
+      }, STALE_SESSION_CLOSE_TIMEOUT_MS)
+
+      try {
+        child = execFile(
+          this.agentBrowserBin,
+          ['--session', sessionName, 'close'],
+          { timeout: STALE_SESSION_CLOSE_TIMEOUT_MS },
+          finish
+        )
+      } catch {
+        finish()
+      }
+    })
   }
 
   private createCommandError(


### PR DESCRIPTION
## Summary
- Add a promise-level timeout around the best-effort stale agent-browser session close performed before creating a fresh tab session.
- Kill the close child best-effort and proceed with the real browser command when cleanup never reports completion.

## Reproduction
- Added a regression test that mocks `agent-browser --session <name> close` to never invoke its `execFile` callback before a fresh `snapshot` command.
- Before the fix, `bridge.snapshot()` stayed pending after 3 seconds of fake time and failed with `AssertionError: expected false to be true` at `src/main/browser/agent-browser-bridge.test.ts:186:23`.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts`
- `git diff --check HEAD~1 HEAD`

Risk: low; stale session close is already best-effort cleanup, and successful command/session behavior is unchanged.