### PR TITLE
perf: trim terminal tail bursts with slice

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -26,7 +26,7 @@ import {
 import { getBranchConflictKind, getDefaultBaseRef } from '../git/repo'
 import type { OrchestrationDb } from './orchestration/db'
 import type { MessagePriority, MessageRow, MessageType } from './orchestration/types'
-import { OrcaRuntimeService } from './orca-runtime'
+import { appendNormalizedToTailBuffer, OrcaRuntimeService } from './orca-runtime'
 import {
   registerSshFilesystemProvider,
   unregisterSshFilesystemProvider
@@ -3927,6 +3927,25 @@ describe('OrcaRuntimeService', () => {
 
     expect(collected).toHaveLength(lines.length)
     expect(collected.findIndex((line, index) => line !== lines[index])).toBe(-1)
+  })
+
+  it('trims oversized terminal output bursts without per-line array shifts', async () => {
+    const shiftSpy = vi.spyOn(Array.prototype, 'shift')
+    const lines = Array.from({ length: 5000 }, (_, index) => `line-${index}`)
+    const result = appendNormalizedToTailBuffer([], '', `${lines.join('\n')}\n`)
+    const shiftCallCount = shiftSpy.mock.calls.length
+    shiftSpy.mockRestore()
+
+    expect(result.truncated).toBe(true)
+    expect(result.lines).toHaveLength(2000)
+    expect(result.lines.slice(0, 5)).toEqual([
+      'line-3000',
+      'line-3001',
+      'line-3002',
+      'line-3003',
+      'line-3004'
+    ])
+    expect(shiftCallCount).toBe(0)
   })
 
   it('bounds retained partial terminal output before preview reads', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12686,7 +12686,7 @@ function buildTerminalWaitText(lines: string[], partialLine: string, preview: st
   return waitText.length > 0 ? waitText : preview
 }
 
-function appendNormalizedToTailBuffer(
+export function appendNormalizedToTailBuffer(
   previousLines: string[],
   previousPartialLine: string,
   normalizedChunk: string
@@ -12719,8 +12719,8 @@ function appendNormalizedToTailBuffer(
       : previousLines
   let truncated = previousPartialWasCapped || nextPartialLine.length > MAX_TAIL_PARTIAL_CHARS
 
-  while (nextLines.length > MAX_TAIL_LINES) {
-    nextLines.shift()
+  if (nextLines.length > MAX_TAIL_LINES) {
+    nextLines = nextLines.slice(nextLines.length - MAX_TAIL_LINES)
     truncated = true
   }
 


### PR DESCRIPTION
## Summary
- replace repeated front-shift trimming of retained terminal tail lines with one tail slice
- keep the same 2,000-line retained tail and truncation behavior
- add a deterministic regression test that a 5,000-line burst trims without helper-level shift calls

## User impact
No intended behavior change; large terminal output bursts should spend less main-process time maintaining retained output for CLI/runtime reads.

## Risk
Low: localized to retained terminal tail-buffer trimming; existing pagination/truncation semantics are preserved by tests.

## Verification
- targeted runtime retained-output vitest before and after rebase
- oxlint on touched files
- pnpm run typecheck:node
- git diff --check
- pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts