### PR TITLE
fix: allow slash remote push targets

### DIFF
--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -335,6 +335,22 @@ describe('git remote operations', () => {
     ])
   })
 
+  it('fetches explicit publish target remotes whose names contain slashes', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await gitFetch('/repo', {
+      remoteName: 'foo/bar',
+      branchName: 'feature/fix'
+    })
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [['check-ref-format', '--branch', 'feature/fix'], { cwd: '/repo' }],
+      [['fetch', '--prune', 'foo/bar'], { cwd: '/repo' }]
+    ])
+  })
+
   it('normalizes fetch authentication errors to a friendly message', async () => {
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('Authentication failed'))
 

--- a/src/shared/git-push-target-validation.test.ts
+++ b/src/shared/git-push-target-validation.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { assertGitPushTargetShape } from './git-push-target-validation'
+
+describe('assertGitPushTargetShape', () => {
+  it('accepts slash-separated git remote names', () => {
+    expect(() =>
+      assertGitPushTargetShape({ remoteName: 'foo/bar', branchName: 'feature/fix' })
+    ).not.toThrow()
+  })
+
+  it('rejects remote names with empty or parent segments', () => {
+    expect(() =>
+      assertGitPushTargetShape({ remoteName: 'foo//bar', branchName: 'feature/fix' })
+    ).toThrow('Invalid git remote name')
+    expect(() =>
+      assertGitPushTargetShape({ remoteName: 'foo/../bar', branchName: 'feature/fix' })
+    ).toThrow('Invalid git remote name')
+  })
+})

--- a/src/shared/git-push-target-validation.ts
+++ b/src/shared/git-push-target-validation.ts
@@ -1,6 +1,6 @@
 import type { GitPushTarget } from './types'
 
-const SAFE_REMOTE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/
+const SAFE_REMOTE_NAME_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
 const GITHUB_CLONE_URL = /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.git$/
 const GITHUB_SSH_URL = /^git@github\.com:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.git$/
 
@@ -10,6 +10,22 @@ function assertString(value: unknown, name: string): asserts value is string {
   }
 }
 
+function isSafeRemoteName(remoteName: string): boolean {
+  if (remoteName.length === 0 || remoteName.length > 100) {
+    return false
+  }
+  return remoteName.split('/').every((segment) => {
+    // Git accepts slash-separated remote names; each segment still needs to be
+    // a concrete name so persisted push targets cannot smuggle path traversal.
+    return (
+      segment !== '' &&
+      segment !== '.' &&
+      segment !== '..' &&
+      SAFE_REMOTE_NAME_SEGMENT.test(segment)
+    )
+  })
+}
+
 export function assertGitPushTargetShape(target: unknown): asserts target is GitPushTarget {
   if (typeof target !== 'object' || target === null) {
     throw new Error('Invalid PR push target.')
@@ -17,11 +33,7 @@ export function assertGitPushTargetShape(target: unknown): asserts target is Git
   const candidate = target as Record<string, unknown>
   assertString(candidate.remoteName, 'remote name')
   assertString(candidate.branchName, 'branch name')
-  if (
-    !SAFE_REMOTE_NAME.test(candidate.remoteName) ||
-    candidate.remoteName === '.' ||
-    candidate.remoteName === '..'
-  ) {
+  if (!isSafeRemoteName(candidate.remoteName)) {
     throw new Error(`Invalid git remote name: ${candidate.remoteName}`)
   }
   if (!candidate.branchName || candidate.branchName.startsWith('-')) {


### PR DESCRIPTION
## Summary
- allow slash-separated Git remote names in persisted explicit push targets
- keep rejecting empty, `.` and `..` remote-name segments
- add shared validator and local fetch routing regressions

## Evidence
Real Git accepts slash-separated remote names:

```text
git remote add foo/bar https://example.com/repo.git
git remote
foo/bar
```

Before the fix, Orca rejected the same persisted push target before Git could run:

```text
assertGitPushTargetShape({ remoteName: 'foo/bar', branchName: 'feature/fix' })
Invalid git remote name: foo/bar
```

After the fix:

```json
{"foo/bar":"ok","foo//bar":"Invalid git remote name: foo//bar","foo/../bar":"Invalid git remote name: foo/../bar"}
```

The local Git fetch regression now executes:

```text
git fetch --prune foo/bar
```

No screenshot attached because this is Git command validation/routing behavior; the real-Git and deterministic test output show the user-visible failure before any network fetch/push starts.

## Verification
- `pnpm exec vitest run src/shared/git-push-target-validation.test.ts src/main/git/remote.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/git-push-target-validation.ts src/shared/git-push-target-validation.test.ts src/main/git/remote.test.ts`
- `pnpm exec oxfmt --check src/shared/git-push-target-validation.ts src/shared/git-push-target-validation.test.ts src/main/git/remote.test.ts`
- `git diff --check origin/main...HEAD`
