### PR TITLE
Fix Copilot hook status, delete callbacks, and quick open path filters

### DIFF
--- a/src/main/copilot/hook-service.test.ts
+++ b/src/main/copilot/hook-service.test.ts
@@ -46,6 +46,16 @@ function readConfig(): Record<string, unknown> {
   return JSON.parse(readFileSync(join(copilotHome, 'hooks', 'orca.json'), 'utf-8'))
 }
 
+function makeStaleManagedHookDefinition(): Record<string, unknown> {
+  if (process.platform === 'win32') {
+    return {
+      type: 'command',
+      powershell: 'powershell.exe -File C:/old/agent-hooks/copilot-hook.ps1'
+    }
+  }
+  return { type: 'command', bash: '/bin/sh "/old/agent-hooks/copilot-hook.sh"' }
+}
+
 describe('CopilotHookService', () => {
   it('installs a user-level Copilot hook file under COPILOT_HOME', () => {
     const service = new CopilotHookService()
@@ -118,9 +128,9 @@ describe('CopilotHookService', () => {
           hooks: {
             UserPromptSubmit: [
               { type: 'command', bash: 'echo user prompt' },
-              { type: 'command', bash: '/bin/sh "/old/agent-hooks/copilot-hook.sh"' }
+              makeStaleManagedHookDefinition()
             ],
-            OldEvent: [{ type: 'command', bash: '/bin/sh "/old/agent-hooks/copilot-hook.sh"' }]
+            OldEvent: [makeStaleManagedHookDefinition()]
           }
         },
         null,
@@ -137,6 +147,46 @@ describe('CopilotHookService', () => {
       expect.arrayContaining([expect.objectContaining({ bash: 'echo user prompt' })])
     )
     expect(hooks.UserPromptSubmit).toHaveLength(2)
+  })
+
+  it('reports partial when stale managed hooks only exist under retired events', () => {
+    const configPath = join(copilotHome, 'hooks', 'orca.json')
+    mkdirSync(join(copilotHome, 'hooks'), { recursive: true })
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          version: 1,
+          hooks: {
+            OldEvent: [makeStaleManagedHookDefinition()]
+          }
+        },
+        null,
+        2
+      )
+    )
+
+    const status = new CopilotHookService().getStatus()
+
+    expect(status.state).toBe('partial')
+    expect(status.managedHooksPresent).toBe(true)
+    expect(status.detail).toBe('Managed Copilot hook file contains stale entries')
+  })
+
+  it('reports partial when stale managed hooks remain alongside current hooks', () => {
+    const service = new CopilotHookService()
+    service.install()
+    const configPath = join(copilotHome, 'hooks', 'orca.json')
+    const config = readConfig()
+    const hooks = config.hooks as Record<string, unknown[]>
+    hooks.UserPromptSubmit.push(makeStaleManagedHookDefinition())
+    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`)
+
+    const status = service.getStatus()
+
+    expect(status.state).toBe('partial')
+    expect(status.managedHooksPresent).toBe(true)
+    expect(status.detail).toBe('Managed Copilot hook file contains stale entries')
   })
 
   it('forces version 1 in the dedicated Copilot hook file', () => {

--- a/src/main/copilot/hook-service.ts
+++ b/src/main/copilot/hook-service.ts
@@ -9,7 +9,6 @@ import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared
 import {
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
-  hookDefinitionHasManagedCommand,
   readHooksJson,
   removeManagedCommands,
   wrapPosixHookCommand,
@@ -88,6 +87,23 @@ function definitionHasCurrentCommand(definition: HookDefinition, command: string
     definition.bash === command ||
     definition.powershell === command ||
     (Array.isArray(definition.hooks) && definition.hooks.some((hook) => hook.command === command))
+  )
+}
+
+function definitionHasStaleManagedCommand(
+  definition: HookDefinition,
+  currentCommand: string | null,
+  isManagedCommand: (command: string | undefined) => boolean
+): boolean {
+  const commands = [definition.command, definition.bash, definition.powershell]
+  if (commands.some((command) => isManagedCommand(command) && command !== currentCommand)) {
+    return true
+  }
+  return (
+    Array.isArray(definition.hooks) &&
+    definition.hooks.some(
+      (hook) => isManagedCommand(hook.command) && hook.command !== currentCommand
+    )
   )
 }
 
@@ -184,6 +200,7 @@ export class CopilotHookService {
     const missing: string[] = []
     let presentCount = 0
     let staleManagedPresent = false
+    const managedEvents = new Set<string>(COPILOT_EVENTS)
     for (const eventName of COPILOT_EVENTS) {
       const command = getManagedCommand(scriptPath, eventName)
       const definitions = Array.isArray(config.hooks?.[eventName]) ? config.hooks![eventName]! : []
@@ -194,12 +211,20 @@ export class CopilotHookService {
         presentCount += 1
       } else {
         missing.push(eventName)
-        staleManagedPresent =
-          staleManagedPresent ||
-          definitions.some((definition) =>
-            hookDefinitionHasManagedCommand(definition, isManagedCommand)
-          )
       }
+    }
+    for (const [eventName, definitions] of Object.entries(config.hooks ?? {})) {
+      if (!Array.isArray(definitions)) {
+        continue
+      }
+      const currentCommand = managedEvents.has(eventName)
+        ? getManagedCommand(scriptPath, eventName)
+        : null
+      staleManagedPresent =
+        staleManagedPresent ||
+        definitions.some((definition) =>
+          definitionHasStaleManagedCommand(definition, currentCommand, isManagedCommand)
+        )
     }
 
     const managedHooksPresent = presentCount > 0 || staleManagedPresent
@@ -208,6 +233,9 @@ export class CopilotHookService {
     if (config.disableAllHooks === true && managedHooksPresent) {
       state = 'partial'
       detail = 'Managed Copilot hook file is disabled'
+    } else if (staleManagedPresent) {
+      state = 'partial'
+      detail = 'Managed Copilot hook file contains stale entries'
     } else if (missing.length === 0) {
       state = 'installed'
       detail = null

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => {
     openSettingsPage: vi.fn(),
     deleteStateByWorktreeId: {}
   }
-  return { state }
+  return { state, buttonProps: [] as Record<string, unknown>[] }
 })
 
 vi.mock('@/store', () => ({
@@ -44,9 +44,10 @@ vi.mock('@/components/ui/button', () => ({
   Button: ({
     children,
     ...props
-  }: ButtonHTMLAttributes<HTMLButtonElement> & { children: ReactNode }) => (
-    <button {...props}>{children}</button>
-  )
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { children: ReactNode }) => {
+    mocks.buttonProps.push({ ...props, children })
+    return <button {...props}>{children}</button>
+  }
 }))
 
 vi.mock('@/components/ui/scroll-area', () => ({
@@ -63,6 +64,8 @@ vi.mock('sonner', () => ({
 vi.mock('./delete-worktree-flow', () => ({
   runWorktreeDeletesInParallel: vi.fn()
 }))
+
+import { runWorktreeDeletesInParallel } from './delete-worktree-flow'
 
 function makeWorktree(id: string, path: string): Worktree {
   return {
@@ -108,6 +111,8 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     mocks.state.repos = []
     mocks.state.worktreeLineageById = {}
     mocks.state.deleteStateByWorktreeId = {}
+    mocks.buttonProps = []
+    vi.mocked(runWorktreeDeletesInParallel).mockResolvedValue([])
   })
 
   it('shows parent-only copy and a delete-all action when the workspace has children', async () => {
@@ -168,5 +173,31 @@ describe('DeleteWorktreeDialog lineage copy', () => {
 
     expect(markup).toContain('from Orca. The project folder on disk will not be deleted.')
     expect(markup).not.toContain('from git and delete its workspace folder.')
+  })
+
+  it('notifies the dialog caller after a toast force delete succeeds', async () => {
+    const workspace = makeWorktree('Workspace', '/workspaces/workspace')
+    const onDeleted = vi.fn()
+    mocks.state.modalData = { worktreeId: workspace.id, onDeleted }
+    mocks.state.allWorktrees.mockReturnValue([workspace])
+
+    const { default: DeleteWorktreeDialog } = await import('./DeleteWorktreeDialog')
+    renderToStaticMarkup(<DeleteWorktreeDialog />)
+
+    const deleteButton = mocks.buttonProps.find((props) => props.variant === 'destructive') as
+      | { onClick?: (event: never) => void }
+      | undefined
+    expect(deleteButton).toBeDefined()
+    deleteButton?.onClick?.(undefined as never)
+
+    expect(runWorktreeDeletesInParallel).toHaveBeenCalledWith([workspace], {
+      onForceDeleted: expect.any(Function)
+    })
+    const options = vi.mocked(runWorktreeDeletesInParallel).mock.calls[0]?.[1] as
+      | { onForceDeleted?: (worktreeId: string) => void }
+      | undefined
+    options?.onForceDeleted?.(workspace.id)
+
+    expect(onDeleted).toHaveBeenCalledWith([workspace.id])
   })
 })

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -185,6 +185,13 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
     })
   }, [openSettingsPage, openSettingsTarget, updateSettings])
 
+  const handleForceDeletedFromToast = useCallback(
+    (deletedId: string): void => {
+      onDeleted?.([deletedId])
+    },
+    [onDeleted]
+  )
+
   const handleDelete = useCallback(
     (force = false) => {
       if (worktreeIds.length === 0) {
@@ -220,7 +227,9 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
             })
           })
       } else {
-        const deletePromise = runWorktreeDeletesInParallel(worktrees)
+        const deletePromise = runWorktreeDeletesInParallel(worktrees, {
+          onForceDeleted: handleForceDeletedFromToast
+        })
         // Why: the workspace card owns the in-progress feedback, so the
         // confirmation should get out of the way as soon as deletion begins.
         closeModal()
@@ -235,6 +244,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
       closeModal,
       dontAskAgain,
       allowSkipConfirm,
+      handleForceDeletedFromToast,
       onDeleted,
       persistDontAskAgainPreference,
       removeWorktree,
@@ -248,7 +258,9 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
     if (lineageDelete.deleteAllTargets.length <= 1) {
       return
     }
-    const deletePromise = runWorktreeDeletesInParallel(lineageDelete.deleteAllTargets)
+    const deletePromise = runWorktreeDeletesInParallel(lineageDelete.deleteAllTargets, {
+      onForceDeleted: handleForceDeletedFromToast
+    })
     // Why: like the parent-only path, deletion progress is shown on the
     // workspace cards; the modal should not sit on top of that in-progress UI.
     closeModal()
@@ -257,7 +269,7 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
         onDeleted?.(deletedIds)
       }
     })
-  }, [closeModal, lineageDelete.deleteAllTargets, onDeleted])
+  }, [closeModal, handleForceDeletedFromToast, lineageDelete.deleteAllTargets, onDeleted])
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -161,6 +161,34 @@ describe('runWorktreeBatchDelete', () => {
     })
   })
 
+  it('notifies onDeleted after a skip-confirm force delete succeeds', async () => {
+    mocks.state.settings = { skipDeleteWorktreeConfirm: true }
+    mocks.state.deleteStateByWorktreeId = {
+      'wt-1': { canForceDelete: true }
+    }
+    mocks.state.removeWorktree
+      .mockResolvedValueOnce({ ok: false, error: 'changed files' })
+      .mockResolvedValueOnce({ ok: true })
+    setWorktrees([{ id: 'wt-1', displayName: 'one' }])
+    const onDeleted = vi.fn()
+
+    const started = runWorktreeBatchDelete(['wt-1'], { onDeleted })
+
+    expect(started).toBe(true)
+    await vi.waitFor(() => {
+      expect(toast.info).toHaveBeenCalled()
+    })
+    const toastOptions = vi.mocked(toast.info).mock.calls[0]?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    toastOptions?.action?.onClick?.()
+
+    await vi.waitFor(() => {
+      expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-1', true)
+      expect(onDeleted).toHaveBeenCalledWith(['wt-1'])
+    })
+  })
+
   it('keeps parent workspace deletes behind confirmation even when confirmation is skipped', () => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: true }
     setWorktrees([

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -163,21 +163,16 @@ describe('runWorktreeBatchDelete', () => {
 
   it('notifies onDeleted after a skip-confirm force delete succeeds', async () => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: true }
-    mocks.state.deleteStateByWorktreeId = {
-      'wt-1': { canForceDelete: true }
-    }
+    mocks.state.deleteStateByWorktreeId = { 'wt-1': { canForceDelete: true } }
     mocks.state.removeWorktree
       .mockResolvedValueOnce({ ok: false, error: 'changed files' })
       .mockResolvedValueOnce({ ok: true })
     setWorktrees([{ id: 'wt-1', displayName: 'one' }])
     const onDeleted = vi.fn()
 
-    const started = runWorktreeBatchDelete(['wt-1'], { onDeleted })
+    expect(runWorktreeBatchDelete(['wt-1'], { onDeleted })).toBe(true)
 
-    expect(started).toBe(true)
-    await vi.waitFor(() => {
-      expect(toast.info).toHaveBeenCalled()
-    })
+    await vi.waitFor(() => expect(toast.info).toHaveBeenCalled())
     const toastOptions = vi.mocked(toast.info).mock.calls[0]?.[1] as
       | { action?: { onClick?: () => void } }
       | undefined

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -15,6 +15,10 @@ type WorktreeBatchDeleteOptions = {
   onDeleted?: (worktreeIds: string[]) => void
 }
 
+type WorktreeDeleteWithToastOptions = {
+  onForceDeleted?: (worktreeId: string) => void
+}
+
 // Why: a failed delete almost always means the worktree still has changes
 // that need attention (uncommitted work, unpushed commits, conflicts). The
 // "View" affordance should surface those changes directly, not just bring
@@ -35,7 +39,8 @@ function isStrictDescendantPath(parentPath: string, childPath: string): boolean 
 }
 
 export async function runWorktreeDeletesInParallel(
-  targets: readonly Pick<Worktree, 'id' | 'displayName' | 'repoId' | 'path'>[]
+  targets: readonly Pick<Worktree, 'id' | 'displayName' | 'repoId' | 'path'>[],
+  options: WorktreeDeleteWithToastOptions = {}
 ): Promise<string[]> {
   // Why: `git worktree remove`/`prune`/`branch -D` mutate repo-wide ref state
   // and contend on `.git/packed-refs.lock` and per-worktree HEAD.lock. Running
@@ -65,7 +70,7 @@ export async function runWorktreeDeletesInParallel(
         if (failedInGroup.some((failed) => isStrictDescendantPath(target.path, failed.path))) {
           continue
         }
-        const deleted = await runWorktreeDeleteWithToast(target.id, target.displayName)
+        const deleted = await runWorktreeDeleteWithToast(target.id, target.displayName, options)
         if (deleted) {
           deletedInGroup.push(target.id)
         } else {
@@ -96,7 +101,8 @@ export async function runWorktreeDeletesInParallel(
  */
 export function runWorktreeDeleteWithToast(
   worktreeId: string,
-  worktreeName: string
+  worktreeName: string,
+  options: WorktreeDeleteWithToastOptions = {}
 ): Promise<boolean> {
   const removeWorktree = useAppStore.getState().removeWorktree
 
@@ -132,7 +138,9 @@ export function runWorktreeDeleteWithToast(
                           onClick: () => viewWorktreeDiff(worktreeId)
                         }
                       })
+                      return
                     }
+                    options.onForceDeleted?.(worktreeId)
                   })
                   .catch((err: unknown) => {
                     toast.error('Failed to delete workspace', {
@@ -235,7 +243,9 @@ export function runWorktreeBatchDelete(
     !singleTargetHasLineageChildren &&
     (state.settings?.skipDeleteWorktreeConfirm ?? false)
   if (skipConfirm) {
-    void runWorktreeDeletesInParallel(targets).then((deletedIds) => {
+    void runWorktreeDeletesInParallel(targets, {
+      onForceDeleted: (deletedId) => options.onDeleted?.([deletedId])
+    }).then((deletedIds) => {
       if (deletedIds.length > 0) {
         options.onDeleted?.(deletedIds)
       }

--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -66,6 +66,16 @@ describe('buildExcludePathPrefixes', () => {
     expect(buildExcludePathPrefixes('/home/u/repo', ['/home/u/other'])).toEqual([])
   })
 
+  it('keeps dot-dot-prefixed names inside the root while rejecting parent escapes', () => {
+    expect(
+      buildExcludePathPrefixes('/home/u/repo', [
+        '/home/u/repo/..env',
+        '/home/u/repo/..workspace/app',
+        '/home/u/repo/../outside'
+      ])
+    ).toEqual(['..env', '..workspace/app'])
+  })
+
   it('handles Windows-style roots and paths', () => {
     expect(buildExcludePathPrefixes('C:\\repo', ['C:\\repo\\packages\\app'])).toEqual([
       'packages/app'
@@ -185,10 +195,16 @@ describe('normalizeQuickOpenRgLine', () => {
     expect(normalizeQuickOpenRgLine('./src/a.ts', { kind: 'cwd-relative' })).toBe('src/a.ts')
   })
 
-  it('keeps cwd-relative files under dotdot-prefixed child directories', () => {
+  it('keeps cwd-relative dot-dot-prefixed names but rejects parent escapes', () => {
     expect(normalizeQuickOpenRgLine('./..fixtures/a.ts', { kind: 'cwd-relative' })).toBe(
       '..fixtures/a.ts'
     )
+    expect(normalizeQuickOpenRgLine('..env', { kind: 'cwd-relative' })).toBe('..env')
+    expect(normalizeQuickOpenRgLine('..workspace/file.ts', { kind: 'cwd-relative' })).toBe(
+      '..workspace/file.ts'
+    )
+    expect(normalizeQuickOpenRgLine('../outside.ts', { kind: 'cwd-relative' })).toBeNull()
+    expect(normalizeQuickOpenRgLine('..', { kind: 'cwd-relative' })).toBeNull()
   })
 
   it('strips CRLF', () => {

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -321,7 +321,11 @@ export function normalizeQuickOpenRgLine(rawLine: string, outputMode: RgOutputMo
   // into single-slash POSIX-looking paths that no rg output can match.
   const normalizedRoot = `${outputMode.rootPath.replace(/\\/g, '/').replace(/\/+$/, '')}/`
   if (normalized.startsWith(normalizedRoot)) {
-    return normalized.substring(normalizedRoot.length)
+    const rel = normalized.substring(normalizedRoot.length)
+    if (!rel || isParentRelativePath(rel) || rel.startsWith('/')) {
+      return null
+    }
+    return rel
   }
   return null
 }


### PR DESCRIPTION
## Summary
- detect stale managed Copilot hook entries under retired/current events as partial installs
- keep workspace delete callbacks wired when force delete is triggered from the toast path
- allow root-local dot-dot-prefixed quick-open names while still rejecting parent escapes

## Tests
- pnpm exec vitest run --config config/vitest.config.ts src/main/copilot/hook-service.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx src/shared/quick-open-filter.test.ts
- pnpm test -- src/main/copilot/hook-service.test.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx src/shared/quick-open-filter.test.ts (ran full configured suite: 1094 files, 11591 tests)
- pnpm typecheck
- pnpm lint

Risk: medium
This combines Copilot hook install-state detection, workspace delete callback wiring, and quick-open path filtering. The tests are broad, but the mixed renderer/main/shared surface and delete-flow behavior keep it above low risk.