### PR TITLE
perf: handle large filesystem auth worktree lists

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -1,0 +1,67 @@
+import { resolve } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type * as RepoWorktrees from '../repo-worktrees'
+import { listRepoWorktrees } from '../repo-worktrees'
+import type { GitWorktreeInfo, Repo } from '../../shared/types'
+import {
+  invalidateAuthorizedRootsCache,
+  rebuildAuthorizedRootsCache,
+  resolveRegisteredWorktreePath
+} from './filesystem-auth'
+
+vi.mock('../repo-worktrees', async () => {
+  const actual = await vi.importActual<typeof RepoWorktrees>('../repo-worktrees')
+  return {
+    ...actual,
+    listRepoWorktrees: vi.fn()
+  }
+})
+
+const LARGE_WORKTREE_ROOT_COUNT = 150_000
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repos/app',
+  displayName: 'app',
+  badgeColor: '#000000',
+  addedAt: 1,
+  kind: 'git'
+}
+
+function makeStore(): Store {
+  return {
+    getRepos: () => [repo],
+    getSettings: () => ({})
+  } as unknown as Store
+}
+
+describe('filesystem auth worktree roots', () => {
+  beforeEach(() => {
+    invalidateAuthorizedRootsCache()
+    vi.mocked(listRepoWorktrees).mockReset()
+  })
+
+  it('rebuilds the authorized roots cache for large worktree lists', async () => {
+    const worktrees: GitWorktreeInfo[] = Array.from(
+      { length: LARGE_WORKTREE_ROOT_COUNT },
+      (_, index) => ({
+        path: `/linked/worktree-${index}`,
+        head: '',
+        branch: `refs/heads/generated-${index}`,
+        isBare: false,
+        isMainWorktree: false
+      })
+    )
+    vi.mocked(listRepoWorktrees).mockResolvedValue(worktrees)
+    const store = makeStore()
+
+    await rebuildAuthorizedRootsCache(store)
+
+    const lastWorktreePath = `/linked/worktree-${LARGE_WORKTREE_ROOT_COUNT - 1}`
+    await expect(resolveRegisteredWorktreePath(lastWorktreePath, store)).resolves.toBe(
+      resolve(lastWorktreePath)
+    )
+    expect(listRepoWorktrees).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -100,9 +100,9 @@ export async function rebuildAuthorizedRootsCache(store: Store): Promise<void> {
       try {
         roots.push(resolve(repo.path))
 
-        const worktrees = await listRepoWorktrees(repo)
-        const worktreeRoots = worktrees.map((wt) => resolve(wt.path))
-        roots.push(...worktreeRoots)
+        for (const worktree of await listRepoWorktrees(repo)) {
+          roots.push(resolve(worktree.path))
+        }
       } catch (error) {
         // Why: a single inaccessible repo (EACCES, EIO, etc.) must not break
         // the entire cache rebuild — that would disable File Explorer and


### PR DESCRIPTION
## Summary
- replace filesystem-auth worktree root spread appends with iterative appends during authorized-root cache rebuilds
- add a regression test for rebuilding the cache with 150k linked worktree roots

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-auth.test.ts`
- `pnpm exec oxlint src/main/ipc/filesystem-auth.ts src/main/ipc/filesystem-auth.test.ts`
- `pnpm run typecheck:node`
- `git diff --check origin/main...HEAD`

Risk: low. This only changes array append mechanics inside the existing local-repo authorized-root rebuild; SSH repos stay excluded and authorization semantics are unchanged.