### PR TITLE
fix: build bitbucket line anchors

### DIFF
--- a/src/main/git/hosted-remote-url.test.ts
+++ b/src/main/git/hosted-remote-url.test.ts
@@ -54,7 +54,7 @@ describe('hosted remote URLs', () => {
 
     expect(
       buildHostedRemoteFileUrl('git@bitbucket.org:team/repo.git', 'src/a.ts', 'feature/x', 7)
-    ).toBe('https://bitbucket.org/team/repo/src/feature%2Fx/src/a.ts#L7')
+    ).toBe('https://bitbucket.org/team/repo/src/feature%2Fx/src/a.ts#a.ts-7')
 
     expect(
       buildHostedRemoteFileUrl(
@@ -64,6 +64,12 @@ describe('hosted remote URLs', () => {
         5
       )
     ).toBe('https://github.com/Org/Repo/blob/feature%2Fx/src/a.ts#L5')
+  })
+
+  it('builds Bitbucket line fragments from the target file name', () => {
+    expect(
+      buildHostedRemoteFileUrl('https://bitbucket.org/team/repo.git', 'src/a file.ts', 'main', 29)
+    ).toBe('https://bitbucket.org/team/repo/src/main/src/a%20file.ts#a%20file.ts-29')
   })
 
   it('rejects unsupported hosts and incomplete repo paths', () => {

--- a/src/main/git/hosted-remote-url.ts
+++ b/src/main/git/hosted-remote-url.ts
@@ -96,6 +96,11 @@ function encodeRelativePath(path: string): string {
   return path.replaceAll('\\', '/').split('/').filter(Boolean).map(encodeURIComponent).join('/')
 }
 
+function encodeBitbucketFileLineFragment(path: string, line: number): string {
+  const fileName = path.replaceAll('\\', '/').split('/').filter(Boolean).at(-1)
+  return fileName ? `#${encodeURIComponent(`${fileName}-${line}`)}` : ''
+}
+
 export function buildHostedRemoteFileUrl(
   remoteUrl: string,
   relativePath: string,
@@ -119,5 +124,5 @@ export function buildHostedRemoteFileUrl(
   if (remote.provider === 'gitlab') {
     return `${baseUrl}/-/blob/${encodedBranch}${filePathSuffix}#L${line}`
   }
-  return `${baseUrl}/src/${encodedBranch}${filePathSuffix}#L${line}`
+  return `${baseUrl}/src/${encodedBranch}${filePathSuffix}${encodeBitbucketFileLineFragment(relativePath, line)}`
 }


### PR DESCRIPTION
## Summary
- Build Bitbucket Cloud source links with `filename-line` fragments instead of GitHub-style `#L<line>` anchors.
- Add coverage for nested paths and filenames with spaces.

## Evidence
Before the fix, the runtime repro returned a Bitbucket URL with a GitHub-style line fragment:

```text
https://bitbucket.org/team/repo/src/main/src/a.ts#L7
```

After the fix, the same repro returns Bitbucket Clouds documented fragment shape:

```text
https://bitbucket.org/team/repo/src/main/src/a.ts#a.ts-7
```

Atlassian documents the Bitbucket Cloud `fileline` fragment as the target file name plus line number, for example `test_auth.py-29`: https://support.atlassian.com/bitbucket-cloud/docs/hyperlink-to-source-code-in-bitbucket/

## Checks
- `pnpm exec tsx -e "import { buildHostedRemoteFileUrl } from ./src/main/git/hosted-remote-url.ts; ..."`
- `pnpm exec vitest run src/main/git/hosted-remote-url.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/git/hosted-remote-url.ts src/main/git/hosted-remote-url.test.ts`
- `pnpm exec oxfmt --check src/main/git/hosted-remote-url.ts src/main/git/hosted-remote-url.test.ts`
- `git diff --check HEAD~1..HEAD`