### PR TITLE
fix: parse quoted ssh config values

### DIFF
--- a/src/main/ssh/ssh-config-parser.test.ts
+++ b/src/main/ssh/ssh-config-parser.test.ts
@@ -104,6 +104,46 @@ Host myserver
     expect(hosts[0].identityFile).toBe(testHomePath('.ssh', 'id_ed25519'))
   })
 
+  it('parses quoted scalar values like OpenSSH', () => {
+    const config = `
+Host quoted
+  HostName "localhost" # local test
+  User "deploy" # deploy user
+  Port "2202" # ssh port
+  IdentityFile "~/.ssh/id with space" # private key
+  IdentityAgent "~/.1password/agent sock" # agent socket
+  IdentitiesOnly "yes" # limit keys
+  ProxyJump "bastion" # jump host
+`
+    const hosts = parseSshConfig(config)
+    expect(hosts[0]).toEqual({
+      host: 'quoted',
+      hostname: 'localhost',
+      user: 'deploy',
+      port: 2202,
+      identityFile: testHomePath('.ssh', 'id with space'),
+      identityAgent: testHomePath('.1password', 'agent sock'),
+      identitiesOnly: true,
+      proxyJump: 'bastion'
+    })
+  })
+
+  it('parses equals-form scalar directives', () => {
+    const config = `
+Host eq
+  HostName=eq.example.com
+  User=deploy
+  Port=2202
+`
+    const hosts = parseSshConfig(config)
+    expect(hosts[0]).toEqual({
+      host: 'eq',
+      hostname: 'eq.example.com',
+      user: 'deploy',
+      port: 2202
+    })
+  })
+
   it('parses IdentityAgent with ~ expansion', () => {
     const config = `
 Host myserver
@@ -136,6 +176,15 @@ Host internal
     expect(hosts[0].proxyCommand).toBe('ssh -W %h:%p bastion')
     expect(hosts[0].proxyUseFdpass).toBe(true)
     expect(hosts[0].proxyJump).toBe('bastion.example.com')
+  })
+
+  it('preserves ProxyCommand as the rest of the line', () => {
+    const config = `
+Host internal
+  ProxyCommand sh -c "nc %h %p" # shell comment
+`
+    const hosts = parseSshConfig(config)
+    expect(hosts[0].proxyCommand).toBe('sh -c "nc %h %p" # shell comment')
   })
 
   it('ignores comments and blank lines', () => {

--- a/src/main/ssh/ssh-config-parser.ts
+++ b/src/main/ssh/ssh-config-parser.ts
@@ -34,21 +34,19 @@ export function parseSshConfig(content: string): SshConfigHost[] {
       continue
     }
 
-    const match = line.match(/^(\S+)\s+(.+)$/)
-    if (!match) {
+    const directive = parseConfigDirective(line)
+    if (!directive) {
       continue
     }
 
-    const [, keyword, rawValue] = match
-    const key = keyword.toLowerCase()
-    const value = rawValue.trim()
+    const { key, rawValue } = directive
 
     if (key === 'host') {
       if (current.length > 0) {
         appendHosts(hosts, current)
       }
 
-      const patterns = splitHostPatterns(value)
+      const patterns = splitHostPatterns(rawValue)
       const concretePatterns = patterns.filter(
         (pattern) => !pattern.startsWith('!') && !pattern.includes('*') && !pattern.includes('?')
       )
@@ -72,6 +70,8 @@ export function parseSshConfig(content: string): SshConfigHost[] {
     if (current.length === 0) {
       continue
     }
+
+    const value = parseScalarConfigValue(rawValue)
 
     switch (key) {
       case 'hostname':
@@ -106,7 +106,9 @@ export function parseSshConfig(content: string): SshConfigHost[] {
         break
       case 'proxycommand':
         for (const host of current) {
-          host.proxyCommand = value
+          // Why: OpenSSH treats ProxyCommand as a shell snippet and preserves
+          // the rest of the line, including quotes and `#` characters.
+          host.proxyCommand = rawValue.trim()
         }
         break
       case 'proxyusefdpass':
@@ -136,8 +138,30 @@ function appendHosts(target: SshConfigHost[], entries: SshConfigHost[]): void {
   }
 }
 
+function parseConfigDirective(line: string): { key: string; rawValue: string } | null {
+  const match = line.match(/^([^=\s]+)(?:\s*=\s*|\s+)(.*)$/)
+  if (!match) {
+    return null
+  }
+
+  return {
+    key: match[1].toLowerCase(),
+    rawValue: match[2].trim()
+  }
+}
+
+function parseScalarConfigValue(input: string): string {
+  // Why: scalar OpenSSH directives strip wrapping quotes and inline comments;
+  // keeping them would turn valid config values into bad hostnames/users/paths.
+  return splitOpenSshArguments(input)[0] ?? ''
+}
+
 function splitHostPatterns(input: string): string[] {
-  const patterns: string[] = []
+  return splitOpenSshArguments(input)
+}
+
+function splitOpenSshArguments(input: string): string[] {
+  const args: string[] = []
   let current = ''
   let inQuotes = false
   let escaped = false
@@ -166,7 +190,7 @@ function splitHostPatterns(input: string): string[] {
 
     if (!inQuotes && /\s/.test(char)) {
       if (current) {
-        patterns.push(current)
+        args.push(current)
         current = ''
       }
       continue
@@ -176,10 +200,10 @@ function splitHostPatterns(input: string): string[] {
   }
 
   if (current) {
-    patterns.push(current)
+    args.push(current)
   }
 
-  return patterns
+  return args
 }
 
 /** Read and parse the user's ~/.ssh/config file. Returns empty array if not found. */


### PR DESCRIPTION
## Summary
- parse scalar `~/.ssh/config` directives with OpenSSH-style quoted argument and inline-comment handling
- support equals-form scalar directives such as `HostName=example.com`
- preserve `ProxyCommand` as rest-of-line shell text because OpenSSH keeps quotes and `#` characters there

## Bug Evidence
Before the fix, this valid SSH config:

```sshconfig
Host quoted
  HostName "localhost"
  User "deploy"
  IdentityFile "~/.ssh/id with space"

Host inline
  HostName localhost # local test
  User deploy # comment
```

OpenSSH resolves it as:

```text
user deploy
hostname localhost
identityfile ~/.ssh/id with space
```

But Orca's import parser saved bad target values like:

```json
{
  "host": "\"localhost\"",
  "username": "\"deploy\"",
  "identityFile": "\"~/.ssh/id with space\""
}
```

and:

```json
{
  "host": "localhost # local test",
  "username": "deploy # comment"
}
```

Those values can make imported targets DNS-resolve the quoted/commented host string or log in with the quoted/commented username.

## Verification
- `ssh -F <config> -G quoted` comparison against the parser output
- `pnpm exec tsx ... parseSshConfig()/sshConfigHostsToTargets()` repro before and after
- `pnpm vitest run --config config/vitest.config.ts src/main/ssh/ssh-config-parser.test.ts src/main/ssh/ssh-config-parser-host-patterns.test.ts src/main/ssh/ssh-config-loader.test.ts src/main/ssh/ssh-config-loader-regression.test.ts src/main/ssh/ssh-connection-utils.test.ts src/main/ssh/ssh-auth-resolution.test.ts src/main/ssh/ssh-system-fallback.test.ts src/main/ssh/ssh-connection-store.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ssh/ssh-config-parser.ts src/main/ssh/ssh-config-parser.test.ts`
- `pnpm exec oxfmt --check src/main/ssh/ssh-config-parser.ts src/main/ssh/ssh-config-parser.test.ts`
- `git diff --check`

## SSH Rig
The Docker-based throwaway SSH rig could not be run because Docker is installed but the daemon is not running:

```text
Cannot connect to the Docker daemon at unix:///Users/nwparker/.docker/run/docker.sock. Is the docker daemon running?
```
