### PR TITLE
fix: block ssh worktrees for remote branch conflicts

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -228,6 +228,71 @@ async function canCheckoutExistingLocalBranchSsh(
   return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
 }
 
+async function listSshRemoteNames(provider: SshGitProvider, repoPath: string): Promise<string[]> {
+  try {
+    const { stdout } = await provider.exec(['remote'], repoPath)
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort((a, b) => b.length - a.length)
+  } catch {
+    return []
+  }
+}
+
+function isAllowedSshRemoteBaseRef(refName: string, allowedBaseRef: string): boolean {
+  if (!allowedBaseRef) {
+    return false
+  }
+  const normalizedAllowedRef = allowedBaseRef.startsWith('refs/remotes/')
+    ? allowedBaseRef
+    : `refs/remotes/${allowedBaseRef}`
+  return refName === normalizedAllowedRef
+}
+
+function resolveSshRemoteBranchName(refName: string, remoteNames: string[]): string {
+  const remotePrefix = 'refs/remotes/'
+  if (!refName.startsWith(remotePrefix)) {
+    return refName
+  }
+  const remoteAndBranch = refName.slice(remotePrefix.length)
+  const remote = remoteNames.find((candidate) => remoteAndBranch.startsWith(`${candidate}/`))
+  if (remote) {
+    return remoteAndBranch.slice(remote.length + 1)
+  }
+  return remoteAndBranch.split('/').slice(1).join('/') || remoteAndBranch
+}
+
+async function hasSshRemoteBranchConflict(
+  provider: SshGitProvider,
+  repoPath: string,
+  branchName: string,
+  allowedBaseRef: string
+): Promise<boolean> {
+  const remoteNames = await listSshRemoteNames(provider, repoPath)
+  try {
+    const { stdout } = await provider.exec(
+      ['for-each-ref', '--format=%(refname)', 'refs/remotes'],
+      repoPath
+    )
+    return stdout.split(/\r?\n/).some((line) => {
+      const refName = line.trim()
+      if (!refName || /^refs\/remotes\/.+\/HEAD$/.test(refName)) {
+        return false
+      }
+      if (isAllowedSshRemoteBaseRef(refName, allowedBaseRef)) {
+        return false
+      }
+      // Why: `git branch --all --list feature/x` does not match
+      // `remotes/origin/feature/x`; parse remote refs directly instead.
+      return resolveSshRemoteBranchName(refName, remoteNames) === branchName
+    })
+  } catch {
+    return false
+  }
+}
+
 type SelectedPrBranchInput = Pick<
   CreateWorktreeArgs,
   'branchNameOverride' | 'linkedPR' | 'pushTarget'
@@ -860,16 +925,10 @@ export async function createRemoteWorktree(
     baseBranch
   )
   if (!checkoutExistingBranch) {
-    // Check branch conflict on remote
-    try {
-      const { stdout } = await provider.exec(['branch', '--list', '--all', branchName], repo.path)
-      if (stdout.trim()) {
-        throw new Error(`Branch "${branchName}" already exists. Pick a different worktree name.`)
-      }
-    } catch (e) {
-      if (e instanceof Error && e.message.includes('already exists')) {
-        throw e
-      }
+    if (await hasSshRemoteBranchConflict(provider, repo.path, branchName, baseBranch)) {
+      throw new Error(
+        `Branch "${branchName}" already exists on a remote. Pick a different worktree name.`
+      )
     }
   }
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1751,6 +1751,113 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('blocks SSH worktree creation when the requested branch already exists on a remote', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'branch' && args.includes('feature/something')) {
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'for-each-ref') {
+          return { stdout: 'refs/remotes/origin/feature/something\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/heads/feature/something^{commit}')) {
+          throw new Error('missing local branch')
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/feature-something',
+          head: 'abc123',
+          branch: 'refs/heads/feature/something',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'feature-something',
+        branchNameOverride: 'feature/something'
+      })
+    ).rejects.toThrow('Branch "feature/something" already exists on a remote.')
+
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+  })
+
+  it('blocks SSH worktree creation when a slashed remote owns the requested branch', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\nfoo/bar\n', stderr: '' }
+        }
+        if (args[0] === 'for-each-ref') {
+          return { stdout: 'refs/remotes/foo/bar/feature/something\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse' && args.includes('refs/heads/feature/something^{commit}')) {
+          throw new Error('missing local branch')
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    }
+    const mux = {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'feature-something',
+        branchNameOverride: 'feature/something'
+      })
+    ).rejects.toThrow('Branch "feature/something" already exists on a remote.')
+
+    expect(provider.addWorktree).not.toHaveBeenCalled()
+  })
+
   it('unsets SSH branch base config before removing a sparse worktree after setup failure', async () => {
     const repo = {
       id: 'repo-ssh',


### PR DESCRIPTION
## Summary
- replace the SSH worktree remote-branch preflight with a refs/remotes scan
- preserve the selected remote base exemption while detecting existing remote branches like `origin/feature/something`
- handle slashed SSH remote names like `foo/bar` when mapping remote refs back to branch names
- add SSH create-flow regression tests for normal and slashed remotes

## Evidence
- Rebased onto current `main` on May 31, 2026.
- Existing SSH regression proves `refs/remotes/origin/feature/something` rejects `branchNameOverride: feature/something` and never calls `provider.addWorktree`.
- Added SSH slashed-remote regression proves `refs/remotes/foo/bar/feature/something` also rejects the same branch using the configured remote list.

## Checks
- `pnpm exec vitest run src/main/ipc/worktrees.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/ipc/worktree-remote.ts src/main/ipc/worktrees.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/worktree-remote.ts src/main/ipc/worktrees.test.ts`
- `git diff --check`

## Risk
risk:low - scoped SSH preflight change, no renderer/IPC contract change, no relay protocol change, and both normal and slashed remote-ref conflict paths are covered in the SSH worktree create handler tests. Electron validation was not used because this behavior is in the main-process SSH git provider path and the visible UI only receives the thrown create-worktree error.

CI: not waiting per instruction.