### PR TITLE
fix: detect branch conflicts for slashed remotes

### DIFF
--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -216,6 +216,16 @@ describe('searchBaseRefs (widened glob)', () => {
     createRemoteRef(tmpDir, 'origin/feature/something', sha)
     createRemoteRef(tmpDir, 'upstream/feature/something', sha)
 
+    expect(
+      await getBranchConflictKind(tmpDir, 'feature/something', 'origin/feature/something')
+    ).toBe('remote')
+  })
+
+  it('reports remote conflicts when the remote name contains a slash', async () => {
+    const sha = getHeadSha(tmpDir)
+    git(tmpDir, ['remote', 'add', 'foo/bar', 'https://example.invalid/repo.git'])
+    createRemoteRef(tmpDir, 'foo/bar/feature/something', sha)
+
     const result = await getBranchConflictKind(
       tmpDir,
       'feature/something',

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -772,20 +772,21 @@ export async function getBranchConflictKind(
   }
 
   try {
+    const remoteNames = (await listRemoteNames(path)).sort((a, b) => b.length - a.length)
     const { stdout } = await gitExecFileAsync(
       ['for-each-ref', '--format=%(refname)', 'refs/remotes'],
       { cwd: path }
     )
-    // Why: refs have the form refs/remotes/<remote>/<branch>. We strip the
-    // first three segments so that e.g. "feature/dashboard" only matches
-    // "refs/remotes/origin/feature/dashboard", not "refs/remotes/origin/other/feature/dashboard".
     const hasRemoteConflict = stdout.split('\n').some((ref) => {
       const trimmed = ref.trim()
       if (isAllowedRemoteBaseRef(trimmed, allowedBaseRef)) {
         return false
       }
-      const parts = trimmed.split('/')
-      return parts.slice(3).join('/') === branchName
+      const shortRef = trimmed.replace(/^refs\/remotes\//, '')
+      // Why: git allows slashes in remote names. Use the configured remote
+      // list so foo/bar/feature resolves as branch "feature" for remote
+      // "foo/bar", matching searchBaseRefDetails.
+      return resolveLocalBranchName(trimmed, shortRef, remoteNames) === branchName
     })
 
     return hasRemoteConflict ? 'remote' : null


### PR DESCRIPTION
## Summary
- detect remote branch conflicts using configured remote names, so remotes like `foo/bar` map `refs/remotes/foo/bar/feature/something` to branch `feature/something`
- add a real-git regression covering a slashed remote name

## Evidence
- Rebased onto current `main` on May 31, 2026.
- Real-git regression covers remote `foo/bar` with `refs/remotes/foo/bar/feature/something` and expects `getBranchConflictKind(dir, "feature/something", "origin/main")` to return `remote`.

## Checks
- `pnpm exec vitest run src/main/git/repo.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/git/repo.ts src/main/git/repo.test.ts`
- `pnpm exec oxfmt --check src/main/git/repo.ts src/main/git/repo.test.ts`
- `git diff --check origin/main...HEAD`

## Risk
risk:low - small helper change, covered by real-git regression, unchanged cache/UI/IPC surface, and verified after rebase onto current main. Electron validation was not used because the changed behavior is entirely in the main-process git helper and has no renderer-visible state unless a repo is constructed to hit the conflict path.

CI: not waiting per instruction.