### PR TITLE
fix: revoke overwritten local image blob urls

### DIFF
--- a/src/renderer/src/components/editor/useLocalImageSrc.test.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.test.ts
@@ -57,4 +57,30 @@ describe('getLocalImageCacheKey', () => {
       loadLocalImageSrc('file:///repo/docs/diagram.png', '/repo/docs/readme.md')
     ).resolves.toBeNull()
   })
+
+  it('revokes a blob URL that is overwritten by a concurrent load for the same image', async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      isBinary: true,
+      content: 'AA==',
+      mimeType: 'image/png'
+    })
+    vi.spyOn(URL, 'createObjectURL')
+      .mockReturnValueOnce('blob:local-image-first')
+      .mockReturnValueOnce('blob:local-image-second')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    vi.stubGlobal('window', {
+      api: {
+        fs: { readFile }
+      }
+    })
+
+    const first = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+    const second = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      'blob:local-image-first',
+      'blob:local-image-second'
+    ])
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:local-image-first')
+  })
 })

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -31,6 +31,15 @@ export function getLocalImageCacheKey(
 // (Map iteration order is insertion order) and revoke its blob URL so the
 // browser can free the underlying data.
 function cacheBlobUrl(key: string, url: string): void {
+  const previousUrl = blobUrlCache.get(key)
+  if (previousUrl !== undefined) {
+    blobUrlCache.delete(key)
+    if (previousUrl !== url) {
+      // Why: concurrent loads for the same image key can both create blob URLs;
+      // overwriting the cache must release the superseded Blob.
+      URL.revokeObjectURL(previousUrl)
+    }
+  }
   blobUrlCache.set(key, url)
   if (blobUrlCache.size > BLOB_URL_CACHE_MAX_SIZE) {
     const oldest = blobUrlCache.keys().next().value


### PR DESCRIPTION
## Summary
- revoke a cached local-image blob URL before overwriting it for the same cache key
- keep existing cache eviction behavior unchanged
- add regression coverage for concurrent loads of the same image path

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/useLocalImageSrc.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/editor/useLocalImageSrc.ts src/renderer/src/components/editor/useLocalImageSrc.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/components/editor/useLocalImageSrc.ts src/renderer/src/components/editor/useLocalImageSrc.test.ts`
- `git diff --check`

## Merge risk assessment
Risk: LOW

Reasoning: the behavior only changes the overwrite path for an existing blob URL cache key. Existing cache hits and size-based eviction are preserved, and the new test proves concurrent same-key loads release the superseded Blob URL.