### PR TITLE
Clean up STT worker lifecycle listeners

### DIFF
--- a/src/main/speech/stt-service.test.ts
+++ b/src/main/speech/stt-service.test.ts
@@ -249,6 +249,32 @@ describe('SttService', () => {
     ).resolves.toBe(undefined)
   })
 
+  it('removes lifecycle listeners when the active worker errors', async () => {
+    const sink = vi.fn()
+    const service = new SttService({
+      getModelState: vi.fn().mockResolvedValue({ id: 'model-a', status: 'ready' }),
+      getModelDir: vi.fn().mockReturnValue('/tmp/model-a')
+    } as never)
+
+    await service.startDictation('model-a', sink, undefined, 'desktop')
+    const worker = getLastWorker()
+    expect(worker).toBeDefined()
+    expect(worker!.listenerCount('message')).toBe(1)
+    expect(worker!.listenerCount('error')).toBe(1)
+    expect(worker!.listenerCount('exit')).toBe(1)
+
+    worker!.emit('error', new Error('worker failed'))
+
+    expect(service.isActive()).toBe(false)
+    expect(sink).toHaveBeenCalledWith({
+      type: 'error',
+      error: 'Error: worker failed'
+    })
+    expect(worker!.listenerCount('message')).toBe(0)
+    expect(worker!.listenerCount('error')).toBe(0)
+    expect(worker!.listenerCount('exit')).toBe(0)
+  })
+
   it('allows slow offline stop decoding before terminating the worker', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/speech/stt-service.ts
+++ b/src/main/speech/stt-service.ts
@@ -30,6 +30,9 @@ export class SttService {
   private canceledOwners = new Set<string>()
   private eventSink: SttEventSink | null = null
   private idleTeardownTimer: NodeJS.Timeout | null = null
+  // Why: warm workers intentionally keep lifecycle listeners while reusable;
+  // stale workers must not retain this service after error, exit, or teardown.
+  private cleanupWorkerLifecycleListeners: (() => void) | null = null
 
   constructor(modelManager: ModelManager) {
     this.modelManager = modelManager
@@ -160,30 +163,41 @@ export class SttService {
       startupTimeout.unref?.()
     })
 
-    worker.on('message', (msg: SttEvent) => {
+    const onWorkerMessage = (msg: SttEvent) => {
       this.eventSink?.(msg)
-    })
+    }
 
-    worker.on('error', (err) => {
+    const onWorkerError = (err: Error) => {
       this.eventSink?.({ type: 'error', error: String(err) })
       if (this.worker === worker) {
+        this.cleanupActiveWorkerLifecycleListeners()
         this.worker = null
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
         this.activeOwner = null
         this.eventSink = null
       }
-    })
+    }
 
-    worker.on('exit', () => {
+    const onWorkerExit = () => {
       if (this.worker === worker) {
+        this.cleanupActiveWorkerLifecycleListeners()
         this.worker = null
         this.activeModelId = null
         this.activeHotwordsFilePath = undefined
         this.activeOwner = null
         this.eventSink = null
       }
-    })
+    }
+
+    worker.on('message', onWorkerMessage)
+    worker.on('error', onWorkerError)
+    worker.on('exit', onWorkerExit)
+    this.cleanupWorkerLifecycleListeners = () => {
+      worker.off('message', onWorkerMessage)
+      worker.off('error', onWorkerError)
+      worker.off('exit', onWorkerExit)
+    }
 
     const modelDir = this.modelManager.getModelDir(modelId)
     worker.postMessage({
@@ -200,6 +214,7 @@ export class SttService {
     try {
       await readyPromise
     } catch (error) {
+      this.cleanupActiveWorkerLifecycleListeners()
       worker.removeAllListeners()
       void worker.terminate()
       if (this.worker === worker) {
@@ -279,6 +294,7 @@ export class SttService {
         cleanup()
         // Why: a worker that cannot finish dictation is no longer reusable; do
         // not keep it in the warm-worker slot or retain its message listeners.
+        this.cleanupActiveWorkerLifecycleListeners()
         worker.removeAllListeners()
         void worker.terminate().finally(resolve)
       }, STOP_DICTATION_TIMEOUT_MS)
@@ -341,6 +357,7 @@ export class SttService {
     }
     const worker = this.worker
     worker.postMessage({ type: 'teardown' })
+    this.cleanupActiveWorkerLifecycleListeners()
     worker.removeAllListeners()
     await worker.terminate().catch(() => undefined)
     if (this.worker === worker) {
@@ -349,6 +366,12 @@ export class SttService {
       this.activeHotwordsFilePath = undefined
       this.eventSink = null
     }
+  }
+
+  private cleanupActiveWorkerLifecycleListeners(): void {
+    const cleanup = this.cleanupWorkerLifecycleListeners
+    this.cleanupWorkerLifecycleListeners = null
+    cleanup?.()
   }
 
   private getSherpaModulePath(): string {


### PR DESCRIPTION
## Summary
- Track STT worker lifecycle message/error/exit listeners while a worker is warm and reusable.
- Detach those lifecycle listeners when the worker errors, exits, times out during startup/stop, or is torn down.
- Add a regression test that active worker error cleanup drops listener counts to zero.

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/speech/stt-service.test.ts`
- `pnpm exec oxlint src/main/speech/stt-service.ts src/main/speech/stt-service.test.ts`
- `pnpm exec oxfmt --check src/main/speech/stt-service.ts src/main/speech/stt-service.test.ts`
- `pnpm typecheck:node`
- `git diff --check origin/main...HEAD`

Risk: low; this is scoped to STT worker listener teardown and preserves warm-worker reuse, with focused lifecycle regression coverage.