### PR TITLE
fix: validate git repo detection

### DIFF
--- a/src/main/git/repo-detection.test.ts
+++ b/src/main/git/repo-detection.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from 'child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isGitRepo } from './repo'
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+describe('isGitRepo', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-repo-detect-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rejects directories with an invalid .git file', () => {
+    const fakeRepo = path.join(tmpDir, 'fake')
+    mkdirSync(fakeRepo)
+    writeFileSync(path.join(fakeRepo, '.git'), 'not a gitdir file')
+
+    expect(isGitRepo(fakeRepo)).toBe(false)
+  })
+
+  it('accepts bare git repositories', () => {
+    const bareRepo = path.join(tmpDir, 'bare.git')
+    git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
+
+    expect(isGitRepo(bareRepo)).toBe(true)
+  })
+})

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines */
 import { execSync } from 'child_process'
 import { existsSync, statSync } from 'fs'
-import { join, basename } from 'path'
+import { basename } from 'path'
 import { gitExecFileSync, gitExecFileAsync } from './runner'
 import type { BaseRefSearchResult } from '../../shared/types'
 import { buildHostedRemoteFileUrl, parseHostedRemote } from './hosted-remote-url'
@@ -53,25 +53,23 @@ export function isGitRepo(path: string): boolean {
     if (!existsSync(path) || !statSync(path).isDirectory()) {
       return false
     }
-    // .git dir or file (for worktrees) or bare repo
-    if (existsSync(join(path, '.git'))) {
-      return true
-    }
-    // Might be a bare repo — ask git
-    const result = gitExecFileSync(['rev-parse', '--is-inside-work-tree'], {
+    const insideWorkTree = gitExecFileSync(['rev-parse', '--is-inside-work-tree'], {
       cwd: path
     }).trim()
-    return result === 'true'
-  } catch {
-    // Also check if it's a bare repo
-    try {
-      const result = gitExecFileSync(['rev-parse', '--is-bare-repository'], {
-        cwd: path
-      }).trim()
-      return result === 'true'
-    } catch {
-      return false
+    if (insideWorkTree === 'true') {
+      return true
     }
+  } catch {
+    // Fall through to the bare-repo probe below.
+  }
+
+  try {
+    const bareRepo = gitExecFileSync(['rev-parse', '--is-bare-repository'], {
+      cwd: path
+    }).trim()
+    return bareRepo === 'true'
+  } catch {
+    return false
   }
 }
 


### PR DESCRIPTION
## Summary
- validate worktree repositories by asking Git instead of trusting any `.git` marker
- separately probe `--is-bare-repository` so real bare repos satisfy the helper contract
- add real-git coverage for invalid `.git` files and bare repositories

## Evidence
- Before the fix, a directory containing a plain `.git` file with `not a gitdir file` returned `true` from `isGitRepo()`.
- Before the fix, a real `git init --bare` repository returned `false`.
- After the fix, the fake `.git` directory is rejected and the bare repo is accepted.

## Validation
- `pnpm exec vitest run --config config/vitest.config.ts src/main/git/repo-detection.test.ts src/main/git/repo.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/git/repo.ts src/main/git/repo-detection.test.ts src/main/git/repo.test.ts`
- `pnpm exec oxfmt --check src/main/git/repo.ts src/main/git/repo-detection.test.ts src/main/git/repo.test.ts`
- `git diff --check HEAD~1..HEAD`