### PR TITLE
perf: narrow terminal attention updates

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -84,6 +84,10 @@ import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 import { shutdownBufferCaptures } from './shutdown-buffer-captures'
 import { mergeCapturedLeafState } from './merge-captured-leaf-state'
 import { pasteTerminalText } from './terminal-bracketed-paste'
+import {
+  applyTerminalPaneAttentionToManager,
+  subscribeTerminalPaneAttention
+} from './terminal-pane-attention-subscriptions'
 
 type TerminalPaneProps = {
   tabId: string
@@ -351,10 +355,6 @@ export default function TerminalPane({
   const clearWorktreeUnread = useAppStore((store) => store.clearWorktreeUnread)
   const clearTerminalTabUnread = useAppStore((store) => store.clearTerminalTabUnread)
   const clearTerminalPaneUnread = useAppStore((store) => store.clearTerminalPaneUnread)
-  const unreadTerminalPanes = useAppStore((store) => store.unreadTerminalPanes)
-  const terminalAttentionEnabled = useAppStore(
-    (store) => store.settings?.experimentalTerminalAttention === true
-  )
   const openSpacePage = useAppStore((store) => store.openSpacePage)
   const refreshWorkspaceSpace = useAppStore((store) => store.refreshWorkspaceSpace)
   const settings = useAppStore((store) => store.settings)
@@ -1268,20 +1268,18 @@ export default function TerminalPane({
     }
   }, [tabId, worktreeId, clearTerminalTabUnread, clearTerminalPaneUnread, clearWorktreeUnread])
 
-  useLayoutEffect(() => {
+  const applyTerminalPaneAttention = useCallback(() => {
     const manager = managerRef.current
     if (!manager) {
       return
     }
-    for (const pane of manager.getPanes()) {
-      const paneKey = makePaneKey(tabId, pane.leafId)
-      if (terminalAttentionEnabled && unreadTerminalPanes[paneKey]) {
-        pane.container.setAttribute('data-terminal-attention', '')
-      } else {
-        pane.container.removeAttribute('data-terminal-attention')
-      }
-    }
-  }, [tabId, paneCount, terminalAttentionEnabled, unreadTerminalPanes])
+    applyTerminalPaneAttentionToManager(manager, tabId)
+  }, [tabId])
+
+  useLayoutEffect(() => {
+    applyTerminalPaneAttention()
+    return subscribeTerminalPaneAttention(tabId, applyTerminalPaneAttention)
+  }, [tabId, paneCount, applyTerminalPaneAttention])
 
   // Sync the data-has-title attribute on pane containers when titles change,
   // and reflow terminals so safeFit() sees the correct available height.

--- a/src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+const storeMock = vi.hoisted(() => ({
+  state: {
+    settings: { experimentalTerminalAttention: true },
+    unreadTerminalPanes: {}
+  } as {
+    settings: { experimentalTerminalAttention?: boolean } | null
+    unreadTerminalPanes: Record<string, true>
+  },
+  subscribers: [] as ((state: {
+    settings: { experimentalTerminalAttention?: boolean } | null
+    unreadTerminalPanes: Record<string, true>
+  }) => void)[]
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => storeMock.state,
+    subscribe: (
+      listener: (state: {
+        settings: { experimentalTerminalAttention?: boolean } | null
+        unreadTerminalPanes: Record<string, true>
+      }) => void
+    ) => {
+      storeMock.subscribers.push(listener)
+      return () => {
+        storeMock.subscribers = storeMock.subscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+import {
+  applyTerminalPaneAttentionToManager,
+  resetTerminalPaneAttentionSubscriptionsForTests,
+  subscribeTerminalPaneAttention
+} from './terminal-pane-attention-subscriptions'
+
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+const LEAF_3 = '33333333-3333-4333-8333-333333333333'
+
+function emitStoreChange(): void {
+  for (const subscriber of storeMock.subscribers.slice()) {
+    subscriber(storeMock.state)
+  }
+}
+
+function createPane(leafId: string) {
+  const attributes = new Set<string>()
+  return {
+    leafId,
+    container: {
+      setAttribute: vi.fn((name: string) => {
+        attributes.add(name)
+      }),
+      removeAttribute: vi.fn((name: string) => {
+        attributes.delete(name)
+      }),
+      hasAttribute: (name: string) => attributes.has(name)
+    }
+  }
+}
+
+function createManager(panes: ReturnType<typeof createPane>[]) {
+  return {
+    getPanes: () => panes
+  }
+}
+
+describe('terminal pane attention subscriptions', () => {
+  beforeEach(() => {
+    storeMock.state = {
+      settings: { experimentalTerminalAttention: true },
+      unreadTerminalPanes: {}
+    }
+    storeMock.subscribers = []
+  })
+
+  afterEach(() => {
+    resetTerminalPaneAttentionSubscriptionsForTests()
+    storeMock.subscribers = []
+  })
+
+  it('shares one store subscriber and notifies only tabs with changed pane attention', () => {
+    const tab1Listener = vi.fn()
+    const tab2Listener = vi.fn()
+    const unsubscribeTab1 = subscribeTerminalPaneAttention('tab-1', tab1Listener)
+    const unsubscribeTab2 = subscribeTerminalPaneAttention('tab-2', tab2Listener)
+
+    expect(storeMock.subscribers).toHaveLength(1)
+
+    storeMock.state = {
+      ...storeMock.state,
+      unreadTerminalPanes: { [makePaneKey('tab-1', LEAF_1)]: true }
+    }
+    emitStoreChange()
+
+    expect(tab1Listener).toHaveBeenCalledTimes(1)
+    expect(tab2Listener).not.toHaveBeenCalled()
+
+    storeMock.state = {
+      ...storeMock.state,
+      unreadTerminalPanes: {
+        ...storeMock.state.unreadTerminalPanes,
+        [makePaneKey('tab-2', LEAF_2)]: true
+      }
+    }
+    emitStoreChange()
+
+    expect(tab1Listener).toHaveBeenCalledTimes(1)
+    expect(tab2Listener).toHaveBeenCalledTimes(1)
+
+    unsubscribeTab1()
+    expect(storeMock.subscribers).toHaveLength(1)
+    unsubscribeTab2()
+    expect(storeMock.subscribers).toHaveLength(0)
+  })
+
+  it('does not notify unread changes while attention is disabled, but notifies all on toggle', () => {
+    storeMock.state = {
+      settings: { experimentalTerminalAttention: false },
+      unreadTerminalPanes: {}
+    }
+    const tab1Listener = vi.fn()
+    const tab2Listener = vi.fn()
+    subscribeTerminalPaneAttention('tab-1', tab1Listener)
+    subscribeTerminalPaneAttention('tab-2', tab2Listener)
+
+    storeMock.state = {
+      ...storeMock.state,
+      unreadTerminalPanes: { [makePaneKey('tab-1', LEAF_1)]: true }
+    }
+    emitStoreChange()
+
+    expect(tab1Listener).not.toHaveBeenCalled()
+    expect(tab2Listener).not.toHaveBeenCalled()
+
+    storeMock.state = {
+      ...storeMock.state,
+      settings: { experimentalTerminalAttention: true }
+    }
+    emitStoreChange()
+
+    expect(tab1Listener).toHaveBeenCalledTimes(1)
+    expect(tab2Listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies attention attributes only to unread panes in the requested tab', () => {
+    storeMock.state = {
+      settings: { experimentalTerminalAttention: true },
+      unreadTerminalPanes: {
+        [makePaneKey('tab-1', LEAF_1)]: true,
+        [makePaneKey('tab-2', LEAF_3)]: true
+      }
+    }
+    const pane1 = createPane(LEAF_1)
+    const pane2 = createPane(LEAF_2)
+
+    applyTerminalPaneAttentionToManager(createManager([pane1, pane2]) as never, 'tab-1')
+
+    expect(pane1.container.hasAttribute('data-terminal-attention')).toBe(true)
+    expect(pane2.container.hasAttribute('data-terminal-attention')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.ts
@@ -1,0 +1,152 @@
+import { useAppStore } from '@/store'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+type TerminalPaneAttentionListener = () => void
+
+type TerminalPaneAttentionState = ReturnType<typeof useAppStore.getState>
+
+const listenersByTabId = new Map<string, Set<TerminalPaneAttentionListener>>()
+let unsubscribeStore: (() => void) | null = null
+let previousUnreadTerminalPanes: TerminalPaneAttentionState['unreadTerminalPanes'] | null = null
+let previousAttentionEnabled = false
+
+function isTerminalAttentionEnabled(state: TerminalPaneAttentionState): boolean {
+  return state.settings?.experimentalTerminalAttention === true
+}
+
+function tabIdFromPaneKey(paneKey: string): string | null {
+  const delimiter = paneKey.indexOf(':')
+  if (delimiter <= 0) {
+    return null
+  }
+  return paneKey.slice(0, delimiter)
+}
+
+function notifyTab(tabId: string): void {
+  const listeners = listenersByTabId.get(tabId)
+  if (!listeners) {
+    return
+  }
+  for (const listener of Array.from(listeners)) {
+    listener()
+  }
+}
+
+function notifyAllTabs(): void {
+  for (const tabId of listenersByTabId.keys()) {
+    notifyTab(tabId)
+  }
+}
+
+function collectChangedTabs(
+  previous: TerminalPaneAttentionState['unreadTerminalPanes'],
+  next: TerminalPaneAttentionState['unreadTerminalPanes']
+): Set<string> {
+  const changed = new Set<string>()
+  for (const paneKey of Object.keys(previous)) {
+    if (!next[paneKey]) {
+      const tabId = tabIdFromPaneKey(paneKey)
+      if (tabId) {
+        changed.add(tabId)
+      }
+    }
+  }
+  for (const paneKey of Object.keys(next)) {
+    if (!previous[paneKey]) {
+      const tabId = tabIdFromPaneKey(paneKey)
+      if (tabId) {
+        changed.add(tabId)
+      }
+    }
+  }
+  return changed
+}
+
+function ensureStoreSubscription(): void {
+  if (unsubscribeStore !== null) {
+    return
+  }
+  const initial = useAppStore.getState()
+  previousUnreadTerminalPanes = initial.unreadTerminalPanes
+  previousAttentionEnabled = isTerminalAttentionEnabled(initial)
+  unsubscribeStore = useAppStore.subscribe((state) => {
+    const nextUnreadTerminalPanes = state.unreadTerminalPanes
+    const nextAttentionEnabled = isTerminalAttentionEnabled(state)
+    const attentionChanged = nextAttentionEnabled !== previousAttentionEnabled
+    const unreadChanged = nextUnreadTerminalPanes !== previousUnreadTerminalPanes
+    if (!attentionChanged && !unreadChanged) {
+      return
+    }
+
+    const changedTabs =
+      unreadChanged && previousUnreadTerminalPanes
+        ? collectChangedTabs(previousUnreadTerminalPanes, nextUnreadTerminalPanes)
+        : new Set<string>()
+
+    previousUnreadTerminalPanes = nextUnreadTerminalPanes
+    previousAttentionEnabled = nextAttentionEnabled
+
+    if (attentionChanged) {
+      notifyAllTabs()
+      return
+    }
+    if (!nextAttentionEnabled) {
+      return
+    }
+    for (const tabId of changedTabs) {
+      notifyTab(tabId)
+    }
+  })
+}
+
+export function subscribeTerminalPaneAttention(
+  tabId: string,
+  listener: TerminalPaneAttentionListener
+): () => void {
+  ensureStoreSubscription()
+  let listeners = listenersByTabId.get(tabId)
+  if (!listeners) {
+    listeners = new Set()
+    listenersByTabId.set(tabId, listeners)
+  }
+  listeners.add(listener)
+  return () => {
+    const current = listenersByTabId.get(tabId)
+    if (!current) {
+      return
+    }
+    current.delete(listener)
+    if (current.size === 0) {
+      listenersByTabId.delete(tabId)
+    }
+    if (listenersByTabId.size === 0 && unsubscribeStore !== null) {
+      unsubscribeStore()
+      unsubscribeStore = null
+      previousUnreadTerminalPanes = null
+      previousAttentionEnabled = false
+    }
+  }
+}
+
+export function applyTerminalPaneAttentionToManager(manager: PaneManager, tabId: string): void {
+  const state = useAppStore.getState()
+  const enabled = isTerminalAttentionEnabled(state)
+  const unreadTerminalPanes = state.unreadTerminalPanes
+  for (const pane of manager.getPanes()) {
+    const paneKey = makePaneKey(tabId, pane.leafId)
+    if (enabled && unreadTerminalPanes[paneKey]) {
+      pane.container.setAttribute('data-terminal-attention', '')
+    } else {
+      pane.container.removeAttribute('data-terminal-attention')
+    }
+  }
+}
+
+export function resetTerminalPaneAttentionSubscriptionsForTests(): void {
+  unsubscribeStore?.()
+  unsubscribeStore = null
+  listenersByTabId.clear()
+  previousUnreadTerminalPanes = null
+  previousAttentionEnabled = false
+}


### PR DESCRIPTION
## Summary
- move terminal attention marker updates off broad TerminalPane Zustand selectors
- share one raw store subscription for terminal pane attention and notify only affected tabs when unread pane keys change
- apply attention DOM attributes directly from the shared subscription so unrelated terminal panes do not re-render on one pane's unread marker

## Risk
Low to medium. This is renderer-only and scoped to the visual terminal attention marker. The store state and mark/clear semantics are unchanged; the new subscription layer still notifies all tabs when the attention setting toggles.

## Local verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.ts src/renderer/src/components/terminal-pane/terminal-pane-attention-subscriptions.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`
- `pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts`