### PR TITLE
fix: prune closed agent hook coordinators

### DIFF
--- a/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
@@ -164,4 +164,27 @@ describe('agent hook completion notifications', () => {
       })
     )
   })
+
+  it('prunes retained coordinators when pane liveness is removed from the store', async () => {
+    const {
+      _getAgentHookCompletionNotificationCoordinatorCountForTest,
+      observeAgentHookCompletionForNotification,
+      syncAgentHookCompletionNotificationSettings
+    } = await import('./agent-hook-completion-notifications')
+
+    observeAgentHookCompletionForNotification({
+      paneKey,
+      worktreeId: 'wt-1',
+      payload: hookStatus('working')
+    })
+
+    expect(_getAgentHookCompletionNotificationCoordinatorCountForTest()).toBe(1)
+
+    mockStoreState.ptyIdsByTabId = {
+      'tab-1': []
+    }
+    syncAgentHookCompletionNotificationSettings()
+
+    expect(_getAgentHookCompletionNotificationCoordinatorCountForTest()).toBe(0)
+  })
 })

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -17,12 +17,34 @@ const paneKeysRequiringFreshWorking = new Set<string>()
 let wasAgentTaskCompleteNotificationEnabled = isAgentTaskCompleteNotificationEnabled()
 let requireFreshWorkingForNewCoordinators = !wasAgentTaskCompleteNotificationEnabled
 
+function disposeCoordinatorForPaneKey(paneKey: string): void {
+  coordinatorsByPaneKey.get(paneKey)?.coordinator.dispose()
+  coordinatorsByPaneKey.delete(paneKey)
+  paneKeysRequiringFreshWorking.delete(paneKey)
+}
+
+function pruneClosedPaneCoordinators(): void {
+  // Why: hook-completion coordinators are module-scoped and may outlive a pane
+  // unless liveness changes from close/sleep paths evict them here.
+  for (const paneKey of coordinatorsByPaneKey.keys()) {
+    if (!paneHasLivePty(paneKey)) {
+      disposeCoordinatorForPaneKey(paneKey)
+    }
+  }
+  for (const paneKey of paneKeysRequiringFreshWorking) {
+    if (!paneHasLivePty(paneKey)) {
+      paneKeysRequiringFreshWorking.delete(paneKey)
+    }
+  }
+}
+
 function isAgentTaskCompleteNotificationEnabled(): boolean {
   const notifications = useAppStore.getState().settings?.notifications
   return notifications?.enabled !== false && notifications?.agentTaskComplete !== false
 }
 
 export function syncAgentHookCompletionNotificationSettings(): boolean {
+  pruneClosedPaneCoordinators()
   const enabled = isAgentTaskCompleteNotificationEnabled()
   if (!enabled || (!wasAgentTaskCompleteNotificationEnabled && enabled)) {
     requireFreshWorkingForNewCoordinators = true
@@ -106,10 +128,8 @@ export function observeAgentHookCompletionForNotification({
   worktreeId: string
   payload: ParsedAgentStatusPayload
 }): void {
+  pruneClosedPaneCoordinators()
   if (!paneHasLivePty(paneKey)) {
-    coordinatorsByPaneKey.get(paneKey)?.coordinator.dispose()
-    coordinatorsByPaneKey.delete(paneKey)
-    paneKeysRequiringFreshWorking.delete(paneKey)
     return
   }
 
@@ -151,4 +171,8 @@ export function resetAgentHookCompletionNotificationCoordinators(): void {
   paneKeysRequiringFreshWorking.clear()
   wasAgentTaskCompleteNotificationEnabled = isAgentTaskCompleteNotificationEnabled()
   requireFreshWorkingForNewCoordinators = !wasAgentTaskCompleteNotificationEnabled
+}
+
+export function _getAgentHookCompletionNotificationCoordinatorCountForTest(): number {
+  return coordinatorsByPaneKey.size
 }


### PR DESCRIPTION
## Summary
- prune module-scoped agent hook completion coordinators whenever store liveness sync shows their pane no longer has a live PTY
- keep fresh-working tracking aligned with the same closed-pane pruning
- add a regression test for pane PTY removal pruning the retained coordinator

## Risk assessment
Risk: low. The change is scoped to cleanup of already-dead pane coordinator state and does not alter live hook notification dispatch paths for panes that still have PTYs. The pruning runs from the existing store subscription that already syncs notification settings and agent-status state.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
- pnpm exec oxlint src/renderer/src/hooks/agent-hook-completion-notifications.ts src/renderer/src/hooks/agent-hook-completion-notifications.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

Electron note: not run because this is a non-visual renderer state cleanup; the regression test exercises the lifecycle boundary directly. Per request, I will not wait for CI before merge.