### PR TITLE
Paste prompts when agent readiness signal is missed

### DIFF
--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -1470,14 +1470,16 @@ export default function ChecksPanel(): React.JSX.Element {
         worktreeId: activeWorktreeId,
         prompt,
         promptDelivery: 'submit-after-ready',
-        launchSource: 'task_page'
+        launchSource: 'task_page',
+        onPromptDelivered: () => {
+          toast.success('Started an AI agent for the broken checks.')
+        }
       })
       if (!result) {
         toast.error('Could not build the agent launch command.')
         return
       }
       focusTerminalTabSurface(result.tabId)
-      toast.success('Started an AI agent for the broken checks.')
     } finally {
       setIsFixingChecksWithAI(false)
     }

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -4,13 +4,16 @@ import { pasteDraftWhenAgentReady, sendBracketedPasteToRunningAgent } from './ag
 const testState = vi.hoisted(() => ({
   appState: {
     settings: {},
-    ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    runtimePaneTitlesByTabId: {},
+    tabsByWorktree: {}
   },
   ptyObserver: null as ((data: string) => void) | null,
   unsubscribe: vi.fn(),
   subscribeToPtyData: vi.fn(),
   isRemoteRuntimePtyId: vi.fn(),
   sendRuntimePtyInputVerified: vi.fn(),
+  inspectRuntimeTerminalProcess: vi.fn(),
   subscribeToRuntimeTerminalData: vi.fn()
 }))
 
@@ -26,7 +29,8 @@ vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
 
 vi.mock('@/runtime/runtime-terminal-inspection', () => ({
   isRemoteRuntimePtyId: testState.isRemoteRuntimePtyId,
-  sendRuntimePtyInputVerified: testState.sendRuntimePtyInputVerified
+  sendRuntimePtyInputVerified: testState.sendRuntimePtyInputVerified,
+  inspectRuntimeTerminalProcess: testState.inspectRuntimeTerminalProcess
 }))
 
 vi.mock('@/runtime/runtime-terminal-stream', () => ({
@@ -47,6 +51,8 @@ describe('pasteDraftWhenAgentReady', () => {
     })
     testState.appState.settings = {}
     testState.appState.ptyIdsByTabId = { 'tab-1': ['pty-1'] }
+    testState.appState.runtimePaneTitlesByTabId = {}
+    testState.appState.tabsByWorktree = {}
     testState.ptyObserver = null
     testState.unsubscribe.mockReset()
     testState.subscribeToPtyData.mockReset()
@@ -60,6 +66,11 @@ describe('pasteDraftWhenAgentReady', () => {
     testState.isRemoteRuntimePtyId.mockReturnValue(false)
     testState.sendRuntimePtyInputVerified.mockReset()
     testState.sendRuntimePtyInputVerified.mockResolvedValue(true)
+    testState.inspectRuntimeTerminalProcess.mockReset()
+    testState.inspectRuntimeTerminalProcess.mockResolvedValue({
+      foregroundProcess: 'bash',
+      hasChildProcesses: false
+    })
     testState.subscribeToRuntimeTerminalData.mockReset()
   })
 
@@ -225,6 +236,29 @@ describe('pasteDraftWhenAgentReady', () => {
     testState.ptyObserver?.(`${DECSET_BRACKETED_PASTE}${CODEX_COMPOSER_PROMPT_RENDER}`)
 
     await expect(promise).resolves.toBe(false)
+  })
+
+  it('best-effort pastes when the ready escape was missed but the agent process is running', async () => {
+    testState.inspectRuntimeTerminalProcess.mockResolvedValue({
+      foregroundProcess: 'codex',
+      hasChildProcesses: false
+    })
+
+    const promise = pasteDraftWhenAgentReady({
+      tabId: 'tab-1',
+      content: ISSUE_URL,
+      agent: 'codex'
+    })
+    await flushMicrotasks()
+
+    await vi.advanceTimersByTimeAsync(8000)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
   })
 
   it('submits to an already running agent without waiting for readiness signals', async () => {

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -7,6 +7,7 @@ import {
   sendRuntimePtyInputVerified
 } from '@/runtime/runtime-terminal-inspection'
 import { subscribeToRuntimeTerminalData } from '@/runtime/runtime-terminal-stream'
+import { waitForAgentReady } from './agent-ready-wait'
 
 // Why: bracketed paste markers let modern TUIs (Claude Code / Codex / Pi /
 // OpenCode / Gemini / cursor-agent / copilot) treat the inserted text as a
@@ -91,8 +92,17 @@ export async function pasteDraftWhenAgentReady(args: {
 
   const ready = await waitForInputBoxReady(ptyId, budget, readySignal)
   if (!ready) {
-    onTimeout?.()
-    return false
+    // Why: fast-starting TUIs can emit the paste-ready escape sequence before
+    // this sidecar subscription attaches. If process/title inspection says the
+    // launched agent owns the PTY, fall back to a best-effort paste instead of
+    // silently dropping generated prompts.
+    const fallbackReady = agentConfig
+      ? await waitForAgentReady(tabId, agentConfig.expectedProcess, { timeoutMs: 1000 })
+      : { ready: false }
+    if (!fallbackReady.ready) {
+      onTimeout?.()
+      return false
+    }
   }
 
   return await sendBracketedPasteToAgent({

--- a/src/renderer/src/lib/agent-ready-wait.test.ts
+++ b/src/renderer/src/lib/agent-ready-wait.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/runtime/runtime-terminal-inspection', () => ({
   inspectRuntimeTerminalProcess: vi.fn()
 }))
 
-vi.mock('@/lib/tui-agent-startup', () => ({
+vi.mock('./tui-agent-startup', () => ({
   isShellProcess: vi.fn(() => false)
 }))
 

--- a/src/renderer/src/lib/agent-ready-wait.ts
+++ b/src/renderer/src/lib/agent-ready-wait.ts
@@ -1,6 +1,6 @@
 import { detectAgentStatusFromTitle } from '../../../shared/agent-detection'
 import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
-import { isShellProcess } from '@/lib/tui-agent-startup'
+import { isShellProcess } from './tui-agent-startup'
 import { useAppStore } from '@/store'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
 


### PR DESCRIPTION
## Summary
- Add a fallback path for agent prompt delivery when the paste-ready escape sequence is missed but terminal inspection shows the expected agent process is running.
- Move the checks-panel success toast to fire only after prompt delivery completes.
- Update tests for the missed-readiness fallback and local mock import paths.

## Testing
- Updated unit tests in `agent-paste-draft.test.ts` and `agent-ready-wait.test.ts`.