### PR TITLE
perf: strip cached macOS screenshots

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -135,6 +135,26 @@ struct Snapshot {
     let elements: [Int: ElementRecord]
     let truncated: Bool
     let maxDepthReached: Bool
+
+    func withoutScreenshotPayload() -> Snapshot {
+        Snapshot(
+            id: id,
+            app: app,
+            windowTitle: windowTitle,
+            windowBounds: windowBounds,
+            windowId: windowId,
+            windowLayer: windowLayer,
+            treeText: treeText,
+            focusedElementId: focusedElementId,
+            screenshot: nil,
+            screenshotStatus: .skipped,
+            screenshotScale: CGSize(width: 1, height: 1),
+            screenshotEngine: nil,
+            elements: elements,
+            truncated: truncated,
+            maxDepthReached: maxDepthReached
+        )
+    }
 }
 
 struct ScreenshotPayload {
@@ -223,18 +243,21 @@ final class Provider {
         )
         let keys = [query, app.name, app.bundleId ?? ""].filter { !$0.isEmpty }.map { $0.lowercased() }
         let namespace = snapshotNamespace(params)
+        // Why: cached snapshots only validate element identity for follow-up
+        // actions; retaining MB-scale screenshot base64 in the long-lived agent grows memory.
+        let cachedSnapshot = snapshot.withoutScreenshotPayload()
         for key in keys {
             if !isExplicitSnapshotNamespace(namespace) {
-                snapshots[key] = snapshot
-                snapshots[snapshotWindowKey(key, snapshot.windowId)] = snapshot
+                snapshots[key] = cachedSnapshot
+                snapshots[snapshotWindowKey(key, snapshot.windowId)] = cachedSnapshot
                 if let windowIndex {
-                    snapshots[snapshotWindowIndexKey(key, windowIndex)] = snapshot
+                    snapshots[snapshotWindowIndexKey(key, windowIndex)] = cachedSnapshot
                 }
             }
-            snapshots[namespacedSnapshotKey(namespace, key)] = snapshot
-            snapshots[namespacedSnapshotKey(namespace, snapshotWindowKey(key, snapshot.windowId))] = snapshot
+            snapshots[namespacedSnapshotKey(namespace, key)] = cachedSnapshot
+            snapshots[namespacedSnapshotKey(namespace, snapshotWindowKey(key, snapshot.windowId))] = cachedSnapshot
             if let windowIndex {
-                snapshots[namespacedSnapshotKey(namespace, snapshotWindowIndexKey(key, windowIndex))] = snapshot
+                snapshots[namespacedSnapshotKey(namespace, snapshotWindowIndexKey(key, windowIndex))] = cachedSnapshot
             }
         }
         return snapshot


### PR DESCRIPTION
## Summary
- stop retaining screenshot base64 payloads inside the long-lived macOS computer-use snapshot cache
- keep cached AX element records/window metadata for follow-up action validation
- keep fresh getAppState/action responses unchanged by returning the full current snapshot before caching the stripped copy

## Risk
Low after focused review. Cached screenshots are not used for follow-up actions; actions only use cached snapshots to validate element identity before a fresh no-screenshot observation. A broader cache LRU was intentionally avoided because aliases/session/window keys need separate tests.

## Verification
- `swift test --package-path native/computer-use-macos`
- `pnpm run build:computer-macos`
- `pnpm run verify:computer-native` (passes locally; Windows parse/handshake skipped because `pwsh` is not installed)
- `git diff --check`