### PR TITLE
fix: strip agent browser exec target flags

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -307,7 +307,9 @@ describe('AgentBrowserBridge', () => {
 
   it('strips --cdp and --session from exec commands', async () => {
     succeedWith({ output: 'ok' })
-    await bridge.exec('dblclick @e3 --cdp ws://evil --session hijack')
+    await bridge.exec(
+      'dblclick @e3 --cdp ws://evil --session hijack --cdp=ws://evil-equals --session=hijack-equals'
+    )
 
     // Why: find the actual exec call (contains 'dblclick'), not the stale-session close
     const execCall = execFileMock.mock.calls.find((c: unknown[]) =>
@@ -315,9 +317,11 @@ describe('AgentBrowserBridge', () => {
     )
     const args = execCall![1] as string[]
     // The bridge's own --session and --cdp (for session init) are expected.
-    // Verify the user-injected ones were stripped: no 'ws://evil' or 'hijack'
+    // Verify the user-injected ones were stripped, including --flag=value forms.
     expect(args.join(' ')).not.toContain('ws://evil')
+    expect(args.join(' ')).not.toContain('ws://evil-equals')
     expect(args.join(' ')).not.toContain('hijack')
+    expect(args.join(' ')).not.toContain('hijack-equals')
     expect(args).toContain('dblclick')
     expect(args).toContain('@e3')
   })

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -171,6 +171,22 @@ function parseShellArgs(input: string): string[] {
   return args
 }
 
+function stripAgentBrowserTargetArgs(args: string[]): string[] {
+  const stripped: string[] = []
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === '--cdp' || arg === '--session') {
+      index++
+      continue
+    }
+    if (arg.startsWith('--cdp=') || arg.startsWith('--session=')) {
+      continue
+    }
+    stripped.push(arg)
+  }
+  return stripped
+}
+
 // Why: agent-browser returns generic error messages for stale/unknown refs.
 // Map them to a specific code so agents can reliably detect and re-snapshot.
 function classifyErrorCode(message: string): string {
@@ -1695,12 +1711,9 @@ export class AgentBrowserBridge {
 
   async exec(command: string, worktreeId?: string, browserPageId?: string): Promise<unknown> {
     return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      // Why: strip --cdp and --session from raw command to prevent session/target injection
-      const sanitized = command
-        .replace(/--cdp\s+\S+/g, '')
-        .replace(/--session\s+\S+/g, '')
-        .trim()
-      const args = parseShellArgs(sanitized)
+      // Why: strip target/session flags from raw passthrough commands so a
+      // caller cannot override Orca's selected browser page or CDP proxy.
+      const args = stripAgentBrowserTargetArgs(parseShellArgs(command.trim()))
       return await this.execAgentBrowser(sessionName, args)
     })
   }


### PR DESCRIPTION
## Summary
- strip raw agent-browser passthrough target flags after shell-style parsing
- cover both separated and equals-form `--cdp` / `--session` injection attempts

## Repro Evidence
- Before the fix, `npm test -- src/main/browser/agent-browser-bridge.test.ts` failed because `bridge.exec('dblclick @e3 --cdp ws://evil --session hijack --cdp=ws://evil-equals --session=hijack-equals')` still passed `--cdp=ws://evil-equals` and `--session=hijack-equals` through to `agent-browser`.

## Verification
- `npm test -- src/main/browser/agent-browser-bridge.test.ts`
- `npm run typecheck:node`
- `npx oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts`
- `npx oxfmt --check src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts`
- `git diff --check HEAD~1..HEAD`

Risk: low; scoped to raw browser exec argument sanitization.