### PR TITLE
fix: resolve slashed upstream remotes

### DIFF
--- a/src/main/git/upstream.test.ts
+++ b/src/main/git/upstream.test.ts
@@ -141,6 +141,39 @@ describe('getUpstreamStatus', () => {
     })
   })
 
+  it('keeps a configured upstream whose remote name contains a slash', async () => {
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.resolve({ stdout: 'feature\n' })
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        return Promise.resolve({ stdout: 'origin/team/feature\n' })
+      }
+      if (args[0] === 'remote') {
+        return Promise.resolve({ stdout: 'origin\norigin/team\n' })
+      }
+      if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/feature')) {
+        return Promise.resolve({ stdout: 'origin-feature-oid\n' })
+      }
+      if (args[0] === 'rev-list' && args.includes('HEAD...origin/team/feature')) {
+        return Promise.resolve({ stdout: '2\t0\n' })
+      }
+      if (args[0] === 'rev-list' && args.includes('HEAD...origin/feature')) {
+        return Promise.resolve({ stdout: '9\t9\n' })
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    const result = await getUpstreamStatus('/repo')
+
+    expect(result).toEqual({
+      hasUpstream: true,
+      upstreamName: 'origin/team/feature',
+      ahead: 2,
+      behind: 0
+    })
+  })
+
   it('uses an explicit publish target instead of the configured upstream', async () => {
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: '', stderr: '' })

--- a/src/shared/git-effective-upstream.ts
+++ b/src/shared/git-effective-upstream.ts
@@ -31,6 +31,37 @@ export function splitRemoteBranchName(refName: string): {
   }
 }
 
+function hasMultipleSlashSegments(refName: string): boolean {
+  return refName.includes('/') && refName.indexOf('/') !== refName.lastIndexOf('/')
+}
+
+async function splitRemoteBranchNameByKnownRemote(
+  runGit: GitCommandRunner,
+  refName: string
+): Promise<{ remoteName: string; branchName: string } | null> {
+  try {
+    const { stdout } = await runGit(['remote'])
+    const remotes = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort((a, b) => b.length - a.length)
+    return (
+      remotes
+        .map((remoteName) => {
+          if (refName === remoteName || !refName.startsWith(`${remoteName}/`)) {
+            return null
+          }
+          const branchName = refName.slice(remoteName.length + 1)
+          return branchName ? { remoteName, branchName } : null
+        })
+        .find((parsed) => parsed !== null) ?? null
+    )
+  } catch {
+    return null
+  }
+}
+
 async function getCurrentBranchName(runGit: GitCommandRunner): Promise<string | null> {
   try {
     const { stdout } = await runGit(['symbolic-ref', '--quiet', '--short', 'HEAD'])
@@ -90,9 +121,21 @@ export async function resolveEffectiveGitUpstream(
   runGit: GitCommandRunner
 ): Promise<EffectiveGitUpstream | null> {
   const currentBranchName = await getCurrentBranchName(runGit)
-  const configured = await getConfiguredUpstream(runGit)
+  let configured = await getConfiguredUpstream(runGit)
 
   if (configured) {
+    if (
+      currentBranchName &&
+      configured.remoteName === 'origin' &&
+      configured.branchName !== currentBranchName &&
+      hasMultipleSlashSegments(configured.upstreamName)
+    ) {
+      const parsed = await splitRemoteBranchNameByKnownRemote(runGit, configured.upstreamName)
+      if (parsed) {
+        configured = { ...configured, ...parsed }
+      }
+    }
+
     if (!currentBranchName || configured.branchName === currentBranchName) {
       return configured
     }


### PR DESCRIPTION
## Summary
- reparse ambiguous configured upstream names against the known Git remote list
- preserve configured upstreams for remotes like `origin/team` before applying the legacy `origin/<current-branch>` fallback
- add a regression where an unrelated `origin/feature` ref exists alongside the real `origin/team/feature` upstream

## Evidence
Real Git accepts and reports a configured upstream for a slash-separated remote name:

```text
git remote rename origin origin/team
git push -u origin/team feature
git rev-parse --abbrev-ref HEAD@{u}
origin/team/feature
git remote
origin/team
```

Before the fix, the focused runtime repro returned the wrong upstream because `origin/team/feature` was parsed as remote `origin` plus branch `team/feature`, then replaced by the legacy `origin/feature` fallback:

```json
{"hasUpstream":true,"upstreamName":"origin/feature","ahead":9,"behind":9,"behindCommitsArePatchEquivalent":false}
```

After the fix, the same repro keeps the configured slash-named remote upstream and intended counts:

```json
{"result":{"hasUpstream":true,"upstreamName":"origin/team/feature","ahead":2,"behind":0},"calls":["symbolic-ref --quiet --short HEAD","rev-parse --abbrev-ref HEAD@{u}","remote","rev-list --left-right --count HEAD...origin/team/feature"]}
```

No screenshot attached because this is source-control upstream resolution; the deterministic upstream-status output shows the wrong branch/counts before and after.

## Verification
- `pnpm exec vitest run src/main/git/upstream.test.ts src/main/git/remote.test.ts src/main/git/branch-rename.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/shared/git-effective-upstream.ts src/main/git/upstream.test.ts`
- `pnpm exec oxfmt --check src/shared/git-effective-upstream.ts src/main/git/upstream.test.ts`
- `git diff --check origin/main...HEAD`
