### PR TITLE
Fix Codex hook status ordering

### DIFF
--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -165,8 +165,16 @@ describe('CodexHookService', () => {
       const prodHooks = JSON.parse(readFileSync(prodHooksPath, 'utf-8')) as {
         hooks: Record<string, { hooks?: { command?: string }[] }[]>
       }
-      expect(devHooks.hooks.Stop?.[0]?.hooks?.[0]?.command).toBe('user-hook')
-      expect(prodHooks.hooks.Stop?.[0]?.hooks?.[0]?.command).toBe('user-hook')
+      expect(
+        devHooks.hooks.Stop?.some((definition) =>
+          definition.hooks?.some((hook) => hook.command === 'user-hook')
+        )
+      ).toBe(true)
+      expect(
+        prodHooks.hooks.Stop?.some((definition) =>
+          definition.hooks?.some((hook) => hook.command === 'user-hook')
+        )
+      ).toBe(true)
       expect(
         devHooks.hooks.Stop?.some((definition) =>
           definition.hooks?.[0]?.command?.includes('codex-hook')
@@ -243,13 +251,60 @@ describe('CodexHookService', () => {
         { matcher?: string; hooks?: { command?: string; statusMessage?: string }[] }[]
       >
     }
-    expect(runtimeHooks.hooks.Stop?.[0]?.matcher).toBe('*')
-    expect(runtimeHooks.hooks.Stop?.[0]?.hooks?.[0]?.command).toBe('user-hook')
-    expect(runtimeHooks.hooks.Stop?.[0]?.hooks?.[0]?.statusMessage).toBe('Running user hook')
+    expect(runtimeHooks.hooks.Stop?.[1]?.matcher).toBe('*')
+    expect(runtimeHooks.hooks.Stop?.[1]?.hooks?.[0]?.command).toBe('user-hook')
+    expect(runtimeHooks.hooks.Stop?.[1]?.hooks?.[0]?.statusMessage).toBe('Running user hook')
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
+  })
+
+  it('runs managed PostToolUse status before mirrored user hooks', () => {
+    const systemCodexHome = join(tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PostToolUse: [{ hooks: [{ type: 'command', command: 'slow-user-post-tool-hook' }] }]
+        }
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(
+      join(systemCodexHome, 'config.toml'),
+      upsertHookTrustEntriesInContent('model = "system-model"\n', [
+        {
+          sourcePath: systemHooksPath,
+          eventLabel: 'post_tool_use',
+          groupIndex: 0,
+          handlerIndex: 0,
+          command: 'slow-user-post-tool-hook'
+        }
+      ]),
+      'utf-8'
+    )
+
+    expect(new CodexHookService().install().state).toBe('installed')
+
+    const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+    const managedHooksPath = join(managedCodexHome, 'hooks.json')
+    const runtimeHooks = JSON.parse(readFileSync(managedHooksPath, 'utf-8')) as {
+      hooks: Record<string, { hooks?: { command?: string }[] }[]>
+    }
+
+    expect(runtimeHooks.hooks.PostToolUse?.[0]?.hooks?.[0]?.command).toContain('codex-hook')
+    expect(runtimeHooks.hooks.PostToolUse?.[1]?.hooks?.[0]?.command).toBe(
+      'slow-user-post-tool-hook'
+    )
+
+    const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:post_tool_use:0:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:post_tool_use:1:0`))
+    expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:post_tool_use:0:0`))
   })
 
   it('mirrors system user hook approvals when the system trust indices are stale', () => {
@@ -300,6 +355,7 @@ describe('CodexHookService', () => {
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:2:0`))
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`))
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:1:0`))
   })
@@ -382,6 +438,7 @@ describe('CodexHookService', () => {
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
     for (const command of pluginCommands) {
       expect(runtimeToml).not.toContain(command)
     }
@@ -481,7 +538,7 @@ describe('CodexHookService', () => {
 
     const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
     const managedHooksPath = join(managedCodexHome, 'hooks.json')
-    const runtimeUserTrustHeader = hookTrustHeader(`${managedHooksPath}:stop:0:0`)
+    const runtimeUserTrustHeader = hookTrustHeader(`${managedHooksPath}:stop:1:0`)
     expect(readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')).toContain(
       runtimeUserTrustHeader
     )
@@ -491,7 +548,7 @@ describe('CodexHookService', () => {
 
     const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
     expect(runtimeToml).not.toContain(runtimeUserTrustHeader)
-    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:0:0`))
   })
 
   it('refreshes mirrored system user hooks when the system hooks file changes', () => {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -76,6 +76,10 @@ const CODEX_EVENT_LABEL: Record<(typeof CODEX_EVENTS)[number], CodexEventLabel> 
   Stop: 'stop'
 }
 
+const CODEX_MANAGED_EVENT_LABELS = new Set<CodexEventLabel>(
+  CODEX_EVENTS.map((eventName) => CODEX_EVENT_LABEL[eventName])
+)
+
 const CODEX_HOOK_EVENT_LABEL: Record<string, CodexEventLabel> = {
   ...CODEX_EVENT_LABEL,
   PreCompact: 'pre_compact',
@@ -427,6 +431,20 @@ function collectMirroredRuntimeUserHookTrustEntries(
   return entries
 }
 
+function moveMirroredRuntimeUserTrustAfterManagedStatusHook(
+  entries: readonly MirroredRuntimeUserHookTrustEntry[]
+): MirroredRuntimeUserHookTrustEntry[] {
+  return entries.map(({ entry, enabled }) => {
+    if (!CODEX_MANAGED_EVENT_LABELS.has(entry.eventLabel)) {
+      return { entry, enabled }
+    }
+    return {
+      entry: { ...entry, groupIndex: entry.groupIndex + 1 },
+      enabled
+    }
+  })
+}
+
 function escapeRegex(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
@@ -699,9 +717,9 @@ export class CodexHookService {
     let presentCount = 0
     for (const eventName of CODEX_EVENTS) {
       const definitions = Array.isArray(config.hooks?.[eventName]) ? config.hooks![eventName]! : []
-      // Why: install() appends our managed definition at the end, so its
-      // group index is the LAST match. Picking the first match would
-      // misreport stale duplicates as trust-missing.
+      // Why: older installs appended this command, while current installs
+      // prepend it. Picking the last match keeps status repair conservative
+      // if duplicate managed definitions survive from a stale hooks.json.
       let foundGroupIndex = -1
       let foundHandlerIndex = -1
       definitions.forEach((definition, idx) => {
@@ -826,7 +844,9 @@ export class CodexHookService {
     // hook sits in the "review required" pile. We compute the trust hash for
     // each managed entry as we install it and persist it alongside hooks.json
     // so the user does not have to /hooks-approve after every install.
-    const mirroredUserTrustEntries = hookPlan.trustEntries
+    const mirroredUserTrustEntries = moveMirroredRuntimeUserTrustAfterManagedStatusHook(
+      hookPlan.trustEntries
+    )
     const trustEntries: CodexTrustEntry[] = mirroredUserTrustEntries.map(({ entry }) => entry)
     for (const eventName of CODEX_EVENTS) {
       const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
@@ -834,15 +854,14 @@ export class CodexHookService {
       const definition: HookDefinition = {
         hooks: [{ type: 'command', command }]
       }
-      nextHooks[eventName] = [...cleaned, definition]
-      // Why: our managed definition is appended after `cleaned`, so its
-      // group index in the resulting hooks.json is `cleaned.length`. The
-      // handler is always the first (and only) entry in the group, so
-      // handler index is 0. Codex's hook_key uses these positional indices.
+      nextHooks[eventName] = [definition, ...cleaned]
+      // Why: the status hook must run before user hooks so a slow
+      // PostToolUse/Stop hook cannot leave the sidebar stuck on the previous
+      // state while Codex visibly reports that hooks are still running.
       trustEntries.push({
         sourcePath: configPath,
         eventLabel: CODEX_EVENT_LABEL[eventName],
-        groupIndex: cleaned.length,
+        groupIndex: 0,
         handlerIndex: 0,
         command
       })


### PR DESCRIPTION
## Summary
- Reproduce the Codex sidebar regression where a slow PostToolUse hook leaves Codex visibly running hooks while Orca has already shown the prior done state.
- Install Orca's managed Codex status hook before mirrored user hooks so status reaches Orca before slow user PostToolUse/Stop hooks run.
- Shift mirrored user-hook trust indices so existing trusted user hooks remain approved after the ordering change.

Slack report: https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1780187336123339

## Test plan
- pnpm vitest run --config config/vitest.config.ts src/main/codex/hook-service.test.ts
- pnpm vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts src/shared/agent-hook-listener.test.ts
- pnpm run typecheck:tsc:node