### PR TITLE
Remove needs response PR badge

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -41,11 +41,6 @@ import type {
 import { getHostedReviewCacheKey, refreshHostedReviewCard } from '@/store/slices/hosted-review'
 import { toast } from 'sonner'
 import {
-  classifyHostedReview,
-  type HostedReviewClassificationOptions
-} from '../../../../shared/hosted-review-queue'
-import { hostedReviewSummaryFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
-import {
   checksPanelAsyncResultKey,
   checksPanelHostedReviewAsyncResultKey,
   shouldCommitChecksPanelAsyncResult
@@ -1689,60 +1684,6 @@ export default function ChecksPanel(): React.JSX.Element {
     ]
   )
 
-  const activeReviewClassification = React.useMemo(() => {
-    if (!pr || !repo) {
-      return null
-    }
-    let host = 'github.com'
-    let owner = 'unknown'
-    let repoName = 'unknown'
-    try {
-      const parsed = new URL(pr.url)
-      host = parsed.host || host
-      const segments = parsed.pathname.split('/').filter(Boolean)
-      if (segments.length >= 2) {
-        owner = segments[0]
-        repoName = segments[1]
-      }
-    } catch {
-      // Why: malformed URLs should not block queue-state classification.
-    }
-
-    // Why: unresolved thread data is paginated and fetched separately. Until
-    // comments have loaded for this PR, do not let queue badges imply a clean review.
-    const commentsForClassification =
-      commentsFetchedAt !== undefined && !commentsLoading ? comments : undefined
-    const summary = hostedReviewSummaryFromGitHubPRInfo({
-      pr,
-      owner,
-      repo: repoName,
-      host,
-      comments: commentsForClassification,
-      checks
-    })
-    const options: HostedReviewClassificationOptions = {
-      agentAuthorLogins: [],
-      viewer: null
-    }
-    return classifyHostedReview(summary, options)
-  }, [pr, repo, comments, commentsFetchedAt, commentsLoading, checks])
-
-  const queueBadges = React.useMemo(() => {
-    if (!activeReviewClassification) {
-      return [] as string[]
-    }
-    const badges: string[] = []
-    if (activeReviewClassification.needsResponse) {
-      badges.push('Needs response')
-    }
-    // Why: viewer/author/requestedReviewer signals are not wired into the
-    // ChecksPanel call site yet, so `state` and `requested` would mis-classify
-    // every PR (collapsing to 'teammate'). Suppress those badges until the
-    // inputs are available; needs-response works from PR metadata alone and
-    // remains accurate.
-    return badges
-  }, [activeReviewClassification])
-
   // ── Empty state ──
   if (!activeWorktree) {
     return (
@@ -1959,19 +1900,6 @@ export default function ChecksPanel(): React.JSX.Element {
         {activeReview.updatedAt && (
           <div className="text-[10px] text-muted-foreground/60">
             {reviewShortLabel} updated {new Date(activeReview.updatedAt).toLocaleString()}
-          </div>
-        )}
-
-        {queueBadges.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {queueBadges.map((badge) => (
-              <span
-                key={badge}
-                className="rounded border border-border bg-accent/30 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground"
-              >
-                {badge}
-              </span>
-            ))}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- remove the Checks panel queue badge that displayed "Needs response"
- remove the now-unused review classification work from that render path

## Validation
- git diff --check
- pnpm typecheck *(blocked: local dependency tree is missing tsgo and project packages)*
- pnpm exec oxlint src/renderer/src/components/right-sidebar/ChecksPanel.tsx *(blocked: local dependency tree is missing oxlint)*