### PR TITLE
Fix stale unknown PR mergeability status

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -51,7 +51,7 @@ function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
     url: 'https://github.com/acme/repo/pull/12',
     checksStatus: 'pending',
     updatedAt: '2026-05-12T00:00:00Z',
-    mergeable: 'UNKNOWN',
+    mergeable: 'MERGEABLE',
     headSha: 'head-sha',
     ...overrides
   }
@@ -98,7 +98,7 @@ describe('pr-refresh-coordinator', () => {
     const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
     getPRForBranchOutcomeMock.mockResolvedValueOnce({
       kind: 'found',
-      pr: makePR({ checksStatus: 'pending' }),
+      pr: makePR({ checksStatus: 'pending', mergeable: 'MERGEABLE' }),
       fetchedAt: Date.now()
     })
 
@@ -119,7 +119,7 @@ describe('pr-refresh-coordinator', () => {
     getPRForBranchOutcomeMock
       .mockResolvedValueOnce({
         kind: 'found',
-        pr: makePR({ checksStatus: 'pending' }),
+        pr: makePR({ checksStatus: 'pending', mergeable: 'MERGEABLE' }),
         fetchedAt: Date.now()
       })
       .mockResolvedValueOnce({
@@ -205,7 +205,7 @@ describe('pr-refresh-coordinator', () => {
     enqueuePRRefresh({ ...candidate, cachedFetchedAt: Date.now() }, 'active', 80, 1)
     visibleOutcome.resolve({
       kind: 'found',
-      pr: makePR({ checksStatus: 'pending' }),
+      pr: makePR({ checksStatus: 'pending', mergeable: 'MERGEABLE' }),
       fetchedAt: Date.now()
     })
     await vi.advanceTimersByTimeAsync(0)
@@ -360,7 +360,7 @@ describe('pr-refresh-coordinator', () => {
     getPRForBranchOutcomeMock
       .mockResolvedValueOnce({
         kind: 'found',
-        pr: makePR({ checksStatus: 'pending' }),
+        pr: makePR({ checksStatus: 'pending', mergeable: 'MERGEABLE' }),
         fetchedAt: Date.now()
       })
       .mockResolvedValueOnce({
@@ -399,6 +399,31 @@ describe('pr-refresh-coordinator', () => {
       '/repo::feature/a',
       '/repo::feature/b'
     ])
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries visible PRs with unknown mergeability before the success-check interval', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock
+      .mockResolvedValueOnce({
+        kind: 'found',
+        pr: makePR({ checksStatus: 'success', mergeable: 'UNKNOWN' }),
+        fetchedAt: Date.now()
+      })
+      .mockResolvedValueOnce({
+        kind: 'found',
+        pr: makePR({ checksStatus: 'success', mergeable: 'MERGEABLE' }),
+        fetchedAt: Date.now()
+      })
+
+    reportVisiblePRRefreshCandidates([makeCandidate()], 1, 1)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(9_999)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -29,6 +29,7 @@ type PRRefreshOutcomeObserver = (
 ) => void
 
 const MIN_BACKGROUND_REFRESH_AGE_MS = 60_000
+const MERGEABILITY_PENDING_REFRESH_MS = 10_000
 const BACKGROUND_BUDGET_WINDOW_MS = 5 * 60_000
 const MIN_BACKGROUND_SPACING_MS = 10_000
 const BACKGROUND_BUDGET_MAX = 20
@@ -183,7 +184,9 @@ function visibleCandidateAfterOutcome(
     cachedFetchedAt: outcome.fetchedAt,
     cachedHasPR: outcome.kind === 'found',
     cachedPRState: outcome.kind === 'found' ? outcome.pr.state : null,
-    cachedChecksStatus: outcome.kind === 'found' ? outcome.pr.checksStatus : null
+    cachedChecksStatus: outcome.kind === 'found' ? outcome.pr.checksStatus : null,
+    cachedMergeable: outcome.kind === 'found' ? outcome.pr.mergeable : null,
+    cachedMergeStateStatus: outcome.kind === 'found' ? (outcome.pr.mergeStateStatus ?? null) : null
   }
 }
 
@@ -295,6 +298,16 @@ function refreshIntervalForCandidate(candidate: GitHubPRRefreshCandidate): numbe
   if (candidate.cachedHasPR === false) {
     return 15 * 60_000
   }
+  if (
+    candidate.cachedHasPR === true &&
+    candidate.cachedPRState === 'open' &&
+    candidate.cachedMergeable === 'UNKNOWN' &&
+    !hasResolvedMergeStateStatus(candidate.cachedMergeStateStatus)
+  ) {
+    // Why: GitHub can return transient UNKNOWN mergeability while it computes
+    // the PR test merge; visible merge buttons need a prompt follow-up.
+    return MERGEABILITY_PENDING_REFRESH_MS
+  }
   if (candidate.cachedChecksStatus === 'success') {
     return 10 * 60_000
   }
@@ -305,6 +318,10 @@ function refreshIntervalForCandidate(candidate: GitHubPRRefreshCandidate): numbe
     return 90_000
   }
   return MIN_BACKGROUND_REFRESH_AGE_MS
+}
+
+function hasResolvedMergeStateStatus(status: string | null | undefined): boolean {
+  return status === 'CLEAN' || status === 'BEHIND' || status === 'BLOCKED'
 }
 
 function backgroundRefreshBuckets(): ('core' | 'graphql')[] {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -62,6 +62,7 @@ import {
 import { track } from '@/lib/telemetry'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
+import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
 import {
   type GroupHeaderRow,
   type ProjectGroupOrdering,
@@ -742,6 +743,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     (s) => s.reportVisibleGitHubPRRefreshCandidates
   )
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
+  const rightSidebarShowsPR = useAppStore((s) => rightSidebarShowsPullRequestData(s))
   const keybindings = useAppStore((s) => s.keybindings)
   const sshConnectedGeneration = useAppStore((s) => s.sshConnectedGeneration)
   const prVisibleRefreshGeneration = useAppStore((s) => s.prVisibleRefreshGeneration)
@@ -2086,7 +2088,17 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       lastVisibleRefreshKeyRef.current = '__document_hidden__'
       return
     }
-    if (groupBy !== 'pr-status' && !cardProps.includes('pr') && !cardProps.includes('ci')) {
+    const currentWorktree = currentWorktreeId ? (worktreeMap.get(currentWorktreeId) ?? null) : null
+    // Why: this visible reporter feeds the GitHub coordinator; GitLab-only MR
+    // panels refresh through hosted-review paths instead.
+    const sidebarWorktreeHasGitHubReview =
+      currentWorktree !== null &&
+      ((currentWorktree.linkedGitLabMR ?? null) === null ||
+        (currentWorktree.linkedPR ?? null) !== null)
+    const shouldTrackSidebarWorktree = rightSidebarShowsPR && sidebarWorktreeHasGitHubReview
+    const shouldTrackVisibleRows =
+      groupBy === 'pr-status' || cardProps.includes('pr') || cardProps.includes('ci')
+    if (!shouldTrackVisibleRows && !shouldTrackSidebarWorktree) {
       if (lastVisibleRefreshKeyRef.current !== '__hidden__') {
         lastVisibleRefreshKeyRef.current = '__hidden__'
         reportVisibleGitHubPRRefreshCandidates([], Date.now())
@@ -2104,25 +2116,40 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       .map((item) => renderRows[item.index])
       .filter((row): row is Extract<Row, { type: 'item' }> => row?.type === 'item')
       .filter((row) => row.repo?.kind === 'git' && !row.worktree.isBare && row.worktree.branch)
-    const visibleWorktreeIds = visibleRows.map((row) => row.worktree.id)
+    const visibleWorktreeIds = new Set(visibleRows.map((row) => row.worktree.id))
+    if (
+      shouldTrackSidebarWorktree &&
+      currentWorktree &&
+      !currentWorktree.isBare &&
+      currentWorktree.branch
+    ) {
+      visibleWorktreeIds.add(currentWorktree.id)
+    }
     const visibleIdentity = visibleRows
       .map((row) => `${row.worktree.id}:${row.worktree.branch}:${row.worktree.linkedPR ?? ''}`)
       .join('|')
-    const key = `${visibleIdentity}:${sshConnectedGeneration}:${prVisibleRefreshGeneration}:${cardProps.join(',')}`
+    const sidebarIdentity =
+      shouldTrackSidebarWorktree && currentWorktree
+        ? `${currentWorktree.id}:${currentWorktree.branch}:${currentWorktree.linkedPR ?? ''}`
+        : ''
+    const key = `${visibleIdentity}:${sidebarIdentity}:${sshConnectedGeneration}:${prVisibleRefreshGeneration}:${cardProps.join(',')}`
     if (!key || key === lastVisibleRefreshKeyRef.current) {
       return
     }
     lastVisibleRefreshKeyRef.current = key
-    reportVisibleGitHubPRRefreshCandidates(visibleWorktreeIds, Date.now())
+    reportVisibleGitHubPRRefreshCandidates(Array.from(visibleWorktreeIds), Date.now())
   }, [
     cardProps,
+    currentWorktreeId,
     documentVisibilityRevision,
     groupBy,
     renderRows,
     reportVisibleGitHubPRRefreshCandidates,
     prVisibleRefreshGeneration,
+    rightSidebarShowsPR,
     sshConnectedGeneration,
-    virtualItems
+    virtualItems,
+    worktreeMap
   ])
 
   const activeDescendantId =

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -2257,7 +2257,8 @@ describe('createGitHubSlice.refreshGitHubForWorktreeIfStale', () => {
         repoPath,
         branch,
         cacheKey: `repo-1::${branch}`,
-        cachedPRState: 'open'
+        cachedPRState: 'open',
+        cachedMergeable: 'UNKNOWN'
       }),
       reason: 'active',
       priority: 80

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -569,6 +569,7 @@ function buildPRRefreshCandidate(
     state.settings,
     repo.connectionId
   )
+  const cachedPR = state.prCache[cacheKey]?.data ?? null
   const hostedReviewFallbackPRNumber = githubHostedReviewFallbackPRNumber(
     state,
     repoPath ?? repo.path,
@@ -576,7 +577,7 @@ function buildPRRefreshCandidate(
     branch,
     repo.connectionId
   )
-  const cachedFallbackPRNumber = state.prCache[cacheKey]?.data?.number ?? null
+  const cachedFallbackPRNumber = cachedPR?.number ?? null
   const fallbackPRNumber =
     worktree.linkedPR == null ? (cachedFallbackPRNumber ?? hostedReviewFallbackPRNumber) : null
   const fallbackPRSource: GitHubPRFallbackSource | null =
@@ -609,9 +610,11 @@ function buildPRRefreshCandidate(
         : 'disconnected'
       : 'unknown',
     cachedFetchedAt: state.prCache[cacheKey]?.fetchedAt ?? null,
-    cachedHasPR: state.prCache[cacheKey]?.data ? true : state.prCache[cacheKey] ? false : null,
-    cachedPRState: state.prCache[cacheKey]?.data?.state ?? null,
-    cachedChecksStatus: state.prCache[cacheKey]?.data?.checksStatus ?? null
+    cachedHasPR: cachedPR ? true : state.prCache[cacheKey] ? false : null,
+    cachedPRState: cachedPR?.state ?? null,
+    cachedChecksStatus: cachedPR?.checksStatus ?? null,
+    cachedMergeable: cachedPR?.mergeable ?? null,
+    cachedMergeStateStatus: cachedPR?.mergeStateStatus ?? null
   }
 }
 
@@ -2003,7 +2006,12 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 fallbackPRNumber,
                 fallbackPRSource,
                 connectionId: repo?.connectionId ?? null,
-                cachedFetchedAt: cached?.fetchedAt ?? null
+                cachedFetchedAt: cached?.fetchedAt ?? null,
+                cachedHasPR: cached?.data ? true : cached ? false : null,
+                cachedPRState: cached?.data?.state ?? null,
+                cachedChecksStatus: cached?.data?.checksStatus ?? null,
+                cachedMergeable: cached?.data?.mergeable ?? null,
+                cachedMergeStateStatus: cached?.data?.mergeStateStatus ?? null
               }
               return window.api.gh.refreshPRNow
                 ? await window.api.gh.refreshPRNow({ candidate })

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -773,6 +773,8 @@ export type GitHubPRRefreshCandidate = GitHubPRRefreshAlias & {
   cachedHasPR?: boolean | null
   cachedPRState?: PRState | null
   cachedChecksStatus?: CheckStatus | null
+  cachedMergeable?: PRMergeableState | null
+  cachedMergeStateStatus?: string | null
 }
 
 export type GitHubPRRefreshSkippedReason =


### PR DESCRIPTION
## Summary
- Refresh visible GitHub PRs promptly while mergeability is still UNKNOWN and merge state is unresolved
- Include cached mergeability fields in PR refresh candidates from list/sidebar and manual refresh paths
- Track the active sidebar PR worktree for GitHub refreshes without affecting GitLab-only review panels

## Validation
- pnpm typecheck
- pnpm -s vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts src/renderer/src/store/slices/github.test.ts

Note: a broad pnpm test invocation ran unrelated pty/zsh tests and failed in pre-existing local node-pty/zsh cases outside this branch scope.