### PR TITLE
Fix runtime status for legacy transport metadata

### DIFF
--- a/src/cli/runtime/status.test.ts
+++ b/src/cli/runtime/status.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, writeFileSync } from 'fs'
+import { createServer, type Socket } from 'net'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getRuntimeMetadataPath } from '../../shared/runtime-bootstrap'
+import { RuntimeClient } from './client'
+
+const servers = new Set<ReturnType<typeof createServer>>()
+const sockets = new Set<Socket>()
+
+afterEach(async () => {
+  for (const socket of sockets) {
+    socket.destroy()
+  }
+  sockets.clear()
+  await Promise.all(
+    [...servers].map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve())
+        })
+    )
+  )
+  servers.clear()
+})
+
+// Why: legacy runtime metadata compatibility only applies to local Unix socket
+// metadata; Windows uses named pipes and cannot run this fixture directly.
+describe.skipIf(process.platform === 'win32')('CLI runtime status', () => {
+  it('uses the legacy singular runtime transport when reporting status', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-status-'))
+    const endpoint = join(userDataPath, 'runtime.sock')
+    const server = createServer((socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      socket.once('data', (data) => {
+        const request = JSON.parse(String(data).trim()) as { id: string }
+        socket.write(
+          `${JSON.stringify({
+            id: request.id,
+            ok: true,
+            result: {
+              runtimeId: 'runtime-legacy',
+              rendererGraphEpoch: 1,
+              graphStatus: 'ready',
+              authoritativeWindowId: null,
+              liveTabCount: 0
+            },
+            _meta: { runtimeId: 'runtime-legacy' }
+          })}\n`
+        )
+      })
+    })
+    servers.add(server)
+    await new Promise<void>((resolve) => server.listen(endpoint, resolve))
+    writeFileSync(
+      getRuntimeMetadataPath(userDataPath),
+      JSON.stringify({
+        runtimeId: 'runtime-legacy',
+        pid: process.pid,
+        transport: { kind: 'unix', endpoint },
+        authToken: 'token',
+        startedAt: Date.now()
+      })
+    )
+
+    const status = await new RuntimeClient(userDataPath).getCliStatus()
+
+    expect(status.result.runtime).toMatchObject({
+      reachable: true,
+      runtimeId: 'runtime-legacy',
+      state: 'ready'
+    })
+  })
+})

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -1,4 +1,5 @@
 import type { CliStatusResult, RuntimeStatus } from '../../shared/runtime-types'
+import { findTransport } from '../../shared/runtime-bootstrap'
 import { tryReadMetadata } from './metadata'
 import { sendRequest } from './transport'
 import { RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
@@ -7,7 +8,8 @@ export async function getCliStatus(
   userDataPath: string
 ): Promise<RuntimeRpcSuccess<CliStatusResult>> {
   const metadata = tryReadMetadata(userDataPath)
-  if (!metadata?.transports?.length || !metadata.authToken) {
+  const transport = metadata ? findTransport(metadata, 'unix', 'named-pipe') : null
+  if (!transport || !metadata?.authToken) {
     return buildCliStatusResponse({
       app: {
         running: false,


### PR DESCRIPTION
## Summary

- Makes local runtime status use the same transport resolution path as runtime RPC calls.
- Preserves compatibility with older metadata files that use a singular `transport` field.
- Adds a status regression test with legacy metadata served over a local Unix socket.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/cli/runtime/status.test.ts`
- `pnpm run typecheck:cli`
