### PR TITLE
perf: clean combobox focus frame effects

### DIFF
--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -146,7 +146,15 @@ export default function AgentCombobox({
     }
   }, [])
 
-  React.useEffect(() => cancelFocusFrame, [cancelFocusFrame])
+  const setInputNode = useCallback(
+    (node: HTMLInputElement | null): void => {
+      if (node === null) {
+        cancelFocusFrame()
+      }
+      inputRef.current = node
+    },
+    [cancelFocusFrame]
+  )
 
   React.useEffect(() => {
     if (!open) {
@@ -284,7 +292,7 @@ export default function AgentCombobox({
         >
           <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
             <CommandInput
-              ref={inputRef}
+              ref={setInputNode}
               placeholder="Search agents..."
               value={query}
               onValueChange={setQuery}

--- a/src/renderer/src/components/automations/WorkspaceCombobox.tsx
+++ b/src/renderer/src/components/automations/WorkspaceCombobox.tsx
@@ -35,7 +35,15 @@ export function WorkspaceCombobox({
     }
   }, [])
 
-  React.useEffect(() => cancelFocusFrame, [cancelFocusFrame])
+  const setInputNode = React.useCallback(
+    (node: HTMLInputElement | null): void => {
+      if (node === null) {
+        cancelFocusFrame()
+      }
+      inputRef.current = node
+    },
+    [cancelFocusFrame]
+  )
 
   const focusSearchInput = React.useCallback(() => {
     cancelFocusFrame()
@@ -80,7 +88,7 @@ export function WorkspaceCombobox({
         }}
       >
         <Command>
-          <CommandInput ref={inputRef} placeholder="Search workspaces..." />
+          <CommandInput ref={setInputNode} placeholder="Search workspaces..." />
           <CommandList className="max-h-72">
             <CommandEmpty>No workspaces found.</CommandEmpty>
             {worktrees.map((worktree) => (

--- a/src/renderer/src/components/repo/RepoCombobox.tsx
+++ b/src/renderer/src/components/repo/RepoCombobox.tsx
@@ -65,7 +65,15 @@ export default function RepoCombobox({
     }
   }, [])
 
-  React.useEffect(() => cancelFocusFrame, [cancelFocusFrame])
+  const setInputNode = useCallback(
+    (node: HTMLInputElement | null): void => {
+      if (node === null) {
+        cancelFocusFrame()
+      }
+      inputRef.current = node
+    },
+    [cancelFocusFrame]
+  )
 
   const focusSearchInput = useCallback(() => {
     cancelFocusFrame()
@@ -215,7 +223,7 @@ export default function RepoCombobox({
         >
           <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
             <CommandInput
-              ref={inputRef}
+              ref={setInputNode}
               placeholder="Search projects/folders..."
               value={query}
               onValueChange={setQuery}


### PR DESCRIPTION
## Summary
- remove cleanup-only focus-frame Effects from agent, repo, and workspace comboboxes
- cancel pending focus frames from the CommandInput ref cleanup instead
- preserve existing deferred focus behavior when popovers open

## Validation
- pnpm exec oxlint src/renderer/src/components/agent/AgentCombobox.tsx src/renderer/src/components/repo/RepoCombobox.tsx src/renderer/src/components/automations/WorkspaceCombobox.tsx src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm exec oxfmt --check src/renderer/src/components/agent/AgentCombobox.tsx src/renderer/src/components/repo/RepoCombobox.tsx src/renderer/src/components/automations/WorkspaceCombobox.tsx src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/agent/AgentCombobox.test.tsx
- pnpm run typecheck:web
- git diff --check

Risk: low
- Local combobox focus cleanup only; no persistence, IPC, transport, or selection behavior changes.

Per request: not waiting for CI checks before merge.