### PR TITLE
Preserve parent agent identity for nested hooks

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -16,6 +16,7 @@ import { join } from 'path'
 import { AgentHookServer, agentHookServer, _internals } from './server'
 import {
   AGENT_STATUS_MAX_FIELD_LENGTH,
+  AGENT_STATUS_STALE_AFTER_MS,
   parseAgentStatusPayload
 } from '../../shared/agent-status-types'
 import { makePaneKey } from '../../shared/stable-pane-id'
@@ -1784,6 +1785,65 @@ describe('AgentHookServer listener replay', () => {
       server.setListener(listener)
 
       expect(listener).not.toHaveBeenCalled()
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('ignores local nested Claude Stop while a parent Codex hook status is active', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const listener = vi.fn()
+      server.setListener(listener)
+      const postHook = async (
+        source: 'codex' | 'claude',
+        payload: Record<string, unknown>
+      ): Promise<void> => {
+        const response = await fetch(
+          `http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/${source}`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+            },
+            body: JSON.stringify(buildBody(payload))
+          }
+        )
+        expect(response.status).toBe(204)
+      }
+
+      await postHook('codex', {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'parent codex'
+      })
+      await postHook('claude', {
+        hook_event_name: 'Stop',
+        last_assistant_message: 'child finished'
+      })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'working',
+          prompt: 'parent codex',
+          agentType: 'codex'
+        })
+      ])
+      const snapshot = server.getStatusSnapshot()[0]
+      expect(snapshot.lastAssistantMessage).toBeUndefined()
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            state: 'working',
+            prompt: 'parent codex',
+            agentType: 'codex'
+          })
+        })
+      )
     } finally {
       server.stop()
     }
@@ -5623,6 +5683,211 @@ describe('AgentHookServer ingestRemote', () => {
         payload
       })
     )
+  })
+
+  it('preserves active pane identity when a nested remote hook reports another agent', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: { state: 'working', prompt: 'parent codex', agentType: 'codex' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(1_100)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: {
+            state: 'working',
+            prompt: 'nested claude',
+            agentType: 'claude',
+            toolName: 'Read',
+            toolInput: '00-review-context.md'
+          }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'working',
+          prompt: 'nested claude',
+          agentType: 'codex',
+          toolName: 'Read',
+          toolInput: '00-review-context.md',
+          receivedAt: 1_100
+        })
+      ])
+      expect(listener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            prompt: 'nested claude',
+            agentType: 'codex'
+          })
+        })
+      )
+      expect(trackMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores nested remote done while the parent pane agent is still active', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const listener = vi.fn()
+      server.setListener(listener)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: { state: 'working', prompt: 'parent codex', agentType: 'codex' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(1_100)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: {
+            state: 'done',
+            prompt: 'nested claude',
+            agentType: 'claude',
+            toolName: 'Read',
+            toolInput: '00-review-context.md',
+            lastAssistantMessage: 'child finished'
+          }
+        },
+        'conn-1'
+      )
+
+      const snapshot = server.getStatusSnapshot()
+      expect(snapshot).toHaveLength(1)
+      expect(snapshot[0]).toMatchObject({
+        paneKey: PANE,
+        state: 'working',
+        prompt: 'parent codex',
+        agentType: 'codex',
+        receivedAt: 1_000,
+        stateStartedAt: 1_000
+      })
+      expect(snapshot[0].toolName).toBeUndefined()
+      expect(snapshot[0].toolInput).toBeUndefined()
+      expect(snapshot[0].lastAssistantMessage).toBeUndefined()
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            state: 'working',
+            prompt: 'parent codex',
+            agentType: 'codex'
+          })
+        })
+      )
+      expect(trackMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows remote pane identity to change after the prior turn is done', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'done', prompt: 'parent codex', agentType: 'codex' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(1_100)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'real claude turn', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'real claude turn',
+          agentType: 'claude',
+          receivedAt: 1_100
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows stale active remote pane identity to change', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'old codex turn', agentType: 'codex' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(1_000 + AGENT_STATUS_STALE_AFTER_MS + 1)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'new claude turn', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'new claude turn',
+          agentType: 'claude',
+          receivedAt: 1_000 + AGENT_STATUS_STALE_AFTER_MS + 1
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('lets remote Claude permission clear when matching approved tool execution starts', () => {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -45,6 +45,10 @@ import {
   normalizeAgentStatusPayload
 } from '../../shared/agent-status-types'
 import {
+  resolveAgentStatusIdentity,
+  shouldSuppressInheritedTerminalStatus
+} from '../../shared/agent-status-identity'
+import {
   isAgentInterruptInputIntent,
   type AgentInterruptInferenceRequest
 } from '../../shared/agent-interrupt-intent'
@@ -539,8 +543,10 @@ export class AgentHookServer {
     }
   }
 
-  private attachStatusTiming(payload: AgentHookEventPayload): EnrichedAgentHookEventPayload {
-    const now = Date.now()
+  private attachStatusTiming(
+    payload: AgentHookEventPayload,
+    now = Date.now()
+  ): EnrichedAgentHookEventPayload {
     const previous = this.state.lastStatusByPaneKey.get(payload.paneKey) as
       | EnrichedAgentHookEventPayload
       | undefined
@@ -627,7 +633,38 @@ export class AgentHookServer {
     const previous = this.state.lastStatusByPaneKey.get(payload.paneKey) as
       | EnrichedAgentHookEventPayload
       | undefined
-    const effectivePayload = attachClaudePermissionToolUseId(previous, payload)
+    const now = Date.now()
+    const identity = resolveAgentStatusIdentity({
+      existing: previous
+        ? {
+            agentType: previous.payload.agentType,
+            state: previous.payload.state,
+            updatedAt: previous.receivedAt
+          }
+        : undefined,
+      incoming: payload.payload.agentType,
+      now
+    })
+    if (
+      previous &&
+      shouldSuppressInheritedTerminalStatus({
+        inheritedFromActivePane: identity.inheritedFromActivePane,
+        incomingState: payload.payload.state
+      })
+    ) {
+      return previous
+    }
+    const identityResolvedPayload =
+      identity.agentType === payload.payload.agentType
+        ? payload
+        : {
+            ...payload,
+            payload: {
+              ...payload.payload,
+              agentType: identity.agentType
+            }
+          }
+    const effectivePayload = attachClaudePermissionToolUseId(previous, identityResolvedPayload)
     if (previous && shouldKeepClaudePermissionVisible(previous, effectivePayload)) {
       return previous
     }
@@ -661,8 +698,10 @@ export class AgentHookServer {
     ) {
       this.clearAssistantMessageRetry(effectivePayload.paneKey)
     }
-    this.maybeTrackAgentPromptSent(effectivePayload, previous)
-    const enriched = this.attachStatusTiming(effectivePayload)
+    if (!identity.inheritedFromActivePane) {
+      this.maybeTrackAgentPromptSent(effectivePayload, previous)
+    }
+    const enriched = this.attachStatusTiming(effectivePayload, now)
     this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
     this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
     this.scheduleStatusPersist()

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -2443,6 +2443,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
       clearTabPtyId: vi.fn(),
       runtimePaneTitlesByTabId: {},
       terminalLayoutsByTabId: {},
+      agentStatusByPaneKey: {},
       repos: [],
       worktreesByRepo: {},
       tabsByWorktree: {},
@@ -2759,6 +2760,81 @@ describe('useIpcEvents agent status snapshot integration', () => {
       'Inactive Tab',
       { updatedAt: 1_700_000_000_200, stateStartedAt: 1_699_999_999_100 }
     )
+  })
+
+  it('drops nested child done push events when the parent pane agent is still active', async () => {
+    const setAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: true, agentTaskComplete: true } },
+      agentStatusByPaneKey: {
+        [FUTURE_PANE_KEY]: {
+          state: 'working',
+          prompt: 'parent codex',
+          agentType: 'codex',
+          updatedAt: 1_700_000_000_000,
+          stateStartedAt: 1_700_000_000_000,
+          paneKey: FUTURE_PANE_KEY,
+          stateHistory: []
+        }
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [FUTURE_LEAF_ID]: 'pty-1' }
+        }
+      },
+      ptyIdsByTabId: { 'tab-future': ['pty-1'] }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'done',
+      prompt: 'nested claude',
+      agentType: 'claude',
+      lastAssistantMessage: 'child finished',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_700_000_000_200
+    })
+
+    expect(setAgentStatus).not.toHaveBeenCalled()
   })
 
   it('keeps OpenClaude hook status distinct when it arrives through Claude-compatible hooks', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -48,6 +48,10 @@ import {
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload
 } from '../../../shared/agent-status-types'
+import {
+  resolveAgentStatusIdentity,
+  shouldSuppressInheritedTerminalStatus
+} from '../../../shared/agent-status-identity'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
@@ -2186,6 +2190,29 @@ export function useIpcEvents(): void {
       const statusPayload = data.orchestration
         ? { ...resolvedPayload, orchestration: data.orchestration }
         : resolvedPayload
+      const existingStatus = store.agentStatusByPaneKey[data.paneKey]
+      const identity = resolveAgentStatusIdentity({
+        existing: existingStatus
+          ? {
+              agentType: existingStatus.agentType,
+              state: existingStatus.state,
+              updatedAt: existingStatus.updatedAt
+            }
+          : undefined,
+        incoming: statusPayload.agentType,
+        now: data.receivedAt
+      })
+      if (
+        existingStatus &&
+        shouldSuppressInheritedTerminalStatus({
+          inheritedFromActivePane: identity.inheritedFromActivePane,
+          incomingState: statusPayload.state
+        })
+      ) {
+        // Why: renderer may receive an old/stale main-process child completion.
+        // Keep the defensive store guard and completion notification path in sync.
+        return 'dropped'
+      }
       store.setAgentStatus(data.paneKey, statusPayload, title, {
         updatedAt: data.receivedAt,
         stateStartedAt: data.stateStartedAt

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -93,6 +93,21 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('openclaude')
   })
 
+  it("uses Codex hook identity over Claude's generic task-title heuristic", () => {
+    expect(
+      resolveTabAgentFromSignals({
+        foreground: undefined,
+        hasObservedAgentSignal: true,
+        shellForegroundAfterAgentSignal: false,
+        isRemote: false,
+        title: '✳ improve-pr-actions-customization',
+        hookAgent: 'codex',
+        hasCompletedHook: false,
+        launchAgent: 'codex'
+      })
+    ).toBe('codex')
+  })
+
   it('keeps explicit Claude Code titles authoritative over stale OpenClaude launch intent', () => {
     expect(
       resolveTabAgentFromSignals({

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -181,16 +181,94 @@ describe('agent status tool + assistant fields', () => {
     expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('claude')
   })
 
-  it('overwrites prior agentType when payload sends a different known value', () => {
+  it('preserves active pane agentType when a nested hook sends a different known value', () => {
     vi.useFakeTimers()
     const store = createTestStore()
     store
       .getState()
-      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', agentType: 'claude' })
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', agentType: 'codex' })
     store
       .getState()
-      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p2', agentType: 'cursor' })
-    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('cursor')
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p2', agentType: 'claude' })
+    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('codex')
+  })
+
+  it('ignores nested done while the parent pane agent is still active', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const setGeneratedTabTitleFromAgentPrompt = vi.fn()
+    store.setState({ setGeneratedTabTitleFromAgentPrompt } as Partial<AppState>)
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:1',
+        { state: 'working', prompt: 'parent codex', agentType: 'codex' },
+        'codex',
+        { updatedAt: 1_000, stateStartedAt: 1_000 }
+      )
+    const firstEpoch = store.getState().agentStatusEpoch
+
+    store.getState().setAgentStatus(
+      'tab-1:1',
+      {
+        state: 'done',
+        prompt: 'nested claude',
+        agentType: 'claude',
+        toolName: 'Read',
+        toolInput: '00-review-context.md',
+        lastAssistantMessage: 'child finished'
+      },
+      'claude',
+      { updatedAt: 1_100, stateStartedAt: 1_100 }
+    )
+
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    expect(entry).toMatchObject({
+      state: 'working',
+      prompt: 'parent codex',
+      agentType: 'codex',
+      updatedAt: 1_000,
+      stateStartedAt: 1_000
+    })
+    expect(entry.toolName).toBeUndefined()
+    expect(entry.toolInput).toBeUndefined()
+    expect(entry.lastAssistantMessage).toBeUndefined()
+    expect(store.getState().agentStatusEpoch).toBe(firstEpoch)
+    expect(setGeneratedTabTitleFromAgentPrompt).toHaveBeenCalledTimes(1)
+    expect(setGeneratedTabTitleFromAgentPrompt).toHaveBeenLastCalledWith('tab-1:1', 'parent codex')
+  })
+
+  it('allows pane agentType to change after the prior turn is done', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:1', { state: 'done', prompt: 'p1', agentType: 'codex' })
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p2', agentType: 'claude' })
+    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('claude')
+  })
+
+  it('allows stale active pane agentType to change', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus('tab-1:1', { state: 'working', prompt: 'p1', agentType: 'codex' }, 'codex', {
+        updatedAt: 1_000,
+        stateStartedAt: 1_000
+      })
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:1',
+        { state: 'working', prompt: 'p2', agentType: 'claude' },
+        'claude',
+        {
+          updatedAt: 1_000 + AGENT_STATUS_STALE_AFTER_MS + 1,
+          stateStartedAt: 1_000 + AGENT_STATUS_STALE_AFTER_MS + 1
+        }
+      )
+    expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('claude')
   })
 
   it('keeps global epochs stable for fresh same-state working pings while updating the entry', () => {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -11,6 +11,10 @@ import {
   type MigrationUnsupportedPtyEntry,
   type ParsedAgentStatusPayload
 } from '../../../../shared/agent-status-types'
+import {
+  resolveAgentStatusIdentity,
+  shouldSuppressInheritedTerminalStatus
+} from '../../../../shared/agent-status-identity'
 import type { TerminalTab } from '../../../../shared/types'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
@@ -199,6 +203,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
     setAgentStatus: (paneKey, payload, terminalTitle, timing) => {
       const updatedAt = timing?.updatedAt ?? Date.now()
       let completionRefreshWorktreeId: string | null = null
+      let suppressedInheritedTerminalStatus = false
       set((s) => {
         const existing = s.agentStatusByPaneKey[paneKey]
         // Why: snapshots and live pushes share receivedAt from the same main-side
@@ -249,6 +254,27 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const stateStartedAt =
           timing?.stateStartedAt ??
           (existing && existing.state === payload.state ? existing.stateStartedAt : updatedAt)
+        const identity = resolveAgentStatusIdentity({
+          existing: existing
+            ? {
+                agentType: existing.agentType,
+                state: existing.state,
+                updatedAt: existing.updatedAt
+              }
+            : undefined,
+          incoming: payload.agentType,
+          now: updatedAt
+        })
+        if (
+          existing &&
+          shouldSuppressInheritedTerminalStatus({
+            inheritedFromActivePane: identity.inheritedFromActivePane,
+            incomingState: payload.state
+          })
+        ) {
+          suppressedInheritedTerminalStatus = true
+          return s
+        }
 
         // Why: tool/assistant fields come pre-merged from the main-process
         // cache (see `resolveToolState` in server.ts), so the payload always
@@ -260,19 +286,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           prompt: payload.prompt,
           updatedAt,
           stateStartedAt,
-          // Why: unlike tool/prompt/assistant fields (which legitimately clear on a
-          // fresh turn), agentType is the agent's identity for the pane — it does
-          // not change between updates. Preserve the prior value when a payload
-          // omits it so the icon/label does not flicker out between hook pings.
-          // 'unknown' is the sentinel for "agent didn't identify itself" in
-          // WellKnownAgentType. Treat it like absence so a well-known prior
-          // identity (e.g. 'claude' learned from an earlier hook ping) isn't
-          // stomped by a later ping that lost the identity (e.g. legacy/partial
-          // integrations).
-          agentType:
-            (payload.agentType && payload.agentType !== 'unknown'
-              ? payload.agentType
-              : existing?.agentType) ?? 'unknown',
+          agentType: identity.agentType,
           paneKey,
           terminalTitle: effectiveTitle,
           stateHistory: history,
@@ -359,6 +373,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             sortRelevantChange || migrationUnsupported.changed ? s.sortEpoch + 1 : s.sortEpoch
         }
       })
+      if (suppressedInheritedTerminalStatus) {
+        return
+      }
       get().setGeneratedTabTitleFromAgentPrompt(paneKey, payload.prompt)
       // Why: schedule after set completes so the timer reads the updated map.
       // queueMicrotask avoids re-entry into the zustand store during set.

--- a/src/shared/agent-status-identity.ts
+++ b/src/shared/agent-status-identity.ts
@@ -1,0 +1,78 @@
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusState,
+  type AgentType
+} from './agent-status-types'
+
+type ExistingAgentIdentity = {
+  agentType?: AgentType
+  state: AgentStatusState
+  updatedAt: number
+}
+
+type AgentIdentityResolution = {
+  agentType: AgentType
+  inheritedFromActivePane: boolean
+}
+
+export function shouldSuppressInheritedTerminalStatus(args: {
+  inheritedFromActivePane: boolean
+  incomingState: AgentStatusState
+}): boolean {
+  // Why: nested child hooks inherit the parent's ORCA_PANE_KEY. A child
+  // completion does not prove the active parent turn completed.
+  return args.inheritedFromActivePane && args.incomingState === 'done'
+}
+
+function normalizedKnownAgentType(agentType: AgentType | null | undefined): AgentType | null {
+  if (!agentType || agentType === 'unknown') {
+    return null
+  }
+  return agentType
+}
+
+function isActiveExistingIdentity(
+  existing: ExistingAgentIdentity,
+  now: number,
+  staleAfterMs: number
+): boolean {
+  return existing.state !== 'done' && now - existing.updatedAt <= staleAfterMs
+}
+
+export function resolveAgentStatusIdentity(args: {
+  existing?: ExistingAgentIdentity
+  incoming?: AgentType
+  now: number
+  staleAfterMs?: number
+}): AgentIdentityResolution {
+  const staleAfterMs = args.staleAfterMs ?? AGENT_STATUS_STALE_AFTER_MS
+  const existingAgentType = normalizedKnownAgentType(args.existing?.agentType)
+  const incomingAgentType = normalizedKnownAgentType(args.incoming)
+
+  if (!incomingAgentType) {
+    return {
+      agentType: existingAgentType ?? 'unknown',
+      inheritedFromActivePane: false
+    }
+  }
+  if (!args.existing || !existingAgentType || existingAgentType === incomingAgentType) {
+    return {
+      agentType: incomingAgentType,
+      inheritedFromActivePane: false
+    }
+  }
+  if (isActiveExistingIdentity(args.existing, args.now, staleAfterMs)) {
+    return {
+      // Why: child agent CLIs inherit ORCA_PANE_KEY from their parent terminal.
+      // While the parent turn is active, do not let a nested hook steal the
+      // pane's visible identity.
+      agentType: existingAgentType,
+      inheritedFromActivePane: true
+    }
+  }
+
+  return {
+    agentType: incomingAgentType,
+    inheritedFromActivePane: false
+  }
+}


### PR DESCRIPTION
## Summary
- Adds shared agent-status identity resolution so nested child hooks that inherit a parent pane key do not steal the pane's visible agent identity.
- Suppresses inherited child `done` statuses while the parent agent is still active, with stale and prior-done cases still allowing identity changes.
- Applies the guard in main hook ingestion, renderer IPC handling, and the agent-status store, plus coverage for local, remote, and tab-agent identity behavior.

## Testing
- Added/updated tests in `src/main/agent-hooks/server.test.ts`, `src/renderer/src/hooks/useIpcEvents.test.ts`, `src/renderer/src/lib/use-tab-agent.test.ts`, and `src/renderer/src/store/slices/agent-status.test.ts`.