### PR TITLE
Fix packaged runtime dependency resolution

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,6 +98,7 @@ jobs:
         run: pnpm build:unpack
 
       # Why: the packaged CLI runs outside Electron's asar integration, so
-      # bare runtime imports must be present in app.asar.unpacked.
+      # bare runtime imports must be present in the package itself. Run from a
+      # temp copy so Node cannot mask missing package deps with repo node_modules.
       - name: Smoke packaged CLI
-        run: dist/linux-unpacked/resources/bin/orca-ide --help
+        run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -2,6 +2,11 @@ const { chmodSync, existsSync, readdirSync } = require('node:fs')
 const { execFileSync } = require('node:child_process')
 const { join, resolve } = require('node:path')
 const electronBuilderNativeRebuild = require('./scripts/electron-builder-native-rebuild.cjs')
+const {
+  createPackagedRuntimeNodeModuleResources,
+  isPackagedExternalSpecifier,
+  packageNameFromSpecifier
+} = require('./packaged-runtime-node-modules.cjs')
 
 const isMacRelease = process.env.ORCA_MAC_RELEASE === '1'
 const featureWallResources = {
@@ -14,6 +19,25 @@ const featureWallResources = {
 const relayExtraResource = {
   from: 'out/relay',
   to: 'relay'
+}
+// Why: the main bundle, packaged CLI, SSH paths, and speech worker all execute
+// from package directories where pnpm's symlink farm is absent. Copy the exact
+// runtime dependency closure to Resources/node_modules so bare require() calls
+// do not fall through to a developer checkout's node_modules.
+const packagedRuntimeNodeModuleResources = createPackagedRuntimeNodeModuleResources()
+
+const commonExtraResources = [relayExtraResource, ...packagedRuntimeNodeModuleResources]
+const macSpeechNativeResource = {
+  from: 'node_modules/sherpa-onnx-darwin-${arch}',
+  to: 'node_modules/sherpa-onnx-darwin-${arch}'
+}
+const linuxSpeechNativeResource = {
+  from: 'node_modules/sherpa-onnx-linux-${arch}',
+  to: 'node_modules/sherpa-onnx-linux-${arch}'
+}
+const winSpeechNativeResource = {
+  from: 'node_modules/sherpa-onnx-win-x64',
+  to: 'node_modules/sherpa-onnx-win-x64'
 }
 
 /** @type {import('electron-builder').Configuration} */
@@ -89,6 +113,7 @@ module.exports = {
     if (!existsSync(resourcesDir)) {
       return
     }
+    verifyPackagedMainRuntimeDeps(resourcesDir)
     for (const filename of readdirSync(resourcesDir)) {
       if (!filename.startsWith('agent-browser-')) {
         continue
@@ -105,7 +130,8 @@ module.exports = {
   win: {
     executableName: 'Orca',
     extraResources: [
-      relayExtraResource,
+      ...commonExtraResources,
+      winSpeechNativeResource,
       {
         from: 'resources/win32/bin/orca.cmd',
         to: 'bin/orca.cmd'
@@ -159,7 +185,8 @@ module.exports = {
     hardenedRuntime: isMacRelease,
     notarize: isMacRelease,
     extraResources: [
-      relayExtraResource,
+      ...commonExtraResources,
+      macSpeechNativeResource,
       {
         from: 'resources/darwin/bin/orca',
         to: 'bin/orca'
@@ -199,7 +226,8 @@ module.exports = {
     // sizes; a single 1024px PNG is ignored by some Linux docks/launchers.
     icon: 'resources/build/icon.icns',
     extraResources: [
-      relayExtraResource,
+      ...commonExtraResources,
+      linuxSpeechNativeResource,
       {
         from: 'resources/linux/bin/orca-ide',
         to: 'bin/orca-ide'
@@ -244,6 +272,39 @@ module.exports = {
     owner: 'stablyai',
     repo: 'orca',
     releaseType: 'release'
+  }
+}
+
+function verifyPackagedMainRuntimeDeps(resourcesDir) {
+  const asarPath = join(resourcesDir, 'app.asar')
+  if (!existsSync(asarPath)) {
+    return
+  }
+
+  const { extractFile } = require('@electron/asar')
+  const mainFiles = ['out/main/index.js', 'out/main/agent-hooks/managed-agent-hook-controls.js']
+  const missing = new Set()
+
+  for (const file of mainFiles) {
+    const source = extractFile(asarPath, file).toString('utf8')
+    for (const match of source.matchAll(/require\(["']([^"']+)["']\)/g)) {
+      const specifier = match[1]
+      if (!isPackagedExternalSpecifier(specifier)) {
+        continue
+      }
+      const packageName = packageNameFromSpecifier(specifier)
+      if (!existsSync(join(resourcesDir, 'node_modules', ...packageName.split('/')))) {
+        missing.add(packageName)
+      }
+    }
+  }
+
+  if (missing.size > 0) {
+    throw new Error(
+      `Packaged main bundle has bare runtime imports without copied node_modules: ${[
+        ...missing
+      ].join(', ')}`
+    )
   }
 }
 

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -1,0 +1,109 @@
+const { existsSync, readFileSync, realpathSync } = require('node:fs')
+const { dirname, join, resolve } = require('node:path')
+const { builtinModules, createRequire } = require('node:module')
+
+const projectDir = resolve(__dirname, '..')
+const requireFromProject = createRequire(join(projectDir, 'package.json'))
+
+const PACKAGED_RUNTIME_PACKAGE_ROOTS = [
+  '@electron-toolkit/utils',
+  '@linear/sdk',
+  'electron-updater',
+  'node-pty',
+  'posthog-node',
+  'qrcode',
+  'ssh2',
+  'tweetnacl',
+  'ws',
+  'yaml',
+  'zod'
+]
+
+const NODE_BUILTINS = new Set([
+  ...builtinModules,
+  ...builtinModules.map((moduleName) => `node:${moduleName}`)
+])
+
+function packageNameFromSpecifier(specifier) {
+  if (specifier.startsWith('@')) {
+    const [scope, name] = specifier.split('/')
+    return scope && name ? `${scope}/${name}` : specifier
+  }
+  return specifier.split('/')[0]
+}
+
+function isPackagedExternalSpecifier(specifier) {
+  return (
+    !specifier.startsWith('.') &&
+    !specifier.startsWith('/') &&
+    specifier !== 'electron' &&
+    !NODE_BUILTINS.has(specifier)
+  )
+}
+
+function resolvePackageJsonPath(packageName, fromDir = projectDir) {
+  try {
+    return requireFromProject.resolve(`${packageName}/package.json`, { paths: [fromDir] })
+  } catch {
+    const entryPath = requireFromProject.resolve(packageName, { paths: [fromDir] })
+    let dir = dirname(entryPath)
+    while (dir !== dirname(dir)) {
+      const packageJsonPath = join(dir, 'package.json')
+      if (existsSync(packageJsonPath)) {
+        return packageJsonPath
+      }
+      dir = dirname(dir)
+    }
+    throw new Error(`Could not find package.json for ${packageName}`)
+  }
+}
+
+function readPackage(packageName, fromDir = projectDir) {
+  const packageJsonPath = resolvePackageJsonPath(packageName, fromDir)
+  const packageDir = realpathSync(dirname(packageJsonPath))
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  return {
+    name: packageJson.name ?? packageName,
+    packageDir,
+    dependencies: Object.keys(packageJson.dependencies ?? {})
+  }
+}
+
+function collectPackagedRuntimePackages() {
+  const packages = new Map()
+  const visit = (packageName, fromDir = projectDir) => {
+    if (packageName === 'electron' || packages.has(packageName)) {
+      return
+    }
+
+    const packageInfo = readPackage(packageName, fromDir)
+    if (packages.has(packageInfo.name)) {
+      return
+    }
+    packages.set(packageInfo.name, packageInfo.packageDir)
+
+    for (const dependencyName of packageInfo.dependencies) {
+      visit(dependencyName, packageInfo.packageDir)
+    }
+  }
+
+  for (const packageName of PACKAGED_RUNTIME_PACKAGE_ROOTS) {
+    visit(packageName)
+  }
+
+  return [...packages.entries()].sort(([left], [right]) => left.localeCompare(right))
+}
+
+function createPackagedRuntimeNodeModuleResources() {
+  return collectPackagedRuntimePackages().map(([packageName, packageDir]) => ({
+    from: packageDir,
+    to: join('node_modules', ...packageName.split('/'))
+  }))
+}
+
+module.exports = {
+  PACKAGED_RUNTIME_PACKAGE_ROOTS,
+  createPackagedRuntimeNodeModuleResources,
+  isPackagedExternalSpecifier,
+  packageNameFromSpecifier
+}

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -133,13 +133,15 @@ describe('Electron runtime package contract', () => {
     expect(installStep.run).toBe('node config/scripts/install-electron-package-binary.mjs')
   })
 
-  it('smokes the packaged Linux CLI launcher that is shipped in resources', () => {
+  it('smokes the packaged CLI from outside the checkout in PR checks', () => {
     const prWorkflow = readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8')
     const parsedWorkflow = parse(prWorkflow)
     const smokeStep = parsedWorkflow.jobs.verify.steps.find(
       (step) => step.name === 'Smoke packaged CLI'
     )
 
-    expect(smokeStep.run).toBe('dist/linux-unpacked/resources/bin/orca-ide --help')
+    expect(smokeStep.run).toBe(
+      'node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked'
+    )
   })
 })

--- a/config/scripts/smoke-packaged-cli.mjs
+++ b/config/scripts/smoke-packaged-cli.mjs
@@ -1,0 +1,46 @@
+import { cp, mkdtemp, rm } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+function readAppDirArg(argv) {
+  const explicit = argv.find((arg) => arg.startsWith('--app-dir='))
+  if (explicit) {
+    return explicit.slice('--app-dir='.length)
+  }
+  if (process.platform === 'darwin') {
+    return 'dist/mac-arm64/Orca.app'
+  }
+  if (process.platform === 'win32') {
+    return 'dist/win-unpacked'
+  }
+  return 'dist/linux-unpacked'
+}
+
+function getPackagedCliPath(appDir) {
+  if (process.platform === 'darwin' || appDir.endsWith('.app')) {
+    return join(appDir, 'Contents', 'Resources', 'bin', 'orca')
+  }
+  if (process.platform === 'win32') {
+    return join(appDir, 'resources', 'bin', 'orca.cmd')
+  }
+  return join(appDir, 'resources', 'bin', 'orca-ide')
+}
+
+const appDir = resolve(readAppDirArg(process.argv.slice(2)))
+const tempRoot = await mkdtemp(join(tmpdir(), 'orca-packaged-cli-smoke-'))
+const copiedAppDir = join(tempRoot, basename(appDir))
+
+try {
+  await cp(appDir, copiedAppDir, { recursive: true, verbatimSymlinks: true })
+  const cliPath = getPackagedCliPath(copiedAppDir)
+  await execFileAsync(cliPath, ['--help'], {
+    env: { ...process.env, NODE_PATH: '' }
+  })
+  console.log(`[packaged-cli-smoke] ${cliPath} --help succeeded outside the repo`)
+} finally {
+  await rm(tempRoot, { recursive: true, force: true })
+}

--- a/src/main/cli/packaged-cli-assets.test.ts
+++ b/src/main/cli/packaged-cli-assets.test.ts
@@ -10,18 +10,32 @@ const require = createRequire(import.meta.url)
 const execFileAsync = promisify(execFile)
 const itRunsUnixShell = process.platform === 'win32' ? it.skip : it
 const builderConfig = require('../../../config/electron-builder.config.cjs') as {
-  asarUnpack?: string[]
+  mac?: { extraResources?: { from?: string; to?: string }[] }
+  linux?: { extraResources?: { from?: string; to?: string }[] }
+  win?: { extraResources?: { from?: string; to?: string }[] }
 }
 const linuxLauncherAsset = new URL('../../../resources/linux/bin/orca-ide', import.meta.url)
 
 describe('packaged CLI assets', () => {
-  it('unpacks runtime dependencies used before Electron asar integration is available', () => {
-    expect(builderConfig.asarUnpack).toEqual(
+  it('copies runtime dependencies used before Electron asar integration is available', () => {
+    const runtimeResourceTargets = new Set(
+      [
+        ...(builderConfig.mac?.extraResources ?? []),
+        ...(builderConfig.linux?.extraResources ?? []),
+        ...(builderConfig.win?.extraResources ?? [])
+      ].map((resource) => resource.to)
+    )
+
+    expect([...runtimeResourceTargets]).toEqual(
       expect.arrayContaining([
-        'node_modules/ws/**',
-        'node_modules/tweetnacl/**',
-        'node_modules/zod/**',
-        'node_modules/yaml/**'
+        join('node_modules', 'ws'),
+        join('node_modules', 'tweetnacl'),
+        join('node_modules', 'zod'),
+        join('node_modules', 'yaml'),
+        join('node_modules', 'node-pty'),
+        join('node_modules', 'sherpa-onnx-darwin-${arch}'),
+        join('node_modules', 'sherpa-onnx-linux-${arch}'),
+        join('node_modules', 'sherpa-onnx-win-x64')
       ])
     )
   })

--- a/src/main/speech/stt-service.ts
+++ b/src/main/speech/stt-service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: speech worker ownership, warm reuse, and
 timeout teardown must stay co-located so dictation lifecycle state cannot drift. */
 import { Worker } from 'worker_threads'
+import { existsSync } from 'fs'
 import { join } from 'path'
 import { app } from 'electron'
 import { getCatalogModel } from './model-catalog'
@@ -386,6 +387,10 @@ export class SttService {
         : `sherpa-onnx-${process.platform}-${process.arch}`
 
     if (app.isPackaged) {
+      const resourcesNodeModule = join(process.resourcesPath, 'node_modules', nativePkg)
+      if (existsSync(resourcesNodeModule)) {
+        return resourcesNodeModule
+      }
       return join(process.resourcesPath, 'app.asar.unpacked', 'node_modules', nativePkg)
     }
 


### PR DESCRIPTION
## Summary
- copy the packaged runtime dependency closure into Resources/node_modules so main-process, CLI, SSH, and hook-control bare require() calls resolve in installed apps
- keep speech native modules in Resources/node_modules and let packaged STT resolve that location
- harden packaged CLI smoke by running it from a temp copy outside the checkout, and add package-time verification for main-process bare runtime imports

## Verification
- pnpm typecheck
- pnpm test
- pnpm exec vitest run --config config/vitest.config.ts src/main/cli/packaged-cli-assets.test.ts src/main/speech/stt-service.test.ts config/scripts/package-electron-runtime-contract.test.mjs config/scripts/electron-builder-config.test.mjs
- pnpm run build:electron-vite
- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder --config config/electron-builder.config.cjs --dir --publish never
- node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/mac-arm64/Orca.app
- isolated ELECTRON_RUN_AS_NODE require of app.asar/out/main/agent-hooks/managed-agent-hook-controls.js from a temp app copy