### PR TITLE
perf: clean mobile diagnostic fetch timeout

### DIFF
--- a/mobile/app/troubleshoot.tsx
+++ b/mobile/app/troubleshoot.tsx
@@ -26,6 +26,10 @@ import {
 } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import { loadHosts } from '../src/transport/host-store'
+import {
+  startDiagnosticFetchTimeout,
+  type DiagnosticFetchTimeout
+} from '../src/diagnostics/diagnostic-fetch-timeout'
 
 type DiagnosticStatus = 'idle' | 'running' | 'done'
 
@@ -113,10 +117,15 @@ export default function TroubleshootScreen() {
   const [diagnosticStatus, setDiagnosticStatus] = useState<DiagnosticStatus>('idle')
   const [checks, setChecks] = useState<CheckResult[]>([])
   const abortRef = useRef(false)
+  const diagnosticRunRef = useRef(0)
+  const activeInternetCheckRef = useRef<DiagnosticFetchTimeout | null>(null)
 
   useEffect(() => {
     return () => {
       abortRef.current = true
+      diagnosticRunRef.current += 1
+      activeInternetCheckRef.current?.dispose()
+      activeInternetCheckRef.current = null
     }
   }, [])
 
@@ -125,11 +134,16 @@ export default function TroubleshootScreen() {
   }, [])
 
   const runDiagnostics = useCallback(async () => {
+    const runId = diagnosticRunRef.current + 1
+    diagnosticRunRef.current = runId
     abortRef.current = false
+    activeInternetCheckRef.current?.dispose()
+    activeInternetCheckRef.current = null
     setDiagnosticStatus('running')
     setChecks([])
 
     const results: CheckResult[] = []
+    const isCurrentRun = () => !abortRef.current && diagnosticRunRef.current === runId
 
     try {
       const hosts = await loadHosts()
@@ -142,33 +156,40 @@ export default function TroubleshootScreen() {
       results.push({ label: 'Paired hosts', status: 'warn', detail: 'Could not read host data' })
     }
 
-    if (abortRef.current) return
+    if (!isCurrentRun()) return
     setChecks([...results])
 
+    const internetCheck = startDiagnosticFetchTimeout(5000)
+    activeInternetCheckRef.current = internetCheck
     try {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 5000)
       const resp = await fetch('https://dns.google/resolve?name=example.com&type=A', {
-        signal: controller.signal
+        signal: internetCheck.signal
       })
-      clearTimeout(timeout)
+      if (!isCurrentRun()) return
       results.push(
         resp.ok
           ? { label: 'Internet', status: 'pass', detail: 'Connected' }
           : { label: 'Internet', status: 'warn', detail: 'Unexpected response' }
       )
     } catch {
+      if (!isCurrentRun()) return
       results.push({ label: 'Internet', status: 'fail', detail: 'No connection' })
+    } finally {
+      internetCheck.dispose()
+      if (activeInternetCheckRef.current === internetCheck) {
+        activeInternetCheckRef.current = null
+      }
     }
 
-    if (abortRef.current) return
+    if (!isCurrentRun()) return
     setChecks([...results])
 
     try {
       const hosts = await loadHosts()
       for (const host of hosts) {
-        if (abortRef.current) return
+        if (!isCurrentRun()) return
         const reachable = await testHostReachability(host.endpoint)
+        if (!isCurrentRun()) return
         results.push({
           label: host.name,
           status: reachable ? 'pass' : 'fail',
@@ -182,7 +203,7 @@ export default function TroubleshootScreen() {
       results.push({ label: 'Hosts', status: 'warn', detail: 'Could not test' })
     }
 
-    if (abortRef.current) return
+    if (!isCurrentRun()) return
 
     results.push({
       label: 'Platform',

--- a/mobile/src/diagnostics/diagnostic-fetch-timeout.test.ts
+++ b/mobile/src/diagnostics/diagnostic-fetch-timeout.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { startDiagnosticFetchTimeout } from './diagnostic-fetch-timeout'
+
+describe('diagnostic fetch timeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('aborts when the timeout fires', () => {
+    vi.useFakeTimers()
+    const attempt = startDiagnosticFetchTimeout(5000)
+
+    expect(attempt.signal.aborted).toBe(false)
+    expect(attempt.timedOut).toBe(false)
+
+    vi.advanceTimersByTime(5000)
+
+    expect(attempt.signal.aborted).toBe(true)
+    expect(attempt.timedOut).toBe(true)
+  })
+
+  it('clears the timeout when disposed early', () => {
+    vi.useFakeTimers()
+    const attempt = startDiagnosticFetchTimeout(5000)
+
+    attempt.dispose()
+    expect(attempt.signal.aborted).toBe(true)
+    expect(attempt.timedOut).toBe(false)
+
+    vi.advanceTimersByTime(5000)
+    expect(attempt.timedOut).toBe(false)
+  })
+})

--- a/mobile/src/diagnostics/diagnostic-fetch-timeout.ts
+++ b/mobile/src/diagnostics/diagnostic-fetch-timeout.ts
@@ -1,0 +1,36 @@
+export type DiagnosticFetchTimeout = {
+  readonly signal: AbortSignal
+  readonly timedOut: boolean
+  dispose: () => void
+}
+
+export function startDiagnosticFetchTimeout(timeoutMs: number): DiagnosticFetchTimeout {
+  const controller = new AbortController()
+  let disposed = false
+  let timedOut = false
+  let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+    timer = null
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+
+  function dispose() {
+    if (disposed) return
+    disposed = true
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    if (!controller.signal.aborted) {
+      controller.abort()
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    get timedOut() {
+      return timedOut
+    },
+    dispose
+  }
+}


### PR DESCRIPTION
## Summary
- clear/abort the mobile Troubleshooting internet-check timeout on success, failure, retry, and unmount
- ignore stale diagnostic runs after a newer run starts
- add focused fake-timer coverage for timeout and early-dispose cleanup

## Risk
Low. This only affects the mobile Troubleshooting diagnostics screen and preserves the same visible pass/warn/fail results while cleaning up stale timeout/fetch work.

## Verification
- cd mobile && pnpm exec vitest run src/diagnostics/diagnostic-fetch-timeout.test.ts
- cd mobile && pnpm exec oxlint app/troubleshoot.tsx src/diagnostics/diagnostic-fetch-timeout.ts src/diagnostics/diagnostic-fetch-timeout.test.ts
- cd mobile && pnpm exec oxfmt --check app/troubleshoot.tsx src/diagnostics/diagnostic-fetch-timeout.ts src/diagnostics/diagnostic-fetch-timeout.test.ts
- cd mobile && pnpm exec tsc --noEmit
- cd mobile && pnpm test
- git diff --check origin/main...HEAD
