### PR TITLE
fix: bound dictation stopped sessions

### DIFF
--- a/src/renderer/src/components/dictation/DictationController.tsx
+++ b/src/renderer/src/components/dictation/DictationController.tsx
@@ -10,7 +10,7 @@ import {
 } from './dictation-insertion-target'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { formatFinalTranscriptSegment } from './dictation-final-segments'
-import { waitForStoppedSession } from './dictation-stopped-sessions'
+import { recordStoppedSession, waitForStoppedSession } from './dictation-stopped-sessions'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 
 export function DictationController() {
@@ -40,6 +40,10 @@ export function DictationController() {
   const finalTranscriptReceivedRef = useRef(false)
   const intentionalTargetCancellationRef = useRef(false)
   const insertedFinalTranscriptRef = useRef('')
+
+  const drainStoppedSession = useCallback((sessionId: string) => {
+    void waitForStoppedSession(sessionId, stoppedSessionIdsRef, stoppedResolversRef)
+  }, [])
 
   const finishDictationSession = useCallback(
     async (sessionId: string) => {
@@ -132,6 +136,7 @@ export function DictationController() {
         insertionTargetRef.current = null
         stopCapture()
         await window.api.speech.stopDictation(sessionId).catch(() => undefined)
+        drainStoppedSession(sessionId)
         return
       }
 
@@ -141,6 +146,7 @@ export function DictationController() {
         insertionTargetRef.current = null
         stopCapture()
         await window.api.speech.stopDictation(sessionId).catch(() => undefined)
+        drainStoppedSession(sessionId)
         return
       }
       if (stopRequestedDuringStartRef.current) {
@@ -156,6 +162,7 @@ export function DictationController() {
         return
       }
       await window.api.speech.stopDictation(sessionId).catch(() => undefined)
+      drainStoppedSession(sessionId)
       if (captureStarted) {
         stopCapture()
       }
@@ -203,6 +210,7 @@ export function DictationController() {
     discardBufferedAudio,
     stopCapture,
     finishDictationSession,
+    drainStoppedSession,
     setPartialTranscript,
     recordFeatureInteraction
   ])
@@ -365,13 +373,7 @@ export function DictationController() {
     })
 
     const cleanupStopped = window.api.speech.onStopped((data) => {
-      const resolver = stoppedResolversRef.current.get(data.sessionId)
-      if (resolver) {
-        stoppedResolversRef.current.delete(data.sessionId)
-        resolver()
-        return
-      }
-      stoppedSessionIdsRef.current.add(data.sessionId)
+      recordStoppedSession(data.sessionId, stoppedSessionIdsRef, stoppedResolversRef)
     })
 
     const cleanupError = window.api.speech.onError((data) => {

--- a/src/renderer/src/components/dictation/dictation-stopped-sessions.test.ts
+++ b/src/renderer/src/components/dictation/dictation-stopped-sessions.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { recordStoppedSession, waitForStoppedSession } from './dictation-stopped-sessions'
+
+function refs() {
+  return {
+    stoppedSessionIdsRef: { current: new Set<string>() },
+    stoppedResolversRef: { current: new Map<string, () => void>() }
+  }
+}
+
+describe('dictation stopped sessions', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('resolves and removes a pending stopped resolver', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout
+    })
+    const { stoppedSessionIdsRef, stoppedResolversRef } = refs()
+    let resolved = false
+
+    const wait = waitForStoppedSession('session-1', stoppedSessionIdsRef, stoppedResolversRef).then(
+      () => {
+        resolved = true
+      }
+    )
+
+    expect(stoppedResolversRef.current.has('session-1')).toBe(true)
+
+    recordStoppedSession('session-1', stoppedSessionIdsRef, stoppedResolversRef)
+    await wait
+
+    expect(resolved).toBe(true)
+    expect(stoppedResolversRef.current.has('session-1')).toBe(false)
+    expect(stoppedSessionIdsRef.current.has('session-1')).toBe(false)
+  })
+
+  it('bounds early stopped sessions that are never awaited', () => {
+    const { stoppedSessionIdsRef, stoppedResolversRef } = refs()
+
+    for (let i = 0; i < 20; i += 1) {
+      recordStoppedSession(`session-${i}`, stoppedSessionIdsRef, stoppedResolversRef)
+    }
+
+    expect(stoppedSessionIdsRef.current.size).toBe(16)
+    expect(stoppedSessionIdsRef.current.has('session-0')).toBe(false)
+    expect(stoppedSessionIdsRef.current.has('session-19')).toBe(true)
+  })
+
+  it('consumes an early stopped session without leaving a resolver', async () => {
+    const { stoppedSessionIdsRef, stoppedResolversRef } = refs()
+
+    recordStoppedSession('session-1', stoppedSessionIdsRef, stoppedResolversRef)
+    await waitForStoppedSession('session-1', stoppedSessionIdsRef, stoppedResolversRef)
+
+    expect(stoppedSessionIdsRef.current.has('session-1')).toBe(false)
+    expect(stoppedResolversRef.current.has('session-1')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/dictation/dictation-stopped-sessions.ts
+++ b/src/renderer/src/components/dictation/dictation-stopped-sessions.ts
@@ -1,6 +1,32 @@
 type RefLike<T> = { current: T }
 
 const STOPPED_SESSION_WAIT_MS = 1000
+const MAX_EARLY_STOPPED_SESSION_IDS = 16
+
+export function recordStoppedSession(
+  sessionId: string,
+  stoppedSessionIdsRef: RefLike<Set<string>>,
+  stoppedResolversRef: RefLike<Map<string, () => void>>
+): void {
+  const resolver = stoppedResolversRef.current.get(sessionId)
+  if (resolver) {
+    stoppedResolversRef.current.delete(sessionId)
+    resolver()
+    return
+  }
+
+  // Why: stopped events can arrive for abandoned startup attempts that will
+  // never wait on the id. Keep the early-event cache bounded across sessions.
+  stoppedSessionIdsRef.current.delete(sessionId)
+  stoppedSessionIdsRef.current.add(sessionId)
+  while (stoppedSessionIdsRef.current.size > MAX_EARLY_STOPPED_SESSION_IDS) {
+    const oldest = stoppedSessionIdsRef.current.values().next().value
+    if (!oldest) {
+      break
+    }
+    stoppedSessionIdsRef.current.delete(oldest)
+  }
+}
 
 export function waitForStoppedSession(
   sessionId: string,


### PR DESCRIPTION
## Summary
- route speech stopped events through bounded stopped-session bookkeeping
- drain stopped events for aborted dictation startup stop paths so abandoned startup attempts do not leave stale session ids
- add focused coverage for resolver cleanup, early stopped-event consumption, and bounding the early-event cache

## Risk assessment
Risk: low. The change is scoped to dictation stopped-event bookkeeping and preserves the existing normal finish flow. The early stopped-event cache is bounded to prevent renderer-session growth from abandoned startup attempts, and stop drains run fire-and-forget on branches that already stop the session.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/dictation/dictation-stopped-sessions.test.ts src/renderer/src/components/dictation/dictation-final-segments.test.ts
- pnpm exec oxlint src/renderer/src/components/dictation/DictationController.tsx src/renderer/src/components/dictation/dictation-stopped-sessions.ts src/renderer/src/components/dictation/dictation-stopped-sessions.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

Electron note: not run because this is non-visual stopped-event bookkeeping; the regression tests exercise the retained-map/set invariant directly. Per request, I will not wait for CI before merge.