### PR TITLE
perf: defer terminal menu pane lookups

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -272,8 +272,11 @@ export function useTerminalPaneContextMenu({
     setOpen(true)
   }
 
-  const paneCount = managerRef.current?.getPanes().length ?? 1
-  const menuPaneId = resolveMenuPane()?.id ?? null
+  // Why: PaneManager.getPanes() allocates public pane wrappers. Closed menus
+  // do not need pane counts or target identity, so avoid that work on every
+  // render across hundreds of mounted terminal tabs.
+  const paneCount = open ? (managerRef.current?.getPanes().length ?? 1) : 1
+  const menuPaneId = open ? (resolveMenuPane()?.id ?? null) : null
 
   return {
     open,


### PR DESCRIPTION
## Summary
- avoid calling PaneManager.getPanes() for closed terminal context menus
- keep pane counts and menu target identity accurate when the menu is actually open

## Verification
- pnpm exec oxlint src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
- git diff --check origin/main..HEAD
- pnpm run typecheck:web

Per request: not waiting for CI before merge.