### PR TITLE
perf: avoid codex legacy trust spread

### DIFF
--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -491,7 +491,10 @@ function cleanupLegacySystemManagedHooks(): void {
       definitions,
       isManagedCommand
     )
-    trustEntries.push(...eventTrustEntries)
+    // Why: user hook configs can be large; avoid the argument limit from push(...entries).
+    for (const entry of eventTrustEntries) {
+      trustEntries.push(entry)
+    }
     const cleaned = removeManagedCommands(definitions, isManagedCommand)
     removedManagedHook ||= definitions.some((definition) =>
       hookDefinitionHasManagedCommand(definition, isManagedCommand)


### PR DESCRIPTION
## Summary
- replace the Codex legacy trust cleanup variadic append with iterative appends
- preserves hook cleanup behavior while avoiding JavaScript argument limits on very large user hook configs

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/main/codex/hook-service.test.ts
- pnpm exec oxlint src/main/codex/hook-service.ts src/main/codex/hook-service.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low
- single main-process cleanup-path change; no behavior change except handling oversized arrays safely