### PR TITLE
perf: clean comment composer focus timers

### DIFF
--- a/src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx
@@ -4,6 +4,10 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { cn } from '@/lib/utils'
+import {
+  clearRightPanelCommentFocusTimer,
+  scheduleRightPanelCommentFocusTimer
+} from './right-panel-comment-focus-timers'
 
 export type RightPanelCommentSubmitResult = { ok: true } | { ok: false; error: string }
 
@@ -74,6 +78,8 @@ export function RightPanelCommentComposer({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const autoFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const selectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isMac = navigator.userAgent.includes('Mac')
   const modLabel = isMac ? '⌘' : 'Ctrl'
 
@@ -87,10 +93,17 @@ export function RightPanelCommentComposer({
   }, [body])
 
   useEffect(() => {
-    if (autoFocus) {
-      setTimeout(() => textareaRef.current?.focus(), 0)
+    if (!autoFocus) {
+      clearRightPanelCommentFocusTimer(autoFocusTimerRef)
+      return
     }
+    scheduleRightPanelCommentFocusTimer(autoFocusTimerRef, () => textareaRef.current?.focus())
+    return () => clearRightPanelCommentFocusTimer(autoFocusTimerRef)
   }, [autoFocus])
+
+  useEffect(() => {
+    return () => clearRightPanelCommentFocusTimer(selectionTimerRef)
+  }, [])
 
   const stopPropagation = useCallback((event: React.SyntheticEvent) => {
     event.stopPropagation()
@@ -104,10 +117,13 @@ export function RightPanelCommentComposer({
       }
       const next = applyMarkdownAction(body, textarea.selectionStart, textarea.selectionEnd, action)
       setBody(next.value)
-      setTimeout(() => {
+      scheduleRightPanelCommentFocusTimer(selectionTimerRef, () => {
+        if (!textarea.isConnected) {
+          return
+        }
         textarea.focus()
         textarea.setSelectionRange(next.selectionStart, next.selectionEnd)
-      }, 0)
+      })
     },
     [body]
   )

--- a/src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearRightPanelCommentFocusTimer,
+  scheduleRightPanelCommentFocusTimer,
+  type RightPanelCommentFocusTimerRef
+} from './right-panel-comment-focus-timers'
+
+function createTimerRef(): RightPanelCommentFocusTimerRef {
+  return { current: null }
+}
+
+describe('right panel comment focus timers', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('clears pending deferred focus work', () => {
+    vi.useFakeTimers()
+    const timerRef = createTimerRef()
+    const callback = vi.fn()
+
+    scheduleRightPanelCommentFocusTimer(timerRef, callback)
+    clearRightPanelCommentFocusTimer(timerRef)
+    vi.runOnlyPendingTimers()
+
+    expect(timerRef.current).toBeNull()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('replaces stale deferred focus work', () => {
+    vi.useFakeTimers()
+    const timerRef = createTimerRef()
+    const staleCallback = vi.fn()
+    const nextCallback = vi.fn()
+
+    scheduleRightPanelCommentFocusTimer(timerRef, staleCallback)
+    scheduleRightPanelCommentFocusTimer(timerRef, nextCallback)
+    vi.runOnlyPendingTimers()
+
+    expect(staleCallback).not.toHaveBeenCalled()
+    expect(nextCallback).toHaveBeenCalledTimes(1)
+    expect(timerRef.current).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.ts
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.ts
@@ -1,0 +1,24 @@
+export type RightPanelCommentFocusTimerRef = {
+  current: ReturnType<typeof setTimeout> | null
+}
+
+export function clearRightPanelCommentFocusTimer(timerRef: RightPanelCommentFocusTimerRef): void {
+  if (timerRef.current === null) {
+    return
+  }
+  clearTimeout(timerRef.current)
+  timerRef.current = null
+}
+
+export function scheduleRightPanelCommentFocusTimer(
+  timerRef: RightPanelCommentFocusTimerRef,
+  callback: () => void
+): void {
+  // Why: right-sidebar panels can unmount before deferred focus work runs.
+  // Replacing the pending timer keeps stale focus callbacks from surviving.
+  clearRightPanelCommentFocusTimer(timerRef)
+  timerRef.current = setTimeout(() => {
+    timerRef.current = null
+    callback()
+  }, 0)
+}


### PR DESCRIPTION
## Summary
- own the right-sidebar comment composer autofocus timer through a cancellable ref
- clear deferred markdown selection focus work on unmount and ignore detached textareas
- add focused timer tests for clearing and replacing deferred focus callbacks

## Risk
Low. This only changes zero-delay focus timer ownership in the PR/comment composer; it does not change submit, markdown formatting, or review data flow.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.test.ts
- pnpm exec oxlint src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.ts src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.test.ts
- pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.ts src/renderer/src/components/right-sidebar/right-panel-comment-focus-timers.test.ts
- pnpm run typecheck:web
- git diff --check