### PR TITLE
perf: pause prompt cache countdown when hidden

### DIFF
--- a/src/renderer/src/components/sidebar/prompt-cache-countdown-clock.test.ts
+++ b/src/renderer/src/components/sidebar/prompt-cache-countdown-clock.test.ts
@@ -3,12 +3,15 @@ import { subscribePromptCacheCountdownClock } from './prompt-cache-countdown-clo
 
 describe('subscribePromptCacheCountdownClock', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('uses one interval for all prompt-cache countdown subscribers', () => {
@@ -33,5 +36,46 @@ describe('subscribePromptCacheCountdownClock', () => {
 
     expect(second).toHaveBeenCalledTimes(3)
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('pauses the interval while the document is hidden', () => {
+    let visibilityState: DocumentVisibilityState = 'hidden'
+    const documentListeners = new Map<string, () => void>()
+    vi.stubGlobal('document', {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener: vi.fn((event: string, listener: () => void) => {
+        documentListeners.set(event, listener)
+      }),
+      removeEventListener: vi.fn()
+    })
+
+    const listener = vi.fn()
+    const unsubscribe = subscribePromptCacheCountdownClock(listener)
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(2_000)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    visibilityState = 'visible'
+    vi.setSystemTime(3_000)
+    documentListeners.get('visibilitychange')?.()
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(1)
+
+    vi.advanceTimersByTime(1_000)
+    expect(listener).toHaveBeenCalledTimes(3)
+
+    visibilityState = 'hidden'
+    documentListeners.get('visibilitychange')?.()
+    expect(vi.getTimerCount()).toBe(0)
+
+    unsubscribe()
+    expect(document.removeEventListener).toHaveBeenCalledWith(
+      'visibilitychange',
+      documentListeners.get('visibilitychange')
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/prompt-cache-countdown-clock.ts
+++ b/src/renderer/src/components/sidebar/prompt-cache-countdown-clock.ts
@@ -1,9 +1,11 @@
 import { useSyncExternalStore } from 'react'
+import { isWindowVisible } from '@/lib/window-visibility-interval'
 
 type Listener = () => void
 
 let currentNow = Date.now()
 let timer: ReturnType<typeof setInterval> | null = null
+let stopVisibilityWatcher: (() => void) | null = null
 const listeners = new Set<Listener>()
 
 function publishTick(): void {
@@ -13,6 +15,51 @@ function publishTick(): void {
   }
 }
 
+function stopTimer(): void {
+  if (timer === null) {
+    return
+  }
+  clearInterval(timer)
+  timer = null
+}
+
+function startTimer(): void {
+  if (timer !== null || !isWindowVisible()) {
+    return
+  }
+  timer = setInterval(publishTick, 1000)
+}
+
+function reconcileVisibility(): void {
+  if (isWindowVisible()) {
+    publishTick()
+    startTimer()
+  } else {
+    stopTimer()
+  }
+}
+
+function startClock(): void {
+  if (stopVisibilityWatcher !== null) {
+    return
+  }
+  startTimer()
+  if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', reconcileVisibility)
+    stopVisibilityWatcher = () => {
+      document.removeEventListener('visibilitychange', reconcileVisibility)
+    }
+  } else {
+    stopVisibilityWatcher = () => {}
+  }
+}
+
+function stopClock(): void {
+  stopTimer()
+  stopVisibilityWatcher?.()
+  stopVisibilityWatcher = null
+}
+
 export function subscribePromptCacheCountdownClock(listener: Listener): () => void {
   listeners.add(listener)
   // Why: the clock only runs while a countdown is visible. Refresh immediately
@@ -20,14 +67,11 @@ export function subscribePromptCacheCountdownClock(listener: Listener): () => vo
   // stale module-load timestamp for one second.
   currentNow = Date.now()
   listener()
-  if (timer === null) {
-    timer = setInterval(publishTick, 1000)
-  }
+  startClock()
   return () => {
     listeners.delete(listener)
-    if (listeners.size === 0 && timer !== null) {
-      clearInterval(timer)
-      timer = null
+    if (listeners.size === 0) {
+      stopClock()
     }
   }
 }


### PR DESCRIPTION
## Summary
- pause the prompt cache countdown interval while the document is hidden
- refresh the countdown immediately when the window becomes visible again
- add focused coverage for hidden/visible timer behavior

## Risk
Low. This only affects the 1s prompt cache countdown clock while the document is hidden; visible countdowns continue to tick, and returning to visible publishes an immediate update.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/prompt-cache-countdown-clock.test.ts
- pnpm exec oxlint src/renderer/src/components/sidebar/prompt-cache-countdown-clock.ts src/renderer/src/components/sidebar/prompt-cache-countdown-clock.test.ts
- git diff --check