### PR TITLE
fix: prune github owner repo cache

### DIFF
--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -15,6 +15,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 }))
 
 import {
+  _getOwnerRepoCacheSize,
   _resetOwnerRepoCache,
   classifyGhError,
   classifyListIssuesError,
@@ -164,6 +165,29 @@ describe('github owner/repo resolution', () => {
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'local', repo: 'orca' })
     await expect(getOwnerRepo('/repo', 'ssh-1')).resolves.toEqual({ owner: 'remote', repo: 'orca' })
+  })
+
+  it('prunes expired distinct owner/repo cache entries on later lookups', async () => {
+    const nowSpy = vi.spyOn(Date, 'now')
+    try {
+      nowSpy.mockReturnValue(1_000)
+      gitExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: 'git@github.com:stablyai/orca.git\n'
+      })
+      await expect(getOwnerRepo('/repo-a')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
+      expect(_getOwnerRepoCacheSize()).toBe(1)
+
+      nowSpy.mockReturnValue(32_000)
+      gitExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: 'git@github.com:acme/widgets.git\n'
+      })
+      await expect(getOwnerRepo('/repo-b')).resolves.toEqual({ owner: 'acme', repo: 'widgets' })
+
+      expect(_getOwnerRepoCacheSize()).toBe(1)
+      expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('resolves PR candidates as upstream then origin and de-dupes matching slugs', async () => {

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -138,6 +138,7 @@ export function ghRepoExecOptions(context: GitHubRepoContext): {
 }
 
 const OWNER_REPO_CACHE_TTL_MS = 30_000
+const OWNER_REPO_CACHE_MAX_ENTRIES = 512
 
 type OwnerRepoCacheEntry = {
   value: OwnerRepo | null
@@ -149,6 +150,26 @@ const ownerRepoCache = new Map<string, OwnerRepoCacheEntry>()
 /** @internal — exposed for tests only */
 export function _resetOwnerRepoCache(): void {
   ownerRepoCache.clear()
+}
+
+/** @internal — exposed for tests only */
+export function _getOwnerRepoCacheSize(): number {
+  return ownerRepoCache.size
+}
+
+function pruneOwnerRepoCache(now: number): void {
+  for (const [key, entry] of ownerRepoCache) {
+    if (entry.expiresAt <= now) {
+      ownerRepoCache.delete(key)
+    }
+  }
+  while (ownerRepoCache.size > OWNER_REPO_CACHE_MAX_ENTRIES) {
+    const oldestKey = ownerRepoCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    ownerRepoCache.delete(oldestKey)
+  }
 }
 
 export function parseGitHubOwnerRepo(remoteUrl: string): OwnerRepo | null {
@@ -222,12 +243,11 @@ export async function getOwnerRepoForRemote(
 ): Promise<OwnerRepo | null> {
   const context = githubRepoContext(repoPath, connectionId)
   const cacheKey = `${context.connectionId ?? 'local'}\0${context.repoPath}\0${remoteName}`
+  const now = Date.now()
+  pruneOwnerRepoCache(now)
   const cached = ownerRepoCache.get(cacheKey)
-  if (cached && cached.expiresAt > Date.now()) {
+  if (cached && cached.expiresAt > now) {
     return cached.value
-  }
-  if (cached) {
-    ownerRepoCache.delete(cacheKey)
   }
   try {
     const remoteUrl = await getRemoteUrlForRepo(context, remoteName)
@@ -235,14 +255,16 @@ export async function getOwnerRepoForRemote(
     if (result) {
       ownerRepoCache.set(cacheKey, {
         value: result,
-        expiresAt: Date.now() + OWNER_REPO_CACHE_TTL_MS
+        expiresAt: now + OWNER_REPO_CACHE_TTL_MS
       })
+      pruneOwnerRepoCache(now)
       return result
     }
   } catch {
     // ignore — non-GitHub remote or no remote
   }
-  ownerRepoCache.set(cacheKey, { value: null, expiresAt: Date.now() + OWNER_REPO_CACHE_TTL_MS })
+  ownerRepoCache.set(cacheKey, { value: null, expiresAt: now + OWNER_REPO_CACHE_TTL_MS })
+  pruneOwnerRepoCache(now)
   return null
 }
 


### PR DESCRIPTION
## Summary
- prune expired GitHub owner/repo cache entries before lookups
- cap the main-process cache so distinct repo paths cannot grow it without bound
- add regression coverage for expired distinct entries being removed

## Risk
Risk: LOW. Existing 30s cache semantics remain unchanged for live entries; this only removes expired keys and oldest overflow keys.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/github/gh-utils.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/github/gh-utils.ts src/main/github/gh-utils.test.ts`
- `pnpm exec oxfmt --check src/main/github/gh-utils.ts src/main/github/gh-utils.test.ts`
- `git diff --check origin/main...HEAD`