### PR TITLE
fix: exclude forward-slash UNC nested worktrees

### DIFF
--- a/src/renderer/src/components/quick-open-file-list.test.ts
+++ b/src/renderer/src/components/quick-open-file-list.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../shared/types'
+import { getNestedWorktreeExcludePaths, isNestedWorktreePath } from './quick-open-file-list'
+
+function makeWorktree(id: string, path: string): Worktree {
+  return {
+    id,
+    repoId: 'repo-1',
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    path,
+    head: 'HEAD',
+    branch: 'main',
+    isBare: false,
+    isMainWorktree: false
+  }
+}
+
+describe('quick-open nested worktree excludes', () => {
+  it('treats forward-slash UNC paths as Windows paths', () => {
+    expect(isNestedWorktreePath('//Server/Share/Repo', '//server/share/repo/packages/app')).toBe(
+      true
+    )
+    expect(isNestedWorktreePath('//Server/Share/Repo', '//server/share/repo2')).toBe(false)
+  })
+
+  it('excludes nested forward-slash UNC worktrees from Quick Open scans', () => {
+    expect(
+      getNestedWorktreeExcludePaths('root', '//Server/Share/Repo', [
+        makeWorktree('root', '//Server/Share/Repo'),
+        makeWorktree('nested', '//server/share/repo/packages/app'),
+        makeWorktree('sibling', '//server/share/repo2')
+      ])
+    ).toEqual(['//server/share/repo/packages/app'])
+  })
+})

--- a/src/renderer/src/components/quick-open-file-list.ts
+++ b/src/renderer/src/components/quick-open-file-list.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { Worktree } from '../../../shared/types'
+import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
 import { getConnectionId } from '@/lib/connection-context'
 import { listRuntimeFiles } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
@@ -17,7 +18,7 @@ export function cleanRuntimeFileListError(error: unknown): string {
 }
 
 export function isNestedWorktreePath(parentPath: string, childPath: string): boolean {
-  const windowsPath = /^[a-zA-Z]:[\\/]/.test(parentPath) || parentPath.startsWith('\\\\')
+  const windowsPath = isWindowsAbsolutePathLike(parentPath)
   const parent = parentPath.replace(/[\\/]+$/, '').replace(/\\/g, '/')
   const child = childPath.replace(/\\/g, '/')
   // Why: Windows paths are case-insensitive and can arrive with mixed slash


### PR DESCRIPTION
## Summary
- Treat forward-slash UNC roots (for example //Server/Share/Repo) as Windows paths when Quick Open computes nested-worktree excludes.
- Add renderer regression coverage proving nested UNC worktrees are excluded and sibling UNC paths are not.

## Evidence
- Reproduced before fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-file-list.test.ts` failed with `expected false to be true` and `expected [] to deeply equal ['//server/share/repo/packages/app']`.
- Verified after fix: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-file-list.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/quick-open-file-list.ts src/renderer/src/components/quick-open-file-list.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/quick-open-file-list.ts src/renderer/src/components/quick-open-file-list.test.ts`
- `git diff --check HEAD~1..HEAD`