### PR TITLE
fix: prune local share from quick open

### DIFF
--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -35,6 +35,11 @@ describe('shouldIncludeQuickOpenPath', () => {
   it('hides GNOME virtual FS runtime mount from Quick Open', () => {
     expect(shouldIncludeQuickOpenPath('.gvfs/mount/file')).toBe(false)
   })
+  it('hides local share runtime state without hiding all .local files', () => {
+    expect(shouldIncludeQuickOpenPath('.local/share/app/state.db')).toBe(false)
+    expect(shouldIncludeQuickOpenPath('nested/.local/share/app/state.db')).toBe(false)
+    expect(shouldIncludeQuickOpenPath('.local/bin/tool')).toBe(true)
+  })
 
   it('does NOT blocklist user-authored dirs like .config, .ssh, .github', () => {
     expect(HIDDEN_DIR_BLOCKLIST.has('.config')).toBe(false)
@@ -111,6 +116,7 @@ describe('buildHiddenDirExcludeGlobs', () => {
     expect(globs).toContain('!**/node_modules')
     expect(globs).toContain('!**/.git')
     expect(globs).toContain('!**/.cache')
+    expect(globs).toContain('!**/.local/share')
     // Directory-match form (not contents form) — contents form lets rg still
     // descend into the directory.
     expect(globs).not.toContain('!**/node_modules/**')

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -44,9 +44,22 @@ export const HIDDEN_DIR_BLOCKLIST: ReadonlySet<string> = new Set([
   '.gvfs'
 ])
 
+// `.local` itself can contain user-authored files; only the generated desktop
+// runtime subtree is part of the home-root failure blocklist.
+const HIDDEN_PATH_BLOCKLIST: readonly string[] = ['.local/share']
+
 // Kept separate from HIDDEN_DIR_BLOCKLIST because node_modules is not a
 // dotfile dir, but it must still be pruned from every traversal.
 const NON_DOTTED_PRUNE = 'node_modules'
+
+function containsBlockedRelPath(path: string, blockedPath: string): boolean {
+  return (
+    path === blockedPath ||
+    path.startsWith(`${blockedPath}/`) ||
+    path.endsWith(`/${blockedPath}`) ||
+    path.includes(`/${blockedPath}/`)
+  )
+}
 
 /**
  * Returns true if `relPath` (a `/`-separated, root-relative path) does not
@@ -59,6 +72,11 @@ const NON_DOTTED_PRUNE = 'node_modules'
  * files.
  */
 export function shouldIncludeQuickOpenPath(path: string): boolean {
+  for (const blockedPath of HIDDEN_PATH_BLOCKLIST) {
+    if (containsBlockedRelPath(path, blockedPath)) {
+      return false
+    }
+  }
   let start = 0
   const len = path.length
   while (start < len) {
@@ -208,6 +226,9 @@ export function buildHiddenDirExcludeGlobs(): string[] {
   const out: string[] = []
   for (const name of names) {
     out.push('--glob', `!**/${escapeGlob(name)}`)
+  }
+  for (const blockedPath of HIDDEN_PATH_BLOCKLIST) {
+    out.push('--glob', `!**/${escapeGlobPath(blockedPath)}`)
   }
   return out
 }


### PR DESCRIPTION
## Summary
- prune `.local/share` as a nested generated-state subtree in the shared Quick Open filter
- keep sibling `.local` content, such as `.local/bin`, visible
- add the corresponding ripgrep traversal-pruning glob and regression coverage

## Evidence
- Rebased onto current `main` on May 31, 2026.
- Deterministic runtime repro returned `{"files":["src/index.ts",".local/bin/tool"],"includeLocalShare":false,"includeNestedLocalShare":false,"includeLocalBin":true}`.
- Electron validation attached to `mem-leak-audit @ fix/quick-open-local-share-prune` and opened Quick Open for a temp repo containing `.local/share/app/state.db`, `nested/.local/share/app/state.db`, `.local/bin/tool`, and `src/index.ts`. The visible Quick Open dialog showed `index.ts` and `tool .local/bin`, and did not show `state.db` or `.local/share`.

## Risk
risk:low - filtering is scoped to generated `.local/share` subtrees, sibling `.local` content remains visible, and the shared local/SSH filter path is covered by unit tests plus Electron-visible Quick Open verification.

## Verification
- `pnpm exec vitest run src/shared/quick-open-filter.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/quick-open-filter.ts src/shared/quick-open-filter.test.ts`
- `pnpm exec oxfmt --check src/shared/quick-open-filter.ts src/shared/quick-open-filter.test.ts`
- `git diff --check origin/main...HEAD`
- Electron CDP Quick Open smoke test on isolated renderer port 5174 / CDP port 9334

CI: not waiting per instruction.