### PR TITLE
fix: tighten GitHub submit shortcut handling

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -66,6 +66,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import { detectLanguage } from '@/lib/language-detect'
+import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { cn } from '@/lib/utils'
 import { DiffSectionItem } from '@/components/editor/DiffSectionItem'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -2749,7 +2750,7 @@ function ConversationTab({
                     setBodyEditing(false)
                     return
                   }
-                  if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                  if (isScreenSubmitShortcut(event)) {
                     event.preventDefault()
                     void handleSaveBody()
                   }
@@ -3173,7 +3174,7 @@ function CommentReplyForm({
             onCancel()
             return
           }
-          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          if (isScreenSubmitShortcut(e)) {
             e.preventDefault()
             void submit()
           }
@@ -5100,7 +5101,7 @@ function GHCommentComposer({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      if (isScreenSubmitShortcut(e)) {
         e.preventDefault()
         handleSubmit()
       }

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -68,6 +68,7 @@ import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
 import { detectLanguage } from '@/lib/language-detect'
 import { cn } from '@/lib/utils'
 import { setWithLRU } from '@/lib/scroll-cache'
+import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import { DiffSectionItem } from '@/components/editor/DiffSectionItem'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import type { DecoratedDiffComment } from '@/components/diff-comments/useDiffCommentDecorator'
@@ -2878,7 +2879,7 @@ function ConversationTab({
                     setBodyEditing(false)
                     return
                   }
-                  if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                  if (isScreenSubmitShortcut(event)) {
                     event.preventDefault()
                     void handleSaveBody()
                   }
@@ -3302,7 +3303,7 @@ function CommentReplyForm({
             onCancel()
             return
           }
-          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          if (isScreenSubmitShortcut(e)) {
             e.preventDefault()
             void submit()
           }
@@ -4995,7 +4996,7 @@ function GHCommentComposer({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      if (isScreenSubmitShortcut(e)) {
         e.preventDefault()
         handleSubmit()
       }

--- a/src/renderer/src/lib/screen-submit-shortcut.test.ts
+++ b/src/renderer/src/lib/screen-submit-shortcut.test.ts
@@ -40,6 +40,12 @@ describe('screen submit shortcut', () => {
     expect(isScreenSubmitShortcut({ key: 'Escape', ctrlKey: true })).toBe(false)
   })
 
+  it('ignores Windows Ctrl+Alt+Enter chords', () => {
+    setUserAgent('Windows NT')
+
+    expect(isScreenSubmitShortcut({ key: 'Enter', ctrlKey: true, altKey: true })).toBe(false)
+  })
+
   it('ignores composing Enter events', () => {
     setUserAgent('Linux')
 


### PR DESCRIPTION
## Summary
- Replace GitHub textarea Cmd/Ctrl+Enter checks with the shared `isScreenSubmitShortcut` helper.
- Add a Windows Ctrl+Alt+Enter regression assertion for submit shortcut handling.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/screen-submit-shortcut.test.ts`
- `pnpm exec oxlint src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/lib/screen-submit-shortcut.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx src/renderer/src/lib/screen-submit-shortcut.test.ts`
- `pnpm run typecheck:web`