### PR TITLE
fix: parse gitlab work item subpaths

### DIFF
--- a/src/renderer/src/lib/gitlab-links.test.ts
+++ b/src/renderer/src/lib/gitlab-links.test.ts
@@ -29,6 +29,14 @@ describe('parseGitLabIssueOrMRNumber', () => {
     ).toBe(55)
   })
 
+  it('parses issue and MR URLs with trailing page segments', () => {
+    expect(parseGitLabIssueOrMRNumber('https://gitlab.com/g/p/-/merge_requests/77/diffs')).toBe(77)
+    expect(
+      parseGitLabIssueOrMRNumber('https://gitlab.com/g/p/-/merge_requests/77/diffs.diff?diff_id=1')
+    ).toBe(77)
+    expect(parseGitLabIssueOrMRNumber('https://gitlab.com/g/p/-/issues/923/designs')).toBe(923)
+  })
+
   it('rejects GitHub URLs (no /-/ separator)', () => {
     expect(parseGitLabIssueOrMRNumber('https://github.com/stablyai/orca/issues/923')).toBeNull()
     expect(parseGitLabIssueOrMRNumber('https://github.com/stablyai/orca/pull/123')).toBeNull()
@@ -61,12 +69,33 @@ describe('parseGitLabIssueOrMRLink', () => {
     })
   })
 
+  it('extracts slug, number, and type from URLs with trailing page segments', () => {
+    expect(parseGitLabIssueOrMRLink('https://gitlab.com/g/p/-/merge_requests/77/diffs')).toEqual({
+      slug: { path: 'g/p' },
+      number: 77,
+      type: 'mr'
+    })
+    expect(
+      parseGitLabIssueOrMRLink('https://gitlab.com/g/p/-/merge_requests/77/diffs.diff?diff_id=1')
+    ).toEqual({
+      slug: { path: 'g/p' },
+      number: 77,
+      type: 'mr'
+    })
+    expect(parseGitLabIssueOrMRLink('https://gitlab.com/g/p/-/issues/923/designs')).toEqual({
+      slug: { path: 'g/p' },
+      number: 923,
+      type: 'issue'
+    })
+  })
+
   it('returns null for single-segment paths (no project)', () => {
     expect(parseGitLabIssueOrMRLink('https://gitlab.com/foo/-/issues/1')).toBeNull()
   })
 
   it('returns null for non-GitLab URL shapes', () => {
     expect(parseGitLabIssueOrMRLink('https://gitlab.com/stablyai/orca/issues/123')).toBeNull()
+    expect(parseGitLabIssueOrMRLink('https://gitlab.com/stablyai/orca/-/issues/123abc')).toBeNull()
   })
 })
 
@@ -79,6 +108,15 @@ describe('normalizeGitLabLinkQuery', () => {
     expect(normalizeGitLabLinkQuery('https://gitlab.com/stablyai/orca/-/issues/923')).toEqual({
       query: 'https://gitlab.com/stablyai/orca/-/issues/923',
       directNumber: 923
+    })
+  })
+
+  it('routes full URLs with trailing page segments to directNumber', () => {
+    expect(
+      normalizeGitLabLinkQuery('https://gitlab.com/stablyai/orca/-/merge_requests/77/diffs')
+    ).toEqual({
+      query: 'https://gitlab.com/stablyai/orca/-/merge_requests/77/diffs',
+      directNumber: 77
     })
   })
 

--- a/src/renderer/src/lib/gitlab-links.ts
+++ b/src/renderer/src/lib/gitlab-links.ts
@@ -4,8 +4,8 @@
 // than locking to gitlab.com. Anything matching `/<path>/-/(issues|
 // merge_requests)/<digits>` is treated as a GitLab item URL regardless
 // of host.
-const GL_ITEM_PATH_RE = /\/(?:issues|merge_requests)\/(\d+)(?:\/)?$/i
-const GL_ITEM_PATH_FULL_RE = /^\/(.+)\/-\/(issues|merge_requests)\/(\d+)(?:\/)?$/i
+const GL_ITEM_PATH_RE = /\/(?:issues|merge_requests)\/(\d+)(?:\/.*)?$/i
+const GL_ITEM_PATH_FULL_RE = /^\/(.+)\/-\/(issues|merge_requests)\/(\d+)(?:\/.*)?$/i
 
 export type ProjectSlug = {
   /** Full GitLab project path including any nested groups. */


### PR DESCRIPTION
## Summary
- Accept GitLab issue/MR URLs that include trailing item page segments, including MR Changes/diffs paths.
- Add parser coverage for MR `/diffs`, documented `/diffs.diff?diff_id=...`, issue subpages, and malformed numeric tails.

## Evidence
Before fix, this runtime repro returned `number: null`, `link: null`, and `directNumber: null` for both URLs:

```bash
pnpm exec tsx -e "import { parseGitLabIssueOrMRLink, parseGitLabIssueOrMRNumber, normalizeGitLabLinkQuery } from ./src/renderer/src/lib/gitlab-links.ts; ..."
```

After fix, the same repro returns MR `77`, slug `stablyai/orca`, and `directNumber: 77` for:
- `https://gitlab.com/stablyai/orca/-/merge_requests/77/diffs`
- `https://gitlab.com/stablyai/orca/-/merge_requests/77/diffs.diff?diff_id=1`

GitLab docs describe the Changes tab flow and diff-version URLs under merge request changes: https://docs.gitlab.com/user/project/merge_requests/changes/

## Checks
- `pnpm exec vitest run src/renderer/src/lib/gitlab-links.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/lib/gitlab-links.ts src/renderer/src/lib/gitlab-links.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/gitlab-links.ts src/renderer/src/lib/gitlab-links.test.ts`
- `git diff --check HEAD~1..HEAD`