### PR TITLE
Tighten repo preload API typing

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -161,6 +161,7 @@ import { subscribeRuntimeEnvironmentFromPreload } from './runtime-environment-su
 import type { RuntimeEnvironmentSubscriptionHandle } from './runtime-environment-subscriptions'
 import type { HostedReviewForBranchArgs } from '../shared/hosted-review'
 import type { CrashReportSubmitArgs, CrashReportSubmitResult } from '../shared/crash-reporting'
+import type { PreloadApi } from './api-types'
 
 type NativeFileDropCallback = (data: NativeFileDropPayload) => void
 
@@ -444,40 +445,27 @@ const api = {
   },
 
   repos: {
-    list: (): Promise<unknown[]> => ipcRenderer.invoke('repos:list'),
+    list: () => ipcRenderer.invoke('repos:list'),
 
-    add: (args: { path: string; kind?: 'git' | 'folder' }): Promise<unknown> =>
-      ipcRenderer.invoke('repos:add', args),
+    add: (args) => ipcRenderer.invoke('repos:add', args),
 
-    addRemote: (args: {
-      connectionId: string
-      remotePath: string
-      displayName?: string
-      kind?: 'git' | 'folder'
-    }): Promise<unknown> => ipcRenderer.invoke('repos:addRemote', args),
+    addRemote: (args) => ipcRenderer.invoke('repos:addRemote', args),
 
-    create: (args: {
-      parentPath: string
-      name: string
-      kind: 'git' | 'folder'
-    }): Promise<unknown> => ipcRenderer.invoke('repos:create', args),
+    create: (args) => ipcRenderer.invoke('repos:create', args),
 
-    remove: (args: { repoId: string }): Promise<void> => ipcRenderer.invoke('repos:remove', args),
+    remove: (args) => ipcRenderer.invoke('repos:remove', args),
 
-    reorder: (args: { orderedIds: string[] }): Promise<{ status: 'applied' | 'rejected' }> =>
-      ipcRenderer.invoke('repos:reorder', args),
+    reorder: (args) => ipcRenderer.invoke('repos:reorder', args),
 
-    update: (args: { repoId: string; updates: Record<string, unknown> }): Promise<unknown> =>
-      ipcRenderer.invoke('repos:update', args),
+    update: (args) => ipcRenderer.invoke('repos:update', args),
 
-    pickFolder: (): Promise<string | null> => ipcRenderer.invoke('repos:pickFolder'),
+    pickFolder: () => ipcRenderer.invoke('repos:pickFolder'),
 
-    pickDirectory: (): Promise<string | null> => ipcRenderer.invoke('repos:pickDirectory'),
+    pickDirectory: () => ipcRenderer.invoke('repos:pickDirectory'),
 
-    clone: (args: { url: string; destination: string }): Promise<unknown> =>
-      ipcRenderer.invoke('repos:clone', args),
+    clone: (args) => ipcRenderer.invoke('repos:clone', args),
 
-    cloneAbort: (): Promise<void> => ipcRenderer.invoke('repos:cloneAbort'),
+    cloneAbort: () => ipcRenderer.invoke('repos:cloneAbort'),
 
     onCloneProgress: (
       callback: (data: { phase: string; percent: number }) => void
@@ -510,52 +498,24 @@ const api = {
       ipcRenderer.on('repos:changed', listener)
       return () => ipcRenderer.removeListener('repos:changed', listener)
     }
-  },
+  } satisfies PreloadApi['repos'],
 
   projectGroups: {
-    list: (): Promise<unknown[]> => ipcRenderer.invoke('projectGroups:list'),
-    create: (args: {
-      name: string
-      parentPath?: string | null
-      parentGroupId?: string | null
-      createdFrom?: 'manual' | 'folder-scan' | 'migration'
-    }): Promise<unknown> => ipcRenderer.invoke('projectGroups:create', args),
-    update: (args: { groupId: string; updates: Record<string, unknown> }): Promise<unknown> =>
-      ipcRenderer.invoke('projectGroups:update', args),
-    delete: (args: { groupId: string }): Promise<boolean> =>
-      ipcRenderer.invoke('projectGroups:delete', args),
-    moveProject: (args: {
-      projectId: string
-      groupId: string | null
-      order?: number
-    }): Promise<unknown> => ipcRenderer.invoke('projectGroups:moveProject', args),
-    scanNested: (args: {
-      path: string
-      connectionId?: string
-      options?: Record<string, unknown>
-    }): Promise<unknown> => ipcRenderer.invoke('projectGroups:scanNested', args),
-    importNested: (args: {
-      parentPath: string
-      groupName: string
-      projectPaths: string[]
-      connectionId?: string
-      mode: 'group' | 'separate'
-    }): Promise<unknown> => ipcRenderer.invoke('projectGroups:importNested', args)
-  },
+    list: () => ipcRenderer.invoke('projectGroups:list'),
+    create: (args) => ipcRenderer.invoke('projectGroups:create', args),
+    update: (args) => ipcRenderer.invoke('projectGroups:update', args),
+    delete: (args) => ipcRenderer.invoke('projectGroups:delete', args),
+    moveProject: (args) => ipcRenderer.invoke('projectGroups:moveProject', args),
+    scanNested: (args) => ipcRenderer.invoke('projectGroups:scanNested', args),
+    importNested: (args) => ipcRenderer.invoke('projectGroups:importNested', args)
+  } satisfies PreloadApi['projectGroups'],
 
   sparsePresets: {
-    list: (args: { repoId: string }): Promise<unknown[]> =>
-      ipcRenderer.invoke('sparsePresets:list', args),
+    list: (args) => ipcRenderer.invoke('sparsePresets:list', args),
 
-    save: (args: {
-      repoId: string
-      id?: string
-      name: string
-      directories: string[]
-    }): Promise<unknown> => ipcRenderer.invoke('sparsePresets:save', args),
+    save: (args) => ipcRenderer.invoke('sparsePresets:save', args),
 
-    remove: (args: { repoId: string; presetId: string }): Promise<void> =>
-      ipcRenderer.invoke('sparsePresets:remove', args),
+    remove: (args) => ipcRenderer.invoke('sparsePresets:remove', args),
 
     onChanged: (callback: (data: { repoId: string }) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, data: { repoId: string }) =>
@@ -563,7 +523,7 @@ const api = {
       ipcRenderer.on('sparsePresets:changed', listener)
       return () => ipcRenderer.removeListener('sparsePresets:changed', listener)
     }
-  },
+  } satisfies PreloadApi['sparsePresets'],
 
   worktrees: {
     list: (args: { repoId: string }): Promise<unknown[]> =>

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -128,7 +128,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(get().settings)
       const repos =
         target.kind === 'local'
-          ? ((await window.api.repos.list()) as Repo[])
+          ? await window.api.repos.list()
           : (
               await callRuntimeRpc<{ repos: Repo[] }>(
                 target,
@@ -162,7 +162,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(get().settings)
       const projectGroups =
         target.kind === 'local'
-          ? ((await window.api.projectGroups.list()) as ProjectGroup[])
+          ? await window.api.projectGroups.list()
           : (
               await callRuntimeRpc<{ groups: ProjectGroup[] }>(
                 target,
@@ -183,10 +183,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     try {
       const target = getActiveRuntimeTarget(get().settings)
       return target.kind === 'local'
-        ? ((await window.api.projectGroups.scanNested({
+        ? await window.api.projectGroups.scanNested({
             path,
             connectionId
-          })) as NestedRepoScanResult)
+          })
         : await callRuntimeRpc<NestedRepoScanResult>(
             target,
             'projectGroup.scanNested',
@@ -204,7 +204,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(get().settings)
       const result =
         target.kind === 'local'
-          ? ((await window.api.projectGroups.importNested(args)) as ProjectGroupImportResult)
+          ? await window.api.projectGroups.importNested(args)
           : await callRuntimeRpc<ProjectGroupImportResult>(
               target,
               'projectGroup.importNested',
@@ -233,10 +233,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(get().settings)
       const group =
         target.kind === 'local'
-          ? ((await window.api.projectGroups.create({
+          ? await window.api.projectGroups.create({
               name,
               createdFrom: 'manual'
-            })) as ProjectGroup)
+            })
           : (
               await callRuntimeRpc<{ group: ProjectGroup }>(
                 target,
@@ -258,7 +258,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(get().settings)
       const updated =
         target.kind === 'local'
-          ? ((await window.api.projectGroups.update({ groupId, updates })) as ProjectGroup | null)
+          ? await window.api.projectGroups.update({ groupId, updates })
           : (
               await callRuntimeRpc<{ group: ProjectGroup | null }>(
                 target,
@@ -320,11 +320,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(get().settings)
       const moved =
         target.kind === 'local'
-          ? ((await window.api.projectGroups.moveProject({
+          ? await window.api.projectGroups.moveProject({
               projectId,
               groupId,
               order
-            })) as Repo | null)
+            })
           : (
               await callRuntimeRpc<{ repo: Repo | null }>(
                 target,


### PR DESCRIPTION
## Summary
- Check the repo, project group, and sparse preset preload sections against the declared PreloadApi contract
- Remove redundant renderer casts on local repo/project group IPC calls

## Tests
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repos-project-groups.test.ts src/main/ipc/repos-remote.test.ts src/shared/project-groups.test.ts

Risk: low; this tightens compile-time preload API typing and removes redundant renderer casts without changing IPC channel behavior.