### PR TITLE
fix: skip cpu-features electron rebuild

### DIFF
--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -11,12 +11,10 @@
  * postinstall step to fail and prevents `pnpm install` from completing.
  *
  * This script replaces `electron-builder install-app-deps` in the postinstall
- * lifecycle.  It calls @electron/rebuild's JS API directly so that we can pass
- * `ignoreModules: ['cpu-features']` on Windows.  Skipping cpu-features is
- * safe: ssh2 detects the missing native module and falls back to pure-JS CPU
- * feature detection automatically.
- *
- * On macOS and Linux the full rebuild (including cpu-features) runs as usual.
+ * lifecycle.  It calls @electron/rebuild's JS API directly so that we can skip
+ * `cpu-features` when rebuilding modules against Electron. Skipping
+ * cpu-features is safe: ssh2 detects the missing native module and falls back
+ * to pure-JS CPU feature detection automatically.
  */
 
 import { rebuild } from '@electron/rebuild'
@@ -31,10 +29,10 @@ const electronVersion = JSON.parse(
   readFileSync(resolve(electronPackageDir, 'package.json'), 'utf8')
 ).version
 
-const ignoreModules = process.platform === 'win32' ? ['cpu-features'] : []
+const ignoreModules = ['cpu-features']
 
 if (ignoreModules.length > 0) {
-  console.log(`[rebuild] Skipping modules on Windows: ${ignoreModules.join(', ')}`)
+  console.log(`[rebuild] Skipping optional Electron rebuild modules: ${ignoreModules.join(', ')}`)
 }
 
 // Why: @electron/rebuild's default module walker doesn't reliably find native


### PR DESCRIPTION
## Summary
- skip `cpu-features` for Electron native-module rebuilds on every platform
- keep normal pnpm install behavior unchanged; this only avoids rebuilding the optional ssh2 acceleration module against Electron headers
- documents the existing pure-JS fallback rationale without limiting it to Windows

## Verification
- `node config/scripts/rebuild-native-deps.mjs`
- `pnpm run lint -- config/scripts/rebuild-native-deps.mjs`
- `git diff --check`

## Context
PR #3925 failed in CI during `pnpm install`, before project tests ran, because `cpu-features` does not build against Electron 42 headers on Linux. `ssh2` treats this module as optional and falls back to pure JS detection.

Risk: low

Risk assessment: Low. This is a narrow Electron rebuild script change for an optional ssh2 acceleration dependency, preserving normal pnpm install behavior and relying on the existing pure-JS fallback.