### PR TITLE
Improve agent picker search

### DIFF
--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { Check, ChevronsUpDown, Star, Terminal } from 'lucide-react'
+import { ArrowRight, Check, ChevronsUpDown, Star, Terminal } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Command,
@@ -16,6 +16,11 @@ import {
 } from '@/components/ui/context-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
+import {
+  agentPickerBlankTerminalMatches,
+  getAgentPickerCommandValue,
+  searchAgentPickerEntries
+} from '@/lib/agent-picker-search'
 import { cn } from '@/lib/utils'
 import type { TuiAgent } from '../../../../shared/types'
 
@@ -98,27 +103,6 @@ function renderItem({
   )
 }
 
-function searchAgents(agents: AgentCatalogEntry[], rawQuery: string): AgentCatalogEntry[] {
-  const query = rawQuery.trim().toLowerCase()
-  if (!query) {
-    return agents
-  }
-  // Why: cheap prefix-favored sort — label matches starting earlier in the
-  // string outrank later matches, mirroring repo-search semantics so the
-  // two comboboxes feel consistent.
-  const matches: { agent: AgentCatalogEntry; score: number; index: number }[] = []
-  agents.forEach((agent, index) => {
-    const labelIdx = agent.label.toLowerCase().indexOf(query)
-    const idIdx = agent.id.toLowerCase().indexOf(query)
-    const score = labelIdx !== -1 ? labelIdx : idIdx !== -1 ? 1000 + idIdx : -1
-    if (score !== -1) {
-      matches.push({ agent, score, index })
-    }
-  })
-  matches.sort((a, b) => a.score - b.score || a.index - b.index)
-  return matches.map((m) => m.agent)
-}
-
 export default function AgentCombobox({
   agents,
   value,
@@ -145,14 +129,15 @@ export default function AgentCombobox({
     () => (value ? (agents.find((agent) => agent.id === value) ?? null) : null),
     [agents, value]
   )
-  const filteredAgents = useMemo(() => searchAgents(agents, query), [agents, query])
-  const blankMatchesQuery = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    if (!q) {
-      return true
-    }
-    return 'blank terminal'.includes(q) || 'terminal'.startsWith(q)
-  }, [query])
+  const filteredAgents = useMemo(() => searchAgentPickerEntries(agents, query), [agents, query])
+  const blankMatchesQuery = useMemo(() => agentPickerBlankTerminalMatches(query), [query])
+  const activeCommandValue = getAgentPickerCommandValue({
+    blankValue: BLANK_VALUE,
+    blankMatchesQuery,
+    currentValue: value,
+    filteredAgents,
+    rawQuery: query
+  })
 
   const cancelFocusFrame = useCallback((): void => {
     if (focusFrameRef.current !== null) {
@@ -162,6 +147,13 @@ export default function AgentCombobox({
   }, [])
 
   React.useEffect(() => cancelFocusFrame, [cancelFocusFrame])
+
+  React.useEffect(() => {
+    if (!open) {
+      return
+    }
+    setCommandValue(activeCommandValue)
+  }, [activeCommandValue, open])
 
   const focusSearchInput = useCallback(() => {
     cancelFocusFrame()
@@ -335,16 +327,7 @@ export default function AgentCombobox({
                   className="h-9 w-full justify-start rounded-none px-3 text-xs font-normal text-muted-foreground"
                 >
                   Manage agents
-                  <svg
-                    className="ml-auto size-3"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    aria-hidden
-                  >
-                    <path d="M5 12h14M12 5l7 7-7 7" />
-                  </svg>
+                  <ArrowRight className="ml-auto size-3" />
                 </Button>
               </div>
             ) : null}

--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import { useAppStore } from '../../store'
 import { AGENT_GENERATED_TAB_TITLES_TITLE } from './agent-generated-tab-title-copy'
 import { AGENT_STATUS_HOOKS_TITLE } from './agent-status-hooks-copy'
@@ -244,6 +245,21 @@ describe('AgentsPane', () => {
   it('includes enable and hide search metadata for agent visibility', () => {
     expect(matchesSettingsSearch('disable', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
     expect(matchesSettingsSearch('hide', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+  })
+
+  it('keeps catalog agent ids, labels, and commands discoverable in settings search', () => {
+    for (const agent of AGENT_CATALOG) {
+      expect(matchesSettingsSearch(agent.id, AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+      expect(matchesSettingsSearch(agent.label, AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+      expect(matchesSettingsSearch(agent.cmd, AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    }
+
+    expect(matchesSettingsSearch('GitHub Copilot', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('open claude', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('command-code', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('command code', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('agy', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
+    expect(matchesSettingsSearch('cursor-agent', AGENTS_PANE_SEARCH_ENTRIES)).toBe(true)
   })
 
   it('renders per-agent availability as labeled status choices with explicit row copy', () => {

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -1,4 +1,5 @@
 import type { SettingsSearchEntry } from './settings-search'
+import { AGENT_CATALOG } from '@/lib/agent-catalog'
 import {
   AGENT_AWAKE_TITLE,
   getAgentAwakeDescription,
@@ -15,53 +16,45 @@ import {
   AGENT_STATUS_HOOKS_TITLE
 } from './agent-status-hooks-copy'
 
+const AGENT_SETTINGS_KEYWORDS = buildAgentSettingsKeywords()
+
+function buildAgentSettingsKeywords(): string[] {
+  const keywords = [
+    'agent',
+    'default',
+    'command',
+    'override',
+    'install',
+    'detected',
+    'enable',
+    'disable',
+    'hide',
+    'show',
+    'github'
+  ]
+
+  for (const agent of AGENT_CATALOG) {
+    keywords.push(...expandAgentSearchText(agent.id), ...expandAgentSearchText(agent.label))
+    keywords.push(...expandAgentSearchText(agent.cmd))
+  }
+
+  return [...new Set(keywords)]
+}
+
+function expandAgentSearchText(value: string): string[] {
+  const spaced = value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .trim()
+
+  return spaced === value ? [value] : [value, spaced]
+}
+
 export const AGENTS_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Agents',
     description: 'Configure AI coding agents, default agent, and command overrides.',
-    keywords: [
-      'agent',
-      'default',
-      'claude',
-      'openclaude',
-      'open claude',
-      'codex',
-      'opencode',
-      'pi',
-      'omp',
-      'gemini',
-      'aider',
-      'goose',
-      'amp',
-      'kilocode',
-      'kiro',
-      'charm',
-      'auggie',
-      'cline',
-      'codebuff',
-      'command code',
-      'continue',
-      'cursor',
-      'droid',
-      'kimi',
-      'mistral',
-      'qwen',
-      'rovo',
-      'hermes',
-      'openclaw',
-      'copilot',
-      'grok',
-      'github',
-      'github copilot',
-      'command',
-      'override',
-      'install',
-      'detected',
-      'enable',
-      'disable',
-      'hide',
-      'show'
-    ]
+    keywords: AGENT_SETTINGS_KEYWORDS
   },
   {
     title: 'Agent Location',

--- a/src/renderer/src/lib/agent-picker-search.test.ts
+++ b/src/renderer/src/lib/agent-picker-search.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  agentPickerBlankTerminalMatches,
+  getAgentPickerCommandValue,
+  searchAgentPickerEntries
+} from './agent-picker-search'
+import { AGENT_CATALOG, type AgentCatalogEntry } from './agent-catalog'
+
+const agents = [
+  entry('claude', 'Claude', 'claude'),
+  entry('codex', 'Codex', 'codex'),
+  entry('copilot', 'GitHub Copilot', 'copilot'),
+  entry('opencode', 'OpenCode', 'opencode'),
+  entry('mistral-vibe', 'Mistral Vibe', 'mistral-vibe'),
+  entry('qwen-code', 'Qwen Code', 'qwen-code'),
+  entry('crush', 'Charm', 'crush'),
+  entry('antigravity', 'Antigravity', 'agy'),
+  entry('cursor', 'Cursor', 'cursor-agent')
+]
+
+describe('agent picker search', () => {
+  it('keeps catalog order for an empty query', () => {
+    expect(searchAgentPickerEntries(agents, '').map((agent) => agent.id)).toEqual(
+      agents.map((agent) => agent.id)
+    )
+  })
+
+  it('prefers label matches over command and id aliases', () => {
+    expect(
+      searchAgentPickerEntries(agents, 'cod')
+        .map((agent) => agent.id)
+        .slice(0, 3)
+    ).toEqual(['codex', 'opencode', 'qwen-code'])
+  })
+
+  it('matches multi-word agents by initials and ordered shorthand', () => {
+    expect(searchAgentPickerEntries(agents, 'gc')[0]?.id).toBe('copilot')
+    expect(searchAgentPickerEntries(agents, 'mv')[0]?.id).toBe('mistral-vibe')
+    expect(searchAgentPickerEntries(agents, 'qc')[0]?.id).toBe('qwen-code')
+  })
+
+  it('matches command aliases that do not appear in the display label', () => {
+    expect(searchAgentPickerEntries(agents, 'agy')[0]?.id).toBe('antigravity')
+    expect(searchAgentPickerEntries(agents, 'cursor-agent')[0]?.id).toBe('cursor')
+  })
+
+  it('resolves every catalog command alias to its agent first', () => {
+    for (const agent of AGENT_CATALOG) {
+      expect(searchAgentPickerEntries(AGENT_CATALOG, agent.cmd)[0]?.id).toBe(agent.id)
+    }
+  })
+
+  it('returns no entries for unrelated text', () => {
+    expect(searchAgentPickerEntries(agents, 'not-an-agent')).toEqual([])
+  })
+
+  it('matches the blank terminal option by terminal, shell, and shorthand queries', () => {
+    expect(agentPickerBlankTerminalMatches('term')).toBe(true)
+    expect(agentPickerBlankTerminalMatches('shell')).toBe(true)
+    expect(agentPickerBlankTerminalMatches('bt')).toBe(true)
+    expect(agentPickerBlankTerminalMatches('agent')).toBe(false)
+  })
+
+  it('highlights the current value until a search should choose the first visible result', () => {
+    const filteredAgents = searchAgentPickerEntries(agents, 'gc')
+
+    expect(
+      getAgentPickerCommandValue({
+        blankValue: '__none__',
+        blankMatchesQuery: false,
+        currentValue: 'claude',
+        filteredAgents: agents,
+        rawQuery: ''
+      })
+    ).toBe('claude')
+    expect(
+      getAgentPickerCommandValue({
+        blankValue: '__none__',
+        blankMatchesQuery: false,
+        currentValue: 'claude',
+        filteredAgents,
+        rawQuery: 'gc'
+      })
+    ).toBe('copilot')
+    expect(
+      getAgentPickerCommandValue({
+        blankValue: '__none__',
+        blankMatchesQuery: true,
+        currentValue: 'claude',
+        filteredAgents: [],
+        rawQuery: 'bt'
+      })
+    ).toBe('__none__')
+  })
+})
+
+function entry(id: AgentCatalogEntry['id'], label: string, cmd: string): AgentCatalogEntry {
+  return {
+    id,
+    label,
+    cmd,
+    homepageUrl: 'https://example.com'
+  }
+}

--- a/src/renderer/src/lib/agent-picker-search.ts
+++ b/src/renderer/src/lib/agent-picker-search.ts
@@ -1,0 +1,182 @@
+import type { AgentCatalogEntry } from '@/lib/agent-catalog'
+
+type RankedAgent = {
+  agent: AgentCatalogEntry
+  score: number
+  index: number
+}
+
+const NO_MATCH = Number.POSITIVE_INFINITY
+
+export function getAgentPickerCommandValue({
+  blankValue,
+  blankMatchesQuery,
+  currentValue,
+  filteredAgents,
+  rawQuery
+}: {
+  blankValue: string
+  blankMatchesQuery: boolean
+  currentValue: AgentCatalogEntry['id'] | null
+  filteredAgents: readonly AgentCatalogEntry[]
+  rawQuery: string
+}): string {
+  if (!normalizeSearchText(rawQuery)) {
+    return currentValue ?? blankValue
+  }
+  if (blankMatchesQuery) {
+    return blankValue
+  }
+  return filteredAgents[0]?.id ?? ''
+}
+
+export function searchAgentPickerEntries(
+  agents: readonly AgentCatalogEntry[],
+  rawQuery: string
+): AgentCatalogEntry[] {
+  const query = normalizeSearchText(rawQuery)
+  if (!query) {
+    return [...agents]
+  }
+
+  const matches: RankedAgent[] = []
+  agents.forEach((agent, index) => {
+    const score = scoreAgent(agent, query)
+    if (score !== NO_MATCH) {
+      matches.push({ agent, score, index })
+    }
+  })
+
+  matches.sort((a, b) => a.score - b.score || a.index - b.index)
+  return matches.map((m) => m.agent)
+}
+
+export function agentPickerBlankTerminalMatches(rawQuery: string): boolean {
+  const query = normalizeSearchText(rawQuery)
+  if (!query) {
+    return true
+  }
+
+  return (
+    scoreCandidate(query, 'Blank Terminal', 0) !== NO_MATCH ||
+    scoreCandidate(query, 'terminal', 0) !== NO_MATCH ||
+    scoreCandidate(query, 'shell', 0) !== NO_MATCH
+  )
+}
+
+function scoreAgent(agent: AgentCatalogEntry, query: string): number {
+  return Math.min(
+    scoreCandidate(query, agent.label, 0),
+    scoreCandidate(query, agent.id, 600),
+    scoreCandidate(query, agent.cmd, 650)
+  )
+}
+
+function scoreCandidate(query: string, rawCandidate: string, baseScore: number): number {
+  const candidate = normalizeSearchText(rawCandidate)
+  if (!candidate) {
+    return NO_MATCH
+  }
+
+  if (candidate === query) {
+    return baseScore
+  }
+  if (candidate.startsWith(query)) {
+    return baseScore + 10
+  }
+
+  const substringIndex = candidate.indexOf(query)
+  if (substringIndex !== -1) {
+    return baseScore + 100 + substringIndex
+  }
+
+  const acronymScore = scoreAcronymQuery(query, rawCandidate)
+  if (acronymScore !== NO_MATCH) {
+    return baseScore + 220 + acronymScore
+  }
+
+  const fuzzyScore = scoreFuzzyQuery(query, candidate)
+  if (fuzzyScore !== NO_MATCH) {
+    return baseScore + 400 + fuzzyScore
+  }
+
+  return NO_MATCH
+}
+
+function scoreAcronymQuery(query: string, rawCandidate: string): number {
+  const acronym = buildAcronym(rawCandidate)
+  if (!acronym) {
+    return NO_MATCH
+  }
+  if (acronym === query) {
+    return 0
+  }
+  if (acronym.startsWith(query)) {
+    return 10
+  }
+  return scoreFuzzyQuery(query, acronym)
+}
+
+function buildAcronym(value: string): string {
+  const chars: string[] = []
+  let previous = ''
+
+  for (const char of value) {
+    if (!/[a-z0-9]/i.test(char)) {
+      previous = char
+      continue
+    }
+
+    if (
+      chars.length === 0 ||
+      !/[a-z0-9]/i.test(previous) ||
+      (/[a-z]/.test(previous) && /[A-Z]/.test(char))
+    ) {
+      chars.push(char.toLowerCase())
+    }
+    previous = char
+  }
+
+  return chars.join('')
+}
+
+function scoreFuzzyQuery(query: string, candidate: string): number {
+  let queryIndex = 0
+  let score = 0
+  let lastMatchIndex = -1
+
+  for (
+    let candidateIndex = 0;
+    candidateIndex < candidate.length && queryIndex < query.length;
+    candidateIndex++
+  ) {
+    if (candidate[candidateIndex] !== query[queryIndex]) {
+      continue
+    }
+
+    const gap = lastMatchIndex === -1 ? candidateIndex : candidateIndex - lastMatchIndex - 1
+    score += gap
+    if (isBoundary(candidate, candidateIndex)) {
+      score -= 4
+    }
+    lastMatchIndex = candidateIndex
+    queryIndex++
+  }
+
+  if (queryIndex < query.length) {
+    return NO_MATCH
+  }
+
+  return score
+}
+
+function isBoundary(value: string, index: number): boolean {
+  if (index === 0) {
+    return true
+  }
+  return value[index - 1] === ' ' || value[index - 1] === '-' || value[index - 1] === '_'
+}
+
+function normalizeSearchText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ')
+}

--- a/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
+++ b/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest'
+import { TUI_AGENT_AUTO_PICK_ORDER } from '../../../shared/tui-agent-selection'
+import { AGENT_CATALOG } from './agent-catalog'
 import { pickQuickWorkspaceAgent } from './quick-workspace-agent-selection'
 
 describe('pickQuickWorkspaceAgent', () => {
+  it('keeps the fallback order in sync with the desktop agent catalog', () => {
+    expect(TUI_AGENT_AUTO_PICK_ORDER).toEqual(AGENT_CATALOG.map((agent) => agent.id))
+    expect(new Set(TUI_AGENT_AUTO_PICK_ORDER).size).toBe(TUI_AGENT_AUTO_PICK_ORDER.length)
+  })
+
   it('uses the first enabled catalog agent while detection is pending', () => {
     expect(pickQuickWorkspaceAgent(null, null, [])).toBe('claude')
     expect(pickQuickWorkspaceAgent(null, null, ['claude'])).toBe('openclaude')

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -7,7 +7,6 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
   'openclaude',
   'codex',
-  'openclaude',
   'grok',
   'copilot',
   'opencode',


### PR DESCRIPTION
## Summary
- add shared agent picker search that supports shorthand, acronyms, fuzzy matches, command aliases, and Blank Terminal aliases
- keep searched agent picker results highlighted so Enter selects the visible match
- derive Agents settings search keywords from the agent catalog and guard auto-pick order against catalog drift

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/agent-picker-search.test.ts src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/lib/quick-workspace-agent-selection.test.ts
- pnpm exec oxlint src/renderer/src/components/agent/AgentCombobox.tsx src/renderer/src/lib/agent-picker-search.ts src/renderer/src/lib/agent-picker-search.test.ts src/renderer/src/components/settings/AgentsPane.test.tsx src/renderer/src/components/settings/agents-search.ts src/renderer/src/lib/quick-workspace-agent-selection.test.ts src/shared/tui-agent-selection.ts
- pnpm exec tsgo --noEmit -p config/tsconfig.tc.web.json
- git diff --check

Risk: low

Risk assessment: Low. Rebased onto current main, focused tests/lint/web typecheck pass, and Electron validation exercised the real Create Worktree agent picker: searching gc visibly narrowed to GitHub Copilot, kept it highlighted, and Enter selected it. Remaining settings-search keyword behavior is covered by the focused AgentsPane tests.