### PR TITLE
Clean up one-shot remote runtime listeners

### DIFF
--- a/src/shared/remote-runtime-client.test.ts
+++ b/src/shared/remote-runtime-client.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'net'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { WebSocketServer, type WebSocket } from 'ws'
+import WebSocketClient, { WebSocketServer, type WebSocket } from 'ws'
 import { encodePairingOffer, parsePairingCode, type PairingOffer } from './pairing'
 import {
   decrypt,
@@ -74,6 +74,25 @@ describe('sendRemoteRuntimeRequest', () => {
       ok: true,
       result: { satisfied: true }
     })
+  })
+
+  it('detaches one-shot socket listeners after a successful response', async () => {
+    const offSpy = vi.spyOn(WebSocketClient.prototype, 'off')
+    try {
+      const server = await createOneShotServer()
+
+      await sendRemoteRuntimeRequest<{ satisfied: boolean }>(
+        server.pairing,
+        'terminal.wait',
+        { terminal: 't1', for: 'tui-idle', timeoutMs: 550 },
+        300
+      )
+
+      const removedEvents = offSpy.mock.calls.map(([event]) => event)
+      expect(removedEvents).toEqual(expect.arrayContaining(['open', 'error', 'close', 'message']))
+    } finally {
+      offSpy.mockRestore()
+    }
   })
 })
 

--- a/src/shared/remote-runtime-client.ts
+++ b/src/shared/remote-runtime-client.ts
@@ -33,6 +33,8 @@ export class RemoteRuntimeClientError extends Error {
   }
 }
 
+function ignoreSettledRemoteRuntimeSocketError(): void {}
+
 export type RemoteRuntimeSubscription = {
   requestId: string
   close: () => void
@@ -61,6 +63,22 @@ export async function sendRemoteRuntimeRequest<TResult>(
     let settled = false
     let ws: WebSocket | null = null
 
+    const cleanupSocketListeners = (): void => {
+      const socket = ws
+      if (!socket) {
+        return
+      }
+      socket.off('open', onOpen)
+      socket.off('error', onError)
+      socket.off('close', onClose)
+      socket.off('message', onMessage)
+      // Why: the settled one-shot no longer needs Orca callbacks, but a ws
+      // can still report a late transport error after close is requested.
+      if (socket.readyState !== WebSocket.CLOSED) {
+        socket.on('error', ignoreSettledRemoteRuntimeSocketError)
+      }
+    }
+
     const timeout = setTimeout(() => {
       finish({
         ok: false,
@@ -80,6 +98,7 @@ export async function sendRemoteRuntimeRequest<TResult>(
       settled = true
       clearTimeout(timeout)
       try {
+        cleanupSocketListeners()
         ws?.close()
       } catch {
         // ignore best-effort close
@@ -105,16 +124,16 @@ export async function sendRemoteRuntimeRequest<TResult>(
       return
     }
 
-    ws.once('open', () => {
+    function onOpen(): void {
       ws?.send(
         JSON.stringify({
           type: 'e2ee_hello',
           publicKeyB64: publicKeyToBase64(keyPair.publicKey)
         })
       )
-    })
+    }
 
-    ws.once('error', () => {
+    function onError(): void {
       finish({
         ok: false,
         error: new RemoteRuntimeClientError(
@@ -122,9 +141,9 @@ export async function sendRemoteRuntimeRequest<TResult>(
           'Could not connect to the remote Orca runtime.'
         )
       })
-    })
+    }
 
-    ws.on('close', () => {
+    function onClose(): void {
       if (!settled) {
         finish({
           ok: false,
@@ -134,9 +153,9 @@ export async function sendRemoteRuntimeRequest<TResult>(
           )
         })
       }
-    })
+    }
 
-    ws.on('message', (data, isBinary) => {
+    function onMessage(data: WebSocket.RawData, isBinary: boolean): void {
       if (settled) {
         return
       }
@@ -175,7 +194,12 @@ export async function sendRemoteRuntimeRequest<TResult>(
       }
 
       handleRpcFrame(plaintext)
-    })
+    }
+
+    ws.once('open', onOpen)
+    ws.once('error', onError)
+    ws.on('close', onClose)
+    ws.on('message', onMessage)
 
     function handleReadyFrame(frame: string): void {
       let ready: unknown


### PR DESCRIPTION
## Summary
- detach one-shot remote-runtime WebSocket open/error/close/message handlers when the request settles
- keep a neutral late-error sink after cleanup so close-time transport errors do not become unhandled
- add a live WebSocket regression asserting one-shot listener detachment after a successful response

## Risk
Risk: low

This is limited to the one-shot remote runtime request teardown path. Handshake, encryption, keepalive timeout refresh, response validation, and subscription behavior are unchanged.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-client.test.ts`
- `pnpm exec oxlint src/shared/remote-runtime-client.ts src/shared/remote-runtime-client.test.ts`
- `pnpm exec oxfmt --check src/shared/remote-runtime-client.ts src/shared/remote-runtime-client.test.ts`
- `pnpm typecheck:node`
- `git diff --check origin/main...HEAD`