### PR TITLE
perf: append agent browser argv without spread

### DIFF
--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -2055,7 +2055,12 @@ export class AgentBrowserBridge {
       args.push('--cdp', String(port))
     }
 
-    args.push(...commandArgs, '--json')
+    // Why: exec passthrough can produce a large argv array; spreading it into
+    // push risks V8 argument limits before execFile receives the command.
+    for (const commandArg of commandArgs) {
+      args.push(commandArg)
+    }
+    args.push('--json')
 
     const stdout = await this.runAgentBrowserRaw(sessionName, args, execOptions)
     const translated = translateResult(stdout)


### PR DESCRIPTION
## Summary
- append agent-browser command argv entries iteratively before adding --json
- avoid V8 call-argument limits for large exec passthrough commands while preserving argument order

## Validation
- pnpm exec oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm exec oxfmt --check src/main/browser/agent-browser-bridge.ts
- pnpm exec vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts
- pnpm run typecheck:node
- git diff --check

Risk: low
- Narrow command assembly change in the agent-browser bridge; no behavior or protocol shape changes.