### PR TITLE
perf: clean smart name focus frame effect

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -231,15 +231,6 @@ export default function SmartWorkspaceNameField({
     [gitlabAvailable, linearAvailable, textOnly]
   )
 
-  const setInputNode = useCallback(
-    (node: HTMLInputElement | null) => {
-      localInputRef.current = node
-      if (inputRef) {
-        inputRef.current = node
-      }
-    },
-    [inputRef]
-  )
   const selectedSourceFocusKey = selectedSource
     ? `${selectedSource.kind}:${selectedSource.label}:${selectedSource.url ?? ''}`
     : null
@@ -271,7 +262,18 @@ export default function SmartWorkspaceNameField({
     localInputFocusFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelLocalInputFocusFrame, [cancelLocalInputFocusFrame])
+  const setInputNode = useCallback(
+    (node: HTMLInputElement | null) => {
+      if (node === null) {
+        cancelLocalInputFocusFrame()
+      }
+      localInputRef.current = node
+      if (inputRef) {
+        inputRef.current = node
+      }
+    },
+    [cancelLocalInputFocusFrame, inputRef]
+  )
 
   useEffect(() => {
     if (disabled || textOnly) {


### PR DESCRIPTION
## Summary
- remove the cleanup-only focus-frame Effect from SmartWorkspaceNameField
- cancel the pending tab-change focus frame from the input ref cleanup instead
- preserve existing tab-change deferred focus behavior

## Validation
- pnpm exec oxlint src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
- pnpm exec oxfmt --check src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
- pnpm run typecheck:web
- git diff --check

Risk: low
- Local new-workspace input focus cleanup only; no persistence, IPC, provider, or workspace creation behavior changes.

Per request: not waiting for CI checks before merge.