### PR TITLE
Clean up computer sidecar child listeners

### DIFF
--- a/src/main/computer/sidecar-client.test.ts
+++ b/src/main/computer/sidecar-client.test.ts
@@ -61,6 +61,9 @@ describe('computer sidecar client', () => {
     await vi.advanceTimersByTimeAsync(60_000)
     await firstRejection
     expect(firstChild.killed).toBe(true)
+    expect(firstChild.listenerCount('message')).toBe(0)
+    expect(firstChild.listenerCount('exit')).toBe(0)
+    expect(firstChild.listenerCount('error')).toBe(1)
 
     const secondCall = callComputerSidecarCapabilities()
     const secondChild = children[1]!
@@ -68,7 +71,12 @@ describe('computer sidecar client', () => {
 
     // Why: OS process events from a timed-out child can arrive after restart.
     // They must not clear/reject the replacement child's active request.
-    firstChild.emit('error', new Error('old sidecar failed late'))
+    firstChild.emit('message', {
+      id: secondRequest.id,
+      ok: false,
+      error: { code: 'old', message: 'old sidecar replied late' }
+    })
+    expect(() => firstChild.emit('error', new Error('old sidecar failed late'))).not.toThrow()
     firstChild.emit('exit', 1, null)
 
     secondChild.emit('message', {
@@ -88,6 +96,9 @@ describe('computer sidecar client', () => {
     firstChild.emit('error', new Error('active sidecar failed'))
     await firstRejection
     expect(firstChild.killed).toBe(true)
+    expect(firstChild.listenerCount('message')).toBe(0)
+    expect(firstChild.listenerCount('exit')).toBe(0)
+    expect(firstChild.listenerCount('error')).toBe(1)
 
     const secondCall = callComputerSidecarCapabilities()
     void secondCall.catch(() => undefined)

--- a/src/main/computer/sidecar-client.ts
+++ b/src/main/computer/sidecar-client.ts
@@ -43,6 +43,10 @@ type PendingRequest = {
 const REQUEST_TIMEOUT_MS = 60_000
 let sidecar: ComputerSidecarProcess | null = null
 
+// Why: Node treats unhandled child 'error' events as process exceptions, so
+// stale children keep a no-op listener that does not retain the sidecar owner.
+function ignoreStaleChildError(): void {}
+
 export function shouldUseComputerSidecar(): boolean {
   return (
     (process.platform === 'darwin' ||
@@ -115,6 +119,7 @@ function loadElectronApp(): { getAppPath(): string; isPackaged: boolean } | null
 
 class ComputerSidecarProcess {
   private child: ChildProcess | null = null
+  private childListenerCleanup: (() => void) | null = null
   private nextId = 1
   private pending = new Map<number, PendingRequest>()
 
@@ -147,6 +152,7 @@ class ComputerSidecarProcess {
   shutdown(): void {
     const child = this.child
     this.child = null
+    this.cleanupActiveChildListeners()
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timer)
       pending.reject(new RuntimeClientError('accessibility_error', 'computer sidecar shut down'))
@@ -159,6 +165,8 @@ class ComputerSidecarProcess {
     if (this.child && !this.child.killed) {
       return this.child
     }
+    this.cleanupActiveChildListeners()
+    this.child = null
 
     const child = fork(this.entryPath, [], {
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
@@ -170,9 +178,25 @@ class ComputerSidecarProcess {
       ...(process.platform === 'win32' ? { windowsHide: true } : {})
     })
 
-    child.on('message', (message) => this.handleMessage(message))
-    child.on('exit', (code, signal) => this.handleExit(child, code, signal))
-    child.on('error', (error) => this.handleError(child, error))
+    const onMessage = (message: unknown) => {
+      if (this.child === child) {
+        this.handleMessage(message)
+      }
+    }
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) =>
+      this.handleExit(child, code, signal)
+    const onError = (error: Error) => this.handleError(child, error)
+
+    child.on('message', onMessage)
+    child.on('exit', onExit)
+    child.on('error', onError)
+    this.childListenerCleanup = () => {
+      child.off('message', onMessage)
+      child.off('exit', onExit)
+      child.off('error', onError)
+      child.off('error', ignoreStaleChildError)
+      child.on('error', ignoreStaleChildError)
+    }
     this.child = child
     return child
   }
@@ -204,6 +228,7 @@ class ComputerSidecarProcess {
     if (this.child !== child) {
       return
     }
+    this.cleanupActiveChildListeners()
     this.child = null
     const detail = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`
     const error = new RuntimeClientError(
@@ -222,6 +247,7 @@ class ComputerSidecarProcess {
     if (this.child !== child) {
       return
     }
+    this.cleanupActiveChildListeners()
     // Why: an active process error makes the IPC sidecar unreliable; restart
     // on the next call instead of reusing a broken helper.
     this.child = null
@@ -232,6 +258,12 @@ class ComputerSidecarProcess {
       pending.reject(wrapped)
       this.pending.delete(id)
     }
+  }
+
+  private cleanupActiveChildListeners(): void {
+    const cleanup = this.childListenerCleanup
+    this.childListenerCleanup = null
+    cleanup?.()
   }
 }
 


### PR DESCRIPTION
## Summary
- Detach computer sidecar child `message`, `exit`, and owner-capturing `error` listeners when the sidecar shuts down, exits, or errors.
- Keep a module-level no-op stale-child error listener so late child errors cannot become unhandled process exceptions.
- Extend stale-child tests to cover listener cleanup and late messages after replacement.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/computer/sidecar-client.test.ts`
- `pnpm exec oxlint src/main/computer/sidecar-client.ts src/main/computer/sidecar-client.test.ts`
- `pnpm exec oxfmt --check src/main/computer/sidecar-client.ts src/main/computer/sidecar-client.test.ts`
- `pnpm typecheck:node`
- `git diff --check origin/main...HEAD`

Risk: low; this is scoped to sidecar child listener teardown and stale-event handling, with focused lifecycle regression coverage.