### PR TITLE
fix: prefer active azure pull requests

### DIFF
--- a/src/main/azure-devops/client.ts
+++ b/src/main/azure-devops/client.ts
@@ -199,17 +199,19 @@ function sortPullRequestsForBranch(
   left: RawAzureDevOpsPullRequest,
   right: RawAzureDevOpsPullRequest
 ): number {
+  const leftStatus = left.status?.trim().toLowerCase()
+  const rightStatus = right.status?.trim().toLowerCase()
+  const abandonedOrder = Number(leftStatus === 'abandoned') - Number(rightStatus === 'abandoned')
+  // Why: abandoned PRs can have newer close dates, but should not hide a usable branch PR.
+  if (abandonedOrder !== 0) {
+    return abandonedOrder
+  }
   const leftTime = Date.parse(left.closedDate ?? left.creationDate ?? '') || 0
   const rightTime = Date.parse(right.closedDate ?? right.creationDate ?? '') || 0
   if (leftTime !== rightTime) {
     return rightTime - leftTime
   }
-  const leftActive = left.status?.trim().toLowerCase() === 'active'
-  const rightActive = right.status?.trim().toLowerCase() === 'active'
-  if (leftActive !== rightActive) {
-    return leftActive ? -1 : 1
-  }
-  return 0
+  return Number(rightStatus === 'active') - Number(leftStatus === 'active')
 }
 
 export async function getAzureDevOpsAuthStatus(): Promise<AzureDevOpsAuthStatus> {

--- a/src/main/source-control/hosted-review-azure-devops.integration.test.ts
+++ b/src/main/source-control/hosted-review-azure-devops.integration.test.ts
@@ -125,4 +125,104 @@ describe('Azure DevOps hosted review integration', () => {
       })
     }
   })
+
+  it('prefers an active Azure Repos PR over a newer abandoned PR for the same branch', async () => {
+    const seen: SeenRequest[] = []
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      seen.push({
+        pathname: url.pathname,
+        search: url.search,
+        authorization: req.headers.authorization
+      })
+
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo') {
+        sendJson(res, {
+          id: 'repo-guid',
+          webUrl: 'https://dev.azure.com/acme/Project/_git/repo'
+        })
+        return
+      }
+
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests') {
+        sendJson(res, {
+          value: [
+            {
+              pullRequestId: 40,
+              title: 'Abandoned branch',
+              status: 'abandoned',
+              creationDate: '2026-05-10T00:00:00Z',
+              closedDate: '2026-05-20T00:00:00Z',
+              mergeStatus: 'conflicts',
+              lastMergeSourceCommit: { commitId: 'old123' }
+            },
+            {
+              pullRequestId: 41,
+              title: 'Active branch',
+              status: 'active',
+              creationDate: '2026-05-01T00:00:00Z',
+              mergeStatus: 'succeeded',
+              lastMergeSourceCommit: { commitId: 'active123' }
+            }
+          ]
+        })
+        return
+      }
+
+      if (
+        url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests/40/statuses'
+      ) {
+        sendJson(res, { value: [{ state: 'failed' }] })
+        return
+      }
+
+      if (
+        url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests/41/statuses'
+      ) {
+        sendJson(res, { value: [{ state: 'succeeded' }] })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-azure-review-active-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+      process.env.ORCA_AZURE_DEVOPS_API_BASE_URL = `http://127.0.0.1:${address.port}/acme/Project`
+
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync(
+        'git',
+        ['remote', 'add', 'origin', 'https://dev.azure.com/acme/Project/_git/repo'],
+        { cwd: repoPath }
+      )
+
+      await expect(
+        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/azure' })
+      ).resolves.toMatchObject({
+        provider: 'azure-devops',
+        number: 41,
+        title: 'Active branch',
+        state: 'open',
+        status: 'success',
+        mergeable: 'MERGEABLE',
+        headSha: 'active123'
+      })
+
+      expect(seen.map((request) => request.pathname)).toContain(
+        '/acme/Project/_apis/git/repositories/repo-guid/pullRequests/41/statuses'
+      )
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- prefer active Azure Repos pull requests when multiple PRs exist for the same branch
- keep recency sorting within the same active/non-active group
- add an integration repro with a real temp git remote and mocked Azure DevOps API

## Evidence
- Before the fix, `pnpm exec vitest run --config config/vitest.config.ts src/main/source-control/hosted-review-azure-devops.integration.test.ts` returned abandoned PR 40 (`state: closed`, `status: failure`, `headSha: old123`) even though active PR 41 existed for the same source branch.
- After the fix, the same branch resolves to active PR 41 (`state: open`, `status: success`, `headSha: active123`).

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/source-control/hosted-review-azure-devops.integration.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/azure-devops/client.ts src/main/source-control/hosted-review-azure-devops.integration.test.ts`
- `pnpm exec oxfmt --check src/main/azure-devops/client.ts src/main/source-control/hosted-review-azure-devops.integration.test.ts`
- `git diff --check HEAD~1..HEAD`