### PR TITLE
perf: reconcile Kagi session draft before commit

### DIFF
--- a/src/renderer/src/components/settings/KagiSessionLinkForm.test.ts
+++ b/src/renderer/src/components/settings/KagiSessionLinkForm.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createKagiSessionLinkDraftState,
+  resolveKagiSessionLinkDraftState
+} from './KagiSessionLinkForm'
+
+describe('KagiSessionLinkForm draft state', () => {
+  it('keeps an unsaved draft while the persisted session link is unchanged', () => {
+    const state = {
+      ...createKagiSessionLinkDraftState('https://kagi.com/search?token=stored'),
+      value: 'https://kagi.com/search?token=typed'
+    }
+
+    expect(resolveKagiSessionLinkDraftState(state, 'https://kagi.com/search?token=stored')).toBe(
+      state
+    )
+  })
+
+  it('reconciles the draft when the persisted session link changes', () => {
+    const state = {
+      ...createKagiSessionLinkDraftState('https://kagi.com/search?token=old'),
+      value: 'https://kagi.com/search?token=typed'
+    }
+
+    expect(resolveKagiSessionLinkDraftState(state, 'https://kagi.com/search?token=new')).toEqual({
+      persisted: 'https://kagi.com/search?token=new',
+      value: 'https://kagi.com/search?token=new'
+    })
+  })
+})

--- a/src/renderer/src/components/settings/KagiSessionLinkForm.tsx
+++ b/src/renderer/src/components/settings/KagiSessionLinkForm.tsx
@@ -1,26 +1,54 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { normalizeKagiSessionLink } from '../../../../shared/browser-url'
 import { useAppStore } from '../../store'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 
+export type KagiSessionLinkDraftState = {
+  persisted: string
+  value: string
+}
+
+export function createKagiSessionLinkDraftState(persisted: string): KagiSessionLinkDraftState {
+  return {
+    persisted,
+    value: persisted
+  }
+}
+
+export function resolveKagiSessionLinkDraftState(
+  state: KagiSessionLinkDraftState,
+  persisted: string
+): KagiSessionLinkDraftState {
+  return state.persisted === persisted ? state : createKagiSessionLinkDraftState(persisted)
+}
+
 export function KagiSessionLinkForm(): React.JSX.Element {
   const browserKagiSessionLink = useAppStore((s) => s.browserKagiSessionLink)
   const setBrowserKagiSessionLink = useAppStore((s) => s.setBrowserKagiSessionLink)
-  const [draft, setDraft] = useState(browserKagiSessionLink ?? '')
+  const persistedDraft = browserKagiSessionLink ?? ''
+  const [draftState, setDraftState] = useState(() =>
+    createKagiSessionLinkDraftState(persistedDraft)
+  )
+  const resolvedDraftState = resolveKagiSessionLinkDraftState(draftState, persistedDraft)
 
   // Why: the Kagi token is edited as a masked draft so accidental typing or
-  // external settings updates do not immediately overwrite the persisted secret.
-  useEffect(() => {
-    setDraft(browserKagiSessionLink ?? '')
-  }, [browserKagiSessionLink])
+  // external settings updates do not immediately overwrite the persisted
+  // secret; when the stored secret changes, reconcile before commit.
+  if (resolvedDraftState !== draftState) {
+    setDraftState(resolvedDraftState)
+  }
+  const draft = resolvedDraftState.value
+  const setDraft = (value: string): void => {
+    setDraftState((current) => ({ ...current, value }))
+  }
 
   const save = (): void => {
     const trimmed = draft.trim()
     if (!trimmed) {
       setBrowserKagiSessionLink(null)
-      setDraft('')
+      setDraftState(createKagiSessionLinkDraftState(''))
       toast.success('Kagi session link cleared.')
       return
     }
@@ -30,7 +58,7 @@ export function KagiSessionLinkForm(): React.JSX.Element {
       return
     }
     setBrowserKagiSessionLink(normalized)
-    setDraft(normalized)
+    setDraftState(createKagiSessionLinkDraftState(normalized))
     toast.success('Kagi session link saved.')
   }
 
@@ -69,7 +97,7 @@ export function KagiSessionLinkForm(): React.JSX.Element {
             className="h-7 text-xs"
             onClick={() => {
               setBrowserKagiSessionLink(null)
-              setDraft('')
+              setDraftState(createKagiSessionLinkDraftState(''))
               toast.success('Kagi session link cleared.')
             }}
           >


### PR DESCRIPTION
## Summary
- replace the Kagi session-link draft sync Effect with guarded render-time reconciliation
- keep unsaved masked edits while the persisted secret is unchanged
- add focused draft-state coverage

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/KagiSessionLinkForm.tsx src/renderer/src/components/settings/KagiSessionLinkForm.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/settings/KagiSessionLinkForm.tsx src/renderer/src/components/settings/KagiSessionLinkForm.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/KagiSessionLinkForm.test.ts src/renderer/src/store/slices/ui.test.ts
- pnpm run typecheck:web
- git diff --check

Risk: medium. This is a narrow settings perf cleanup, but it touches the masked Kagi auth/session-link draft path.