### PR TITLE
perf: share system theme listener across terminal panes

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-system-prefers-dark.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-system-prefers-dark.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getSystemPrefersDarkSnapshot,
+  resetSystemPrefersDarkSubscriptionForTests,
+  subscribeToSystemPrefersDarkChange
+} from './use-system-prefers-dark'
+
+type MediaChangeListener = (event: MediaQueryListEvent) => void
+
+function installMatchMedia(initialMatches: boolean): {
+  media: {
+    addEventListener: ReturnType<typeof vi.fn>
+    removeEventListener: ReturnType<typeof vi.fn>
+    emit: (matches: boolean) => void
+  }
+  matchMedia: ReturnType<typeof vi.fn>
+} {
+  let matches = initialMatches
+  const listeners = new Set<MediaChangeListener>()
+  const media = {
+    get matches() {
+      return matches
+    },
+    addEventListener: vi.fn((type: string, listener: MediaChangeListener) => {
+      if (type === 'change') {
+        listeners.add(listener)
+      }
+    }),
+    removeEventListener: vi.fn((type: string, listener: MediaChangeListener) => {
+      if (type === 'change') {
+        listeners.delete(listener)
+      }
+    }),
+    emit(nextMatches: boolean): void {
+      matches = nextMatches
+      for (const listener of listeners) {
+        listener({ matches: nextMatches } as MediaQueryListEvent)
+      }
+    }
+  }
+  const matchMedia = vi.fn(() => media as unknown as MediaQueryList)
+  vi.stubGlobal('window', { matchMedia })
+  return { media, matchMedia }
+}
+
+afterEach(() => {
+  resetSystemPrefersDarkSubscriptionForTests()
+  vi.unstubAllGlobals()
+})
+
+describe('useSystemPrefersDark subscription store', () => {
+  it('caches the initial media query snapshot', () => {
+    const { matchMedia } = installMatchMedia(false)
+
+    expect(getSystemPrefersDarkSnapshot()).toBe(false)
+    expect(getSystemPrefersDarkSnapshot()).toBe(false)
+    expect(matchMedia).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares one media query listener across subscribers', () => {
+    const { media, matchMedia } = installMatchMedia(true)
+    const firstSubscriber = vi.fn()
+    const secondSubscriber = vi.fn()
+
+    const unsubscribeFirst = subscribeToSystemPrefersDarkChange(firstSubscriber)
+    const unsubscribeSecond = subscribeToSystemPrefersDarkChange(secondSubscriber)
+
+    expect(matchMedia).toHaveBeenCalledTimes(1)
+    expect(media.addEventListener).toHaveBeenCalledTimes(1)
+
+    media.emit(false)
+
+    expect(getSystemPrefersDarkSnapshot()).toBe(false)
+    expect(firstSubscriber).toHaveBeenCalledTimes(1)
+    expect(secondSubscriber).toHaveBeenCalledTimes(1)
+
+    unsubscribeFirst()
+    expect(media.removeEventListener).not.toHaveBeenCalled()
+
+    media.emit(true)
+
+    expect(getSystemPrefersDarkSnapshot()).toBe(true)
+    expect(firstSubscriber).toHaveBeenCalledTimes(1)
+    expect(secondSubscriber).toHaveBeenCalledTimes(2)
+
+    unsubscribeSecond()
+    expect(media.removeEventListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-system-prefers-dark.ts
+++ b/src/renderer/src/components/terminal-pane/use-system-prefers-dark.ts
@@ -1,21 +1,80 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 
-export function useSystemPrefersDark(): boolean {
-  const [systemPrefersDark, setSystemPrefersDark] = useState(() =>
-    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : true
-  )
+const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)'
 
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+// Why: terminal panes can number in the hundreds, but OS color-scheme is one
+// browser signal. Share a single media listener instead of one per pane.
+const subscribers = new Set<() => void>()
+let mediaQueryList: MediaQueryList | null = null
+let unsubscribeMediaQuery: (() => void) | null = null
+let hasSnapshot = false
+let snapshot = true
+
+function readMediaQueryList(): MediaQueryList | null {
+  if (mediaQueryList) {
+    return mediaQueryList
+  }
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return null
+  }
+  mediaQueryList = window.matchMedia(SYSTEM_DARK_QUERY)
+  return mediaQueryList
+}
+
+function refreshSnapshot(): void {
+  snapshot = readMediaQueryList()?.matches ?? true
+  hasSnapshot = true
+}
+
+export function getSystemPrefersDarkSnapshot(): boolean {
+  if (!hasSnapshot) {
+    refreshSnapshot()
+  }
+  return snapshot
+}
+
+export function subscribeToSystemPrefersDarkChange(onChange: () => void): () => void {
+  subscribers.add(onChange)
+  if (!unsubscribeMediaQuery) {
+    const media = readMediaQueryList()
+    if (media) {
+      snapshot = media.matches
+      hasSnapshot = true
+      const handleChange = (event: MediaQueryListEvent): void => {
+        snapshot = event.matches
+        for (const subscriber of subscribers) {
+          subscriber()
+        }
+      }
+      media.addEventListener('change', handleChange)
+      unsubscribeMediaQuery = () => media.removeEventListener('change', handleChange)
+    }
+  }
+  return () => {
+    subscribers.delete(onChange)
+    if (subscribers.size > 0) {
       return
     }
-    const media = window.matchMedia('(prefers-color-scheme: dark)')
-    const handleChange = (event: MediaQueryListEvent): void => setSystemPrefersDark(event.matches)
-    media.addEventListener('change', handleChange)
-    return () => media.removeEventListener('change', handleChange)
-  }, [])
+    unsubscribeMediaQuery?.()
+    unsubscribeMediaQuery = null
+    mediaQueryList = null
+    hasSnapshot = false
+  }
+}
 
-  return systemPrefersDark
+export function useSystemPrefersDark(): boolean {
+  return useSyncExternalStore(
+    subscribeToSystemPrefersDarkChange,
+    getSystemPrefersDarkSnapshot,
+    () => true
+  )
+}
+
+export function resetSystemPrefersDarkSubscriptionForTests(): void {
+  unsubscribeMediaQuery?.()
+  subscribers.clear()
+  mediaQueryList = null
+  unsubscribeMediaQuery = null
+  hasSnapshot = false
+  snapshot = true
 }


### PR DESCRIPTION
Summary
- Replace per-consumer system color-scheme effects with a shared useSyncExternalStore-backed subscription.
- Keep one cached matchMedia object and one browser change listener while any terminal/settings consumers are mounted.
- Add regression coverage that multiple subscribers share one media listener, still receive updates, and detach the listener after the last unsubscribe.

Risk
- Low: the hook still returns the same system dark-mode snapshot and responds to the same browser change event; the change only moves listener ownership from each component to a shared store.
- User impact: none expected beyond reduced renderer listener/subscription churn when many terminal panes are mounted, especially 200+ terminal workspaces.

Local verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-system-prefers-dark.test.ts
- pnpm exec oxlint src/renderer/src/components/terminal-pane/use-system-prefers-dark.ts src/renderer/src/components/terminal-pane/use-system-prefers-dark.test.ts
- pnpm run typecheck:web
- git diff --check origin/main..HEAD

Per request: not waiting for CI checks before merge.