### PR TITLE
Tighten local state preload API typing

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1922,8 +1922,8 @@ const api = {
 
   cache: {
     getGitHub: () => ipcRenderer.invoke('cache:getGitHub'),
-    setGitHub: (args: { cache: unknown }) => ipcRenderer.invoke('cache:setGitHub', args)
-  },
+    setGitHub: (args) => ipcRenderer.invoke('cache:setGitHub', args)
+  } satisfies PreloadApi['cache'],
 
   session: {
     get: () => ipcRenderer.invoke('session:get'),
@@ -2286,10 +2286,9 @@ const api = {
   },
 
   ui: {
-    get: (): Promise<unknown> => ipcRenderer.invoke('ui:get'),
-    set: (args: Record<string, unknown>): Promise<void> => ipcRenderer.invoke('ui:set', args),
-    recordFeatureInteraction: (id: string): Promise<unknown> =>
-      ipcRenderer.invoke('ui:recordFeatureInteraction', id),
+    get: () => ipcRenderer.invoke('ui:get'),
+    set: (args) => ipcRenderer.invoke('ui:set', args),
+    recordFeatureInteraction: (id) => ipcRenderer.invoke('ui:recordFeatureInteraction', id),
     onOpenSettings: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:openSettings', listener)
@@ -2828,7 +2827,7 @@ const api = {
     confirmWindowClose: (): void => {
       ipcRenderer.send('window:confirm-close')
     }
-  },
+  } satisfies PreloadApi['ui'],
 
   stats: {
     getSummary: (): Promise<{


### PR DESCRIPTION
## Summary
- Check cache and UI preload APIs against the declared PreloadApi contract
- Replace loose cache/UI payload annotations with contextual shared contract typing
- Keep existing IPC channels and runtime behavior unchanged

## Tests
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ui.test.ts src/main/ipc/ui.test.ts src/main/ipc/settings.test.ts src/renderer/src/web/web-preload-api.test.ts

Risk: low

Risk assessment: Low. This is a small preload typing-only cleanup in one file, with no IPC channel or runtime behavior changes.