### PR TITLE
perf: scan terminal previews from tail

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -26,7 +26,7 @@ import {
 import { getBranchConflictKind, getDefaultBaseRef } from '../git/repo'
 import type { OrchestrationDb } from './orchestration/db'
 import type { MessagePriority, MessageRow, MessageType } from './orchestration/types'
-import { appendNormalizedToTailBuffer, OrcaRuntimeService } from './orca-runtime'
+import { appendNormalizedToTailBuffer, buildPreview, OrcaRuntimeService } from './orca-runtime'
 import {
   registerSshFilesystemProvider,
   unregisterSshFilesystemProvider
@@ -3946,6 +3946,22 @@ describe('OrcaRuntimeService', () => {
       'line-3004'
     ])
     expect(shiftCallCount).toBe(0)
+  })
+
+  it('builds terminal previews without mapping the full retained tail', () => {
+    const lines = Array.from({ length: 5000 }, (_, index) =>
+      index % 2 === 0 ? `line-${index}` : '   '
+    )
+    const mapSpy = vi.spyOn(Array.prototype, 'map')
+
+    const preview = buildPreview(lines, 'partial-tail')
+    const mapCallCount = mapSpy.mock.calls.length
+    mapSpy.mockRestore()
+
+    expect(preview).toBe(
+      ['line-4990', 'line-4992', 'line-4994', 'line-4996', 'line-4998', 'partial-tail'].join('\n')
+    )
+    expect(mapCallCount).toBe(0)
   })
 
   it('bounds retained partial terminal output before preview reads', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12665,11 +12665,27 @@ function withTimeoutResult<T>(
   })
 }
 
-function buildPreview(lines: string[], partialLine: string): string {
-  const previewLines = buildTailLines(lines, partialLine)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .slice(-MAX_PREVIEW_LINES)
+export function buildPreview(lines: string[], partialLine: string): string {
+  const previewLines: string[] = []
+  const collectVisibleLine = (line: string): void => {
+    const trimmed = line.trim()
+    if (trimmed.length > 0) {
+      previewLines.push(trimmed)
+    }
+  }
+
+  if (partialLine.length > 0) {
+    collectVisibleLine(partialLine)
+  }
+  for (
+    let index = lines.length - 1;
+    index >= 0 && previewLines.length < MAX_PREVIEW_LINES;
+    index--
+  ) {
+    collectVisibleLine(lines[index])
+  }
+  previewLines.reverse()
+
   const preview = previewLines.join('\n')
   return preview.length > MAX_PREVIEW_CHARS
     ? preview.slice(preview.length - MAX_PREVIEW_CHARS)


### PR DESCRIPTION
## Summary
- build retained terminal previews by scanning backward from the tail
- stop once the six visible preview lines are collected instead of mapping/filtering the full retained buffer
- add direct helper coverage that a 5,000-line tail preview does not use full-array map

## User impact
No intended behavior change; active terminal output should spend less main-process time refreshing runtime/worktree preview text once retained buffers are large.

## Risk
Low: preview text keeps the same last-six-non-empty-lines and character budget semantics, with focused tests.

## Verification
- targeted runtime preview/tail vitest before and after rebase
- oxlint on touched files
- pnpm run typecheck:node
- git diff --check
- pnpm run test:e2e -- tests/e2e/terminal-typing-latency.spec.ts