### PR TITLE
Add unbound workspace delete shortcut

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -880,6 +880,74 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenNthCalledWith(2, 'ui:toggleWorktreePalette')
   })
 
+  it('forwards the configured workspace delete shortcut while terminal input is focused', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(
+      {
+        getUI: () => ({}),
+        getSettings: () => ({ terminalShortcutPolicy: 'terminal-first' })
+      } as never,
+      {
+        getKeybindings: () => ({ 'workspace.delete': ['Mod+Shift+Backspace'] })
+      }
+    )
+
+    const setFocusedListener = vi
+      .mocked(ipcMain.on)
+      .mock.calls.find(([channel]) => channel === 'ui:setTerminalInputFocused')?.[1]
+    expect(setFocusedListener).toBeTypeOf('function')
+    setFocusedListener?.({ sender: webContents } as never, true)
+
+    const isDarwin = process.platform === 'darwin'
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault } as never,
+      {
+        type: 'keyDown',
+        code: 'Backspace',
+        key: 'Backspace',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: true
+      } as never
+    )
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.send).toHaveBeenCalledTimes(1)
+    expect(webContents.send).toHaveBeenCalledWith('ui:deleteCurrentWorkspace')
+  })
+
   it('toggles devtools on F12 in development', () => {
     isMock.dev = true
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -839,6 +839,11 @@ export function createMainWindow(
       return
     }
 
+    if (action.type === 'deleteCurrentWorkspace') {
+      mainWindow.webContents.send('ui:deleteCurrentWorkspace')
+      return
+    }
+
     if (action.type === 'openTasks') {
       mainWindow.webContents.send('ui:openTasks')
       return

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1825,6 +1825,7 @@ export type PreloadApi = {
     ) => () => void
     onOpenQuickOpen: (callback: () => void) => () => void
     onOpenNewWorkspace: (callback: () => void) => () => void
+    onDeleteCurrentWorkspace: (callback: () => void) => () => void
     onOpenTasks: (callback: () => void) => () => void
     onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
     onJumpToTabIndex: (callback: (index: number) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2418,6 +2418,11 @@ const api = {
       ipcRenderer.on('ui:openNewWorkspace', listener)
       return () => ipcRenderer.removeListener('ui:openNewWorkspace', listener)
     },
+    onDeleteCurrentWorkspace: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:deleteCurrentWorkspace', listener)
+      return () => ipcRenderer.removeListener('ui:deleteCurrentWorkspace', listener)
+    },
     onOpenTasks: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:openTasks', listener)

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/components/browser-pane/browser-focus'
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { useSettingsNavigationMetadata } from '@/hooks/useSettingsNavigationMetadata'
+import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
 import {
   buildCmdJActionResults,
   buildCmdJSettingsResults,
@@ -490,6 +491,16 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     )
   }, [openModal])
 
+  const deleteActiveWorkspaceAction = useCallback(() => {
+    const { activeView, activeWorktreeId } = useAppStore.getState()
+    if (activeView !== 'terminal' || !activeWorktreeId) {
+      return
+    }
+    // Why: the delete confirmation is also a modal; let the palette close
+    // before mounting it so Radix focus teardown cannot fight the new dialog.
+    queueMicrotask(() => runWorktreeDelete(activeWorktreeId))
+  }, [])
+
   const openAddQuickCommandAction = useCallback(() => {
     openSettingsTarget({ pane: 'quick-commands', repoId: null, intent: 'add-quick-command' })
     openSettingsPage()
@@ -504,9 +515,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         openNewMarkdownFile: openNewMarkdownInActiveWorkspace,
         openNewTerminalTab: openNewTerminalTabInActiveWorkspace,
         openCreateWorkspace: openCreateWorkspaceAction,
+        deleteActiveWorkspace: deleteActiveWorkspaceAction,
         openAddQuickCommand: openAddQuickCommandAction
       }),
     [
+      deleteActiveWorkspaceAction,
       openAddQuickCommandAction,
       openCreateWorkspaceAction,
       openNewBrowserTabInActiveWorkspace,

--- a/src/renderer/src/components/cmd-j/palette-results.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.test.ts
@@ -53,6 +53,16 @@ const actions: CmdJQuickAction[] = [
     run: noopRun
   },
   {
+    id: 'delete-workspace',
+    kind: 'action',
+    title: 'Delete Workspace',
+    description: 'Delete the current workspace.',
+    icon: Globe,
+    verbKeywords: ['delete workspace', 'delete current workspace', 'remove workspace'],
+    isAvailable: available,
+    run: noopRun
+  },
+  {
     id: 'add-quick-command',
     kind: 'action',
     title: 'Add Quick Command',
@@ -147,6 +157,8 @@ describe('Cmd+J palette middle-band ranking', () => {
     ['create workspace', 'create-workspace'],
     ['add workspace', 'create-workspace'],
     ['new workspace', 'create-workspace'],
+    ['delete workspace', 'delete-workspace'],
+    ['remove workspace', 'delete-workspace'],
     ['terminal settings', 'settings:terminal'],
     ['browser settings', 'settings:browser'],
     ['ssh', 'settings:ssh'],

--- a/src/renderer/src/components/cmd-j/quick-action-context.test.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildCmdJQuickActionContext,
+  getCurrentWorkspaceActionAvailability,
   getWorkspaceScopedActionAvailability,
   resolveCmdJActiveGroupId,
   type CmdJQuickActionContext
@@ -13,10 +14,17 @@ type GroupState = Pick<AppState, 'activeGroupIdByWorktree' | 'groupsByWorktree'>
 
 function ctx(
   overrides: Partial<
-    Pick<CmdJQuickActionContext, 'activeGroupId' | 'activeWorktreeId' | 'isLoading' | 'sshStatus'>
+    Pick<
+      CmdJQuickActionContext,
+      'activeView' | 'activeGroupId' | 'activeWorktreeId' | 'isLoading' | 'sshStatus'
+    >
   >
-): Pick<CmdJQuickActionContext, 'activeGroupId' | 'activeWorktreeId' | 'isLoading' | 'sshStatus'> {
+): Pick<
+  CmdJQuickActionContext,
+  'activeView' | 'activeGroupId' | 'activeWorktreeId' | 'isLoading' | 'sshStatus'
+> {
   return {
+    activeView: 'terminal',
     activeGroupId: 'group-1',
     activeWorktreeId: 'wt-1',
     isLoading: false,
@@ -72,6 +80,24 @@ describe('Cmd+J quick action context', () => {
     expect(getWorkspaceScopedActionAvailability(ctx({}))).toEqual({ available: true })
   })
 
+  it('checks current-workspace action availability without requiring a tab group', () => {
+    expect(getCurrentWorkspaceActionAvailability(ctx({ activeWorktreeId: null }))).toEqual({
+      available: false,
+      reason: 'no-active-workspace'
+    })
+    expect(getCurrentWorkspaceActionAvailability(ctx({ activeView: 'settings' }))).toEqual({
+      available: false,
+      reason: 'no-active-workspace'
+    })
+    expect(
+      getCurrentWorkspaceActionAvailability(ctx({ activeGroupId: null, activeView: 'terminal' }))
+    ).toEqual({ available: true })
+    expect(getCurrentWorkspaceActionAvailability(ctx({ sshStatus: 'disconnected' }))).toEqual({
+      available: false,
+      reason: 'ssh-disconnected'
+    })
+  })
+
   it('keeps workspace-agnostic actions available while loading without an active workspace', () => {
     const context = {
       ...ctx({ activeWorktreeId: null, activeGroupId: null, isLoading: true }),
@@ -81,6 +107,7 @@ describe('Cmd+J quick action context', () => {
       openNewMarkdownFile: async () => {},
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
@@ -97,6 +124,7 @@ describe('Cmd+J quick action context', () => {
 
   it('applies the availability matrix across curated actions', () => {
     const workspaceActions = ['new-browser-tab', 'new-markdown-file', 'new-terminal-tab']
+    const currentWorkspaceActions = ['delete-workspace']
     const workspaceAgnosticActions = ['create-workspace', 'add-quick-command']
     const actionById = new Map(CMD_J_QUICK_ACTIONS.map((action) => [action.id, action]))
     const baseContext = {
@@ -107,6 +135,7 @@ describe('Cmd+J quick action context', () => {
       openNewMarkdownFile: async () => {},
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
@@ -142,6 +171,19 @@ describe('Cmd+J quick action context', () => {
         })
       ).toEqual({ available: true })
     }
+
+    for (const actionId of currentWorkspaceActions) {
+      expect(actionById.get(actionId)?.isAvailable(baseContext)).toEqual({ available: true })
+      expect(
+        actionById.get(actionId)?.isAvailable({ ...baseContext, activeGroupId: null })
+      ).toEqual({ available: true })
+      expect(
+        actionById.get(actionId)?.isAvailable({ ...baseContext, activeView: 'settings' })
+      ).toEqual({ available: false, reason: 'no-active-workspace' })
+      expect(
+        actionById.get(actionId)?.isAvailable({ ...baseContext, sshStatus: 'disconnected' })
+      ).toEqual({ available: false, reason: 'ssh-disconnected' })
+    }
   })
 
   it('recomputes active group from the open snapshot against fresh store state', () => {
@@ -162,6 +204,7 @@ describe('Cmd+J quick action context', () => {
       groupsByWorktree: {
         'wt-1': [{ id: 'first-group', worktreeId: 'wt-1', activeTabId: null, tabOrder: [] }]
       },
+      activeView: 'terminal',
       settings: null
     } as unknown as AppState
 
@@ -172,6 +215,7 @@ describe('Cmd+J quick action context', () => {
       openNewMarkdownFile: async () => {},
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
       openAddQuickCommand: () => {}
     })
 
@@ -186,6 +230,7 @@ describe('Cmd+J quick action context', () => {
       sshConnectionStates: new Map(),
       activeGroupIdByWorktree: {},
       groupsByWorktree: {},
+      activeView: 'terminal',
       settings: null
     } as unknown as AppState
 
@@ -196,6 +241,7 @@ describe('Cmd+J quick action context', () => {
       openNewMarkdownFile: async () => {},
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
       openAddQuickCommand: () => {}
     })
 
@@ -215,6 +261,7 @@ describe('Cmd+J quick action context', () => {
         calls.push(groupId)
       },
       openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
@@ -223,5 +270,26 @@ describe('Cmd+J quick action context', () => {
       reason: 'no-active-group'
     })
     expect(calls).toEqual([])
+  })
+
+  it('runtime re-check invokes the current workspace delete action when available', async () => {
+    const calls: string[] = []
+    const action = CMD_J_QUICK_ACTIONS.find((entry) => entry.id === 'delete-workspace')
+    const context = {
+      ...ctx({ activeGroupId: null }),
+      activeWorktree: null,
+      runtimeMode: 'local-desktop' as const,
+      openNewBrowserTab: async () => {},
+      openNewMarkdownFile: async () => {},
+      openNewTerminalTab: async () => {},
+      openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {
+        calls.push('delete')
+      },
+      openAddQuickCommand: () => {}
+    } satisfies CmdJQuickActionContext
+
+    await expect(action?.run(context)).resolves.toEqual({ status: 'ok' })
+    expect(calls).toEqual(['delete'])
   })
 })

--- a/src/renderer/src/components/cmd-j/quick-action-context.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.ts
@@ -19,6 +19,7 @@ export type CmdJActiveGroupSnapshot = {
 }
 
 export type CmdJQuickActionContext = {
+  activeView: AppState['activeView']
   activeWorktreeId: string | null
   activeWorktree: Worktree | null
   isLoading: boolean
@@ -29,6 +30,7 @@ export type CmdJQuickActionContext = {
   openNewMarkdownFile: (groupId: string) => Promise<void>
   openNewTerminalTab: (groupId: string) => Promise<void>
   openCreateWorkspace: () => void
+  deleteActiveWorkspace: () => void
   openAddQuickCommand: () => void
 }
 
@@ -108,6 +110,21 @@ export function getWorkspaceScopedActionAvailability(
   return { available: true }
 }
 
+export function getCurrentWorkspaceActionAvailability(
+  ctx: Pick<CmdJQuickActionContext, 'activeView' | 'activeWorktreeId' | 'isLoading' | 'sshStatus'>
+): CmdJQuickActionAvailability {
+  if (ctx.activeView !== 'terminal' || !ctx.activeWorktreeId) {
+    return { available: false, reason: 'no-active-workspace' }
+  }
+  if (ctx.isLoading) {
+    return { available: false, reason: 'loading' }
+  }
+  if (ctx.sshStatus != null && ctx.sshStatus !== 'connected') {
+    return { available: false, reason: 'ssh-disconnected' }
+  }
+  return { available: true }
+}
+
 export function buildCmdJQuickActionContext(args: {
   state: AppState
   activeGroupSnapshot: CmdJActiveGroupSnapshot | null
@@ -115,6 +132,7 @@ export function buildCmdJQuickActionContext(args: {
   openNewMarkdownFile: (groupId: string) => Promise<void>
   openNewTerminalTab: (groupId: string) => Promise<void>
   openCreateWorkspace: () => void
+  deleteActiveWorkspace: () => void
   openAddQuickCommand: () => void
 }): CmdJQuickActionContext {
   const activeWorktreeId = args.state.activeWorktreeId
@@ -135,6 +153,7 @@ export function buildCmdJQuickActionContext(args: {
       : 'local-desktop'
 
   return {
+    activeView: args.state.activeView,
     activeWorktreeId,
     activeWorktree,
     isLoading,
@@ -145,6 +164,7 @@ export function buildCmdJQuickActionContext(args: {
     openNewMarkdownFile: args.openNewMarkdownFile,
     openNewTerminalTab: args.openNewTerminalTab,
     openCreateWorkspace: args.openCreateWorkspace,
+    deleteActiveWorkspace: args.deleteActiveWorkspace,
     openAddQuickCommand: args.openAddQuickCommand
   }
 }

--- a/src/renderer/src/components/cmd-j/quick-actions.ts
+++ b/src/renderer/src/components/cmd-j/quick-actions.ts
@@ -1,7 +1,10 @@
-import { FileText, FolderPlus, Globe, Play, SquareTerminal } from 'lucide-react'
+import { FileText, FolderPlus, Globe, Play, SquareTerminal, Trash2 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { CmdJQuickActionAvailability, CmdJQuickActionContext } from './quick-action-context'
-import { getWorkspaceScopedActionAvailability } from './quick-action-context'
+import {
+  getCurrentWorkspaceActionAvailability,
+  getWorkspaceScopedActionAvailability
+} from './quick-action-context'
 
 export type CmdJQuickActionRunResult =
   | { status: 'ok' }
@@ -23,6 +26,12 @@ export type CmdJQuickAction = {
 
 function workspaceActionAvailability(ctx: CmdJQuickActionContext): CmdJQuickActionAvailability {
   return getWorkspaceScopedActionAvailability(ctx)
+}
+
+function currentWorkspaceActionAvailability(
+  ctx: CmdJQuickActionContext
+): CmdJQuickActionAvailability {
+  return getCurrentWorkspaceActionAvailability(ctx)
 }
 
 async function runWorkspaceAction(
@@ -84,6 +93,30 @@ export const CMD_J_QUICK_ACTIONS: readonly CmdJQuickAction[] = [
     isAvailable: () => ({ available: true }),
     run: async (ctx) => {
       ctx.openCreateWorkspace()
+      return { status: 'ok' }
+    }
+  },
+  {
+    id: 'delete-workspace',
+    kind: 'action',
+    title: 'Delete Workspace',
+    description: 'Delete the current workspace.',
+    icon: Trash2,
+    verbKeywords: [
+      'delete workspace',
+      'delete current workspace',
+      'delete worktree',
+      'remove workspace',
+      'remove worktree',
+      'trash workspace'
+    ],
+    isAvailable: currentWorkspaceActionAvailability,
+    run: async (ctx) => {
+      const availability = currentWorkspaceActionAvailability(ctx)
+      if (!availability.available) {
+        return { status: 'unavailable', reason: availability.reason }
+      }
+      ctx.deleteActiveWorkspace()
       return { status: 'ok' }
     }
   },

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -4,6 +4,7 @@ import { useAppStore } from '../store'
 import { getWorktreeMapFromState, getRepoMapFromState } from '@/store/selectors'
 import { applyUIZoom } from '@/lib/ui-zoom'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
 import { runSleepWorktree } from '@/components/sidebar/sleep-worktree-flow'
 import {
   BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
@@ -780,6 +781,22 @@ export function useIpcEvents(): void {
         store.openModal('new-workspace-composer', { telemetrySource: 'shortcut' })
       })
     )
+
+    if (window.api.ui.onDeleteCurrentWorkspace) {
+      unsubs.push(
+        window.api.ui.onDeleteCurrentWorkspace(() => {
+          const store = useAppStore.getState()
+          if (
+            store.activeModal !== 'none' ||
+            store.activeView !== 'terminal' ||
+            !store.activeWorktreeId
+          ) {
+            return
+          }
+          runWorktreeDelete(store.activeWorktreeId)
+        })
+      )
+    }
 
     unsubs.push(
       window.api.ui.onOpenTasks(() => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1647,6 +1647,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onOpenQuickOpen: () => noopUnsubscribe,
     onOpenTasks: () => noopUnsubscribe,
     onOpenNewWorkspace: () => noopUnsubscribe,
+    onDeleteCurrentWorkspace: () => noopUnsubscribe,
     onJumpToWorktreeIndex: () => noopUnsubscribe,
     onJumpToTabIndex: () => noopUnsubscribe,
     onWorktreeHistoryNavigate: () => noopUnsubscribe,

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -171,6 +171,25 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
+  it('keeps workspace delete unassigned until users customize it', () => {
+    const binding = {
+      key: 'Backspace',
+      code: 'Backspace',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: true
+    }
+
+    expect(getEffectiveKeybindingsForAction('workspace.delete', 'linux')).toEqual([])
+    expect(keybindingMatchesAction('workspace.delete', binding, 'linux')).toBe(false)
+    expect(
+      keybindingMatchesAction('workspace.delete', binding, 'linux', {
+        'workspace.delete': ['Mod+Shift+Backspace']
+      })
+    ).toBe(true)
+  })
+
   it('reports customized renderer conflicts with native menu accelerators', () => {
     expect(findKeybindingConflicts('darwin')).toEqual([])
 
@@ -223,6 +242,15 @@ describe('keybindings', () => {
   })
 
   it('keeps terminal-allowed app shortcuts active in terminal-first mode', () => {
+    const deleteBinding = {
+      key: 'Backspace',
+      code: 'Backspace',
+      control: true,
+      meta: false,
+      alt: false,
+      shift: true
+    }
+
     expect(
       keybindingMatchesAction(
         'floatingTerminal.toggle',
@@ -238,6 +266,15 @@ describe('keybindings', () => {
         { key: 'Tab', code: 'Tab', control: true, meta: false, alt: false, shift: false },
         'linux',
         undefined,
+        { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'workspace.delete',
+        deleteBinding,
+        'linux',
+        { 'workspace.delete': ['Mod+Shift+Backspace'] },
         { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
       )
     ).toBe(true)

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -31,6 +31,7 @@ export type KeybindingActionId =
   | 'app.forceReload'
   | 'file.exportPdf'
   | 'workspace.create'
+  | 'workspace.delete'
   | 'voice.dictation'
   | 'view.tasks'
   | 'sidebar.left.toggle'
@@ -228,6 +229,26 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'global',
     searchKeywords: ['shortcut', 'global', 'worktree', 'create', 'new workspace'],
     defaultBindings: platformBindings(['Mod+N', 'Mod+Shift+N'])
+  },
+  {
+    id: 'workspace.delete',
+    title: 'Delete Workspace',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'workspace',
+      'current workspace',
+      'worktree',
+      'delete',
+      'remove',
+      'trash'
+    ],
+    // Why: ship the command now without claiming a default chord; user
+    // overrides still win automatically when a future default is assigned.
+    defaultBindings: platformBindings([]),
+    allowInTerminal: true
   },
   {
     id: 'voice.dictation',

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -261,6 +261,32 @@ describe('resolveWindowShortcutAction', () => {
     ).toEqual({ type: 'openTasks' })
   })
 
+  it('leaves workspace delete unbound by default but honors custom terminal-active bindings', () => {
+    const input = {
+      code: 'Backspace',
+      key: 'Backspace',
+      meta: false,
+      control: true,
+      alt: false,
+      shift: true
+    }
+
+    expect(resolveWindowShortcutAction(input, 'linux')).toBeNull()
+    expect(
+      resolveWindowShortcutAction(input, 'linux', {
+        'workspace.delete': ['Mod+Shift+Backspace']
+      })
+    ).toEqual({ type: 'deleteCurrentWorkspace' })
+    expect(
+      resolveWindowShortcutAction(
+        input,
+        'linux',
+        { 'workspace.delete': ['Mod+Shift+Backspace'] },
+        { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
+      )
+    ).toEqual({ type: 'deleteCurrentWorkspace' })
+  })
+
   it('resolves the MRU tab quick-toggle chord', () => {
     expect(
       resolveWindowShortcutAction(

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -34,6 +34,7 @@ export type WindowShortcutAction =
   | { type: 'toggleRightSidebar' }
   | { type: 'openQuickOpen' }
   | { type: 'openNewWorkspace' }
+  | { type: 'deleteCurrentWorkspace' }
   | { type: 'openTasks' }
   | { type: 'switchRecentTab' }
   | { type: 'jumpToWorktreeIndex'; index: number }
@@ -197,6 +198,10 @@ export function resolveWindowShortcutAction(
     return { type: 'openNewWorkspace' }
   }
 
+  if (actionMatches('workspace.delete', input, platform, keybindings, options)) {
+    return { type: 'deleteCurrentWorkspace' }
+  }
+
   if (actionMatches('voice.dictation', input, platform, keybindings, options)) {
     return { type: 'dictationKeyDown' }
   }
@@ -265,6 +270,8 @@ export function getWindowShortcutActionId(action: WindowShortcutAction): Keybind
       return 'worktree.quickOpen'
     case 'openNewWorkspace':
       return 'workspace.create'
+    case 'deleteCurrentWorkspace':
+      return 'workspace.delete'
     case 'openTasks':
       return 'view.tasks'
     case 'switchRecentTab':


### PR DESCRIPTION
## Summary
- add an unbound `workspace.delete` keybinding action that can be customized without assigning a default chord yet
- route the action through the main-window shortcut bridge so customized bindings work while terminal input is focused
- add a Cmd+J `Delete Workspace` action that reuses the existing workspace delete confirmation flow

Closes #2808

## Test plan
- `pnpm vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts src/shared/window-shortcut-policy.test.ts src/main/window/createMainWindow.test.ts src/renderer/src/components/cmd-j/quick-action-context.test.ts src/renderer/src/components/cmd-j/palette-results.test.ts`
- `pnpm run typecheck`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/useIpcEvents.test.ts src/renderer/src/web/web-preload-api.test.ts`
- `pnpm run lint`

Risk: high
This introduces a workspace delete command path through keybindings, the main-window shortcut bridge, Cmd+J actions, preload, and renderer IPC. Even without a default chord, delete-workspace behavior is destructive and should get another review pass.