### PR TITLE
Update mobile 0.0.10 APK download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Control your agents from your phone.
 </p>
 
 - **iOS:** [Download from App Store](https://apps.apple.com/us/app/orca-ide/id6766130217)
-- **Android:** [Download from GH release](https://github.com/stablyai/orca/releases/tag/mobile-v0.0.10)
+- **Android:** [Download APK from GitHub Releases](https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk)
 
 ---
 

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -45,7 +45,7 @@ export const PLATFORM_COPY: Record<
   android: {
     description: 'Scan with your Android camera to download the latest APK from GitHub Releases.',
     ctaLabel: 'Download APK',
-    url: 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.10'
+    url: 'https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk'
   }
 }
 

--- a/src/renderer/src/components/settings/MobileSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileSettingsPane.tsx
@@ -11,7 +11,8 @@ import {
 export { MOBILE_SETTINGS_PANE_SEARCH_ENTRIES }
 
 const ORCA_IOS_APP_STORE_URL = 'https://apps.apple.com/app/orca-ide/id6766130217'
-const ORCA_ANDROID_RELEASE_URL = 'https://github.com/stablyai/orca/releases/tag/mobile-v0.0.10'
+const ORCA_ANDROID_APK_URL =
+  'https://github.com/stablyai/orca/releases/download/mobile-v0.0.10/app-release.apk'
 
 type MobileSettingsPaneProps = {
   settings: GlobalSettings
@@ -52,12 +53,11 @@ export function MobileSettingsPane({
                 <button
                   type="button"
                   // Why: Android is moving to Google Play soon, but until then
-                  // link directly to the current mobile release tag instead of
-                  // the noisy desktop-dominated releases index.
-                  onClick={() => void window.api.shell.openUrl(ORCA_ANDROID_RELEASE_URL)}
+                  // link directly to the pinned APK asset for the current mobile release.
+                  onClick={() => void window.api.shell.openUrl(ORCA_ANDROID_APK_URL)}
                   className="cursor-pointer underline underline-offset-2 hover:text-foreground"
                 >
-                  GitHub Releases page
+                  GitHub Releases
                 </button>
                 .
               </p>


### PR DESCRIPTION
## Summary
- Point README Android mobile download at the verified mobile-v0.0.10 APK asset
- Point in-app mobile Android download actions at the same APK asset

## Release verification
- Latest published mobile release: mobile-v0.0.10
- APK asset verified: app-release.apk

## Verification
- pnpm typecheck
- pnpm exec oxlint src/renderer/src/components/settings/MobileSettingsPane.tsx src/renderer/src/components/mobile/MobilePage.tsx

## Notes
- pnpm lint is blocked in this dirty worktree by unrelated untracked gbrain-demo/.oxlintrc.json
- pnpm run lint:switch-exhaustiveness crashed inside tsgolint while parsing dependency declarations