### PR TITLE
perf: trim terminal subscribe pending output with splice

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -159,12 +159,25 @@ function resolveMobileFloorClientId(
 function appendPendingMultiplexOutput(stream: TerminalMultiplexStream, data: string): void {
   stream.pendingOutput.push(data)
   stream.pendingOutputChars += data.length
+  stream.pendingOutputChars = trimPendingOutputToBudget(
+    stream.pendingOutput,
+    stream.pendingOutputChars
+  )
+}
+
+function trimPendingOutputToBudget(pendingOutput: string[], pendingOutputChars: number): number {
+  let omittedChunkCount = 0
   while (
-    stream.pendingOutputChars > TERMINAL_MULTIPLEX_PENDING_MAX_CHARS &&
-    stream.pendingOutput.length > 0
+    pendingOutputChars > TERMINAL_MULTIPLEX_PENDING_MAX_CHARS &&
+    omittedChunkCount < pendingOutput.length
   ) {
-    stream.pendingOutputChars -= stream.pendingOutput.shift()?.length ?? 0
+    pendingOutputChars -= pendingOutput[omittedChunkCount].length
+    omittedChunkCount += 1
   }
+  if (omittedChunkCount > 0) {
+    pendingOutput.splice(0, omittedChunkCount)
+  }
+  return pendingOutputChars
 }
 
 function isTerminalReadPayloadIncomplete(read: { truncated: boolean; limited?: boolean }): boolean {
@@ -1210,12 +1223,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           if (buffering) {
             pendingOutput.push(data)
             pendingOutputChars += data.length
-            while (
-              pendingOutputChars > TERMINAL_MULTIPLEX_PENDING_MAX_CHARS &&
-              pendingOutput.length > 0
-            ) {
-              pendingOutputChars -= pendingOutput.shift()?.length ?? 0
-            }
+            pendingOutputChars = trimPendingOutputToBudget(pendingOutput, pendingOutputChars)
             return
           }
           outputBatcher?.push(data)

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -330,9 +330,12 @@ describe('terminal subscribe buffering', () => {
       )
 
       await vi.waitFor(() => expect(dataListenerRef.current).toBeDefined())
+      const shiftSpy = vi.spyOn(Array.prototype, 'shift')
       for (let index = 0; index < 400; index += 1) {
         dataListenerRef.current?.(`${String(index).padStart(3, '0')}${'x'.repeat(1021)}`)
       }
+      const shiftCallCount = shiftSpy.mock.calls.length
+      shiftSpy.mockRestore()
       await vi.waitFor(() => expect(runtime.serializeTerminalBuffer).toHaveBeenCalled())
       resolveSnapshot({ data: '', cols: 120, rows: 40 })
       await vi.waitFor(() =>
@@ -348,6 +351,7 @@ describe('terminal subscribe buffering', () => {
       expect(output.length).toBeLessThanOrEqual(256 * 1024)
       expect(output).not.toContain('000')
       expect(output).toContain('399')
+      expect(shiftCallCount).toBe(0)
 
       runtime.cleanupSubscription('terminal-1:desktop-1')
       await dispatchPromise


### PR DESCRIPTION
Summary
- Replace per-chunk Array.shift trimming in terminal subscribe pending-output buffers with a trim-count pass plus one splice.
- Reuse the same cap helper for multiplex streams and legacy snapshot-buffered output.
- Extend the subscribe-buffer regression test to confirm the 256 KiB cap is preserved without shift calls.

Risk
- Very low: preserves output order and the existing byte cap while changing only how discarded leading chunks are removed.
- User impact: none expected beyond lower main-process array churn while live terminal output is buffered during snapshot serialization.

Local verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts --testNamePattern "bounds legacy binary output"
- pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
- pnpm exec oxlint src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
- pnpm run typecheck:node
- git diff --check origin/main..HEAD

Per request: not waiting for CI checks before merge.