### PR TITLE
Fix orchestration completion handling

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -20,10 +20,12 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   #
   # RULE: send worker_done exactly once. Failure is still a worker_done
   # with subject like "Failed: <reason>" — never silently exit.
+  # Include BOTH taskId and dispatchId in the payload so a late completion
+  # from a failed retry cannot complete the current dispatch.
   orca orchestration send --to term_COORD \\
     --type worker_done --subject "<short status>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
-    --payload '{"taskId":"task_SNAP","filesModified":["path/a","path/b"],"reportPath":"<optional: path to the full artifact>"}'
+    --payload '{"taskId":"task_SNAP","dispatchId":"ctx_SNAP","filesModified":["path/a","path/b"],"reportPath":"<optional: path to the full artifact>"}'
 
   # BEHAVIOR RULE: send a heartbeat every 5 minutes
   # while actively working on the task. The coordinator uses this to

--- a/src/main/runtime/orchestration/coordinator.test.ts
+++ b/src/main/runtime/orchestration/coordinator.test.ts
@@ -65,6 +65,34 @@ function createMockRuntime(): CoordinatorRuntime & {
   return mock
 }
 
+function insertWorkerDone(
+  db: OrchestrationDb,
+  params: {
+    taskId: string
+    to?: string
+    from?: string
+    dispatchId?: string
+    filesModified?: string[]
+  }
+): void {
+  const dispatch = db.getDispatchContext(params.taskId)
+  const dispatchId = params.dispatchId ?? dispatch?.id
+  if (!dispatchId) {
+    throw new Error(`No dispatch for task ${params.taskId}`)
+  }
+  db.insertMessage({
+    from: params.from ?? dispatch?.assignee_handle ?? 'term_unknown',
+    to: params.to ?? 'coord',
+    subject: 'Done',
+    type: 'worker_done',
+    payload: JSON.stringify({
+      taskId: params.taskId,
+      dispatchId,
+      ...(params.filesModified ? { filesModified: params.filesModified } : {})
+    })
+  })
+}
+
 describe('Coordinator', () => {
   let db: OrchestrationDb
 
@@ -105,13 +133,7 @@ describe('Coordinator', () => {
     })
 
     // Simulate the worker completing
-    db.insertMessage({
-      from: 'term_a',
-      to: 'coord',
-      subject: 'Done',
-      type: 'worker_done',
-      payload: JSON.stringify({ taskId: task.id, filesModified: ['a.ts'] })
-    })
+    insertWorkerDone(db, { taskId: task.id, filesModified: ['a.ts'] })
 
     const result = await runPromise
     expect(result.status).toBe('completed')
@@ -140,13 +162,7 @@ describe('Coordinator', () => {
     expect(runtime.createdTerminals.length).toBe(1)
 
     // Complete the task
-    db.insertMessage({
-      from: runtime.createdTerminals[0],
-      to: 'coord',
-      subject: 'Done',
-      type: 'worker_done',
-      payload: JSON.stringify({ taskId: task.id })
-    })
+    insertWorkerDone(db, { taskId: task.id, from: runtime.createdTerminals[0] })
 
     const result = await runPromise
     expect(result.status).toBe('completed')
@@ -263,13 +279,7 @@ describe('Coordinator', () => {
       setTimeout(r, 200)
     })
 
-    db.insertMessage({
-      from: 'term_a',
-      to: 'coord',
-      subject: 'Done',
-      type: 'worker_done',
-      payload: JSON.stringify({ taskId: task.id })
-    })
+    insertWorkerDone(db, { taskId: task.id })
 
     const result = await runPromise
     expect(result.status).toBe('completed')
@@ -303,13 +313,7 @@ describe('Coordinator', () => {
     expect(db.getTask(t2.id)?.status).toBe('pending')
 
     // Complete t1
-    db.insertMessage({
-      from: 'term_a',
-      to: 'coord',
-      subject: 'Done',
-      type: 'worker_done',
-      payload: JSON.stringify({ taskId: t1.id })
-    })
+    insertWorkerDone(db, { taskId: t1.id })
 
     // Wait for t2 to be promoted and dispatched
     await new Promise((r) => {
@@ -321,13 +325,7 @@ describe('Coordinator', () => {
     expect(t2Status === 'dispatched' || t2Status === 'ready').toBe(true)
 
     // Complete t2
-    db.insertMessage({
-      from: 'term_a',
-      to: 'coord',
-      subject: 'Done',
-      type: 'worker_done',
-      payload: JSON.stringify({ taskId: t2.id })
-    })
+    insertWorkerDone(db, { taskId: t2.id })
 
     const result = await runPromise
     expect(result.status).toBe('completed')
@@ -367,13 +365,7 @@ describe('Coordinator', () => {
 
     // Complete all tasks
     for (const task of [t1, t2, t3]) {
-      db.insertMessage({
-        from: 'term_a',
-        to: 'coord',
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify({ taskId: task.id })
-      })
+      insertWorkerDone(db, { taskId: task.id })
       await new Promise((r) => {
         setTimeout(r, 100)
       })
@@ -453,16 +445,97 @@ describe('Coordinator', () => {
     expect(db.getDispatchContext(task.id)?.last_heartbeat_at).toBeTruthy()
 
     // Complete the task so the coordinator run finishes cleanly.
-    db.insertMessage({
-      from: 'term_a',
-      to: 'coord',
-      subject: 'Done',
-      type: 'worker_done',
-      payload: JSON.stringify({ taskId: task.id })
-    })
+    insertWorkerDone(db, { taskId: task.id })
 
     const result = await runPromise
     expect(result.status).toBe('completed')
+  })
+
+  it('ignores stale worker_done from a failed retry before accepting the active dispatch', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = createMockRuntime()
+    const logs: string[] = []
+
+    const task = db.createTask({ spec: 'retry-sensitive work' })
+    const staleCtx = db.createDispatchContext(task.id, 'term_old')
+    db.failDispatch(staleCtx.id, 'retry elsewhere')
+    const activeCtx = db.createDispatchContext(task.id, 'term_current')
+
+    db.insertMessage({
+      from: 'term_old',
+      to: 'coord',
+      subject: 'Late done',
+      type: 'worker_done',
+      payload: JSON.stringify({ taskId: task.id, dispatchId: staleCtx.id })
+    })
+
+    const staleCoordinator = new Coordinator(db, runtime, {
+      spec: 'go',
+      coordinatorHandle: 'coord',
+      pollIntervalMs: 20,
+      onLog: (m) => logs.push(m)
+    })
+    const staleRun = staleCoordinator.run()
+    await new Promise((r) => {
+      setTimeout(r, 80)
+    })
+    staleCoordinator.stop()
+    await staleRun
+
+    expect(db.getTask(task.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(staleCtx.id)?.status).toBe('failed')
+    expect(db.getDispatchContextById(activeCtx.id)?.status).toBe('dispatched')
+    expect(logs.some((m) => m.includes('inactive dispatch'))).toBe(true)
+
+    insertWorkerDone(db, {
+      taskId: task.id,
+      from: 'term_current',
+      dispatchId: activeCtx.id
+    })
+    const completionCoordinator = new Coordinator(db, runtime, {
+      spec: 'go',
+      coordinatorHandle: 'coord',
+      pollIntervalMs: 20
+    })
+    const result = await completionCoordinator.run()
+
+    expect(result.status).toBe('completed')
+    expect(db.getTask(task.id)?.status).toBe('completed')
+    expect(db.getDispatchContextById(activeCtx.id)?.status).toBe('completed')
+  })
+
+  it('ignores worker_done sent by a terminal that does not own the dispatch', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = createMockRuntime()
+    const logs: string[] = []
+
+    const task = db.createTask({ spec: 'owned work' })
+    const ctx = db.createDispatchContext(task.id, 'term_owner')
+
+    db.insertMessage({
+      from: 'term_intruder',
+      to: 'coord',
+      subject: 'Spoofed done',
+      type: 'worker_done',
+      payload: JSON.stringify({ taskId: task.id, dispatchId: ctx.id })
+    })
+
+    const coordinator = new Coordinator(db, runtime, {
+      spec: 'go',
+      coordinatorHandle: 'coord',
+      pollIntervalMs: 20,
+      onLog: (m) => logs.push(m)
+    })
+    const runPromise = coordinator.run()
+    await new Promise((r) => {
+      setTimeout(r, 80)
+    })
+    coordinator.stop()
+    await runPromise
+
+    expect(db.getTask(task.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(ctx.id)?.status).toBe('dispatched')
+    expect(logs.some((m) => m.includes('expected term_owner'))).toBe(true)
   })
 
   it('can be stopped', async () => {
@@ -512,13 +585,7 @@ describe('Coordinator', () => {
         setTimeout(r, 100)
       })
 
-      db.insertMessage({
-        from: 'term_a',
-        to: 'coord',
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify({ taskId: task.id })
-      })
+      insertWorkerDone(db, { taskId: task.id })
 
       const result = await runPromise
       expect(result.status).toBe('completed')
@@ -594,13 +661,7 @@ allow-stale-base: true`
         setTimeout(r, 100)
       })
 
-      db.insertMessage({
-        from: 'term_a',
-        to: 'coord',
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify({ taskId: task.id })
-      })
+      insertWorkerDone(db, { taskId: task.id })
 
       const result = await runPromise
       expect(result.status).toBe('completed')
@@ -633,13 +694,7 @@ allow-stale-base: true`
         setTimeout(r, 100)
       })
 
-      db.insertMessage({
-        from: 'term_a',
-        to: 'coord',
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify({ taskId: task.id })
-      })
+      insertWorkerDone(db, { taskId: task.id })
 
       const result = await runPromise
       expect(result.status).toBe('completed')
@@ -669,13 +724,7 @@ allow-stale-base: true`
         setTimeout(r, 100)
       })
 
-      db.insertMessage({
-        from: 'term_a',
-        to: 'coord',
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify({ taskId: task.id })
-      })
+      insertWorkerDone(db, { taskId: task.id })
 
       const result = await runPromise
       expect(result.status).toBe('completed')
@@ -705,13 +754,7 @@ allow-stale-base: true`
         setTimeout(r, 100)
       })
 
-      db.insertMessage({
-        from: 'term_a',
-        to: 'coord',
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify({ taskId: task.id })
-      })
+      insertWorkerDone(db, { taskId: task.id })
 
       const result = await runPromise
       expect(result.status).toBe('completed')

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -303,7 +303,7 @@ export class Coordinator {
   private handleWorkerDone(msg: MessageRow): void {
     this.opts.onLog(`Worker done: ${msg.from_handle} — ${msg.subject}`)
 
-    let payload: { taskId?: string; filesModified?: string[] } = {}
+    let payload: { taskId?: unknown; dispatchId?: unknown; filesModified?: unknown } = {}
     if (msg.payload) {
       try {
         payload = JSON.parse(msg.payload)
@@ -313,8 +313,14 @@ export class Coordinator {
     }
 
     const taskId = payload.taskId
-    if (!taskId) {
+    if (typeof taskId !== 'string' || taskId.length === 0) {
       this.opts.onLog(`Warning: worker_done without taskId from ${msg.from_handle}`)
+      return
+    }
+
+    const dispatchId = payload.dispatchId
+    if (typeof dispatchId !== 'string' || dispatchId.length === 0) {
+      this.opts.onLog(`Warning: worker_done without dispatchId from ${msg.from_handle}`)
       return
     }
 
@@ -324,20 +330,47 @@ export class Coordinator {
       return
     }
 
+    // Why: taskId alone is not a completion authority; retried tasks can have
+    // stale worker_done messages racing the current active dispatch.
+    const dispatch = this.db.getDispatchContextById(dispatchId)
+    if (!dispatch) {
+      this.opts.onLog(`Warning: worker_done for unknown dispatch ${dispatchId}`)
+      return
+    }
+    if (dispatch.task_id !== taskId) {
+      this.opts.onLog(
+        `Warning: worker_done dispatch ${dispatchId} belongs to ${dispatch.task_id}, not ${taskId}`
+      )
+      return
+    }
+    if (dispatch.assignee_handle !== msg.from_handle) {
+      this.opts.onLog(
+        `Warning: worker_done for dispatch ${dispatchId} came from ${msg.from_handle}, expected ${dispatch.assignee_handle ?? '<unknown>'}`
+      )
+      return
+    }
+    if (dispatch.status !== 'dispatched') {
+      this.opts.onLog(`Warning: worker_done for inactive dispatch ${dispatchId} ignored`)
+      return
+    }
+    if (this.db.getDispatchContext(taskId)?.id !== dispatchId || task.status !== 'dispatched') {
+      this.opts.onLog(`Warning: worker_done for stale dispatch ${dispatchId} ignored`)
+      return
+    }
+
+    const filesModified =
+      Array.isArray(payload.filesModified) &&
+      payload.filesModified.every((file) => typeof file === 'string')
+        ? payload.filesModified
+        : []
+
     const result = JSON.stringify({
       completedBy: msg.from_handle,
-      filesModified: payload.filesModified ?? [],
+      filesModified,
       completedAt: new Date().toISOString()
     })
     this.db.updateTaskStatus(taskId, 'completed', result)
     this.state.completedTasks.push(taskId)
-
-    // Why: complete the dispatch context so the terminal is freed for
-    // subsequent task assignments.
-    const dispatch = this.db.getDispatchContext(taskId)
-    if (dispatch) {
-      this.db.completeDispatch(dispatch.id)
-    }
 
     this.opts.onLog(`Task ${taskId} completed`)
   }

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -380,7 +380,15 @@ export class OrchestrationDb {
   // message for a handle regardless of read/delivered state; never touches the
   // read bit. Stale-handle safe: if the handle no longer exists, the query
   // just returns whatever historical rows remain (§3.3).
-  getAllMessagesForHandle(toHandle: string, limit = 100): MessageRow[] {
+  getAllMessagesForHandle(toHandle: string, limit = 100, types?: MessageType[]): MessageRow[] {
+    if (types && types.length > 0) {
+      const placeholders = types.map(() => '?').join(',')
+      return this.db
+        .prepare(
+          `SELECT * FROM messages WHERE to_handle = ? AND type IN (${placeholders}) ORDER BY sequence DESC LIMIT ?`
+        )
+        .all(toHandle, ...types, limit) as MessageRow[]
+    }
     return this.db
       .prepare('SELECT * FROM messages WHERE to_handle = ? ORDER BY sequence DESC LIMIT ?')
       .all(toHandle, limit) as MessageRow[]
@@ -586,6 +594,12 @@ export class OrchestrationDb {
     return this.db
       .prepare('SELECT * FROM dispatch_contexts WHERE task_id = ? ORDER BY rowid DESC LIMIT 1')
       .get(taskId) as DispatchContextRow | undefined
+  }
+
+  getDispatchContextById(dispatchId: string): DispatchContextRow | undefined {
+    return this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(dispatchId) as
+      | DispatchContextRow
+      | undefined
   }
 
   getActiveDispatchForTerminal(handle: string): DispatchContextRow | undefined {

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -32,6 +32,11 @@ describe('buildDispatchPreamble', () => {
     expect(result).toContain('--body')
     expect(result).toMatch(/3-sentence summary/)
     expect(result).toContain('reportPath')
+    const workerDoneLine = result
+      .split('\n')
+      .find((line) => line.includes('"taskId"') && line.includes('filesModified'))
+    expect(workerDoneLine).toContain('dispatchId')
+    expect(workerDoneLine).toContain('ctx_def456')
   })
 
   it('CLI examples parse as valid shell (bash -n on the extracted block)', () => {

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -1,11 +1,10 @@
 export type PreambleParams = {
   taskId: string
-  // Why: the heartbeat payload attributes liveness to a specific dispatch
-  // context (not just a task). A retried task has multiple dispatch_contexts
-  // rows; keying heartbeats on dispatchId prevents a straggler heartbeat from
-  // a previously-failed dispatch from masking a hung retry. Both call sites
-  // already have this value in scope (coordinator.ts dispatch.id, rpc
-  // orchestration.ts ctx.id).
+  // Why: completion and heartbeat payloads attribute activity to a specific
+  // dispatch context (not just a task). A retried task has multiple
+  // dispatch_contexts rows; keying worker_done/heartbeat on dispatchId
+  // prevents stale messages from a previously-failed dispatch from completing
+  // or refreshing the retry.
   dispatchId: string
   taskSpec: string
   coordinatorHandle: string
@@ -60,10 +59,12 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   #
   # RULE: send worker_done exactly once. Failure is still a worker_done
   # with subject like "Failed: <reason>" — never silently exit.
+  # Include BOTH taskId and dispatchId in the payload so a late completion
+  # from a failed retry cannot complete the current dispatch.
   ${cli} orchestration send --to ${params.coordinatorHandle} \\
     --type worker_done --subject "<short status>" \\
     --body "<3-sentence summary: what you did, what you found, what's left>" \\
-    --payload '{"taskId":"${params.taskId}","filesModified":["path/a","path/b"],"reportPath":"<optional: path to the full artifact>"}'
+    --payload '{"taskId":"${params.taskId}","dispatchId":"${params.dispatchId}","filesModified":["path/a","path/b"],"reportPath":"<optional: path to the full artifact>"}'
 
   # BEHAVIOR RULE: send a heartbeat every ${HEARTBEAT_INTERVAL_MIN} minutes
   # while actively working on the task. The coordinator uses this to

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -310,6 +310,23 @@ describe('orchestration RPC methods', () => {
       expect(stillUnread).toHaveLength(1)
     })
 
+    it('--all applies type filters without marking rows as read', async () => {
+      setup()
+      db.insertMessage({ from: 'a', to: 'b', subject: 'status', type: 'status' })
+      db.insertMessage({ from: 'a', to: 'b', subject: 'dispatch', type: 'dispatch' })
+      db.insertMessage({ from: 'a', to: 'b', subject: 'done', type: 'worker_done' })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'b',
+        all: true,
+        types: 'worker_done,dispatch'
+      })) as { messages: { type: string }[]; count: number }
+
+      expect(result.count).toBe(2)
+      expect(result.messages.map((m) => m.type).sort()).toEqual(['dispatch', 'worker_done'])
+      expect(db.getUnreadMessages('b')).toHaveLength(3)
+    })
+
     it('--all returns rows with delivered_at set after push-on-idle stamped them', async () => {
       setup()
       const msg = db.insertMessage({ from: 'a', to: 'b', subject: 'hi' })

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -240,7 +240,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const readAndReturn = () => {
         const messages = showUnread
           ? db.getUnreadMessages(handle, typeFilter)
-          : db.getAllMessagesForHandle(handle)
+          : db.getAllMessagesForHandle(handle, undefined, typeFilter)
 
         if (showUnread && messages.length > 0) {
           db.markAsRead(messages.map((m) => m.id))


### PR DESCRIPTION
## Summary
- require worker_done messages to include dispatchId and verify the dispatch is active and owned by the sending terminal before completing a task
- include dispatchId in worker completion preambles and snapshots
- preserve --all message reads while applying orchestration.check type filters

## Validation
- node config/scripts/ensure-native-runtime.mjs --runtime=node && pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/coordinator.test.ts src/main/runtime/orchestration/preamble.test.ts src/main/runtime/orchestration/db.test.ts src/main/runtime/rpc/methods/orchestration.test.ts
- pnpm typecheck
- pnpm lint

## Review
- Full diff reviewed against origin/main; no Critical/High/Medium follow-up issues found.

Risk: medium
This changes orchestration completion validation and worker_done dispatch semantics. The added ownership checks reduce risk, but it affects multi-agent task completion and message filtering behavior.