### PR TITLE
fix: reset implicit ssh config host on edit

### DIFF
--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Plus, Upload } from 'lucide-react'
-import {
-  DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS,
-  MAX_SSH_RELAY_GRACE_PERIOD_SECONDS,
-  type SshTarget
-} from '../../../../shared/ssh-types'
+import { MAX_SSH_RELAY_GRACE_PERIOD_SECONDS, type SshTarget } from '../../../../shared/ssh-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../../../shared/constants'
 import { useAppStore } from '@/store'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -15,6 +11,7 @@ import { SshTargetCard } from './SshTargetCard'
 import { SshTargetDestructiveActions } from './SshTargetDestructiveActions'
 import { SshTargetForm, EMPTY_FORM, type EditingTarget } from './SshTargetForm'
 import {
+  getEditingTargetForSshTarget,
   getSshTargetDraftConnectionFields,
   isRelayGracePeriodValid,
   parseRelayGracePeriodSeconds
@@ -149,22 +146,7 @@ export function SshPane(_props: SshPaneProps): React.JSX.Element {
 
   const handleEdit = (target: SshTarget): void => {
     setEditingId(target.id)
-    setForm({
-      label: target.label,
-      configHost: target.configHost ?? target.host,
-      host: target.host,
-      port: String(target.port),
-      username: target.username,
-      identityFile: target.identityFile ?? '',
-      proxyCommand: target.proxyCommand ?? '',
-      jumpHost: target.jumpHost ?? '',
-      relayGracePeriodSeconds: String(
-        target.relayGracePeriodSeconds === 0
-          ? DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS
-          : (target.relayGracePeriodSeconds ?? DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS)
-      ),
-      relayKeepAliveUntilReset: target.relayGracePeriodSeconds === 0
-    })
+    setForm(getEditingTargetForSshTarget(target))
     setShowForm(true)
   }
 

--- a/src/renderer/src/components/settings/ssh-target-draft.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   EMPTY_FORM,
   applyParsedSshHostInput,
+  getEditingTargetForSshTarget,
   getSshTargetDraftConnectionFields,
   parseSshHostInput
 } from './ssh-target-draft'
@@ -89,6 +90,50 @@ describe('getSshTargetDraftConnectionFields', () => {
       host: 'prod-box',
       configHost: 'prod-box',
       username: '',
+      port: 22
+    })
+  })
+})
+
+describe('getEditingTargetForSshTarget', () => {
+  it('recomputes implicit configHost when a manual target host is edited', () => {
+    const draft = getEditingTargetForSshTarget({
+      id: 'ssh-1',
+      label: 'Server',
+      configHost: 'old.example.com',
+      host: 'old.example.com',
+      port: 22,
+      username: ''
+    })
+
+    expect(
+      getSshTargetDraftConnectionFields({
+        ...draft,
+        host: 'new.example.com'
+      })
+    ).toEqual({
+      host: 'new.example.com',
+      configHost: 'new.example.com',
+      username: '',
+      port: 22
+    })
+  })
+
+  it('preserves explicit SSH config aliases when editing imported targets', () => {
+    const draft = getEditingTargetForSshTarget({
+      id: 'ssh-1',
+      label: 'Production',
+      configHost: 'prod',
+      host: 'prod.internal',
+      port: 22,
+      username: 'deploy'
+    })
+
+    expect(draft.configHost).toBe('prod')
+    expect(getSshTargetDraftConnectionFields(draft)).toEqual({
+      host: 'prod.internal',
+      configHost: 'prod',
+      username: 'deploy',
       port: 22
     })
   })

--- a/src/renderer/src/components/settings/ssh-target-draft.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.ts
@@ -1,7 +1,8 @@
 import {
   DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS,
   MAX_SSH_RELAY_GRACE_PERIOD_SECONDS,
-  MIN_SSH_RELAY_GRACE_PERIOD_SECONDS
+  MIN_SSH_RELAY_GRACE_PERIOD_SECONDS,
+  type SshTarget
 } from '../../../../shared/ssh-types'
 
 export type EditingTarget = {
@@ -28,6 +29,28 @@ export const EMPTY_FORM: EditingTarget = {
   jumpHost: '',
   relayGracePeriodSeconds: String(DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS),
   relayKeepAliveUntilReset: false
+}
+
+export function getEditingTargetForSshTarget(target: SshTarget): EditingTarget {
+  // Why: manual targets store configHost as their host. Clear that implicit
+  // value on edit so changing Host recomputes the alias instead of keeping stale resolution.
+  const configHost = target.configHost && target.configHost !== target.host ? target.configHost : ''
+  return {
+    label: target.label,
+    configHost,
+    host: target.host,
+    port: String(target.port),
+    username: target.username,
+    identityFile: target.identityFile ?? '',
+    proxyCommand: target.proxyCommand ?? '',
+    jumpHost: target.jumpHost ?? '',
+    relayGracePeriodSeconds: String(
+      target.relayGracePeriodSeconds === 0
+        ? DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS
+        : (target.relayGracePeriodSeconds ?? DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS)
+    ),
+    relayKeepAliveUntilReset: target.relayGracePeriodSeconds === 0
+  }
 }
 
 export type ParsedSshHostInput = {


### PR DESCRIPTION
## Summary
- move SSH target-to-edit-draft conversion into a tested helper
- clear implicit `configHost` values when editing manual targets so host changes recompute the hidden alias
- preserve explicit SSH config aliases for imported targets, e.g. `prod -> prod.internal`

## Bug Evidence
Before the fix, an edit draft equivalent to changing a manual target from `old.example.com` to `new.example.com` produced this save payload:

```json
{
  "host": "new.example.com",
  "configHost": "old.example.com",
  "username": "",
  "port": 22
}
```

The settings card would show the edited host, but the hidden `configHost` stayed stale. That can make OpenSSH config resolution, remote workspace namespace hashing, and system-SSH fallback paths keep using the old host.

After the fix, manual targets clear the implicit config host when entering edit mode, so the same edit resolves to:

```json
{
  "draft": {
    "configHost": "",
    "host": "old.example.com"
  },
  "fields": {
    "host": "new.example.com",
    "configHost": "new.example.com",
    "username": "",
    "port": 22
  }
}
```

Imported SSH config aliases are still preserved:

```json
{
  "host": "prod.internal",
  "configHost": "prod",
  "username": "deploy",
  "port": 22
}
```

## Verification
- targeted `tsx` repro for the edit draft conversion
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ssh-target-draft.test.ts src/renderer/src/components/settings/ssh-target-action-state.test.ts src/renderer/src/components/settings/ssh-target-remove.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/settings/SshPane.tsx src/renderer/src/components/settings/ssh-target-draft.ts src/renderer/src/components/settings/ssh-target-draft.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/settings/SshPane.tsx src/renderer/src/components/settings/ssh-target-draft.ts src/renderer/src/components/settings/ssh-target-draft.test.ts`
- `git diff --check`
