### PR TITLE
fix: reuse automation split-pane pty

### DIFF
--- a/src/renderer/src/lib/automation-session-reuse.test.ts
+++ b/src/renderer/src/lib/automation-session-reuse.test.ts
@@ -5,6 +5,8 @@ import { findReusableAutomationSession } from './automation-session-reuse'
 
 const leafId = '11111111-1111-4111-8111-111111111111'
 const paneKey = `tab-1:${leafId}`
+const splitLeafId = '22222222-2222-4222-8222-222222222222'
+const splitPaneKey = `tab-1:${splitLeafId}`
 
 function run(overrides: Partial<AutomationRun>): AutomationRun {
   return {
@@ -56,6 +58,10 @@ describe('automation session reuse', () => {
       state: {
         agentStatusByPaneKey: { [paneKey]: status() },
         ptyIdsByTabId: { 'tab-1': ['pty-1'], 'tab-old': ['pty-old'] },
+        terminalLayoutsByTabId: {
+          'tab-1': { ptyIdsByLeafId: { [leafId]: 'pty-1' } },
+          'tab-old': { ptyIdsByLeafId: {} }
+        },
         unifiedTabsByWorktree: {
           'wt-1': [
             { contentType: 'terminal', entityId: 'tab-1' },
@@ -68,6 +74,35 @@ describe('automation session reuse', () => {
     expect(session).toEqual({ tabId: 'tab-1', ptyId: 'pty-1', paneKey })
   })
 
+  it('uses the PTY that belongs to the matched split-pane leaf', () => {
+    const session = findReusableAutomationSession({
+      automationId: 'auto-1',
+      agentId: 'claude',
+      worktreeId: 'wt-1',
+      currentRunId: 'run-current',
+      runs: [run({ id: 'run-new', terminalSessionId: 'tab-1', createdAt: 2 })],
+      state: {
+        agentStatusByPaneKey: {
+          [splitPaneKey]: status({ paneKey: splitPaneKey })
+        },
+        ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            ptyIdsByLeafId: {
+              [leafId]: 'pty-left',
+              [splitLeafId]: 'pty-right'
+            }
+          }
+        },
+        unifiedTabsByWorktree: {
+          'wt-1': [{ contentType: 'terminal', entityId: 'tab-1' }]
+        }
+      } as never
+    })
+
+    expect(session).toEqual({ tabId: 'tab-1', ptyId: 'pty-right', paneKey: splitPaneKey })
+  })
+
   it('rejects sessions that are not idle in a live agent pane', () => {
     const session = findReusableAutomationSession({
       automationId: 'auto-1',
@@ -78,6 +113,7 @@ describe('automation session reuse', () => {
       state: {
         agentStatusByPaneKey: { [paneKey]: status({ state: 'working' }) },
         ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        terminalLayoutsByTabId: { 'tab-1': { ptyIdsByLeafId: { [leafId]: 'pty-1' } } },
         unifiedTabsByWorktree: {
           'wt-1': [{ contentType: 'terminal', entityId: 'tab-1' }]
         }

--- a/src/renderer/src/lib/automation-session-reuse.ts
+++ b/src/renderer/src/lib/automation-session-reuse.ts
@@ -16,7 +16,10 @@ export function findReusableAutomationSession(args: {
   worktreeId: string
   currentRunId: string
   runs: AutomationRun[]
-  state: Pick<AppState, 'agentStatusByPaneKey' | 'ptyIdsByTabId' | 'unifiedTabsByWorktree'>
+  state: Pick<
+    AppState,
+    'agentStatusByPaneKey' | 'ptyIdsByTabId' | 'terminalLayoutsByTabId' | 'unifiedTabsByWorktree'
+  >
 }): ReusableAutomationSession | null {
   const { automationId, agentId, worktreeId, currentRunId, runs, state } = args
   const worktreeTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
@@ -40,24 +43,24 @@ export function findReusableAutomationSession(args: {
     if (!tabId) {
       continue
     }
-    const ptyId = state.ptyIdsByTabId[tabId]?.[0]
+    const pane = findReusablePane(state.agentStatusByPaneKey, tabId, agentId)
+    if (!pane) {
+      continue
+    }
+    const ptyId = getReusablePanePtyId(state, tabId, pane.leafId)
     if (!ptyId) {
       continue
     }
-    const paneKey = findReusablePaneKey(state.agentStatusByPaneKey, tabId, agentId)
-    if (!paneKey) {
-      continue
-    }
-    return { tabId, ptyId, paneKey }
+    return { tabId, ptyId, paneKey: pane.paneKey }
   }
   return null
 }
 
-function findReusablePaneKey(
+function findReusablePane(
   entries: Record<string, AgentStatusEntry>,
   tabId: string,
   agentId: TuiAgent
-): string | null {
+): { paneKey: string; leafId: string } | null {
   for (const [paneKey, entry] of Object.entries(entries)) {
     const parsed = parsePaneKey(paneKey)
     if (parsed?.tabId !== tabId || entry.state !== 'done') {
@@ -66,7 +69,21 @@ function findReusablePaneKey(
     if (entry.agentType && entry.agentType !== 'unknown' && entry.agentType !== agentId) {
       continue
     }
-    return paneKey
+    return { paneKey, leafId: parsed.leafId }
   }
   return null
+}
+
+function getReusablePanePtyId(
+  state: Pick<AppState, 'ptyIdsByTabId' | 'terminalLayoutsByTabId'>,
+  tabId: string,
+  leafId: string
+): string | null {
+  const ptyIdsByLeafId = state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId
+  if (ptyIdsByLeafId && Object.keys(ptyIdsByLeafId).length > 0) {
+    // Why: split terminal tabs can contain multiple PTYs; reuse must observe
+    // the PTY assigned to the idle agent pane's stable leaf.
+    return ptyIdsByLeafId[leafId] ?? null
+  }
+  return state.ptyIdsByTabId[tabId]?.[0] ?? null
 }


### PR DESCRIPTION
## Summary
- resolve reusable automation sessions to the PTY for the matched stable pane leaf
- avoid observing the first PTY in a split terminal tab when the idle agent lives in another pane
- add regression coverage for split-pane session reuse

## Repro
Before the fix, `findReusableAutomationSession()` with a completed run in `tab-1`, an idle agent status at pane key `tab-1:<right-leaf>`, and `ptyIdsByTabId[tab-1] = ["pty-left", "pty-right"]` returned:

```json
{ "tabId": "tab-1", "ptyId": "pty-left", "paneKey": "tab-1:<right-leaf>" }
```

That meant automation reuse could submit to the selected tab but observe the wrong split pane. After the fix, the same repro returns `pty-right`, using `terminalLayoutsByTabId[tab-1].ptyIdsByLeafId[<right-leaf>]`.

## Checks
- `pnpm exec tsx -e "...findReusableAutomationSession split-pane repro..."`
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/automation-session-reuse.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/lib/automation-session-reuse.ts src/renderer/src/lib/automation-session-reuse.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/automation-session-reuse.ts src/renderer/src/lib/automation-session-reuse.test.ts`
- `git diff --check`