### PR TITLE
Fix runtime and computer-use bugs

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -252,8 +252,8 @@ final class Provider {
 
     private func currentKeyboardSnapshot(params: [String: JSONValue]) throws -> Snapshot {
         let snapshot = try currentSnapshot(params: params.merging(["noScreenshot": .bool(true)]) { _, replacement in replacement })
-        if params["restoreWindow"]?.bool != true && !isTargetWindowFocused(snapshot) {
-            throw ProviderError.coded("window_not_focused", "keyboard input requires the target \(snapshot.app.name) window to be focused; retry with --restore-window or use set-value for editable elements")
+        if params["restoreWindow"]?.bool != true {
+            try requireTargetWindowFocused(snapshot)
         }
         return snapshot
     }
@@ -646,12 +646,14 @@ final class Provider {
 
     private func typeText(params: [String: JSONValue]) throws -> [String: Any] {
         let snapshot = try currentKeyboardSnapshot(params: params)
+        try requireTargetWindowFocused(snapshot)
         try Input.typeText(try requiredString(params, "text"), pid: snapshot.app.pid)
         return actionMetadata(path: "synthetic")
     }
 
     private func pressKey(params: [String: JSONValue]) throws -> [String: Any] {
         let snapshot = try currentKeyboardSnapshot(params: params)
+        try requireTargetWindowFocused(snapshot)
         try Input.pressKey(try requiredString(params, "key"), pid: snapshot.app.pid)
         return actionMetadata(path: "synthetic")
     }
@@ -666,6 +668,7 @@ final class Provider {
                 verification: TextInput.selectionVerification(focused.element)
             )
         }
+        try requireTargetWindowFocused(snapshot)
         try Input.pressKey(key, pid: snapshot.app.pid)
         return actionMetadata(
             path: "synthetic",
@@ -680,6 +683,7 @@ final class Provider {
         if let focused = focusedRecord(snapshot), let verification = TextInput.replaceSelection(focused.element, with: text) {
             return actionMetadata(path: "accessibility", actionName: "AXReplaceSelection", verification: verification)
         }
+        try requireTargetWindowFocused(snapshot)
         try Input.pasteText(text, pid: snapshot.app.pid)
         return actionMetadata(
             path: "clipboard",
@@ -914,6 +918,12 @@ private func isTargetWindowFocused(_ snapshot: Snapshot) -> Bool {
     }
     let intersection = frame.intersection(snapshot.windowBounds)
     return !intersection.isNull && intersection.area >= min(frame.area, snapshot.windowBounds.area) * 0.75
+}
+
+private func requireTargetWindowFocused(_ snapshot: Snapshot) throws {
+    guard KeyboardInputSafety.allowsSyntheticInput(targetWindowFocused: isTargetWindowFocused(snapshot)) else {
+        throw ProviderError.coded("window_not_focused", "keyboard input requires the target \(snapshot.app.name) window to be focused; retry with --restore-window or use set-value for editable elements")
+    }
 }
 
 private func matchingWindow(appElement: AXUIElement, capture: WindowCapture, focused: AXUIElement, explicitTarget: Bool) -> AXUIElement? {
@@ -3000,11 +3010,11 @@ private final class SocketListener: @unchecked Sendable {
             close(socketFd)
             socketFd = -1
         }
-        unlink(socketPath)
+        // Why: the parent owns the private temp directory cleanup; the helper
+        // must not unlink arbitrary caller-supplied paths on shutdown.
     }
 
     private func bindSocket() throws {
-        unlink(socketPath)
         socketFd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard socketFd >= 0 else {
             throw ProviderError.coded("accessibility_error", "failed to create computer-use socket")
@@ -3028,9 +3038,16 @@ private final class SocketListener: @unchecked Sendable {
             }
         }
         guard result == 0 else {
-            let message = String(cString: strerror(errno))
+            let bindErrno = errno
+            let message = String(cString: strerror(bindErrno))
             close(socketFd)
             socketFd = -1
+            if UnixSocketPathSafety.shouldRejectExistingPathAfterBindFailure(
+                bindErrno: bindErrno,
+                existingMode: existingPathMode(socketPath)
+            ) {
+                throw ProviderError.coded("invalid_argument", "refusing to replace non-socket file at computer-use socket path")
+            }
             throw ProviderError.coded("accessibility_error", "failed to bind computer-use socket: \(message)")
         }
         chmod(socketPath, 0o600)
@@ -3078,6 +3095,14 @@ private final class SocketListener: @unchecked Sendable {
             writeJSON(response, to: fd)
         }
     }
+}
+
+private func existingPathMode(_ path: String) -> mode_t? {
+    var statInfo = stat()
+    guard lstat(path, &statInfo) == 0 else {
+        return nil
+    }
+    return statInfo.st_mode
 }
 
 private func peerProcessId(_ fd: Int32) -> pid_t? {
@@ -3290,7 +3315,6 @@ if arguments.first == "--agent" {
         let valueIndex = index + 1
         guard valueIndex < arguments.count else { return nil }
         let tokenPath = arguments[valueIndex]
-        defer { unlink(tokenPath) }
         return try? String(contentsOfFile: tokenPath, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/KeyboardInputSafety.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/KeyboardInputSafety.swift
@@ -1,0 +1,5 @@
+public enum KeyboardInputSafety {
+    public static func allowsSyntheticInput(targetWindowFocused: Bool) -> Bool {
+        targetWindowFocused
+    }
+}

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/UnixSocketPathSafety.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/UnixSocketPathSafety.swift
@@ -1,0 +1,14 @@
+import Darwin
+
+public enum UnixSocketPathSafety {
+    public static func isSocketMode(_ mode: mode_t) -> Bool {
+        (mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK)
+    }
+
+    public static func shouldRejectExistingPathAfterBindFailure(
+        bindErrno: Int32,
+        existingMode: mode_t?
+    ) -> Bool {
+        bindErrno == EADDRINUSE && existingMode.map { !isSocketMode($0) } == true
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+final class AgentEntrypointSourceSafetyTests: XCTestCase {
+    func testAgentEntrypointDoesNotUnlinkCallerSuppliedPaths() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let packageRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let mainPath = packageRoot
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("OrcaComputerUseMacOS")
+            .appendingPathComponent("main.swift")
+        let source = try String(contentsOf: mainPath, encoding: .utf8)
+
+        // Why: --agent accepts caller-supplied paths; deleting them in the
+        // helper can remove user files if argument validation is bypassed.
+        XCTAssertFalse(source.contains("unlink(tokenPath)"))
+        XCTAssertFalse(source.contains("unlink(socketPath)"))
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/KeyboardInputSafetyTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/KeyboardInputSafetyTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import OrcaComputerUseMacOSCore
+
+final class KeyboardInputSafetyTests: XCTestCase {
+    func testSyntheticInputRequiresFocusedTargetWindow() {
+        XCTAssertTrue(KeyboardInputSafety.allowsSyntheticInput(targetWindowFocused: true))
+        XCTAssertFalse(KeyboardInputSafety.allowsSyntheticInput(targetWindowFocused: false))
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/UnixSocketPathSafetyTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/UnixSocketPathSafetyTests.swift
@@ -1,0 +1,39 @@
+import Darwin
+import XCTest
+@testable import OrcaComputerUseMacOSCore
+
+final class UnixSocketPathSafetyTests: XCTestCase {
+    func testOnlyUnixSocketModesAreAccepted() {
+        XCTAssertTrue(UnixSocketPathSafety.isSocketMode(mode_t(S_IFSOCK | 0o600)))
+        XCTAssertFalse(UnixSocketPathSafety.isSocketMode(mode_t(S_IFREG | 0o600)))
+        XCTAssertFalse(UnixSocketPathSafety.isSocketMode(mode_t(S_IFDIR | 0o700)))
+        XCTAssertFalse(UnixSocketPathSafety.isSocketMode(mode_t(S_IFLNK | 0o777)))
+    }
+
+    func testRejectsOnlyNonSocketPathsAfterAddressInUseBindFailure() {
+        XCTAssertTrue(
+            UnixSocketPathSafety.shouldRejectExistingPathAfterBindFailure(
+                bindErrno: EADDRINUSE,
+                existingMode: mode_t(S_IFREG | 0o600)
+            )
+        )
+        XCTAssertFalse(
+            UnixSocketPathSafety.shouldRejectExistingPathAfterBindFailure(
+                bindErrno: EADDRINUSE,
+                existingMode: mode_t(S_IFSOCK | 0o600)
+            )
+        )
+        XCTAssertFalse(
+            UnixSocketPathSafety.shouldRejectExistingPathAfterBindFailure(
+                bindErrno: EACCES,
+                existingMode: mode_t(S_IFREG | 0o600)
+            )
+        )
+        XCTAssertFalse(
+            UnixSocketPathSafety.shouldRejectExistingPathAfterBindFailure(
+                bindErrno: EADDRINUSE,
+                existingMode: nil
+            )
+        )
+    }
+}

--- a/src/cli/runtime/launch.test.ts
+++ b/src/cli/runtime/launch.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events'
 import { resolve } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,7 +10,12 @@ vi.mock('child_process', () => ({
   spawn: spawnMock
 }))
 
-import { serveOrcaApp } from './launch'
+import { launchOrcaApp, serveOrcaApp } from './launch'
+
+class FakeChildProcess extends EventEmitter {
+  kill = vi.fn()
+  unref = vi.fn()
+}
 
 describe('serveOrcaApp', () => {
   beforeEach(() => {
@@ -145,5 +151,29 @@ describe('serveOrcaApp', () => {
         Object.defineProperty(process, 'platform', platformDescriptor)
       }
     }
+  })
+})
+
+describe('launchOrcaApp', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    delete process.env.ORCA_OPEN_COMMAND
+    delete process.env.ORCA_APP_EXECUTABLE
+    delete process.env.ORCA_APP_EXECUTABLE_NEEDS_APP_ROOT
+  })
+
+  it('handles asynchronous detached spawn errors without throwing', async () => {
+    process.env.ORCA_APP_EXECUTABLE = '/missing/Orca'
+    const child = new FakeChildProcess()
+    spawnMock.mockReturnValue(child)
+
+    launchOrcaApp()
+    child.emit('error', new Error('ENOENT'))
+    await Promise.resolve()
+
+    expect(child.unref).toHaveBeenCalled()
   })
 })

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -5,22 +5,16 @@ import { RuntimeClientError } from './types'
 export function launchOrcaApp(): void {
   const overrideCommand = process.env.ORCA_OPEN_COMMAND
   if (typeof overrideCommand === 'string' && overrideCommand.trim().length > 0) {
-    spawnProcess(overrideCommand, {
-      detached: true,
-      stdio: 'ignore',
-      shell: true
-    }).unref()
+    spawnDetached(overrideCommand, [], { shell: true })
     return
   }
 
   const overrideExecutable = process.env.ORCA_APP_EXECUTABLE
   if (typeof overrideExecutable === 'string' && overrideExecutable.trim().length > 0) {
-    spawnProcess(overrideExecutable, getExecutableAppArgs(), {
-      detached: true,
-      stdio: 'ignore',
+    spawnDetached(overrideExecutable, getExecutableAppArgs(), {
       ...getExecutableSpawnOptions(overrideExecutable),
       env: stripElectronRunAsNode(process.env)
-    }).unref()
+    })
     return
   }
 
@@ -31,20 +25,16 @@ export function launchOrcaApp(): void {
         // Why: launching the inner MacOS binary directly can trigger macOS app
         // launch failures and bypass normal bundle lifecycle. The public
         // packaged CLI should re-open the .app the same way Finder does.
-        spawnProcess('open', [appBundlePath], {
-          detached: true,
-          stdio: 'ignore',
+        spawnDetached('open', [appBundlePath], {
           env: stripElectronRunAsNode(process.env)
-        }).unref()
+        })
         return
       }
     }
 
-    spawnProcess(process.execPath, [], {
-      detached: true,
-      stdio: 'ignore',
+    spawnDetached(process.execPath, [], {
       env: stripElectronRunAsNode(process.env)
-    }).unref()
+    })
     return
   }
 
@@ -52,6 +42,18 @@ export function launchOrcaApp(): void {
     'runtime_open_failed',
     'Could not determine how to launch Orca. Start Orca manually and try again.'
   )
+}
+
+function spawnDetached(command: string, args: string[], options: SpawnOptions): void {
+  const child = spawnProcess(command, args, {
+    detached: true,
+    stdio: 'ignore',
+    ...options
+  })
+  // Why: detached launch errors are reported asynchronously after this function
+  // returns; openOrca already reports the user-facing timeout if startup fails.
+  child.once('error', () => {})
+  child.unref()
 }
 
 export function serveOrcaApp(

--- a/src/cli/runtime/status.test.ts
+++ b/src/cli/runtime/status.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, writeFileSync } from 'fs'
+import { createServer, type Socket } from 'net'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getRuntimeMetadataPath } from '../../shared/runtime-bootstrap'
+import { RuntimeClient } from './client'
+
+const servers = new Set<ReturnType<typeof createServer>>()
+const sockets = new Set<Socket>()
+
+afterEach(async () => {
+  for (const socket of sockets) {
+    socket.destroy()
+  }
+  sockets.clear()
+  await Promise.all(
+    [...servers].map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve())
+        })
+    )
+  )
+  servers.clear()
+})
+
+// Why: legacy runtime metadata compatibility only applies to local Unix socket
+// metadata; Windows uses named pipes and cannot run this fixture directly.
+describe.skipIf(process.platform === 'win32')('CLI runtime status', () => {
+  it('uses the legacy singular runtime transport when reporting status', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-status-'))
+    const endpoint = join(userDataPath, 'runtime.sock')
+    const server = createServer((socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      socket.once('data', (data) => {
+        const request = JSON.parse(String(data).trim()) as { id: string }
+        socket.write(
+          `${JSON.stringify({
+            id: request.id,
+            ok: true,
+            result: {
+              runtimeId: 'runtime-legacy',
+              rendererGraphEpoch: 1,
+              graphStatus: 'ready',
+              authoritativeWindowId: null,
+              liveTabCount: 0
+            },
+            _meta: { runtimeId: 'runtime-legacy' }
+          })}\n`
+        )
+      })
+    })
+    servers.add(server)
+    await new Promise<void>((resolve) => server.listen(endpoint, resolve))
+    writeFileSync(
+      getRuntimeMetadataPath(userDataPath),
+      JSON.stringify({
+        runtimeId: 'runtime-legacy',
+        pid: process.pid,
+        transport: { kind: 'unix', endpoint },
+        authToken: 'token',
+        startedAt: Date.now()
+      })
+    )
+
+    const status = await new RuntimeClient(userDataPath).getCliStatus()
+
+    expect(status.result.runtime).toMatchObject({
+      reachable: true,
+      runtimeId: 'runtime-legacy',
+      state: 'ready'
+    })
+  })
+})

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -1,4 +1,5 @@
 import type { CliStatusResult, RuntimeStatus } from '../../shared/runtime-types'
+import { findTransport } from '../../shared/runtime-bootstrap'
 import { tryReadMetadata } from './metadata'
 import { sendRequest } from './transport'
 import { RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
@@ -7,7 +8,8 @@ export async function getCliStatus(
   userDataPath: string
 ): Promise<RuntimeRpcSuccess<CliStatusResult>> {
   const metadata = tryReadMetadata(userDataPath)
-  if (!metadata?.transports?.length || !metadata.authToken) {
+  const transport = metadata ? findTransport(metadata, 'unix', 'named-pipe') : null
+  if (!transport || !metadata?.authToken) {
     return buildCliStatusResponse({
       app: {
         running: false,

--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -60,6 +61,11 @@ class FakeSocket extends EventEmitter {
   }
 }
 
+class FakeProvider extends EventEmitter {
+  kill = vi.fn()
+  unref = vi.fn()
+}
+
 async function loadClientModule() {
   vi.resetModules()
   return await import('./macos-native-provider-client')
@@ -67,15 +73,21 @@ async function loadClientModule() {
 
 describe('MacOSNativeProviderClient', () => {
   const sockets: FakeSocket[] = []
+  const providers: FakeProvider[] = []
 
   beforeEach(() => {
     vi.useFakeTimers()
     sockets.length = 0
+    providers.length = 0
     mkdtempSyncMock.mockImplementation((prefix: string) => `${prefix}${sockets.length}`)
     resolveMacOSComputerUseExecutablePathMock.mockReturnValue(
       '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos'
     )
-    spawnMock.mockReturnValue({ unref: vi.fn() })
+    spawnMock.mockImplementation(() => {
+      const provider = new FakeProvider()
+      providers.push(provider)
+      return provider
+    })
     connectMacOSProviderSocketMock.mockImplementation(async () => {
       const socket = new FakeSocket()
       sockets.push(socket)
@@ -174,5 +186,84 @@ describe('MacOSNativeProviderClient', () => {
     )
 
     await expect(secondCall).resolves.toEqual(capabilities)
+  })
+
+  it('rejects helper spawn errors before socket connection and removes temp state', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+    connectMacOSProviderSocketMock.mockReturnValue(new Promise(() => {}))
+
+    const call = client.capabilities()
+    await vi.waitFor(() => expect(providers).toHaveLength(1))
+    const socketDirectory = mkdtempSyncMock.mock.results[0]?.value as string
+    const connectSignal = connectMacOSProviderSocketMock.mock.calls[0]?.[2] as AbortSignal
+    expect(connectSignal.aborted).toBe(false)
+    providers[0]!.emit('error', new Error('helper missing'))
+
+    await expect(call).rejects.toThrow('native macOS helper app failed to start: helper missing')
+    expect(connectSignal.aborted).toBe(true)
+    expect(providers[0]!.kill).toHaveBeenCalled()
+    expect(rmSyncMock).toHaveBeenCalledWith(socketDirectory, {
+      recursive: true,
+      force: true
+    })
+  })
+
+  it('rejects helper exits before socket connection and aborts the pending connect', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+    connectMacOSProviderSocketMock.mockReturnValue(new Promise(() => {}))
+
+    const call = client.capabilities()
+    await vi.waitFor(() => expect(providers).toHaveLength(1))
+    const connectSignal = connectMacOSProviderSocketMock.mock.calls[0]?.[2] as AbortSignal
+    providers[0]!.emit('exit', 13, null)
+
+    await expect(call).rejects.toThrow('native macOS helper app exited before connecting: code 13')
+    expect(connectSignal.aborted).toBe(true)
+    expect(providers[0]!.kill).toHaveBeenCalled()
+  })
+
+  it('kills the helper and removes temp state when socket connection fails', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+    connectMacOSProviderSocketMock.mockRejectedValue(new Error('socket unavailable'))
+
+    const call = client.capabilities()
+    await vi.waitFor(() => expect(providers).toHaveLength(1))
+    const socketDirectory = mkdtempSyncMock.mock.results[0]?.value as string
+
+    await expect(call).rejects.toThrow('socket unavailable')
+    expect(providers[0]!.kill).toHaveBeenCalled()
+    expect(rmSyncMock).toHaveBeenCalledWith(socketDirectory, {
+      recursive: true,
+      force: true
+    })
+  })
+
+  it('removes the parent-owned token file after the helper socket connects', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+
+    const call = client.capabilities()
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const socket = sockets[0]!
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(1))
+    const request = JSON.parse(socket.writes[0]!) as { id: number }
+    const socketDirectory = mkdtempSyncMock.mock.results[0]?.value as string
+
+    expect(rmSyncMock).toHaveBeenCalledWith(join(socketDirectory, 'provider.token'), {
+      force: true
+    })
+
+    socket.emit(
+      'data',
+      `${JSON.stringify({
+        id: request.id,
+        ok: true,
+        result: { protocolVersion: 1, supports: {} }
+      })}\n`
+    )
+    await expect(call).resolves.toMatchObject({ protocolVersion: 1 })
   })
 })

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: the macOS provider transport owns one lifecycle across stdio fallback and helper-app socket mode. */
-import { spawn } from 'child_process'
+import { spawn, type ChildProcess } from 'child_process'
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import type net from 'net'
 import { release, tmpdir } from 'os'
@@ -192,14 +192,16 @@ export class MacOSNativeProviderClient {
     writeFileSync(this.socketTokenPath, this.socketToken, { encoding: 'utf8', mode: 0o600 })
     // Why: launching the nested helper via LaunchServices can make TCC evaluate
     // Orca.app as responsible; the signed helper executable owns this grant.
-    const provider = spawn(
-      helperExecutablePath,
-      ['--agent', this.socketPath, '--token-file', this.socketTokenPath],
-      { detached: true, stdio: 'ignore' }
-    )
-    provider.unref()
+    const provider = spawnProvider(helperExecutablePath, this.socketPath, this.socketTokenPath)
+    const providerFailure = waitForProviderLaunchFailure(provider)
+    const connectAbort = new AbortController()
     try {
-      const socket = await connectMacOSProviderSocket(this.socketPath, HELPER_CONNECT_TIMEOUT_MS)
+      const socket = await Promise.race([
+        connectMacOSProviderSocket(this.socketPath, HELPER_CONNECT_TIMEOUT_MS, connectAbort.signal),
+        providerFailure.promise.finally(() => connectAbort.abort())
+      ])
+      providerFailure.cleanup()
+      rmSync(this.socketTokenPath, { force: true })
       socket.setEncoding('utf8')
       this.socketBuffer = ''
       const onData = (chunk: string) => this.handleSocketData(socket, chunk)
@@ -218,6 +220,9 @@ export class MacOSNativeProviderClient {
       this.socket = socket
       return socket
     } catch (error) {
+      connectAbort.abort()
+      providerFailure.cleanup()
+      provider.kill()
       this.cleanupSocketDirectory()
       this.socketPath = null
       this.socketTokenPath = null
@@ -323,4 +328,52 @@ export class MacOSNativeProviderClient {
 function isMacOS14OrNewer(): boolean {
   const darwinMajor = Number.parseInt(release().split('.')[0] ?? '', 10)
   return Number.isFinite(darwinMajor) && darwinMajor >= 23
+}
+
+function spawnProvider(
+  helperExecutablePath: string,
+  socketPath: string,
+  socketTokenPath: string
+): ChildProcess {
+  const provider = spawn(
+    helperExecutablePath,
+    ['--agent', socketPath, '--token-file', socketTokenPath],
+    { detached: true, stdio: 'ignore' }
+  )
+  provider.unref()
+  return provider
+}
+
+function waitForProviderLaunchFailure(provider: ChildProcess): {
+  promise: Promise<never>
+  cleanup: () => void
+} {
+  let cleanup = (): void => {}
+  const promise = new Promise<never>((_resolve, reject) => {
+    const fail = (error: Error) => {
+      reject(
+        new RuntimeClientError(
+          'accessibility_error',
+          `native macOS helper app failed to start: ${error.message}`
+        )
+      )
+    }
+    const exit = (code: number | null, signal: NodeJS.Signals | null) => {
+      reject(
+        new RuntimeClientError(
+          'accessibility_error',
+          `native macOS helper app exited before connecting: ${
+            typeof code === 'number' ? `code ${code}` : `signal ${signal ?? 'unknown'}`
+          }`
+        )
+      )
+    }
+    provider.once('error', fail)
+    provider.once('exit', exit)
+    cleanup = () => {
+      provider.off('error', fail)
+      provider.off('exit', exit)
+    }
+  })
+  return { promise, cleanup }
 }

--- a/src/main/computer/macos-native-provider-socket.test.ts
+++ b/src/main/computer/macos-native-provider-socket.test.ts
@@ -44,4 +44,19 @@ describe('connectMacOSProviderSocket', () => {
       vi.useRealTimers()
     }
   })
+
+  it('destroys the pending socket and removes listeners when aborted', async () => {
+    const socket = new FakeSocket()
+    createConnectionMock.mockReturnValueOnce(socket)
+    const abort = new AbortController()
+
+    const promise = connectMacOSProviderSocket('/tmp/orca-computer.sock', 5_000, abort.signal)
+    await Promise.resolve()
+    abort.abort()
+
+    await expect(promise).rejects.toThrow('startup was cancelled')
+    expect(socket.destroy).toHaveBeenCalledTimes(1)
+    expect(socket.listenerCount('error')).toBe(0)
+    expect(socket.listenerCount('connect')).toBe(0)
+  })
 })

--- a/src/main/computer/macos-native-provider-socket.ts
+++ b/src/main/computer/macos-native-provider-socket.ts
@@ -3,17 +3,27 @@ import { RuntimeClientError } from './runtime-client-error'
 
 export async function connectMacOSProviderSocket(
   socketPath: string,
-  timeoutMs: number
+  timeoutMs: number,
+  signal?: AbortSignal
 ): Promise<net.Socket> {
   const deadline = Date.now() + timeoutMs
   let lastError: Error | null = null
-  while (Date.now() < deadline) {
+  while (Date.now() < deadline && !signal?.aborted) {
     try {
-      return await connectSocket(socketPath)
+      return await connectSocket(socketPath, signal)
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error))
-      await new Promise((resolve) => setTimeout(resolve, 100))
+      if (signal?.aborted) {
+        break
+      }
+      await sleep(100, signal)
     }
+  }
+  if (signal?.aborted) {
+    throw new RuntimeClientError(
+      'accessibility_error',
+      'native macOS helper app startup was cancelled'
+    )
   }
   throw new RuntimeClientError(
     'action_timeout',
@@ -21,12 +31,22 @@ export async function connectMacOSProviderSocket(
   )
 }
 
-function connectSocket(socketPath: string): Promise<net.Socket> {
+function connectSocket(socketPath: string, signal?: AbortSignal): Promise<net.Socket> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(
+        new RuntimeClientError(
+          'accessibility_error',
+          'native macOS helper app startup was cancelled'
+        )
+      )
+      return
+    }
     const socket = net.createConnection(socketPath)
     const cleanup = (): void => {
       socket.off('error', onError)
       socket.off('connect', onConnect)
+      signal?.removeEventListener('abort', onAbort)
     }
     const onError = (error: Error): void => {
       cleanup()
@@ -37,7 +57,31 @@ function connectSocket(socketPath: string): Promise<net.Socket> {
       cleanup()
       resolve(socket)
     }
+    const onAbort = (): void => {
+      cleanup()
+      socket.destroy()
+      reject(
+        new RuntimeClientError(
+          'accessibility_error',
+          'native macOS helper app startup was cancelled'
+        )
+      )
+    }
     socket.once('error', onError)
     socket.once('connect', onConnect)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(finish, ms)
+    const onAbort = (): void => finish()
+    function finish(): void {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
   })
 }


### PR DESCRIPTION
## Summary

- Fixes five medium bug findings across CLI runtime status/launch and macOS computer-use helper lifecycle.
- Re-checks macOS target-window focus immediately before synthetic keyboard/clipboard fallback paths.
- Moves helper token cleanup to the parent-owned temp directory flow and prevents helper-side deletion of caller-supplied paths.
- Adds regression coverage for legacy runtime metadata, detached spawn errors, helper spawn/connect failures, abort cleanup, and native safety policies.

## Findings fixed

- Native helper launch failures are not handled before socket connect
- Detached app launch can crash on spawn errors
- Status ignores legacy runtime metadata transports
- Restored keyboard actions can type into the wrong foreground app
- `Agent mode unlinks caller-supplied paths before validating they are helper-owned temporaries

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/cli/runtime/status.test.ts src/cli/runtime/launch.test.ts src/main/computer/macos-native-provider-client.test.ts src/main/computer/macos-native-provider-socket.test.ts`
- `swift test --package-path native/computer-use-macos`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec oxfmt --check src/cli/runtime/status.ts src/cli/runtime/status.test.ts src/cli/runtime/launch.ts src/cli/runtime/launch.test.ts src/main/computer/macos-native-provider-client.ts src/main/computer/macos-native-provider-client.test.ts src/main/computer/macos-native-provider-socket.ts src/main/computer/macos-native-provider-socket.test.ts`

## Review process

- Ran `$compound-engineering:ce-simplify-code` reviewer pass and applied actionable findings.
- Ran a structured code review pass and addressed actionable findings.
