### PR TITLE
fix: open Windows OSC file path links

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -371,6 +371,36 @@ describe('handleOscLink', () => {
     expect(openFilePathMock).not.toHaveBeenCalled()
   })
 
+  it('opens Windows absolute OSC link targets that parse as URL schemes', async () => {
+    setPlatform('Windows')
+
+    handleOscLink(
+      'C:\\repo\\src\\index.ts:12:3',
+      { metaKey: false, ctrlKey: true },
+      {
+        ...deps,
+        startupCwd: 'C:\\repo',
+        worktreePath: 'C:\\repo'
+      }
+    )
+    await flushAsyncWork()
+    await flushDoubleRaf()
+
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith({
+      targetPath: 'C:/repo/src/index.ts'
+    })
+    expect(openFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: 'C:/repo/src/index.ts' })
+    )
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(1, null)
+    expect(setPendingEditorRevealMock).toHaveBeenNthCalledWith(2, {
+      filePath: 'C:/repo/src/index.ts',
+      line: 12,
+      column: 3,
+      matchLength: 0
+    })
+  })
+
   it('opens Windows UNC file URL links from Windows worktrees', async () => {
     setPlatform('Windows')
 

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -30,21 +30,37 @@ export function handleOscLink(
   // without holding a button) extends a selection until the next click/Esc.
   event?.preventDefault?.()
 
-  let parsed: URL
-  try {
-    parsed = new URL(rawText)
-  } catch {
+  const openDetectedPathLink = (): boolean => {
     const resolved = resolveTerminalFileLinkText(
       rawText,
       deps.startupCwd || deps.worktreePath,
       deps.terminalHomePath
     )
-    if (resolved) {
-      openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
-        ...deps,
-        openWithSystemDefault: Boolean(event?.shiftKey)
-      })
+    if (!resolved) {
+      return false
     }
+    openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
+      ...deps,
+      openWithSystemDefault: Boolean(event?.shiftKey)
+    })
+    return true
+  }
+
+  if (
+    isWindowsAbsolutePathLike(rawText) &&
+    isWindowsAbsolutePathLike(deps.startupCwd || deps.worktreePath) &&
+    openDetectedPathLink()
+  ) {
+    // Why: `new URL("C:\\path\\file.ts")` succeeds with protocol `c:`;
+    // Windows OSC links need file-path routing before generic URL parsing.
+    return
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(rawText)
+  } catch {
+    openDetectedPathLink()
     return
   }
 


### PR DESCRIPTION
## Summary
- route Windows absolute path-like OSC hyperlink targets through the terminal file-link resolver before generic URL parsing
- preserve existing http(s), file://, UNC, and relative OSC link behavior
- add a regression for `C:\repo\src\index.ts:12:3` opening in Orca on Windows

## Evidence
- Before the fix, the new repro failed because `handleOscLink('C:\\repo\\src\\index.ts:12:3')` made zero file-open calls after `new URL(...)` parsed the target as protocol `c:`.
- After the fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts` -> 4 files, 120 tests passed.
- `pnpm run typecheck:web` passed.
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts` passed.
- `git diff --check` passed.

## Risk
Low: scoped to terminal OSC link routing, with existing URL/file/UNC behavior covered by the surrounding tests.