### PR TITLE
test: make SSH SFTP tests Windows-safe

### DIFF
--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -117,6 +117,7 @@ describe('SshFilesystemProvider', () => {
       const written: Buffer[] = []
       const writeStream = {
         on: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => writeStream),
+        off: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => writeStream),
         end: vi.fn((buffer: Buffer) => {
           written.push(buffer)
           const closeHandler = writeStream.on.mock.calls.find(([event]) => event === 'close')?.[1]
@@ -141,6 +142,7 @@ describe('SshFilesystemProvider', () => {
     it('can append decoded chunks through SFTP', async () => {
       const writeStream = {
         on: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => writeStream),
+        off: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => writeStream),
         end: vi.fn((_buffer: Buffer) => {
           const closeHandler = writeStream.on.mock.calls.find(([event]) => event === 'close')?.[1]
           closeHandler?.()

--- a/src/main/ssh/sftp-upload.test.ts
+++ b/src/main/ssh/sftp-upload.test.ts
@@ -58,11 +58,20 @@ describe('sftp-upload', () => {
 
   it('does not create the remote file when the local source is a symlink', async () => {
     const localDir = await mkdtemp(join(tmpdir(), 'orca-sftp-upload-'))
-    await writeFile(join(localDir, 'target.txt'), 'secret')
-    await symlink(join(localDir, 'target.txt'), join(localDir, 'link.txt'))
+    const targetPath = join(localDir, process.platform === 'win32' ? 'target-dir' : 'target.txt')
+    const linkPath = join(localDir, process.platform === 'win32' ? 'link-dir' : 'link.txt')
+    if (process.platform === 'win32') {
+      await mkdir(targetPath)
+      // Why: file symlinks often require Developer Mode/admin on Windows, while
+      // junctions still exercise the symlink rejection branch.
+      await symlink(targetPath, linkPath, 'junction')
+    } else {
+      await writeFile(targetPath, 'secret')
+      await symlink(targetPath, linkPath)
+    }
     const sftp = createSftpMock()
 
-    await expect(uploadFile(sftp, join(localDir, 'link.txt'), '/remote/link.txt')).rejects.toThrow()
+    await expect(uploadFile(sftp, linkPath, '/remote/link.txt')).rejects.toThrow()
 
     expect(sftp.createWriteStream).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- add the stream listener-removal method expected by the SFTP write stream mock
- use a Windows junction in the symlink rejection test so it runs without Developer Mode/admin file-symlink privileges

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider.test.ts src/main/ssh/sftp-upload.test.ts
- pnpm run lint -- src/main/providers/ssh-filesystem-provider.test.ts src/main/ssh/sftp-upload.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low
Test-only SSH/SFTP fixture portability changes; no production behavior changes.