### PR TITLE
fix: normalize forward-slash UNC terminal paths

### DIFF
--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -13,6 +13,15 @@ describe('terminal path helpers', () => {
     expect(toWorktreeRelativePath('C:\\repo\\src\\file.ts', 'C:\\repo')).toBe('src/file.ts')
   })
 
+  it('keeps worktree-relative paths for forward-slash Windows UNC paths', () => {
+    expect(isPathInsideWorktree('//server/share/repo/src/file.ts', '\\\\server\\share\\repo')).toBe(
+      true
+    )
+    expect(
+      toWorktreeRelativePath('//server/share/repo/src/file.ts', '\\\\server\\share\\repo')
+    ).toBe('src/file.ts')
+  })
+
   describe('extractTerminalFileLinks bare-filename tokens', () => {
     it('does not treat regular URL hosts as local file paths', () => {
       expect(

--- a/src/renderer/src/lib/terminal-path-normalization.ts
+++ b/src/renderer/src/lib/terminal-path-normalization.ts
@@ -36,7 +36,7 @@ export function normalizeAbsolutePath(pathValue: string): NormalizedAbsolutePath
     }
   }
 
-  const uncMatch = /^\\\\([^\\/]+)[\\/]+([^\\/]+)(?:[\\/]*(.*))?$/.exec(pathValue)
+  const uncMatch = /^(?:\\\\|\/\/)([^\\/]+)[\\/]+([^\\/]+)(?:[\\/]*(.*))?$/.exec(pathValue)
   if (uncMatch) {
     const server = uncMatch[1]
     const share = uncMatch[2]


### PR DESCRIPTION
## Summary
- treat `//server/share/...` as a Windows UNC path in terminal path normalization
- preserve worktree-relative paths when a UNC file URL decodes to forward slashes
- add regression coverage for forward-slash UNC paths against a backslash UNC worktree root

## Why
Windows `file://server/share/path` links decode to `//server/share/path`. Terminal path normalization only recognized `\\server\share`, so the file could open but worktree-relative calculations treated the decoded path as POSIX and lost the relative path.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts`
- `pnpm run lint -- src/renderer/src/lib/terminal-path-normalization.ts src/renderer/src/lib/terminal-links.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`