### PR TITLE
Allow per-project worktree folders

### DIFF
--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -6,6 +6,7 @@
     "../src/renderer/src/**/*.tsx",
     "../src/preload/api-types.ts",
     "../src/shared/**/*",
+    "../src/main/repo-worktree-folder-path.ts",
     "../src/main/ipc/worktree-logic.ts",
     "../src/main/wsl.ts"
   ],

--- a/docs/per-project-worktree-folders.md
+++ b/docs/per-project-worktree-folders.md
@@ -1,0 +1,247 @@
+# Per-Project Worktree Folders
+
+## Problem
+
+Orca has one global workspace directory and nesting mode in `GlobalSettings`
+(`src/shared/types.ts:1688`). Local desktop creation uses
+`computeWorktreePath(sanitizedName, repo.path, settings)` and then validates
+against either the global workspace root or the WSL-mapped root
+(`src/main/ipc/worktree-remote.ts:1116`). Runtime/CLI creation repeats the same
+calculation (`src/main/runtime/orca-runtime.ts:7605`).
+
+WSL is not a simple global-root case. `computeWorktreePath` currently ignores
+`settings.workspaceDir` for WSL repos when `getWslHome()` succeeds and always
+maps to `<wsl home>/orca/workspaces` (`src/main/ipc/worktree-logic.ts:105`).
+Passing a project override through the current `settings` parameter would still
+be ignored for WSL.
+
+Desktop-managed SSH creation has separate behavior: it does not use global
+workspace settings and currently creates a sibling of the repo with the literal
+string `${repo.path}/../${sanitizedName}` (`src/main/ipc/worktree-remote.ts:738`).
+Current relay `session.registerRoot` is an upgrade-compatibility no-op in new
+relays, not an authorization mechanism.
+
+Create-path collision behavior is not uniform. Local desktop creation has a
+bounded suffix retry loop (`-2`, `-3`, ...). Runtime/CLI local creation and SSH
+creation do not; they fail on branch/path conflicts today.
+
+Project settings already persist per-project worktree-affecting fields such as
+`worktreeBaseRef` (`src/shared/types.ts:88`), but the repo update types, IPC/RPC
+schemas, renderer update type, and persistence update path do not include a
+worktree folder field (`src/main/ipc/repos.ts:912`,
+`src/main/runtime/rpc/methods/repo.ts:47`,
+`src/renderer/src/store/slices/repos.ts:25`,
+`src/main/persistence.ts:2258`).
+
+## Goal
+
+Allow each Git project to optionally define a worktree folder path. New
+worktrees for that project are created directly under that folder. Projects
+without an override keep current behavior:
+
+- local repos use the global workspace layout, including existing WSL mapping;
+- desktop-managed SSH repos use the sibling-of-repo layout;
+- runtime/CLI calls use the repo metadata stored in that runtime;
+- existing repos and existing worktrees are not moved or rewritten.
+
+## Non-goals
+
+- Do not move, rewrite, or re-parent existing worktrees.
+- Do not add a per-project nesting toggle in v1. A project folder override is
+  already the project-specific container, so new worktrees are direct children.
+- Do not make folder-mode projects create Git worktrees.
+- Do not change clone destination defaults.
+- Do not add GitHub-only behavior.
+- Do not add suffix retry behavior to runtime/CLI or SSH create paths as part of
+  this feature.
+- Do not accept relative paths or `~` expansion in v1. Store absolute
+  runtime-native paths only.
+- Do not let desktop-local WSL overrides escape to Windows drive paths in v1.
+  WSL repos keep worktrees on the WSL filesystem.
+
+## Design
+
+1. Persist an optional repo field.
+   - Add `worktreeFolderPath?: string` to `Repo`.
+   - Add it to the renderer `RepoUpdate`, preload/web API typing if narrowed,
+     local `repos:update`, runtime `repo.update`, `OrcaRuntimeService.updateRepo`,
+     and `Store.updateRepo` allow-lists.
+   - Persist the field only for Git repos. If a folder-mode repo reaches the
+     boundary with this field, or an update changes a repo to `kind: 'folder'`,
+     strip or clear it; the create path must not consult it for folder
+     workspaces.
+   - Normalize at every IPC/RPC/persistence boundary: accept only strings, trim
+     whitespace, reject NUL/control characters, require an absolute path for the
+     target runtime/path shape, reject filesystem roots (`/`, drive roots, UNC
+     share roots), and store `undefined` for an explicit clear. Do not call host
+     `resolve`/`realpath` on SSH or remote-runtime path strings while saving;
+     preserve runtime-native strings after shape validation.
+   - Runtime RPC cannot rely on `OptionalString -> undefined` for clearing. The
+     current `runtime.updateRepo` calls `omitUndefinedProperties(updates)`, which
+     drops clear signals before `Store.updateRepo` can delete the field. Preserve
+     an explicit clear for `worktreeFolderPath` before that omit step, or accept a
+     `null`/empty-string clear sentinel in the RPC schema and translate it to a
+     present `undefined` at the store boundary.
+   - For desktop-local WSL repos, persisted paths must be in the same distro and
+     in the Windows-facing WSL UNC form that `listWorktrees()` returns. If the UI
+     accepts a Linux absolute path such as `/home/me/worktrees`, convert it to
+     `\\wsl.localhost\<distro>\home\me\worktrees` before storing it. Reject
+     Windows drive paths and Linux `/mnt/<drive>` paths for WSL repos in v1;
+     otherwise terminal routing, performance assumptions, post-create path
+     matching, and local filesystem authorization diverge.
+
+2. Centralize effective layout resolution.
+   - Replace the implicit WSL behavior inside `computeWorktreePath` with a helper
+     that resolves the effective layout first:
+     - project override present and valid for this repo/runtime:
+       `{ path: repo.worktreeFolderPath, nestWorkspaces: false, source: 'project' }`;
+     - no override and WSL home available: `{ path: <wslHome>/orca/workspaces, nestWorkspaces: settings.nestWorkspaces, source: 'wsl-default' }`;
+     - otherwise: `{ path: settings.workspaceDir, nestWorkspaces: settings.nestWorkspaces, source: 'global' }`.
+   - The path builder should only join `{ layout.path, repo basename?, sanitizedName }`.
+     It must not call `getWslHome()` or remap WSL again after the resolver has
+     selected a project override.
+   - Pick path operations from the shape of `repo.path` and `layout.path`
+     (`win32` for drive/UNC paths, POSIX otherwise). Keep Windows drive paths and
+     UNC paths out of POSIX `join`/`resolve`.
+   - Validation must use the same path operations and the effective layout root,
+     not `settings.workspaceDir` and not the inherited WSL root when
+     `source === 'project'`. Replace `ensurePathWithinWorkspace` or make it
+     operation-aware; the current helper uses host `path.resolve/relative`.
+
+3. Apply the resolver to create paths.
+   - Local desktop `createLocalWorktree`: resolve the effective layout before the
+     suffix loop. On each suffix attempt, compute and validate the candidate path
+     against `layout.path`; keep the existing branch/path/PR suffix behavior.
+   - Runtime/CLI local `createManagedWorktree`: use the same effective layout and
+     validation, but preserve current no-suffix behavior.
+   - Desktop SSH `createRemoteWorktree`: keep sibling-of-repo semantics when no
+     override is set, but compute it with the same remote path helper instead of
+     the current literal `${repo.path}/../${sanitizedName}` interpolation. With
+     an override, compute `<worktreeFolderPath>/<sanitizedName>` using that
+     helper selected from the repo/folder shape. Preserve current no-suffix
+     behavior.
+   - For SSH relay compatibility, keep the existing priming pattern around
+     `session.registerRoot`, but treat it as upgrade-window compatibility only.
+     Register the repo path and the computed target path; do not depend on
+     registerRoot for security in new relays.
+   - Runtime remote helper `createManagedRemoteWorktree` already delegates to
+     `createRemoteWorktree`; do not invent a separate path policy there.
+   - Do not implicitly `mkdir -p` the override folder in v1. Local browse chooses
+     an existing directory; manual SSH/runtime typos should fail clearly before or
+     during `git worktree add`, not create unexpected remote directories.
+
+4. Stamp metadata and keep ownership conservative.
+   - For new Git worktrees, stamp `orcaCreationWorkspaceLayout.path` and
+     `nestWorkspaces` from the effective layout, not always global settings
+     (`src/main/ipc/worktree-remote.ts:972`,
+     `src/main/ipc/worktree-remote.ts:1361`,
+     `src/main/runtime/orca-runtime.ts:7736`).
+   - Folder-mode runtime workspaces stay out of scope; do not apply
+     `worktreeFolderPath` to the folder-mode branch at
+     `src/main/runtime/orca-runtime.ts:7452`.
+   - Extend `buildKnownOrcaWorkspaceLayouts` to accept
+     `repo.worktreeFolderPath` for local repos only, including repos owned by a
+     remote runtime but excluding desktop-managed SSH repos (`connectionId`).
+     Add the override as a flat known root (`nestWorkspaces: false`) so existing
+     arbitrary worktrees under that folder are not upgraded to strongly
+     Orca-managed solely because the setting changed. New worktrees rely on
+     their metadata for ownership.
+   - Keep SSH layouts out of local ownership and local filesystem authorization.
+     SSH paths are meaningful only on the remote host.
+   - Extend `getAllowedRoots` in the runtime that owns the repo store to include
+     valid non-SSH project folder overrides so file APIs can authorize future
+     worktrees outside the global workspace root. Filter out desktop-managed SSH
+     repo overrides. The desktop client must not resolve environment-runtime
+     strings; the environment runtime authorizes its own local paths.
+   - Continue invalidating authorized-root caches after successful local/runtime
+     creates. If repo-update handling adds any cached canonical project roots,
+     invalidate that cache when `worktreeFolderPath` changes.
+
+5. Surface the setting in Project Settings.
+   - In `RepositoryPane`, add a Git-project-only setting next to "Default
+     Worktree Base" in Identity (`src/renderer/src/components/settings/RepositoryPane.tsx:245`).
+   - Add "Worktree Folder" to the Identity search filter and to
+     `repository-search.ts`.
+   - Use a local draft and commit on blur/Enter/Browse instead of persisting on
+     every keystroke. The create path reads the main/runtime store, so the UI
+     should wait for the repo update call to settle before treating the setting as
+     saved.
+   - Use existing `Input`, `Button`, `Label`, `Tooltip`, and token classes.
+   - Helper text: blank inherits the global workspace directory for local/runtime
+     projects, including existing WSL default mapping, or the repo sibling folder
+     for SSH projects.
+   - Show a Browse button only when the active runtime target is local and the
+     repo is not SSH-backed. For SSH repos and remote runtime projects, use manual
+     text entry because a local folder picker returns a client-local path.
+
+6. Tests.
+   - Repo update tests for accepting, trimming, clearing, rejecting non-strings,
+     rejecting relative paths and filesystem roots, rejecting WSL drive escapes,
+     clearing the field when a repo becomes folder-mode, ignoring folder-mode
+     repos, and preserving clear signals through runtime RPC.
+   - Effective layout/path tests for inherited global layout, WSL inherited
+     layout, WSL override not being remapped to `~/orca/workspaces`, WSL Linux
+     input converted to UNC, operation-aware validation on Windows drive paths,
+     and UNC paths.
+   - Local desktop create tests asserting the project folder path is passed to
+     `addWorktree`, the suffix loop checks project-folder candidates, metadata
+     stamps the effective layout, and authorized roots are invalidated.
+   - Runtime local create tests asserting the override path and metadata layout
+     are used without adding suffix retry behavior.
+   - SSH create tests asserting legacy sibling semantics are unchanged without an
+     override, override behavior creates under the project folder, path helpers
+     handle POSIX and Windows-shaped remote paths for both default and override
+     cases, and relay root priming remains compatibility-only.
+   - Ownership/auth tests asserting local overrides are known roots, SSH overrides
+     are ignored locally, and existing worktrees with metadata remain stable when
+     the override is changed or cleared.
+   - RepositoryPane/search tests asserting the setting is visible for Git repos,
+     hidden for folder repos, Browse is hidden for SSH/remote runtime projects,
+     and clearing the draft sends an explicit clear.
+
+## Edge Cases
+
+- Empty or whitespace-only input clears the override.
+- Changing or clearing the override affects only future creates.
+- Existing worktrees keep their current paths and metadata.
+- Local overrides outside the global workspace directory are valid and must be
+  authorized as project workspace roots.
+- Desktop SSH overrides are remote paths; never authorize or browse them through
+  local filesystem APIs.
+- Desktop-local WSL overrides must compare in WSL UNC form unless the whole
+  create/list/auth pipeline is taught to compare Linux and UNC forms together.
+- Desktop-local WSL overrides must stay in the same distro's WSL filesystem;
+  reject Windows drive paths and Linux `/mnt/<drive>` paths in v1.
+- Missing override folders fail clearly; v1 does not create them implicitly.
+- Filesystem roots are rejected as overrides so filesystem authorization does not
+  widen to an entire drive, share, or POSIX root.
+- Windows drive and UNC paths must not be joined or validated with POSIX path
+  helpers.
+- A create in flight uses the layout resolved when the create handler starts;
+  later setting changes affect only later creates.
+- The local desktop suffix loop remains bounded and checks the project-folder
+  candidate path on each attempt.
+- Runtime/CLI and SSH create paths keep their current no-suffix conflict
+  behavior.
+- Runtime/mobile callers that pass no new create argument inherit the repo's
+  persisted setting from the runtime store.
+- Multi-window updates remain last-writer-wins through the existing repo update
+  flow; create uses the main/runtime store value at the time the create handler
+  runs.
+
+## Rollout
+
+1. Add the `Repo.worktreeFolderPath` type and repo update sanitization across
+   renderer, IPC, RPC, runtime service, and persistence.
+2. Add the effective layout/path helper and tests for global, WSL, Windows, UNC,
+   and invalid path cases.
+3. Wire local desktop and runtime local creation to the helper, including layout
+   metadata and filesystem authorization.
+4. Wire desktop SSH creation to use the override while preserving sibling
+   defaults and no-suffix behavior.
+5. Add the Project Settings UI and search coverage.
+6. Run focused tests around worktree logic, IPC worktree creation, runtime
+   worktree creation, repo update, ownership/auth, and RepositoryPane, then run
+   `pnpm typecheck` and `pnpm lint`.
+7. The local checkout ignores `docs/**`; force-add this design doc in the PR
+   step with `git add -f docs/per-project-worktree-folders.md`.

--- a/src/main/ipc/filesystem-auth-roots.ts
+++ b/src/main/ipc/filesystem-auth-roots.ts
@@ -1,0 +1,11 @@
+import { resolve } from 'path'
+import { isFolderRepo } from '../../shared/repo-kind'
+import type { Repo } from '../../shared/types'
+
+export function getLocalRepoAllowedRoots(repo: Repo): string[] {
+  const roots = [resolve(repo.path)]
+  if (!isFolderRepo(repo) && repo.worktreeFolderPath) {
+    roots.push(resolve(repo.worktreeFolderPath))
+  }
+  return roots
+}

--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -8,6 +8,7 @@ import type * as RepoWorktrees from '../repo-worktrees'
 import { listRepoWorktrees } from '../repo-worktrees'
 import type { GitWorktreeInfo, Repo } from '../../shared/types'
 import {
+  getAllowedRoots,
   invalidateAuthorizedRootsCache,
   isDescendantOrEqual,
   rebuildAuthorizedRootsCache,
@@ -91,6 +92,27 @@ describe('filesystem auth worktree roots', () => {
 
     expect(listRepoWorktrees).toHaveBeenCalledTimes(repos.length)
     expect(maxActive).toBeLessThanOrEqual(8)
+  })
+
+  it('allows local project worktree folder overrides but ignores SSH overrides', () => {
+    const localOverrideRepo: Repo = {
+      ...repo,
+      worktreeFolderPath: '/project-worktrees'
+    }
+    const sshRepo: Repo = {
+      ...repo,
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      connectionId: 'ssh-1',
+      worktreeFolderPath: '/remote/worktrees'
+    }
+    const store = {
+      getRepos: () => [localOverrideRepo, sshRepo],
+      getSettings: () => ({ workspaceDir: '/workspace' })
+    } as unknown as Store
+
+    expect(getAllowedRoots(store)).toContain(resolve('/project-worktrees'))
+    expect(getAllowedRoots(store)).not.toContain(resolve('/remote/worktrees'))
   })
 })
 

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -7,6 +7,7 @@ import { realpath } from 'fs/promises'
 import type { Store } from '../persistence'
 import { isRepoRoot, listRepoWorktrees } from '../repo-worktrees'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './worktree-logic'
+import { getLocalRepoAllowedRoots } from './filesystem-auth-roots'
 
 export const PATH_ACCESS_DENIED_MESSAGE =
   'Access denied: path resolves outside allowed directories. If this blocks a legitimate workflow, please file a GitHub issue.'
@@ -63,7 +64,7 @@ export function isDescendantOrEqual(resolvedTarget: string, resolvedBase: string
 export function getAllowedRoots(store: Store): string[] {
   const localRepos = getLocalRepos(store)
   const settings = store.getSettings()
-  const roots = localRepos.map((repo) => resolve(repo.path))
+  const roots = localRepos.flatMap(getLocalRepoAllowedRoots)
   if (settings.workspaceDir) {
     if (localRepos.length === 0) {
       roots.push(resolve(settings.workspaceDir))

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -20,6 +20,7 @@ import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
 import { normalizeRepoBadgeColor } from '../../shared/repo-badge-color'
 import { sanitizeRepoIcon } from '../../shared/repo-icon'
 import { normalizeRepoSourceControlAiOverrides } from '../../shared/source-control-ai'
+import { normalizeRepoWorktreeFolderPath } from '../repo-worktree-folder-path'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'child_process'
 import { access, mkdir, readdir, rm } from 'fs/promises'
@@ -1064,6 +1065,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
             | 'hookSettings'
             | 'worktreeBaseRef'
             | 'worktreeBasePath'
+            | 'worktreeFolderPath'
             | 'kind'
             | 'symlinkPaths'
             | 'issueSourcePreference'
@@ -1075,6 +1077,10 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         > & { sourceControlAi?: Repo['sourceControlAi'] | null }
       }
     ) => {
+      const existingRepo = store.getRepo(args.repoId)
+      if (!existingRepo) {
+        return null
+      }
       // Why: validate the persisted preference string at the IPC boundary
       // — the TypeScript signature is erased at runtime, and a preload
       // version skew or renderer bug could otherwise persist a garbage
@@ -1157,9 +1163,19 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           updates.sourceControlAi = normalizedSourceControlAi
         }
       }
+      if ('worktreeFolderPath' in updates) {
+        const nextIsFolder =
+          updates.kind === 'folder' || (updates.kind === undefined && isFolderRepo(existingRepo))
+        updates.worktreeFolderPath = nextIsFolder
+          ? undefined
+          : normalizeRepoWorktreeFolderPath(updates.worktreeFolderPath, existingRepo)
+      }
+      if (updates.kind === 'folder' && !('worktreeFolderPath' in updates)) {
+        updates.worktreeFolderPath = undefined
+      }
       const updated = store.updateRepo(args.repoId, updates)
       if (updated) {
-        if ('worktreeBasePath' in updates) {
+        if ('worktreeBasePath' in updates || 'worktreeFolderPath' in updates) {
           invalidateAuthorizedRootsCache()
         }
         notifyReposChanged(mainWindow)

--- a/src/main/ipc/worktree-logic-wsl.test.ts
+++ b/src/main/ipc/worktree-logic-wsl.test.ts
@@ -11,7 +11,11 @@ vi.mock('../wsl', () => ({
   parseWslPath: parseWslPathMock
 }))
 
-import { computeWorktreePath } from './worktree-logic'
+import {
+  computeWorktreePath,
+  resolveEffectiveWorktreeLayout,
+  computeWorktreePathForLayout
+} from './worktree-logic'
 
 describe('computeWorktreePath WSL layout', () => {
   beforeEach(() => {
@@ -61,6 +65,35 @@ describe('computeWorktreePath WSL layout', () => {
         nestWorkspaces: false,
         workspaceDir: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\custom-worktrees'
       })
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\custom-worktrees\\feature')
+  })
+
+  it('does not remap a WSL project override through the inherited WSL default', () => {
+    parseWslPathMock.mockReturnValue({
+      distro: 'Ubuntu',
+      linuxPath: '/home/jin/src/repo'
+    })
+    getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\jin')
+
+    const layout = resolveEffectiveWorktreeLayout(
+      {
+        path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+        worktreeFolderPath: '/home/jin/custom-worktrees'
+      },
+      { nestWorkspaces: true, workspaceDir: 'C:\\workspaces' }
+    )
+
+    expect(layout).toEqual({
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\custom-worktrees',
+      nestWorkspaces: false,
+      source: 'project'
+    })
+    expect(
+      computeWorktreePathForLayout(
+        'feature',
+        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\src\\repo',
+        layout
+      )
     ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\jin\\custom-worktrees\\feature')
   })
 })

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -2,6 +2,8 @@
 single setup-free pure-logic module, and splitting them would make the related
 edge cases harder to audit together. */
 import { join, resolve } from 'path'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'fs'
+import { tmpdir } from 'os'
 import { describe, expect, it } from 'vitest'
 import {
   sanitizeWorktreeName,
@@ -19,7 +21,8 @@ import {
   formatWorktreeRemovalError,
   isOrphanCompatiblePreflightError,
   isOrphanedWorktreeError,
-  areWorktreePathsEqual
+  areWorktreePathsEqual,
+  resolveEffectiveWorktreeLayout
 } from './worktree-logic'
 
 describe('sanitizeWorktreeName', () => {
@@ -252,6 +255,40 @@ describe('computeWorktreePath', () => {
   })
 })
 
+describe('effective worktree layouts', () => {
+  it('uses a flat project override ahead of the global nested layout', () => {
+    const layout = resolveEffectiveWorktreeLayout(
+      {
+        path: '/repos/my-project',
+        worktreeFolderPath: '/project-worktrees'
+      },
+      { nestWorkspaces: true, workspaceDir: '/global-worktrees' }
+    )
+
+    expect(layout).toEqual({
+      path: '/project-worktrees',
+      nestWorkspaces: false,
+      source: 'project'
+    })
+    expect(
+      computeWorktreePath('feature', '/repos/my-project', {
+        workspaceDir: layout.path,
+        nestWorkspaces: layout.nestWorkspaces
+      })
+    ).toBe(join('/project-worktrees', 'feature'))
+  })
+
+  it('keeps SSH defaults as repo siblings and overrides as flat roots', () => {
+    expect(computeRemoteWorktreePath('feature', { path: '/remote/repo' })).toBe('/remote/feature')
+    expect(
+      computeRemoteWorktreePath('feature', {
+        path: 'C:\\remote\\repo',
+        worktreeFolderPath: 'D:\\worktrees'
+      })
+    ).toBe('D:\\worktrees\\feature')
+  })
+})
+
 describe('areWorktreePathsEqual', () => {
   it('treats Windows slash and casing differences as the same path', () => {
     expect(
@@ -275,6 +312,35 @@ describe('areWorktreePathsEqual', () => {
         'darwin'
       )
     ).toBe(true)
+  })
+
+  it('treats existing POSIX symlink aliases as the same path', () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const root = mkdtempSync(join(tmpdir(), 'orca-worktree-path-equal-'))
+    try {
+      const realRoot = join(root, 'real')
+      const aliasRoot = join(root, 'alias')
+      mkdirSync(join(realRoot, 'created-worktree'), { recursive: true })
+      symlinkSync(realRoot, aliasRoot, 'dir')
+
+      expect(
+        areWorktreePathsEqual(
+          join(aliasRoot, 'created-worktree'),
+          join(realRoot, 'created-worktree'),
+          'darwin'
+        )
+      ).toBe(true)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+        return
+      }
+      throw error
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })
 

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -1,4 +1,5 @@
-import { basename, resolve, relative, isAbsolute, posix, sep, win32 } from 'path'
+import { realpathSync } from 'fs'
+import { posix, win32 } from 'path'
 import type {
   GitWorktreeInfo,
   GlobalSettings,
@@ -12,9 +13,10 @@ import { isWslUncPath } from '../../shared/wsl-paths'
 import { splitWorktreeId } from '../../shared/worktree-id'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import { getWslHome, parseWslPath } from '../wsl'
+import { normalizeRepoWorktreeFolderPath } from '../repo-worktree-folder-path'
 
 type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
-type WorktreeBasePathRepo = Pick<Repo, 'path' | 'worktreeBasePath'>
+type WorktreeLayoutRepo = Pick<Repo, 'path' | 'kind' | 'worktreeBasePath' | 'worktreeFolderPath'>
 
 /**
  * Sanitize a worktree name for use in branch names and directory paths.
@@ -65,11 +67,12 @@ export function sanitizeWorktreeDisplayName(input: string): string | undefined {
  * Ensure a target path is within the workspace directory (prevent path traversal).
  */
 export function ensurePathWithinWorkspace(targetPath: string, workspaceDir: string): string {
-  const resolvedWorkspaceDir = resolve(workspaceDir)
-  const resolvedTargetPath = resolve(targetPath)
-  const rel = relative(resolvedWorkspaceDir, resolvedTargetPath)
+  const pathOps = getWorktreePathOps(targetPath, workspaceDir)
+  const resolvedWorkspaceDir = pathOps.resolve(workspaceDir)
+  const resolvedTargetPath = pathOps.resolve(targetPath)
+  const rel = pathOps.relative(resolvedWorkspaceDir, resolvedTargetPath)
 
-  if (isAbsolute(rel) || rel === '..' || rel.startsWith(`..${sep}`)) {
+  if (pathOps.isAbsolute(rel) || rel === '..' || rel.startsWith(`..${pathOps.sep}`)) {
     throw new Error('Invalid worktree path')
   }
 
@@ -94,6 +97,76 @@ export function computeBranchName(
   return sanitizedName
 }
 
+export type EffectiveWorktreeLayout = OrcaWorkspaceLayout & {
+  source: 'project' | 'wsl-default' | 'global'
+}
+
+export type RemoteWorktreeLayout = OrcaWorkspaceLayout & {
+  source: 'project' | 'ssh-sibling'
+}
+
+export function resolveEffectiveWorktreeLayout(
+  repo: Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>,
+  settings: Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
+): EffectiveWorktreeLayout {
+  const projectPath = normalizeRepoWorktreeFolderPath(repo.worktreeFolderPath, repo)
+  if (projectPath) {
+    return { path: projectPath, nestWorkspaces: false, source: 'project' }
+  }
+
+  const basePath = getRepoWorktreeBasePath(repo)
+  if (basePath) {
+    return {
+      path: computeWorkspaceRoot(repo.path, { workspaceDir: basePath }),
+      nestWorkspaces: settings.nestWorkspaces,
+      source: 'project'
+    }
+  }
+
+  const wsl = parseWslPath(repo.path)
+  if (wsl) {
+    const wslHome = getWslHome(wsl.distro)
+    if (wslHome) {
+      return {
+        path: win32.join(wslHome, 'orca', 'workspaces'),
+        nestWorkspaces: settings.nestWorkspaces,
+        source: 'wsl-default'
+      }
+    }
+  }
+
+  return {
+    path: settings.workspaceDir,
+    nestWorkspaces: settings.nestWorkspaces,
+    source: 'global'
+  }
+}
+
+export function resolveRemoteWorktreeLayout(
+  repo: Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>
+): RemoteWorktreeLayout {
+  const projectPath = normalizeRepoWorktreeFolderPath(repo.worktreeFolderPath, repo)
+  if (projectPath) {
+    return { path: projectPath, nestWorkspaces: false, source: 'project' }
+  }
+
+  const basePath = getRepoWorktreeBasePath(repo)
+  if (basePath) {
+    return {
+      path: resolveWorkspaceDirForRepo(repo.path, basePath),
+      nestWorkspaces: false,
+      source: 'project'
+    }
+  }
+
+  const pathOps = getWorktreePathOps(repo.path)
+  return {
+    path: pathOps.dirname(repo.path),
+    nestWorkspaces: false,
+    source: 'ssh-sibling'
+  }
+}
+
 /**
  * Compute the filesystem path where the worktree directory will be created.
  *
@@ -107,10 +180,14 @@ export function computeBranchName(
 export function computeWorktreePath(
   sanitizedName: string,
   repoPath: string,
-  settings: WorktreePathSettings
+  settings: { nestWorkspaces: boolean; workspaceDir: string },
+  options: { useWslDefault?: boolean } = {}
 ): string {
-  const workspaceRoot = computeWorkspaceRoot(repoPath, settings)
-  const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
+  const workspaceRoot =
+    options.useWslDefault === false
+      ? resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
+      : computeWorkspaceRoot(repoPath, settings)
+  const pathOps = getWorktreePathOps(repoPath, workspaceRoot)
 
   if (settings.nestWorkspaces) {
     const repoName = pathOps.basename(repoPath).replace(/\.git$/, '')
@@ -134,26 +211,8 @@ export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir:
   return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
 }
 
-export function computeRemoteWorktreePath(
-  sanitizedName: string,
-  repoPath: string,
-  settings: WorktreePathSettings,
-  options: { useConfiguredAbsolutePath?: boolean } = {}
-): string {
-  if (
-    options.useConfiguredAbsolutePath ||
-    isWorkspaceDirRelativeToRepo(repoPath, settings.workspaceDir)
-  ) {
-    return computeWorktreePath(sanitizedName, repoPath, settings)
-  }
-  // Why: absolute global workspaceDir values belong to the desktop machine.
-  // SSH worktrees keep the legacy repo-sibling root unless a repo-specific
-  // path opts into a remote-host location.
-  return getRuntimePathOps(repoPath, repoPath).join(repoPath, '..', sanitizedName)
-}
-
 export function getWorktreePathSettings(
-  repo: WorktreeBasePathRepo,
+  repo: Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>,
   settings: WorktreePathSettings
 ): WorktreePathSettings {
   return {
@@ -163,9 +222,13 @@ export function getWorktreePathSettings(
 }
 
 export function getWorktreeCreationLayout(
-  repo: WorktreeBasePathRepo,
+  repo: Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>,
   settings: WorktreePathSettings
 ): OrcaWorkspaceLayout {
+  const folderPath = normalizeRepoWorktreeFolderPath(repo.worktreeFolderPath, repo)
+  if (folderPath) {
+    return { path: folderPath, nestWorkspaces: false }
+  }
   return {
     path: getEffectiveWorktreeBasePath(repo, settings),
     nestWorkspaces: settings.nestWorkspaces
@@ -174,6 +237,55 @@ export function getWorktreeCreationLayout(
 
 export function hasRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): boolean {
   return getRepoWorktreeBasePath(repo) !== undefined
+}
+
+export function computeWorktreePathForLayout(
+  sanitizedName: string,
+  repoPath: string,
+  layout: Pick<OrcaWorkspaceLayout, 'path' | 'nestWorkspaces'>
+): string {
+  return computeWorktreePath(
+    sanitizedName,
+    repoPath,
+    { workspaceDir: layout.path, nestWorkspaces: layout.nestWorkspaces },
+    { useWslDefault: false }
+  )
+}
+
+export function computeRemoteWorktreePath(
+  sanitizedName: string,
+  repo: Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>
+): string
+export function computeRemoteWorktreePath(
+  sanitizedName: string,
+  repoPath: string,
+  settings: WorktreePathSettings,
+  options?: { useConfiguredAbsolutePath?: boolean }
+): string
+export function computeRemoteWorktreePath(
+  sanitizedName: string,
+  repoOrPath: (Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>) | string,
+  settings?: WorktreePathSettings,
+  options: { useConfiguredAbsolutePath?: boolean } = {}
+): string {
+  if (typeof repoOrPath !== 'string') {
+    const layout = resolveRemoteWorktreeLayout(repoOrPath)
+    return computeWorktreePathForLayout(sanitizedName, repoOrPath.path, layout)
+  }
+  if (
+    !settings ||
+    options.useConfiguredAbsolutePath ||
+    isWorkspaceDirRelativeToRepo(repoOrPath, settings.workspaceDir)
+  ) {
+    if (!settings) {
+      return getWorktreePathOps(repoOrPath).join(repoOrPath, '..', sanitizedName)
+    }
+    return computeWorktreePath(sanitizedName, repoOrPath, settings)
+  }
+  // Why: absolute global workspaceDir values belong to the desktop machine.
+  // SSH worktrees keep the legacy repo-sibling root unless a repo-specific
+  // path opts into a remote-host location.
+  return getWorktreePathOps(repoOrPath, repoOrPath).join(repoOrPath, '..', sanitizedName)
 }
 
 export function areWorktreePathsEqual(
@@ -190,9 +302,25 @@ export function areWorktreePathsEqual(
     // create spuriously fails until the next full reload repopulates state.
     return left.toLowerCase() === right.toLowerCase()
   }
-  const left = normalizePosixWorktreePathForComparison(leftPath, platform)
-  const right = normalizePosixWorktreePathForComparison(rightPath, platform)
+  const left = normalizePosixWorktreePathForComparison(
+    realpathExistingPosixPath(leftPath),
+    platform
+  )
+  const right = normalizePosixWorktreePathForComparison(
+    realpathExistingPosixPath(rightPath),
+    platform
+  )
   return left === right
+}
+
+function realpathExistingPosixPath(pathValue: string): string {
+  try {
+    // Why: git worktree list reports canonical paths on macOS, where /var is
+    // a symlink to /private/var. Match the path Git returns after creation.
+    return realpathSync(pathValue)
+  } catch {
+    return pathValue
+  }
 }
 
 function looksLikeWindowsPath(pathValue: string): boolean {
@@ -219,7 +347,7 @@ function getRuntimePathOps(
   repoPath: string,
   workspaceDir: string
 ): Pick<typeof posix, 'basename' | 'isAbsolute' | 'join' | 'normalize'> {
-  return looksLikeWindowsPath(repoPath) || looksLikeWindowsPath(workspaceDir) ? win32 : posix
+  return getWorktreePathOps(repoPath, workspaceDir)
 }
 
 function resolveWorkspaceDirForRepo(repoPath: string, workspaceDir: string): string {
@@ -234,9 +362,13 @@ function isWorkspaceDirRelativeToRepo(repoPath: string, workspaceDir: string): b
 }
 
 function getEffectiveWorktreeBasePath(
-  repo: WorktreeBasePathRepo,
+  repo: Partial<WorktreeLayoutRepo> & Pick<Repo, 'path'>,
   settings: WorktreePathSettings
 ): string {
+  const folderPath = normalizeRepoWorktreeFolderPath(repo.worktreeFolderPath, repo)
+  if (folderPath) {
+    return folderPath
+  }
   return getRepoWorktreeBasePath(repo) ?? settings.workspaceDir
 }
 
@@ -250,6 +382,10 @@ function shouldMirrorWorkspaceDirInsideWsl(repoPath: string, workspaceDir: strin
     return false
   }
   return !isWslUncPath(workspaceDir)
+}
+
+function getWorktreePathOps(...paths: string[]) {
+  return paths.some(looksLikeWindowsPath) ? win32 : posix
 }
 
 /**
@@ -285,7 +421,11 @@ export function mergeWorktree(
     isBare: git.isBare,
     ...(git.isSparse === true ? { isSparse: true } : {}),
     isMainWorktree: git.isMainWorktree,
-    displayName: meta?.displayName || branchShort || defaultDisplayName || basename(git.path),
+    displayName:
+      meta?.displayName ||
+      branchShort ||
+      defaultDisplayName ||
+      getWorktreePathOps(git.path).basename(git.path),
     comment: meta?.comment || '',
     linkedIssue: meta?.linkedIssue ?? null,
     linkedPR: meta?.linkedPR ?? null,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -58,11 +58,9 @@ import {
   computeBranchName,
   computeWorktreePath,
   computeRemoteWorktreePath,
-  computeWorkspaceRoot,
   ensurePathWithinWorkspace,
-  getWorktreeCreationLayout,
-  getWorktreePathSettings,
-  hasRepoWorktreeBasePath,
+  resolveEffectiveWorktreeLayout,
+  resolveRemoteWorktreeLayout,
   shouldSetDisplayName,
   mergeWorktree,
   areWorktreePathsEqual
@@ -1153,7 +1151,6 @@ export async function createRemoteWorktree(
   const fsProvider = getSshFilesystemProvider(repo.connectionId!)
 
   const settings = store.getSettings()
-  const worktreePathSettings = getWorktreePathSettings(repo, settings)
   let effectiveRequestedName = args.name
   const sanitizedName = sanitizeWorktreeName(args.name)
   let effectiveSanitizedName = sanitizedName
@@ -1174,9 +1171,8 @@ export async function createRemoteWorktree(
     username
   )
 
-  let remotePath = computeRemoteWorktreePath(sanitizedName, repo.path, worktreePathSettings, {
-    useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
-  })
+  const remoteLayout = resolveRemoteWorktreeLayout(repo)
+  let remotePath = computeRemoteWorktreePath(sanitizedName, repo)
 
   // Determine base branch
   // Why: previously fell back to a hardcoded 'origin/main' when
@@ -1215,14 +1211,7 @@ export async function createRemoteWorktree(
         : args.name.trim()
           ? `${args.name}-${suffix}`
           : effectiveSanitizedName
-    remotePath = computeRemoteWorktreePath(
-      effectiveSanitizedName,
-      repo.path,
-      worktreePathSettings,
-      {
-        useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
-      }
-    )
+    remotePath = computeRemoteWorktreePath(effectiveSanitizedName, repo)
     if (!(await remotePathExists(fsProvider, remotePath))) {
       remotePathResolved = true
       break
@@ -1426,7 +1415,10 @@ export async function createRemoteWorktree(
     createdAt: now,
     orcaCreatedAt: now,
     orcaCreationSource: 'ssh',
-    orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
+    orcaCreationWorkspaceLayout: {
+      path: remoteLayout.path,
+      nestWorkspaces: remoteLayout.nestWorkspaces
+    },
     baseRef: baseBranch,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),
@@ -1529,7 +1521,9 @@ export async function createLocalWorktree(
 ): Promise<CreateWorktreeResult> {
   const timing = createWorktreeCreateTimingRecorder()
   const settings = store.getSettings()
-  const worktreePathSettings = getWorktreePathSettings(repo, settings)
+  // Why: Store.updateRepo mutates repo objects in place; an in-flight create
+  // must keep using the layout that was current when the handler started.
+  const worktreeLayout = resolveEffectiveWorktreeLayout(repo, settings)
 
   const username = getGitUsername(repo.path)
   const requestedName = args.name
@@ -1591,8 +1585,6 @@ export async function createLocalWorktree(
       .catch(() => undefined)
     emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
   }
-  const workspaceRoot = computeWorkspaceRoot(repo.path, worktreePathSettings)
-
   // Why: this validation does not depend on remote refs, so it can overlap a
   // required remote-tracking base refresh.
   const primarySetupScript = getEffectiveHooks(repo)?.scripts.setup
@@ -1723,8 +1715,16 @@ export async function createLocalWorktree(
     }
 
     worktreePath = ensurePathWithinWorkspace(
-      computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
-      workspaceRoot
+      computeWorktreePath(
+        effectiveSanitizedName,
+        repo.path,
+        {
+          workspaceDir: worktreeLayout.path,
+          nestWorkspaces: worktreeLayout.nestWorkspaces
+        },
+        { useWslDefault: false }
+      ),
+      worktreeLayout.path
     )
     if (existsSync(worktreePath)) {
       continue
@@ -1919,7 +1919,10 @@ export async function createLocalWorktree(
     createdAt: now,
     orcaCreatedAt: now,
     orcaCreationSource: 'desktop',
-    orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
+    orcaCreationWorkspaceLayout: {
+      path: worktreeLayout.path,
+      nestWorkspaces: worktreeLayout.nestWorkspaces
+    },
     baseRef: baseBranch,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),
     ...(configuredPushTarget ? { pushTarget: configuredPushTarget } : {}),

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -579,7 +579,7 @@ describe('registerWorktreeHandlers', () => {
     })
     listWorktreesMock.mockResolvedValue([
       {
-        path: '../worktrees/feature',
+        path: '/workspace/worktrees/feature',
         head: 'abc123',
         branch: 'feature',
         isBare: false,
@@ -592,21 +592,26 @@ describe('registerWorktreeHandlers', () => {
       name: 'feature'
     })
 
-    expect(computeWorktreePathMock).toHaveBeenCalledWith('feature', '/workspace/repo', {
-      nestWorkspaces: false,
-      workspaceDir: '../worktrees'
-    })
+    expect(computeWorktreePathMock).toHaveBeenCalledWith(
+      'feature',
+      '/workspace/repo',
+      {
+        nestWorkspaces: false,
+        workspaceDir: '/workspace/worktrees'
+      },
+      { useWslDefault: false }
+    )
     expect(addWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',
-      '../worktrees/feature',
+      '/workspace/worktrees/feature',
       'feature',
       'origin/main',
       false
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
-      'repo-1::../worktrees/feature',
+      'repo-1::/workspace/worktrees/feature',
       expect.objectContaining({
-        orcaCreationWorkspaceLayout: { path: '../worktrees', nestWorkspaces: false }
+        orcaCreationWorkspaceLayout: { path: '/workspace/worktrees', nestWorkspaces: false }
       })
     )
   })
@@ -643,6 +648,116 @@ describe('registerWorktreeHandlers', () => {
       worktree: expect.objectContaining({
         path: '/workspace/feature-something',
         branch: 'feature/something'
+      })
+    })
+  })
+
+  it('creates local desktop worktrees under the project folder override and stamps that layout', async () => {
+    const repoWithOverride = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeFolderPath: '/project-worktrees'
+    }
+    store.getRepo.mockReturnValue({ ...repoWithOverride, worktreeBaseRef: null })
+    store.getRepos.mockReturnValue([repoWithOverride])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/project-worktrees/project-feature',
+        head: 'abc123',
+        branch: 'project-feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'project-feature'
+    })
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/project-worktrees/project-feature',
+      'project-feature',
+      'origin/main',
+      false
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/project-worktrees/project-feature',
+      expect.objectContaining({
+        orcaCreationWorkspaceLayout: {
+          path: '/project-worktrees',
+          nestWorkspaces: false
+        }
+      })
+    )
+  })
+
+  it('uses the project folder captured when local desktop create starts', async () => {
+    const repoWithOverride = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: null,
+      worktreeFolderPath: '/project-worktrees'
+    }
+    let resolveRemoteBase!: (value: null) => void
+    runtimeStub.resolveRemoteTrackingBase.mockReturnValue(
+      new Promise<null>((resolve) => {
+        resolveRemoteBase = resolve
+      })
+    )
+    store.getRepo.mockReturnValue(repoWithOverride)
+    store.getRepos.mockReturnValue([repoWithOverride])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/project-worktrees/create-race',
+        head: 'abc123',
+        branch: 'create-race',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const createPromise = handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'create-race'
+    })
+
+    await vi.waitFor(() => {
+      expect(runtimeStub.resolveRemoteTrackingBase).toHaveBeenCalled()
+    })
+    repoWithOverride.worktreeFolderPath = '/changed-worktrees'
+    resolveRemoteBase(null)
+
+    const result = await createPromise
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/project-worktrees/create-race',
+      'create-race',
+      'origin/main',
+      false
+    )
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-1::/project-worktrees/create-race',
+      expect.objectContaining({
+        orcaCreationWorkspaceLayout: {
+          path: '/project-worktrees',
+          nestWorkspaces: false
+        }
+      })
+    )
+    expect(result).toMatchObject({
+      worktree: expect.objectContaining({
+        path: '/project-worktrees/create-race'
       })
     })
   })
@@ -2156,7 +2271,11 @@ describe('registerWorktreeHandlers', () => {
       expect.objectContaining({
         sparseDirectories: ['apps/mobile', 'packages/shared'],
         sparseBaseRef: 'origin/main',
-        sparsePresetId: 'preset-1'
+        sparsePresetId: 'preset-1',
+        orcaCreationWorkspaceLayout: {
+          path: '/remote',
+          nestWorkspaces: false
+        }
       })
     )
     expect(result).toMatchObject({
@@ -2360,6 +2479,68 @@ describe('registerWorktreeHandlers', () => {
     ).rejects.toThrow('Branch "feature/something" already exists on a remote.')
 
     expect(provider.addWorktree).not.toHaveBeenCalled()
+  })
+
+  it('creates SSH worktrees under the project folder override', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main',
+      worktreeFolderPath: '/remote/custom-worktrees'
+    }
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/custom-worktrees/ssh-feature',
+          head: 'abc123',
+          branch: 'refs/heads/ssh-feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    store.getSparsePresets.mockReturnValue([])
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'ssh-feature'
+    })
+
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/repo',
+      'ssh-feature',
+      '/remote/custom-worktrees/ssh-feature',
+      { base: 'origin/main' }
+    )
+    expect(mux.request).toHaveBeenCalledWith('session.registerRoot', { rootPath: '/remote/repo' })
+    expect(mux.request).toHaveBeenCalledWith('session.registerRoot', {
+      rootPath: '/remote/custom-worktrees/ssh-feature'
+    })
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      'repo-ssh::/remote/custom-worktrees/ssh-feature',
+      expect.objectContaining({
+        orcaCreationWorkspaceLayout: {
+          path: '/remote/custom-worktrees',
+          nestWorkspaces: false
+        }
+      })
+    )
   })
 
   it('unsets SSH branch base config before removing a sparse worktree after setup failure', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2351,6 +2351,29 @@ describe('Store', () => {
     expect(reloaded.getRepo('r1')!.issueSourcePreference).toBeUndefined()
   })
 
+  it('updateRepo normalizes and clears per-project worktree folders', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+
+    const updated = store.updateRepo('r1', { worktreeFolderPath: '  /worktrees/repo  ' })
+    expect(updated!.worktreeFolderPath).toBe('/worktrees/repo')
+
+    store.updateRepo('r1', { worktreeFolderPath: '' })
+    expect(store.getRepo('r1')!.worktreeFolderPath).toBeUndefined()
+  })
+
+  it('updateRepo rejects invalid worktree folders and clears them for folder repos', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ worktreeFolderPath: '/worktrees/repo' }))
+
+    expect(() => store.updateRepo('r1', { worktreeFolderPath: 'relative/path' })).toThrow(
+      'absolute'
+    )
+
+    store.updateRepo('r1', { kind: 'folder' })
+    expect(store.getRepo('r1')!.worktreeFolderPath).toBeUndefined()
+  })
+
   it('updateRepo stamps legacy external-worktree visibility before changing old repos', async () => {
     const store = await createStore()
     store.addRepo(

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -55,6 +55,7 @@ import type {
 import type { MigrationUnsupportedPtyEntry } from '../shared/agent-status-types'
 import type { SshRemotePtyLease, SshTarget } from '../shared/ssh-types'
 import { isFolderRepo } from '../shared/repo-kind'
+import { normalizeRepoWorktreeFolderPath } from './repo-worktree-folder-path'
 import { getGitUsername } from './git/repo'
 import {
   getDefaultPersistedState,
@@ -699,7 +700,9 @@ function sanitizeRepoUpstream(value: unknown): Repo['upstream'] | undefined {
 }
 
 function sanitizeRepoUpdatesForPersistence<
-  T extends Partial<Pick<Repo, 'badgeColor' | 'repoIcon' | 'upstream' | 'worktreeBasePath'>>
+  T extends Partial<
+    Pick<Repo, 'badgeColor' | 'repoIcon' | 'upstream' | 'worktreeBasePath' | 'worktreeFolderPath'>
+  >
 >(updates: T): T {
   const sanitized = { ...updates }
   if ('badgeColor' in sanitized) {
@@ -2599,6 +2602,7 @@ export class Store {
         | 'hookSettings'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
+        | 'worktreeFolderPath'
         | 'kind'
         | 'symlinkPaths'
         | 'issueSourcePreference'
@@ -2614,6 +2618,24 @@ export class Store {
       return null
     }
     const sanitizedUpdates = sanitizeRepoUpdatesForPersistence(updates)
+    const nextIsFolder =
+      sanitizedUpdates.kind === 'folder' ||
+      (sanitizedUpdates.kind === undefined && isFolderRepo(repo))
+    if (nextIsFolder) {
+      delete repo.worktreeFolderPath
+      delete sanitizedUpdates.worktreeFolderPath
+    } else if ('worktreeFolderPath' in sanitizedUpdates) {
+      const normalizedWorktreeFolderPath = normalizeRepoWorktreeFolderPath(
+        sanitizedUpdates.worktreeFolderPath,
+        repo
+      )
+      if (normalizedWorktreeFolderPath === undefined) {
+        delete repo.worktreeFolderPath
+        delete sanitizedUpdates.worktreeFolderPath
+      } else {
+        sanitizedUpdates.worktreeFolderPath = normalizedWorktreeFolderPath
+      }
+    }
     if ('projectGroupId' in sanitizedUpdates) {
       const nextGroupId = sanitizedUpdates.projectGroupId
       if (
@@ -2683,6 +2705,7 @@ export class Store {
       repoIcon: rawRepoIcon,
       upstream: rawUpstream,
       sourceControlAi: rawSourceControlAi,
+      worktreeFolderPath,
       ...repoWithoutIcon
     } = repo
     const repoIcon = sanitizeRepoIcon(rawRepoIcon)
@@ -2702,6 +2725,7 @@ export class Store {
       ...(repoIcon !== undefined ? { repoIcon } : {}),
       ...(upstream !== undefined ? { upstream } : {}),
       ...(sourceControlAi !== undefined ? { sourceControlAi } : {}),
+      ...(!isFolderRepo(repo) && worktreeFolderPath ? { worktreeFolderPath } : {}),
       kind: isFolderRepo(repo) ? 'folder' : 'git',
       gitUsername,
       hookSettings: {

--- a/src/main/repo-worktree-folder-path.test.ts
+++ b/src/main/repo-worktree-folder-path.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../shared/types'
+import { normalizeRepoWorktreeFolderPath } from './repo-worktree-folder-path'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repos/app',
+    displayName: 'app',
+    badgeColor: '#000',
+    addedAt: 1,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+describe('repo worktree folder path normalization', () => {
+  it('trims POSIX paths and clears empty input', () => {
+    const repo = makeRepo()
+
+    expect(normalizeRepoWorktreeFolderPath('  /worktrees/app  ', repo)).toBe('/worktrees/app')
+    expect(normalizeRepoWorktreeFolderPath('   ', repo)).toBeUndefined()
+  })
+
+  it('rejects malformed POSIX project folders', () => {
+    const repo = makeRepo()
+
+    expect(() => normalizeRepoWorktreeFolderPath('relative/path', repo)).toThrow('absolute')
+    expect(() => normalizeRepoWorktreeFolderPath('/', repo)).toThrow('filesystem root')
+    expect(() => normalizeRepoWorktreeFolderPath('/tmp/\u0000bad', repo)).toThrow(
+      'control characters'
+    )
+    expect(() => normalizeRepoWorktreeFolderPath(42, repo)).toThrow('must be a string')
+  })
+
+  it('normalizes Windows drive and UNC paths for Windows-shaped repos', () => {
+    const repo = makeRepo({ path: 'C:\\repos\\app' })
+
+    expect(normalizeRepoWorktreeFolderPath('C:/worktrees/app', repo)).toBe('C:\\worktrees\\app')
+    expect(normalizeRepoWorktreeFolderPath('\\\\Server\\Share\\worktrees', repo)).toBe(
+      '\\\\Server\\Share\\worktrees'
+    )
+    expect(() => normalizeRepoWorktreeFolderPath('C:\\', repo)).toThrow('filesystem root')
+    expect(() => normalizeRepoWorktreeFolderPath('\\\\Server\\Share', repo)).toThrow(
+      'filesystem root'
+    )
+  })
+
+  it('keeps desktop-local WSL overrides inside the repo distro filesystem', () => {
+    const repo = makeRepo({ path: '\\\\wsl.localhost\\Ubuntu\\home\\me\\src\\app' })
+
+    expect(normalizeRepoWorktreeFolderPath('/home/me/worktrees', repo)).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\me\\worktrees'
+    )
+    expect(
+      normalizeRepoWorktreeFolderPath('\\\\wsl.localhost\\Ubuntu\\home\\me\\worktrees', repo)
+    ).toBe('\\\\wsl.localhost\\Ubuntu\\home\\me\\worktrees')
+    expect(() => normalizeRepoWorktreeFolderPath('D:\\worktrees', repo)).toThrow('WSL')
+    expect(() => normalizeRepoWorktreeFolderPath('/mnt/c/worktrees', repo)).toThrow('/mnt/<drive>')
+    expect(() =>
+      normalizeRepoWorktreeFolderPath('\\\\wsl.localhost\\Debian\\home\\me\\worktrees', repo)
+    ).toThrow('same distro')
+  })
+
+  it('strips folder-mode worktree folders', () => {
+    expect(
+      normalizeRepoWorktreeFolderPath('/worktrees/app', makeRepo({ kind: 'folder' }))
+    ).toBeUndefined()
+  })
+})

--- a/src/main/repo-worktree-folder-path.ts
+++ b/src/main/repo-worktree-folder-path.ts
@@ -1,0 +1,129 @@
+import { posix, win32 } from 'path'
+import { isFolderRepo } from '../shared/repo-kind'
+import type { Repo } from '../shared/types'
+import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
+import { parseWslUncPath } from '../shared/wsl-paths'
+
+const WSL_DRIVE_MOUNT_PATTERN = /^\/mnt\/[a-z](?:\/|$)/i
+
+type RepoWorktreeFolderPathRepo = Pick<Repo, 'path' | 'kind'>
+
+export function normalizeRepoWorktreeFolderPath(
+  value: unknown,
+  repo: RepoWorktreeFolderPathRepo
+): string | undefined {
+  if (isFolderRepo(repo)) {
+    return undefined
+  }
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'string') {
+    throw new Error('Worktree folder path must be a string.')
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return undefined
+  }
+  if (containsControlCharacter(trimmed)) {
+    throw new Error('Worktree folder path cannot contain control characters.')
+  }
+
+  const wslRepo = parseWslUncPath(repo.path)
+  if (wslRepo) {
+    return normalizeWslRepoWorktreeFolderPath(trimmed, wslRepo.distro)
+  }
+
+  if (isWindowsAbsolutePathLike(repo.path)) {
+    return normalizeWindowsRepoWorktreeFolderPath(trimmed)
+  }
+
+  return normalizePosixRepoWorktreeFolderPath(trimmed)
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+      return true
+    }
+  }
+  return false
+}
+
+function normalizeWslRepoWorktreeFolderPath(value: string, distro: string): string {
+  if (isWindowsDrivePath(value)) {
+    throw new Error('WSL worktree folders must stay inside the WSL distro filesystem.')
+  }
+
+  const wslInput = parseWslUncPath(value)
+  if (wslInput) {
+    if (wslInput.distro.toLowerCase() !== distro.toLowerCase()) {
+      throw new Error('WSL worktree folders must stay in the same distro as the repo.')
+    }
+    return wslLinuxPathToUnc(normalizeWslLinuxPath(wslInput.linuxPath), distro)
+  }
+
+  if (isWindowsAbsolutePathLike(value)) {
+    throw new Error('WSL worktree folders must stay inside the WSL distro filesystem.')
+  }
+  if (!value.startsWith('/')) {
+    throw new Error('Worktree folder path must be absolute.')
+  }
+  return wslLinuxPathToUnc(normalizeWslLinuxPath(value), distro)
+}
+
+function normalizeWslLinuxPath(value: string): string {
+  const normalized = posix.normalize(value)
+  if (normalized === '/') {
+    throw new Error('Worktree folder path cannot be a filesystem root.')
+  }
+  if (WSL_DRIVE_MOUNT_PATTERN.test(normalized)) {
+    throw new Error('WSL worktree folders cannot use /mnt/<drive> paths.')
+  }
+  return normalized
+}
+
+function wslLinuxPathToUnc(linuxPath: string, distro: string): string {
+  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}
+
+function normalizeWindowsRepoWorktreeFolderPath(value: string): string {
+  if (!isWindowsAbsolutePathLike(value)) {
+    throw new Error('Worktree folder path must be absolute for the repo runtime.')
+  }
+  const normalized = win32.normalize(value)
+  if (isWindowsFilesystemRoot(normalized)) {
+    throw new Error('Worktree folder path cannot be a filesystem root.')
+  }
+  return normalized
+}
+
+function normalizePosixRepoWorktreeFolderPath(value: string): string {
+  if (isWindowsAbsolutePathLike(value)) {
+    throw new Error('Worktree folder path must be absolute for the repo runtime.')
+  }
+  if (!value.startsWith('/')) {
+    throw new Error('Worktree folder path must be absolute.')
+  }
+  const normalized = posix.normalize(value)
+  if (normalized === '/') {
+    throw new Error('Worktree folder path cannot be a filesystem root.')
+  }
+  return normalized
+}
+
+function isWindowsDrivePath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value)
+}
+
+function isWindowsFilesystemRoot(value: string): boolean {
+  const normalized = win32.normalize(value)
+  const parsed = win32.parse(normalized)
+  return trimWindowsRoot(normalized).toLowerCase() === trimWindowsRoot(parsed.root).toLowerCase()
+}
+
+function trimWindowsRoot(value: string): string {
+  return value.replace(/[\\/]+$/g, '')
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1453,6 +1453,140 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('creates runtime local worktrees under the project folder override without suffix retry', async () => {
+    const repo = {
+      id: TEST_REPO_ID,
+      path: TEST_REPO_PATH,
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      worktreeFolderPath: '/project-worktrees'
+    }
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [repo],
+      getRepo: (id: string) => (id === repo.id ? repo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    computeWorktreePathMock.mockReturnValue('/project-worktrees/runtime-project-feature')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/project-worktrees/runtime-project-feature')
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      {
+        path: '/project-worktrees/runtime-project-feature',
+        head: 'def',
+        branch: 'runtime-project-feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-project-feature'
+    })
+
+    expect(addWorktree).toHaveBeenCalledWith(
+      TEST_REPO_PATH,
+      '/project-worktrees/runtime-project-feature',
+      'runtime-project-feature',
+      'origin/main',
+      false
+    )
+    expect(metaById[result.worktree.id]).toMatchObject({
+      orcaCreationWorkspaceLayout: {
+        path: '/project-worktrees',
+        nestWorkspaces: false
+      }
+    })
+  })
+
+  it('uses the project folder captured when runtime local create starts', async () => {
+    const repo = {
+      id: TEST_REPO_ID,
+      path: TEST_REPO_PATH,
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      worktreeFolderPath: '/project-worktrees'
+    }
+    const metaById: Record<string, WorktreeMeta> = {}
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [repo],
+      getRepo: (id: string) => (id === repo.id ? repo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    let resolvePr!: (value: null) => void
+    getPRForBranchMock.mockReturnValue(
+      new Promise<null>((resolve) => {
+        resolvePr = resolve
+      })
+    )
+    computeWorktreePathMock.mockImplementation(
+      (
+        sanitizedName: string,
+        _repoPath: string,
+        settings: { nestWorkspaces: boolean; workspaceDir: string }
+      ) => `${settings.workspaceDir}/${sanitizedName}`
+    )
+    ensurePathWithinWorkspaceMock.mockImplementation((targetPath: string) => targetPath)
+    vi.mocked(listWorktrees).mockResolvedValueOnce([
+      {
+        path: '/project-worktrees/runtime-captured-layout',
+        head: 'def',
+        branch: 'runtime-captured-layout',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockResolvedValue({
+      stdout: '',
+      stderr: ''
+    })
+    try {
+      const createPromise = runtime.createManagedWorktree({
+        repoSelector: 'id:repo-1',
+        name: 'runtime-captured-layout'
+      })
+
+      await vi.waitFor(() => {
+        expect(getPRForBranchMock).toHaveBeenCalled()
+      })
+      repo.worktreeFolderPath = '/changed-worktrees'
+      resolvePr(null)
+      const result = await createPromise
+
+      expect(addWorktree).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        '/project-worktrees/runtime-captured-layout',
+        'runtime-captured-layout',
+        'origin/main',
+        false
+      )
+      expect(metaById[result.worktree.id]).toMatchObject({
+        orcaCreationWorkspaceLayout: {
+          path: '/project-worktrees',
+          nestWorkspaces: false
+        }
+      })
+    } finally {
+      gitSpy.mockRestore()
+    }
+  })
+
   it('does not create runtime local worktrees when remote-tracking base refresh fails', async () => {
     const runtime = new OrcaRuntimeService(store)
     const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -442,14 +442,12 @@ import { AgentDetector } from '../stats/agent-detector'
 import {
   computeBranchName,
   computeWorktreePath,
-  computeWorkspaceRoot,
   ensurePathWithinWorkspace,
   formatWorktreeRemovalError,
-  getWorktreeCreationLayout,
-  getWorktreePathSettings,
   isOrphanCompatiblePreflightError,
   isOrphanedWorktreeError,
   mergeWorktree,
+  resolveEffectiveWorktreeLayout,
   sanitizeWorktreeName,
   shouldSetDisplayName,
   areWorktreePathsEqual
@@ -6981,6 +6979,7 @@ export class OrcaRuntimeService {
         | 'hookSettings'
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
+        | 'worktreeFolderPath'
         | 'kind'
         | 'symlinkPaths'
         | 'issueSourcePreference'
@@ -6989,24 +6988,31 @@ export class OrcaRuntimeService {
         | 'projectGroupId'
         | 'projectGroupOrder'
       >
-    > & { sourceControlAi?: Repo['sourceControlAi'] | null }
+    > & { sourceControlAi?: Repo['sourceControlAi'] | null; worktreeFolderPath?: string | null }
   ): Promise<Repo> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
     const repo = await this.resolveRepoSelector(repoSelector)
-    const sanitizedUpdates = omitUndefinedProperties(updates)
-    if ('worktreeBasePath' in updates && updates.worktreeBasePath === undefined) {
-      sanitizedUpdates.worktreeBasePath = undefined
+    const repoUpdates = { ...updates }
+    if ('worktreeFolderPath' in repoUpdates && repoUpdates.worktreeFolderPath === null) {
+      repoUpdates.worktreeFolderPath = undefined
     }
-    if ('sourceControlAi' in updates && updates.sourceControlAi === null) {
-      sanitizedUpdates.sourceControlAi = null
+    const compactUpdates = omitUndefinedProperties(repoUpdates)
+    if ('worktreeBasePath' in repoUpdates && repoUpdates.worktreeBasePath === undefined) {
+      compactUpdates.worktreeBasePath = undefined
     }
-    const updated = this.store.updateRepo(repo.id, sanitizedUpdates)
+    if ('worktreeFolderPath' in repoUpdates && repoUpdates.worktreeFolderPath === undefined) {
+      compactUpdates.worktreeFolderPath = undefined
+    }
+    if ('sourceControlAi' in repoUpdates && repoUpdates.sourceControlAi === null) {
+      compactUpdates.sourceControlAi = null
+    }
+    const updated = this.store.updateRepo(repo.id, compactUpdates)
     if (!updated) {
       throw new Error('repo_not_found')
     }
-    if ('worktreeBasePath' in updates) {
+    if ('worktreeBasePath' in repoUpdates || 'worktreeFolderPath' in repoUpdates) {
       invalidateAuthorizedRootsCache()
     }
     this.invalidateResolvedWorktreeCache()
@@ -8935,6 +8941,12 @@ export class OrcaRuntimeService {
     const repo = await this.resolveRepoSelector(args.repoSelector)
     const createSettings = this.store.getSettings()
     const requestedAgent = args.startupAgent ?? args.createdWithAgent
+    // Why: Store.updateRepo mutates repo objects in place; local Git creates
+    // must keep the project-folder decision made when this request started.
+    const localWorktreeLayout =
+      !isFolderRepo(repo) && !repo.connectionId
+        ? resolveEffectiveWorktreeLayout(repo, createSettings)
+        : null
     const requestedAgentEnabled =
       requestedAgent !== undefined
         ? isTuiAgentEnabled(requestedAgent, createSettings.disabledTuiAgents)
@@ -9086,7 +9098,6 @@ export class OrcaRuntimeService {
       }
     }
     const settings = createSettings
-    const worktreePathSettings = getWorktreePathSettings(repo, settings)
     let effectiveRequestedName = args.name
     const requestedDisplayName = args.displayName?.trim() || undefined
     const sanitizedName = sanitizeWorktreeName(args.name)
@@ -9153,10 +9164,7 @@ export class OrcaRuntimeService {
       }
     }
 
-    const workspaceRoot = computeWorkspaceRoot(repo.path, worktreePathSettings)
-    // Why: CLI-managed WSL worktrees live under ~/orca/workspaces inside the
-    // distro filesystem through computeWorkspaceRoot. If home lookup fails,
-    // still validate against the effective workspace dir.
+    const worktreeLayout = localWorktreeLayout ?? resolveEffectiveWorktreeLayout(repo, settings)
     let worktreePath = ''
     let worktreePathResolved = !args.branchNameOverride
     for (let suffix = 1; suffix < 100; suffix += 1) {
@@ -9168,8 +9176,16 @@ export class OrcaRuntimeService {
             ? `${args.name}-${suffix}`
             : effectiveSanitizedName
       worktreePath = ensurePathWithinWorkspace(
-        computeWorktreePath(effectiveSanitizedName, repo.path, worktreePathSettings),
-        workspaceRoot
+        computeWorktreePath(
+          effectiveSanitizedName,
+          repo.path,
+          {
+            workspaceDir: worktreeLayout.path,
+            nestWorkspaces: worktreeLayout.nestWorkspaces
+          },
+          { useWslDefault: false }
+        ),
+        worktreeLayout.path
       )
       if (!args.branchNameOverride || !(await pathExists(worktreePath))) {
         worktreePathResolved = true
@@ -9353,7 +9369,10 @@ export class OrcaRuntimeService {
       createdAt: now,
       orcaCreatedAt: now,
       orcaCreationSource: 'runtime',
-      orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
+      orcaCreationWorkspaceLayout: {
+        path: worktreeLayout.path,
+        nestWorkspaces: worktreeLayout.nestWorkspaces
+      },
       ...displayNameMeta,
       baseRef: baseBranch,
       ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),

--- a/src/main/runtime/rpc/methods/repo-worktree-folder.test.ts
+++ b/src/main/runtime/rpc/methods/repo-worktree-folder.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { REPO_METHODS } from './repo'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+describe('repo RPC worktree folder updates', () => {
+  it('preserves worktree folder clear sentinels through repo.update', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateRepo: vi.fn().mockResolvedValue({ id: 'repo-1', path: '/srv/repo' })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('repo.update', {
+        repo: 'repo-1',
+        updates: { worktreeFolderPath: null }
+      })
+    )
+
+    expect(runtime.updateRepo).toHaveBeenCalledWith('repo-1', {
+      worktreeFolderPath: null
+    })
+    expect(response).toMatchObject({
+      ok: true,
+      result: { repo: { id: 'repo-1' } }
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -68,6 +68,7 @@ const RepoUpdate = RepoSelector.extend({
     hookSettings: z.unknown().optional(),
     worktreeBaseRef: OptionalString,
     worktreeBasePath: OptionalString,
+    worktreeFolderPath: z.union([z.string(), z.null()]).optional(),
     kind: z.enum(['git', 'folder']).optional(),
     symlinkPaths: z.array(z.string()).optional(),
     issueSourcePreference: z.enum(['auto', 'upstream', 'origin']).optional(),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -734,6 +734,7 @@ export type PreloadApi = {
           | 'hookSettings'
           | 'worktreeBaseRef'
           | 'worktreeBasePath'
+          | 'worktreeFolderPath'
           | 'kind'
           | 'issueSourcePreference'
           | 'externalWorktreeVisibility'

--- a/src/renderer/src/components/settings/RepositoryPane.test.ts
+++ b/src/renderer/src/components/settings/RepositoryPane.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import {
+  canBrowseProjectWorktreeFolder,
   getRepositoryPaneSearchEntries,
   matchesRepositoryIdentitySearch,
   RepositoryPane
@@ -33,6 +34,7 @@ describe('RepositoryPane search entries', () => {
     expect(matchesSettingsSearch('local settings scripts', entries)).toBe(true)
     expect(matchesSettingsSearch('../worktrees', entries)).toBe(true)
     expect(matchesSettingsSearch('worktree path', entries)).toBe(true)
+    expect(matchesSettingsSearch('worktree folder', entries)).toBe(true)
   })
 
   it('matches project identity searches on display name and path only', () => {
@@ -74,5 +76,66 @@ describe('RepositoryPane search entries', () => {
         settingsSearchInputQuery: ''
       })
     }
+  })
+
+  it('renders the worktree folder setting for Git repos but not folder repos', () => {
+    const gitHtml = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(RepositoryPane, {
+          repo,
+          yamlHooks: null,
+          hasHooksFile: false,
+          hooksInspectionReady: true,
+          mayNeedUpdate: false,
+          updateRepo: vi.fn(),
+          removeProject: vi.fn()
+        })
+      )
+    )
+    const folderHtml = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(RepositoryPane, {
+          repo: { ...repo, kind: 'folder' },
+          yamlHooks: null,
+          hasHooksFile: false,
+          hooksInspectionReady: true,
+          mayNeedUpdate: false,
+          updateRepo: vi.fn(),
+          removeProject: vi.fn()
+        })
+      )
+    )
+
+    expect(gitHtml).toContain('Worktree Folder')
+    expect(gitHtml).toContain('lucide-folder-open')
+    expect(folderHtml).not.toContain('Worktree Folder')
+  })
+
+  it('hides the worktree folder Browse button for SSH and remote runtime projects', () => {
+    const render = (project: Repo): string =>
+      renderToStaticMarkup(
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(RepositoryPane, {
+            repo: project,
+            yamlHooks: null,
+            hasHooksFile: false,
+            hooksInspectionReady: true,
+            mayNeedUpdate: false,
+            updateRepo: vi.fn(),
+            removeProject: vi.fn()
+          })
+        )
+      )
+
+    expect(render({ ...repo, connectionId: 'ssh-1' })).not.toContain('lucide-folder-open')
+
+    expect(canBrowseProjectWorktreeFolder(repo, 'env-1')).toBe(false)
+    expect(canBrowseProjectWorktreeFolder(repo, '  ')).toBe(true)
   })
 })

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -5,7 +5,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Separator } from '../ui/separator'
-import { Trash2 } from 'lucide-react'
+import { FolderOpen, Trash2 } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { BaseRefPicker } from './BaseRefPicker'
 import { RepositoryHooksSection } from './RepositoryHooksSection'
@@ -32,7 +32,7 @@ type RepositoryPaneProps = {
   hasHooksFile: boolean
   hooksInspectionReady: boolean
   mayNeedUpdate: boolean
-  updateRepo: (repoId: string, updates: RepositoryPaneRepoUpdate) => void
+  updateRepo: (repoId: string, updates: RepositoryPaneRepoUpdate) => void | Promise<boolean>
   removeProject: (repoId: string) => void
 }
 
@@ -182,7 +182,7 @@ export function RepositoryPane({
       'Display Name',
       'Project Icon',
       'Default Worktree Base',
-      'Worktree Location',
+      'Worktree Folder',
       'Remove Project'
     ].includes(entry.title)
   )
@@ -321,45 +321,11 @@ export function RepositoryPane({
                 onUsePrimary={() => updateRepo(repo.id, { worktreeBaseRef: undefined })}
               />
             </SearchableSetting>
-
-            <SearchableSetting
-              title={translate("auto.components.settings.RepositoryPane.e9bd57a336", "Worktree Location")}
-              description={translate("auto.components.settings.RepositoryPane.e63bb96a9b", "Project-specific directory for new worktrees.")}
-              keywords={[
-                repo.displayName,
-                'worktree path',
-                'workspace path',
-                'directory',
-                'relative',
-                '../worktrees'
-              ]}
-              className="space-y-2"
+            <WorktreeFolderSetting
+              repo={repo}
+              updateRepo={updateRepo}
               forceVisible={forceFullPaneForRepoMatch}
-            >
-              <div className="flex items-center justify-between gap-3">
-                <Label className="text-sm font-semibold">{translate("auto.components.settings.RepositoryPane.e9bd57a336", "Worktree Location")}</Label>
-                {repo.worktreeBasePath ? (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => updateRepo(repo.id, { worktreeBasePath: undefined })}
-                  >
-                    {translate("auto.components.settings.RepositoryPane.8ccacbeb5a", "Use Global")}</Button>
-                ) : null}
-              </div>
-              <RepoSettingsDraftInput
-                repoId={repo.id}
-                storeValue={repo.worktreeBasePath ?? ''}
-                placeholder={settings?.workspaceDir ?? ''}
-                onTextChange={(text) =>
-                  updateRepo(repo.id, { worktreeBasePath: text.trim() ? text : undefined })
-                }
-                className="h-9 text-sm"
-              />
-              <p className="text-xs text-muted-foreground">
-                {translate("auto.components.settings.RepositoryPane.15a99d9b9f", "Relative paths resolve from this project root.")}</p>
-            </SearchableSetting>
+            />
           </>
         ) : null}
       </section>
@@ -398,4 +364,118 @@ export function RepositoryPane({
       ))}
     </div>
   )
+}
+
+function WorktreeFolderSetting({
+  repo,
+  updateRepo,
+  forceVisible
+}: {
+  repo: Repo
+  updateRepo: (repoId: string, updates: RepositoryPaneRepoUpdate) => void | Promise<boolean>
+  forceVisible: boolean
+}): React.JSX.Element {
+  const activeRuntimeEnvironmentId = useAppStore(
+    (state) => state.settings?.activeRuntimeEnvironmentId ?? null
+  )
+  const [draftPath, setDraftPath] = useState(repo.worktreeFolderPath ?? '')
+  const [saving, setSaving] = useState(false)
+  const canBrowse = canBrowseProjectWorktreeFolder(repo, activeRuntimeEnvironmentId)
+
+  useEffect(() => {
+    setDraftPath(repo.worktreeFolderPath ?? '')
+  }, [repo.id, repo.worktreeFolderPath])
+
+  const commitDraft = useCallback(
+    async (nextPath = draftPath): Promise<void> => {
+      const trimmed = nextPath.trim()
+      if (trimmed === (repo.worktreeFolderPath ?? '')) {
+        setDraftPath(repo.worktreeFolderPath ?? '')
+        return
+      }
+      setSaving(true)
+      try {
+        const result = await updateRepo(repo.id, { worktreeFolderPath: trimmed })
+        if (result === false) {
+          setDraftPath(repo.worktreeFolderPath ?? '')
+          return
+        }
+        setDraftPath(trimmed)
+      } finally {
+        setSaving(false)
+      }
+    },
+    [draftPath, repo.id, repo.worktreeFolderPath, updateRepo]
+  )
+
+  const handleBrowse = async (): Promise<void> => {
+    const path = await window.api.repos.pickDirectory()
+    if (!path) {
+      return
+    }
+    setDraftPath(path)
+    await commitDraft(path)
+  }
+
+  return (
+    <SearchableSetting
+      title={translate("auto.components.settings.RepositoryPane.5589fbfb88", "Worktree Folder")}
+      description={translate("auto.components.settings.RepositoryPane.e5fac1d80b", "Optional folder for new worktrees from this project.")}
+      keywords={[
+        repo.displayName,
+        repo.path,
+        'worktree folder',
+        'workspace folder',
+        'worktree path',
+        'workspace path',
+        'directory',
+        'relative',
+        '../worktrees'
+      ]}
+      className="space-y-2"
+      forceVisible={forceVisible}
+    >
+      <div className="space-y-1">
+        <Label className="text-sm font-semibold">{translate("auto.components.settings.RepositoryPane.5589fbfb88", "Worktree Folder")}</Label>
+        <p className="text-xs text-muted-foreground">
+          {translate("auto.components.settings.RepositoryPane.f003e028b2", "Blank inherits the global workspace folder for local projects, including WSL defaults, or the repo sibling folder for SSH projects.")}
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={draftPath}
+          onChange={(event) => setDraftPath(event.target.value)}
+          onBlur={() => void commitDraft()}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              void commitDraft()
+            }
+          }}
+          placeholder={translate("auto.components.settings.RepositoryPane.66fa6a5d6f", "Inherit default")}
+          className="h-9 text-sm"
+        />
+        {canBrowse ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => void handleBrowse()}
+            disabled={saving}
+          >
+            <FolderOpen className="size-4" />
+            {translate("auto.components.settings.RepositoryPane.5027858f1e", "Browse")}
+          </Button>
+        ) : null}
+      </div>
+    </SearchableSetting>
+  )
+}
+
+export function canBrowseProjectWorktreeFolder(
+  repo: Repo,
+  activeRuntimeEnvironmentId: string | null | undefined
+): boolean {
+  return !repo.connectionId && !activeRuntimeEnvironmentId?.trim()
 }

--- a/src/renderer/src/components/settings/repository-git-worktree-search-entries.ts
+++ b/src/renderer/src/components/settings/repository-git-worktree-search-entries.ts
@@ -26,14 +26,23 @@ export function getRepositoryGitWorktreeSearchEntries(repo: Repo): SettingsSearc
     {
       title: translate(
         'auto.components.settings.repository.search.443d127b5a',
-        'Worktree Location'
+        'Worktree Folder'
       ),
       description: translate(
         'auto.components.settings.repository.search.cd33a5525e',
-        'Project-specific directory for new worktrees.'
+        'Optional folder for new worktrees from this project.'
       ),
       keywords: [
         repo.displayName,
+        repo.path,
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.41405c7a7c',
+          'worktree folder'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.d0863b3a8e',
+          'workspace folder'
+        ),
         ...translateSearchKeyword(
           'auto.components.settings.repository.search.f3e6dee5fe',
           'worktree path'

--- a/src/renderer/src/store/slices/repos-worktree-folder.test.ts
+++ b/src/renderer/src/store/slices/repos-worktree-folder.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import { createTestStore } from './store-test-helpers'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+const remoteRepo: Repo = {
+  id: 'remote-repo',
+  path: '/remote',
+  displayName: 'Remote',
+  badgeColor: '#111',
+  addedAt: 2
+}
+
+const reposUpdate = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposUpdate.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: { update: reposUpdate },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('repo slice worktree folder updates', () => {
+  it('sends an explicit worktree folder clear through remote runtime updates', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-clear-worktree-folder',
+      ok: true,
+      result: { repo: { ...remoteRepo, worktreeFolderPath: undefined } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [{ ...remoteRepo, worktreeFolderPath: '/worktrees/remote' }]
+    })
+
+    await store.getState().updateRepo(remoteRepo.id, { worktreeFolderPath: undefined })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'repo.update',
+      params: { repo: remoteRepo.id, updates: { worktreeFolderPath: '' } },
+      timeoutMs: 15_000
+    })
+    expect(reposUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -36,6 +36,7 @@ type RepoUpdate = Partial<
     | 'hookSettings'
     | 'worktreeBaseRef'
     | 'worktreeBasePath'
+    | 'worktreeFolderPath'
     | 'kind'
     | 'symlinkPaths'
     | 'issueSourcePreference'
@@ -81,6 +82,9 @@ function sanitizeRepoUpdate(updates: RepoUpdate): RepoUpdate {
   }
   if ('worktreeBasePath' in sanitized && sanitized.worktreeBasePath !== undefined) {
     sanitized.worktreeBasePath = sanitized.worktreeBasePath.trim() || undefined
+  }
+  if ('worktreeFolderPath' in sanitized && sanitized.worktreeFolderPath === undefined) {
+    sanitized.worktreeFolderPath = ''
   }
   return sanitized
 }
@@ -285,9 +289,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       return result
     } catch (err) {
       console.error('Failed to import nested repos:', err)
-      toast.error(translate("auto.store.slices.repos.6d3318e813", "Failed to import repositories"), {
-        description: err instanceof Error ? err.message : String(err)
-      })
+      toast.error(
+        translate('auto.store.slices.repos.6d3318e813', 'Failed to import repositories'),
+        {
+          description: err instanceof Error ? err.message : String(err)
+        }
+      )
       return null
     }
   },
@@ -453,18 +460,25 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         return { repos: [...s.repos, repo] }
       })
       if (alreadyAdded) {
-        toast.info(translate("auto.store.slices.repos.a8e4b3af5b", "Project already added"), { description: repo.displayName })
-      } else {
-        toast.success(isGitRepoKind(repo) ? translate("auto.store.slices.repos.8bb3ad7935", "Project added") : translate("auto.store.slices.repos.90d129b48b", "Folder added"), {
+        toast.info(translate('auto.store.slices.repos.a8e4b3af5b', 'Project already added'), {
           description: repo.displayName
         })
+      } else {
+        toast.success(
+          isGitRepoKind(repo)
+            ? translate('auto.store.slices.repos.8bb3ad7935', 'Project added')
+            : translate('auto.store.slices.repos.90d129b48b', 'Folder added'),
+          {
+            description: repo.displayName
+          }
+        )
       }
       return repo
     } catch (err) {
       console.error('Failed to add project:', err)
       const message = err instanceof Error ? err.message : String(err)
       const duration = ERROR_TOAST_DURATION
-      toast.error(translate("auto.store.slices.repos.c6e022ddfc", "Failed to add project"), {
+      toast.error(translate('auto.store.slices.repos.c6e022ddfc', 'Failed to add project'), {
         description: message,
         duration
       })
@@ -477,7 +491,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     if (target.kind !== 'local') {
       // Why: OS folder pickers return client-local paths. Remote environments
       // need an explicit server path, which the Add Project dialog handles.
-      toast.error(translate("auto.store.slices.repos.e649269645", "Use a server path to add projects from a remote runtime."))
+      toast.error(
+        translate(
+          'auto.store.slices.repos.e649269645',
+          'Use a server path to add projects from a remote runtime.'
+        )
+      )
       return null
     }
     const path = await window.api.repos.pickFolder()
@@ -523,7 +542,10 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     } catch (err) {
       console.error('Failed to add folder:', err)
       const message = err instanceof Error ? err.message : String(err)
-      toast.error(translate("auto.store.slices.repos.b7e14472ae", "Failed to add folder"), { description: message, duration: ERROR_TOAST_DURATION })
+      toast.error(translate('auto.store.slices.repos.b7e14472ae', 'Failed to add folder'), {
+        description: message,
+        duration: ERROR_TOAST_DURATION
+      })
       return null
     }
   },
@@ -682,18 +704,26 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             if (updatedRepo) {
               return updatedRepo
             }
-            if (sanitizedUpdates.sourceControlAi === null) {
-              const { sourceControlAi: _sourceControlAi, ...repoWithoutSourceControlAi } = r
-              const { sourceControlAi: _clearedSourceControlAi, ...updatesWithoutSourceControlAi } =
-                sanitizedUpdates
-              return { ...repoWithoutSourceControlAi, ...updatesWithoutSourceControlAi }
+            const {
+              sourceControlAi: nextSourceControlAi,
+              worktreeFolderPath: nextWorktreeFolderPath,
+              ...otherUpdates
+            } = sanitizedUpdates
+            let nextRepo: Repo = { ...r, ...otherUpdates }
+            if (nextSourceControlAi === null) {
+              const { sourceControlAi: _sourceControlAi, ...repoWithoutSourceControlAi } = nextRepo
+              nextRepo = repoWithoutSourceControlAi
+            } else if (nextSourceControlAi !== undefined) {
+              nextRepo = { ...nextRepo, sourceControlAi: nextSourceControlAi }
             }
-            const { sourceControlAi, ...updatesWithoutSourceControlAi } = sanitizedUpdates
-            return {
-              ...r,
-              ...updatesWithoutSourceControlAi,
-              ...(sourceControlAi !== undefined ? { sourceControlAi } : {})
+            if (nextWorktreeFolderPath === '') {
+              const { worktreeFolderPath: _worktreeFolderPath, ...repoWithoutWorktreeFolderPath } =
+                nextRepo
+              nextRepo = repoWithoutWorktreeFolderPath
+            } else if (nextWorktreeFolderPath !== undefined) {
+              nextRepo = { ...nextRepo, worktreeFolderPath: nextWorktreeFolderPath }
             }
+            return nextRepo
           })
         }))
         return true

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -99,6 +99,8 @@ export type Repo = {
   worktreeBaseRef?: string
   /** Optional repo-scoped workspace root override. Relative paths resolve from `path`. */
   worktreeBasePath?: string
+  /** Optional absolute folder where new Git worktrees for this repo are created. */
+  worktreeFolderPath?: string
   hookSettings?: RepoHookSettings
   /** SSH target ID for remote repos. null/undefined = local. */
   connectionId?: string | null

--- a/src/shared/worktree-ownership-project-folders.test.ts
+++ b/src/shared/worktree-ownership-project-folders.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings, Repo, Worktree, WorktreeMeta } from './types'
+import {
+  buildKnownOrcaWorkspaceLayouts,
+  classifyWorktreeOwnership,
+  EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT
+} from './worktree-ownership'
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repos/app',
+    displayName: 'app',
+    badgeColor: '#000',
+    addedAt: EXTERNAL_WORKTREE_VISIBILITY_ROLLOUT_AT + 1,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
+  return {
+    workspaceDir: '/orca/workspaces',
+    nestWorkspaces: true,
+    workspaceDirHistory: [],
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: '',
+    enableGitHubAttribution: false,
+    ...overrides
+  } as GlobalSettings
+}
+
+function makeWorktree(overrides: Partial<Worktree>): Worktree {
+  return {
+    id: `repo-1::${overrides.path}`,
+    repoId: 'repo-1',
+    path: '/repos/app',
+    head: 'abc',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'main',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    workspaceStatus: 'todo',
+    ...overrides
+  }
+}
+
+function makeMeta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: '',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    workspaceStatus: 'todo',
+    ...overrides
+  }
+}
+
+describe('worktree ownership project folder overrides', () => {
+  it('adds local project folder overrides as flat known roots', () => {
+    const repo = makeRepo({ worktreeFolderPath: '/project-worktrees' })
+    const settings = makeSettings()
+    const layouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
+
+    expect(layouts).toContainEqual({ path: '/project-worktrees', nestWorkspaces: false })
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree({ path: '/project-worktrees/existing-external' }),
+        knownOrcaLayouts: layouts
+      })
+    ).toBe('unknown-legacy')
+    expect(
+      classifyWorktreeOwnership({
+        repo,
+        settings,
+        worktree: makeWorktree({ path: '/project-worktrees/new-managed' }),
+        meta: makeMeta({ orcaCreatedAt: 1 }),
+        knownOrcaLayouts: layouts
+      })
+    ).toBe('orca-managed')
+  })
+
+  it('does not add SSH project folder overrides to local ownership layouts', () => {
+    const layouts = buildKnownOrcaWorkspaceLayouts(
+      makeSettings(),
+      makeRepo({ connectionId: 'ssh-1', worktreeFolderPath: '/remote/worktrees' })
+    )
+
+    expect(layouts).not.toContainEqual({ path: '/remote/worktrees', nestWorkspaces: false })
+  })
+})

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -8,6 +8,7 @@ import {
   resolveRuntimePath
 } from './cross-platform-path'
 import { parseWslUncPath } from './wsl-paths'
+import { isFolderRepo } from './repo-kind'
 import type {
   DetectedWorktree,
   ExternalWorktreeVisibility,
@@ -46,7 +47,7 @@ export function effectiveExternalWorktreeVisibility(
 
 export function buildKnownOrcaWorkspaceLayouts(
   settings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces' | 'workspaceDirHistory'>,
-  repo?: Pick<Repo, 'path' | 'connectionId' | 'worktreeBasePath'>
+  repo?: Pick<Repo, 'path' | 'connectionId' | 'kind' | 'worktreeBasePath' | 'worktreeFolderPath'>
 ): OrcaWorkspaceLayout[] {
   const layouts: OrcaWorkspaceLayout[] = []
   const repoBasePath = getRepoWorktreeBasePath(repo)
@@ -72,6 +73,9 @@ export function buildKnownOrcaWorkspaceLayouts(
           path: repo ? resolveWorkspaceLayoutPath(repo.path, layout.path) : layout.path
         }))
     )
+  }
+  if (repo && !repo.connectionId && !isFolderRepo(repo) && repo.worktreeFolderPath) {
+    layouts.push({ path: repo.worktreeFolderPath, nestWorkspaces: false })
   }
 
   const wslLayouts = repo ? buildWslWorkspaceLayouts(repo.path, settings) : []


### PR DESCRIPTION
## Summary

- adds a per-project `worktreeFolderPath` setting for Git projects, including persistence, renderer/store updates, local IPC, runtime RPC, and preload typing
- routes local desktop, runtime local, and SSH worktree creation through effective worktree layouts while preserving existing default behavior and collision semantics
- updates ownership/filesystem authorization, Project Settings UI/search, and focused regression coverage for local, WSL, Windows/UNC-shaped, SSH-path, and explicit-clear behavior
- includes reviewed design notes in `docs/per-project-worktree-folders.md`

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/repo-worktree-folder-path.test.ts src/main/ipc/worktree-logic.test.ts src/main/ipc/worktree-logic-wsl.test.ts src/main/persistence.test.ts src/main/runtime/rpc/methods/repo.test.ts src/main/runtime/rpc/methods/repo-worktree-folder.test.ts src/shared/worktree-ownership.test.ts src/shared/worktree-ownership-project-folders.test.ts src/main/ipc/filesystem-auth.test.ts src/renderer/src/store/slices/repos.test.ts src/renderer/src/store/slices/repos-worktree-folder.test.ts src/renderer/src/components/settings/RepositoryPane.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts` passed: 14 files, 603 tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktree-logic.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts` passed after the macOS canonical-path fix: 3 files, 368 tests
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- Electron validation rerun passed with an isolated temp Git repo: visible Worktree Folder setting persisted/cleared, visible Create Worktree created under the project-specific folder, the global folder stayed empty, and folder-mode settings hid the field. Local report: `validation-screenshots/worktree-folder-validation-rerun-report.md` (ignored, not committed).

## Gaps

- SSH and remote-runtime flows were covered by unit/integration tests but not manually exercised in Electron.
- WSL path handling was covered by tests but not manually exercised in Electron.

Risk: high

Risk assessment: High. This adds a new per-project worktree-folder contract across persistence, renderer/store, local IPC, runtime RPC, filesystem authorization, worktree creation, and SSH-path handling; SSH and WSL are covered by tests but not manually exercised.