### PR TITLE
perf: cache terminal unified group lookup

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -89,6 +89,7 @@ import {
   subscribeTerminalPaneAttention
 } from './terminal-pane-attention-subscriptions'
 import { getCachedTerminalTabForWorktree } from './terminal-tab-lookup'
+import { getCachedTerminalGroupIdForWorktree } from './terminal-unified-tab-lookup'
 import { useRepoById } from '@/store/selectors'
 
 type TerminalPaneProps = {
@@ -437,9 +438,7 @@ export default function TerminalPane({
   const quickCommandGroupId =
     useAppStore(
       (s) =>
-        s.unifiedTabsByWorktree[worktreeId]?.find(
-          (tab) => tab.entityId === tabId && tab.contentType === 'terminal'
-        )?.groupId ??
+        getCachedTerminalGroupIdForWorktree(s.unifiedTabsByWorktree, worktreeId, tabId) ??
         s.activeGroupIdByWorktree[worktreeId] ??
         null
     ) ?? null

--- a/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Tab } from '../../../../shared/types'
+import { getCachedTerminalGroupIdForWorktree } from './terminal-unified-tab-lookup'
+
+function makeTerminalTab(entityId: string, groupId: string): Tab {
+  return {
+    id: entityId,
+    entityId,
+    groupId,
+    worktreeId: 'wt-1',
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeEditorTab(id: string): Tab {
+  return {
+    id,
+    entityId: id,
+    groupId: 'group-editor',
+    worktreeId: 'wt-1',
+    contentType: 'editor',
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function iterableTabs(tabs: Tab[]): {
+  value: Tab[]
+  iterator: ReturnType<typeof vi.fn>
+} {
+  const iterator = vi.fn(function* () {
+    yield* tabs
+  })
+  return {
+    value: { [Symbol.iterator]: iterator } as unknown as Tab[],
+    iterator
+  }
+}
+
+describe('getCachedTerminalGroupIdForWorktree', () => {
+  it('reuses the terminal group lookup while the unified tab array is unchanged', () => {
+    const tabs = [
+      makeEditorTab('editor-1'),
+      ...Array.from({ length: 200 }, (_, index) =>
+        makeTerminalTab(`terminal-${index}`, `group-${index % 4}`)
+      )
+    ]
+    const { value, iterator } = iterableTabs(tabs)
+    const unifiedTabsByWorktree = { 'wt-1': value }
+
+    expect(getCachedTerminalGroupIdForWorktree(unifiedTabsByWorktree, 'wt-1', 'terminal-199')).toBe(
+      'group-3'
+    )
+    expect(getCachedTerminalGroupIdForWorktree(unifiedTabsByWorktree, 'wt-1', 'terminal-0')).toBe(
+      'group-0'
+    )
+    expect(
+      getCachedTerminalGroupIdForWorktree(unifiedTabsByWorktree, 'wt-1', 'editor-1')
+    ).toBeNull()
+
+    expect(iterator).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds the lookup when the unified tab array reference changes', () => {
+    const first = iterableTabs([makeTerminalTab('terminal-1', 'group-a')])
+    const second = iterableTabs([makeTerminalTab('terminal-1', 'group-b')])
+
+    expect(getCachedTerminalGroupIdForWorktree({ 'wt-1': first.value }, 'wt-1', 'terminal-1')).toBe(
+      'group-a'
+    )
+    expect(
+      getCachedTerminalGroupIdForWorktree({ 'wt-1': second.value }, 'wt-1', 'terminal-1')
+    ).toBe('group-b')
+
+    expect(first.iterator).toHaveBeenCalledTimes(1)
+    expect(second.iterator).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts
@@ -1,0 +1,29 @@
+import type { Tab } from '../../../../shared/types'
+
+const terminalGroupLookupByUnifiedTabs = new WeakMap<readonly Tab[], Map<string, string>>()
+
+export function getCachedTerminalGroupIdForWorktree(
+  unifiedTabsByWorktree: Record<string, Tab[]>,
+  worktreeId: string,
+  terminalTabId: string
+): string | null {
+  const unifiedTabs = unifiedTabsByWorktree[worktreeId]
+  if (!unifiedTabs) {
+    return null
+  }
+
+  let lookup = terminalGroupLookupByUnifiedTabs.get(unifiedTabs)
+  if (!lookup) {
+    // Why: every mounted TerminalPane asks for its owning group on store updates.
+    // Cache by immutable tab-array ref so 200 panes do not repeat the same scan.
+    lookup = new Map()
+    for (const tab of unifiedTabs) {
+      if (tab.contentType === 'terminal') {
+        lookup.set(tab.entityId, tab.groupId)
+      }
+    }
+    terminalGroupLookupByUnifiedTabs.set(unifiedTabs, lookup)
+  }
+
+  return lookup.get(terminalTabId) ?? null
+}


### PR DESCRIPTION
## Summary
- cache terminal tab-to-group lookups by immutable unified tab array reference
- use the cached lookup in TerminalPane's quick-command group selector
- add regression coverage proving repeated lookups scan a 200-terminal array once and rebuild on array replacement

## Verification
- pnpm exec vitest run src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
- pnpm exec vitest run src/renderer/src/components/terminal-pane/terminal-tab-lookup.test.ts src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
- pnpm exec oxlint src/renderer/src/components/terminal-pane/TerminalPane.tsx src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.ts src/renderer/src/components/terminal-pane/terminal-unified-tab-lookup.test.ts
- git diff --check
- pnpm run typecheck:web

Per request: not waiting for CI before merge.