### PR TITLE
perf: move browser settings scroll cleanup to ref

### DIFF
--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MutableRefObject } from 'react'
+import { useCallback, useRef, useState, type MutableRefObject } from 'react'
 import { Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import type { GlobalSettings } from '../../../../shared/types'
@@ -83,8 +83,13 @@ export function BrowserPane({
     setHomePageDraftState((current) => ({ ...current, value }))
   }
 
-  useEffect(() => {
-    return () => cancelBrowserSessionCookieScrollFrames(sessionCookieScrollFrameIdsRef)
+  const setBrowserPaneRootNode = useCallback((node: HTMLDivElement | null) => {
+    if (node !== null) {
+      return
+    }
+    // Why: session-cookie scroll frames are owned by this Settings pane surface;
+    // cancel them as soon as the pane unmounts so stale jumps cannot fire later.
+    cancelBrowserSessionCookieScrollFrames(sessionCookieScrollFrameIdsRef)
   }, [])
 
   const selectedSearchEngine = browserDefaultSearchEngine ?? 'google'
@@ -136,7 +141,7 @@ export function BrowserPane({
   }
 
   return (
-    <div className="space-y-6">
+    <div ref={setBrowserPaneRootNode} className="space-y-6">
       {showBrowserUse ? (
         <BrowserUseSetup
           onConfigureMoreBrowsers={scrollToSessionCookies}


### PR DESCRIPTION
## Summary
- replace the cleanup-only Browser settings scroll-frame effect with a stable root callback ref
- cancel pending Session & Cookies double-RAF scroll frames when the Browser settings pane unmounts

## Verification
- pnpm exec oxlint src/renderer/src/components/settings/BrowserPane.tsx
- pnpm exec oxfmt --check src/renderer/src/components/settings/BrowserPane.tsx
- pnpm run typecheck:web
- git diff --check
- scoped AST count: BrowserPane.tsx now has 0 Effect hooks and 0 cleanup-only Effect hooks

Risk: low. This only moves existing unmount cleanup for Settings BrowserPane scroll animation frames to the owning DOM ref; settings state, browser profile behavior, and IPC paths are unchanged.