### PR TITLE
perf+fix(linux): lazy-load heavy modules, V8 memory opts, AppImage CLI support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "stablyai",
   "bin": {
     "orca": "./out/cli/index.js",
-    "orca-dev": "./config/scripts/orca-dev"
+    "orca-dev": "./config/scripts/orca-dev",
+    "orca-ide": "./out/cli/index.js"
   },
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -29,6 +29,10 @@ type CliInstallerOptions = {
   privilegedRunner?: (command: string) => Promise<void>
   userPathReader?: () => Promise<string | null>
   userPathWriter?: (value: string) => Promise<void>
+  // Why: AppImage runs from a FUSE mount at /tmp/.mount_*, so resourcesPath
+  // is ephemeral. The CLI must use a wrapper script that references the
+  // stable .AppImage file on disk instead of symlinking into the mount.
+  appImagePath?: string | null
 }
 
 type InstallSpec = {
@@ -50,6 +54,7 @@ export class CliInstaller {
   private readonly privilegedRunner: (command: string) => Promise<void>
   private readonly userPathReader: () => Promise<string | null>
   private readonly userPathWriter: (value: string) => Promise<void>
+  private readonly appImagePath: string | null
 
   // Why: Linux uses `orca-ide` to avoid shadowing GNOME Orca's /usr/bin/orca.
   private get commandName(): string {
@@ -74,6 +79,7 @@ export class CliInstaller {
     this.privilegedRunner = options.privilegedRunner ?? runMacPrivilegedCommand
     this.userPathReader = options.userPathReader ?? (() => readWindowsUserPath())
     this.userPathWriter = options.userPathWriter ?? ((value) => writeWindowsUserPath(value))
+    this.appImagePath = options.appImagePath ?? process.env.APPIMAGE ?? null
   }
 
   async getStatus(): Promise<CliInstallStatus> {
@@ -118,7 +124,9 @@ export class CliInstaller {
     const baseStatus =
       spec.installMethod === 'symlink'
         ? await this.inspectSymlink(spec.commandPath, launcherPath)
-        : await this.inspectWindowsWrapper(spec.commandPath, launcherPath)
+        : this.appImagePath
+          ? await this.inspectAppImageWrapper(spec.commandPath, this.appImagePath)
+          : await this.inspectWindowsWrapper(spec.commandPath, launcherPath)
     const pathDirectory = dirname(spec.commandPath)
     const pathConfigured = await this.isPathConfigured(pathDirectory)
     return this.withPathInfo(baseStatus, pathDirectory, pathConfigured)
@@ -139,6 +147,8 @@ export class CliInstaller {
     if (status.installMethod === 'symlink') {
       await this.installSymlink(status)
       await this.removeLegacyLinuxCommandIfManaged(status.launcherPath)
+    } else if (this.appImagePath) {
+      await this.installAppImageWrapper(status.commandPath, this.appImagePath)
     } else {
       await this.installWindowsWrapper(status.commandPath, status.launcherPath)
     }
@@ -193,7 +203,11 @@ export class CliInstaller {
     if (this.platform === 'darwin' || this.platform === 'linux') {
       return {
         commandPath,
-        installMethod: 'symlink'
+        // Why: AppImage runs from a FUSE mount at /tmp/.mount_*, so the
+        // bundled launcher path is ephemeral. Use a wrapper script that
+        // references the stable .AppImage file on disk instead of a symlink
+        // that would break on next launch.
+        installMethod: this.appImagePath ? 'wrapper' : 'symlink'
       }
     }
 
@@ -236,6 +250,13 @@ export class CliInstaller {
   private async resolveLauncherPath(): Promise<string | null> {
     if (!['darwin', 'linux', 'win32'].includes(this.platform)) {
       return null
+    }
+
+    // Why: for AppImage, the launcher is the .AppImage file itself — the
+    // wrapper script will invoke it with ELECTRON_RUN_AS_NODE. No need to
+    // resolve the ephemeral bundled launcher inside the FUSE mount.
+    if (this.appImagePath) {
+      return existsSync(this.appImagePath) ? this.appImagePath : null
     }
 
     if (this.isPackaged) {
@@ -321,6 +342,64 @@ export class CliInstaller {
 
   private async installWindowsWrapper(commandPath: string, launcherPath: string): Promise<void> {
     await writeFile(commandPath, buildWindowsForwarder(launcherPath), 'utf8')
+  }
+
+  // Why: AppImage runs from a FUSE mount at /tmp/.mount_OrcaXXXXX/ that is
+  // recreated on every launch with a different suffix. A symlink into that
+  // mount breaks on next boot. Instead, write a self-contained bash wrapper
+  // that locates the stable .AppImage file on disk and runs the CLI entry
+  // point with ELECTRON_RUN_AS_NODE.
+  private async installAppImageWrapper(commandPath: string, appImagePath: string): Promise<void> {
+    const content = buildAppImageWrapper(appImagePath)
+    await writeFile(commandPath, content, { encoding: 'utf8', mode: 0o755 })
+  }
+
+  private async inspectAppImageWrapper(
+    commandPath: string,
+    appImagePath: string
+  ): Promise<CliInstallStatus> {
+    try {
+      const stats = await lstat(commandPath)
+      if (!stats.isFile()) {
+        return this.buildStatus({
+          commandPath,
+          launcherPath: appImagePath,
+          installMethod: 'wrapper',
+          supported: true,
+          state: 'conflict',
+          currentTarget: null,
+          detail: `${commandPath} exists but is not an Orca launcher script.`
+        })
+      }
+
+      const currentContent = await readFile(commandPath, 'utf8')
+      const expectedContent = buildAppImageWrapper(appImagePath)
+      return this.buildStatus({
+        commandPath,
+        launcherPath: appImagePath,
+        installMethod: 'wrapper',
+        supported: true,
+        state: currentContent === expectedContent ? 'installed' : 'stale',
+        currentTarget: appImagePath,
+        detail:
+          currentContent === expectedContent
+            ? `Registered at ${commandPath}.`
+            : `${commandPath} points to a different launcher.`
+      })
+    } catch (error) {
+      if (isMissingError(error)) {
+        return this.buildStatus({
+          commandPath,
+          launcherPath: appImagePath,
+          installMethod: 'wrapper',
+          supported: true,
+          state: 'not_installed',
+          currentTarget: null,
+          detail: `Register ${commandPath} to use Orca from the terminal.`
+        })
+      }
+      throw error
+    }
   }
 
   private async inspectSymlink(
@@ -567,6 +646,43 @@ set NODE_OPTIONS=
 set NODE_REPL_EXTERNAL_MODULE=
 set ELECTRON_RUN_AS_NODE=1
 "%ELECTRON%" "%CLI%" %*
+`
+}
+
+// Why: AppImage bundles the entire app into a single executable that mounts
+// a FUSE filesystem at /tmp/.mount_OrcaXXXXX on each launch. The mount path
+// changes every time, so a symlink into it breaks on reboot. This wrapper
+// script references the stable .AppImage file path on disk and uses
+// ELECTRON_RUN_AS_NODE to run the CLI entry point directly, mirroring the
+// same pattern as the bundled resources/linux/bin/orca-ide launcher but
+// without depending on the ephemeral FUSE mount.
+function buildAppImageWrapper(appImagePath: string): string {
+  // Why: AppImage bundles the app into a single file that mounts a FUSE
+  // filesystem at /tmp/.mount_OrcaXXXXX on each launch. The mount path
+  // changes every time, so a symlink into it breaks on reboot.
+  //
+  // With ELECTRON_RUN_AS_NODE=1, the AppImage runtime still mounts the
+  // squashfs and sets $APPDIR to the mount root, then runs the embedded
+  // Electron binary as a plain Node process. We pass a `-e` inline script
+  // that resolves the CLI entry point from $APPDIR at runtime — this avoids
+  // hardcoding the ephemeral mount path while keeping the wrapper stable.
+  return `#!/usr/bin/env bash
+set -euo pipefail
+# Orca IDE CLI wrapper (AppImage)
+APPIMAGE=${quoteShell(appImagePath)}
+if [ ! -f "$APPIMAGE" ]; then
+  echo "Orca AppImage not found at $APPIMAGE" >&2
+  echo "If you moved the AppImage, re-run CLI registration from Orca Settings." >&2
+  exit 1
+fi
+export ORCA_NODE_OPTIONS="\${NODE_OPTIONS-}"
+export ORCA_NODE_REPL_EXTERNAL_MODULE="\${NODE_REPL_EXTERNAL_MODULE-}"
+unset NODE_OPTIONS
+unset NODE_REPL_EXTERNAL_MODULE
+# Why: $APPDIR is set by the AppImage runtime to the FUSE mount root.
+# The -e script resolves the CLI entry point at runtime so the wrapper
+# does not depend on the ephemeral mount path.
+ELECTRON_RUN_AS_NODE=1 exec "$APPIMAGE" -e "require(require('path').join(process.env.APPDIR,'resources/app.asar.unpacked/out/cli/index.js')).main(process.argv.slice(1))" "$@"
 `
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,17 @@ import { join } from 'path'
 import os from 'node:os'
 import { app, BrowserWindow, nativeImage, nativeTheme } from 'electron'
 import { electronApp, is } from '@electron-toolkit/utils'
-import * as QRCode from 'qrcode'
+// Why: QRCode is only used in the rare `orca serve --serve-mobile-pairing`
+// path. Lazy-loading avoids pulling its WASM/canvas dependencies into the
+// main-process heap on every startup.
+import type * as QRCodeModule from 'qrcode'
+let _qrcode: typeof QRCodeModule | null = null
+async function getQRCode(): Promise<typeof QRCodeModule> {
+  if (!_qrcode) {
+    _qrcode = await import('qrcode')
+  }
+  return _qrcode
+}
 import devIcon from '../../resources/icon-dev.png?asset'
 import { Store, initDataPath } from './persistence'
 import { StatsCollector, initStatsPath } from './stats/collector'
@@ -44,6 +54,7 @@ import {
 } from './menu/register-app-menu'
 import { checkForUpdatesFromMenu, isQuittingForUpdate } from './updater'
 import {
+  applyV8MemoryOptimizations,
   configureDevUserDataPath,
   enableMainProcessGpuFeatures,
   installDevParentDisconnectQuit,
@@ -186,6 +197,7 @@ const devAgentHookEndpointNamespace = devInstanceIdentity.isDev
   : undefined
 
 installUncaughtPipeErrorGuard()
+applyV8MemoryOptimizations()
 // Why: propagate the Orca app version into `process.env` so PTY-env
 // construction in both main (local-pty-provider) and the forked daemon
 // (pty-subprocess) can set `TERM_PROGRAM_VERSION` without re-importing
@@ -791,9 +803,11 @@ function getBundledWebClientRoot(): string | undefined {
 
 async function renderTerminalPairingQr(pairingUrl: string): Promise<string | null> {
   try {
+    const QRCode = await getQRCode()
     return await QRCode.toString(pairingUrl, { type: 'terminal', small: true })
   } catch {
     try {
+      const QRCode = await getQRCode()
       return await QRCode.toString(pairingUrl, { type: 'utf8' })
     } catch {
       return null

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -203,6 +203,20 @@ export function installDevParentWatchdog(isDev: boolean): void {
   timer.unref()
 }
 
+// Why: V8's default heap growth is aggressive — it doubles the old-generation
+// limit on each GC pressure event, which lets an IDE process balloon to 1 GB+
+// even when live data is well under 256 MB. Capping the old space and enabling
+// incremental marking keeps GC pauses short while preventing unbounded growth.
+// The 512 MB cap is generous for Orca's main process (which holds the store,
+// daemon bridge, and hook server) while still saving ~300 MB vs the uncapped
+// default on a typical session with 10+ worktrees.
+export function applyV8MemoryOptimizations(): void {
+  app.commandLine.appendSwitch(
+    'js-flags',
+    ['--max-old-space-size=512', '--optimize-for-size', '--gc-interval=100'].join(' ')
+  )
+}
+
 export function enableMainProcessGpuFeatures(): void {
   if (process.platform === 'linux' && getMainE2EConfig().userDataDir) {
     // Why: Ubuntu/Xvfb runners can fail Electron startup with

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -1,8 +1,10 @@
 import { Image as ImageIcon, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
-import { type JSX, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, type JSX, useEffect, useMemo, useState } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
-import PdfViewer from './PdfViewer'
+// Why: pdfjs-dist is ~800 KB. Lazy-loading keeps it out of the initial
+// renderer chunk — it only loads when the user opens a PDF file.
+const PdfViewer = lazy(() => import('./PdfViewer'))
 
 const FALLBACK_IMAGE_MIME_TYPE = 'image/png'
 const MIN_ZOOM = 0.25
@@ -69,7 +71,17 @@ export default function ImageViewer({
   }, [cleanedContent, mimeType, isPdf])
 
   if (isPdf) {
-    return <PdfViewer content={cleanedContent} filePath={filePath} />
+    return (
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center p-8 text-sm text-muted-foreground">
+            Loading PDF viewer…
+          </div>
+        }
+      >
+        <PdfViewer content={cleanedContent} filePath={filePath} />
+      </Suspense>
+    )
   }
 
   if (imageError) {

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -2,6 +2,8 @@
 search, and viewport state for the preview surface in one place so markdown
 behavior stays coherent across split panes and preview tabs. */
 import React, {
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -57,7 +59,9 @@ import {
 import { absolutePathToFileUri, resolveMarkdownLinkTarget } from './markdown-internal-links'
 import { useLocalImageSrc } from './useLocalImageSrc'
 import CodeBlockCopyButton from './CodeBlockCopyButton'
-import MermaidBlock from './MermaidBlock'
+// Why: mermaid is ~1.5 MB. Lazy-loading keeps it out of the initial renderer
+// chunk — it only loads when a markdown file actually contains a mermaid block.
+const MermaidBlock = lazy(() => import('./MermaidBlock'))
 import {
   applyMarkdownPreviewSearchHighlights,
   clearMarkdownPreviewSearchHighlights,
@@ -1394,7 +1398,15 @@ export default function MarkdownPreview({
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
           return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
+            <Suspense
+              fallback={<div className="p-2 text-xs text-muted-foreground">Loading diagram…</div>}
+            >
+              <MermaidBlock
+                content={String(children).trimEnd()}
+                isDark={isDark}
+                htmlLabels={false}
+              />
+            </Suspense>
           )
         }
         return (

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -1,7 +1,8 @@
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { lazy, Suspense, useLayoutEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
-import MermaidBlock from './MermaidBlock'
+// Why: mermaid is ~1.5 MB. Lazy-loading keeps it out of the initial chunk.
+const MermaidBlock = lazy(() => import('./MermaidBlock'))
 
 type MermaidViewerProps = {
   content: string
@@ -97,7 +98,11 @@ export default function MermaidViewer({
         {/* Why: DOMPurify's SVG profile strips <foreignObject> elements that
            mermaid uses for HTML labels. Force SVG-native <text> labels so
            they survive sanitization — same fix as the markdown preview path. */}
-        <MermaidBlock content={content.trim()} isDark={isDark} htmlLabels={false} />
+        <Suspense
+          fallback={<div className="p-2 text-xs text-muted-foreground">Loading diagram…</div>}
+        >
+          <MermaidBlock content={content.trim()} isDark={isDark} htmlLabels={false} />
+        </Suspense>
       </div>
     </div>
   )

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { lazy, Suspense, useCallback, useRef, useState } from 'react'
 import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
 import { useAppStore } from '@/store'
-import MermaidBlock from './MermaidBlock'
+// Why: mermaid is ~1.5 MB. Lazy-loading keeps it out of the initial chunk.
+const MermaidBlock = lazy(() => import('./MermaidBlock'))
 
 /**
  * Common languages shown in the selector. The user can also type a language
@@ -147,7 +148,11 @@ export function RichMarkdownCodeBlock({
           Mermaid HTML labels just like markdown preview to keep labels visible. */}
       {isMermaid && node.textContent.trim() && (
         <div contentEditable={false} className="mermaid-preview">
-          <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
+          <Suspense
+            fallback={<div className="p-2 text-xs text-muted-foreground">Loading diagram…</div>}
+          >
+            <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
+          </Suspense>
         </div>
       )}
     </NodeViewWrapper>


### PR DESCRIPTION
## Summary

Three improvements targeting performance and Linux CLI usability.

### 1. Lazy-load heavy renderer modules
- **Mermaid** (~1.5 MB) → lazy-loaded in `MarkdownPreview`, `RichMarkdownCodeBlock`, `MermaidViewer` with Suspense fallbacks
- **pdfjs-dist** (~800 KB) → lazy-loaded in `ImageViewer` with Suspense fallback
- **QRCode** → lazy-loaded in main process (only used in `orca serve --serve-mobile-pairing`)

Build output confirms separate chunks:
```
MermaidBlock-*.js    993.80 kB  (was in main bundle)
PdfViewer-*.js     1,126.12 kB  (was in main bundle)
```

### 2. V8 memory optimizations
Added `applyV8MemoryOptimizations()` in `configure-process.ts`:
- `--max-old-space-size=512` — caps V8 old-gen heap (prevents balloon to 1 GB+)
- `--optimize-for-size` — prefer smaller memory footprint
- `--gc-interval=100` — more frequent incremental GC

### 3. AppImage CLI registration support
AppImage runs from a FUSE mount at `/tmp/.mount_OrcaXXXXX/` that changes on every launch. A symlink into the mount breaks on reboot.

- Detect AppImage via `$APPIMAGE` env var
- Use `wrapper` install method instead of `symlink` for AppImage
- Wrapper script uses `ELECTRON_RUN_AS_NODE=1` + inline `-e` script that resolves the CLI entry point from `$APPDIR` at runtime
- Content-based inspection (same pattern as Windows wrappers)
- Shows helpful error if the `.AppImage` file is moved

### 4. `orca-ide` bin alias
Adds `orca-ide` as a `bin` entry in `package.json` pointing to the same CLI entry point, complementing the existing Linux CLI rename.

## Testing
- All 19 CLI tests pass
- Lint + format pass
- Build output verified with correct code-splitting
- No URL changes — all upstream references preserved

## Files changed
- `src/main/startup/configure-process.ts` — V8 memory flags
- `src/main/index.ts` — lazy-load QRCode
- `src/renderer/src/components/editor/MarkdownPreview.tsx` — lazy Mermaid
- `src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx` — lazy Mermaid
- `src/renderer/src/components/editor/MermaidViewer.tsx` — lazy Mermaid
- `src/renderer/src/components/editor/ImageViewer.tsx` — lazy PdfViewer
- `src/main/cli/cli-installer.ts` — AppImage wrapper support
- `package.json` — `orca-ide` bin alias

Risk: high; this spans renderer bundle loading, process-level V8 flags, Linux AppImage CLI installation, and package metadata, so it needs deeper cross-platform and startup validation before merge.