### PR TITLE
Fix workspace delete indicators

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.deleting.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.deleting.test.tsx
@@ -1,0 +1,115 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import type WorkspaceKanbanCardComponent from './WorkspaceKanbanCard'
+
+const updateWorktreeMeta = vi.fn()
+const openModal = vi.fn()
+let isDeleting = false
+let WorkspaceKanbanCard: typeof WorkspaceKanbanCardComponent
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      deleteStateByWorktreeId: {
+        'repo-1::/repo/worktrees/deleting': {
+          isDeleting,
+          error: null,
+          canForceDelete: false
+        }
+      },
+      openModal,
+      updateWorktreeMeta
+    })
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/components/ui/hover-card', () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: () => null,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./WorktreeActivityStatusIndicator', () => ({
+  WorktreeActivityStatusIndicator: () => null
+}))
+
+vi.mock('./WorktreeTitleInlineRename', () => ({
+  WorktreeTitleInlineRename: ({ displayName }: { displayName: string }) => (
+    <span>{displayName}</span>
+  )
+}))
+
+vi.mock('./workspace-delete-quick-action', () => ({
+  canShowWorkspaceDeleteQuickAction: () => false,
+  useWorkspaceDeleteModifierPressed: () => false
+}))
+
+function makeWorktree(): Worktree {
+  return {
+    id: 'repo-1::/repo/worktrees/deleting',
+    repoId: 'repo-1',
+    path: '/repo/worktrees/deleting',
+    displayName: 'Deleting card',
+    branch: 'deleting',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1
+  }
+}
+
+describe('WorkspaceKanbanCard deleting state', () => {
+  beforeAll(async () => {
+    WorkspaceKanbanCard = (await import('./WorkspaceKanbanCard')).default
+  }, 20_000)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isDeleting = false
+  })
+
+  it('renders a visible loader on compact kanban cards while deleting', () => {
+    isDeleting = true
+
+    const markup = renderToStaticMarkup(
+      <WorkspaceKanbanCard
+        worktree={makeWorktree()}
+        repo={undefined}
+        isActive={false}
+        isSelected={false}
+        compact
+        onActivate={vi.fn()}
+        onSelectionGesture={() => false}
+        onContextMenuSelect={() => []}
+      />
+    )
+
+    expect(markup).toContain('aria-busy="true"')
+    expect(markup).toContain('Deleting…')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
-import { Pin, Trash2 } from 'lucide-react'
+import { LoaderCircle, Pin, Trash2 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Badge } from '@/components/ui/badge'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
@@ -290,6 +290,14 @@ function WorkspaceKanbanCompactCard({
             aria-disabled={isDeleting ? true : undefined}
             aria-busy={isDeleting}
           >
+            {isDeleting ? (
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-sidebar/60 backdrop-blur-[1px]">
+                <div className="inline-flex max-w-[calc(100%-0.75rem)] items-center gap-1 rounded-full border border-border/50 bg-background px-2 py-0.5 text-[10px] font-medium text-foreground shadow-xs">
+                  <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground" />
+                  <span className="truncate">Deleting…</span>
+                </div>
+              </div>
+            ) : null}
             <WorktreeActivityStatusIndicator worktreeId={worktree.id} className="mr-1" />
             <WorktreeTitleInlineRename
               displayName={worktree.displayName}

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -17,10 +17,24 @@ const mocks = vi.hoisted(() => {
     repos: [] as { id: string; displayName: string }[],
     worktreeLineageById: {},
     allWorktrees: () => Array.from(state.worktreeMap.values()),
-    clearWorktreeDeleteState: vi.fn(),
+    clearWorktreeDeleteState: vi.fn((worktreeId: string) => {
+      delete state.deleteStateByWorktreeId[worktreeId]
+    }),
+    markWorktreesDeleting: vi.fn((worktreeIds: readonly string[]) => {
+      for (const worktreeId of new Set(worktreeIds)) {
+        state.deleteStateByWorktreeId[worktreeId] = {
+          isDeleting: true,
+          error: null,
+          canForceDelete: false
+        }
+      }
+    }),
     openModal: vi.fn(),
     removeWorktree: vi.fn().mockResolvedValue({ ok: true }),
-    deleteStateByWorktreeId: {}
+    deleteStateByWorktreeId: {} as Record<
+      string,
+      { isDeleting?: boolean; error?: string | null; canForceDelete?: boolean }
+    >
   }
   return { state }
 })
@@ -47,22 +61,7 @@ vi.mock('sonner', () => ({
 }))
 
 import { toast } from 'sonner'
-import {
-  runWorktreeBatchDelete,
-  runWorktreeDelete,
-  runWorktreeDeletesInParallel
-} from './delete-worktree-flow'
-
-function deferredDeleteResult(): {
-  promise: Promise<{ ok: true }>
-  resolve: (value: { ok: true }) => void
-} {
-  let resolve: (value: { ok: true }) => void = () => {}
-  const promise = new Promise<{ ok: true }>((innerResolve) => {
-    resolve = innerResolve
-  })
-  return { promise, resolve }
-}
+import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 
 function setWorktrees(
   worktrees: {
@@ -93,6 +92,7 @@ describe('runWorktreeBatchDelete', () => {
   beforeEach(() => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: false }
     mocks.state.clearWorktreeDeleteState.mockClear()
+    mocks.state.markWorktreesDeleting.mockClear()
     mocks.state.openModal.mockClear()
     mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
     mocks.state.deleteStateByWorktreeId = {}
@@ -163,9 +163,15 @@ describe('runWorktreeBatchDelete', () => {
 
   it('notifies onDeleted after a skip-confirm force delete succeeds', async () => {
     mocks.state.settings = { skipDeleteWorktreeConfirm: true }
-    mocks.state.deleteStateByWorktreeId = { 'wt-1': { canForceDelete: true } }
     mocks.state.removeWorktree
-      .mockResolvedValueOnce({ ok: false, error: 'changed files' })
+      .mockImplementationOnce(async (worktreeId: string) => {
+        mocks.state.deleteStateByWorktreeId[worktreeId] = {
+          isDeleting: false,
+          error: 'changed files',
+          canForceDelete: true
+        }
+        return { ok: false, error: 'changed files' }
+      })
       .mockResolvedValueOnce({ ok: true })
     setWorktrees([{ id: 'wt-1', displayName: 'one' }])
     const onDeleted = vi.fn()
@@ -288,61 +294,5 @@ describe('runWorktreeBatchDelete', () => {
     expect(toast.info).toHaveBeenCalledWith('No deletable workspaces selected', {
       description: 'Refresh Space and try again if the workspace list looks stale.'
     })
-  })
-})
-
-describe('runWorktreeDeletesInParallel', () => {
-  beforeEach(() => {
-    mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
-    mocks.state.deleteStateByWorktreeId = {}
-    vi.mocked(toast.error).mockClear()
-    vi.mocked(toast.info).mockClear()
-  })
-
-  it('starts every selected delete before waiting for earlier deletes to finish', async () => {
-    const first = deferredDeleteResult()
-    const second = deferredDeleteResult()
-    mocks.state.removeWorktree
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise)
-
-    const deleted = runWorktreeDeletesInParallel([
-      { id: 'wt-1', displayName: 'one', repoId: 'repo-a', path: '/workspaces/one' },
-      { id: 'wt-2', displayName: 'two', repoId: 'repo-b', path: '/workspaces/two' }
-    ])
-
-    expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(2)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', false)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', false)
-
-    second.resolve({ ok: true })
-    await Promise.resolve()
-    first.resolve({ ok: true })
-
-    await expect(deleted).resolves.toEqual(['wt-1', 'wt-2'])
-  })
-
-  it('deletes nested workspaces before their parent within the same repo', async () => {
-    await runWorktreeDeletesInParallel([
-      { id: 'parent', displayName: 'parent', repoId: 'repo-a', path: '/workspaces/parent' },
-      { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
-    ])
-
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false)
-  })
-
-  it('does not delete an ancestor when a nested descendant delete fails', async () => {
-    mocks.state.removeWorktree.mockResolvedValueOnce({ ok: false, error: 'changed files' })
-
-    await expect(
-      runWorktreeDeletesInParallel([
-        { id: 'parent', displayName: 'parent', repoId: 'repo-a', path: '/workspaces/parent' },
-        { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
-      ])
-    ).resolves.toEqual([])
-
-    expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
-    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
   })
 })

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -42,6 +42,9 @@ export async function runWorktreeDeletesInParallel(
   targets: readonly Pick<Worktree, 'id' | 'displayName' | 'repoId' | 'path'>[],
   options: WorktreeDeleteWithToastOptions = {}
 ): Promise<string[]> {
+  // Why: deletes are serialized per repo to avoid git lock races, but every
+  // selected/lineage workspace should show in-flight feedback immediately.
+  useAppStore.getState().markWorktreesDeleting(targets.map((target) => target.id))
   // Why: `git worktree remove`/`prune`/`branch -D` mutate repo-wide ref state
   // and contend on `.git/packed-refs.lock` and per-worktree HEAD.lock. Running
   // every target through Promise.all races those locks on the same repo and
@@ -68,6 +71,7 @@ export async function runWorktreeDeletesInParallel(
       const failedInGroup: (typeof group)[number][] = []
       for (const target of group) {
         if (failedInGroup.some((failed) => isStrictDescendantPath(target.path, failed.path))) {
+          useAppStore.getState().clearWorktreeDeleteState(target.id)
           continue
         }
         const deleted = await runWorktreeDeleteWithToast(target.id, target.displayName, options)

--- a/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    worktreeMap: new Map<string, unknown>(),
+    clearWorktreeDeleteState: vi.fn((worktreeId: string) => {
+      delete state.deleteStateByWorktreeId[worktreeId]
+    }),
+    markWorktreesDeleting: vi.fn((worktreeIds: readonly string[]) => {
+      for (const worktreeId of new Set(worktreeIds)) {
+        state.deleteStateByWorktreeId[worktreeId] = {
+          isDeleting: true,
+          error: null,
+          canForceDelete: false
+        }
+      }
+    }),
+    removeWorktree: vi.fn().mockResolvedValue({ ok: true }),
+    deleteStateByWorktreeId: {} as Record<
+      string,
+      { isDeleting?: boolean; error?: string | null; canForceDelete?: boolean }
+    >
+  }
+  return { state }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mocks.state
+  }
+}))
+
+vi.mock('@/store/selectors', () => ({
+  getWorktreeMapFromState: () => mocks.state.worktreeMap
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+import { toast } from 'sonner'
+import { runWorktreeDeletesInParallel } from './delete-worktree-flow'
+
+function deferredDeleteResult(): {
+  promise: Promise<{ ok: true }>
+  resolve: (value: { ok: true }) => void
+} {
+  let resolve: (value: { ok: true }) => void = () => {}
+  const promise = new Promise<{ ok: true }>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+describe('runWorktreeDeletesInParallel', () => {
+  beforeEach(() => {
+    mocks.state.removeWorktree.mockClear().mockResolvedValue({ ok: true })
+    mocks.state.clearWorktreeDeleteState.mockClear()
+    mocks.state.markWorktreesDeleting.mockClear()
+    mocks.state.deleteStateByWorktreeId = {}
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(toast.info).mockClear()
+  })
+
+  it('starts every selected delete before waiting for earlier deletes to finish', async () => {
+    const first = deferredDeleteResult()
+    const second = deferredDeleteResult()
+    mocks.state.removeWorktree
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const deleted = runWorktreeDeletesInParallel([
+      { id: 'wt-1', displayName: 'one', repoId: 'repo-a', path: '/workspaces/one' },
+      { id: 'wt-2', displayName: 'two', repoId: 'repo-b', path: '/workspaces/two' }
+    ])
+
+    expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(2)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'wt-1', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'wt-2', false)
+    expect(mocks.state.markWorktreesDeleting).toHaveBeenCalledWith(['wt-1', 'wt-2'])
+
+    second.resolve({ ok: true })
+    await Promise.resolve()
+    first.resolve({ ok: true })
+
+    await expect(deleted).resolves.toEqual(['wt-1', 'wt-2'])
+  })
+
+  it('marks every same-repo target deleting before serialized deletes finish', async () => {
+    const childDelete = deferredDeleteResult()
+    mocks.state.removeWorktree.mockReturnValueOnce(childDelete.promise)
+
+    const deleted = runWorktreeDeletesInParallel([
+      { id: 'parent', displayName: 'parent', repoId: 'repo-a', path: '/workspaces/parent' },
+      { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
+    ])
+
+    expect(mocks.state.markWorktreesDeleting).toHaveBeenCalledWith(['parent', 'child'])
+    expect(mocks.state.deleteStateByWorktreeId['parent']).toEqual({
+      isDeleting: true,
+      error: null,
+      canForceDelete: false
+    })
+    expect(mocks.state.deleteStateByWorktreeId['child']).toEqual({
+      isDeleting: true,
+      error: null,
+      canForceDelete: false
+    })
+    expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
+
+    childDelete.resolve({ ok: true })
+
+    await expect(deleted).resolves.toEqual(['parent', 'child'])
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false)
+  })
+
+  it('deletes nested workspaces before their parent within the same repo', async () => {
+    await runWorktreeDeletesInParallel([
+      { id: 'parent', displayName: 'parent', repoId: 'repo-a', path: '/workspaces/parent' },
+      { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
+    ])
+
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(2, 'parent', false)
+  })
+
+  it('clears a pending ancestor when a nested descendant delete fails', async () => {
+    mocks.state.removeWorktree.mockImplementationOnce(async (worktreeId: string) => {
+      mocks.state.deleteStateByWorktreeId[worktreeId] = {
+        isDeleting: false,
+        error: 'changed files',
+        canForceDelete: true
+      }
+      return { ok: false, error: 'changed files' }
+    })
+
+    await expect(
+      runWorktreeDeletesInParallel([
+        { id: 'parent', displayName: 'parent', repoId: 'repo-a', path: '/workspaces/parent' },
+        { id: 'child', displayName: 'child', repoId: 'repo-a', path: '/workspaces/parent/child' }
+      ])
+    ).resolves.toEqual([])
+
+    expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(1)
+    expect(mocks.state.removeWorktree).toHaveBeenNthCalledWith(1, 'child', false)
+    expect(mocks.state.clearWorktreeDeleteState).toHaveBeenCalledWith('parent')
+    expect(mocks.state.deleteStateByWorktreeId['parent']).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -240,6 +240,25 @@ describe('removeWorktree cascade', () => {
     expect(s.activeWorktreeId).toBe(worktreeId)
   })
 
+  it('marks multiple worktrees deleting in one optimistic state update', () => {
+    const store = createTestStore()
+    const first = 'repo1::/path/wt1'
+    const second = 'repo1::/path/wt2'
+
+    seedStore(store, {
+      deleteStateByWorktreeId: {
+        [first]: { isDeleting: false, error: 'old failure', canForceDelete: true }
+      }
+    })
+
+    store.getState().markWorktreesDeleting([first, second, first])
+
+    expect(store.getState().deleteStateByWorktreeId).toMatchObject({
+      [first]: { isDeleting: true, error: null, canForceDelete: false },
+      [second]: { isDeleting: true, error: null, canForceDelete: false }
+    })
+  })
+
   it('offers force delete for Electron-wrapped local dirty preflight errors', async () => {
     const store = createTestStore()
     const worktreeId = 'repo1::/workspace/feature-wt'

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -105,6 +105,7 @@ export type WorktreeSlice = {
     worktreeId: string,
     force?: boolean
   ) => Promise<({ ok: true } & RemoveWorktreeResult) | { ok: false; error: string }>
+  markWorktreesDeleting: (worktreeIds: readonly string[]) => void
   forceDeletePreservedBranch: (
     worktreeId: string,
     branchName: string,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1413,6 +1413,29 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     }
   },
 
+  markWorktreesDeleting: (worktreeIds) => {
+    if (worktreeIds.length === 0) {
+      return
+    }
+    set((s) => {
+      const nextDeleteState = { ...s.deleteStateByWorktreeId }
+      let changed = false
+      for (const worktreeId of new Set(worktreeIds)) {
+        const current = nextDeleteState[worktreeId]
+        if (current?.isDeleting && current.error === null && !current.canForceDelete) {
+          continue
+        }
+        nextDeleteState[worktreeId] = {
+          isDeleting: true,
+          error: null,
+          canForceDelete: false
+        }
+        changed = true
+      }
+      return changed ? { deleteStateByWorktreeId: nextDeleteState } : {}
+    })
+  },
+
   forceDeletePreservedBranch: async (worktreeId, branchName, expectedHead) => {
     try {
       const target = getActiveRuntimeTarget(get().settings)


### PR DESCRIPTION
## Summary
- Mark every selected or lineage delete target as deleting before serialized per-repo deletion starts
- Clear skipped ancestor pending state when a child delete fails
- Render a visible compact kanban deleting loader

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts src/renderer/src/components/sidebar/WorkspaceKanbanCard.deleting.test.tsx src/renderer/src/store/slices/store-cascades.test.ts
- pnpm run typecheck:web
- pnpm exec oxlint src/renderer/src/components/sidebar/delete-worktree-flow.ts src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx src/renderer/src/components/sidebar/delete-worktree-flow.test.ts src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts src/renderer/src/components/sidebar/WorkspaceKanbanCard.deleting.test.tsx src/renderer/src/store/slices/worktree-helpers.ts src/renderer/src/store/slices/worktrees.ts src/renderer/src/store/slices/store-cascades.test.ts