### PR TITLE
Clean up runtime WebSocket transport listeners

### DIFF
--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -4,7 +4,7 @@
 import { mkdtempSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { describe, expect, it, afterEach } from 'vitest'
+import { describe, expect, it, afterEach, vi } from 'vitest'
 import WebSocket from 'ws'
 import { WebSocketTransport } from './ws-transport'
 import { loadOrCreateTlsCertificate } from '../tls-certificate'
@@ -239,6 +239,34 @@ describe('WebSocketTransport', () => {
     }
 
     expect(calls).toEqual([{ clientId: null, hasOtherConnections: false }])
+  })
+
+  it('detaches server socket listeners after client close', async () => {
+    const { transport } = await createTransport()
+    let cleanupSeen = false
+    transport.onConnectionClose(() => {
+      cleanupSeen = true
+    })
+
+    await transport.start()
+
+    const client = await connectWs(transport)
+    const wss = (transport as unknown as { wss: { clients: Set<WebSocket> } }).wss
+    const serverSocket = Array.from(wss.clients)[0]
+    expect(serverSocket).toBeDefined()
+    const offSpy = vi.spyOn(serverSocket!, 'off')
+
+    client.close()
+
+    const start = Date.now()
+    while (!cleanupSeen && Date.now() - start < 2_000) {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    }
+
+    expect(cleanupSeen).toBe(true)
+    const removedEvents = offSpy.mock.calls.map(([event]) => event)
+    expect(removedEvents).toEqual(expect.arrayContaining(['pong', 'message', 'close', 'error']))
+    offSpy.mockRestore()
   })
 
   it('terminates every active connection for a revoked client id', async () => {

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -277,11 +277,48 @@ export class WebSocketTransport implements RpcTransport {
   // and dispatch logic to the message handler set by OrcaRuntimeRpcServer.
   private handleConnection(ws: WebSocket): void {
     let finalized = false
+    const onPong = (): void => {
+      this.wsAlive.add(ws)
+    }
+    const onMessage = (data: WebSocket.RawData, isBinary: boolean): void => {
+      // Why: any inbound traffic counts as proof of life, not just pongs.
+      // RN's WebSocket runtime auto-pongs server pings transparently, but
+      // app-level frames also count toward liveness so an actively-talking
+      // client doesn't get terminated mid-request.
+      this.wsAlive.add(ws)
+      const msg =
+        typeof data === 'string'
+          ? data
+          : isBinary
+            ? new Uint8Array(data as Buffer)
+            : data.toString()
+      this.messageHandler?.(
+        msg,
+        (response) => {
+          // Why: mobile clients disconnect frequently (backgrounding, network
+          // switch, phone locked). Guard writes to avoid errors on dead sockets.
+          if (ws.readyState === ws.OPEN) {
+            ws.send(response)
+          }
+        },
+        ws
+      )
+    }
+    const onError = (): void => {
+      // Why: close is not guaranteed after every ws error path; finalize here
+      // too so pre-auth E2EE channels and connection ids cannot leak.
+      finalizeConnection()
+      ws.close()
+    }
     const finalizeConnection = (): void => {
       if (finalized) {
         return
       }
       finalized = true
+      ws.off('pong', onPong)
+      ws.off('message', onMessage)
+      ws.off('close', finalizeConnection)
+      ws.off('error', onError)
       this.clearPreAuthTimer(ws)
       const clientId = this.wsClientIds.get(ws) ?? null
       this.wsClientIds.delete(ws)
@@ -308,46 +345,14 @@ export class WebSocketTransport implements RpcTransport {
     // re-arm it.
     this.wsAlive.add(ws)
 
-    ws.on('pong', () => {
-      this.wsAlive.add(ws)
-    })
-
-    ws.on('message', (data, isBinary) => {
-      // Why: any inbound traffic counts as proof of life, not just pongs.
-      // RN's WebSocket runtime auto-pongs server pings transparently, but
-      // app-level frames also count toward liveness so an actively-talking
-      // client doesn't get terminated mid-request.
-      this.wsAlive.add(ws)
-      const msg =
-        typeof data === 'string'
-          ? data
-          : isBinary
-            ? new Uint8Array(data as Buffer)
-            : data.toString()
-      this.messageHandler?.(
-        msg,
-        (response) => {
-          // Why: mobile clients disconnect frequently (backgrounding, network
-          // switch, phone locked). Guard writes to avoid errors on dead sockets.
-          if (ws.readyState === ws.OPEN) {
-            ws.send(response)
-          }
-        },
-        ws
-      )
-    })
+    ws.on('pong', onPong)
+    ws.on('message', onMessage)
 
     // Why: mobile clients disconnect when the phone locks, loses wifi, or
     // backgrounds the app. The runtime must clean up connection-scoped state
     // (e.g., mobile-fit overrides) to prevent orphaned phone-fit on desktop.
     ws.on('close', finalizeConnection)
-
-    ws.on('error', () => {
-      // Why: close is not guaranteed after every ws error path; finalize here
-      // too so pre-auth E2EE channels and connection ids cannot leak.
-      finalizeConnection()
-      ws.close()
-    })
+    ws.on('error', onError)
   }
 
   private clearPreAuthTimer(ws: WebSocket): void {


### PR DESCRIPTION
Summary:
- Name runtime WebSocket transport handlers so they can be detached.
- Remove server-side pong/message/close/error listeners when a socket finalizes.
- Add lifecycle coverage proving listeners are removed after client close.

Risk: low
The change is limited to listener cleanup on the runtime WebSocket transport close/error path. Existing message, heartbeat, and connection-close semantics are preserved, and the focused transport suite covers close, heartbeat, pre-auth, and shutdown behavior.

Validation:
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/ws-transport.test.ts
- pnpm exec oxlint src/main/runtime/rpc/ws-transport.ts src/main/runtime/rpc/ws-transport.test.ts
- pnpm exec oxfmt --check src/main/runtime/rpc/ws-transport.ts src/main/runtime/rpc/ws-transport.test.ts
- pnpm typecheck:node
- git diff --check