### PR TITLE
Fix Linear scope selector follow-ups

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -4271,6 +4271,7 @@ export default function TaskPage(): React.JSX.Element {
           setLinearTeamRefreshNonce((n) => n + 1)
         })
         .catch(() => {
+          setLinearLoading(false)
           toast.error('Failed to switch Linear workspace.')
         })
     },
@@ -6900,7 +6901,7 @@ export default function TaskPage(): React.JSX.Element {
         open={linearConnectOpen}
         onOpenChange={setLinearConnectOpen}
         workspace={selectedLinearWorkspace}
-        connectLabel={linearStatus.connected ? 'Update access' : 'Add Linear access'}
+        connectLabel={selectedLinearWorkspace ? 'Update access' : 'Add Linear access'}
         onConnected={handleLinearAccessConnected}
       />
     </div>

--- a/src/renderer/src/components/linear-api-key-dialog.tsx
+++ b/src/renderer/src/components/linear-api-key-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import { ExternalLink, LoaderCircle, Lock } from 'lucide-react'
 import type { LinearWorkspace } from '../../../shared/types'
 import {
@@ -18,6 +18,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
 
 type LinearApiKeyDialogProps = {
@@ -46,6 +47,8 @@ export function LinearApiKeyDialog({
   const settings = useAppStore((s) => s.settings)
   const connectLinear = useAppStore((s) => s.connectLinear)
   const mountedRef = useMountedRef()
+  const apiKeyInputId = useId()
+  const apiKeyErrorId = useId()
   const [apiKeyDraft, setApiKeyDraft] = useState('')
   const [connectState, setConnectState] = useState<'idle' | 'connecting' | 'error'>('idle')
   const [connectError, setConnectError] = useState<string | null>(null)
@@ -106,7 +109,7 @@ export function LinearApiKeyDialog({
     description ??
     (workspace
       ? `Paste a Personal API key for ${workspace.organizationName}. If this workspace is already connected, Orca replaces its stored key.`
-      : 'Paste a Personal API key for the Linear workspace you want Orca to use.')
+      : 'Paste a Personal API key for the Linear workspace you want Orca to use. If that workspace is already connected, Orca replaces its stored key.')
   const storageCopy =
     runtimeTarget.kind === 'environment'
       ? 'This key is stored by the active remote runtime.'
@@ -129,22 +132,32 @@ export function LinearApiKeyDialog({
           <DialogDescription>{resolvedDescription}</DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
-          <Input
-            autoFocus
-            type="password"
-            placeholder="lin_api_..."
-            value={apiKeyDraft}
-            onChange={(event) => {
-              setApiKeyDraft(event.target.value)
-              if (connectState === 'error') {
-                setConnectState('idle')
-                setConnectError(null)
-              }
-            }}
-            disabled={connectState === 'connecting'}
-          />
+          <div className="space-y-2">
+            <Label htmlFor={apiKeyInputId} className="text-xs">
+              Personal API key
+            </Label>
+            <Input
+              id={apiKeyInputId}
+              autoFocus
+              type="password"
+              placeholder="lin_api_..."
+              value={apiKeyDraft}
+              onChange={(event) => {
+                setApiKeyDraft(event.target.value)
+                if (connectState === 'error') {
+                  setConnectState('idle')
+                  setConnectError(null)
+                }
+              }}
+              disabled={connectState === 'connecting'}
+              aria-invalid={connectState === 'error'}
+              aria-describedby={connectState === 'error' ? apiKeyErrorId : undefined}
+            />
+          </div>
           {connectState === 'error' && connectError ? (
-            <p className="text-xs text-destructive">{connectError}</p>
+            <p id={apiKeyErrorId} className="text-xs text-destructive">
+              {connectError}
+            </p>
           ) : null}
           <div className="space-y-2 text-xs leading-relaxed text-muted-foreground">
             <p>
@@ -189,7 +202,7 @@ export function LinearApiKeyDialog({
         </div>
         <DialogFooter>
           <Button
-            variant="outline"
+            variant="ghost"
             onClick={() => onOpenChange(false)}
             disabled={connectState === 'connecting'}
           >

--- a/src/renderer/src/components/linear-scope-selector.tsx
+++ b/src/renderer/src/components/linear-scope-selector.tsx
@@ -173,6 +173,12 @@ export function LinearScopeSelector({
     [onOpen]
   )
 
+  const closeSelector = useCallback(() => {
+    setOpen(false)
+    setQuery('')
+    setCommandValue('')
+  }, [])
+
   const commitTeamSelection = useCallback(
     (nextSelectedTeamIds: ReadonlySet<string>) => {
       const normalized = normalizeLinearScopeTeamSelection({
@@ -211,7 +217,7 @@ export function LinearScopeSelector({
           role="combobox"
           aria-expanded={open}
           className={cn(
-            'h-8 min-w-[180px] max-w-[260px] justify-between rounded-md border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none',
+            'h-8 w-[220px] max-w-[calc(100vw-5rem)] justify-between rounded-md border-border/50 bg-muted/50 px-2 text-xs font-medium shadow-sm transition hover:bg-muted/50 focus:ring-2 focus:ring-ring/20 focus:outline-none',
             className
           )}
         >
@@ -234,13 +240,13 @@ export function LinearScopeSelector({
                 <div className="px-3 pb-1 pt-1 text-[11px] font-medium uppercase text-muted-foreground">
                   Workspace
                 </div>
-                <button
-                  type="button"
-                  onClick={() => {
+                <CommandItem
+                  value="workspace:all"
+                  onSelect={() => {
                     onWorkspaceChange('all')
-                    setOpen(false)
+                    closeSelector()
                   }}
-                  className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition hover:bg-accent hover:text-accent-foreground"
+                  className="items-center gap-2 px-3 py-1.5 text-xs"
                 >
                   <Check
                     className={cn(
@@ -249,16 +255,16 @@ export function LinearScopeSelector({
                     )}
                   />
                   <span>All workspaces</span>
-                </button>
+                </CommandItem>
                 {workspaces.map((workspace) => (
-                  <button
+                  <CommandItem
                     key={workspace.id}
-                    type="button"
-                    onClick={() => {
+                    value={`workspace:${workspace.id}`}
+                    onSelect={() => {
                       onWorkspaceChange(workspace.id)
-                      setOpen(false)
+                      closeSelector()
                     }}
-                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition hover:bg-accent hover:text-accent-foreground"
+                    className="items-center gap-2 px-3 py-1.5 text-xs"
                   >
                     <Check
                       className={cn(
@@ -267,7 +273,7 @@ export function LinearScopeSelector({
                       )}
                     />
                     <span className="min-w-0 truncate">{workspace.organizationName}</span>
-                  </button>
+                  </CommandItem>
                 ))}
               </div>
             ) : null}
@@ -275,10 +281,10 @@ export function LinearScopeSelector({
               <div className="px-3 pb-1 pt-1 text-[11px] font-medium uppercase text-muted-foreground">
                 Teams
               </div>
-              <button
-                type="button"
-                onClick={handleAllTeams}
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition hover:bg-accent hover:text-accent-foreground"
+              <CommandItem
+                value="teams:all"
+                onSelect={() => handleAllTeams()}
+                className="items-center gap-2 px-3 py-1.5 text-xs"
               >
                 <Check
                   className={cn(
@@ -287,7 +293,7 @@ export function LinearScopeSelector({
                   )}
                 />
                 <span>All teams</span>
-              </button>
+              </CommandItem>
             </div>
             {filteredTeams.length > 0 ? (
               filteredTeams.map((team) => {
@@ -337,7 +343,7 @@ export function LinearScopeSelector({
           <button
             type="button"
             onClick={() => {
-              setOpen(false)
+              closeSelector()
               onAddTeamAccess()
             }}
             className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-foreground transition hover:bg-accent hover:text-accent-foreground"

--- a/src/renderer/src/components/onboarding/IntegrationsStep.tsx
+++ b/src/renderer/src/components/onboarding/IntegrationsStep.tsx
@@ -131,7 +131,7 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
               </div>
               <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
                 {linearStatus.connected
-                  ? `${workspaceCount} workspace${workspaceCount === 1 ? '' : 's'} linked. Update restricted access any time.`
+                  ? `${workspaceCount} workspace${workspaceCount === 1 ? '' : 's'} linked. Add another workspace or replace a restricted key any time.`
                   : 'Add Linear access with a Personal API key. Full-access keys can show every team the key owner can access.'}
               </p>
             </div>
@@ -139,7 +139,7 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
           <div className={cn('flex items-center gap-2', compact ? 'flex-wrap' : 'shrink-0')}>
             {linearStatus.connected ? (
               <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
-                Update access
+                Add workspace access
               </Button>
             ) : (
               <Button size="sm" onClick={() => setDialogOpen(true)}>
@@ -160,7 +160,7 @@ export function LinearRow(props: { compact?: boolean } = {}): React.JSX.Element 
         onOpenChange={setDialogOpen}
         overlayClassName="z-[110]"
         contentClassName="z-[120]"
-        connectLabel={linearStatus.connected ? 'Update access' : 'Add Linear access'}
+        connectLabel="Add Linear access"
       />
     </>
   )

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -635,7 +635,7 @@ export function IntegrationsPane(): React.JSX.Element {
           {linearStatus.connected ? (
             <div className="flex shrink-0 items-center gap-1.5">
               <Button variant="outline" size="sm" onClick={() => setLinearDialogOpen(true)}>
-                Update access
+                Add workspace access
               </Button>
               <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
                 Connected
@@ -719,7 +719,7 @@ export function IntegrationsPane(): React.JSX.Element {
       <LinearApiKeyDialog
         open={linearDialogOpen}
         onOpenChange={setLinearDialogOpen}
-        connectLabel={linearStatus.connected ? 'Update access' : 'Add Linear access'}
+        connectLabel="Add Linear access"
         onConnected={() => setLinearTestResultByWorkspace({})}
       />
     </div>

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -226,6 +226,29 @@ describe('createLinearSlice', () => {
     expect(store.getState().linearStatusChecked).toBe(true)
   })
 
+  it('ignores stale forced connection checks when a newer forced check finishes first', async () => {
+    const staleCheck = deferred<LinearConnectionStatus>()
+    const freshCheck = deferred<LinearConnectionStatus>()
+    const viewer = {
+      displayName: 'Test User',
+      email: 'test@example.com',
+      organizationName: 'Test Org'
+    }
+    linearStatus.mockReturnValueOnce(staleCheck.promise).mockReturnValueOnce(freshCheck.promise)
+    const store = createTestStore()
+
+    const stalePromise = store.getState().checkLinearConnection(true)
+    const freshPromise = store.getState().checkLinearConnection(true)
+
+    freshCheck.resolve({ connected: true, viewer })
+    await freshPromise
+    staleCheck.resolve({ connected: false, viewer: null })
+    await stalePromise
+
+    expect(store.getState().linearStatus.connected).toBe(true)
+    expect(store.getState().linearStatus.viewer?.email).toBe('test@example.com')
+  })
+
   it('ignores stale status checks after a successful connect', async () => {
     const staleMountCheck = deferred<LinearConnectionStatus>()
     const freshConnectCheck = deferred<LinearConnectionStatus>()
@@ -251,6 +274,38 @@ describe('createLinearSlice', () => {
 
     staleMountCheck.resolve({ connected: false, viewer: null })
     await mountCheck
+
+    expect(store.getState().linearStatus.connected).toBe(true)
+    expect(store.getState().linearStatus.viewer?.email).toBe('test@example.com')
+  })
+
+  it('does not let a background status refresh cancel an in-flight connect', async () => {
+    const connectResult = deferred<{ ok: true; viewer: LinearViewer }>()
+    const backgroundStatus = deferred<LinearConnectionStatus>()
+    const connectStatus = deferred<LinearConnectionStatus>()
+    const viewer = {
+      displayName: 'Test User',
+      email: 'test@example.com',
+      organizationName: 'Test Org'
+    }
+    linearConnect.mockReturnValueOnce(connectResult.promise)
+    linearStatus
+      .mockReturnValueOnce(backgroundStatus.promise)
+      .mockReturnValueOnce(connectStatus.promise)
+    const store = createTestStore()
+
+    const connectPromise = store.getState().connectLinear('linear-key')
+    const refreshPromise = store.getState().checkLinearConnection(true)
+
+    backgroundStatus.resolve({ connected: false, viewer: null })
+    await refreshPromise
+
+    connectResult.resolve({ ok: true, viewer })
+    await Promise.resolve()
+    expect(linearStatus).toHaveBeenCalledTimes(2)
+
+    connectStatus.resolve({ connected: true, viewer })
+    await connectPromise
 
     expect(store.getState().linearStatus.connected).toBe(true)
     expect(store.getState().linearStatus.viewer?.email).toBe('test@example.com')

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -77,7 +77,8 @@ type InflightLinearTeamRequest = {
 
 const inflightTeamRequests = new Map<string, InflightLinearTeamRequest>()
 let inflightStatusRequest: Promise<void> | null = null
-let statusRequestGeneration = 0
+let linearStatusReadGeneration = 0
+let linearMutationGeneration = 0
 let linearCacheGeneration = 0
 
 function getSelectedWorkspaceId(status: LinearConnectionStatus): LinearWorkspaceSelection | null {
@@ -159,14 +160,14 @@ type LinearIssueReadArgs =
 
 type LinearFetchOptions = { force?: boolean }
 
-function beginStatusOperation(): number {
-  statusRequestGeneration += 1
+function beginLinearMutation(): number {
+  linearMutationGeneration += 1
   inflightStatusRequest = null
-  return statusRequestGeneration
+  return linearMutationGeneration
 }
 
-function isCurrentStatusOperation(generation: number): boolean {
-  return generation === statusRequestGeneration
+function isCurrentLinearMutation(generation: number): boolean {
+  return generation === linearMutationGeneration
 }
 
 export type LinearSlice = {
@@ -219,10 +220,14 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       return inflightStatusRequest
     }
 
-    const requestGeneration = beginStatusOperation()
+    const mutationGeneration = linearMutationGeneration
+    const statusReadGeneration = (linearStatusReadGeneration += 1)
     inflightStatusRequest = linearStatus(get().settings)
       .then((status) => {
-        if (!isCurrentStatusOperation(requestGeneration)) {
+        if (
+          mutationGeneration !== linearMutationGeneration ||
+          statusReadGeneration !== linearStatusReadGeneration
+        ) {
           return
         }
         const typedStatus = status as LinearConnectionStatus
@@ -243,7 +248,10 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         }
       })
       .catch(() => {
-        if (!isCurrentStatusOperation(requestGeneration)) {
+        if (
+          mutationGeneration !== linearMutationGeneration ||
+          statusReadGeneration !== linearStatusReadGeneration
+        ) {
           return
         }
         if (get().linearStatus.connected) {
@@ -253,7 +261,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
         }
       })
       .finally(() => {
-        if (isCurrentStatusOperation(requestGeneration)) {
+        if (statusReadGeneration === linearStatusReadGeneration) {
           inflightStatusRequest = null
         }
       })
@@ -262,13 +270,13 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   },
 
   testLinearConnection: async (workspaceId) => {
-    const requestGeneration = beginStatusOperation()
+    const requestGeneration = beginLinearMutation()
     try {
       const result = (await linearTestConnection(get().settings, workspaceId)) as
         | { ok: true; viewer: LinearViewer }
         | { ok: false; error: string }
       const status = await linearStatus(get().settings)
-      if (isCurrentStatusOperation(requestGeneration)) {
+      if (isCurrentLinearMutation(requestGeneration)) {
         const prev = get().linearStatus
         if (linearStatusScopeSignature(prev) !== linearStatusScopeSignature(status)) {
           invalidateLinearCaches()
@@ -291,10 +299,10 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   },
 
   connectLinear: async (apiKey: string) => {
-    const requestGeneration = beginStatusOperation()
+    const requestGeneration = beginLinearMutation()
     try {
       const result = await linearConnect(get().settings, apiKey)
-      if (result.ok && isCurrentStatusOperation(requestGeneration)) {
+      if (result.ok && isCurrentLinearMutation(requestGeneration)) {
         invalidateLinearCaches()
         set({
           linearIssueCache: {},
@@ -302,7 +310,7 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
           linearTeamCache: {}
         })
         const status = await linearStatus(get().settings)
-        if (!isCurrentStatusOperation(requestGeneration)) {
+        if (!isCurrentLinearMutation(requestGeneration)) {
           return result as { ok: true; viewer: LinearViewer } | { ok: false; error: string }
         }
         set({
@@ -318,9 +326,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   },
 
   selectLinearWorkspace: async (workspaceId) => {
-    const requestGeneration = beginStatusOperation()
+    const requestGeneration = beginLinearMutation()
     const status = await linearSelectWorkspace(get().settings, workspaceId)
-    if (!isCurrentStatusOperation(requestGeneration)) {
+    if (!isCurrentLinearMutation(requestGeneration)) {
       return
     }
     invalidateLinearCaches()
@@ -334,9 +342,9 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   },
 
   disconnectLinear: async () => {
-    const requestGeneration = beginStatusOperation()
+    const requestGeneration = beginLinearMutation()
     await linearDisconnect(get().settings)
-    if (!isCurrentStatusOperation(requestGeneration)) {
+    if (!isCurrentLinearMutation(requestGeneration)) {
       return
     }
     invalidateLinearCaches()
@@ -350,10 +358,10 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
   },
 
   disconnectLinearWorkspace: async (workspaceId) => {
-    const requestGeneration = beginStatusOperation()
+    const requestGeneration = beginLinearMutation()
     await linearDisconnectWorkspace(get().settings, workspaceId)
     const status = await linearStatus(get().settings)
-    if (!isCurrentStatusOperation(requestGeneration)) {
+    if (!isCurrentLinearMutation(requestGeneration)) {
       return
     }
     invalidateLinearCaches()


### PR DESCRIPTION
## Summary
- Follow up on #3850 with UX/copy polish for the Linear scope selector and shared API-key dialog.
- Keep generic access flows on “Add Linear access” while preserving “Update access” for a single scoped workspace.
- Make selector command rows keyboard-consistent, stabilize the trigger width, and reset search when closing.
- Prevent forced Linear status refreshes from racing newer status reads or in-flight connect mutations.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/linear-links.test.ts src/main/linear/teams.test.ts src/renderer/src/store/slices/linear.test.ts src/renderer/src/store/slices/linear-invalidation.test.ts src/renderer/src/components/task-page-linear-team-selection.test.ts src/renderer/src/components/linear-scope-selector.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- Electron CDP visual verification of Linear Tasks selector, search-empty state, API-key dialog, and Settings Integrations Linear row. Screenshots saved locally under ignored `validation-screenshots/`.

Risk: low

Risk assessment: Low. Rebased onto current main and reran the focused Linear link/team/store invalidation/selector tests, touched-file lint, web typecheck, and diff check successfully. The PR body already includes Electron CDP visual verification of the Linear Tasks selector, search-empty state, API-key dialog, and Settings Integrations Linear row.