### PR TITLE
perf: avoid sorting CLI worktree selectors

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -198,6 +198,7 @@ describe('orca cli worktree awareness', () => {
     queueFixtures(
       callMock,
       worktreeListFixture([
+        buildWorktree('/tmp/repo', 'main'),
         buildWorktree('/tmp/repo/feature', 'feature/foo'),
         buildWorktree('/tmp/repo/feature', 'feature/foo', 'abc', 'duplicate-repo')
       ]),

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -1,5 +1,9 @@
 import { isAbsolute, relative, resolve as resolvePath } from 'path'
-import type { ComputerAppQuery, RuntimeWorktreeListResult } from '../shared/runtime-types'
+import type {
+  ComputerAppQuery,
+  RuntimeWorktreeListResult,
+  RuntimeWorktreeRecord
+} from '../shared/runtime-types'
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime-client'
@@ -57,9 +61,16 @@ export async function resolveCurrentWorktreeSelector(
   const worktrees = await client.call<RuntimeWorktreeListResult>('worktree.list', {
     limit: 10_000
   })
-  const enclosingWorktree = worktrees.result.worktrees
-    .filter((worktree) => isWithinPath(resolvePath(worktree.path), currentPath))
-    .sort((left, right) => right.path.length - left.path.length)[0]
+  let enclosingWorktree: RuntimeWorktreeRecord | undefined
+  let enclosingPathLength = -1
+  for (const worktree of worktrees.result.worktrees) {
+    const worktreePath = resolvePath(worktree.path)
+    if (!isWithinPath(worktreePath, currentPath) || worktreePath.length <= enclosingPathLength) {
+      continue
+    }
+    enclosingWorktree = worktree
+    enclosingPathLength = worktreePath.length
+  }
 
   if (!enclosingWorktree) {
     throw new RuntimeClientError(


### PR DESCRIPTION
## Summary
- resolve implicit/current CLI worktree selectors with a single pass over worktree.list results
- preserve deepest enclosing-worktree behavior without filter/sort allocation
- extend coverage with a nested parent worktree fixture

## Validation
- pnpm exec vitest run src/cli/index.test.ts src/cli/browser.test.ts src/cli/handlers/file.test.ts src/cli/handlers/computer.test.ts
- pnpm run typecheck:cli
- pnpm lint
- git diff --check

Risk: low. The RPC shape is unchanged and the existing duplicate-path first-match behavior is preserved.