### PR TITLE
fix: map closed gitea drafts as closed

### DIFF
--- a/src/main/gitea/pull-request-mappers.test.ts
+++ b/src/main/gitea/pull-request-mappers.test.ts
@@ -11,6 +11,7 @@ describe('Gitea pull request mappers', () => {
     expect(mapGiteaPullRequestState({ state: 'open' })).toBe('open')
     expect(mapGiteaPullRequestState({ state: 'closed' })).toBe('closed')
     expect(mapGiteaPullRequestState({ state: 'open', draft: true })).toBe('draft')
+    expect(mapGiteaPullRequestState({ state: 'closed', draft: true })).toBe('closed')
     expect(mapGiteaPullRequestState({ state: 'closed', merged: true })).toBe('merged')
   })
 

--- a/src/main/gitea/pull-request-mappers.ts
+++ b/src/main/gitea/pull-request-mappers.ts
@@ -93,10 +93,15 @@ export function mapGiteaPullRequestState(
   if (raw.merged) {
     return 'merged'
   }
+  // Closed Gitea PRs can still carry the draft flag; terminal state should
+  // win so review summaries do not show closed PRs as active drafts.
+  if (raw.state?.trim().toLowerCase() === 'closed') {
+    return 'closed'
+  }
   if (raw.draft) {
     return 'draft'
   }
-  return raw.state?.trim().toLowerCase() === 'closed' ? 'closed' : 'open'
+  return 'open'
 }
 
 export function mapGiteaMergeable(value: boolean | null | undefined): PRMergeableState {


### PR DESCRIPTION
## Summary
- make terminal Gitea PR state win over the draft flag
- keep open drafts mapped as `draft` and merged PRs mapped as `merged`
- add regression coverage for closed draft PR payloads

## Evidence
Before the fix, the focused regression failed because a closed draft payload mapped to `draft`:

```text
AssertionError: expected `draft` to be `closed`
src/main/gitea/pull-request-mappers.test.ts:14
```

Before-fix runtime repro:

```json
{"closedDraft":"draft","mergedDraft":"merged","openDraft":"draft"}
```

After-fix runtime repro:

```json
{"closedDraft":"closed","mergedDraft":"merged","openDraft":"draft"}
```

No screenshot attached because this is provider response mapping; the deterministic mapper output shows the exact rendered state Orca receives.

## Verification
- `pnpm exec vitest run src/main/gitea/pull-request-mappers.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/main/gitea/pull-request-mappers.ts src/main/gitea/pull-request-mappers.test.ts`
- `pnpm exec oxfmt --check src/main/gitea/pull-request-mappers.ts src/main/gitea/pull-request-mappers.test.ts`
- `git diff --check origin/main...HEAD`
