### PR TITLE
fix: paginate gitlab work item issues

### DIFF
--- a/src/main/gitlab/client-work-items.test.ts
+++ b/src/main/gitlab/client-work-items.test.ts
@@ -119,6 +119,20 @@ describe('gitlab client — combined listWorkItems', () => {
     expect(issuesCallPath.at(-1)).toContain('search=ambiguous%20selector')
   })
 
+  it('passes the requested page through to merge request and issue fetches', async () => {
+    glabApiWithHeadersMock.mockResolvedValueOnce({ body: '[]', headers: {} })
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    await listWorkItems('/repo', 'opened', 2, 20)
+
+    const mergeRequestCallPath = glabApiWithHeadersMock.mock.calls[0][0] as string[]
+    const issuesCallPath = glabExecFileAsyncMock.mock.calls[0][0] as string[]
+    const mergeRequestParams = new URLSearchParams(mergeRequestCallPath[0].split('?')[1])
+    const issueParams = new URLSearchParams(issuesCallPath.at(-1)?.split('?')[1])
+    expect(mergeRequestParams.get('page')).toBe('2')
+    expect(issueParams.get('page')).toBe('2')
+  })
+
   it("omits the state param when 'all'", async () => {
     glabExecFileAsyncMock.mockImplementation(async () => {
       return { stdout: '[]' }
@@ -143,7 +157,7 @@ describe('gitlab client — combined listWorkItems', () => {
       'api',
       '--hostname',
       'git.internal',
-      'projects/g%2Fp/issues?per_page=20&order_by=updated_at&sort=desc&state=opened'
+      'projects/g%2Fp/issues?page=1&per_page=20&order_by=updated_at&sort=desc&state=opened'
     ])
   })
 

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -558,7 +558,7 @@ export async function listWorkItems(
           items: [] as GitLabWorkItem[],
           error: undefined as ClassifiedError | undefined
         })
-      : fetchIssuesAsWorkItems(repoPath, projectRef, issueState, perPage, query, connectionId)
+      : fetchIssuesAsWorkItems(repoPath, projectRef, issueState, page, perPage, query, connectionId)
   ])
   const merged = [...mrs.items, ...issues.items].sort((a, b) =>
     (b.updatedAt ?? '').localeCompare(a.updatedAt ?? '')
@@ -587,6 +587,7 @@ export async function fetchIssuesAsWorkItems(
   repoPath: string,
   projectRef: ProjectRef,
   state: IssueListState,
+  page: number,
   perPage: number,
   query?: string,
   connectionId?: string | null
@@ -599,7 +600,7 @@ export async function fetchIssuesAsWorkItems(
       [
         'api',
         ...glabHostnameArgs(projectRef, connectionId),
-        `projects/${encodedProject(projectRef.path)}/issues?per_page=${perPage}&order_by=updated_at&sort=desc${stateParam}${searchParam}`
+        `projects/${encodedProject(projectRef.path)}/issues?page=${page}&per_page=${perPage}&order_by=updated_at&sort=desc${stateParam}${searchParam}`
       ],
       glabRepoExecOptions(repoPath, connectionId)
     )


### PR DESCRIPTION
## Summary
- Carry the requested page into the issue side of GitLab combined work-item pagination.
- Add regression coverage so page 2 is present on both MR and issue API paths.

## Evidence
Before the fix, the focused regression failed because `listWorkItems("/repo", "opened", 2, 20)` produced an issue API path with no `page` parameter:

```text
AssertionError: expected null to be "2"
```

After the fix, the same test sees `page=2` on both the MR and issue fetch paths.

## Checks
- `pnpm exec vitest run src/main/gitlab/client-work-items.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/gitlab/client.ts src/main/gitlab/client-work-items.test.ts`
- `pnpm exec oxfmt --check src/main/gitlab/client.ts src/main/gitlab/client-work-items.test.ts`
- `git diff --check HEAD~1..HEAD`