### PR TITLE
perf: move markdown preview timer cleanup to ref

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -597,16 +597,6 @@ export default function MarkdownPreview({
     markdownAnnotationsEnabled && sourceWorktree && sourceRelativePath !== null
   )
 
-  useEffect(() => {
-    return () => {
-      // Why: review-note reveal/copy timers are event-owned, but the final
-      // cancellation belongs to the preview surface unmount.
-      cancelMarkdownPreviewEditorRevealFrames(pendingEditorRevealFrameIdsRef)
-      clearMarkdownPreviewTimeout(attentionReviewCommentTimeoutRef)
-      clearMarkdownPreviewTimeout(reviewNotesCopiedResetTimerRef)
-    }
-  }, [])
-
   // Why: each split pane needs its own markdown preview viewport even when the
   // underlying file is shared. The caller passes a pane-scoped cache key so
   // duplicate tabs do not overwrite each other's preview scroll state.
@@ -715,15 +705,23 @@ export default function MarkdownPreview({
     }
   }, [])
 
+  const cleanupPreviewSurfaceTimers = useCallback((): void => {
+    // Why: reveal/copy timers are event-owned, but the final cancellation
+    // belongs to the preview surface unmount.
+    cancelMarkdownPreviewEditorRevealFrames(pendingEditorRevealFrameIdsRef)
+    clearMarkdownPreviewTimeout(attentionReviewCommentTimeoutRef)
+    clearReviewNotesCopiedResetTimer()
+  }, [clearReviewNotesCopiedResetTimer])
+
   const setRootRef = useCallback(
     (node: HTMLDivElement | null) => {
       rootRef.current = node
       reviewNotesCopyMountedRef.current = node !== null
       if (node === null) {
-        clearReviewNotesCopiedResetTimer()
+        cleanupPreviewSurfaceTimers()
       }
     },
-    [clearReviewNotesCopiedResetTimer]
+    [cleanupPreviewSurfaceTimers]
   )
 
   const scrollToAnchor = useCallback((rawAnchor: string): boolean => {


### PR DESCRIPTION
## Summary
- move markdown preview reveal/copy timer cleanup onto the existing preview root callback ref
- remove the cleanup-only effect while preserving unmount cancellation for reveal frames and review-note timers

## Verification
- pnpm exec oxlint src/renderer/src/components/editor/MarkdownPreview.tsx
- pnpm exec oxfmt --check src/renderer/src/components/editor/MarkdownPreview.tsx
- pnpm run typecheck:web
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.test.ts src/renderer/src/components/editor/markdown-preview-search.test.ts
- git diff --check
- AST scan: MarkdownPreview.tsx effects 6, cleanup-only 0; repo React-scope total effects 855