### PR TITLE
perf: skip stale replay concat for large pty chunks

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -26,7 +26,12 @@ import {
 import { getBranchConflictKind, getDefaultBaseRef } from '../git/repo'
 import type { OrchestrationDb } from './orchestration/db'
 import type { MessagePriority, MessageRow, MessageType } from './orchestration/types'
-import { appendNormalizedToTailBuffer, buildPreview, OrcaRuntimeService } from './orca-runtime'
+import {
+  appendNormalizedToTailBuffer,
+  appendRecentPtyOutput,
+  buildPreview,
+  OrcaRuntimeService
+} from './orca-runtime'
 import {
   registerSshFilesystemProvider,
   unregisterSshFilesystemProvider
@@ -3962,6 +3967,16 @@ describe('OrcaRuntimeService', () => {
       ['line-4990', 'line-4992', 'line-4994', 'line-4996', 'line-4998', 'partial-tail'].join('\n')
     )
     expect(mapCallCount).toBe(0)
+  })
+
+  it('keeps recent PTY replay output capped without needing previous data for large chunks', () => {
+    const previous = 'old-output'.repeat(1000)
+    const data = 'new-output'.repeat(1000)
+    const expected = `${previous}${data}`.slice(-4096)
+
+    expect(appendRecentPtyOutput(previous, 'tail')).toBe(`${previous}tail`.slice(-4096))
+    expect(appendRecentPtyOutput(previous, data)).toBe(expected)
+    expect(appendRecentPtyOutput(undefined, data)).toBe(data.slice(-4096))
   })
 
   it('bounds retained partial terminal output before preview reads', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2257,7 +2257,7 @@ export class OrcaRuntimeService {
     this.ptyOutputSequenceById.set(ptyId, outputSequence)
     this.recentPtyOutputById.set(
       ptyId,
-      `${this.recentPtyOutputById.get(ptyId) ?? ''}${data}`.slice(-RECENT_PTY_OUTPUT_LIMIT)
+      appendRecentPtyOutput(this.recentPtyOutputById.get(ptyId), data)
     )
     // Agent detection runs on raw data before leaf processing, since the
     // tail buffer logic normalizes away the OSC sequences we need.
@@ -12663,6 +12663,13 @@ function withTimeoutResult<T>(
       clearTimeout(timeout)
     }
   })
+}
+
+export function appendRecentPtyOutput(previous: string | undefined, data: string): string {
+  if (data.length >= RECENT_PTY_OUTPUT_LIMIT) {
+    return data.slice(-RECENT_PTY_OUTPUT_LIMIT)
+  }
+  return `${previous ?? ''}${data}`.slice(-RECENT_PTY_OUTPUT_LIMIT)
 }
 
 export function buildPreview(lines: string[], partialLine: string): string {


### PR DESCRIPTION
Summary
- Add a bounded PTY replay append helper in the main runtime.
- Skip concatenating stale prior replay text when an incoming PTY chunk already exceeds the replay cap.
- Cover normal append, bounded trimming, and oversized chunk behavior in the existing runtime test file.

Risk
- Low: behavior-preserving for the retained replay string because previous output cannot affect the final capped value when the new chunk is already at or above the cap.
- User impact: none expected beyond marginally less main-process allocation/copy work during very large PTY bursts.

Local verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern "recent PTY replay output|oversized terminal output bursts"
- pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts
- pnpm run typecheck:node
- git diff --check origin/main..HEAD

Per request: not waiting for CI checks before merge.