### PR TITLE
Clean up system SSH command listeners

### DIFF
--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const { existsSyncMock, spawnMock } = vi.hoisted(() => ({
@@ -17,7 +18,8 @@ import {
   buildSshArgs,
   findSystemSsh,
   spawnSystemSsh,
-  spawnSystemSshCommand
+  spawnSystemSshCommand,
+  writeFileViaSystemSsh
 } from './ssh-system-fallback'
 import type { SshTarget } from '../../shared/ssh-types'
 
@@ -30,6 +32,34 @@ function createTarget(overrides?: Partial<SshTarget>): SshTarget {
     username: 'deploy',
     ...overrides
   }
+}
+
+type EventedProcess = EventEmitter & {
+  stdin: EventEmitter & {
+    write: ReturnType<typeof vi.fn>
+    end: ReturnType<typeof vi.fn>
+  }
+  stdout: EventEmitter
+  stderr: EventEmitter
+  pid: number
+  kill: ReturnType<typeof vi.fn>
+  exitCode: number | null
+  killed: boolean
+}
+
+function createEventedProcess(): EventedProcess {
+  const proc = new EventEmitter() as EventedProcess
+  proc.stdin = Object.assign(new EventEmitter(), {
+    write: vi.fn((_chunk, _encoding, cb?: (err?: Error | null) => void) => cb?.()),
+    end: vi.fn()
+  })
+  proc.stdout = new EventEmitter()
+  proc.stderr = new EventEmitter()
+  proc.pid = 12345
+  proc.kill = vi.fn()
+  proc.exitCode = null
+  proc.killed = false
+  return proc
 }
 
 describe('findSystemSsh', () => {
@@ -180,6 +210,37 @@ describe('spawnSystemSsh', () => {
     channel.stdin.end('contents')
 
     expect(mockProc.stdin.end).toHaveBeenCalledWith('contents')
+  })
+
+  it('removes wrapped process listeners after command close', () => {
+    const proc = createEventedProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const channel = spawnSystemSshCommand(createTarget(), 'echo hello')
+    const onClose = vi.fn()
+    channel.on('close', onClose)
+    proc.emit('close', 0, null)
+
+    expect(onClose).toHaveBeenCalledWith(0, null)
+    expect(proc.stdout.listenerCount('data')).toBe(0)
+    expect(proc.stdout.listenerCount('end')).toBe(0)
+    expect(proc.stdout.listenerCount('error')).toBe(0)
+    expect(proc.stdin.listenerCount('error')).toBe(0)
+    expect(proc.listenerCount('exit')).toBe(0)
+    expect(proc.listenerCount('close')).toBe(0)
+    expect(proc.listenerCount('error')).toBe(0)
+  })
+
+  it('removes write command wait listeners after close', async () => {
+    const proc = createEventedProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const promise = writeFileViaSystemSsh(createTarget(), '/tmp/file', 'contents')
+    proc.emit('close', 0, null)
+
+    await expect(promise).resolves.toBeUndefined()
+    expect(proc.stdin.end).toHaveBeenCalledWith('contents')
+    expect(proc.stderr.listenerCount('data')).toBe(0)
   })
 
   it('throws when no system ssh is found', () => {

--- a/src/main/ssh/ssh-system-fallback.ts
+++ b/src/main/ssh/ssh-system-fallback.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: system-ssh process wrapping and fallback file operations share cleanup contracts. */
 import { spawn, type ChildProcess } from 'child_process'
 import { existsSync } from 'fs'
 import { Duplex } from 'stream'
@@ -245,13 +246,46 @@ function wrapCommandProcess(proc: ChildProcess): SystemSshCommandChannel {
     }
   }
 
-  proc.stdout!.on('data', (data) => duplex.push(data))
-  proc.stdout!.on('end', () => duplex.push(null))
-  proc.on('exit', (code, signal) => channel.emit('exit', code, signal))
-  proc.on('close', (code, signal) => channel.emit('close', code, signal))
-  proc.on('error', (err) => duplex.destroy(err))
-  proc.stdin!.on('error', (err) => duplex.destroy(err))
-  proc.stdout!.on('error', (err) => duplex.destroy(err))
+  const cleanupProcessListeners = (): void => {
+    proc.stdout!.off('data', onStdoutData)
+    proc.stdout!.off('end', onStdoutEnd)
+    proc.off('exit', onExit)
+    proc.off('close', onClose)
+    proc.off('error', onProcessError)
+    proc.stdin!.off('error', onStreamError)
+    proc.stdout!.off('error', onStreamError)
+  }
+  const fail = (err: Error): void => {
+    cleanupProcessListeners()
+    duplex.destroy(err)
+  }
+  const onStdoutData = (data: Buffer): void => {
+    duplex.push(data)
+  }
+  const onStdoutEnd = (): void => {
+    duplex.push(null)
+  }
+  const onExit = (code: number | null, signal?: NodeJS.Signals | null): void => {
+    channel.emit('exit', code, signal)
+  }
+  const onClose = (code: number | null, signal?: NodeJS.Signals | null): void => {
+    cleanupProcessListeners()
+    channel.emit('close', code, signal)
+  }
+  const onProcessError = (err: Error): void => {
+    fail(err)
+  }
+  const onStreamError = (err: Error): void => {
+    fail(err)
+  }
+
+  proc.stdout!.on('data', onStdoutData)
+  proc.stdout!.on('end', onStdoutEnd)
+  proc.on('exit', onExit)
+  proc.on('close', onClose)
+  proc.on('error', onProcessError)
+  proc.stdin!.on('error', onStreamError)
+  proc.stdout!.on('error', onStreamError)
 
   return channel
 }
@@ -259,18 +293,33 @@ function wrapCommandProcess(proc: ChildProcess): SystemSshCommandChannel {
 function waitForChannelClose(channel: SystemSshCommandChannel, label: string): Promise<void> {
   return new Promise((resolve, reject) => {
     let stderr = ''
-    channel.stderr.on('data', (data: Buffer) => {
+    const cleanup = (): void => {
+      channel.stderr.off('data', onStderrData)
+      channel.off('error', onError)
+      channel.off('close', onClose)
+    }
+    const settle = (fn: typeof resolve | typeof reject, val?: unknown): void => {
+      cleanup()
+      fn(val as never)
+    }
+    const onStderrData = (data: Buffer): void => {
       stderr += data.toString('utf-8')
-    })
-    channel.on('error', reject)
-    channel.on('close', (code: number | null, signal?: NodeJS.Signals | null) => {
+    }
+    const onError = (err: Error): void => {
+      settle(reject, err)
+    }
+    const onClose = (code: number | null, signal?: NodeJS.Signals | null): void => {
       if (code !== 0) {
         const detail = code === null ? `signal ${signal ?? 'unknown'}` : `exit ${code}`
-        reject(new Error(`${label} failed (${detail}): ${stderr.trim()}`))
+        settle(reject, new Error(`${label} failed (${detail}): ${stderr.trim()}`))
         return
       }
-      resolve()
-    })
+      settle(resolve)
+    }
+
+    channel.stderr.on('data', onStderrData)
+    channel.on('error', onError)
+    channel.on('close', onClose)
   })
 }
 
@@ -279,17 +328,32 @@ type ProcessResult = { label: string; stderr: string }
 function waitForProcess(proc: ChildProcess, label: string): Promise<ProcessResult> {
   return new Promise((resolve, reject) => {
     let stderr = ''
-    proc.stderr?.on('data', (data: Buffer) => {
+    const cleanup = (): void => {
+      proc.stderr?.off('data', onStderrData)
+      proc.off('error', onError)
+      proc.off('close', onClose)
+    }
+    const settle = (fn: typeof resolve | typeof reject, val: ProcessResult | Error): void => {
+      cleanup()
+      fn(val as never)
+    }
+    const onStderrData = (data: Buffer): void => {
       stderr += data.toString('utf-8')
-    })
-    proc.on('error', reject)
-    proc.on('close', (code) => {
+    }
+    const onError = (err: Error): void => {
+      settle(reject, err)
+    }
+    const onClose = (code: number | null): void => {
       if (code !== 0) {
-        reject(new Error(`${label} failed (exit ${code}): ${stderr.trim()}`))
+        settle(reject, new Error(`${label} failed (exit ${code}): ${stderr.trim()}`))
         return
       }
-      resolve({ label, stderr })
-    })
+      settle(resolve, { label, stderr })
+    }
+
+    proc.stderr?.on('data', onStderrData)
+    proc.on('error', onError)
+    proc.on('close', onClose)
   })
 }
 


### PR DESCRIPTION
## Summary
- detach wrapped system-ssh process listeners when command channels close or error
- clean temporary stderr/error/close listeners in system-ssh wait helpers
- add EventEmitter-based regression coverage for command close and write-file wait cleanup

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-system-fallback.test.ts`
- `pnpm exec oxlint src/main/ssh/ssh-system-fallback.ts src/main/ssh/ssh-system-fallback.test.ts`
- `pnpm typecheck:node`
- `git diff --check`

Risk: low
System-ssh fallback listener cleanup only; no SSH arguments or protocol behavior changes. Full Docker SSH rig was not run because this is local wrapper/listener cleanup covered by focused unit tests.