### PR TITLE
fix: dispose file watch batcher on early abort

### DIFF
--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -194,6 +194,53 @@ describe('file RPC methods', () => {
     expect(replies).toEqual([])
   })
 
+  it('drops queued file watch events when aborted before setup resolves', async () => {
+    vi.useFakeTimers()
+    try {
+      type WatchCallback = (
+        events: { kind: 'update'; absolutePath: string; isDirectory?: boolean }[]
+      ) => void
+      const unwatch = vi.fn()
+      let resolveWatch: (value: () => void) => void = () => {}
+      const watchFileExplorer = vi.fn((_worktree: string, callback: WatchCallback) => {
+        callback([{ kind: 'update', absolutePath: '/repo/queued.ts', isDirectory: false }])
+        return new Promise<() => void>((resolve) => {
+          resolveWatch = resolve
+        })
+      })
+      const runtime = {
+        getRuntimeId: () => 'test-runtime',
+        watchFileExplorer,
+        registerSubscriptionCleanup: vi.fn()
+      } as unknown as OrcaRuntimeService
+      const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
+      const abortController = new AbortController()
+      const replies: unknown[] = []
+
+      const dispatch = dispatcher.dispatchStreaming(
+        makeRequest('files.watch', { worktree: 'id:wt-1' }),
+        (response) => replies.push(JSON.parse(response)),
+        { connectionId: 'conn-1', signal: abortController.signal }
+      )
+      await vi.waitFor(() => {
+        expect(watchFileExplorer).toHaveBeenCalled()
+      })
+
+      abortController.abort()
+      await dispatch
+      await vi.runOnlyPendingTimersAsync()
+      resolveWatch(unwatch)
+      await vi.waitFor(() => {
+        expect(unwatch).toHaveBeenCalled()
+      })
+
+      expect(runtime.registerSubscriptionCleanup).not.toHaveBeenCalled()
+      expect(replies).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('reads a relative file path for a selected worktree', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -300,6 +300,9 @@ export const FILE_METHODS: RpcAnyMethod[] = [
           if (unwatch) {
             cleanup()
           } else {
+            // Why: watch setup may have queued events before resolving its
+            // unwatch callback. Dispose that transient batcher on early abort.
+            eventBatcher.dispose()
             finish()
           }
         }
@@ -313,6 +316,7 @@ export const FILE_METHODS: RpcAnyMethod[] = [
               // Why: the connection can close while watch setup is still
               // resolving. Tear down the late watcher immediately instead of
               // registering cleanup on a connection that was already reaped.
+              eventBatcher.dispose()
               nextUnwatch()
               return
             }


### PR DESCRIPTION
## Summary
- dispose the transient file-watch event batcher when a files.watch stream aborts before watcher setup resolves
- dispose again if the watcher resolves late after the stream has already settled
- add a regression covering queued watch events before early abort

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/files.test.ts src/main/runtime/rpc/methods/file-watch-event-batcher.test.ts
- pnpm run typecheck:node
- pnpm exec oxlint src/main/runtime/rpc/methods/files.ts src/main/runtime/rpc/methods/files.test.ts src/main/runtime/rpc/methods/file-watch-event-batcher.ts src/main/runtime/rpc/methods/file-watch-event-batcher.test.ts
- pnpm exec oxfmt --check src/main/runtime/rpc/methods/files.ts src/main/runtime/rpc/methods/files.test.ts src/main/runtime/rpc/methods/file-watch-event-batcher.ts src/main/runtime/rpc/methods/file-watch-event-batcher.test.ts
- git diff --check

## Merge risk assessment
Risk: LOW

Reasoning: change is limited to the aborted setup path for files.watch. Ready watchers keep the same cleanup behavior, and the new regression proves queued events are discarded and late unwatch is invoked after abort. No Electron UI behavior changed.