### PR TITLE
Show compact agent image notes

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2530,6 +2530,8 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
 .orca-diff-comment-actions-pill {
   display: inline-flex;
   align-items: center;
+  gap: 2px;
+  padding: 0 2px;
   border: 1px solid color-mix(in srgb, var(--foreground) 10%, var(--border));
   border-radius: 6px;
   background: var(--background);
@@ -2546,7 +2548,8 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 8px;
+  min-width: 28px;
+  padding: 4px 7px;
   font-size: 11px;
   font-weight: 500;
   color: var(--muted-foreground);
@@ -2557,6 +2560,13 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   transition:
     background-color 100ms ease,
     color 100ms ease;
+}
+
+.orca-diff-comment-edit {
+  min-width: 28px;
+  height: 24px;
+  padding: 4px 7px;
+  border-radius: 4px;
 }
 
 .orca-diff-comment-pill-btn:hover {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4155,70 +4155,72 @@ function SourceControlInner(): React.JSX.Element {
                   </span>
                 )}
               </button>
-              <DiffNotesSendMenu
-                worktreeId={activeWorktreeId}
-                groupId={activeGroupId ?? activeWorktreeId}
-                comments={diffCommentsForActive}
-                triggerClassName="size-6"
-              />
-              {diffCommentCount > 0 && (
-                <TooltipProvider delayDuration={400}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                        onClick={() => void handleCopyDiffComments()}
-                        aria-label="Copy all notes to clipboard"
-                      >
-                        {diffCommentsCopied ? (
-                          <Check className="size-3.5" />
-                        ) : (
-                          <Copy className="size-3.5" />
-                        )}
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      Copy all notes
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
-              <DropdownMenu>
-                <TooltipProvider delayDuration={400}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
+              <div className="ml-1 flex shrink-0 items-center gap-1.5">
+                <DiffNotesSendMenu
+                  worktreeId={activeWorktreeId}
+                  groupId={activeGroupId ?? activeWorktreeId}
+                  comments={diffCommentsForActive}
+                  triggerClassName="size-6"
+                />
+                {diffCommentCount > 0 && (
+                  <TooltipProvider delayDuration={400}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
                         <button
                           type="button"
                           className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                          aria-label="More note actions"
+                          onClick={() => void handleCopyDiffComments()}
+                          aria-label="Copy all notes to clipboard"
                         >
-                          <MoreHorizontal className="size-3.5" />
+                          {diffCommentsCopied ? (
+                            <Check className="size-3.5" />
+                          ) : (
+                            <Copy className="size-3.5" />
+                          )}
                         </button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={6}>
-                      More note actions
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-                <DropdownMenuContent align="end" className="min-w-[180px]">
-                  <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
-                    disabled={diffCommentCount === 0}
-                    onSelect={() => {
-                      if (!activeWorktreeId || diffCommentCount === 0) {
-                        return
-                      }
-                      setPendingDiffCommentsClear({ kind: 'all', worktreeId: activeWorktreeId })
-                    }}
-                  >
-                    <Trash2 className="size-3.5" />
-                    Clear all notes...
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        Copy all notes
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+                <DropdownMenu>
+                  <TooltipProvider delayDuration={400}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                            aria-label="More note actions"
+                          >
+                            <MoreHorizontal className="size-3.5" />
+                          </button>
+                        </DropdownMenuTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={6}>
+                        More note actions
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                  <DropdownMenuContent align="end" className="min-w-[180px]">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      disabled={diffCommentCount === 0}
+                      onSelect={() => {
+                        if (!activeWorktreeId || diffCommentCount === 0) {
+                          return
+                        }
+                        setPendingDiffCommentsClear({ kind: 'all', worktreeId: activeWorktreeId })
+                      }}
+                    >
+                      <Trash2 className="size-3.5" />
+                      Clear all notes...
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </div>
             {diffCommentsExpanded && (
               <DiffCommentsInlineList

--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -42,6 +42,26 @@ describe('CommentMarkdown', () => {
     expect(markup).not.toContain('href="https://github.com/stablyai/orca/issues/2317"')
   })
 
+  it('keeps remote compact markdown images as links', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content="See this: ![Image #1](https://example.com/screenshot.png)" />
+    )
+
+    expect(markup).not.toContain('<img')
+    expect(markup).toContain('href="https://example.com/screenshot.png"')
+    expect(markup).toContain('>Image #1</a>')
+  })
+
+  it('renders trusted compact markdown images inline', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content="See this: ![Image #1](data:image/png;base64,abc123)" />
+    )
+
+    expect(markup).toContain('<img')
+    expect(markup).toContain('alt="Image #1"')
+    expect(markup).toContain('src="data:image/png;base64,abc123"')
+  })
+
   it('autolinks very large generated GitHub reference comments', () => {
     const referenceCount = 130_000
     const tree = {

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Markdown from 'react-markdown'
+import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import rehypeRaw from 'rehype-raw'
@@ -8,6 +8,7 @@ import type { Components } from 'react-markdown'
 import { cn } from '@/lib/utils'
 
 type MarkdownPlugins = NonNullable<React.ComponentProps<typeof Markdown>['rehypePlugins']>
+type UrlTransform = NonNullable<React.ComponentProps<typeof Markdown>['urlTransform']>
 
 type GitHubRepoReference = {
   owner: string
@@ -30,6 +31,23 @@ type MarkdownNode = {
   type: string
   value?: string
   children?: MarkdownNode[]
+}
+
+function isTrustedCompactImageSrc(src: string | undefined): src is string {
+  if (!src) {
+    return false
+  }
+  const normalized = src.trim().toLowerCase()
+  return (
+    normalized.startsWith('blob:') || /^data:image\/(?:png|jpe?g|gif|webp);base64,/.test(normalized)
+  )
+}
+
+const commentMarkdownUrlTransform: UrlTransform = (value, key, node) => {
+  if (key === 'src' && node?.tagName === 'img' && isTrustedCompactImageSrc(value)) {
+    return value
+  }
+  return defaultUrlTransform(value)
 }
 
 // Why: sidebar comments are rendered at 11px in a narrow card, so we strip
@@ -97,20 +115,42 @@ const compactComponents: Components = {
       {children}
     </blockquote>
   ),
-  // Why: images in a ~200px sidebar card would blow out the layout or look
-  // broken at any reasonable size. Render as a text link instead so the URL is
-  // still accessible without disrupting the card.
-  img: ({ alt, src }) => (
-    <a
-      href={src}
-      target="_blank"
-      rel="noreferrer"
-      className="underline underline-offset-2 text-foreground/80 hover:text-foreground"
-      onClick={(e) => e.stopPropagation()}
-    >
-      {alt || 'image'}
-    </a>
-  ),
+  // Why: agent replies and workspace notes often carry screenshot markdown
+  // like "Image #1"; compact cards inline app-managed thumbnails without
+  // auto-fetching arbitrary remote image URLs.
+  img: ({ alt, src }) => {
+    if (!isTrustedCompactImageSrc(src)) {
+      if (!src) {
+        return alt ? <span>{alt}</span> : null
+      }
+      return (
+        <a
+          href={src}
+          target="_blank"
+          rel="noreferrer"
+          className="underline underline-offset-2 text-foreground/80 hover:text-foreground"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {alt || src}
+        </a>
+      )
+    }
+
+    const image = (
+      <img
+        src={src}
+        alt={alt ?? ''}
+        className="my-1 max-h-32 max-w-full rounded-sm object-contain outline outline-1 outline-border/70"
+      />
+    )
+    return src ? (
+      <a href={src} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}>
+        {image}
+      </a>
+    ) : (
+      image
+    )
+  },
   // Why: GFM tables in a ~200px sidebar would overflow badly. Wrapping in an
   // overflow container keeps the card layout stable while still letting the
   // user scroll to see the full table.
@@ -296,6 +336,10 @@ const commentMarkdownSanitizeSchema = {
     input: [...(defaultSchema.attributes?.input ?? []), 'type', 'checked', 'disabled'],
     td: [...(defaultSchema.attributes?.td ?? []), 'align'],
     th: [...(defaultSchema.attributes?.th ?? []), 'align']
+  },
+  protocols: {
+    ...defaultSchema.protocols,
+    src: [...(defaultSchema.protocols?.src ?? []), 'data', 'blob']
   }
 }
 
@@ -340,6 +384,7 @@ const CommentMarkdown = React.memo(
           remarkPlugins={activeRemarkPlugins}
           rehypePlugins={rehypePlugins}
           components={components}
+          urlTransform={commentMarkdownUrlTransform}
         >
           {content}
         </Markdown>

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- Why: this suite shares a broad mocked sidebar
+   harness across compact/full mode, lineage, and image-note cases. */
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,6 +11,7 @@ type MockAgentOptions = {
   state?: string
   startedAt?: number
   prompt?: string
+  lastAssistantMessage?: string
   stateStartedAt?: number
   orchestration?: { parentPaneKey: string }
   lineage?: {
@@ -26,6 +29,7 @@ function mockAgent({
   state = 'working',
   startedAt,
   prompt,
+  lastAssistantMessage,
   stateStartedAt = 1000,
   orchestration,
   lineage
@@ -38,6 +42,7 @@ function mockAgent({
     startedAt,
     entry: {
       prompt,
+      lastAssistantMessage,
       state,
       stateStartedAt,
       stateHistory: prompt === undefined ? undefined : [],
@@ -282,6 +287,49 @@ describe('WorktreeCardAgents', () => {
     expect(markup).not.toContain('aria-label="Expand')
   })
 
+  it('renders compact agent messages with images as inline thumbnails', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        state: 'done',
+        startedAt: 1000,
+        prompt: 'Check screenshot',
+        lastAssistantMessage: 'Result:\n\n![Image #1](data:image/png;base64,abc123)'
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('group/compact-agent-row')
+    expect(markup).toContain('<img')
+    expect(markup).toContain('alt="Image #1"')
+    expect(markup).toContain('max-h-36')
+    expect(markup).not.toContain('data-testid="agent-row"')
+  })
+
+  it('bounds long compact agent messages that include image markdown', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    mockAgents = [
+      mockAgent({
+        agentType: 'codex',
+        state: 'done',
+        startedAt: 1000,
+        prompt: 'Check screenshot',
+        lastAssistantMessage: `${'Detailed result. '.repeat(400)}\n\n![Image #1](https://example.com/screenshot.png)`
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('max-h-36')
+    expect(markup).toContain('overflow-hidden')
+    expect(markup).not.toContain('<img')
+    expect(markup).toContain('href="https://example.com/screenshot.png"')
+  })
+
   it('renders a compact summary affordance for multiple flat agents', async () => {
     mockAgentActivityDisplayMode = 'compact'
     mockAgents = [
@@ -312,6 +360,8 @@ describe('WorktreeCardAgents', () => {
     const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
 
     expect(markup).toContain('aria-expanded="false"')
+    expect(markup).toContain('items-center gap-0.5')
+    expect(markup).not.toContain('-space-x-1')
     expect(markup).toContain('3 agents: 1 waiting, 1 working, 1 done')
     expect(markup).toContain('Expand 3 agents: 1 waiting, 1 working, 1 done')
     expect(markup).not.toContain('data-testid="agent-row"')

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agents.tsx
@@ -6,6 +6,9 @@ import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { cn } from '@/lib/utils'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import CommentMarkdown from './CommentMarkdown'
+
+const MARKDOWN_IMAGE_PATTERN = /!\[[^\]\n]*\]\([^)]+\)/
 
 function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
   switch (state) {
@@ -252,7 +255,7 @@ export function CompactAgentSummaryButton({
       onPointerDown={stopPointerPropagation}
       onDragStart={stopPointerPropagation}
     >
-      <span className="flex shrink-0 items-center -space-x-1" aria-hidden>
+      <span className="flex shrink-0 items-center gap-0.5" aria-hidden>
         {iconAgents.map((agent) => (
           <span
             key={agent.paneKey}
@@ -306,7 +309,11 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     typeof onToggleChildAgents === 'function'
   const dotState = getAgentDotState(agent)
   const primary = getCompactAgentPrimary(agent)
-  const secondary = getCompactAgentSecondary(agent)
+  const assistantMessage = agent.entry.lastAssistantMessage?.trim() ?? ''
+  const hasAssistantImage = MARKDOWN_IMAGE_PATTERN.test(assistantMessage)
+  const secondary = hasAssistantImage
+    ? formatAgentTypeLabel(agent.agentType)
+    : getCompactAgentSecondary(agent)
   const shortTime = getCompactAgentTime(agent, now)
 
   const handleActivate = useCallback(
@@ -325,24 +332,8 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     [onToggleChildAgents]
   )
 
-  return (
-    <div
-      draggable={false}
-      className={cn(
-        'group/compact-agent-row flex h-6 min-w-0 cursor-pointer items-center gap-1 rounded-sm px-1 text-[11px] leading-none',
-        'text-muted-foreground worktree-agent-row-hover',
-        isFocusedPane && 'bg-sidebar-accent'
-      )}
-      onClick={handleActivate}
-      onMouseDown={(e) => e.stopPropagation()}
-      onPointerDown={(e) => e.stopPropagation()}
-      onDragStart={(e) => e.stopPropagation()}
-      data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
-      role={agent.lineage ? 'treeitem' : undefined}
-      aria-level={agent.lineage ? agent.lineage.depth + 1 : undefined}
-      aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}
-      title={`${primary}${secondary ? ` - ${secondary}` : ''}`}
-    >
+  const rowBody = (
+    <>
       {hasChildDisclosure ? (
         <button
           type="button"
@@ -384,6 +375,39 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/60">
           {shortTime}
         </span>
+      )}
+    </>
+  )
+
+  return (
+    <div
+      draggable={false}
+      className={cn(
+        'group/compact-agent-row min-w-0 cursor-pointer rounded-sm px-1 text-[11px] leading-none',
+        'text-muted-foreground worktree-agent-row-hover',
+        hasAssistantImage ? 'flex flex-col py-0.5' : 'flex h-6 items-center gap-1',
+        isFocusedPane && 'bg-sidebar-accent'
+      )}
+      onClick={handleActivate}
+      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onDragStart={(e) => e.stopPropagation()}
+      data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
+      role={agent.lineage ? 'treeitem' : undefined}
+      aria-level={agent.lineage ? agent.lineage.depth + 1 : undefined}
+      aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}
+      title={`${primary}${secondary ? ` - ${secondary}` : ''}`}
+    >
+      {hasAssistantImage ? (
+        <>
+          <div className="flex h-6 min-w-0 items-center gap-1">{rowBody}</div>
+          <CommentMarkdown
+            content={assistantMessage}
+            className="ml-5 max-h-36 max-w-full overflow-hidden text-[10px] leading-snug text-muted-foreground/80 [&_.comment-md-p]:block [&_.comment-md-p+.comment-md-p]:mt-1"
+          />
+        </>
+      ) : (
+        rowBody
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- render trusted app-managed image notes inline in compact agent rows while keeping remote image URLs as links
- bound compact image note previews so long assistant messages do not expand the sidebar excessively
- tighten diff note toolbar/action spacing in the source control sidebar

## Tests
- pnpm typecheck
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/tui-agent-startup.test.ts src/renderer/src/components/sidebar/CommentMarkdown.test.tsx src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx