### PR TITLE
perf: clean mobile task copy feedback timers

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -113,6 +113,10 @@ import {
 } from '../../../src/tasks/mobile-task-providers'
 import { MOBILE_TUI_AGENT_AUTO_PICK_ORDER } from '../../../src/tasks/mobile-tui-agents'
 import { resolveComposerBranchSelection } from '../../../src/tasks/mobile-composer-branch-selection'
+import {
+  clearMobileTaskCopyFeedbackTimer,
+  scheduleMobileTaskCopyFeedbackReset
+} from '../../../src/tasks/mobile-task-copy-feedback-timer'
 import type {
   BaseRefSearchResult,
   PersistedTrustedOrcaHooks,
@@ -2146,6 +2150,7 @@ export default function MobileTasksScreen() {
   const [prFileLoadingPath, setPrFileLoadingPath] = useState<string | null>(null)
   const [prFileCommentDrafts, setPrFileCommentDrafts] = useState<Record<string, string>>({})
   const [copiedLinkKey, setCopiedLinkKey] = useState<string | null>(null)
+  const copiedLinkResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [expandedResolvedCommentGroups, setExpandedResolvedCommentGroups] = useState<Set<string>>(
     () => new Set()
   )
@@ -3737,6 +3742,10 @@ export default function MobileTasksScreen() {
     }, 300)
     return () => clearTimeout(timer)
   }, [githubKind, provider, query, taskStateHydrated])
+
+  useEffect(() => {
+    return () => clearMobileTaskCopyFeedbackTimer(copiedLinkResetTimerRef)
+  }, [])
 
   useEffect(() => {
     if (!taskUiReady || provider !== 'github' || githubMode !== 'items') return
@@ -6809,9 +6818,7 @@ export default function MobileTasksScreen() {
     try {
       await Clipboard.setStringAsync(url)
       setCopiedLinkKey(key)
-      setTimeout(() => {
-        setCopiedLinkKey((current) => (current === key ? null : current))
-      }, 1500)
+      scheduleMobileTaskCopyFeedbackReset(copiedLinkResetTimerRef, key, setCopiedLinkKey)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to copy link')
     }
@@ -6821,9 +6828,7 @@ export default function MobileTasksScreen() {
     try {
       await Clipboard.setStringAsync(value)
       setCopiedLinkKey(key)
-      setTimeout(() => {
-        setCopiedLinkKey((current) => (current === key ? null : current))
-      }, 1500)
+      scheduleMobileTaskCopyFeedbackReset(copiedLinkResetTimerRef, key, setCopiedLinkKey)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to copy text')
     }

--- a/mobile/src/tasks/mobile-task-copy-feedback-timer.test.ts
+++ b/mobile/src/tasks/mobile-task-copy-feedback-timer.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearMobileTaskCopyFeedbackTimer,
+  scheduleMobileTaskCopyFeedbackReset,
+  type MobileTaskCopyFeedbackTimerRef
+} from './mobile-task-copy-feedback-timer'
+
+function createTimerRef(): MobileTaskCopyFeedbackTimerRef {
+  return { current: null }
+}
+
+function createCopiedKeyState(initial: string | null) {
+  let value = initial
+  return {
+    get value() {
+      return value
+    },
+    setCopiedKey(updater: (current: string | null) => string | null) {
+      value = updater(value)
+    }
+  }
+}
+
+describe('mobile task copy feedback timer', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('clears the copied key only when the scheduled key is still current', () => {
+    vi.useFakeTimers()
+    const timerRef = createTimerRef()
+    const copied = createCopiedKeyState('task:one')
+
+    scheduleMobileTaskCopyFeedbackReset(timerRef, 'task:one', copied.setCopiedKey)
+    copied.setCopiedKey(() => 'task:two')
+    vi.runOnlyPendingTimers()
+
+    expect(copied.value).toBe('task:two')
+    expect(timerRef.current).toBeNull()
+  })
+
+  it('replaces stale copy feedback timers', () => {
+    vi.useFakeTimers()
+    const timerRef = createTimerRef()
+    const copied = createCopiedKeyState('task:one')
+
+    scheduleMobileTaskCopyFeedbackReset(timerRef, 'task:one', copied.setCopiedKey)
+    copied.setCopiedKey(() => 'task:two')
+    scheduleMobileTaskCopyFeedbackReset(timerRef, 'task:two', copied.setCopiedKey)
+    vi.runOnlyPendingTimers()
+
+    expect(copied.value).toBeNull()
+    expect(timerRef.current).toBeNull()
+  })
+
+  it('cancels pending copy feedback work', () => {
+    vi.useFakeTimers()
+    const timerRef = createTimerRef()
+    const copied = createCopiedKeyState('task:one')
+
+    scheduleMobileTaskCopyFeedbackReset(timerRef, 'task:one', copied.setCopiedKey)
+    clearMobileTaskCopyFeedbackTimer(timerRef)
+    vi.runOnlyPendingTimers()
+
+    expect(copied.value).toBe('task:one')
+    expect(timerRef.current).toBeNull()
+  })
+})

--- a/mobile/src/tasks/mobile-task-copy-feedback-timer.ts
+++ b/mobile/src/tasks/mobile-task-copy-feedback-timer.ts
@@ -1,0 +1,28 @@
+export type MobileTaskCopyFeedbackTimerRef = {
+  current: ReturnType<typeof setTimeout> | null
+}
+
+type SetCopiedTaskKey = (updater: (current: string | null) => string | null) => void
+
+export function clearMobileTaskCopyFeedbackTimer(timerRef: MobileTaskCopyFeedbackTimerRef): void {
+  if (timerRef.current === null) {
+    return
+  }
+  clearTimeout(timerRef.current)
+  timerRef.current = null
+}
+
+export function scheduleMobileTaskCopyFeedbackReset(
+  timerRef: MobileTaskCopyFeedbackTimerRef,
+  key: string,
+  setCopiedKey: SetCopiedTaskKey,
+  delayMs = 1500
+): void {
+  // Why: task copy actions share one copied key; replacing the timer prevents
+  // an older copy from clearing newer feedback or surviving unmount.
+  clearMobileTaskCopyFeedbackTimer(timerRef)
+  timerRef.current = setTimeout(() => {
+    timerRef.current = null
+    setCopiedKey((current) => (current === key ? null : current))
+  }, delayMs)
+}


### PR DESCRIPTION
## Summary
- replace independent mobile Tasks copy-feedback reset timers with one owned timer ref
- clear pending copied-key reset work on unmount
- add focused fake-timer coverage for replacement, cancellation, and stale-key protection

## Risk
Low. This only changes transient mobile Tasks copy feedback timer ownership; clipboard writes, copied labels, and task data flow stay unchanged.

## Verification
- pnpm exec vitest run src/tasks/mobile-task-copy-feedback-timer.test.ts (mobile/)
- pnpm exec oxlint app/h/[hostId]/tasks.tsx src/tasks/mobile-task-copy-feedback-timer.ts src/tasks/mobile-task-copy-feedback-timer.test.ts (mobile/)
- pnpm exec oxfmt --check app/h/[hostId]/tasks.tsx src/tasks/mobile-task-copy-feedback-timer.ts src/tasks/mobile-task-copy-feedback-timer.test.ts (mobile/)
- pnpm exec tsc --noEmit (mobile/)
- git diff --check