### PR TITLE
Update agent-browser to 0.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@xterm/addon-webgl": "0.20.0-beta.219",
     "@xterm/headless": "6.1.0-beta.220",
     "@xterm/xterm": "6.1.0-beta.220",
-    "agent-browser": "~0.24.1",
+    "agent-browser": "~0.27.0",
     "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: 6.1.0-beta.220
         version: 6.1.0-beta.220
       agent-browser:
-        specifier: ~0.24.1
-        version: 0.24.1
+        specifier: ~0.27.0
+        version: 0.27.0
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -3077,8 +3077,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agent-browser@0.24.1:
-    resolution: {integrity: sha512-csWJtYEQow52b+p93zVZfNrcNBwbxGCZDXDMNWl2ij2i0MFKubIzN+icUeX2/NrkZe5iIau8px+HQlxata2oPw==}
+  agent-browser@0.27.0:
+    resolution: {integrity: sha512-mmHzVsYFVA6nshNNGJzg83aVMgKpf4h98ytY3pvtJB1Cot0ZyA2bfnkbSngGD56Azkj+GlhVH6qx9DfKOVE0yg==}
     hasBin: true
 
   ajv-formats@3.0.1:
@@ -8966,7 +8966,7 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-browser@0.24.1: {}
+  agent-browser@0.27.0: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Update `agent-browser` from `~0.24.1` to `~0.27.0`.
- Pull in upstream fixes/features from 0.25.x-0.27.0, including hidden checkbox/radio snapshot refs, Linux Chrome idle cleanup fix, CDP discovery fixes, stable tab ids, `doctor`, versioned `skills get core`, React introspection, Web Vitals, SPA `pushstate`, and dashboard proxy support.
- Verified the npm package still ships the native binary names Orca resolves and electron-builder copies for macOS, Linux, and Windows.

Upstream refs:
- https://github.com/vercel-labs/agent-browser/releases/tag/v0.27.0
- https://github.com/vercel-labs/agent-browser/releases/tag/v0.26.0
- https://github.com/vercel-labs/agent-browser/releases/tag/v0.25.5

## Verification
- `pnpm run typecheck`
- `pnpm lint`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts src/main/browser/cdp-ws-proxy.test.ts src/main/browser/cdp-bridge-integration.test.ts src/cli/browser.test.ts`
- `pnpm exec agent-browser doctor --offline --quick --json`
- `pnpm exec agent-browser --session <tmp> open/snapshot/get/close --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm audit --prod --audit-level high`

Full-suite note: `pnpm test` currently fails one local live-zsh test outside this diff: `src/main/providers/local-pty-shell-ready.test.ts` expects `/custom/bin` first in PATH but sees the local Orca terminal attribution path. The changed files are only `package.json` and `pnpm-lock.yaml`.

## Review
- Reviewed the package-only diff for lockfile consistency, native binary layout, command contract compatibility, packaged-resource paths, cross-platform naming, and SSH/remote implications. No in-scope issues found.

Risk: medium; this is a package and lockfile upgrade for the agent-browser runtime dependency, so it needs broader tool/runtime confidence before merge.