### PR TITLE
fix: use platform-aware browser link shortcut copy

### DIFF
--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -16,13 +16,17 @@ import {
 } from '../../../../shared/browser-url'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
-import { BROWSER_PANE_SEARCH_ENTRIES as BROWSER_CORE_SEARCH_ENTRIES } from './browser-search'
+import {
+  BROWSER_PANE_SEARCH_ENTRIES as BROWSER_CORE_SEARCH_ENTRIES,
+  getBrowserLinkRoutingDescription
+} from './browser-search'
 import { BROWSER_USE_PANE_SEARCH_ENTRIES } from './browser-use-search'
 import { BROWSER_PANE_SEARCH_ENTRIES } from './browser-pane-search'
 import { BrowserProfileRow } from './BrowserProfileRow'
 import { BrowserUseSetup } from './BrowserUsePane'
 import { KagiSessionLinkForm } from './KagiSessionLinkForm'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { isMacUserAgent } from '@/components/terminal-pane/pane-helpers'
 export { BROWSER_PANE_SEARCH_ENTRIES }
 
 type BrowserPaneProps = {
@@ -80,6 +84,8 @@ export function BrowserPane({
   const showLinkRouting = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[2]])
   const showCookies = matchesSettingsSearch(searchQuery, [BROWSER_CORE_SEARCH_ENTRIES[3]])
   const showBrowserUse = matchesSettingsSearch(searchQuery, BROWSER_USE_PANE_SEARCH_ENTRIES)
+  const isMac = isMacUserAgent()
+  const linkRoutingDescription = getBrowserLinkRoutingDescription({ isMac })
 
   const requestSessionCookieScrollFrame = (callback: FrameRequestCallback): void => {
     let completed = false
@@ -226,7 +232,7 @@ export function BrowserPane({
       {showLinkRouting ? (
         <SearchableSetting
           title="Link Routing"
-          description="Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. Shift+Cmd/Ctrl+click always uses your system browser."
+          description={linkRoutingDescription}
           keywords={[
             'browser',
             'preview',
@@ -234,6 +240,7 @@ export function BrowserPane({
             'localhost',
             'webview',
             'markdown',
+            isMac ? 'cmd' : 'ctrl',
             'file',
             'editor'
           ]}
@@ -241,10 +248,7 @@ export function BrowserPane({
         >
           <div className="space-y-0.5">
             <Label>Link Routing</Label>
-            <p className="text-xs text-muted-foreground">
-              Open http(s) links in Orca&apos;s built-in browser — from the terminal, markdown, and
-              the editor. Shift+Cmd/Ctrl+click always uses your system browser.
-            </p>
+            <p className="text-xs text-muted-foreground">{linkRoutingDescription}</p>
           </div>
           <button
             role="switch"

--- a/src/renderer/src/components/settings/browser-search.test.ts
+++ b/src/renderer/src/components/settings/browser-search.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getBrowserLinkRoutingDescription,
+  getBrowserLinkRoutingShortcutLabel,
+  getBrowserPaneSearchEntries
+} from './browser-search'
+
+describe('browser settings search copy', () => {
+  it('uses macOS shortcut symbols for Link Routing copy and search metadata', () => {
+    expect(getBrowserLinkRoutingShortcutLabel({ isMac: true })).toBe('⇧⌘-click')
+
+    const description = getBrowserLinkRoutingDescription({ isMac: true })
+    expect(description).toContain('⇧⌘-click')
+    expect(description).not.toContain('Cmd/Ctrl')
+
+    const linkRoutingEntry = getBrowserPaneSearchEntries({ isMac: true }).find(
+      (entry) => entry.title === 'Link Routing'
+    )
+    expect(linkRoutingEntry?.description).toBe(description)
+    expect(linkRoutingEntry?.keywords).toContain('cmd')
+    expect(linkRoutingEntry?.keywords).not.toContain('ctrl')
+  })
+
+  it('uses Ctrl shortcut text for Link Routing copy and search metadata off macOS', () => {
+    expect(getBrowserLinkRoutingShortcutLabel({ isMac: false })).toBe('Shift+Ctrl+click')
+
+    const description = getBrowserLinkRoutingDescription({ isMac: false })
+    expect(description).toContain('Shift+Ctrl+click')
+    expect(description).not.toContain('Cmd/Ctrl')
+
+    const linkRoutingEntry = getBrowserPaneSearchEntries({ isMac: false }).find(
+      (entry) => entry.title === 'Link Routing'
+    )
+    expect(linkRoutingEntry?.description).toBe(description)
+    expect(linkRoutingEntry?.keywords).toContain('ctrl')
+    expect(linkRoutingEntry?.keywords).not.toContain('cmd')
+  })
+})

--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -1,62 +1,84 @@
 import type { SettingsSearchEntry } from './settings-search'
 
-export const BROWSER_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
-  {
-    title: 'Default Home Page',
-    description: 'URL opened when creating a new browser tab. Leave empty to open a blank tab.',
-    keywords: ['browser', 'home', 'homepage', 'default', 'url', 'new tab', 'blank', 'landing']
-  },
-  {
-    title: 'Default Search Engine',
-    description: 'Search engine used when typing non-URL text in the address bar.',
-    keywords: [
-      'browser',
-      'search',
-      'engine',
-      'google',
-      'duckduckgo',
-      'bing',
-      'kagi',
-      'session',
-      'private',
-      'token',
-      'omnibox',
-      'query'
-    ]
-  },
-  {
-    title: 'Link Routing',
-    description:
-      "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. Shift+Cmd/Ctrl+click always uses your system browser.",
-    keywords: [
-      'browser',
-      'preview',
-      'links',
-      'localhost',
-      'webview',
-      'shift',
-      'cmd',
-      'ctrl',
-      'markdown',
-      'file',
-      'editor'
-    ]
-  },
-  {
-    title: 'Session & Cookies',
-    description:
-      'Import cookies from Chrome, Edge, or other browsers to use existing logins inside Orca.',
-    keywords: [
-      'browser',
-      'cookies',
-      'session',
-      'import',
-      'auth',
-      'login',
-      'chrome',
-      'edge',
-      'arc',
-      'profile'
-    ]
+type BrowserShortcutPlatform = {
+  isMac: boolean
+}
+
+function getDefaultBrowserShortcutPlatform(): BrowserShortcutPlatform {
+  return {
+    isMac: typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
   }
-]
+}
+
+export function getBrowserLinkRoutingShortcutLabel(platform: BrowserShortcutPlatform): string {
+  return platform.isMac ? '⇧⌘-click' : 'Shift+Ctrl+click'
+}
+
+export function getBrowserLinkRoutingDescription(platform: BrowserShortcutPlatform): string {
+  return `Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. ${getBrowserLinkRoutingShortcutLabel(platform)} always uses your system browser.`
+}
+
+export function getBrowserPaneSearchEntries(
+  platform: BrowserShortcutPlatform = getDefaultBrowserShortcutPlatform()
+): SettingsSearchEntry[] {
+  return [
+    {
+      title: 'Default Home Page',
+      description: 'URL opened when creating a new browser tab. Leave empty to open a blank tab.',
+      keywords: ['browser', 'home', 'homepage', 'default', 'url', 'new tab', 'blank', 'landing']
+    },
+    {
+      title: 'Default Search Engine',
+      description: 'Search engine used when typing non-URL text in the address bar.',
+      keywords: [
+        'browser',
+        'search',
+        'engine',
+        'google',
+        'duckduckgo',
+        'bing',
+        'kagi',
+        'session',
+        'private',
+        'token',
+        'omnibox',
+        'query'
+      ]
+    },
+    {
+      title: 'Link Routing',
+      description: getBrowserLinkRoutingDescription(platform),
+      keywords: [
+        'browser',
+        'preview',
+        'links',
+        'localhost',
+        'webview',
+        'shift',
+        platform.isMac ? 'cmd' : 'ctrl',
+        'markdown',
+        'file',
+        'editor'
+      ]
+    },
+    {
+      title: 'Session & Cookies',
+      description:
+        'Import cookies from Chrome, Edge, or other browsers to use existing logins inside Orca.',
+      keywords: [
+        'browser',
+        'cookies',
+        'session',
+        'import',
+        'auth',
+        'login',
+        'chrome',
+        'edge',
+        'arc',
+        'profile'
+      ]
+    }
+  ]
+}
+
+export const BROWSER_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = getBrowserPaneSearchEntries()


### PR DESCRIPTION
## Summary
- replace hardcoded Shift+Cmd/Ctrl+click browser link-routing copy with platform-aware shortcut text
- keep settings search metadata aligned with the platform-specific copy
- add focused tests for Mac and Windows/Linux shortcut labels/search entries

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/browser-search.test.ts
- pnpm exec oxlint src/renderer/src/components/settings/BrowserPane.tsx src/renderer/src/components/settings/browser-search.ts src/renderer/src/components/settings/browser-search.test.ts
- pnpm run typecheck:web

Risk: low
Settings copy/search metadata only; platform-specific shortcut labels are covered by focused renderer tests.