### PR TITLE
fix: bound metadata request caches

### DIFF
--- a/src/renderer/src/hooks/metadata-request-cache.test.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.test.ts
@@ -82,4 +82,36 @@ describe('metadata-request-cache', () => {
     await expect(pending).resolves.toEqual(['old-user'])
     expect(getFreshMetadata(store, 'team:members', 1_100)).toBeNull()
   })
+
+  it('prunes stale cache entries when they age past the metadata ttl', async () => {
+    const store = createMetadataRequestStore<string[]>()
+
+    await loadMetadata(
+      store,
+      'repo:labels',
+      () => Promise.resolve(['bug']),
+      () => 1_000
+    )
+
+    expect(store.cache.has('repo:labels')).toBe(true)
+    expect(getFreshMetadata(store, 'repo:labels', 301_000)).toBeNull()
+    expect(store.cache.has('repo:labels')).toBe(false)
+  })
+
+  it('bounds retained cache entries by newest fetch time', async () => {
+    const store = createMetadataRequestStore<string[]>()
+
+    for (let i = 0; i <= 500; i++) {
+      await loadMetadata(
+        store,
+        `repo-${i}:labels`,
+        () => Promise.resolve([`label-${i}`]),
+        () => i
+      )
+    }
+
+    expect(store.cache.size).toBe(500)
+    expect(store.cache.has('repo-0:labels')).toBe(false)
+    expect(store.cache.get('repo-500:labels')?.data).toEqual(['label-500'])
+  })
 })

--- a/src/renderer/src/hooks/metadata-request-cache.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.ts
@@ -1,4 +1,5 @@
 const METADATA_TTL = 300_000 // 5 min
+const MAX_METADATA_CACHE_ENTRIES = 500
 
 type CachedMetadata<T> = { data: T; fetchedAt: number }
 
@@ -22,11 +23,31 @@ export function clearMetadataRequestStore<T>(store: MetadataRequestStore<T>): vo
   store.inflight.clear()
 }
 
+function pruneMetadataCache<T>(
+  store: MetadataRequestStore<T>,
+  now: number,
+  maxEntries = MAX_METADATA_CACHE_ENTRIES
+): void {
+  for (const [key, entry] of store.cache) {
+    if (now - entry.fetchedAt >= METADATA_TTL) {
+      store.cache.delete(key)
+    }
+  }
+  if (store.cache.size <= maxEntries) {
+    return
+  }
+  const sorted = [...store.cache.entries()].sort((a, b) => b[1].fetchedAt - a[1].fetchedAt)
+  for (const [key] of sorted.slice(maxEntries)) {
+    store.cache.delete(key)
+  }
+}
+
 export function getFreshMetadata<T>(
   store: MetadataRequestStore<T>,
   key: string,
   now = Date.now()
 ): CachedMetadata<T> | null {
+  pruneMetadataCache(store, now)
   const entry = store.cache.get(key)
   if (!entry || now - entry.fetchedAt >= METADATA_TTL) {
     return null
@@ -56,7 +77,12 @@ export function loadMetadata<T>(
   const promise = fetcher()
     .then((data) => {
       if (store.generation === generation) {
-        store.cache.set(key, { data, fetchedAt: now() })
+        const fetchedAt = now()
+        store.cache.set(key, { data, fetchedAt })
+        // Why: these module-level stores are reused across dialogs and
+        // repo/runtime keys; TTL controls freshness but also needs pruning so
+        // long sessions do not retain stale metadata indefinitely.
+        pruneMetadataCache(store, fetchedAt)
       }
       return data
     })


### PR DESCRIPTION
Summary
- Prune stale metadata request cache entries once they pass the 5 minute TTL.
- Cap each metadata cache store to the newest 500 fetched entries.
- Add regressions for TTL pruning and newest-entry eviction.

Risk assessment: LOW
- The change only reduces retained stale metadata in module-level hook caches.
- Fresh cache hits and in-flight dedupe behavior are unchanged.

Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/metadata-request-cache.test.ts
- pnpm exec oxlint src/renderer/src/hooks/metadata-request-cache.ts src/renderer/src/hooks/metadata-request-cache.test.ts
- pnpm exec oxfmt --check src/renderer/src/hooks/metadata-request-cache.ts src/renderer/src/hooks/metadata-request-cache.test.ts
- pnpm run typecheck:web
- git diff --check

CI: not waiting per instruction.