### PR TITLE
fix: parse empty markdown front matter

### DIFF
--- a/src/renderer/src/components/editor/markdown-frontmatter.test.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter.test.ts
@@ -49,6 +49,26 @@ describe('extractFrontMatter', () => {
     expect(result!.raw).toBe('---\n\n---\n')
     expect(result!.body).toBe('# Body\n')
   })
+
+  it('handles empty front-matter block without a blank line', () => {
+    const content = '---\n---\n# Body\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.raw).toBe('---\n---\n')
+    expect(result!.body).toBe('# Body\n')
+  })
+
+  it('handles empty TOML front-matter block without a blank line', () => {
+    const content = '+++\n+++\nBody\n'
+    const result = extractFrontMatter(content)
+    expect(result).not.toBeNull()
+    expect(result!.raw).toBe('+++\n+++\n')
+    expect(result!.body).toBe('Body\n')
+  })
+
+  it('does not treat same-line delimiter text as a closing delimiter', () => {
+    expect(extractFrontMatter('---\ntitle: Hello---\n# Body\n')).toBeNull()
+  })
 })
 
 describe('prependFrontMatter', () => {

--- a/src/renderer/src/components/editor/markdown-frontmatter.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter.ts
@@ -1,4 +1,4 @@
-const FRONTMATTER_RE = /^(---|\+\+\+)\r?\n([\s\S]*?)\r?\n\1(?:\r?\n|$)/
+const FRONTMATTER_RE = /^(---|\+\+\+)\r?\n(?:[\s\S]*?\r?\n)?\1(?:\r?\n|$)/
 
 export type FrontMatter = {
   /** The full raw front-matter block including delimiters and trailing newline. */


### PR DESCRIPTION
## Summary
- parse empty YAML/TOML front-matter blocks whose closing delimiter immediately follows the opening delimiter
- keep same-line delimiter text from being treated as a closing delimiter
- add regression coverage for empty YAML and TOML blocks

## Repro
Before the fix, `extractFrontMatter('---\n---\n# Body\n')` and `extractFrontMatter('+++\n+++\nBody\n')` returned `null`, so the editor/preview treated the delimiters as document body instead of front matter. After the fix they return raw front matter plus the expected body, while `---\ntitle: Hello---\n# Body\n` still does not match.

## Checks
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/markdown-frontmatter.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/editor/markdown-frontmatter.ts src/renderer/src/components/editor/markdown-frontmatter.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/editor/markdown-frontmatter.ts src/renderer/src/components/editor/markdown-frontmatter.test.ts`
- `git diff --check`