### PR TITLE
fix: parse github https remotes with auth

### DIFF
--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -39,6 +39,14 @@ describe('github owner/repo resolution', () => {
       owner: 'acme',
       repo: 'widgets'
     })
+    expect(parseGitHubOwnerRepo('https://alice@github.com/acme/widgets.git')).toEqual({
+      owner: 'acme',
+      repo: 'widgets'
+    })
+    expect(parseGitHubOwnerRepo('https://github.com:443/acme/widgets.git')).toEqual({
+      owner: 'acme',
+      repo: 'widgets'
+    })
     expect(parseGitHubOwnerRepo('git@github.com:stablyai/orca.git')).toEqual({
       owner: 'stablyai',
       repo: 'orca'
@@ -78,6 +86,17 @@ describe('github owner/repo resolution', () => {
     })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+      cwd: '/repo'
+    })
+  })
+
+  it('resolves GitHub HTTPS origin remotes with user info and a default port', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'https://alice@github.com:443/acme/widgets.git\n'
+    })
+
+    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'acme', repo: 'widgets' })
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -160,8 +160,9 @@ export function parseGitHubOwnerRepo(remoteUrl: string): OwnerRepo | null {
 }
 
 function normalizeGitHubRemoteHost(host: string): string {
+  const normalizedHost = host.toLowerCase()
   // Why: GitHub documents ssh.github.com:443 as SSH-over-HTTPS for github.com repos.
-  return host.toLowerCase() === 'ssh.github.com' ? 'github.com' : host
+  return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
 }
 
 function parseGitHubRemotePath(path: string): Pick<GitHubRemoteIdentity, 'owner' | 'repo'> | null {
@@ -179,14 +180,6 @@ function parseGitHubRemotePath(path: string): Pick<GitHubRemoteIdentity, 'owner'
 
 export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdentity | null {
   const trimmed = remoteUrl.trim()
-  const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i)
-  if (httpsMatch) {
-    return {
-      host: normalizeGitHubRemoteHost(httpsMatch[1]),
-      owner: httpsMatch[2],
-      repo: httpsMatch[3]
-    }
-  }
   const sshMatch = trimmed.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/i)
   if (sshMatch) {
     return { host: normalizeGitHubRemoteHost(sshMatch[1]), owner: sshMatch[2], repo: sshMatch[3] }
@@ -194,7 +187,7 @@ export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdenti
 
   try {
     const url = new URL(trimmed)
-    if (!['git:', 'git+ssh:', 'ssh:'].includes(url.protocol.toLowerCase())) {
+    if (!['git:', 'git+ssh:', 'http:', 'https:', 'ssh:'].includes(url.protocol.toLowerCase())) {
       return null
     }
     const path = parseGitHubRemotePath(url.pathname)


### PR DESCRIPTION
## Summary
- parse GitHub HTTP(S) remotes through `URL` so credentials and explicit ports do not become part of the hostname
- keep scp-like and SSH URL remote handling intact
- add coverage through both `parseGitHubOwnerRepo()` and `getOwnerRepo()`

## Evidence
- Before the fix, `pnpm exec vitest run --config config/vitest.config.ts src/main/github/gh-utils.test.ts` failed because `parseGitHubOwnerRepo("https://alice@github.com/acme/widgets.git")` returned `null`.
- After the fix, valid remotes like `https://alice@github.com/acme/widgets.git` and `https://alice@github.com:443/acme/widgets.git` resolve to `{ owner: "acme", repo: "widgets" }`, so GitHub PR/status/task surfaces stay enabled.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/gh-utils.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/github/gh-utils.ts src/main/github/gh-utils.test.ts`
- `pnpm exec oxfmt --check src/main/github/gh-utils.ts src/main/github/gh-utils.test.ts`
- `git diff --check HEAD~1..HEAD`