### PR TITLE
perf: narrow terminal repo subscription

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -89,6 +89,7 @@ import {
   subscribeTerminalPaneAttention
 } from './terminal-pane-attention-subscriptions'
 import { getCachedTerminalTabForWorktree } from './terminal-tab-lookup'
+import { useRepoById } from '@/store/selectors'
 
 type TerminalPaneProps = {
   tabId: string
@@ -104,6 +105,31 @@ type TerminalPaneProps = {
   isolatedPaneKey?: string | null
   onPtyExit: (ptyId: string) => void
   onCloseTab: () => void
+}
+
+type TerminalQuickCommandEditorDialogProps = {
+  command: TerminalQuickCommand
+  onOpenChange: (open: boolean) => void
+  onSave: (command: TerminalQuickCommand) => void
+}
+
+function TerminalQuickCommandEditorDialog({
+  command,
+  onOpenChange,
+  onSave
+}: TerminalQuickCommandEditorDialogProps): React.JSX.Element {
+  const repos = useAppStore((store) => store.repos)
+
+  return (
+    <TerminalQuickCommandDialog
+      open
+      mode="add"
+      command={command}
+      repos={repos}
+      onOpenChange={onOpenChange}
+      onSave={onSave}
+    />
+  )
 }
 
 function formatClipboardImagePasteError(error: unknown): string {
@@ -359,7 +385,6 @@ export default function TerminalPane({
   const openSpacePage = useAppStore((store) => store.openSpacePage)
   const refreshWorkspaceSpace = useAppStore((store) => store.refreshWorkspaceSpace)
   const settings = useAppStore((store) => store.settings)
-  const repos = useAppStore((store) => store.repos)
   const updateSettings = useAppStore((store) => store.updateSettings)
   const keybindings = useAppStore((store) => store.keybindings)
   // Why: Windows is the only platform where bare right-click is repurposed as
@@ -393,7 +418,7 @@ export default function TerminalPane({
 
   const quickCommandRepoId =
     worktreeId === FLOATING_TERMINAL_WORKTREE_ID ? null : getRepoIdFromWorktreeId(worktreeId)
-  const quickCommandRepo = repos.find((repo) => repo.id === quickCommandRepoId) ?? null
+  const quickCommandRepo = useRepoById(quickCommandRepoId)
   const quickCommandRepoLabel = quickCommandRepo
     ? quickCommandRepo.displayName || quickCommandRepo.path
     : quickCommandRepoId
@@ -1764,14 +1789,14 @@ export default function TerminalPane({
         onSetTitle={contextMenu.onSetTitle}
         onCopyPaneId={contextMenu.onCopyPaneId}
       />
-      <TerminalQuickCommandDialog
-        open={quickCommandEditorOpen}
-        mode="add"
-        command={quickCommandDraft}
-        repos={repos}
-        onOpenChange={setQuickCommandEditorOpen}
-        onSave={saveQuickCommand}
-      />
+      {/* Why: repos is a broad store slice; only subscribe while the editor is visible. */}
+      {quickCommandEditorOpen ? (
+        <TerminalQuickCommandEditorDialog
+          command={quickCommandDraft}
+          onOpenChange={setQuickCommandEditorOpen}
+          onSave={saveQuickCommand}
+        />
+      ) : null}
       {/* Title bar overlays — portaled into each pane container that has a title
           or is currently being renamed (so the inline input appears even for
           untitled panes when "Set Title..." is triggered).


### PR DESCRIPTION
## Summary
- replace TerminalPane's full repos subscription with a repo-by-id selector for quick-command context labels
- mount the repo-list-backed quick-command editor only while it is visible

## Verification
- pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalPane.tsx
- git diff --check
- pnpm run typecheck:web

Per request: not waiting for CI before merge.