### PR TITLE
fix: use platform separators for default workspace dir

### DIFF
--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { getDefaultPrimarySelectionMiddleClickPaste, getDefaultSettings } from './constants'
 
 describe('getDefaultSettings', () => {
+  it('uses platform-consistent separators for the default workspace directory', () => {
+    expect(getDefaultSettings('/Users/alice').workspaceDir).toBe('/Users/alice/orca/workspaces')
+    expect(getDefaultSettings('C:\\Users\\alice').workspaceDir).toBe(
+      'C:\\Users\\alice\\orca\\workspaces'
+    )
+  })
+
   it('enables gitignored file decorations by default', () => {
     expect(getDefaultSettings('/tmp').showGitIgnoredFiles).toBe(true)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -154,9 +154,15 @@ export function getDefaultOnboardingState(): OnboardingState {
   }
 }
 
+function getDefaultWorkspaceDir(homeDir: string): string {
+  const separator = homeDir.includes('\\') ? '\\' : '/'
+  const trimmedHomeDir = homeDir.replace(/[\\/]+$/, '')
+  return [trimmedHomeDir, 'orca', 'workspaces'].join(separator)
+}
+
 export function getDefaultSettings(homedir: string): GlobalSettings {
   return {
-    workspaceDir: `${homedir}/orca/workspaces`,
+    workspaceDir: getDefaultWorkspaceDir(homedir),
     nestWorkspaces: true,
     workspaceDirHistory: [],
     refreshLocalBaseRefOnWorktreeCreate: false,


### PR DESCRIPTION
## Summary
- build the default workspace directory with separators that match the supplied home directory
- trim trailing slashes before appending `orca/workspaces`
- add coverage for POSIX and Windows-style homes

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/constants.test.ts`
- `pnpm run lint -- src/shared/constants.ts src/shared/constants.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `git diff --check`
- Electron smoke check: onboarding project setup showed `C:\Users\jinwo\orca\workspaces` after the fix