### PR TITLE
perf: move update card timer cleanup to ref

### DIFF
--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the update card owns the full updater lifecycle in one
    renderer surface. Keeping the state machine and its presentation variants together avoids
    scattering tightly coupled update behavior across multiple files. */
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { useAppStore } from '../store'
 import { Card } from './ui/card'
@@ -200,16 +200,28 @@ export function UpdateCard() {
   // ── Prefers-reduced-motion ──────────────────────────────────────────
   const prefersReducedMotion = usePrefersReducedMotion()
 
-  useEffect(() => {
-    return () => {
-      if (dismissAnimationTimerRef.current !== null) {
-        window.clearTimeout(dismissAnimationTimerRef.current)
-      }
-      if (collapseAnimationTimerRef.current !== null) {
-        window.clearTimeout(collapseAnimationTimerRef.current)
-      }
+  const clearAnimationTimers = useCallback(() => {
+    if (dismissAnimationTimerRef.current !== null) {
+      window.clearTimeout(dismissAnimationTimerRef.current)
+      dismissAnimationTimerRef.current = null
+    }
+    if (collapseAnimationTimerRef.current !== null) {
+      window.clearTimeout(collapseAnimationTimerRef.current)
+      collapseAnimationTimerRef.current = null
     }
   }, [])
+
+  const cardRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node !== null) {
+        return
+      }
+      // Why: exit timers are owned by the visible update-card surface, so
+      // stale callbacks should be cancelled as soon as that surface unmounts.
+      clearAnimationTimers()
+    },
+    [clearAnimationTimers]
+  )
 
   // ── Visibility gates ──────────────────────────────────────────────
 
@@ -542,6 +554,7 @@ export function UpdateCard() {
 
   return (
     <div
+      ref={cardRootRef}
       className="fixed bottom-10 right-4 z-40 w-[360px] max-w-[calc(100vw-32px)] flex flex-col gap-2
       max-[480px]:left-4 max-[480px]:right-4 max-[480px]:w-auto"
     >


### PR DESCRIPTION
## Summary
- replace the cleanup-only update-card animation timer effect with a stable root callback ref
- clear and null dismiss/collapse animation timer refs as soon as the update-card surface unmounts

## Verification
- pnpm exec oxlint src/renderer/src/components/UpdateCard.tsx
- pnpm exec oxfmt --check src/renderer/src/components/UpdateCard.tsx
- pnpm run typecheck:web
- git diff --check
- scoped AST count: UpdateCard now has 2 Effect hooks and 0 cleanup-only Effect hooks

Risk: low. This only moves existing unmount cleanup for two UI animation timers to the owning DOM ref; updater state and IPC behavior are unchanged.