### PR TITLE
fix: count cancelled github checks as failed

### DIFF
--- a/src/shared/hosted-review-github.test.ts
+++ b/src/shared/hosted-review-github.test.ts
@@ -80,6 +80,17 @@ describe('hostedReviewSummaryFromGitHubPRInfo', () => {
     expect(summary.checksStatus).toBe('failure')
   })
 
+  it('treats cancelled checks as failed in hosted review summaries', () => {
+    const summary = hostedReviewSummaryFromGitHubPRInfo({
+      pr: { ...pr, checksStatus: 'success' },
+      owner: 'acme',
+      repo: 'orca',
+      checks: [{ name: 'ci', status: 'completed', conclusion: 'cancelled', url: null }]
+    })
+
+    expect(summary.checksStatus).toBe('failure')
+  })
+
   it('distinguishes loaded empty comments from unknown comments', () => {
     expect(
       hostedReviewSummaryFromGitHubPRInfo({

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -36,7 +36,10 @@ function deriveChecksStatus(
     return prChecksStatus
   }
   const hasFailure = checks.some(
-    (check) => check.conclusion === 'failure' || check.conclusion === 'timed_out'
+    (check) =>
+      check.conclusion === 'failure' ||
+      check.conclusion === 'timed_out' ||
+      check.conclusion === 'cancelled'
   )
   if (hasFailure) {
     return 'failure'


### PR DESCRIPTION
## Summary
- Treat cancelled GitHub check conclusions as failed when deriving hosted-review queue summaries.
- Add shared coverage so summary aggregation matches the detailed check cache behavior.

## Evidence
Before the fix, a completed cancelled check produced a neutral hosted-review summary:

```text
"neutral"
```

After the fix, the same repro returns:

```text
"failure"
```

## Checks
- `pnpm exec tsx -e "import { hostedReviewSummaryFromGitHubPRInfo } from ./src/shared/hosted-review-github.ts; ..."`
- `pnpm exec vitest run src/shared/hosted-review-github.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/hosted-review-github.ts src/shared/hosted-review-github.test.ts`
- `pnpm exec oxfmt --check src/shared/hosted-review-github.ts src/shared/hosted-review-github.test.ts`
- `git diff --check HEAD~1..HEAD`