### PR TITLE
fix: bound hosted review cache

### DIFF
--- a/src/renderer/src/store/slices/hosted-review-cache.test.ts
+++ b/src/renderer/src/store/slices/hosted-review-cache.test.ts
@@ -168,4 +168,29 @@ describe('hosted review cache revalidation', () => {
 
     expect(mockApi.hostedReview.forBranch).toHaveBeenCalledTimes(2)
   })
+
+  it('bounds cached hosted review branches by evicting the oldest entries', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    mockApi.hostedReview.forBranch.mockImplementation(async ({ branch }: { branch: string }) => ({
+      ...review,
+      number: Number(branch.replace('feature/cache-', '')) || review.number,
+      title: branch
+    }))
+    const store = makeStore()
+
+    for (let i = 0; i < 501; i += 1) {
+      vi.setSystemTime(1_000 + i)
+      await store.getState().fetchHostedReviewForBranch('/repo', `feature/cache-${i}`)
+    }
+
+    expect(
+      store.getState().hostedReviewCache[getHostedReviewCacheKey('/repo', 'feature/cache-0')]
+    ).toBeUndefined()
+    expect(
+      store.getState().hostedReviewCache[getHostedReviewCacheKey('/repo', 'feature/cache-500')]
+        ?.data
+    ).toMatchObject({ title: 'feature/cache-500' })
+    expect(Object.keys(store.getState().hostedReviewCache)).toHaveLength(500)
+  })
 })

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -23,6 +23,7 @@ type CacheEntry<T> = { data: T | null; fetchedAt: number; linkedReviewHintKey?: 
 type FetchOptions = { force?: boolean; repoId?: string; staleWhileRevalidate?: boolean }
 
 const CACHE_TTL_MS = 60_000
+const HOSTED_REVIEW_CACHE_MAX = 500
 
 const inflightHostedReviewRequests = new Map<
   string,
@@ -81,6 +82,30 @@ function hasNewerHostedReviewCacheEntry(
     (entry.fetchedAt > requestStartedAt ||
       (entry.fetchedAt === requestStartedAt && entry !== requestStartedEntry))
   )
+}
+
+function withHostedReviewCacheEntry(
+  cache: HostedReviewSlice['hostedReviewCache'],
+  cacheKey: string,
+  entry: CacheEntry<HostedReviewInfo>
+): HostedReviewSlice['hostedReviewCache'] {
+  const next = { ...cache, [cacheKey]: entry }
+  const keys = Object.keys(next)
+  if (keys.length <= HOSTED_REVIEW_CACHE_MAX) {
+    return next
+  }
+  const keep = new Set(
+    keys
+      .map((key) => ({ key, fetchedAt: next[key].fetchedAt }))
+      .sort((a, b) => b.fetchedAt - a.fetchedAt)
+      .slice(0, HOSTED_REVIEW_CACHE_MAX)
+      .map((item) => item.key)
+  )
+  const pruned: HostedReviewSlice['hostedReviewCache'] = {}
+  for (const key of keep) {
+    pruned[key] = next[key]
+  }
+  return pruned
 }
 
 export type HostedReviewSlice = {
@@ -278,10 +303,11 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
                   : currentPRCache
               return {
                 ...(prCache === currentPRCache ? {} : { prCache }),
-                hostedReviewCache: {
-                  ...state.hostedReviewCache,
-                  [cacheKey]: { data: review, fetchedAt: Date.now(), linkedReviewHintKey: hintKey }
-                }
+                hostedReviewCache: withHostedReviewCacheEntry(state.hostedReviewCache, cacheKey, {
+                  data: review,
+                  fetchedAt: Date.now(),
+                  linkedReviewHintKey: hintKey
+                })
               }
             })
           }
@@ -301,10 +327,11 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
                 return {}
               }
               return {
-                hostedReviewCache: {
-                  ...state.hostedReviewCache,
-                  [cacheKey]: { data: null, fetchedAt: Date.now(), linkedReviewHintKey: hintKey }
-                }
+                hostedReviewCache: withHostedReviewCacheEntry(state.hostedReviewCache, cacheKey, {
+                  data: null,
+                  fetchedAt: Date.now(),
+                  linkedReviewHintKey: hintKey
+                })
               }
             })
           }


### PR DESCRIPTION
## Summary
- bound hosted review branch metadata cache to the 500 newest entries
- apply the same pruning to successful lookups and cached null/error results
- add regression coverage for oldest-entry eviction

## Risk
Risk: LOW. This preserves existing cache behavior for normal use; only entries beyond 500 retained hosted-review branch lookups are evicted, causing an old branch to re-fetch if revisited.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/hosted-review-cache.test.ts src/renderer/src/store/slices/hosted-review-cache-race.test.ts src/renderer/src/store/slices/hosted-review.test.ts`
- `pnpm exec oxlint src/renderer/src/store/slices/hosted-review.ts src/renderer/src/store/slices/hosted-review-cache.test.ts`
- `pnpm exec oxfmt --check src/renderer/src/store/slices/hosted-review.ts src/renderer/src/store/slices/hosted-review-cache.test.ts`
- `git diff --check`
- `pnpm run typecheck:web`
