### PR TITLE
fix: translate dropped paths for WSL worktrees

### DIFF
--- a/src/main/ipc/dropped-path-resolution.test.ts
+++ b/src/main/ipc/dropped-path-resolution.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLocalDroppedPathsForAgent } from './dropped-path-resolution'
+
+describe('resolveLocalDroppedPathsForAgent', () => {
+  it('translates dropped Windows paths for local WSL worktrees', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      expect(
+        resolveLocalDroppedPathsForAgent(
+          [
+            'C:\\Users\\alice\\Desktop\\notes.txt',
+            '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo\\README.md'
+          ],
+          '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
+        )
+      ).toEqual(['/mnt/c/Users/alice/Desktop/notes.txt', '/home/alice/repo/README.md'])
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('leaves dropped paths unchanged for non-WSL worktrees', () => {
+    const paths = ['C:\\Users\\alice\\Desktop\\notes.txt']
+
+    expect(resolveLocalDroppedPathsForAgent(paths, 'C:\\Users\\alice\\repo')).toBe(paths)
+  })
+})

--- a/src/main/ipc/dropped-path-resolution.ts
+++ b/src/main/ipc/dropped-path-resolution.ts
@@ -1,0 +1,7 @@
+import { parseWslPath, toLinuxPath } from '../wsl'
+
+export function resolveLocalDroppedPathsForAgent(paths: string[], worktreePath: string): string[] {
+  // Why: a local WSL PTY runs inside Linux, so Windows drop paths must be
+  // rewritten to paths the shell and agent can read.
+  return parseWslPath(worktreePath) ? paths.map((droppedPath) => toLinuxPath(droppedPath)) : paths
+}

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -19,6 +19,7 @@ import { pipeline } from 'stream/promises'
 import type { Store } from '../persistence'
 import { authorizeExternalPath, resolveAuthorizedPath, isENOENT } from './filesystem-auth'
 import { requireSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import { resolveLocalDroppedPathsForAgent } from './dropped-path-resolution'
 import { importExternalPathsSsh } from './filesystem-import-ssh'
 import { assertNoClobberRenameDestinationAvailable } from '../../shared/filesystem-rename-collision'
 
@@ -209,7 +210,11 @@ export function registerFilesystemMutationHandlers(store: Store): void {
       // Why: `== null` (not `!args.connectionId`) so an empty string is
       // treated as a renderer error, not silently routed to the local branch.
       if (args.connectionId == null) {
-        return { resolvedPaths: args.paths, skipped: [], failed: [] }
+        return {
+          resolvedPaths: resolveLocalDroppedPathsForAgent(args.paths, args.worktreePath),
+          skipped: [],
+          failed: []
+        }
       }
       const worktreePath = args.worktreePath.replace(/\/+$/, '')
       const destDir = `${worktreePath}/.orca/drops`


### PR DESCRIPTION
## Summary
- translate local drag/drop paths into Linux paths when the target worktree is a local WSL UNC path
- keep non-WSL local worktrees on the existing reference-in-place path behavior
- add focused regression coverage for Windows drive paths and WSL UNC paths

## Reproduction
Before the fix, s:resolveDroppedPathsForAgent returned dropped paths unchanged for local WSL worktrees, so a drop like C:\\Users\\alice\\Desktop\\notes.txt was injected into a WSL shell that cannot read it. The new regression test showed the unchanged Windows paths before the fix.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/dropped-path-resolution.test.ts src/main/ipc/filesystem-mutations.test.ts
- pnpm run lint -- src/main/ipc/dropped-path-resolution.ts src/main/ipc/dropped-path-resolution.test.ts src/main/ipc/filesystem-mutations.ts src/main/ipc/filesystem-mutations.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low
Focused local WSL dropped-path translation with regression coverage; non-WSL local worktree behavior is unchanged.