### PR TITLE
fix: reuse attached cdp debugger

### DIFF
--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -77,6 +77,7 @@ function createMockGuest(id: number, url: string, title: string) {
   let currentTitle = title
   let currentTree = EXAMPLE_COM_TREE
   let navHistoryId = 1
+  let debuggerAttached = false
 
   const sendCommandMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
     switch (method) {
@@ -181,7 +182,13 @@ function createMockGuest(id: number, url: string, title: string) {
     on: vi.fn(),
     off: vi.fn(),
     debugger: {
-      attach: vi.fn(),
+      isAttached: vi.fn(() => debuggerAttached),
+      attach: vi.fn(() => {
+        if (debuggerAttached) {
+          throw new Error('Another debugger is already attached')
+        }
+        debuggerAttached = true
+      }),
       detach: vi.fn(),
       sendCommand: sendCommandMock,
       on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
@@ -239,12 +246,14 @@ describe('Browser automation pipeline (integration)', () => {
   let server: OrcaRuntimeRpcServer
   let endpoint: string
   let authToken: string
+  let activeGuest: ReturnType<typeof createMockGuest>['guest']
 
   const GUEST_WC_ID = 5001
   const RENDERER_WC_ID = 1
 
   beforeEach(async () => {
     const { guest } = createMockGuest(GUEST_WC_ID, 'https://example.com', 'Example Domain')
+    activeGuest = guest
     webContentsFromIdMock.mockImplementation((id: number) => {
       if (id === GUEST_WC_ID) {
         return guest
@@ -313,6 +322,7 @@ describe('Browser automation pipeline (integration)', () => {
       role: 'link',
       name: 'More information...'
     })
+    expect(activeGuest.debugger.attach).toHaveBeenCalledTimes(1)
   })
 
   // ── Click ──

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -1140,7 +1140,12 @@ export class CdpBridge {
     }
 
     try {
-      guest.debugger.attach('1.3')
+      // Why: browser tabs are already debugger-attached by BrowserManager's
+      // anti-detection injection. Reusing that attachment lets CDP commands
+      // run instead of failing with "another debugger is already attached."
+      if (!guest.debugger.isAttached()) {
+        guest.debugger.attach('1.3')
+      }
     } catch {
       throw new BrowserError(
         'browser_cdp_error',


### PR DESCRIPTION
## Summary
- make the CDP bridge reuse an existing Electron debugger attachment instead of calling `attach()` unconditionally
- update the browser automation integration mock to match Electron duplicate-attach behavior
- assert the command path still works when BrowserManager has already attached for anti-detection

## Repro evidence
- Before the fix, `npm test -- src/main/browser/cdp-bridge-integration.test.ts` failed across CDP browser commands with `browser_cdp_error` after the mock started throwing on duplicate `debugger.attach()` calls.
- This reproduces the normal tab setup where BrowserManager has already attached the debugger for `Page.addScriptToEvaluateOnNewDocument` anti-detection injection.

## Validation
- `npm test -- src/main/browser/cdp-bridge-integration.test.ts`
- `npm run typecheck:node`
- `npx oxlint src/main/browser/cdp-bridge.ts src/main/browser/cdp-bridge-integration.test.ts`
- `npx oxfmt --check src/main/browser/cdp-bridge.ts src/main/browser/cdp-bridge-integration.test.ts`
- `git diff --check HEAD~1..HEAD`

Risk: low

Risk assessment: Low. Narrow attach guard; existing debugger command setup is unchanged.