### PR TITLE
perf: handle large ssh include files

### DIFF
--- a/src/main/ssh/ssh-config-include-expander.ts
+++ b/src/main/ssh/ssh-config-include-expander.ts
@@ -64,12 +64,20 @@ function expandSshConfigFile(
 
     for (const includeArg of includeArgs) {
       for (const matchedPath of resolveIncludePaths(includeArg, context)) {
-        expandedLines.push(...expandSshConfigFile(matchedPath, context, nextStack))
+        appendExpandedLines(expandedLines, expandSshConfigFile(matchedPath, context, nextStack))
       }
     }
   }
 
   return expandedLines
+}
+
+function appendExpandedLines(target: string[], lines: readonly string[]): void {
+  // Why: SSH config includes are user-controlled files, and a large included
+  // file can exceed the JavaScript call argument limit when spread into push.
+  for (const line of lines) {
+    target.push(line)
+  }
 }
 
 function readCachedFile(filePath: string, context: IncludeExpansionContext): string | null {

--- a/src/main/ssh/ssh-config-loader.test.ts
+++ b/src/main/ssh/ssh-config-loader.test.ts
@@ -23,6 +23,7 @@ vi.mock('os', async () => {
 
 const originalEnv = { ...process.env }
 const tempDirs: string[] = []
+const LARGE_INCLUDE_LINE_COUNT = 150_000
 
 afterEach(() => {
   for (const key of Object.keys(process.env)) {
@@ -155,6 +156,23 @@ describe('loadUserSshConfig', () => {
       'inner',
       'matched',
       'after'
+    ])
+  })
+
+  it('continues parsing after a large included file', () => {
+    const home = makeHome()
+    writeFile(
+      home,
+      '.ssh/config',
+      ['Include large.conf', 'Host after', '  HostName after.example.com'].join('\n')
+    )
+    writeFile(home, '.ssh/large.conf', '\n'.repeat(LARGE_INCLUDE_LINE_COUNT))
+
+    expect(loadUserSshConfig()).toEqual([
+      {
+        host: 'after',
+        hostname: 'after.example.com'
+      }
     ])
   })
 


### PR DESCRIPTION
## Summary
- replace spread appends in SSH config Include expansion with iterative appends
- add a regression test for a 150k-line included SSH config file so later hosts still parse

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-config-loader.test.ts src/main/ssh/ssh-config-loader-regression.test.ts src/main/ssh/ssh-config-parser.test.ts`
- `pnpm exec oxlint src/main/ssh/ssh-config-include-expander.ts src/main/ssh/ssh-config-loader.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

Risk: low. This only changes array append mechanics during SSH config include expansion; parsing, include resolution, glob caps, and file-size guards are unchanged.