### PR TITLE
perf: move settings subsection scroll cleanup to ref

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -258,6 +258,16 @@ function Settings(): React.JSX.Element {
     [setSettingsSearchQuery]
   )
 
+  const setContentScrollNode = useCallback((node: HTMLDivElement | null): void => {
+    contentScrollRef.current = node
+    if (node !== null) {
+      return
+    }
+    // Why: pending subsection jumps are scoped to the scroll container; cancel
+    // them with the container so a stale deep-link frame cannot run after close.
+    cancelPendingSettingsSubsectionScrollFrame(pendingSubsectionScrollFrameRef)
+  }, [])
+
   const confirmDiscardSourceControlAiPromptChanges = useCallback(async (): Promise<boolean> => {
     if (!hasUnsavedSourceControlAiPromptChanges) {
       return true
@@ -606,10 +616,6 @@ function Settings(): React.JSX.Element {
   }, [neededRepoIds, repos, runtimeTargetIdentity])
 
   useEffect(() => {
-    return () => cancelPendingSettingsSubsectionScrollFrame(pendingSubsectionScrollFrameRef)
-  }, [])
-
-  useEffect(() => {
     const scrollTargetId = pendingScrollTargetRef.current
     const pendingNavSectionId = pendingNavSectionRef.current
 
@@ -777,7 +783,7 @@ function Settings(): React.JSX.Element {
 
       <div className="flex min-h-0 flex-1 flex-col">
         <div
-          ref={contentScrollRef}
+          ref={setContentScrollNode}
           className={cn(
             'min-h-0 flex-1',
             isFocusedShortcutsPane ? 'overflow-hidden' : 'overflow-y-auto scrollbar-sleek'


### PR DESCRIPTION
## Summary
- replace the cleanup-only Settings subsection scroll-frame effect with a stable content scroller callback ref
- cancel pending deep-link subsection animation frames when the Settings content scroller unmounts

## Verification
- pnpm exec oxlint src/renderer/src/components/settings/Settings.tsx
- pnpm exec oxfmt --check src/renderer/src/components/settings/Settings.tsx
- pnpm run typecheck:web
- git diff --check
- scoped AST count: Settings.tsx now has 10 Effect hooks and 0 cleanup-only Effect hooks

Risk: low. This only moves existing unmount cleanup for a Settings deep-link animation frame to the owning scroll container ref; Settings navigation, persistence, SSH/runtime sections, and IPC behavior are unchanged.