### PR TITLE
Fix Shift-check prerelease updater race

### DIFF
--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -4,11 +4,11 @@
  *
  * The standard `electron-builder install-app-deps` uses @electron/rebuild
  * internally but does not expose the `ignoreModules` option (as of
- * electron-builder 26.x).  On Windows dev machines that lack the full
- * Visual C++ / Python build toolchain, `cpu-features@0.0.10` (an optional
- * performance dependency of `ssh2`) fails to build with node-gyp because
- * `buildcheck.gypi` is missing from the tarball.  This causes the entire
- * postinstall step to fail and prevents `pnpm install` from completing.
+ * electron-builder 26.x).  `cpu-features@0.0.10` is an optional performance
+ * dependency of `ssh2`; it fails to build in common environments (missing
+ * buildcheck.gypi on Windows, and Electron 42's V8 external-pointer API on
+ * Linux).  This can make the entire postinstall step fail and prevent
+ * `pnpm install` from completing.
  *
  * This script replaces `electron-builder install-app-deps` in the postinstall
  * lifecycle.  It calls @electron/rebuild's JS API directly so that we can skip

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -8,18 +8,23 @@ import type { RuntimeTerminalSummary } from '../../../../shared/runtime-types'
 
 describe('orchestration RPC methods', () => {
   let db: OrchestrationDb
+  let dbOpen = false
   let runtime: OrcaRuntimeService
   let ctx: RpcContext
 
   function setup(): void {
     db = new OrchestrationDb(':memory:')
+    dbOpen = true
     runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
     ctx = { runtime }
   }
 
   afterEach(() => {
-    db?.close()
+    if (dbOpen) {
+      db.close()
+      dbOpen = false
+    }
   })
 
   function findMethod(name: string) {

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -363,6 +363,56 @@ describe('updater', () => {
     })
   })
 
+  it('runs a fresh prerelease check when Shift-click promotes an in-flight stable check', async () => {
+    let resolveStableTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
+    fetchNewerReleaseTagsMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ tags: string[]; state: 'no-newer' }>((resolve) => {
+            resolveStableTags = resolve
+          })
+      )
+      .mockResolvedValueOnce({ tags: ['v1.4.36-rc.5'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined)
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    appMock.getVersion.mockReturnValue('1.4.35')
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => null })
+    checkForUpdatesFromMenu({ includePrerelease: true })
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'checking',
+      userInitiated: true
+    })
+    expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+
+    resolveStableTags({ tags: [], state: 'no-newer' })
+    await vi.waitFor(() => {
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+    })
+
+    autoUpdaterMock.emit('update-not-available')
+
+    await vi.waitFor(() => {
+      expect(fetchNewerReleaseTagsMock).toHaveBeenCalledWith('1.4.35', 2, {
+        includePrerelease: true
+      })
+      expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2)
+    })
+    expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+      provider: 'generic',
+      url: 'https://github.com/stablyai/orca/releases/download/v1.4.36-rc.5'
+    })
+    expect(
+      sendMock.mock.calls
+        .filter(([channel]) => channel === 'updater:status')
+        .map(([, status]) => status)
+    ).not.toContainEqual({ state: 'not-available', userInitiated: true })
+  })
+
   it('keeps promoted background promise failures user-initiated after a paired error event', async () => {
     let resolveTags: (value: { tags: string[]; state: 'no-newer' }) => void = () => {}
     fetchNewerReleaseTagsMock.mockImplementation(

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -58,6 +58,7 @@ let backgroundCheckLaunchPending = false
 // Why: a manually promoted background check can emit an error event before the
 // paired promise catch runs; keep the promotion attached to that launch.
 let backgroundCheckPromotedToUserInitiated = false
+let pendingPrereleaseUserInitiatedCheckAfterInFlight = false
 let activeUpdateNudgeId: string | null = null
 let awaitingNudgeCheckOutcome = false
 let nudgeCheckInFlight = false
@@ -144,6 +145,12 @@ function decorateStatusWithActiveNudge(status: UpdateStatus): UpdateStatus {
 }
 
 function sendStatus(status: UpdateStatus): void {
+  const shouldLaunchPendingPrereleaseCheck =
+    pendingPrereleaseUserInitiatedCheckAfterInFlight &&
+    (status.state === 'idle' ||
+      status.state === 'not-available' ||
+      status.state === 'available' ||
+      status.state === 'error')
   const shouldPreserveNudgeForPublishingWindow =
     publishingWindowLastGoodCheck !== null &&
     (status.state === 'idle' ||
@@ -203,11 +210,28 @@ function sendStatus(status: UpdateStatus): void {
   ) {
     downloadInFlight = false
   }
+  if (shouldLaunchPendingPrereleaseCheck) {
+    launchPendingPrereleaseUserInitiatedCheckAfterInFlight()
+    return
+  }
   if (statusesEqual(currentStatus, decoratedStatus)) {
     return
   }
   currentStatus = decoratedStatus
   mainWindowRef?.webContents.send('updater:status', decoratedStatus)
+}
+
+function launchPendingPrereleaseUserInitiatedCheckAfterInFlight(): void {
+  pendingPrereleaseUserInitiatedCheckAfterInFlight = false
+  setTimeout(() => {
+    // Why: electron-updater clears its in-flight promise after emitting the
+    // terminal event. Deferring one tick lets the queued RC check start fresh
+    // instead of being deduped into the just-finished stable check.
+    if (currentStatus.state === 'checking') {
+      currentStatus = { state: 'idle' }
+    }
+    checkForUpdatesFromMenu({ includePrerelease: true })
+  }, 0)
 }
 
 function clearBackgroundCheckLaunchPending(): void {
@@ -696,6 +720,11 @@ export function checkForUpdatesFromMenu(options?: { includePrerelease?: boolean 
   sendStatus({ state: 'checking', userInitiated: true })
   if (checkAlreadyInFlight) {
     backgroundCheckPromotedToUserInitiated = true
+    if (options?.includePrerelease) {
+      // Why: the in-flight check may have already pinned the stable feed.
+      // Queue a fresh RC check so Shift-click doesn't inherit a stable result.
+      pendingPrereleaseUserInitiatedCheckAfterInFlight = true
+    }
     return
   }
 


### PR DESCRIPTION
## Summary
- queue a fresh prerelease update check when Shift-click collides with an in-flight stable check
- suppress the stale stable not-available result so the queued RC check can report accurately
- add regression coverage for the promoted background-check race

## Validation
- pnpm vitest run --config config/vitest.config.ts src/main/updater.test.ts src/main/updater-prerelease-feed.test.ts
- pnpm exec tsc --noEmit -p config/tsconfig.node.json --composite false --pretty false
- git diff --check

Risk: medium

Risk assessment: Medium. The fix is targeted to updater prerelease check ordering, but updater state and user-visible update prompts are release-sensitive and need maintainer review before merge.