### PR TITLE
perf: clean create-from focus frame effect

### DIFF
--- a/src/renderer/src/components/automations/CreateFromPicker.tsx
+++ b/src/renderer/src/components/automations/CreateFromPicker.tsx
@@ -77,7 +77,15 @@ export function CreateFromPicker({
     }
   }, [])
 
-  React.useEffect(() => cancelFocusFrame, [cancelFocusFrame])
+  const setInputNode = React.useCallback(
+    (node: HTMLInputElement | null): void => {
+      if (node === null) {
+        cancelFocusFrame()
+      }
+      inputRef.current = node
+    },
+    [cancelFocusFrame]
+  )
 
   const focusSearchInput = React.useCallback(() => {
     cancelFocusFrame()
@@ -188,7 +196,7 @@ export function CreateFromPicker({
         >
           <Command>
             <CommandInput
-              ref={inputRef}
+              ref={setInputNode}
               value={query}
               onValueChange={setQuery}
               placeholder="Search repo branches..."


### PR DESCRIPTION
## Summary
- remove the cleanup-only focus-frame Effect from CreateFromPicker
- cancel the pending popover focus frame from CommandInput ref cleanup instead
- preserve existing delayed focus behavior when the picker opens

## Validation
- pnpm exec oxlint src/renderer/src/components/automations/CreateFromPicker.tsx
- pnpm exec oxfmt --check src/renderer/src/components/automations/CreateFromPicker.tsx
- pnpm run typecheck:web
- git diff --check

Risk: low
- Local picker focus cleanup only; no persistence, IPC, runtime branch search, or automation behavior changes.

Per request: not waiting for CI checks before merge.