### PR TITLE
fix: allow spaces in browser file paths

### DIFF
--- a/src/shared/browser-url.test.ts
+++ b/src/shared/browser-url.test.ts
@@ -50,6 +50,18 @@ describe('browser-url helpers', () => {
     ).toBe('file://wsl.localhost/Ubuntu/home/me/Example.ipynb')
   })
 
+  it('normalizes absolute local paths with spaces and reserved URL characters', () => {
+    expect(normalizeBrowserNavigationUrl('/Users/me/My Site/index #1.html')).toBe(
+      'file:///Users/me/My%20Site/index%20%231.html'
+    )
+    expect(normalizeBrowserNavigationUrl('C:\\Users\\me\\My Site\\index #1.html')).toBe(
+      'file:///C:/Users/me/My%20Site/index%20%231.html'
+    )
+    expect(normalizeBrowserNavigationUrl('C:\\tmp\\orca & 100% ! ^\\index.html')).toBe(
+      'file:///C:/tmp/orca%20%26%20100%25%20!%20%5E/index.html'
+    )
+  })
+
   // Why: in-app preview is fine (sandboxed webview), but handing file:// to
   // shell.openExternal would let a remote page drive Finder/Explorer to
   // arbitrary paths. External-open paths must still refuse file://.

--- a/src/shared/browser-url.ts
+++ b/src/shared/browser-url.ts
@@ -8,9 +8,9 @@ const LOCAL_ADDRESS_PATTERN =
 // A single-word input containing a dot with a valid TLD-like suffix is treated as
 // a URL attempt, not a search query.
 const LOOKS_LIKE_URL_PATTERN = /^[^\s]+\.[a-z]{2,}(\/.*)?$/i
-const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/][^\s]*$/
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[A-Za-z]:[\\/].*$/
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\s\\/]+[\\/][^\\/]+(?:[\\/].*)?$/
-const UNIX_ABSOLUTE_PATH_PATTERN = /^\/[^\s]*$/
+const UNIX_ABSOLUTE_PATH_PATTERN = /^\/.*$/
 
 export type SearchEngine = 'google' | 'duckduckgo' | 'bing' | 'kagi'
 


### PR DESCRIPTION
## Summary
- allow absolute Windows and POSIX file paths with spaces to normalize to `file://` URLs
- preserve existing URL encoding for spaces, `#`, `&`, `%`, and `^`
- add regression coverage for Windows and POSIX local paths

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/browser-url.test.ts`
- `pnpm run lint -- src/shared/browser-url.ts src/shared/browser-url.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `git diff --check`

Risk: low; this is a focused shared URL normalization fix with regression coverage for the affected path parsing cases.