### PR TITLE
Improve Linear scope selection

### DIFF
--- a/docs/linear-scope-selector.md
+++ b/docs/linear-scope-selector.md
@@ -1,0 +1,126 @@
+# Linear Scope Selector
+
+## Problem
+
+- `src/renderer/src/components/TaskPage.tsx:4368` renders workspace selection, "open in Linear", and team selection as separate controls even though they define one Linear issue-list scope.
+- `src/renderer/src/components/ui/team-multi-combobox.tsx:127` offers only "All teams" plus team rows. When a team is absent, there is no affordance that explains whether the key is team-limited, the user lacks private-team access, the team is archived/retired, or the backend failed to fetch every page.
+- Settings and onboarding both say a workspace is connected, but the connect copy only points to personal API-key settings. It does not explain full-access keys, team-limited keys, member API-key restrictions, or private-team access.
+- The backend already supports the core scope model: `workspaceId === 'all'` fans out across stored Linear clients, and team list calls are routed through the same runtime APIs used for local and SSH sessions. The gaps are renderer UX plus stale/incomplete data handling.
+
+## Goal
+
+Make Linear task scoping feel like one selector:
+
+1. Replace the separate workspace dropdown and team dropdown in the Tasks toolbar with one Linear scope popover.
+2. Preserve the existing state model: `selectedWorkspaceId` is one workspace id or `all`; `defaultLinearTeamSelection` remains a nullable global list where `null` means sticky-all and an array means an explicit subset of team IDs.
+3. Add an "Add team access" path from the selector. It opens a reusable API-key dialog. Pasting a key for an already connected workspace replaces that workspace token because the workspace id is stable.
+4. Make the copy accurate: one full-access personal API key for a Linear workspace can cover every team the key owner can access in that workspace; restricted/team-limited keys only expose permitted teams; private teams require the key owner to be a member or otherwise have access.
+5. Link to the most specific Linear settings URL Orca can build from `organizationUrlKey`, with global fallbacks when the workspace is unknown or `all`.
+
+## Non-goals
+
+- Do not change Linear authentication storage, encryption, IPC/RPC method names, or the `LinearWorkspaceSelection` type.
+- Do not switch Linear auth to OAuth.
+- Do not create, join, unarchive, or grant access to Linear teams from Orca. "Add team access" means paste a key whose owner/scope can already see the team.
+- Do not make team selection per-workspace in this change.
+- Do not touch provider-generic review code.
+
+## Required Fixes Before UI
+
+1. Fix team-list completeness.
+   - `src/main/linear/teams.ts` currently calls `entry.client.teams()` once per workspace. The SDK query is paginated, so this can omit teams in larger workspaces.
+   - Fetch all pages before the selector relies on team absence as a meaningful signal. Use `teams({ first })` plus `fetchNext()` until `pageInfo.hasNextPage` is false, or an equivalent raw GraphQL query. Keep the existing `MAX_CONCURRENT` limiter and do not set `includeArchived`; retired teams should stay absent.
+
+2. Invalidate caches when a Linear key is connected or replaced.
+   - Replacing a team-limited key with a full-access key must not leave the old `linearTeamCache` visible for up to `TEAM_CACHE_TTL`.
+   - On successful `connectLinear`, synchronously clear Linear issue/search/team caches, in-flight issue/search/list/team requests, and metadata. Do this before publishing success, then await a forced status refresh before resolving so callers see the selected workspace and workspace list that came from the new key. The renderer `linearConnect` result is typed as `{ viewer }` only; do not rely on the main-process-only `workspace` field.
+   - Guard `fetchLinearIssue()` and `listLinearTeams()` cache writes with a request generation or entry identity check. Clearing their in-flight maps is not enough today: those promises write unconditionally after resolution and can repopulate old issue/team data after key replacement. `searchLinearIssues()` and `listLinearIssues()` already use in-flight entry identity checks for forced refreshes; keep them covered by the same generation if connect/disconnect clears their maps.
+   - Force a team refetch for the selected/connected workspace if the Linear Tasks view is open.
+   - Issue list caches also need invalidation because changing key scope can add or remove visible issues.
+
+3. Handle auth-driven token removal explicitly.
+   - Backend calls can clear a workspace token on auth errors. In `all` workspace mode, `listTeams()`, `listIssues()`, and `searchIssues()` may return partial results instead of throwing.
+   - After any auth-driven clear, the renderer must get a forced Linear status refresh or a typed signal so disconnected workspaces disappear without waiting for a later manual check. The current array-returning issue/search/team APIs have no signal for `all`-mode partial auth clears, so either add an auth-cleared result envelope end-to-end or force a metadata-only status refresh after `all`-workspace issue/search/team reads. Do not set `linearStatus` to globally disconnected from a single request error; refresh status because multi-workspace failures may only remove one workspace.
+   - Strengthen `checkLinearConnection()` status equality. It currently compares workspace count, effective selected id, connected state, and viewer email. It misses active workspace id and workspace metadata changes when the count is unchanged. Compare a stable workspace signature including id, organization id/name/url key, display name, and email.
+   - When a forced status refresh observes a changed selected workspace or workspace signature, clear issue/search/team caches, in-flight issue/search/list/team requests, and metadata. `checkLinearConnection()` currently only updates `linearStatus`, so removed workspaces can leave stale rows in `all` caches.
+
+4. Be honest about team filtering.
+   - Current Linear issue reads do not accept team IDs; team selection filters the already-limited issue/search result in the renderer after the `LINEAR_ITEM_LIMIT` page arrives. In `all` workspace mode, each workspace may fetch up to the limit, but the backend aggregates and trims back to `LINEAR_ITEM_LIMIT` before the renderer filters by team.
+   - This UI change should not imply exhaustive server-side team scope. Empty task states must say no fetched/current issues match the selected teams. True server-side team scoping needs a separate change to add team IDs to cache keys, runtime RPC params, and Linear GraphQL filters.
+
+## Design
+
+1. Add URL helpers in `src/shared/linear-links.ts`.
+   - `buildLinearPersonalApiKeySettingsUrl(organizationUrlKey?: string | null)` returns `https://linear.app/<slug>/settings/account/security` when a slug exists, otherwise `https://linear.app/settings/account/security`.
+   - `buildLinearWorkspaceApiSettingsUrl(organizationUrlKey?: string | null)` returns `https://linear.app/<slug>/settings/api` when a slug exists, otherwise `https://linear.app/settings/api`.
+   - Encode path segments consistently with `buildLinearTeamUrl`.
+
+2. Add `LinearApiKeyDialog` in `src/renderer/src/components/linear-api-key-dialog.tsx`.
+   - Props: `open`, `onOpenChange`, optional `workspace`, optional `title`, optional `description`, optional `connectLabel`, optional `onConnected`, optional `overlayClassName`/`contentClassName`.
+   - Own input, connecting/error state, Enter-to-submit, and `connectLinear`. Fire `onConnected` only after `connectLinear` resolves with refreshed store status.
+   - Use org-specific URLs only when a single workspace context is known. For `all`, use the global fallback and copy that tells the user to choose the intended Linear workspace.
+   - Guidance:
+     - Create a Personal API key from Account > Security & Access.
+     - Prefer full access when Orca should show every team the account can access in that workspace.
+     - If member API keys are blocked, ask a workspace admin to allow them from workspace API settings. Do not imply the workspace API page creates the personal key.
+     - A key never grants teams the owner cannot access.
+   - Make storage copy runtime-aware. Local runtime keys use the local OS keychain when Electron encryption is available; SSH/remote-runtime keys are stored by that runtime, not necessarily on this machine.
+
+3. Replace the Tasks toolbar Linear controls with `LinearScopeSelector`.
+   - Suggested file: `src/renderer/src/components/linear-scope-selector.tsx`.
+   - Keep state updates in `TaskPage`: workspaces, selected workspace id, teams, selected team ids, callbacks for workspace select, team select, select-all teams, open selected team URL, and open API-key dialog.
+   - Trigger label examples:
+     - One workspace + sticky-all: `All teams`
+     - One workspace + subset: `ENG, STA +1`
+     - Multiple workspaces + `all` + sticky-all: `All workspaces`
+     - Multiple workspaces + one workspace + sticky-all: `<Workspace name> / All teams`
+     - Multiple workspaces + subset: `<Workspace name> / ENG, STA +1` or `All workspaces / ENG +1`
+     - If the active scope is `all` and selected team keys are duplicated or span multiple workspaces, prefer `All workspaces / 2 teams` over an ambiguous key list.
+   - Popover content:
+     - Search filters team rows by team name, team key, and workspace name.
+     - Workspace section appears only when more than one workspace is connected. It includes "All workspaces" and each workspace.
+     - Selecting a workspace must call the existing `selectLinearWorkspace` flow, clear selected issue/list/error/loading state the same way `TaskPage` does now, and must not mutate `defaultLinearTeamSelection`.
+     - Team section includes "All teams" and selectable team rows. "All teams" persists `defaultLinearTeamSelection: null`; explicit subsets persist an array. Normalize a selection equal to all available teams back to `null`, even if the user selected teams one by one. Never persist an empty array; keep the last team selected or save `null`.
+     - Team rows show name, key, and workspace name when active workspace is `all` or when multiple workspaces exist.
+     - Footer has "Add team access" with a key/link icon. Close the popover before opening the API-key dialog.
+     - Keep the external-link button as an icon-only sibling. It remains an action, and should stay enabled only when exactly one selected team has a URL.
+
+4. Keep team selection reconciliation, but document its limits.
+   - `reconcileLinearTeamSelection()` preserves sticky-all and drops stale team IDs.
+   - Because the saved team subset is global, switching workspaces may temporarily select all teams in the new workspace while preserving the old saved subset for later. Do not introduce per-workspace persistence here.
+
+5. Update Settings and onboarding to use `LinearApiKeyDialog`.
+   - Rename "Add workspace" to "Add Linear access" when disconnected and "Update access" or "Add workspace access" when connected.
+   - Replace "Each workspace uses its own locally stored API key" with copy that says each connected Linear workspace has one key stored by the active runtime; a full-access key can cover all visible teams in that workspace, and a restricted key can be replaced any time.
+   - Keep existing per-workspace Test and Disconnect controls.
+
+## Edge Cases
+
+- No Linear workspaces connected: no Tasks selector; Settings/onboarding still show Connect.
+- One workspace connected: hide the workspace section, but keep "Add team access" visible.
+- Multiple workspaces + `all`: team keys/names can repeat across workspaces; always show workspace names in rows.
+- Empty team result: show an empty state plus footer action. Do not claim the key is the only possible cause; absence can also come from private-team membership, archived teams, permissions, or a fetch failure.
+- Empty issue result after team selection: say no fetched/current issues match the selected teams. Do not imply Linear was queried exhaustively for those teams.
+- Legacy or missing `organizationUrlKey`: use global Linear settings URLs and keep the paste flow usable.
+- Replacement key for an existing workspace: select that workspace, invalidate caches, refresh status, and refetch teams immediately.
+- Auth errors: a backend call may clear a token. The selector must tolerate stale rows during the refresh, then drop disconnected workspaces when status updates.
+- Multi-window/external mutations: there is no real-time renderer broadcast. Force `checkLinearConnection(true)` after connect/disconnect/test flows and when opening the selector if stale status would be visible. Forced refresh must still update state and invalidate caches when workspace metadata changed but the workspace count did not. A same-workspace key replacement with identical viewer/workspace metadata is invisible to status today; do not claim that case is handled unless this change adds a non-secret credential revision or a renderer broadcast.
+- Remote runtime/SSH: continue routing through `connectLinear`, `selectLinearWorkspace`, `listLinearTeams`, and runtime RPC. Do not call local Electron APIs directly except for opening Linear URLs.
+- Accessibility: trigger is a combobox-style button, rows are keyboard-selectable, icon buttons have labels/tooltips, and the dialog traps focus.
+
+## Tests
+
+- `src/shared/linear-links.test.ts`: URL helpers, fallback behavior, and path encoding.
+- `src/main/linear/teams.test.ts`: paginated team fetching and `all` workspace aggregation.
+- `src/renderer/src/store/slices/linear.test.ts`: successful connect invalidates issue/search/team caches, drops stale in-flight writes, awaits refreshed status, and does not mark all Linear disconnected for one workspace auth failure.
+- `src/renderer/src/store/slices/linear.test.ts`: forced status refresh detects changed workspace ids/metadata with the same workspace count and invalidates Linear caches when the scope signature changes.
+- Component-independent label and selection-persistence helper tests for `LinearScopeSelector`, including selecting every visible team persisting sticky-all (`null`) rather than a frozen full-team array.
+- Avoid brittle popover DOM tests unless matching an existing selector test pattern.
+
+## Rollout
+
+1. Fix backend/store correctness: team pagination, connect invalidation, and auth-clear status refresh.
+2. Add Linear settings URL helpers and tests.
+3. Add `LinearApiKeyDialog`; migrate Settings, onboarding, and the existing Tasks connect dialog.
+4. Add `LinearScopeSelector` and replace only the Linear toolbar selector block in `TaskPage`.
+5. Run focused Linear tests, then `pnpm typecheck` and `pnpm lint`.

--- a/src/main/linear/client.ts
+++ b/src/main/linear/client.ts
@@ -160,7 +160,11 @@ function normalizeWorkspace(input: unknown): LinearWorkspace | null {
     organizationUrlKey:
       typeof record.organizationUrlKey === 'string' ? record.organizationUrlKey : undefined,
     displayName: record.displayName,
-    email: typeof record.email === 'string' ? record.email : null
+    email: typeof record.email === 'string' ? record.email : null,
+    credentialRevision:
+      typeof record.credentialRevision === 'number' && Number.isFinite(record.credentialRevision)
+        ? record.credentialRevision
+        : undefined
   }
 }
 
@@ -431,8 +435,11 @@ function workspaceFromLinearData(
 
 function upsertWorkspace(workspace: LinearWorkspace, options: { select?: boolean } = {}): void {
   const file = getWorkspaceFile()
+  const current = file.workspaces.find((entry) => entry.id === workspace.id)
+  const credentialRevision = (current?.credentialRevision ?? 0) + 1
+  const workspaceWithRevision = { ...workspace, credentialRevision }
   const withoutCurrent = file.workspaces.filter((entry) => entry.id !== workspace.id)
-  const workspaces = [...withoutCurrent, workspace].sort((a, b) =>
+  const workspaces = [...withoutCurrent, workspaceWithRevision].sort((a, b) =>
     a.organizationName.localeCompare(b.organizationName)
   )
   const selectedWorkspaceId = options.select

--- a/src/main/linear/teams.test.ts
+++ b/src/main/linear/teams.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LinearClientForWorkspace } from './client'
+
+const getClients = vi.fn()
+const clearToken = vi.fn()
+
+vi.mock('./client', () => ({
+  acquire: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+  getClients: (...args: unknown[]) => getClients(...args),
+  isAuthError: vi.fn().mockReturnValue(false),
+  clearToken: (...args: unknown[]) => clearToken(...args)
+}))
+
+type TeamNode = {
+  id: string
+  name: string
+  key: string
+}
+
+function team(id: string, name = id, key = id.toUpperCase()): TeamNode {
+  return { id, name, key }
+}
+
+function makeTeamConnection(pages: TeamNode[][]) {
+  const nodes = [...(pages[0] ?? [])]
+  let pageIndex = 0
+  return {
+    nodes,
+    pageInfo: { hasNextPage: pages.length > 1 },
+    fetchNext: vi
+      .fn()
+      .mockImplementation(
+        async function fetchNext(this: { nodes: TeamNode[]; pageInfo: { hasNextPage: boolean } }) {
+          pageIndex += 1
+          this.nodes.push(...(pages[pageIndex] ?? []))
+          this.pageInfo.hasNextPage = pageIndex < pages.length - 1
+          return this
+        }
+      )
+  }
+}
+
+function makeEntry(
+  workspaceId: string,
+  organizationName: string,
+  organizationUrlKey: string,
+  pages: TeamNode[][]
+): LinearClientForWorkspace {
+  return {
+    workspace: {
+      id: workspaceId,
+      organizationId: workspaceId,
+      organizationName,
+      organizationUrlKey,
+      displayName: 'Ada',
+      email: 'ada@example.com'
+    },
+    client: {
+      teams: vi.fn().mockResolvedValue(makeTeamConnection(pages))
+    }
+  } as unknown as LinearClientForWorkspace
+}
+
+describe('Linear teams', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches every page of teams for a workspace', async () => {
+    const entry = makeEntry('workspace-1', 'Workspace', 'acme', [
+      [team('team-1', 'Backend', 'BE')],
+      [team('team-2', 'Frontend', 'FE')],
+      [team('team-3', 'Support', 'SUP')]
+    ])
+    getClients.mockReturnValue([entry])
+    const { listTeams } = await import('./teams')
+
+    await expect(listTeams('workspace-1')).resolves.toMatchObject([
+      { id: 'team-1', url: 'https://linear.app/acme/team/BE/all' },
+      { id: 'team-2', url: 'https://linear.app/acme/team/FE/all' },
+      { id: 'team-3', url: 'https://linear.app/acme/team/SUP/all' }
+    ])
+
+    expect(entry.client.teams).toHaveBeenCalledWith({ first: 100 })
+  })
+
+  it('aggregates teams across all selected workspaces', async () => {
+    getClients.mockReturnValue([
+      makeEntry('workspace-1', 'Alpha', 'alpha', [[team('team-a', 'Alpha Team', 'ALP')]]),
+      makeEntry('workspace-2', 'Beta', 'beta', [[team('team-b', 'Beta Team', 'BET')]])
+    ])
+    const { listTeams } = await import('./teams')
+
+    await expect(listTeams('all')).resolves.toMatchObject([
+      { id: 'team-a', workspaceId: 'workspace-1', workspaceName: 'Alpha' },
+      { id: 'team-b', workspaceId: 'workspace-2', workspaceName: 'Beta' }
+    ])
+  })
+})

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -6,7 +6,35 @@ import type {
   LinearWorkspaceSelection
 } from '../../shared/types'
 import { buildLinearTeamUrl } from '../../shared/linear-links'
-import { acquire, release, getClients, isAuthError, clearToken } from './client'
+import {
+  acquire,
+  release,
+  getClients,
+  isAuthError,
+  clearToken,
+  type LinearClientForWorkspace
+} from './client'
+
+const TEAM_PAGE_SIZE = 100
+
+async function fetchAllTeamsForWorkspace(entry: LinearClientForWorkspace): Promise<LinearTeam[]> {
+  let page = await entry.client.teams({ first: TEAM_PAGE_SIZE })
+  while (page.pageInfo.hasNextPage) {
+    await page.fetchNext()
+  }
+  return page.nodes.map((t) => ({
+    id: t.id,
+    workspaceId: entry.workspace.id,
+    workspaceName: entry.workspace.organizationName,
+    name: t.name,
+    key: t.key,
+    url:
+      buildLinearTeamUrl({
+        organizationUrlKey: entry.workspace.organizationUrlKey,
+        teamKey: t.key
+      }) ?? undefined
+  }))
+}
 
 export async function listTeams(
   workspaceId?: LinearWorkspaceSelection | null
@@ -20,19 +48,7 @@ export async function listTeams(
     entries.map(async (entry) => {
       await acquire()
       try {
-        const teams = await entry.client.teams()
-        return teams.nodes.map((t) => ({
-          id: t.id,
-          workspaceId: entry.workspace.id,
-          workspaceName: entry.workspace.organizationName,
-          name: t.name,
-          key: t.key,
-          url:
-            buildLinearTeamUrl({
-              organizationUrlKey: entry.workspace.organizationUrlKey,
-              teamKey: t.key
-            }) ?? undefined
-        }))
+        return fetchAllTeamsForWorkspace(entry)
       } catch (error) {
         if (isAuthError(error)) {
           clearToken(entry.workspace.id)

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -26,7 +26,6 @@ import {
   LayoutGrid,
   List,
   LoaderCircle,
-  Lock,
   Minus,
   Plus,
   RefreshCw,
@@ -76,7 +75,8 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import RepoMultiCombobox from '@/components/ui/repo-multi-combobox'
-import TeamMultiCombobox from '@/components/ui/team-multi-combobox'
+import { LinearApiKeyDialog } from '@/components/linear-api-key-dialog'
+import { LinearScopeSelector } from '@/components/linear-scope-selector'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
 import IssueSourceIndicator, { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
 import IssueSourceSelector, { issueSourceChipClass } from '@/components/github/IssueSourceSelector'
@@ -143,6 +143,7 @@ import type {
   LinearIssue,
   LinearProjectSummary,
   LinearTeam,
+  LinearWorkspaceSelection,
   LinearWorkflowState,
   Repo,
   TaskProvider,
@@ -1959,7 +1960,6 @@ export default function TaskPage(): React.JSX.Element {
   const linearStatusChecked = useAppStore((s) => s.linearStatusChecked)
   const preflightStatus = useAppStore((s) => s.preflightStatus)
   const preflightStatusChecked = useAppStore((s) => s.preflightStatusChecked)
-  const connectLinear = useAppStore((s) => s.connectLinear)
   const selectLinearWorkspace = useAppStore((s) => s.selectLinearWorkspace)
   const searchLinearIssues = useAppStore((s) => s.searchLinearIssues)
   const listLinearIssues = useAppStore((s) => s.listLinearIssues)
@@ -2046,6 +2046,10 @@ export default function TaskPage(): React.JSX.Element {
     linearStatus.activeWorkspaceId ??
     linearWorkspaces[0]?.id ??
     null
+  const selectedLinearWorkspace =
+    selectedLinearWorkspaceId && selectedLinearWorkspaceId !== 'all'
+      ? (linearWorkspaces.find((workspace) => workspace.id === selectedLinearWorkspaceId) ?? null)
+      : null
   const preferredVisibleTaskProviders = useMemo(
     () => normalizeVisibleTaskProviders(settings?.visibleTaskProviders),
     [settings?.visibleTaskProviders]
@@ -2598,6 +2602,7 @@ export default function TaskPage(): React.JSX.Element {
   // all teams the user belongs to, not just teams with issues in the current
   // fetch window. Fetched once when the Linear tab is active and connected.
   const [availableTeams, setAvailableTeams] = useState<LinearTeam[]>([])
+  const [linearTeamRefreshNonce, setLinearTeamRefreshNonce] = useState(0)
 
   useEffect(() => {
     if (!taskResumeApplied) {
@@ -2632,6 +2637,7 @@ export default function TaskPage(): React.JSX.Element {
     taskSource,
     linearStatus.connected,
     selectedLinearWorkspaceId,
+    linearTeamRefreshNonce,
     taskResumeApplied,
     getCachedLinearTeams,
     listLinearTeams
@@ -3165,19 +3171,6 @@ export default function TaskPage(): React.JSX.Element {
   }, [newLinearStates.data, newLinearIssueStateId])
 
   const [linearConnectOpen, setLinearConnectOpen] = useState(false)
-  const [linearApiKeyDraft, setLinearApiKeyDraft] = useState('')
-  const [linearConnectState, setLinearConnectState] = useState<'idle' | 'connecting' | 'error'>(
-    'idle'
-  )
-  const [linearConnectError, setLinearConnectError] = useState<string | null>(null)
-  const linearConnectMountedRef = useRef(true)
-
-  useEffect(() => {
-    linearConnectMountedRef.current = true
-    return () => {
-      linearConnectMountedRef.current = false
-    }
-  }, [])
 
   const activeGithubTaskKind = getGitHubTaskKind(activeTaskPreset, appliedTaskSearch)
   const selectedGitHubRepoExternalLink = useMemo(() => {
@@ -4258,33 +4251,48 @@ export default function TaskPage(): React.JSX.Element {
     [openComposerForLinearItem]
   )
 
-  const handleLinearConnect = useCallback(async (): Promise<void> => {
-    const key = linearApiKeyDraft.trim()
-    if (!key) {
-      return
-    }
-    setLinearConnectState('connecting')
-    setLinearConnectError(null)
-    try {
-      const result = await connectLinear(key)
-      if (!linearConnectMountedRef.current) {
-        return
-      }
-      if (result.ok) {
-        setLinearApiKeyDraft('')
-        setLinearConnectState('idle')
-        setLinearConnectOpen(false)
-      } else {
-        setLinearConnectState('error')
-        setLinearConnectError(result.error)
-      }
-    } catch (error) {
-      if (linearConnectMountedRef.current) {
-        setLinearConnectState('error')
-        setLinearConnectError(error instanceof Error ? error.message : 'Connection failed')
-      }
-    }
-  }, [connectLinear, linearApiKeyDraft])
+  const handleLinearWorkspaceChange = useCallback(
+    (workspaceId: LinearWorkspaceSelection): void => {
+      clearSelectedLinearIssue()
+      setLinearIssues([])
+      setLinearError(null)
+      setLinearLoading(true)
+      void selectLinearWorkspace(workspaceId)
+        .then(() => {
+          setLinearTeamRefreshNonce((n) => n + 1)
+        })
+        .catch(() => {
+          toast.error('Failed to switch Linear workspace.')
+        })
+    },
+    [clearSelectedLinearIssue, selectLinearWorkspace]
+  )
+
+  const handleLinearTeamSelectionChange = useCallback(
+    (next: ReadonlySet<string>, persisted: string[] | null): void => {
+      setLinearTeamSelection(new Set(next))
+      void updateSettings({ defaultLinearTeamSelection: persisted }).catch(() => {
+        toast.error('Failed to save team selection.')
+      })
+    },
+    [updateSettings]
+  )
+
+  const handleLinearScopeOpen = useCallback((): void => {
+    void checkLinearConnection(true)
+    void listLinearTeams(selectedLinearWorkspaceId, { force: true })
+      .then((teams) => {
+        setAvailableTeams(teams)
+      })
+      .catch(() => {
+        console.warn('[TaskPage] Failed to refresh Linear teams')
+      })
+  }, [checkLinearConnection, listLinearTeams, selectedLinearWorkspaceId])
+
+  const handleLinearAccessConnected = useCallback((): void => {
+    setLinearTeamRefreshNonce((n) => n + 1)
+    setLinearRefreshNonce((n) => n + 1)
+  }, [])
 
   return (
     <div className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background text-foreground">
@@ -4366,32 +4374,17 @@ export default function TaskPage(): React.JSX.Element {
                   </div>
                   {taskSource === 'linear' && linearStatus.connected ? (
                     <div className="flex items-center gap-2">
-                      {linearWorkspaces.length > 1 ? (
-                        <Select
-                          value={selectedLinearWorkspaceId ?? undefined}
-                          onValueChange={(value) => {
-                            clearSelectedLinearIssue()
-                            setLinearIssues([])
-                            setLinearError(null)
-                            setLinearLoading(true)
-                            void selectLinearWorkspace(value).catch(() => {
-                              toast.error('Failed to switch Linear workspace.')
-                            })
-                          }}
-                        >
-                          <SelectTrigger className="h-8 w-[200px] rounded-md border-border/50 bg-muted/50 text-xs font-medium shadow-sm">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="all">All workspaces</SelectItem>
-                            {linearWorkspaces.map((workspace) => (
-                              <SelectItem key={workspace.id} value={workspace.id}>
-                                {workspace.organizationName}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      ) : null}
+                      <LinearScopeSelector
+                        workspaces={linearWorkspaces}
+                        selectedWorkspaceId={selectedLinearWorkspaceId}
+                        teams={linearTeamOptions}
+                        selectedTeamIds={linearTeamSelection}
+                        teamSelectionIsStickyAll={defaultLinearTeamSelection == null}
+                        onWorkspaceChange={handleLinearWorkspaceChange}
+                        onTeamSelectionChange={handleLinearTeamSelectionChange}
+                        onAddTeamAccess={() => setLinearConnectOpen(true)}
+                        onOpen={handleLinearScopeOpen}
+                      />
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Button
@@ -4404,6 +4397,7 @@ export default function TaskPage(): React.JSX.Element {
                               }
                               void window.api.shell.openUrl(selectedLinearTeamForExternalLink.url)
                             }}
+                            disabled={!selectedLinearTeamForExternalLink}
                             aria-label={
                               selectedLinearTeamForExternalLink
                                 ? `Open ${selectedLinearTeamForExternalLink.name} in Linear`
@@ -4420,27 +4414,6 @@ export default function TaskPage(): React.JSX.Element {
                             : 'Select one team to open in Linear'}
                         </TooltipContent>
                       </Tooltip>
-                      <div className="min-w-0 w-full sm:w-[200px]">
-                        <TeamMultiCombobox
-                          teams={linearTeamOptions}
-                          selected={linearTeamSelection}
-                          onChange={(next) => {
-                            setLinearTeamSelection(next)
-                            void updateSettings({ defaultLinearTeamSelection: [...next] }).catch(
-                              () => {
-                                toast.error('Failed to save team selection.')
-                              }
-                            )
-                          }}
-                          onSelectAll={() => {
-                            setLinearTeamSelection(new Set(linearTeamOptions.map((t) => t.id)))
-                            void updateSettings({ defaultLinearTeamSelection: null }).catch(() => {
-                              toast.error('Failed to save team selection.')
-                            })
-                          }}
-                          triggerClassName="h-8 w-full rounded-md border border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none"
-                        />
-                      </div>
                     </div>
                   ) : null}
                 </div>
@@ -5663,13 +5636,10 @@ export default function TaskPage(): React.JSX.Element {
               <Button
                 className="mt-5"
                 onClick={() => {
-                  setLinearApiKeyDraft('')
-                  setLinearConnectState('idle')
-                  setLinearConnectError(null)
                   setLinearConnectOpen(true)
                 }}
               >
-                Connect Linear
+                Add Linear access
               </Button>
             </div>
           ) : (
@@ -5827,11 +5797,11 @@ export default function TaskPage(): React.JSX.Element {
 
                 {!linearLoading && linearIssues.length === 0 && !linearError ? (
                   <div className="px-4 py-10 text-center">
-                    <p className="text-sm font-medium text-foreground">No Linear issues found</p>
+                    <p className="text-sm font-medium text-foreground">No Linear issues fetched</p>
                     <p className="mt-2 text-sm text-muted-foreground">
                       {linearSearchInput
-                        ? 'Try a different search query.'
-                        : 'No assigned issues. Try searching for something.'}
+                        ? 'No fetched Linear issues match this search query.'
+                        : 'No current Linear issues were fetched for this view.'}
                     </p>
                   </div>
                 ) : null}
@@ -5839,10 +5809,11 @@ export default function TaskPage(): React.JSX.Element {
                 {!linearLoading && linearIssues.length > 0 && filteredLinearIssues.length === 0 ? (
                   <div className="px-4 py-10 text-center">
                     <p className="text-sm font-medium text-foreground">
-                      No issues match the selected teams
+                      No fetched issues match the selected teams
                     </p>
                     <p className="mt-2 text-sm text-muted-foreground">
-                      Try selecting more teams or click &ldquo;All teams&rdquo;.
+                      Try selecting more teams or refreshing; team filters apply to the current
+                      fetched issue set.
                     </p>
                   </div>
                 ) : null}
@@ -6903,94 +6874,13 @@ export default function TaskPage(): React.JSX.Element {
         onClose={() => setGitlabDialogItem(null)}
       />
 
-      <Dialog
+      <LinearApiKeyDialog
         open={linearConnectOpen}
-        onOpenChange={(open) => {
-          if (linearConnectState !== 'connecting') {
-            setLinearConnectOpen(open)
-          }
-        }}
-      >
-        <DialogContent
-          className="sm:max-w-md"
-          onKeyDown={(e) => {
-            if (
-              e.key === 'Enter' &&
-              linearApiKeyDraft.trim() &&
-              linearConnectState !== 'connecting'
-            ) {
-              e.preventDefault()
-              void handleLinearConnect()
-            }
-          }}
-        >
-          <DialogHeader className="gap-3">
-            <DialogTitle className="leading-tight">Connect Linear workspace</DialogTitle>
-            <DialogDescription>
-              Paste a <strong className="font-semibold text-foreground">Personal API key</strong> to
-              browse issues from that workspace.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-3">
-            <Input
-              autoFocus
-              type="password"
-              placeholder="lin_api_..."
-              value={linearApiKeyDraft}
-              onChange={(e) => {
-                setLinearApiKeyDraft(e.target.value)
-                if (linearConnectState === 'error') {
-                  setLinearConnectState('idle')
-                  setLinearConnectError(null)
-                }
-              }}
-              disabled={linearConnectState === 'connecting'}
-            />
-            {linearConnectState === 'error' && linearConnectError && (
-              <p className="text-xs text-destructive">{linearConnectError}</p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Create one in{' '}
-              <button
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl('https://linear.app/settings/account/security')
-                }
-              >
-                Linear Settings → Security
-              </button>{' '}
-              → <strong className="font-semibold text-foreground">New API key</strong> (not{' '}
-              <span className="text-foreground">New passkey</span>).
-            </p>
-            <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
-              <Lock className="size-3 shrink-0" />
-              Your key is encrypted via the OS keychain and stored locally.
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setLinearConnectOpen(false)}
-              disabled={linearConnectState === 'connecting'}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void handleLinearConnect()}
-              disabled={!linearApiKeyDraft.trim() || linearConnectState === 'connecting'}
-            >
-              {linearConnectState === 'connecting' ? (
-                <>
-                  <LoaderCircle className="size-4 animate-spin" />
-                  Verifying…
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setLinearConnectOpen}
+        workspace={selectedLinearWorkspace}
+        connectLabel={linearStatus.connected ? 'Update access' : 'Add Linear access'}
+        onConnected={handleLinearAccessConnected}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/linear-api-key-dialog.tsx
+++ b/src/renderer/src/components/linear-api-key-dialog.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ExternalLink, LoaderCircle, Lock } from 'lucide-react'
+import type { LinearWorkspace } from '../../../shared/types'
+import {
+  buildLinearPersonalApiKeySettingsUrl,
+  buildLinearWorkspaceApiSettingsUrl
+} from '../../../shared/linear-links'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { useAppStore } from '@/store'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+type LinearApiKeyDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspace?: LinearWorkspace | null
+  title?: string
+  description?: string
+  connectLabel?: string
+  onConnected?: () => void
+  overlayClassName?: string
+  contentClassName?: string
+}
+
+export function LinearApiKeyDialog({
+  open,
+  onOpenChange,
+  workspace,
+  title,
+  description,
+  connectLabel,
+  onConnected,
+  overlayClassName,
+  contentClassName
+}: LinearApiKeyDialogProps): React.JSX.Element {
+  const settings = useAppStore((s) => s.settings)
+  const connectLinear = useAppStore((s) => s.connectLinear)
+  const mountedRef = useMountedRef()
+  const [apiKeyDraft, setApiKeyDraft] = useState('')
+  const [connectState, setConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
+  const [connectError, setConnectError] = useState<string | null>(null)
+
+  const runtimeTarget = useMemo(() => getActiveRuntimeTarget(settings), [settings])
+  const personalKeyUrl = buildLinearPersonalApiKeySettingsUrl(workspace?.organizationUrlKey)
+  const workspaceApiUrl = buildLinearWorkspaceApiSettingsUrl(workspace?.organizationUrlKey)
+  const submitLabel = connectLabel ?? (workspace ? 'Update access' : 'Connect')
+
+  useEffect(() => {
+    if (open) {
+      return
+    }
+    setApiKeyDraft('')
+    setConnectState('idle')
+    setConnectError(null)
+  }, [open])
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (connectState !== 'connecting') {
+      onOpenChange(nextOpen)
+    }
+  }
+
+  const handleConnect = async (): Promise<void> => {
+    const apiKey = apiKeyDraft.trim()
+    if (!apiKey || connectState === 'connecting') {
+      return
+    }
+    setConnectState('connecting')
+    setConnectError(null)
+    try {
+      const result = await connectLinear(apiKey)
+      if (!mountedRef.current) {
+        return
+      }
+      if (result.ok) {
+        setApiKeyDraft('')
+        setConnectState('idle')
+        onOpenChange(false)
+        onConnected?.()
+        return
+      }
+      setConnectState('error')
+      setConnectError(result.error)
+    } catch (error) {
+      if (mountedRef.current) {
+        setConnectState('error')
+        setConnectError(error instanceof Error ? error.message : 'Connection failed')
+      }
+    }
+  }
+
+  const resolvedTitle =
+    title ??
+    (workspace ? `Update Linear access for ${workspace.organizationName}` : 'Add Linear access')
+  const resolvedDescription =
+    description ??
+    (workspace
+      ? `Paste a Personal API key for ${workspace.organizationName}. If this workspace is already connected, Orca replaces its stored key.`
+      : 'Paste a Personal API key for the Linear workspace you want Orca to use.')
+  const storageCopy =
+    runtimeTarget.kind === 'environment'
+      ? 'This key is stored by the active remote runtime.'
+      : 'Local runtime keys are stored on this device using Electron encrypted storage when available.'
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        overlayClassName={overlayClassName}
+        className={cn('sm:max-w-lg', contentClassName)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && apiKeyDraft.trim() && connectState !== 'connecting') {
+            event.preventDefault()
+            void handleConnect()
+          }
+        }}
+      >
+        <DialogHeader className="gap-3">
+          <DialogTitle className="leading-tight">{resolvedTitle}</DialogTitle>
+          <DialogDescription>{resolvedDescription}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <Input
+            autoFocus
+            type="password"
+            placeholder="lin_api_..."
+            value={apiKeyDraft}
+            onChange={(event) => {
+              setApiKeyDraft(event.target.value)
+              if (connectState === 'error') {
+                setConnectState('idle')
+                setConnectError(null)
+              }
+            }}
+            disabled={connectState === 'connecting'}
+          />
+          {connectState === 'error' && connectError ? (
+            <p className="text-xs text-destructive">{connectError}</p>
+          ) : null}
+          <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
+            <p>
+              Create a Personal API key from Account &gt; Security &amp; Access.{' '}
+              {!workspace
+                ? 'Use Linear to choose the intended workspace before creating the key.'
+                : null}
+            </p>
+            <p>
+              Prefer full access when Orca should show every team the account can access in that
+              workspace. Restricted keys only expose permitted teams, and private teams require the
+              key owner to have access.
+            </p>
+            <p>
+              If member API keys are blocked, ask a workspace admin to allow them from workspace API
+              settings.
+            </p>
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 text-primary underline-offset-2 hover:underline"
+                onClick={() => window.api.shell.openUrl(personalKeyUrl)}
+              >
+                <ExternalLink className="size-3" />
+                Personal API keys
+              </button>
+              <span className="text-muted-foreground/60">|</span>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 text-primary underline-offset-2 hover:underline"
+                onClick={() => window.api.shell.openUrl(workspaceApiUrl)}
+              >
+                <ExternalLink className="size-3" />
+                Workspace API settings
+              </button>
+            </div>
+          </div>
+          <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
+            <Lock className="size-3 shrink-0" />
+            {storageCopy}
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={connectState === 'connecting'}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleConnect()}
+            disabled={!apiKeyDraft.trim() || connectState === 'connecting'}
+          >
+            {connectState === 'connecting' ? (
+              <>
+                <LoaderCircle className="size-4 animate-spin" />
+                Verifying...
+              </>
+            ) : (
+              submitLabel
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/linear-scope-selector.test.ts
+++ b/src/renderer/src/components/linear-scope-selector.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { LinearTeam, LinearWorkspace } from '../../../shared/types'
+import {
+  getLinearScopeTriggerLabel,
+  normalizeLinearScopeTeamSelection
+} from './linear-scope-selector'
+
+const workspaces: LinearWorkspace[] = [
+  {
+    id: 'workspace-1',
+    organizationId: 'workspace-1',
+    organizationName: 'Alpha',
+    displayName: 'Ada',
+    email: 'ada@example.com'
+  },
+  {
+    id: 'workspace-2',
+    organizationId: 'workspace-2',
+    organizationName: 'Beta',
+    displayName: 'Ada',
+    email: 'ada@example.com'
+  }
+]
+
+function team(
+  id: string,
+  key: string,
+  workspaceId = 'workspace-1',
+  workspaceName = 'Alpha'
+): LinearTeam {
+  return { id, key, name: key, workspaceId, workspaceName }
+}
+
+describe('LinearScopeSelector helpers', () => {
+  it('normalizes selecting every visible team back to sticky-all', () => {
+    const result = normalizeLinearScopeTeamSelection({
+      teams: [team('eng', 'ENG'), team('sta', 'STA')],
+      currentSelectedTeamIds: new Set(['eng']),
+      nextSelectedTeamIds: new Set(['eng', 'sta'])
+    })
+
+    expect(Array.from(result.selectedTeamIds)).toEqual(['eng', 'sta'])
+    expect(result.persisted).toBeNull()
+  })
+
+  it('never persists an empty team array', () => {
+    const result = normalizeLinearScopeTeamSelection({
+      teams: [team('eng', 'ENG')],
+      currentSelectedTeamIds: new Set(['eng']),
+      nextSelectedTeamIds: new Set()
+    })
+
+    expect(Array.from(result.selectedTeamIds)).toEqual(['eng'])
+    expect(result.persisted).toBeNull()
+  })
+
+  it('labels sticky-all in one workspace as all teams', () => {
+    expect(
+      getLinearScopeTriggerLabel({
+        workspaces: [workspaces[0]],
+        selectedWorkspaceId: 'workspace-1',
+        teams: [team('eng', 'ENG')],
+        selectedTeamIds: new Set(['eng']),
+        teamSelectionIsStickyAll: true
+      })
+    ).toBe('All teams')
+  })
+
+  it('labels multi-workspace sticky-all as all workspaces', () => {
+    expect(
+      getLinearScopeTriggerLabel({
+        workspaces,
+        selectedWorkspaceId: 'all',
+        teams: [team('eng', 'ENG'), team('ops', 'OPS', 'workspace-2', 'Beta')],
+        selectedTeamIds: new Set(['eng', 'ops']),
+        teamSelectionIsStickyAll: true
+      })
+    ).toBe('All workspaces')
+  })
+
+  it('uses team counts for ambiguous all-workspace subsets', () => {
+    expect(
+      getLinearScopeTriggerLabel({
+        workspaces,
+        selectedWorkspaceId: 'all',
+        teams: [
+          team('eng-a', 'ENG'),
+          team('eng-b', 'ENG', 'workspace-2', 'Beta'),
+          team('ops', 'OPS', 'workspace-2', 'Beta')
+        ],
+        selectedTeamIds: new Set(['eng-a', 'eng-b']),
+        teamSelectionIsStickyAll: false
+      })
+    ).toBe('All workspaces / 2 teams')
+  })
+})

--- a/src/renderer/src/components/linear-scope-selector.tsx
+++ b/src/renderer/src/components/linear-scope-selector.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Check, ChevronDown, KeyRound } from 'lucide-react'
+import type { LinearTeam, LinearWorkspace, LinearWorkspaceSelection } from '../../../shared/types'
+import { Command, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+type LinearScopeSelectorProps = {
+  workspaces: LinearWorkspace[]
+  selectedWorkspaceId: LinearWorkspaceSelection | null
+  teams: LinearTeam[]
+  selectedTeamIds: ReadonlySet<string>
+  teamSelectionIsStickyAll: boolean
+  onWorkspaceChange: (workspaceId: LinearWorkspaceSelection) => void
+  onTeamSelectionChange: (next: ReadonlySet<string>, persisted: string[] | null) => void
+  onAddTeamAccess: () => void
+  onOpen?: () => void
+  className?: string
+}
+
+type LinearScopeLabelInput = Pick<
+  LinearScopeSelectorProps,
+  'workspaces' | 'selectedWorkspaceId' | 'teams' | 'selectedTeamIds' | 'teamSelectionIsStickyAll'
+>
+
+type LinearScopeTeamSelectionInput = {
+  teams: LinearTeam[]
+  currentSelectedTeamIds: ReadonlySet<string>
+  nextSelectedTeamIds: ReadonlySet<string>
+}
+
+export function normalizeLinearScopeTeamSelection({
+  teams,
+  currentSelectedTeamIds,
+  nextSelectedTeamIds
+}: LinearScopeTeamSelectionInput): {
+  selectedTeamIds: ReadonlySet<string>
+  persisted: string[] | null
+} {
+  const visibleIds = teams.map((team) => team.id)
+  if (visibleIds.length === 0) {
+    return { selectedTeamIds: new Set(), persisted: null }
+  }
+
+  const visibleIdSet = new Set(visibleIds)
+  const next = new Set([...nextSelectedTeamIds].filter((id) => visibleIdSet.has(id)))
+  if (next.size === 0) {
+    const current = [...currentSelectedTeamIds].filter((id) => visibleIdSet.has(id))
+    const fallback = current.length > 0 ? current : visibleIds
+    return {
+      selectedTeamIds: new Set(fallback),
+      persisted: fallback.length === visibleIds.length ? null : fallback
+    }
+  }
+
+  if (next.size === visibleIds.length) {
+    return { selectedTeamIds: new Set(visibleIds), persisted: null }
+  }
+
+  return { selectedTeamIds: next, persisted: [...next] }
+}
+
+function summarizeTeamKeys(
+  teams: LinearTeam[],
+  selectedTeamIds: ReadonlySet<string>,
+  options: { activeAllWorkspaces: boolean; multipleWorkspaces: boolean }
+): string {
+  const selectedTeams = teams.filter((team) => selectedTeamIds.has(team.id))
+  if (selectedTeams.length === 0) {
+    return 'All teams'
+  }
+
+  if (options.activeAllWorkspaces && options.multipleWorkspaces) {
+    const workspaceIds = new Set(selectedTeams.map((team) => team.workspaceId ?? ''))
+    const keys = selectedTeams.map((team) => team.key)
+    const keyCount = new Set(keys).size
+    if (workspaceIds.size > 1 || keyCount < keys.length) {
+      return `${selectedTeams.length} team${selectedTeams.length === 1 ? '' : 's'}`
+    }
+  }
+
+  const [first, second, ...rest] = selectedTeams
+  const labels = [first?.key, second?.key].filter(Boolean)
+  return `${labels.join(', ')}${rest.length > 0 ? ` +${rest.length}` : ''}`
+}
+
+export function getLinearScopeTriggerLabel({
+  workspaces,
+  selectedWorkspaceId,
+  teams,
+  selectedTeamIds,
+  teamSelectionIsStickyAll
+}: LinearScopeLabelInput): string {
+  const multipleWorkspaces = workspaces.length > 1
+  const activeAllWorkspaces = selectedWorkspaceId === 'all'
+  const selectedWorkspace =
+    selectedWorkspaceId && selectedWorkspaceId !== 'all'
+      ? workspaces.find((workspace) => workspace.id === selectedWorkspaceId)
+      : null
+  const allVisibleTeamsSelected =
+    teams.length > 0 && teams.every((team) => selectedTeamIds.has(team.id))
+  const teamLabel =
+    teamSelectionIsStickyAll || selectedTeamIds.size === 0 || allVisibleTeamsSelected
+      ? 'All teams'
+      : summarizeTeamKeys(teams, selectedTeamIds, {
+          activeAllWorkspaces,
+          multipleWorkspaces
+        })
+
+  if (!multipleWorkspaces) {
+    return teamLabel
+  }
+  if (activeAllWorkspaces) {
+    return teamLabel === 'All teams' ? 'All workspaces' : `All workspaces / ${teamLabel}`
+  }
+  return `${selectedWorkspace?.organizationName ?? 'Linear'} / ${teamLabel}`
+}
+
+export function LinearScopeSelector({
+  workspaces,
+  selectedWorkspaceId,
+  teams,
+  selectedTeamIds,
+  teamSelectionIsStickyAll,
+  onWorkspaceChange,
+  onTeamSelectionChange,
+  onAddTeamAccess,
+  onOpen,
+  className
+}: LinearScopeSelectorProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [commandValue, setCommandValue] = useState('')
+  const workspaceById = useMemo(
+    () => new Map(workspaces.map((workspace) => [workspace.id, workspace])),
+    [workspaces]
+  )
+  const triggerLabel = getLinearScopeTriggerLabel({
+    workspaces,
+    selectedWorkspaceId,
+    teams,
+    selectedTeamIds,
+    teamSelectionIsStickyAll
+  })
+  const showWorkspaceNames = selectedWorkspaceId === 'all' || workspaces.length > 1
+  const allTeamsSelected = teams.length > 0 && teams.every((team) => selectedTeamIds.has(team.id))
+  const filteredTeams = useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) {
+      return teams
+    }
+    return teams.filter((team) => {
+      const workspaceName =
+        team.workspaceName ??
+        (team.workspaceId ? workspaceById.get(team.workspaceId)?.organizationName : '')
+      return [team.name, team.key, workspaceName ?? ''].some((value) =>
+        value.toLowerCase().includes(trimmed)
+      )
+    })
+  }, [query, teams, workspaceById])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (nextOpen) {
+        onOpen?.()
+        return
+      }
+      setQuery('')
+      setCommandValue('')
+    },
+    [onOpen]
+  )
+
+  const commitTeamSelection = useCallback(
+    (nextSelectedTeamIds: ReadonlySet<string>) => {
+      const normalized = normalizeLinearScopeTeamSelection({
+        teams,
+        currentSelectedTeamIds: selectedTeamIds,
+        nextSelectedTeamIds
+      })
+      onTeamSelectionChange(normalized.selectedTeamIds, normalized.persisted)
+    },
+    [onTeamSelectionChange, selectedTeamIds, teams]
+  )
+
+  const handleAllTeams = useCallback(() => {
+    onTeamSelectionChange(new Set(teams.map((team) => team.id)), null)
+  }, [onTeamSelectionChange, teams])
+
+  const handleTeamToggle = useCallback(
+    (teamId: string) => {
+      const next = new Set(selectedTeamIds)
+      if (next.has(teamId)) {
+        next.delete(teamId)
+      } else {
+        next.add(teamId)
+      }
+      commitTeamSelection(next)
+    },
+    [commitTeamSelection, selectedTeamIds]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            'h-8 min-w-[180px] max-w-[260px] justify-between rounded-md border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none',
+            className
+          )}
+        >
+          <span className="min-w-0 truncate">{triggerLabel}</span>
+          <ChevronDown className="size-3.5 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[min(380px,calc(100vw-1rem))] p-0">
+        <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
+          <CommandInput
+            autoFocus
+            placeholder="Search teams..."
+            value={query}
+            onValueChange={setQuery}
+            className="text-xs"
+          />
+          <CommandList className="max-h-[360px] scrollbar-sleek">
+            {workspaces.length > 1 ? (
+              <div className="border-b border-border py-1">
+                <div className="px-3 pb-1 pt-1 text-[11px] font-medium uppercase text-muted-foreground">
+                  Workspace
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onWorkspaceChange('all')
+                    setOpen(false)
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition hover:bg-accent hover:text-accent-foreground"
+                >
+                  <Check
+                    className={cn(
+                      'size-3 text-muted-foreground',
+                      selectedWorkspaceId === 'all' ? 'opacity-70' : 'opacity-0'
+                    )}
+                  />
+                  <span>All workspaces</span>
+                </button>
+                {workspaces.map((workspace) => (
+                  <button
+                    key={workspace.id}
+                    type="button"
+                    onClick={() => {
+                      onWorkspaceChange(workspace.id)
+                      setOpen(false)
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition hover:bg-accent hover:text-accent-foreground"
+                  >
+                    <Check
+                      className={cn(
+                        'size-3 text-muted-foreground',
+                        selectedWorkspaceId === workspace.id ? 'opacity-70' : 'opacity-0'
+                      )}
+                    />
+                    <span className="min-w-0 truncate">{workspace.organizationName}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            <div className="border-b border-border py-1">
+              <div className="px-3 pb-1 pt-1 text-[11px] font-medium uppercase text-muted-foreground">
+                Teams
+              </div>
+              <button
+                type="button"
+                onClick={handleAllTeams}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition hover:bg-accent hover:text-accent-foreground"
+              >
+                <Check
+                  className={cn(
+                    'size-3 text-muted-foreground',
+                    allTeamsSelected || teamSelectionIsStickyAll ? 'opacity-70' : 'opacity-0'
+                  )}
+                />
+                <span>All teams</span>
+              </button>
+            </div>
+            {filteredTeams.length > 0 ? (
+              filteredTeams.map((team) => {
+                const isSelected = selectedTeamIds.has(team.id)
+                const workspaceName =
+                  team.workspaceName ??
+                  (team.workspaceId ? workspaceById.get(team.workspaceId)?.organizationName : null)
+                return (
+                  <CommandItem
+                    key={`${team.workspaceId ?? 'workspace'}:${team.id}`}
+                    value={`${team.workspaceId ?? 'workspace'}:${team.id}`}
+                    onSelect={() => handleTeamToggle(team.id)}
+                    className="items-center gap-2 px-3 py-1.5 text-xs"
+                  >
+                    <Check
+                      className={cn(
+                        'size-3 text-muted-foreground',
+                        isSelected ? 'opacity-70' : 'opacity-0'
+                      )}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span className="min-w-0 truncate">{team.name}</span>
+                        <span className="shrink-0 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                          {team.key}
+                        </span>
+                      </div>
+                      {showWorkspaceNames && workspaceName ? (
+                        <div className="truncate text-[11px] text-muted-foreground">
+                          {workspaceName}
+                        </div>
+                      ) : null}
+                    </div>
+                  </CommandItem>
+                )
+              })
+            ) : (
+              <div className="px-3 py-5 text-xs leading-relaxed text-muted-foreground">
+                {query.trim()
+                  ? 'No fetched teams match your search.'
+                  : 'No teams were fetched. Access can depend on key scope, private-team membership, archived teams, permissions, or a fetch failure.'}
+              </div>
+            )}
+          </CommandList>
+        </Command>
+        <div className="border-t border-border p-1">
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              onAddTeamAccess()
+            }}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-foreground transition hover:bg-accent hover:text-accent-foreground"
+          >
+            <KeyRound className="size-3.5 text-muted-foreground" />
+            <span>Add team access</span>
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -1,20 +1,11 @@
 import { useEffect, useState } from 'react'
-import { ExternalLink, Github, Loader2, Terminal } from 'lucide-react'
+import { ExternalLink, Github, Terminal } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
+import { LinearApiKeyDialog } from '@/components/linear-api-key-dialog'
 import { useAppStore } from '@/store'
 import { IntegrationStatusPill } from '@/components/integration-status-pill'
 import { cn } from '@/lib/utils'
-import { useMountedRef } from '@/hooks/useMountedRef'
 import { OnboardingInlineCommandTerminal } from './OnboardingInlineCommandTerminal'
 
 type GitHubSetupState = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
@@ -118,43 +109,10 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
   const { compact = false } = props
   const linearStatus = useAppStore((s) => s.linearStatus)
   const checkLinearConnection = useAppStore((s) => s.checkLinearConnection)
-  const connectLinear = useAppStore((s) => s.connectLinear)
 
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [apiKeyDraft, setApiKeyDraft] = useState('')
-  const [connectState, setConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
-  const [connectError, setConnectError] = useState<string | null>(null)
-  const mountedRef = useMountedRef()
 
   const workspaceCount = linearStatus.workspaces?.length ?? (linearStatus.connected ? 1 : 0)
-
-  const handleConnect = async (): Promise<void> => {
-    const apiKey = apiKeyDraft.trim()
-    if (!apiKey || connectState === 'connecting') {
-      return
-    }
-    setConnectState('connecting')
-    setConnectError(null)
-    try {
-      const result = await connectLinear(apiKey)
-      if (!mountedRef.current) {
-        return
-      }
-      if (result.ok) {
-        setApiKeyDraft('')
-        setConnectState('idle')
-        setDialogOpen(false)
-        return
-      }
-      setConnectState('error')
-      setConnectError(result.error)
-    } catch (error) {
-      if (mountedRef.current) {
-        setConnectState('error')
-        setConnectError(error instanceof Error ? error.message : 'Connection failed')
-      }
-    }
-  }
 
   return (
     <>
@@ -173,19 +131,19 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
               </div>
               <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
                 {linearStatus.connected
-                  ? `${workspaceCount} workspace${workspaceCount === 1 ? '' : 's'} linked. Add another any time.`
-                  : 'Paste a Linear API key to link issues to workspaces. Stored locally; nothing leaves this machine.'}
+                  ? `${workspaceCount} workspace${workspaceCount === 1 ? '' : 's'} linked. Update restricted access any time.`
+                  : 'Add Linear access with a Personal API key. Full-access keys can show every team the key owner can access.'}
               </p>
             </div>
           </div>
           <div className={cn('flex items-center gap-2', compact ? 'flex-wrap' : 'shrink-0')}>
             {linearStatus.connected ? (
               <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
-                Add workspace
+                Update access
               </Button>
             ) : (
               <Button size="sm" onClick={() => setDialogOpen(true)}>
-                Connect
+                Add Linear access
               </Button>
             )}
             {!linearStatus.connected ? (
@@ -197,85 +155,13 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
         </div>
       </div>
 
-      <Dialog
+      <LinearApiKeyDialog
         open={dialogOpen}
-        onOpenChange={(open) => {
-          if (connectState !== 'connecting') {
-            setDialogOpen(open)
-          }
-        }}
-      >
-        <DialogContent
-          overlayClassName="z-[110]"
-          className="z-[120] sm:max-w-md"
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' && apiKeyDraft.trim() && connectState !== 'connecting') {
-              event.preventDefault()
-              void handleConnect()
-            }
-          }}
-        >
-          <DialogHeader className="gap-3">
-            <DialogTitle className="leading-tight">Connect Linear workspace</DialogTitle>
-            <DialogDescription>
-              Paste a Personal API key to add a Linear workspace to Orca.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-3">
-            <Input
-              autoFocus
-              type="password"
-              placeholder="lin_api_..."
-              value={apiKeyDraft}
-              onChange={(event) => {
-                setApiKeyDraft(event.target.value)
-                if (connectState === 'error') {
-                  setConnectState('idle')
-                  setConnectError(null)
-                }
-              }}
-              disabled={connectState === 'connecting'}
-            />
-            {connectState === 'error' && connectError ? (
-              <p className="text-xs text-destructive">{connectError}</p>
-            ) : null}
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              Create one in{' '}
-              <button
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl('https://linear.app/settings/account/security')
-                }
-              >
-                Linear Settings &rarr; Security
-              </button>
-              .
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setDialogOpen(false)}
-              disabled={connectState === 'connecting'}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void handleConnect()}
-              disabled={!apiKeyDraft.trim() || connectState === 'connecting'}
-            >
-              {connectState === 'connecting' ? (
-                <>
-                  <Loader2 className="size-4 animate-spin" />
-                  Verifying...
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setDialogOpen}
+        overlayClassName="z-[110]"
+        contentClassName="z-[120]"
+        connectLabel={linearStatus.connected ? 'Update access' : 'Add Linear access'}
+      />
     </>
   )
 }

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -10,7 +10,6 @@ import {
   GitPullRequestArrow,
   ExternalLink,
   LoaderCircle,
-  Lock,
   Terminal,
   Unlink,
   CheckCircle2,
@@ -18,16 +17,8 @@ import {
 } from 'lucide-react'
 import { useAppStore } from '../../store'
 import { Button } from '../ui/button'
-import { Input } from '../ui/input'
 import { useMountedRef } from '@/hooks/useMountedRef'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from '../ui/dialog'
+import { LinearApiKeyDialog } from '@/components/linear-api-key-dialog'
 export { INTEGRATIONS_PANE_SEARCH_ENTRIES } from './integrations-search'
 
 function LinearIcon({ className }: { className?: string }): React.JSX.Element {
@@ -90,7 +81,6 @@ function giteaStatusFromPreflight(status: GiteaPreflightStatus | undefined): Git
 export function IntegrationsPane(): React.JSX.Element {
   const linearStatus = useAppStore((s) => s.linearStatus)
   const preflightStatus = useAppStore((s) => s.preflightStatus)
-  const connectLinear = useAppStore((s) => s.connectLinear)
   const disconnectLinear = useAppStore((s) => s.disconnectLinear)
   const disconnectLinearWorkspace = useAppStore((s) => s.disconnectLinearWorkspace)
   const checkLinearConnection = useAppStore((s) => s.checkLinearConnection)
@@ -110,11 +100,6 @@ export function IntegrationsPane(): React.JSX.Element {
   const [giteaAccount, setGiteaAccount] = useState<string | null>(null)
   const [giteaBaseUrl, setGiteaBaseUrl] = useState<string | null>(null)
   const [linearDialogOpen, setLinearDialogOpen] = useState(false)
-  const [linearApiKeyDraft, setLinearApiKeyDraft] = useState('')
-  const [linearConnectState, setLinearConnectState] = useState<'idle' | 'connecting' | 'error'>(
-    'idle'
-  )
-  const [linearConnectError, setLinearConnectError] = useState<string | null>(null)
   const [linearTestingWorkspaceId, setLinearTestingWorkspaceId] = useState<string | null>(null)
   const [linearTestResultByWorkspace, setLinearTestResultByWorkspace] = useState<
     Record<string, { state: 'ok' | 'error'; error?: string }>
@@ -163,41 +148,11 @@ export function IntegrationsPane(): React.JSX.Element {
     setGiteaStatus(giteaStatusFromPreflight(gitea))
   }, [preflightStatus])
 
-  const handleLinearConnect = async (): Promise<void> => {
-    if (!linearApiKeyDraft.trim()) {
-      return
-    }
-    setLinearConnectState('connecting')
-    setLinearConnectError(null)
-    try {
-      const result = await connectLinear(linearApiKeyDraft.trim())
-      if (!mountedRef.current) {
-        return
-      }
-      if (result.ok) {
-        setLinearApiKeyDraft('')
-        setLinearConnectState('idle')
-        setLinearDialogOpen(false)
-        setLinearTestResultByWorkspace({})
-      } else {
-        setLinearConnectState('error')
-        setLinearConnectError(result.error)
-      }
-    } catch (error) {
-      if (mountedRef.current) {
-        setLinearConnectState('error')
-        setLinearConnectError(error instanceof Error ? error.message : 'Connection failed')
-      }
-    }
-  }
-
   const handleLinearDisconnect = async (workspaceId?: string): Promise<void> => {
     await (workspaceId ? disconnectLinearWorkspace(workspaceId) : disconnectLinear())
     if (!mountedRef.current) {
       return
     }
-    setLinearConnectState('idle')
-    setLinearConnectError(null)
     setLinearTestResultByWorkspace({})
   }
 
@@ -674,13 +629,13 @@ export function IntegrationsPane(): React.JSX.Element {
             <p className="text-xs text-muted-foreground">
               {linearStatus.connected
                 ? `${linearWorkspaces.length} workspace${linearWorkspaces.length === 1 ? '' : 's'} connected`
-                : 'Browse and link issues to workspaces.'}
+                : 'Add Linear access to browse and link issues.'}
             </p>
           </div>
           {linearStatus.connected ? (
             <div className="flex shrink-0 items-center gap-1.5">
               <Button variant="outline" size="sm" onClick={() => setLinearDialogOpen(true)}>
-                Add workspace
+                Update access
               </Button>
               <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
                 Connected
@@ -691,7 +646,7 @@ export function IntegrationsPane(): React.JSX.Element {
               className="shrink-0 rounded-full border border-border/50 bg-muted/40 px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               onClick={() => setLinearDialogOpen(true)}
             >
-              Connect
+              Add Linear access
             </button>
           )}
         </div>
@@ -753,101 +708,20 @@ export function IntegrationsPane(): React.JSX.Element {
               )
             })}
             <p className="text-[11px] text-muted-foreground/70">
-              Each workspace uses its own locally stored API key.
+              Each connected Linear workspace has one key stored by the active runtime. Full-access
+              keys can cover all teams the key owner can access; restricted keys can be replaced any
+              time.
             </p>
           </div>
         )}
       </div>
 
-      {/* Linear Connect Dialog */}
-      <Dialog
+      <LinearApiKeyDialog
         open={linearDialogOpen}
-        onOpenChange={(open) => {
-          if (linearConnectState !== 'connecting') {
-            setLinearDialogOpen(open)
-          }
-        }}
-      >
-        <DialogContent
-          className="sm:max-w-md"
-          onKeyDown={(e) => {
-            if (
-              e.key === 'Enter' &&
-              linearApiKeyDraft.trim() &&
-              linearConnectState !== 'connecting'
-            ) {
-              e.preventDefault()
-              void handleLinearConnect()
-            }
-          }}
-        >
-          <DialogHeader className="gap-3">
-            <DialogTitle className="leading-tight">Connect Linear workspace</DialogTitle>
-            <DialogDescription>
-              Paste a <strong className="font-semibold text-foreground">Personal API key</strong> to
-              add a workspace to Orca.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-3">
-            <Input
-              autoFocus
-              type="password"
-              placeholder="lin_api_..."
-              value={linearApiKeyDraft}
-              onChange={(e) => {
-                setLinearApiKeyDraft(e.target.value)
-                if (linearConnectState === 'error') {
-                  setLinearConnectState('idle')
-                  setLinearConnectError(null)
-                }
-              }}
-              disabled={linearConnectState === 'connecting'}
-            />
-            {linearConnectState === 'error' && linearConnectError && (
-              <p className="text-xs text-destructive">{linearConnectError}</p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Create one in{' '}
-              <button
-                className="text-primary underline-offset-2 hover:underline"
-                onClick={() =>
-                  window.api.shell.openUrl('https://linear.app/settings/account/security')
-                }
-              >
-                Linear Settings → Security
-              </button>{' '}
-              → <strong className="font-semibold text-foreground">New API key</strong> (not{' '}
-              <span className="text-foreground">New passkey</span>).
-            </p>
-            <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
-              <Lock className="size-3 shrink-0" />
-              Your key is encrypted via the OS keychain and stored locally.
-            </p>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setLinearDialogOpen(false)}
-              disabled={linearConnectState === 'connecting'}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void handleLinearConnect()}
-              disabled={!linearApiKeyDraft.trim() || linearConnectState === 'connecting'}
-            >
-              {linearConnectState === 'connecting' ? (
-                <>
-                  <LoaderCircle className="size-4 animate-spin" />
-                  Verifying…
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setLinearDialogOpen}
+        connectLabel={linearStatus.connected ? 'Update access' : 'Add Linear access'}
+        onConnected={() => setLinearTestResultByWorkspace({})}
+      />
     </div>
   )
 }

--- a/src/renderer/src/store/slices/linear-invalidation.test.ts
+++ b/src/renderer/src/store/slices/linear-invalidation.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import type { AppState } from '../types'
+import type { LinearConnectionStatus, LinearIssue, LinearTeam } from '../../../../shared/types'
+import { createLinearSlice } from './linear'
+
+const linearStatus = vi.fn()
+const linearConnect = vi.fn()
+const linearListIssues = vi.fn()
+const linearSearchIssues = vi.fn()
+const linearListTeams = vi.fn()
+const linearGetIssue = vi.fn()
+
+vi.mock('@/runtime/runtime-linear-client', () => ({
+  linearConnect: (...args: unknown[]) => linearConnect(...args),
+  linearDisconnect: vi.fn(),
+  linearDisconnectWorkspace: vi.fn(),
+  linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
+  linearListIssues: (...args: unknown[]) => linearListIssues(...args),
+  linearListTeams: (...args: unknown[]) => linearListTeams(...args),
+  linearSearchIssues: (...args: unknown[]) => linearSearchIssues(...args),
+  linearSelectWorkspace: vi.fn(),
+  linearStatus: (...args: unknown[]) => linearStatus(...args),
+  linearTestConnection: vi.fn()
+}))
+
+vi.mock('../../hooks/useIssueMetadata', () => ({
+  clearLinearMetadataCache: vi.fn()
+}))
+
+const viewer = {
+  displayName: 'Ada',
+  email: 'ada@example.com',
+  organizationName: 'Alpha'
+}
+
+function createTestStore() {
+  return create<AppState>()(
+    (...a) =>
+      ({
+        settings: null,
+        ...createLinearSlice(...a)
+      }) as AppState
+  )
+}
+
+function issue(id: string): LinearIssue {
+  return {
+    id,
+    identifier: id,
+    title: id,
+    url: `https://linear.app/${id}`,
+    state: { name: 'Todo', type: 'unstarted', color: '#888888' },
+    team: { id: 'team-1', name: 'Team', key: 'TM' },
+    labels: [],
+    labelIds: [],
+    priority: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  }
+}
+
+function team(id: string): LinearTeam {
+  return { id, name: id, key: id, workspaceId: 'workspace-1', workspaceName: 'Workspace' }
+}
+
+function status(
+  workspaceId: string,
+  organizationName = 'Alpha',
+  credentialRevision?: number
+): LinearConnectionStatus {
+  return {
+    connected: true,
+    viewer: { ...viewer, organizationName },
+    selectedWorkspaceId: workspaceId,
+    activeWorkspaceId: workspaceId,
+    workspaces: [
+      {
+        id: workspaceId,
+        organizationId: workspaceId,
+        organizationName,
+        displayName: viewer.displayName,
+        email: viewer.email,
+        credentialRevision
+      }
+    ]
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('createLinearSlice invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('keeps literal search queries separate from list cache keys', async () => {
+    const store = createTestStore()
+    store.setState({
+      linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
+      linearSearchCache: {
+        'workspace-1::list::all::36': { data: [issue('LIST')], fetchedAt: Date.now() }
+      }
+    })
+    linearSearchIssues.mockResolvedValueOnce([issue('SEARCH')])
+
+    await expect(store.getState().searchLinearIssues('list::all', 36)).resolves.toMatchObject([
+      { id: 'SEARCH' }
+    ])
+
+    expect(
+      store.getState().getCachedLinearIssues({ kind: 'search', query: 'list::all', limit: 36 })
+    ).toMatchObject([{ id: 'SEARCH' }])
+    expect(
+      store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
+    ).toMatchObject([{ id: 'LIST' }])
+  })
+
+  it('caches teams by workspace and dedupes fresh reads', async () => {
+    const store = createTestStore()
+    linearListTeams.mockResolvedValueOnce([team('team-1')])
+
+    await expect(store.getState().listLinearTeams('workspace-1')).resolves.toMatchObject([
+      { id: 'team-1' }
+    ])
+    await expect(store.getState().listLinearTeams('workspace-1')).resolves.toMatchObject([
+      { id: 'team-1' }
+    ])
+
+    expect(linearListTeams).toHaveBeenCalledTimes(1)
+    expect(store.getState().getCachedLinearTeams('workspace-1')).toMatchObject([{ id: 'team-1' }])
+  })
+
+  it('patches issue-cache entries keyed by workspace-qualified ids', () => {
+    const store = createTestStore()
+    store.setState({
+      linearIssueCache: {
+        'workspace-1::issue-id': { data: issue('issue-id'), fetchedAt: Date.now() }
+      }
+    })
+
+    store.getState().patchLinearIssue('issue-id', { title: 'Updated' })
+
+    expect(store.getState().linearIssueCache['workspace-1::issue-id'].data?.title).toBe('Updated')
+    expect(store.getState().linearIssueCache['workspace-1::issue-id'].fetchedAt).toBe(0)
+  })
+
+  it('connect invalidates cached Linear rows and waits for refreshed status', async () => {
+    const store = createTestStore()
+    const statusRefresh = deferred<LinearConnectionStatus>()
+    store.setState({
+      linearIssueCache: {
+        'workspace-1::issue-1': { data: issue('issue-1'), fetchedAt: Date.now() }
+      },
+      linearSearchCache: {
+        'workspace-1::list::all::36': { data: [issue('LIN-CACHED')], fetchedAt: Date.now() }
+      },
+      linearTeamCache: {
+        'workspace-1::teams': { data: [team('team-old')], fetchedAt: Date.now() }
+      }
+    })
+    linearConnect.mockResolvedValueOnce({ ok: true, viewer })
+    linearStatus.mockReturnValueOnce(statusRefresh.promise)
+
+    let resolved = false
+    const connectPromise = store
+      .getState()
+      .connectLinear('linear-key')
+      .then((result) => {
+        resolved = true
+        return result
+      })
+    await Promise.resolve()
+
+    expect(resolved).toBe(false)
+    expect(store.getState().linearIssueCache).toEqual({})
+    expect(store.getState().linearSearchCache).toEqual({})
+    expect(store.getState().linearTeamCache).toEqual({})
+
+    statusRefresh.resolve(status('workspace-1'))
+    await expect(connectPromise).resolves.toEqual({ ok: true, viewer })
+    expect(store.getState().linearStatus.selectedWorkspaceId).toBe('workspace-1')
+  })
+
+  it('drops stale in-flight issue and team cache writes after connect invalidation', async () => {
+    const store = createTestStore()
+    const staleIssue = deferred<LinearIssue | null>()
+    const staleTeams = deferred<LinearTeam[]>()
+    store.setState({
+      linearStatus: { connected: true, viewer, selectedWorkspaceId: 'workspace-1' }
+    })
+    linearGetIssue.mockReturnValueOnce(staleIssue.promise)
+    linearListTeams.mockReturnValueOnce(staleTeams.promise)
+    linearConnect.mockResolvedValueOnce({ ok: true, viewer })
+    linearStatus.mockResolvedValueOnce(status('workspace-1'))
+
+    const issuePromise = store.getState().fetchLinearIssue('issue-1', 'workspace-1')
+    const teamPromise = store.getState().listLinearTeams('workspace-1')
+    await store.getState().connectLinear('linear-key')
+
+    staleIssue.resolve(issue('issue-1'))
+    staleTeams.resolve([team('team-stale')])
+    await Promise.all([issuePromise, teamPromise])
+
+    expect(store.getState().linearIssueCache).toEqual({})
+    expect(store.getState().getCachedLinearTeams('workspace-1')).toBeNull()
+  })
+
+  it('forced status refresh detects workspace metadata changes with the same count', async () => {
+    const store = createTestStore()
+    store.setState({
+      linearStatus: status('workspace-1', 'Old Org'),
+      linearSearchCache: {
+        'workspace-1::list::all::36': { data: [issue('LIN-CACHED')], fetchedAt: Date.now() }
+      },
+      linearTeamCache: {
+        'workspace-1::teams': { data: [team('team-old')], fetchedAt: Date.now() }
+      }
+    })
+    linearStatus.mockResolvedValueOnce(status('workspace-1', 'New Org', 2))
+
+    await store.getState().checkLinearConnection(true)
+
+    expect(store.getState().linearStatus.workspaces?.[0]?.organizationName).toBe('New Org')
+    expect(store.getState().linearSearchCache).toEqual({})
+    expect(store.getState().linearTeamCache).toEqual({})
+  })
+
+  it('refreshes status after an all-workspace auth failure without marking all Linear disconnected', async () => {
+    const store = createTestStore()
+    store.setState({
+      linearStatus: {
+        connected: true,
+        viewer,
+        selectedWorkspaceId: 'all',
+        activeWorkspaceId: 'workspace-1',
+        workspaces: [
+          {
+            id: 'workspace-1',
+            organizationId: 'workspace-1',
+            organizationName: 'Alpha',
+            displayName: 'Ada',
+            email: 'ada@example.com'
+          },
+          {
+            id: 'workspace-2',
+            organizationId: 'workspace-2',
+            organizationName: 'Beta',
+            displayName: 'Ada',
+            email: 'ada@example.com'
+          }
+        ]
+      }
+    })
+    linearListIssues.mockRejectedValueOnce(new Error('401 unauthorized'))
+    linearStatus.mockResolvedValueOnce(status('workspace-2', 'Beta'))
+
+    await expect(store.getState().listLinearIssues('all', 36, { force: true })).resolves.toEqual([])
+    expect(store.getState().linearStatus.connected).toBe(true)
+    await vi.waitFor(() => {
+      expect(store.getState().linearStatus.workspaces?.map((workspace) => workspace.id)).toEqual([
+        'workspace-2'
+      ])
+    })
+  })
+})

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -1,12 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
-import type {
-  LinearConnectionStatus,
-  LinearIssue,
-  LinearTeam,
-  LinearViewer
-} from '../../../../shared/types'
+import type { LinearConnectionStatus, LinearIssue, LinearViewer } from '../../../../shared/types'
 import { createLinearSlice } from './linear'
 
 const linearStatus = vi.fn()
@@ -15,13 +10,14 @@ const linearDisconnect = vi.fn()
 const linearListIssues = vi.fn()
 const linearSearchIssues = vi.fn()
 const linearListTeams = vi.fn()
+const linearGetIssue = vi.fn()
 const linearTestConnection = vi.fn()
 
 vi.mock('@/runtime/runtime-linear-client', () => ({
   linearConnect: (...args: unknown[]) => linearConnect(...args),
   linearDisconnect: (...args: unknown[]) => linearDisconnect(...args),
   linearDisconnectWorkspace: vi.fn(),
-  linearGetIssue: vi.fn(),
+  linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
   linearListIssues: (...args: unknown[]) => linearListIssues(...args),
   linearListTeams: (...args: unknown[]) => linearListTeams(...args),
   linearSearchIssues: (...args: unknown[]) => linearSearchIssues(...args),
@@ -57,10 +53,6 @@ function issue(id: string): LinearIssue {
     priority: 0,
     updatedAt: '2026-01-01T00:00:00.000Z'
   }
-}
-
-function team(id: string): LinearTeam {
-  return { id, name: id, key: id, workspaceId: 'workspace-1', workspaceName: 'Workspace' }
 }
 
 function deferred<T>() {
@@ -197,58 +189,6 @@ describe('createLinearSlice caching', () => {
       store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
     ).toEqual([issue('LIN-1')])
   })
-
-  it('keeps literal search queries separate from list cache keys', async () => {
-    const store = createTestStore()
-    store.setState({
-      linearStatus: { connected: true, viewer: null, selectedWorkspaceId: 'workspace-1' },
-      linearSearchCache: {
-        'workspace-1::list::all::36': { data: [issue('LIST')], fetchedAt: Date.now() }
-      }
-    })
-    linearSearchIssues.mockResolvedValueOnce([issue('SEARCH')])
-
-    await expect(store.getState().searchLinearIssues('list::all', 36)).resolves.toMatchObject([
-      { id: 'SEARCH' }
-    ])
-
-    expect(linearSearchIssues).toHaveBeenCalledTimes(1)
-    expect(
-      store.getState().getCachedLinearIssues({ kind: 'search', query: 'list::all', limit: 36 })
-    ).toMatchObject([{ id: 'SEARCH' }])
-    expect(
-      store.getState().getCachedLinearIssues({ kind: 'list', filter: 'all', limit: 36 })
-    ).toMatchObject([{ id: 'LIST' }])
-  })
-
-  it('caches teams by workspace and dedupes fresh reads', async () => {
-    const store = createTestStore()
-    linearListTeams.mockResolvedValueOnce([team('team-1')])
-
-    await expect(store.getState().listLinearTeams('workspace-1')).resolves.toMatchObject([
-      { id: 'team-1' }
-    ])
-    await expect(store.getState().listLinearTeams('workspace-1')).resolves.toMatchObject([
-      { id: 'team-1' }
-    ])
-
-    expect(linearListTeams).toHaveBeenCalledTimes(1)
-    expect(store.getState().getCachedLinearTeams('workspace-1')).toMatchObject([{ id: 'team-1' }])
-  })
-
-  it('patches issue-cache entries keyed by workspace-qualified ids', () => {
-    const store = createTestStore()
-    store.setState({
-      linearIssueCache: {
-        'workspace-1::issue-id': { data: issue('issue-id'), fetchedAt: Date.now() }
-      }
-    })
-
-    store.getState().patchLinearIssue('issue-id', { title: 'Updated' })
-
-    expect(store.getState().linearIssueCache['workspace-1::issue-id'].data?.title).toBe('Updated')
-    expect(store.getState().linearIssueCache['workspace-1::issue-id'].fetchedAt).toBe(0)
-  })
 })
 
 describe('createLinearSlice', () => {
@@ -256,6 +196,10 @@ describe('createLinearSlice', () => {
     linearStatus.mockReset()
     linearConnect.mockReset()
     linearDisconnect.mockReset()
+    linearListIssues.mockReset()
+    linearSearchIssues.mockReset()
+    linearListTeams.mockReset()
+    linearGetIssue.mockReset()
     linearTestConnection.mockReset()
   })
 
@@ -297,13 +241,13 @@ describe('createLinearSlice', () => {
     const store = createTestStore()
 
     const mountCheck = store.getState().checkLinearConnection()
-    await store.getState().connectLinear('linear-key')
+    const connectPromise = store.getState().connectLinear('linear-key')
+    await Promise.resolve()
 
     expect(linearStatus).toHaveBeenCalledTimes(2)
-    expect(store.getState().linearStatus.connected).toBe(true)
 
     freshConnectCheck.resolve({ connected: true, viewer })
-    await Promise.resolve()
+    await connectPromise
 
     staleMountCheck.resolve({ connected: false, viewer: null })
     await mountCheck

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -8,6 +8,7 @@ import type {
   LinearConnectionStatus,
   LinearIssue,
   LinearTeam,
+  LinearWorkspace,
   LinearWorkspaceSelection
 } from '../../../../shared/types'
 import type { CacheEntry } from './github'
@@ -54,17 +55,30 @@ function looksLikeAuthError(error: unknown): boolean {
   return /authenticat|unauthorized|401/i.test(msg)
 }
 
-const inflightIssueRequests = new Map<string, Promise<LinearIssue | null>>()
+type InflightLinearIssueRequest = {
+  promise: Promise<LinearIssue | null>
+  generation: number
+}
+
+const inflightIssueRequests = new Map<string, InflightLinearIssueRequest>()
 type InflightLinearListRequest = {
   promise: Promise<LinearIssue[]>
   force: boolean
+  generation: number
 }
 
 const inflightSearchRequests = new Map<string, InflightLinearListRequest>()
 const inflightListRequests = new Map<string, InflightLinearListRequest>()
-const inflightTeamRequests = new Map<string, Promise<LinearTeam[]>>()
+type InflightLinearTeamRequest = {
+  promise: Promise<LinearTeam[]>
+  force: boolean
+  generation: number
+}
+
+const inflightTeamRequests = new Map<string, InflightLinearTeamRequest>()
 let inflightStatusRequest: Promise<void> | null = null
 let statusRequestGeneration = 0
+let linearCacheGeneration = 0
 
 function getSelectedWorkspaceId(status: LinearConnectionStatus): LinearWorkspaceSelection | null {
   return status.selectedWorkspaceId ?? status.activeWorkspaceId ?? null
@@ -88,6 +102,55 @@ function linearListCacheKey(
 
 function linearTeamsCacheKey(workspaceId: LinearWorkspaceSelection | null | undefined): string {
   return `${workspaceId ?? 'default'}::teams`
+}
+
+function linearWorkspaceSignature(workspace: LinearWorkspace): string {
+  return [
+    workspace.id,
+    workspace.organizationId,
+    workspace.organizationName,
+    workspace.organizationUrlKey ?? '',
+    workspace.displayName,
+    workspace.email ?? '',
+    workspace.credentialRevision ?? 0
+  ].join('\u001f')
+}
+
+function linearStatusScopeSignature(status: LinearConnectionStatus): string {
+  return JSON.stringify({
+    connected: status.connected,
+    activeWorkspaceId: status.activeWorkspaceId ?? null,
+    selectedWorkspaceId: getSelectedWorkspaceId(status),
+    viewer: status.viewer
+      ? [
+          status.viewer.organizationId ?? '',
+          status.viewer.organizationName,
+          status.viewer.organizationUrlKey ?? '',
+          status.viewer.displayName,
+          status.viewer.email ?? ''
+        ]
+      : null,
+    workspaces: (status.workspaces ?? []).map(linearWorkspaceSignature)
+  })
+}
+
+function clearLinearRequestMaps(): void {
+  inflightIssueRequests.clear()
+  inflightSearchRequests.clear()
+  inflightListRequests.clear()
+  inflightTeamRequests.clear()
+}
+
+function invalidateLinearCaches(): void {
+  linearCacheGeneration += 1
+  clearLinearRequestMaps()
+  clearLinearMetadataCache()
+}
+
+function shouldRefreshStatusAfterRead(
+  workspaceId: LinearWorkspaceSelection | null | undefined
+): boolean {
+  return workspaceId === 'all'
 }
 
 type LinearIssueReadArgs =
@@ -164,13 +227,17 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         }
         const typedStatus = status as LinearConnectionStatus
         const prev = get().linearStatus
-        if (
-          prev.connected !== typedStatus.connected ||
-          prev.viewer?.email !== typedStatus.viewer?.email ||
-          getSelectedWorkspaceId(prev) !== getSelectedWorkspaceId(typedStatus) ||
-          (prev.workspaces?.length ?? 0) !== (typedStatus.workspaces?.length ?? 0)
-        ) {
-          set({ linearStatus: typedStatus, linearStatusChecked: true })
+        const prevScopeSignature = linearStatusScopeSignature(prev)
+        const nextScopeSignature = linearStatusScopeSignature(typedStatus)
+        if (prevScopeSignature !== nextScopeSignature) {
+          invalidateLinearCaches()
+          set({
+            linearStatus: typedStatus,
+            linearIssueCache: {},
+            linearSearchCache: {},
+            linearTeamCache: {},
+            linearStatusChecked: true
+          })
         } else if (!get().linearStatusChecked) {
           set({ linearStatusChecked: true })
         }
@@ -202,7 +269,19 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         | { ok: false; error: string }
       const status = await linearStatus(get().settings)
       if (isCurrentStatusOperation(requestGeneration)) {
-        set({ linearStatus: status, linearStatusChecked: true })
+        const prev = get().linearStatus
+        if (linearStatusScopeSignature(prev) !== linearStatusScopeSignature(status)) {
+          invalidateLinearCaches()
+          set({
+            linearStatus: status,
+            linearIssueCache: {},
+            linearSearchCache: {},
+            linearTeamCache: {},
+            linearStatusChecked: true
+          })
+        } else {
+          set({ linearStatus: status, linearStatusChecked: true })
+        }
       }
       return result
     } catch (error) {
@@ -216,13 +295,20 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     try {
       const result = await linearConnect(get().settings, apiKey)
       if (result.ok && isCurrentStatusOperation(requestGeneration)) {
+        invalidateLinearCaches()
         set({
-          linearStatus: {
-            connected: true,
-            viewer: result.viewer as LinearViewer
-          }
+          linearIssueCache: {},
+          linearSearchCache: {},
+          linearTeamCache: {}
         })
-        void get().checkLinearConnection(true)
+        const status = await linearStatus(get().settings)
+        if (!isCurrentStatusOperation(requestGeneration)) {
+          return result as { ok: true; viewer: LinearViewer } | { ok: false; error: string }
+        }
+        set({
+          linearStatus: status,
+          linearStatusChecked: true
+        })
       }
       return result as { ok: true; viewer: LinearViewer } | { ok: false; error: string }
     } catch (error) {
@@ -237,11 +323,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     if (!isCurrentStatusOperation(requestGeneration)) {
       return
     }
-    inflightIssueRequests.clear()
-    inflightSearchRequests.clear()
-    inflightListRequests.clear()
-    inflightTeamRequests.clear()
-    clearLinearMetadataCache()
+    invalidateLinearCaches()
     set({
       linearStatus: status,
       linearIssueCache: {},
@@ -257,16 +339,13 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     if (!isCurrentStatusOperation(requestGeneration)) {
       return
     }
-    inflightIssueRequests.clear()
-    inflightSearchRequests.clear()
-    inflightListRequests.clear()
-    inflightTeamRequests.clear()
-    clearLinearMetadataCache()
+    invalidateLinearCaches()
     set({
       linearStatus: { connected: false, viewer: null },
       linearIssueCache: {},
       linearSearchCache: {},
-      linearTeamCache: {}
+      linearTeamCache: {},
+      linearStatusChecked: true
     })
   },
 
@@ -277,11 +356,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     if (!isCurrentStatusOperation(requestGeneration)) {
       return
     }
-    inflightIssueRequests.clear()
-    inflightSearchRequests.clear()
-    inflightListRequests.clear()
-    inflightTeamRequests.clear()
-    clearLinearMetadataCache()
+    invalidateLinearCaches()
     set({
       linearStatus: status,
       linearIssueCache: {},
@@ -300,32 +375,42 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
 
     const inflight = inflightIssueRequests.get(issueCacheKey)
     if (inflight) {
-      return inflight
+      return inflight.promise
     }
 
+    let entry: InflightLinearIssueRequest
+    const requestCacheGeneration = linearCacheGeneration
     const promise = linearGetIssue(get().settings, id, workspaceId)
       .then((issue) => {
         const data = issue as LinearIssue | null
-        set((s) => ({
-          linearIssueCache: evictStaleEntries({
-            ...s.linearIssueCache,
-            [issueCacheKey]: { data, fetchedAt: Date.now() }
-          })
-        }))
+        if (
+          inflightIssueRequests.get(issueCacheKey) === entry &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
+          set((s) => ({
+            linearIssueCache: evictStaleEntries({
+              ...s.linearIssueCache,
+              [issueCacheKey]: { data, fetchedAt: Date.now() }
+            })
+          }))
+        }
         return data
       })
       .catch((error) => {
         console.warn('[linear] fetchLinearIssue failed:', error)
         if (looksLikeAuthError(error)) {
-          set({ linearStatus: { connected: false, viewer: null } })
+          void get().checkLinearConnection(true)
         }
         return null
       })
       .finally(() => {
-        inflightIssueRequests.delete(issueCacheKey)
+        if (inflightIssueRequests.get(issueCacheKey) === entry) {
+          inflightIssueRequests.delete(issueCacheKey)
+        }
       })
 
-    inflightIssueRequests.set(issueCacheKey, promise)
+    entry = { promise, generation: requestCacheGeneration }
+    inflightIssueRequests.set(issueCacheKey, entry)
     return promise
   },
 
@@ -374,10 +459,14 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     }
 
     let entry: InflightLinearListRequest
+    const requestCacheGeneration = linearCacheGeneration
     const promise = linearSearchIssues(get().settings, query, limit, workspaceId)
       .then((issues) => {
         const data = issues as LinearIssue[]
-        if (inflightSearchRequests.get(cacheKey) === entry) {
+        if (
+          inflightSearchRequests.get(cacheKey) === entry &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
           set((s) => ({
             linearSearchCache: evictStaleEntries({
               ...s.linearSearchCache,
@@ -390,7 +479,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       .catch((error) => {
         console.warn('[linear] searchLinearIssues failed:', error)
         if (looksLikeAuthError(error)) {
-          set({ linearStatus: { connected: false, viewer: null } })
+          if (!shouldRefreshStatusAfterRead(workspaceId)) {
+            void get().checkLinearConnection(true)
+          }
           return []
         }
         return get().linearSearchCache[cacheKey]?.data ?? []
@@ -399,9 +490,15 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         if (inflightSearchRequests.get(cacheKey) === entry) {
           inflightSearchRequests.delete(cacheKey)
         }
+        if (
+          shouldRefreshStatusAfterRead(workspaceId) &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
+          void get().checkLinearConnection(true)
+        }
       })
 
-    entry = { promise, force: Boolean(options?.force) }
+    entry = { promise, force: Boolean(options?.force), generation: requestCacheGeneration }
     inflightSearchRequests.set(cacheKey, entry)
     return promise
   },
@@ -420,10 +517,14 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     }
 
     let entry: InflightLinearListRequest
+    const requestCacheGeneration = linearCacheGeneration
     const promise = linearListIssues(get().settings, filter, limit, workspaceId)
       .then((issues) => {
         const data = issues as LinearIssue[]
-        if (inflightListRequests.get(cacheKey) === entry) {
+        if (
+          inflightListRequests.get(cacheKey) === entry &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
           set((s) => ({
             linearSearchCache: evictStaleEntries({
               ...s.linearSearchCache,
@@ -436,7 +537,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       .catch((error) => {
         console.warn('[linear] listLinearIssues failed:', error)
         if (looksLikeAuthError(error)) {
-          set({ linearStatus: { connected: false, viewer: null } })
+          if (!shouldRefreshStatusAfterRead(workspaceId)) {
+            void get().checkLinearConnection(true)
+          }
           return []
         }
         return get().linearSearchCache[cacheKey]?.data ?? []
@@ -445,9 +548,15 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         if (inflightListRequests.get(cacheKey) === entry) {
           inflightListRequests.delete(cacheKey)
         }
+        if (
+          shouldRefreshStatusAfterRead(workspaceId) &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
+          void get().checkLinearConnection(true)
+        }
       })
 
-    entry = { promise, force: Boolean(options?.force) }
+    entry = { promise, force: Boolean(options?.force), generation: requestCacheGeneration }
     inflightListRequests.set(cacheKey, entry)
     return promise
   },
@@ -466,34 +575,52 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
     }
 
     const inflight = inflightTeamRequests.get(cacheKey)
-    if (inflight && !options?.force) {
-      return inflight
+    if (inflight && (!options?.force || inflight.force)) {
+      return inflight.promise
     }
 
+    let entry: InflightLinearTeamRequest
+    const requestCacheGeneration = linearCacheGeneration
     const promise = linearListTeams(get().settings, resolvedWorkspaceId)
       .then((teams) => {
         const data = teams as LinearTeam[]
-        set((s) => ({
-          linearTeamCache: evictStaleEntries({
-            ...s.linearTeamCache,
-            [cacheKey]: { data, fetchedAt: Date.now() }
-          })
-        }))
+        if (
+          inflightTeamRequests.get(cacheKey) === entry &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
+          set((s) => ({
+            linearTeamCache: evictStaleEntries({
+              ...s.linearTeamCache,
+              [cacheKey]: { data, fetchedAt: Date.now() }
+            })
+          }))
+        }
         return data
       })
       .catch((error) => {
         console.warn('[linear] listLinearTeams failed:', error)
         if (looksLikeAuthError(error)) {
-          set({ linearStatus: { connected: false, viewer: null } })
+          if (!shouldRefreshStatusAfterRead(resolvedWorkspaceId)) {
+            void get().checkLinearConnection(true)
+          }
           return []
         }
         return get().linearTeamCache[cacheKey]?.data ?? []
       })
       .finally(() => {
-        inflightTeamRequests.delete(cacheKey)
+        if (inflightTeamRequests.get(cacheKey) === entry) {
+          inflightTeamRequests.delete(cacheKey)
+        }
+        if (
+          shouldRefreshStatusAfterRead(resolvedWorkspaceId) &&
+          requestCacheGeneration === linearCacheGeneration
+        ) {
+          void get().checkLinearConnection(true)
+        }
       })
 
-    inflightTeamRequests.set(cacheKey, promise)
+    entry = { promise, force: Boolean(options?.force), generation: requestCacheGeneration }
+    inflightTeamRequests.set(cacheKey, entry)
     return promise
   },
 

--- a/src/shared/linear-links.test.ts
+++ b/src/shared/linear-links.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildLinearTeamUrl, getLinearOrganizationUrlKeyFromIssueUrl } from './linear-links'
+import {
+  buildLinearPersonalApiKeySettingsUrl,
+  buildLinearTeamUrl,
+  buildLinearWorkspaceApiSettingsUrl,
+  getLinearOrganizationUrlKeyFromIssueUrl
+} from './linear-links'
 
 describe('linear links', () => {
   it('builds team URLs from workspace and team keys', () => {
@@ -19,5 +24,21 @@ describe('linear links', () => {
     expect(getLinearOrganizationUrlKeyFromIssueUrl('https://linear.app/acme/issue/ENG-1')).toBe(
       'acme'
     )
+  })
+
+  it('builds organization-scoped API key settings URLs', () => {
+    expect(buildLinearPersonalApiKeySettingsUrl('acme inc')).toBe(
+      'https://linear.app/acme%20inc/settings/account/security'
+    )
+    expect(buildLinearWorkspaceApiSettingsUrl('acme/inc')).toBe(
+      'https://linear.app/acme%2Finc/settings/api'
+    )
+  })
+
+  it('falls back to global API settings URLs when no organization slug is available', () => {
+    expect(buildLinearPersonalApiKeySettingsUrl()).toBe(
+      'https://linear.app/settings/account/security'
+    )
+    expect(buildLinearWorkspaceApiSettingsUrl('   ')).toBe('https://linear.app/settings/api')
   })
 })

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -10,6 +10,20 @@ export function buildLinearTeamUrl(args: {
   return `https://linear.app/${encodeURIComponent(organizationUrlKey)}/team/${encodeURIComponent(teamKey)}/all`
 }
 
+export function buildLinearPersonalApiKeySettingsUrl(organizationUrlKey?: string | null): string {
+  const trimmed = organizationUrlKey?.trim()
+  return trimmed
+    ? `https://linear.app/${encodeURIComponent(trimmed)}/settings/account/security`
+    : 'https://linear.app/settings/account/security'
+}
+
+export function buildLinearWorkspaceApiSettingsUrl(organizationUrlKey?: string | null): string {
+  const trimmed = organizationUrlKey?.trim()
+  return trimmed
+    ? `https://linear.app/${encodeURIComponent(trimmed)}/settings/api`
+    : 'https://linear.app/settings/api'
+}
+
 export function getLinearOrganizationUrlKeyFromIssueUrl(issueUrl?: string | null): string | null {
   if (!issueUrl) {
     return null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1057,6 +1057,7 @@ export type LinearWorkspace = LinearViewer & {
   id: string
   organizationId: string
   isLegacy?: true
+  credentialRevision?: number
 }
 
 export type LinearWorkspaceSelection = string | 'all'


### PR DESCRIPTION
## Summary
- Replace the split Linear workspace/team controls with one Linear scope selector and an Add team access path.
- Add a reusable Linear API-key dialog used from Tasks, Settings, and onboarding with clearer full-access/restricted-key guidance.
- Fix Linear team pagination, key-replacement cache invalidation, all-workspace auth refreshes, and same-workspace credential-revision visibility.
- Add URL helpers, design doc, and focused tests for selector labels/persistence, Linear links, team pagination, and cache invalidation.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/linear-links.test.ts src/main/linear/teams.test.ts src/renderer/src/store/slices/linear.test.ts src/renderer/src/store/slices/linear-invalidation.test.ts src/renderer/src/components/task-page-linear-team-selection.test.ts src/renderer/src/components/linear-scope-selector.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- Electron CDP validation on `Orca: improve-linear-team-2`: Linear Tasks toolbar, scope popover, search-empty state, API-key dialog, Settings Integrations copy/dialog, and GitHub Tasks neighbor surface. Local screenshots saved under ignored `validation-screenshots/`.

Risk: high
Broad Linear scope-selection change touching main Linear API behavior, renderer task/settings/onboarding surfaces, store state, shared links, and UI flows.