### PR TITLE
fix: keep framework route terminal links whole

### DIFF
--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -119,6 +119,19 @@ describe('terminal path helpers', () => {
       })
     })
 
+    it('detects framework route paths with bracket and paren segments', () => {
+      const links = extractTerminalFileLinks(
+        'Error in app/(shop)/products/[productId]/page.tsx:42:7'
+      )
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({
+        pathText: 'app/(shop)/products/[productId]/page.tsx',
+        line: 42,
+        column: 7,
+        displayText: 'app/(shop)/products/[productId]/page.tsx:42:7'
+      })
+    })
+
     it('handles large spaced path lists without quadratic overlap scans', () => {
       const line = Array.from({ length: 20_000 }, () => '/tmp/Foo Bar/file').join(', ')
 

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -25,8 +25,10 @@ export type ResolvedTerminalFileLink = Pick<ParsedTerminalFileLink, 'line' | 'co
 
 // Matches a path with at least one `/` separator, optionally followed by
 // `:line` and `:col` suffixes (e.g. `src/foo.ts:12:3`, `./bin`, `/abs/path`).
+// Why: framework route files commonly use punctuation segments like
+// `app/(shop)/products/[id]/page.tsx`; keep those links whole.
 const LOCAL_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[A-Za-z0-9._~\-/%+@\\]*(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
 
 // Matches separator paths whose file or folder names include spaces. This runs
 // before LOCAL_PATH_REGEX so `/Users/A/Foo Bar/file.ts` is claimed as one link


### PR DESCRIPTION
## Summary
- keep bracket and paren route segments inside terminal file-link matches
- add a regression for `app/(shop)/products/[productId]/page.tsx:42:7`
- preserve existing URL suppression, Windows/UNC, markdown, and terminal-link routing behavior

## Evidence
- Before the fix, the new repro failed because `extractTerminalFileLinks('Error in app/(shop)/products/[productId]/page.tsx:42:7')` returned only `/page.tsx:42:7`.
- After the fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/terminal-links.test.ts src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts src/renderer/src/components/editor/markdown-internal-links.test.ts src/renderer/src/components/editor/markdown-preview-links.test.ts` -> 4 files, 120 tests passed.
- `pnpm run typecheck:web` passed.
- `pnpm exec oxlint src/renderer/src/lib/terminal-links.ts src/renderer/src/lib/terminal-links.test.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/lib/terminal-links.ts src/renderer/src/lib/terminal-links.test.ts` passed.
- `git diff --check` passed.

## Risk
Low: scoped to terminal file-link tokenization. Surrounding tests cover URL hosts, Windows/UNC paths, OSC link routing, and markdown file URI behavior.