### PR TITLE
Clean up SFTP upload stream listeners

### DIFF
--- a/src/main/ssh/sftp-upload.test.ts
+++ b/src/main/ssh/sftp-upload.test.ts
@@ -32,6 +32,9 @@ describe('sftp-upload', () => {
     expect(sftp.createWriteStream).toHaveBeenCalledWith('/remote/.logo.orca-upload', {
       flags: 'wx'
     })
+    const writeStream = vi.mocked(sftp.createWriteStream).mock.results[0]?.value as Writable
+    expect(writeStream.listenerCount('close')).toBe(0)
+    expect(writeStream.listenerCount('error')).toBe(0)
   })
 
   it('uses no-clobber writes for nested files during exclusive directory upload', async () => {
@@ -48,6 +51,9 @@ describe('sftp-upload', () => {
     expect(sftp.createWriteStream).toHaveBeenCalledWith('/remote/assets/nested/asset.txt', {
       flags: 'wx'
     })
+    const writeStream = vi.mocked(sftp.createWriteStream).mock.results[0]?.value as Writable
+    expect(writeStream.listenerCount('close')).toBe(0)
+    expect(writeStream.listenerCount('error')).toBe(0)
   })
 
   it('does not create the remote file when the local source is a symlink', async () => {

--- a/src/main/ssh/sftp-upload.ts
+++ b/src/main/ssh/sftp-upload.ts
@@ -36,16 +36,25 @@ export function uploadFile(
     let fileHandle: Awaited<ReturnType<typeof open>> | null = null
     let writeStream: ReturnType<SFTPWrapper['createWriteStream']> | null = null
 
+    const cleanupListeners = (): void => {
+      writeStream?.off('close', onWriteClose)
+      writeStream?.off('error', onWriteError)
+      readStream?.off('error', onReadError)
+    }
     const settle = (fn: typeof resolve | typeof reject, val?: unknown): void => {
       if (settled) {
         return
       }
       settled = true
+      cleanupListeners()
       readStream?.destroy()
       writeStream?.destroy()
       void fileHandle?.close().catch(() => {})
       fn(val as never)
     }
+    const onWriteClose = (): void => settle(resolve)
+    const onWriteError = (err: Error): void => settle(reject, err)
+    const onReadError = (err: Error): void => settle(reject, err)
 
     void open(localPath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
       .then(async (handle) => {
@@ -72,10 +81,10 @@ export function uploadFile(
         writeStream = sftp.createWriteStream(remotePath, {
           flags: options?.exclusive ? 'wx' : 'w'
         })
-        writeStream.on('close', () => settle(resolve))
-        writeStream.on('error', (err) => settle(reject, err))
+        writeStream.on('close', onWriteClose)
+        writeStream.on('error', onWriteError)
         readStream = handle.createReadStream()
-        readStream.on('error', (err) => settle(reject, err))
+        readStream.on('error', onReadError)
         readStream.pipe(writeStream)
       })
       .catch((err: unknown) => settle(reject, err))
@@ -94,17 +103,24 @@ export function uploadBuffer(
       flags: options?.append ? 'a' : options?.exclusive ? 'wx' : 'w'
     })
 
+    const cleanupListeners = (): void => {
+      writeStream.off('close', onClose)
+      writeStream.off('error', onError)
+    }
     const settle = (fn: typeof resolve | typeof reject, val?: unknown): void => {
       if (settled) {
         return
       }
       settled = true
+      cleanupListeners()
       writeStream.destroy()
       fn(val as never)
     }
+    const onClose = (): void => settle(resolve)
+    const onError = (err: Error): void => settle(reject, err)
 
-    writeStream.on('close', () => settle(resolve))
-    writeStream.on('error', (err) => settle(reject, err))
+    writeStream.on('close', onClose)
+    writeStream.on('error', onError)
     writeStream.end(buffer)
   })
 }


### PR DESCRIPTION
## Summary
- detach SFTP upload write/read stream listeners when upload promises settle
- keep existing stream destroy/file-handle cleanup behavior
- assert successful buffer and file uploads leave no write stream close/error listeners behind

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/sftp-upload.test.ts`
- `pnpm exec oxlint src/main/ssh/sftp-upload.ts src/main/ssh/sftp-upload.test.ts`
- `pnpm typecheck:node`
- `git diff --check`

Risk: low
Small SFTP helper cleanup with no protocol changes; focused unit coverage exercises the touched stream paths. Full Docker SSH rig was not run because this does not change relay connection or PTY behavior.