### PR TITLE
fix: align hourly automation start times

### DIFF
--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -32,6 +32,16 @@ describe('automation schedules', () => {
     expect(latest).toBe(new Date('2026-05-13T14:00:00').getTime())
   })
 
+  it('does not return a future hourly dtstart that is off the scheduled minute', () => {
+    const rrule = buildAutomationRrule({ preset: 'hourly', hour: 9, minute: 0 })
+    const next = nextAutomationOccurrenceAfter(
+      rrule,
+      new Date('2026-05-13T10:30:00').getTime(),
+      new Date('2026-05-13T09:00:00').getTime()
+    )
+    expect(next).toBe(new Date('2026-05-13T11:00:00').getTime())
+  })
+
   it('computes weekday schedules without returning weekend candidates', () => {
     const rrule = buildAutomationRrule({ preset: 'weekdays', hour: 9, minute: 30 })
     const next = nextAutomationOccurrenceAfter(

--- a/src/shared/automation-schedules.ts
+++ b/src/shared/automation-schedules.ts
@@ -541,10 +541,10 @@ export function nextAutomationOccurrenceAfter(
     const base = new Date(start)
     base.setMinutes(rule.byMinute, 0, 0)
     let candidate = base.getTime()
-    if (candidate <= after) {
+    if (candidate <= after || candidate < dtstart) {
       candidate += HOUR_MS
     }
-    return Math.max(candidate, dtstart)
+    return candidate
   }
   const candidate = scanDayCandidates(rule, Math.max(dtstart - 1, after), 1)
   if (candidate === null) {


### PR DESCRIPTION
## Summary
- avoid returning `dtstart` as the next hourly occurrence when it is not on the scheduled minute
- advance to the next valid hourly boundary when the schedule starts after this hour's run minute
- add regression coverage for a future `dtstart` at `:30` with an hourly-at-`:00` rule

## Repro
Before the fix:

```ts
const rrule = buildAutomationRrule({ preset: "hourly", hour: 9, minute: 0 })
nextAutomationOccurrenceAfter(
  rrule,
  new Date("2026-05-13T10:30:00").getTime(),
  new Date("2026-05-13T09:00:00").getTime()
)
```

returned `2026-05-13T10:30:00` local time, so an hourly-at-`:00` automation could be scheduled at minute `30`. After the fix, the same repro returns `2026-05-13T11:00:00` local time.

## Checks
- `pnpm exec tsx -e "...nextAutomationOccurrenceAfter repro..."`
- `pnpm vitest run --config config/vitest.config.ts src/shared/automation-schedules.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run typecheck:cli`
- `pnpm exec oxlint src/shared/automation-schedules.ts src/shared/automation-schedules.test.ts`
- `pnpm exec oxfmt --check src/shared/automation-schedules.ts src/shared/automation-schedules.test.ts`
- `git diff --check`