### PR TITLE
Fix stale source control conflict error banners

### DIFF
--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -32,6 +32,19 @@ Use `orca-cli` instead for ordinary terminal control, shell commands, browser au
 - The orchestration experimental feature must be enabled in Settings > Experimental.
 - All `orca orchestration` commands are RPC calls to the running Orca runtime — they require an active Orca session.
 
+## Ownership And Handoff Boundaries
+
+Orchestration messages and tasks are runtime-global. The authority for a worker completion is the active dispatch context (`taskId` + `dispatchId` + assignee handle), not the filesystem worktree by itself. Cross-worktree coordination is valid when a live coordinator intentionally owns the task graph.
+
+Do not treat a copied or injected preamble as automatic parentage for new work. First classify the situation:
+
+- **Coordinated subtask**: a live coordinator owns the DAG and is waiting on this dispatch. Use the exact `worker_done`, heartbeat, `ask`, and escalation flow from the preamble, even if the coordinator terminal is in another worktree.
+- **Full handoff**: the original actor intentionally delegated ownership and does not want to monitor the work. Finish the current assignment in the current session. Create a new coordinator only when the user asks for orchestration or you deliberately decompose fresh subtasks in the current worktree; if you spawn workers, pass your current-worktree coordinator handle and use a current-worktree selector such as `--worktree active`.
+
+When the handoff type is unclear, inspect `orca orchestration task-list --json`, `orca orchestration dispatch-show`, and `orca terminal list --json` for the task, dispatch, and handle ownership before sending lifecycle messages. If you still cannot tell whether the remote handle owns an active dispatch, ask the current owner instead of silently completing a task into an unrelated workstream.
+
+Why: a stale or copied cross-worktree `worker_done` can make an unrelated feature coordinator responsible for work it intentionally delegated away. Conversely, refusing every cross-worktree completion would break legitimate orchestrated DAGs, so the decision must follow dispatch ownership, not location alone.
+
 ## Command Surface
 
 ### Messaging
@@ -165,8 +178,9 @@ Why: the 120-line terminal output buffer (`terminal read`) is for status monitor
 
 ## Agent Guidance
 
-- When dispatched with a preamble, **always run the `worker_done` command when done**. This is the primary feedback mechanism — it keeps the coordinator's context window clean.
-- If blocked or unable to complete a task, send an `escalation` message to the coordinator instead of silently stalling.
+- When dispatched with a valid live preamble, **send `worker_done` exactly once to the owning coordinator**. The `dispatchId` in the payload is the completion authority.
+- Treat a preamble inherited through terminal history or a full handoff as stale unless the current prompt explicitly keeps that coordinator in the loop.
+- If blocked or unable to complete a task, send an `escalation` message to the owning coordinator only when ownership is valid; otherwise report the blocker in the current session.
 - Use `orca orchestration check` to read incoming messages from the coordinator or other agents. Messages are delivered automatically when you go idle, but you can also poll explicitly.
 - Treat `orca orchestration` commands the same way you treat `git` or `npm` — they are CLI tools available in your shell.
 - The coordinator uses `orca orchestration task-list --ready` as its external memory. Prefer querying orchestration state over tracking it in your context window.

--- a/src/renderer/src/components/right-sidebar/SourceControl.remote-action-errors.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.remote-action-errors.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { clearRemoteActionErrorsForCompletedConflictOperations } from './SourceControl'
+
+describe('SourceControl remote action error reconciliation', () => {
+  it('clears a rebase failure after git status observes the rebase completed', () => {
+    const errors = {
+      'wt-1': { kind: 'rebase' as const, message: 'Rebase failed. Could not apply abc123' }
+    }
+
+    expect(
+      clearRemoteActionErrorsForCompletedConflictOperations({
+        remoteActionErrors: errors,
+        previousConflictOperations: { 'wt-1': 'rebase' },
+        currentConflictOperations: { 'wt-1': 'unknown' }
+      })
+    ).toEqual({ 'wt-1': null })
+  })
+
+  it('keeps a rebase failure while the rebase is still in progress', () => {
+    const errors = {
+      'wt-1': { kind: 'rebase' as const, message: 'Rebase failed. Could not apply abc123' }
+    }
+
+    expect(
+      clearRemoteActionErrorsForCompletedConflictOperations({
+        remoteActionErrors: errors,
+        previousConflictOperations: { 'wt-1': 'rebase' },
+        currentConflictOperations: { 'wt-1': 'rebase' }
+      })
+    ).toBe(errors)
+  })
+
+  it('keeps immediate rebase failures that never entered a rebase operation', () => {
+    const errors = {
+      'wt-1': { kind: 'rebase' as const, message: 'Rebase blocked - commit first.' }
+    }
+
+    expect(
+      clearRemoteActionErrorsForCompletedConflictOperations({
+        remoteActionErrors: errors,
+        previousConflictOperations: { 'wt-1': 'unknown' },
+        currentConflictOperations: { 'wt-1': 'unknown' }
+      })
+    ).toBe(errors)
+  })
+
+  it('clears pull and sync conflict errors after their merge operation completes', () => {
+    const errors = {
+      'wt-pull': { kind: 'pull' as const, message: 'Pull stopped with merge conflicts.' },
+      'wt-sync': { kind: 'sync' as const, message: 'Sync stopped with merge conflicts.' },
+      'wt-fetch': { kind: 'fetch' as const, message: 'Fetch failed. network timeout' }
+    }
+
+    expect(
+      clearRemoteActionErrorsForCompletedConflictOperations({
+        remoteActionErrors: errors,
+        previousConflictOperations: {
+          'wt-pull': 'merge',
+          'wt-sync': 'merge',
+          'wt-fetch': 'merge'
+        },
+        currentConflictOperations: {
+          'wt-pull': 'unknown',
+          'wt-sync': 'unknown',
+          'wt-fetch': 'unknown'
+        }
+      })
+    ).toEqual({
+      'wt-pull': null,
+      'wt-sync': null,
+      'wt-fetch': errors['wt-fetch']
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -188,7 +188,10 @@ import {
 export type SourceControlScope = 'all' | 'uncommitted'
 type AbortConflictOperation = Extract<GitConflictOperation, 'merge' | 'rebase'>
 type AbortActionErrorKind = 'abort_merge' | 'abort_rebase'
-type SourceControlActionError = { kind: RemoteOpKind | AbortActionErrorKind; message: string }
+export type SourceControlActionError = {
+  kind: RemoteOpKind | AbortActionErrorKind
+  message: string
+}
 type SourceControlAiInstructionGuidance = {
   operation: SourceControlAiOperation
   repoBacked: boolean
@@ -942,6 +945,51 @@ export function refreshSourceControlAfterRemoteAction({
   void Promise.all([refreshGitStatus(), refreshBranchCompare(), refreshGitHistory()]).catch(onError)
 }
 
+function remoteActionErrorMatchesSettledConflictOperation(
+  kind: SourceControlActionError['kind'],
+  operation: GitConflictOperation
+): boolean {
+  if (kind === 'rebase' || kind === 'abort_rebase') {
+    return operation === 'rebase'
+  }
+  if (kind === 'abort_merge') {
+    return operation === 'merge'
+  }
+  if (kind === 'pull' || kind === 'sync') {
+    return operation === 'merge' || operation === 'rebase'
+  }
+  return false
+}
+
+export function clearRemoteActionErrorsForCompletedConflictOperations({
+  remoteActionErrors,
+  previousConflictOperations,
+  currentConflictOperations
+}: {
+  remoteActionErrors: Record<string, SourceControlActionError | null>
+  previousConflictOperations: Record<string, GitConflictOperation>
+  currentConflictOperations: Record<string, GitConflictOperation>
+}): Record<string, SourceControlActionError | null> {
+  let next: Record<string, SourceControlActionError | null> | null = null
+  for (const [worktreeId, error] of Object.entries(remoteActionErrors)) {
+    if (!error) {
+      continue
+    }
+    const previousOperation = previousConflictOperations[worktreeId] ?? 'unknown'
+    const currentOperation = currentConflictOperations[worktreeId] ?? 'unknown'
+    if (
+      previousOperation === 'unknown' ||
+      currentOperation !== 'unknown' ||
+      !remoteActionErrorMatchesSettledConflictOperation(error.kind, previousOperation)
+    ) {
+      continue
+    }
+    next ??= { ...remoteActionErrors }
+    next[worktreeId] = null
+  }
+  return next ?? remoteActionErrors
+}
+
 function HostedReviewIcon({
   review,
   className
@@ -1030,6 +1078,7 @@ function SourceControlInner(): React.JSX.Element {
   const conflictOperation = useAppStore((s) =>
     activeWorktreeId ? (s.gitConflictOperationByWorktree[activeWorktreeId] ?? 'unknown') : 'unknown'
   )
+  const conflictOperationsByWorktree = useAppStore((s) => s.gitConflictOperationByWorktree)
   // Why: leave undefined until fetchUpstreamStatus resolves for this worktree.
   // A synthetic "no upstream" flashes "Publish Branch" during worktree switches.
   const remoteStatus = useAppStore((s) =>
@@ -1235,6 +1284,7 @@ function SourceControlInner(): React.JSX.Element {
   const [remoteActionErrors, setRemoteActionErrors] = useState<
     Record<string, SourceControlActionError | null>
   >({})
+  const previousConflictOperationsRef = useRef<Record<string, GitConflictOperation>>({})
   // Why: keep commit-in-flight state per-worktree. A single boolean would be
   // cleared when the user switched worktrees, letting them double-click Commit
   // on worktree A after briefly navigating to B and back while A's original
@@ -1894,6 +1944,21 @@ function SourceControlInner(): React.JSX.Element {
       }
     }
   }, [worktreeMap])
+
+  useEffect(() => {
+    // Why: users often finish merge/rebase conflicts in a terminal. Once git
+    // status observes that operation end, the old Source Control failure banner
+    // is stale and should not survive the successful external continue/abort.
+    const previousConflictOperations = previousConflictOperationsRef.current
+    setRemoteActionErrors((prev) =>
+      clearRemoteActionErrorsForCompletedConflictOperations({
+        remoteActionErrors: prev,
+        previousConflictOperations,
+        currentConflictOperations: conflictOperationsByWorktree
+      })
+    )
+    previousConflictOperationsRef.current = conflictOperationsByWorktree
+  }, [conflictOperationsByWorktree])
 
   // Why: the sidebar no longer uses key={activeWorktreeId} to force a full
   // remount on worktree switch (that caused an IPC storm on Windows).


### PR DESCRIPTION
## Summary
- Clear stale source-control remote action errors once merge/rebase conflict operations complete externally
- Add focused coverage for completed, ongoing, and non-conflict remote action failures
- Clarify orchestration ownership boundaries for copied or handed-off preambles

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/SourceControl.remote-action-errors.test.ts
- pnpm typecheck

Note: an accidental full `pnpm test -- SourceControl.remote-action-errors.test.ts` invocation ran the broader suite and hit unrelated existing node-pty/zsh environment failures before the focused file command was run successfully.