### PR TITLE
Diagnose macOS single-instance lock false exits

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,8 +57,11 @@ import { getDevInstanceIdentity } from './startup/dev-instance-identity'
 import { hydrateShellPath, mergePathSegments } from './startup/hydrate-shell-path'
 import {
   acquireSingleInstanceLock,
-  logSingleInstanceLockFailure
+  logSingleInstanceLockBypass,
+  logSingleInstanceLockFailure,
+  shouldBypassSingleInstanceLock
 } from './startup/single-instance-lock'
+import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup/startup-diagnostics'
 import { RateLimitService } from './rate-limits/service'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
@@ -211,6 +214,17 @@ configureDevUserDataPath(is.dev)
 // Why: CLI-shared Codex helpers cannot import Electron. Seed the resolved
 // app userData path once Electron has applied dev/e2e overrides.
 process.env.ORCA_USER_DATA_PATH ??= app.getPath('userData')
+const startupDiagnosticsEnabled = isStartupDiagnosticsEnabled()
+if (startupDiagnosticsEnabled) {
+  logStartupDiagnostic('before-single-instance-lock', {
+    version: app.getVersion(),
+    packaged: app.isPackaged,
+    platform: process.platform,
+    osRelease: os.release(),
+    userData: app.getPath('userData'),
+    e2eUserData: Boolean(process.env.ORCA_E2E_USER_DATA_DIR)
+  })
+}
 
 function focusExistingWindow(): void {
   // Why: the second-instance event fires on the *primary* Electron process
@@ -274,8 +288,28 @@ function getExpectedTeardownScope(webContentsId?: number): ExpectedTeardownScope
 // hook endpoint files are namespaced per dev instance when the hook server
 // starts below. Packaged Orca keeps the lock to protect against the corruption
 // documented in PR #1326 / issue #1312.
+const bypassSingleInstanceLock = shouldBypassSingleInstanceLock({
+  isDev: is.dev,
+  isServeMode
+})
+if (bypassSingleInstanceLock) {
+  // Why: this is an explicit diagnostic escape hatch for macOS builds where
+  // Electron reports a false lock loss before any normal app logs exist.
+  logSingleInstanceLockBypass()
+}
 const hasSingleInstanceLock =
-  is.dev && !isServeMode ? true : acquireSingleInstanceLock(app, focusExistingWindow)
+  is.dev && !isServeMode
+    ? true
+    : bypassSingleInstanceLock
+      ? true
+      : acquireSingleInstanceLock(app, focusExistingWindow)
+if (startupDiagnosticsEnabled) {
+  logStartupDiagnostic('single-instance-lock-result', {
+    acquired: hasSingleInstanceLock,
+    bypassed: bypassSingleInstanceLock,
+    skippedForDev: is.dev && !isServeMode
+  })
+}
 if (!hasSingleInstanceLock) {
   // Why: if Electron returns a false negative here, packaged macOS launches
   // otherwise look like silent crashes. `open --stderr` can capture this line.

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -2,7 +2,10 @@ import type { App } from 'electron'
 import { describe, expect, it, vi } from 'vitest'
 import {
   acquireSingleInstanceLock,
+  logSingleInstanceLockBypass,
   logSingleInstanceLockFailure,
+  shouldBypassSingleInstanceLock,
+  SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE,
   SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE
 } from './single-instance-lock'
 
@@ -71,12 +74,52 @@ describe('acquireSingleInstanceLock', () => {
 })
 
 describe('logSingleInstanceLockFailure', () => {
-  it('emits a production-visible diagnostic for the early quit path', () => {
-    const logger = { error: vi.fn() }
+  it('emits a production-visible synchronous diagnostic for the early quit path', () => {
+    const write = vi.fn()
 
-    logSingleInstanceLockFailure(logger)
+    logSingleInstanceLockFailure(write)
 
-    expect(logger.error).toHaveBeenCalledWith(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE)
-    expect(logger.error.mock.calls[0]?.[0]).toContain('Electron/macOS single-instance lock failure')
+    expect(write).toHaveBeenCalledWith(2, `${SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE}\n`)
+    expect(write.mock.calls[0]?.[1]).toContain('Electron/macOS single-instance lock failure')
+  })
+})
+
+describe('shouldBypassSingleInstanceLock', () => {
+  it('allows the hidden diagnostic bypass only for packaged macOS app launches', () => {
+    expect(
+      shouldBypassSingleInstanceLock({
+        env: { ORCA_BYPASS_SINGLE_INSTANCE_LOCK: '1' },
+        isDev: false,
+        isServeMode: false,
+        platform: 'darwin'
+      })
+    ).toBe(true)
+    expect(
+      shouldBypassSingleInstanceLock({
+        env: { ORCA_BYPASS_SINGLE_INSTANCE_LOCK: '1' },
+        isDev: true,
+        isServeMode: false,
+        platform: 'darwin'
+      })
+    ).toBe(false)
+    expect(
+      shouldBypassSingleInstanceLock({
+        env: { ORCA_BYPASS_SINGLE_INSTANCE_LOCK: '1' },
+        isDev: false,
+        isServeMode: false,
+        platform: 'linux'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('logSingleInstanceLockBypass', () => {
+  it('emits a warning when the diagnostic bypass is active', () => {
+    const write = vi.fn()
+
+    logSingleInstanceLockBypass(write)
+
+    expect(write).toHaveBeenCalledWith(2, `${SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE}\n`)
+    expect(write.mock.calls[0]?.[1]).toContain('bypassing the packaged macOS single-instance lock')
   })
 })

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -1,7 +1,11 @@
 import type { App } from 'electron'
+import { writeStartupDiagnosticLine, type StartupDiagnosticSink } from './startup-diagnostics'
 
 export const SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE =
   '[single-instance] Another Orca instance is already running for this userData profile; exiting this launch after requesting the existing window. If no Orca process is running, this may be an Electron/macOS single-instance lock failure.'
+export const SINGLE_INSTANCE_LOCK_BYPASS_ENV = 'ORCA_BYPASS_SINGLE_INSTANCE_LOCK'
+export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
+  '[single-instance] ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1 is set; bypassing the packaged macOS single-instance lock for diagnostics. Do not use this with another Orca instance running for the same profile.'
 
 /**
  * Why: Orca writes two canonical discovery files into `<userData>/`:
@@ -29,6 +33,26 @@ export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void
   return true
 }
 
-export function logSingleInstanceLockFailure(logger: Pick<Console, 'error'> = console): void {
-  logger.error(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE)
+export function shouldBypassSingleInstanceLock(options: {
+  env?: NodeJS.ProcessEnv
+  isDev: boolean
+  isServeMode: boolean
+  platform?: NodeJS.Platform
+}): boolean {
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  return (
+    platform === 'darwin' &&
+    !options.isDev &&
+    !options.isServeMode &&
+    env[SINGLE_INSTANCE_LOCK_BYPASS_ENV] === '1'
+  )
+}
+
+export function logSingleInstanceLockFailure(write?: StartupDiagnosticSink): void {
+  writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE, write)
+}
+
+export function logSingleInstanceLockBypass(write?: StartupDiagnosticSink): void {
+  writeStartupDiagnosticLine(SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE, write)
 }

--- a/src/main/startup/startup-diagnostics.test.ts
+++ b/src/main/startup/startup-diagnostics.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isStartupDiagnosticsEnabled,
+  logStartupDiagnostic,
+  STARTUP_DIAGNOSTICS_ENV,
+  writeStartupDiagnosticLine
+} from './startup-diagnostics'
+
+describe('writeStartupDiagnosticLine', () => {
+  it('writes directly to stderr fd 2 with a newline', () => {
+    const write = vi.fn()
+
+    writeStartupDiagnosticLine('[startup] test', write)
+
+    expect(write).toHaveBeenCalledWith(2, '[startup] test\n')
+  })
+})
+
+describe('isStartupDiagnosticsEnabled', () => {
+  it('requires an explicit opt-in env flag', () => {
+    expect(isStartupDiagnosticsEnabled({ [STARTUP_DIAGNOSTICS_ENV]: '1' })).toBe(true)
+    expect(isStartupDiagnosticsEnabled({ [STARTUP_DIAGNOSTICS_ENV]: 'true' })).toBe(false)
+    expect(isStartupDiagnosticsEnabled({})).toBe(false)
+  })
+})
+
+describe('logStartupDiagnostic', () => {
+  it('formats event details as a synchronous startup diagnostic line', () => {
+    const write = vi.fn()
+
+    logStartupDiagnostic('before-lock', { packaged: true, userData: '/tmp/orca' }, write)
+
+    expect(write).toHaveBeenCalledWith(
+      2,
+      '[startup] before-lock packaged=true userData="/tmp/orca"\n'
+    )
+  })
+})

--- a/src/main/startup/startup-diagnostics.ts
+++ b/src/main/startup/startup-diagnostics.ts
@@ -1,0 +1,31 @@
+import { writeSync } from 'node:fs'
+
+export const STARTUP_DIAGNOSTICS_ENV = 'ORCA_STARTUP_DIAGNOSTICS'
+
+export type StartupDiagnosticSink = (fd: number, text: string) => unknown
+
+export function writeStartupDiagnosticLine(
+  message: string,
+  write: StartupDiagnosticSink = writeSync
+): void {
+  try {
+    write(2, message.endsWith('\n') ? message : `${message}\n`)
+  } catch {
+    console.error(message)
+  }
+}
+
+export function isStartupDiagnosticsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[STARTUP_DIAGNOSTICS_ENV] === '1'
+}
+
+export function logStartupDiagnostic(
+  event: string,
+  details: Record<string, unknown> = {},
+  write?: StartupDiagnosticSink
+): void {
+  const detailText = Object.entries(details)
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join(' ')
+  writeStartupDiagnosticLine(`[startup] ${event}${detailText ? ` ${detailText}` : ''}`, write)
+}


### PR DESCRIPTION
## Summary
- write early startup diagnostics synchronously to stderr so `open --stderr` can capture them before Electron logging flushes
- add `ORCA_STARTUP_DIAGNOSTICS=1` to emit the pre-lock state and single-instance lock result
- add a macOS packaged-app diagnostic escape hatch, `ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1`, to confirm whether issue #3464 is blocked only by the lock gate

## Test plan
- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/single-instance-lock.test.ts src/main/startup/startup-diagnostics.test.ts`
- `pnpm run typecheck:node`
- `pnpm run lint`
- `pnpm typecheck`
- `pnpm run build:electron-vite`

Fixes follow-up diagnostics for #3464.
