### PR TITLE
fix: queue scheduled gitlab checks

### DIFF
--- a/src/shared/gitlab-pipeline-checks.test.ts
+++ b/src/shared/gitlab-pipeline-checks.test.ts
@@ -20,6 +20,22 @@ describe('gitLabPipelineJobsToPRChecks', () => {
         status: 'manual',
         webUrl: '',
         duration: null
+      },
+      {
+        id: 3,
+        name: 'delayed deploy',
+        stage: 'deploy',
+        status: 'scheduled',
+        webUrl: 'https://gitlab.com/acme/orca/-/jobs/3',
+        duration: null
+      },
+      {
+        id: 4,
+        name: 'external callback',
+        stage: 'integration',
+        status: 'waiting_for_callback',
+        webUrl: 'https://gitlab.com/acme/orca/-/jobs/4',
+        duration: null
       }
     ]
 
@@ -35,6 +51,18 @@ describe('gitLabPipelineJobsToPRChecks', () => {
         status: 'completed',
         conclusion: 'neutral',
         url: null
+      },
+      {
+        name: 'deploy: delayed deploy',
+        status: 'queued',
+        conclusion: 'pending',
+        url: 'https://gitlab.com/acme/orca/-/jobs/3'
+      },
+      {
+        name: 'integration: external callback',
+        status: 'queued',
+        conclusion: 'pending',
+        url: 'https://gitlab.com/acme/orca/-/jobs/4'
       }
     ])
   })

--- a/src/shared/gitlab-pipeline-checks.ts
+++ b/src/shared/gitlab-pipeline-checks.ts
@@ -3,7 +3,14 @@ import type { PRCheckDetail } from './types'
 
 export function mapGitLabPipelineJobStatusToCheckStatus(status: string): PRCheckDetail['status'] {
   const s = status.toLowerCase()
-  if (s === 'created' || s === 'pending' || s === 'waiting_for_resource' || s === 'preparing') {
+  if (
+    s === 'created' ||
+    s === 'pending' ||
+    s === 'scheduled' ||
+    s === 'waiting_for_callback' ||
+    s === 'waiting_for_resource' ||
+    s === 'preparing'
+  ) {
     return 'queued'
   }
   if (s === 'running') {
@@ -37,6 +44,7 @@ export function mapGitLabPipelineJobStatusToConclusion(
     s === 'created' ||
     s === 'pending' ||
     s === 'running' ||
+    s === 'waiting_for_callback' ||
     s === 'waiting_for_resource' ||
     s === 'preparing' ||
     s === 'scheduled'


### PR DESCRIPTION
## Summary
- Map GitLab `scheduled` and `waiting_for_callback` jobs to queued/pending checks instead of completed rows.
- Extend shared mapper coverage for these not-yet-running GitLab job states.

## Evidence
Before the fix, this runtime repro rendered a scheduled GitLab job as completed even though its conclusion was pending:

```json
[{ "name": "deploy: delayed deploy", "status": "completed", "conclusion": "pending" }]
```

After the fix, the same repro returns:

```json
[{ "name": "deploy: delayed deploy", "status": "queued", "conclusion": "pending" }]
```

GitLab documents `scheduled` as a job that has not started yet and `waiting_for_callback` as waiting on an external callback: https://docs.gitlab.com/api/jobs/

## Checks
- `pnpm exec tsx -e "import { gitLabPipelineJobsToPRChecks } from ./src/shared/gitlab-pipeline-checks.ts; ..."`
- `pnpm exec vitest run src/shared/gitlab-pipeline-checks.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/gitlab-pipeline-checks.ts src/shared/gitlab-pipeline-checks.test.ts`
- `pnpm exec oxfmt --check src/shared/gitlab-pipeline-checks.ts src/shared/gitlab-pipeline-checks.test.ts`
- `git diff --check HEAD~1..HEAD`