### PR TITLE
perf: coalesce startup history gc

### DIFF
--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -2,7 +2,7 @@
 injection, fallback patching, WSL translation, cleanup, and GC with a TOCTOU age
 guard — covering each path in one test file keeps assertions co-located with the
 shared mock harness rather than splitting across files. */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   existsSyncMock,
@@ -57,10 +57,15 @@ import {
   injectHistoryEnv,
   updateHistFileForFallback,
   deleteWorktreeHistoryDir,
-  runHistoryGc
+  runHistoryGc,
+  scheduleHistoryGc
 } from './terminal-history'
 
 describe('terminal-history', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     getPathMock.mockReturnValue('/fake/userData')
@@ -274,6 +279,19 @@ describe('terminal-history', () => {
   })
 
   describe('runHistoryGc', () => {
+    it('coalesces duplicate scheduled startup GC calls', async () => {
+      vi.useFakeTimers()
+      existsSyncMock.mockReturnValue(false)
+      const getLiveWorktreeIds = vi.fn().mockResolvedValue(new Set<string>())
+
+      scheduleHistoryGc(getLiveWorktreeIds)
+      scheduleHistoryGc(getLiveWorktreeIds)
+
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      expect(getLiveWorktreeIds).toHaveBeenCalledTimes(1)
+    })
+
     it('prunes orphaned directories', () => {
       existsSyncMock.mockImplementation((p: string) => {
         // WSL root doesn't exist, so GC skips it

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -19,6 +19,9 @@ const HISTORY_DIR_NAME_WSL = 'terminal-history-wsl'
 
 type ShellKind = 'zsh' | 'bash' | 'fish' | 'pwsh' | 'powershell' | 'cmd' | 'unknown'
 
+let scheduledHistoryGcTimer: ReturnType<typeof setTimeout> | null = null
+let historyGcRunning = false
+
 // ─── Shell Detection ───────────────────────────────────────────────
 
 /** Resolve the shell kind from a shell binary path.
@@ -353,9 +356,16 @@ export function runHistoryGc(liveWorktreeIds: Set<string>): void {
 /** Schedule GC after a delay so it runs after workspace hydration completes.
  *  `getLiveWorktreeIds` should use already-known IDs, not probe repo paths. */
 export function scheduleHistoryGc(getLiveWorktreeIds: () => Promise<Set<string>>): void {
+  // Why: main-window services can reattach during reload/reactivation; one
+  // pending/running disk GC is enough and avoids duplicate startup I/O.
+  if (scheduledHistoryGcTimer !== null || historyGcRunning) {
+    return
+  }
   // Why 10s: avoids competing with startup-critical I/O while still running
   // early enough to clean up before the user notices disk usage (§7.6).
-  setTimeout(async () => {
+  scheduledHistoryGcTimer = setTimeout(async () => {
+    scheduledHistoryGcTimer = null
+    historyGcRunning = true
     try {
       const liveIds = await getLiveWorktreeIds()
       runHistoryGc(liveIds)
@@ -363,6 +373,8 @@ export function scheduleHistoryGc(getLiveWorktreeIds: () => Promise<Set<string>>
       console.warn(
         `[pty:history:gc] Failed to enumerate live worktrees for GC: ${err instanceof Error ? err.message : String(err)}`
       )
+    } finally {
+      historyGcRunning = false
     }
   }, 10_000)
 }


### PR DESCRIPTION
## Summary
- coalesce pending/running terminal history startup GC so repeated main-window service attaches do not queue duplicate disk-GC passes
- allow future scheduling again once the current delayed/running pass completes
- add fake-timer coverage proving duplicate schedules only enumerate live worktrees once

## Perf scan category
- Resource cleanup / startup I/O

## Risk
Low. The GC remains delayed by 10s and still runs with the same live-worktree source and pruning logic. The only behavior change is suppressing duplicate pending/running passes during reload/reactivation churn.

## Evidence
- Before shape: two `scheduleHistoryGc()` calls before the 10s delay could queue two live-worktree enumerations and disk-GC passes.
- After shape: duplicate pending calls produce one live-worktree enumeration; a later schedule is allowed after the pass finishes.
- `pnpm vitest run --config config/vitest.config.ts src/main/terminal-history.test.ts`
- `pnpm exec oxlint src/main/terminal-history.ts src/main/terminal-history.test.ts`
