### PR TITLE
fix: handle Windows asar paths in runtime dep verifier

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -4,8 +4,7 @@ const { join, resolve } = require('node:path')
 const electronBuilderNativeRebuild = require('./scripts/electron-builder-native-rebuild.cjs')
 const {
   createPackagedRuntimeNodeModuleResources,
-  isPackagedExternalSpecifier,
-  packageNameFromSpecifier
+  verifyPackagedMainRuntimeDeps
 } = require('./packaged-runtime-node-modules.cjs')
 
 const isMacRelease = process.env.ORCA_MAC_RELEASE === '1'
@@ -272,39 +271,6 @@ module.exports = {
     owner: 'stablyai',
     repo: 'orca',
     releaseType: 'release'
-  }
-}
-
-function verifyPackagedMainRuntimeDeps(resourcesDir) {
-  const asarPath = join(resourcesDir, 'app.asar')
-  if (!existsSync(asarPath)) {
-    return
-  }
-
-  const { extractFile } = require('@electron/asar')
-  const mainFiles = ['out/main/index.js', 'out/main/agent-hooks/managed-agent-hook-controls.js']
-  const missing = new Set()
-
-  for (const file of mainFiles) {
-    const source = extractFile(asarPath, file).toString('utf8')
-    for (const match of source.matchAll(/require\(["']([^"']+)["']\)/g)) {
-      const specifier = match[1]
-      if (!isPackagedExternalSpecifier(specifier)) {
-        continue
-      }
-      const packageName = packageNameFromSpecifier(specifier)
-      if (!existsSync(join(resourcesDir, 'node_modules', ...packageName.split('/')))) {
-        missing.add(packageName)
-      }
-    }
-  }
-
-  if (missing.size > 0) {
-    throw new Error(
-      `Packaged main bundle has bare runtime imports without copied node_modules: ${[
-        ...missing
-      ].join(', ')}`
-    )
   }
 }
 

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -101,9 +101,60 @@ function createPackagedRuntimeNodeModuleResources() {
   }))
 }
 
+function normalizeAsarEntryPath(entry) {
+  return entry.replace(/\\/g, '/').replace(/^\/+/, '')
+}
+
+function findAsarEntry(entries, expectedPath) {
+  return entries.find((entry) => normalizeAsarEntryPath(entry) === expectedPath)
+}
+
+function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/asar')) {
+  const asarPath = join(resourcesDir, 'app.asar')
+  if (!existsSync(asarPath)) {
+    return
+  }
+
+  const mainFiles = ['out/main/index.js', 'out/main/agent-hooks/managed-agent-hook-controls.js']
+  const entries = asar.listPackage(asarPath)
+  const missing = new Set()
+
+  for (const file of mainFiles) {
+    const entry = findAsarEntry(entries, file)
+    if (!entry) {
+      throw new Error(`Packaged main file ${file} was not found in ${asarPath}`)
+    }
+
+    // Why: @electron/asar lists entries with host separators; Windows returns
+    // backslashes, and extractFile expects that same host-style path.
+    const internalPath = entry.replace(/^[\\/]+/, '')
+    const source = asar.extractFile(asarPath, internalPath).toString('utf8')
+    for (const match of source.matchAll(/require\(["']([^"']+)["']\)/g)) {
+      const specifier = match[1]
+      if (!isPackagedExternalSpecifier(specifier)) {
+        continue
+      }
+      const packageName = packageNameFromSpecifier(specifier)
+      if (!existsSync(join(resourcesDir, 'node_modules', ...packageName.split('/')))) {
+        missing.add(packageName)
+      }
+    }
+  }
+
+  if (missing.size > 0) {
+    throw new Error(
+      `Packaged main bundle has bare runtime imports without copied node_modules: ${[
+        ...missing
+      ].join(', ')}`
+    )
+  }
+}
+
 module.exports = {
   PACKAGED_RUNTIME_PACKAGE_ROOTS,
   createPackagedRuntimeNodeModuleResources,
+  findAsarEntry,
   isPackagedExternalSpecifier,
-  packageNameFromSpecifier
+  packageNameFromSpecifier,
+  verifyPackagedMainRuntimeDeps
 }

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -1,9 +1,13 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const electronBuilderConfig = require('../electron-builder.config.cjs')
 const electronBuilderNativeRebuild = require('./electron-builder-native-rebuild.cjs')
+const { findAsarEntry, verifyPackagedMainRuntimeDeps } = require('../packaged-runtime-node-modules.cjs')
 
 describe('electron-builder config', () => {
   it('uses the multi-size icon source for Linux packages', () => {
@@ -23,5 +27,37 @@ describe('electron-builder config', () => {
   it('uses Orca native rebuild hook instead of electron-builder default rebuild', () => {
     expect(electronBuilderConfig.beforeBuild).toBe(electronBuilderNativeRebuild)
     expect(electronBuilderConfig.npmRebuild).toBe(true)
+  })
+
+  it('verifies packaged main runtime deps from Windows-style asar entries', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-deps-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+      await mkdir(join(resourcesDir, 'node_modules', 'yaml'), { recursive: true })
+      await mkdir(join(resourcesDir, 'node_modules', 'zod'), { recursive: true })
+
+      const sources = new Map([
+        ['out\\main\\index.js', 'const z = require("zod")'],
+        [
+          'out\\main\\agent-hooks\\managed-agent-hook-controls.js',
+          'const YAML = require("yaml")'
+        ]
+      ])
+      const asar = {
+        listPackage: () => [...sources.keys()].map((entry) => `\\${entry}`),
+        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('normalizes host-specific asar entry separators', () => {
+    expect(findAsarEntry(['\\out\\main\\index.js'], 'out/main/index.js')).toBe(
+      '\\out\\main\\index.js'
+    )
+    expect(findAsarEntry(['/out/main/index.js'], 'out/main/index.js')).toBe('/out/main/index.js')
   })
 })


### PR DESCRIPTION
Fixes the release-cut Windows packaging failure from run 26702004095.\n\nThe packaged runtime dependency verifier now locates files through @electron/asar listPackage and normalizes host separators before extracting the host-style entry path. This matches the existing telemetry verifier behavior and keeps the guard active on Windows.\n\nVerification:\n- pnpm exec vitest run --config config/vitest.config.ts config/scripts/electron-builder-config.test.mjs src/main/cli/packaged-cli-assets.test.ts config/scripts/package-electron-runtime-contract.test.mjs\n- pnpm exec oxlint config/electron-builder.config.cjs config/packaged-runtime-node-modules.cjs config/scripts/electron-builder-config.test.mjs\n- pnpm run build:electron-vite\n- CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder --config config/electron-builder.config.cjs --dir --publish never\n- node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/mac-arm64/Orca.app