### PR TITLE
fix: preserve automation output snapshot tail

### DIFF
--- a/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
@@ -73,6 +73,19 @@ describe('automation run output snapshot buffer', () => {
     })
   })
 
+  it('keeps the tail of earlier chunks when a later chunk crosses the size cap', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('A'.repeat(256 * 1024))
+    buffer.append('TAIL')
+
+    const snapshot = buffer.snapshot()
+    expect(snapshot?.content).toHaveLength(256 * 1024)
+    expect(snapshot?.content.startsWith('A')).toBe(true)
+    expect(snapshot?.content.endsWith('TAIL')).toBe(true)
+    expect(snapshot?.truncated).toBe(true)
+  })
+
   it('creates a saved snapshot from agent transcript text', () => {
     expect(createAutomationRunOutputSnapshotFromText('\nFinal summary.\n')).toEqual({
       format: 'plain_text',

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.ts
@@ -65,14 +65,20 @@ export function createAutomationRunOutputSnapshotBuffer(): AutomationRunOutputSn
       }
       chunks.push(chunk)
       totalChars += chunk.length
-      while (totalChars > MAX_OUTPUT_SNAPSHOT_CHARS && chunks.length > 1) {
-        totalChars -= chunks.shift()!.length
+      let overflowChars = totalChars - MAX_OUTPUT_SNAPSHOT_CHARS
+      while (overflowChars > 0 && chunks.length > 0) {
+        const firstChunk = chunks[0]
+        if (firstChunk.length <= overflowChars) {
+          chunks.shift()
+          totalChars -= firstChunk.length
+          overflowChars -= firstChunk.length
+          truncated = true
+          continue
+        }
+        chunks[0] = firstChunk.slice(overflowChars)
+        totalChars -= overflowChars
         truncated = true
-      }
-      if (totalChars > MAX_OUTPUT_SNAPSHOT_CHARS && chunks.length === 1) {
-        chunks[0] = chunks[0].slice(-MAX_OUTPUT_SNAPSHOT_CHARS)
-        totalChars = chunks[0].length
-        truncated = true
+        overflowChars = 0
       }
     },
     snapshot() {


### PR DESCRIPTION
## Summary
- trim oversized automation output snapshots by the exact overflow amount instead of dropping the whole oldest chunk
- preserve the latest 256 KiB across chunk boundaries
- add regression coverage for a full-size chunk followed by a small final chunk

## Repro
Before the fix:

```ts
const buffer = createAutomationRunOutputSnapshotBuffer()
buffer.append("A".repeat(256 * 1024))
buffer.append("TAIL")
buffer.snapshot()?.content
```

returned only `TAIL` with length `4`, so the saved automation run snapshot lost the previous output when the final chunk crossed the cap. After the fix, the same repro returns length `262144`, starts with retained `A` content, ends with `TAIL`, and remains marked `truncated: true`.

## Checks
- `pnpm exec tsx -e "...createAutomationRunOutputSnapshotBuffer repro..."`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/automations/automation-run-output-snapshot.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/automations/automation-run-output-snapshot.ts src/renderer/src/components/automations/automation-run-output-snapshot.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/automations/automation-run-output-snapshot.ts src/renderer/src/components/automations/automation-run-output-snapshot.test.ts`
- `git diff --check`