### PR TITLE
Omit folder badge from worktree card titles

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -181,7 +181,7 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
   })
 
-  it('renders folder kind in the title row without creating a folder-only metadata row', () => {
+  it('omits folder kind from the title row without creating a folder-only metadata row', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCard
         worktree={makeWorktree({ displayName: 'Docs folder', branch: '' })}
@@ -191,8 +191,7 @@ describe('WorktreeCard quick actions', () => {
     )
 
     expect(markup).toContain('Docs folder')
-    expect(markup).toContain('>Folder</span>')
-    expect(markup.indexOf('>Folder</span>')).toBeLessThan(markup.indexOf('Docs folder'))
+    expect(markup).not.toContain('>Folder</span>')
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -25,7 +25,7 @@ import WorktreeCardAgents from './WorktreeCardAgents'
 import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { getRepoKindLabel, isFolderRepo } from '../../../../shared/repo-kind'
+import { isFolderRepo } from '../../../../shared/repo-kind'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type {
   GitHubWorkItem,
@@ -700,15 +700,6 @@ const WorktreeCard = React.memo(function WorktreeCard({
                 </TooltipContent>
               </Tooltip>
             )}
-
-            {isFolder ? (
-              <Badge
-                variant="secondary"
-                className="h-[16px] px-1.5 text-[10px] font-medium rounded shrink-0 text-muted-foreground bg-accent border border-border dark:bg-accent/80 dark:border-border/50 leading-none"
-              >
-                {repo ? getRepoKindLabel(repo) : 'Folder'}
-              </Badge>
-            ) : null}
 
             {showInlineRepoBadge && (
               <Tooltip>


### PR DESCRIPTION
## Summary
- Remove the inline folder kind badge from worktree card title rows.
- Update the quick actions snapshot-style assertion to verify folder cards still avoid creating a folder-only metadata row.

## Testing
- Updated `WorktreeCard.quick-actions.test.tsx` coverage for the folder card title row behavior.