### PR TITLE
fix: dispose stale pty title sources

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-buffer-serializer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-buffer-serializer.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IDisposable } from '@xterm/xterm'
+
+describe('pty buffer serializer registry', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+
+  beforeEach(() => {
+    vi.resetModules()
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          onClearBufferRequest: vi.fn(() => () => {}),
+          onSerializeBufferRequest: vi.fn(() => () => {}),
+          sendSerializedBuffer: vi.fn()
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('tracks a remounted quiet title source even when the stale owner unregisters later', async () => {
+    const { registerPtySerializer, registerPtyTitleSource } =
+      await import('./pty-buffer-serializer')
+    const oldDispose = vi.fn()
+    const newDispose = vi.fn()
+
+    const unregisterOldSerializer = registerPtySerializer('pty-1', () => null)
+    const unregisterOldTitle = registerPtyTitleSource(
+      'pty-1',
+      () => ({ dispose: oldDispose }) satisfies IDisposable
+    )
+
+    const unregisterNewSerializer = registerPtySerializer('pty-1', () => null)
+    const unregisterNewTitle = registerPtyTitleSource(
+      'pty-1',
+      () => ({ dispose: newDispose }) satisfies IDisposable
+    )
+
+    expect(oldDispose).toHaveBeenCalledTimes(1)
+    expect(newDispose).not.toHaveBeenCalled()
+
+    unregisterOldTitle()
+    unregisterOldSerializer()
+
+    expect(newDispose).not.toHaveBeenCalled()
+
+    unregisterNewTitle()
+    unregisterNewSerializer()
+
+    expect(newDispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-buffer-serializer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-buffer-serializer.ts
@@ -82,6 +82,15 @@ export function registerPtyTitleSource(
     // owner token is available. Calling out of order is a programming bug.
     throw new Error(`registerPtyTitleSource called before serializer for ptyId ${ptyId}`)
   }
+  const existing = lastTitleByPtyId.get(ptyId)
+  const initialTitle = existing?.owner === serializerOwner ? existing.title : ''
+  if (existing) {
+    // Why: same-PTY remounts can install the new serializer/title source before
+    // the stale mount unregisters. Replace the tracked disposable immediately
+    // so the new quiet-pane listener cannot become unowned.
+    existing.disposable.dispose()
+    lastTitleByPtyId.delete(ptyId)
+  }
   const disposable = attach((title) => {
     const current = lastTitleByPtyId.get(ptyId)
     if (current && current.owner !== serializerOwner) {
@@ -91,10 +100,7 @@ export function registerPtyTitleSource(
   })
   // Seed an entry with an empty title so the disposable is tracked even
   // before the first onTitleChange fires. Subsequent updates overwrite it.
-  const existing = lastTitleByPtyId.get(ptyId)
-  if (!existing) {
-    lastTitleByPtyId.set(ptyId, { title: '', owner: serializerOwner, disposable })
-  }
+  lastTitleByPtyId.set(ptyId, { title: initialTitle, owner: serializerOwner, disposable })
   return () => {
     const entry = lastTitleByPtyId.get(ptyId)
     if (entry?.owner === serializerOwner) {


### PR DESCRIPTION
## Summary
- replace stale same-PTY title-source entries when a remounted pane registers a new serializer owner
- preserve title state only when the existing entry belongs to the same owner
- add focused coverage for quiet-pane remounts where the stale owner unregisters after the new title source is installed

## Risk assessment
Risk: low. The change is scoped to PTY serializer/title-source bookkeeping for same-PTY remount handoff. It only disposes the previous tracked title-source disposable when a replacement is registered, preventing an unowned xterm listener; live serializer dispatch remains owner-token guarded.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-buffer-serializer.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts
- pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-buffer-serializer.ts src/renderer/src/components/terminal-pane/pty-buffer-serializer.test.ts
- pnpm run typecheck:web
- git diff --check origin/main...HEAD

Electron note: not run because this is non-visual PTY registry ownership cleanup; the regression test exercises the listener-retention invariant directly. Per request, I will not wait for CI before merge.