### PR TITLE
perf: handle large workspace layout history

### DIFF
--- a/src/shared/worktree-ownership.test.ts
+++ b/src/shared/worktree-ownership.test.ts
@@ -10,6 +10,8 @@ import {
   EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT
 } from './worktree-ownership'
 
+const LARGE_WORKSPACE_HISTORY_COUNT = 150_000
+
 function makeRepo(overrides: Partial<Repo> = {}): Repo {
   return {
     id: 'repo-1',
@@ -170,6 +172,31 @@ describe('worktree ownership classification', () => {
         knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
       })
     ).toBe('orca-managed')
+  })
+
+  it('builds known layouts from large workspace history lists', () => {
+    const repo = makeRepo()
+    const workspaceDirHistory = Array.from(
+      { length: LARGE_WORKSPACE_HISTORY_COUNT },
+      (_, index) => ({
+        path: `/history/workspaces-${index}`,
+        nestWorkspaces: index % 2 === 0
+      })
+    )
+    const settings = makeSettings({
+      workspaceDir: '/new/workspaces',
+      workspaceDirHistory
+    })
+
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+
+    expect(layouts).toHaveLength(LARGE_WORKSPACE_HISTORY_COUNT + 1)
+    expect(layouts[0]).toEqual({ path: '/new/workspaces', nestWorkspaces: true })
+    expect(layouts[1]).toEqual({ path: '/history/workspaces-0', nestWorkspaces: true })
+    expect(layouts.at(-1)).toEqual({
+      path: `/history/workspaces-${LARGE_WORKSPACE_HISTORY_COUNT - 1}`,
+      nestWorkspaces: false
+    })
   })
 
   it('handles Windows drive casing and separators', () => {

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -49,11 +49,11 @@ export function buildKnownOrcaWorkspaceLayouts(
   const layouts: OrcaWorkspaceLayout[] = []
   if (!repo?.connectionId && settings.workspaceDir) {
     layouts.push({ path: settings.workspaceDir, nestWorkspaces: settings.nestWorkspaces })
-    layouts.push(...(settings.workspaceDirHistory ?? []))
+    appendWorkspaceLayouts(layouts, settings.workspaceDirHistory ?? [])
   }
 
   const wslLayouts = repo ? buildWslWorkspaceLayouts(repo.path, settings) : []
-  layouts.push(...wslLayouts)
+  appendWorkspaceLayouts(layouts, wslLayouts)
 
   const seen = new Set<string>()
   return layouts.filter((layout) => {
@@ -64,6 +64,17 @@ export function buildKnownOrcaWorkspaceLayouts(
     seen.add(key)
     return Boolean(layout.path)
   })
+}
+
+function appendWorkspaceLayouts(
+  target: OrcaWorkspaceLayout[],
+  source: readonly OrcaWorkspaceLayout[]
+): void {
+  // Why: workspace history is persisted user data and can grow large enough
+  // for `push(...source)` to exceed the JavaScript call argument limit.
+  for (const layout of source) {
+    target.push(layout)
+  }
 }
 
 function buildWslWorkspaceLayouts(


### PR DESCRIPTION
## Summary
- replace spread appends when building known Orca workspace layouts with an iterative append
- add a regression test for 150k persisted workspace history entries

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/worktree-ownership.test.ts`
- `pnpm exec oxlint src/shared/worktree-ownership.ts src/shared/worktree-ownership.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

Risk: low. This only changes how existing layout entries are appended before the same de-duplication/classification logic runs.