### PR TITLE
perf: stream mobile PR diff previews

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -50,7 +50,7 @@ import { MobileAgentIcon } from '../../../src/components/MobileAgentIcon'
 import { PickerModal, type PickerOption } from '../../../src/components/PickerModal'
 import { TaskProviderLogo } from '../../../src/components/TaskProviderLogo'
 import {
-  buildGitHubPrFileDiffLines,
+  buildGitHubPrFileDiffPreview,
   type GitHubPrFileDiffLine
 } from '../../../src/tasks/github-pr-file-diff'
 import { buildGitHubCheckSummary } from '../../../src/tasks/github-check-summary'
@@ -1873,14 +1873,19 @@ function GitHubPrFileDiff({
   onCommentDraftChange: (key: string, value: string) => void
   onSubmitComment: (line: number) => void
 }): ReactNode {
-  const diffLines = useMemo(
-    () => buildGitHubPrFileDiffLines(contents.original, contents.modified),
+  const diffPreview = useMemo(
+    () =>
+      buildGitHubPrFileDiffPreview(
+        contents.original,
+        contents.modified,
+        MAX_RENDERED_PR_DIFF_LINES
+      ),
     [contents.modified, contents.original]
   )
-  const visibleDiffLines = diffLines.slice(0, MAX_RENDERED_PR_DIFF_LINES)
-  const hiddenDiffLineCount = Math.max(0, diffLines.length - visibleDiffLines.length)
+  const visibleDiffLines = diffPreview.lines
+  const hiddenDiffLineCount = Math.max(0, diffPreview.totalLineCount - visibleDiffLines.length)
 
-  if (diffLines.length === 0) {
+  if (diffPreview.totalLineCount === 0) {
     return <Text style={styles.detailMuted}>No text changes found.</Text>
   }
 
@@ -1888,7 +1893,7 @@ function GitHubPrFileDiff({
     <View style={styles.fileDiff}>
       {hiddenDiffLineCount > 0 ? (
         <Text style={styles.detailMuted}>
-          Showing first {MAX_RENDERED_PR_DIFF_LINES} of {diffLines.length} diff lines.
+          Showing first {MAX_RENDERED_PR_DIFF_LINES} of {diffPreview.totalLineCount} diff lines.
         </Text>
       ) : null}
       {visibleDiffLines.map((line) => {

--- a/mobile/src/tasks/github-pr-file-diff.test.ts
+++ b/mobile/src/tasks/github-pr-file-diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildGitHubPrFileDiffLines } from './github-pr-file-diff'
+import { buildGitHubPrFileDiffLines, buildGitHubPrFileDiffPreview } from './github-pr-file-diff'
 
 describe('buildGitHubPrFileDiffLines', () => {
   it('preserves context and marks added and removed lines', () => {
@@ -49,5 +49,29 @@ describe('buildGitHubPrFileDiffLines', () => {
     expect(lines).toHaveLength(1000)
     expect(lines[0]).toMatchObject({ kind: 'removed', oldLineNumber: 1, text: 'old-0' })
     expect(lines.at(-1)).toMatchObject({ kind: 'added', newLineNumber: 500, text: 'new-499' })
+  })
+
+  it('builds capped previews while preserving the exact total line count', () => {
+    const original = Array.from({ length: 500 }, (_, index) => `old-${index}`).join('\n')
+    const modified = Array.from({ length: 500 }, (_, index) => `new-${index}`).join('\n')
+
+    const preview = buildGitHubPrFileDiffPreview(original, modified, 400)
+
+    expect(preview.totalLineCount).toBe(1000)
+    expect(preview.lines).toHaveLength(400)
+    expect(preview.lines[0]).toMatchObject({ kind: 'removed', oldLineNumber: 1, text: 'old-0' })
+    expect(preview.lines.at(-1)).toMatchObject({
+      kind: 'removed',
+      oldLineNumber: 400,
+      text: 'old-399'
+    })
+  })
+
+  it('can compute the total without retaining preview rows', () => {
+    const modified = Array.from({ length: 20 }, (_, index) => `new-${index}`).join('\n')
+
+    const preview = buildGitHubPrFileDiffPreview('', modified, 0)
+
+    expect(preview).toEqual({ lines: [], totalLineCount: 20 })
   })
 })

--- a/mobile/src/tasks/github-pr-file-diff.ts
+++ b/mobile/src/tasks/github-pr-file-diff.ts
@@ -6,6 +6,11 @@ export type GitHubPrFileDiffLine = {
   text: string
 }
 
+export type GitHubPrFileDiffPreview = {
+  lines: GitHubPrFileDiffLine[]
+  totalLineCount: number
+}
+
 type DiffOperation =
   | { kind: 'context'; oldLine: string; newLine: string }
   | { kind: 'removed'; oldLine: string }
@@ -21,7 +26,11 @@ function splitContentLines(value: string): string[] {
   return lines.at(-1) === '' ? lines.slice(0, -1) : lines
 }
 
-function exactLineDiff(original: string[], modified: string[]): DiffOperation[] {
+function appendExactLineDiff(
+  original: string[],
+  modified: string[],
+  appendOperation: (operation: DiffOperation) => void
+): void {
   const rowWidth = modified.length + 1
   const table = new Uint16Array((original.length + 1) * rowWidth)
 
@@ -39,14 +48,13 @@ function exactLineDiff(original: string[], modified: string[]): DiffOperation[] 
     }
   }
 
-  const operations: DiffOperation[] = []
   let oldIndex = 0
   let newIndex = 0
   while (oldIndex < original.length && newIndex < modified.length) {
     const oldLine = original[oldIndex]
     const newLine = modified[newIndex]
     if (oldLine === newLine) {
-      operations.push({ kind: 'context', oldLine, newLine })
+      appendOperation({ kind: 'context', oldLine, newLine })
       oldIndex += 1
       newIndex += 1
       continue
@@ -54,45 +62,66 @@ function exactLineDiff(original: string[], modified: string[]): DiffOperation[] 
     const removeScore = table[(oldIndex + 1) * rowWidth + newIndex]
     const addScore = table[oldIndex * rowWidth + newIndex + 1]
     if (removeScore >= addScore) {
-      operations.push({ kind: 'removed', oldLine })
+      appendOperation({ kind: 'removed', oldLine })
       oldIndex += 1
     } else {
-      operations.push({ kind: 'added', newLine })
+      appendOperation({ kind: 'added', newLine })
       newIndex += 1
     }
   }
   while (oldIndex < original.length) {
-    operations.push({ kind: 'removed', oldLine: original[oldIndex] })
+    appendOperation({ kind: 'removed', oldLine: original[oldIndex] })
     oldIndex += 1
   }
   while (newIndex < modified.length) {
-    operations.push({ kind: 'added', newLine: modified[newIndex] })
+    appendOperation({ kind: 'added', newLine: modified[newIndex] })
     newIndex += 1
   }
-  return operations
 }
 
-function buildMiddleDiff(original: string[], modified: string[]): DiffOperation[] {
+function appendMiddleDiff(
+  original: string[],
+  modified: string[],
+  appendOperation: (operation: DiffOperation) => void
+): void {
   if (original.length === 0) {
-    return modified.map((newLine) => ({ kind: 'added', newLine }))
+    for (const newLine of modified) {
+      appendOperation({ kind: 'added', newLine })
+    }
+    return
   }
   if (modified.length === 0) {
-    return original.map((oldLine) => ({ kind: 'removed', oldLine }))
+    for (const oldLine of original) {
+      appendOperation({ kind: 'removed', oldLine })
+    }
+    return
   }
   if (original.length * modified.length <= EXACT_DIFF_CELL_LIMIT) {
-    return exactLineDiff(original, modified)
+    appendExactLineDiff(original, modified, appendOperation)
+    return
   }
-  // Why: very large files must still show all content without an O(n*m) mobile stall.
-  return [
-    ...original.map((oldLine) => ({ kind: 'removed' as const, oldLine })),
-    ...modified.map((newLine) => ({ kind: 'added' as const, newLine }))
-  ]
+  // Why: the Tasks diff UI renders a capped preview. Stream fallback rows so a
+  // generated PR file does not allocate thousands of discarded row objects.
+  for (const oldLine of original) {
+    appendOperation({ kind: 'removed', oldLine })
+  }
+  for (const newLine of modified) {
+    appendOperation({ kind: 'added', newLine })
+  }
 }
 
 export function buildGitHubPrFileDiffLines(
   originalContent: string,
   modifiedContent: string
 ): GitHubPrFileDiffLine[] {
+  return buildGitHubPrFileDiffPreview(originalContent, modifiedContent).lines
+}
+
+export function buildGitHubPrFileDiffPreview(
+  originalContent: string,
+  modifiedContent: string,
+  maxLines = Number.POSITIVE_INFINITY
+): GitHubPrFileDiffPreview {
   const originalLines = splitContentLines(originalContent)
   const modifiedLines = splitContentLines(modifiedContent)
   let prefixLength = 0
@@ -114,7 +143,6 @@ export function buildGitHubPrFileDiffLines(
     suffixLength += 1
   }
 
-  const prefix = originalLines.slice(0, prefixLength)
   const originalMiddle = originalLines.slice(
     prefixLength,
     suffixLength === 0 ? originalLines.length : originalLines.length - suffixLength
@@ -123,46 +151,63 @@ export function buildGitHubPrFileDiffLines(
     prefixLength,
     suffixLength === 0 ? modifiedLines.length : modifiedLines.length - suffixLength
   )
-  const suffix = originalLines.slice(originalLines.length - suffixLength)
-  const operations: DiffOperation[] = [
-    ...prefix.map((line) => ({ kind: 'context' as const, oldLine: line, newLine: line })),
-    ...buildMiddleDiff(originalMiddle, modifiedMiddle),
-    ...suffix.map((line) => ({ kind: 'context' as const, oldLine: line, newLine: line }))
-  ]
 
   const result: GitHubPrFileDiffLine[] = []
   let oldLineNumber = 1
   let newLineNumber = 1
-  operations.forEach((operation, index) => {
+  let operationIndex = 0
+  let totalLineCount = 0
+  const normalizedMaxLines = Math.max(0, Math.floor(maxLines))
+  function appendOperation(operation: DiffOperation): void {
+    const index = operationIndex
+    operationIndex += 1
+    totalLineCount += 1
     if (operation.kind === 'context') {
-      result.push({
-        key: `${index}:context:${oldLineNumber}:${newLineNumber}`,
-        kind: 'context',
-        oldLineNumber,
-        newLineNumber,
-        text: operation.newLine
-      })
+      if (result.length < normalizedMaxLines) {
+        result.push({
+          key: `${index}:context:${oldLineNumber}:${newLineNumber}`,
+          kind: 'context',
+          oldLineNumber,
+          newLineNumber,
+          text: operation.newLine
+        })
+      }
       oldLineNumber += 1
       newLineNumber += 1
       return
     }
     if (operation.kind === 'removed') {
-      result.push({
-        key: `${index}:removed:${oldLineNumber}`,
-        kind: 'removed',
-        oldLineNumber,
-        text: operation.oldLine
-      })
+      if (result.length < normalizedMaxLines) {
+        result.push({
+          key: `${index}:removed:${oldLineNumber}`,
+          kind: 'removed',
+          oldLineNumber,
+          text: operation.oldLine
+        })
+      }
       oldLineNumber += 1
       return
     }
-    result.push({
-      key: `${index}:added:${newLineNumber}`,
-      kind: 'added',
-      newLineNumber,
-      text: operation.newLine
-    })
+    if (result.length < normalizedMaxLines) {
+      result.push({
+        key: `${index}:added:${newLineNumber}`,
+        kind: 'added',
+        newLineNumber,
+        text: operation.newLine
+      })
+    }
     newLineNumber += 1
-  })
-  return result
+  }
+
+  for (let i = 0; i < prefixLength; i += 1) {
+    const line = originalLines[i] ?? ''
+    appendOperation({ kind: 'context', oldLine: line, newLine: line })
+  }
+  appendMiddleDiff(originalMiddle, modifiedMiddle, appendOperation)
+  for (let i = originalLines.length - suffixLength; i < originalLines.length; i += 1) {
+    const line = originalLines[i] ?? ''
+    appendOperation({ kind: 'context', oldLine: line, newLine: line })
+  }
+
+  return { lines: result, totalLineCount }
 }


### PR DESCRIPTION
## Summary
- add a capped GitHub PR diff preview builder that streams fallback/exact diff operations into the rendered row limit while still counting total rows
- switch the mobile Tasks PR file diff view to use the preview result instead of building all rows then slicing
- keep the existing full-line helper for tests/compatibility and cover capped and zero-retained previews

## Risk
Low. The UI already rendered only the first 400 PR diff rows; this keeps the same visible rows and exact total count while avoiding discarded row allocations.

## Verification
- pnpm vitest run src/tasks/github-pr-file-diff.test.ts
- pnpm exec tsc --noEmit
- pnpm test
- pnpm lint
- git diff --check
- git diff --check HEAD~1..HEAD