### PR TITLE
perf: move GitHub link copy timers to handlers

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -5312,21 +5312,24 @@ export default function GitHubItemDialog({
   // Why: clipboard IPC can resolve after the dialog unmounts; skip copied-state
   // feedback instead of starting its reset timer on a stale surface.
   const linkCopyMountedRef = useRef(false)
+  const linkCopiedResetTimerRef = useRef<number | null>(null)
+  const clearLinkCopiedResetTimer = useCallback((): void => {
+    if (linkCopiedResetTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(linkCopiedResetTimerRef.current)
+    linkCopiedResetTimerRef.current = null
+  }, [])
   const setLinkCopyButtonRef = useCallback((node: HTMLButtonElement | null) => {
     linkCopyMountedRef.current = node !== null
   }, [])
 
   useEffect(() => {
+    clearLinkCopiedResetTimer()
     setLinkCopied(false)
-  }, [workItemId])
+  }, [clearLinkCopiedResetTimer, workItemId])
 
-  useEffect(() => {
-    if (!linkCopied) {
-      return
-    }
-    const handle = window.setTimeout(() => setLinkCopied(false), 1500)
-    return () => window.clearTimeout(handle)
-  }, [linkCopied])
+  useEffect(() => clearLinkCopiedResetTimer, [clearLinkCopiedResetTimer])
 
   const handleCopyWorkItemLink = useCallback(async (): Promise<void> => {
     if (!workItem) {
@@ -5339,12 +5342,17 @@ export default function GitHubItemDialog({
       if (!linkCopyMountedRef.current) {
         return
       }
+      clearLinkCopiedResetTimer()
       setLinkCopied(true)
+      linkCopiedResetTimerRef.current = window.setTimeout(() => {
+        linkCopiedResetTimerRef.current = null
+        setLinkCopied(false)
+      }, 1500)
       toast.success('GitHub link copied')
     } catch {
       toast.error('Failed to copy GitHub link')
     }
-  }, [workItem])
+  }, [clearLinkCopiedResetTimer, workItem])
 
   const appendOptimisticComment = useCallback(
     (comment: PRComment) => {

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -5397,21 +5397,24 @@ export default function PullRequestPage({
   // Why: clipboard IPC can resolve after the page unmounts; skip copied-state
   // feedback instead of starting its reset timer on a stale surface.
   const linkCopyMountedRef = useRef(false)
+  const linkCopiedResetTimerRef = useRef<number | null>(null)
+  const clearLinkCopiedResetTimer = useCallback((): void => {
+    if (linkCopiedResetTimerRef.current === null) {
+      return
+    }
+    window.clearTimeout(linkCopiedResetTimerRef.current)
+    linkCopiedResetTimerRef.current = null
+  }, [])
   const setLinkCopyButtonRef = useCallback((node: HTMLButtonElement | null) => {
     linkCopyMountedRef.current = node !== null
   }, [])
 
   useEffect(() => {
+    clearLinkCopiedResetTimer()
     setLinkCopied(false)
-  }, [workItemId])
+  }, [clearLinkCopiedResetTimer, workItemId])
 
-  useEffect(() => {
-    if (!linkCopied) {
-      return
-    }
-    const handle = window.setTimeout(() => setLinkCopied(false), 1500)
-    return () => window.clearTimeout(handle)
-  }, [linkCopied])
+  useEffect(() => clearLinkCopiedResetTimer, [clearLinkCopiedResetTimer])
 
   const handleCopyWorkItemLink = useCallback(async (): Promise<void> => {
     if (!workItem) {
@@ -5424,12 +5427,17 @@ export default function PullRequestPage({
       if (!linkCopyMountedRef.current) {
         return
       }
+      clearLinkCopiedResetTimer()
       setLinkCopied(true)
+      linkCopiedResetTimerRef.current = window.setTimeout(() => {
+        linkCopiedResetTimerRef.current = null
+        setLinkCopied(false)
+      }, 1500)
       toast.success('GitHub link copied')
     } catch {
       toast.error('Failed to copy GitHub link')
     }
-  }, [workItem])
+  }, [clearLinkCopiedResetTimer, workItem])
 
   const appendOptimisticComment = useCallback(
     (comment: PRComment) => {


### PR DESCRIPTION
## Summary
- move GitHub link-copy feedback reset timers into the copy handlers
- clear pending link-copy timers from unmount/item-change cleanup without clearing the new timer during icon re-render
- remove copied-state timer Effects from both the full PR page and GitHub item dialog

## Risk
Risk: low

Lowered from medium after focused validation plus Electron verification on both changed surfaces. The Electron pass caught and fixed a stuck-check-icon case before merge. Scope is transient copy-link feedback only; clipboard URLs and reset behavior are verified.

## Validation
- pnpm exec oxlint src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/GitHubItemDialog.tsx
- pnpm exec oxfmt --check src/renderer/src/components/PullRequestPage.tsx src/renderer/src/components/GitHubItemDialog.tsx
- pnpm run typecheck:web
- git diff --check origin/main...HEAD
- Electron CDP: PR page copy button copied https://github.com/stablyai/orca/pull/4028, swapped Copy icon -> check icon, then reset to Copy after 1.7s
- Electron CDP: GitHub item dialog/page copy button copied https://github.com/stablyai/orca/issues/123, swapped Copy icon -> check icon, then reset to Copy after 1.7s