### PR TITLE
fix: release remote agent detection promises

### DIFF
--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -2,17 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
 import type { AppState } from '../types'
 import type { Repo, Worktree } from '../../../../shared/types'
-import { createDetectedAgentsSlice } from './detected-agents'
+import { _getRemoteDetectPromiseCountForTest, createDetectedAgentsSlice } from './detected-agents'
 
 const detectAgents = vi.fn()
 const refreshAgents = vi.fn()
+const detectRemoteAgents = vi.fn()
 
 globalThis.window = {
   api: {
     preflight: {
       detectAgents,
       refreshAgents,
-      detectRemoteAgents: vi.fn().mockResolvedValue([])
+      detectRemoteAgents
     }
   } as unknown as Window['api']
 } as Window & typeof globalThis
@@ -77,6 +78,7 @@ describe('createDetectedAgentsSlice WSL context', () => {
       pathSource: 'shell_hydrate',
       pathFailureReason: 'none'
     })
+    detectRemoteAgents.mockReset().mockResolvedValue([])
   })
 
   it('detects local agents inside the active WSL worktree distro', async () => {
@@ -201,5 +203,45 @@ describe('createDetectedAgentsSlice WSL context', () => {
     expect(store.getState().detectedAgentIds).toBeNull()
     await expect(detected).resolves.toEqual([])
     expect(store.getState().detectedAgentIds).toEqual([])
+  })
+})
+
+describe('createDetectedAgentsSlice remote detection', () => {
+  beforeEach(() => {
+    detectAgents.mockReset().mockResolvedValue(['claude'])
+    refreshAgents.mockReset().mockResolvedValue({
+      agents: ['codex'],
+      addedPathSegments: [],
+      shellHydrationOk: true,
+      pathSource: 'shell_hydrate',
+      pathFailureReason: 'none'
+    })
+    detectRemoteAgents.mockReset().mockResolvedValue([])
+  })
+
+  it('retains remote detection promises only while requests are in flight', async () => {
+    const store = createTestStore()
+    let resolveRemote: (ids: string[]) => void = () => {}
+    detectRemoteAgents.mockReturnValueOnce(
+      new Promise<string[]>((resolve) => {
+        resolveRemote = resolve
+      })
+    )
+
+    const first = store.getState().ensureRemoteDetectedAgents('ssh-1')
+    const second = store.getState().ensureRemoteDetectedAgents('ssh-1')
+
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
+    expect(_getRemoteDetectPromiseCountForTest()).toBe(1)
+
+    resolveRemote(['claude'])
+
+    await expect(first).resolves.toEqual(['claude'])
+    await expect(second).resolves.toEqual(['claude'])
+    expect(store.getState().remoteDetectedAgentIds['ssh-1']).toEqual(['claude'])
+    expect(_getRemoteDetectPromiseCountForTest()).toBe(0)
+
+    await expect(store.getState().ensureRemoteDetectedAgents('ssh-1')).resolves.toEqual(['claude'])
+    expect(detectRemoteAgents).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -40,6 +40,10 @@ let refreshPromise: { key: string; promise: Promise<TuiAgent[]> } | null = null
 let detectedContextKey: string | null = null
 const remoteDetectPromises = new Map<string, Promise<TuiAgent[]>>()
 
+export function _getRemoteDetectPromiseCountForTest(): number {
+  return remoteDetectPromises.size
+}
+
 export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedAgentsSlice> = (
   set,
   get
@@ -160,11 +164,18 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
       })
       .catch(() => {
         // Why: allow retry on next call (SSH may reconnect). Do not cache failure.
-        remoteDetectPromises.delete(connectionId)
         set((s) => ({
           isDetectingRemoteAgents: { ...s.isDetectingRemoteAgents, [connectionId]: false }
         }))
         return [] as TuiAgent[]
+      })
+      .finally(() => {
+        // Why: this map is only for in-flight dedupe. Successful results live
+        // in remoteDetectedAgentIds, so keeping resolved promises duplicates
+        // one entry per SSH connection for the rest of the renderer session.
+        if (remoteDetectPromises.get(connectionId) === pending) {
+          remoteDetectPromises.delete(connectionId)
+        }
       })
 
     remoteDetectPromises.set(connectionId, pending)


### PR DESCRIPTION
Summary
- Release remote agent detection dedupe promises once each request settles.
- Keep concurrent remote detections deduped while relying on `remoteDetectedAgentIds` for successful cached results.
- Add a regression proving the in-flight map drops back to zero after resolution.

Risk assessment: LOW
- The dedupe map remains active during the request, then clears after the cached result is in Zustand state.
- No IPC/API behavior changes; repeated callers still receive cached remote agent IDs.

Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/detected-agents.test.ts
- pnpm exec oxlint src/renderer/src/store/slices/detected-agents.ts src/renderer/src/store/slices/detected-agents.test.ts
- pnpm exec oxfmt --check src/renderer/src/store/slices/detected-agents.ts src/renderer/src/store/slices/detected-agents.test.ts
- pnpm run typecheck:web
- git diff --check

CI: not waiting per instruction.