### PR TITLE
Clean up agent hook request listeners

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable max-lines -- Why: this fixture keeps cross-agent hook normalization and cache behavior together so regressions in shared listener state are visible. */
+import { EventEmitter } from 'node:events'
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
@@ -7,9 +9,11 @@ import {
   createHookListenerState,
   getEndpointFileName,
   hasPendingAgentResultText,
+  HOOK_REQUEST_MAX_BYTES,
   isShellSafeEndpointValue,
   normalizeHookPayload,
   parseFormEncodedBody,
+  readRequestBody,
   resolveHookSource,
   writeEndpointFile,
   type HookListenerState
@@ -18,6 +22,26 @@ import { makePaneKey } from './stable-pane-id'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const PANE_KEY = makePaneKey('tab-1', LEAF_ID)
+
+type FakeIncomingMessage = EventEmitter & {
+  headers: IncomingHttpHeaders
+  destroy: ReturnType<typeof vi.fn>
+}
+
+function createReadableRequest(headers: IncomingHttpHeaders = {}): FakeIncomingMessage {
+  const req = new EventEmitter() as FakeIncomingMessage
+  req.headers = headers
+  req.destroy = vi.fn(() => req.emit('close'))
+  return req
+}
+
+function expectRequestParserListenersReleased(req: FakeIncomingMessage): void {
+  expect(req.listenerCount('data')).toBe(0)
+  expect(req.listenerCount('end')).toBe(0)
+  expect(req.listenerCount('close')).toBe(0)
+  expect(req.listenerCount('error')).toBe(1)
+  expect(() => req.emit('error', new Error('late request error'))).not.toThrow()
+}
 
 describe('shared agent-hook-listener', () => {
   let state: HookListenerState
@@ -34,6 +58,28 @@ describe('shared agent-hook-listener', () => {
     const decoded = parseFormEncodedBody('paneKey=tab-1%3A0&worktreeId=foo')
     expect(decoded.paneKey).toBe('tab-1:0')
     expect(decoded.worktreeId).toBe('foo')
+  })
+
+  it('releases request parser listeners after reading a JSON body', async () => {
+    const req = createReadableRequest({ 'content-type': 'application/json' })
+    const body = readRequestBody(req as unknown as IncomingMessage)
+
+    req.emit('data', Buffer.from('{"ok":true}'))
+    req.emit('end')
+
+    await expect(body).resolves.toEqual({ ok: true })
+    expectRequestParserListenersReleased(req)
+  })
+
+  it('releases request parser listeners after rejecting an oversized body', async () => {
+    const req = createReadableRequest({ 'content-type': 'application/json' })
+    const body = readRequestBody(req as unknown as IncomingMessage)
+
+    req.emit('data', Buffer.alloc(HOOK_REQUEST_MAX_BYTES + 1))
+
+    await expect(body).rejects.toThrow('payload too large')
+    expect(req.destroy).toHaveBeenCalledTimes(1)
+    expectRequestParserListenersReleased(req)
   })
 
   it('routes pathnames to a known source or null', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -198,68 +198,83 @@ export function readRequestBody(req: IncomingMessage): Promise<unknown> {
     const chunks: Buffer[] = []
     let byteLength = 0
     let settled = false
-    req.on('data', (chunk: Buffer) => {
+    const cleanup = (): void => {
+      req.off('data', onData)
+      req.off('end', onEnd)
+      req.off('error', onError)
+      req.off('close', onClose)
+      // Why: detached parser closures release body chunks; keep a neutral
+      // error sink so a late IncomingMessage error cannot become unhandled.
+      req.on('error', ignoreSettledRequestError)
+    }
+    const settleResolve = (value: unknown): void => {
       if (settled) {
         return
       }
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const settleReject = (error: unknown): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(error)
+    }
+    const onData = (chunk: Buffer): void => {
       // Why: check size in bytes (not UTF-16 code units) and stop accumulating
       // after rejection so a malicious client cannot push memory past the cap.
       if (byteLength + chunk.length > HOOK_REQUEST_MAX_BYTES) {
-        settled = true
-        reject(new Error('payload too large'))
+        settleReject(new Error('payload too large'))
         req.destroy()
         return
       }
       byteLength += chunk.length
       chunks.push(chunk)
-    })
-    req.on('end', () => {
-      if (settled) {
-        return
-      }
-      settled = true
+    }
+    const onEnd = (): void => {
       try {
         // Why: decode once via Buffer.concat so multi-byte UTF-8 characters
         // that straddle a chunk boundary are reassembled correctly.
         const body = chunks.length > 0 ? Buffer.concat(chunks).toString('utf8') : ''
         const contentType = req.headers['content-type'] ?? ''
         if (typeof contentType === 'string' && contentType.includes('application/json')) {
-          resolve(body ? JSON.parse(body) : {})
+          settleResolve(body ? JSON.parse(body) : {})
           return
         }
         if (
           typeof contentType === 'string' &&
           contentType.includes('application/x-www-form-urlencoded')
         ) {
-          resolve(parseFormEncodedBody(body))
+          settleResolve(parseFormEncodedBody(body))
           return
         }
         // Why: existing managed scripts POST JSON; updated POSIX scripts POST
         // form-encoded. Default to JSON for unknown content types.
-        resolve(body ? JSON.parse(body) : {})
+        settleResolve(body ? JSON.parse(body) : {})
       } catch (error) {
-        reject(error)
+        settleReject(error)
       }
-    })
-    req.on('error', (err) => {
-      if (settled) {
-        return
-      }
-      settled = true
-      reject(err)
-    })
+    }
+    const onError = (err: Error): void => {
+      settleReject(err)
+    }
     // Why: req.destroy() (called by the slowloris timer) emits 'close' but
     // not 'end'/'error'. Without this handler the promise would never settle
     // and the chunk buffers would be retained for the process lifetime.
-    req.on('close', () => {
-      if (settled) {
-        return
-      }
-      settled = true
-      reject(new Error('aborted'))
-    })
+    const onClose = (): void => {
+      settleReject(new Error('aborted'))
+    }
+    req.on('data', onData)
+    req.on('end', onEnd)
+    req.on('error', onError)
+    req.on('close', onClose)
   })
 }
+
+function ignoreSettledRequestError(): void {}
 
 // ─── Per-pane field caches + extractors ─────────────────────────────
 


### PR DESCRIPTION
## Summary
- detach agent-hook request body parser listeners on every settle path
- keep a neutral late-error sink after parser cleanup so aborted IncomingMessage errors do not become unhandled
- add regressions for listener cleanup after successful JSON reads and oversized-body rejection

## Risk
Risk: low

This only changes post-settle cleanup for the shared agent-hook HTTP request parser used by local and relay hook listeners. Body parsing semantics, size limits, content-type handling, and hook normalization are unchanged.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-hook-listener.test.ts`
- `pnpm exec oxlint src/shared/agent-hook-listener.ts src/shared/agent-hook-listener.test.ts`
- `pnpm exec oxfmt --check src/shared/agent-hook-listener.ts src/shared/agent-hook-listener.test.ts`
- `pnpm typecheck:node`
- `git diff --check origin/main...HEAD`