### PR TITLE
fix: preserve newline worktree paths

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -52,7 +52,15 @@ function mockGitCommands(results: Record<string, MockResult>): void {
     const key = `git ${args.join(' ')}`
     const callCount = (callCounts.get(key) ?? 0) + 1
     callCounts.set(key, callCount)
-    const result = results[`${key}#${callCount}`] ?? results[key] ?? {}
+    const lineListKey =
+      key === 'git worktree list --porcelain -z' ? 'git worktree list --porcelain' : ''
+    const result =
+      results[`${key}#${callCount}`] ??
+      results[key] ??
+      (lineListKey
+        ? (results[`${lineListKey}#${callCount}`] ?? results[lineListKey])
+        : undefined) ??
+      {}
 
     if (result.error) {
       throw Object.assign(result.error, {
@@ -184,7 +192,7 @@ branch refs/heads/feature/test
       expect.arrayContaining([
         'git worktree remove /repo-feature',
         'git worktree prune',
-        'git worktree list --porcelain'
+        'git worktree list --porcelain -z'
       ])
     )
     expect(calls).not.toContain('git branch -d -- feature/test')
@@ -476,7 +484,7 @@ describe('listWorktrees', () => {
     // Why: the non-sparse main worktree gets an fs probe of its sparse config
     // file; the linked worktree short-circuits on the parsed `sparse` token and
     // does not. Only one git subprocess runs regardless of worktree count.
-    expect(getGitCalls()).toEqual(['git worktree list --porcelain'])
+    expect(getGitCalls()).toEqual(['git worktree list --porcelain -z'])
     expect(statMock).toHaveBeenCalledTimes(1)
     expect(translateWslOutputPathsMock).toHaveBeenCalledTimes(2)
   })
@@ -492,7 +500,7 @@ describe('listWorktrees', () => {
 
     await expect(listWorktrees('/workspace/deleted-repo')).resolves.toEqual([])
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain'], {
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
       cwd: '/workspace/deleted-repo'
     })
     expect(statMock).toHaveBeenCalledWith('/workspace/deleted-repo')
@@ -514,7 +522,7 @@ describe('listWorktrees', () => {
 
     await expect(listWorktrees('/private/tmp/orca-issue-1582-test/my-repo')).resolves.toEqual([])
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain'], {
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], {
       cwd: '/private/tmp/orca-issue-1582-test/my-repo'
     })
     expect(warnSpy).not.toHaveBeenCalled()
@@ -523,7 +531,7 @@ describe('listWorktrees', () => {
 
   it('detects sparse checkout after translating paths when porcelain omits sparse token', async () => {
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
-      if (args.join(' ') === 'worktree list --porcelain') {
+      if (args.join(' ') === 'worktree list --porcelain -z') {
         return {
           stdout:
             'worktree /home/me/repo\nHEAD abc123\nbranch refs/heads/main\n\n' +
@@ -572,7 +580,43 @@ describe('listWorktrees', () => {
     // Why: the detection path must not spawn a git subprocess per worktree —
     // the perf regression in #1131 came from `git sparse-checkout list` firing
     // on every poll.
-    expect(getGitCalls()).toEqual(['git worktree list --porcelain'])
+    expect(getGitCalls()).toEqual(['git worktree list --porcelain -z'])
+  })
+
+  it('falls back to line-block porcelain output when Git rejects -z', async () => {
+    mockGitCommands({
+      'git worktree list --porcelain -z': {
+        error: Object.assign(new Error("unknown switch `z'"), {
+          stderr: "error: unknown switch `z'"
+        })
+      },
+      'git worktree list --porcelain': {
+        stdout:
+          'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n' +
+          'worktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
+      }
+    })
+
+    await expect(listWorktrees('/repo')).resolves.toEqual([
+      {
+        path: '/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: '/repo-feature',
+        head: 'def456',
+        branch: 'refs/heads/feature/test',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    expect(getGitCalls()).toEqual([
+      'git worktree list --porcelain -z',
+      'git worktree list --porcelain'
+    ])
   })
 })
 

--- a/src/main/git/worktree-list-paths.test.ts
+++ b/src/main/git/worktree-list-paths.test.ts
@@ -1,0 +1,71 @@
+import { execFileSync } from 'child_process'
+import { mkdtemp, realpath, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { listWorktrees, removeWorktree } from './worktree'
+
+const tempRoots: string[] = []
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+async function createRepoWithNewlineWorktree(): Promise<{
+  repoPath: string
+  worktreePath: string
+}> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-worktree-paths-'))
+  tempRoots.push(root)
+  const repoPath = path.join(root, 'repo')
+  const requestedWorktreePath = path.join(root, 'linked\nworktree')
+
+  execFileSync('git', ['init', '--quiet', repoPath])
+  git(repoPath, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
+  git(repoPath, ['config', 'user.email', 'test@example.com'])
+  git(repoPath, ['config', 'user.name', 'Test User'])
+  git(repoPath, ['commit', '--allow-empty', '--quiet', '-m', 'initial'])
+  git(repoPath, ['worktree', 'add', '--quiet', '-b', 'feature/newline', requestedWorktreePath])
+
+  return {
+    repoPath: await realpath(repoPath),
+    worktreePath: await realpath(requestedWorktreePath)
+  }
+}
+
+function branchExists(repoPath: string, branchName: string): boolean {
+  try {
+    git(repoPath, ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('git worktree paths', () => {
+  it.skipIf(process.platform === 'win32')(
+    'lists worktrees whose paths contain newlines',
+    async () => {
+      const { repoPath, worktreePath } = await createRepoWithNewlineWorktree()
+
+      const worktrees = await listWorktrees(repoPath)
+
+      expect(worktrees.map((worktree) => worktree.path)).toContain(worktreePath)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'deletes the matching local branch after removing a newline-path worktree',
+    async () => {
+      const { repoPath, worktreePath } = await createRepoWithNewlineWorktree()
+
+      await removeWorktree(repoPath, worktreePath)
+
+      expect(branchExists(repoPath, 'feature/newline')).toBe(false)
+    }
+  )
+})

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -160,6 +160,36 @@ branch refs/heads/main
     ])
   })
 
+  it('parses NUL-delimited porcelain output with newline paths', () => {
+    const output = [
+      'worktree /repo',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/linked\nworktree',
+      'HEAD def456',
+      'branch refs/heads/feature/newline',
+      ''
+    ].join('\0')
+
+    expect(parseWorktreeList(output, { nulDelimited: true })).toEqual([
+      {
+        path: '/repo',
+        head: 'abc123',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      },
+      {
+        path: '/repo/linked\nworktree',
+        head: 'def456',
+        branch: 'refs/heads/feature/newline',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+  })
+
   it('parses multiple bare entries mixed with regular entries', () => {
     const output = `worktree /bare-one
 HEAD 0000000

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -43,6 +43,12 @@ function isNotGitRepositoryError(error: unknown): boolean {
   return /not a git repository/i.test(getErrorText(error))
 }
 
+function isUnsupportedWorktreeListZError(error: unknown): boolean {
+  return /(?:unknown|invalid) (?:switch|option).*`?-z'?|(?:unknown|invalid) (?:switch|option).*`?z'?/i.test(
+    getErrorText(error)
+  )
+}
+
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
@@ -106,12 +112,12 @@ function looksLikeWindowsPath(pathValue: string): boolean {
 /**
  * Parse the porcelain output of `git worktree list --porcelain`.
  */
-export function parseWorktreeList(output: string): GitWorktreeInfo[] {
+export function parseWorktreeList(
+  output: string,
+  options: { nulDelimited?: boolean } = {}
+): GitWorktreeInfo[] {
   const worktrees: GitWorktreeInfo[] = []
-  const blocks = output
-    .trim()
-    .split(/\r?\n\r?\n/)
-    .map((block) => block.trim().split(/\r?\n/))
+  const blocks = options.nulDelimited ? splitNulWorktreeList(output) : splitLineWorktreeList(output)
 
   for (const lines of blocks) {
     if (lines.length === 0) {
@@ -154,18 +160,65 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
   return worktrees
 }
 
+function splitLineWorktreeList(output: string): string[][] {
+  return output
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map((block) => block.trim().split(/\r?\n/))
+}
+
+function splitNulWorktreeList(output: string): string[][] {
+  if (!output.includes('\0')) {
+    return splitLineWorktreeList(output)
+  }
+
+  const blocks: string[][] = []
+  let currentBlock: string[] = []
+
+  for (const field of output.split('\0')) {
+    if (field) {
+      currentBlock.push(field)
+      continue
+    }
+    if (currentBlock.length > 0) {
+      blocks.push(currentBlock)
+      currentBlock = []
+    }
+  }
+
+  if (currentBlock.length > 0) {
+    blocks.push(currentBlock)
+  }
+
+  return blocks
+}
+
+async function readWorktreeList(repoPath: string): Promise<GitWorktreeInfo[]> {
+  try {
+    const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain', '-z'], {
+      cwd: repoPath
+    })
+    return parseWorktreeList(stdout, { nulDelimited: true })
+  } catch (error) {
+    if (!isUnsupportedWorktreeListZError(error)) {
+      throw error
+    }
+  }
+
+  // Why: `-z` is required to preserve worktree paths containing newlines, but
+  // Git <2.36 rejects it. Keep the old parser as a compatibility fallback.
+  const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain'], {
+    cwd: repoPath
+  })
+  return parseWorktreeList(stdout)
+}
+
 /**
  * List all worktrees for a git repo at the given path.
  */
 export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]> {
   try {
-    // Why: do not pass `-z` here. `-z` requires Git ≥ 2.36; older Git rejects
-    // it, listWorktrees returns [], and every create flow throws "Worktree
-    // created but not found in listing" (issue #1453).
-    const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain'], {
-      cwd: repoPath
-    })
-    const worktrees = parseWorktreeList(stdout).map((worktree) => {
+    const worktrees = (await readWorktreeList(repoPath)).map((worktree) => {
       const translatedPath = translateWorktreePath(worktree.path, repoPath)
       return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
     })
@@ -192,8 +245,8 @@ export async function listWorktrees(repoPath: string): Promise<GitWorktreeInfo[]
     if (isNotGitRepositoryError(err)) {
       return []
     }
-    // Why: a silent catch turned issue #1453's underlying
-    // "git: unknown switch -z" into the opaque "not found in listing" toast.
+    // Why: a silent catch turns git compatibility or repo-state failures into
+    // opaque downstream errors like "Worktree created but not found in listing".
     // Surface the cause so future regressions show up immediately.
     console.warn(`[git/worktree] listWorktrees failed for ${repoPath}:`, err)
     return []

--- a/src/relay/git-handler-utils.ts
+++ b/src/relay/git-handler-utils.ts
@@ -133,15 +133,37 @@ export function parseBranchDiff(
 
 // ─── Worktree parsing ────────────────────────────────────────────────
 
-export function parseWorktreeList(output: string): Record<string, unknown>[] {
-  const worktrees: Record<string, unknown>[] = []
-  const blocks = output.trim().split(/\r?\n\r?\n/)
+function getErrorText(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const parts: string[] = []
+    if ('message' in error && typeof error.message === 'string') {
+      parts.push(error.message)
+    }
+    if ('stderr' in error && typeof error.stderr === 'string') {
+      parts.push(error.stderr)
+    }
+    return parts.join('\n')
+  }
+  return String(error)
+}
 
-  for (const block of blocks) {
-    if (!block.trim()) {
+export function isUnsupportedWorktreeListZError(error: unknown): boolean {
+  return /(?:unknown|invalid) (?:switch|option).*`?-z'?|(?:unknown|invalid) (?:switch|option).*`?z'?/i.test(
+    getErrorText(error)
+  )
+}
+
+export function parseWorktreeList(
+  output: string,
+  options: { nulDelimited?: boolean } = {}
+): Record<string, unknown>[] {
+  const worktrees: Record<string, unknown>[] = []
+  const blocks = options.nulDelimited ? splitNulWorktreeList(output) : splitLineWorktreeList(output)
+
+  for (const lines of blocks) {
+    if (lines.length === 0) {
       continue
     }
-    const lines = block.trim().split(/\r?\n/)
     let wtPath = ''
     let head = ''
     let branch = ''
@@ -170,6 +192,39 @@ export function parseWorktreeList(output: string): Record<string, unknown>[] {
     }
   }
   return worktrees
+}
+
+function splitLineWorktreeList(output: string): string[][] {
+  return output
+    .trim()
+    .split(/\r?\n\r?\n/)
+    .map((block) => block.trim().split(/\r?\n/))
+}
+
+function splitNulWorktreeList(output: string): string[][] {
+  if (!output.includes('\0')) {
+    return splitLineWorktreeList(output)
+  }
+
+  const blocks: string[][] = []
+  let currentBlock: string[] = []
+
+  for (const field of output.split('\0')) {
+    if (field) {
+      currentBlock.push(field)
+      continue
+    }
+    if (currentBlock.length > 0) {
+      blocks.push(currentBlock)
+      currentBlock = []
+    }
+  }
+
+  if (currentBlock.length > 0) {
+    blocks.push(currentBlock)
+  }
+
+  return blocks
 }
 
 // ─── Binary / blob helpers ───────────────────────────────────────────

--- a/src/relay/git-handler-worktree-clean.test.ts
+++ b/src/relay/git-handler-worktree-clean.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { worktreeIsCleanOp } from './git-handler-worktree-ops'
+
+describe('worktreeIsCleanOp', () => {
+  it('reports clean SSH worktrees without returning porcelain output', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '\n', stderr: '' }))
+
+    await expect(worktreeIsCleanOp(git, { worktreePath: '/repo-feature' })).resolves.toEqual({
+      clean: true,
+      stdout: undefined
+    })
+
+    expect(git).toHaveBeenCalledWith(
+      ['status', '--porcelain', '--untracked-files=all'],
+      '/repo-feature'
+    )
+  })
+
+  it('returns porcelain output for dirty SSH worktrees', async () => {
+    const stdout = ' M src/file.ts\n?? scratch.txt\n'
+    const git = vi.fn<GitExec>(async () => ({ stdout, stderr: '' }))
+
+    await expect(worktreeIsCleanOp(git, { worktreePath: '/repo-feature' })).resolves.toEqual({
+      clean: false,
+      stdout
+    })
+  })
+})

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { GitExec } from './git-handler-ops'
-import { addWorktreeOp, removeWorktreeOp, worktreeIsCleanOp } from './git-handler-worktree-ops'
+import { addWorktreeOp, removeWorktreeOp } from './git-handler-worktree-ops'
 
 function worktreeList(...entries: { path: string; branch?: string }[]): string {
   return entries
@@ -151,10 +151,10 @@ describe('removeWorktreeOp', () => {
 
     expect(calls).toEqual([
       '/repo-feature$ rev-parse --git-common-dir',
-      '/repo$ worktree list --porcelain',
+      '/repo$ worktree list --porcelain -z',
       '/repo$ worktree remove /repo-feature',
       '/repo$ worktree prune',
-      '/repo$ worktree list --porcelain',
+      '/repo$ worktree list --porcelain -z',
       '/repo$ branch -d -- feature/test'
     ])
   })
@@ -248,7 +248,7 @@ describe('removeWorktreeOp', () => {
 
     expect(calls).toEqual([
       '/repo-feature$ rev-parse --git-common-dir',
-      '/repo$ worktree list --porcelain',
+      '/repo$ worktree list --porcelain -z',
       '/repo$ worktree remove /repo-feature',
       '/repo$ worktree prune'
     ])
@@ -283,31 +283,5 @@ describe('removeWorktreeOp', () => {
 
     expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
     expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'feature/test'], expect.any(String))
-  })
-})
-
-describe('worktreeIsCleanOp', () => {
-  it('reports clean SSH worktrees without returning porcelain output', async () => {
-    const git = vi.fn<GitExec>(async () => ({ stdout: '\n', stderr: '' }))
-
-    await expect(worktreeIsCleanOp(git, { worktreePath: '/repo-feature' })).resolves.toEqual({
-      clean: true,
-      stdout: undefined
-    })
-
-    expect(git).toHaveBeenCalledWith(
-      ['status', '--porcelain', '--untracked-files=all'],
-      '/repo-feature'
-    )
-  })
-
-  it('returns porcelain output for dirty SSH worktrees', async () => {
-    const stdout = ' M src/file.ts\n?? scratch.txt\n'
-    const git = vi.fn<GitExec>(async () => ({ stdout, stderr: '' }))
-
-    await expect(worktreeIsCleanOp(git, { worktreePath: '/repo-feature' })).resolves.toEqual({
-      clean: false,
-      stdout
-    })
   })
 })

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -8,7 +8,7 @@ import * as path from 'path'
 import type { RemoveWorktreeResult } from '../shared/types'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
 import type { GitExec } from './git-handler-ops'
-import { parseWorktreeList } from './git-handler-utils'
+import { isUnsupportedWorktreeListZError, parseWorktreeList } from './git-handler-utils'
 
 // ─── Worktree management ─────────────────────────────────────────────
 
@@ -197,17 +197,36 @@ type RelayWorktreeInfo = {
 
 async function listRelayWorktrees(git: GitExec, repoPath: string): Promise<RelayWorktreeInfo[]> {
   try {
-    const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
-    return parseWorktreeList(stdout)
-      .map((worktree) => ({
-        path: typeof worktree.path === 'string' ? worktree.path : '',
-        head: typeof worktree.head === 'string' ? worktree.head : undefined,
-        branch: typeof worktree.branch === 'string' ? worktree.branch : undefined
-      }))
-      .filter((worktree) => worktree.path.length > 0)
+    return await readRelayWorktreeList(git, repoPath)
   } catch {
     return []
   }
+}
+
+async function readRelayWorktreeList(git: GitExec, repoPath: string): Promise<RelayWorktreeInfo[]> {
+  try {
+    const { stdout } = await git(['worktree', 'list', '--porcelain', '-z'], repoPath)
+    return normalizeRelayWorktrees(parseWorktreeList(stdout, { nulDelimited: true }))
+  } catch (error) {
+    if (!isUnsupportedWorktreeListZError(error)) {
+      throw error
+    }
+  }
+
+  // Why: `-z` preserves remote worktree paths containing newlines, while this
+  // fallback keeps SSH worktree operations compatible with Git <2.36.
+  const { stdout } = await git(['worktree', 'list', '--porcelain'], repoPath)
+  return normalizeRelayWorktrees(parseWorktreeList(stdout))
+}
+
+function normalizeRelayWorktrees(worktrees: Record<string, unknown>[]): RelayWorktreeInfo[] {
+  return worktrees
+    .map((worktree) => ({
+      path: typeof worktree.path === 'string' ? worktree.path : '',
+      head: typeof worktree.head === 'string' ? worktree.head : undefined,
+      branch: typeof worktree.branch === 'string' ? worktree.branch : undefined
+    }))
+    .filter((worktree) => worktree.path.length > 0)
 }
 
 function normalizeLocalBranchRef(branch: string): string {

--- a/src/relay/git-handler-worktree-paths.test.ts
+++ b/src/relay/git-handler-worktree-paths.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { removeWorktreeOp } from './git-handler-worktree-ops'
+
+function lineWorktreeList(...entries: { path: string; branch?: string }[]): string {
+  return entries
+    .map((entry, index) =>
+      [
+        `worktree ${entry.path}`,
+        `HEAD ${index}`,
+        ...(entry.branch ? [`branch refs/heads/${entry.branch}`] : [])
+      ].join('\n')
+    )
+    .join('\n\n')
+}
+
+function nulWorktreeList(...entries: { path: string; branch?: string }[]): string {
+  return entries
+    .map((entry, index) =>
+      [
+        `worktree ${entry.path}`,
+        `HEAD ${index}`,
+        ...(entry.branch ? [`branch refs/heads/${entry.branch}`] : []),
+        ''
+      ].join('\0')
+    )
+    .join('\0')
+}
+
+describe('relay worktree path parsing', () => {
+  it('deletes the matching branch for SSH worktrees whose paths contain newlines', async () => {
+    const worktreePath = '/repo-feature\nremote'
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? nulWorktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: worktreePath, branch: 'feature/newline' }
+                )
+              : nulWorktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeOp(git, { worktreePath })
+
+    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/newline'], '/repo')
+  })
+
+  it('falls back to line-block worktree listing when remote Git rejects -z', async () => {
+    const calls: string[] = []
+    let listCount = 0
+    const git = vi.fn<GitExec>(async (args, cwd) => {
+      calls.push(`${cwd}$ ${args.join(' ')}`)
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
+        throw Object.assign(new Error("unknown switch `z'"), {
+          stderr: "error: unknown switch `z'"
+        })
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        listCount += 1
+        return {
+          stdout:
+            listCount === 1
+              ? lineWorktreeList(
+                  { path: '/repo', branch: 'main' },
+                  { path: '/repo-feature', branch: 'feature/test' }
+                )
+              : lineWorktreeList({ path: '/repo', branch: 'main' }),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await removeWorktreeOp(git, { worktreePath: '/repo-feature' })
+
+    expect(calls).toEqual([
+      '/repo-feature$ rev-parse --git-common-dir',
+      '/repo$ worktree list --porcelain -z',
+      '/repo$ worktree list --porcelain',
+      '/repo$ worktree remove /repo-feature',
+      '/repo$ worktree prune',
+      '/repo$ worktree list --porcelain -z',
+      '/repo$ worktree list --porcelain',
+      '/repo$ branch -d -- feature/test'
+    ])
+  })
+})

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -1037,6 +1037,39 @@ describe('GitHandler', () => {
       expect(result.length).toBeGreaterThanOrEqual(1)
       expect(result[0].isMainWorktree).toBe(true)
     })
+
+    it.skipIf(process.platform === 'win32')(
+      'lists worktrees whose paths contain newlines',
+      async () => {
+        gitInit(tmpDir)
+        writeFileSync(path.join(tmpDir, 'file.txt'), 'hello')
+        gitCommit(tmpDir, 'initial')
+        const worktreePath = path.join(
+          path.dirname(tmpDir),
+          `${path.basename(tmpDir)}-linked\nremote`
+        )
+
+        try {
+          execFileSync(
+            'git',
+            ['worktree', 'add', '--quiet', '-b', 'feature/newline', worktreePath],
+            {
+              cwd: tmpDir,
+              stdio: 'pipe'
+            }
+          )
+          const realWorktreePath = await fs.realpath(worktreePath)
+
+          const result = (await dispatcher.callRequest('git.listWorktrees', {
+            repoPath: tmpDir
+          })) as Record<string, unknown>[]
+
+          expect(result.map((worktree) => worktree.path)).toContain(realWorktreePath)
+        } finally {
+          await fs.rm(worktreePath, { recursive: true, force: true })
+        }
+      }
+    )
   })
 
   describe('addWorktree', () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -6,7 +6,11 @@ import * as path from 'path'
 import type { RelayDispatcher } from './dispatcher'
 import type { RelayContext } from './context'
 import { expandTilde } from './context'
-import { parseBranchDiff, parseWorktreeList } from './git-handler-utils'
+import {
+  isUnsupportedWorktreeListZError,
+  parseBranchDiff,
+  parseWorktreeList
+} from './git-handler-utils'
 import { parseNumstat } from '../shared/git-uncommitted-line-stats'
 import {
   computeDiff,
@@ -617,6 +621,17 @@ export class GitHandler {
 
   private async listWorktrees(params: Record<string, unknown>) {
     const repoPath = params.repoPath as string
+    try {
+      const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath)
+      return parseWorktreeList(stdout, { nulDelimited: true })
+    } catch (error) {
+      if (!isUnsupportedWorktreeListZError(error)) {
+        return []
+      }
+    }
+
+    // Why: `-z` keeps newline-containing SSH worktree paths intact, but older
+    // Git rejects it. Fall back to the original line-block parser there.
     try {
       const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath)
       return parseWorktreeList(stdout)


### PR DESCRIPTION
## Summary
- read `git worktree list --porcelain -z` first for local and SSH relay worktree listing/removal paths so worktree paths containing newlines survive parsing
- keep the existing line-based parser as a fallback for older Git versions that reject `-z`
- add real-git local and relay coverage for listing/removing newline-path worktrees, plus remote fallback coverage

## Evidence
Before the local fix, the real-git repro failed:
```
pnpm vitest run --config config/vitest.config.ts src/main/git/worktree-list-paths.test.ts
× lists worktrees whose paths contain newlines
× deletes the matching local branch after removing a newline-path worktree
```

Before the relay fix, the SSH removal repro failed:
```
pnpm vitest run --config config/vitest.config.ts src/relay/git-handler-worktree-ops.test.ts
× deletes the matching branch for SSH worktrees whose paths contain newlines
```

After the fixes:
```
pnpm vitest run --config config/vitest.config.ts src/main/git/worktree-list-paths.test.ts src/main/git/worktree.test.ts src/main/git/remove-worktree.test.ts src/relay/git-handler-worktree-ops.test.ts src/relay/git-handler-worktree-clean.test.ts src/relay/git-handler-worktree-paths.test.ts src/relay/git-handler.test.ts
Test Files  7 passed (7)
Tests  122 passed (122)

pnpm run typecheck:node
pnpm run build:relay
pnpm exec oxlint <touched local/relay worktree files>
pnpm exec oxfmt --check <touched local/relay worktree files>
git diff --check
```

Docker is installed but the daemon is not running in this session (`Cannot connect to the Docker daemon...`), so I could not run the full throwaway-container SSH rig. Relay build plus relay real-git/unit coverage passed.

Risk: low. This changes only Git worktree list parsing and keeps the prior line-block behavior as a fallback for older Git.