### PR TITLE
Add rich markdown Linear issue editor

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -841,6 +841,131 @@
   outline-offset: 2px;
 }
 
+/* ── Linear Issue Markdown Editor ────────────────────── */
+
+.linear-issue-markdown-editor {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--foreground);
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.linear-issue-markdown-editor-page {
+  margin-top: 1.75rem;
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.linear-issue-markdown-editor-drawer {
+  font-size: 14px;
+  line-height: 1.625;
+}
+
+.linear-issue-markdown-editor:hover {
+  border-color: color-mix(in srgb, var(--border) 50%, transparent);
+  background: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.linear-issue-markdown-editor:focus-within {
+  border-color: var(--border);
+  background: var(--background);
+  box-shadow: 0 0 0 1px var(--ring);
+}
+
+.linear-issue-markdown-editor.is-disabled {
+  opacity: 0.8;
+}
+
+.linear-issue-markdown-toolbar {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  overflow-x: auto;
+  padding: 4px 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--background) 72%, transparent);
+}
+
+.linear-issue-markdown-toolbar-button {
+  display: inline-flex;
+  width: 26px;
+  min-width: 26px;
+  height: 26px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.linear-issue-markdown-toolbar-button:hover:not(:disabled),
+.linear-issue-markdown-toolbar-button.is-active {
+  border-color: color-mix(in srgb, var(--border) 78%, transparent);
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.linear-issue-markdown-toolbar-button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.linear-issue-markdown-toolbar-separator {
+  width: 1px;
+  min-width: 1px;
+  height: 16px;
+  background: color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.linear-issue-markdown-scroll {
+  min-width: 0;
+}
+
+.linear-issue-markdown-editor .rich-markdown-editor {
+  min-height: 96px;
+  padding: 10px 12px 26px;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.linear-issue-markdown-editor-page .rich-markdown-editor {
+  min-height: 132px;
+  padding: 12px 12px 28px;
+}
+
+.linear-issue-markdown-editor .rich-markdown-editor p,
+.linear-issue-markdown-editor .rich-markdown-editor ul,
+.linear-issue-markdown-editor .rich-markdown-editor ol,
+.linear-issue-markdown-editor .rich-markdown-editor blockquote {
+  margin: 0.55em 0;
+}
+
+.linear-issue-markdown-editor .rich-markdown-editor p.is-editor-empty:first-child::before {
+  font-style: italic;
+}
+
+.linear-issue-markdown-save-hint {
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.linear-issue-markdown-editor:focus-within .linear-issue-markdown-save-hint {
+  opacity: 1;
+}
+
 .rich-markdown-slash-menu {
   position: absolute;
   z-index: 30;

--- a/src/renderer/src/components/LinearIssueMarkdownDescriptionEditor.tsx
+++ b/src/renderer/src/components/LinearIssueMarkdownDescriptionEditor.tsx
@@ -1,0 +1,345 @@
+import React, { useCallback, useEffect, useRef } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import type { Editor } from '@tiptap/react'
+import Placeholder from '@tiptap/extension-placeholder'
+import {
+  Bold,
+  Code,
+  Heading1,
+  Heading2,
+  Italic,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  ListTodo,
+  LoaderCircle,
+  Pilcrow,
+  Quote,
+  Strikethrough
+} from 'lucide-react'
+
+import { createRichMarkdownExtensions } from '@/components/editor/rich-markdown-extensions'
+import { encodeRawMarkdownHtmlForRichEditor } from '@/components/editor/raw-markdown-html'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
+import { cn } from '@/lib/utils'
+
+type LinearIssueMarkdownDescriptionEditorProps = {
+  value: string
+  onChange: (value: string) => void
+  onSave: (value: string) => void
+  density: 'page' | 'drawer'
+  disabled: boolean
+  submitShortcutLabel: string
+}
+
+type LinearIssueMarkdownToolbarButtonProps = {
+  active?: boolean
+  disabled?: boolean
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+}
+
+const linearIssueMarkdownExtensions = [
+  ...createRichMarkdownExtensions(),
+  Placeholder.configure({
+    placeholder: 'No description provided.'
+  })
+]
+
+function LinearIssueMarkdownToolbarButton({
+  active = false,
+  disabled = false,
+  label,
+  onClick,
+  children
+}: LinearIssueMarkdownToolbarButtonProps): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          disabled={disabled}
+          className={cn('linear-issue-markdown-toolbar-button', active && 'is-active')}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={onClick}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function LinearIssueMarkdownToolbarSeparator(): React.JSX.Element {
+  return <div className="linear-issue-markdown-toolbar-separator" />
+}
+
+function applyLinearIssueLink(editor: Editor | null): void {
+  if (!editor) {
+    return
+  }
+  if (editor.isActive('link')) {
+    editor.chain().focus().unsetLink().run()
+    return
+  }
+
+  const previousHref = editor.getAttributes('link').href as string | undefined
+  const href = window.prompt('Link URL', previousHref ?? '')
+  if (href === null) {
+    editor.chain().focus().run()
+    return
+  }
+
+  const trimmed = href.trim()
+  if (!trimmed) {
+    editor.chain().focus().unsetLink().run()
+    return
+  }
+
+  editor.chain().focus().extendMarkRange('link').setLink({ href: trimmed }).run()
+}
+
+function LinearIssueMarkdownToolbar({
+  editor,
+  disabled
+}: {
+  editor: Editor | null
+  disabled: boolean
+}): React.JSX.Element {
+  const runCommand = useCallback(
+    (command: (editor: Editor) => void) => {
+      if (!editor || disabled) {
+        return
+      }
+      command(editor)
+    },
+    [disabled, editor]
+  )
+
+  return (
+    <div className="linear-issue-markdown-toolbar" aria-label="Issue description formatting">
+      <LinearIssueMarkdownToolbarButton
+        label="Body text"
+        disabled={disabled}
+        onClick={() => runCommand((nextEditor) => nextEditor.chain().focus().setParagraph().run())}
+      >
+        <Pilcrow className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Heading 1"
+        active={editor?.isActive('heading', { level: 1 }) ?? false}
+        disabled={disabled}
+        onClick={() =>
+          runCommand((nextEditor) => nextEditor.chain().focus().toggleHeading({ level: 1 }).run())
+        }
+      >
+        <Heading1 className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Heading 2"
+        active={editor?.isActive('heading', { level: 2 }) ?? false}
+        disabled={disabled}
+        onClick={() =>
+          runCommand((nextEditor) => nextEditor.chain().focus().toggleHeading({ level: 2 }).run())
+        }
+      >
+        <Heading2 className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarSeparator />
+      <LinearIssueMarkdownToolbarButton
+        label="Bold"
+        active={editor?.isActive('bold') ?? false}
+        disabled={disabled}
+        onClick={() => runCommand((nextEditor) => nextEditor.chain().focus().toggleBold().run())}
+      >
+        <Bold className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Italic"
+        active={editor?.isActive('italic') ?? false}
+        disabled={disabled}
+        onClick={() => runCommand((nextEditor) => nextEditor.chain().focus().toggleItalic().run())}
+      >
+        <Italic className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Strike"
+        active={editor?.isActive('strike') ?? false}
+        disabled={disabled}
+        onClick={() => runCommand((nextEditor) => nextEditor.chain().focus().toggleStrike().run())}
+      >
+        <Strikethrough className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Inline code"
+        active={editor?.isActive('code') ?? false}
+        disabled={disabled}
+        onClick={() => runCommand((nextEditor) => nextEditor.chain().focus().toggleCode().run())}
+      >
+        <Code className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarSeparator />
+      <LinearIssueMarkdownToolbarButton
+        label="Bullet list"
+        active={editor?.isActive('bulletList') ?? false}
+        disabled={disabled}
+        onClick={() =>
+          runCommand((nextEditor) => nextEditor.chain().focus().toggleBulletList().run())
+        }
+      >
+        <List className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Numbered list"
+        active={editor?.isActive('orderedList') ?? false}
+        disabled={disabled}
+        onClick={() =>
+          runCommand((nextEditor) => nextEditor.chain().focus().toggleOrderedList().run())
+        }
+      >
+        <ListOrdered className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label="Checklist"
+        active={editor?.isActive('taskList') ?? false}
+        disabled={disabled}
+        onClick={() =>
+          runCommand((nextEditor) => nextEditor.chain().focus().toggleTaskList().run())
+        }
+      >
+        <ListTodo className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarSeparator />
+      <LinearIssueMarkdownToolbarButton
+        label="Quote"
+        active={editor?.isActive('blockquote') ?? false}
+        disabled={disabled}
+        onClick={() =>
+          runCommand((nextEditor) => nextEditor.chain().focus().toggleBlockquote().run())
+        }
+      >
+        <Quote className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+      <LinearIssueMarkdownToolbarButton
+        label={editor?.isActive('link') ? 'Remove link' : 'Link'}
+        active={editor?.isActive('link') ?? false}
+        disabled={disabled}
+        onClick={() => runCommand(applyLinearIssueLink)}
+      >
+        <LinkIcon className="size-3.5" />
+      </LinearIssueMarkdownToolbarButton>
+    </div>
+  )
+}
+
+export function LinearIssueMarkdownDescriptionEditor({
+  value,
+  onChange,
+  onSave,
+  density,
+  disabled,
+  submitShortcutLabel
+}: LinearIssueMarkdownDescriptionEditorProps): React.JSX.Element {
+  const lastEditorMarkdownRef = useRef(value)
+  const editorRef = useRef<Editor | null>(null)
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: linearIssueMarkdownExtensions,
+    content: encodeRawMarkdownHtmlForRichEditor(value),
+    contentType: 'markdown',
+    editable: !disabled,
+    editorProps: {
+      attributes: {
+        class: 'rich-markdown-editor',
+        spellcheck: 'true',
+        'aria-label': 'Issue description'
+      },
+      handleKeyDown: (_view, event) => {
+        if (!isScreenSubmitShortcut(event)) {
+          return false
+        }
+        event.preventDefault()
+        editorRef.current?.commands.blur()
+        return true
+      }
+    },
+    onFocus: () => {
+      window.api.ui.setMarkdownEditorFocused(true)
+    },
+    onBlur: ({ editor: nextEditor }) => {
+      window.api.ui.setMarkdownEditorFocused(false)
+      const nextValue = nextEditor.getMarkdown()
+      lastEditorMarkdownRef.current = nextValue
+      onChange(nextValue)
+      onSave(nextValue)
+    },
+    onUpdate: ({ editor: nextEditor }) => {
+      const nextValue = nextEditor.getMarkdown()
+      lastEditorMarkdownRef.current = nextValue
+      onChange(nextValue)
+    }
+  })
+
+  useEffect(() => {
+    editorRef.current = editor
+  }, [editor])
+
+  useEffect(() => {
+    editor?.setEditable(!disabled)
+  }, [disabled, editor])
+
+  useEffect(() => {
+    if (!editor || value === lastEditorMarkdownRef.current) {
+      return
+    }
+
+    const currentMarkdown = editor.getMarkdown()
+    if (currentMarkdown === value) {
+      lastEditorMarkdownRef.current = value
+      return
+    }
+
+    // Why: Linear remains the source of truth when the selected issue changes
+    // or an optimistic save is reverted; keep the rich view aligned with it.
+    editor.commands.setContent(encodeRawMarkdownHtmlForRichEditor(value), {
+      contentType: 'markdown',
+      emitUpdate: false
+    })
+    lastEditorMarkdownRef.current = value
+  }, [editor, value])
+
+  return (
+    <div
+      className={cn(
+        'linear-issue-markdown-editor',
+        density === 'page'
+          ? 'linear-issue-markdown-editor-page'
+          : 'linear-issue-markdown-editor-drawer',
+        disabled && 'is-disabled'
+      )}
+    >
+      <LinearIssueMarkdownToolbar editor={editor} disabled={disabled} />
+      <div className="linear-issue-markdown-scroll scrollbar-sleek">
+        <EditorContent editor={editor} />
+      </div>
+      <div className="linear-issue-markdown-save-hint pointer-events-none absolute bottom-1.5 right-2 z-10 flex items-center gap-1.5 text-[10px] text-muted-foreground/75">
+        <span className="flex items-center gap-1">
+          <span>{submitShortcutLabel}</span>
+          <span>save</span>
+        </span>
+        <span className="text-muted-foreground/35">·</span>
+        <span>Markdown</span>
+      </div>
+      {disabled ? (
+        <LoaderCircle className="absolute right-2 top-2 size-4 animate-spin text-muted-foreground" />
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/LinearIssueTextEditor.tsx
+++ b/src/renderer/src/components/LinearIssueTextEditor.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { toast } from 'sonner'
 
+import { LinearIssueMarkdownDescriptionEditor } from '@/components/LinearIssueMarkdownDescriptionEditor'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
@@ -44,7 +45,6 @@ export function LinearIssueTextEditor({
   const [savingField, setSavingField] = useState<'title' | 'description' | null>(null)
   const submitShortcutLabel = getScreenSubmitShortcutLabel()
   const titleRef = useAutosizeTextArea(titleDraft)
-  const descriptionRef = useAutosizeTextArea(descriptionDraft)
   const lastIssueIdRef = useRef(issue.id)
   const mountedRef = useMountedRef()
   const lastSyncedTitleRef = useRef(issue.title)
@@ -79,9 +79,9 @@ export function LinearIssueTextEditor({
   }, [descriptionDraft, issue.description, issue.id, issue.title, titleDraft])
 
   const saveField = useCallback(
-    async (field: 'title' | 'description') => {
+    async (field: 'title' | 'description', descriptionOverride?: string) => {
       const nextTitle = titleDraft.trim()
-      const nextDescription = descriptionDraft.trimEnd()
+      const nextDescription = (descriptionOverride ?? descriptionDraft).trimEnd()
       if (field === 'title' && !nextTitle) {
         setTitleDraft(issue.title)
         toast.error('Title is required')
@@ -155,6 +155,14 @@ export function LinearIssueTextEditor({
     []
   )
 
+  const saveDescriptionValue = useCallback(
+    (value: string) => {
+      setDescriptionDraft(value)
+      void saveField('description', value)
+    },
+    [saveField]
+  )
+
   const handleTitleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === 'Enter') {
@@ -171,9 +179,6 @@ export function LinearIssueTextEditor({
     density === 'page'
       ? 'text-[28px] font-semibold leading-tight'
       : 'text-[15px] font-semibold leading-tight'
-  const descriptionClass =
-    density === 'page' ? 'mt-7 px-3 text-[15px] leading-7' : 'px-3 text-[14px] leading-relaxed'
-
   return (
     <div className="min-w-0">
       {fields !== 'description' ? (
@@ -206,37 +211,14 @@ export function LinearIssueTextEditor({
 
       {fields !== 'title' ? (
         <div className="relative">
-          <textarea
-            ref={descriptionRef}
+          <LinearIssueMarkdownDescriptionEditor
             value={descriptionDraft}
-            onChange={(event) => setDescriptionDraft(event.target.value)}
-            onBlur={() => void saveField('description')}
-            onKeyDown={handleDescriptionKeyDown}
+            onChange={setDescriptionDraft}
+            onSave={saveDescriptionValue}
+            density={density}
             disabled={savingField === 'description'}
-            rows={descriptionDraft.trim() ? 3 : 1}
-            placeholder="No description provided."
-            aria-label="Issue description"
-            className={cn(
-              'peer scrollbar-sleek block w-full resize-none overflow-hidden rounded-md border border-transparent bg-transparent py-1 text-foreground outline-none transition placeholder:italic placeholder:text-muted-foreground hover:border-border/50 hover:bg-accent/40 focus-visible:border-border focus-visible:bg-background focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-80',
-              descriptionClass
-            )}
+            submitShortcutLabel={submitShortcutLabel}
           />
-          <div className="pointer-events-none absolute bottom-1.5 right-2 z-10 flex items-center gap-1.5 text-[10px] text-muted-foreground/75 opacity-0 transition-opacity peer-focus:opacity-100">
-            <span className="flex items-center gap-1">
-              <span>{submitShortcutLabel}</span>
-              <span>save</span>
-            </span>
-            <span className="text-muted-foreground/35">·</span>
-            <span className="flex items-center gap-1">
-              <kbd className="inline-flex h-4 min-w-4 select-none items-center justify-center rounded border border-border bg-muted/70 px-1 font-mono text-[9px] font-medium shadow-xs">
-                ↵
-              </kbd>
-              <span>newline</span>
-            </span>
-          </div>
-          {savingField === 'description' ? (
-            <LoaderCircle className="absolute right-2 top-2 size-4 animate-spin text-muted-foreground" />
-          ) : null}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- replace the Linear issue description textarea with a Tiptap rich markdown editor
- add a compact formatting toolbar for headings, inline formatting, lists, quotes, and links
- keep Linear issue description saves on blur and Cmd/Ctrl+Enter while preserving markdown serialization

## Verification
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/LinearIssueTextEditor.tsx src/renderer/src/components/LinearIssueMarkdownDescriptionEditor.tsx
- pnpm run check:styled-scrollbars
- git diff --check