### PR TITLE
perf: pause mobile session fallback polling

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -2383,14 +2383,20 @@ export default function SessionScreen() {
     return () => unsubscribe()
   }, [applySessionTabs, client, connState, worktreeId])
 
-  useEffect(() => {
-    if (connState !== 'connected') return
-    const interval = setInterval(() => {
+  useFocusEffect(
+    useCallback(() => {
+      if (connState !== 'connected') return
       void fetchSessionTabs()
       void fetchTerminals()
-    }, 2000)
-    return () => clearInterval(interval)
-  }, [connState, fetchSessionTabs, fetchTerminals])
+      // Why: the live tab subscription stays mounted for stream ownership,
+      // but the fallback list poll should stop while this route is hidden.
+      const interval = setInterval(() => {
+        void fetchSessionTabs()
+        void fetchTerminals()
+      }, 2000)
+      return () => clearInterval(interval)
+    }, [connState, fetchSessionTabs, fetchTerminals])
+  )
 
   // Why: unsubscribe the old terminal so the server restores its desktop dims
   // (clearing the phone-fit banner), then subscribe the new terminal with the


### PR DESCRIPTION
## Summary
- scope the mobile session fallback tab/terminal list poll to route focus
- keep an immediate refresh when the session screen is focused and connected
- leave live terminal/tab subscriptions mounted so stream ownership and phone-fit behavior do not change

## Risk
Low. This only removes the 2s fallback list poll while the route is blurred; foreground behavior refreshes immediately and keeps the existing cadence. Live subscriptions remain unchanged.

## Verification
- pnpm exec oxlint app/h/[hostId]/session/[worktreeId].tsx (mobile/)
- pnpm exec tsc --noEmit (mobile/)
- pnpm test (mobile/)
- git diff --check