### PR TITLE
fix: preserve quick open newline excludes

### DIFF
--- a/src/renderer/src/components/quick-open-file-list.test.ts
+++ b/src/renderer/src/components/quick-open-file-list.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../shared/types'
-import { getNestedWorktreeExcludePaths, isNestedWorktreePath } from './quick-open-file-list'
+import { buildExcludePathPrefixes } from '../../../shared/quick-open-filter'
+import {
+  getNestedWorktreeExcludePaths,
+  getNestedWorktreeExcludeRequest,
+  isNestedWorktreePath
+} from './quick-open-file-list'
 
 function makeWorktree(id: string, path: string): Worktree {
   return {
@@ -40,5 +45,16 @@ describe('quick-open nested worktree excludes', () => {
         makeWorktree('sibling', '//server/share/repo2')
       ])
     ).toEqual(['//server/share/repo/packages/app'])
+  })
+
+  it('keeps newline-containing nested worktree paths intact for listFiles requests', () => {
+    const request = getNestedWorktreeExcludeRequest('root', '/tmp/repo', [
+      makeWorktree('root', '/tmp/repo'),
+      makeWorktree('nested', '/tmp/repo/linked\nworktree')
+    ])
+
+    expect(request.paths).toEqual(['/tmp/repo/linked\nworktree'])
+    expect(request.key).toBe('["/tmp/repo/linked\\nworktree"]')
+    expect(buildExcludePathPrefixes('/tmp/repo', request.paths)).toEqual(['linked\nworktree'])
   })
 })

--- a/src/renderer/src/components/quick-open-file-list.ts
+++ b/src/renderer/src/components/quick-open-file-list.ts
@@ -42,6 +42,25 @@ export function getNestedWorktreeExcludePaths(
     .sort()
 }
 
+export type NestedWorktreeExcludeRequest = {
+  paths: string[]
+  key: string
+}
+
+export function getNestedWorktreeExcludeRequest(
+  worktreeId: string | null,
+  worktreePath: string | null,
+  repoWorktrees: readonly Worktree[]
+): NestedWorktreeExcludeRequest {
+  if (!worktreeId || !worktreePath || repoWorktrees.length === 0) {
+    return { paths: [], key: '[]' }
+  }
+  const paths = getNestedWorktreeExcludePaths(worktreeId, worktreePath, repoWorktrees)
+  // Why: worktree paths can contain newlines. Use JSON as a stable dependency
+  // key while passing the original array to IPC so paths stay lossless.
+  return { paths, key: JSON.stringify(paths) }
+}
+
 export function useRuntimeFileListForWorktree({
   enabled,
   worktreeId
@@ -57,12 +76,10 @@ export function useRuntimeFileListForWorktree({
   const lastRequestKeyRef = useRef('')
 
   const worktreePath = worktree?.path ?? null
-  const excludePathsKey = useMemo(() => {
-    if (!worktreeId || !worktreePath || repoWorktrees.length === 0) {
-      return ''
-    }
-    return getNestedWorktreeExcludePaths(worktreeId, worktreePath, repoWorktrees).join('\n')
-  }, [repoWorktrees, worktreeId, worktreePath])
+  const excludeRequest = useMemo(
+    () => getNestedWorktreeExcludeRequest(worktreeId, worktreePath, repoWorktrees),
+    [repoWorktrees, worktreeId, worktreePath]
+  )
 
   const connectionId = useMemo(() => getConnectionId(worktreeId) ?? undefined, [worktreeId])
   const activeTargetStatus = useAppStore((state) =>
@@ -74,8 +91,8 @@ export function useRuntimeFileListForWorktree({
     activeTargetStatus === 'reconnecting'
   const requestKey = useMemo(
     () =>
-      `${worktreePath ?? ''}\n${connectionId ?? ''}\n${excludePathsKey}\n${activeTargetStatus ?? ''}`,
-    [activeTargetStatus, connectionId, excludePathsKey, worktreePath]
+      `${worktreePath ?? ''}\n${connectionId ?? ''}\n${excludeRequest.key}\n${activeTargetStatus ?? ''}`,
+    [activeTargetStatus, connectionId, excludeRequest.key, worktreePath]
   )
 
   useEffect(() => {
@@ -100,7 +117,7 @@ export function useRuntimeFileListForWorktree({
     setLoadError(null)
     setLoading(true)
 
-    const excludePaths = excludePathsKey ? excludePathsKey.split('\n') : undefined
+    const excludePaths = excludeRequest.paths.length > 0 ? excludeRequest.paths : undefined
 
     void listRuntimeFiles(
       {
@@ -134,7 +151,7 @@ export function useRuntimeFileListForWorktree({
     return () => {
       cancelled = true
     }
-  }, [connectionId, enabled, excludePathsKey, requestKey, worktreeId, worktreePath])
+  }, [connectionId, enabled, excludeRequest, requestKey, worktreeId, worktreePath])
 
   return { files, loading: loading || connectionPending, loadError }
 }


### PR DESCRIPTION
## Summary
- keep nested worktree exclude paths as an array when Quick Open asks `listFiles` for a worktree
- use JSON only as the stable request key so valid paths containing newlines are not split into fake paths
- add regression coverage for newline-containing nested worktree paths

## Evidence
- Before fix repro of the request-shaping logic: a nested exclude path `/tmp/repo/linked\nworktree` became request paths `["/tmp/repo/linked", "worktree"]`, and `buildExcludePathPrefixes('/tmp/repo', ...)` produced the wrong prefix `linked` instead of `linked\nworktree`.
- After fix: `getNestedWorktreeExcludeRequest()` keeps `paths: ["/tmp/repo/linked\nworktree"]`, uses key `["/tmp/repo/linked\\nworktree"]`, and `buildExcludePathPrefixes('/tmp/repo', request.paths)` returns `linked\nworktree`.

## Checks
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-file-list.test.ts src/shared/quick-open-filter.test.ts`
- `pnpm run typecheck:web`
- targeted `pnpm exec oxlint ...`
- targeted `pnpm exec oxfmt --check ...`
- `git diff --check`
