### PR TITLE
Make delete-all primary in parent delete dialog

### DIFF
--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -102,6 +102,10 @@ function makeLineage(child: Worktree, parent: Worktree): WorktreeLineage {
   }
 }
 
+function buttonText(props: Record<string, unknown>): string {
+  return renderToStaticMarkup(<>{props.children as ReactNode}</>)
+}
+
 describe('DeleteWorktreeDialog lineage copy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -133,6 +137,14 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     expect(markup).toContain('Delete All 2')
     expect(markup).toContain('Delete Parent Only')
     expect(markup).not.toContain('Don&apos;t ask again')
+
+    const destructiveButton = mocks.buttonProps.find((props) => props.variant === 'destructive')
+    const parentOnlyButton = mocks.buttonProps.find((props) =>
+      buttonText(props).includes('Delete Parent Only')
+    )
+
+    expect(destructiveButton ? buttonText(destructiveButton) : '').toContain('Delete All 2')
+    expect(parentOnlyButton?.variant).toBe('outline')
   })
 
   it('keeps long child workspace paths constrained inside the lineage notice', async () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -402,8 +402,8 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
               <>
                 {canDeleteAllLineage ? (
                   <Button
-                    variant="outline"
-                    className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    ref={confirmButtonRef}
+                    variant="destructive"
                     onClick={handleDeleteAll}
                     disabled={isDeleting}
                   >
@@ -414,8 +414,13 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
                   </Button>
                 ) : null}
                 <Button
-                  ref={confirmButtonRef}
-                  variant="destructive"
+                  ref={canDeleteAllLineage ? undefined : confirmButtonRef}
+                  variant={canDeleteAllLineage ? 'outline' : 'destructive'}
+                  className={
+                    canDeleteAllLineage
+                      ? 'border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive'
+                      : undefined
+                  }
                   onClick={() => handleDelete(false)}
                   disabled={isDeleting}
                 >


### PR DESCRIPTION
## Summary
- Make `Delete All N` the destructive primary action when deleting a parent workspace with child workspaces.
- Move `Delete Parent Only` to the secondary destructive-outline action and keep keyboard focus on the primary action.
- Add component coverage for the primary/secondary button roles.

## Tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx src/renderer/src/components/sidebar/delete-worktree-flow.test.ts`