### PR TITLE
fix: bound renderer crash dedupe cache

### DIFF
--- a/src/main/ipc/crash-reporting.test.ts
+++ b/src/main/ipc/crash-reporting.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- Why: crash-reporting IPC handlers share one mocked ipcMain registry and store contract. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CrashReportRecord } from '../../shared/crash-reporting'
 
@@ -22,7 +23,10 @@ vi.mock('./feedback', () => ({
   submitFeedback: submitFeedbackMock
 }))
 
-import { registerCrashReportingHandlers } from './crash-reporting'
+import {
+  _resetRendererErrorReportDedupeForTests,
+  registerCrashReportingHandlers
+} from './crash-reporting'
 
 function report(
   status: CrashReportRecord['status'] = 'pending',
@@ -52,6 +56,7 @@ describe('registerCrashReportingHandlers', () => {
     clipboardWriteTextMock.mockReset()
     submitFeedbackMock.mockReset()
     submitFeedbackMock.mockResolvedValue({ ok: true })
+    _resetRendererErrorReportDedupeForTests()
   })
 
   it('copies the latest pending diagnostic text to the clipboard', async () => {
@@ -298,5 +303,56 @@ describe('registerCrashReportingHandlers', () => {
       })
     ).resolves.toEqual({ ok: false, error: 'Invalid renderer error report.' })
     expect(recordMock).not.toHaveBeenCalled()
+  })
+
+  it('bounds renderer error dedupe keys by evicting the oldest unique reports', async () => {
+    let recordCount = 0
+    const recordMock = vi.fn(async () => report('pending', `react-render-${recordCount++}`))
+    registerCrashReportingHandlers({
+      getById: vi.fn(),
+      dismiss: vi.fn(),
+      markSent: vi.fn(),
+      markDismissedSent: vi.fn(),
+      listRecent: vi.fn(async () => []),
+      record: recordMock,
+      formatDiagnosticText: vi.fn()
+    } as never)
+
+    const baseArgs = {
+      boundaryId: 'terminal.workbench',
+      surface: 'terminal-workbench',
+      errorName: 'TypeError',
+      componentStack: 'at Terminal'
+    }
+
+    for (let i = 0; i < 260; i += 1) {
+      await handlers.get('crashReports:recordRendererError')?.(null, {
+        ...baseArgs,
+        errorMessage: `unique-render-error-${i}`
+      })
+    }
+
+    await expect(
+      handlers.get('crashReports:recordRendererError')?.(null, {
+        ...baseArgs,
+        errorMessage: 'unique-render-error-0'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      report: expect.objectContaining({ id: 'react-render-260' }),
+      deduped: false
+    })
+    await expect(
+      handlers.get('crashReports:recordRendererError')?.(null, {
+        ...baseArgs,
+        errorMessage: 'unique-render-error-259'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      report: null,
+      deduped: true
+    })
+
+    expect(recordMock).toHaveBeenCalledTimes(261)
   })
 })

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -17,6 +17,7 @@ const recentRendererErrorReportKeys = new Map<string, number>()
 
 const RENDERER_ERROR_DEDUPE_MS = 10 * 60 * 1000
 const MAX_RENDERER_ERROR_KEY_AGE_MS = RENDERER_ERROR_DEDUPE_MS * 2
+const MAX_RECENT_RENDERER_ERROR_REPORT_KEYS = 256
 
 const REACT_ERROR_BOUNDARY_SURFACES = new Set<ReactErrorBoundaryReportArgs['surface']>([
   'app-root',
@@ -101,6 +102,13 @@ function pruneRendererErrorReportKeys(now: number): void {
       recentRendererErrorReportKeys.delete(key)
     }
   }
+  while (recentRendererErrorReportKeys.size > MAX_RECENT_RENDERER_ERROR_REPORT_KEYS) {
+    const oldestKey = recentRendererErrorReportKeys.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    recentRendererErrorReportKeys.delete(oldestKey)
+  }
 }
 
 function getRendererErrorReportKey(args: ReactErrorBoundaryReportArgs): string {
@@ -129,6 +137,10 @@ async function recordRendererErrorReport(
     return { ok: true, report: null, deduped: true }
   }
   recentRendererErrorReportKeys.set(key, now)
+  // Why: renderer error reports are IPC input. A broken renderer can vary the
+  // component stack/message inside the age window, so bound the main-side
+  // dedupe map by count as well as time.
+  pruneRendererErrorReportKeys(now)
 
   const report = await store.record({
     source: 'renderer',
@@ -164,6 +176,10 @@ async function recordRendererErrorReport(
   })
 
   return { ok: true, report, deduped: false }
+}
+
+export function _resetRendererErrorReportDedupeForTests(): void {
+  recentRendererErrorReportKeys.clear()
 }
 
 async function getLatestPendingReport(


### PR DESCRIPTION
## Summary
- cap the main-process renderer error-boundary dedupe map at 256 entries in addition to age pruning
- keep the newest dedupe keys while evicting oldest unique reports under bursty renderer IPC input
- reset dedupe state in crash-reporting tests and add coverage that the oldest key is evicted while recent keys still dedupe

## Risk assessment
Risk: low. The change only affects the defensive dedupe cache for renderer crash reports. It preserves same-key dedupe behavior for recent entries and bounds memory if a broken renderer varies error messages/component stacks rapidly.

## Verification
- pnpm vitest run --config config/vitest.config.ts src/main/ipc/crash-reporting.test.ts
- pnpm exec oxlint src/main/ipc/crash-reporting.ts src/main/ipc/crash-reporting.test.ts
- pnpm run typecheck:node
- git diff --check origin/main...HEAD

Electron note: not run because this is non-visual main-process IPC cache bookkeeping; the regression test exercises the retention bound directly. Per request, I will not wait for CI before merge.