### PR TITLE
fix: bound terminal capability cache

### DIFF
--- a/src/renderer/src/lib/windows-terminal-capabilities.test.ts
+++ b/src/renderer/src/lib/windows-terminal-capabilities.test.ts
@@ -197,6 +197,54 @@ describe('windows terminal capabilities', () => {
     expect(runtimeGetStatus).toHaveBeenCalledTimes(2)
   })
 
+  it('prunes expired runtime owner capability caches', async () => {
+    stubTerminalCapabilityApi({
+      wslAvailable: false,
+      pwshAvailable: false,
+      hostPlatform: 'linux'
+    })
+
+    await loadWindowsTerminalCapabilities({ ownerKey: 'runtime:old-host', now: 1_000 })
+    expect(getCachedWindowsTerminalCapabilities('runtime:old-host')).toMatchObject({
+      hostPlatform: 'linux'
+    })
+
+    await loadWindowsTerminalCapabilities({ ownerKey: 'runtime:new-host', now: 32_000 })
+
+    expect(getCachedWindowsTerminalCapabilities('runtime:old-host')).toEqual({
+      wslAvailable: false,
+      wslDistros: [],
+      pwshAvailable: false,
+      gitBashAvailable: false,
+      hostPlatform: null,
+      isLoading: false
+    })
+  })
+
+  it('bounds runtime owner capability caches by evicting the oldest owner', async () => {
+    stubTerminalCapabilityApi({
+      wslAvailable: false,
+      pwshAvailable: false,
+      hostPlatform: 'linux'
+    })
+
+    for (let i = 0; i < 33; i += 1) {
+      await loadWindowsTerminalCapabilities({ ownerKey: `runtime:host-${i}`, now: 1_000 + i })
+    }
+
+    expect(getCachedWindowsTerminalCapabilities('runtime:host-0')).toEqual({
+      wslAvailable: false,
+      wslDistros: [],
+      pwshAvailable: false,
+      gitBashAvailable: false,
+      hostPlatform: null,
+      isLoading: false
+    })
+    expect(getCachedWindowsTerminalCapabilities('runtime:host-32')).toMatchObject({
+      hostPlatform: 'linux'
+    })
+  })
+
   it('does not select the previous owner capabilities while a new owner loads', async () => {
     const isGitBashAvailable = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false)
     vi.stubGlobal('window', {

--- a/src/renderer/src/lib/windows-terminal-capabilities.ts
+++ b/src/renderer/src/lib/windows-terminal-capabilities.ts
@@ -19,6 +19,7 @@ const UNAVAILABLE_CAPABILITIES: WindowsTerminalCapabilities = {
 }
 
 const CAPABILITY_CACHE_TTL_MS = 30_000
+const CAPABILITY_OWNER_CACHE_MAX = 32
 const cachedCapabilitiesByOwnerKey = new Map<
   string,
   { capabilities: WindowsTerminalCapabilities; loadedAt: number }
@@ -53,9 +54,37 @@ function publish(
   ownerKey: string,
   loadedAt = Date.now()
 ): void {
+  cachedCapabilitiesByOwnerKey.delete(ownerKey)
   cachedCapabilitiesByOwnerKey.set(ownerKey, { capabilities, loadedAt })
+  trimCapabilityOwnerCaches()
   for (const subscriber of subscribersByOwnerKey.get(ownerKey) ?? []) {
     subscriber(capabilities)
+  }
+}
+
+function pruneExpiredCapabilityOwners(now: number): void {
+  for (const [ownerKey, cached] of cachedCapabilitiesByOwnerKey) {
+    if (
+      now - cached.loadedAt >= CAPABILITY_CACHE_TTL_MS &&
+      !pendingCapabilitiesByOwnerKey.has(ownerKey) &&
+      !subscribersByOwnerKey.has(ownerKey)
+    ) {
+      cachedCapabilitiesByOwnerKey.delete(ownerKey)
+      latestCapabilityRequestIdByOwnerKey.delete(ownerKey)
+    }
+  }
+}
+
+function trimCapabilityOwnerCaches(): void {
+  while (cachedCapabilitiesByOwnerKey.size > CAPABILITY_OWNER_CACHE_MAX) {
+    const oldest = cachedCapabilitiesByOwnerKey.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    cachedCapabilitiesByOwnerKey.delete(oldest)
+    if (!pendingCapabilitiesByOwnerKey.has(oldest) && !subscribersByOwnerKey.has(oldest)) {
+      latestCapabilityRequestIdByOwnerKey.delete(oldest)
+    }
   }
 }
 
@@ -74,6 +103,7 @@ export function loadWindowsTerminalCapabilities(
 ): Promise<WindowsTerminalCapabilities> {
   const now = options.now ?? Date.now()
   const ownerKey = options.ownerKey ?? 'local'
+  pruneExpiredCapabilityOwners(now)
   const cached = cachedCapabilitiesByOwnerKey.get(ownerKey)
   if (cached && !options.force && now - cached.loadedAt < CAPABILITY_CACHE_TTL_MS) {
     return Promise.resolve(cached.capabilities)


### PR DESCRIPTION
## Summary
- prune expired Windows terminal capability cache entries for inactive runtime owners
- cap retained owner capability caches to 32 most-recent entries
- add regression coverage for expired-owner pruning and oldest-owner eviction

## Risk
Risk: LOW. This only changes stale/inactive cache retention. Active subscribers and in-flight probes are preserved, and stale/evicted owners already re-probe through the existing load path when needed.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/lib/windows-terminal-capabilities.test.ts`
- `pnpm exec oxlint src/renderer/src/lib/windows-terminal-capabilities.ts src/renderer/src/lib/windows-terminal-capabilities.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/lib/windows-terminal-capabilities.ts src/renderer/src/lib/windows-terminal-capabilities.test.ts`
- `git diff --check`
- `pnpm run typecheck:web`
