### PR TITLE
fix: use nul numstat for compare counts

### DIFF
--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -49,6 +49,7 @@ import {
   detectConflictOperation,
   discardChanges,
   getBranchCompare,
+  getCommitCompare,
   getDiff,
   getStagedCommitContext,
   getStatus,
@@ -945,6 +946,102 @@ describe('getBranchCompare', () => {
     )
     expect(result.entries).toEqual([
       { path: 'docs/日本語/sample.md', status: 'modified', added: 2, removed: 1 }
+    ])
+  })
+
+  it('attaches counts for branch compare paths containing rename markers', async () => {
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'branch') {
+        return Promise.resolve({ stdout: 'main\n' })
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD')) {
+        return Promise.resolve({ stdout: 'head-oid\n' })
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'base-oid\n' })
+      }
+      if (args[0] === 'merge-base') {
+        return Promise.resolve({ stdout: 'merge-base-oid\n' })
+      }
+      if (args.includes('--name-status')) {
+        return Promise.resolve({ stdout: 'M\tdocs/a => b.txt\n' })
+      }
+      if (args.includes('--numstat')) {
+        return Promise.resolve({
+          stdout: args.includes('-z') ? '1\t0\tdocs/a => b.txt\0' : '1\t0\tdocs/a => b.txt\n'
+        })
+      }
+      if (args[0] === 'rev-list') {
+        return Promise.resolve({ stdout: '1\n' })
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    const result = await getBranchCompare('/repo', 'origin/main')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        '-c',
+        'core.quotePath=false',
+        'diff',
+        '-z',
+        '--numstat',
+        '-M',
+        '-C',
+        'merge-base-oid',
+        'head-oid'
+      ],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+    expect(result.entries).toEqual([
+      { path: 'docs/a => b.txt', status: 'modified', added: 1, removed: 0 }
+    ])
+  })
+})
+
+describe('getCommitCompare', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncBufferMock.mockReset()
+  })
+
+  it('attaches counts for commit compare paths containing rename markers', async () => {
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'commit-oid\n' })
+      }
+      if (args[0] === 'rev-list') {
+        return Promise.resolve({ stdout: 'commit-oid parent-oid\n' })
+      }
+      if (args.includes('--name-status')) {
+        return Promise.resolve({ stdout: 'M\tdocs/a => b.txt\n' })
+      }
+      if (args.includes('--numstat')) {
+        return Promise.resolve({
+          stdout: args.includes('-z') ? '1\t0\tdocs/a => b.txt\0' : '1\t0\tdocs/a => b.txt\n'
+        })
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    const result = await getCommitCompare('/repo', 'commit-oid')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        '-c',
+        'core.quotePath=false',
+        'diff',
+        '-z',
+        '--numstat',
+        '-M',
+        '-C',
+        'parent-oid',
+        'commit-oid'
+      ],
+      expect.objectContaining({ cwd: '/repo' })
+    )
+    expect(result.entries).toEqual([
+      { path: 'docs/a => b.txt', status: 'modified', added: 1, removed: 0 }
     ])
   })
 })

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -754,7 +754,7 @@ async function loadBranchChanges(
       gitOptions
     ),
     gitExecFileAsync(
-      ['-c', 'core.quotePath=false', 'diff', '--numstat', '-M', '-C', mergeBase, headOid],
+      ['-c', 'core.quotePath=false', 'diff', '-z', '--numstat', '-M', '-C', mergeBase, headOid],
       gitOptions
     )
   ])
@@ -797,11 +797,12 @@ async function loadCommitChanges(
         commitOid
       ]
   const numstatArgs = parentOid
-    ? ['-c', 'core.quotePath=false', 'diff', '--numstat', '-M', '-C', parentOid, commitOid]
+    ? ['-c', 'core.quotePath=false', 'diff', '-z', '--numstat', '-M', '-C', parentOid, commitOid]
     : [
         '-c',
         'core.quotePath=false',
         'diff-tree',
+        '-z',
         '--root',
         '--no-commit-id',
         '--numstat',


### PR DESCRIPTION
## Summary
- request `-z` for branch compare and commit compare numstat calls
- preserve added/removed counts for compare rows whose literal filenames contain ` => `
- add branch and commit compare regressions for the compare surfaces

## Evidence
Before the fix, branch/commit compare still used non-NUL numstat. The parser output for Git's non-NUL line form keyed the count to the wrong path:

```json
{"nonZ":[["b.txt",{"added":1,"removed":0}]]}
```

After the fix, compare paths request NUL-delimited numstat, which preserves the literal row path:

```json
{"z":[["docs/a => b.txt",{"added":1,"removed":0}]]}
```

Focused tests failed before the fix because the compare numstat calls did not include `-z`; they now pass and attach `{ added: 1, removed: 0 }` to `docs/a => b.txt` in both branch and commit compare results.

No screenshot attached because this is source-control compare data parsing; the deterministic parser and compare-row test output show the exact count-key mismatch.

## Verification
- `pnpm exec vitest run src/main/git/status.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/main/git/status.ts src/main/git/status.test.ts`
- `pnpm exec oxfmt --check src/main/git/status.ts src/main/git/status.test.ts`
- `git diff --check origin/main...HEAD`
