### PR TITLE
fix: sniff csv delimiters outside quotes

### DIFF
--- a/src/renderer/src/components/editor/csv-parse.test.ts
+++ b/src/renderer/src/components/editor/csv-parse.test.ts
@@ -83,4 +83,14 @@ describe('detectCsvDelimiter', () => {
   it('strips a leading BOM before sniffing', () => {
     expect(detectCsvDelimiter('x.csv', '\uFEFFa\tb\tc')).toBe('\t')
   })
+
+  it('ignores delimiters inside quoted fields when sniffing', () => {
+    const content = '"Doe, Jane"\tAge\n"Roe, John"\t42\n'
+
+    expect(detectCsvDelimiter('contacts.csv', content)).toBe('\t')
+    expect(parseCsv(content, detectCsvDelimiter('contacts.csv', content)).rows).toEqual([
+      ['Doe, Jane', 'Age'],
+      ['Roe, John', '42']
+    ])
+  })
 })

--- a/src/renderer/src/components/editor/csv-parse.ts
+++ b/src/renderer/src/components/editor/csv-parse.ts
@@ -122,7 +122,27 @@ export function detectCsvDelimiter(filePath: string, content: string): string {
       break
     }
   }
-  const tabs = (firstLine.match(/\t/g) ?? []).length
-  const commas = (firstLine.match(/,/g) ?? []).length
+  const tabs = countDelimiterOutsideQuotes(firstLine, '\t')
+  const commas = countDelimiterOutsideQuotes(firstLine, ',')
   return tabs > commas ? '\t' : ','
+}
+
+function countDelimiterOutsideQuotes(line: string, delimiter: string): number {
+  let count = 0
+  let inQuotes = false
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i]
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        i += 1
+      } else {
+        inQuotes = !inQuotes
+      }
+      continue
+    }
+    if (!inQuotes && ch === delimiter) {
+      count += 1
+    }
+  }
+  return count
 }


### PR DESCRIPTION
## Summary
- ignore commas/tabs inside quoted fields when sniffing CSV vs TSV delimiter
- add regression coverage for a tab-delimited `.csv` whose quoted names contain commas

## Evidence
- Before fix repro: for `"Doe, Jane"\tAge\n"Roe, John"\t42\n`, `detectCsvDelimiter('contacts.csv', content)` returned comma, and `parseCsv` rendered one column: `Doe, Jane\tAge`.
- After fix repro: the same content detects tab and parses two columns: `Doe, Jane | Age`, `Roe, John | 42`.

## Checks
- `pnpm exec tsx -e "import { detectCsvDelimiter, parseCsv } from './src/renderer/src/components/editor/csv-parse.ts'; const content='\"Doe, Jane\"\tAge\n\"Roe, John\"\t42\n'; const delimiter=detectCsvDelimiter('contacts.csv', content); console.log(JSON.stringify({ delimiter: delimiter === '\\t' ? 'tab' : delimiter, rows: parseCsv(content, delimiter).rows }, null, 2));"`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/csv-parse.test.ts`
- `pnpm run typecheck:web`
- targeted `pnpm exec oxlint ...`
- targeted `pnpm exec oxfmt --check ...`
- `git diff --check`
