### PR TITLE
feat(theme): app-wide window glass with vibrancy/acrylic

### DIFF
--- a/src/main/ghostty/mapper.test.ts
+++ b/src/main/ghostty/mapper.test.ts
@@ -178,6 +178,25 @@ describe('mapGhosttyToOrca — background & colors', () => {
     expect(result.unsupportedKeys).toEqual(['background-blur-radius'])
   })
 
+  it('maps boolean and numeric background-blur forms to windowBackgroundBlur', () => {
+    expect(mapGhosttyToOrca({ 'background-blur': 'true' }).diff.windowBackgroundBlur).toBe(true)
+    expect(mapGhosttyToOrca({ 'background-blur': 'false' }).diff.windowBackgroundBlur).toBe(false)
+    // 0 means off — no radius to lose, so no drop note.
+    const off = mapGhosttyToOrca({ 'background-blur': '0' })
+    expect(off.diff.windowBackgroundBlur).toBe(false)
+    expect(off.unsupportedKeys).toEqual([])
+    // A positive radius enables blur; the numeric value is dropped with a note.
+    const radius = mapGhosttyToOrca({ 'background-blur': '20' })
+    expect(radius.diff.windowBackgroundBlur).toBe(true)
+    expect(radius.unsupportedKeys).toEqual(['background-blur (radius value not preserved)'])
+  })
+
+  it('rejects invalid background-blur', () => {
+    const result = mapGhosttyToOrca({ 'background-blur': 'heavy' })
+    expect(result.diff).toEqual({})
+    expect(result.unsupportedKeys).toEqual(['background-blur'])
+  })
+
   it('maps background with hash to terminalColorOverrides.background', () => {
     const result = mapGhosttyToOrca({ background: '#111111' })
     expect(result.diff).toEqual({ terminalColorOverrides: { background: '#111111' } })

--- a/src/main/ghostty/mapper.ts
+++ b/src/main/ghostty/mapper.ts
@@ -152,6 +152,23 @@ export function mapGhosttyToOrca(
       return { key: 'windowBackgroundBlur', value: num > 0 }
     },
 
+    // Why: Ghostty accepts `background-blur` as either a boolean or an integer
+    // radius (an alias for background-blur-radius). Orca only has a boolean
+    // blur toggle, so any positive radius — or an explicit `true` — enables it.
+    'background-blur': (v) => {
+      if (v === 'true') {
+        return { key: 'windowBackgroundBlur', value: true }
+      }
+      if (v === 'false') {
+        return { key: 'windowBackgroundBlur', value: false }
+      }
+      const num = parseStrictInt(v)
+      if (num === null || num < 0) {
+        return null
+      }
+      return { key: 'windowBackgroundBlur', value: num > 0 }
+    },
+
     'split-divider-color': (v) => {
       if (!HEX_COLOR_RE.test(v)) {
         return null
@@ -301,15 +318,14 @@ export function mapGhosttyToOrca(
     }
 
     // Why: Orca's windowBackgroundBlur is a boolean; the numeric radius is lost.
-    // Only note the drop when blur is actually being turned on — a `0` cleanly
-    // maps to `false` and there is no radius to lose.
-    if (
-      key === 'background-blur-radius' &&
-      !Array.isArray(result) &&
-      'key' in result &&
-      result.value === true
-    ) {
-      unsupportedKeys.push('background-blur-radius (radius value not preserved)')
+    // Only note the drop when blur is actually being turned on by a radius — a
+    // `0` cleanly maps to `false`, and the boolean `background-blur = true` form
+    // carries no radius to lose.
+    const droppedBlurRadius =
+      key === 'background-blur-radius' ||
+      (key === 'background-blur' && value !== 'true' && value !== 'false')
+    if (droppedBlurRadius && !Array.isArray(result) && 'key' in result && result.value === true) {
+      unsupportedKeys.push(`${key} (radius value not preserved)`)
     }
 
     if (Array.isArray(result)) {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -109,6 +109,82 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.loadURL).not.toHaveBeenCalled()
   })
 
+  const makeWindowInstance = (): Record<string, unknown> => {
+    const webContents = {
+      id: 1,
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    return {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+  }
+
+  const storeWith = (settings: Record<string, unknown>): never =>
+    ({
+      getUI: () => ({}),
+      getSettings: () => settings,
+      updateUI: vi.fn()
+    }) as never
+
+  it('uses a transparent window background when blur is enabled so vibrancy can show', () => {
+    browserWindowMock.mockImplementation(function () {
+      return makeWindowInstance()
+    })
+
+    createMainWindow(storeWith({ windowBackgroundBlur: true }))
+
+    const options = browserWindowMock.mock.calls[0]?.[0]
+    if (process.platform === 'darwin') {
+      // Why: vibrancy provides the blur. transparent:true would suppress it,
+      // and any opaque backgroundColor would paint over it — so neither is set.
+      expect(options).toMatchObject({
+        vibrancy: 'under-window',
+        visualEffectState: 'active'
+      })
+      expect(options.transparent).toBeUndefined()
+      expect(options.backgroundColor).toBeUndefined()
+    } else if (process.platform === 'win32') {
+      expect(options).toMatchObject({ backgroundMaterial: 'acrylic' })
+      expect(options.backgroundColor).toBeUndefined()
+    } else {
+      // Linux has no native blur surface, so the window must stay opaque
+      // rather than become a clear, unblurred window.
+      expect(options.backgroundColor).toBe('#ffffff')
+      expect(options.transparent).toBeUndefined()
+    }
+  })
+
+  it('keeps an opaque window background when blur is disabled', () => {
+    browserWindowMock.mockImplementation(function () {
+      return makeWindowInstance()
+    })
+
+    createMainWindow(storeWith({ windowBackgroundBlur: false }))
+
+    const options = browserWindowMock.mock.calls[0]?.[0]
+    // nativeTheme.shouldUseDarkColors is mocked false → light opaque fill.
+    expect(options.backgroundColor).toBe('#ffffff')
+    expect(options.transparent).toBeUndefined()
+  })
+
   it('enables renderer sandboxing and opens external links safely', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -221,11 +221,22 @@ export function createMainWindow(
   // changing the setting requires a restart.
   const platformBlurOptions = blur
     ? process.platform === 'darwin'
-      ? { vibrancy: 'under-window' as const, transparent: true }
+      ? // macOS: the blur comes from an NSVisualEffectView (vibrancy). Do NOT
+        // set transparent:true here — it makes the window fully clear and
+        // suppresses the vibrancy view (the reason blur rendered as opaque).
+        // visualEffectState:'active' keeps the blur alive when unfocused.
+        { vibrancy: 'under-window' as const, visualEffectState: 'active' as const }
       : process.platform === 'win32'
         ? { backgroundMaterial: 'acrylic' as const }
         : {}
     : {}
+  // Why: macOS vibrancy / Windows acrylic require a non-opaque window. An
+  // opaque backgroundColor paints over the blur layer, and a transparent
+  // #00000000 fill is only honored alongside transparent:true (which breaks
+  // vibrancy) — so omit backgroundColor entirely for a blur surface and let the
+  // platform material show through. Linux has no native blur, so it stays
+  // opaque to avoid a clear, unblurred window.
+  const hasBlurSurface = blur && (process.platform === 'darwin' || process.platform === 'win32')
 
   const mainWindow = new BrowserWindow({
     width: savedBounds?.width ?? defaultBounds.width,
@@ -242,7 +253,9 @@ export function createMainWindow(
     // Window/Help menus by pressing Alt, matching native Windows/Linux
     // conventions (File Explorer, Firefox, etc.).
     autoHideMenuBar: true,
-    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
+    ...(hasBlurSurface
+      ? {}
+      : { backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff' }),
     // Why: on macOS 'hiddenInset' keeps the native traffic lights positioned
     // inside our custom 42px titlebar. On Windows 'hidden' removes the default
     // OS title bar (which would otherwise stack on top of our renderer titlebar

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1075,6 +1075,19 @@ function App(): React.JSX.Element {
     )
   }, [settings?.appFontFamily])
 
+  // Why: blur makes the Electron window transparent (see createMainWindow); the
+  // `glass` class drops the opaque body so the vibrancy shows through. The two
+  // --glass-opacity* vars feed main.css's translucent surfaces from the
+  // Background Opacity setting — chrome at terminal + 0.25 (readable), middle
+  // view at the terminal opacity. Gated on blur; opacity alone leaves it opaque.
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.toggle('glass', settings?.windowBackgroundBlur ?? false)
+    const terminalOpacity = settings?.terminalBackgroundOpacity ?? 1
+    root.style.setProperty('--glass-opacity', String(Math.min(1, terminalOpacity + 0.25)))
+    root.style.setProperty('--glass-opacity-mid', String(terminalOpacity))
+  }, [settings?.windowBackgroundBlur, settings?.terminalBackgroundOpacity])
+
   // Refresh GitHub data (PR/issue status) when window regains focus
   useEffect(() => {
     const handler = (): void => {
@@ -1772,24 +1785,38 @@ function App(): React.JSX.Element {
                           <Terminal />
                         </RecoverableRenderErrorBoundary>
                       </div>
-                      <Suspense fallback={null}>
-                        <RecoverableRenderErrorBoundary
-                          boundaryId={`page.${activeView}`}
-                          surface="page"
-                          resetKey={`${activeView}:${activeWorktreeId ?? 'none'}`}
-                          title="This page hit an error."
-                          description="Retry the page or navigate to another Orca surface."
-                        >
-                          {activeView === 'settings' ? <Settings /> : null}
-                          {activeView === 'skills' ? <SkillsPage /> : null}
-                          {activeView === 'tasks' ? <TaskPage /> : null}
-                          {activeView === 'automations' ? <AutomationsPage /> : null}
-                          {activeView === 'activity' ? <ActivityPrototypePage /> : null}
-                          {activeView === 'space' ? <WorkspaceSpacePage /> : null}
-                          {activeView === 'mobile' ? <MobilePage /> : null}
-                          {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
-                        </RecoverableRenderErrorBoundary>
-                      </Suspense>
+                      {/* Why: layout-only wrapper for the non-terminal page
+                      region — no background here. Each page paints its own
+                      bg-background; adding one on the wrapper too would stack two
+                      translucent glass layers and make pages read as more opaque
+                      than the terminal/editor. Hidden (not just empty) when the
+                      terminal is active so it never covers the terminal area. */}
+                      <div
+                        className={
+                          activeView !== 'terminal' || !activeWorktreeId
+                            ? 'flex flex-1 min-w-0 min-h-0 flex-col'
+                            : 'hidden'
+                        }
+                      >
+                        <Suspense fallback={null}>
+                          <RecoverableRenderErrorBoundary
+                            boundaryId={`page.${activeView}`}
+                            surface="page"
+                            resetKey={`${activeView}:${activeWorktreeId ?? 'none'}`}
+                            title="This page hit an error."
+                            description="Retry the page or navigate to another Orca surface."
+                          >
+                            {activeView === 'settings' ? <Settings /> : null}
+                            {activeView === 'skills' ? <SkillsPage /> : null}
+                            {activeView === 'tasks' ? <TaskPage /> : null}
+                            {activeView === 'automations' ? <AutomationsPage /> : null}
+                            {activeView === 'activity' ? <ActivityPrototypePage /> : null}
+                            {activeView === 'space' ? <WorkspaceSpacePage /> : null}
+                            {activeView === 'mobile' ? <MobilePage /> : null}
+                            {activeView === 'terminal' && !activeWorktreeId ? <Landing /> : null}
+                          </RecoverableRenderErrorBoundary>
+                        </Suspense>
+                      </div>
                     </div>
                     {showFloatingTerminalButton ? (
                       <FloatingTerminalToggleButton

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -282,11 +282,124 @@
   }
 }
 
+/* Why: window blur makes the Electron window transparent so vibrancy/acrylic can
+   show; the opaque body would paint over it, so drop it here. Chrome and the
+   page region keep their own backgrounds, so only the glass surfaces reveal it. */
+html.glass body {
+  background-color: transparent;
+}
+
+/* Why: in glass mode the structural surface tokens go translucent so the blur
+   shows through the whole shell. Alphas come from App.tsx, derived from the
+   Background Opacity setting: --glass-opacity (chrome, terminal + 0.25 for
+   readability) and --glass-opacity-mid (middle view = terminal). The *-solid
+   tokens keep the opaque values for elements pinned solid below (the base tokens
+   are translucent here). Overlays use --popover, left untouched. */
+html.glass.dark {
+  --background: rgb(10 10 10 / var(--glass-opacity-mid, 0.35));
+  --card: rgb(23 23 23 / var(--glass-opacity, 0.6));
+  --sidebar: rgb(23 23 23 / var(--glass-opacity, 0.6));
+  --bg-titlebar: rgb(23 23 23 / var(--glass-opacity, 0.6));
+  --editor-surface: rgb(30 30 30 / var(--glass-opacity-mid, 0.35));
+  --background-solid: #0a0a0a;
+  --editor-surface-solid: #1e1e1e;
+}
+html.glass:not(.dark) {
+  --background: rgb(255 255 255 / var(--glass-opacity-mid, 0.35));
+  --card: rgb(255 255 255 / var(--glass-opacity, 0.6));
+  --sidebar: rgb(250 250 250 / var(--glass-opacity, 0.6));
+  --bg-titlebar: rgb(255 255 255 / var(--glass-opacity, 0.6));
+  --editor-surface: rgb(255 255 255 / var(--glass-opacity-mid, 0.35));
+  --background-solid: #ffffff;
+  --editor-surface-solid: #ffffff;
+}
+
+/* Why: these surfaces use bg-background / text-background, which is translucent
+   in glass — pin them to the solid surface token so modal content, the inverted
+   tooltip text, and the toggle knob stay legible over the blur. */
+html.glass [data-slot='dialog-content'],
+html.glass [data-slot='sheet-content'] {
+  background-color: var(--background-solid);
+}
+html.glass [data-slot='tooltip-content'] {
+  color: var(--background-solid);
+}
+html.glass [role='switch'] > span {
+  background-color: var(--background-solid);
+}
+
+/* Editor (Monaco) glass: the vs-dark / vs themes paint a hardcoded opaque
+   background that ignores our CSS variables, so the file viewer/editor stayed
+   solid. In glass mode, let the editor root carry the translucent
+   --editor-surface and clear Monaco's inner background layers, so the code area
+   reads as a single glass pane like the rest of the shell. */
+html.glass .monaco-editor {
+  background-color: var(--editor-surface) !important;
+}
+html.glass .monaco-editor-background,
+html.glass .monaco-editor .overflow-guard,
+html.glass .monaco-editor .margin,
+html.glass .monaco-editor .minimap {
+  background-color: transparent !important;
+}
+/* Sticky scroll: the pinned header sits over scrolling code, so it must be
+   opaque — a translucent header lets the code below show through and overlap its
+   text (Monaco's layered rendering also breaks backdrop-blur, so frosting isn't
+   an option). Use the solid editor-surface base color; Monaco keeps its subtle
+   bottom border as a separator. */
+html.glass .monaco-editor .sticky-widget {
+  background-color: var(--editor-surface-solid) !important;
+}
+html.glass .monaco-editor .sticky-widget .sticky-widget-lines-scrollable,
+html.glass .monaco-editor .sticky-widget .sticky-widget-line-numbers,
+html.glass .monaco-editor .sticky-widget .sticky-widget-lines,
+html.glass .monaco-editor .sticky-widget .sticky-line-content,
+html.glass .monaco-editor .sticky-widget .sticky-line-number {
+  background-color: transparent !important;
+}
+/* Current-line highlight: its border box is invisible on the opaque vs-dark
+   theme but shows as a hard outline against the transparent glass editor. */
+html.glass .monaco-editor .view-overlays .current-line,
+html.glass .monaco-editor .margin-view-overlays .current-line {
+  border-color: transparent !important;
+}
+
 /* ── Sleek scrollbar (VS Code-like) ─────────────────── */
 
 .scrollbar-sleek {
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 34%, transparent) transparent;
+}
+
+/* Why: xterm's scrollbar is unstyled (native viewport → bright white bar). It
+   should match the file editor's scrollbar, but xterm owns those internal
+   elements so we can't put the `.scrollbar-editor` class on them — mirror that
+   class's exact values here instead (keep both in sync). Covers the native
+   viewport scrollbar and the VS Code overlay slider. */
+.xterm-viewport {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(121, 121, 121, 0.4) transparent;
+}
+.xterm-viewport::-webkit-scrollbar {
+  width: 14px;
+}
+.xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+}
+.xterm-viewport::-webkit-scrollbar-thumb {
+  background: rgba(121, 121, 121, 0.4);
+  border: 3px solid transparent;
+  border-radius: 7px;
+  background-clip: padding-box;
+}
+.xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: rgba(121, 121, 121, 0.7);
+}
+.xterm .xterm-scrollable-element .xterm-slider {
+  background: rgba(121, 121, 121, 0.4) !important;
+}
+.xterm .xterm-scrollable-element .xterm-slider:hover {
+  background: rgba(121, 121, 121, 0.7) !important;
 }
 
 .scrollbar-sleek::-webkit-scrollbar {

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -20,6 +20,7 @@ import { DEFAULT_APP_FONT_FAMILY } from '../../../../shared/constants'
 import { useAvailableStatusBarToggles } from '../status-bar/use-available-status-bar-toggles'
 import {
   APPEARANCE_PANE_SEARCH_ENTRIES,
+  GLASS_ENTRIES,
   LAYOUT_ENTRIES,
   SIDEBAR_ENTRIES,
   STATUS_BAR_ENTRIES,
@@ -29,6 +30,7 @@ import {
   TYPOGRAPHY_ENTRIES,
   ZOOM_ENTRIES
 } from './appearance-search'
+import { GlassAppearanceSection } from './GlassAppearanceSection'
 export { APPEARANCE_PANE_SEARCH_ENTRIES }
 
 type AppearancePaneProps = {
@@ -148,6 +150,9 @@ export function AppearancePane({
           </SearchableSetting>
         ) : null}
       </section>
+    ) : null,
+    matchesSettingsSearch(searchQuery, GLASS_ENTRIES) ? (
+      <GlassAppearanceSection key="glass" settings={settings} updateSettings={updateSettings} />
     ) : null,
     matchesSettingsSearch(searchQuery, LAYOUT_ENTRIES) ? (
       <section key="layout" className="space-y-3">

--- a/src/renderer/src/components/settings/GlassAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/GlassAppearanceSection.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from 'react'
+import { RotateCw } from 'lucide-react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { Button } from '../ui/button'
+import { SearchableSetting } from './SearchableSetting'
+import { NumberField, SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
+import { clampNumber } from '@/lib/terminal-theme'
+import { useMountedRef } from '@/hooks/useMountedRef'
+
+type GlassAppearanceSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+/**
+ * Glass Mode + Glass Opacity. These used to live under Terminal → Window as
+ * "Window Blur" and "Background Opacity", but the effect is now app-wide
+ * (translucent window with the desktop blurred through the whole shell), so they
+ * belong in Appearance.
+ */
+export function GlassAppearanceSection({
+  settings,
+  updateSettings
+}: GlassAppearanceSectionProps): React.JSX.Element {
+  // Why: windowBackgroundBlur is only read by createMainWindow() at startup
+  // (macOS vibrancy / Windows acrylic both require window-creation options), so
+  // the UI has to ask the user to restart for the change to take effect.
+  // Snapshot the value on first render and compare to the live setting to show a
+  // "Restart required" banner only when they differ.
+  const blurAtMountRef = useRef<boolean>(settings.windowBackgroundBlur ?? false)
+  const blurPendingRestart = (settings.windowBackgroundBlur ?? false) !== blurAtMountRef.current
+  const [relaunching, setRelaunching] = useState(false)
+  const mountedRef = useMountedRef()
+
+  // Why: the mount-time snapshot captures local state; if settings load async,
+  // keep the ref honest so the banner only appears on a real user-driven change.
+  useEffect(() => {
+    blurAtMountRef.current = settings.windowBackgroundBlur ?? false
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleRelaunch = async (): Promise<void> => {
+    if (relaunching) {
+      return
+    }
+    setRelaunching(true)
+    try {
+      await window.api.app.relaunch()
+    } catch {
+      if (mountedRef.current) {
+        setRelaunching(false)
+      }
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <SettingsSubsectionHeader title="Window Glass" />
+
+      <div className="divide-y divide-border/40">
+        <SearchableSetting
+          title="Glass Mode"
+          description="Make the window translucent so the blurred desktop shows through the whole app."
+          keywords={[
+            'glass',
+            'blur',
+            'vibrancy',
+            'acrylic',
+            'transparent',
+            'translucent',
+            'window',
+            'background'
+          ]}
+          className="space-y-3 py-2"
+        >
+          <SettingsSwitchRow
+            label="Glass Mode"
+            description="Turn the whole app — sidebars, terminals, editor, and panels — into translucent glass with the desktop blurred behind it. Requires a restart."
+            checked={settings.windowBackgroundBlur ?? false}
+            onChange={() =>
+              updateSettings({ windowBackgroundBlur: !settings.windowBackgroundBlur })
+            }
+          />
+
+          {blurPendingRestart ? (
+            <div className="flex items-center justify-between gap-3 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2.5">
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
+                  Restart required
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Restart Orca to apply the Glass Mode change.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="default"
+                className="shrink-0 gap-1.5"
+                disabled={relaunching}
+                onClick={() => void handleRelaunch()}
+              >
+                <RotateCw className={`size-3 ${relaunching ? 'animate-spin' : ''}`} />
+                {relaunching ? 'Restarting…' : 'Restart now'}
+              </Button>
+            </div>
+          ) : null}
+        </SearchableSetting>
+
+        <SearchableSetting
+          title="Glass Opacity"
+          description="How opaque the app surfaces are in Glass Mode."
+          keywords={['glass', 'opacity', 'transparency', 'background', 'alpha', 'blur']}
+        >
+          <NumberField
+            label="Glass Opacity"
+            description="How opaque the app surfaces are when Glass Mode is on. 1 is fully solid, 0 is transparent. Has no effect while Glass Mode is off."
+            value={settings.terminalBackgroundOpacity ?? 1}
+            defaultValue={1}
+            min={0}
+            max={1}
+            step={0.05}
+            suffix="0 to 1"
+            onChange={(value) =>
+              updateSettings({ terminalBackgroundOpacity: clampNumber(value, 0, 1) })
+            }
+          />
+        </SearchableSetting>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.lifecycle.test.tsx
@@ -219,6 +219,18 @@ describe('TerminalSettingsPreview terminal lifecycle', () => {
     expect(terminal.dispose).toHaveBeenCalledOnce()
   })
 
+  it('stays opaque when Glass Mode (blur) is off, even at a low opacity', () => {
+    // Why: terminal transparency only applies in glass mode; with blur off the
+    // preview must show the solid theme, not a washed-out translucent one.
+    renderPreview(makeSettings({ windowBackgroundBlur: false, terminalBackgroundOpacity: 0.4 }))
+    expect(mockXterm.instances[0].options.allowTransparency).toBe(false)
+  })
+
+  it('allows transparency when Glass Mode is on and opacity < 1', () => {
+    renderPreview(makeSettings({ windowBackgroundBlur: true, terminalBackgroundOpacity: 0.4 }))
+    expect(mockXterm.instances[0].options.allowTransparency).toBe(true)
+  })
+
   it('disposes the ligatures addon before disposing the terminal', () => {
     mockLigaturesAddon.enabled = true
 

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -117,16 +117,29 @@ export function TerminalSettingsPreview({
     ]
   )
 
+  // Why: terminal opacity/transparency only applies in glass mode (blur on). With
+  // blur off the whole app — including this preview — must render the solid
+  // theme, so compose without the opacity. Otherwise a low opacity makes the
+  // preview transparent over the dark settings card and a light theme reads dark.
+  const previewBlurActive =
+    settings.windowBackgroundBlur === true &&
+    settings.terminalBackgroundOpacity !== undefined &&
+    settings.terminalBackgroundOpacity < 1
   // Why: same — list the composeActiveTerminalTheme inputs explicitly so font
   // and cursor option changes don't trigger a buffer rewrite.
   const composedTheme = useMemo(
-    () => composeActiveTerminalTheme(appearance.theme, settings),
+    () =>
+      composeActiveTerminalTheme(
+        appearance.theme,
+        previewBlurActive ? settings : { ...settings, terminalBackgroundOpacity: undefined }
+      ),
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     [
       appearance,
       settings.terminalColorOverrides,
       settings.terminalBackgroundOpacity,
-      settings.terminalCursorOpacity
+      settings.terminalCursorOpacity,
+      previewBlurActive
     ]
   )
 
@@ -162,8 +175,7 @@ export function TerminalSettingsPreview({
       fontWeightBold: weights.fontWeightBold,
       lineHeight: settings.terminalLineHeight,
       theme: composedTheme ?? undefined,
-      allowTransparency:
-        settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1,
+      allowTransparency: previewBlurActive,
       cols: PREVIEW_COLS,
       rows: PREVIEW_ROWS
     })
@@ -227,11 +239,10 @@ export function TerminalSettingsPreview({
       return
     }
     terminal.options.theme = composedTheme
-    // Why: matches the live pane policy in applyTerminalAppearance — without
-    // this, an opacity < 1 background renders opaque inside xterm even though
-    // the theme color carries an alpha channel.
-    terminal.options.allowTransparency =
-      settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1
+    // Why: matches the live pane policy in applyTerminalAppearance — transparency
+    // only when glass is active (blur on + opacity < 1); with blur off the solid
+    // theme renders normally.
+    terminal.options.allowTransparency = previewBlurActive
     if (skipInitialThemeRewriteRef.current) {
       skipInitialThemeRewriteRef.current = false
       return
@@ -244,7 +255,7 @@ export function TerminalSettingsPreview({
     // from a clean slate.
     terminal.reset()
     terminal.write(PREVIEW_BUFFER)
-  }, [composedTheme, settings.terminalBackgroundOpacity])
+  }, [composedTheme, settings.terminalBackgroundOpacity, previewBlurActive])
 
   useEffect(() => {
     const terminal = terminalRef.current

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -1,12 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
-import { RotateCw } from 'lucide-react'
+import { useState } from 'react'
 import type { GlobalSettings, TerminalColorOverrides } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { ColorField, NumberField } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
-import { clampNumber } from '@/lib/terminal-theme'
-import { useMountedRef } from '@/hooks/useMountedRef'
 
 type TerminalWindowSectionProps = {
   settings: GlobalSettings
@@ -78,119 +75,15 @@ export function TerminalWindowSection({
   updateSettings
 }: TerminalWindowSectionProps): React.JSX.Element {
   const [colorOverridesExpanded, setColorOverridesExpanded] = useState(false)
-  // Why: windowBackgroundBlur is only read by createMainWindow() at startup
-  // (macOS vibrancy / Windows acrylic both require window creation options),
-  // so the UI has to ask the user to restart for the change to take effect.
-  // Snapshot the value on first render and compare to the live setting to
-  // show a "Restart required" banner only when they differ.
-  const blurAtMountRef = useRef<boolean>(settings.windowBackgroundBlur ?? false)
-  const blurPendingRestart = (settings.windowBackgroundBlur ?? false) !== blurAtMountRef.current
-  const [relaunchingBlur, setRelaunchingBlur] = useState(false)
-  const mountedRef = useMountedRef()
-
-  // Why: the mount-time snapshot captures local state, not main-process state.
-  // If the setting is persisted and read correctly on next boot we never need
-  // to re-snapshot, but tests mount the component with arbitrary initial
-  // values — keep `blurAtMountRef` honest if the settings load asynchronously
-  // and the value arrives after mount.
-  useEffect(() => {
-    blurAtMountRef.current = settings.windowBackgroundBlur ?? false
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const handleRelaunch = async (): Promise<void> => {
-    if (relaunchingBlur) {
-      return
-    }
-    setRelaunchingBlur(true)
-    try {
-      await window.api.app.relaunch()
-    } catch {
-      if (mountedRef.current) {
-        setRelaunchingBlur(false)
-      }
-    }
-  }
 
   return (
     <section className="space-y-4">
       <div className="space-y-1">
         <h3 className="text-sm font-semibold">Window</h3>
-        <p className="text-xs text-muted-foreground">Window appearance and background settings.</p>
+        <p className="text-xs text-muted-foreground">
+          Terminal padding, mouse, and color settings.
+        </p>
       </div>
-
-      <SearchableSetting
-        title="Background Opacity"
-        description="Controls the transparency of the terminal background."
-        keywords={['opacity', 'transparency', 'background', 'alpha']}
-      >
-        <NumberField
-          label="Background Opacity"
-          description="Controls the transparency of the terminal background. 1 is fully opaque, 0 is fully transparent."
-          value={settings.terminalBackgroundOpacity ?? 1}
-          defaultValue={1}
-          min={0}
-          max={1}
-          step={0.05}
-          suffix="0 to 1"
-          onChange={(value) =>
-            updateSettings({ terminalBackgroundOpacity: clampNumber(value, 0, 1) })
-          }
-        />
-      </SearchableSetting>
-
-      <SearchableSetting
-        title="Window Blur"
-        description="Apply background blur to the terminal window. Requires restart."
-        keywords={['window', 'blur', 'background', 'transparency', 'vibrancy']}
-        className="space-y-3 py-2"
-      >
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-0.5">
-            <Label>Window Blur</Label>
-            <p className="text-xs text-muted-foreground">
-              Apply background blur to the terminal window. Requires restart.
-            </p>
-          </div>
-          <button
-            role="switch"
-            aria-checked={settings.windowBackgroundBlur ?? false}
-            onClick={() => updateSettings({ windowBackgroundBlur: !settings.windowBackgroundBlur })}
-            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
-              (settings.windowBackgroundBlur ?? false) ? 'bg-foreground' : 'bg-muted-foreground/30'
-            }`}
-          >
-            <span
-              className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                (settings.windowBackgroundBlur ?? false) ? 'translate-x-4' : 'translate-x-0.5'
-              }`}
-            />
-          </button>
-        </div>
-
-        {blurPendingRestart ? (
-          <div className="flex items-center justify-between gap-3 rounded-md border border-yellow-500/50 bg-yellow-500/10 px-3 py-2.5">
-            <div className="min-w-0 flex-1 space-y-0.5">
-              <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
-                Restart required
-              </p>
-              <p className="text-xs text-muted-foreground">
-                Restart Orca to apply the window blur change.
-              </p>
-            </div>
-            <Button
-              size="sm"
-              variant="default"
-              className="shrink-0 gap-1.5"
-              disabled={relaunchingBlur}
-              onClick={() => void handleRelaunch()}
-            >
-              <RotateCw className={`size-3 ${relaunchingBlur ? 'animate-spin' : ''}`} />
-              {relaunchingBlur ? 'Restarting…' : 'Restart now'}
-            </Button>
-          </div>
-        ) : null}
-      </SearchableSetting>
 
       <SearchableSetting
         title="Horizontal Padding"

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -86,6 +86,28 @@ export const TYPOGRAPHY_ENTRIES: SettingsSearchEntry[] = [
   }
 ]
 
+export const GLASS_ENTRIES: SettingsSearchEntry[] = [
+  {
+    title: 'Glass Mode',
+    description: 'Make the window translucent so the blurred desktop shows through the whole app.',
+    keywords: [
+      'glass',
+      'blur',
+      'vibrancy',
+      'acrylic',
+      'transparent',
+      'translucent',
+      'window',
+      'background'
+    ]
+  },
+  {
+    title: 'Glass Opacity',
+    description: 'How opaque the app surfaces are in Glass Mode.',
+    keywords: ['glass', 'opacity', 'transparency', 'background', 'alpha', 'blur']
+  }
+]
+
 export const LAYOUT_ENTRIES: SettingsSearchEntry[] = [
   {
     title: 'Show Git-Ignored Files',
@@ -123,6 +145,7 @@ export const APPEARANCE_PANE_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   ...THEME_ENTRIES,
   ...TYPOGRAPHY_ENTRIES,
   ...ZOOM_ENTRIES,
+  ...GLASS_ENTRIES,
   ...LAYOUT_ENTRIES,
   ...TITLEBAR_ENTRIES,
   ...STATUS_BAR_ENTRIES,

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -218,16 +218,6 @@ export const MANAGE_SESSIONS_SEARCH_ENTRIES: SettingsSearchEntry[] = [
 
 export const TERMINAL_WINDOW_SEARCH_ENTRIES: SettingsSearchEntry[] = [
   {
-    title: 'Background Opacity',
-    description: 'Controls the transparency of the terminal background.',
-    keywords: ['opacity', 'transparency', 'background', 'alpha']
-  },
-  {
-    title: 'Window Blur',
-    description: 'Apply background blur to the terminal window. Requires restart.',
-    keywords: ['window', 'blur', 'background', 'transparency', 'vibrancy']
-  },
-  {
     title: 'Horizontal Padding',
     description: 'Horizontal padding around the terminal grid in pixels.',
     keywords: ['padding', 'horizontal', 'spacing', 'margin']

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -196,8 +196,26 @@ export function applyTerminalAppearance(
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
   const baseTheme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
-  const theme = composeActiveTerminalTheme(baseTheme, settings)
-  const paneBackground = theme?.background ?? '#000000'
+  const opacityActive =
+    settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1
+  // Why: terminal transparency only makes sense when window blur is on — there's
+  // a blurred desktop behind the window to reveal. With blur off, a transparent
+  // terminal would just composite muddily over the opaque app shell and the
+  // theme would look washed out, so compose the theme WITHOUT the opacity (solid
+  // background). When glass is active, compose WITH opacity, then clear the xterm
+  // background and ground the pane on the shared --editor-surface so the terminal
+  // matches the editor/file viewer exactly.
+  const glassActive = settings.windowBackgroundBlur === true && opacityActive
+  const composedTheme = composeActiveTerminalTheme(
+    baseTheme,
+    glassActive ? settings : { ...settings, terminalBackgroundOpacity: undefined }
+  )
+  const paneBackground = composedTheme?.background ?? '#000000'
+  const theme =
+    glassActive && composedTheme
+      ? { ...composedTheme, background: 'rgba(0, 0, 0, 0)' }
+      : composedTheme
+  const effectivePaneBackground = glassActive ? 'var(--editor-surface)' : paneBackground
 
   const terminalFontWeights = resolveTerminalFontWeights(settings.terminalFontWeight)
   const ligaturesEnabled = resolveTerminalLigaturesEnabled(
@@ -209,11 +227,10 @@ export function applyTerminalAppearance(
     if (theme) {
       pane.terminal.options.theme = theme
     }
-    // Why: xterm's allowTransparency has measurable rendering cost, so clear
-    // it explicitly when opacity is at (or above) 1 to avoid a stale `true`
-    // bleeding in from a prior opacity setting that has since been reset.
-    pane.terminal.options.allowTransparency =
-      settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1
+    // Why: only allow transparency in glass mode (blur on + opacity < 1). With
+    // blur off there is nothing behind the window to reveal, so the terminal
+    // stays fully opaque and renders its solid theme background.
+    pane.terminal.options.allowTransparency = glassActive
     const cursorStyle = settings.terminalCursorStyle ?? 'bar'
     pane.terminal.options.cursorStyle = cursorStyle
     pane.terminal.options.cursorInactiveStyle = resolveTerminalCursorInactiveStyle(cursorStyle)
@@ -256,8 +273,8 @@ export function applyTerminalAppearance(
   }
 
   manager.setPaneStyleOptions({
-    splitBackground: paneBackground,
-    paneBackground,
+    splitBackground: effectivePaneBackground,
+    paneBackground: effectivePaneBackground,
     inactivePaneOpacity: paneStyles.inactivePaneOpacity,
     activePaneOpacity: paneStyles.activePaneOpacity,
     opacityTransitionMs: paneStyles.opacityTransitionMs,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -926,7 +926,17 @@ export function useTerminalPaneLifecycle({
           cursorBlink: currentSettings?.terminalCursorBlink ?? true,
           macOptionIsMeta: effectiveMacOptionAsAltRef.current === 'true',
           lineHeight: currentSettings?.terminalLineHeight ?? 1,
-          wordSeparator: currentSettings?.terminalWordSeparator
+          wordSeparator: currentSettings?.terminalWordSeparator,
+          // Why: xterm only sets up its renderer for an alpha background when
+          // allowTransparency is true at open() time. Seed it before
+          // new Terminal()/open() so a semi-transparent theme renders correctly
+          // on the first paint. Gated on blur to match the live policy in
+          // applyTerminalAppearance: transparency only applies in glass mode, so
+          // with blur off the terminal stays fully opaque on its solid theme.
+          allowTransparency:
+            currentSettings?.windowBackgroundBlur === true &&
+            currentSettings.terminalBackgroundOpacity !== undefined &&
+            currentSettings.terminalBackgroundOpacity < 1
         }
       },
       onLinkClick: (event, url) => {


### PR DESCRIPTION
**Root cause this fixes**: blur & background opacity never visibly worked before because the macOS window set `transparent: true` together with `vibrancy`, which suppresses the vibrancy view, and an opaque `backgroundColor` painted over the blur layer.

## Summary

Adds **Window Glass** - a translucent window mode that lets the blurred desktop show through the whole app (sidebars, terminals, editor, panels), backed by macOS vibrancy and Windows acrylic.

User-visible changes:

- **New "Window Glass" section in Settings → Appearance** (placed above File Explorer) with two controls:
  - **Glass Mode** (toggle) - turns the whole app into translucent glass with the desktop blurred behind it. Requires a restart (the window's transparency/material is set at window creation), so the toggle shows a "Restart required" banner with a relaunch button.
  - **Glass Opacity** (0–1) - how opaque the app surfaces are in Glass Mode. The middle view (terminal, editor/file viewer, page backgrounds) tracks this value exactly; chrome (sidebars, titlebar, cards) sits `+0.25` more opaque so framing stays readable. Floating overlays (dropdowns, dialogs, tooltips, command palette) stay fully opaque for readability.
- These two settings **moved out of Settings → Terminal → Window and were renamed** (previously "Window Blur" and "Background Opacity"), since the effect is now app-wide rather than terminal-only. Their descriptions were updated and the in-settings search index was moved accordingly. Persisted setting keys are unchanged (`windowBackgroundBlur`, `terminalBackgroundOpacity`), so existing configs keep working.
- **Ghostty import:** `background-blur` (boolean or numeric radius) now maps to the Glass Mode setting, alongside the existing `background-blur-radius`.

Behavior when Glass Mode is **off** is unchanged from today - the window is opaque and the terminal/editor/preview render their solid themes (the glass/opacity logic is fully gated on the blur setting).

## Screenshots

- Opacity at 0 - Glass On
<img width="1744" height="1044" alt="image" src="https://github.com/user-attachments/assets/6939b5eb-8196-4386-b050-74a03d1cefba" />

- Glass Off
<img width="1726" height="1043" alt="image" src="https://github.com/user-attachments/assets/54409af8-cbfa-45cd-8932-9ecd988572a1" />

- Opacity at 0 - Glass On
<img width="1751" height="1057" alt="image" src="https://github.com/user-attachments/assets/8b8aac5c-1fb8-47e4-99f5-4d44321ba98b" />

- Glass Off
<img width="1737" height="1043" alt="image" src="https://github.com/user-attachments/assets/d95720b5-3e90-4b99-8dbb-11b872dd302c" />

- Opacity at 0 - Glass On
<img width="1718" height="1042" alt="image" src="https://github.com/user-attachments/assets/2468b510-4fef-44d9-958d-80da6b425bd1" />

<img width="1734" height="1044" alt="image" src="https://github.com/user-attachments/assets/112676c4-1299-4ec2-8518-c794692e1ffd" />

- Glass Off
<img width="1722" height="1044" alt="image" src="https://github.com/user-attachments/assets/b69f0e83-0694-489f-aed9-54fbdda60140" />

- Opacity at 0 - Glass On
<img width="1726" height="1050" alt="image" src="https://github.com/user-attachments/assets/8ff18738-dc66-4343-867d-ad37ed65a985" />

- Glass Off
<img width="1726" height="1046" alt="image" src="https://github.com/user-attachments/assets/8b5495af-a1d9-4ff1-8b7b-c9f8e8761ee1" />

- Opacity at 0.3 - Glass On
<img width="1725" height="1032" alt="image" src="https://github.com/user-attachments/assets/ecddf850-1cb5-45f5-b118-d144ef8001e2" />


## Testing

- [x] `pnpm lint` - passes (oxlint, switch-exhaustiveness, and the `check-styled-scrollbars` guard).
- [x] `pnpm typecheck` - `typecheck:node` and `typecheck:web` both clean (0 errors).
- [x] `pnpm test` - touched suites green: `mapper.test.ts`, `createMainWindow.test.ts`, `terminal-appearance.test.ts`, `TerminalSettingsPreview.lifecycle.test.tsx`.
- [x] `pnpm build` - passes (typecheck → relay → computer-macos → cli → electron-vite → web all succeed).
- [x] Added or updated high-quality tests that would catch regressions:
  - Ghostty `background-blur` mapping (boolean / numeric radius / `0` / invalid + the "radius not preserved" note).
  - `createMainWindow` window options per platform (macOS vibrancy without `transparent`, Windows acrylic, Linux opaque fallback).
  - Settings preview transparency gated on blur (catches the "preview shows a light theme as dark when blur is off" regression).

Manually verified on **macOS** (dark mode) via the running dev app: Glass Mode on → vibrancy shows through; Glass Opacity drives terminal/editor/chrome at the expected levels; Glass Mode off → solid themes everywhere (terminal, editor, preview); floating overlays stay opaque; terminal scrollbar matches the file editor. Windows & Linux are not tested and should be verified.

## AI Review Report

Reviewed the diff with an AI coding agent across the dimensions CONTRIBUTING requires:

- **Cross-platform (macOS / Linux / Windows):** All window-material logic in `createMainWindow.ts` is guarded by `process.platform` - macOS uses `vibrancy: 'under-window'` + `visualEffectState: 'active'` (no `transparent: true`, which was the bug); Windows uses `backgroundMaterial: 'acrylic'`; Linux has no native blur surface and keeps an opaque `backgroundColor`. No keyboard shortcuts, accelerators, shortcut labels, or filesystem paths were added or changed, so there are no `metaKey`/`CmdOrCtrl`/`⌘`-vs-`Ctrl`/`path.join` concerns in this PR. The renderer CSS gates everything on a `glass` class driven by the blur setting, identical across platforms. **macOS verified live; Windows acrylic and Linux opaque-fallback paths are guarded but were not visually verified - flagged in Notes.**
- **SSH / remote / local:** Changes are window-level (main process) and renderer styling only; no assumptions about processes, files, shells, credentials, or network paths. The relaunch uses the existing `window.api.app.relaunch()` IPC. No SSH/remote-specific behavior.
- **Agents / integrations / git providers:** Provider-neutral. The only integration touch is the Ghostty importer, guarded by an explicit key (`background-blur`) with strict value validation; nothing GitHub/GitLab-specific.
- **Performance:** No new work in hot paths. The glass effect is pure CSS variables; `applyTerminalAppearance` only sets `allowTransparency`/theme when blur is on, and the per-pane loop is unchanged. Two `documentElement.style.setProperty` calls fire only when the blur/opacity settings change.
- **UI quality (STYLEGUIDE):** Used existing tokens and shadcn/settings primitives (`SettingsSwitchRow`, `NumberField`, `SettingsSubsectionHeader`, `SearchableSetting`). Flagged and fixed by the review: hardcoded hex in the "pin solid" rules → new `--background-solid` / `--editor-surface-solid` tokens; the custom terminal-scrollbar style was reconciled with the "don't write a fourth scrollbar style" rule by mirroring `.scrollbar-editor`'s exact values (xterm owns its internal scrollbar elements, so the class can't be attached) and documenting it - `check-styled-scrollbars` passes. Light and dark both covered.
- **Security:** see below.

## Security Audit

Low risk. No input handling, command execution, path handling, auth, secrets, or new dependencies are introduced.

- **IPC:** No new IPC channels; reuses the existing `app:relaunch` path that the old Window Blur toggle already used.
- **Window security:** Only adds non-opaque window material options (vibrancy/acrylic) and omits the opaque `backgroundColor` on a blur surface - `sandbox`, `contextIsolation`, `webviewTag`, and the webview hardening in `createMainWindow` are untouched.
- **Untrusted input:** The Ghostty `background-blur` value is parsed through the existing strict integer/boolean validation (rejects anything else), so a malformed config can't smuggle a value through.
- **Follow-up:** none required.

## Notes

- **Restart required:** Glass Mode changes the Electron window's transparency/material, which can only be set at window creation, so toggling it prompts a restart (the toggle surfaces a relaunch button). This matches the prior Window Blur behavior.
- **Glass is fully gated on blur:** with Glass Mode off, none of the translucency applies - the terminal, editor, settings preview, and app shell render exactly as before. Glass Opacity only has an effect while Glass Mode is on.
- **Platform verification:** verified on macOS (vibrancy). Windows (acrylic) and Linux (opaque, no native blur) paths are guarded by `process.platform` but should be sanity-checked on those platforms before merge.

## Comparison to PR #2791

[#2791](https://github.com/stablyai/orca/pull/2791) ("macOS native glass effect as an orthogonal setting") produces the same visual result - a translucent window with the desktop blurred through the shell. This PR reaches it with ~6× less code by layering on settings that already exist instead of building a new feature platform.

|                 | This PR                                                     | #2791                                                 |
| --------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
| Files / lines   | 15 · +524 / −170                                            | 89 · +1492 / −145                                     |
| Setting         | Reuses `windowBackgroundBlur` + `terminalBackgroundOpacity` | New `glassEffect: boolean`                            |
| Opaque surfaces | Flip design tokens translucent once; pin a few overlays     | New `bg-background-opaque` util across ~30 components |
| Monaco          | CSS override                                                | New theme module + 5-component wiring                 |
| Platforms       | macOS + Windows + Linux (opaque fallback)                   | macOS-only by design                                  |
| Migration       | None                                                        | Rewrites a legacy 5-value theme on disk               |

**Why ours is smaller:**

- **No new setting.** Glass rides on the existing `windowBackgroundBlur` + `terminalBackgroundOpacity`, so there's no new type, predicate module, IPC plumbing, on-disk migration, or onboarding.
- **Inverted CSS strategy.** We make the design _tokens_ translucent in glass mode in one place and pin back only the handful of real overlays (dialog/sheet/tooltip/switch); popovers, dropdowns, and selects stay opaque automatically via the untouched `--popover`. The PR #2791 instead tags ~30 components with `bg-background-opaque`.
- **Monaco via CSS**, not a new theme module wired through five editor components.

**Where we differ technically:** on macOS we **omit** `transparent: true` (the PR #2791 sets `transparent: true` + `backgroundColor: '#00000000'`). That combination suppresses the vibrancy view - the actual reason blur rendered opaque - so we use `vibrancy: 'under-window'` + `visualEffectState: 'active'` and omit `backgroundColor` on a blur surface. We also cover Windows (acrylic) and Linux (opaque fallback); the PR #2791 is macOS-only.

**Trade-offs vs #2791:**

- **Coupling:** blur and the glass look are one switch (`windowBackgroundBlur`); the (PR 2791) keeps them independent. In practice this gives up little - when tested, the existing `windowBackgroundBlur` never actually rendered blur (it showed opaque, the bug fixed here - see Summary), so there was no working "blur without glass" to preserve.
- **No migration needed:** the legacy 5-value theme (`glass-light` / `glass-dark`) is (PR 2791)'s lineage, not ours. Our `theme` is the 3-value enum (`system` / `dark` / `light`, see `src/shared/types.ts`), and we reuse the existing `windowBackgroundBlur` + `terminalBackgroundOpacity` settings rather than adding a key, so there's no on-disk state to convert. A migration here would match zero persisted values.
- **Token blast radius:** any new `bg-background` surface is translucent by default under glass (we pin exceptions with `*-solid`; (PR 2791) opts in with `bg-background-opaque`).
- **No `prefers-reduced-transparency` fallback** yet (PR 2791) has one; could be added as a single media query against the same tokens).

## ELI5

Window Glass mode makes the whole app translucent with desktop blur (macOS vibrancy / Windows acrylic)—sidebars, terminals, and panels.
