### PR TITLE
fix: prune smart github submit cache

### DIFF
--- a/src/renderer/src/lib/smart-github-submit.test.ts
+++ b/src/renderer/src/lib/smart-github-submit.test.ts
@@ -3,6 +3,7 @@ import {
   clearSmartGitHubSubmitLookupCacheForTests,
   getSmartGitHubSubmitIntent,
   getSmartGitHubSubmitResolution,
+  getSmartGitHubSubmitLookupCacheSizeForTests,
   lookupSmartGitHubSubmitItem
 } from './smart-github-submit'
 
@@ -178,6 +179,51 @@ describe('lookupSmartGitHubSubmitItem', () => {
     await expect(lookup()).resolves.toEqual(item)
     expect(workItemByOwnerRepo).toHaveBeenCalledTimes(2)
     expect(workItem).not.toHaveBeenCalled()
+  })
+
+  it('prunes expired distinct lookup entries on later lookups', async () => {
+    const nowSpy = vi.spyOn(Date, 'now')
+    const workItemByOwnerRepo = vi.fn()
+    const workItem = vi.fn().mockImplementation(({ number }) =>
+      Promise.resolve({
+        id: `issue-${number}`,
+        type: 'issue' as const,
+        number,
+        title: `Issue ${number}`,
+        state: 'open' as const,
+        url: `https://github.com/stablyai/orca/issues/${number}`,
+        labels: [],
+        updatedAt: '2026-05-26T00:00:00.000Z',
+        author: 'octocat',
+        repoId: 'repo-1'
+      })
+    )
+
+    try {
+      nowSpy.mockReturnValue(1_000)
+      await lookupSmartGitHubSubmitItem({
+        repoId: 'repo-1',
+        repoPath: '/repo',
+        intent: { kind: 'hash-number', number: 2049 },
+        workItem,
+        workItemByOwnerRepo
+      })
+      expect(getSmartGitHubSubmitLookupCacheSizeForTests()).toBe(1)
+
+      nowSpy.mockReturnValue(62_000)
+      await lookupSmartGitHubSubmitItem({
+        repoId: 'repo-1',
+        repoPath: '/repo',
+        intent: { kind: 'hash-number', number: 2050 },
+        workItem,
+        workItemByOwnerRepo
+      })
+
+      expect(getSmartGitHubSubmitLookupCacheSizeForTests()).toBe(1)
+      expect(workItem).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 })
 

--- a/src/renderer/src/lib/smart-github-submit.ts
+++ b/src/renderer/src/lib/smart-github-submit.ts
@@ -44,6 +44,7 @@ export type SmartGitHubSubmitLookup = {
 }
 
 const SMART_GITHUB_SUBMIT_LOOKUP_TTL_MS = 60_000
+const SMART_GITHUB_SUBMIT_LOOKUP_CACHE_MAX_ENTRIES = 128
 
 type SmartGitHubSubmitLookupCacheEntry = {
   expiresAt: number
@@ -51,6 +52,21 @@ type SmartGitHubSubmitLookupCacheEntry = {
 }
 
 const smartGitHubSubmitLookupCache = new Map<string, SmartGitHubSubmitLookupCacheEntry>()
+
+function pruneSmartGitHubSubmitLookupCache(now: number): void {
+  for (const [key, entry] of smartGitHubSubmitLookupCache) {
+    if (entry.expiresAt <= now) {
+      smartGitHubSubmitLookupCache.delete(key)
+    }
+  }
+  while (smartGitHubSubmitLookupCache.size > SMART_GITHUB_SUBMIT_LOOKUP_CACHE_MAX_ENTRIES) {
+    const oldestKey = smartGitHubSubmitLookupCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    smartGitHubSubmitLookupCache.delete(oldestKey)
+  }
+}
 
 export function getSmartGitHubSubmitIntent(input: string): SmartGitHubSubmitIntent | null {
   const trimmed = input.trim()
@@ -106,6 +122,7 @@ export function lookupSmartGitHubSubmitItem({
 }: SmartGitHubSubmitLookup): Promise<GitHubWorkItem | null> {
   const key = getSmartGitHubSubmitLookupCacheKey({ repoId, repoPath, intent })
   const now = Date.now()
+  pruneSmartGitHubSubmitLookupCache(now)
   const cached = smartGitHubSubmitLookupCache.get(key)
   if (cached && cached.expiresAt > now) {
     return cached.promise
@@ -131,6 +148,7 @@ export function lookupSmartGitHubSubmitItem({
     promise: stampedPromise,
     expiresAt: now + SMART_GITHUB_SUBMIT_LOOKUP_TTL_MS
   })
+  pruneSmartGitHubSubmitLookupCache(now)
   // Why: transient GitHub/IPC failures should dedupe while in flight, but
   // must not poison immediate create retries for the full cache TTL.
   void stampedPromise.catch(() => {
@@ -143,6 +161,10 @@ export function lookupSmartGitHubSubmitItem({
 
 export function clearSmartGitHubSubmitLookupCacheForTests(): void {
   smartGitHubSubmitLookupCache.clear()
+}
+
+export function getSmartGitHubSubmitLookupCacheSizeForTests(): number {
+  return smartGitHubSubmitLookupCache.size
 }
 
 export function getSmartGitHubSubmitResolution(


### PR DESCRIPTION
## Summary
- prune expired smart GitHub submit lookup cache entries before lookups
- cap the renderer-session cache so distinct issue/PR submissions cannot grow it without bound
- add regression coverage for expired distinct entries being removed

## Risk
Risk: LOW. The existing 60s in-flight/success dedupe remains intact; this only removes expired entries and bounds oldest entries beyond the cap.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/smart-github-submit.test.ts`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/lib/smart-github-submit.ts src/renderer/src/lib/smart-github-submit.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/smart-github-submit.ts src/renderer/src/lib/smart-github-submit.test.ts`
- `git diff --check origin/main...HEAD`