### PR TITLE
perf: skip redundant advertised url pty binds

### DIFF
--- a/src/main/ports/advertised-url-watcher.test.ts
+++ b/src/main/ports/advertised-url-watcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   AdvertisedUrlWatcher,
   classifyHost,
@@ -183,6 +183,25 @@ describe('AdvertisedUrlWatcher.ingest', () => {
     watcher.ingest('pty-X', 'early https://app.example.com:3001/\n')
     expect(watcher.lookup(WORKTREE, 3001)).toBeUndefined()
     watcher.bindPty('pty-X', WORKTREE)
+    expect(watcher.lookup(WORKTREE, 3001)?.host).toBe('app.example.com')
+  })
+
+  it('keeps repeated PTY binds as no-ops once pending data is drained', () => {
+    const watcher = new AdvertisedUrlWatcher({ now: () => 1_000 })
+    watcher.ingest(PTY, 'early https://app.example.com:3001/\n')
+    watcher.bindPty(PTY, WORKTREE)
+
+    const internals = watcher as unknown as { ptyToWorktree: Map<string, string> }
+    const originalSet = internals.ptyToWorktree.set
+    const setSpy = vi.fn(originalSet.bind(internals.ptyToWorktree))
+    internals.ptyToWorktree.set = setSpy
+    try {
+      watcher.bindPty(PTY, WORKTREE)
+    } finally {
+      internals.ptyToWorktree.set = originalSet
+    }
+
+    expect(setSpy).not.toHaveBeenCalled()
     expect(watcher.lookup(WORKTREE, 3001)?.host).toBe('app.example.com')
   })
 

--- a/src/main/ports/advertised-url-watcher.ts
+++ b/src/main/ports/advertised-url-watcher.ts
@@ -281,8 +281,11 @@ export class AdvertisedUrlWatcher {
   }
 
   bindPty(ptyId: string, worktreeId: string): void {
-    this.ptyToWorktree.set(ptyId, worktreeId)
     const pending = this.pending.get(ptyId)
+    if (this.ptyToWorktree.get(ptyId) === worktreeId && pending === undefined) {
+      return
+    }
+    this.ptyToWorktree.set(ptyId, worktreeId)
     if (pending !== undefined) {
       this.pending.delete(ptyId)
       this.ingest(ptyId, pending)


### PR DESCRIPTION
Summary
- Make advertised URL PTY binding a no-op when the PTY is already bound to the same worktree and has no pending pre-bind output.
- Add a focused test that verifies repeated binds avoid another map write while preserving pending-output replay behavior.

Risk
- Very low: same PTY/worktree binding with no pending data already had no observable effect beyond rewriting the same map entry.
- User impact: none expected beyond slightly less main-process work on terminal output paths that refresh PTY worktree records.

Local verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ports/advertised-url-watcher.test.ts --testNamePattern "repeated PTY binds|buffers data that arrives before bindPty"
- pnpm exec vitest run --config config/vitest.config.ts src/main/ports/advertised-url-watcher.test.ts
- pnpm exec oxlint src/main/ports/advertised-url-watcher.ts src/main/ports/advertised-url-watcher.test.ts
- pnpm run typecheck:node
- git diff --check origin/main..HEAD

Per request: not waiting for CI checks before merge.