### PR TITLE
fix: clear removed browser eviction notices

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -35,12 +35,12 @@ import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import EditorAutosaveController from './editor/EditorAutosaveController'
 import type { TabGroupLayoutNode } from '../../../shared/types'
 import BrowserPane from './browser-pane/BrowserPane'
-import { destroyPersistentWebview } from './browser-pane/webview-registry'
 import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
 import { useBrowserAutomationVisibilityForAny } from './browser-pane/browser-automation-visibility'
 import TerminalPaneOverlayLayer from './terminal-pane/TerminalPaneOverlayLayer'
 import {
   collectBrowserWebviewIds,
+  destroyRemovedBrowserWebview,
   destroyWorkspaceWebviews
 } from '../store/slices/browser-webview-cleanup'
 import {
@@ -1442,7 +1442,7 @@ function Terminal(): React.JSX.Element | null {
       )
       for (const prevId of prevBrowserWebviewIdsRef.current) {
         if (!currentIds.has(prevId)) {
-          destroyPersistentWebview(prevId)
+          destroyRemovedBrowserWebview(prevId)
         }
       }
       prevBrowserWebviewIdsRef.current = currentIds

--- a/src/renderer/src/components/browser-pane/browser-runtime.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-runtime.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _getEvictedBrowserTabCountForTest,
+  clearEvictedBrowserTab,
+  consumeEvictedBrowserTab,
+  markEvictedBrowserTab
+} from './browser-runtime'
+
+describe('browser runtime eviction notices', () => {
+  beforeEach(() => {
+    clearEvictedBrowserTab('page-1')
+    clearEvictedBrowserTab('page-2')
+  })
+
+  it('clears an eviction notice without waiting for the page to remount', () => {
+    markEvictedBrowserTab('page-1')
+
+    expect(_getEvictedBrowserTabCountForTest()).toBe(1)
+
+    clearEvictedBrowserTab('page-1')
+
+    expect(consumeEvictedBrowserTab('page-1')).toBe(false)
+    expect(_getEvictedBrowserTabCountForTest()).toBe(0)
+  })
+
+  it('keeps active eviction notices consumable', () => {
+    markEvictedBrowserTab('page-2')
+
+    expect(consumeEvictedBrowserTab('page-2')).toBe(true)
+    expect(consumeEvictedBrowserTab('page-2')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-runtime.ts
+++ b/src/renderer/src/components/browser-pane/browser-runtime.ts
@@ -13,6 +13,10 @@ export function clearLiveBrowserUrl(browserTabId: string): void {
   liveBrowserUrlByTabId.delete(browserTabId)
 }
 
+export function clearEvictedBrowserTab(browserTabId: string): void {
+  evictedBrowserTabIds.delete(browserTabId)
+}
+
 export function markEvictedBrowserTab(browserTabId: string): void {
   evictedBrowserTabIds.add(browserTabId)
 }
@@ -23,4 +27,8 @@ export function consumeEvictedBrowserTab(browserTabId: string): boolean {
     evictedBrowserTabIds.delete(browserTabId)
   }
   return wasEvicted
+}
+
+export function _getEvictedBrowserTabCountForTest(): number {
+  return evictedBrowserTabIds.size
 }

--- a/src/renderer/src/store/slices/browser-webview-cleanup.test.ts
+++ b/src/renderer/src/store/slices/browser-webview-cleanup.test.ts
@@ -4,9 +4,17 @@ import type { BrowserPage, BrowserWorkspace } from '../../../../shared/types'
 vi.mock('../../components/browser-pane/webview-registry', () => ({
   destroyPersistentWebview: vi.fn()
 }))
+vi.mock('../../components/browser-pane/browser-runtime', () => ({
+  clearEvictedBrowserTab: vi.fn()
+}))
 
-import { collectBrowserWebviewIds, destroyWorkspaceWebviews } from './browser-webview-cleanup'
+import {
+  collectBrowserWebviewIds,
+  destroyRemovedBrowserWebview,
+  destroyWorkspaceWebviews
+} from './browser-webview-cleanup'
 import { destroyPersistentWebview } from '../../components/browser-pane/webview-registry'
+import { clearEvictedBrowserTab } from '../../components/browser-pane/browser-runtime'
 
 function workspace(id: string): BrowserWorkspace {
   return {
@@ -63,6 +71,14 @@ describe('collectBrowserWebviewIds', () => {
 describe('destroyWorkspaceWebviews', () => {
   beforeEach(() => {
     vi.mocked(destroyPersistentWebview).mockClear()
+    vi.mocked(clearEvictedBrowserTab).mockClear()
+  })
+
+  it('clears stale eviction notices when the backing page is removed', () => {
+    destroyRemovedBrowserWebview('page-1')
+
+    expect(clearEvictedBrowserTab).toHaveBeenCalledWith('page-1')
+    expect(destroyPersistentWebview).toHaveBeenCalledWith('page-1')
   })
 
   it('destroys every page id for a multi-page workspace', () => {
@@ -74,6 +90,8 @@ describe('destroyWorkspaceWebviews', () => {
     expect(destroyPersistentWebview).toHaveBeenCalledTimes(2)
     expect(destroyPersistentWebview).toHaveBeenCalledWith('page-1')
     expect(destroyPersistentWebview).toHaveBeenCalledWith('page-2')
+    expect(clearEvictedBrowserTab).toHaveBeenCalledWith('page-1')
+    expect(clearEvictedBrowserTab).toHaveBeenCalledWith('page-2')
   })
 
   it('falls back to the workspace id when no pages exist (legacy sessions)', () => {

--- a/src/renderer/src/store/slices/browser-webview-cleanup.ts
+++ b/src/renderer/src/store/slices/browser-webview-cleanup.ts
@@ -1,10 +1,18 @@
 import type { BrowserPage, BrowserWorkspace } from '../../../../shared/types'
+import { clearEvictedBrowserTab } from '../../components/browser-pane/browser-runtime'
 import {
   destroyPersistentWebview,
   moveFocusToRendererBeforeFocusedWebviewHidden
 } from '../../components/browser-pane/webview-registry'
 
 export { moveFocusToRendererBeforeFocusedWebviewHidden }
+
+export function destroyRemovedBrowserWebview(browserPageId: string): void {
+  // Why: eviction notices are intentionally kept while the page model exists,
+  // but once the backing page is gone there is no future mount to consume it.
+  clearEvictedBrowserTab(browserPageId)
+  destroyPersistentWebview(browserPageId)
+}
 
 export function collectBrowserWebviewIds(
   browserTabsByWorktree: Record<string, BrowserWorkspace[]>,
@@ -35,10 +43,10 @@ export function destroyWorkspaceWebviews(
   if (pages.length === 0) {
     // Why: legacy sessions persisted before pages existed still key their
     // webview by workspace id. Preserve the legacy destroy as a fallback.
-    destroyPersistentWebview(workspaceId)
+    destroyRemovedBrowserWebview(workspaceId)
     return
   }
   for (const page of pages) {
-    destroyPersistentWebview(page.id)
+    destroyRemovedBrowserWebview(page.id)
   }
 }


### PR DESCRIPTION
## Summary
- clear stale browser eviction-notice entries when a browser page/workspace backing model is removed
- keep existing eviction notices intact for tabs that still exist and can remount
- add focused regression coverage for runtime notice cleanup and removed-webview cleanup

## Merge risk assessment
Risk: LOW (`risk:low`)

This only clears an in-memory eviction notice at the point where the corresponding browser page/workspace model is gone. Parked-webview resource eviction still marks existing tabs and remains consumable on the next mount.

## Verification
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/browser-runtime.test.ts src/renderer/src/store/slices/browser-webview-cleanup.test.ts`
- `pnpm exec oxlint src/renderer/src/components/browser-pane/browser-runtime.ts src/renderer/src/components/browser-pane/browser-runtime.test.ts src/renderer/src/store/slices/browser-webview-cleanup.ts src/renderer/src/store/slices/browser-webview-cleanup.test.ts src/renderer/src/components/Terminal.tsx`
- `pnpm exec oxfmt --check src/renderer/src/components/browser-pane/browser-runtime.ts src/renderer/src/components/browser-pane/browser-runtime.test.ts src/renderer/src/store/slices/browser-webview-cleanup.ts src/renderer/src/store/slices/browser-webview-cleanup.test.ts src/renderer/src/components/Terminal.tsx`
- `pnpm run typecheck:web`
- `git diff --check`

Per request, I will not wait for CI before merging this low-risk PR.