### PR TITLE
fix: parse numstat paths with nul output

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -609,6 +609,32 @@ describe('getStatus', () => {
     ])
   })
 
+  it('attaches numstat counts for literal paths containing rename markers', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        return Promise.resolve({
+          stdout: '1 .M N... 100644 100644 100644 aaaa aaaa docs/a => b.txt\n'
+        })
+      }
+      if (args.includes('--numstat')) {
+        return Promise.resolve({ stdout: '1\t0\tdocs/a => b.txt\0' })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const result = await getStatus('/repo')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['-c', 'core.quotePath=false', 'diff', '-z', '--numstat', '-M'],
+      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
+    )
+    expect(result.entries).toEqual([
+      { path: 'docs/a => b.txt', status: 'modified', area: 'unstaged', added: 1, removed: 0 }
+    ])
+  })
+
   it('attaches staged rename counts to the new path', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
     existsSyncMock.mockReturnValue(false)

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -219,7 +219,15 @@ async function runNumstat(
 ): Promise<Map<string, GitLineStats>> {
   try {
     const { stdout } = await gitExecFileAsync(
-      ['-c', 'core.quotePath=false', 'diff', ...(cached ? ['--cached'] : []), '--numstat', '-M'],
+      [
+        '-c',
+        'core.quotePath=false',
+        'diff',
+        '-z',
+        ...(cached ? ['--cached'] : []),
+        '--numstat',
+        '-M'
+      ],
       { cwd: worktreePath, env: gitOptionalLocksDisabledEnv() }
     )
     return parseNumstat(stdout)

--- a/src/shared/git-uncommitted-line-stats.test.ts
+++ b/src/shared/git-uncommitted-line-stats.test.ts
@@ -45,6 +45,18 @@ describe('parseNumstat', () => {
     expect(plain.get('new.ts')).toEqual({ added: 2, removed: 1 })
   })
 
+  it('keeps literal rename-marker filenames when parsing NUL-delimited numstat', () => {
+    const stats = parseNumstat('1\t0\tdocs/a => b.txt\0')
+
+    expect(stats.get('docs/a => b.txt')).toEqual({ added: 1, removed: 0 })
+  })
+
+  it('keys NUL-delimited renames to the post-rename path', () => {
+    const stats = parseNumstat('2\t1\t\0old.ts\0new.ts\0')
+
+    expect(stats.get('new.ts')).toEqual({ added: 2, removed: 1 })
+  })
+
   it('ignores blank lines', () => {
     expect(parseNumstat('').size).toBe(0)
   })

--- a/src/shared/git-uncommitted-line-stats.ts
+++ b/src/shared/git-uncommitted-line-stats.ts
@@ -45,6 +45,10 @@ function normalizeNumstatPath(rawPath: string): string {
 }
 
 export function parseNumstat(stdout: string): Map<string, GitLineStats> {
+  if (stdout.includes('\0')) {
+    return parseNulDelimitedNumstat(stdout)
+  }
+
   const stats = new Map<string, GitLineStats>()
   for (const line of stdout.split(/\r?\n/)) {
     if (!line) {
@@ -56,6 +60,34 @@ export function parseNumstat(stdout: string): Map<string, GitLineStats> {
       continue
     }
     stats.set(normalizeNumstatPath(rawPath), {
+      added: parseNumstatCount(parts[0] ?? ''),
+      removed: parseNumstatCount(parts[1] ?? '')
+    })
+  }
+  return stats
+}
+
+function parseNulDelimitedNumstat(stdout: string): Map<string, GitLineStats> {
+  const stats = new Map<string, GitLineStats>()
+  const records = stdout.split('\0')
+  for (let i = 0; i < records.length; i += 1) {
+    const record = records[i]
+    if (!record) {
+      continue
+    }
+    const parts = record.split('\t')
+    const rawPath = parts.slice(2).join('\t')
+    let path = rawPath
+    if (!path) {
+      // Git -z emits rename paths as: "added<TAB>removed<TAB>\0old\0new\0".
+      // The split record has an empty path in the header; the postimage is next.
+      i += 2
+      path = records[i] ?? ''
+    }
+    if (!path) {
+      continue
+    }
+    stats.set(path, {
       added: parseNumstatCount(parts[0] ?? ''),
       removed: parseNumstatCount(parts[1] ?? '')
     })


### PR DESCRIPTION
## Summary
- request `git diff -z --numstat -M` for source-control line counts
- parse NUL-delimited regular file and rename records so literal ` => ` filenames are not mistaken for rename notation
- add parser and status-level regressions for the source-control sidebar count path

## Evidence
Real Git repro before the fix:

```text
STATUS
1 .M ... docs/a => b.txt
NUMSTAT
1<TAB>0<TAB>docs/a => b.txt
```

Before-fix runtime parser output keyed the count to the wrong path:

```json
[["b.txt",{"added":1,"removed":0}]]
```

After-fix runtime parser output preserves literal paths and still keys real renames to the new path:

```json
{"literal":[["docs/a => b.txt",{"added":1,"removed":0}]],"rename":[["new.ts",{"added":2,"removed":1}]]}
```

No screenshot attached because this is source-control line-count parsing; the deterministic Git/status output shows the exact sidebar row key mismatch.

## Verification
- `pnpm exec vitest run src/shared/git-uncommitted-line-stats.test.ts src/main/git/status.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/git-uncommitted-line-stats.ts src/shared/git-uncommitted-line-stats.test.ts src/main/git/status.ts src/main/git/status.test.ts`
- `pnpm exec oxfmt --check src/shared/git-uncommitted-line-stats.ts src/shared/git-uncommitted-line-stats.test.ts src/main/git/status.ts src/main/git/status.test.ts`
- `git diff --check origin/main...HEAD`
