### PR TITLE
perf: defer hidden picker option rows

### DIFF
--- a/mobile/src/components/PickerModal.tsx
+++ b/mobile/src/components/PickerModal.tsx
@@ -23,6 +23,11 @@ type Props<T extends string = string> = {
   zIndex?: number
 }
 
+type PickerModalContentProps<T extends string = string> = Pick<
+  Props<T>,
+  'options' | 'selected' | 'onSelect' | 'onLongSelect' | 'onClose'
+>
+
 export function PickerModal<T extends string = string>({
   visible,
   title,
@@ -39,50 +44,70 @@ export function PickerModal<T extends string = string>({
         <Text style={styles.title}>{title}</Text>
       </View>
 
-      <View style={styles.group}>
-        {options.map((opt, i) => {
-          const isSelected = opt.value === selected
-          return (
-            <View key={opt.value}>
-              {i > 0 && <View style={styles.separator} />}
-              <Pressable
-                disabled={opt.disabled}
-                style={({ pressed }) => [
-                  styles.row,
-                  pressed && !opt.disabled && styles.rowPressed,
-                  opt.disabled && styles.rowDisabled
-                ]}
-                onPress={() => {
-                  if (opt.disabled) return
-                  onSelect(opt.value)
-                  onClose()
-                }}
-                onLongPress={
-                  onLongSelect
-                    ? () => {
-                        if (opt.disabled) return
-                        onLongSelect(opt.value)
-                        onClose()
-                      }
-                    : undefined
-                }
-              >
-                {opt.renderIcon ? (
-                  <View style={styles.rowIcon}>{opt.renderIcon(isSelected)}</View>
-                ) : null}
-                <View style={styles.rowContent}>
-                  <Text style={[styles.rowLabel, isSelected && styles.rowLabelSelected]}>
-                    {opt.label}
-                  </Text>
-                  {opt.subtitle ? <Text style={styles.rowSubtitle}>{opt.subtitle}</Text> : null}
-                </View>
-                {isSelected && <Check size={16} color={colors.textPrimary} />}
-              </Pressable>
-            </View>
-          )
-        })}
-      </View>
+      <PickerModalContent
+        options={options}
+        selected={selected}
+        onSelect={onSelect}
+        onLongSelect={onLongSelect}
+        onClose={onClose}
+      />
     </BottomDrawer>
+  )
+}
+
+function PickerModalContent<T extends string = string>({
+  options,
+  selected,
+  onSelect,
+  onLongSelect,
+  onClose
+}: PickerModalContentProps<T>) {
+  // Why: closed BottomDrawer instances return null, so keeping option rows in
+  // this child avoids rebuilding hidden picker contents on every parent render.
+  return (
+    <View style={styles.group}>
+      {options.map((opt, i) => {
+        const isSelected = opt.value === selected
+        return (
+          <View key={opt.value}>
+            {i > 0 && <View style={styles.separator} />}
+            <Pressable
+              disabled={opt.disabled}
+              style={({ pressed }) => [
+                styles.row,
+                pressed && !opt.disabled && styles.rowPressed,
+                opt.disabled && styles.rowDisabled
+              ]}
+              onPress={() => {
+                if (opt.disabled) return
+                onSelect(opt.value)
+                onClose()
+              }}
+              onLongPress={
+                onLongSelect
+                  ? () => {
+                      if (opt.disabled) return
+                      onLongSelect(opt.value)
+                      onClose()
+                    }
+                  : undefined
+              }
+            >
+              {opt.renderIcon ? (
+                <View style={styles.rowIcon}>{opt.renderIcon(isSelected)}</View>
+              ) : null}
+              <View style={styles.rowContent}>
+                <Text style={[styles.rowLabel, isSelected && styles.rowLabelSelected]}>
+                  {opt.label}
+                </Text>
+                {opt.subtitle ? <Text style={styles.rowSubtitle}>{opt.subtitle}</Text> : null}
+              </View>
+              {isSelected && <Check size={16} color={colors.textPrimary} />}
+            </Pressable>
+          </View>
+        )
+      })}
+    </View>
   )
 }
 


### PR DESCRIPTION
## Summary
- move PickerModal row rendering into a child component so closed BottomDrawer pickers avoid mapping option rows on parent renders
- keep the visible picker UI and selection behavior unchanged

## Risk
Low. This only changes where the same JSX rows are constructed; BottomDrawer still owns mount/close animation behavior.

## Verification
- cd mobile && pnpm exec oxlint src/components/PickerModal.tsx app/h/[hostId]/tasks.tsx
- cd mobile && pnpm exec tsc --noEmit
- cd mobile && pnpm test
- git diff --check