### PR TITLE
fix: tighten feature wall submit shortcut

### DIFF
--- a/src/renderer/src/components/feature-wall/FeatureWallContinueButton.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallContinueButton.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 export function FeatureWallContinueButton(props: {
   label: string
   enableKeyboardShortcut: boolean
-  isMacPlatform: boolean
+  shortcutModifierLabel: string
   onClick: () => void
 }): JSX.Element {
   return (
@@ -13,7 +13,7 @@ export function FeatureWallContinueButton(props: {
       {props.label}
       {props.enableKeyboardShortcut ? (
         <span className="ml-1 inline-flex items-center gap-0.5 rounded border border-primary-foreground/20 px-1.5 py-0.5 text-[10px] font-medium leading-none text-current/80">
-          <span>{props.isMacPlatform ? '⌘' : 'Ctrl'}</span>
+          <span>{props.shortcutModifierLabel}</span>
           <CornerDownLeft className="size-3" />
         </span>
       ) : null}

--- a/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx
@@ -27,9 +27,9 @@ import { useFeatureWallTourTelemetry } from './use-feature-wall-tour-telemetry'
 import { FeatureWallContinueButton } from './FeatureWallContinueButton'
 import { FeatureWallTourPanel } from './FeatureWallTourPanel'
 import { getFeatureWallActiveStepCopy } from './feature-wall-active-step-copy'
+import { getScreenSubmitModifierLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 
 const NAVIGATION_KEYS = new Set<string>(['ArrowUp', 'ArrowDown', 'Home', 'End'])
-const IS_MAC_PLATFORM = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
 
 type FeatureWallTourSurfaceProps = {
   isOpen: boolean
@@ -330,11 +330,11 @@ export function FeatureWallTourSurface({
       return
     }
     const onKeyDown = (event: globalThis.KeyboardEvent): void => {
-      const mod = IS_MAC_PLATFORM ? event.metaKey : event.ctrlKey
-      if (mod && event.key === 'Enter') {
-        event.preventDefault()
-        handleContinue()
+      if (!isScreenSubmitShortcut(event)) {
+        return
       }
+      event.preventDefault()
+      handleContinue()
     }
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
@@ -351,7 +351,7 @@ export function FeatureWallTourSurface({
     <FeatureWallContinueButton
       label={continueLabel}
       enableKeyboardShortcut={enableKeyboardShortcut}
-      isMacPlatform={IS_MAC_PLATFORM}
+      shortcutModifierLabel={getScreenSubmitModifierLabel()}
       onClick={handleContinue}
     />
   )

--- a/src/renderer/src/lib/screen-submit-shortcut.test.ts
+++ b/src/renderer/src/lib/screen-submit-shortcut.test.ts
@@ -23,6 +23,14 @@ describe('screen submit shortcut', () => {
     expect(getScreenSubmitShortcutLabel()).toBe('⌘ Enter')
   })
 
+  it('ignores extra modifiers on macOS', () => {
+    setUserAgent('Macintosh')
+
+    expect(isScreenSubmitShortcut({ key: 'Enter', metaKey: true, shiftKey: true })).toBe(false)
+    expect(isScreenSubmitShortcut({ key: 'Enter', metaKey: true, altKey: true })).toBe(false)
+    expect(isScreenSubmitShortcut({ key: 'Enter', metaKey: true, ctrlKey: true })).toBe(false)
+  })
+
   it('uses Ctrl+Enter off macOS', () => {
     setUserAgent('Linux')
 


### PR DESCRIPTION
## Summary
- use the shared screen-submit shortcut helper for feature-wall continue handling
- derive the visible shortcut modifier from the same shared helper
- add macOS coverage for rejecting extra modifier submit chords

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/screen-submit-shortcut.test.ts`
- `pnpm run lint -- src/renderer/src/components/feature-wall/FeatureWallTourSurface.tsx src/renderer/src/components/feature-wall/FeatureWallContinueButton.tsx src/renderer/src/lib/screen-submit-shortcut.test.ts`
- `pnpm run typecheck:web`
- `git diff --check`

Risk: low

Risk assessment: Low. The change routes the feature-wall submit shortcut through an existing shared helper and adds focused shortcut coverage; blast radius is limited to the feature-wall continue action and shortcut label.