### PR TITLE
perf: defer agent output classification

### DIFF
--- a/src/main/stats/agent-detector.test.ts
+++ b/src/main/stats/agent-detector.test.ts
@@ -19,6 +19,35 @@ describe('AgentDetector', () => {
     expect(stats.onAgentStop).not.toHaveBeenCalled()
   })
 
+  it('does not inspect unknown non-agent output for meaningful content', () => {
+    const stats = {
+      onAgentStart: vi.fn(),
+      onAgentStop: vi.fn()
+    }
+    const detectMeaningfulContent = vi.fn(() => true)
+    const detector = new AgentDetector(stats as never, detectMeaningfulContent)
+
+    detector.onData('pty-1', '\x1b[2K\x1b[1G'.repeat(100), 100)
+
+    expect(detectMeaningfulContent).not.toHaveBeenCalled()
+    expect(stats.onAgentStart).not.toHaveBeenCalled()
+    expect(stats.onAgentStop).not.toHaveBeenCalled()
+  })
+
+  it('inspects content once when an agent title starts a session', () => {
+    const stats = {
+      onAgentStart: vi.fn(),
+      onAgentStop: vi.fn()
+    }
+    const detectMeaningfulContent = vi.fn(() => true)
+    const detector = new AgentDetector(stats as never, detectMeaningfulContent)
+
+    detector.onData('pty-1', `${oscTitle('⠂ Writing patch')}real output`, 100)
+
+    expect(detectMeaningfulContent).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStart).toHaveBeenCalledWith('pty-1', 100)
+  })
+
   it('stops a session on working to idle transition using the last meaningful output time', () => {
     const stats = {
       onAgentStart: vi.fn(),

--- a/src/main/stats/agent-detector.ts
+++ b/src/main/stats/agent-detector.ts
@@ -18,6 +18,8 @@ type PtyRecord = {
   lastMeaningfulOutputAt: number | null
 }
 
+type MeaningfulContentDetector = (chunk: string) => boolean
+
 /**
  * Lightweight normalization to detect whether a PTY data chunk contains
  * meaningful (non-ANSI, non-OSC) output. Mirrors the regex passes in
@@ -72,9 +74,11 @@ function hasMeaningfulContent(chunk: string): boolean {
 export class AgentDetector {
   private ptys = new Map<string, PtyRecord>()
   private stats: StatsCollector
+  private meaningfulContentDetector: MeaningfulContentDetector
 
-  constructor(stats: StatsCollector) {
+  constructor(stats: StatsCollector, meaningfulContentDetector = hasMeaningfulContent) {
     this.stats = stats
+    this.meaningfulContentDetector = meaningfulContentDetector
   }
 
   /**
@@ -99,8 +103,13 @@ export class AgentDetector {
       return
     }
 
-    const hasMeaningfulOutput = hasMeaningfulContent(rawData)
-    if (record.sessionOpen && hasMeaningfulOutput) {
+    let hasMeaningfulOutput: boolean | null = null
+    const getHasMeaningfulOutput = (): boolean => {
+      hasMeaningfulOutput ??= this.meaningfulContentDetector(rawData)
+      return hasMeaningfulOutput
+    }
+
+    if (record.sessionOpen && getHasMeaningfulOutput()) {
       record.lastMeaningfulOutputAt = at
     }
 
@@ -119,7 +128,7 @@ export class AgentDetector {
       record.lastStatus = status
       record.sessionOpen = true
       record.sessionStartAt = at
-      record.lastMeaningfulOutputAt = hasMeaningfulOutput ? at : null
+      record.lastMeaningfulOutputAt = getHasMeaningfulOutput() ? at : null
       this.stats.onAgentStart(ptyId, at)
       return
     }
@@ -139,7 +148,7 @@ export class AgentDetector {
       // title is the start boundary for the next tracked session.
       record.sessionOpen = true
       record.sessionStartAt = at
-      record.lastMeaningfulOutputAt = hasMeaningfulOutput ? at : null
+      record.lastMeaningfulOutputAt = getHasMeaningfulOutput() ? at : null
       this.stats.onAgentStart(ptyId, at)
     }
 


### PR DESCRIPTION
## Summary
- defer AgentDetector meaningful-output classification until an active/starting agent session can use it
- avoid ANSI-stripping unknown non-agent PTY chunks in the main terminal output path
- add deterministic call-count coverage for the lazy classifier

## User impact
- No intended behavior change; reduces main-process CPU work for ordinary ANSI-heavy terminal output with no agent OSC title.

## Risk
- Low: localized to stats agent lifecycle detection and preserves classification when a session is active or starts.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/stats/agent-detector.test.ts
- pnpm exec oxlint src/main/stats/agent-detector.ts src/main/stats/agent-detector.test.ts
- pnpm run typecheck:node
- git diff --check
- pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts

Risk: low; localized stats agent-output classification deferral with focused call-count and e2e latency coverage.