### PR TITLE
perf: reconcile browser home draft before commit

### DIFF
--- a/src/renderer/src/components/settings/BrowserHomePageSetting.tsx
+++ b/src/renderer/src/components/settings/BrowserHomePageSetting.tsx
@@ -1,0 +1,64 @@
+import { toast } from 'sonner'
+import { ORCA_BROWSER_BLANK_URL } from '../../../../shared/constants'
+import { normalizeBrowserNavigationUrl } from '../../../../shared/browser-url'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+
+type BrowserHomePageSettingProps = {
+  value: string
+  onChange: (value: string) => void
+  onSave: (url: string | null) => void
+}
+
+export function BrowserHomePageSetting({
+  value,
+  onChange,
+  onSave
+}: BrowserHomePageSettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title="Default Home Page"
+      description="URL opened when creating a new browser tab. Leave empty to open a blank tab."
+      keywords={['browser', 'home', 'homepage', 'default', 'url', 'new tab', 'blank']}
+      className="flex items-start justify-between gap-4 py-2"
+    >
+      <div className="min-w-0 shrink space-y-0.5">
+        <Label>Default Home Page</Label>
+        <p className="text-xs text-muted-foreground">
+          URL opened when creating a new browser tab. Leave empty to open a blank tab.
+        </p>
+      </div>
+      <form
+        className="flex shrink-0 items-center gap-2"
+        onSubmit={(event) => {
+          event.preventDefault()
+          const trimmed = value.trim()
+          if (!trimmed) {
+            onSave(null)
+            return
+          }
+          const normalized = normalizeBrowserNavigationUrl(trimmed)
+          if (normalized && normalized !== ORCA_BROWSER_BLANK_URL) {
+            onSave(normalized)
+            toast.success('Home page saved.')
+          }
+        }}
+      >
+        <Input
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="https://google.com"
+          spellCheck={false}
+          autoCapitalize="none"
+          autoCorrect="off"
+          className="h-7 w-52 text-xs"
+        />
+        <Button type="submit" size="sm" variant="outline" className="h-7 text-xs">
+          Save
+        </Button>
+      </form>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserPane.test.ts
+++ b/src/renderer/src/components/settings/BrowserPane.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createBrowserHomePageDraftState,
+  resolveBrowserHomePageDraftState
+} from './browser-home-page-draft-state'
+
+describe('BrowserPane home page draft state', () => {
+  it('keeps an unsaved draft while the persisted home page is unchanged', () => {
+    const state = {
+      ...createBrowserHomePageDraftState('https://example.com'),
+      value: 'https://typed.example.com'
+    }
+
+    expect(resolveBrowserHomePageDraftState(state, 'https://example.com')).toBe(state)
+  })
+
+  it('reconciles the draft when the persisted home page changes externally', () => {
+    const state = {
+      ...createBrowserHomePageDraftState('https://old.example.com'),
+      value: 'https://typed.example.com'
+    }
+
+    expect(resolveBrowserHomePageDraftState(state, 'https://new.example.com')).toEqual({
+      persisted: 'https://new.example.com',
+      value: 'https://new.example.com'
+    })
+  })
+})

--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -8,12 +8,7 @@ import { Label } from '../ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { useAppStore } from '../../store'
-import { ORCA_BROWSER_BLANK_URL } from '../../../../shared/constants'
-import {
-  normalizeBrowserNavigationUrl,
-  SEARCH_ENGINE_LABELS,
-  type SearchEngine
-} from '../../../../shared/browser-url'
+import { SEARCH_ENGINE_LABELS, type SearchEngine } from '../../../../shared/browser-url'
 import { SearchableSetting } from './SearchableSetting'
 import { matchesSettingsSearch } from './settings-search'
 import {
@@ -22,9 +17,14 @@ import {
 } from './browser-search'
 import { BROWSER_USE_PANE_SEARCH_ENTRIES } from './browser-use-search'
 import { BROWSER_PANE_SEARCH_ENTRIES } from './browser-pane-search'
+import { BrowserHomePageSetting } from './BrowserHomePageSetting'
 import { BrowserProfileRow } from './BrowserProfileRow'
 import { BrowserUseSetup } from './BrowserUsePane'
 import { KagiSessionLinkForm } from './KagiSessionLinkForm'
+import {
+  createBrowserHomePageDraftState,
+  resolveBrowserHomePageDraftState
+} from './browser-home-page-draft-state'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { isMacUserAgent } from '@/components/terminal-pane/pane-helpers'
 export { BROWSER_PANE_SEARCH_ENTRIES }
@@ -60,18 +60,28 @@ export function BrowserPane({
   const defaultProfile = browserSessionProfiles.find((p) => p.id === 'default')
   const nonDefaultProfiles = browserSessionProfiles.filter((p) => p.scope !== 'default')
   const mountedRef = useMountedRef()
-  const [homePageDraft, setHomePageDraft] = useState(browserDefaultUrl ?? '')
+  const persistedHomePageDraft = browserDefaultUrl ?? ''
+  const [homePageDraftState, setHomePageDraftState] = useState(() =>
+    createBrowserHomePageDraftState(persistedHomePageDraft)
+  )
   const [newProfileDialogOpen, setNewProfileDialogOpen] = useState(false)
   const [newProfileName, setNewProfileName] = useState('')
   const [isCreatingProfile, setIsCreatingProfile] = useState(false)
   const sessionCookieScrollFrameIdsRef = useRef<number[]>([])
+  const resolvedHomePageDraftState = resolveBrowserHomePageDraftState(
+    homePageDraftState,
+    persistedHomePageDraft
+  )
 
-  // Why: sync draft with store value whenever it changes externally (e.g. the
-  // in-app browser tab's address bar saves a home page). Without this, the
-  // settings field would show stale text after another surface wrote the value.
-  useEffect(() => {
-    setHomePageDraft(browserDefaultUrl ?? '')
-  }, [browserDefaultUrl])
+  // Why: the in-app browser address bar can save the home page from outside
+  // Settings, so reconcile the draft before commit when that stored URL changes.
+  if (resolvedHomePageDraftState !== homePageDraftState) {
+    setHomePageDraftState(resolvedHomePageDraftState)
+  }
+  const homePageDraft = resolvedHomePageDraftState.value
+  const setHomePageDraft = (value: string): void => {
+    setHomePageDraftState((current) => ({ ...current, value }))
+  }
 
   useEffect(() => {
     return () => cancelBrowserSessionCookieScrollFrames(sessionCookieScrollFrameIdsRef)
@@ -135,49 +145,14 @@ export function BrowserPane({
       ) : null}
 
       {showHomePage ? (
-        <SearchableSetting
-          title="Default Home Page"
-          description="URL opened when creating a new browser tab. Leave empty to open a blank tab."
-          keywords={['browser', 'home', 'homepage', 'default', 'url', 'new tab', 'blank']}
-          className="flex items-start justify-between gap-4 py-2"
-        >
-          <div className="min-w-0 shrink space-y-0.5">
-            <Label>Default Home Page</Label>
-            <p className="text-xs text-muted-foreground">
-              URL opened when creating a new browser tab. Leave empty to open a blank tab.
-            </p>
-          </div>
-          <form
-            className="flex shrink-0 items-center gap-2"
-            onSubmit={(e) => {
-              e.preventDefault()
-              const trimmed = homePageDraft.trim()
-              if (!trimmed) {
-                setBrowserDefaultUrl(null)
-                return
-              }
-              const normalized = normalizeBrowserNavigationUrl(trimmed)
-              if (normalized && normalized !== ORCA_BROWSER_BLANK_URL) {
-                setBrowserDefaultUrl(normalized)
-                setHomePageDraft(normalized)
-                toast.success('Home page saved.')
-              }
-            }}
-          >
-            <Input
-              value={homePageDraft}
-              onChange={(e) => setHomePageDraft(e.target.value)}
-              placeholder="https://google.com"
-              spellCheck={false}
-              autoCapitalize="none"
-              autoCorrect="off"
-              className="h-7 w-52 text-xs"
-            />
-            <Button type="submit" size="sm" variant="outline" className="h-7 text-xs">
-              Save
-            </Button>
-          </form>
-        </SearchableSetting>
+        <BrowserHomePageSetting
+          value={homePageDraft}
+          onChange={setHomePageDraft}
+          onSave={(url) => {
+            setBrowserDefaultUrl(url)
+            setHomePageDraftState(createBrowserHomePageDraftState(url ?? ''))
+          }}
+        />
       ) : null}
 
       {showSearchEngine ? (

--- a/src/renderer/src/components/settings/browser-home-page-draft-state.ts
+++ b/src/renderer/src/components/settings/browser-home-page-draft-state.ts
@@ -1,0 +1,18 @@
+export type BrowserHomePageDraftState = {
+  persisted: string
+  value: string
+}
+
+export function createBrowserHomePageDraftState(persisted: string): BrowserHomePageDraftState {
+  return {
+    persisted,
+    value: persisted
+  }
+}
+
+export function resolveBrowserHomePageDraftState(
+  state: BrowserHomePageDraftState,
+  persisted: string
+): BrowserHomePageDraftState {
+  return state.persisted === persisted ? state : createBrowserHomePageDraftState(persisted)
+}


### PR DESCRIPTION
## Summary
- replace the Browser settings home-page draft sync Effect with guarded render-time reconciliation
- extract the home-page setting surface so BrowserPane stays under lint line limits
- add focused draft-state coverage

## Validation
- pnpm exec oxlint src/renderer/src/components/settings/BrowserPane.tsx src/renderer/src/components/settings/BrowserHomePageSetting.tsx src/renderer/src/components/settings/browser-home-page-draft-state.ts src/renderer/src/components/settings/BrowserPane.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/settings/BrowserPane.tsx src/renderer/src/components/settings/BrowserHomePageSetting.tsx src/renderer/src/components/settings/browser-home-page-draft-state.ts src/renderer/src/components/settings/BrowserPane.test.ts
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/BrowserPane.test.ts src/renderer/src/components/settings/browser-search.test.ts src/renderer/src/store/slices/ui.test.ts
- pnpm run typecheck:web
- git diff --check

Risk: medium. This is a settings perf cleanup, but it touches the browser default home-page draft/save path and splits the setting into a new component.