### PR TITLE
perf: clean resource popover focus frame effect

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -714,8 +714,6 @@ export function ResourceUsageStatusSegment({
     popoverBodyFocusFrameRef.current = null
   }, [])
 
-  useEffect(() => cancelPopoverBodyFocusFrame, [cancelPopoverBodyFocusFrame])
-
   const setPopoverBodyNode = useCallback(
     (node: HTMLDivElement | null): void => {
       // Why: the queued post-kill focus is only valid while the popover body exists.


### PR DESCRIPTION
## Summary
- remove the cleanup-only Effect that only cancelled a queued resource-popover focus frame
- keep cancellation tied to the popover body callback ref, which already owns that DOM lifetime
- leave resource/session polling, daemon IPC, and kill-session behavior unchanged

## Risk
Risk: low

## Validation
- pnpm exec oxlint src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm exec oxfmt --check src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
- pnpm run typecheck:web
- git diff --check

Note: no focused component test exists for this callback-ref cleanup path; nearby resource-usage tests cover helper logic rather than the popover DOM lifetime.