### PR TITLE
Clean up SSH proxy command listeners

### DIFF
--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -1,7 +1,16 @@
 /* eslint-disable max-lines -- Why: SSH connection utility tests share mocked filesystem and environment setup across auth, proxy, and retry helpers. */
+import { EventEmitter } from 'events'
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
 import { join } from 'path'
 import { BaseAgent, utils, type ParsedKey } from 'ssh2'
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock
+}))
 
 vi.mock('os', () => ({
   homedir: () => '/home/testuser'
@@ -33,10 +42,27 @@ import {
   CONNECT_TIMEOUT_MS,
   INITIAL_RETRY_ATTEMPTS,
   INITIAL_RETRY_DELAY_MS,
-  RECONNECT_BACKOFF_MS
+  RECONNECT_BACKOFF_MS,
+  spawnProxyCommand
 } from './ssh-connection-utils'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { SshResolvedConfig } from './ssh-config-parser'
+
+type MockProxyProcess = EventEmitter & {
+  stdin: EventEmitter & { write: ReturnType<typeof vi.fn> }
+  stdout: EventEmitter
+  stderr: EventEmitter
+}
+
+function createMockProxyProcess(): MockProxyProcess {
+  const proc = new EventEmitter() as MockProxyProcess
+  proc.stdin = Object.assign(new EventEmitter(), {
+    write: vi.fn((_chunk, cb?: (error?: Error | null) => void) => cb?.())
+  })
+  proc.stdout = new EventEmitter()
+  proc.stderr = new EventEmitter()
+  return proc
+}
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -549,5 +575,37 @@ describe('resolveEffectiveProxy', () => {
 
   it('returns undefined when no proxy is configured', () => {
     expect(resolveEffectiveProxy(makeTarget(), null)).toBeUndefined()
+  })
+})
+
+// ── spawnProxyCommand ───────────────────────────────────────────────
+
+describe('spawnProxyCommand', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  it('removes proxy process listeners when the socket is destroyed', () => {
+    const proc = createMockProxyProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const { sock } = spawnProxyCommand(
+      { kind: 'jump-host', jumpHost: 'bastion.example.com' },
+      'target.example.com',
+      22,
+      'deploy'
+    )
+
+    expect(proc.stdout.listenerCount('data')).toBe(1)
+    expect(proc.stdout.listenerCount('end')).toBe(1)
+    expect(proc.stdin.listenerCount('error')).toBe(1)
+    expect(proc.listenerCount('error')).toBe(1)
+
+    sock.destroy()
+
+    expect(proc.stdout.listenerCount('data')).toBe(0)
+    expect(proc.stdout.listenerCount('end')).toBe(0)
+    expect(proc.stdin.listenerCount('error')).toBe(0)
+    expect(proc.listenerCount('error')).toBe(0)
   })
 })

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -198,16 +198,43 @@ export function spawnProxyCommand(
 
   // Why: a single PassThrough for both directions creates a feedback loop.
   // Reads come from the proxy's stdout; writes go to its stdin.
+  let cleanedUp = false
+  const cleanup = (): void => {
+    if (cleanedUp) {
+      return
+    }
+    cleanedUp = true
+    proc.stdout!.off('data', onStdoutData)
+    proc.stdout!.off('end', onStdoutEnd)
+    proc.stdin!.off('error', onInputError)
+    proc.off('error', onProcessError)
+  }
+  const onStdoutData = (data: Buffer): void => {
+    stream.push(data)
+  }
+  const onStdoutEnd = (): void => {
+    stream.push(null)
+  }
+  const onInputError = (err: Error): void => {
+    stream.destroy(err)
+  }
+  const onProcessError = (err: Error): void => {
+    stream.destroy(err)
+  }
   const stream = new Duplex({
     read() {},
     write(chunk, _encoding, cb) {
       proc.stdin!.write(chunk, cb)
+    },
+    destroy(err, cb) {
+      cleanup()
+      cb(err)
     }
   })
-  proc.stdout!.on('data', (data) => stream.push(data))
-  proc.stdout!.on('end', () => stream.push(null))
-  proc.stdin!.on('error', (err) => stream.destroy(err))
-  proc.on('error', (err) => stream.destroy(err))
+  proc.stdout!.on('data', onStdoutData)
+  proc.stdout!.on('end', onStdoutEnd)
+  proc.stdin!.on('error', onInputError)
+  proc.on('error', onProcessError)
 
   return { process: proc, sock: stream as unknown as NetSocket }
 }


### PR DESCRIPTION
Summary:
- Detach ProxyCommand process stdout/stdin/error listeners when the ssh2 socket wrapper is destroyed.
- Keep existing stdout forwarding and stdin writing behavior.
- Add unit coverage proving listeners are removed on socket destroy.

Risk: low
The change is isolated to ProxyCommand listener cleanup and preserves the existing data flow. The focused unit test covers the cleanup path; full Docker SSH rig was not run because this does not change SSH transport semantics beyond the socket wrapper lifecycle.

Validation:
- pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-connection-utils.test.ts
- pnpm exec oxlint src/main/ssh/ssh-connection-utils.ts src/main/ssh/ssh-connection-utils.test.ts
- pnpm exec oxfmt --check src/main/ssh/ssh-connection-utils.ts src/main/ssh/ssh-connection-utils.test.ts
- pnpm typecheck:node
- git diff --check