### PR TITLE
fix: normalize IPv6 SSH URL hosts

### DIFF
--- a/src/renderer/src/components/settings/ssh-target-draft.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.test.ts
@@ -25,6 +25,15 @@ describe('parseSshHostInput', () => {
     })
   })
 
+  it('normalizes bracketed IPv6 hosts from ssh URLs', () => {
+    expect(parseSshHostInput('ssh://deploy@[::1]:2202/srv/app')).toEqual({
+      host: '::1',
+      username: 'deploy',
+      port: 2202,
+      configHost: '::1'
+    })
+  })
+
   it('keeps plain OpenSSH config aliases valid without a username', () => {
     expect(parseSshHostInput('prod-box')).toEqual({
       host: 'prod-box',

--- a/src/renderer/src/components/settings/ssh-target-draft.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.ts
@@ -120,15 +120,18 @@ function parseSshUrl(input: string): ParsedSshHostInput | null {
     if (url.protocol !== 'ssh:' || !url.hostname) {
       return null
     }
+    // Why: URL.hostname keeps IPv6 literals bracketed, but ssh2 and DNS
+    // resolution expect the bare address. The non-URL parser already strips.
+    const host = url.hostname.replace(/^\[|\]$/g, '')
     const port = url.port ? parseInt(url.port, 10) : undefined
     if (port !== undefined && !isValidPort(port)) {
       return null
     }
     return {
-      host: url.hostname,
+      host,
       username: url.username ? decodeURIComponent(url.username) : undefined,
       port,
-      configHost: url.hostname
+      configHost: host
     }
   } catch {
     return null


### PR DESCRIPTION
## Summary
- strip IPv6 brackets from parsed `ssh://` URL hostnames before saving SSH targets
- keep URL and non-URL SSH host parsing consistent for IPv6 literals
- add a regression for `ssh://deploy@[::1]:2202/srv/app`

## Evidence
- Before the fix, the new repro failed because `parseSshHostInput('ssh://deploy@[::1]:2202/srv/app')` returned `host: '[::1]'` and `configHost: '[::1]'`.
- Runtime proof: Node DNS lookup resolves `::1`, while `[::1]` returns `ENOTFOUND`, matching the bracketed host Orca would pass to the SSH layer after saving the target.
- After the fix: `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-draft.test.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts src/renderer/src/components/settings/ssh-target-remove.test.ts src/main/ssh/ssh-connection-utils.test.ts src/main/ssh/ssh-system-fallback.test.ts` -> 5 files, 99 tests passed.
- `pnpm run typecheck:web` passed.
- `pnpm exec oxlint src/renderer/src/components/settings/ssh-target-draft.ts src/renderer/src/components/settings/ssh-target-draft.test.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/components/settings/ssh-target-draft.ts src/renderer/src/components/settings/ssh-target-draft.test.ts` passed.
- `git diff --check` passed.

## Risk
Low: scoped to SSH target form URL parsing; non-URL `[host]:port` parsing already used the normalized bare IPv6 host shape.