### PR TITLE
perf: skip url watcher scans for partial pty lines

### DIFF
--- a/src/main/ports/advertised-url-watcher.test.ts
+++ b/src/main/ports/advertised-url-watcher.test.ts
@@ -123,6 +123,18 @@ describe('AdvertisedUrlWatcher.ingest', () => {
     expect(watcher.lookup(WORKTREE, 3001)?.origin).toBe('https://local.getmontecarlo.com:3001')
   })
 
+  it('does not scan buffered PTY text until a line break arrives', () => {
+    const watcher = bindFresh()
+    const charCodeAtSpy = vi.spyOn(String.prototype, 'charCodeAt')
+    watcher.ingest(PTY, '  Network: https://local.getmontecarlo')
+    const charCodeAtCalls = charCodeAtSpy.mock.calls.length
+    charCodeAtSpy.mockRestore()
+
+    expect(charCodeAtCalls).toBe(0)
+    watcher.ingest(PTY, '.com:3001/\n')
+    expect(watcher.lookup(WORKTREE, 3001)?.origin).toBe('https://local.getmontecarlo.com:3001')
+  })
+
   it('reassembles an ANSI escape split across two chunks', () => {
     const watcher = bindFresh()
     watcher.ingest(PTY, '\x1b[32mhttps://example.com:3001/\x1b')

--- a/src/main/ports/advertised-url-watcher.ts
+++ b/src/main/ports/advertised-url-watcher.ts
@@ -82,9 +82,13 @@ class PtyBuffer {
    *  and including the last newline). Whatever follows the last newline stays
    *  buffered so that a URL or ANSI sequence split across chunks survives. */
   ingest(chunk: string): string {
+    const chunkHasLineBreak = chunk.includes('\n') || chunk.includes('\r')
     this.raw += chunk
     if (this.raw.length > PER_PTY_BUFFER_LIMIT) {
       this.raw = this.raw.slice(-PER_PTY_BUFFER_LIMIT)
+    }
+    if (!chunkHasLineBreak) {
+      return ''
     }
     const lastNewline = lastLineBreak(this.raw)
     if (lastNewline === -1) {


### PR DESCRIPTION
Summary
- Return early from the advertised URL watcher buffer when a PTY chunk contains no line break.
- Preserve split-URL buffering while avoiding the backward line-break scan for newline-free chunks.
- Add a focused regression test that verifies newline-free chunks do not invoke the scan and still resolve once the line completes.

Risk
- Very low: the per-PTY buffer only retains text after the last finalized newline, so a chunk with no newline cannot produce finalized URL text.
- User impact: none expected beyond less main-process string scanning on PTY output chunks that do not complete a line.

Local verification
- pnpm exec vitest run --config config/vitest.config.ts src/main/ports/advertised-url-watcher.test.ts --testNamePattern "does not scan buffered PTY text|reassembles a URL split"
- pnpm exec vitest run --config config/vitest.config.ts src/main/ports/advertised-url-watcher.test.ts
- pnpm exec oxlint src/main/ports/advertised-url-watcher.ts src/main/ports/advertised-url-watcher.test.ts
- pnpm run typecheck:node
- git diff --check origin/main..HEAD

Per request: not waiting for CI checks before merge.