### PR TITLE
Add GitHub label management link

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -38,6 +38,7 @@ import {
   Plus,
   RefreshCw,
   Send,
+  Settings,
   UndoDot,
   Users,
   Wrench,
@@ -163,6 +164,27 @@ function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
       return null
     }
     return { owner: segments[0], repo: segments[1] }
+  } catch {
+    return null
+  }
+}
+
+function getGitHubRepositoryLabelsUrl(itemUrl: string): string | null {
+  try {
+    const parsed = new URL(itemUrl)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return null
+    }
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return null
+    }
+    // Why: label management is repository-scoped; preserving the origin keeps
+    // GitHub Enterprise URLs working while navigating away from the issue path.
+    parsed.pathname = `/${segments[0]}/${segments[1]}/labels`
+    parsed.search = ''
+    parsed.hash = ''
+    return parsed.toString()
   } catch {
     return null
   }
@@ -4334,6 +4356,37 @@ async function runPullRequestStateUpdate(args: {
   }
 }
 
+function GitHubLabelsSettingsLink({
+  url,
+  separated,
+  onOpen
+}: {
+  url: string | null
+  separated?: boolean
+  onOpen?: () => void
+}): React.JSX.Element | null {
+  if (!url) {
+    return null
+  }
+
+  return (
+    <div className={cn(separated && 'mt-1 border-t border-border/60 pt-1')}>
+      <button
+        type="button"
+        onClick={() => {
+          onOpen?.()
+          void window.api.shell.openUrl(url)
+        }}
+        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        <Settings className="size-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 text-left">Edit labels on GitHub</span>
+        <ExternalLink className="size-3 shrink-0 opacity-70" />
+      </button>
+    </div>
+  )
+}
+
 function GHEditSection({
   item,
   repoPath,
@@ -4404,6 +4457,7 @@ function GHEditSection({
   )
   const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo)
   const repoLabels = projectOrigin ? repoLabelsBySlug : repoLabelsByPath
+  const repositoryLabelsUrl = useMemo(() => getGitHubRepositoryLabelsUrl(item.url), [item.url])
   const repoAssigneesByPath = useRepoAssignees(
     projectOrigin ? null : repoPath,
     projectOrigin ? null : repoId
@@ -4811,7 +4865,8 @@ function GHEditSection({
                   <div className="px-2 py-3 text-center text-[12px] text-destructive">
                     {repoLabels.error}
                   </div>
-                ) : (
+                ) : null}
+                {!repoLabels.error ? (
                   <div>
                     {repoLabels.data.map((label) => (
                       <button
@@ -4834,7 +4889,12 @@ function GHEditSection({
                       </button>
                     ))}
                   </div>
-                )}
+                ) : null}
+                <GitHubLabelsSettingsLink
+                  url={repositoryLabelsUrl}
+                  separated={!repoLabels.error && repoLabels.data.length > 0}
+                  onOpen={() => setLabelPopoverOpen(false)}
+                />
               </PopoverContent>
             </Popover>
           </div>
@@ -4978,7 +5038,8 @@ function GHEditSection({
             <div className="px-2 py-3 text-center text-[12px] text-destructive">
               {repoLabels.error}
             </div>
-          ) : (
+          ) : null}
+          {!repoLabels.error ? (
             <div>
               {repoLabels.data.map((label) => (
                 <button
@@ -5001,7 +5062,12 @@ function GHEditSection({
                 </button>
               ))}
             </div>
-          )}
+          ) : null}
+          <GitHubLabelsSettingsLink
+            url={repositoryLabelsUrl}
+            separated={!repoLabels.error && repoLabels.data.length > 0}
+            onOpen={() => setLabelPopoverOpen(false)}
+          />
         </PopoverContent>
       </Popover>
 

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -38,6 +38,7 @@ import {
   Plus,
   RefreshCw,
   Send,
+  Settings,
   UndoDot,
   Users,
   Wrench,
@@ -157,6 +158,27 @@ function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
       return null
     }
     return { owner: segments[0], repo: segments[1] }
+  } catch {
+    return null
+  }
+}
+
+function getGitHubRepositoryLabelsUrl(itemUrl: string): string | null {
+  try {
+    const parsed = new URL(itemUrl)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return null
+    }
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    if (segments.length < 2) {
+      return null
+    }
+    // Why: label management is repository-scoped; preserving the origin keeps
+    // GitHub Enterprise URLs working while navigating away from the issue path.
+    parsed.pathname = `/${segments[0]}/${segments[1]}/labels`
+    parsed.search = ''
+    parsed.hash = ''
+    return parsed.toString()
   } catch {
     return null
   }
@@ -4456,6 +4478,37 @@ async function runPullRequestStateUpdate(args: {
   }
 }
 
+function GitHubLabelsSettingsLink({
+  url,
+  separated,
+  onOpen
+}: {
+  url: string | null
+  separated?: boolean
+  onOpen?: () => void
+}): React.JSX.Element | null {
+  if (!url) {
+    return null
+  }
+
+  return (
+    <div className={cn(separated && 'mt-1 border-t border-border/60 pt-1')}>
+      <button
+        type="button"
+        onClick={() => {
+          onOpen?.()
+          void window.api.shell.openUrl(url)
+        }}
+        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      >
+        <Settings className="size-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 text-left">Edit labels on GitHub</span>
+        <ExternalLink className="size-3 shrink-0 opacity-70" />
+      </button>
+    </div>
+  )
+}
+
 function GHEditSection({
   item,
   repoPath,
@@ -4517,6 +4570,7 @@ function GHEditSection({
   )
   const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo)
   const repoLabels = projectOrigin ? repoLabelsBySlug : repoLabelsByPath
+  const repositoryLabelsUrl = useMemo(() => getGitHubRepositoryLabelsUrl(item.url), [item.url])
   const repoAssigneesByPath = useRepoAssignees(
     projectOrigin ? null : repoPath,
     projectOrigin ? null : repoId
@@ -4816,7 +4870,8 @@ function GHEditSection({
             <div className="px-2 py-3 text-center text-[12px] text-destructive">
               {repoLabels.error}
             </div>
-          ) : (
+          ) : null}
+          {!repoLabels.error ? (
             <div>
               {repoLabels.data.map((label) => (
                 <button
@@ -4839,7 +4894,12 @@ function GHEditSection({
                 </button>
               ))}
             </div>
-          )}
+          ) : null}
+          <GitHubLabelsSettingsLink
+            url={repositoryLabelsUrl}
+            separated={!repoLabels.error && repoLabels.data.length > 0}
+            onOpen={() => setLabelPopoverOpen(false)}
+          />
         </PopoverContent>
       </Popover>
 

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -38,7 +38,6 @@ import {
   Plus,
   RefreshCw,
   Send,
-  Settings,
   UndoDot,
   Users,
   Wrench,
@@ -158,27 +157,6 @@ function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
       return null
     }
     return { owner: segments[0], repo: segments[1] }
-  } catch {
-    return null
-  }
-}
-
-function getGitHubRepositoryLabelsUrl(itemUrl: string): string | null {
-  try {
-    const parsed = new URL(itemUrl)
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-      return null
-    }
-    const segments = parsed.pathname.split('/').filter(Boolean)
-    if (segments.length < 2) {
-      return null
-    }
-    // Why: label management is repository-scoped; preserving the origin keeps
-    // GitHub Enterprise URLs working while navigating away from the issue path.
-    parsed.pathname = `/${segments[0]}/${segments[1]}/labels`
-    parsed.search = ''
-    parsed.hash = ''
-    return parsed.toString()
   } catch {
     return null
   }
@@ -4478,37 +4456,6 @@ async function runPullRequestStateUpdate(args: {
   }
 }
 
-function GitHubLabelsSettingsLink({
-  url,
-  separated,
-  onOpen
-}: {
-  url: string | null
-  separated?: boolean
-  onOpen?: () => void
-}): React.JSX.Element | null {
-  if (!url) {
-    return null
-  }
-
-  return (
-    <div className={cn(separated && 'mt-1 border-t border-border/60 pt-1')}>
-      <button
-        type="button"
-        onClick={() => {
-          onOpen?.()
-          void window.api.shell.openUrl(url)
-        }}
-        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-      >
-        <Settings className="size-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 text-left">Edit labels on GitHub</span>
-        <ExternalLink className="size-3 shrink-0 opacity-70" />
-      </button>
-    </div>
-  )
-}
-
 function GHEditSection({
   item,
   repoPath,
@@ -4570,7 +4517,6 @@ function GHEditSection({
   )
   const repoLabelsBySlug = useRepoLabelsBySlug(slugOwner, slugRepo)
   const repoLabels = projectOrigin ? repoLabelsBySlug : repoLabelsByPath
-  const repositoryLabelsUrl = useMemo(() => getGitHubRepositoryLabelsUrl(item.url), [item.url])
   const repoAssigneesByPath = useRepoAssignees(
     projectOrigin ? null : repoPath,
     projectOrigin ? null : repoId
@@ -4870,8 +4816,7 @@ function GHEditSection({
             <div className="px-2 py-3 text-center text-[12px] text-destructive">
               {repoLabels.error}
             </div>
-          ) : null}
-          {!repoLabels.error ? (
+          ) : (
             <div>
               {repoLabels.data.map((label) => (
                 <button
@@ -4894,12 +4839,7 @@ function GHEditSection({
                 </button>
               ))}
             </div>
-          ) : null}
-          <GitHubLabelsSettingsLink
-            url={repositoryLabelsUrl}
-            separated={!repoLabels.error && repoLabels.data.length > 0}
-            onOpen={() => setLabelPopoverOpen(false)}
-          />
+          )}
         </PopoverContent>
       </Popover>
 


### PR DESCRIPTION
## Summary
- Adds a final "Edit labels on GitHub" action to the GitHub issue label picker.
- Opens the repository-level `/labels` page using the current work item URL origin, preserving GitHub Enterprise-style hosts.
- Removes an unreachable duplicate PR-page copy so the final diff is limited to the verified issue dialog surface.

## Verification
- `pnpm exec oxlint src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/GitHubItemDialog.tsx src/renderer/src/components/PullRequestPage.tsx`
- `pnpm run typecheck:web`
- `git diff --check`
- Electron dev app attached via CDP to `mem-leak-audit @ allow-editing-labels`; opened a registered repo-backed GitHub issue detail, opened the label picker, and verified the `Edit labels on GitHub` action renders with the repo label list and no final renderer console errors after reload.

## Risk assessment
Risk: low. Final diff is one renderer-only issue dialog affordance with no data mutation path changes. The only behavior added is an external repository labels link derived from the existing GitHub issue URL; the PR-page duplicate was removed as unreachable.