### PR TITLE
fix: bound github auxiliary caches

### DIFF
--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -8,6 +8,8 @@ import {
   createGitHubSlice,
   mergePRCommentIntoList,
   prChecksCacheSuffix,
+  prCommentsCacheSuffix,
+  projectViewCacheKey,
   workItemsCacheKey
 } from './github'
 import { createHostedReviewSlice } from './hosted-review'
@@ -523,6 +525,30 @@ describe('createGitHubSlice.fetchPRChecks', () => {
     })
   })
 
+  it('bounds checks cache entries across many repo and head combinations', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = createTestStore()
+      mockApi.gh.prChecks.mockResolvedValue([])
+
+      for (let i = 0; i <= 500; i++) {
+        vi.setSystemTime(1_000 + i)
+        await store.getState().fetchPRChecks(`/repo/${i}`, 12, `feature/${i}`, `head-${i}`, null, {
+          force: true,
+          repoId: `repo-${i}`
+        })
+      }
+
+      const cache = store.getState().checksCache
+      expect(Object.keys(cache)).toHaveLength(500)
+      expect(cache[`repo-0::${prChecksCacheSuffix(12, null, 'head-0')}`]).toBeUndefined()
+      expect(cache[`repo-500::${prChecksCacheSuffix(12, null, 'head-500')}`]).toBeDefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not sync stale checks into a PR cache entry for a different PR repo', async () => {
     const store = createTestStore()
     const repoPath = '/repo'
@@ -679,6 +705,30 @@ describe('createGitHubSlice.fetchPRComments', () => {
     expect(
       store.getState().commentsCache[`${repoId}::pr-comments::acme/widgets::12`]
     ).toBeUndefined()
+  })
+
+  it('bounds PR comment cache entries across many repos', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = createTestStore()
+      mockApi.gh.prComments.mockResolvedValue([])
+
+      for (let i = 0; i <= 500; i++) {
+        vi.setSystemTime(1_000 + i)
+        await store.getState().fetchPRComments(`/repo/${i}`, 12, {
+          force: true,
+          repoId: `repo-${i}`
+        })
+      }
+
+      const cache = store.getState().commentsCache
+      expect(Object.keys(cache)).toHaveLength(500)
+      expect(cache[`repo-0::${prCommentsCacheSuffix(12)}`]).toBeUndefined()
+      expect(cache[`repo-500::${prCommentsCacheSuffix(12)}`]).toBeDefined()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('preserves cached checks when the checks IPC fails', async () => {
@@ -3068,6 +3118,30 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     })
   })
 
+  it('bounds work-item cache entries across many repos', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = createTestStore()
+      mockApi.gh.listWorkItems.mockResolvedValue({
+        items: [],
+        sources: { issues: null, prs: null, upstreamCandidate: null }
+      })
+
+      for (let i = 0; i <= 500; i++) {
+        vi.setSystemTime(1_000 + i)
+        await store.getState().fetchWorkItems(`repo-${i}`, `/repo/${i}`, 24, '')
+      }
+
+      const cache = store.getState().workItemsCache
+      expect(Object.keys(cache)).toHaveLength(500)
+      expect(cache[workItemsCacheKey('repo-0', 24, '')]).toBeUndefined()
+      expect(cache[workItemsCacheKey('repo-500', 24, '')]).toBeDefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('quietly skips SSH repos without a resolved GitHub remote in cross-repo fetches', async () => {
     const store = createTestStore()
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -3203,6 +3277,62 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       },
       timeoutMs: 60_000
     })
+  })
+
+  it('bounds project view table cache entries across many projects', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const store = createTestStore()
+      mockApi.gh.getProjectViewTable.mockImplementation(
+        async (args: Parameters<AppState['fetchProjectViewTable']>[0]) => ({
+          ok: true,
+          data: {
+            project: {
+              id: `project-${args.projectNumber}`,
+              owner: args.owner,
+              ownerType: args.ownerType,
+              number: args.projectNumber,
+              title: 'Roadmap',
+              url: `https://github.com/orgs/${args.owner}/projects/${args.projectNumber}`
+            },
+            selectedView: {
+              id: args.viewId ?? `view-${args.projectNumber}`,
+              number: args.projectNumber,
+              name: 'Table',
+              layout: 'TABLE_LAYOUT',
+              filter: '',
+              fields: [],
+              groupByFields: [],
+              sortByFields: []
+            },
+            rows: [],
+            totalCount: 0,
+            parentFieldDropped: false
+          }
+        })
+      )
+
+      for (let i = 0; i <= 500; i++) {
+        vi.setSystemTime(1_000 + i)
+        await store.getState().fetchProjectViewTable(
+          {
+            owner: 'acme',
+            ownerType: 'organization',
+            projectNumber: i,
+            viewId: `view-${i}`
+          },
+          { force: true }
+        )
+      }
+
+      const cache = store.getState().projectViewCache
+      expect(Object.keys(cache)).toHaveLength(500)
+      expect(projectViewCacheKey('organization', 'acme', 0, 'view-0') in cache).toBe(false)
+      expect(projectViewCacheKey('organization', 'acme', 500, 'view-500') in cache).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -968,10 +968,10 @@ function applyGitHubPRResultToCaches(args: {
  * Evict the oldest entries from a cache record when it exceeds the max size.
  * Returns a pruned copy, or the original reference if no eviction was needed.
  */
-function evictStaleEntries<T>(
-  cache: Record<string, CacheEntry<T>>,
+function evictStaleEntries<T extends { fetchedAt: number }>(
+  cache: Record<string, T>,
   maxEntries = MAX_CACHE_ENTRIES
-): Record<string, CacheEntry<T>> {
+): Record<string, T> {
   const keys = Object.keys(cache)
   if (keys.length <= maxEntries) {
     return cache
@@ -980,11 +980,19 @@ function evictStaleEntries<T>(
     .map((k) => ({ key: k, fetchedAt: cache[k].fetchedAt }))
     .sort((a, b) => b.fetchedAt - a.fetchedAt)
   const keep = new Set(sorted.slice(0, maxEntries).map((e) => e.key))
-  const pruned: Record<string, CacheEntry<T>> = {}
+  const pruned: Record<string, T> = {}
   for (const k of keep) {
     pruned[k] = cache[k]
   }
   return pruned
+}
+
+function withBoundedCacheEntry<T extends { fetchedAt: number }>(
+  cache: Record<string, T>,
+  key: string,
+  entry: T
+): Record<string, T> {
+  return evictStaleEntries({ ...cache, [key]: entry })
 }
 
 function shouldRefreshIssueDecorations(state: AppState): boolean {
@@ -1307,24 +1315,21 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             args.queryOverride
           )
           set((s) => ({
-            projectViewCache: {
-              ...s.projectViewCache,
-              [key]: { data: table, fetchedAt: Date.now() }
-            }
+            projectViewCache: withBoundedCacheEntry(s.projectViewCache, key, {
+              data: table,
+              fetchedAt: Date.now()
+            })
           }))
         } else if (maybeKnownKey) {
           // Only stamp the error onto the cache when we have a resolved key
           // (i.e. caller supplied viewId). Otherwise we have nowhere to write
           // it — the renderer classifies the error directly from the envelope.
           set((s) => ({
-            projectViewCache: {
-              ...s.projectViewCache,
-              [maybeKnownKey]: {
-                data: s.projectViewCache[maybeKnownKey]?.data ?? null,
-                fetchedAt: Date.now(),
-                error: envelope.error
-              }
-            }
+            projectViewCache: withBoundedCacheEntry(s.projectViewCache, maybeKnownKey, {
+              data: s.projectViewCache[maybeKnownKey]?.data ?? null,
+              fetchedAt: Date.now(),
+              error: envelope.error
+            })
           }))
         }
         return envelope
@@ -1772,16 +1777,13 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             ? { ...issuesError, source: envelope.sources.issues }
             : undefined
         set((s) => ({
-          workItemsCache: {
-            ...s.workItemsCache,
-            [key]: {
-              data: items,
-              fetchedAt: Date.now(),
-              sources: envelope.sources,
-              ...(errorForCache ? { error: errorForCache } : {}),
-              ...(envelope.issueSourceFellBack ? { issueSourceFellBack: true } : {})
-            }
-          }
+          workItemsCache: withBoundedCacheEntry(s.workItemsCache, key, {
+            data: items,
+            fetchedAt: Date.now(),
+            sources: envelope.sources,
+            ...(errorForCache ? { error: errorForCache } : {}),
+            ...(envelope.issueSourceFellBack ? { issueSourceFellBack: true } : {})
+          })
         }))
         return items
       } catch (err) {
@@ -2211,10 +2213,11 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             })) as PRCheckDetail[])
         set((s) => {
           const nextState: Partial<AppState> = {
-            checksCache: {
-              ...s.checksCache,
-              [cacheKey]: { data: checks, fetchedAt: Date.now(), headSha }
-            }
+            checksCache: withBoundedCacheEntry(s.checksCache, cacheKey, {
+              data: checks,
+              fetchedAt: Date.now(),
+              headSha
+            })
           }
 
           const prStatusUpdate = syncPRChecksStatus(
@@ -2330,10 +2333,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               noCache: options?.force
             })) as PRComment[])
         set((s) => ({
-          commentsCache: {
-            ...s.commentsCache,
-            [cacheKey]: { data: comments, fetchedAt: Date.now() }
-          }
+          commentsCache: withBoundedCacheEntry(s.commentsCache, cacheKey, {
+            data: comments,
+            fetchedAt: Date.now()
+          })
         }))
         return comments
       } catch (err) {
@@ -2395,13 +2398,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     set((s) => {
       const entry = s.commentsCache[cacheKey]
       return {
-        commentsCache: {
-          ...s.commentsCache,
-          [cacheKey]: {
-            data: mergePRCommentIntoList(entry?.data, result.comment),
-            fetchedAt: Date.now()
-          }
-        }
+        commentsCache: withBoundedCacheEntry(s.commentsCache, cacheKey, {
+          data: mergePRCommentIntoList(entry?.data, result.comment),
+          fetchedAt: Date.now()
+        })
       }
     })
     return result
@@ -2466,13 +2466,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     set((s) => {
       const entry = s.commentsCache[cacheKey]
       return {
-        commentsCache: {
-          ...s.commentsCache,
-          [cacheKey]: {
-            data: mergePRCommentIntoList(entry?.data, comment),
-            fetchedAt: Date.now()
-          }
-        }
+        commentsCache: withBoundedCacheEntry(s.commentsCache, cacheKey, {
+          data: mergePRCommentIntoList(entry?.data, comment),
+          fetchedAt: Date.now()
+        })
       }
     })
     return { ok: true, comment }
@@ -2741,12 +2738,15 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
   refreshAllGitHub: () => {
     // Invalidate comments cache so it refreshes on next access.
-    // Also evict old entries from prCache and issueCache to prevent unbounded
-    // growth across many repos and branches over a long-running session.
+    // Also evict old entries from retained caches to prevent unbounded growth
+    // across many repos and branches over a long-running session.
     set((s) => ({
       commentsCache: {},
       prCache: evictStaleEntries(s.prCache),
-      issueCache: evictStaleEntries(s.issueCache)
+      issueCache: evictStaleEntries(s.issueCache),
+      checksCache: evictStaleEntries(s.checksCache),
+      workItemsCache: evictStaleEntries(s.workItemsCache),
+      projectViewCache: evictStaleEntries(s.projectViewCache)
     }))
 
     // Why: prRequestGenerations tracks only live inflight fetches and is


### PR DESCRIPTION
Summary
- Bound GitHub checks, comments, work item, and project view caches with the existing 500-entry eviction policy.
- Added regression tests proving each cache drops the oldest entry after 501 distinct keys.

Risk assessment: LOW
- Cache writes now use the same fetchedAt-based eviction helper already used by PR/issue caches.
- Behavior is limited to retaining less stale data in long-running sessions; active fetch paths and cache key formats are unchanged.

Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/github.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/github.ts src/renderer/src/store/slices/github.test.ts
- pnpm exec oxfmt --check src/renderer/src/store/slices/github.ts src/renderer/src/store/slices/github.test.ts
- git diff --check
- pnpm run typecheck:web

CI: not waiting per instruction.