### PR TITLE
fix: preserve multiline browser fill values

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -526,9 +526,9 @@ describe('AgentBrowserBridge', () => {
         expect(wc.on).toHaveBeenCalledWith('did-finish-load', expect.any(Function))
       })
 
-      const finishListener = wc.on.mock.calls.find(
-        ([event]) => event === 'did-finish-load'
-      )?.[1] as (() => void) | undefined
+      const finishListener = wc.on.mock.calls.find(([event]) => event === 'did-finish-load')?.[1] as
+        | (() => void)
+        | undefined
       const failListener = wc.on.mock.calls.find(([event]) => event === 'did-fail-load')?.[1] as
         | (() => void)
         | undefined
@@ -1105,6 +1105,20 @@ describe('AgentBrowserBridge', () => {
     const args = execFileMock.mock.calls.at(-1)![1] as string[]
     expect(args).toContain('goto')
     expect(args).toContain('https://example.com')
+  })
+
+  it('builds valid fill eval JavaScript for multiline values', async () => {
+    succeedWith({ ok: true })
+
+    await bridge.fill('@textarea', "line one\nline two with 'quote' and \\ slash")
+
+    const evalCall = execFileMock.mock.calls.find((call: unknown[]) =>
+      (call[1] as string[]).includes('eval')
+    )
+    expect(evalCall).toBeDefined()
+    const args = evalCall![1] as string[]
+    const expression = args[args.indexOf('eval') + 1]
+    expect(() => new Function(expression)).not.toThrow()
   })
 
   // ── Cookie command arg building ──

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -706,10 +706,10 @@ export class AgentBrowserBridge {
     // directly via JS and dispatch input/change events for React/framework compat.
     return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
       await this.execAgentBrowser(sessionName, ['focus', element])
-      const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+      const serializedValue = JSON.stringify(value)
       await this.execAgentBrowser(sessionName, [
         'eval',
-        `(() => { const el = document.activeElement; if (el) { const nativeSetter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value')?.set; if (nativeSetter) { nativeSetter.call(el, '${escaped}'); } else { el.value = '${escaped}'; } el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); } })()`
+        `(() => { const el = document.activeElement; if (el) { const nativeSetter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value')?.set; if (nativeSetter) { nativeSetter.call(el, ${serializedValue}); } else { el.value = ${serializedValue}; } el.dispatchEvent(new Event('input', { bubbles: true })); el.dispatchEvent(new Event('change', { bubbles: true })); } })()`
       ])
       return { filled: element } as BrowserFillResult
     })


### PR DESCRIPTION
## Summary
- serialize browser fill values with `JSON.stringify` before embedding them in the eval script
- add a regression test for multiline values with quotes and backslashes

## Repro Evidence
- Before the fix, `npm test -- src/main/browser/agent-browser-bridge.test.ts` failed because `bridge.fill('@textarea', "line one\nline two with 'quote' and \\ slash")` generated an eval expression that threw `SyntaxError: Invalid or unexpected token` under `new Function(...)`.

## Verification
- `npm test -- src/main/browser/agent-browser-bridge.test.ts`
- `npm run typecheck:node`
- `npx oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts`
- `npx oxfmt --check src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts`
- `git diff --check HEAD~1..HEAD`

Risk: low; scoped to the generated JS literal used by browser fill.