### PR TITLE
Fix renderer editor settings edge cases

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-doc-link-code-context.ts
+++ b/src/renderer/src/components/editor/rich-markdown-doc-link-code-context.ts
@@ -1,0 +1,16 @@
+type DocLinkTextNodeContext = {
+  marks: readonly { type: { name: string } }[]
+}
+
+type DocLinkParentContext = {
+  type: { spec: { code?: boolean } }
+}
+
+// Why: inline/fenced code content is literal markdown; auto-converting it would
+// corrupt examples and commands that intentionally contain [[...]] text.
+export function isDocLinkLiteralCodeTextNode(
+  node: DocLinkTextNodeContext,
+  parent: DocLinkParentContext | null
+): boolean {
+  return parent?.type.spec.code === true || node.marks.some((mark) => mark.type.name === 'code')
+}

--- a/src/renderer/src/components/editor/rich-markdown-doc-link.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-doc-link.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { isDocLinkLiteralCodeTextNode } from './rich-markdown-doc-link-code-context'
+
+function textContext(markNames: string[] = []) {
+  return {
+    marks: markNames.map((name) => ({ type: { name } }))
+  }
+}
+
+function parentContext(code: boolean) {
+  return {
+    type: {
+      spec: { code }
+    }
+  }
+}
+
+describe('isDocLinkLiteralCodeTextNode', () => {
+  it('allows doc link conversion in ordinary prose text', () => {
+    expect(isDocLinkLiteralCodeTextNode(textContext(), parentContext(false))).toBe(false)
+  })
+
+  it('skips doc link conversion for inline code marks', () => {
+    expect(isDocLinkLiteralCodeTextNode(textContext(['code']), parentContext(false))).toBe(true)
+  })
+
+  it('skips doc link conversion for fenced code block text', () => {
+    expect(isDocLinkLiteralCodeTextNode(textContext(), parentContext(true))).toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-doc-link.ts
+++ b/src/renderer/src/components/editor/rich-markdown-doc-link.ts
@@ -9,6 +9,7 @@ import {
   parseMarkdownDocLink,
   resolveMarkdownDocLink
 } from './markdown-doc-links'
+import { isDocLinkLiteralCodeTextNode } from './rich-markdown-doc-link-code-context'
 
 const DOC_LINK_PLACEHOLDER_PREFIX = '[[ORCA_DOC_LINK:'
 const DOC_LINK_PLACEHOLDER_SUFFIX = ']]'
@@ -46,8 +47,11 @@ function buildPreviewDecorations(state: EditorState, storage: DocLinkStorage): D
   const decorations: Decoration[] = []
   const index = getDocIndex(storage)
   const cursor = state.selection.from
-  state.doc.descendants((node, pos) => {
+  state.doc.descendants((node, pos, parent) => {
     if (node.type.name !== 'text' || !node.text) {
+      return
+    }
+    if (isDocLinkLiteralCodeTextNode(node, parent)) {
       return
     }
     for (const match of node.text.matchAll(DOC_LINK_PATTERN)) {
@@ -272,8 +276,11 @@ export const MarkdownDocLink = Node.create({
           const cursor = newState.selection.from
           let modified = false
 
-          newState.doc.descendants((node, pos) => {
+          newState.doc.descendants((node, pos, parent) => {
             if (node.type.name !== 'text' || !node.text) {
+              return
+            }
+            if (isDocLinkLiteralCodeTextNode(node, parent)) {
               return
             }
 

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -33,6 +33,7 @@ import { ShortcutRowsList } from './ShortcutRowsList'
 import { ShortcutTerminalPolicyControl } from './ShortcutTerminalPolicyControl'
 import { TERMINAL_SHORTCUT_POLICY_SEARCH_ENTRY } from './shortcuts-search'
 import { matchesSettingsSearch, normalizeSettingsSearchQuery } from './settings-search'
+import { clearRecordingActionForShortcutMutation } from './shortcut-recording-state'
 import { useMountedRef } from '@/hooks/useMountedRef'
 
 type ShortcutGroup = {
@@ -330,6 +331,12 @@ export function ShortcutsPane(): React.JSX.Element {
     setErrors((prev) => ({ ...prev, [actionId]: undefined }))
   }
 
+  const clearRecordingForAction = (actionId: KeybindingActionId): void => {
+    // Why: disable/reset are final shortcut edits; the next keypress must not
+    // be captured into the shortcut the user just removed or restored.
+    setRecordingActionId((current) => clearRecordingActionForShortcutMutation(current, actionId))
+  }
+
   const showPolicy = matchesSettingsSearch(searchQuery, TERMINAL_SHORTCUT_POLICY_SEARCH_ENTRY)
 
   return (
@@ -378,8 +385,14 @@ export function ShortcutsPane(): React.JSX.Element {
               onCancelRecording={() => setRecordingActionId(null)}
               onCapture={(actionId, input) => void captureBinding(actionId, input)}
               onClearError={clearError}
-              onDisable={(actionId) => void disableBinding(actionId)}
-              onReset={(actionId) => void resetBinding(actionId)}
+              onDisable={(actionId) => {
+                clearRecordingForAction(actionId)
+                void disableBinding(actionId)
+              }}
+              onReset={(actionId) => {
+                clearRecordingForAction(actionId)
+                void resetBinding(actionId)
+              }}
             />
           </div>
         </div>

--- a/src/renderer/src/components/settings/SparsePresetSettingsSection.test.tsx
+++ b/src/renderer/src/components/settings/SparsePresetSettingsSection.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SparsePreset } from '../../../../shared/types'
+import { SparsePresetSettingsSection } from './SparsePresetSettingsSection'
+
+const storeMock = vi.hoisted(() => ({
+  state: {
+    sparsePresetsByRepo: {} as Record<string, SparsePreset[]>,
+    sparsePresetsLoadStatusByRepo: {} as Record<string, 'idle' | 'loading' | 'loaded' | 'error'>,
+    sparsePresetsErrorByRepo: {} as Record<string, string | undefined>,
+    fetchSparsePresets: vi.fn(),
+    saveSparsePreset: vi.fn(),
+    removeSparsePreset: vi.fn()
+  }
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: typeof storeMock.state) => unknown) => selector(storeMock.state)
+}))
+
+describe('SparsePresetSettingsSection', () => {
+  beforeEach(() => {
+    storeMock.state.sparsePresetsByRepo = {}
+    storeMock.state.sparsePresetsLoadStatusByRepo = {}
+    storeMock.state.sparsePresetsErrorByRepo = {}
+    storeMock.state.fetchSparsePresets.mockReset()
+    storeMock.state.saveSparsePreset.mockReset()
+    storeMock.state.removeSparsePreset.mockReset()
+  })
+
+  it('surfaces sparse preset load failures inline instead of showing an endless loader', () => {
+    storeMock.state.sparsePresetsLoadStatusByRepo = { 'repo-1': 'error' }
+    storeMock.state.sparsePresetsErrorByRepo = { 'repo-1': 'disk failed' }
+
+    const markup = renderToStaticMarkup(<SparsePresetSettingsSection repoId="repo-1" />)
+
+    expect(markup).toContain('role="alert"')
+    expect(markup).toContain('disk failed')
+    expect(markup).toContain('Sparse presets could not be loaded.')
+  })
+})

--- a/src/renderer/src/components/settings/SparsePresetSettingsSection.tsx
+++ b/src/renderer/src/components/settings/SparsePresetSettingsSection.tsx
@@ -8,6 +8,7 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
+import { getSparsePresetOperationErrorMessage } from './sparse-preset-operation-error'
 import { formatSparsePresetUpdatedAt } from './sparse-preset-date'
 
 type SparsePresetSettingsSectionProps = {
@@ -53,6 +54,8 @@ export function SparsePresetSettingsSection({
   repoId
 }: SparsePresetSettingsSectionProps): React.JSX.Element {
   const presets = useAppStore((s) => s.sparsePresetsByRepo[repoId])
+  const loadStatus = useAppStore((s) => s.sparsePresetsLoadStatusByRepo[repoId] ?? 'idle')
+  const loadError = useAppStore((s) => s.sparsePresetsErrorByRepo[repoId])
   const fetchSparsePresets = useAppStore((s) => s.fetchSparsePresets)
   const saveSparsePreset = useAppStore((s) => s.saveSparsePreset)
   const removeSparsePreset = useAppStore((s) => s.removeSparsePreset)
@@ -60,13 +63,21 @@ export function SparsePresetSettingsSection({
   const [draft, setDraft] = useState<SparsePresetDraft | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<string | null>(null)
+  const [deletingPresetId, setDeletingPresetId] = useState<string | null>(null)
+  const [operationError, setOperationError] = useState<string | null>(null)
   const mountedRef = useMountedRef()
 
   useEffect(() => {
-    if (presets === undefined) {
-      void fetchSparsePresets(repoId)
+    if (presets === undefined && loadStatus === 'idle') {
+      void fetchSparsePresets(repoId).catch((error: unknown) => {
+        if (mountedRef.current) {
+          setOperationError(
+            getSparsePresetOperationErrorMessage(error, 'Failed to load sparse presets.')
+          )
+        }
+      })
     }
-  }, [fetchSparsePresets, presets, repoId])
+  }, [fetchSparsePresets, loadStatus, mountedRef, presets, repoId])
 
   const sortedPresets = presets ?? []
   const parsedDirectories = draft ? parseSparsePresetDirectories(draft.directoriesText) : null
@@ -89,9 +100,11 @@ export function SparsePresetSettingsSection({
           : null
   const canSaveDraft =
     !!draft && !submitting && !nameError && parsedDirectories !== null && !parsedDirectories.error
+  const visibleError = operationError ?? loadError ?? null
 
   const startNewPreset = (): void => {
     setConfirmingDeleteId(null)
+    setOperationError(null)
     setDraft({
       mode: 'new',
       name: '',
@@ -101,6 +114,7 @@ export function SparsePresetSettingsSection({
 
   const startEditPreset = (preset: SparsePreset): void => {
     setConfirmingDeleteId(null)
+    setOperationError(null)
     setDraft({
       mode: 'edit',
       presetId: preset.id,
@@ -114,6 +128,7 @@ export function SparsePresetSettingsSection({
       return
     }
     setSubmitting(true)
+    setOperationError(null)
     try {
       const saved = await saveSparsePreset({
         repoId,
@@ -123,6 +138,19 @@ export function SparsePresetSettingsSection({
       })
       if (saved && mountedRef.current) {
         setDraft(null)
+      } else if (mountedRef.current) {
+        setOperationError(
+          draft.mode === 'new' ? 'Failed to save preset.' : 'Failed to update preset.'
+        )
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        setOperationError(
+          getSparsePresetOperationErrorMessage(
+            error,
+            draft.mode === 'new' ? 'Failed to save preset.' : 'Failed to update preset.'
+          )
+        )
       }
     } finally {
       if (mountedRef.current) {
@@ -136,11 +164,28 @@ export function SparsePresetSettingsSection({
       setConfirmingDeleteId(preset.id)
       return
     }
-    if (draft?.presetId === preset.id) {
-      setDraft(null)
+    setDeletingPresetId(preset.id)
+    setOperationError(null)
+    try {
+      // Why: SSH-backed settings can fail after confirmation; keep local edit
+      // state intact until persistence actually reports success.
+      await removeSparsePreset({ repoId, presetId: preset.id })
+      if (mountedRef.current) {
+        if (draft?.presetId === preset.id) {
+          setDraft(null)
+        }
+        setConfirmingDeleteId(null)
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        setOperationError(getSparsePresetOperationErrorMessage(error, 'Failed to delete preset.'))
+        setConfirmingDeleteId(preset.id)
+      }
+    } finally {
+      if (mountedRef.current) {
+        setDeletingPresetId(null)
+      }
     }
-    setConfirmingDeleteId(null)
-    await removeSparsePreset({ repoId, presetId: preset.id })
   }
 
   const renderDraftEditor = (): React.JSX.Element | null => {
@@ -260,11 +305,20 @@ export function SparsePresetSettingsSection({
         </Button>
       </div>
 
+      {visibleError ? (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          {visibleError}
+        </div>
+      ) : null}
+
       {renderDraftEditor()}
 
       {presets === undefined ? (
         <div className="rounded-xl border border-dashed border-border/60 bg-background/60 px-4 py-6 text-sm text-muted-foreground">
-          Loading sparse presets...
+          {loadError ? 'Sparse presets could not be loaded.' : 'Loading sparse presets...'}
         </div>
       ) : sortedPresets.length === 0 && !draft ? (
         <div className="rounded-xl border border-dashed border-border/60 bg-background/60 px-4 py-6 text-sm text-muted-foreground">
@@ -276,6 +330,7 @@ export function SparsePresetSettingsSection({
             // Why: users can already have locally persisted presets from older
             // builds or hand-edited state; a bad timestamp must not blank Settings.
             const updatedLabel = formatSparsePresetUpdatedAt(preset.updatedAt)
+            const isDeleting = deletingPresetId === preset.id
 
             return (
               <div
@@ -307,7 +362,7 @@ export function SparsePresetSettingsSection({
                       size="icon-sm"
                       aria-label={`Edit ${preset.name}`}
                       onClick={() => startEditPreset(preset)}
-                      disabled={submitting}
+                      disabled={submitting || deletingPresetId !== null}
                     >
                       <Pencil className="size-3.5" />
                     </Button>
@@ -318,14 +373,22 @@ export function SparsePresetSettingsSection({
                       aria-label={`Delete ${preset.name}`}
                       onClick={() => void handleDeletePreset(preset)}
                       onBlur={() => setConfirmingDeleteId(null)}
-                      disabled={submitting}
+                      disabled={submitting || (deletingPresetId !== null && !isDeleting)}
                       className={cn(
-                        'w-[5.75rem] px-2 text-xs',
+                        'w-[6.5rem] px-2 text-xs',
                         confirmingDeleteId !== preset.id && 'text-muted-foreground'
                       )}
                     >
-                      <Trash2 className="size-3.5" />
-                      {confirmingDeleteId === preset.id ? 'Confirm' : 'Delete'}
+                      {isDeleting ? (
+                        <LoaderCircle className="size-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="size-3.5" />
+                      )}
+                      {isDeleting
+                        ? 'Deleting'
+                        : confirmingDeleteId === preset.id
+                          ? 'Confirm'
+                          : 'Delete'}
                     </Button>
                   </div>
                 </div>

--- a/src/renderer/src/components/settings/shortcut-recording-state.test.ts
+++ b/src/renderer/src/components/settings/shortcut-recording-state.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import type { KeybindingActionId } from '../../../../shared/keybindings'
+import { clearRecordingActionForShortcutMutation } from './shortcut-recording-state'
+
+describe('clearRecordingActionForShortcutMutation', () => {
+  it('ends recording when the edited shortcut is disabled or reset', () => {
+    expect(
+      clearRecordingActionForShortcutMutation(
+        'app.settings' satisfies KeybindingActionId,
+        'app.settings'
+      )
+    ).toBeNull()
+  })
+
+  it('keeps a different active recorder untouched', () => {
+    expect(
+      clearRecordingActionForShortcutMutation(
+        'app.settings' satisfies KeybindingActionId,
+        'tab.close'
+      )
+    ).toBe('app.settings')
+  })
+})

--- a/src/renderer/src/components/settings/shortcut-recording-state.ts
+++ b/src/renderer/src/components/settings/shortcut-recording-state.ts
@@ -1,0 +1,8 @@
+import type { KeybindingActionId } from '../../../../shared/keybindings'
+
+export function clearRecordingActionForShortcutMutation(
+  recordingActionId: KeybindingActionId | null,
+  actionId: KeybindingActionId
+): KeybindingActionId | null {
+  return recordingActionId === actionId ? null : recordingActionId
+}

--- a/src/renderer/src/components/settings/sparse-preset-operation-error.test.ts
+++ b/src/renderer/src/components/settings/sparse-preset-operation-error.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getSparsePresetOperationErrorMessage } from './sparse-preset-operation-error'
+
+describe('getSparsePresetOperationErrorMessage', () => {
+  it('uses the thrown error message when an async sparse preset action rejects', () => {
+    expect(getSparsePresetOperationErrorMessage(new Error('disk failed'), 'fallback')).toBe(
+      'disk failed'
+    )
+  })
+
+  it('falls back for non-error rejections', () => {
+    expect(getSparsePresetOperationErrorMessage('nope', 'Failed to save preset.')).toBe(
+      'Failed to save preset.'
+    )
+  })
+})

--- a/src/renderer/src/components/settings/sparse-preset-operation-error.ts
+++ b/src/renderer/src/components/settings/sparse-preset-operation-error.ts
@@ -1,0 +1,3 @@
+export function getSparsePresetOperationErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
+}

--- a/src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts
@@ -12,6 +12,12 @@ function targetMatching(selector: string | null): EventTarget & {
   } as EventTarget & { closest: (value: string) => Element | null }
 }
 
+function textTargetInside(selector: string): EventTarget {
+  return {
+    parentElement: targetMatching(selector)
+  } as unknown as EventTarget
+}
+
 describe('shouldOpenStatusBarContextMenu', () => {
   it('opens for plain status-bar right-clicks', () => {
     expect(shouldOpenStatusBarContextMenu(targetMatching(null))).toBe(true)
@@ -31,5 +37,11 @@ describe('shouldOpenStatusBarContextMenu', () => {
 
   it('opens when the browser gives a non-element target', () => {
     expect(shouldOpenStatusBarContextMenu(null)).toBe(true)
+  })
+
+  it('honors exemptions when the event target is a text node inside the exempt surface', () => {
+    expect(
+      shouldOpenStatusBarContextMenu(textTargetInside(STATUS_BAR_CONTEXT_MENU_EXEMPT_SELECTOR))
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-context-menu-policy.ts
+++ b/src/renderer/src/components/status-bar/status-bar-context-menu-policy.ts
@@ -6,21 +6,40 @@ export const STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS = {
 
 const FLOATING_TERMINAL_TOGGLE_SELECTOR = '[data-floating-terminal-toggle]'
 
-function hasClosest(target: EventTarget | null): target is EventTarget & {
+type ClosestCapableTarget = EventTarget & {
   closest: (selector: string) => Element | null
-} {
+}
+
+function hasClosest(target: unknown): target is ClosestCapableTarget {
   return typeof (target as { closest?: unknown } | null)?.closest === 'function'
 }
 
+function closestTargetFromEventTarget(target: EventTarget | null): ClosestCapableTarget | null {
+  if (hasClosest(target)) {
+    return target
+  }
+
+  // Why: contextmenu can target Text nodes inside exempt surfaces; their
+  // Element parent still carries the opt-out selector.
+  const parentElement = (target as { parentElement?: unknown } | null)?.parentElement
+  if (hasClosest(parentElement)) {
+    return parentElement
+  }
+
+  const parentNode = (target as { parentNode?: unknown } | null)?.parentNode
+  return hasClosest(parentNode) ? parentNode : null
+}
+
 export function shouldOpenStatusBarContextMenu(target: EventTarget | null): boolean {
-  if (!hasClosest(target)) {
+  const closestTarget = closestTargetFromEventTarget(target)
+  if (!closestTarget) {
     return true
   }
 
   // Why: Radix portal events can still bubble through the StatusBar React tree;
   // nested status-bar surfaces opt out so their right-clicks stay local.
   return (
-    target.closest(FLOATING_TERMINAL_TOGGLE_SELECTOR) === null &&
-    target.closest(STATUS_BAR_CONTEXT_MENU_EXEMPT_SELECTOR) === null
+    closestTarget.closest(FLOATING_TERMINAL_TOGGLE_SELECTOR) === null &&
+    closestTarget.closest(STATUS_BAR_CONTEXT_MENU_EXEMPT_SELECTOR) === null
   )
 }

--- a/src/renderer/src/store/slices/sparse-presets.test.ts
+++ b/src/renderer/src/store/slices/sparse-presets.test.ts
@@ -226,7 +226,9 @@ describe('createSparsePresetsSlice', () => {
     mockApi.sparsePresets.remove.mockRejectedValueOnce(new Error('disk failed'))
     store.setState({ sparsePresetsByRepo: { 'repo-1': [preset] } } as Partial<AppState>)
 
-    await store.getState().removeSparsePreset({ repoId: 'repo-1', presetId: 'preset-1' })
+    await expect(
+      store.getState().removeSparsePreset({ repoId: 'repo-1', presetId: 'preset-1' })
+    ).rejects.toThrow('disk failed')
 
     expect(store.getState().sparsePresetsByRepo['repo-1']).toEqual([preset])
   })

--- a/src/renderer/src/store/slices/sparse-presets.ts
+++ b/src/renderer/src/store/slices/sparse-presets.ts
@@ -130,6 +130,8 @@ export const createSparsePresetsSlice: StateCreator<AppState, [], [], SparsePres
         description: message,
         duration: ERROR_TOAST_DURATION
       })
+      // Why: settings UI keeps confirmation/edit state until persistence succeeds.
+      throw err
     }
   }
 })


### PR DESCRIPTION
## Summary
- skip rich Markdown doc-link auto-conversion and preview inside inline/fenced code contexts
- keep shortcut recording state from capturing after reset/disable edits
- surface sparse preset load/save/delete failures inline and keep delete/edit state until persistence succeeds
- honor status-bar context-menu exemptions for text-node event targets

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-doc-link.test.ts src/renderer/src/components/editor/markdown-round-trip.test.ts src/renderer/src/components/settings/SparsePresetSettingsSection.test.tsx src/renderer/src/components/settings/shortcut-recording-state.test.ts src/renderer/src/components/settings/sparse-preset-operation-error.test.ts src/renderer/src/components/status-bar/status-bar-context-menu-policy.test.ts src/renderer/src/store/slices/sparse-presets.test.ts
- pnpm typecheck
- pnpm lint

Risk: medium
This batches editor doc-link behavior, shortcut recording state, sparse preset persistence failures, status-bar context-menu policy, and renderer store behavior. The tests are focused, but the renderer/editor/settings breadth keeps it above low risk.