### PR TITLE
perf: cache pty spawn repo lookups

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/agent-status'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
+import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import type { PtyConnectResult } from './pty-transport'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
@@ -1013,9 +1014,8 @@ export function connectPanePty(
   // Why: remote repos route PTY spawn through the SSH provider. Resolve the
   // repo's connectionId from the store so the transport passes it to pty:spawn.
   const state = useAppStore.getState()
-  const allWorktrees = Object.values(state.worktreesByRepo ?? {}).flat()
-  const worktree = allWorktrees.find((w) => w.id === deps.worktreeId)
-  const repo = worktree ? state.repos?.find((r) => r.id === worktree.repoId) : null
+  const worktree = getWorktreeMapFromState(state).get(deps.worktreeId)
+  const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
   const connectionId = repo?.connectionId ?? null
   const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find((t) => t.id === deps.tabId)
   const shellOverride = tab?.shellOverride


### PR DESCRIPTION
## Summary
- replace per-pane PTY spawn worktree/repo array scans with cached store maps
- keep SSH connectionId and Windows PTY suppression behavior unchanged

## Verification
- pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts
- git diff --check
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "startup command"
- pnpm run typecheck:web

Per request: not waiting for CI before merge.