### PR TITLE
Improve computer-use action follow-up commands

### DIFF
--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { RuntimeRpcFailureError } from './runtime-client'
-import { formatCliError, formatTerminalRead, formatWorktreeList } from './format'
-import type { RuntimeWorktreeRecord } from '../shared/runtime-types'
+import {
+  formatCliError,
+  formatComputerAction,
+  formatTerminalRead,
+  formatWorktreeList
+} from './format'
+import type { ComputerActionResult, RuntimeWorktreeRecord } from '../shared/runtime-types'
 
 function worktree(overrides: Partial<RuntimeWorktreeRecord> = {}): RuntimeWorktreeRecord {
   const base: RuntimeWorktreeRecord = {
@@ -172,5 +177,61 @@ describe('formatTerminalRead', () => {
     expect(output).toContain('warning: older output is no longer retained')
     expect(output).toContain('old server output')
     expect(output).not.toContain('undefined')
+  })
+})
+
+describe('formatComputerAction', () => {
+  it('includes routed worktree and explicit window target in the suggested follow-up command', () => {
+    const result: ComputerActionResult = {
+      snapshot: {
+        id: 'snap-1',
+        app: { name: 'Text Editor', bundleId: null, pid: 100 },
+        window: { title: 'Document', id: 42, width: 800, height: 600 },
+        coordinateSpace: 'window',
+        treeText: 'tree',
+        elementCount: 5,
+        focusedElementId: null
+      },
+      screenshot: null,
+      screenshotStatus: { state: 'skipped', reason: 'no_screenshot_flag' },
+      action: {
+        path: 'accessibility',
+        targetWindowId: 41
+      }
+    }
+
+    const output = formatComputerAction('click', result, {
+      worktree: 'id:repo::/tmp/repo',
+      windowId: 99
+    })
+
+    expect(output).toContain(
+      "Use `orca computer get-app-state --app 'Text Editor' --worktree id:repo::/tmp/repo --window-id 99`"
+    )
+  })
+
+  it('preserves explicit window-index targeting in the suggested follow-up command', () => {
+    const result: ComputerActionResult = {
+      snapshot: {
+        id: 'snap-1',
+        app: { name: 'Finder', bundleId: 'com.apple.finder', pid: 100 },
+        window: { title: 'Document', id: 42, width: 800, height: 600 },
+        coordinateSpace: 'window',
+        treeText: 'tree',
+        elementCount: 5,
+        focusedElementId: null
+      },
+      screenshot: null,
+      screenshotStatus: { state: 'skipped', reason: 'no_screenshot_flag' }
+    }
+
+    const output = formatComputerAction('click', result, {
+      session: 'manual',
+      windowIndex: 1
+    })
+
+    expect(output).toContain(
+      'Use `orca computer get-app-state --app com.apple.finder --session manual --window-index 1`'
+    )
   })
 })

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -584,15 +584,55 @@ export function formatListWindows(result: ComputerListWindowsResult): string {
     .join('\n')
 }
 
-export function formatComputerAction(verb: string, result: ComputerActionResult): string {
+export type ComputerActionFollowUpTarget = {
+  session?: string
+  worktree?: string
+  windowId?: number
+  windowIndex?: number
+  restoreWindow?: boolean
+}
+
+export function formatComputerAction(
+  verb: string,
+  result: ComputerActionResult,
+  target: ComputerActionFollowUpTarget = {}
+): string {
   const path = result.action?.path ? ` via ${result.action.path}` : ''
   const verification = formatActionVerification(result.action?.verification)
-  const app = shellQuote(result.snapshot.app.bundleId ?? result.snapshot.app.name)
-  const windowId =
-    result.snapshot.window.id === null || result.snapshot.window.id === undefined
-      ? ''
-      : ` --window-id ${result.snapshot.window.id}`
-  return `${formatActionVerb(verb)} completed${path}${verification}; ${result.snapshot.elementCount} elements in current window. Use \`orca computer get-app-state --app ${app}${windowId}\` to inspect.`
+  const followUpCommand = formatComputerFollowUpCommand(result, target)
+  return `${formatActionVerb(verb)} completed${path}${verification}; ${result.snapshot.elementCount} elements in current window. Use \`${followUpCommand}\` to inspect.`
+}
+
+function formatComputerFollowUpCommand(
+  result: ComputerActionResult,
+  target: ComputerActionFollowUpTarget
+): string {
+  const args = [
+    'orca',
+    'computer',
+    'get-app-state',
+    '--app',
+    shellQuote(result.snapshot.app.bundleId ?? result.snapshot.app.name)
+  ]
+  if (target.session) {
+    args.push('--session', shellQuote(target.session))
+  } else if (target.worktree) {
+    args.push('--worktree', shellQuote(target.worktree))
+  }
+  if (target.windowId !== undefined) {
+    args.push('--window-id', String(target.windowId))
+  } else if (target.windowIndex !== undefined) {
+    args.push('--window-index', String(target.windowIndex))
+  } else {
+    const windowId = result.action?.targetWindowId ?? result.snapshot.window.id
+    if (windowId !== null && windowId !== undefined) {
+      args.push('--window-id', String(windowId))
+    }
+  }
+  if (target.restoreWindow) {
+    args.push('--restore-window')
+  }
+  return args.join(' ')
 }
 
 function formatActionVerification(verification: ComputerActionVerification | undefined): string {

--- a/src/cli/handlers/computer.test.ts
+++ b/src/cli/handlers/computer.test.ts
@@ -212,6 +212,32 @@ describe('orca computer CLI handlers', () => {
     })
   })
 
+  it('prints session and window context in action follow-up commands', async () => {
+    queueFixtures(callMock, okFixture('req_click', sampleSnapshot()))
+
+    await main(
+      [
+        'computer',
+        'click',
+        '--session',
+        'manual',
+        '--app',
+        'Finder',
+        '--element-index',
+        '3',
+        '--window-index',
+        '1',
+        '--restore-window'
+      ],
+      '/tmp/repo/src'
+    )
+
+    const output = vi.mocked(console.log).mock.calls[0][0]
+    expect(output).toContain(
+      'Use `orca computer get-app-state --app com.apple.finder --session manual --window-index 1 --restore-window`'
+    )
+  })
+
   it('maps action command flags to RPC payloads', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/handlers/computer.ts
+++ b/src/cli/handlers/computer.ts
@@ -85,6 +85,7 @@ export const COMPUTER_HANDLERS: Record<string, CommandHandler> = {
   },
   'computer click': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.click', {
       ...target,
       elementIndex: getOptionalNonNegativeIntegerFlag(flags, 'element-index'),
@@ -92,22 +93,28 @@ export const COMPUTER_HANDLERS: Record<string, CommandHandler> = {
       y: getOptionalNumberFlag(flags, 'y'),
       clickCount: getOptionalPositiveIntegerFlag(flags, 'click-count'),
       mouseButton: getOptionalStringFlag(flags, 'mouse-button'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('click', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('click', value, { ...target, ...observeFlags })
+    )
   },
   'computer perform-secondary-action': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.performSecondaryAction', {
       ...target,
       elementIndex: getRequiredNonNegativeIntegerFlag(flags, 'element-index'),
       action: getRequiredStringFlag(flags, 'action'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('perform-secondary-action', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('perform-secondary-action', value, { ...target, ...observeFlags })
+    )
   },
   'computer scroll': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.scroll', {
       ...target,
       elementIndex: getOptionalNonNegativeIntegerFlag(flags, 'element-index'),
@@ -115,12 +122,15 @@ export const COMPUTER_HANDLERS: Record<string, CommandHandler> = {
       y: getOptionalNumberFlag(flags, 'y'),
       direction: getRequiredStringFlag(flags, 'direction'),
       pages: getOptionalPositiveNumberFlag(flags, 'pages'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('scroll', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('scroll', value, { ...target, ...observeFlags })
+    )
   },
   'computer drag': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.drag', {
       ...target,
       fromElementIndex: getOptionalNonNegativeIntegerFlag(flags, 'from-element-index'),
@@ -129,55 +139,72 @@ export const COMPUTER_HANDLERS: Record<string, CommandHandler> = {
       fromY: getOptionalNumberFlag(flags, 'from-y'),
       toX: getOptionalNumberFlag(flags, 'to-x'),
       toY: getOptionalNumberFlag(flags, 'to-y'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('drag', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('drag', value, { ...target, ...observeFlags })
+    )
   },
   'computer type-text': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.typeText', {
       ...target,
       text: await getTextPayload(flags, 'text'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('type-text', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('type-text', value, { ...target, ...observeFlags })
+    )
   },
   'computer press-key': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.pressKey', {
       ...target,
       key: getRequiredStringFlag(flags, 'key'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('press-key', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('press-key', value, { ...target, ...observeFlags })
+    )
   },
   'computer hotkey': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.hotkey', {
       ...target,
       key: getRequiredStringFlag(flags, 'key'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('hotkey', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('hotkey', value, { ...target, ...observeFlags })
+    )
   },
   'computer paste-text': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.pasteText', {
       ...target,
       text: await getTextPayload(flags, 'text'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('paste-text', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('paste-text', value, { ...target, ...observeFlags })
+    )
   },
   'computer set-value': async ({ flags, client, cwd, json }) => {
     const target = await getComputerCommandTarget(flags, cwd, client)
+    const observeFlags = getComputerActionObserveFlags(flags)
     const result = await client.call<ComputerActionResult>('computer.setValue', {
       ...target,
       elementIndex: getRequiredNonNegativeIntegerFlag(flags, 'element-index'),
       value: await getTextPayload(flags, 'value'),
-      ...getComputerActionObserveFlags(flags)
+      ...observeFlags
     })
-    printResult(result, json, (value) => formatComputerAction('set-value', value))
+    printResult(result, json, (value) =>
+      formatComputerAction('set-value', value, { ...target, ...observeFlags })
+    )
   }
 }
 
@@ -255,24 +282,12 @@ function getComputerActionObserveFlags(flags: Map<string, string | boolean>): {
   windowId?: number
   windowIndex?: number
 } {
-  const observeFlags: {
-    noScreenshot?: boolean
-    restoreWindow?: boolean
-    windowId?: number
-    windowIndex?: number
-  } = {
-    noScreenshot: flags.has('no-screenshot') ? true : undefined
-  }
-  if (flags.has('restore-window')) {
-    observeFlags.restoreWindow = true
-  }
   const windowId = getOptionalNumberFlag(flags, 'window-id')
-  if (windowId !== undefined) {
-    observeFlags.windowId = windowId
-  }
   const windowIndex = getOptionalNonNegativeIntegerFlag(flags, 'window-index')
-  if (windowIndex !== undefined) {
-    observeFlags.windowIndex = windowIndex
+  return {
+    noScreenshot: flags.has('no-screenshot') ? true : undefined,
+    ...(flags.has('restore-window') ? { restoreWindow: true } : {}),
+    ...(windowId !== undefined ? { windowId } : {}),
+    ...(windowIndex !== undefined ? { windowIndex } : {})
   }
-  return observeFlags
 }


### PR DESCRIPTION
## Summary
- Preserve computer-use action routing context in suggested follow-up `get-app-state` commands
- Include session/worktree, explicit window selectors, and restore-window when applicable
- Add CLI formatter and handler coverage for routed follow-up commands

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/computer.test.ts src/cli/format.test.ts src/cli/specs/computer.test.ts`
- `pnpm run typecheck:cli`
- `pnpm run lint`
- `pnpm run build:cli` (passes; dev symlink install reports /usr/local/bin/orca-dev permission warning)

Risk: low; this is scoped to CLI follow-up command formatting for computer-use actions and includes focused formatter and handler coverage.