### PR TITLE
fix: bound unwatchable filesystem roots

### DIFF
--- a/src/main/ipc/filesystem-watcher-unwatchable-roots.test.ts
+++ b/src/main/ipc/filesystem-watcher-unwatchable-roots.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock } = vi.hoisted(() => ({
+  handleMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('fs/promises', () => ({
+  stat: vi.fn()
+}))
+
+vi.mock('@parcel/watcher', () => ({
+  subscribe: vi.fn()
+}))
+
+vi.mock('./filesystem-watcher-wsl', () => ({
+  createWslWatcher: vi.fn()
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+import { closeAllWatchers, registerFilesystemWatcherHandlers } from './filesystem-watcher'
+import { stat } from 'fs/promises'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
+
+describe('filesystem watcher unwatchable root cache', () => {
+  const handlers: HandlerMap = {}
+
+  beforeEach(async () => {
+    handleMock.mockReset()
+    vi.mocked(stat).mockReset()
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+    registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  it('evicts oldest failed local roots while suppressing recent retries', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+    vi.mocked(stat).mockRejectedValue(new Error('missing'))
+
+    for (let i = 0; i < 257; i += 1) {
+      await handlers['fs:watchWorktree']({ sender }, { worktreePath: `/tmp/missing-${i}` })
+    }
+    expect(stat).toHaveBeenCalledTimes(257)
+
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/missing-0' })
+    expect(stat).toHaveBeenCalledTimes(258)
+
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/missing-256' })
+    expect(stat).toHaveBeenCalledTimes(258)
+
+    warnSpy.mockRestore()
+    await closeAllWatchers()
+  })
+})

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -49,7 +49,22 @@ const watchedRoots = new Map<string, WatchedRoot>()
 // @parcel/watcher's ReadDirectoryChangesW doesn't work) are cached so
 // we don't retry on every worktree switch and spam the console with
 // repeated "Failed to read changes" / "watchman not found" errors.
+const UNWATCHABLE_ROOT_CACHE_MAX = 256
 const unwatchableRoots = new Set<string>()
+
+function rememberUnwatchableRoot(rootKey: string): void {
+  // Why: missing/deleted worktrees can churn through unique paths during a long
+  // session; keep retry suppression useful without retaining every failed path.
+  unwatchableRoots.delete(rootKey)
+  unwatchableRoots.add(rootKey)
+  while (unwatchableRoots.size > UNWATCHABLE_ROOT_CACHE_MAX) {
+    const oldest = unwatchableRoots.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    unwatchableRoots.delete(oldest)
+  }
+}
 
 // Why: watcher cleanup is keyed to the renderer WebContents, not to a specific
 // watched root. One listener per sender avoids MaxListeners warnings when a
@@ -376,6 +391,7 @@ async function subscribe(worktreePath: string, sender: WebContents): Promise<voi
 
   // Don't retry roots that already failed — avoids repeated error spam.
   if (unwatchableRoots.has(rootKey)) {
+    rememberUnwatchableRoot(rootKey)
     return
   }
 
@@ -394,12 +410,12 @@ async function subscribe(worktreePath: string, sender: WebContents): Promise<voi
       const s = await stat(rootKey)
       if (!s.isDirectory()) {
         console.warn(`[filesystem-watcher] not a directory: ${rootKey}`)
-        unwatchableRoots.add(rootKey)
+        rememberUnwatchableRoot(rootKey)
         return
       }
     } catch {
       console.warn(`[filesystem-watcher] cannot stat root: ${rootKey}`)
-      unwatchableRoots.add(rootKey)
+      rememberUnwatchableRoot(rootKey)
       return
     }
 
@@ -417,7 +433,7 @@ async function subscribe(worktreePath: string, sender: WebContents): Promise<voi
       // Why: createWatcher / createWslWatcher already logged the error.
       // Swallow it here so the renderer's watchWorktree call resolves
       // without crashing the main process.
-      unwatchableRoots.add(rootKey)
+      rememberUnwatchableRoot(rootKey)
       return
     }
     watchedRoots.set(rootKey, root)
@@ -731,6 +747,7 @@ export function registerFilesystemWatcherHandlers(): void {
 /** Tear down all watchers on app shutdown. */
 export async function closeAllWatchers(): Promise<void> {
   senderCleanupRegistered.clear()
+  unwatchableRoots.clear()
 
   // Cancel any pending grace-period teardowns — we're tearing down everything.
   for (const timer of pendingTeardowns.values()) {


### PR DESCRIPTION
## Summary
- bound the local filesystem watcher's failed-root retry-suppression cache to 256 MRU entries
- refresh recency for repeated failed roots and clear the cache during watcher shutdown
- add regression coverage that the oldest failed root is retried after eviction while recent failures remain suppressed

## Risk
Risk: LOW. This only affects roots that already failed watcher setup. Normal successful local, WSL, and SSH watcher lifecycles are unchanged; after more than 256 distinct failed roots, the oldest failure may be retried instead of suppressed forever.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-unwatchable-roots.test.ts`
- `pnpm exec oxlint src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-unwatchable-roots.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/filesystem-watcher.ts src/main/ipc/filesystem-watcher.test.ts src/main/ipc/filesystem-watcher-unwatchable-roots.test.ts`
- `git diff --check`
- `pnpm run typecheck:node`
