### PR TITLE
Keep dev CLI installs isolated

### DIFF
--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -69,6 +69,8 @@ describe('CliInstaller', () => {
 
       const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
       expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
+      expect(launcherContent).toContain(`export ORCA_USER_DATA_PATH='${fixture.userDataPath}'`)
+      expect(launcherContent).toContain('export ORCA_APP_EXECUTABLE="$ELECTRON"')
       expect(launcherContent).toContain(join(fixture.appPath, 'out', 'cli', 'index.js'))
 
       const removed = await installer.remove()
@@ -100,9 +102,37 @@ describe('CliInstaller', () => {
 
       const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
       expect(launcherContent).toContain('ELECTRON_RUN_AS_NODE=1')
+      expect(launcherContent).toContain(`export ORCA_USER_DATA_PATH='${fixture.userDataPath}'`)
 
       const removed = await installer.remove()
       expect(removed.state).toBe('not_installed')
+    }
+  )
+
+  // Why: dev installs are useful for validation, but they must not replace the
+  // packaged `orca` / `orca-ide` commands developers rely on day to day.
+  it.skipIf(process.platform === 'win32')(
+    'uses a separate orca-dev command for default development installs',
+    async () => {
+      const fixture = await makeFixture()
+      const homePath = join(fixture.root, 'home')
+      const commandDir = join(homePath, '.local', 'bin')
+      const installer = new CliInstaller({
+        platform: 'linux',
+        isPackaged: false,
+        userDataPath: fixture.userDataPath,
+        execPath: '/opt/Orca/orca-ide',
+        appPath: fixture.appPath,
+        homePath,
+        processPathEnv: commandDir
+      })
+
+      const installed = await installer.install()
+      expect(installed.state).toBe('installed')
+      expect(installed.commandName).toBe('orca-dev')
+      expect(installed.commandPath).toBe(join(commandDir, 'orca-dev'))
+      expect(installed.launcherPath).toBe(join(fixture.userDataPath, 'cli', 'bin', 'orca-dev'))
+      await expect(readlink(installed.commandPath as string)).resolves.toBe(installed.launcherPath)
     }
   )
 
@@ -114,19 +144,20 @@ describe('CliInstaller', () => {
       const fixture = await makeFixture()
       const homePath = join(fixture.root, 'home')
       const commandDir = join(homePath, '.local', 'bin')
-      const oldLauncherPath = join(fixture.userDataPath, 'cli', 'bin', 'orca')
+      const resourcesPath = join(fixture.root, 'resources')
+      const launcherPath = join(resourcesPath, 'bin', 'orca-ide')
+      const oldLauncherPath = join(resourcesPath, 'bin', 'orca')
       const legacyCommandPath = join(commandDir, 'orca')
       await mkdir(commandDir, { recursive: true })
-      await mkdir(join(fixture.userDataPath, 'cli', 'bin'), { recursive: true })
+      await mkdir(join(resourcesPath, 'bin'), { recursive: true })
+      await writeFile(launcherPath, '#!/usr/bin/env bash\n', 'utf8')
       await writeFile(oldLauncherPath, '#!/usr/bin/env bash\n', 'utf8')
       await symlink(oldLauncherPath, legacyCommandPath)
 
       const installer = new CliInstaller({
         platform: 'linux',
-        isPackaged: false,
-        userDataPath: fixture.userDataPath,
-        execPath: '/opt/Orca/orca-ide',
-        appPath: fixture.appPath,
+        isPackaged: true,
+        resourcesPath,
         homePath,
         processPathEnv: commandDir
       })
@@ -162,6 +193,9 @@ describe('CliInstaller', () => {
     const wrapperContent = await readFile(installPath, 'utf8')
     expect(wrapperContent).toContain('ORCA_LAUNCHER=')
     expect(wrapperContent).toContain('orca.cmd')
+    const launcherContent = await readFile(installed.launcherPath as string, 'utf8')
+    expect(launcherContent).toContain(`set "ORCA_USER_DATA_PATH=${fixture.userDataPath}"`)
+    expect(launcherContent).toContain('set "ORCA_APP_EXECUTABLE=%ELECTRON%"')
 
     const removed = await installer.remove()
     expect(removed.state).toBe('not_installed')
@@ -258,6 +292,46 @@ describe('CliInstaller', () => {
       })
       await expect(installer.install()).resolves.toMatchObject({ state: 'installed' })
       await expect(readlink(installPath)).resolves.toBe(launcherPath)
+    }
+  )
+
+  // Why: a dev build can temporarily own the public command on developer
+  // machines; packaged Orca should treat that as stale, not a hard conflict.
+  it.skipIf(process.platform === 'win32')(
+    'replaces stale sibling dev launcher symlinks from packaged installs',
+    async () => {
+      const fixture = await makeFixture()
+      for (const devLauncherName of ['orca', 'orca-dev']) {
+        const caseRoot = join(fixture.root, devLauncherName)
+        const commandDir = join(caseRoot, 'bin')
+        const installPath = join(commandDir, 'orca')
+        const userDataPath = join(caseRoot, 'orca')
+        const resourcesPath = join(caseRoot, 'Current.app', 'Contents', 'Resources')
+        const launcherPath = join(resourcesPath, 'bin', 'orca')
+        const devLauncherPath = join(`${userDataPath}-dev`, 'cli', 'bin', devLauncherName)
+        await mkdir(commandDir, { recursive: true })
+        await mkdir(join(resourcesPath, 'bin'), { recursive: true })
+        await mkdir(join(`${userDataPath}-dev`, 'cli', 'bin'), { recursive: true })
+        await writeFile(launcherPath, '#!/usr/bin/env bash\n', 'utf8')
+        await writeFile(devLauncherPath, '#!/usr/bin/env bash\n', 'utf8')
+        await symlink(devLauncherPath, installPath)
+
+        const installer = new CliInstaller({
+          platform: 'darwin',
+          isPackaged: true,
+          userDataPath,
+          resourcesPath,
+          commandPathOverride: installPath,
+          processPathEnv: commandDir
+        })
+
+        await expect(installer.getStatus()).resolves.toMatchObject({
+          state: 'stale',
+          currentTarget: devLauncherPath
+        })
+        await expect(installer.install()).resolves.toMatchObject({ state: 'installed' })
+        await expect(readlink(installPath)).resolves.toBe(launcherPath)
+      }
     }
   )
 })

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -10,6 +10,7 @@ import type { CliInstallMethod, CliInstallStatus } from '../../shared/cli-instal
 
 const execFileAsync = promisify(execFile)
 const DEFAULT_MAC_COMMAND_PATH = '/usr/local/bin/orca'
+const DEV_COMMAND_NAME = 'orca-dev'
 const LINUX_COMMAND_NAME = 'orca-ide'
 const LEGACY_LINUX_COMMAND_NAME = 'orca'
 const DEV_LAUNCHER_DIR = ['cli', 'bin']
@@ -51,8 +52,12 @@ export class CliInstaller {
   private readonly userPathReader: () => Promise<string | null>
   private readonly userPathWriter: (value: string) => Promise<void>
 
-  // Why: Linux uses `orca-ide` to avoid shadowing GNOME Orca's /usr/bin/orca.
   private get commandName(): string {
+    if (!this.isPackaged && !this.commandPathOverride) {
+      // Why: development builds must not claim the production shell command.
+      return DEV_COMMAND_NAME
+    }
+    // Why: packaged Linux uses `orca-ide` to avoid shadowing GNOME Orca's /usr/bin/orca.
     return this.platform === 'linux' ? LINUX_COMMAND_NAME : 'orca'
   }
 
@@ -212,6 +217,20 @@ export class CliInstaller {
       return this.commandPathOverride
     }
 
+    if (!this.isPackaged) {
+      // Why: default dev registration is a separate command, while tests and
+      // diagnostics can still exercise production paths via commandPathOverride.
+      if (this.platform === 'darwin') {
+        return `/usr/local/bin/${DEV_COMMAND_NAME}`
+      }
+      if (this.platform === 'linux') {
+        return join(this.homePath, '.local', 'bin', DEV_COMMAND_NAME)
+      }
+      if (this.platform === 'win32') {
+        return join(this.localAppDataPath, 'Programs', 'Orca Dev', 'bin', `${DEV_COMMAND_NAME}.cmd`)
+      }
+    }
+
     if (this.platform === 'darwin') {
       return DEFAULT_MAC_COMMAND_PATH
     }
@@ -247,7 +266,8 @@ export class CliInstaller {
       platform: this.platform,
       userDataPath: this.userDataPath,
       execPath: this.execPathValue,
-      cliEntryPath: join(this.appPathValue, 'out', 'cli', 'index.js')
+      cliEntryPath: join(this.appPathValue, 'out', 'cli', 'index.js'),
+      commandName: this.commandName
     })
   }
 
@@ -378,13 +398,16 @@ export class CliInstaller {
 
   private isManagedSymlinkTarget(resolvedTarget: string, launcherPath: string): boolean {
     const expectedName = basename(launcherPath)
+    if (this.isPackaged && this.isSiblingDevLauncherTarget(resolvedTarget, expectedName)) {
+      return true
+    }
+
     if (basename(resolvedTarget) !== expectedName) {
       return false
     }
 
     const devLauncherDir = resolve(this.userDataPath, ...DEV_LAUNCHER_DIR)
-    const devRelative = relative(devLauncherDir, resolvedTarget)
-    if (devRelative && !devRelative.startsWith('..') && !isAbsolute(devRelative)) {
+    if (isPathInsideOrEqual(devLauncherDir, resolvedTarget)) {
       return true
     }
 
@@ -401,6 +424,26 @@ export class CliInstaller {
     }
 
     return false
+  }
+
+  private isSiblingDevLauncherTarget(
+    resolvedTarget: string,
+    packagedLauncherName: string
+  ): boolean {
+    if (![packagedLauncherName, DEV_COMMAND_NAME].includes(basename(resolvedTarget))) {
+      return false
+    }
+
+    const packagedUserDataPath = resolve(this.userDataPath)
+    const siblingDevUserDataPath = `${packagedUserDataPath}-dev`
+    const siblingDevLauncherDir = resolve(siblingDevUserDataPath, ...DEV_LAUNCHER_DIR)
+
+    // Why: development builds generate launchers under the sibling `*-dev`
+    // profile; packaged Orca must be able to reclaim that public command.
+    return (
+      basename(siblingDevUserDataPath) === `${basename(packagedUserDataPath)}-dev` &&
+      isPathInsideOrEqual(siblingDevLauncherDir, resolvedTarget)
+    )
   }
 
   private async inspectWindowsWrapper(
@@ -543,6 +586,7 @@ async function ensureDevLauncher(args: {
   userDataPath: string
   execPath: string
   cliEntryPath: string
+  commandName: string
 }): Promise<string | null> {
   if (
     !isAbsoluteForPlatform(args.platform, args.execPath) ||
@@ -555,7 +599,7 @@ async function ensureDevLauncher(args: {
   const launcherPath = join(
     args.userDataPath,
     ...DEV_LAUNCHER_DIR,
-    args.platform === 'win32' ? 'orca.cmd' : args.platform === 'linux' ? LINUX_COMMAND_NAME : 'orca'
+    args.platform === 'win32' ? `${args.commandName}.cmd` : args.commandName
   )
   await mkdir(dirname(launcherPath), { recursive: true })
 
@@ -565,8 +609,8 @@ async function ensureDevLauncher(args: {
   // changing the packaged registration contract.
   const content =
     args.platform === 'win32'
-      ? buildWindowsDevLauncher(args.execPath, args.cliEntryPath)
-      : buildUnixDevLauncher(args.execPath, args.cliEntryPath)
+      ? buildWindowsDevLauncher(args.execPath, args.cliEntryPath, args.userDataPath)
+      : buildUnixDevLauncher(args.execPath, args.cliEntryPath, args.userDataPath)
   await writeFile(launcherPath, content, {
     encoding: 'utf8',
     mode: args.platform === 'win32' ? undefined : 0o755
@@ -574,11 +618,20 @@ async function ensureDevLauncher(args: {
   return launcherPath
 }
 
-function buildUnixDevLauncher(execPathValue: string, cliEntryPath: string): string {
+function buildUnixDevLauncher(
+  execPathValue: string,
+  cliEntryPath: string,
+  userDataPath: string
+): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
 ELECTRON=${quoteShell(execPathValue)}
 CLI=${quoteShell(cliEntryPath)}
+export ORCA_USER_DATA_PATH=${quoteShell(userDataPath)}
+if [ -z "\${ORCA_APP_EXECUTABLE:-}" ]; then
+  export ORCA_APP_EXECUTABLE="$ELECTRON"
+  export ORCA_APP_EXECUTABLE_NEEDS_APP_ROOT=1
+fi
 export ORCA_NODE_OPTIONS="\${NODE_OPTIONS-}"
 export ORCA_NODE_REPL_EXTERNAL_MODULE="\${NODE_REPL_EXTERNAL_MODULE-}"
 unset NODE_OPTIONS
@@ -587,11 +640,20 @@ ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
 `
 }
 
-function buildWindowsDevLauncher(execPathValue: string, cliEntryPath: string): string {
+function buildWindowsDevLauncher(
+  execPathValue: string,
+  cliEntryPath: string,
+  userDataPath: string
+): string {
   return `@echo off
 setlocal
 set "ELECTRON=${escapeWindowsBatchValue(execPathValue)}"
 set "CLI=${escapeWindowsBatchValue(cliEntryPath)}"
+set "ORCA_USER_DATA_PATH=${escapeWindowsBatchValue(userDataPath)}"
+if not defined ORCA_APP_EXECUTABLE (
+  set "ORCA_APP_EXECUTABLE=%ELECTRON%"
+  set "ORCA_APP_EXECUTABLE_NEEDS_APP_ROOT=1"
+)
 set "ORCA_NODE_OPTIONS=%NODE_OPTIONS%"
 set "ORCA_NODE_REPL_EXTERNAL_MODULE=%NODE_REPL_EXTERNAL_MODULE%"
 set NODE_OPTIONS=
@@ -623,6 +685,11 @@ function samePathEntry(platform: NodeJS.Platform, left: string, right: string): 
   return platform === 'win32'
     ? normalizeWindowsPath(left) === normalizeWindowsPath(right)
     : left === right
+}
+
+function isPathInsideOrEqual(parentPath: string, childPath: string): boolean {
+  const childRelative = relative(parentPath, childPath)
+  return childRelative === '' || (!childRelative.startsWith('..') && !isAbsolute(childRelative))
 }
 
 function normalizeWindowsPath(value: string): string {


### PR DESCRIPTION
Summary:
- install default development CLI registration as orca-dev instead of replacing packaged commands
- let packaged installs reclaim stale sibling dev launcher symlinks
- seed dev launcher ORCA_USER_DATA_PATH and app executable env for runtime isolation

Verification:
- pnpm test src/main/cli/cli-installer.test.ts
- pnpm typecheck
- review round 2: no issues found