### PR TITLE
Clean up SSH import write stream listeners

### DIFF
--- a/src/main/ipc/filesystem-import-ssh.test.ts
+++ b/src/main/ipc/filesystem-import-ssh.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { constants } from 'fs'
+import { EventEmitter } from 'events'
 import { Readable, Writable } from 'stream'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -71,10 +72,30 @@ const store = {
 }
 const enoent = (): Error => Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
 
+type MockSftpWriteStream = EventEmitter & {
+  destroy: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+}
+
+function createMockSftpWriteStream(): MockSftpWriteStream {
+  const stream = new EventEmitter() as MockSftpWriteStream
+  stream.destroy = vi.fn()
+  stream.end = vi.fn(() => stream.emit('close'))
+  return stream
+}
+
 describe('fs:importExternalPaths — SSH routing & connection', () => {
   const destDir = '/home/user/project/src'
   const connId = 'ssh-conn-1'
-  const mockSftp = { end: vi.fn() }
+  const sftpWriteStreams: MockSftpWriteStream[] = []
+  const mockSftp = {
+    end: vi.fn(),
+    createWriteStream: vi.fn(() => {
+      const stream = createMockSftpWriteStream()
+      sftpWriteStreams.push(stream)
+      return stream
+    })
+  }
   const makeConn = (status = 'connected') => ({
     getState: () => ({ status }),
     sftp: vi.fn().mockResolvedValue(mockSftp)
@@ -111,6 +132,8 @@ describe('fs:importExternalPaths — SSH routing & connection', () => {
       getConnMgrMock
     ].forEach((m) => m.mockReset())
     mockSftp.end.mockReset()
+    mockSftp.createWriteStream.mockClear()
+    sftpWriteStreams.length = 0
     handleMock.mockImplementation((ch: string, h: never) => {
       handlers.set(ch, h)
     })
@@ -234,5 +257,22 @@ describe('fs:importExternalPaths — SSH routing & connection', () => {
     })
     expect(results[0]).toMatchObject({ status: 'failed', reason: 'disk full' })
     expect(mockSftp.end).toHaveBeenCalledOnce()
+  })
+
+  it('removes staging marker write listeners after remote stream close', async () => {
+    getConnMgrMock.mockReturnValue({ getConnection: () => makeConn() })
+    mockFile('/tmp/dropped/file.txt')
+
+    await invoke({
+      sourcePaths: ['/tmp/dropped/file.txt'],
+      destDir: '/home/user/project/.orca/drops',
+      connectionId: connId,
+      ensureDir: true
+    })
+
+    expect(mockSftp.createWriteStream).toHaveBeenCalledWith('/home/user/project/.orca/.gitignore')
+    expect(sftpWriteStreams[0]!.listenerCount('close')).toBe(0)
+    expect(sftpWriteStreams[0]!.listenerCount('error')).toBe(0)
+    expect(sftpWriteStreams[0]!.destroy).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/ipc/filesystem-import-ssh.ts
+++ b/src/main/ipc/filesystem-import-ssh.ts
@@ -203,16 +203,24 @@ function writeSftpFile(sftp: SFTPWrapper, remotePath: string, contents: string):
   return new Promise((resolve, reject) => {
     let settled = false
     const writeStream = sftp.createWriteStream(remotePath)
+    const cleanup = (): void => {
+      writeStream.off('close', onClose)
+      writeStream.off('error', onError)
+    }
     const settle = (fn: typeof resolve | typeof reject, val?: unknown): void => {
       if (settled) {
         return
       }
       settled = true
+      cleanup()
       writeStream.destroy()
       fn(val as never)
     }
-    writeStream.on('close', () => settle(resolve))
-    writeStream.on('error', (err) => settle(reject, err))
+    const onClose = (): void => settle(resolve)
+    const onError = (err: Error): void => settle(reject, err)
+
+    writeStream.on('close', onClose)
+    writeStream.on('error', onError)
     writeStream.end(contents)
   })
 }


### PR DESCRIPTION
## Summary
- detach the SFTP marker write stream `close`/`error` listeners when the write settles
- keep the existing best-effort stream destroy behavior
- add a regression through the SSH import staging path that verifies listener cleanup after the remote stream closes

## Risk
Risk: low

This only changes teardown for the temporary `.orca/.gitignore` SFTP write stream used by SSH drag/drop staging. Upload paths, staging path selection, and SFTP session ownership are unchanged.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/filesystem-import-ssh.test.ts`
- `pnpm exec oxlint src/main/ipc/filesystem-import-ssh.ts src/main/ipc/filesystem-import-ssh.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem-import-ssh.ts src/main/ipc/filesystem-import-ssh.test.ts`
- `pnpm typecheck:node`
- `git diff --check origin/main...HEAD`

Full Docker SSH rig not run; this is limited to an isolated SFTP write stream cleanup covered by the IPC regression.