### PR TITLE
perf: avoid flattening worktree selector snapshots

### DIFF
--- a/src/renderer/src/store/selectors.test.ts
+++ b/src/renderer/src/store/selectors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../shared/types'
+import { getAllWorktreesFromState, getWorktreeMapFromState } from './selectors'
+
+function makeWorktree(args: { id: string; repoId: string; displayName: string }): Worktree {
+  return {
+    id: args.id,
+    repoId: args.repoId,
+    displayName: args.displayName,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    path: args.id,
+    head: 'HEAD',
+    branch: 'main',
+    isBare: false,
+    isMainWorktree: false
+  }
+}
+
+describe('store selectors', () => {
+  it('deduplicates cached worktree snapshots without changing reference reuse', () => {
+    const first = makeWorktree({ id: 'wt-1', repoId: 'repo-1', displayName: 'first' })
+    const second = makeWorktree({ id: 'wt-2', repoId: 'repo-1', displayName: 'second' })
+    const replacement = makeWorktree({
+      id: 'wt-1',
+      repoId: 'repo-2',
+      displayName: 'replacement'
+    })
+    const state = {
+      worktreesByRepo: {
+        'repo-1': [first, second],
+        'repo-2': [replacement]
+      }
+    }
+
+    const allWorktrees = getAllWorktreesFromState(state)
+    const worktreeMap = getWorktreeMapFromState(state)
+
+    expect(allWorktrees).toEqual([replacement, second])
+    expect(worktreeMap.get('wt-1')).toBe(replacement)
+    expect(getAllWorktreesFromState(state)).toBe(allWorktrees)
+    expect(getWorktreeMapFromState(state)).toBe(worktreeMap)
+  })
+})

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -29,8 +29,12 @@ function getWorktreeSnapshot(worktreesByRepo: AppState['worktreesByRepo']): Work
   // within a single repo's array. Deduplicating here prevents React from
   // seeing duplicate keys, which can corrupt terminal DOM containers.
   const worktreeMap = new Map<string, Worktree>()
-  for (const worktree of Object.values(worktreesByRepo).flat()) {
-    worktreeMap.set(worktree.id, worktree)
+  // Why: this selector sits on hot Zustand subscription paths; avoid building
+  // a transient flattened array just to populate the snapshot cache.
+  for (const worktrees of Object.values(worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      worktreeMap.set(worktree.id, worktree)
+    }
   }
   const allWorktrees = Array.from(worktreeMap.values())
 


### PR DESCRIPTION
## Summary
- avoid building a transient flattened worktree array on cached selector snapshot misses
- preserve duplicate-worktree replacement semantics and cached reference reuse
- add focused selector coverage for the snapshot behavior

## Risk
Low. The selector still iterates worktrees in the same repo/object order, keeps the same Map dedupe semantics, and returns the same cached array/map references for an unchanged worktreesByRepo object.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/selectors.test.ts
- pnpm exec oxlint src/renderer/src/store/selectors.ts src/renderer/src/store/selectors.test.ts
- git diff --check