### PR TITLE
Fix hidden Codex composer background

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -71,6 +71,9 @@ vi.mock('electron', () => ({
     isPackaged: true,
     getPath: getPathMock
   },
+  nativeTheme: {
+    shouldUseDarkColors: true
+  },
   ipcMain: {
     handle: handleMock,
     on: onMock,
@@ -2893,6 +2896,65 @@ describe('registerPtyHandlers', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('answers mode 2031 subscribes while renderer PTY output is paused', async () => {
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    registerPtyHandlers(mainWindow as never)
+    const spawnResult = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp'
+    })) as { id: string }
+    const pauseCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:pauseOutput')
+    if (!pauseCall) {
+      throw new Error('missing pty:pauseOutput listener')
+    }
+    const pauseRendererOutput = pauseCall[1] as (
+      event: unknown,
+      args: { id: string; paused: boolean }
+    ) => void
+    mainWindow.webContents.send.mockClear()
+
+    pauseRendererOutput(null, { id: spawnResult.id, paused: true })
+    mockProc.emitData('\x1b[?2031h')
+
+    expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b[?997;1n')
+    expect(mainWindow.webContents.send).not.toHaveBeenCalledWith(
+      'pty:data',
+      expect.objectContaining({ id: spawnResult.id })
+    )
+  })
+
+  it('answers split paused mode 2031 subscribes using current app color scheme', async () => {
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    registerPtyHandlers(mainWindow as never, undefined, undefined, (() => ({
+      theme: 'light'
+    })) as never)
+    const spawnResult = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp'
+    })) as { id: string }
+    const pauseCall = onMock.mock.calls.find((call: unknown[]) => call[0] === 'pty:pauseOutput')
+    if (!pauseCall) {
+      throw new Error('missing pty:pauseOutput listener')
+    }
+    const pauseRendererOutput = pauseCall[1] as (
+      event: unknown,
+      args: { id: string; paused: boolean }
+    ) => void
+
+    pauseRendererOutput(null, { id: spawnResult.id, paused: true })
+    mockProc.emitData('\x1b[?20')
+    expect(mockProc.proc.write).not.toHaveBeenCalled()
+
+    mockProc.emitData('31h')
+    expect(mockProc.proc.write).toHaveBeenCalledWith('\x1b[?997;2n')
   })
 
   it('keeps 250 paused background PTYs off the renderer input path', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5,7 +5,7 @@ boundary. Splitting it by line count would scatter tightly coupled terminal
 process behavior across files without a cleaner ownership seam. */
 import { join, delimiter } from 'path'
 import { randomUUID } from 'crypto'
-import { type BrowserWindow, ipcMain, app } from 'electron'
+import { type BrowserWindow, ipcMain, app, nativeTheme } from 'electron'
 export { getBashShellReadyRcfileContent } from '../providers/local-pty-shell-ready'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { Store } from '../persistence'
@@ -44,6 +44,11 @@ import {
 } from '../../shared/telemetry-events'
 import { isRemoteAgentHooksEnabled } from '../../shared/agent-hook-relay'
 import { createTerminalSessionStateSaveFailureMessage } from '../../shared/terminal-session-state-save-failure'
+import {
+  mode2031SequenceFor,
+  resolveTerminalColorSchemeMode,
+  scanMode2031Sequences
+} from '../../shared/terminal-color-scheme-protocol'
 import { readShellStartupEnvVar } from '../pty/shell-startup-env'
 import {
   isTerminalLeafId,
@@ -81,6 +86,7 @@ const lastInputAtByPty = new Map<string, number>()
 // Why: hidden renderer panes restore from main-owned snapshots, so ordinary
 // PTY bytes do not need to wake the renderer while a pane is hidden.
 const rendererPausedOutputPtys = new Set<string>()
+const rendererPausedMode2031ScanTailByPty = new Map<string, string>()
 // Why: the agent-hooks server caches per-paneKey state (last prompt, last
 // tool) that otherwise grows unbounded as panes come and go. Track the
 // spawn-time paneKey so clearProviderPtyState can clear that cache on PTY
@@ -732,6 +738,7 @@ export function clearProviderPtyState(id: string): void {
   ptySizes.delete(id)
   lastInputAtByPty.delete(id)
   rendererPausedOutputPtys.delete(id)
+  rendererPausedMode2031ScanTailByPty.delete(id)
   const paneKey = ptyPaneKey.get(id)
   const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY does not keep
@@ -1098,6 +1105,32 @@ export function registerPtyHandlers(
       return
     }
     rendererPausedOutputPtys.delete(id)
+    rendererPausedMode2031ScanTailByPty.delete(id)
+  }
+
+  function respondToPausedRendererMode2031Subscribe(id: string, data: string): void {
+    const scan = scanMode2031Sequences(rendererPausedMode2031ScanTailByPty.get(id) ?? '', data)
+    if (scan.tail) {
+      rendererPausedMode2031ScanTailByPty.set(id, scan.tail)
+    } else {
+      rendererPausedMode2031ScanTailByPty.delete(id)
+    }
+    if (!scan.subscribe) {
+      return
+    }
+    const provider = tryGetProviderForPty(id)
+    if (!provider) {
+      return
+    }
+    const mode = resolveTerminalColorSchemeMode(getSettings?.(), nativeTheme.shouldUseDarkColors)
+    try {
+      // Why: paused renderer panes still need protocol replies that affect how
+      // TUIs draw into the main-owned snapshot. Without this, Codex starts in a
+      // fallback prompt style and the restored composer loses its background.
+      provider.write(id, mode2031SequenceFor(mode))
+    } catch {
+      // Best effort; renderer restore will continue from whatever the TUI emits.
+    }
   }
 
   // Why: extracted so the "Restart daemon" flow can rebind against the fresh
@@ -1133,6 +1166,7 @@ export function registerPtyHandlers(
         return
       }
       if (rendererPausedOutputPtys.has(payload.id)) {
+        respondToPausedRendererMode2031Subscribe(payload.id, payload.data)
         pendingData.delete(payload.id)
         clearFlushTimerIfIdle()
         return

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -49,6 +49,7 @@ type StoreState = {
   sshConnectionStates: Map<string, { status: string }>
   cacheTimerByKey: Record<string, number | null>
   settings: {
+    theme?: 'system' | 'dark' | 'light'
     promptCacheTimerEnabled?: boolean
     activeRuntimeEnvironmentId?: string | null
     experimentalTerminalAttention?: boolean
@@ -2741,6 +2742,175 @@ describe('connectPanePty', () => {
       'hidden while paused\r\n',
       expect.any(Function)
     )
+
+    binding.dispose()
+  })
+
+  it('keeps hidden Codex telemetry startup output parsing briefly before pausing renderer output', async () => {
+    const originalSetTimeout = globalThis.setTimeout
+    const originalClearTimeout = globalThis.clearTimeout
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(0)
+    const scheduledTimers: { callback: () => void; delay: number }[] = []
+    globalThis.setTimeout = vi.fn((callback: () => void, delay?: number) => {
+      scheduledTimers.push({ callback, delay: typeof delay === 'number' ? delay : 0 })
+      return scheduledTimers.length as unknown as ReturnType<typeof setTimeout>
+    }) as unknown as typeof setTimeout
+    globalThis.clearTimeout = vi.fn() as unknown as typeof clearTimeout
+    let binding: { dispose: () => void } | null = null
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const pauseOutput = window.api.pty.pauseOutput as unknown as ReturnType<typeof vi.fn>
+
+      const pane = createPane(1)
+      const manager = createManager(1)
+      binding = connectPanePty(
+        pane as never,
+        manager as never,
+        createDeps({
+          isVisibleRef: { current: false },
+          startup: {
+            command: 'wrapped-agent',
+            telemetry: {
+              agent_kind: 'codex',
+              launch_source: 'tab_bar_quick_launch',
+              request_kind: 'new'
+            }
+          }
+        }) as never
+      )
+      await flushAsyncTicks(6)
+
+      expect(capturedDataCallback.current).not.toBeNull()
+      expect(pauseOutput).not.toHaveBeenCalledWith('pty-id', true)
+
+      capturedDataCallback.current?.('\x1b]11;?\x1b\\startup frame\r\n')
+
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        '\x1b]11;?\x1b\\startup frame\r\n',
+        expect.any(Function)
+      )
+
+      dateNowSpy.mockReturnValue(10_001)
+      scheduledTimers.find((timer) => timer.delay === 10_000)?.callback()
+      await flushAsyncTicks()
+
+      expect(pauseOutput).toHaveBeenCalledWith('pty-id', true)
+    } finally {
+      binding?.dispose()
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.clearTimeout = originalClearTimeout
+      dateNowSpy.mockRestore()
+    }
+  })
+
+  it('keeps hidden bare Codex startup commands parsing briefly', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const pauseOutput = window.api.pty.pauseOutput as unknown as ReturnType<typeof vi.fn>
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const binding = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({
+        isVisibleRef: { current: false },
+        startup: { command: 'codex' }
+      }) as never
+    )
+    await flushAsyncTicks(6)
+
+    expect(capturedDataCallback.current).not.toBeNull()
+    expect(pauseOutput).not.toHaveBeenCalledWith('pty-id', true)
+
+    capturedDataCallback.current?.('\x1b]11;?\x1b\\startup frame\r\n')
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b]11;?\x1b\\startup frame\r\n',
+      expect.any(Function)
+    )
+
+    binding.dispose()
+  })
+
+  it('pauses arbitrary hidden startup commands immediately', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const pauseOutput = window.api.pty.pauseOutput as unknown as ReturnType<typeof vi.fn>
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const binding = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({
+        isVisibleRef: { current: false },
+        startup: { command: 'printf noisy startup' }
+      }) as never
+    )
+    await flushAsyncTicks(6)
+
+    expect(capturedDataCallback.current).not.toBeNull()
+    expect(pauseOutput).toHaveBeenCalledWith('pty-id', true)
+
+    capturedDataCallback.current?.('hidden startup output\r\n')
+
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      'hidden startup output\r\n',
+      expect.any(Function)
+    )
+
+    binding.dispose()
+  })
+
+  it('answers mode 2031 in hidden snapshot-backed chunks skipped from xterm parsing', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      settings: { ...mockStoreState.settings, theme: 'light' }
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const binding = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.('\x1b[?2031h')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b[?997;2n')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('\x1b[?2031h', expect.any(Function))
 
     binding.dispose()
   })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -23,6 +23,12 @@ import {
   POST_REPLAY_REATTACH_RESET,
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
+import { getSystemPrefersDark } from '@/lib/terminal-theme'
+import {
+  mode2031SequenceFor,
+  resolveTerminalColorSchemeMode,
+  scanMode2031Sequences
+} from '../../../../shared/terminal-color-scheme-protocol'
 import { warnTerminalLifecycleAnomaly } from './terminal-lifecycle-diagnostics'
 import { registerPtySerializer, registerPtyTitleSource } from './pty-buffer-serializer'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
@@ -72,10 +78,40 @@ const AGENT_TASK_COMPLETE_NOTIFICATION_DETAIL_MAX_AGE_MS = 10_000
 const COMMAND_CODE_OUTPUT_DONE_SETTLE_MS = 1500
 const HIDDEN_OUTPUT_RESTORE_SCROLLBACK_ROWS = 5000
 const HIDDEN_OUTPUT_RESTORE_PENDING_CHARS = 512 * 1024
+const HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS = 10_000
+const STARTUP_COMMAND_EXTENSION_RE = /\.(?:exe|cmd|bat|ps1)$/i
 // Why: this is only shown if renderer backlog overflowed and main-owned
 // terminal state is unavailable, so the user has an explicit loss signal.
 const HIDDEN_OUTPUT_RESTORE_UNAVAILABLE_WARNING =
   '\x18\x1b[0m\r\n[Orca skipped hidden terminal output because the backlog exceeded 2 MB and main recovery was unavailable.]\r\n'
+
+function firstStartupCommandToken(command: string): string {
+  const trimmed = command.trim()
+  const quote = trimmed[0]
+  if ((quote === '"' || quote === "'") && trimmed.length > 1) {
+    const end = trimmed.indexOf(quote, 1)
+    if (end > 1) {
+      return trimmed.slice(1, end)
+    }
+  }
+  return trimmed.split(/\s+/)[0] ?? ''
+}
+
+function isCodexStartupCommand(command: string): boolean {
+  const executable = firstStartupCommandToken(command)
+    .split(/[\\/]/)
+    .pop()
+    ?.toLowerCase()
+    .replace(STARTUP_COMMAND_EXTENSION_RE, '')
+  return executable === 'codex' || executable?.startsWith('codex-') === true
+}
+
+function shouldKeepHiddenStartupRendererQueriesLive(
+  startup: PtyConnectionDeps['startup']
+): boolean {
+  return startup?.telemetry?.agent_kind === 'codex' || isCodexStartupCommand(startup?.command ?? '')
+}
+
 let codexRestartNoticePresenceSource: Record<
   string,
   { previousAccountLabel: string; nextAccountLabel: string }
@@ -1164,6 +1200,7 @@ export function connectPanePty(
   }
   let rendererOutputPausedPtyId: string | null = null
   let syncRendererOutputVisibility = (): void => {}
+  let clearHiddenStartupRendererQueryTimer = (): void => {}
 
   // Defer PTY spawn/attach to next frame so FitAddon has time to calculate
   // the correct terminal dimensions from the laid-out container.
@@ -1345,6 +1382,11 @@ export function connectPanePty(
     // can reuse the pane object for a different session before visibility.
     let hiddenOutputRestorePtyId: string | null = null
     let hiddenOutputRestoreGeneration = 0
+    let hiddenMode2031ScanTail = ''
+    let hiddenStartupRendererQueryTimer: ReturnType<typeof setTimeout> | null = null
+    const hiddenStartupRendererQueryUntil = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
+      ? Date.now() + HIDDEN_STARTUP_RENDERER_QUERY_WINDOW_MS
+      : 0
 
     function canUseMainBufferSnapshot(ptyId: string | null): ptyId is string {
       return Boolean(ptyId) && !isRemoteRuntimePtyId(ptyId)
@@ -1359,6 +1401,46 @@ export function connectPanePty(
       rendererOutputPausedPtyId = paused ? ptyId : null
     }
 
+    clearHiddenStartupRendererQueryTimer = (): void => {
+      if (hiddenStartupRendererQueryTimer !== null) {
+        clearTimeout(hiddenStartupRendererQueryTimer)
+        hiddenStartupRendererQueryTimer = null
+      }
+    }
+
+    function isHiddenStartupRendererQueryWindowActive(): boolean {
+      return (
+        paneStartup !== null &&
+        Date.now() < hiddenStartupRendererQueryUntil &&
+        !shouldWritePtyOutputForeground(deps.isVisibleRef.current)
+      )
+    }
+
+    function scheduleHiddenStartupRendererQueryExpiry(): void {
+      if (hiddenStartupRendererQueryTimer !== null) {
+        return
+      }
+      const delay = Math.max(0, hiddenStartupRendererQueryUntil - Date.now())
+      hiddenStartupRendererQueryTimer = setTimeout(() => {
+        hiddenStartupRendererQueryTimer = null
+        syncRendererOutputVisibility()
+      }, delay)
+    }
+
+    function respondToSkippedMode2031Subscribe(data: string): void {
+      const scan = scanMode2031Sequences(hiddenMode2031ScanTail, data)
+      hiddenMode2031ScanTail = scan.tail
+      if (!scan.subscribe) {
+        return
+      }
+      const settings = useAppStore.getState().settings
+      const mode = resolveTerminalColorSchemeMode(settings, getSystemPrefersDark())
+      // Why: hidden snapshot-backed panes skip xterm.write for PTY bytes. Answer
+      // mode 2031 out-of-band so TUIs still render the snapshot with the same
+      // theme-dependent styling they would have used in a visible pane.
+      transport.sendInput(mode2031SequenceFor(mode))
+    }
+
     syncRendererOutputVisibility = (): void => {
       const ptyId = transport.getPtyId()
       if (rendererOutputPausedPtyId !== null && rendererOutputPausedPtyId !== ptyId) {
@@ -1369,6 +1451,17 @@ export function connectPanePty(
       }
       const shouldPause = !shouldWritePtyOutputForeground(deps.isVisibleRef.current)
       if (shouldPause) {
+        if (isHiddenStartupRendererQueryWindowActive()) {
+          // Why: startup TUIs often query OSC 10/11 and DEC color-scheme state
+          // before their first stable frame. Let xterm parse that short window
+          // so its theme-aware auto-replies reach the PTY.
+          scheduleHiddenStartupRendererQueryExpiry()
+          if (rendererOutputPausedPtyId === ptyId) {
+            setRendererOutputPaused(ptyId, false)
+          }
+          return
+        }
+        clearHiddenStartupRendererQueryTimer()
         if (rendererOutputPausedPtyId !== ptyId) {
           // Why: main owns the retained terminal buffer for snapshot-capable
           // PTYs, so hidden panes can stop receiving live bytes entirely.
@@ -1376,6 +1469,7 @@ export function connectPanePty(
         }
         return
       }
+      clearHiddenStartupRendererQueryTimer()
       if (rendererOutputPausedPtyId === ptyId) {
         setRendererOutputPaused(ptyId, false)
         markHiddenOutputRestoreNeeded()
@@ -1393,15 +1487,27 @@ export function connectPanePty(
     }
 
     function writePtyOutputToXterm(data: string, foreground: boolean): void {
-      if (!foreground && canUseMainBufferSnapshot(transport.getPtyId())) {
+      const parseHiddenStartupOutput =
+        !foreground &&
+        canUseMainBufferSnapshot(transport.getPtyId()) &&
+        isHiddenStartupRendererQueryWindowActive()
+      if (
+        !foreground &&
+        canUseMainBufferSnapshot(transport.getPtyId()) &&
+        !parseHiddenStartupOutput
+      ) {
+        respondToSkippedMode2031Subscribe(data)
         // Why: hidden panes do not need live xterm parsing. Main already
         // retains the PTY buffer, so defer display work until the pane is
         // visible and restore from that snapshot instead.
         markHiddenOutputRestoreNeeded()
         return
       }
+      if (hiddenMode2031ScanTail) {
+        respondToSkippedMode2031Subscribe(data)
+      }
       writeTerminalOutput(pane.terminal, data, {
-        foreground,
+        foreground: foreground || parseHiddenStartupOutput,
         beforeWrite: beforeTerminalOutputWrite,
         onBackgroundBacklogDropped: markHiddenOutputRestoreNeeded
       })
@@ -2404,6 +2510,7 @@ export function connectPanePty(
       unregisterBacklogRecovery = null
       unregisterDocumentVisibilityRecovery?.()
       unregisterDocumentVisibilityRecovery = null
+      clearHiddenStartupRendererQueryTimer()
       if (rendererOutputPausedPtyId !== null) {
         window.api.pty.pauseOutput(rendererOutputPausedPtyId, false)
         rendererOutputPausedPtyId = null

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -1,6 +1,7 @@
 import type { IDisposable, IParser, ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
+import { mode2031SequenceFor } from '../../../../shared/terminal-color-scheme-protocol'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import {
@@ -16,14 +17,7 @@ import type { PtyTransport } from './pty-transport'
 import type { EffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/detect-option-as-alt'
 import { HEX_COLOR_RE } from '../../../../shared/color-validation'
 
-// Contour/Kitty "color-scheme update" protocol (DEC mode 2031 + CSI 997):
-// the terminal pushes `CSI ?997;1n` for dark and `CSI ?997;2n` for light to
-// subscribed TUIs. This helper is the single source of truth so the push
-// site in applyTerminalAppearance and the subscribe-time seed in the
-// lifecycle hook cannot drift.
-export function mode2031SequenceFor(mode: 'dark' | 'light'): string {
-  return mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
-}
+export { mode2031SequenceFor }
 
 // Why Pick<IParser, ...> over a hand-rolled structural type: keeps the helper
 // tied to xterm's canonical signature so any upstream tightening (added

--- a/src/shared/terminal-color-scheme-protocol.test.ts
+++ b/src/shared/terminal-color-scheme-protocol.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  mode2031SequenceFor,
+  resolveTerminalColorSchemeMode,
+  scanMode2031Sequences
+} from './terminal-color-scheme-protocol'
+
+describe('terminal color scheme protocol', () => {
+  it('maps mode 2031 replies to CSI 997 status reports', () => {
+    expect(mode2031SequenceFor('dark')).toBe('\x1b[?997;1n')
+    expect(mode2031SequenceFor('light')).toBe('\x1b[?997;2n')
+  })
+
+  it('resolves system color scheme from app settings and system preference', () => {
+    expect(resolveTerminalColorSchemeMode({ theme: 'dark' }, false)).toBe('dark')
+    expect(resolveTerminalColorSchemeMode({ theme: 'light' }, true)).toBe('light')
+    expect(resolveTerminalColorSchemeMode({ theme: 'system' }, true)).toBe('dark')
+    expect(resolveTerminalColorSchemeMode({ theme: 'system' }, false)).toBe('light')
+  })
+
+  it('detects mode 2031 subscribes in compound and split private mode sequences', () => {
+    expect(scanMode2031Sequences('', '\x1b[?25;2031h')).toMatchObject({
+      subscribe: true,
+      tail: ''
+    })
+
+    const first = scanMode2031Sequences('', '\x1b[?20')
+    expect(first).toMatchObject({ subscribe: false, tail: '\x1b[?20' })
+
+    expect(scanMode2031Sequences(first.tail, '31h')).toMatchObject({
+      subscribe: true,
+      tail: ''
+    })
+  })
+})

--- a/src/shared/terminal-color-scheme-protocol.ts
+++ b/src/shared/terminal-color-scheme-protocol.ts
@@ -1,0 +1,88 @@
+import type { GlobalSettings } from './types'
+
+export type TerminalColorSchemeMode = 'dark' | 'light'
+
+const MODE_2031_SCAN_TAIL_LIMIT = 128
+
+// Contour/Kitty "color-scheme update" protocol (DEC mode 2031 + CSI 997):
+// terminals push `CSI ?997;1n` for dark and `CSI ?997;2n` for light to
+// subscribed TUIs.
+export function mode2031SequenceFor(mode: TerminalColorSchemeMode): string {
+  return mode === 'dark' ? '\x1b[?997;1n' : '\x1b[?997;2n'
+}
+
+export function resolveTerminalColorSchemeMode(
+  settings: Pick<GlobalSettings, 'theme'> | null | undefined,
+  systemPrefersDark: boolean
+): TerminalColorSchemeMode {
+  const theme = settings?.theme ?? 'system'
+  return theme === 'system' ? (systemPrefersDark ? 'dark' : 'light') : theme
+}
+
+export type Mode2031ScanResult = {
+  subscribe: boolean
+  unsubscribe: boolean
+  tail: string
+}
+
+const NO_MODE_2031_SEQUENCE: Mode2031ScanResult = {
+  subscribe: false,
+  unsubscribe: false,
+  tail: ''
+}
+
+export function scanMode2031Sequences(previousTail: string, data: string): Mode2031ScanResult {
+  if (!previousTail && !data.includes('\x1b') && !data.includes('\x9b')) {
+    return NO_MODE_2031_SEQUENCE
+  }
+  const input = `${previousTail}${data}`
+  const result: Mode2031ScanResult = {
+    subscribe: false,
+    unsubscribe: false,
+    tail: extractPrivateModeScanTail(input)
+  }
+  // oxlint-disable-next-line no-control-regex -- terminal escape sequences require control chars
+  const privateModeRe = /\x1b\[\?([0-9;]+)([hl])|\x9b\?([0-9;]+)([hl])/g
+  let match: RegExpExecArray | null
+  while ((match = privateModeRe.exec(input)) !== null) {
+    const params = match[1] ?? match[3]
+    if (!hasMode2031(params)) {
+      continue
+    }
+    if ((match[2] ?? match[4]) === 'h') {
+      result.subscribe = true
+    } else {
+      result.unsubscribe = true
+    }
+  }
+  return result
+}
+
+function hasMode2031(params: string): boolean {
+  return params.split(';').some((param) => Number(param) === 2031)
+}
+
+function extractPrivateModeScanTail(input: string): string {
+  const start = Math.max(input.lastIndexOf('\x1b'), input.lastIndexOf('\x9b'))
+  if (start === -1) {
+    return ''
+  }
+  const tail = input.slice(start)
+  if (tail.length > MODE_2031_SCAN_TAIL_LIMIT) {
+    return ''
+  }
+  if (tail === '\x1b' || tail === '\x1b[' || tail === '\x9b') {
+    return tail
+  }
+  if (tail.startsWith('\x1b[?')) {
+    return isIncompletePrivateModeParams(tail.slice(3)) ? tail : ''
+  }
+  if (tail.startsWith('\x9b?')) {
+    return isIncompletePrivateModeParams(tail.slice(2)) ? tail : ''
+  }
+  return ''
+}
+
+function isIncompletePrivateModeParams(params: string): boolean {
+  return /^[0-9;]*$/.test(params)
+}


### PR DESCRIPTION
## Summary
- keep a short hidden-startup parsing window for Codex so xterm can answer startup color queries before hidden-output pausing resumes
- answer mode 2031 color-scheme subscribes while renderer PTY output is paused
- share terminal color-scheme protocol helpers and add regression coverage for Codex and non-Codex hidden startup paths

## Verification
- `vitest run --config config/vitest.config.ts src/shared/terminal-color-scheme-protocol.test.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `oxlint` on the 7 touched files
- `pnpm run typecheck`
- `git diff --check`
- Electron hidden Codex startup repro: retained snapshot contains `48;2;65;69;76` composer background and activated TUI screenshot shows the input background

## Review
- Ran auto-review-fix before PR creation; it found and fixed the bare `codex` startup coverage gap. Follow-up review found no remaining actionable issues.

Risk: medium
This touches PTY hidden-output handling and renderer terminal startup behavior, so it has user-visible terminal risk even though the scope is covered by focused regression tests and Electron repro evidence.