### PR TITLE
fix: bound hosted repo ref caches

### DIFF
--- a/src/main/azure-devops/repository-ref.test.ts
+++ b/src/main/azure-devops/repository-ref.test.ts
@@ -5,6 +5,7 @@ const { sshExecMock } = vi.hoisted(() => ({
 }))
 
 import {
+  _getAzureDevOpsRepoRefCacheSize,
   _resetAzureDevOpsRepoRefCache,
   getAzureDevOpsRepoRefForRemote,
   parseAzureDevOpsRepoRef
@@ -92,6 +93,20 @@ describe('parseAzureDevOpsRepoRef', () => {
     })
 
     expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo')
+  })
+
+  it('bounds cached repository refs for distinct repo paths', async () => {
+    sshExecMock.mockResolvedValue({
+      stdout: 'git@ssh.dev.azure.com:v3/acme/Project/repo\n',
+      stderr: ''
+    })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    for (let i = 0; i < 513; i += 1) {
+      await getAzureDevOpsRepoRefForRemote(`/repo-${i}`, 'origin', 'conn-1')
+    }
+
+    expect(_getAzureDevOpsRepoRefCacheSize()).toBe(512)
   })
 
   it('does not cache transient SSH provider failures as unsupported repos', async () => {

--- a/src/main/azure-devops/repository-ref.ts
+++ b/src/main/azure-devops/repository-ref.ts
@@ -10,11 +10,28 @@ export type AzureDevOpsRepoRef = {
   organization?: string | null
 }
 
+const REPO_REF_CACHE_MAX_ENTRIES = 512
 const repoRefCache = new Map<string, AzureDevOpsRepoRef | null>()
 
 /** @internal - exposed for tests only */
 export function _resetAzureDevOpsRepoRefCache(): void {
   repoRefCache.clear()
+}
+
+/** @internal - exposed for tests only */
+export function _getAzureDevOpsRepoRefCacheSize(): number {
+  return repoRefCache.size
+}
+
+function rememberRepoRefCacheEntry(cacheKey: string, value: AzureDevOpsRepoRef | null): void {
+  repoRefCache.set(cacheKey, value)
+  while (repoRefCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
+    const oldestKey = repoRefCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    repoRefCache.delete(oldestKey)
+  }
 }
 
 function decodeSegment(value: string): string {
@@ -203,7 +220,7 @@ export async function getAzureDevOpsRepoRefForRemote(
           cwd: repoPath
         })
     const result = parseAzureDevOpsRepoRef(stdout)
-    repoRefCache.set(cacheKey, result)
+    rememberRepoRefCacheEntry(cacheKey, result)
     return result
   } catch {
     if (connectionId) {
@@ -211,7 +228,7 @@ export async function getAzureDevOpsRepoRefForRemote(
       // caching them as "not Azure DevOps" would poison the repo for the session.
       return null
     }
-    repoRefCache.set(cacheKey, null)
+    rememberRepoRefCacheEntry(cacheKey, null)
     return null
   }
 }

--- a/src/main/bitbucket/repository-ref.test.ts
+++ b/src/main/bitbucket/repository-ref.test.ts
@@ -10,6 +10,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import {
+  _getBitbucketRepoRefCacheSize,
   _resetBitbucketRepoRefCache,
   getBitbucketRepoRefForRemote,
   getBitbucketRepoRef,
@@ -80,6 +81,19 @@ describe('Bitbucket repository refs', () => {
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
+  })
+
+  it('bounds cached repository refs for distinct repo paths', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git@bitbucket.org:team/project.git\n',
+      stderr: ''
+    })
+
+    for (let i = 0; i < 513; i += 1) {
+      await getBitbucketRepoRef(`/repo-${i}`)
+    }
+
+    expect(_getBitbucketRepoRefCacheSize()).toBe(512)
   })
 
   it('resolves project refs through the SSH git provider for connected repos', async () => {

--- a/src/main/bitbucket/repository-ref.ts
+++ b/src/main/bitbucket/repository-ref.ts
@@ -6,11 +6,28 @@ export type BitbucketRepoRef = {
   repoSlug: string
 }
 
+const REPO_REF_CACHE_MAX_ENTRIES = 512
 const repoRefCache = new Map<string, BitbucketRepoRef | null>()
 
 /** @internal - exposed for tests only */
 export function _resetBitbucketRepoRefCache(): void {
   repoRefCache.clear()
+}
+
+/** @internal - exposed for tests only */
+export function _getBitbucketRepoRefCacheSize(): number {
+  return repoRefCache.size
+}
+
+function rememberRepoRefCacheEntry(cacheKey: string, value: BitbucketRepoRef | null): void {
+  repoRefCache.set(cacheKey, value)
+  while (repoRefCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
+    const oldestKey = repoRefCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    repoRefCache.delete(oldestKey)
+  }
 }
 
 function decodeSegment(value: string): string {
@@ -79,7 +96,7 @@ export async function getBitbucketRepoRefForRemote(
           cwd: repoPath
         })
     const result = parseBitbucketRepoRef(stdout)
-    repoRefCache.set(cacheKey, result)
+    rememberRepoRefCacheEntry(cacheKey, result)
     return result
   } catch {
     if (connectionId) {
@@ -87,7 +104,7 @@ export async function getBitbucketRepoRefForRemote(
       // caching them as "not Bitbucket" would poison the repo for the session.
       return null
     }
-    repoRefCache.set(cacheKey, null)
+    rememberRepoRefCacheEntry(cacheKey, null)
     return null
   }
 }

--- a/src/main/gitea/repository-ref.test.ts
+++ b/src/main/gitea/repository-ref.test.ts
@@ -10,6 +10,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import {
+  _getGiteaRepoRefCacheSize,
   _resetGiteaRepoRefCache,
   getGiteaRepoRef,
   getGiteaRepoRefForRemote,
@@ -107,6 +108,19 @@ describe('Gitea repository ref parsing', () => {
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
+  })
+
+  it('bounds cached repository refs for distinct repo paths', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://git.example.com/team/project.git\n',
+      stderr: ''
+    })
+
+    for (let i = 0; i < 513; i += 1) {
+      await getGiteaRepoRef(`/repo-${i}`)
+    }
+
+    expect(_getGiteaRepoRefCacheSize()).toBe(512)
   })
 
   it('resolves repository refs through the SSH git provider for connected repos', async () => {

--- a/src/main/gitea/repository-ref.ts
+++ b/src/main/gitea/repository-ref.ts
@@ -16,11 +16,28 @@ const KNOWN_NON_GITEA_HOSTS = new Set([
   'dev.azure.com',
   'ssh.dev.azure.com'
 ])
+const REPO_REF_CACHE_MAX_ENTRIES = 512
 const repoRefCache = new Map<string, GiteaRepoRef | null>()
 
 /** @internal - exposed for tests only */
 export function _resetGiteaRepoRefCache(): void {
   repoRefCache.clear()
+}
+
+/** @internal - exposed for tests only */
+export function _getGiteaRepoRefCacheSize(): number {
+  return repoRefCache.size
+}
+
+function rememberRepoRefCacheEntry(cacheKey: string, value: GiteaRepoRef | null): void {
+  repoRefCache.set(cacheKey, value)
+  while (repoRefCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
+    const oldestKey = repoRefCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    repoRefCache.delete(oldestKey)
+  }
 }
 
 function decodeSegment(value: string): string {
@@ -140,7 +157,7 @@ export async function getGiteaRepoRefForRemote(
           cwd: repoPath
         })
     const result = parseGiteaRepoRef(stdout)
-    repoRefCache.set(cacheKey, result)
+    rememberRepoRefCacheEntry(cacheKey, result)
     return result
   } catch {
     if (connectionId) {
@@ -148,7 +165,7 @@ export async function getGiteaRepoRefForRemote(
       // caching them as "not Gitea" would poison the repo for the session.
       return null
     }
-    repoRefCache.set(cacheKey, null)
+    rememberRepoRefCacheEntry(cacheKey, null)
     return null
   }
 }

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -13,6 +13,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import {
+  _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,
   classifyGlabError,
@@ -177,6 +178,19 @@ describe('gitlab project ref resolution', () => {
 
     expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo')
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('bounds cached project refs for distinct repo paths', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'git@gitlab.com:stablyai/orca.git\n',
+      stderr: ''
+    })
+
+    for (let i = 0; i < 513; i += 1) {
+      await getProjectRef(`/repo-${i}`)
+    }
+
+    expect(_getProjectRefCacheSize()).toBe(512)
   })
 
   it('does not cache a missing SSH provider as a permanent null project ref', async () => {

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -103,11 +103,28 @@ export function classifyListIssuesError(stderr: string): ClassifiedError {
 // the short local name `ProjectRef`.
 export type ProjectRef = GitLabProjectRef
 
+const PROJECT_REF_CACHE_MAX_ENTRIES = 512
 const projectRefCache = new Map<string, ProjectRef | null>()
 
 /** @internal — exposed for tests only */
 export function _resetProjectRefCache(): void {
   projectRefCache.clear()
+}
+
+/** @internal — exposed for tests only */
+export function _getProjectRefCacheSize(): number {
+  return projectRefCache.size
+}
+
+function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
+  projectRefCache.set(cacheKey, value)
+  while (projectRefCache.size > PROJECT_REF_CACHE_MAX_ENTRIES) {
+    const oldestKey = projectRefCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    projectRefCache.delete(oldestKey)
+  }
 }
 
 /**
@@ -187,7 +204,7 @@ export async function getProjectRefForRemote(
       : await gitExecFileAsync(['remote', 'get-url', remoteName], { cwd: repoPath })
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
-      projectRefCache.set(cacheKey, result)
+      rememberProjectRefCacheEntry(cacheKey, result)
       return result
     }
   } catch {
@@ -198,7 +215,7 @@ export async function getProjectRefForRemote(
     }
     // ignore — non-GitLab remote or no remote configured
   }
-  projectRefCache.set(cacheKey, null)
+  rememberProjectRefCacheEntry(cacheKey, null)
   return null
 }
 


### PR DESCRIPTION
## Summary
- bound GitLab, Bitbucket, Azure DevOps, and Gitea repo-ref caches
- evict oldest entries after 512 distinct repo/remote keys per provider
- add regression coverage for each provider cache bound

## Risk
Risk: LOW. Existing cache semantics are preserved for normal sessions; only oldest entries beyond the cap are evicted, and transient SSH failures remain uncached.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/gitlab/gl-utils.test.ts src/main/bitbucket/repository-ref.test.ts src/main/azure-devops/repository-ref.test.ts src/main/gitea/repository-ref.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/gitlab/gl-utils.ts src/main/gitlab/gl-utils.test.ts src/main/bitbucket/repository-ref.ts src/main/bitbucket/repository-ref.test.ts src/main/azure-devops/repository-ref.ts src/main/azure-devops/repository-ref.test.ts src/main/gitea/repository-ref.ts src/main/gitea/repository-ref.test.ts`
- `pnpm exec oxfmt --check src/main/gitlab/gl-utils.ts src/main/gitlab/gl-utils.test.ts src/main/bitbucket/repository-ref.ts src/main/bitbucket/repository-ref.test.ts src/main/azure-devops/repository-ref.ts src/main/azure-devops/repository-ref.test.ts src/main/gitea/repository-ref.ts src/main/gitea/repository-ref.test.ts`
- `git diff --check origin/main...HEAD`
