### PR TITLE
perf: reset automation branch picker by repo key

### DIFF
--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -318,6 +318,9 @@ export function AutomationEditorDialog({
                     />
                   ) : (
                     <CreateFromPicker
+                      // Why: branch search state belongs to the selected project,
+                      // so repo switches should reset it before the next paint.
+                      key={draft.projectId}
                       repoId={draft.projectId}
                       repoMap={repoMap}
                       worktrees={worktrees}

--- a/src/renderer/src/components/automations/CreateFromPicker.tsx
+++ b/src/renderer/src/components/automations/CreateFromPicker.tsx
@@ -128,12 +128,6 @@ export function CreateFromPicker({
   }, [activeRuntimeEnvironmentId, repoId])
 
   React.useEffect(() => {
-    setQuery('')
-    setSearchResults([])
-    setIsSearching(false)
-  }, [repoId])
-
-  React.useEffect(() => {
     const trimmedQuery = query.trim()
     if (!open || !repoId || trimmedQuery.length < 2) {
       setSearchResults([])


### PR DESCRIPTION
## Summary
- key the automation create-from branch picker by selected project
- remove the passive repo-change reset Effect from the picker

## Risk
risk:low - isolated local popover search state reset; no persistence, IPC contract, or provider behavior changes.

## Verification
- pnpm exec oxlint src/renderer/src/components/automations/AutomationEditorDialog.tsx src/renderer/src/components/automations/CreateFromPicker.tsx
- pnpm exec oxfmt --check src/renderer/src/components/automations/AutomationEditorDialog.tsx src/renderer/src/components/automations/CreateFromPicker.tsx
- pnpm run typecheck:web
- git diff --check
